### PR TITLE
fix(agents): route per-agent model to every backend, not just claude/openai/google

### DIFF
--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -50,6 +50,19 @@ Updated: 2026-06-13 (feat/claude-sdk-prewarm) — added ``prewarm``, which eager
   digest matches too. Fire-and-forget: never raises (the backend's ``prewarm``
   swallows its own errors; this guards instance load + prompt assembly). The EE
   trigger fires it as a background task in ``run_core.execute_run``.
+Updated: 2026-06-26 (feat/mcg-3-pool-route-model) — ``_build`` now routes the
+  per-agent ``config.model`` onto the correct backend Settings field via
+  ``pocketpaw.llm.providers.base.route_model`` instead of the old brittle
+  ``"claude" in backend`` / ``"openai" in backend`` / ``"google" in backend``
+  substring chain. That chain silently dropped the per-agent model for
+  ``codex_cli``, ``opencode``, ``deep_agents``, ``copilot_sdk`` and
+  ``langchain_react`` (and even wrote OpenAI Agents' model to the wrong field,
+  ``openai_model`` instead of ``openai_agents_model``). ``route_model`` is
+  driven by ``_BACKEND_MODEL_ATTR`` (+ the langchain_react->deep_agents_model
+  alias) so it covers every registered backend and preserves the composite
+  ``provider:model`` / ``provider/model`` formats verbatim. Legacy backend names
+  are resolved through ``_LEGACY_BACKENDS`` before routing so old agent docs
+  still map to the right field. Empty model stays a no-op (backend default).
 """
 
 from __future__ import annotations
@@ -524,8 +537,9 @@ class AgentPool:
     async def _build(self, agent_doc: Any) -> AgentInstance:
         """Build a new AgentInstance from an Agent document."""
         from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
-        from pocketpaw.agents.registry import get_backend_class
+        from pocketpaw.agents.registry import _LEGACY_BACKENDS, get_backend_class
         from pocketpaw.config import Settings
+        from pocketpaw.llm.providers.base import route_model
         from pocketpaw.tools.policy import OPT_IN_MCP_SERVERS, ToolPolicy
 
         agent_id = str(agent_doc.id)
@@ -535,15 +549,21 @@ class AgentPool:
         settings = Settings.load()
         settings.agent_backend = config.get("backend", "claude_agent_sdk")
 
-        # Map model to the correct settings field based on backend
+        # Map the per-agent model onto the Settings field the chosen backend
+        # actually reads, for EVERY registered backend — the old ``"claude" in
+        # backend`` substring routing silently dropped the model for codex_cli /
+        # opencode / deep_agents / copilot_sdk / langchain_react. ``route_model``
+        # is the single source of truth (driven by ``_BACKEND_MODEL_ATTR`` +
+        # the langchain_react->deep_agents alias) and preserves the composite
+        # ``provider:model`` / ``provider/model`` formats verbatim. An empty
+        # model is a no-op, so the backend falls through to its own default.
+        # Catalog existence-validation is NOT done here — it lives upstream in
+        # the picker / EE catalog layer (MCG-1/4); OSS can't import EE.
+        # Resolve legacy backend names to their canonical key first so an old
+        # agent doc (e.g. ``claude_code``) still routes to the right field.
         model = config.get("model", "")
-        if model:
-            if "claude" in settings.agent_backend:
-                settings.claude_sdk_model = model
-            elif "openai" in settings.agent_backend:
-                settings.openai_model = model
-            elif "google" in settings.agent_backend:
-                settings.google_adk_model = model
+        canonical_backend = _LEGACY_BACKENDS.get(settings.agent_backend, settings.agent_backend)
+        route_model(settings, canonical_backend, model)
 
         # Instantiate backend
         backend_cls = get_backend_class(settings.agent_backend)

--- a/src/pocketpaw/llm/providers/base.py
+++ b/src/pocketpaw/llm/providers/base.py
@@ -1,4 +1,14 @@
-"""Base types for the provider adapter pattern."""
+"""Base types for the provider adapter pattern.
+
+Updated: 2026-06-26 (feat/mcg-3-pool-route-model) — added ``route_model``, the
+  single writer that maps a per-agent ``model`` string onto the correct
+  ``Settings`` field for ANY registered agent backend, driven by
+  ``_BACKEND_MODEL_ATTR`` (plus ``_BACKEND_MODEL_ATTR_ALIASES`` for backends
+  that read another backend's field, e.g. ``langchain_react`` reads
+  ``deep_agents_model``). Replaces the brittle ``"claude" in backend`` substring
+  routing in ``AgentPool._build`` that silently dropped the per-agent model for
+  ``codex_cli``/``opencode``/``deep_agents``/``copilot_sdk``/``langchain_react``.
+"""
 
 from __future__ import annotations
 
@@ -42,6 +52,18 @@ _BACKEND_MODEL_ATTR: dict[str, str] = {
     "deep_agents": "deep_agents_model",
 }
 
+# -- Backends that read another backend's model field instead of their own --
+# ``langchain_react`` subclasses ``DeepAgentsBackend`` and reads
+# ``settings.deep_agents_model`` directly (it has no ``langchain_react_model``
+# field), so it shares deep_agents' slot. Kept SEPARATE from
+# ``_BACKEND_MODEL_ATTR`` so that map stays a 1:1 backend->own-field registry;
+# ``route_model`` consults this alias map only when a backend isn't a primary
+# key. ``resolve_model``'s backend lookup is unaffected (langchain_react resolves
+# via the deep_agents path in the backend itself, not through this table).
+_BACKEND_MODEL_ATTR_ALIASES: dict[str, str] = {
+    "langchain_react": "deep_agents_model",
+}
+
 # -- Maps provider name -> settings attribute for provider-level model --
 _PROVIDER_MODEL_ATTR: dict[str, str] = {
     "anthropic": "anthropic_model",
@@ -78,6 +100,47 @@ def resolve_model(settings: Settings, backend: str, provider: str) -> str:
 
     # 3. Provider default
     return PROVIDER_DEFAULT_MODELS.get(provider, "")
+
+
+def route_model(settings: Settings, backend: str, model: str) -> bool:
+    """Write a per-agent ``model`` onto the ``Settings`` field that ``backend``
+    actually reads, for EVERY registered agent backend.
+
+    This is the inverse of ``resolve_model``'s backend-specific lookup: given a
+    model string chosen for one agent, it sets the single backend-model attribute
+    so the backend instantiated from these settings picks it up. The field is
+    chosen from ``_BACKEND_MODEL_ATTR`` (the 1:1 backend->own-field registry),
+    falling back to ``_BACKEND_MODEL_ATTR_ALIASES`` for backends that read a
+    sibling's field (``langchain_react`` -> ``deep_agents_model``).
+
+    The model string is written VERBATIM. Backends whose field carries a
+    composite format keep it intact — ``deep_agents``/``langchain_react`` expect
+    ``provider:model`` and ``opencode`` expects ``provider/model``; this helper
+    does NOT split or reformat, so those round-trip exactly as supplied by the
+    upstream picker.
+
+    Catalog/existence validation of the model is NOT done here — that lives
+    upstream in the picker / EE catalog layer (MCG-1/4); OSS cannot import EE.
+    This is the field-routing seam only.
+
+    Args:
+        settings: the per-agent ``Settings`` clone to mutate in place.
+        backend: the registered backend name (e.g. ``"codex_cli"``).
+        model: the per-agent model string. Empty/blank is a no-op — the backend
+            then falls through to its own default via ``resolve_model``.
+
+    Returns:
+        ``True`` if a Settings field was written; ``False`` if the model was
+        empty or the backend has no known model field (unknown backend — the
+        caller leaves defaults untouched, matching legacy fall-through).
+    """
+    if not model:
+        return False
+    attr = _BACKEND_MODEL_ATTR.get(backend) or _BACKEND_MODEL_ATTR_ALIASES.get(backend)
+    if not attr:
+        return False
+    setattr(settings, attr, model)
+    return True
 
 
 @runtime_checkable

--- a/tests/test_pool_route_model.py
+++ b/tests/test_pool_route_model.py
@@ -1,0 +1,199 @@
+# tests/test_pool_route_model.py
+# Created: 2026-06-26 (feat/mcg-3-pool-route-model) — regression coverage for the
+# AgentPool model-routing seam (MCG-3). The old ``AgentPool._build`` mapped a
+# per-agent model onto a Settings field with a brittle ``"claude"/"openai"/
+# "google" in backend`` substring chain that SILENTLY DROPPED the per-agent
+# model for codex_cli / opencode / deep_agents / copilot_sdk / langchain_react
+# (and wrote OpenAI Agents' model to the wrong field). These tests pin:
+#   1. ``route_model`` writes the model to the correct Settings field for EVERY
+#      registered backend (including the langchain_react -> deep_agents_model
+#      alias), preserves the composite provider:model / provider/model formats
+#      verbatim, and no-ops on an empty model.
+#   2. A thin ``_build`` integration check drives the real build path with a fake
+#      backend class and asserts the per-agent model reaches the right Settings
+#      field for the previously-dropped backends — i.e. it is NOT dropped.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from pocketpaw.agents.registry import list_backends
+from pocketpaw.config import Settings
+from pocketpaw.llm.providers.base import (
+    _BACKEND_MODEL_ATTR,
+    _BACKEND_MODEL_ATTR_ALIASES,
+    route_model,
+)
+
+# ---------------------------------------------------------------------------
+# 1. route_model — the single source of truth for backend -> Settings field
+# ---------------------------------------------------------------------------
+
+# (backend name, model string, the Settings attr it must land in)
+_ROUTING_CASES = [
+    ("claude_agent_sdk", "claude-opus-4-8", "claude_sdk_model"),
+    ("openai_agents", "gpt-5.2", "openai_agents_model"),
+    ("google_adk", "gemini-3-pro-preview", "google_adk_model"),
+    ("codex_cli", "gpt-5.3-codex", "codex_cli_model"),
+    ("copilot_sdk", "gpt-5.2", "copilot_sdk_model"),
+    ("opencode", "anthropic/claude-sonnet-4-6", "opencode_model"),
+    ("deep_agents", "anthropic:claude-sonnet-4-6", "deep_agents_model"),
+    # langchain_react has no field of its own — it reads deep_agents_model.
+    ("langchain_react", "ollama:llama3.2", "deep_agents_model"),
+]
+
+
+@pytest.mark.parametrize(("backend", "model", "attr"), _ROUTING_CASES)
+def test_route_model_writes_correct_field(backend: str, model: str, attr: str) -> None:
+    settings = Settings.load()
+    wrote = route_model(settings, backend, model)
+    assert wrote is True
+    # The model landed in the right field, byte-for-byte (composite formats kept).
+    assert getattr(settings, attr) == model
+
+
+def test_route_model_covers_every_registered_backend() -> None:
+    """Every backend in the registry must route — otherwise its per-agent model
+    is silently dropped (the exact bug MCG-3 fixes)."""
+    for backend in list_backends():
+        settings = Settings.load()
+        assert route_model(settings, backend, "some-model:value") is True, (
+            f"backend {backend!r} does not route a per-agent model -> it would be dropped"
+        )
+
+
+def test_route_model_previously_dropped_backends_not_silently_dropped() -> None:
+    """Focused guard on the five backends the substring chain dropped."""
+    dropped = {
+        "codex_cli": "codex_cli_model",
+        "opencode": "opencode_model",
+        "deep_agents": "deep_agents_model",
+        "copilot_sdk": "copilot_sdk_model",
+        "langchain_react": "deep_agents_model",
+    }
+    for backend, attr in dropped.items():
+        settings = Settings.load()
+        # Field starts unset (or default) — prove the model actually arrives.
+        route_model(settings, backend, "mymodel:tag")
+        assert getattr(settings, attr) == "mymodel:tag", f"{backend!r} dropped its per-agent model"
+
+
+def test_route_model_preserves_provider_model_for_deep_agents() -> None:
+    """deep_agents / langchain_react take a single ``provider:model`` string in
+    deep_agents_model — route_model must NOT split it into provider/model."""
+    settings = Settings.load()
+    route_model(settings, "deep_agents", "anthropic:claude-sonnet-4-6")
+    assert settings.deep_agents_model == "anthropic:claude-sonnet-4-6"
+
+    settings2 = Settings.load()
+    route_model(settings2, "langchain_react", "ollama:llama3.2")
+    # langchain_react inherits the deep_agents slot, single composite string.
+    assert settings2.deep_agents_model == "ollama:llama3.2"
+
+
+def test_route_model_empty_model_is_noop() -> None:
+    """Empty model leaves the default untouched (fall-through to resolve_model)."""
+    settings = Settings.load()
+    default = settings.deep_agents_model  # "anthropic:claude-sonnet-4-6"
+    assert route_model(settings, "deep_agents", "") is False
+    assert settings.deep_agents_model == default
+
+    # codex_cli keeps its own default too.
+    codex_default = settings.codex_cli_model
+    assert route_model(settings, "codex_cli", "") is False
+    assert settings.codex_cli_model == codex_default
+
+
+def test_route_model_unknown_backend_is_noop() -> None:
+    settings = Settings.load()
+    assert route_model(settings, "no_such_backend", "x") is False
+
+
+def test_alias_map_targets_a_real_settings_field() -> None:
+    """The langchain_react alias must point at a field that exists on Settings."""
+    settings = Settings.load()
+    for backend, attr in _BACKEND_MODEL_ATTR_ALIASES.items():
+        assert hasattr(settings, attr), (
+            f"alias for {backend!r} -> {attr!r} is not a real Settings field"
+        )
+
+
+def test_backend_model_attr_fields_exist_on_settings() -> None:
+    """Sanity: every primary backend->field mapping names a real Settings field."""
+    settings = Settings.load()
+    for backend, attr in _BACKEND_MODEL_ATTR.items():
+        assert hasattr(settings, attr), f"{backend!r} -> {attr!r} is not a real Settings field"
+
+
+# ---------------------------------------------------------------------------
+# 2. _build integration — the real pool path routes the model end-to-end
+# ---------------------------------------------------------------------------
+
+
+class _CapturingBackend:
+    """Stand-in backend that records the Settings it was built with."""
+
+    last_settings = None  # class attr — read after _build
+
+    def __init__(self, settings, **_kwargs) -> None:
+        type(self).last_settings = settings
+
+    async def stop(self) -> None:  # pragma: no cover — teardown path
+        pass
+
+
+def _fake_agent_doc(backend: str, model: str):
+    """A minimal Agent-doc stand-in for ``_build`` (soul disabled to skip I/O)."""
+    cfg = {
+        "backend": backend,
+        "model": model,
+        "soul_enabled": False,
+        "tools": [],
+    }
+    return SimpleNamespace(
+        id="64b7f0000000000000000001",
+        name=f"agent-{backend}",
+        slug=f"agent-{backend}",
+        workspace="ws-test",
+        updatedAt=datetime.now(UTC),
+        config=SimpleNamespace(model_dump=lambda: dict(cfg)),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("backend", "model", "attr"),
+    [
+        ("codex_cli", "gpt-5.3-codex", "codex_cli_model"),
+        ("opencode", "anthropic/claude-sonnet-4-6", "opencode_model"),
+        ("deep_agents", "anthropic:claude-sonnet-4-6", "deep_agents_model"),
+        ("langchain_react", "ollama:llama3.2", "deep_agents_model"),
+    ],
+)
+async def test_build_routes_model_to_backend_settings(
+    monkeypatch, backend: str, model: str, attr: str
+) -> None:
+    """The real ``_build`` must land the per-agent model on the right Settings
+    field for backends the old substring chain dropped."""
+    from pocketpaw.agents import pool as pool_mod
+    from pocketpaw.agents import registry as registry_mod
+
+    _CapturingBackend.last_settings = None
+    # ``_build`` imports ``get_backend_class`` locally from the registry module,
+    # so patch it at its source. Stubs backend resolution so the test doesn't
+    # import optional SDKs or hit a network.
+    monkeypatch.setattr(registry_mod, "get_backend_class", lambda _name: _CapturingBackend)
+
+    p = pool_mod.AgentPool()
+    instance = await p._build(_fake_agent_doc(backend, model))
+
+    settings = _CapturingBackend.last_settings
+    assert settings is not None, "_build never instantiated the backend"
+    assert settings.agent_backend == backend
+    # The proof: the per-agent model reached the field the backend reads.
+    assert getattr(settings, attr) == model
+    # And it's the same Settings the instance carries downstream.
+    assert instance.config["model"] == model


### PR DESCRIPTION
## What ships

Per-agent model selection now reaches every backend. `AgentPool._build` routed the stored model onto a Settings field with a substring check that only knew claude/openai/google, so a model set for `codex_cli`, `opencode`, `deep_agents`, `copilot_sdk`, or `langchain_react` was silently dropped. The openai case also wrote `openai_model`, which isn't the field that backend reads first (`openai_agents_model`).

This replaces the substring chain with a single `route_model` helper keyed off the existing backend→field map, so all eight backends route correctly.

## Why now

Foundation for the model picker (MCG-4): a picker is pointless if the chosen model doesn't actually reach the backend. This fixes the silent-drop the catalog work surfaced.

## Scope

- `llm/providers/base.py` — new `route_model(settings, backend, model)` over the existing `_BACKEND_MODEL_ATTR`, plus a `langchain_react → deep_agents_model` alias.
- `agents/pool.py::_build` — calls `route_model`; the substring chain is gone; legacy backend names are canonicalized first.
- `deep_agents` / `langchain_react` (`provider:model`) and `opencode` (`provider/model`) strings are written verbatim, not split.
- OSS-only. No catalog existence-validation here — that belongs to the EE picker (MCG-1/4).

## Tests

`uv run pytest tests/test_pool_route_model.py tests/test_agent_pool_entity_profile_runtime.py tests/test_provider_adapters.py` — 58 passing. The integration tests drive the real `_build` path and prove codex / opencode / deep_agents / langchain_react are no longer dropped. A coverage test fails if a future backend is added without a field mapping.
