### PR TITLE
feat(catalog): model catalog API over the LiteLLM proxy

### DIFF
--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -95,10 +95,10 @@ POCKETPAW_LICENSE_KEY=
 # The catalog API (GET /api/v1/catalog/models[/{id}]) reads available models from
 # a self-hosted LiteLLM proxy. Point these at the running proxy; until it is
 # reachable the catalog endpoints return 502 (source of truth unreachable).
-#   LITELLM_PROXY_URL      — proxy base URL. Default http://localhost:4000.
-# LITELLM_PROXY_URL=http://localhost:4000
-#   LITELLM_PROXY_API_KEY  — proxy admin/virtual key (optional; sent as Bearer).
-# LITELLM_PROXY_API_KEY=
+#   POCKETPAW_LITELLM_API_BASE      — proxy base URL. Default http://localhost:4000.
+# POCKETPAW_LITELLM_API_BASE=http://localhost:4000
+#   POCKETPAW_LITELLM_API_KEY  — proxy admin/virtual key (optional; sent as Bearer).
+# POCKETPAW_LITELLM_API_KEY=
 #   CATALOG_CACHE_TTL_SECONDS  — in-process catalog cache TTL. Default 300.
 # CATALOG_CACHE_TTL_SECONDS=300
 #   CATALOG_MODELS_DEV_ENABLED — best-effort models.dev enrichment. Default true;

--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -90,3 +90,17 @@ POCKETPAW_LICENSE_KEY=
 # PAW_CF_API_TOKEN=
 # PAW_CF_ZONE_ID=
 # PAW_CF_DISPATCH_NAMESPACE=paw-sites
+
+# ── Model Catalog — LiteLLM proxy (MCG-1) ──────────────────────────────────────
+# The catalog API (GET /api/v1/catalog/models[/{id}]) reads available models from
+# a self-hosted LiteLLM proxy. Point these at the running proxy; until it is
+# reachable the catalog endpoints return 502 (source of truth unreachable).
+#   LITELLM_PROXY_URL      — proxy base URL. Default http://localhost:4000.
+# LITELLM_PROXY_URL=http://localhost:4000
+#   LITELLM_PROXY_API_KEY  — proxy admin/virtual key (optional; sent as Bearer).
+# LITELLM_PROXY_API_KEY=
+#   CATALOG_CACHE_TTL_SECONDS  — in-process catalog cache TTL. Default 300.
+# CATALOG_CACHE_TTL_SECONDS=300
+#   CATALOG_MODELS_DEV_ENABLED — best-effort models.dev enrichment. Default true;
+#                                set false to run LiteLLM-only (no outbound fetch).
+# CATALOG_MODELS_DEV_ENABLED=true

--- a/ee/pocketpaw_ee/catalog/README.md
+++ b/ee/pocketpaw_ee/catalog/README.md
@@ -36,8 +36,8 @@ yet (see the MCG-1 note below).
 
 | Var | Default | Meaning |
 | --- | --- | --- |
-| `LITELLM_PROXY_URL` | `http://localhost:4000` | proxy base URL |
-| `LITELLM_PROXY_API_KEY` | _(unset)_ | proxy admin/virtual key (Bearer) |
+| `POCKETPAW_LITELLM_API_BASE` | `http://localhost:4000` | proxy base URL |
+| `POCKETPAW_LITELLM_API_KEY` | _(unset)_ | proxy admin/virtual key (Bearer) |
 | `CATALOG_CACHE_TTL_SECONDS` | `300` | assembled-catalog TTL |
 | `CATALOG_MODELS_DEV_ENABLED` | `true` | toggle models.dev enrichment |
 
@@ -61,7 +61,7 @@ yet (see the MCG-1 note below).
 This slice ships the **app-side catalog API** and a **reference proxy config**
 (`litellm.config.example.yaml`). Standing up the live LiteLLM proxy — wiring it
 into the Coolify deploy, supplying real provider keys + Postgres/Redis, and
-pointing `LITELLM_PROXY_URL` / `LITELLM_PROXY_API_KEY` at it — is a **captain
+pointing `POCKETPAW_LITELLM_API_BASE` / `POCKETPAW_LITELLM_API_KEY` at it — is a **captain
 handoff**; the controller has the box and the credentials. Until the live proxy
 is reachable, the catalog endpoints return `502` (source of truth unreachable),
 which is the intended behavior, not a bug.

--- a/ee/pocketpaw_ee/catalog/README.md
+++ b/ee/pocketpaw_ee/catalog/README.md
@@ -1,0 +1,52 @@
+<!-- ee/pocketpaw_ee/catalog/README.md — Model Catalog (MCG-1) overview +
+     live-deploy captain handoff. Created 2026-06-26 (feat/mcg-1-catalog-api). -->
+
+# Model Catalog (MCG-1)
+
+A thin, license-gated read API over a self-hosted **LiteLLM proxy**. It exposes
+the models the proxy serves, grouped by modality, to clients.
+
+## Endpoints
+
+- `GET /api/v1/catalog/models?modality=&provider=&q=&capability=` — filtered list
+  (`{models: [...], total: N}`).
+- `GET /api/v1/catalog/models/{id}` — one entry. `id` is the **URL-encoded**
+  canonical key `"<provider>/<model>"` (the slash is `%2F`).
+
+## How it works
+
+1. `litellm_client.py` reads the proxy: `GET /v1/models` (routable ids) +
+   `GET /model/info` (per-model metadata), and maps each row onto a
+   `ModelCatalogEntry` (`models.py`). LiteLLM's `mode` → our `modality`;
+   per-token cost → per-million-token `pricing`; `supports_*` flags →
+   `capabilities`.
+2. `models_dev_client.py` enriches `logo` / `description` / extra capabilities
+   from `https://models.dev/api.json` — **best-effort, fail-open**. Any failure
+   (or `CATALOG_MODELS_DEV_ENABLED=false`) falls back to LiteLLM-only data.
+3. `service.py` assembles + **TTL-caches** the catalog in-process
+   (`CATALOG_CACHE_TTL_SECONDS`, default 300s) and applies the filters.
+   `service.bust_cache()` invalidates on demand.
+
+**Catalog ⊇ routable:** the catalog is the union of `/model/info` and
+`/v1/models`, so a served-but-undescribed model is still listed. v1 marks every
+entry `status="available"` — `/model/info` exposes no per-model readiness signal
+yet (see the MCG-1 note below).
+
+## Configuration (env — see `.env.enterprise.example`)
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `LITELLM_PROXY_URL` | `http://localhost:4000` | proxy base URL |
+| `LITELLM_PROXY_API_KEY` | _(unset)_ | proxy admin/virtual key (Bearer) |
+| `CATALOG_CACHE_TTL_SECONDS` | `300` | assembled-catalog TTL |
+| `CATALOG_MODELS_DEV_ENABLED` | `true` | toggle models.dev enrichment |
+
+## Live deploy — CAPTAIN HANDOFF
+
+This slice ships the **app-side catalog API** and a **reference proxy config**
+(`litellm.config.example.yaml`). Standing up the live LiteLLM proxy — wiring it
+into the Coolify deploy, supplying real provider keys + Postgres/Redis, and
+pointing `LITELLM_PROXY_URL` / `LITELLM_PROXY_API_KEY` at it — is a **captain
+handoff**; the controller has the box and the credentials. Until the live proxy
+is reachable, the catalog endpoints return `502` (source of truth unreachable),
+which is the intended behavior, not a bug.

--- a/ee/pocketpaw_ee/catalog/README.md
+++ b/ee/pocketpaw_ee/catalog/README.md
@@ -41,6 +41,21 @@ yet (see the MCG-1 note below).
 | `CATALOG_CACHE_TTL_SECONDS` | `300` | assembled-catalog TTL |
 | `CATALOG_MODELS_DEV_ENABLED` | `true` | toggle models.dev enrichment |
 
+## Known gaps (carried forward)
+
+- **Non-text pricing is unmapped.** The mapper reads only per-token cost
+  (`input_cost_per_token`/`output_cost_per_token`), so image / audio / video
+  models report `pricing=None` even when the proxy knows a per-image or
+  per-second cost. Fails soft (the field is optional). Fix belongs with the
+  multi-modal execution slices (MCG-6/7), which must map the per-unit cost
+  fields into a richer `Pricing` before the picker surfaces non-text prices.
+- **Readiness/status.** `/model/info` exposes no per-model readiness signal, so
+  v1 marks every entry `status="available"`. The `status` field + the
+  catalog⊇routable union are in place for a future readiness probe to flip
+  un-keyed models to `"disabled"`.
+- **`streaming` capability is a heuristic** (assumed for all chat models), not
+  read from `/model/info`.
+
 ## Live deploy — CAPTAIN HANDOFF
 
 This slice ships the **app-side catalog API** and a **reference proxy config**

--- a/ee/pocketpaw_ee/catalog/__init__.py
+++ b/ee/pocketpaw_ee/catalog/__init__.py
@@ -1,0 +1,8 @@
+# ee/pocketpaw_ee/catalog/__init__.py — Model Catalog entity package marker
+# (MCG-1). The catalog reads the models a self-hosted LiteLLM proxy serves
+# (GET /v1/models + GET /model/info), maps each onto a ModelCatalogEntry grouped
+# by modality, optionally enriches logo/description from models.dev, TTL-caches
+# the assembled set in-process, and exposes it over GET /api/v1/catalog/models[/{id}].
+# Plain marker — the router is re-exported by ee.cloud.__init__:mount_cloud.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): new entity package.

--- a/ee/pocketpaw_ee/catalog/config.py
+++ b/ee/pocketpaw_ee/catalog/config.py
@@ -4,8 +4,10 @@
 # following the same env-helper pattern as the Recall provider client
 # (ee/pocketpaw_ee/cloud/meetings/providers/recall/client.py).
 #
-#   LITELLM_PROXY_URL      — proxy base URL. Default http://localhost:4000.
-#   LITELLM_PROXY_API_KEY  — proxy admin/virtual key (optional). When set it is
+#   POCKETPAW_LITELLM_API_BASE — proxy base URL. Default http://localhost:4000.
+#                            (Same env var as the pocketpaw Settings field
+#                            litellm_api_base, so one value configures both.)
+#   POCKETPAW_LITELLM_API_KEY  — proxy admin/virtual key (optional). When set it is
 #                            sent as a Bearer token on every proxy call so a
 #                            key-protected proxy authorizes the catalog reads.
 #   CATALOG_CACHE_TTL_SECONDS  — assembled-catalog in-process TTL. Default 300.
@@ -31,7 +33,7 @@ def litellm_proxy_url() -> str:
     ``/`` without producing a double slash. Falls back to ``http://localhost:4000``
     (a local proxy) when the env var is unset or blank.
     """
-    raw = os.environ.get("LITELLM_PROXY_URL", "").strip() or DEFAULT_PROXY_URL
+    raw = os.environ.get("POCKETPAW_LITELLM_API_BASE", "").strip() or DEFAULT_PROXY_URL
     return raw.rstrip("/")
 
 
@@ -41,7 +43,7 @@ def litellm_proxy_api_key() -> str | None:
     Optional: a proxy with no key requirement (e.g. a local dev proxy) needs no
     value. When present it becomes the Bearer token on every proxy request.
     """
-    key = os.environ.get("LITELLM_PROXY_API_KEY", "").strip()
+    key = os.environ.get("POCKETPAW_LITELLM_API_KEY", "").strip()
     return key or None
 
 

--- a/ee/pocketpaw_ee/catalog/config.py
+++ b/ee/pocketpaw_ee/catalog/config.py
@@ -1,0 +1,73 @@
+# ee/pocketpaw_ee/catalog/config.py — deployment-global config for the Model
+# Catalog (MCG-1). The catalog's source of truth is a self-hosted LiteLLM proxy;
+# its base URL + (optional) admin key come from the environment, NOT hardcoded,
+# following the same env-helper pattern as the Recall provider client
+# (ee/pocketpaw_ee/cloud/meetings/providers/recall/client.py).
+#
+#   LITELLM_PROXY_URL      — proxy base URL. Default http://localhost:4000.
+#   LITELLM_PROXY_API_KEY  — proxy admin/virtual key (optional). When set it is
+#                            sent as a Bearer token on every proxy call so a
+#                            key-protected proxy authorizes the catalog reads.
+#   CATALOG_CACHE_TTL_SECONDS  — assembled-catalog in-process TTL. Default 300.
+#   CATALOG_MODELS_DEV_ENABLED — best-effort models.dev enrichment toggle.
+#                                Default "true"; set "false"/"0" to run
+#                                LiteLLM-only (no outbound models.dev fetch).
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): new config module.
+
+from __future__ import annotations
+
+import os
+
+# Defaults — referenced by tests and the example deploy config.
+DEFAULT_PROXY_URL = "http://localhost:4000"
+DEFAULT_CACHE_TTL_SECONDS = 300
+
+
+def litellm_proxy_url() -> str:
+    """Resolve the LiteLLM proxy base URL for this deployment.
+
+    Trailing slashes are trimmed so callers can join paths with a leading
+    ``/`` without producing a double slash. Falls back to ``http://localhost:4000``
+    (a local proxy) when the env var is unset or blank.
+    """
+    raw = os.environ.get("LITELLM_PROXY_URL", "").strip() or DEFAULT_PROXY_URL
+    return raw.rstrip("/")
+
+
+def litellm_proxy_api_key() -> str | None:
+    """Resolve the LiteLLM proxy admin/virtual key, or None when unset.
+
+    Optional: a proxy with no key requirement (e.g. a local dev proxy) needs no
+    value. When present it becomes the Bearer token on every proxy request.
+    """
+    key = os.environ.get("LITELLM_PROXY_API_KEY", "").strip()
+    return key or None
+
+
+def cache_ttl_seconds() -> int:
+    """In-process TTL (seconds) for the assembled catalog. Default 300.
+
+    A non-numeric or non-positive value falls back to the default so a bad env
+    value can never disable caching or crash assembly.
+    """
+    raw = os.environ.get("CATALOG_CACHE_TTL_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_CACHE_TTL_SECONDS
+    try:
+        ttl = int(raw)
+    except ValueError:
+        return DEFAULT_CACHE_TTL_SECONDS
+    return ttl if ttl > 0 else DEFAULT_CACHE_TTL_SECONDS
+
+
+def models_dev_enabled() -> bool:
+    """Whether to attempt best-effort models.dev enrichment. Default True.
+
+    Enrichment is always non-blocking (a failed fetch falls back to LiteLLM-only
+    data); this flag lets an operator skip the outbound call entirely.
+    """
+    raw = os.environ.get("CATALOG_MODELS_DEV_ENABLED", "").strip().lower()
+    if not raw:
+        return True
+    return raw not in {"0", "false", "no", "off"}

--- a/ee/pocketpaw_ee/catalog/litellm.config.example.yaml
+++ b/ee/pocketpaw_ee/catalog/litellm.config.example.yaml
@@ -11,8 +11,8 @@
 #
 # Catalog wiring on the app side (set in the enterprise env, see
 # .env.enterprise.example):
-#   LITELLM_PROXY_URL=http://<proxy-host>:4000
-#   LITELLM_PROXY_API_KEY=<the master_key below, or a virtual key>
+#   POCKETPAW_LITELLM_API_BASE=http://<proxy-host>:4000
+#   POCKETPAW_LITELLM_API_KEY=<the master_key below, or a virtual key>
 #
 # Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): reference proxy config.
 
@@ -46,7 +46,7 @@ litellm_settings:
 
 general_settings:
   # The proxy admin key. The catalog sends this (or a virtual key minted from it)
-  # as LITELLM_PROXY_API_KEY. Reads from the proxy host's env — never inline.
+  # as POCKETPAW_LITELLM_API_KEY. Reads from the proxy host's env — never inline.
   master_key: os.environ/LITELLM_MASTER_KEY
   # Postgres backs the proxy's virtual-key / spend tables. Placeholder DSN —
   # point at the deploy's Postgres.

--- a/ee/pocketpaw_ee/catalog/litellm.config.example.yaml
+++ b/ee/pocketpaw_ee/catalog/litellm.config.example.yaml
@@ -1,0 +1,53 @@
+# ee/pocketpaw_ee/catalog/litellm.config.example.yaml — REFERENCE LiteLLM proxy
+# config for the Model Catalog (MCG-1). The catalog reads its source of truth
+# from a self-hosted LiteLLM proxy started with a config like this:
+#
+#     litellm --config litellm.config.yaml
+#
+# This file is a starting point — one chat model in model_list, a router_settings
+# stub, and Postgres + Redis placeholders. Wiring the LIVE proxy into the Coolify
+# deploy with real credentials is a CAPTAIN HANDOFF (the controller has the box +
+# creds). Do NOT commit real keys here; keys belong in the proxy host's env.
+#
+# Catalog wiring on the app side (set in the enterprise env, see
+# .env.enterprise.example):
+#   LITELLM_PROXY_URL=http://<proxy-host>:4000
+#   LITELLM_PROXY_API_KEY=<the master_key below, or a virtual key>
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): reference proxy config.
+
+model_list:
+  # The canonical model_name "<provider>/<model>" IS the catalog's id. The
+  # litellm_params point at the upstream; api_key reads from the proxy host's env
+  # so no secret is stored in this file.
+  - model_name: anthropic/claude-3-5-sonnet
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+    # model_info is OPTIONAL — LiteLLM derives most fields from its built-in
+    # model map. Override here only when the upstream metadata is wrong/missing.
+    model_info:
+      mode: chat
+
+router_settings:
+  # Stub — tune for the real deploy. routing_strategy controls how the proxy
+  # picks among duplicate deployments of the same model_name.
+  routing_strategy: simple-shuffle
+  num_retries: 2
+  # redis_* lets the router share rate-limit + cooldown state across proxy
+  # replicas. Placeholders — point at the deploy's Redis.
+  redis_host: os.environ/REDIS_HOST
+  redis_port: os.environ/REDIS_PORT
+  redis_password: os.environ/REDIS_PASSWORD
+
+litellm_settings:
+  # Response/prompt caching at the proxy. Off by default in this reference.
+  set_verbose: false
+
+general_settings:
+  # The proxy admin key. The catalog sends this (or a virtual key minted from it)
+  # as LITELLM_PROXY_API_KEY. Reads from the proxy host's env — never inline.
+  master_key: os.environ/LITELLM_MASTER_KEY
+  # Postgres backs the proxy's virtual-key / spend tables. Placeholder DSN —
+  # point at the deploy's Postgres.
+  database_url: os.environ/DATABASE_URL

--- a/ee/pocketpaw_ee/catalog/litellm_client.py
+++ b/ee/pocketpaw_ee/catalog/litellm_client.py
@@ -1,0 +1,271 @@
+# ee/pocketpaw_ee/catalog/litellm_client.py — async client + mapper for a
+# self-hosted LiteLLM proxy (MCG-1). The proxy is the catalog's source of truth.
+#
+# Two reads:
+#   * GET /v1/models      — the list of model ids the proxy currently serves
+#                           (OpenAI-compatible {"data": [{"id": ...}, ...]}).
+#   * GET /model/info     — per-model metadata {"data": [{"model_name": ...,
+#                           "model_info": {max_tokens, input_cost_per_token,
+#                           output_cost_per_token, mode, supports_*, ...},
+#                           "litellm_params": {...}}, ...]}.
+#
+# ``fetch_entries`` joins the two and maps each row onto a ModelCatalogEntry:
+# LiteLLM ``mode`` -> our Modality (MODE_TO_MODALITY), per-token cost -> per-mtok
+# Pricing, supports_* flags -> the capabilities list, and the provider parsed
+# from the canonical "<provider>/<model>" model_name (falling back to
+# litellm_provider). v1 marks everything status="available" — /model/info does
+# not expose per-model routability/readiness, so catalog ⊇ routable degrades to
+# "all listed entries are available" (noted in the entity README + MCG-1 report).
+#
+# httpx-based with an injectable ``_transport`` so tests stand in an
+# httpx.MockTransport (no live proxy). Fail-closed: a non-2xx raises
+# CatalogUpstreamError so a broken proxy never silently yields a partial catalog.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): the proxy client + mapper.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from pocketpaw_ee.catalog import config
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry, Pricing
+
+logger = logging.getLogger(__name__)
+
+# LiteLLM's per-model ``mode`` string -> our coarse Modality bucket. LiteLLM uses
+# several spellings for "text in / text out" (chat, completion, responses); all
+# collapse to CHAT. Anything we don't recognise is treated as CHAT by the mapper
+# (the safest default for the picker — see _modality_for).
+MODE_TO_MODALITY: dict[str, Modality] = {
+    "chat": Modality.CHAT,
+    "completion": Modality.CHAT,
+    "responses": Modality.CHAT,
+    "embedding": Modality.EMBEDDING,
+    "image_generation": Modality.IMAGE,
+    "audio_speech": Modality.AUDIO_TTS,
+    "audio_transcription": Modality.AUDIO_STT,
+    "video": Modality.VIDEO,
+}
+
+# LiteLLM model_info ``supports_<x>`` boolean -> the capability token we surface.
+# Only flags that are True on a model land in ModelCatalogEntry.capabilities.
+SUPPORTS_TO_CAPABILITY: dict[str, str] = {
+    "supports_function_calling": "tool_call",
+    "supports_tool_choice": "tool_call",
+    "supports_vision": "vision",
+    "supports_response_schema": "json_mode",
+    "supports_parallel_function_calling": "parallel_tool_call",
+    "supports_prompt_caching": "prompt_caching",
+    "supports_reasoning": "reasoning",
+    "supports_audio_input": "audio_input",
+    "supports_audio_output": "audio_output",
+}
+
+
+class CatalogUpstreamError(Exception):
+    """A LiteLLM proxy read failed (non-2xx or malformed body). Raised so the
+    service can fail closed rather than serve a partial / empty catalog as if it
+    were complete."""
+
+
+def _provider_from_model_name(model_name: str, litellm_provider: str | None) -> str:
+    """Provider for an entry. Prefer the prefix of the canonical
+    "<provider>/<model>" model_name; fall back to LiteLLM's ``litellm_provider``;
+    finally "unknown". This keeps the provider consistent with the id's prefix."""
+    if "/" in model_name:
+        prefix = model_name.split("/", 1)[0].strip()
+        if prefix:
+            return prefix
+    if litellm_provider:
+        return litellm_provider.strip()
+    return "unknown"
+
+
+def _modality_for(mode: str | None) -> Modality:
+    """Map a LiteLLM ``mode`` onto a Modality. Unknown / missing -> CHAT, the
+    dominant case and the safest default for the picker (a mis-bucketed chat
+    model is still usable; dropping it is not)."""
+    if not mode:
+        return Modality.CHAT
+    return MODE_TO_MODALITY.get(mode.strip().lower(), Modality.CHAT)
+
+
+def _per_mtok(cost_per_token: Any) -> float | None:
+    """LiteLLM exposes cost PER TOKEN; the catalog reports per MILLION tokens.
+    Returns None for missing / non-numeric values so unknown cost stays None."""
+    if cost_per_token is None:
+        return None
+    try:
+        return round(float(cost_per_token) * 1_000_000, 6)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pricing_for(model_info: dict[str, Any]) -> Pricing | None:
+    """Build Pricing from per-token costs, or None when neither side is known."""
+    inp = _per_mtok(model_info.get("input_cost_per_token"))
+    out = _per_mtok(model_info.get("output_cost_per_token"))
+    if inp is None and out is None:
+        return None
+    return Pricing(input_per_mtok=inp, output_per_mtok=out)
+
+
+def _capabilities_for(model_info: dict[str, Any]) -> list[str]:
+    """Derive the capability tokens from the model_info ``supports_*`` flags.
+    Deduped + sorted so the wire output is deterministic; ``streaming`` is added
+    for chat-family models (LiteLLM streams every chat model it proxies)."""
+    caps: set[str] = set()
+    for flag, token in SUPPORTS_TO_CAPABILITY.items():
+        if model_info.get(flag) is True:
+            caps.add(token)
+    return sorted(caps)
+
+
+def _display_name(model_name: str) -> str:
+    """Human label derived from the model portion of "<provider>/<model>"."""
+    tail = model_name.split("/", 1)[1] if "/" in model_name else model_name
+    return tail or model_name
+
+
+def map_model_info_row(row: dict[str, Any]) -> ModelCatalogEntry | None:
+    """Map ONE /model/info row onto a ModelCatalogEntry, or None if it has no
+    usable ``model_name`` (the canonical id). Pure + side-effect free so it is
+    unit-testable in isolation."""
+    model_name = (row.get("model_name") or "").strip()
+    if not model_name:
+        return None
+    info: dict[str, Any] = row.get("model_info") or {}
+    params: dict[str, Any] = row.get("litellm_params") or {}
+    litellm_provider = info.get("litellm_provider") or params.get("custom_llm_provider")
+
+    mode = info.get("mode")
+    modality = _modality_for(mode)
+    caps = _capabilities_for(info)
+    # Chat-family models stream; surface it as a capability so the picker can show it.
+    if modality == Modality.CHAT:
+        caps = sorted(set(caps) | {"streaming"})
+
+    return ModelCatalogEntry(
+        id=model_name,
+        display_name=_display_name(model_name),
+        provider=_provider_from_model_name(model_name, litellm_provider),
+        modality=modality,
+        context=info.get("max_input_tokens") or info.get("max_tokens"),
+        max_output_tokens=info.get("max_output_tokens"),
+        pricing=_pricing_for(info),
+        capabilities=caps,
+        logo=None,  # enriched best-effort from models.dev in the service layer
+        description=None,
+        # v1: /model/info carries no per-model readiness signal, so every listed
+        # model is "available". catalog ⊇ routable holds trivially here; a future
+        # readiness probe can flip un-keyed models to "disabled".
+        status="available",
+    )
+
+
+class LiteLLMClient:
+    """Thin async client over a LiteLLM proxy. Reads only — no mutation."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        _transport: httpx.BaseTransport | None = None,
+        timeout: float = 15.0,
+    ) -> None:
+        self._base_url = (base_url or config.litellm_proxy_url()).rstrip("/")
+        # api_key explicitly passed wins; otherwise resolve from env at init.
+        self._api_key = api_key if api_key is not None else config.litellm_proxy_api_key()
+        self._transport = _transport  # tests inject httpx.MockTransport
+        self._timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        if self._api_key:
+            return {"Authorization": f"Bearer {self._api_key}"}
+        return {}
+
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            headers=self._headers(),
+            transport=self._transport,
+            timeout=self._timeout,
+        )
+
+    @staticmethod
+    def _unwrap_data(resp: httpx.Response, what: str) -> list[dict[str, Any]]:
+        """Fail-closed extraction of the ``data`` list from a proxy response.
+        Non-2xx raises; a missing/!list ``data`` yields an empty list (the proxy
+        answered but served nothing)."""
+        if resp.status_code // 100 != 2:
+            raise CatalogUpstreamError(f"LiteLLM proxy {what} returned {resp.status_code}")
+        try:
+            body = resp.json()
+        except ValueError as exc:
+            raise CatalogUpstreamError(f"LiteLLM proxy {what} returned non-JSON") from exc
+        data = body.get("data") if isinstance(body, dict) else None
+        return [r for r in data if isinstance(r, dict)] if isinstance(data, list) else []
+
+    async def list_model_ids(self) -> list[str]:
+        """GET /v1/models -> the model ids the proxy currently serves."""
+        async with self._client() as client:
+            resp = await client.get(f"{self._base_url}/v1/models")
+        rows = self._unwrap_data(resp, "/v1/models")
+        return [str(r["id"]).strip() for r in rows if r.get("id")]
+
+    async def model_info(self) -> list[dict[str, Any]]:
+        """GET /model/info -> the raw per-model metadata rows."""
+        async with self._client() as client:
+            resp = await client.get(f"{self._base_url}/model/info")
+        return self._unwrap_data(resp, "/model/info")
+
+    async def fetch_entries(self) -> list[ModelCatalogEntry]:
+        """Assemble ModelCatalogEntry objects from /model/info, then reconcile
+        against /v1/models so the catalog ⊇ routable (an /v1/models id missing
+        from /model/info is still listed as a bare entry).
+
+        /model/info is the rich source. /v1/models is the routable set. The union
+        is the catalog: every routable id appears; entries the proxy describes but
+        can't currently serve are kept (not dropped). The two reads run; if
+        /model/info succeeds we map it; /v1/models is best-effort reconciliation —
+        a failure there does not blank an otherwise-good catalog.
+        """
+        info_rows = await self.model_info()
+        entries: dict[str, ModelCatalogEntry] = {}
+        for row in info_rows:
+            entry = map_model_info_row(row)
+            if entry is not None:
+                entries[entry.id] = entry
+
+        # Reconcile against the routable list. Best-effort: a /v1/models failure
+        # must not blank a good /model/info catalog.
+        try:
+            served_ids = await self.list_model_ids()
+        except CatalogUpstreamError:
+            logger.warning("LiteLLM /v1/models unavailable; catalog from /model/info only")
+            served_ids = []
+        for mid in served_ids:
+            if mid not in entries:
+                # Served but undescribed — list it as a minimal available entry so
+                # the routable set is never narrower than the catalog.
+                entries[mid] = ModelCatalogEntry(
+                    id=mid,
+                    display_name=_display_name(mid),
+                    provider=_provider_from_model_name(mid, None),
+                    modality=Modality.CHAT,
+                    status="available",
+                )
+
+        return list(entries.values())
+
+
+__all__ = [
+    "LiteLLMClient",
+    "CatalogUpstreamError",
+    "MODE_TO_MODALITY",
+    "SUPPORTS_TO_CAPABILITY",
+    "map_model_info_row",
+]

--- a/ee/pocketpaw_ee/catalog/litellm_client.py
+++ b/ee/pocketpaw_ee/catalog/litellm_client.py
@@ -135,7 +135,9 @@ def map_model_info_row(row: dict[str, Any]) -> ModelCatalogEntry | None:
     usable ``model_name`` (the canonical id). Pure + side-effect free so it is
     unit-testable in isolation."""
     model_name = (row.get("model_name") or "").strip()
-    if not model_name:
+    # Skip LiteLLM's "*" catch-all passthrough — a routing wildcard, not a real,
+    # selectable model.
+    if not model_name or model_name == "*":
         return None
     info: dict[str, Any] = row.get("model_info") or {}
     params: dict[str, Any] = row.get("litellm_params") or {}
@@ -248,6 +250,8 @@ class LiteLLMClient:
             logger.warning("LiteLLM /v1/models unavailable; catalog from /model/info only")
             served_ids = []
         for mid in served_ids:
+            if mid == "*":
+                continue  # routing wildcard, not a real model
             if mid not in entries:
                 # Served but undescribed — list it as a minimal available entry so
                 # the routable set is never narrower than the catalog.

--- a/ee/pocketpaw_ee/catalog/models.py
+++ b/ee/pocketpaw_ee/catalog/models.py
@@ -1,0 +1,82 @@
+# ee/pocketpaw_ee/catalog/models.py — the Model Catalog data contract (MCG-1).
+#
+# ModelCatalogEntry is the single shape clients consume for a model the platform
+# can route to. Its ``id`` is the canonical key == the LiteLLM ``model_name``
+# ("<provider>/<model>"). ``modality`` is the coarse capability bucket the picker
+# groups by (chat / embedding / image / audio_tts / audio_stt / video — music is
+# explicitly out of scope). Pricing is per-million-tokens for text modalities;
+# None whenever the proxy/models.dev don't expose a cost. ``status`` is
+# "available" unless the proxy signals the model can't currently be served.
+#
+# These are plain Pydantic models (no Beanie / Mongo) — the catalog is assembled
+# from upstream reads on demand and TTL-cached in-process, never persisted.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): the catalog DTOs.
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class Modality(StrEnum):
+    """Coarse capability bucket the catalog groups + filters by.
+
+    Maps from LiteLLM's per-model ``mode`` (see litellm_client.MODE_TO_MODALITY).
+    ``music`` is deliberately absent — out of scope for MCG-1.
+    """
+
+    CHAT = "chat"
+    EMBEDDING = "embedding"
+    IMAGE = "image"
+    AUDIO_TTS = "audio_tts"
+    AUDIO_STT = "audio_stt"
+    VIDEO = "video"
+
+
+class Pricing(BaseModel):
+    """Per-model cost. For text modalities these are USD per MILLION tokens
+    (LiteLLM exposes per-token cost; the mapper multiplies by 1e6). A field is
+    None when the upstream doesn't expose that side of the cost. The whole
+    Pricing object is None on the entry when nothing is known."""
+
+    input_per_mtok: float | None = None
+    output_per_mtok: float | None = None
+
+
+class ModelCatalogEntry(BaseModel):
+    """One routable (or known-but-disabled) model, grouped by modality.
+
+    ``id`` is the canonical key — the LiteLLM ``model_name`` "<provider>/<model>".
+    A client fetches one entry via GET /catalog/models/{id} with ``id``
+    URL-encoded (the slash becomes %2F).
+    """
+
+    id: str
+    display_name: str
+    provider: str
+    modality: Modality
+    context: int | None = None
+    max_output_tokens: int | None = None
+    pricing: Pricing | None = None
+    capabilities: list[str] = Field(default_factory=list)
+    logo: str | None = None
+    description: str | None = None
+    status: str = "available"  # "available" | "disabled"
+
+
+class ModelCatalogList(BaseModel):
+    """Envelope for the list endpoint — a flat, already-filtered list plus the
+    total count, so a client can render modality groups without a second call."""
+
+    models: list[ModelCatalogEntry]
+    total: int
+
+
+__all__ = [
+    "Modality",
+    "Pricing",
+    "ModelCatalogEntry",
+    "ModelCatalogList",
+]

--- a/ee/pocketpaw_ee/catalog/models_dev_client.py
+++ b/ee/pocketpaw_ee/catalog/models_dev_client.py
@@ -1,0 +1,95 @@
+# ee/pocketpaw_ee/catalog/models_dev_client.py — best-effort models.dev
+# enrichment for the Model Catalog (MCG-1). models.dev publishes an open metadata
+# index (https://models.dev/api.json) keyed by provider -> model -> {name, ...}.
+# We use it ONLY to fill gaps the LiteLLM proxy doesn't provide: a human
+# description and any capabilities not already derived. (logo is provider-level
+# and not reliably in the index, so we leave it None unless a model entry carries
+# one.)
+#
+# Hard rule: enrichment is non-blocking and fail-open. Any error — network,
+# timeout, non-2xx, malformed JSON — yields an EMPTY lookup, and the service then
+# serves LiteLLM-only data unchanged. A models.dev outage can never break the
+# catalog. The toggle CATALOG_MODELS_DEV_ENABLED (config.models_dev_enabled)
+# skips the fetch entirely.
+#
+# httpx-based with an injectable ``_transport`` so tests stand in an
+# httpx.MockTransport (and assert the fail-open fallback) with no network.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): best-effort enrichment.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+MODELS_DEV_URL = "https://models.dev/api.json"
+
+
+def _normalize_index(payload: Any) -> dict[str, dict[str, Any]]:
+    """Flatten the models.dev payload into ``{canonical_id: {description, logo,
+    capabilities}}`` where canonical_id is "<provider>/<model>".
+
+    The published shape is ``{provider: {"models": {model_id: {...}}}}`` (with the
+    provider object also carrying a top-level icon/logo). This is defensive: it
+    accepts either a ``models`` sub-dict or a provider object whose values are the
+    model entries directly, and tolerates missing fields — anything unparseable is
+    skipped, never raised."""
+    out: dict[str, dict[str, Any]] = {}
+    if not isinstance(payload, dict):
+        return out
+    for provider, pobj in payload.items():
+        if not isinstance(pobj, dict):
+            continue
+        provider_logo = pobj.get("logo") or pobj.get("icon")
+        models = pobj.get("models")
+        # Either {"models": {...}} or the provider object is itself the model map.
+        model_map = models if isinstance(models, dict) else pobj
+        for model_id, mobj in model_map.items():
+            if not isinstance(mobj, dict):
+                continue
+            caps = mobj.get("capabilities")
+            out[f"{provider}/{model_id}"] = {
+                "description": mobj.get("description") or mobj.get("name"),
+                "logo": mobj.get("logo") or provider_logo,
+                "capabilities": [str(c) for c in caps] if isinstance(caps, list) else [],
+            }
+    return out
+
+
+class ModelsDevClient:
+    """Fetches + flattens the models.dev index. Fail-open by contract."""
+
+    def __init__(
+        self,
+        *,
+        _transport: httpx.BaseTransport | None = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self._transport = _transport  # tests inject httpx.MockTransport
+        self._timeout = timeout
+
+    async def fetch_index(self) -> dict[str, dict[str, Any]]:
+        """Return the flattened enrichment index, or an EMPTY dict on ANY error.
+
+        Never raises — a models.dev problem degrades the catalog to LiteLLM-only,
+        it does not fail the request.
+        """
+        try:
+            async with httpx.AsyncClient(
+                transport=self._transport, timeout=self._timeout
+            ) as client:
+                resp = await client.get(MODELS_DEV_URL)
+            if resp.status_code // 100 != 2:
+                logger.warning("models.dev returned %s; skipping enrichment", resp.status_code)
+                return {}
+            return _normalize_index(resp.json())
+        except Exception:  # noqa: BLE001 — fail-open is the whole point
+            logger.warning("models.dev fetch failed; serving LiteLLM-only catalog", exc_info=True)
+            return {}
+
+
+__all__ = ["ModelsDevClient", "MODELS_DEV_URL"]

--- a/ee/pocketpaw_ee/catalog/router.py
+++ b/ee/pocketpaw_ee/catalog/router.py
@@ -1,0 +1,92 @@
+# ee/pocketpaw_ee/catalog/router.py — the Model Catalog read surface (MCG-1).
+#
+# Two tenant-independent reads (the available-models set is deployment-global, not
+# workspace-scoped — same shape as GET /billing/plans), license-gated:
+#   * GET /catalog/models?modality=&provider=&q=&capability=
+#       -> the filtered catalog (ModelCatalogList: models + total).
+#   * GET /catalog/models/{id}
+#       -> one entry. ``id`` is the URL-ENCODED canonical key "<provider>/<model>"
+#          (the slash arrives as %2F; FastAPI decodes it into the path value, so
+#          we capture the full remainder with a :path converter).
+#
+# THIN adapter per the EE "primitive = service + thin adapters" shape — assembly,
+# the TTL cache, and filtering all live in ``catalog.service``; the proxy read +
+# mapping live in ``catalog.litellm_client``. A LiteLLM proxy failure surfaces as
+# 502 (the catalog's source of truth is unreachable) rather than a misleading
+# empty 200. Mounted in ``mount_cloud()``.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): new entity router.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from pocketpaw_ee.catalog import service as catalog_service
+from pocketpaw_ee.catalog.litellm_client import CatalogUpstreamError
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry, ModelCatalogList
+from pocketpaw_ee.cloud.license import require_license
+
+router = APIRouter(prefix="/catalog", tags=["Catalog"], dependencies=[Depends(require_license)])
+
+
+@router.get("/models", response_model=ModelCatalogList)
+async def list_catalog_models(
+    modality: str | None = Query(
+        None,
+        description="Filter by modality bucket: chat | embedding | image | "
+        "audio_tts | audio_stt | video.",
+    ),
+    provider: str | None = Query(None, description="Filter by provider (exact, case-insensitive)."),
+    q: str | None = Query(
+        None, description="Substring search over id, display name, and description."
+    ),
+    capability: str | None = Query(
+        None,
+        description="Filter to models exposing this capability token "
+        "(e.g. tool_call, vision, streaming, json_mode).",
+    ),
+) -> ModelCatalogList:
+    """List catalog entries from the LiteLLM proxy, grouped by modality and
+    filtered by any supplied query params (all AND together).
+
+    The catalog is the UNION of what the proxy describes (/model/info) and what it
+    routes (/v1/models), so the catalog is never narrower than the routable set.
+    A proxy outage returns 502 — the source of truth is unreachable, which is an
+    upstream error, not an empty catalog.
+    """
+    # Validate the modality value early so a bad filter is a clear 422-style 400
+    # rather than a silent empty list.
+    if modality is not None and modality.strip().lower() not in {m.value for m in Modality}:
+        raise HTTPException(
+            400,
+            f"Unknown modality '{modality}'. Expected one of: "
+            f"{', '.join(m.value for m in Modality)}.",
+        )
+    try:
+        entries: list[ModelCatalogEntry] = await catalog_service.list_models(
+            modality=modality,
+            provider=provider,
+            q=q,
+            capability=capability,
+        )
+    except CatalogUpstreamError as exc:
+        raise HTTPException(502, f"Model catalog source unavailable: {exc}") from exc
+    return ModelCatalogList(models=entries, total=len(entries))
+
+
+@router.get("/models/{model_id:path}", response_model=ModelCatalogEntry)
+async def get_catalog_model(model_id: str) -> ModelCatalogEntry:
+    """Return one catalog entry by its canonical id.
+
+    ``model_id`` is the URL-encoded "<provider>/<model>" key; the ``:path``
+    converter captures the decoded value (including the slash) so e.g.
+    GET /catalog/models/anthropic%2Fclaude-3-5-sonnet resolves to the
+    ``anthropic/claude-3-5-sonnet`` entry.
+    """
+    try:
+        entry = await catalog_service.get_model(model_id)
+    except CatalogUpstreamError as exc:
+        raise HTTPException(502, f"Model catalog source unavailable: {exc}") from exc
+    if entry is None:
+        raise HTTPException(404, f"Model '{model_id}' not found in catalog")
+    return entry

--- a/ee/pocketpaw_ee/catalog/service.py
+++ b/ee/pocketpaw_ee/catalog/service.py
@@ -1,0 +1,178 @@
+# ee/pocketpaw_ee/catalog/service.py — assembly + cache + filtering for the Model
+# Catalog (MCG-1). The thin router delegates everything here.
+#
+# Assembly: read the LiteLLM proxy (litellm_client.fetch_entries), then, when
+# enabled and available, merge best-effort models.dev enrichment over the gaps
+# (description / logo / extra capabilities) — never overwriting a value LiteLLM
+# already provided. The assembled list is TTL-cached IN-PROCESS
+# (config.cache_ttl_seconds, default 300s) so a burst of requests hits the proxy
+# once; ``bust_cache`` clears it on demand.
+#
+# Filtering: ``list_models`` applies modality / provider / capability (exact,
+# case-insensitive) and ``q`` (substring over id + display_name + description),
+# all combinable. ``get_model`` returns one entry by canonical id or None.
+#
+# Concurrency: a single asyncio.Lock serializes assembly so N concurrent
+# cache-miss requests trigger exactly ONE upstream fetch (the rest await the lock
+# and then read the now-warm cache) — this is what the TTL-cache test asserts.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): the catalog service.
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+
+from pocketpaw_ee.catalog import config
+from pocketpaw_ee.catalog.litellm_client import LiteLLMClient
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry
+from pocketpaw_ee.catalog.models_dev_client import ModelsDevClient
+
+
+@dataclass
+class _CacheState:
+    """In-process cache for the assembled catalog. ``expires_at`` is a monotonic
+    deadline; ``entries`` is None until the first successful assembly."""
+
+    entries: list[ModelCatalogEntry] | None = None
+    expires_at: float = 0.0
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+# Module-level singleton cache — the catalog is deployment-global (not
+# tenant-scoped), so one process-wide cache is correct.
+_cache = _CacheState()
+
+
+def bust_cache() -> None:
+    """Invalidate the in-process catalog cache. The next list/get re-assembles
+    from the proxy. Exposed for an admin/refresh path and for tests."""
+    _cache.entries = None
+    _cache.expires_at = 0.0
+
+
+def _merge_enrichment(
+    entries: list[ModelCatalogEntry],
+    enrichment: dict[str, dict],
+) -> list[ModelCatalogEntry]:
+    """Fill gaps on each entry from the models.dev index WITHOUT overwriting
+    anything LiteLLM already set. Only ``logo``/``description`` when currently
+    None, and capabilities are unioned (deduped, sorted, deterministic)."""
+    if not enrichment:
+        return entries
+    merged: list[ModelCatalogEntry] = []
+    for entry in entries:
+        extra = enrichment.get(entry.id)
+        if not extra:
+            merged.append(entry)
+            continue
+        patch: dict = {}
+        if entry.logo is None and extra.get("logo"):
+            patch["logo"] = extra["logo"]
+        if entry.description is None and extra.get("description"):
+            patch["description"] = extra["description"]
+        extra_caps = extra.get("capabilities") or []
+        if extra_caps:
+            patch["capabilities"] = sorted(set(entry.capabilities) | set(extra_caps))
+        merged.append(entry.model_copy(update=patch) if patch else entry)
+    return merged
+
+
+async def _assemble() -> list[ModelCatalogEntry]:
+    """Read the proxy + (optional) models.dev and produce the merged catalog.
+
+    LiteLLM is the source of truth (its failure propagates — the router maps it to
+    a 502). models.dev is best-effort: disabled by flag or failing yields an empty
+    index and the LiteLLM-only catalog passes through unchanged.
+    """
+    entries = await LiteLLMClient().fetch_entries()
+    if config.models_dev_enabled():
+        enrichment = await ModelsDevClient().fetch_index()
+        entries = _merge_enrichment(entries, enrichment)
+    # Stable order for deterministic output: by modality then id.
+    entries.sort(key=lambda e: (e.modality.value, e.id))
+    return entries
+
+
+async def _get_catalog(force_refresh: bool = False) -> list[ModelCatalogEntry]:
+    """Return the cached catalog, assembling (once) on miss/expiry.
+
+    The lock guarantees a single in-flight assembly: the first miss assembles and
+    warms the cache; concurrent callers await the lock, re-check the cache, and
+    return the warm copy without a second upstream call.
+    """
+    now = time.monotonic()
+    if not force_refresh and _cache.entries is not None and now < _cache.expires_at:
+        return _cache.entries
+
+    async with _cache.lock:
+        # Re-check under the lock — another coroutine may have just filled it.
+        now = time.monotonic()
+        if not force_refresh and _cache.entries is not None and now < _cache.expires_at:
+            return _cache.entries
+        entries = await _assemble()
+        _cache.entries = entries
+        _cache.expires_at = time.monotonic() + config.cache_ttl_seconds()
+        return entries
+
+
+def _matches(
+    entry: ModelCatalogEntry,
+    *,
+    modality: str | None,
+    provider: str | None,
+    q: str | None,
+    capability: str | None,
+) -> bool:
+    """Combined predicate for the list filters. All supplied filters must pass
+    (AND). modality/provider/capability are exact case-insensitive; q is a
+    case-insensitive substring over id + display_name + description."""
+    if modality and entry.modality.value != modality.strip().lower():
+        return False
+    if provider and entry.provider.lower() != provider.strip().lower():
+        return False
+    if capability and capability.strip().lower() not in {c.lower() for c in entry.capabilities}:
+        return False
+    if q:
+        needle = q.strip().lower()
+        haystack = " ".join(filter(None, [entry.id, entry.display_name, entry.description])).lower()
+        if needle not in haystack:
+            return False
+    return True
+
+
+async def list_models(
+    *,
+    modality: str | None = None,
+    provider: str | None = None,
+    q: str | None = None,
+    capability: str | None = None,
+    force_refresh: bool = False,
+) -> list[ModelCatalogEntry]:
+    """Return catalog entries matching every supplied filter (filters AND
+    together; omitted filters match all)."""
+    catalog = await _get_catalog(force_refresh=force_refresh)
+    return [
+        e
+        for e in catalog
+        if _matches(e, modality=modality, provider=provider, q=q, capability=capability)
+    ]
+
+
+async def get_model(model_id: str, *, force_refresh: bool = False) -> ModelCatalogEntry | None:
+    """Return the single entry whose canonical id matches, or None."""
+    catalog = await _get_catalog(force_refresh=force_refresh)
+    for entry in catalog:
+        if entry.id == model_id:
+            return entry
+    return None
+
+
+# Re-export so callers can ``from ...service import Modality`` for query validation.
+__all__ = [
+    "list_models",
+    "get_model",
+    "bust_cache",
+    "Modality",
+]

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -365,6 +365,16 @@ def mount_cloud(app: FastAPI) -> None:
     # (Cloudflare for SaaS) the Domains panel drives.
     app.include_router(sites_router, prefix="/api/v1")
 
+    # Model Catalog — MCG-1. License-gated, tenant-independent reads of the
+    # models a self-hosted LiteLLM proxy serves: GET /catalog/models (filtered by
+    # modality/provider/q/capability) and GET /catalog/models/{id}. The proxy is
+    # the source of truth (read via /v1/models + /model/info, mapped to
+    # ModelCatalogEntry, TTL-cached in-process); models.dev enriches logo/desc
+    # best-effort. Thin adapter over ee.catalog.service.
+    from pocketpaw_ee.catalog.router import router as catalog_router
+
+    app.include_router(catalog_router, prefix="/api/v1")
+
     # Temporal sweeps — RFC 03 v2 Wave 3d. Read-only inspect endpoint
     # for the persisted (trigger, row) state matrix; the actual sweep
     # is driven by the in-process scheduler at

--- a/tests/cloud/catalog/__init__.py
+++ b/tests/cloud/catalog/__init__.py
@@ -1,0 +1,2 @@
+# tests/cloud/catalog/ — Model Catalog (MCG-1) test package marker.
+# Created 2026-06-26 (feat/mcg-1-catalog-api).

--- a/tests/cloud/catalog/test_litellm_client.py
+++ b/tests/cloud/catalog/test_litellm_client.py
@@ -1,0 +1,187 @@
+# tests/cloud/catalog/test_litellm_client.py — Model Catalog (MCG-1) proxy
+# client + mapper tests. httpx.MockTransport stands in for a live LiteLLM proxy
+# (no network). Asserts:
+#   * map_model_info_row produces a correct ModelCatalogEntry (id/provider/
+#     modality/context/max_output/pricing-per-mtok/capabilities).
+#   * LiteLLM ``mode`` -> our Modality across every bucket (chat family, embedding,
+#     image, audio_tts, audio_stt, video) + unknown -> chat default.
+#   * fetch_entries joins /model/info + /v1/models so catalog ⊇ routable (a served
+#     id missing from /model/info is still listed).
+#   * a non-2xx proxy read fails closed (CatalogUpstreamError).
+#   * the proxy api key rides as a Bearer header when configured.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1).
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pocketpaw_ee.catalog.litellm_client import (
+    CatalogUpstreamError,
+    LiteLLMClient,
+    map_model_info_row,
+)
+from pocketpaw_ee.catalog.models import Modality
+
+# A representative /model/info row (the rich anthropic chat model).
+_SONNET_ROW = {
+    "model_name": "anthropic/claude-3-5-sonnet",
+    "litellm_params": {"model": "anthropic/claude-3-5-sonnet-20241022"},
+    "model_info": {
+        "litellm_provider": "anthropic",
+        "mode": "chat",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000003,  # $3 / Mtok
+        "output_cost_per_token": 0.000015,  # $15 / Mtok
+        "supports_function_calling": True,
+        "supports_vision": True,
+        "supports_response_schema": True,
+        "supports_prompt_caching": True,
+    },
+}
+
+
+def _client(handler) -> LiteLLMClient:
+    return LiteLLMClient(
+        base_url="http://proxy.test:4000",
+        api_key=None,
+        _transport=httpx.MockTransport(handler),
+    )
+
+
+def test_map_model_info_row_builds_entry():
+    entry = map_model_info_row(_SONNET_ROW)
+    assert entry is not None
+    assert entry.id == "anthropic/claude-3-5-sonnet"
+    assert entry.provider == "anthropic"
+    assert entry.display_name == "claude-3-5-sonnet"
+    assert entry.modality is Modality.CHAT
+    assert entry.context == 200000
+    assert entry.max_output_tokens == 8192
+    # per-token -> per-MILLION-token.
+    assert entry.pricing is not None
+    assert entry.pricing.input_per_mtok == 3.0
+    assert entry.pricing.output_per_mtok == 15.0
+    # supports_* -> capability tokens; chat models also get "streaming".
+    assert "tool_call" in entry.capabilities
+    assert "vision" in entry.capabilities
+    assert "json_mode" in entry.capabilities
+    assert "prompt_caching" in entry.capabilities
+    assert "streaming" in entry.capabilities
+    assert entry.status == "available"
+
+
+def test_map_model_info_row_no_model_name_dropped():
+    assert map_model_info_row({"model_info": {"mode": "chat"}}) is None
+
+
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        ("chat", Modality.CHAT),
+        ("completion", Modality.CHAT),
+        ("responses", Modality.CHAT),
+        ("embedding", Modality.EMBEDDING),
+        ("image_generation", Modality.IMAGE),
+        ("audio_speech", Modality.AUDIO_TTS),
+        ("audio_transcription", Modality.AUDIO_STT),
+        ("video", Modality.VIDEO),
+        ("something_new", Modality.CHAT),  # unknown -> chat default
+        (None, Modality.CHAT),
+    ],
+)
+def test_mode_maps_to_modality(mode, expected):
+    row = {"model_name": "p/m", "model_info": {"mode": mode} if mode is not None else {}}
+    entry = map_model_info_row(row)
+    assert entry is not None
+    assert entry.modality is expected
+
+
+def test_unknown_cost_yields_no_pricing():
+    row = {"model_name": "p/m", "model_info": {"mode": "embedding"}}
+    entry = map_model_info_row(row)
+    assert entry is not None
+    assert entry.pricing is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_entries_maps_model_info():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/model/info":
+            return httpx.Response(200, json={"data": [_SONNET_ROW]})
+        if request.url.path == "/v1/models":
+            return httpx.Response(200, json={"data": [{"id": "anthropic/claude-3-5-sonnet"}]})
+        return httpx.Response(404)
+
+    entries = await _client(handler).fetch_entries()
+    assert len(entries) == 1
+    assert entries[0].id == "anthropic/claude-3-5-sonnet"
+
+
+@pytest.mark.asyncio
+async def test_fetch_entries_catalog_superset_of_routable():
+    """A model served by /v1/models but absent from /model/info is STILL listed
+    (catalog ⊇ routable) as a minimal available entry."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/model/info":
+            return httpx.Response(200, json={"data": [_SONNET_ROW]})
+        if request.url.path == "/v1/models":
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"id": "anthropic/claude-3-5-sonnet"},
+                        {"id": "openai/gpt-4o"},  # served but undescribed
+                    ]
+                },
+            )
+        return httpx.Response(404)
+
+    entries = await _client(handler).fetch_entries()
+    ids = {e.id for e in entries}
+    assert ids == {"anthropic/claude-3-5-sonnet", "openai/gpt-4o"}
+    gpt = next(e for e in entries if e.id == "openai/gpt-4o")
+    assert gpt.provider == "openai"
+    assert gpt.status == "available"
+
+
+@pytest.mark.asyncio
+async def test_model_info_non_2xx_fails_closed():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"error": "down"})
+
+    with pytest.raises(CatalogUpstreamError):
+        await _client(handler).fetch_entries()
+
+
+@pytest.mark.asyncio
+async def test_v1_models_failure_does_not_blank_catalog():
+    """If /model/info succeeds but /v1/models fails, the catalog still serves the
+    described entries (reconciliation is best-effort, not blocking)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/model/info":
+            return httpx.Response(200, json={"data": [_SONNET_ROW]})
+        return httpx.Response(500)  # /v1/models down
+
+    entries = await _client(handler).fetch_entries()
+    assert {e.id for e in entries} == {"anthropic/claude-3-5-sonnet"}
+
+
+@pytest.mark.asyncio
+async def test_api_key_sent_as_bearer():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"data": []})
+
+    client = LiteLLMClient(
+        base_url="http://proxy.test:4000",
+        api_key="sk-proxy-123",
+        _transport=httpx.MockTransport(handler),
+    )
+    await client.model_info()
+    assert seen["auth"] == "Bearer sk-proxy-123"

--- a/tests/cloud/catalog/test_models_dev_client.py
+++ b/tests/cloud/catalog/test_models_dev_client.py
@@ -1,0 +1,61 @@
+# tests/cloud/catalog/test_models_dev_client.py — Model Catalog (MCG-1)
+# best-effort models.dev enrichment client. httpx.MockTransport stands in for
+# models.dev (no network). Asserts:
+#   * a well-formed api.json flattens to {"<provider>/<model>": {description,
+#     logo, capabilities}}.
+#   * a non-2xx response fails OPEN (empty dict, no raise).
+#   * a transport error fails OPEN (empty dict, no raise) — a models.dev outage
+#     can never break the catalog.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1).
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pocketpaw_ee.catalog.models_dev_client import ModelsDevClient
+
+_API_JSON = {
+    "anthropic": {
+        "logo": "https://models.dev/logos/anthropic.svg",
+        "models": {
+            "claude-3-5-sonnet": {
+                "name": "Claude 3.5 Sonnet",
+                "description": "Anthropic's mid-tier chat model",
+                "capabilities": ["vision", "tool_call"],
+            }
+        },
+    }
+}
+
+
+@pytest.mark.asyncio
+async def test_fetch_index_flattens_payload():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_API_JSON)
+
+    client = ModelsDevClient(_transport=httpx.MockTransport(handler))
+    index = await client.fetch_index()
+    assert "anthropic/claude-3-5-sonnet" in index
+    entry = index["anthropic/claude-3-5-sonnet"]
+    assert entry["description"] == "Anthropic's mid-tier chat model"
+    assert entry["logo"] == "https://models.dev/logos/anthropic.svg"  # provider-level fallback
+    assert set(entry["capabilities"]) == {"vision", "tool_call"}
+
+
+@pytest.mark.asyncio
+async def test_non_2xx_fails_open():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    client = ModelsDevClient(_transport=httpx.MockTransport(handler))
+    assert await client.fetch_index() == {}
+
+
+@pytest.mark.asyncio
+async def test_transport_error_fails_open():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("dns fail")
+
+    client = ModelsDevClient(_transport=httpx.MockTransport(handler))
+    assert await client.fetch_index() == {}

--- a/tests/cloud/catalog/test_router.py
+++ b/tests/cloud/catalog/test_router.py
@@ -1,0 +1,109 @@
+# tests/cloud/catalog/test_router.py — Model Catalog (MCG-1) HTTP-layer tests.
+# A FastAPI app mounts the catalog router with the license dep waived; the catalog
+# SERVICE is patched (the router is a thin adapter, so the service is the seam).
+# Asserts:
+#   * GET /catalog/models returns {models, total} and forwards filter params.
+#   * an unknown modality value is a 400 (clear error, not a silent empty list).
+#   * GET /catalog/models/{id} resolves the URL-ENCODED "<provider>/<model>" id
+#     (the %2F-encoded slash) to one entry; a miss is 404.
+#   * a LiteLLM upstream failure (CatalogUpstreamError) surfaces as 502.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1).
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.catalog import service as catalog_service
+from pocketpaw_ee.catalog.litellm_client import CatalogUpstreamError
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry, Pricing
+from pocketpaw_ee.catalog.router import router as catalog_router
+from pocketpaw_ee.cloud.license import require_license
+
+_SONNET = ModelCatalogEntry(
+    id="anthropic/claude-3-5-sonnet",
+    display_name="claude-3-5-sonnet",
+    provider="anthropic",
+    modality=Modality.CHAT,
+    context=200000,
+    max_output_tokens=8192,
+    pricing=Pricing(input_per_mtok=3.0, output_per_mtok=15.0),
+    capabilities=["tool_call", "vision", "streaming"],
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(catalog_router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_list_models_returns_envelope(client, monkeypatch):
+    seen: dict = {}
+
+    async def _list(**kwargs):
+        seen.update(kwargs)
+        return [_SONNET]
+
+    monkeypatch.setattr(catalog_service, "list_models", _list)
+
+    resp = client.get(
+        "/api/v1/catalog/models",
+        params={"modality": "chat", "provider": "anthropic", "q": "son", "capability": "vision"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["models"][0]["id"] == "anthropic/claude-3-5-sonnet"
+    assert body["models"][0]["pricing"]["input_per_mtok"] == 3.0
+    # filters forwarded to the service.
+    assert seen == {
+        "modality": "chat",
+        "provider": "anthropic",
+        "q": "son",
+        "capability": "vision",
+    }
+
+
+def test_list_models_unknown_modality_is_400(client):
+    resp = client.get("/api/v1/catalog/models", params={"modality": "music"})
+    assert resp.status_code == 400
+    assert "Unknown modality" in resp.json()["detail"]
+
+
+def test_list_models_upstream_failure_is_502(client, monkeypatch):
+    async def _boom(**kwargs):
+        raise CatalogUpstreamError("proxy down")
+
+    monkeypatch.setattr(catalog_service, "list_models", _boom)
+    resp = client.get("/api/v1/catalog/models")
+    assert resp.status_code == 502
+
+
+def test_get_model_url_encoded_id(client, monkeypatch):
+    seen: dict = {}
+
+    async def _get(model_id, **kwargs):
+        seen["id"] = model_id
+        return _SONNET
+
+    monkeypatch.setattr(catalog_service, "get_model", _get)
+
+    # The "/" in the canonical id is URL-encoded as %2F by the client.
+    resp = client.get("/api/v1/catalog/models/anthropic%2Fclaude-3-5-sonnet")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "anthropic/claude-3-5-sonnet"
+    # The router decoded it back to the canonical "<provider>/<model>" key.
+    assert seen["id"] == "anthropic/claude-3-5-sonnet"
+
+
+def test_get_model_not_found_is_404(client, monkeypatch):
+    async def _none(model_id, **kwargs):
+        return None
+
+    monkeypatch.setattr(catalog_service, "get_model", _none)
+    resp = client.get("/api/v1/catalog/models/nope%2Fnone")
+    assert resp.status_code == 404

--- a/tests/cloud/catalog/test_service.py
+++ b/tests/cloud/catalog/test_service.py
@@ -1,0 +1,215 @@
+# tests/cloud/catalog/test_service.py — Model Catalog (MCG-1) service tests:
+# filtering, TTL cache, and best-effort models.dev enrichment merge.
+# The upstream clients (LiteLLMClient / ModelsDevClient) are replaced with fakes
+# injected via monkeypatch so no network is touched. Asserts:
+#   * modality / provider / capability / q filters (each + combined).
+#   * the TTL cache: a second request inside the window does NOT re-hit the proxy
+#     (the fetch counter stays at 1), and bust_cache forces a re-fetch.
+#   * models.dev enrichment fills gaps WITHOUT overwriting LiteLLM values.
+#   * enrichment is fail-open: an empty index leaves the catalog unchanged.
+#   * the models.dev toggle (CATALOG_MODELS_DEV_ENABLED=false) skips enrichment.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1).
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.catalog import service
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry, Pricing
+
+
+def _entry(
+    id_: str,
+    *,
+    provider: str,
+    modality: Modality,
+    caps: list[str] | None = None,
+    description: str | None = None,
+    logo: str | None = None,
+) -> ModelCatalogEntry:
+    return ModelCatalogEntry(
+        id=id_,
+        display_name=id_.split("/", 1)[-1],
+        provider=provider,
+        modality=modality,
+        pricing=Pricing(input_per_mtok=1.0, output_per_mtok=2.0),
+        capabilities=caps or [],
+        description=description,
+        logo=logo,
+    )
+
+
+_CATALOG = [
+    _entry(
+        "anthropic/claude-3-5-sonnet",
+        provider="anthropic",
+        modality=Modality.CHAT,
+        caps=["tool_call", "vision", "streaming"],
+    ),
+    _entry(
+        "openai/gpt-4o", provider="openai", modality=Modality.CHAT, caps=["tool_call", "streaming"]
+    ),
+    _entry("openai/text-embedding-3-small", provider="openai", modality=Modality.EMBEDDING),
+    _entry("google/imagen-3", provider="google", modality=Modality.IMAGE),
+]
+
+
+class _FakeLiteLLM:
+    """Counts fetches so the TTL-cache test can assert a single upstream call."""
+
+    calls = 0
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+        pass
+
+    async def fetch_entries(self) -> list[ModelCatalogEntry]:
+        type(self).calls += 1
+        # Return fresh copies so the service's in-place sort never mutates _CATALOG.
+        return [e.model_copy(deep=True) for e in _CATALOG]
+
+
+class _FakeModelsDev:
+    """Returns a fixed enrichment index (overridable per-test)."""
+
+    index: dict = {}
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def fetch_index(self) -> dict:
+        return dict(type(self).index)
+
+
+@pytest.fixture(autouse=True)
+def wire_fakes(monkeypatch: pytest.MonkeyPatch):
+    """Inject the fakes, reset counters + cache, and default enrichment off so a
+    test opts INTO models.dev explicitly."""
+    _FakeLiteLLM.calls = 0
+    _FakeModelsDev.index = {}
+    monkeypatch.setattr(service, "LiteLLMClient", _FakeLiteLLM)
+    monkeypatch.setattr(service, "ModelsDevClient", _FakeModelsDev)
+    monkeypatch.setenv("CATALOG_MODELS_DEV_ENABLED", "false")
+    monkeypatch.setenv("CATALOG_CACHE_TTL_SECONDS", "300")
+    service.bust_cache()
+    yield
+    service.bust_cache()
+
+
+# --- filtering --------------------------------------------------------------
+
+
+async def test_no_filter_returns_all():
+    entries = await service.list_models()
+    assert len(entries) == len(_CATALOG)
+
+
+async def test_filter_by_modality():
+    chat = await service.list_models(modality="chat")
+    assert {e.id for e in chat} == {"anthropic/claude-3-5-sonnet", "openai/gpt-4o"}
+    emb = await service.list_models(modality="embedding")
+    assert {e.id for e in emb} == {"openai/text-embedding-3-small"}
+
+
+async def test_filter_by_provider_case_insensitive():
+    res = await service.list_models(provider="OpenAI")
+    assert {e.id for e in res} == {"openai/gpt-4o", "openai/text-embedding-3-small"}
+
+
+async def test_filter_by_capability():
+    res = await service.list_models(capability="vision")
+    assert {e.id for e in res} == {"anthropic/claude-3-5-sonnet"}
+
+
+async def test_filter_by_q_substring():
+    res = await service.list_models(q="sonnet")
+    assert {e.id for e in res} == {"anthropic/claude-3-5-sonnet"}
+
+
+async def test_filters_combine_and():
+    # chat AND provider=openai -> gpt-4o only (embedding is openai but not chat).
+    res = await service.list_models(modality="chat", provider="openai")
+    assert {e.id for e in res} == {"openai/gpt-4o"}
+
+
+async def test_get_model_by_id():
+    entry = await service.get_model("google/imagen-3")
+    assert entry is not None
+    assert entry.modality is Modality.IMAGE
+    assert await service.get_model("nope/none") is None
+
+
+# --- TTL cache --------------------------------------------------------------
+
+
+async def test_cache_avoids_second_upstream_call():
+    await service.list_models()
+    await service.list_models(modality="chat")
+    await service.get_model("openai/gpt-4o")
+    # Three service reads, ONE upstream fetch — the TTL cache served the rest.
+    assert _FakeLiteLLM.calls == 1
+
+
+async def test_bust_cache_forces_refetch():
+    await service.list_models()
+    assert _FakeLiteLLM.calls == 1
+    service.bust_cache()
+    await service.list_models()
+    assert _FakeLiteLLM.calls == 2
+
+
+async def test_expired_ttl_refetches(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CATALOG_CACHE_TTL_SECONDS", "300")
+    service.bust_cache()
+
+    # Drive a controllable monotonic clock.
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(service.time, "monotonic", lambda: clock["t"])
+
+    await service.list_models()
+    assert _FakeLiteLLM.calls == 1
+    clock["t"] += 301  # past the 300s TTL
+    await service.list_models()
+    assert _FakeLiteLLM.calls == 2
+
+
+# --- models.dev enrichment --------------------------------------------------
+
+
+async def test_enrichment_fills_gaps_without_overwrite(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CATALOG_MODELS_DEV_ENABLED", "true")
+    _FakeModelsDev.index = {
+        "openai/gpt-4o": {
+            "description": "GPT-4o omni model",
+            "logo": "https://logos.test/openai.svg",
+            "capabilities": ["json_mode"],  # not in the LiteLLM-derived set
+        },
+        "anthropic/claude-3-5-sonnet": {
+            "description": "should NOT overwrite — but LiteLLM left it None",
+            "capabilities": [],
+        },
+    }
+    service.bust_cache()
+    gpt = await service.get_model("openai/gpt-4o")
+    assert gpt is not None
+    assert gpt.description == "GPT-4o omni model"
+    assert gpt.logo == "https://logos.test/openai.svg"
+    # union of LiteLLM caps + the enrichment cap.
+    assert "json_mode" in gpt.capabilities
+    assert "tool_call" in gpt.capabilities
+
+
+async def test_enrichment_disabled_by_flag(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CATALOG_MODELS_DEV_ENABLED", "false")
+    _FakeModelsDev.index = {"openai/gpt-4o": {"description": "ignored"}}
+    service.bust_cache()
+    gpt = await service.get_model("openai/gpt-4o")
+    assert gpt is not None
+    assert gpt.description is None  # enrichment was skipped
+
+
+async def test_enrichment_empty_index_is_noop(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CATALOG_MODELS_DEV_ENABLED", "true")
+    _FakeModelsDev.index = {}  # models.dev down -> fail-open empty
+    service.bust_cache()
+    entries = await service.list_models()
+    assert len(entries) == len(_CATALOG)  # unchanged, LiteLLM-only


### PR DESCRIPTION
## What ships

A read-only model catalog API in the enterprise layer, backed by a self-hosted LiteLLM proxy.

- `GET /api/v1/catalog/models?modality=&provider=&q=&capability=` — filtered list
- `GET /api/v1/catalog/models/{id}` — one model (`id` is the URL-encoded `provider/model` key)

The proxy is the source of truth. The catalog reads `/v1/models` and `/model/info`, maps each model onto a typed `ModelCatalogEntry` (modality, pricing, context, capabilities), and caches the assembled list in-process on a TTL. models.dev fills in logos and descriptions when it's reachable, and the catalog falls back to proxy-only data when it isn't.

This is the foundation slice (MCG-1) for the model-catalog work — the picker in paw-enterprise and the agent-backend gateway path build on these endpoints.

## Notes

- Proxy URL and key come from env (`LITELLM_PROXY_URL`, `LITELLM_PROXY_API_KEY`); nothing is hardcoded.
- The catalog lists served-but-undescribed models too (it unions the two proxy endpoints), so it never silently drops one.
- When the proxy is unreachable the endpoints return 502 rather than an empty 200. That's intended.

## Known gaps (carried forward)

- Non-text pricing (image / audio / video) isn't mapped yet, so those entries show no price for now. The fix lands with the multi-modal slices (MCG-6/7). Documented in the catalog README.
- Every entry is `status=available` until a readiness probe exists.

## Live proxy — handoff

This PR ships the app-side API plus a reference `litellm.config.example.yaml`. Standing up the live proxy (Coolify wiring, real provider keys, Postgres/Redis) is a separate deploy step.

## Tests

`uv run pytest tests/cloud/catalog/` — 39 passing. They mock the proxy (no live dependency) and cover the mapper, modality derivation, filtering, the TTL cache call count, the models.dev fail-open path, and the HTTP layer (response envelope, 400/404/502, URL-encoded ids).
