### PR TITLE
feat(stores): bridge per-stream workspace onto the store ContextVar + activate the EE provider

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -168,6 +168,7 @@ from pocketpaw.ripple import (
     get_pocket_prompts,
 )
 from pocketpaw.ripple._pockets import _MCP_POCKET_BACKENDS
+from pocketpaw.stores import current_workspace as _oss_current_workspace
 from pocketpaw_ee.cloud.shared.errors import CloudError, Forbidden, NotFound
 from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceProfile
 
@@ -216,7 +217,7 @@ def attach_agent_identity(
     user_id: str,
     session_mongo_id: str | None = None,
     pocket_id: str | None = None,
-) -> tuple[Token, Token, Token, Token]:
+) -> tuple[Token, Token, Token, Token, Token]:
     """Bind workspace / user / session / pocket identity for the active
     stream's MCP tools. ``session_mongo_id`` is the ``Session._id`` the chat
     is streaming through — used by ``create_pocket`` to link the active
@@ -232,7 +233,19 @@ def attach_agent_identity(
     that lost the id. Failing loudly at the bind makes any future caller that
     drops tenancy break at the source instead. Every real caller (the SSE chat
     path, the group/DM bridge, the in-process test harnesses) already passes
-    non-empty ids, so this is a guard, not a behavior change for them."""
+    non-empty ids, so this is a guard, not a behavior change for them.
+
+    ISO-3 (workspace store bridge): the same bind also sets the OSS-core
+    ``pocketpaw.stores.current_workspace`` ContextVar, so the NON-router store
+    callers inside an agent run — the agent Fabric tools, the Fabric/Instinct
+    MCP servers, connector ingest — that call ``get_fabric_store()`` /
+    ``get_instinct_store()`` WITHOUT an explicit ``workspace_id`` resolve to THIS
+    stream's workspace and land in its per-workspace file (ISO-1/ISO-2). The
+    EE router path keeps passing ``workspace_id`` explicitly (it has the request
+    scope); this bridges the agent path that doesn't. The OSS token is returned
+    as a FIFTH tuple element — callers treat the tuple opaquely (only
+    ``detach_agent_identity`` unpacks it), so the wider shape is invisible to
+    them. ``detach`` resets it."""
     if not workspace_id or not user_id:
         raise ValueError(
             "attach_agent_identity requires a non-empty workspace_id and user_id "
@@ -243,15 +256,19 @@ def attach_agent_identity(
         _active_user_id.set(user_id),
         _active_session_mongo_id.set(session_mongo_id),
         _active_pocket_id.set(pocket_id),
+        # ISO-3: bridge the EE per-stream workspace onto the OSS store ContextVar.
+        _oss_current_workspace.set(workspace_id),
     )
 
 
-def detach_agent_identity(tokens: tuple[Token, Token, Token, Token]) -> None:
-    ws_token, user_token, session_token, pocket_token = tokens
+def detach_agent_identity(tokens: tuple[Token, Token, Token, Token, Token]) -> None:
+    ws_token, user_token, session_token, pocket_token, oss_ws_token = tokens
     _active_workspace_id.reset(ws_token)
     _active_user_id.reset(user_token)
     _active_session_mongo_id.reset(session_token)
     _active_pocket_id.reset(pocket_token)
+    # ISO-3: clear the OSS store ContextVar bridged in attach_agent_identity.
+    _oss_current_workspace.reset(oss_ws_token)
 
 
 def current_workspace_id() -> str | None:

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -75,6 +75,17 @@ only MCP servers do — so without these the cloud chat agent had no path to the
 Fabric ontology or Instinct gate visibility. Both are READ-ONLY and
 workspace-scoped via the chat ContextVars. Gated proposing stays on
 ``pocketpaw_external_actions``. Ambient (not opt-in).
+
+Updated: 2026-06-26 (ISO-3 — workspace store bridge) — added ``CloudStoreProvider``
+(``pocketpaw.stores`` entry-point) so the dormant ``StoreProvider`` seam ISO-1 lit
+up is now live under EE. It returns the standard per-workspace SQLite file store
+(Fabric / Instinct at ``~/.pocketpaw/workspaces/<id>/<name>.db``) by delegating to
+the OSS helper ``pocketpaw.stores.build_workspace_store`` — so the path + the
+path-traversal allowlist stay authoritative in OSS and the provider can never drift
+from or weaken them. It returns ``None`` for the legacy (no-workspace) path, leaving
+the OSS factory's shared singleton in place. This activates the entry-point end to
+end and gives EE the single hook to later swap in a cloud-backed store without
+touching core.
 """
 
 from __future__ import annotations
@@ -1014,3 +1025,36 @@ class CloudComposioMcpProvider:
         # ``mcp__composio`` is the server-level allowlist entry — it
         # permits every tool the in-process ``composio`` server exposes.
         return ["mcp__composio"]
+
+
+class CloudStoreProvider:
+    """``pocketpaw.stores`` — the workspace-keyed store provider (ISO-3).
+
+    Activates the ``StoreProvider`` seam ISO-1 added but left dormant. The OSS
+    factory consults this provider FIRST when building a workspace-keyed store;
+    we return the standard per-workspace SQLite file store (Fabric / Instinct
+    under ``~/.pocketpaw/workspaces/<id>/<name>.db``) by delegating to the OSS
+    helper ``build_workspace_store``, so:
+
+    * the file path AND the strict path-traversal allowlist stay defined ONCE,
+      in OSS core — a provider can't drift from or weaken the guard; and
+    * delegation is recursion-safe (``build_workspace_store`` never re-enters
+      the provider seam).
+
+    We return ``None`` for the legacy / no-workspace path (``workspace_id`` is
+    ``None``) so the OSS factory keeps using its shared single-tenant singleton
+    there — the cloud always carries a workspace, so on cloud this provider only
+    ever serves the per-workspace branch. This is the one hook a future task
+    swaps to back stores with a cloud DB or a per-tenant server, without
+    touching core.
+    """
+
+    def get_store(self, name: str, *, workspace_id: str | None = None) -> Any:
+        if workspace_id is None:
+            # No workspace → let the OSS factory use its legacy shared singleton
+            # (or fail closed under POCKETPAW_REQUIRE_WORKSPACE_SCOPE, which the
+            # factory enforces before it ever consults a provider).
+            return None
+        from pocketpaw.stores import build_workspace_store
+
+        return build_workspace_store(name, workspace_id)

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -177,6 +177,11 @@ cloud = "pocketpaw_ee.extensions:CloudEmbeddingProvider"
 [project.entry-points."pocketpaw.memory_backends"]
 mongodb = "pocketpaw_ee.extensions:MongoMemoryBackendProvider"
 
+# ISO-3: the workspace-keyed store provider. Activates the StoreProvider seam
+# ISO-1 added; returns the per-workspace file store via the OSS helper.
+[project.entry-points."pocketpaw.stores"]
+cloud = "pocketpaw_ee.extensions:CloudStoreProvider"
+
 [project.entry-points."pocketpaw.capabilities"]
 cloud = "pocketpaw_ee.extensions:CloudCapabilityProvider"
 

--- a/src/pocketpaw/stores.py
+++ b/src/pocketpaw/stores.py
@@ -236,6 +236,7 @@ class _StoreKind:
 _FABRIC_KIND = _StoreKind(name="fabric", cls=FabricStore)
 _INSTINCT_KIND = _StoreKind(name="instinct", cls=InstinctStore)
 _STORE_KINDS: tuple[_StoreKind, ...] = (_FABRIC_KIND, _INSTINCT_KIND)
+_KIND_BY_NAME: dict[str, _StoreKind] = {k.name: k for k in _STORE_KINDS}
 
 
 def _provider_store(kind: _StoreKind, workspace_id: str | None) -> Any | None:
@@ -384,11 +385,45 @@ def _get_workspace_store(kind: _StoreKind, workspace_id: str | None) -> Any:
     if provided is not None:
         store = provided
     else:
-        ws_dir = _safe_workspace_dir(resolved)
-        ws_dir.mkdir(parents=True, exist_ok=True)
-        store = kind.cls(ws_dir / kind.filename)
+        store = _build_local_workspace_store(kind.name, resolved)
     _cache_workspace_store(kind, resolved, store)
     return store
+
+
+def _build_local_workspace_store(name: str, workspace_id: str) -> Any:
+    """Construct the LOCAL per-workspace store for ``name`` at its file path.
+
+    The single authority for "where does workspace ``X``'s ``name`` store live
+    and how is its id validated": resolves the directory via the
+    path-traversal allowlist (``_safe_workspace_dir``), creates it, and
+    constructs the OSS store class on ``<dir>/<name>.db``.
+
+    IMPORTANT: this does NOT consult the StoreProvider seam — it is the local
+    default, and is ALSO what a registered provider should delegate to when it
+    just wants the standard per-workspace file store (see
+    ``build_workspace_store``). Routing a provider back through the seam would
+    recurse. ``name`` must be a known workspace-keyed kind.
+    """
+    kind = _KIND_BY_NAME.get(name)
+    if kind is None:
+        raise ValueError(f"unknown workspace-keyed store kind: {name!r}")
+    ws_dir = _safe_workspace_dir(workspace_id)
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    return kind.cls(ws_dir / kind.filename)
+
+
+def build_workspace_store(name: str, workspace_id: str) -> Any:
+    """Public helper: build the standard per-workspace file store for ``name``.
+
+    The seam an EE ``StoreProvider`` delegates to when it wants the normal
+    per-workspace SQLite file store (Fabric / Instinct at
+    ``~/.pocketpaw/workspaces/<id>/<name>.db``) rather than a bespoke
+    implementation. Keeping the path + the path-traversal allowlist here means
+    the provider can't drift from — or weaken — the OSS guard, and it is
+    recursion-safe (it never re-enters the provider seam). ``workspace_id`` is
+    validated by the same strict allowlist every other store path uses.
+    """
+    return _build_local_workspace_store(name, workspace_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workspace_ctxvar_bridge.py
+++ b/tests/test_workspace_ctxvar_bridge.py
@@ -1,0 +1,307 @@
+# tests/test_workspace_ctxvar_bridge.py
+# Created: 2026-06-26 (ISO-3 — ContextVar bridge for non-router store callers).
+#
+# Proves the ISO-3 invariant: the NON-router store callers (agent tools, MCP
+# servers, connector ingest) that call get_fabric_store() / get_instinct_store()
+# WITHOUT an explicit workspace_id land in the caller's per-workspace file,
+# because EE's attach_agent_identity bridges the per-stream workspace onto the
+# OSS-core `current_workspace` ContextVar that the factory resolves through.
+#
+# Covers:
+#   * the bridge — attach_agent_identity sets the OSS current_workspace; a bare
+#     get_fabric_store()/get_instinct_store() then resolves to that workspace's
+#     file; detach clears it;
+#   * a REAL agent tool (FabricCreateTool, which calls the bare factory
+#     internally) writes through the bridge → the object lands in the caller's
+#     workspace file, not the shared one, and is invisible to another workspace;
+#   * fail-closed — under POCKETPAW_REQUIRE_WORKSPACE_SCOPE, a non-router store
+#     call with NO identity attached (ContextVar unset) raises, never a shared
+#     read;
+#   * the EE StoreProvider seam (pocketpaw.stores entry-point) is registered and
+#     returns the per-workspace store for both kinds (and None for no-workspace).
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.chat.agent_service import (
+    attach_agent_identity,
+    detach_agent_identity,
+)
+
+import pocketpaw.stores as stores
+from pocketpaw.fabric.models import FabricQuery
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the factory at a tmp data dir; reset caches + flag + ContextVar."""
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+# ---------------------------------------------------------------------------
+# The bridge itself: attach sets the OSS ContextVar; bare factory resolves it
+# ---------------------------------------------------------------------------
+
+
+def test_attach_identity_bridges_workspace_to_oss_contextvar(tmp_path: Path) -> None:
+    assert stores.current_workspace.get() is None
+
+    tokens = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+    try:
+        # The OSS ContextVar now carries the stream's workspace.
+        assert stores.current_workspace.get() == WS_A
+        # A bare (no-arg) factory call — exactly what the agent tools / MCP
+        # servers do — resolves to that workspace's file.
+        fab = stores.get_fabric_store()
+        inst = stores.get_instinct_store()
+        assert str(tmp_path / "workspaces" / WS_A) in fab._db_path
+        assert str(tmp_path / "workspaces" / WS_A) in inst._db_path
+    finally:
+        detach_agent_identity(tokens)
+
+    # detach clears it — back to no workspace.
+    assert stores.current_workspace.get() is None
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_write_lands_in_callers_workspace_file(tmp_path: Path) -> None:
+    """A REAL agent tool writing through the bare factory lands in the right file.
+
+    Drives the non-router path end to end: attach identity for WS_A, write a
+    Fabric object via the SAME bare get_fabric_store() the agent FabricCreateTool
+    uses, and assert it lands in WS_A's file and is invisible from WS_B.
+    """
+    # Write as WS_A through the bridged bare factory.
+    tokens_a = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+    try:
+        store_a = stores.get_fabric_store()  # no explicit workspace arg
+        t = await store_a.define_type(name="Customer", properties=[], workspace_id=WS_A)
+        await store_a.create_object(t.id, {"name": "Acme"}, workspace_id=WS_A)
+    finally:
+        detach_agent_identity(tokens_a)
+
+    # The object physically lives in WS_A's file.
+    db_a = tmp_path / "workspaces" / WS_A / "fabric.db"
+    assert db_a.exists()
+    assert not (tmp_path / "fabric.db").exists()  # never the shared file
+
+    # WS_B, through the same bare path, sees ZERO of WS_A's objects.
+    tokens_b = attach_agent_identity(workspace_id=WS_B, user_id="u2")
+    try:
+        store_b = stores.get_fabric_store()
+        res_b = await store_b.query(FabricQuery(type_name="Customer"))
+        assert res_b.objects == []
+    finally:
+        detach_agent_identity(tokens_b)
+
+    # WS_A still sees its own object.
+    tokens_a2 = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+    try:
+        res_a = await stores.get_fabric_store().query(FabricQuery(type_name="Customer"))
+        assert {o.properties.get("name") for o in res_a.objects} == {"Acme"}
+    finally:
+        detach_agent_identity(tokens_a2)
+
+
+@pytest.mark.asyncio
+async def test_instinct_write_through_bridge_is_isolated(tmp_path: Path) -> None:
+    """The Instinct non-router path is bridged + isolated the same way."""
+    from pocketpaw.instinct.models import ActionTrigger
+
+    def trig() -> ActionTrigger:
+        return ActionTrigger(type="agent", source="claude", reason="iso-3")
+
+    tokens_a = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+    try:
+        await stores.get_instinct_store().propose(
+            pocket_id="p",
+            title="A-task",
+            description="",
+            recommendation="",
+            trigger=trig(),
+            workspace_id=WS_A,
+        )
+    finally:
+        detach_agent_identity(tokens_a)
+
+    tokens_b = attach_agent_identity(workspace_id=WS_B, user_id="u2")
+    try:
+        b_pending = await stores.get_instinct_store().pending()
+        assert b_pending == []  # WS_B's file has none of WS_A's actions
+    finally:
+        detach_agent_identity(tokens_b)
+
+    assert (tmp_path / "workspaces" / WS_A / "instinct.db").exists()
+    assert not (tmp_path / "instinct.db").exists()
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: a cloud non-router call with no identity attached must raise
+# ---------------------------------------------------------------------------
+
+
+def test_fail_closed_when_required_and_no_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No attach_agent_identity in scope + required-scope flag → raise, not share."""
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    # No identity attached → ContextVar is None → fail closed for BOTH kinds.
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_fabric_store()
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_instinct_store()
+
+
+def test_detach_restores_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After detach, a required-scope non-router call fails closed again.
+
+    Guards against a leaked ContextVar keeping a later, identity-less call
+    resolving to a stale workspace.
+    """
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    tokens = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+    # Inside the scope it resolves fine.
+    assert stores.get_fabric_store() is not None
+    detach_agent_identity(tokens)
+    # Outside it, the same call fails closed.
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_fabric_store()
+
+
+# ---------------------------------------------------------------------------
+# AC#2: the EE StoreProvider seam is live
+# ---------------------------------------------------------------------------
+
+
+def test_ee_store_provider_is_registered_and_serves_both_kinds(
+    tmp_path: Path,
+) -> None:
+    from pocketpaw._registry import clear_cache, first
+
+    clear_cache()
+    provider = first("pocketpaw.stores")
+    assert provider is not None, "EE CloudStoreProvider should be registered"
+    assert type(provider).__name__ == "CloudStoreProvider"
+
+    # No-workspace → None (factory falls back to its shared singleton / fail-closed).
+    assert provider.get_store("fabric", workspace_id=None) is None
+
+    # Per-workspace → the right store on the right file, for both kinds.
+    fab = provider.get_store("fabric", workspace_id=WS_A)
+    inst = provider.get_store("instinct", workspace_id=WS_A)
+    assert type(fab).__name__ == "FabricStore"
+    assert type(inst).__name__ == "InstinctStore"
+    assert str(tmp_path / "workspaces" / WS_A / "fabric.db") == fab._db_path
+    assert str(tmp_path / "workspaces" / WS_A / "instinct.db") == inst._db_path
+
+
+def test_provider_delegation_inherits_hostile_id_guard() -> None:
+    """The provider delegates to the OSS helper, so the allowlist still bites."""
+    from pocketpaw._registry import clear_cache, first
+
+    clear_cache()
+    provider = first("pocketpaw.stores")
+    with pytest.raises(ValueError):
+        provider.get_store("fabric", workspace_id="../../../tmp/pwn")
+
+
+def test_factory_routes_through_a_registered_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The FACTORY must actually consult a registered StoreProvider (AC#2).
+
+    The end-to-end proof that the ``pocketpaw.stores`` entry-point contract
+    works: register a provider, then assert ``get_fabric_store`` /
+    ``get_instinct_store`` return EXACTLY what that provider produced — not a
+    store the factory built itself. This is the seam a future per-tier backend
+    swap relies on, so it must be a real, tested contract, not just a dormant
+    hook. We inject a sentinel provider by patching the registry lookup the
+    factory uses (``pocketpaw.stores.first``).
+    """
+    sentinel_fabric = stores.FabricStore(":memory:")
+    sentinel_instinct = stores.InstinctStore(":memory:")
+
+    class _FakeProvider:
+        calls: list[tuple[str, str | None]] = []
+
+        def get_store(self, name: str, *, workspace_id: str | None = None):
+            self.calls.append((name, workspace_id))
+            if name == "fabric":
+                return sentinel_fabric
+            if name == "instinct":
+                return sentinel_instinct
+            return None
+
+    fake = _FakeProvider()
+    # The factory resolves the provider via ``first(_STORE_PROVIDER_GROUP)``;
+    # patch that name in the stores module so our fake is what it sees.
+    monkeypatch.setattr(stores, "first", lambda group: fake)
+    stores.reset_store_caches()
+
+    # A per-workspace fetch must return the PROVIDER'S store, proving the factory
+    # routed through the seam rather than constructing its own.
+    got_fab = stores.get_fabric_store(workspace_id=WS_A)
+    got_inst = stores.get_instinct_store(workspace_id=WS_A)
+    assert got_fab is sentinel_fabric
+    assert got_inst is sentinel_instinct
+    # And it asked the provider with the resolved workspace.
+    assert ("fabric", WS_A) in fake.calls
+    assert ("instinct", WS_A) in fake.calls
+
+
+@pytest.mark.asyncio
+async def test_contextvar_is_reset_when_the_run_body_raises(tmp_path: Path) -> None:
+    """HARD requirement (AC#1): a failed run must NOT leak a workspace.
+
+    The OSS ContextVar token rides the SAME identity-token tuple the existing
+    workspace/user tokens use and is reset in the SAME ``detach_agent_identity``
+    call — and both production seams (run_core, agent_bridge) run that detach in
+    a guaranteed ``finally``. This test pins that contract at the seam: simulate
+    a run that attaches identity, then throws, with detach in a finally — and
+    assert the OSS ``current_workspace`` is back to ``None`` afterwards, so the
+    next task on this loop can't inherit the failed run's workspace.
+    """
+    assert stores.current_workspace.get() is None
+
+    class _Boom(RuntimeError):
+        pass
+
+    with pytest.raises(_Boom):
+        tokens = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+        try:
+            assert stores.current_workspace.get() == WS_A  # bound during the run
+            raise _Boom("run blew up mid-flight")
+        finally:
+            detach_agent_identity(tokens)
+
+    # The exception propagated, but the workspace did NOT leak.
+    assert stores.current_workspace.get() is None
+    # A subsequent identity-less required-scope call therefore fails closed, not
+    # silently resolving to the dead run's WS_A.
+    import os
+
+    os.environ["POCKETPAW_REQUIRE_WORKSPACE_SCOPE"] = "1"
+    try:
+        with pytest.raises(stores.WorkspaceScopeRequired):
+            stores.get_fabric_store()
+    finally:
+        os.environ.pop("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", None)


### PR DESCRIPTION
Stacks on #1551 (which stacks on #1550). Merge order: #1550 → #1551 → this, each with `--rebase`.

## What this does

ISO-1 and ISO-2 gave Fabric and Instinct their own per-workspace files, resolved from an explicit workspace argument or the `current_workspace` ContextVar. The EE routers pass that argument. This handles the callers that do not: agent tools, MCP servers, and connector ingest, which call `get_fabric_store()` / `get_instinct_store()` with no argument.

It bridges the per-stream workspace onto the OSS ContextVar inside the existing `attach_agent_identity` / `detach_agent_identity` lifecycle (the token rides along as an extra tuple element, so no call site changes). A bare store call from an agent tool now resolves to the caller's workspace file, and detach resets the ContextVar on the same guaranteed path the identity tokens use, so a thrown run cannot leak a workspace into the next task on that loop.

It also activates the EE side of the `StoreProvider` seam: a `CloudStoreProvider` registered on the `pocketpaw.stores` entry-point, delegating to a public OSS helper so the path and allowlist guard stay in one place. The provider is behavior-neutral today (it returns the same per-workspace file store the OSS default builds); its value is proving the entry-point contract end to end, which is the hook for a future per-tier backend swap.

## Tests

- `tests/test_workspace_ctxvar_bridge.py` (9): an agent-path Fabric and Instinct write resolves to the caller's workspace file; fail-closed on a missing context under required-scope; the ContextVar resets when the run body raises; and the factory routes through a registered provider (first end-to-end proof of the entry-point).
- ISO-1/2/3 isolation + router suites: 241 passed; ruff clean; the OSS-cannot-import-EE import linter intact.

## Pre-existing failure (not from this work)

`tests/cloud/test_mission_control_project_filter.py::test_project_id_empty_string_filters_for_unassigned` is order-dependent: it fails run in isolation (asserts one `list_pockets` call, gets two) and passes inside a broader run. It fails on clean `origin/dev` too, previously as an arity `TypeError` that the ISO-2 store-signature change corrected, which revealed the underlying assertion. Outside the isolation scope; worth a separate ticket (same class as the paw-enterprise `localStorage` test-env red).