### PR TITLE
feat(sites): workers.dev deploy mode — static sites on the free tier

### DIFF
--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -90,3 +90,33 @@ POCKETPAW_LICENSE_KEY=
 # PAW_CF_API_TOKEN=
 # PAW_CF_ZONE_ID=
 # PAW_CF_DISPATCH_NAMESPACE=paw-sites
+#
+#   PAW_CF_DEPLOY_MODE    — EXPLICIT deploy target (local | workers | wfp). Unset
+#                           (default) keeps the legacy selection: local when no
+#                           PAW_CF_ACCOUNT_ID, else Workers-for-Platforms (wfp).
+#     * local   — serve the static site from a localhost URL (dev / smoke).
+#     * workers — deploy a STATIC site as a regular Worker on the FREE workers.dev
+#                 tier (no WfP namespace / D1 / Queue needed). Dynamic sites are
+#                 Phase 2 here (they need a per-tenant D1) and are rejected.
+#     * wfp     — Workers-for-Platforms dispatch namespace (the multi-tenant path).
+# PAW_CF_DEPLOY_MODE=
+#   PAW_CF_WORKERS_SUBDOMAIN — the account's workers.dev subdomain (the
+#                           <subdomain> in https://<name>.<subdomain>.workers.dev).
+#                           Used ONLY to construct the deployed URL when it can't be
+#                           parsed from wrangler's output; wrangler normally prints
+#                           it, so this is a fallback. Find it in the CF dashboard
+#                           (Workers & Pages → your subdomain).
+# PAW_CF_WORKERS_SUBDOMAIN=
+#   PAW_CF_WRANGLER_CMD   — the wrangler invocation for workers mode. Default
+#                           "bunx wrangler@4.101.0" (pulls + runs the pinned
+#                           wrangler at publish time — NEEDS NETWORK). Override to
+#                           pin a different version or point at a baked binary.
+#                           NOTE: baking wrangler into the image is the robust
+#                           follow-up so a publish doesn't depend on a network pull.
+# PAW_CF_WRANGLER_CMD=bunx wrangler@4.101.0
+#
+# Workers mode (PAW_CF_DEPLOY_MODE=workers) runs `wrangler deploy`, which reads the
+# Cloudflare creds from these two env vars DIRECTLY (wrangler's own names — NOT the
+# PAW_CF_* ones above). Set them alongside PAW_CF_ACCOUNT_ID for a workers deploy.
+# CLOUDFLARE_API_TOKEN=
+# CLOUDFLARE_ACCOUNT_ID=

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,20 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-25 (feat/sites-workers-deploy-mode — workers.dev deploy mode):
+# ``_deploy_site_doc`` now picks one of THREE deploy targets via a new
+# ``_deploy_mode()`` helper reading PAW_CF_DEPLOY_MODE (``local`` | ``workers`` |
+# ``wfp``): ``local`` → ``local_server.deploy_local`` (unchanged), ``workers`` →
+# the NEW ``workers_deploy.deploy_workers`` (deploy a STATIC site as a regular
+# Worker on the free workers.dev tier — a DYNAMIC site raises ``ValidationError``
+# since it needs a per-tenant D1, Phase 2), ``wfp`` → ``cf.put_worker`` (the
+# Workers-for-Platforms path, unchanged). When PAW_CF_DEPLOY_MODE is UNSET the
+# LEGACY selection is preserved exactly (``_local_mode()`` → local, else WfP), and
+# an injected ``_cloudflare`` still forces the WfP branch over an env-requested
+# local mode — so the existing local/CF tests are unaffected. New
+# ``_workers_deploy`` test-injection seam threads ``publish`` → ``_deploy_site_doc``
+# (mirrors ``_local_deploy``/``_cloudflare``). Billing/charge-first logic untouched.
+#
 # Updated 2026-06-25 (feat/paw-sites-prod-deploy, DEP-3 — graceful generator
 # failure): the publish path shells out to the paw-sites generator + bun, which in
 # a misconfigured deploy (an image missing the toolchain) raised a bare
@@ -717,6 +731,38 @@ def _local_mode() -> bool:
     return not os.environ.get("PAW_CF_ACCOUNT_ID")
 
 
+def _deploy_mode() -> str | None:
+    """The EXPLICIT deploy target for a live publish, read from PAW_CF_DEPLOY_MODE
+    (``local`` | ``workers`` | ``wfp``), or ``None`` when unset.
+
+    A 3-way selector layered OVER the existing local/Cloudflare decision without
+    disturbing it:
+      * ``local``   → serve the static site from localhost (local_server.deploy_local).
+      * ``workers`` → deploy as a regular Worker on the free workers.dev tier
+                      (workers_deploy.deploy_workers — STATIC sites only; a dynamic
+                      site raises rather than deploying a broken site).
+      * ``wfp``     → the Workers-for-Platforms dispatch-namespace path
+                      (cloudflare_client.put_worker) — today's Cloudflare default.
+      * UNSET (``None``) → PRESERVE today's behaviour: ``_local_mode()`` selects the
+                      local branch, else the cf/put_worker (wfp) path. So nothing
+                      changes for an environment that does not set the var.
+
+    A value other than the three known modes is treated as UNSET (logged) so a typo
+    degrades to the safe legacy behaviour rather than failing the publish."""
+    import os
+
+    raw = (os.environ.get("PAW_CF_DEPLOY_MODE") or "").strip().lower()
+    if not raw:
+        return None
+    if raw in ("local", "workers", "wfp"):
+        return raw
+    logger.warning(
+        "sites: unknown PAW_CF_DEPLOY_MODE=%r — falling back to legacy local/wfp selection",
+        raw,
+    )
+    return None
+
+
 async def _promote_pocket_draft_to_published(
     *, pocket_id: str, workspace_id: str, author: str | None, content: dict[str, Any]
 ) -> None:
@@ -850,6 +896,7 @@ async def publish(
     _cloudflare: Any | None = None,
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
     _local_deploy: Callable[[str, str], str] | None = None,
+    _workers_deploy: Callable[[str, str], Any] | None = None,
 ) -> _SiteDoc:
     """Generate, smoke-gate, deploy, and persist a site. Raises SmokeGateFailed
     (from generator_client) if the workerd smoke render fails — the site is not
@@ -1035,6 +1082,7 @@ async def publish(
         cloudflare=_cloudflare,
         bundle_reader=_bundle_reader,
         local_deploy=_local_deploy,
+        workers_deploy=_workers_deploy,
     )
 
 
@@ -1056,6 +1104,7 @@ async def _deploy_site_doc(
     cloudflare: Any | None = None,
     bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
     local_deploy: Callable[[str, str], str] | None = None,
+    workers_deploy: Callable[[str, str], Any] | None = None,
 ) -> _SiteDoc:
     """Generate, smoke-gate, deploy, and UPSERT the LIVE canonical Site doc.
 
@@ -1063,10 +1112,19 @@ async def _deploy_site_doc(
     (``activate_site``) can run the SAME deferred deploy at payment-confirm time
     using the inputs captured on the pending Site doc. It runs
     ``generator.build`` (with the SSR smoke fail-gate ON — a broken site is
-    rejected before it deploys), deploys via the LOCAL static server or Cloudflare
-    Workers-for-Platforms, and upserts ONE canonical Site doc per (workspace,
-    pocket_id) keyed on the stable ``_id`` (== ``site_id``), flipping
-    ``deployed=True`` + stamping ``deployed_at``.
+    rejected before it deploys), deploys via one of THREE targets, and upserts ONE
+    canonical Site doc per (workspace, pocket_id) keyed on the stable ``_id`` (==
+    ``site_id``), flipping ``deployed=True`` + stamping ``deployed_at``.
+
+    Deploy target (``_deploy_mode()`` reading PAW_CF_DEPLOY_MODE):
+      * ``local``   → the LOCAL static server (``local_server.deploy_local``);
+      * ``workers`` → a regular Worker on the free workers.dev tier
+                      (``workers_deploy.deploy_workers``) — STATIC sites only; a
+                      DYNAMIC site raises ``ValidationError`` (Phase 2 / use WfP);
+      * ``wfp``     → Cloudflare Workers-for-Platforms (``cf.put_worker``).
+    When PAW_CF_DEPLOY_MODE is UNSET the legacy selection stands: ``_local_mode()``
+    → local, else WfP. An injected CF client forces the WfP branch over an
+    env-requested local mode (the existing CF-test contract).
 
     Identity (``site_id`` / ``signed_key`` / ``site_name``) is resolved by the
     caller so the same values flow through a publish and a later activation (the
@@ -1075,6 +1133,10 @@ async def _deploy_site_doc(
     ``pending_deploy_inputs`` (the site is now live, not pending). Raises
     ``SmokeGateFailed`` (from generator_client) if the SSR render fails — nothing
     is deployed and no doc is flipped to deployed.
+
+    ``workers_deploy`` is the test-injection seam for the workers-mode deployer
+    (mirrors ``local_deploy``/``cloudflare``); ``None`` uses the real
+    ``workers_deploy.deploy_workers``.
     """
     gen = generator or GeneratorClient()
     # DEP-3: map a generator/install/smoke failure (missing toolchain, non-zero
@@ -1117,16 +1179,44 @@ async def _deploy_site_doc(
             getattr(_prior, "d1_database_id", "") if _prior is not None else ""
         ) or _derive_d1_database_id(workspace_id, pocket_id)
 
-    # Local mode only when the caller did NOT inject a CF client (tests inject a
-    # fake CF and expect the real branch) AND the environment selects it.
-    use_local = cloudflare is None and _local_mode()
+    # Deploy-mode selection (workers-deploy-mode). PAW_CF_DEPLOY_MODE explicitly
+    # picks one of three targets (local | workers | wfp); when UNSET we preserve the
+    # exact prior behaviour — ``_local_mode()`` → the local branch, else the
+    # cf/put_worker (WfP) path. An injected CF client (tests) still FORCES the real
+    # Cloudflare branch over an env-driven local selection, so the existing CF tests
+    # keep exercising put_worker and the local branch never hijacks them.
+    mode = _deploy_mode()
+    if mode is None:
+        # Legacy selection: local only when no CF client was injected AND the env
+        # selects it; else WfP.
+        use_local = cloudflare is None and _local_mode()
+        mode = "local" if use_local else "wfp"
+    elif mode == "local" and cloudflare is not None:
+        # An injected CF client (a test asserting the real CF branch) wins over an
+        # env that requests local — mirrors the legacy ``cloudflare is None`` guard.
+        mode = "wfp"
+
     url = ""
-    if use_local:
+    if mode == "local":
         from pocketpaw_ee.sites import local_server
 
         deploy = local_deploy or local_server.deploy_local
         url = deploy(site_id, build.project_dir)
-    else:
+    elif mode == "workers":
+        # Free workers.dev tier — STATIC sites only. A dynamic site needs a
+        # per-tenant D1 + Queues (Phase 2 / use WfP), so reject it cleanly rather
+        # than deploying a broken site that can't reach its data.
+        if is_dynamic:
+            raise ValidationError(
+                "sites.workers_dynamic_unsupported",
+                "Dynamic sites aren't supported in workers mode yet (Phase 2) — they "
+                "need a per-tenant D1; publish via Workers-for-Platforms instead.",
+            )
+        from pocketpaw_ee.sites import workers_deploy as workers_deploy_mod
+
+        deploy_w = workers_deploy or workers_deploy_mod.deploy_workers
+        url = await deploy_w(site_id, build.project_dir)
+    else:  # "wfp"
         cf = cloudflare or _cf_client()
         bundle = bundle_reader(build.project_dir)
         # Only a dynamic site passes bindings; a static publish passes None so the

--- a/ee/pocketpaw_ee/sites/workers_deploy.py
+++ b/ee/pocketpaw_ee/sites/workers_deploy.py
@@ -1,0 +1,244 @@
+# ee/pocketpaw_ee/sites/workers_deploy.py — deploy a STATIC Paw Site as a regular
+# Cloudflare Worker on the FREE tier (workers.dev) via `wrangler deploy`.
+#
+# Created: 2026-06-25 (feat/sites-workers-deploy-mode) — the "workers" deploy mode.
+#
+# This is the third deploy target for a Paw Site, beside the LOCAL static server
+# (local_server.deploy_local — dev/smoke) and Workers-for-Platforms
+# (cloudflare_client.put_worker — the multi-tenant dispatch namespace). The
+# "workers" mode publishes a static site as an ordinary Worker on a free
+# workers.dev subdomain, which needs NO WfP dispatch namespace, NO D1, NO Queue —
+# just a Cloudflare account token. It is the cheapest path to a real public URL and
+# the one PROVEN live by the manual recipe this module automates.
+#
+# THE RECIPE (verified live — a real paw site serves on workers.dev with exactly
+# this). After the generator emits ``<project>/.svelte-kit/cloudflare/`` (the
+# adapter-cloudflare static output: ``_worker.js`` + the ``_app/...`` asset tree),
+# two files make it deployable to workers.dev with wrangler 4.x:
+#   1. ``<project>/.svelte-kit/cloudflare/.assetsignore`` — REQUIRED. wrangler 4.x
+#      HARD-ERRORS ("Uploading a Pages _worker.js file as an asset") if the worker
+#      entry sits inside the asset dir without it, and adapter-cloudflare does NOT
+#      emit it. Contents are exactly the three lines ``_worker.js`` / ``_routes.json``
+#      / ``_headers``.
+#   2. ``<project>/wrangler.jsonc`` — the clean static config: ``main`` →
+#      ``.svelte-kit/cloudflare/_worker.js``, ``assets.directory`` → the SAME dir,
+#      ``workers_dev: true``, ``nodejs_compat``. We do NOT reuse the generator's own
+#      ``wrangler.toml`` (it stamps an UNDERSCORE name variant + D1/Queue bindings
+#      for the dynamic path — invalid for a clean static worker).
+# Deploy: ``bunx wrangler@4.101.0 deploy`` with ``CLOUDFLARE_API_TOKEN`` +
+# ``CLOUDFLARE_ACCOUNT_ID`` in the env. wrangler prints the deployed
+# ``https://<name>.<account-subdomain>.workers.dev`` URL on stdout; we parse it
+# (falling back to constructing it from PAW_CF_WORKERS_SUBDOMAIN if the parse fails).
+#
+# HARD RULES from the live test:
+#   * Worker/subdomain names MUST match ``^[a-z0-9][a-z0-9-]*$`` (lowercase,
+#     hyphens; NO underscores). The site_id is a 24-hex ObjectId (already
+#     lowercase-safe), so the name is ``paw-site-<site_id>``. ``_sanitize`` guards a
+#     non-conforming id so a bad id can never produce an invalid name.
+#   * STATIC sites ONLY. A DYNAMIC site (pattern=="dynamic", or a spec carrying
+#     live bindings) needs a per-tenant D1 + Queues provisioned — that is Phase 2.
+#     In workers mode a dynamic site raises a clean ``ValidationError`` rather than
+#     deploying a broken site that can't reach its data.
+#
+# The wrangler invocation is overridable via PAW_CF_WRANGLER_CMD (default
+# ``bunx wrangler@4.101.0``) so it is pinnable, ``shlex.split`` like
+# PAW_SITES_GEN_CMD. The subprocess style mirrors generator_client.py
+# (``asyncio.create_subprocess_exec``, captured stdout/stderr, non-zero → raise
+# with the stderr tail).
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import shlex
+from pathlib import Path
+
+from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
+
+logger = logging.getLogger(__name__)
+
+# The static-output dir adapter-cloudflare emits, relative to the project dir. The
+# worker entry AND the asset tree both live here; ``main`` and ``assets.directory``
+# in the generated wrangler.jsonc both point at it.
+_CF_OUTPUT_REL = ".svelte-kit/cloudflare"
+
+# The REQUIRED .assetsignore contents (exact three lines, no trailing blank). Drops
+# the Pages-style worker/routing/header files so wrangler 4.x does not try to upload
+# the worker entry as a static asset (which it HARD-ERRORS on). adapter-cloudflare
+# does not emit this file, so the deploy step writes it.
+_ASSETSIGNORE_LINES = ("_worker.js", "_routes.json", "_headers")
+
+# wrangler reads the worker name + name-segment of the workers.dev URL from
+# ``wrangler.jsonc``'s ``name``. It must match this (lowercase alnum + hyphen,
+# leading alnum). The recipe names a site ``paw-site-<site_id>``; the 24-hex
+# ObjectId is already lowercase-safe, so this is really a guard against a
+# non-ObjectId id slipping through.
+_WORKER_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+# The pinned wrangler invocation. Overridable (and ``shlex.split``) via
+# PAW_CF_WRANGLER_CMD — mirrors generator_client._gen_cmd_argv's PAW_SITES_GEN_CMD
+# so the deploy image can pin / swap the wrangler version without a code change.
+_DEFAULT_WRANGLER_CMD = "bunx wrangler@4.101.0"
+
+
+def _wrangler_argv() -> list[str]:
+    """The wrangler invocation, tokenised. Default ``bunx wrangler@4.101.0`` (pulls
+    + runs the pinned wrangler at publish time — needs network). Override with
+    PAW_CF_WRANGLER_CMD to pin a different version or point at a baked binary, e.g.
+    ``/opt/node_modules/.bin/wrangler``. Mirrors PAW_SITES_GEN_CMD's override seam.
+    """
+    return shlex.split(os.environ.get("PAW_CF_WRANGLER_CMD", _DEFAULT_WRANGLER_CMD))
+
+
+def _sanitize(raw: str) -> str:
+    """Coerce an arbitrary id into a valid worker-name SEGMENT: lowercase, with any
+    run of disallowed chars (incl. underscores) collapsed to a single hyphen, and
+    leading/trailing hyphens stripped. A 24-hex ObjectId passes through unchanged
+    (already lowercase + hyphen-free); this only ever bites a non-ObjectId id. Falls
+    back to ``"site"`` if sanitizing leaves an empty string, so the name is never
+    invalid."""
+    s = raw.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = s.strip("-")
+    return s or "site"
+
+
+def _worker_name(site_id: str) -> str:
+    """The worker / workers.dev subdomain name for a site: ``paw-site-<site_id>``,
+    sanitized so it always matches ``^[a-z0-9][a-z0-9-]*$`` (CF rejects underscores
+    + uppercase). The ``paw-site-`` prefix starts with a letter, so the leading-char
+    rule holds regardless of the (sanitized) id."""
+    return f"paw-site-{_sanitize(site_id)}"
+
+
+def _wrangler_jsonc(name: str) -> str:
+    """The clean STATIC-site wrangler config (the proven recipe). ``main`` points at
+    the worker entry adapter-cloudflare emits INSIDE the asset dir, and
+    ``assets.directory`` points at that SAME dir (the ``.assetsignore`` we write
+    keeps wrangler from uploading the worker entry as an asset). ``workers_dev:
+    true`` publishes to the free ``<name>.<subdomain>.workers.dev`` URL;
+    ``nodejs_compat`` is what the SvelteKit worker needs at runtime. Deliberately
+    minimal — NO D1 / Queue bindings (those are the dynamic-site Phase-2 path, and
+    the generator's own wrangler.toml that carries them is NOT reused here)."""
+    config = {
+        "name": name,
+        "main": f"{_CF_OUTPUT_REL}/_worker.js",
+        "compatibility_date": "2024-09-23",
+        "compatibility_flags": ["nodejs_compat"],
+        "workers_dev": True,
+        "assets": {"binding": "ASSETS", "directory": _CF_OUTPUT_REL},
+    }
+    return json.dumps(config, indent=2) + "\n"
+
+
+# The workers.dev URL wrangler prints on a successful deploy, e.g.
+# ``https://paw-site-abc.my-acct.workers.dev``. We parse the FIRST such URL out of
+# stdout; the fallback constructs it from PAW_CF_WORKERS_SUBDOMAIN when the parse
+# fails (a wrangler output format change must not lose the URL).
+_WORKERS_DEV_URL_RE = re.compile(r"https://[a-z0-9][a-z0-9.-]*\.workers\.dev\S*")
+
+
+def _parse_deploy_url(stdout: str, *, name: str) -> str:
+    """Pull the deployed ``https://...workers.dev`` URL out of wrangler's stdout.
+
+    wrangler prints the published URL on success; we return the FIRST workers.dev
+    URL it emits. When the parse fails (no match — e.g. a wrangler output-format
+    change), construct the canonical URL from the worker name + the account's
+    workers.dev subdomain (PAW_CF_WORKERS_SUBDOMAIN). The fallback returns ``""``
+    only when the subdomain is also unconfigured, so the caller still gets a
+    successful deploy (just without a resolved URL to store)."""
+    m = _WORKERS_DEV_URL_RE.search(stdout)
+    if m:
+        return m.group(0).rstrip(".,)\"'")
+    subdomain = os.environ.get("PAW_CF_WORKERS_SUBDOMAIN", "").strip()
+    if subdomain:
+        return f"https://{name}.{subdomain}.workers.dev"
+    return ""
+
+
+def _write_deploy_files(project_dir: str, name: str) -> None:
+    """Write the two files the recipe needs into the project: the REQUIRED
+    ``.svelte-kit/cloudflare/.assetsignore`` (exact three lines) and the clean
+    static ``wrangler.jsonc`` at the project root. Both are overwritten on a
+    re-publish so a stale config can never linger."""
+    out_dir = Path(project_dir, _CF_OUTPUT_REL)
+    if not out_dir.is_dir():
+        # The static output must exist before this runs — generator.build() emits it.
+        # If it is missing the deploy can't proceed (nothing to upload).
+        raise ValidationError(
+            "sites.workers_no_build",
+            "The static build output is missing — the site must be built before a workers deploy.",
+        )
+    (out_dir / ".assetsignore").write_text("\n".join(_ASSETSIGNORE_LINES) + "\n")
+    Path(project_dir, "wrangler.jsonc").write_text(_wrangler_jsonc(name))
+
+
+def _cf_env() -> dict[str, str]:
+    """The subprocess env for wrangler: the current env plus the two CF vars
+    wrangler reads itself (``CLOUDFLARE_API_TOKEN`` + ``CLOUDFLARE_ACCOUNT_ID``).
+    We pass the full ``os.environ`` through (so PATH / HOME / bun caches resolve)
+    and let wrangler pick up the CF creds from it. The vars are NOT logged."""
+    return dict(os.environ)
+
+
+async def deploy_workers(site_id: str, project_dir: str) -> str:
+    """Deploy a STATIC Paw Site as a regular Worker on the free workers.dev tier.
+
+    Writes the proven recipe files (``.assetsignore`` + ``wrangler.jsonc``) into the
+    already-built project, then runs ``wrangler deploy`` (PAW_CF_WRANGLER_CMD, default
+    ``bunx wrangler@4.101.0``) with the CF creds in the env, and returns the deployed
+    ``https://<name>.<subdomain>.workers.dev`` URL (parsed from wrangler's stdout,
+    falling back to constructing it from PAW_CF_WORKERS_SUBDOMAIN).
+
+    The project MUST already carry the generator's ``.svelte-kit/cloudflare/``
+    static output (generator.build() emits it before this is called). On a non-zero
+    wrangler exit this raises ``Internal`` with the stderr tail so the failure
+    surfaces as a clean 5xx envelope, not an opaque crash.
+
+    NOTE: dynamic-site rejection is the CALLER's job (the service deploy-mode
+    selector knows the pattern). This function deploys whatever static output it is
+    given — it does not re-classify the site."""
+    name = _worker_name(site_id)
+    if not _WORKER_NAME_RE.match(name):  # defensive — _worker_name always sanitizes
+        raise ValidationError(
+            "sites.workers_bad_name",
+            f"Computed an invalid worker name from site id {site_id!r}.",
+        )
+    _write_deploy_files(project_dir, name)
+
+    argv = [*_wrangler_argv(), "deploy"]
+    logger.info("sites.workers: deploying %s via %s", name, argv[:-1])
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=project_dir,
+            env=_cf_env(),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        # wrangler / bunx not on PATH — a misconfigured deploy image.
+        raise Internal(
+            "sites.workers_wrangler_missing",
+            "The wrangler toolchain is unavailable — a workers-mode deploy needs "
+            "wrangler reachable (bunx pulls it at publish time).",
+        ) from exc
+    stdout_b, stderr_b = await proc.communicate()
+    stdout = stdout_b.decode(errors="replace")
+    stderr = stderr_b.decode(errors="replace")
+    if proc.returncode != 0:
+        tail = (stderr or stdout)[-800:]
+        logger.error("sites.workers: wrangler deploy failed (exit %s): %s", proc.returncode, tail)
+        raise Internal(
+            "sites.workers_deploy_failed",
+            f"wrangler deploy failed (exit {proc.returncode}): {tail}",
+        )
+    url = _parse_deploy_url(stdout, name=name)
+    logger.info("sites.workers: deployed %s -> %s", name, url or "(url unresolved)")
+    return url
+
+
+__all__ = ["deploy_workers"]

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -44,6 +44,12 @@
 # put_worker and persists that id on the Site doc (reused on re-publish), that a
 # static (landing/None) publish passes NO bindings (single-module path, regress
 # guard), and that publish_pocket threads the pocket's pattern through.
+# Updated 2026-06-25 (feat/sites-workers-deploy-mode): coverage for the 3-way
+# deploy-mode selector — PAW_CF_DEPLOY_MODE=workers routes a STATIC publish to the
+# injected workers deployer (and stamps the returned workers.dev url on the Site);
+# a DYNAMIC site in workers mode raises a clean ValidationError (Phase 2); and with
+# PAW_CF_DEPLOY_MODE UNSET the legacy local/wfp selection is preserved (an injected
+# CF client still wins → put_worker; no env creds + no CF → local deployer).
 from __future__ import annotations
 
 import pytest
@@ -1142,3 +1148,134 @@ async def test_publish_pocket_threads_dynamic_pattern(beanie_test_db):
     assert site.d1_database_id
     d1 = [b for b in (cf.put_bindings[0] or []) if b.get("type") == "d1"]
     assert len(d1) == 1
+
+
+# ── workers deploy mode (PAW_CF_DEPLOY_MODE=workers) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_workers_mode_routes_static_publish_to_workers_deployer(beanie_test_db, monkeypatch):
+    """PAW_CF_DEPLOY_MODE=workers routes a STATIC publish to the injected workers
+    deployer (NOT put_worker, NOT the local server) and stamps the returned
+    workers.dev URL on the Site doc."""
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "workers")
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+
+    calls: list[tuple[str, str]] = []
+
+    async def fake_workers_deploy(site_id: str, project_dir: str) -> str:
+        calls.append((site_id, project_dir))
+        return f"https://paw-site-{site_id}.acct.workers.dev"
+
+    def cf_boom(*a, **k):  # pragma: no cover - must not run in workers mode
+        raise AssertionError("workers mode must not build a real CF client")
+
+    gen = _FakeGenerator()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_w1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Workers Site",
+        _generator=gen,
+        # No _cloudflare injected → the workers branch owns the deploy.
+        _bundle_reader=lambda d: b"unused-in-workers-mode",
+        _workers_deploy=fake_workers_deploy,
+    )
+
+    assert site.deployed is True
+    assert calls == [(str(site.id), "/tmp/site")]
+    assert site.url == f"https://paw-site-{site.id}.acct.workers.dev"
+    resp = sites_service._to_response(site)
+    assert resp.url == site.url
+
+
+@pytest.mark.asyncio
+async def test_workers_mode_dynamic_site_raises_validation_error(beanie_test_db, monkeypatch):
+    """A DYNAMIC site in workers mode is rejected with a clean ValidationError
+    (Phase 2 needs a per-tenant D1) rather than deploying a broken site. The
+    injected workers deployer must NOT be called."""
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "workers")
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+
+    async def must_not_run(site_id: str, project_dir: str) -> str:  # pragma: no cover
+        raise AssertionError("a dynamic site must not reach the workers deployer")
+
+    gen = _FakeGenerator()
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.publish(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk_w_dyn",
+            ripple_spec={
+                "type": "container",
+                "objects": [{"name": "rows", "fields": {"x": "text"}}],
+                "actions": [{"name": "add", "object": "rows", "op": "insert"}],
+            },
+            theme={},
+            name="Dynamic in Workers",
+            pattern="dynamic",
+            _generator=gen,
+            _bundle_reader=lambda d: b"unused",
+            _workers_deploy=must_not_run,
+        )
+    assert "workers" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_unset_deploy_mode_preserves_legacy_cf_branch(beanie_test_db, monkeypatch):
+    """With PAW_CF_DEPLOY_MODE UNSET, an injected CF client takes the legacy WfP
+    (put_worker) branch — the workers deployer must NOT run."""
+    monkeypatch.delenv("PAW_CF_DEPLOY_MODE", raising=False)
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    cf = _FakeCF()
+
+    async def workers_boom(*a, **k):  # pragma: no cover - must not run
+        raise AssertionError("workers deployer must not run with mode unset + CF injected")
+
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_legacy_cf",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Legacy CF",
+        _generator=_FakeGenerator(),
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+        _workers_deploy=workers_boom,
+    )
+    assert cf.put_calls == [site.script_name]
+    assert site.url == ""  # CF/WfP path leaves url empty in v1
+
+
+@pytest.mark.asyncio
+async def test_unset_deploy_mode_preserves_legacy_local_branch(beanie_test_db, monkeypatch):
+    """With PAW_CF_DEPLOY_MODE UNSET and no CF creds / no CF client, publish() still
+    takes the legacy LOCAL branch — the workers deployer must NOT run."""
+    monkeypatch.delenv("PAW_CF_DEPLOY_MODE", raising=False)
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+
+    def fake_local_deploy(site_id: str, project_dir: str) -> str:
+        return f"http://127.0.0.1:9999/{site_id}/"
+
+    async def workers_boom(*a, **k):  # pragma: no cover - must not run
+        raise AssertionError("workers deployer must not run in legacy local mode")
+
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_legacy_local",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Legacy Local",
+        _generator=_FakeGenerator(),
+        _bundle_reader=lambda d: b"unused",
+        _local_deploy=fake_local_deploy,
+        _workers_deploy=workers_boom,
+    )
+    assert site.url == f"http://127.0.0.1:9999/{site.id}/"

--- a/tests/ee/sites/test_workers_deploy.py
+++ b/tests/ee/sites/test_workers_deploy.py
@@ -1,0 +1,220 @@
+# tests/ee/sites/test_workers_deploy.py — unit tests for the "workers" deploy mode
+# (workers_deploy.deploy_workers): deploy a STATIC Paw Site as a regular Worker on
+# the free workers.dev tier. The wrangler subprocess is MOCKED (no network / no
+# real CF account), mirroring the sites tests' convention of faking the subprocess
+# so the orchestration is unit-testable. The LIVE deploy (with a real token) is run
+# by the captain, not here.
+#
+# Coverage:
+#   * deploy_workers writes a correct ``.assetsignore`` (exact 3 lines) +
+#     ``wrangler.jsonc`` (name/main/assets/workers_dev/compatibility_flags) into the
+#     built project dir;
+#   * name sanitization: an ObjectId → ``paw-site-<id>`` (lowercase, no underscores);
+#     a non-conforming id is sanitized to a valid worker name;
+#   * URL parsing from a fake wrangler stdout containing a workers.dev line, and the
+#     fallback construction from PAW_CF_WORKERS_SUBDOMAIN when the parse fails;
+#   * a non-zero wrangler exit raises Internal with the stderr tail;
+#   * a missing static-build dir raises a clean ValidationError before any subprocess.
+#
+# Created: 2026-06-25 (feat/sites-workers-deploy-mode).
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
+from pocketpaw_ee.sites import workers_deploy
+
+
+class _FakeProc:
+    """A stand-in for the asyncio subprocess wrangler runs: returns a fixed
+    (returncode, stdout, stderr) from communicate()."""
+
+    def __init__(self, returncode: int, stdout: bytes, stderr: bytes) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+
+def _build_project(tmp_path: Path) -> str:
+    """Create a minimal built project: the static output dir generator.build()
+    emits (``.svelte-kit/cloudflare/``) with a worker entry, so deploy_workers has
+    something to write into."""
+    out = tmp_path / ".svelte-kit" / "cloudflare"
+    out.mkdir(parents=True)
+    (out / "_worker.js").write_text("export default {}")
+    (out / "index.html").write_text("<h1>hi</h1>")
+    return str(tmp_path)
+
+
+def _patch_subprocess(monkeypatch, proc: _FakeProc) -> dict:
+    """Patch asyncio.create_subprocess_exec to return ``proc`` and capture the call
+    (argv, cwd, env) so a test can assert on the invocation."""
+    captured: dict = {}
+
+    async def _fake_exec(*argv, cwd=None, env=None, stdout=None, stderr=None):
+        captured["argv"] = list(argv)
+        captured["cwd"] = cwd
+        captured["env"] = env
+        return proc
+
+    monkeypatch.setattr(workers_deploy.asyncio, "create_subprocess_exec", _fake_exec)
+    return captured
+
+
+# ── name sanitization ────────────────────────────────────────────────────────
+
+
+def test_worker_name_from_objectid_is_lowercase_no_underscore():
+    # A 24-hex ObjectId is already lowercase-safe → paw-site-<id> verbatim.
+    site_id = "507f1f77bcf86cd799439011"
+    name = workers_deploy._worker_name(site_id)
+    assert name == f"paw-site-{site_id}"
+    assert workers_deploy._WORKER_NAME_RE.match(name)
+    assert "_" not in name
+    assert name == name.lower()
+
+
+def test_worker_name_sanitizes_bad_id():
+    # A hypothetical non-ObjectId id with underscores / uppercase / spaces is
+    # coerced into a valid worker-name segment.
+    name = workers_deploy._worker_name("Bad_ID__With  Spaces!")
+    assert workers_deploy._WORKER_NAME_RE.match(name)
+    assert "_" not in name
+    assert name == "paw-site-bad-id-with-spaces"
+
+
+def test_sanitize_empty_falls_back():
+    assert workers_deploy._sanitize("___") == "site"
+    assert workers_deploy._sanitize("") == "site"
+
+
+# ── the recipe files ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_deploy_writes_assetsignore_and_wrangler_jsonc(tmp_path, monkeypatch):
+    project = _build_project(tmp_path)
+    site_id = "507f1f77bcf86cd799439011"
+    proc = _FakeProc(0, b"https://paw-site-507f1f77bcf86cd799439011.acct.workers.dev\n", b"")
+    _patch_subprocess(monkeypatch, proc)
+
+    url = await workers_deploy.deploy_workers(site_id, project)
+
+    # .assetsignore — EXACTLY the three recipe lines, in order.
+    assetsignore = Path(project, ".svelte-kit/cloudflare/.assetsignore").read_text()
+    assert assetsignore.splitlines() == ["_worker.js", "_routes.json", "_headers"]
+
+    # wrangler.jsonc — the clean static config (parse it; it is JSON-compatible).
+    cfg = json.loads(Path(project, "wrangler.jsonc").read_text())
+    assert cfg["name"] == f"paw-site-{site_id}"
+    assert cfg["main"] == ".svelte-kit/cloudflare/_worker.js"
+    assert cfg["workers_dev"] is True
+    assert cfg["compatibility_flags"] == ["nodejs_compat"]
+    assert cfg["compatibility_date"] == "2024-09-23"
+    assert cfg["assets"] == {"binding": "ASSETS", "directory": ".svelte-kit/cloudflare"}
+
+    assert url == "https://paw-site-507f1f77bcf86cd799439011.acct.workers.dev"
+
+
+@pytest.mark.asyncio
+async def test_deploy_invokes_wrangler_with_deploy_in_project_dir(tmp_path, monkeypatch):
+    project = _build_project(tmp_path)
+    proc = _FakeProc(0, b"https://x.y.workers.dev\n", b"")
+    captured = _patch_subprocess(monkeypatch, proc)
+    # Pin the wrangler cmd so the assertion is deterministic.
+    monkeypatch.setenv("PAW_CF_WRANGLER_CMD", "bunx wrangler@4.101.0")
+
+    await workers_deploy.deploy_workers("507f1f77bcf86cd799439011", project)
+
+    assert captured["argv"] == ["bunx", "wrangler@4.101.0", "deploy"]
+    assert captured["cwd"] == project
+    # The CF creds wrangler reads itself ride through the env (full os.environ).
+    assert captured["env"] is not None
+
+
+# ── URL resolution ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_url_parsed_from_stdout(tmp_path, monkeypatch):
+    project = _build_project(tmp_path)
+    stdout = (
+        b"Total Upload: 10 KiB\n"
+        b"Uploaded paw-site-x (1.2 sec)\n"
+        b"  https://paw-site-x.my-acct.workers.dev\n"
+        b"Current Deployment ID: abc\n"
+    )
+    _patch_subprocess(monkeypatch, _FakeProc(0, stdout, b""))
+
+    url = await workers_deploy.deploy_workers("x", project)
+    assert url == "https://paw-site-x.my-acct.workers.dev"
+
+
+@pytest.mark.asyncio
+async def test_url_fallback_from_subdomain_env(tmp_path, monkeypatch):
+    project = _build_project(tmp_path)
+    # wrangler printed nothing parseable → construct from PAW_CF_WORKERS_SUBDOMAIN.
+    _patch_subprocess(monkeypatch, _FakeProc(0, b"deployed, no url here\n", b""))
+    monkeypatch.setenv("PAW_CF_WORKERS_SUBDOMAIN", "acme-team")
+
+    url = await workers_deploy.deploy_workers("507f1f77bcf86cd799439011", project)
+    assert url == "https://paw-site-507f1f77bcf86cd799439011.acme-team.workers.dev"
+
+
+@pytest.mark.asyncio
+async def test_url_empty_when_unparseable_and_no_subdomain(tmp_path, monkeypatch):
+    project = _build_project(tmp_path)
+    _patch_subprocess(monkeypatch, _FakeProc(0, b"deployed, no url\n", b""))
+    monkeypatch.delenv("PAW_CF_WORKERS_SUBDOMAIN", raising=False)
+
+    # The deploy still SUCCEEDS (returncode 0) — just with no resolved URL.
+    url = await workers_deploy.deploy_workers("x", project)
+    assert url == ""
+
+
+# ── failure paths ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_raises_internal_with_stderr_tail(tmp_path, monkeypatch):
+    project = _build_project(tmp_path)
+    _patch_subprocess(
+        monkeypatch,
+        _FakeProc(1, b"", b"Authentication error [code: 10000] - invalid token"),
+    )
+
+    with pytest.raises(Internal) as exc:
+        await workers_deploy.deploy_workers("x", project)
+    assert "invalid token" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_missing_build_dir_raises_validation_error(tmp_path, monkeypatch):
+    # No .svelte-kit/cloudflare/ — the project was never built. Should raise a clean
+    # ValidationError BEFORE any subprocess (the subprocess would be a NameError if
+    # reached, since we don't patch it).
+    project = str(tmp_path)
+    with pytest.raises(ValidationError):
+        await workers_deploy.deploy_workers("x", project)
+
+
+@pytest.mark.asyncio
+async def test_wrangler_not_on_path_raises_internal(tmp_path, monkeypatch):
+    project = _build_project(tmp_path)
+
+    async def _boom(*argv, **kwargs):
+        raise FileNotFoundError("bunx: command not found")
+
+    monkeypatch.setattr(workers_deploy.asyncio, "create_subprocess_exec", _boom)
+    with pytest.raises(Internal) as exc:
+        await workers_deploy.deploy_workers("x", project)
+    assert "wrangler" in str(exc.value).lower()


### PR DESCRIPTION
## What this does

Adds a **`workers` deploy mode** so a static Paw Site publishes as a regular Cloudflare Worker on the **free tier** (`workers.dev`) — proven live end-to-end (a real paw site serves with working CSS through this code path).

This sidesteps Workers for Platforms ($25/mo, a separate plan) for getting started: regular Workers + Workers Assets are free and directly addressable — no dispatch worker, no wildcard DNS, no advanced cert.

- **`ee/pocketpaw_ee/sites/workers_deploy.py`** — `deploy_workers(site_id, project_dir)`: writes the proven recipe (`.svelte-kit/cloudflare/.assetsignore` + a clean `wrangler.jsonc` with `main` / `assets` binding / `workers_dev`), runs `bunx wrangler@4.101.0 deploy` with the CF env, parses the `workers.dev` URL (falls back to constructing it from `PAW_CF_WORKERS_SUBDOMAIN`). Sanitizes the worker name (`paw-site-<id>`, lowercase-hyphens — underscores are invalid). `PAW_CF_WRANGLER_CMD` is overridable (pin a version or point at a baked binary).
- **`ee/pocketpaw_ee/sites/service.py`** — a 3-way deploy-mode selector (`local | workers | wfp`) via `PAW_CF_DEPLOY_MODE`; **unset preserves today's exact behavior** so nothing breaks. `workers` mode rejects dynamic sites cleanly (Phase 2).
- env docs (`PAW_CF_DEPLOY_MODE`, `PAW_CF_WORKERS_SUBDOMAIN`, `PAW_CF_WRANGLER_CMD`, `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID`) + tests.

## Verified

- 11 `workers_deploy` unit tests + 4 routing tests (subprocess mocked) → **275 passed**. ruff clean; OSS→EE boundary holds.
- **Live integration test (the real code path against real Cloudflare):** `deploy_workers()` → a live `*.workers.dev` URL → page HTTP 200 (hero copy) + `/_app/immutable/assets/*.css` HTTP 200. The static-asset gap that single-module `put_worker` couldn't cover is solved.

## Turn it on (free tier)

In Coolify, set: `PAW_CF_DEPLOY_MODE=workers`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` (wrangler reads the last two), optionally `PAW_CF_WORKERS_SUBDOMAIN` for the URL fallback. Then publish → `https://paw-site-<id>.<your-sub>.workers.dev`.

## Scope / follow-ups

- **Static sites only.** Dynamic sites (need per-tenant D1 + Queues provisioned) = **Phase 2**; rejected cleanly for now.
- **Bake `wrangler` into the Coolify deploy image** — `bunx wrangler` pulls it at publish time (needs network); a baked binary + `PAW_CF_WRANGLER_CMD` is the robust follow-up.
