### PR TITLE
feat(stores): per-workspace store factory + physical Fabric isolation

### DIFF
--- a/ee/pocketpaw_ee/fabric/router.py
+++ b/ee/pocketpaw_ee/fabric/router.py
@@ -43,11 +43,19 @@
 #   scoped on the type's own ``workspace_id`` now). This supersedes the W4a /
 #   fix/fabric-stats note above that called definitions "global in the schema"
 #   — they carry their own workspace column as of SZD-2.
+# Updated: 2026-06-26 (ISO-1 — physical per-workspace isolation) — the store is
+#   no longer a single shared ``~/.pocketpaw/fabric.db``. ``_store`` now takes
+#   the caller's ``workspace_id`` and routes through
+#   ``pocketpaw.stores.get_fabric_store(workspace_id=...)``, so every read/write
+#   in this router hits that tenant's OWN
+#   ``~/.pocketpaw/workspaces/<id>/fabric.db`` file. The per-endpoint W4a
+#   ``workspace_id`` filter args are UNCHANGED — physical file isolation is
+#   additive defense-in-depth, kept alongside the in-row WHERE-filter, not a
+#   replacement for it.
 
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -62,6 +70,7 @@ from pocketpaw.fabric.models import (
     PropertyDef,
 )
 from pocketpaw.fabric.store import FabricStore
+from pocketpaw.stores import get_fabric_store
 from pocketpaw_ee.cloud._core.deps import current_workspace_id, require_plan_feature
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import require_action_any_workspace
@@ -73,11 +82,18 @@ router = APIRouter(
     dependencies=[Depends(require_license), Depends(require_plan_feature("fabric"))],
 )
 
-_DB_PATH = Path.home() / ".pocketpaw" / "fabric.db"
 
+def _store(workspace_id: str) -> FabricStore:
+    """Return the FabricStore for ``workspace_id`` (ISO-1 — physical isolation).
 
-def _store() -> FabricStore:
-    return FabricStore(_DB_PATH)
+    Routes through the workspace-keyed factory so every Fabric read/write in
+    this router hits the caller's OWN ``~/.pocketpaw/workspaces/<id>/fabric.db``
+    file, not the shared one. ``workspace_id`` is the caller's active workspace,
+    already resolved by ``current_workspace_id`` on each endpoint. The W4a
+    in-row ``workspace_id`` WHERE-filter the endpoints already pass STAYS — the
+    physical file split is additive defense-in-depth on top of it.
+    """
+    return get_fabric_store(workspace_id=workspace_id)
 
 
 # ---------------------------------------------------------------------------
@@ -124,7 +140,7 @@ async def list_types(workspace_id: str = Depends(current_workspace_id)):
     object row visible to the workspace — type names are tenant metadata on a
     shared deployment.
     """
-    return await _store().list_types(workspace_id=workspace_id)
+    return await _store(workspace_id).list_types(workspace_id=workspace_id)
 
 
 @router.post(
@@ -138,7 +154,7 @@ async def define_type(
     workspace_id: str = Depends(current_workspace_id),
 ):
     """Define an object type stamped with the caller's active workspace (SZD-2)."""
-    return await _store().define_type(
+    return await _store(workspace_id).define_type(
         name=req.name,
         properties=req.properties,
         description=req.description,
@@ -181,7 +197,7 @@ async def list_objects(
     workspace so a tenant never sees another tenant's objects.
     """
     q = FabricQuery(type_id=type_id, type_name=type_name, limit=limit, offset=offset)
-    result = await _store().query(q, workspace_id=workspace_id)
+    result = await _store(workspace_id).query(q, workspace_id=workspace_id)
     return ObjectsListResponse(objects=result.objects, total=result.total)
 
 
@@ -203,7 +219,7 @@ async def list_links(
     W4a — scoped to the caller's active workspace (plus legacy NULL-workspace
     links) so a tenant cannot enumerate another tenant's relationships.
     """
-    links, total = await _store().list_links(
+    links, total = await _store(workspace_id).list_links(
         from_id=from_id,
         to_id=to_id,
         link_type=link_type,
@@ -225,7 +241,7 @@ async def create_object(
     workspace_id: str = Depends(current_workspace_id),
 ):
     """Create an object stamped with the caller's active workspace (W4a)."""
-    return await _store().create_object(
+    return await _store(workspace_id).create_object(
         type_id=req.type_id,
         properties=req.properties,
         source_connector=req.source_connector,
@@ -248,7 +264,7 @@ async def get_object(
     A 404 — not a 403 — is returned for another tenant's object so the
     endpoint never leaks the existence of cross-workspace ids.
     """
-    obj = await _store().get_object(obj_id, workspace_id=workspace_id)
+    obj = await _store(workspace_id).get_object(obj_id, workspace_id=workspace_id)
     if not obj:
         raise HTTPException(404, "Object not found")
     return obj
@@ -264,7 +280,7 @@ async def query_fabric(
     workspace_id: str = Depends(current_workspace_id),
 ):
     """Run an arbitrary FabricQuery, scoped to the caller's workspace (W4a)."""
-    return await _store().query(q, workspace_id=workspace_id)
+    return await _store(workspace_id).query(q, workspace_id=workspace_id)
 
 
 @router.post(
@@ -277,7 +293,7 @@ async def create_link(
     workspace_id: str = Depends(current_workspace_id),
 ):
     """Create a link stamped with the caller's active workspace (W4a)."""
-    return await _store().link(
+    return await _store(workspace_id).link(
         from_id=req.from_id,
         to_id=req.to_id,
         link_type=req.link_type,
@@ -299,4 +315,4 @@ async def fabric_stats(workspace_id: str = Depends(current_workspace_id)):
     names are tenant metadata on a shared deployment, so an unscoped stats here
     leaked another tenant's experimental type names into chat.
     """
-    return await _store().stats(workspace_id=workspace_id)
+    return await _store(workspace_id).stats(workspace_id=workspace_id)

--- a/src/pocketpaw/extensions.py
+++ b/src/pocketpaw/extensions.py
@@ -15,6 +15,12 @@ Updated: 2026-06-12 (connector-store-unification CS-3) — added
 ``ConnectorStateStoreProvider`` (group ``pocketpaw.connector_state_stores``)
 so EE can back the ConnectorRegistry's durable state with the cloud DB
 instead of the file store.
+
+Updated: 2026-06-26 (ISO-1 — workspace-keyed store factory) — activated the
+previously-dormant ``StoreProvider`` seam: ``pocketpaw.stores.get_fabric_store``
+now consults it, and ``get_store`` gained a ``workspace_id`` keyword so a future
+EE provider can return a per-workspace / cloud-backed Fabric store. The EE
+registration is a later task; core only consults the seam here.
 """
 
 from __future__ import annotations
@@ -82,11 +88,24 @@ class AuthProvider(Protocol):
 class StoreProvider(Protocol):
     """Entry-point group: ``pocketpaw.stores``
 
-    Overrides the default singleton store factories (instinct, fabric, …).
-    Core ships local SQLite-backed defaults; EE swaps in cloud-backed ones.
+    Overrides the default store factories (instinct, fabric, …). Core ships
+    local SQLite-backed defaults; EE swaps in cloud-backed ones.
+
+    Activated by ISO-1 (2026-06-26): ``pocketpaw.stores.get_fabric_store``
+    consults this seam before building its own store, so EE can later register a
+    workspace-keyed / cloud-backed Fabric store without core importing EE. The
+    EE registration itself is a LATER task — core merely consults the seam now.
+
+    ``get_store`` takes the logical store *name* (``"fabric"``, ``"instinct"``,
+    …) and the resolved ``workspace_id`` (``None`` for the single-tenant /
+    unscoped path). A provider returns the store it wants core to use, or
+    ``None`` to decline that name (core then builds its local default).
+    Implementations should accept ``workspace_id`` as a keyword so the core
+    factory can pass it; the factory tolerates a legacy no-``workspace_id``
+    signature for back-compat.
     """
 
-    def get_store(self, name: str) -> Any: ...
+    def get_store(self, name: str, *, workspace_id: str | None = None) -> Any: ...
 
 
 @runtime_checkable

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -135,6 +135,14 @@
 #        match. ``ensure_type`` / ``ingest_records`` (connectors/fabric_ingest.py)
 #        thread ``workspace_id`` so existing ingestion keeps working and minted
 #        types land in the caller's tenant.
+# Updated: 2026-06-26 (ISO-1 — physical per-workspace isolation) — added
+#   aclose(): a best-effort WAL-checkpoint + state reset the new workspace-keyed
+#   store factory (src/pocketpaw/stores.py) runs when it evicts a per-workspace
+#   FabricStore from its bounded LRU. The store still holds no long-lived
+#   connection; aclose exists only so an idle tenant's write-ahead-log sidecar
+#   gets truncated instead of growing unbounded across 128+ cached tenants. The
+#   W4a in-row workspace_id WHERE-filter is UNCHANGED — physical file isolation
+#   is ADDITIVE defense-in-depth layered on top of it, never a replacement.
 
 
 from __future__ import annotations
@@ -530,6 +538,29 @@ class FabricStore:
     def _conn(self) -> aiosqlite.Connection:
         """Return a new connection context manager. Use with `async with`."""
         return aiosqlite.connect(self._db_path)
+
+    async def aclose(self) -> None:
+        """Release this store's on-disk resources (ISO-1).
+
+        ``FabricStore`` holds NO long-lived connection — every method opens and
+        closes its own ``aiosqlite.connect()`` per call — so there is no socket
+        or cursor to close. What CAN accumulate is a write-ahead-log sidecar
+        (``fabric.db-wal`` / ``-shm``) that grows until a checkpoint folds it
+        back into the main file. Under per-workspace physical isolation the
+        store factory caches up to 128 of these and evicts the least-recently
+        used; ``aclose`` is what the factory runs on eviction so an idle
+        tenant's WAL is truncated rather than left to grow unbounded, and the
+        next ``_ensure_schema`` re-runs cleanly on the cold handle.
+
+        Best-effort and idempotent: a checkpoint failure (DB never created,
+        WAL not in use, file vanished) is swallowed — eviction must never raise.
+        """
+        self._initialized = False
+        try:
+            async with aiosqlite.connect(self._db_path) as db:
+                await db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except Exception:  # noqa: BLE001 — eviction cleanup is best-effort
+            logger.debug("FabricStore.aclose checkpoint skipped", exc_info=True)
 
     # --- Object Types ---
 

--- a/src/pocketpaw/stores.py
+++ b/src/pocketpaw/stores.py
@@ -1,27 +1,198 @@
-"""Process-wide singletons for the local SQLite-backed runtime stores.
+"""Process-wide store factories for the local SQLite-backed runtime stores.
 
-Instinct, Fabric and Paw Print all keep their state in SQLite under
-``~/.pocketpaw/``. These factories return a lazily-created singleton each so
-agent tools, automations and routers share one instance per process.
+Instinct, Fabric and Paw Print keep their state in SQLite under
+``~/.pocketpaw/``. These factories return a lazily-created handle so agent
+tools, automations and routers share one instance per process (or, for Fabric,
+one instance per WORKSPACE — see below).
 
-This is plain core infrastructure — there is no cloud-backed override. The
-factories moved here from ``pocketpaw_ee/api.py`` in the OSS-EE split
-(Phase 3); ``pocketpaw_ee.api`` now re-exports from this module for the
-enterprise routers that still import via that path.
+ISO-1 (2026-06-26 — physical per-workspace isolation): Fabric is no longer a
+single process-wide singleton on a SHARED ``~/.pocketpaw/fabric.db``. On a
+shared cloud box every tenant used to read and write the same file, with only
+the W4a in-row ``workspace_id`` WHERE-filter standing between them. ISO-1 adds
+PHYSICAL isolation: each workspace gets its OWN file at
+``~/.pocketpaw/workspaces/<workspace_id>/fabric.db`` — mirroring how KB
+(``~/.knowledge-base/{scope}/``) and Soul (one ``.soul`` per entity) already
+isolate by directory. The W4a WHERE-filter STAYS; physical isolation is
+ADDITIVE defense-in-depth, not a replacement.
+
+``get_fabric_store`` resolves the target workspace in this order:
+
+    explicit ``workspace_id=`` arg  →  the ``current_workspace`` ContextVar  →  None
+
+When a workspace resolves, a per-workspace ``FabricStore`` is returned (and the
+directory is created), cached in a bounded LRU that ``aclose()``s the handle it
+evicts. When NO workspace resolves:
+
+  * if ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` is truthy (cloud mode — set by the
+    EE cloud bootstrap, mirroring the ``POCKETPAW_MEMORY_BACKEND`` precedent),
+    we RAISE ``WorkspaceScopeRequired`` (fail-closed). A missing workspace on a
+    cloud path must NEVER silently fall back to a shared store.
+  * otherwise (single-tenant OSS) we return the legacy
+    ``~/.pocketpaw/fabric.db`` singleton, so a self-hosted install keeps working
+    exactly as before.
+
+The ``current_workspace`` ContextVar lives HERE in OSS core (``pocketpaw``) on
+purpose: EE imports from OSS, never the reverse. ISO-3 (a later task) wires the
+non-router callers — the agent-tool path, the MCP servers — to SET this
+ContextVar per request/stream so they too land in the right file; THIS task only
+creates and consults it and wires the EE Fabric router (which already resolves
+the workspace) to pass it explicitly.
+
+The factory consults the previously-dormant ``pocketpaw.stores`` entry-point
+seam (``StoreProvider``): if EE (or a third party) registers a provider, it gets
+first refusal on building the store, so a later task can swap in a cloud-backed
+implementation without touching core. An OSS-only install finds no provider and
+uses the local SQLite default.
+
+Instinct and Paw Print are UNCHANGED here — still process-wide singletons on the
+shared file. Per-workspace Instinct isolation is a separate later task (ISO-2);
+the workspace-keyed machinery below is written generically so it can be reused.
+
+The factories moved here from ``pocketpaw_ee/api.py`` in the OSS-EE split
+(Phase 3); ``pocketpaw_ee.api`` re-exports from this module for the enterprise
+routers that still import via that path.
 """
 
 from __future__ import annotations
 
+import logging
+import os
+import re
+from collections import OrderedDict
+from contextvars import ContextVar
 from pathlib import Path
 
+from pocketpaw._registry import first
 from pocketpaw.fabric.store import FabricStore
 from pocketpaw.instinct.store import InstinctStore
 from pocketpaw.paw_print.store import PawPrintStore
 
+logger = logging.getLogger(__name__)
+
 _DATA_DIR = Path.home() / ".pocketpaw"
 
+# Entry-point group that supplies a `StoreProvider` (see pocketpaw.extensions).
+# EE registers a provider to back stores with cloud-native implementations; an
+# OSS install registers none and the local SQLite defaults below are used.
+_STORE_PROVIDER_GROUP = "pocketpaw.stores"
+
+# Env flag that turns on fail-closed workspace scoping. Set by the EE cloud
+# bootstrap (a later task), mirroring the POCKETPAW_MEMORY_BACKEND precedent in
+# ee/pocketpaw_ee/cloud/memory/bootstrap.py. When truthy, a Fabric store request
+# that resolves to NO workspace raises instead of returning the shared file.
+_REQUIRE_WORKSPACE_SCOPE_ENV = "POCKETPAW_REQUIRE_WORKSPACE_SCOPE"
+
+# Bounded cap on the per-workspace FabricStore handle cache. A FabricStore is a
+# cheap object (a path string + an `_initialized` bool; it opens/closes a
+# connection per call), so 128 live handles is light — but unbounded growth
+# across thousands of tenants on a long-lived process would still leak WAL
+# sidecars and handle objects, so we cap and evict LRU, aclose()-ing the victim.
+_WORKSPACE_STORE_CACHE_CAP = 128
+
+# STRICT allowlist for a workspace id that is about to name a directory under
+# ``workspaces/``. A real workspace id is either a 24-hex Mongo ObjectId
+# (e.g. ``69e4f93b57ff64b3903868e3``) or a slug (``ws-acme``, ``w_1``) — all of
+# which START with an alphanumeric and then carry only ``[A-Za-z0-9_-]``. We
+# validate POSITIVELY against that shape and FAIL CLOSED (raise) on anything
+# else, rather than trying to sanitize a hostile id into something "safe". An
+# allowlist can't be out-thought by a novel traversal encoding the way a
+# denylist can.
+#
+# The FIRST char must be alphanumeric: this rejects a leading ``-`` (which the
+# charset would otherwise allow) so a workspace dir name can never be mistaken
+# for an argv flag (``-rf``, ``--force``) if the path is ever handed to a
+# subprocess / CLI as a bare argument — a defense-in-depth concern even though a
+# leading-dash id stays inside ``workspaces/`` and doesn't itself escape.
+#
+# Security-critical: this is the load-bearing guard that keeps one tenant's id
+# from ever resolving to another tenant's (or the OS's) files, and it governs
+# the GENERIC factory so ISO-2's Instinct path inherits it.
+_WORKSPACE_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_-]*\Z")
+
+
+# ---------------------------------------------------------------------------
+# Workspace context + fail-closed error
+# ---------------------------------------------------------------------------
+
+
+class WorkspaceScopeRequired(RuntimeError):
+    """Raised when a workspace-scoped store is required but none resolved.
+
+    Fail-closed guard for the cloud path: with
+    ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` set, a store request that carries no
+    explicit ``workspace_id`` and finds no ``current_workspace`` ContextVar
+    value raises this rather than silently reading the shared store — which
+    would re-open the very cross-tenant leak physical isolation closes.
+    """
+
+
+# The active workspace for the current execution context. OSS core owns this so
+# EE (and the agent-tool / MCP callers wired in ISO-3) can SET it without core
+# ever importing EE. ``None`` means "no workspace in context" — the resolution
+# in get_fabric_store then falls through to the env-flag decision.
+current_workspace: ContextVar[str | None] = ContextVar("current_workspace", default=None)
+
+
+def _resolve_workspace_id(explicit: str | None) -> str | None:
+    """Resolve the effective workspace: explicit arg → ContextVar → None.
+
+    A blank / whitespace-only value (from either source) is treated as "no
+    workspace" so an empty string can never name a real per-workspace directory
+    NOR satisfy the fail-closed required-scope check.
+    """
+    candidate = explicit if explicit is not None else current_workspace.get()
+    if candidate is None:
+        return None
+    candidate = candidate.strip()
+    return candidate or None
+
+
+def _require_workspace_scope() -> bool:
+    """True when the env flag mandates fail-closed workspace scoping."""
+    return os.environ.get(_REQUIRE_WORKSPACE_SCOPE_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _safe_workspace_dir(workspace_id: str) -> Path:
+    """Map a workspace id to its data dir, FAILING CLOSED on a non-token id.
+
+    Security-critical (ISO-1 physically isolates tenants): the id is about to
+    become a directory name under ``workspaces/``, so it must be a single, safe
+    path segment. We validate it POSITIVELY against ``_WORKSPACE_ID_RE``
+    (``[A-Za-z0-9_-]+`` — covers a 24-hex ObjectId and every slug form) and
+    RAISE ``ValueError`` on anything else: empty, a ``/`` or ``\\`` separator,
+    ``.`` / ``..``, a space, a null byte, a leading dash that argv could read as
+    a flag, any non-ASCII. We do NOT sanitize-and-continue — a hostile id is
+    refused outright. The resolved-path containment check below is kept as
+    defense-in-depth (a second, independent line) but the allowlist is the
+    primary guard, because a denylist can be defeated by a novel encoding.
+    """
+    if not isinstance(workspace_id, str) or not _WORKSPACE_ID_RE.match(workspace_id):
+        raise ValueError(
+            f"unsafe workspace_id for store path: {workspace_id!r} "
+            "(must match [A-Za-z0-9][A-Za-z0-9_-]*)"
+        )
+
+    root = (_DATA_DIR / "workspaces").resolve()
+    target = (root / workspace_id).resolve()
+    # Defense-in-depth: even though the allowlist already forbids separators and
+    # dots, re-assert that the resolved real path sits DIRECTLY under the
+    # workspaces root. A future loosening of the regex, or a symlinked root,
+    # cannot silently let an id escape without tripping this check too.
+    if target.parent != root:
+        raise ValueError(f"workspace_id escapes workspaces dir: {workspace_id!r}")
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Instinct / Paw Print — process-wide singletons (UNCHANGED by ISO-1)
+# ---------------------------------------------------------------------------
+
 _instinct_store: InstinctStore | None = None
-_fabric_store: FabricStore | None = None
 _paw_print_store: PawPrintStore | None = None
 
 
@@ -33,17 +204,194 @@ def get_instinct_store() -> InstinctStore:
     return _instinct_store
 
 
-def get_fabric_store() -> FabricStore:
-    """Return the global FabricStore singleton (``~/.pocketpaw/fabric.db``)."""
-    global _fabric_store
-    if _fabric_store is None:
-        _fabric_store = FabricStore(_DATA_DIR / "fabric.db")
-    return _fabric_store
-
-
 def get_paw_print_store() -> PawPrintStore:
     """Return the global PawPrintStore singleton (``~/.pocketpaw/paw_print.db``)."""
     global _paw_print_store
     if _paw_print_store is None:
         _paw_print_store = PawPrintStore(_DATA_DIR / "paw_print.db")
     return _paw_print_store
+
+
+# ---------------------------------------------------------------------------
+# Fabric — workspace-keyed physical isolation (ISO-1)
+# ---------------------------------------------------------------------------
+
+# Legacy shared singleton (single-tenant OSS / unscoped, non-required path).
+_fabric_store: FabricStore | None = None
+
+# Per-workspace handle cache: workspace_id -> FabricStore, ordered by recency so
+# we can evict the least-recently-used past the cap. Bounded by
+# _WORKSPACE_STORE_CACHE_CAP; the evicted handle is aclose()d.
+_workspace_fabric_stores: OrderedDict[str, FabricStore] = OrderedDict()
+
+
+def _provider_fabric_store(workspace_id: str | None) -> FabricStore | None:
+    """Ask the StoreProvider seam for a Fabric store, if one is registered.
+
+    Returns the provider's store, or ``None`` when no provider is installed
+    (the OSS case) or the provider declines (returns ``None`` / lacks Fabric).
+    A provider that raises is isolated: we log and fall back to the local store
+    rather than take the factory down — a broken EE plugin must not break core.
+    """
+    provider = first(_STORE_PROVIDER_GROUP)
+    if provider is None:
+        return None
+    try:
+        store = provider.get_store("fabric", workspace_id=workspace_id)
+    except TypeError:
+        # Back-compat for a provider whose get_store predates the workspace_id
+        # keyword: call it the old way. (Core ships no such provider; this just
+        # keeps the seam tolerant.)
+        try:
+            store = provider.get_store("fabric")
+        except Exception:  # noqa: BLE001
+            logger.warning("StoreProvider.get_store('fabric') failed", exc_info=True)
+            return None
+    except Exception:  # noqa: BLE001 — isolate plugin failures
+        logger.warning("StoreProvider.get_store('fabric', ...) failed", exc_info=True)
+        return None
+    if store is not None and not isinstance(store, FabricStore):
+        logger.warning(
+            "StoreProvider returned a %s for 'fabric', expected FabricStore — ignoring",
+            type(store).__name__,
+        )
+        return None
+    return store
+
+
+def _cache_workspace_store(workspace_id: str, store: FabricStore) -> None:
+    """Insert ``store`` as most-recently-used, evicting + closing LRU past cap."""
+    _workspace_fabric_stores[workspace_id] = store
+    _workspace_fabric_stores.move_to_end(workspace_id)
+    while len(_workspace_fabric_stores) > _WORKSPACE_STORE_CACHE_CAP:
+        _evict_key, evicted = _workspace_fabric_stores.popitem(last=False)
+        _schedule_aclose(evicted)
+
+
+def _schedule_aclose(store: FabricStore) -> None:
+    """Best-effort release of an evicted store's on-disk resources.
+
+    The evicted store holds no live connection, so the only cleanup is a WAL
+    checkpoint (see ``FabricStore.aclose``). How we run it depends on the caller:
+
+    * A running event loop is present (the common case — eviction fires from an
+      async request building another store): fire-and-forget the async
+      ``aclose`` as a task on that loop, so we don't block the request and we
+      reuse the live loop's aiosqlite worker.
+    * No running loop (a sync caller, or test teardown via
+      ``reset_store_caches``): do the checkpoint SYNCHRONOUSLY with stdlib
+      ``sqlite3`` instead of spinning up a throwaway ``asyncio.run`` loop. A
+      short-lived loop would start an aiosqlite worker thread that races process
+      teardown and emits noisy "Event loop is closed" warnings; a plain
+      ``sqlite3`` checkpoint is faster and side-effect-free.
+
+    Any failure is swallowed — eviction cleanup must never raise into the caller
+    building a DIFFERENT store.
+    """
+    import asyncio
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None and loop.is_running():
+        loop.create_task(_safe_aclose(store))
+    else:
+        _sync_checkpoint(store)
+
+
+def _sync_checkpoint(store: FabricStore) -> None:
+    """Synchronously checkpoint a store's WAL via stdlib sqlite3 (no event loop).
+
+    Resets the store's ``_initialized`` flag to mirror ``aclose`` so a later
+    re-fetch of the same path re-runs ``_ensure_schema`` cleanly. Best-effort:
+    a missing DB / WAL is fine and is swallowed.
+    """
+    import sqlite3
+
+    store._initialized = False
+    try:
+        with sqlite3.connect(store._db_path) as conn:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    except Exception:  # noqa: BLE001 — eviction cleanup is best-effort
+        logger.debug("evicted FabricStore sync checkpoint skipped", exc_info=True)
+
+
+async def _safe_aclose(store: FabricStore) -> None:
+    try:
+        await store.aclose()
+    except Exception:  # noqa: BLE001
+        logger.debug("evicted FabricStore aclose failed", exc_info=True)
+
+
+def get_fabric_store(*, workspace_id: str | None = None) -> FabricStore:
+    """Return the FabricStore for the resolved workspace (ISO-1).
+
+    Resolution order: explicit ``workspace_id`` arg → ``current_workspace``
+    ContextVar → ``None``. See the module docstring for the full contract.
+
+    * A resolved workspace returns a per-workspace store at
+      ``~/.pocketpaw/workspaces/<workspace_id>/fabric.db`` (directory created),
+      cached in a bounded LRU.
+    * No workspace + ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` truthy → raises
+      :class:`WorkspaceScopeRequired` (fail-closed; never a shared read).
+    * No workspace + flag unset → the legacy shared ``~/.pocketpaw/fabric.db``
+      singleton (single-tenant OSS back-compat).
+
+    A registered ``StoreProvider`` (entry-point group ``pocketpaw.stores``) gets
+    first refusal in every branch, so EE can later supply a cloud-backed store.
+    """
+    resolved = _resolve_workspace_id(workspace_id)
+
+    if resolved is None:
+        if _require_workspace_scope():
+            # Fail-closed: a cloud deployment must carry a workspace. Never fall
+            # back to the shared store — that is the exact cross-tenant leak
+            # physical isolation exists to close.
+            raise WorkspaceScopeRequired(
+                "A workspace-scoped Fabric store is required "
+                f"(${_REQUIRE_WORKSPACE_SCOPE_ENV} is set) but no workspace was "
+                "resolved from the explicit argument or the current_workspace "
+                "context. Refusing to fall back to the shared store."
+            )
+        # Single-tenant OSS path: legacy shared singleton.
+        global _fabric_store
+        if _fabric_store is None:
+            provided = _provider_fabric_store(None)
+            _fabric_store = (
+                provided if provided is not None else FabricStore(_DATA_DIR / "fabric.db")
+            )
+        return _fabric_store
+
+    # Workspace resolved: per-workspace physically-isolated store.
+    cached = _workspace_fabric_stores.get(resolved)
+    if cached is not None:
+        _workspace_fabric_stores.move_to_end(resolved)  # mark MRU
+        return cached
+
+    provided = _provider_fabric_store(resolved)
+    if provided is not None:
+        store = provided
+    else:
+        ws_dir = _safe_workspace_dir(resolved)
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        store = FabricStore(ws_dir / "fabric.db")
+    _cache_workspace_store(resolved, store)
+    return store
+
+
+def reset_store_caches() -> None:
+    """Drop every cached store handle (legacy singletons + per-workspace LRU).
+
+    For tests that install/remove providers, swap the data dir, or need a clean
+    factory between cases. Evicted per-workspace handles are aclose()d
+    best-effort so a checkpoint runs and no WAL sidecar is left behind.
+    """
+    global _fabric_store, _instinct_store, _paw_print_store
+    _fabric_store = None
+    _instinct_store = None
+    _paw_print_store = None
+    while _workspace_fabric_stores:
+        _key, store = _workspace_fabric_stores.popitem(last=False)
+        _schedule_aclose(store)

--- a/tests/cloud/test_ee_fabric_list_endpoints.py
+++ b/tests/cloud/test_ee_fabric_list_endpoints.py
@@ -11,6 +11,12 @@
 #   stays gated on require_plan_feature("fabric"), which is now ENTERPRISE-ONLY
 #   (Sites/Leads were decoupled onto the "sites" flag). The fixture therefore
 #   patches get_workspace_plan to "enterprise" so the ontology gate passes.
+# Updated: 2026-06-26 (ISO-1 — physical per-workspace isolation) — the router
+#   dropped its module-level _DB_PATH and now routes through
+#   pocketpaw.stores.get_fabric_store(workspace_id=...). The client fixture
+#   therefore isolates by patching stores._DATA_DIR to tmp_path and resetting the
+#   factory caches (so the router's store lands in tmp_path/workspaces/ws-test/
+#   fabric.db) instead of patching the removed _DB_PATH.
 
 from __future__ import annotations
 
@@ -56,10 +62,17 @@ def client(tmp_path: Path, monkeypatch) -> TestClient:
         ENTERPRISE-only feature in PLAN_FEATURES after Sites/Leads were
         decoupled onto the 'sites' flag).
     """
-    # Point the module-level store at the tmp db. The router always calls
-    # _store() lazily so setattr is enough.
-    test_db = tmp_path / "fabric-test.db"
-    monkeypatch.setattr(fabric_router_module, "_DB_PATH", test_db)
+    # ISO-1: the router no longer holds a module-level _DB_PATH — it routes
+    # through pocketpaw.stores.get_fabric_store(workspace_id=...), which builds a
+    # per-workspace file under <_DATA_DIR>/workspaces/<id>/fabric.db. Point the
+    # factory's data dir at tmp and reset its caches so this client's store lands
+    # in tmp_path/workspaces/ws-test/fabric.db, fully isolated from ~/.pocketpaw
+    # and from any handle a prior test cached. Imported locally so the import
+    # sorter can't drop it as "unused" (it's only referenced in this fixture).
+    import pocketpaw.stores as stores
+
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    stores.reset_store_caches()
 
     import pocketpaw_ee.cloud.workspace.service as ws_svc
 

--- a/tests/test_fabric_workspace_isolation.py
+++ b/tests/test_fabric_workspace_isolation.py
@@ -1,0 +1,387 @@
+# tests/test_fabric_workspace_isolation.py
+# Created: 2026-06-26 (ISO-1 — workspace-keyed store factory + physical Fabric isolation).
+#
+# Proves ISO-1's new invariant: each workspace gets its OWN fabric.db file under
+# ~/.pocketpaw/workspaces/<workspace_id>/, layered ON TOP of W4a's in-row
+# workspace_id WHERE-filter (physical isolation is additive defense-in-depth).
+#
+# Covers:
+#   * two-workspace physical isolation — objects created in A and B land in two
+#     SEPARATE db files on disk, and a query in A returns ZERO of B's objects;
+#   * fail-closed — POCKETPAW_REQUIRE_WORKSPACE_SCOPE set + no workspace resolves
+#     to a hard error, never a silent shared-store read;
+#   * back-compat — with the flag unset and no workspace, the factory returns the
+#     legacy ~/.pocketpaw/fabric.db so single-tenant OSS keeps working;
+#   * ContextVar resolution — the current_workspace ContextVar is consulted when
+#     no explicit workspace_id is passed, and the explicit arg wins over it;
+#   * the bounded LRU caches handles and evicts (aclose) past the cap;
+#   * path-traversal safety — a hostile workspace_id (incl. ../../../tmp/pwn,
+#     url-encoded traversal, null bytes, leading-dash flag-injection, non-ASCII)
+#     is rejected by a STRICT positive allowlist ([A-Za-z0-9][A-Za-z0-9_-]*),
+#     fails closed (raises), and leaves the filesystem untouched (writes nothing
+#     outside workspaces/).
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import pocketpaw.stores as stores
+from pocketpaw.fabric.models import FabricQuery
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the store factory at a tmp data dir and reset module + LRU state.
+
+    Every test gets a clean ~/.pocketpaw equivalent, an empty cache, and the
+    required-scope flag unset, so tests can't leak db files or cached handles
+    into one another.
+    """
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    # Make sure no ContextVar value bleeds in from another test.
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            # A test that reloads the module replaces the ContextVar object, so
+            # the token no longer matches. Fall back to clearing the (new) var.
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+# ---------------------------------------------------------------------------
+# Core ISO-1 invariant: two workspaces => two physical files, no cross-read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_workspaces_get_separate_files_and_no_cross_read(
+    tmp_path: Path,
+) -> None:
+    store_a = stores.get_fabric_store(workspace_id=WS_A)
+    store_b = stores.get_fabric_store(workspace_id=WS_B)
+
+    # Distinct handles backed by distinct paths under workspaces/.
+    assert store_a is not store_b
+    assert store_a._db_path != store_b._db_path
+
+    # A defines a type + object; B defines its own.
+    type_a = await store_a.define_type(name="Customer", properties=[], workspace_id=WS_A)
+    await store_a.create_object(type_a.id, {"name": "Acme"}, workspace_id=WS_A)
+
+    type_b = await store_b.define_type(name="Customer", properties=[], workspace_id=WS_B)
+    await store_b.create_object(type_b.id, {"name": "Globex"}, workspace_id=WS_B)
+
+    # (a) Two SEPARATE db files exist on disk.
+    db_a = tmp_path / "workspaces" / WS_A / "fabric.db"
+    db_b = tmp_path / "workspaces" / WS_B / "fabric.db"
+    assert db_a.exists(), "workspace A fabric.db should exist on disk"
+    assert db_b.exists(), "workspace B fabric.db should exist on disk"
+    assert db_a != db_b
+
+    # The shared legacy file must NOT have been created by a scoped call.
+    assert not (tmp_path / "fabric.db").exists()
+
+    # (b) A query in A returns ZERO of B's objects — even unscoped at the store
+    # level (workspace_id=None), because B's row physically isn't in A's file.
+    res_a = await store_a.query(FabricQuery(type_name="Customer"))
+    names_a = {o.properties.get("name") for o in res_a.objects}
+    assert names_a == {"Acme"}
+    assert "Globex" not in names_a
+
+    res_b = await store_b.query(FabricQuery(type_name="Customer"))
+    names_b = {o.properties.get("name") for o in res_b.objects}
+    assert names_b == {"Globex"}
+    assert "Acme" not in names_b
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: required-scope mode + no workspace => raise, never shared read
+# ---------------------------------------------------------------------------
+
+
+def test_fail_closed_when_scope_required_and_no_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_fabric_store()  # no workspace, no ContextVar
+
+
+def test_fail_closed_ignores_blank_contextvar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blank/whitespace ContextVar must not satisfy required-scope mode."""
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    token = stores.current_workspace.set("   ")
+    try:
+        with pytest.raises(stores.WorkspaceScopeRequired):
+            stores.get_fabric_store()
+    finally:
+        stores.current_workspace.reset(token)
+
+
+def test_required_scope_with_workspace_returns_scoped_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Required-scope mode is satisfied by an explicit workspace_id."""
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    store = stores.get_fabric_store(workspace_id=WS_A)
+    assert str(tmp_path / "workspaces" / WS_A) in store._db_path
+
+
+# ---------------------------------------------------------------------------
+# Back-compat: flag unset + no workspace => legacy shared file
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_shared_store_when_unscoped_and_not_required(
+    tmp_path: Path,
+) -> None:
+    store = stores.get_fabric_store()  # no workspace, flag unset
+    assert store._db_path == str(tmp_path / "fabric.db")
+    # Same handle is returned on a second unscoped call (singleton preserved).
+    assert stores.get_fabric_store() is store
+
+
+# ---------------------------------------------------------------------------
+# ContextVar resolution + precedence
+# ---------------------------------------------------------------------------
+
+
+def test_contextvar_is_consulted_when_no_explicit_arg(tmp_path: Path) -> None:
+    token = stores.current_workspace.set(WS_A)
+    try:
+        store = stores.get_fabric_store()
+        assert str(tmp_path / "workspaces" / WS_A) in store._db_path
+    finally:
+        stores.current_workspace.reset(token)
+
+
+def test_explicit_arg_wins_over_contextvar(tmp_path: Path) -> None:
+    token = stores.current_workspace.set(WS_B)
+    try:
+        store = stores.get_fabric_store(workspace_id=WS_A)
+        assert str(tmp_path / "workspaces" / WS_A) in store._db_path
+        assert WS_B not in store._db_path
+    finally:
+        stores.current_workspace.reset(token)
+
+
+def test_same_workspace_returns_cached_handle(tmp_path: Path) -> None:
+    first = stores.get_fabric_store(workspace_id=WS_A)
+    second = stores.get_fabric_store(workspace_id=WS_A)
+    assert first is second
+
+
+# ---------------------------------------------------------------------------
+# Bounded LRU: evicts past the cap and closes the evicted handle
+# ---------------------------------------------------------------------------
+
+
+async def _drain_pending_tasks() -> None:
+    """Run every fire-and-forget eviction task this test started to completion.
+
+    Eviction from inside a running loop schedules ``aclose`` via
+    ``loop.create_task``. Draining those tasks before the test's loop closes
+    keeps the aiosqlite worker from racing teardown (the source of spurious
+    "Event loop is closed" warnings).
+    """
+    import asyncio
+
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_lru_evicts_past_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Shrink the cap so the test stays fast and deterministic.
+    monkeypatch.setattr(stores, "_WORKSPACE_STORE_CACHE_CAP", 3)
+    stores.reset_store_caches()
+
+    handles = [stores.get_fabric_store(workspace_id=f"ws-{i}") for i in range(3)]
+    # Touch ws-0 so it becomes most-recently-used; ws-1 is now the LRU victim.
+    again_0 = stores.get_fabric_store(workspace_id="ws-0")
+    assert again_0 is handles[0]
+
+    # A 4th distinct workspace evicts the least-recently-used (ws-1).
+    stores.get_fabric_store(workspace_id="ws-3")
+    # ws-1 was evicted: a fresh fetch builds a NEW handle, not the old one.
+    new_1 = stores.get_fabric_store(workspace_id="ws-1")
+    assert new_1 is not handles[1]
+    # ws-0 survived (it was touched), so it's still the same handle.
+    assert stores.get_fabric_store(workspace_id="ws-0") is handles[0]
+
+    await _drain_pending_tasks()
+
+
+@pytest.mark.asyncio
+async def test_eviction_closes_handle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On eviction the factory calls the store's aclose() (best-effort)."""
+    monkeypatch.setattr(stores, "_WORKSPACE_STORE_CACHE_CAP", 1)
+    stores.reset_store_caches()
+
+    closed: list[str] = []
+
+    victim = stores.get_fabric_store(workspace_id="ws-victim")
+    # Wrap the real aclose so we can observe it firing on eviction.
+    real_aclose = victim.aclose
+
+    async def _spy() -> None:
+        closed.append("ws-victim")
+        await real_aclose()
+
+    monkeypatch.setattr(victim, "aclose", _spy)
+
+    # A second distinct workspace evicts ws-victim (cap is 1).
+    stores.get_fabric_store(workspace_id="ws-next")
+
+    # Eviction schedules aclose as a task on this loop; drain it to completion
+    # (deterministic — no bare sleep) and assert the spy fired.
+    await _drain_pending_tasks()
+    assert closed == ["ws-victim"]
+
+
+# ---------------------------------------------------------------------------
+# Path-traversal safety (security-critical isolation code)
+# ---------------------------------------------------------------------------
+
+
+_HOSTILE_IDS = [
+    "../../../tmp/pwn",  # the captain's canonical payload
+    "../../etc",
+    "..",
+    "a/b",
+    "a/../../b",
+    "with space/../escape",
+    "/abs/path",
+    "\\windows\\path",
+    "x\x00y",  # null byte
+    ".",  # non-empty, would resolve to CWD if not refused
+    "-rf",  # leading dash — rejected so it can't be read as an argv flag
+    "--force",  # leading double-dash — same flag-injection concern
+    "..%2f..%2fetc",  # url-encoded traversal — must NOT be decoded into a slash
+    "ws\tname",  # embedded control char
+    "wörkspace",  # non-ASCII
+    "a.b",  # a dot in the middle — not in the allowlist
+]
+
+
+@pytest.mark.parametrize("hostile", _HOSTILE_IDS)
+def test_traversal_workspace_id_is_rejected(hostile: str) -> None:
+    """A non-token id that could escape ``workspaces/`` must RAISE, never build.
+
+    These ids are non-empty after strip, so they reach ``_safe_workspace_dir``
+    and MUST be rejected outright (fail closed) — the factory must never hand
+    back a store on a traversal-laden / non-allowlisted id. The guard is a
+    POSITIVE allowlist (``[A-Za-z0-9_-]+``), so even a novel encoding that a
+    denylist might miss is refused because it simply isn't on the allowlist.
+    """
+    with pytest.raises(ValueError):
+        stores.get_fabric_store(workspace_id=hostile)
+
+
+@pytest.mark.parametrize("hostile", _HOSTILE_IDS)
+def test_hostile_workspace_id_writes_nothing_outside_workspaces_dir(
+    tmp_path: Path, hostile: str
+) -> None:
+    """A rejected hostile id must leave the filesystem untouched.
+
+    The captain's explicit requirement: assert the call raises AND that NOTHING
+    was created outside ``~/.pocketpaw/workspaces/`` (here: the tmp data dir). We
+    snapshot the data dir before, attempt the build, and assert (a) it raised and
+    (b) the data-dir tree is byte-for-byte unchanged — no escape file, no stray
+    ``workspaces/<hostile>`` dir, no ``/tmp/pwn``.
+    """
+    data_dir = tmp_path  # the autouse fixture points stores._DATA_DIR here
+
+    def _snapshot() -> set[Path]:
+        return set(data_dir.rglob("*")) if data_dir.exists() else set()
+
+    before = _snapshot()
+    with pytest.raises(ValueError):
+        stores.get_fabric_store(workspace_id=hostile)
+    after = _snapshot()
+
+    assert after == before, (
+        f"hostile workspace_id {hostile!r} created filesystem entries: "
+        f"{sorted(str(p) for p in (after - before))}"
+    )
+    # And specifically: no escape artifact landed at the obvious target.
+    assert not Path("/tmp/pwn").exists()
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t", None])
+def test_blank_workspace_id_falls_back_to_legacy_not_escape(
+    tmp_path: Path, blank: str | None
+) -> None:
+    """Empty / whitespace / None = 'no workspace' → OSS legacy shared file.
+
+    A blank id is NOT a traversal payload; it means the caller carries no
+    workspace. In OSS mode (flag unset) that is the documented back-compat: the
+    shared ``~/.pocketpaw/fabric.db``. The one thing it must never do is land
+    somewhere OTHER than that legacy file (e.g. escape to CWD or to a stray
+    ``workspaces/`` entry).
+    """
+    store = stores.get_fabric_store(workspace_id=blank)
+    assert store._db_path == str(tmp_path / "fabric.db")
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_blank_workspace_id_fails_closed_under_required_scope(
+    blank: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same blank ids must FAIL CLOSED, not read the shared store, on cloud.
+
+    AC#3: a missing workspace on a cloud path must never silently read a shared
+    store. A blank id is a missing workspace, so under the required-scope flag
+    it raises rather than returning the legacy file.
+    """
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_fabric_store(workspace_id=blank)
+
+
+def test_reset_helper_clears_caches(tmp_path: Path) -> None:
+    """reset_store_caches drops both the legacy singleton and the LRU."""
+    legacy = stores.get_fabric_store()
+    scoped = stores.get_fabric_store(workspace_id=WS_A)
+    stores.reset_store_caches()
+    assert stores.get_fabric_store() is not legacy
+    assert stores.get_fabric_store(workspace_id=WS_A) is not scoped
+
+
+def test_fresh_import_has_no_side_effects(tmp_path: Path) -> None:
+    """Importing the module creates no DB and no dirs at import time.
+
+    Loaded under an INDEPENDENT module object (not ``importlib.reload(stores)``,
+    which would swap the shared module's ContextVar out from under the autouse
+    fixture). We point its data dir at an empty tmp dir and assert importing it
+    touched nothing on disk — the factory must be lazy.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_stores_probe", stores.__file__)
+    assert spec and spec.loader
+    probe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probe)
+
+    probe._DATA_DIR = tmp_path
+    # Nothing should exist yet — import alone must not create files/dirs.
+    assert list(tmp_path.iterdir()) == []
+    # And the module exposes the ISO-1 surface.
+    assert hasattr(probe, "get_fabric_store")
+    assert hasattr(probe, "current_workspace")
+    assert hasattr(probe, "WorkspaceScopeRequired")
+    assert hasattr(probe, "reset_store_caches")


### PR DESCRIPTION
## What this does

Fabric (the ontology store) currently writes every tenant's data to one shared SQLite file at `~/.pocketpaw/fabric.db`. On a shared cloud box two workspaces sit in the same file, separated only by the `workspace_id` WHERE-clause (the W4a read filter). This change gives each workspace its own file at `~/.pocketpaw/workspaces/<workspace_id>/fabric.db`, the same way KB and Soul already isolate per scope by directory.

`get_fabric_store()` becomes a workspace-keyed factory. It resolves the workspace from an explicit argument, then the `current_workspace` ContextVar, then nothing. With a workspace it returns that workspace's file (cached in a bounded LRU). With no workspace and `POCKETPAW_REQUIRE_WORKSPACE_SCOPE` set (cloud), it raises instead of falling back to the shared file, so a missing workspace on cloud fails closed rather than leaking. Single-tenant OSS keeps the old shared file.

The W4a WHERE-filter stays as a second layer.

## Why

First slice of the cloud paw-os multi-tenant offering (design: `docs/design/drafts/2026-06-26-cloud-paw-os-multi-tenant-offering.md`). Per-file isolation is defense in depth: a missed WHERE clause cannot cross a file boundary.

## Security

`workspace_id` reaches a filesystem path, so it goes through a strict allowlist (`^[A-Za-z0-9][A-Za-z0-9_-]*$`) and fails closed on anything else, with a resolved-path containment recheck behind it. A hostile-id test covers `../../../tmp/pwn`, absolute paths, a null byte, url-encoded `..%2f`, a leading dash, and non-ASCII, asserting each one raises and writes nothing outside the workspaces directory. Independent spec and security reviews both passed.

## Scope

Fabric only. Instinct isolation, the non-router ContextVar bridge, the NULL-row migration, and the EE provider registration are the follow-up slices (ISO-2/3/4) that stack on this branch.

## Tests

- `tests/test_fabric_workspace_isolation.py`: two-workspace separation, fail-closed, and the hostile-id matrix (57 passed)
- fabric regression set: 156 passed; ruff clean; the OSS-cannot-import-EE import linter intact
- new env var `POCKETPAW_REQUIRE_WORKSPACE_SCOPE` (cloud sets it; documented in the module docstring)

Stacked PR: ISO-2/3/4 base on this branch, not `dev`.