### PR TITLE
feat(stores): physically isolate Instinct per workspace + per-tenant audit chain

### DIFF
--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,20 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-06-26 (ISO-2 — physical per-workspace isolation) — the store is
+#   no longer one shared ``~/.pocketpaw/instinct.db``. ``_store`` now takes the
+#   caller's ``workspace_id`` and routes through
+#   ``pocketpaw.stores.get_instinct_store(workspace_id=...)``, so every action +
+#   audit read/write hits that tenant's OWN
+#   ``~/.pocketpaw/workspaces/<id>/instinct.db`` — and therefore that tenant's
+#   own audit hash-chain. The audit ``verify`` and ``corrections`` endpoints,
+#   which previously took no workspace, now resolve ``current_workspace_id`` so
+#   ``verify_audit_chain`` checks the CALLER'S per-tenant chain (not a global
+#   chain spanning tenants — the correct multi-tenant model). The internal
+#   helpers ``_forward_to_soul`` and ``_fetch_current_fabric`` take
+#   ``workspace_id`` from their endpoint callers (the latter also threads it into
+#   the per-workspace Fabric store so it doesn't fail closed on a cloud path).
+#   The per-endpoint W4a ``workspace_id`` filter args are UNCHANGED — physical
+#   file isolation is additive defense-in-depth on top of the in-row filter.
 # Updated: 2026-06-19 (SZD-5b — _pocket_create proposal type) — added a gated
 #   starter-Pocket-create proposal kind (TENANCY GATE). ``_pocket_create_blob`` +
 #   ``_assert_pocket_create_workspace`` are the peers of the existing blob
@@ -422,7 +437,7 @@ async def _run_auto_triage(action: Any, workspace_id: str) -> Any:
         )
 
         outcome = await maybe_auto_approve(
-            store=_store(),
+            store=_store(workspace_id),
             action=action,
             context=context,
             level=level,
@@ -808,10 +823,20 @@ router = APIRouter(
 )
 
 
-def _store():
-    from pocketpaw_ee.api import get_instinct_store
+def _store(workspace_id: str):
+    """Return the InstinctStore for ``workspace_id`` (ISO-2 — physical isolation).
 
-    return get_instinct_store()
+    Routes through the workspace-keyed factory so every Instinct action +
+    audit-ledger read/write in this router hits the caller's OWN
+    ``~/.pocketpaw/workspaces/<id>/instinct.db`` file — and therefore that
+    tenant's own audit hash-chain. ``workspace_id`` is the caller's active
+    workspace, already resolved by ``current_workspace_id`` on each endpoint. The
+    W4a in-row ``workspace_id`` read-filter the endpoints already pass STAYS — the
+    physical file split is additive defense-in-depth on top of it.
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    return get_instinct_store(workspace_id=workspace_id)
 
 
 # ---------------------------------------------------------------------------
@@ -984,7 +1009,7 @@ async def propose_action(
     triager failure escalates to the human, and a wiring failure can never
     break this propose response.
     """
-    action = await _store().propose(
+    action = await _store(workspace_id).propose(
         pocket_id=req.pocket_id,
         title=req.title,
         description=req.description,
@@ -1024,7 +1049,9 @@ async def pending_actions(
     W4a — scoped to the caller's active workspace (plus legacy NULL-workspace
     rows) so The Tray for tenant A never surfaces tenant B's pending decisions.
     """
-    return await _store().pending(pocket_id=pocket_id, assignee=assignee, workspace_id=workspace_id)
+    return await _store(workspace_id).pending(
+        pocket_id=pocket_id, assignee=assignee, workspace_id=workspace_id
+    )
 
 
 @router.get(
@@ -1045,7 +1072,7 @@ async def list_actions(
     W4a — scoped to the caller's active workspace (plus legacy NULL-workspace
     rows) so a tenant can't enumerate another tenant's actions.
     """
-    store = _store()
+    store = _store(workspace_id)
     status_enum = ActionStatus(status) if status else None
     actions = await store.list_actions(
         pocket_id=pocket_id,
@@ -1093,7 +1120,7 @@ async def bulk_approve_actions(
       * SHOULD-FIX 1 — the audit actor is the authenticated user id, not
         the free-text ``req.approver`` field.
     """
-    store = _store()
+    store = _store(workspace_id)
     approver_id = str(user.id)
 
     # BLOCKER 1 — verify tenancy on every requested action up front. A
@@ -1380,7 +1407,7 @@ async def bulk_reject_actions(
     item would hide a cross-tenant rejection-escalation attempt
     (mirror of bulk-approve's BLOCKER 1 behaviour).
     """
-    store = _store()
+    store = _store(workspace_id)
     rejector_id = str(user.id)
 
     # Touch-time security fix — verify tenancy on every requested
@@ -1618,7 +1645,7 @@ async def approve_action(
       * SHOULD-FIX 1 — the audit actor + outcome actor are the
         authenticated user id, never the free-text ``req.approver``.
     """
-    store = _store()
+    store = _store(workspace_id)
     before = await store.get_action(action_id)
     if not before:
         raise HTTPException(404, "Action not found")
@@ -1673,7 +1700,7 @@ async def approve_action(
             )
             await store.record_correction(correction)
             await _persist_edits(store, after, edited_fields)
-            await _forward_to_soul(correction, after)
+            await _forward_to_soul(correction, after, workspace_id)
 
     approved = await store.approve(action_id, approver=approver_id)
     if not approved:
@@ -1963,8 +1990,12 @@ async def approve_action(
     return ApproveResponse(action=approved, correction=correction)
 
 
-async def _forward_to_soul(correction: Correction, action: Action) -> None:
-    """Hand off to the soul bridge — always best-effort, never breaks approval."""
+async def _forward_to_soul(correction: Correction, action: Action, workspace_id: str) -> None:
+    """Hand off to the soul bridge — always best-effort, never breaks approval.
+
+    ISO-2: takes the caller's ``workspace_id`` so the bridge's InstinctStore is
+    the tenant's own per-workspace file, not the shared one.
+    """
     try:
         from pocketpaw.instinct.correction_soul_bridge import CorrectionSoulBridge
         from pocketpaw.soul import get_soul_manager
@@ -1972,7 +2003,7 @@ async def _forward_to_soul(correction: Correction, action: Action) -> None:
         manager = get_soul_manager()
         if manager is None:
             return
-        bridge = CorrectionSoulBridge(soul_manager=manager, store=_store())
+        bridge = CorrectionSoulBridge(soul_manager=manager, store=_store(workspace_id))
         await bridge.record(correction, action)
     except Exception:
         logger.exception("Correction soul-bridge failed (non-fatal)")
@@ -2012,7 +2043,7 @@ async def reject_action(
          scope. The bridge is NOT invoked on reject so the router owns
          the chain close.
     """
-    store = _store()
+    store = _store(workspace_id)
     before = await store.get_action(action_id)
     if not before:
         raise HTTPException(404, "Action not found")
@@ -2332,9 +2363,14 @@ async def list_corrections(
     pocket_id: str | None = Query(None, description="Filter by pocket ID"),
     action_id: str | None = Query(None, description="Filter by action ID"),
     limit: int = Query(100, ge=1, le=500),
+    workspace_id: str = Depends(current_workspace_id),
 ):
-    """List corrections captured when humans edited proposed actions."""
-    store = _store()
+    """List corrections captured when humans edited proposed actions.
+
+    ISO-2: corrections live in the tenant's own ``instinct.db``, so resolving the
+    store by ``workspace_id`` keeps one tenant's corrections out of another's.
+    """
+    store = _store(workspace_id)
     if action_id:
         corrections = await store.get_corrections_for_action(action_id)
     elif pocket_id:
@@ -2388,7 +2424,7 @@ async def query_audit(
     """
     response.headers["Deprecation"] = "true"
     response.headers["Link"] = '</api/v1/runtime/audit>; rel="successor-version"'
-    entries = await _store().query_audit(
+    entries = await _store(workspace_id).query_audit(
         pocket_id=pocket_id,
         category=category,
         event=event,
@@ -2458,7 +2494,7 @@ async def export_audit(
     the ledger verified at export time. Call ``GET /instinct/audit/verify`` for
     the full break-point detail.
     """
-    store = _store()
+    store = _store(workspace_id)
     data = await store.export_audit(pocket_id=pocket_id, workspace_id=workspace_id)
     verdict = await store.verify_audit_chain()
     return Response(
@@ -2476,21 +2512,27 @@ async def export_audit(
     response_model=AuditVerifyResponse,
     dependencies=[Depends(require_action_any_workspace("instinct.audit"))],
 )
-async def verify_audit_chain():
+async def verify_audit_chain(workspace_id: str = Depends(current_workspace_id)):
     """Verify the tamper-evident audit hash chain end to end.
 
-    Walks the entire ``instinct_audit`` ledger in insertion order, recomputes
-    each row's hash from its canonical content + the running previous hash, and
-    reports whether the chain is intact. Any insertion, edit, or deletion of a
-    hashed row surfaces as ``intact=false`` with ``broken_at`` pointing at the
-    first failing row — proof an auditor or insurer can run themselves.
+    Walks this workspace's ``instinct_audit`` ledger in insertion order,
+    recomputes each row's hash from its canonical content + the running previous
+    hash, and reports whether the chain is intact. Any insertion, edit, or
+    deletion of a hashed row surfaces as ``intact=false`` with ``broken_at``
+    pointing at the first failing row — proof an auditor or insurer can run
+    themselves.
 
-    The chain is global (not pocket-scoped), so this endpoint takes no filter:
-    integrity is a property of the whole ledger. Pre-W2b rows without a hash
-    are counted under ``legacy_unhashed`` and are not enforced — see the store
-    docstring for the genesis/legacy boundary.
+    ISO-2: the chain is now PER WORKSPACE. Each tenant has its own
+    ``instinct.db`` with its own genesis→…→head chain, so this endpoint verifies
+    the CALLER'S chain (resolved via ``current_workspace_id``), not a global
+    chain mixing tenants. That is the correct multi-tenant model — a tenant's
+    auditor verifies only that tenant's ledger, and one tenant's tampering can
+    never flip another tenant's verdict. The chain spans the whole (per-tenant)
+    file rather than a single pocket, so there is no pocket filter. Pre-W2b rows
+    without a hash are counted under ``legacy_unhashed`` and are not enforced —
+    see the store docstring for the genesis/legacy boundary.
     """
-    verdict = await _store().verify_audit_chain()
+    verdict = await _store(workspace_id).verify_audit_chain()
     return AuditVerifyResponse(**verdict)
 
 
@@ -2521,7 +2563,7 @@ async def get_audit_entry(
     the prior path paged the most-recent rows and matched in Python, 404-ing on
     valid ids past that window for a tenant with a large ledger.
     """
-    store = _store()
+    store = _store(workspace_id)
     entry = await store.get_audit_entry(audit_id, workspace_id=workspace_id)
     if entry is None:
         raise HTTPException(404, "Audit entry not found")
@@ -2534,7 +2576,7 @@ async def get_audit_entry(
     current: list[dict[str, Any]] = []
     if trace is not None:
         snapshots = await store.get_snapshots_for_audit(audit_id)
-        current = await _fetch_current_fabric(trace.fabric_queries)
+        current = await _fetch_current_fabric(trace.fabric_queries, workspace_id)
 
     return HydratedAuditEntry(
         entry=entry,
@@ -2555,21 +2597,27 @@ def _decode_trace(entry: AuditEntry) -> ReasoningTrace | None:
         return None
 
 
-async def _fetch_current_fabric(object_ids: list[str]) -> list[dict[str, Any]]:
-    """Look up live Fabric objects by ID, tolerating a missing ee module."""
+async def _fetch_current_fabric(object_ids: list[str], workspace_id: str) -> list[dict[str, Any]]:
+    """Look up live Fabric objects by ID, tolerating a missing ee module.
+
+    ISO-2: takes the caller's ``workspace_id`` so the Fabric store is the
+    tenant's own per-workspace file (ISO-1). Passing it is also REQUIRED on a
+    cloud path — an unscoped Fabric-store fetch there now fails closed — and it
+    keeps the W4a in-row filter on ``get_object``.
+    """
     if not object_ids:
         return []
     try:
-        from pocketpaw_ee.api import get_fabric_store
+        from pocketpaw.stores import get_fabric_store
 
-        fabric = get_fabric_store()
+        fabric = get_fabric_store(workspace_id=workspace_id)
     except ImportError:
         return []
 
     results: list[dict[str, Any]] = []
     for oid in object_ids:
         try:
-            obj = await fabric.get_object(oid)
+            obj = await fabric.get_object(oid, workspace_id=workspace_id)
         except Exception:
             obj = None
         if obj is None:

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,19 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-06-26 (ISO-2 — physical per-workspace isolation) — added
+#   aclose(): a best-effort WAL-checkpoint + state reset the workspace-keyed
+#   store factory (src/pocketpaw/stores.py) runs when it evicts a per-workspace
+#   InstinctStore from its bounded LRU. The store still holds no long-lived
+#   connection; aclose exists only so an idle tenant's write-ahead-log sidecar
+#   gets truncated instead of growing across 128+ cached tenants. ISO-2 gives
+#   each workspace its OWN instinct.db (~/.pocketpaw/workspaces/<id>/instinct.db),
+#   so the W2b audit hash-chain below is now PER-FILE: each tenant's chain has its
+#   own genesis→…→head and ``verify_audit_chain`` runs PER WORKSPACE (a tenant's
+#   auditor verifies only that tenant's chain — the correct multi-tenant model).
+#   The W4a in-row ``workspace_id`` read-filter is UNCHANGED — physical file
+#   isolation is ADDITIVE defense-in-depth layered on top of it. The store class
+#   itself is workspace-agnostic; isolation is entirely in which file the factory
+#   hands it.
 # Updated: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — ADDITIVE
 #   generic scope on the actions table. ``instinct_actions`` now carries a
 #   nullable ``scope_type`` column (additive ALTER, mirrors the assignee /
@@ -102,6 +116,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -121,6 +136,8 @@ from pocketpaw.instinct.models import (
     OutcomeVerdict,
 )
 from pocketpaw.instinct.trace import FabricObjectSnapshot, ReasoningTrace
+
+logger = logging.getLogger(__name__)
 
 
 def _serialize_outcome(outcome: str | OutcomeVerdict | None) -> str | None:
@@ -427,6 +444,29 @@ class InstinctStore:
     def _conn(self) -> aiosqlite.Connection:
         """Return a new connection context manager."""
         return aiosqlite.connect(self._db_path)
+
+    async def aclose(self) -> None:
+        """Release this store's on-disk resources (ISO-2).
+
+        Like ``FabricStore``, ``InstinctStore`` holds NO long-lived connection —
+        every method opens and closes its own ``aiosqlite.connect()`` per call —
+        so there is no socket or cursor to close. What CAN accumulate is a
+        write-ahead-log sidecar (``instinct.db-wal`` / ``-shm``). Under
+        per-workspace physical isolation (ISO-2) the store factory caches up to
+        128 per-workspace handles and evicts the least-recently-used; ``aclose``
+        is what the factory runs on eviction so an idle tenant's WAL is truncated
+        rather than left to grow, and the next ``_ensure_schema`` re-runs cleanly
+        on the cold handle.
+
+        Best-effort and idempotent: a checkpoint failure (DB never created, WAL
+        not in use, file vanished) is swallowed — eviction must never raise.
+        """
+        self._initialized = False
+        try:
+            async with aiosqlite.connect(self._db_path) as db:
+                await db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except Exception:  # noqa: BLE001 — eviction cleanup is best-effort
+            logger.debug("InstinctStore.aclose checkpoint skipped", exc_info=True)
 
     # --- Actions ---
 
@@ -1144,14 +1184,22 @@ class InstinctStore:
     async def verify_audit_chain(self) -> dict[str, Any]:
         """Walk the audit hash chain and report whether it is intact.
 
-        The chain is GLOBAL (each row's ``prev_hash`` links to the previous
-        *hashed* row across the whole ledger, not within a pocket), so
+        The chain spans the WHOLE FILE (each row's ``prev_hash`` links to the
+        previous *hashed* row in this ledger, not within a pocket), so
         verification always runs over the entire table in insertion order
         (``rowid``). It recomputes each row's ``entry_hash`` from the row's
         canonical content + the recomputed running ``prev_hash`` and compares
         against the stored value. The first row that fails to match is the
         break point — any insertion, edit, or deletion of a hashed row shifts
         or invalidates every subsequent link.
+
+        ISO-2: under per-workspace physical isolation each workspace has its OWN
+        ``instinct.db``, so "the whole ledger" here is exactly ONE tenant's
+        ledger — the chain is per-workspace, with its own genesis→…→head, and
+        this verifies that tenant's chain independently. (On a single-tenant OSS
+        install, or the legacy shared file, it verifies the one shared chain, as
+        before. The method is workspace-agnostic — isolation is entirely in which
+        file the factory opened.)
 
         Legacy boundary: rows written before W2b have a NULL ``entry_hash``.
         They are counted as ``legacy_unhashed`` and skipped — the chain is

--- a/src/pocketpaw/stores.py
+++ b/src/pocketpaw/stores.py
@@ -2,8 +2,8 @@
 
 Instinct, Fabric and Paw Print keep their state in SQLite under
 ``~/.pocketpaw/``. These factories return a lazily-created handle so agent
-tools, automations and routers share one instance per process (or, for Fabric,
-one instance per WORKSPACE — see below).
+tools, automations and routers share one instance per process (or, for Fabric
+and Instinct, one instance per WORKSPACE — see below).
 
 ISO-1 (2026-06-26 — physical per-workspace isolation): Fabric is no longer a
 single process-wide singleton on a SHARED ``~/.pocketpaw/fabric.db``. On a
@@ -31,12 +31,21 @@ evicts. When NO workspace resolves:
     ``~/.pocketpaw/fabric.db`` singleton, so a self-hosted install keeps working
     exactly as before.
 
+ISO-2 (2026-06-26 — Instinct isolation) extends the SAME machinery to Instinct:
+``get_instinct_store(*, workspace_id=...)`` returns a per-workspace
+``~/.pocketpaw/workspaces/<id>/instinct.db``. Because each workspace gets its own
+file, its W2b audit hash-chain (genesis→…→head) is INDEPENDENT and
+``verify_audit_chain`` runs PER WORKSPACE — the correct multi-tenant model (a
+tenant's auditor verifies only that tenant's chain, never a global chain mixing
+tenants). The generic ``_StoreKind`` + ``_get_workspace_store`` engine below
+drives both stores; adding a third is a one-liner.
+
 The ``current_workspace`` ContextVar lives HERE in OSS core (``pocketpaw``) on
 purpose: EE imports from OSS, never the reverse. ISO-3 (a later task) wires the
 non-router callers — the agent-tool path, the MCP servers — to SET this
-ContextVar per request/stream so they too land in the right file; THIS task only
-creates and consults it and wires the EE Fabric router (which already resolves
-the workspace) to pass it explicitly.
+ContextVar per request/stream so they too land in the right file; ISO-1/ISO-2
+create and consult it and wire the EE Fabric + Instinct routers (which already
+resolve the workspace) to pass it explicitly.
 
 The factory consults the previously-dormant ``pocketpaw.stores`` entry-point
 seam (``StoreProvider``): if EE (or a third party) registers a provider, it gets
@@ -44,9 +53,8 @@ first refusal on building the store, so a later task can swap in a cloud-backed
 implementation without touching core. An OSS-only install finds no provider and
 uses the local SQLite default.
 
-Instinct and Paw Print are UNCHANGED here — still process-wide singletons on the
-shared file. Per-workspace Instinct isolation is a separate later task (ISO-2);
-the workspace-keyed machinery below is written generically so it can be reused.
+Paw Print is UNCHANGED — still a plain process-wide singleton on the shared file
+(not tenant-isolated yet).
 
 The factories moved here from ``pocketpaw_ee/api.py`` in the OSS-EE split
 (Phase 3); ``pocketpaw_ee.api`` re-exports from this module for the enterprise
@@ -60,7 +68,9 @@ import os
 import re
 from collections import OrderedDict
 from contextvars import ContextVar
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from pocketpaw._registry import first
 from pocketpaw.fabric.store import FabricStore
@@ -189,90 +199,96 @@ def _safe_workspace_dir(workspace_id: str) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# Instinct / Paw Print — process-wide singletons (UNCHANGED by ISO-1)
+# Generic workspace-keyed store machinery (ISO-1 built it; ISO-2 generalized it)
 # ---------------------------------------------------------------------------
-
-_instinct_store: InstinctStore | None = None
-_paw_print_store: PawPrintStore | None = None
-
-
-def get_instinct_store() -> InstinctStore:
-    """Return the global InstinctStore singleton (``~/.pocketpaw/instinct.db``)."""
-    global _instinct_store
-    if _instinct_store is None:
-        _instinct_store = InstinctStore(_DATA_DIR / "instinct.db")
-    return _instinct_store
+#
+# Both Fabric (ISO-1) and Instinct (ISO-2) need the SAME per-workspace plumbing:
+# resolve workspace -> fail-closed-or-legacy when absent -> per-workspace file
+# under workspaces/<id>/<name>.db -> bounded LRU that aclose()s the evicted
+# handle -> StoreProvider-seam first-refusal. Rather than duplicate that for each
+# store, a ``_StoreKind`` captures the few things that differ (the store class,
+# the file/provider name, the db filename) and one set of generic functions
+# drives every kind. Adding a third workspace-keyed store later is a one-liner.
 
 
-def get_paw_print_store() -> PawPrintStore:
-    """Return the global PawPrintStore singleton (``~/.pocketpaw/paw_print.db``)."""
-    global _paw_print_store
-    if _paw_print_store is None:
-        _paw_print_store = PawPrintStore(_DATA_DIR / "paw_print.db")
-    return _paw_print_store
+@dataclass
+class _StoreKind:
+    """Per-store-type config for the generic workspace-keyed factory.
+
+    ``name`` is BOTH the StoreProvider ``get_store(name=...)`` key and the on-disk
+    db filename stem (``fabric`` -> ``fabric.db``). ``cls`` is the concrete store
+    class the local default constructs. ``legacy`` holds the single-tenant shared
+    singleton; ``cache`` is the bounded per-workspace LRU (workspace_id -> store).
+    """
+
+    name: str
+    cls: type
+    legacy: Any = None  # the lazily-built shared singleton (legacy / OSS path)
+    cache: OrderedDict[str, Any] = field(default_factory=OrderedDict)
+
+    @property
+    def filename(self) -> str:
+        return f"{self.name}.db"
 
 
-# ---------------------------------------------------------------------------
-# Fabric — workspace-keyed physical isolation (ISO-1)
-# ---------------------------------------------------------------------------
-
-# Legacy shared singleton (single-tenant OSS / unscoped, non-required path).
-_fabric_store: FabricStore | None = None
-
-# Per-workspace handle cache: workspace_id -> FabricStore, ordered by recency so
-# we can evict the least-recently-used past the cap. Bounded by
-# _WORKSPACE_STORE_CACHE_CAP; the evicted handle is aclose()d.
-_workspace_fabric_stores: OrderedDict[str, FabricStore] = OrderedDict()
+# The registry of workspace-keyed store kinds. Fabric is wired by ISO-1, Instinct
+# by ISO-2. Paw Print stays a plain shared singleton (not tenant-isolated yet).
+_FABRIC_KIND = _StoreKind(name="fabric", cls=FabricStore)
+_INSTINCT_KIND = _StoreKind(name="instinct", cls=InstinctStore)
+_STORE_KINDS: tuple[_StoreKind, ...] = (_FABRIC_KIND, _INSTINCT_KIND)
 
 
-def _provider_fabric_store(workspace_id: str | None) -> FabricStore | None:
-    """Ask the StoreProvider seam for a Fabric store, if one is registered.
+def _provider_store(kind: _StoreKind, workspace_id: str | None) -> Any | None:
+    """Ask the StoreProvider seam for a store of ``kind``, if one is registered.
 
-    Returns the provider's store, or ``None`` when no provider is installed
-    (the OSS case) or the provider declines (returns ``None`` / lacks Fabric).
-    A provider that raises is isolated: we log and fall back to the local store
+    Returns the provider's store, or ``None`` when no provider is installed (the
+    OSS case) or the provider declines (returns ``None`` / lacks this kind). A
+    provider that raises is isolated: we log and fall back to the local store
     rather than take the factory down — a broken EE plugin must not break core.
+    The returned store must be an instance of ``kind.cls`` or it is ignored.
     """
     provider = first(_STORE_PROVIDER_GROUP)
     if provider is None:
         return None
     try:
-        store = provider.get_store("fabric", workspace_id=workspace_id)
+        store = provider.get_store(kind.name, workspace_id=workspace_id)
     except TypeError:
         # Back-compat for a provider whose get_store predates the workspace_id
         # keyword: call it the old way. (Core ships no such provider; this just
         # keeps the seam tolerant.)
         try:
-            store = provider.get_store("fabric")
+            store = provider.get_store(kind.name)
         except Exception:  # noqa: BLE001
-            logger.warning("StoreProvider.get_store('fabric') failed", exc_info=True)
+            logger.warning("StoreProvider.get_store(%r) failed", kind.name, exc_info=True)
             return None
     except Exception:  # noqa: BLE001 — isolate plugin failures
-        logger.warning("StoreProvider.get_store('fabric', ...) failed", exc_info=True)
+        logger.warning("StoreProvider.get_store(%r, ...) failed", kind.name, exc_info=True)
         return None
-    if store is not None and not isinstance(store, FabricStore):
+    if store is not None and not isinstance(store, kind.cls):
         logger.warning(
-            "StoreProvider returned a %s for 'fabric', expected FabricStore — ignoring",
+            "StoreProvider returned a %s for %r, expected %s — ignoring",
             type(store).__name__,
+            kind.name,
+            kind.cls.__name__,
         )
         return None
     return store
 
 
-def _cache_workspace_store(workspace_id: str, store: FabricStore) -> None:
+def _cache_workspace_store(kind: _StoreKind, workspace_id: str, store: Any) -> None:
     """Insert ``store`` as most-recently-used, evicting + closing LRU past cap."""
-    _workspace_fabric_stores[workspace_id] = store
-    _workspace_fabric_stores.move_to_end(workspace_id)
-    while len(_workspace_fabric_stores) > _WORKSPACE_STORE_CACHE_CAP:
-        _evict_key, evicted = _workspace_fabric_stores.popitem(last=False)
+    kind.cache[workspace_id] = store
+    kind.cache.move_to_end(workspace_id)
+    while len(kind.cache) > _WORKSPACE_STORE_CACHE_CAP:
+        _evict_key, evicted = kind.cache.popitem(last=False)
         _schedule_aclose(evicted)
 
 
-def _schedule_aclose(store: FabricStore) -> None:
+def _schedule_aclose(store: Any) -> None:
     """Best-effort release of an evicted store's on-disk resources.
 
     The evicted store holds no live connection, so the only cleanup is a WAL
-    checkpoint (see ``FabricStore.aclose``). How we run it depends on the caller:
+    checkpoint (see the store's ``aclose``). How we run it depends on the caller:
 
     * A running event loop is present (the common case — eviction fires from an
       async request building another store): fire-and-forget the async
@@ -301,7 +317,7 @@ def _schedule_aclose(store: FabricStore) -> None:
         _sync_checkpoint(store)
 
 
-def _sync_checkpoint(store: FabricStore) -> None:
+def _sync_checkpoint(store: Any) -> None:
     """Synchronously checkpoint a store's WAL via stdlib sqlite3 (no event loop).
 
     Resets the store's ``_initialized`` flag to mirror ``aclose`` so a later
@@ -315,14 +331,69 @@ def _sync_checkpoint(store: FabricStore) -> None:
         with sqlite3.connect(store._db_path) as conn:
             conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
     except Exception:  # noqa: BLE001 — eviction cleanup is best-effort
-        logger.debug("evicted FabricStore sync checkpoint skipped", exc_info=True)
+        logger.debug("evicted %s sync checkpoint skipped", type(store).__name__, exc_info=True)
 
 
-async def _safe_aclose(store: FabricStore) -> None:
+async def _safe_aclose(store: Any) -> None:
     try:
         await store.aclose()
     except Exception:  # noqa: BLE001
-        logger.debug("evicted FabricStore aclose failed", exc_info=True)
+        logger.debug("evicted %s aclose failed", type(store).__name__, exc_info=True)
+
+
+def _get_workspace_store(kind: _StoreKind, workspace_id: str | None) -> Any:
+    """Resolve + return the per-workspace (or legacy) store for ``kind``.
+
+    The shared engine behind ``get_fabric_store`` / ``get_instinct_store``.
+    Resolution order: explicit ``workspace_id`` -> ``current_workspace``
+    ContextVar -> ``None``. With a workspace, returns a per-workspace store at
+    ``~/.pocketpaw/workspaces/<id>/<kind>.db`` (dir created), cached in a bounded
+    LRU. Without one: fail-closed (``WorkspaceScopeRequired``) under
+    ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE``, else the legacy shared singleton. A
+    registered ``StoreProvider`` gets first refusal in every branch.
+
+    The path-traversal allowlist (``_safe_workspace_dir``) is applied to EVERY
+    kind, so Instinct inherits the exact ISO-1 guard for free.
+    """
+    resolved = _resolve_workspace_id(workspace_id)
+
+    if resolved is None:
+        if _require_workspace_scope():
+            # Fail-closed: a cloud deployment must carry a workspace. Never fall
+            # back to the shared store — that is the exact cross-tenant leak
+            # physical isolation exists to close.
+            raise WorkspaceScopeRequired(
+                f"A workspace-scoped {kind.name} store is required "
+                f"(${_REQUIRE_WORKSPACE_SCOPE_ENV} is set) but no workspace was "
+                "resolved from the explicit argument or the current_workspace "
+                "context. Refusing to fall back to the shared store."
+            )
+        # Single-tenant OSS path: legacy shared singleton.
+        if kind.legacy is None:
+            provided = _provider_store(kind, None)
+            kind.legacy = provided if provided is not None else kind.cls(_DATA_DIR / kind.filename)
+        return kind.legacy
+
+    # Workspace resolved: per-workspace physically-isolated store.
+    cached = kind.cache.get(resolved)
+    if cached is not None:
+        kind.cache.move_to_end(resolved)  # mark MRU
+        return cached
+
+    provided = _provider_store(kind, resolved)
+    if provided is not None:
+        store = provided
+    else:
+        ws_dir = _safe_workspace_dir(resolved)
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        store = kind.cls(ws_dir / kind.filename)
+    _cache_workspace_store(kind, resolved, store)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Public factories
+# ---------------------------------------------------------------------------
 
 
 def get_fabric_store(*, workspace_id: str | None = None) -> FabricStore:
@@ -342,56 +413,59 @@ def get_fabric_store(*, workspace_id: str | None = None) -> FabricStore:
     A registered ``StoreProvider`` (entry-point group ``pocketpaw.stores``) gets
     first refusal in every branch, so EE can later supply a cloud-backed store.
     """
-    resolved = _resolve_workspace_id(workspace_id)
+    return _get_workspace_store(_FABRIC_KIND, workspace_id)
 
-    if resolved is None:
-        if _require_workspace_scope():
-            # Fail-closed: a cloud deployment must carry a workspace. Never fall
-            # back to the shared store — that is the exact cross-tenant leak
-            # physical isolation exists to close.
-            raise WorkspaceScopeRequired(
-                "A workspace-scoped Fabric store is required "
-                f"(${_REQUIRE_WORKSPACE_SCOPE_ENV} is set) but no workspace was "
-                "resolved from the explicit argument or the current_workspace "
-                "context. Refusing to fall back to the shared store."
-            )
-        # Single-tenant OSS path: legacy shared singleton.
-        global _fabric_store
-        if _fabric_store is None:
-            provided = _provider_fabric_store(None)
-            _fabric_store = (
-                provided if provided is not None else FabricStore(_DATA_DIR / "fabric.db")
-            )
-        return _fabric_store
 
-    # Workspace resolved: per-workspace physically-isolated store.
-    cached = _workspace_fabric_stores.get(resolved)
-    if cached is not None:
-        _workspace_fabric_stores.move_to_end(resolved)  # mark MRU
-        return cached
+def get_instinct_store(*, workspace_id: str | None = None) -> InstinctStore:
+    """Return the InstinctStore for the resolved workspace (ISO-2).
 
-    provided = _provider_fabric_store(resolved)
-    if provided is not None:
-        store = provided
-    else:
-        ws_dir = _safe_workspace_dir(resolved)
-        ws_dir.mkdir(parents=True, exist_ok=True)
-        store = FabricStore(ws_dir / "fabric.db")
-    _cache_workspace_store(resolved, store)
-    return store
+    Physically isolates Instinct per workspace through the SAME generic factory
+    Fabric uses: explicit ``workspace_id`` arg → ``current_workspace`` ContextVar
+    → ``None``.
+
+    * A resolved workspace returns a per-workspace store at
+      ``~/.pocketpaw/workspaces/<workspace_id>/instinct.db`` — its OWN file, so
+      its W2b audit hash-chain (genesis→…→head) is independent and
+      ``verify_audit_chain`` runs PER WORKSPACE. That is the correct multi-tenant
+      model: a tenant's auditor verifies only that tenant's chain.
+    * No workspace + ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` truthy → raises
+      :class:`WorkspaceScopeRequired` (fail-closed; never a shared read).
+    * No workspace + flag unset → the legacy shared ``~/.pocketpaw/instinct.db``
+      singleton (single-tenant OSS back-compat).
+
+    The W4a in-row ``workspace_id`` read-filter STAYS as a second layer; physical
+    file isolation is additive defense-in-depth. The path-traversal allowlist is
+    inherited from the generic factory.
+    """
+    return _get_workspace_store(_INSTINCT_KIND, workspace_id)
+
+
+# ---------------------------------------------------------------------------
+# Paw Print — plain process-wide singleton (NOT workspace-isolated yet)
+# ---------------------------------------------------------------------------
+
+_paw_print_store: PawPrintStore | None = None
+
+
+def get_paw_print_store() -> PawPrintStore:
+    """Return the global PawPrintStore singleton (``~/.pocketpaw/paw_print.db``)."""
+    global _paw_print_store
+    if _paw_print_store is None:
+        _paw_print_store = PawPrintStore(_DATA_DIR / "paw_print.db")
+    return _paw_print_store
 
 
 def reset_store_caches() -> None:
-    """Drop every cached store handle (legacy singletons + per-workspace LRU).
+    """Drop every cached store handle (legacy singletons + per-workspace LRUs).
 
     For tests that install/remove providers, swap the data dir, or need a clean
     factory between cases. Evicted per-workspace handles are aclose()d
     best-effort so a checkpoint runs and no WAL sidecar is left behind.
     """
-    global _fabric_store, _instinct_store, _paw_print_store
-    _fabric_store = None
-    _instinct_store = None
+    global _paw_print_store
     _paw_print_store = None
-    while _workspace_fabric_stores:
-        _key, store = _workspace_fabric_stores.popitem(last=False)
-        _schedule_aclose(store)
+    for kind in _STORE_KINDS:
+        kind.legacy = None
+        while kind.cache:
+            _key, store = kind.cache.popitem(last=False)
+            _schedule_aclose(store)

--- a/tests/cloud/pockets/test_tools_run_v2_instinct.py
+++ b/tests/cloud/pockets/test_tools_run_v2_instinct.py
@@ -100,7 +100,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     """Isolated InstinctStore on a tmp file, wired where the propose helper and
     the executor both read it (`pocketpaw.stores.get_instinct_store`)."""
     st = InstinctStore(tmp_path / "instinct_tools_run_v2.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_belt_autopilot.py
+++ b/tests/cloud/test_belt_autopilot.py
@@ -102,8 +102,8 @@ def graph(tmp_path: Path) -> DecisionGraph:
 @pytest.fixture
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     st = InstinctStore(tmp_path / "instinct_autopilot.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_belt_console.py
+++ b/tests/cloud/test_belt_console.py
@@ -121,7 +121,7 @@ def settings_allowlist(roots: Path, monkeypatch) -> Path:
 @pytest.fixture
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     st = InstinctStore(tmp_path / "instinct_console.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 
@@ -720,7 +720,7 @@ async def test_executor_emits_landed_and_persists_pr_result(
     monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
 
     st = InstinctStore(tmp_path / "exec.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
 
     action = await _propose_run(
         st,
@@ -784,7 +784,7 @@ async def test_executor_local_only_emits_landed_without_pr_url(
     monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
 
     st = InstinctStore(tmp_path / "exec_local.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
 
     action = await _propose_run(
         st,
@@ -856,7 +856,7 @@ async def test_executor_emits_failed_on_apply_conflict(monkeypatch, recording_bu
     monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
 
     st = InstinctStore(tmp_path / "exec_fail.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
 
     action = await _propose_run(
         st,

--- a/tests/cloud/test_belt_gate.py
+++ b/tests/cloud/test_belt_gate.py
@@ -142,7 +142,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     reads it (the MCP handler + the executor both lazy-import
     ``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_belt_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_belt_headless.py
+++ b/tests/cloud/test_belt_headless.py
@@ -62,7 +62,7 @@ index e69de29..3b18e51 100644
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     """Isolated InstinctStore wired into the global resolver the runner reads."""
     st = InstinctStore(tmp_path / "instinct_headless.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_belt_mandates.py
+++ b/tests/cloud/test_belt_mandates.py
@@ -105,8 +105,8 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     service, the instinct router, and the plan executor all resolve through
     ``pocketpaw.stores.get_instinct_store`` or the router indirection)."""
     st = InstinctStore(tmp_path / "instinct_mandates.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_belt_trace.py
+++ b/tests/cloud/test_belt_trace.py
@@ -175,8 +175,8 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     handler, the router's ``_store``, and the executor all resolve through
     ``pocketpaw.stores.get_instinct_store`` or the router indirection)."""
     st = InstinctStore(tmp_path / "instinct.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_correction_soul_bridge.py
+++ b/tests/cloud/test_correction_soul_bridge.py
@@ -272,7 +272,7 @@ class TestInstinctCorrectionsTool:
         empty_store = InstinctStore(tmp_path / "empty.db")
         monkeypatch.setattr(
             "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
-            lambda: empty_store,
+            lambda *a, **k: empty_store,
         )
 
         tool = InstinctCorrectionsTool()
@@ -297,7 +297,7 @@ class TestInstinctCorrectionsTool:
         )
         monkeypatch.setattr(
             "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
-            lambda: store,
+            lambda *a, **k: store,
         )
 
         tool = InstinctCorrectionsTool()
@@ -316,7 +316,7 @@ class TestInstinctCorrectionsTool:
 
         monkeypatch.setattr(
             "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
-            lambda: None,
+            lambda *a, **k: None,
         )
 
         tool = InstinctCorrectionsTool()

--- a/tests/cloud/test_external_action_gate.py
+++ b/tests/cloud/test_external_action_gate.py
@@ -114,7 +114,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     (the propose helper + the executor both lazy-import
     ``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_external_action_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 
@@ -449,7 +449,7 @@ async def test_production_path_approve_runs_executor_one_terminal(
     # executor). The router's _store indirection points at our tmp store.
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 200, resp.text
 
@@ -497,7 +497,7 @@ async def test_production_path_reject_router_closes_executor_never_called(
 
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
     assert resp.status_code == 200, resp.text
 
@@ -539,7 +539,7 @@ async def test_router_cross_workspace_approval_forbidden(store, journal, graph, 
     # Caller is in w1 but the action belongs to w-OTHER.
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 403, resp.text
     # Nothing fired.

--- a/tests/cloud/test_external_action_mcp.py
+++ b/tests/cloud/test_external_action_mcp.py
@@ -52,7 +52,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     """Isolated InstinctStore on a tmp file, wired in everywhere the propose
     helper reads it (``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_ea_mcp_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_fabric_objects_gate.py
+++ b/tests/cloud/test_fabric_objects_gate.py
@@ -72,7 +72,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     (the propose helper + the executor both lazy-import
     ``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_fabric_objects_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 
@@ -402,7 +402,7 @@ async def test_production_path_approve_runs_executor_one_terminal(
 
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 200, resp.text
 
@@ -441,7 +441,7 @@ async def test_production_path_reject_router_closes_executor_never_runs(
 
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
     assert resp.status_code == 200, resp.text
 
@@ -480,7 +480,7 @@ async def test_cross_workspace_single_approve_forbidden(store, fabric, journal, 
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 403, resp.text
@@ -496,7 +496,7 @@ async def test_cross_workspace_single_reject_forbidden(store, fabric, journal, g
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "no"})
     assert resp.status_code == 403, resp.text
@@ -510,7 +510,7 @@ async def test_cross_workspace_bulk_approve_forbidden(store, fabric, journal, gr
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post("/instinct/actions/bulk-approve", json={"ids": [action_id]})
     assert resp.status_code == 403, resp.text
@@ -525,7 +525,7 @@ async def test_cross_workspace_bulk_reject_forbidden(store, fabric, journal, gra
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post("/instinct/actions/bulk-reject", json={"ids": [action_id], "reason": "no"})
     assert resp.status_code == 403, resp.text

--- a/tests/cloud/test_instinct_approval_security.py
+++ b/tests/cloud/test_instinct_approval_security.py
@@ -404,7 +404,7 @@ class TestBlocker2BulkApproveFiresWrites:
         monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
         # The bridge lazy-imports get_instinct_store from pocketpaw.stores —
         # point it at the same router_store so propose + execute share state.
-        monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+        monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: router_store)
 
         with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
             action_id = _propose(

--- a/tests/cloud/test_instinct_mcp.py
+++ b/tests/cloud/test_instinct_mcp.py
@@ -55,7 +55,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     """Isolated InstinctStore on a tmp file, wired in where the handlers read
     it (``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_mcp_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 
@@ -300,7 +300,7 @@ async def test_store_error_is_relayed(store, monkeypatch):
         async def pending(self, pocket_id=None, workspace_id=None):
             raise RuntimeError("instinct db is locked")
 
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: _Boom())
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: _Boom())
     with _identity(workspace="w1"):
         res = await instinct_mcp._instinct_pending_handler({})
     assert res.get("is_error") is True

--- a/tests/cloud/test_mission_control_bulk_reassign.py
+++ b/tests/cloud/test_mission_control_bulk_reassign.py
@@ -45,7 +45,7 @@ def store(tmp_path: Path) -> InstinctStore:
 @pytest.fixture(autouse=True)
 def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
     """Same test doubles as the other Mission Control suites."""
-    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda *a, **k: store)
     monkeypatch.setattr(
         mc_service.pockets_service,
         "list_pockets",

--- a/tests/cloud/test_mission_control_bulk_snooze.py
+++ b/tests/cloud/test_mission_control_bulk_snooze.py
@@ -42,7 +42,7 @@ def store(tmp_path: Path) -> InstinctStore:
 
 @pytest.fixture(autouse=True)
 def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
-    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda *a, **k: store)
     monkeypatch.setattr(
         mc_service.pockets_service,
         "list_pockets",

--- a/tests/cloud/test_mission_control_project_filter.py
+++ b/tests/cloud/test_mission_control_project_filter.py
@@ -43,7 +43,7 @@ def store(tmp_path: Path) -> InstinctStore:
 def _patch_store(monkeypatch, store: InstinctStore):
     from unittest.mock import AsyncMock
 
-    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda *a, **k: store)
     # Façade composes Tasks alongside Nudges; stub the Tasks read so the
     # Instinct-only project-filter tests don't need a Beanie test DB.
     monkeypatch.setattr(

--- a/tests/cloud/test_mission_control_router.py
+++ b/tests/cloud/test_mission_control_router.py
@@ -37,7 +37,7 @@ def store(tmp_path: Path) -> InstinctStore:
 @pytest.fixture(autouse=True)
 def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
     """Same test doubles as the service tests — the router delegates."""
-    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda *a, **k: store)
     monkeypatch.setattr(
         mc_service.pockets_service,
         "list_pockets",

--- a/tests/cloud/test_mission_control_service.py
+++ b/tests/cloud/test_mission_control_service.py
@@ -122,7 +122,7 @@ def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
       forcing every façade test to initialize Beanie. Tests that
       exercise the Tasks branch override this with their own patch.
     """
-    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda *a, **k: store)
     monkeypatch.setattr(
         mc_service.pockets_service,
         "list_pockets",
@@ -427,7 +427,7 @@ class TestBulkApproveExecutesWrites:
             _get_creds,
         )
         monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", run_action)
-        monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+        monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     @pytest.mark.asyncio
     async def test_bulk_approve_executes_each_parked_write_and_reaches_executed(

--- a/tests/cloud/test_paw_print_decision_loop.py
+++ b/tests/cloud/test_paw_print_decision_loop.py
@@ -74,7 +74,7 @@ def stores(tmp_path: Path, monkeypatch):
     """
     pp_store = PawPrintStore(tmp_path / "paw_print_loop.db")
     instinct_store = InstinctStore(tmp_path / "instinct_loop.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: instinct_store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: instinct_store)
     monkeypatch.setattr("pocketpaw.stores.get_paw_print_store", lambda: pp_store)
     return pp_store, instinct_store
 
@@ -84,7 +84,7 @@ def client(stores, monkeypatch):
     pp_store, _ = stores
     app = FastAPI()
     app.include_router(router)
-    monkeypatch.setattr("pocketpaw_ee.paw_print.router._store", lambda: pp_store)
+    monkeypatch.setattr("pocketpaw_ee.paw_print.router._store", lambda *a, **k: pp_store)
     return TestClient(app)
 
 

--- a/tests/cloud/test_pocket_create_gate.py
+++ b/tests/cloud/test_pocket_create_gate.py
@@ -82,7 +82,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     (the propose helper + the executor both lazy-import
     ``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_pocket_create_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 
@@ -391,7 +391,7 @@ async def test_production_path_approve_runs_executor_one_terminal(
 
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 200, resp.text
 
@@ -429,7 +429,7 @@ async def test_production_path_reject_router_closes_executor_never_runs(
 
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
     assert resp.status_code == 200, resp.text
 
@@ -464,7 +464,7 @@ async def test_cross_workspace_single_approve_forbidden(
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 403, resp.text
@@ -483,7 +483,7 @@ async def test_cross_workspace_single_reject_forbidden(
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "no"})
     assert resp.status_code == 403, resp.text
@@ -497,7 +497,7 @@ async def test_cross_workspace_bulk_approve_forbidden(store, mongo_db, journal, 
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post("/instinct/actions/bulk-approve", json={"ids": [action_id]})
     assert resp.status_code == 403, resp.text
@@ -512,7 +512,7 @@ async def test_cross_workspace_bulk_reject_forbidden(store, mongo_db, journal, g
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post("/instinct/actions/bulk-reject", json={"ids": [action_id], "reason": "no"})
     assert resp.status_code == 403, resp.text

--- a/tests/cloud/test_pocket_instinct_bridge.py
+++ b/tests/cloud/test_pocket_instinct_bridge.py
@@ -37,7 +37,7 @@ def store(tmp_path, monkeypatch):
     temp-backed store and never touch ``~/.pocketpaw/instinct.db``.
     """
     st = InstinctStore(tmp_path / "instinct_bridge_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/ee/agent/test_pocket_router/test_router.py
+++ b/tests/ee/agent/test_pocket_router/test_router.py
@@ -535,7 +535,7 @@ def _isolated_instinct_store(monkeypatch, tmp_path):
     from pocketpaw.instinct.store import InstinctStore
 
     st = InstinctStore(tmp_path / "w2c_router_instinct.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/ee/sites/test_edit_draft_not_publish.py
+++ b/tests/ee/sites/test_edit_draft_not_publish.py
@@ -99,7 +99,7 @@ def instinct_store(tmp_path, monkeypatch):
     """A throwaway InstinctStore wired into the accessor the sites service reads so
     request_publish_pocket() can actually create the review Action."""
     store = InstinctStore(tmp_path / "edit_draft_instinct.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
     return store
 
 

--- a/tests/ee/sites/test_pipeline_regression_gate.py
+++ b/tests/ee/sites/test_pipeline_regression_gate.py
@@ -148,7 +148,7 @@ async def test_sites_pipeline_regression_gate(beanie_test_db, tmp_path, monkeypa
     from pocketpaw.instinct.store import InstinctStore
 
     store = InstinctStore(tmp_path / "gate_instinct.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     from pocketpaw_ee.versions import service as versions
 

--- a/tests/ee/sites/test_request_publish.py
+++ b/tests/ee/sites/test_request_publish.py
@@ -34,7 +34,7 @@ def instinct_store(tmp_path, monkeypatch):
     executor (same accessor). Returns the store so a test can read the Action
     back."""
     store = InstinctStore(tmp_path / "rp_instinct.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
     return store
 
 

--- a/tests/ee/test_action_sweeper.py
+++ b/tests/ee/test_action_sweeper.py
@@ -82,7 +82,7 @@ def instinct_store(tmp_path: Path) -> InstinctStore:
 def patch_instinct_store(monkeypatch, instinct_store: InstinctStore):
     """Patch the sweeper's lazy ``ee.api.get_instinct_store`` lookup so
     the test's fixture wins."""
-    monkeypatch.setattr("pocketpaw_ee.api.get_instinct_store", lambda: instinct_store)
+    monkeypatch.setattr("pocketpaw_ee.api.get_instinct_store", lambda *a, **k: instinct_store)
 
 
 async def _seed_pending_action(

--- a/tests/ee/test_discovery_propose.py
+++ b/tests/ee/test_discovery_propose.py
@@ -150,7 +150,7 @@ def recording_bus():
 @pytest.fixture
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     st = InstinctStore(tmp_path / "instinct_discovery_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/ee/test_instinct_decision_events.py
+++ b/tests/ee/test_instinct_decision_events.py
@@ -243,7 +243,7 @@ async def test_propose_emits_policy_evaluated_and_persists_event_id(
     onto the parked blob's ``parked_policy_event_id`` field so the
     eventual ``human.corrected`` can chain its ``causation_id`` back."""
     corr = uuid4()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: router_store)
 
     park_blob = {
         "action": "mark_renewed",
@@ -294,7 +294,7 @@ async def test_propose_without_correlation_id_skips_policy_emit(
     parks without minting one) skips the policy.evaluated emit — the
     Slice 4 abandon sweeper will eventually close the chain. The
     propose call still succeeds."""
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: router_store)
 
     park_blob = {
         "action": "mark_renewed",
@@ -613,7 +613,7 @@ async def test_full_chain_causation_wires_policy_to_human(
     propose-side emits this test cares about."""
     user = _FakeUser("user-A", "ws-A")
     client = _make_client(router_store, user, monkeypatch)
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: router_store)
 
     async def _noop_execute(_action):
         return None
@@ -803,7 +803,7 @@ async def test_full_chain_via_graph_with_real_proposed_event(
 
     user = _FakeUser("user-A", "ws-A")
     client = _make_client(router_store, user, monkeypatch)
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: router_store)
 
     def _fake_getaddrinfo(host, *_args, **_kwargs):
         return [(2, 1, 6, "", ("8.8.8.8", 0))]

--- a/tests/ee/test_pocket_runtime_decision_events.py
+++ b/tests/ee/test_pocket_runtime_decision_events.py
@@ -623,7 +623,7 @@ async def test_parked_blob_carries_correlation_id_and_event_id_placeholder(
 
             return _A()
 
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: _StubStore())
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: _StubStore())
 
     pocket = {"_id": "p1", "workspace": "w1", "owner": "u_alice", "name": "Lease 42"}
     await instinct_bridge_module.propose_pocket_write(
@@ -714,7 +714,7 @@ async def test_schema_1_parked_blob_marked_failed_on_post_deploy_approval(
         async def mark_executed(self, action_id: str, reason: str) -> None:  # noqa: ARG002
             pytest.fail("should not have executed a schema-1 blob")
 
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: _StubStore())
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: _StubStore())
 
     # Schema-1 blob — pre-Slice-2 shape, no correlation_id field.
     schema_1_blob = {

--- a/tests/ee/versions/test_instinct_executor.py
+++ b/tests/ee/versions/test_instinct_executor.py
@@ -73,7 +73,7 @@ async def test_approve_merges_publishes_and_deploys(
     """APPROVE = MERGE: the candidate is promoted to published, the site deploy
     fires, and the Action is marked executed."""
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     deploys: list[dict] = []
 
@@ -117,7 +117,7 @@ async def test_approve_merge_marks_failed_when_deploy_raises(
     """If the deploy raises, the Action is marked FAILED — the version is still
     published (published != live, the BP-2 invariant)."""
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     async def _boom_deploy(**kwargs):
         raise RuntimeError("workerd smoke gate failed")
@@ -147,7 +147,7 @@ async def test_reject_discards_candidate_and_leaves_published(
     """REJECT = DISCARD: the candidate is reverted, the published pointer is
     untouched."""
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     # A live published version, plus a candidate draft.
     live = await versions.write_draft(
@@ -190,7 +190,7 @@ async def test_reject_clears_all_accumulated_drafts(
     so the other accumulated drafts remain → get_draft is non-None → fails.
     """
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     # A live published version.
     live = await versions.write_draft(

--- a/tests/test_fabric_workspace_isolation.py
+++ b/tests/test_fabric_workspace_isolation.py
@@ -371,11 +371,22 @@ def test_fresh_import_has_no_side_effects(tmp_path: Path) -> None:
     touched nothing on disk — the factory must be lazy.
     """
     import importlib.util
+    import sys
 
-    spec = importlib.util.spec_from_file_location("_stores_probe", stores.__file__)
+    name = "_stores_probe"
+    spec = importlib.util.spec_from_file_location(name, stores.__file__)
     assert spec and spec.loader
     probe = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(probe)
+    # Register in sys.modules BEFORE exec: the module defines an @dataclass
+    # (``_StoreKind``), and the dataclasses machinery resolves the owning module
+    # via ``sys.modules[cls.__module__]`` to look up annotations — an unregistered
+    # module makes that lookup return None and raise. Clean it up afterward so the
+    # probe never leaks into other tests.
+    sys.modules[name] = probe
+    try:
+        spec.loader.exec_module(probe)
+    finally:
+        sys.modules.pop(name, None)
 
     probe._DATA_DIR = tmp_path
     # Nothing should exist yet — import alone must not create files/dirs.

--- a/tests/test_instinct_workspace_isolation.py
+++ b/tests/test_instinct_workspace_isolation.py
@@ -1,0 +1,268 @@
+# tests/test_instinct_workspace_isolation.py
+# Created: 2026-06-26 (ISO-2 — Instinct physically isolated + per-workspace audit chain).
+#
+# Proves ISO-2's invariant: each workspace gets its OWN instinct.db file under
+# ~/.pocketpaw/workspaces/<workspace_id>/, with its OWN W2b audit hash-chain
+# (genesis→…→head). Physical isolation is layered ON TOP of the W4a in-row
+# workspace_id read-filter (additive defense-in-depth), and reuses the generic
+# workspace-keyed factory ISO-1 built (so the path-traversal guard + fail-closed
+# + bounded LRU are inherited).
+#
+# Covers:
+#   * two-workspace physical isolation — actions proposed in A and B land in two
+#     SEPARATE db files on disk; pending() and query_audit() in A return ZERO of
+#     B's rows (even unscoped at the store level, because B's rows physically
+#     aren't in A's file);
+#   * per-workspace audit chain — verify_audit_chain() passes INDEPENDENTLY for
+#     each workspace's file, each with its own genesis (prev_hash="");
+#   * fail-closed — POCKETPAW_REQUIRE_WORKSPACE_SCOPE + no workspace → raises,
+#     never a silent shared-store read;
+#   * back-compat — flag unset + no workspace → legacy ~/.pocketpaw/instinct.db;
+#   * inherited hostile-id guard — a traversal workspace_id is rejected by the
+#     same strict allowlist Fabric uses, and writes nothing outside workspaces/.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import pocketpaw.stores as stores
+from pocketpaw.instinct.models import ActionTrigger
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+def make_trigger() -> ActionTrigger:
+    """Minimal ActionTrigger for a proposed action (matches test_ee_instinct)."""
+    return ActionTrigger(type="agent", source="claude", reason="iso-2 unit test")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the store factory at a tmp data dir; reset module + LRU state.
+
+    Every test gets a clean ~/.pocketpaw equivalent, empty caches, the
+    required-scope flag unset, and a cleared ContextVar so nothing leaks between
+    tests.
+    """
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+async def _propose(store, *, pocket: str, title: str, workspace_id: str):
+    return await store.propose(
+        pocket_id=pocket,
+        title=title,
+        description="",
+        recommendation="",
+        trigger=make_trigger(),
+        workspace_id=workspace_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core ISO-2 invariant: two workspaces => two files, no cross-read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_workspaces_get_separate_files_and_no_cross_read(
+    tmp_path: Path,
+) -> None:
+    store_a = stores.get_instinct_store(workspace_id=WS_A)
+    store_b = stores.get_instinct_store(workspace_id=WS_B)
+
+    assert store_a is not store_b
+    assert store_a._db_path != store_b._db_path
+
+    await _propose(store_a, pocket="p", title="A-task", workspace_id=WS_A)
+    await _propose(store_b, pocket="p", title="B-task", workspace_id=WS_B)
+
+    # (a) Two SEPARATE db files exist on disk under workspaces/.
+    db_a = tmp_path / "workspaces" / WS_A / "instinct.db"
+    db_b = tmp_path / "workspaces" / WS_B / "instinct.db"
+    assert db_a.exists(), "workspace A instinct.db should exist"
+    assert db_b.exists(), "workspace B instinct.db should exist"
+    # The shared legacy file must NOT have been created by a scoped call.
+    assert not (tmp_path / "instinct.db").exists()
+
+    # (b) pending() in A returns ZERO of B's actions — even UNSCOPED at the store
+    # level (workspace_id=None), because B's row physically isn't in A's file.
+    a_pending = await store_a.pending()
+    b_pending = await store_b.pending()
+    assert {a.title for a in a_pending} == {"A-task"}
+    assert {a.title for a in b_pending} == {"B-task"}
+
+    # (c) query_audit() is likewise physically isolated.
+    a_audit = await store_a.query_audit(pocket_id="p")
+    b_audit = await store_b.query_audit(pocket_id="p")
+    a_titles = {e.description for e in a_audit}
+    # B's "Proposed: B-task" audit line can't appear in A's file.
+    assert not any("B-task" in d for d in a_titles)
+    assert any("A-task" in (e.description or "") for e in a_audit)
+    assert any("B-task" in (e.description or "") for e in b_audit)
+
+
+# ---------------------------------------------------------------------------
+# Per-workspace audit hash chain: each file verifies independently
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_each_workspace_has_its_own_verifiable_chain(tmp_path: Path) -> None:
+    store_a = stores.get_instinct_store(workspace_id=WS_A)
+    store_b = stores.get_instinct_store(workspace_id=WS_B)
+
+    # Build a few hashed rows in each tenant's file (propose + approve both write
+    # audit rows, extending that file's chain).
+    for i in range(3):
+        act = await _propose(store_a, pocket="p", title=f"a{i}", workspace_id=WS_A)
+        await store_a.approve(act.id)
+    for i in range(2):
+        act = await _propose(store_b, pocket="p", title=f"b{i}", workspace_id=WS_B)
+        await store_b.approve(act.id)
+
+    # Each chain verifies INDEPENDENTLY and intact — its own genesis→…→head.
+    verdict_a = await store_a.verify_audit_chain()
+    verdict_b = await store_b.verify_audit_chain()
+
+    assert verdict_a["intact"] is True
+    assert verdict_a["broken_at"] is None
+    assert verdict_a["hashed"] == verdict_a["checked"]
+    assert verdict_a["hashed"] > 0
+
+    assert verdict_b["intact"] is True
+    assert verdict_b["broken_at"] is None
+    assert verdict_b["hashed"] == verdict_b["checked"]
+    assert verdict_b["hashed"] > 0
+
+    # The chains are independent: A has more hashed rows than B (3 vs 2 actions,
+    # each ~2 audit rows), so they are NOT one shared global chain.
+    assert verdict_a["hashed"] != verdict_b["hashed"]
+
+
+@pytest.mark.asyncio
+async def test_tampering_one_workspace_does_not_break_the_other(tmp_path: Path) -> None:
+    """A tampered row in A's file must not flip B's verdict (independent chains)."""
+    import sqlite3
+
+    store_a = stores.get_instinct_store(workspace_id=WS_A)
+    store_b = stores.get_instinct_store(workspace_id=WS_B)
+
+    a_act = await _propose(store_a, pocket="p", title="a", workspace_id=WS_A)
+    await store_a.approve(a_act.id)
+    b_act = await _propose(store_b, pocket="p", title="b", workspace_id=WS_B)
+    await store_b.approve(b_act.id)
+
+    # Both intact to start.
+    assert (await store_a.verify_audit_chain())["intact"] is True
+    assert (await store_b.verify_audit_chain())["intact"] is True
+
+    # Tamper with A's ledger directly on disk (mutate a hashed row's content).
+    # Target the lowest-rowid hashed row via a subquery — this SQLite build does
+    # not support UPDATE ... ORDER BY ... LIMIT (needs a compile-time flag).
+    with sqlite3.connect(store_a._db_path) as conn:
+        conn.execute(
+            "UPDATE instinct_audit SET description = 'TAMPERED' WHERE rowid = ("
+            "SELECT rowid FROM instinct_audit WHERE entry_hash IS NOT NULL "
+            "ORDER BY rowid LIMIT 1)"
+        )
+        conn.commit()
+
+    # A is now broken; B is untouched and still intact — proof the chains are
+    # per-tenant, not one global chain whose break would implicate every tenant.
+    assert (await store_a.verify_audit_chain())["intact"] is False
+    assert (await store_b.verify_audit_chain())["intact"] is True
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed + back-compat + ContextVar (mirrors the ISO-1 guards)
+# ---------------------------------------------------------------------------
+
+
+def test_fail_closed_when_scope_required_and_no_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_instinct_store()  # no workspace, no ContextVar
+
+
+def test_legacy_shared_store_when_unscoped_and_not_required(tmp_path: Path) -> None:
+    store = stores.get_instinct_store()  # no workspace, flag unset
+    assert store._db_path == str(tmp_path / "instinct.db")
+    assert stores.get_instinct_store() is store  # singleton preserved
+
+
+def test_contextvar_is_consulted_and_explicit_arg_wins(tmp_path: Path) -> None:
+    token = stores.current_workspace.set(WS_B)
+    try:
+        # No explicit arg → ContextVar (WS_B).
+        from_ctx = stores.get_instinct_store()
+        assert str(tmp_path / "workspaces" / WS_B) in from_ctx._db_path
+        # Explicit arg wins over the ContextVar.
+        explicit = stores.get_instinct_store(workspace_id=WS_A)
+        assert str(tmp_path / "workspaces" / WS_A) in explicit._db_path
+        assert WS_B not in explicit._db_path
+    finally:
+        stores.current_workspace.reset(token)
+
+
+def test_same_workspace_returns_cached_handle(tmp_path: Path) -> None:
+    first = stores.get_instinct_store(workspace_id=WS_A)
+    second = stores.get_instinct_store(workspace_id=WS_A)
+    assert first is second
+
+
+def test_fabric_and_instinct_caches_are_independent(tmp_path: Path) -> None:
+    """The two store kinds keep separate LRUs — same workspace, different files."""
+    fab = stores.get_fabric_store(workspace_id=WS_A)
+    inst = stores.get_instinct_store(workspace_id=WS_A)
+    assert fab is not inst
+    assert fab._db_path.endswith("fabric.db")
+    assert inst._db_path.endswith("instinct.db")
+    # Both under the SAME workspace dir.
+    assert str(tmp_path / "workspaces" / WS_A) in fab._db_path
+    assert str(tmp_path / "workspaces" / WS_A) in inst._db_path
+
+
+# ---------------------------------------------------------------------------
+# Inherited hostile-id guard (the generic factory governs Instinct too)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "../../../tmp/pwn",
+        "..",
+        "a/b",
+        "/abs/path",
+        "-rf",
+        "x\x00y",
+        ".",
+    ],
+)
+def test_hostile_workspace_id_rejected_and_writes_nothing(tmp_path: Path, hostile: str) -> None:
+    """Instinct inherits ISO-1's strict-allowlist guard: reject + FS untouched."""
+
+    def _snapshot() -> set[Path]:
+        return set(tmp_path.rglob("*")) if tmp_path.exists() else set()
+
+    before = _snapshot()
+    with pytest.raises(ValueError):
+        stores.get_instinct_store(workspace_id=hostile)
+    assert _snapshot() == before
+    assert not Path("/tmp/pwn").exists()


### PR DESCRIPTION
Stacks on #1550 (merge that first, with `--rebase`).

## What this does

ISO-1 gave Fabric its own per-workspace file. This does the same for Instinct (the approval Gate and its audit ledger): each workspace persists to its own `~/.pocketpaw/workspaces/<id>/instinct.db`, so actions, corrections, and the W2b tamper-evident audit chain are physically separated per tenant.

It also generalizes ISO-1's machinery. Instead of two near-identical factories, there is one `_StoreKind` + `_get_workspace_store` engine driving both Fabric and Instinct, so the path-traversal allowlist, the fail-closed behavior, and the bounded LRU all run once for both stores.

## The audit chain becomes per-tenant

The W2b hash chain used to be global (one chain across the shared file). With per-file isolation, each workspace's `instinct.db` carries its own chain with its own genesis, and `verify_audit_chain` runs per tenant. That is the correct multi-tenant model: a tenant's auditor verifies that tenant's chain, and one tenant's tampering cannot affect another's verdict (there is a test for exactly that). `workspace_id` stays out of the hash, so the W2b invariant is unchanged. Every reader of the chain (the verify and export endpoints) was checked; none needs it to span tenants.

## Tenancy threading

The EE Instinct router routes all 16 store-access sites through `get_instinct_store(workspace_id=...)`, including `/audit/verify`, `/corrections`, the soul-forwarding bridge, and the fabric-snapshot fetch. The W4a in-row filter stays as a second layer.

## Tests

- `tests/test_instinct_workspace_isolation.py`: 15 tests covering two-workspace separation, per-tenant chain verification, the tamper-in-A-does-not-break-B proof, fail-closed, and inherited hostile-id coverage
- instinct + fabric regression: 252 passed; broad sweep 612 passed; ruff clean; the OSS-cannot-import-EE linter intact

Independent spec and security reviews both passed. The security review also confirmed this fixes the import bug carried on the base branch and hardens the allowlist so a leading-dash id is rejected structurally.

## Follow-up note

Under heavy churn (128+ other workspaces touched between two of one tenant's audit appends), an evicted-then-rebuilt store gets a fresh per-instance lock, which leaves a narrow window for a within-tenant chain fork (never cross-tenant; the store re-reads the true head on each append). A per-workspace lock keyed outside the evictable instance would close it. Noted for the ISO-4 / GA hardening pass.