### PR TITLE
feat(stores): per-workspace migration + isolation lint guard + audit-lock fix

### DIFF
--- a/src/pocketpaw/_store_locks.py
+++ b/src/pocketpaw/_store_locks.py
@@ -1,0 +1,61 @@
+# src/pocketpaw/_store_locks.py
+# Created: 2026-06-26 (ISO-4 — audit-lock carry from the ISO-2 security review).
+#
+# Process-global registry of per-db-file asyncio locks, keyed by db_path. The
+# Instinct audit hash-chain is serialized by a lock held across the chain
+# read-head + insert in InstinctStore._log: without it, two concurrent _log
+# calls could both read the same prev_hash before either inserts, forking the
+# chain. Until ISO-4 that lock lived on the STORE INSTANCE (self._log_lock).
+#
+# The ISO-2 security review flagged the gap that motivates this module: under
+# the workspace-keyed factory's bounded LRU (ISO-1/2), a workspace's
+# InstinctStore can be EVICTED and a NEW instance built for the same file while
+# an async _log on the old instance is still in flight. Two instances for the
+# same db_path each held their OWN per-instance lock, so they did NOT mutually
+# exclude — re-opening the within-tenant chain-fork window the lock exists to
+# close. Keying the lock by db_path here (OUTSIDE any evictable store instance)
+# means every instance that targets the same file shares ONE lock, so eviction
+# can never split it. Different files (different tenants) still get different
+# locks and never contend — the property the old per-instance design wanted,
+# now without the eviction hole.
+
+from __future__ import annotations
+
+import asyncio
+
+# (db_path, running-loop id) -> the lock guarding that file's audit-chain
+# append. Module-global so it survives store eviction/recreation.
+#
+# Why the loop id is part of the key: an ``asyncio.Lock`` bound to one running
+# loop cannot be awaited under a different loop (it raises "bound to a different
+# event loop"). Production runs a single long-lived loop, so this degenerates to
+# "one lock per db file" — exactly what we want. The pytest-asyncio suite runs a
+# FRESH loop per test, so without the loop in the key a lock cached under test
+# A's loop would blow up in test B. Scoping by loop gives each loop its own lock
+# per file with zero introspection of private Lock internals, and never weakens
+# isolation: a brand-new loop has no in-flight appends from the old one to
+# serialize against, and within ANY single loop every instance for the same file
+# still shares one lock (the eviction-hole fix).
+_locks: dict[tuple[str, int], asyncio.Lock] = {}
+
+
+def audit_lock_for(db_path: str) -> asyncio.Lock:
+    """Return the process-global audit-append lock for ``db_path``.
+
+    All InstinctStore instances pointing at the same file (under the same event
+    loop) get the SAME lock, so a store evicted+rebuilt mid-append still
+    serializes against its replacement. Must be called with a running event
+    loop (it always is — it is invoked from inside an ``async`` append).
+    """
+    loop = asyncio.get_running_loop()
+    key = (db_path, id(loop))
+    lock = _locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _locks[key] = lock
+    return lock
+
+
+def reset_audit_locks() -> None:
+    """Drop every cached lock. For tests that need a clean registry."""
+    _locks.clear()

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,17 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-06-26 (ISO-4 — audit-lock keyed outside the evictable instance)
+#   — the audit-append lock (``_log_lock``, which serializes the chain
+#   read-head + insert in ``_log``) is no longer a per-instance
+#   ``asyncio.Lock`` set in ``__init__``. It is now a PROPERTY that fetches a
+#   process-global lock keyed by ``db_path`` from ``pocketpaw._store_locks``.
+#   The ISO-2 security review flagged the hole: under the ISO-1/2 bounded-LRU
+#   store factory, a workspace's store can be evicted and rebuilt for the same
+#   file while an append is in flight, so two instances with two per-instance
+#   locks let their appends race and fork the chain. A db_path-keyed lock makes
+#   every instance for the same file share ONE lock; different tenants (files)
+#   still never contend. The two ``async with self._log_lock`` call sites are
+#   unchanged — the property is transparent.
 # Updated: 2026-06-26 (ISO-2 — physical per-workspace isolation) — added
 #   aclose(): a best-effort WAL-checkpoint + state reset the workspace-keyed
 #   store factory (src/pocketpaw/stores.py) runs when it evicts a per-workspace
@@ -384,13 +396,29 @@ class InstinctStore:
     def __init__(self, db_path: str | Path) -> None:
         self._db_path = str(db_path)
         self._initialized = False
-        # Serializes the audit-chain read-head + insert in _log (REVIEW-1):
-        # each _log opens its own connection, so without this lock two
-        # concurrent _log calls could both read the same prev_hash before
-        # either inserts, forking the chain and producing false-positive
-        # tamper reports in verify_audit_chain. Per-instance (not module-level)
-        # so separate tenants/stores don't contend.
-        self._log_lock = asyncio.Lock()
+
+    @property
+    def _log_lock(self) -> asyncio.Lock:
+        """The lock serializing this file's audit-chain read-head + insert.
+
+        Held across the prev_hash read + the append in ``_log``: each ``_log``
+        opens its own connection, so without it two concurrent appends could
+        both read the same prev_hash before either inserts, forking the chain
+        and producing false-positive tamper reports in ``verify_audit_chain``.
+
+        ISO-4: the lock is now keyed by ``db_path`` in a PROCESS-GLOBAL registry
+        (``pocketpaw._store_locks``), not stored on this instance. The ISO-2
+        security review flagged that a per-instance lock does NOT cover the
+        bounded-LRU eviction window: when the store factory evicts a workspace's
+        InstinctStore and builds a fresh one for the same file, two instances
+        briefly coexist, and per-instance locks let their appends race and fork
+        that tenant's chain. A db_path-keyed lock makes every instance for the
+        same file share ONE lock, closing that window. Different tenants (files)
+        still get different locks and never contend.
+        """
+        from pocketpaw._store_locks import audit_lock_for
+
+        return audit_lock_for(self._db_path)
 
     async def _ensure_schema(self) -> None:
         if self._initialized:

--- a/src/pocketpaw/migrations/__init__.py
+++ b/src/pocketpaw/migrations/__init__.py
@@ -1,0 +1,2 @@
+# pocketpaw/migrations/__init__.py — Migration utilities for PocketPaw data stores.
+# Created: 2026-06-26 — Package init for one-time, idempotent data migrations.

--- a/src/pocketpaw/migrations/split_workspace_stores.py
+++ b/src/pocketpaw/migrations/split_workspace_stores.py
@@ -1,0 +1,583 @@
+# pocketpaw/migrations/split_workspace_stores.py — One-time migration that splits
+# the shared per-process SQLite stores (fabric.db, instinct.db) into per-workspace
+# files under ~/.pocketpaw/workspaces/<workspace_id>/<name>.db.
+#
+# Created: 2026-06-26 (ISO-4) — Companion to ISO-1/2/3 physical isolation work.
+#
+# Background
+# ----------
+# ISO-1 and ISO-2 introduced per-workspace physical isolation: new writes land in
+# ~/.pocketpaw/workspaces/<workspace_id>/fabric.db (or instinct.db). But existing
+# rows were written to the SHARED ~/.pocketpaw/fabric.db and instinct.db files.
+# This migration reads those shared files and copies each row into the correct
+# per-workspace file (grouping by the ``workspace_id`` column; NULL rows go to the
+# ``system_workspace`` bucket, default ``"system0"``).
+#
+# Why "system0" not "__system__": the path-traversal allowlist in
+# pocketpaw.stores._safe_workspace_dir requires the first character to be
+# alphanumeric ([A-Za-z0-9][A-Za-z0-9_-]*). A leading underscore is rejected
+# by that guard, so "__system__" is not a valid workspace dir name. "system0"
+# satisfies the allowlist and is unambiguous.
+#
+# Idempotency
+# -----------
+# We use a marker file: after a successful migration we rename each shared file to
+# <name>.db.migrated. Re-running detects the .migrated files and skips gracefully,
+# returning a summary with skipped=True. The original shared data is therefore
+# preserved (in .migrated form) for rollback; we NEVER delete it.
+#
+# Instinct audit re-chain (+ source-integrity gate)
+# --------------------------------------------------
+# The shared instinct_audit ledger has a GLOBAL hash chain whose prev_hash links
+# span all workspaces interleaved. After splitting into per-workspace files, each
+# workspace's chain must be RE-COMPUTED from genesis (prev_hash="") in rowid order
+# within that workspace, using the existing _canonical_audit_payload + compute_audit_hash
+# helpers. Non-audit tables are plain row copies.
+#
+# SECURITY GATE: re-chaining is only sound over AUTHENTIC rows, so BEFORE we
+# re-chain we ``verify_audit_chain`` on the SHARED instinct.db. If the source
+# chain is broken/tampered we ABORT (SourceChainTamperedError) — a clean
+# re-chain over tampered rows would launder them into fresh valid-looking
+# per-tenant chains, blessing exactly what tamper-evidence exists to catch.
+# ``force=True`` overrides (logs LOUD at WARNING). The source verdict is recorded
+# in the marker (see below) so the migration leaves an auditable attestation of
+# what it re-chained over. The verify is read-only and runs before the rename, so
+# an abort leaves the source intact.
+#
+# Safety contract
+# ---------------
+# * build_workspace_store() applies the path-traversal allowlist — no traversal possible.
+# * Source instinct chain is verified intact before any re-chain (abort on tamper unless force).
+# * No DELETE on source files — only rename to .migrated AFTER all rows land.
+# * Idempotent: a second call is a no-op (detects .migrated marker or .workspace_split_done).
+# * The marker is JSON recording the source-chain verdict + timestamp + force flag.
+# * Returns a structured summary dict: per-store row counts, skipped flag, source_chain verdict.
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from pocketpaw.instinct.store import (
+    InstinctStore,
+    _canonical_audit_payload,
+    compute_audit_hash,
+)
+from pocketpaw.stores import build_workspace_store
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DATA_DIR = Path.home() / ".pocketpaw"
+
+# Marker written in data_dir after a successful migration so a second run is a no-op.
+_MARKER_FILENAME = ".workspace_split_done"
+
+
+class SourceChainTamperedError(RuntimeError):
+    """Raised when the shared instinct.db audit chain is NOT intact at migration.
+
+    Re-chaining the per-workspace ledgers is only sound over authentic rows. If
+    the source global chain is broken/tampered, the migration aborts with this
+    rather than silently re-chain — a clean re-chain over tampered rows would
+    launder them into fresh valid-looking per-tenant chains, blessing exactly
+    what the tamper-evidence exists to catch. Pass ``force=True`` to override.
+    """
+
+
+async def _verify_source_instinct_chain(src: Path) -> dict[str, Any]:
+    """Run verify_audit_chain on the SHARED instinct.db before any re-chain.
+
+    Returns the verdict dict (intact / broken_at / hashed / …). Read-only — it
+    never mutates the source — so it is safe to call before the rename.
+    """
+    return await InstinctStore(str(src)).verify_audit_chain()
+
+
+def _write_marker(marker: Path, *, source_chain: dict[str, Any] | None, forced: bool) -> None:
+    """Write the idempotency marker, recording the source-chain attestation.
+
+    The marker doubles as an audit record of what the migration re-chained over:
+    the source ``verify_audit_chain`` verdict + a timestamp + whether the tamper
+    gate was force-overridden. ``source_chain`` is ``None`` when there was no
+    instinct.db to migrate (nothing was re-chained). Best-effort on the body —
+    if JSON serialization somehow fails we still create the marker (an empty
+    marker is enough for idempotency), so a write hiccup can't break re-run
+    safety.
+    """
+    payload: dict[str, Any] = {
+        "migrated_at": datetime.now(UTC).isoformat(),
+        "source_chain_verified": source_chain,
+        "forced": forced,
+    }
+    try:
+        marker.write_text(json.dumps(payload, indent=2))
+    except Exception:  # noqa: BLE001 — marker presence is what matters for idempotency
+        logger.warning("split_workspace_stores: could not write marker body", exc_info=True)
+        marker.touch()
+
+
+# Tables belonging to the Fabric store.
+_FABRIC_TABLES = ("fabric_object_types", "fabric_objects", "fabric_links")
+
+# Tables belonging to the Instinct store; the audit table is treated specially
+# (re-chain); all others are plain copies.
+_INSTINCT_NON_AUDIT_TABLES = (
+    "instinct_actions",
+    "instinct_corrections",
+    "instinct_fabric_snapshots",
+)
+_INSTINCT_AUDIT_TABLE = "instinct_audit"
+
+
+async def migrate_shared_stores_to_workspaces(
+    data_dir: Path | None = None,
+    *,
+    system_workspace: str = "system0",
+    force: bool = False,
+) -> dict[str, Any]:
+    """Split shared fabric.db and instinct.db into per-workspace files.
+
+    Parameters
+    ----------
+    data_dir:
+        Root of the PocketPaw data directory (where fabric.db and instinct.db
+        live). Defaults to ``~/.pocketpaw`` when ``None``.
+    system_workspace:
+        The workspace id to assign to rows whose ``workspace_id`` column is
+        NULL (pre-tenancy rows written before W4a). Defaults to ``"system0"``.
+        Must satisfy the path-traversal allowlist: start with [A-Za-z0-9],
+        followed only by [A-Za-z0-9_-]. Leading underscores (e.g. "__system__")
+        are rejected by the allowlist guard in pocketpaw.stores.
+    force:
+        Security override for the source-chain integrity gate. Re-chaining the
+        Instinct audit ledger per workspace is only safe over AUTHENTIC rows, so
+        before re-chaining we ``verify_audit_chain`` on the SHARED instinct.db.
+        If the source chain is BROKEN/tampered we ABORT
+        (:class:`SourceChainTamperedError`) rather than silently re-chain — a
+        clean re-chain over tampered rows would launder them into fresh
+        valid-looking per-tenant chains, blessing exactly what tamper-evidence
+        exists to catch. ``force=True`` overrides the abort, logs LOUD at
+        WARNING, and proceeds anyway (for a deliberate operator who has
+        inspected the breakage). The source-verify result is recorded in the
+        migration marker either way.
+
+    Returns
+    -------
+    dict with keys:
+        - ``skipped`` (bool) — True when already migrated (no-op run).
+        - ``fabric`` (dict) — per-workspace row counts migrated, keyed by table.
+        - ``instinct`` (dict) — same for the instinct store.
+
+    Raises
+    ------
+    ValueError
+        If a workspace_id read from the shared DB is unsafe (would fail
+        build_workspace_store's path-traversal allowlist). This is loud by
+        design: a hostile id in the source data must be flagged, not silently
+        dropped. The system_workspace arg is the escape hatch for NULL rows.
+    """
+    root = data_dir if data_dir is not None else _DEFAULT_DATA_DIR
+    marker = root / _MARKER_FILENAME
+
+    if marker.exists():
+        logger.info(
+            "split_workspace_stores: marker %s exists — skipping (already migrated)", marker
+        )
+        return {"skipped": True, "fabric": {}, "instinct": {}}
+
+    fabric_src = root / "fabric.db"
+    instinct_src = root / "instinct.db"
+
+    # Both migrated files may already exist from a partial run; treat the marker
+    # as the definitive idempotency signal so we always finish the rename pair.
+    fabric_already_done = (root / "fabric.db.migrated").exists()
+    instinct_already_done = (root / "instinct.db.migrated").exists()
+
+    fabric_summary: dict[str, dict[str, int]] = {}
+    instinct_summary: dict[str, dict[str, int]] = {}
+
+    if fabric_src.exists() and not fabric_already_done:
+        fabric_summary = await _migrate_fabric(fabric_src, root, system_workspace=system_workspace)
+        # Rename AFTER success; any exception before this line leaves the source intact.
+        fabric_src.rename(root / "fabric.db.migrated")
+        logger.info(
+            "split_workspace_stores: fabric migration done, source renamed to fabric.db.migrated"
+        )
+    else:
+        if not fabric_src.exists():
+            logger.info("split_workspace_stores: fabric.db not found — nothing to migrate")
+        else:
+            logger.info(
+                "split_workspace_stores: fabric.db.migrated already present — skipping fabric"
+            )
+
+    source_chain: dict[str, Any] | None = None
+    if instinct_src.exists() and not instinct_already_done:
+        # SECURITY GATE (captain hard requirement): re-chaining the audit ledger
+        # is only sound over AUTHENTIC rows. Verify the SHARED chain is intact
+        # BEFORE we re-chain; abort on tamper unless force-overridden — never
+        # launder a broken chain into fresh valid-looking per-tenant chains. This
+        # runs before the rename, so an abort leaves the source untouched.
+        source_chain = await _verify_source_instinct_chain(instinct_src)
+        if not source_chain["intact"]:
+            if not force:
+                raise SourceChainTamperedError(
+                    "split_workspace_stores: the shared instinct.db audit chain is "
+                    f"NOT intact (broken_at={source_chain.get('broken_at')!r}). "
+                    "Refusing to re-chain tampered history into per-workspace files. "
+                    "Inspect the breakage; pass force=True to override deliberately."
+                )
+            logger.warning(
+                "split_workspace_stores: source instinct.db audit chain is BROKEN "
+                "(broken_at=%r) — proceeding under force=True. The migrated "
+                "per-workspace chains will be freshly valid over POSSIBLY-TAMPERED "
+                "rows; this override has been recorded in the marker.",
+                source_chain.get("broken_at"),
+            )
+        instinct_summary = await _migrate_instinct(
+            instinct_src, root, system_workspace=system_workspace
+        )
+        instinct_src.rename(root / "instinct.db.migrated")
+        logger.info(
+            "split_workspace_stores: instinct migration done,"
+            " source renamed to instinct.db.migrated"
+        )
+    else:
+        if not instinct_src.exists():
+            logger.info("split_workspace_stores: instinct.db not found — nothing to migrate")
+        else:
+            logger.info(
+                "split_workspace_stores: instinct.db.migrated already present — skipping instinct"
+            )
+
+    # Write the marker so re-runs are instant no-ops. Record the source-chain
+    # verify result (the captain hard requirement) so the migration leaves an
+    # auditable attestation of what it re-chained over.
+    _write_marker(marker, source_chain=source_chain, forced=force)
+    logger.info("split_workspace_stores: marker written at %s", marker)
+
+    return {
+        "skipped": False,
+        "fabric": fabric_summary,
+        "instinct": instinct_summary,
+        "source_chain": source_chain,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fabric migration — plain row copy, no hash chain
+# ---------------------------------------------------------------------------
+
+
+async def _migrate_fabric(
+    src: Path,
+    root: Path,
+    *,
+    system_workspace: str,
+) -> dict[str, dict[str, int]]:
+    """Copy every fabric table row into the correct per-workspace file."""
+    summary: dict[str, dict[str, int]] = {t: {} for t in _FABRIC_TABLES}
+
+    async with aiosqlite.connect(str(src)) as db:
+        db.row_factory = aiosqlite.Row
+
+        for table in _FABRIC_TABLES:
+            # Check the table exists in the source DB (a very old DB may lack some).
+            async with db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ) as cur:
+                if await cur.fetchone() is None:
+                    logger.debug(
+                        "split_workspace_stores: table %s not found in fabric.db — skipping", table
+                    )
+                    continue
+
+            # Read all rows.
+            async with db.execute(f"SELECT * FROM {table} ORDER BY rowid ASC") as cur:  # noqa: S608
+                rows = await cur.fetchall()
+
+            # Group rows by effective workspace_id.
+            by_ws: dict[str, list[Any]] = {}
+            for row in rows:
+                ws = _effective_ws(row, system_workspace)
+                by_ws.setdefault(ws, []).append(row)
+
+            for ws_id, ws_rows in by_ws.items():
+                store = build_workspace_store("fabric", ws_id)
+                # Ensure schema exists in the target file before writing.
+                await store._ensure_schema()
+
+                dest_path = store._db_path
+                columns = [description[0] for description in (await _get_columns(db, table))]
+
+                async with aiosqlite.connect(dest_path) as dest:
+                    count = 0
+                    for row in ws_rows:
+                        row_dict = dict(zip(columns, [row[c] for c in columns], strict=False))
+                        # Stamp workspace_id where it was NULL.
+                        if "workspace_id" in row_dict and row_dict["workspace_id"] is None:
+                            row_dict["workspace_id"] = ws_id
+
+                        # Idempotent insert: skip if primary key already exists.
+                        pk = row_dict.get("id")
+                        if pk is not None:
+                            async with dest.execute(
+                                f"SELECT 1 FROM {table} WHERE id = ?",
+                                (pk,),  # noqa: S608
+                            ) as check:
+                                if await check.fetchone() is not None:
+                                    continue
+
+                        placeholders = ", ".join(["?"] * len(row_dict))
+                        col_names = ", ".join(row_dict.keys())
+                        await dest.execute(
+                            f"INSERT OR IGNORE INTO {table} ({col_names}) VALUES ({placeholders})",  # noqa: S608
+                            list(row_dict.values()),
+                        )
+                        count += 1
+                    await dest.commit()
+
+                summary[table][ws_id] = summary[table].get(ws_id, 0) + count
+                logger.debug(
+                    "split_workspace_stores: fabric/%s -> ws=%s count=%d", table, ws_id, count
+                )
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Instinct migration — plain row copy + audit re-chain
+# ---------------------------------------------------------------------------
+
+
+async def _migrate_instinct(
+    src: Path,
+    root: Path,
+    *,
+    system_workspace: str,
+) -> dict[str, dict[str, int]]:
+    """Copy every instinct table row into the correct per-workspace file.
+
+    Non-audit tables: plain row copy (grouped by workspace_id).
+    instinct_audit: re-chain each per-workspace file's rows from genesis (prev_hash="")
+    in original rowid order, using the canonical hash helpers from instinct.store.
+    """
+    summary: dict[str, dict[str, int]] = {}
+    for t in (*_INSTINCT_NON_AUDIT_TABLES, _INSTINCT_AUDIT_TABLE):
+        summary[t] = {}
+
+    async with aiosqlite.connect(str(src)) as db:
+        db.row_factory = aiosqlite.Row
+
+        # --- Non-audit tables: plain copy ---
+        for table in _INSTINCT_NON_AUDIT_TABLES:
+            async with db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ) as cur:
+                if await cur.fetchone() is None:
+                    logger.debug(
+                        "split_workspace_stores: table %s not found in instinct.db — skipping",
+                        table,
+                    )
+                    continue
+
+            async with db.execute(f"SELECT * FROM {table} ORDER BY rowid ASC") as cur:  # noqa: S608
+                rows = await cur.fetchall()
+
+            by_ws: dict[str, list[Any]] = {}
+            for row in rows:
+                ws = _effective_ws(row, system_workspace)
+                by_ws.setdefault(ws, []).append(row)
+
+            for ws_id, ws_rows in by_ws.items():
+                store = build_workspace_store("instinct", ws_id)
+                await store._ensure_schema()
+                dest_path = store._db_path
+                columns = [d[0] for d in (await _get_columns(db, table))]
+
+                async with aiosqlite.connect(dest_path) as dest:
+                    count = 0
+                    for row in ws_rows:
+                        row_dict = dict(zip(columns, [row[c] for c in columns], strict=False))
+                        if "workspace_id" in row_dict and row_dict["workspace_id"] is None:
+                            row_dict["workspace_id"] = ws_id
+
+                        pk = row_dict.get("id")
+                        if pk is not None:
+                            async with dest.execute(
+                                f"SELECT 1 FROM {table} WHERE id = ?",
+                                (pk,),  # noqa: S608
+                            ) as check:
+                                if await check.fetchone() is not None:
+                                    continue
+
+                        placeholders = ", ".join(["?"] * len(row_dict))
+                        col_names = ", ".join(row_dict.keys())
+                        await dest.execute(
+                            f"INSERT OR IGNORE INTO {table} ({col_names}) VALUES ({placeholders})",  # noqa: S608
+                            list(row_dict.values()),
+                        )
+                        count += 1
+                    await dest.commit()
+
+                summary[table][ws_id] = summary[table].get(ws_id, 0) + count
+
+        # --- Audit table: read all rows, group by ws, re-chain per-ws ---
+        table = _INSTINCT_AUDIT_TABLE
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ) as cur:
+            if await cur.fetchone() is None:
+                logger.debug(
+                    "split_workspace_stores: instinct_audit not found in instinct.db — skipping"
+                )
+                return summary
+
+        # Read ALL audit rows in original insertion order (rowid ASC).
+        # We need EVERY column including prev_hash/entry_hash from the source,
+        # because we'll DISCARD them and recompute per-workspace chain links.
+        async with db.execute(
+            "SELECT rowid, id, action_id, pocket_id, timestamp, actor, event,"
+            " category, description, context, ai_recommendation, outcome,"
+            " prev_hash, entry_hash, workspace_id"
+            " FROM instinct_audit ORDER BY rowid ASC"
+        ) as cur:
+            audit_rows = await cur.fetchall()
+
+        # Group by effective workspace, PRESERVING original rowid order within each group.
+        by_ws_audit: dict[str, list[Any]] = {}
+        for row in audit_rows:
+            ws = _effective_ws(row, system_workspace)
+            by_ws_audit.setdefault(ws, []).append(row)
+
+        import json as _json
+
+        for ws_id, ws_audit_rows in by_ws_audit.items():
+            store = build_workspace_store("instinct", ws_id)
+            await store._ensure_schema()
+            dest_path = store._db_path
+
+            async with aiosqlite.connect(dest_path) as dest:
+                # Check which row ids are already present (idempotent).
+                async with dest.execute("SELECT id FROM instinct_audit") as existing_cur:
+                    existing_ids = {r[0] async for r in existing_cur}
+
+                # Separate new rows from already-migrated ones.
+                new_rows = [r for r in ws_audit_rows if r["id"] not in existing_ids]
+
+                if not new_rows:
+                    summary[table][ws_id] = 0
+                    continue
+
+                # RE-CHAIN: find the current chain head in the destination file
+                # (there may be pre-existing hashed rows if schema was already
+                # bootstrapped with audit entries). Start prev_hash from the
+                # current chain head so we extend it correctly.
+                async with dest.execute(
+                    "SELECT entry_hash FROM instinct_audit"
+                    " WHERE entry_hash IS NOT NULL ORDER BY rowid DESC LIMIT 1"
+                ) as head_cur:
+                    head_row = await head_cur.fetchone()
+                running_prev = head_row[0] if head_row else ""
+
+                count = 0
+                for row in new_rows:
+                    import json
+
+                    context_raw = row["context"]
+                    try:
+                        context_obj = json.loads(context_raw) if context_raw else {}
+                    except (json.JSONDecodeError, ValueError):
+                        context_obj = {}
+
+                    timestamp = row["timestamp"] or ""
+                    ws_col = ws_id  # stamp the resolved workspace
+
+                    # Only re-chain rows that originally had an entry_hash (hashed rows).
+                    # Legacy NULL-hash rows stay un-chained (NULL prev_hash, NULL entry_hash).
+                    if row["entry_hash"] is not None:
+                        canonical = _canonical_audit_payload(
+                            id=row["id"],
+                            action_id=row["action_id"],
+                            pocket_id=row["pocket_id"],
+                            timestamp=timestamp,
+                            actor=row["actor"],
+                            event=row["event"],
+                            category=row["category"],
+                            description=row["description"],
+                            context=context_obj,
+                            ai_recommendation=row["ai_recommendation"],
+                            outcome=row["outcome"],
+                        )
+                        new_entry_hash = compute_audit_hash(canonical, running_prev)
+                        new_prev_hash = running_prev
+                        running_prev = new_entry_hash
+                    else:
+                        # Legacy un-hashed row: preserve NULL hashes.
+                        new_prev_hash = None
+                        new_entry_hash = None
+
+                    context_json = _json.dumps(context_obj) if not context_raw else context_raw
+
+                    await dest.execute(
+                        "INSERT OR IGNORE INTO instinct_audit"
+                        " (id, action_id, pocket_id, timestamp, actor, event,"
+                        " category, description, context, ai_recommendation,"
+                        " outcome, prev_hash, entry_hash, workspace_id)"
+                        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            row["id"],
+                            row["action_id"],
+                            row["pocket_id"],
+                            timestamp,
+                            row["actor"],
+                            row["event"],
+                            row["category"] or "decision",
+                            row["description"],
+                            context_json,
+                            row["ai_recommendation"],
+                            row["outcome"],
+                            new_prev_hash,
+                            new_entry_hash,
+                            ws_col,
+                        ),
+                    )
+                    count += 1
+
+                await dest.commit()
+
+            summary[table][ws_id] = count
+            logger.debug(
+                "split_workspace_stores: instinct_audit -> ws=%s count=%d (re-chained)",
+                ws_id,
+                count,
+            )
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _effective_ws(row: Any, system_workspace: str) -> str:
+    """Return the effective workspace id for a row, substituting NULL with system_workspace."""
+    try:
+        ws = row["workspace_id"]
+    except (IndexError, KeyError):
+        ws = None
+    return ws if (ws is not None and ws != "") else system_workspace
+
+
+async def _get_columns(db: aiosqlite.Connection, table: str) -> list[tuple[str, ...]]:
+    """Return column descriptions for a table via PRAGMA table_info."""
+    async with db.execute(f"PRAGMA table_info({table})") as cur:  # noqa: S608
+        infos = await cur.fetchall()
+    # PRAGMA table_info columns: cid, name, type, notnull, dflt_value, pk
+    return [(info[1],) for info in infos]

--- a/tests/test_audit_lock_survives_eviction.py
+++ b/tests/test_audit_lock_survives_eviction.py
@@ -1,0 +1,145 @@
+# tests/test_audit_lock_survives_eviction.py
+# Created: 2026-06-26 (ISO-4 — audit-lock keyed outside the evictable store instance).
+#
+# Proves the ISO-4 fix for the chain-fork window the ISO-2 security review
+# flagged: the Instinct audit-append lock is keyed by db_path in a process-global
+# registry (pocketpaw._store_locks), NOT stored on the evictable store instance.
+# So when the bounded-LRU store factory evicts a workspace's InstinctStore and
+# builds a fresh one for the same file, BOTH instances share ONE lock and their
+# concurrent appends still serialize — the chain cannot fork.
+#
+# Covers:
+#   * two InstinctStore instances for the same file share the same lock object;
+#   * different files get different locks (tenants never contend);
+#   * the lock survives a real factory eviction (cap-1 LRU): a store fetched,
+#     evicted, and re-fetched yields a handle whose lock matches the original's;
+#   * end-to-end: interleaved appends across an eviction boundary keep the chain
+#     intact (verify_audit_chain stays intact=True, no fork).
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import pocketpaw.stores as stores
+from pocketpaw._store_locks import audit_lock_for, reset_audit_locks
+from pocketpaw.instinct.models import ActionTrigger
+from pocketpaw.instinct.store import InstinctStore
+
+WS = "ws-lock"
+
+
+def _trig() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="iso-4 lock test")
+
+
+async def _drain_pending_tasks() -> None:
+    """Run fire-and-forget eviction tasks (aclose) to completion before the test
+    loop closes, so the aiosqlite worker doesn't race teardown."""
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    reset_audit_locks()
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+        reset_audit_locks()
+
+
+@pytest.mark.asyncio
+async def test_same_file_two_instances_share_one_lock(tmp_path: Path) -> None:
+    db = str(tmp_path / "instinct.db")
+    a = InstinctStore(db)
+    b = InstinctStore(db)
+    # Distinct instances, SAME lock — the eviction-hole fix.
+    assert a is not b
+    assert a._log_lock is b._log_lock
+    # And it's the registry's lock for that path.
+    assert a._log_lock is audit_lock_for(db)
+
+
+@pytest.mark.asyncio
+async def test_different_files_get_different_locks(tmp_path: Path) -> None:
+    a = InstinctStore(str(tmp_path / "a.db"))
+    b = InstinctStore(str(tmp_path / "b.db"))
+    assert a._log_lock is not b._log_lock  # tenants never contend
+
+
+@pytest.mark.asyncio
+async def test_lock_survives_a_real_factory_eviction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Evict a workspace's store via the cap-1 LRU; the rebuilt one keeps the lock."""
+    monkeypatch.setattr(stores, "_WORKSPACE_STORE_CACHE_CAP", 1)
+    stores.reset_store_caches()
+
+    first = stores.get_instinct_store(workspace_id=WS)
+    lock_before = first._log_lock
+
+    # A second distinct workspace evicts WS (cap is 1).
+    stores.get_instinct_store(workspace_id="ws-other")
+
+    # Re-fetch WS → a NEW instance (it was evicted), but the SAME db file.
+    rebuilt = stores.get_instinct_store(workspace_id=WS)
+    assert rebuilt is not first  # genuinely evicted + rebuilt
+    assert rebuilt._db_path == first._db_path
+    # The audit lock is the SAME object across the eviction boundary — proof the
+    # fork window is closed: an in-flight append on `first` and a new append on
+    # `rebuilt` would contend on one lock.
+    assert rebuilt._log_lock is lock_before
+    await _drain_pending_tasks()
+
+
+@pytest.mark.asyncio
+async def test_chain_stays_intact_across_eviction_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Concurrent appends straddling an eviction keep the chain intact (no fork)."""
+    monkeypatch.setattr(stores, "_WORKSPACE_STORE_CACHE_CAP", 1)
+    stores.reset_store_caches()
+
+    first = stores.get_instinct_store(workspace_id=WS)
+    # Seed one action on the original instance.
+    a0 = await first.propose("p", "a0", "", "", _trig())
+    await first.approve(a0.id)
+
+    # Evict WS, then re-fetch a fresh instance for the same file.
+    stores.get_instinct_store(workspace_id="ws-other")
+    rebuilt = stores.get_instinct_store(workspace_id=WS)
+    assert rebuilt is not first
+
+    # Fire concurrent appends from BOTH the stale and the rebuilt instance at the
+    # same file. With a per-instance lock these could interleave their prev_hash
+    # reads and fork; with the db_path-keyed lock they serialize.
+    async def append(store: InstinctStore, n: int) -> None:
+        act = await store.propose("p", f"t{n}", "", "", _trig())
+        await store.approve(act.id)
+
+    await asyncio.gather(
+        append(first, 1),
+        append(rebuilt, 2),
+        append(first, 3),
+        append(rebuilt, 4),
+    )
+
+    verdict = await rebuilt.verify_audit_chain()
+    assert verdict["intact"] is True, verdict
+    assert verdict["broken_at"] is None
+    assert verdict["hashed"] == verdict["checked"]
+    assert verdict["hashed"] > 0
+    await _drain_pending_tasks()

--- a/tests/test_store_isolation_lint.py
+++ b/tests/test_store_isolation_lint.py
@@ -1,0 +1,306 @@
+# tests/test_store_isolation_lint.py
+# Created: 2026-06-26 (ISO-4 — store-isolation lint guard)
+#
+# AST-based regression guard: ensures no code in src/pocketpaw/ or
+# ee/pocketpaw_ee/ directly constructs FabricStore(...) or
+# InstinctStore(...) outside the approved factory seam.
+#
+# WORKSPACE RULE: all store access MUST go through the factories in
+# pocketpaw.stores — get_fabric_store() and get_instinct_store(). Direct
+# construction bypasses workspace resolution, the fail-closed scope check,
+# the bounded LRU cache, and the StoreProvider seam, silently re-opening a
+# shared store that breaks per-tenant physical isolation (ISO-1 / ISO-2).
+#
+# CHECKS IMPLEMENTED:
+#   (a) Direct construction guard — ACTIVE.
+#       Flags any ast.Call whose func is a Name or Attribute with id/attr
+#       equal to "FabricStore" or "InstinctStore". This is the load-bearing
+#       guard. The current factory in stores.py uses kind.cls(path) — an
+#       Attribute on a dataclass field — which the AST represents as
+#       Attribute(value=Name(id='kind'), attr='cls'), NOT as a Name/Attribute
+#       ending in FabricStore/InstinctStore. So the factory is correctly
+#       transparent to the guard without needing an allowlist exception.
+#
+#   (b) Bare get_fabric_store() / get_instinct_store() call without
+#       workspace_id keyword — DROPPED.
+#       The OSS agent-tool path legitimately calls these bare and relies on
+#       the current_workspace ContextVar (ISO-3). Distinguishing that
+#       legitimate bare call from a bug requires cross-module dataflow
+#       analysis that an AST-only pass cannot reliably do. The
+#       fail-closed POCKETPAW_REQUIRE_WORKSPACE_SCOPE env flag provides
+#       the runtime guard for the cloud path; check (b) would produce
+#       too many false positives to be useful as a CI gate.
+#
+# ALLOWLIST (construction guard):
+#   Two files are excluded, each for a precise reason; everything else is
+#   protected (a direct FabricStore(...)/InstinctStore(...) anywhere else fails
+#   the guard and points the dev at the factory).
+#     - the factory implementation (stores.py) — the legitimate construction site.
+#     - the ISO-4 migration — its WRITES go through build_workspace_store (the
+#       approved seam), but it must also READ the SHARED {fabric,instinct}.db and
+#       verify the source audit chain before re-chaining, and the shared file is
+#       NOT a workspace path, so no factory call can open it. Direct construction
+#       on the shared path is legitimate there and only there.
+#
+#   ALLOWLIST_PATHS (relative to the worktree root):
+#     src/pocketpaw/stores.py
+#         The factory module — the ONLY place direct construction is a
+#         legitimate implementation choice (today the factory uses kind.cls
+#         indirection, not a bare Name call, so it would not be flagged anyway;
+#         the exemption future-proofs an explicit refactor).
+#     src/pocketpaw/migrations/split_workspace_stores.py
+#         The shared->per-workspace migration — must construct a store on the
+#         SHARED db path (not a workspace path) to read it + verify its audit
+#         chain, which no factory call can do.
+#
+# NO pytest-asyncio needed — pure synchronous AST walk.
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+_SOURCE_ROOTS = [
+    _REPO_ROOT / "src" / "pocketpaw",
+    _REPO_ROOT / "ee" / "pocketpaw_ee",
+]
+
+# Relative-to-repo-root paths that are ALLOWED to contain direct FabricStore /
+# InstinctStore construction calls.
+_ALLOWLIST_REL: frozenset[str] = frozenset(
+    [
+        # The factory module IS the legitimate construction site (the _StoreKind
+        # registry + _build_local_workspace_store).
+        "src/pocketpaw/stores.py",
+        # The ISO-4 migration is the one place that bridges the SHARED stores to
+        # the per-workspace ones. Its WRITES go through build_workspace_store (the
+        # approved seam), but it must also READ the shared ~/.pocketpaw/{fabric,
+        # instinct}.db files + verify the source audit chain before re-chaining —
+        # and the shared file is, by definition, NOT a workspace path, so NO
+        # factory call can open it. Constructing the store on the shared path
+        # directly is therefore legitimate HERE and only here. Exempted with that
+        # narrow justification; the guard still protects every other module.
+        "src/pocketpaw/migrations/split_workspace_stores.py",
+    ]
+)
+
+# Store class names whose direct construction is forbidden outside the allowlist.
+_FORBIDDEN_NAMES: frozenset[str] = frozenset(["FabricStore", "InstinctStore"])
+
+# ---------------------------------------------------------------------------
+# Core checker (reusable — called by both the real-tree test and the self-test)
+# ---------------------------------------------------------------------------
+
+
+def find_store_construction_violations(
+    tree: ast.AST,
+    filename: str,
+    allowlist: frozenset[str],
+) -> list[str]:
+    """Walk ``tree`` and return a list of violation strings.
+
+    A violation is any ``ast.Call`` whose ``func`` is:
+      * an ``ast.Name`` with ``id`` in _FORBIDDEN_NAMES, OR
+      * an ``ast.Attribute`` with ``attr`` in _FORBIDDEN_NAMES.
+
+    Each string in the returned list is formatted as::
+
+        path/to/file.py:LINE — FabricStore() called directly; use get_fabric_store()
+
+    ``filename`` is the string used in the violation message (and matched
+    against ``allowlist``).  ``allowlist`` is a frozenset of filenames /
+    relative paths to skip.
+    """
+    if filename in allowlist:
+        return []
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name: str | None = None
+        if isinstance(func, ast.Name):
+            name = func.id
+        elif isinstance(func, ast.Attribute):
+            name = func.attr
+        if name in _FORBIDDEN_NAMES:
+            violations.append(
+                f"{filename}:{node.lineno} — {name}() called directly; "
+                f"use get_{name[0].lower() + name[1:]}() from pocketpaw.stores"
+            )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_source_files() -> list[pathlib.Path]:
+    """Return all .py files under the source roots, excluding noise."""
+    files: list[pathlib.Path] = []
+    for root in _SOURCE_ROOTS:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            parts = path.parts
+            # Skip bytecode cache and virtual environments.
+            if any(segment in ("__pycache__", ".venv") for segment in parts):
+                continue
+            files.append(path)
+    return files
+
+
+def _rel(path: pathlib.Path) -> str:
+    """Return a repo-root-relative POSIX string for ``path``."""
+    try:
+        return path.relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Real-tree scan test
+# ---------------------------------------------------------------------------
+
+
+def test_no_direct_store_construction_in_source() -> None:
+    """Fail if any source file directly constructs FabricStore or InstinctStore.
+
+    Scans src/pocketpaw/ and ee/pocketpaw_ee/ via the Python AST.  The
+    allowlisted files (the factory implementation + the ISO-4 migration) are
+    exempted.  The test reports every violation with file and line number so
+    a developer knows exactly where to fix the regression.
+    """
+    source_files = _iter_source_files()
+    assert source_files, (
+        "No source files found under the expected roots — "
+        "check that _SOURCE_ROOTS point to the right directories."
+    )
+
+    all_violations: list[str] = []
+    parse_errors: list[str] = []
+
+    for path in source_files:
+        rel = _rel(path)
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError as exc:
+            parse_errors.append(f"{rel}: {exc}")
+            continue
+
+        violations = find_store_construction_violations(tree, rel, _ALLOWLIST_REL)
+        all_violations.extend(violations)
+
+    if parse_errors:
+        pytest.fail(
+            "Syntax errors prevented full scan — fix these files first:\n"
+            + "\n".join(f"  {e}" for e in parse_errors)
+        )
+
+    if all_violations:
+        lines = "\n".join(f"  {v}" for v in all_violations)
+        pytest.fail(
+            f"Store isolation violation(s) detected ({len(all_violations)} total).\n"
+            "Direct FabricStore/InstinctStore construction bypasses the factory,\n"
+            "workspace resolution, the fail-closed scope check, and the LRU cache.\n"
+            "Use get_fabric_store() / get_instinct_store() from pocketpaw.stores.\n"
+            f"\nViolations:\n{lines}\n"
+            f"\nAllowlisted paths (exempt from this check):\n"
+            + "\n".join(f"  {p}" for p in sorted(_ALLOWLIST_REL))
+        )
+
+
+# ---------------------------------------------------------------------------
+# Self-test — planted violation must be caught
+# ---------------------------------------------------------------------------
+
+
+def test_checker_catches_planted_violation() -> None:
+    """Self-test: the checker must flag a synthetic FabricStore() construction.
+
+    Feeds a small snippet of code containing a forbidden direct construction
+    call (parsed in-memory) to find_store_construction_violations and asserts
+    at least one violation is returned.  This proves the guard is not vacuously
+    passing — it actually detects the pattern it is supposed to catch.
+    """
+    snippet = """
+from pocketpaw.fabric.store import FabricStore
+
+def bad_function(db_path):
+    # BUG: direct construction bypasses the factory
+    store = FabricStore(db_path)
+    return store
+"""
+    tree = ast.parse(snippet)
+    violations = find_store_construction_violations(
+        tree,
+        filename="hypothetical/bad_module.py",
+        allowlist=frozenset(),  # no exemptions — violation must be reported
+    )
+    assert violations, (
+        "Self-test FAILED: find_store_construction_violations did not catch a "
+        "planted FabricStore() direct-construction call.  The guard is broken."
+    )
+    # Confirm the violation message mentions the right class and line.
+    assert any("FabricStore" in v for v in violations), (
+        f"Expected 'FabricStore' in violation messages, got: {violations}"
+    )
+
+
+def test_checker_catches_planted_instinct_violation() -> None:
+    """Self-test: the checker must flag a synthetic InstinctStore() construction.
+
+    Same pattern as the FabricStore self-test but for InstinctStore, ensuring
+    both forbidden names are live in the guard.
+    """
+    snippet = """
+from pocketpaw.instinct.store import InstinctStore
+
+class BadService:
+    def __init__(self, path):
+        # BUG: should call get_instinct_store() instead
+        self.store = InstinctStore(path)
+"""
+    tree = ast.parse(snippet)
+    violations = find_store_construction_violations(
+        tree,
+        filename="hypothetical/bad_service.py",
+        allowlist=frozenset(),
+    )
+    assert violations, (
+        "Self-test FAILED: find_store_construction_violations did not catch a "
+        "planted InstinctStore() direct-construction call.  The guard is broken."
+    )
+    assert any("InstinctStore" in v for v in violations), (
+        f"Expected 'InstinctStore' in violation messages, got: {violations}"
+    )
+
+
+def test_allowlisted_file_is_not_flagged() -> None:
+    """Self-test: files in the allowlist must not produce violations.
+
+    Feeds the same forbidden snippet but uses 'src/pocketpaw/stores.py'
+    as the filename, which IS in the allowlist.  Confirms exemptions work
+    correctly and the factory file can legitimately contain construction calls.
+    """
+    snippet = """
+from pocketpaw.fabric.store import FabricStore
+store = FabricStore('/some/path/fabric.db')
+"""
+    tree = ast.parse(snippet)
+    violations = find_store_construction_violations(
+        tree,
+        filename="src/pocketpaw/stores.py",
+        allowlist=_ALLOWLIST_REL,
+    )
+    assert not violations, f"Allowlisted file should not produce violations, but got: {violations}"

--- a/tests/test_workspace_store_migration.py
+++ b/tests/test_workspace_store_migration.py
@@ -1,0 +1,482 @@
+# tests/test_workspace_store_migration.py
+# Created: 2026-06-26 (ISO-4) — Tests for the one-time shared-store split migration.
+#
+# Verifies migrate_shared_stores_to_workspaces():
+#   - seeds a SHARED fabric.db + instinct.db with rows across two workspaces
+#     (ws-a, ws-b) plus NULL-workspace rows;
+#   - runs the migration and asserts per-workspace files exist on disk;
+#   - row counts match (sum across workspaces == shared total; no rows lost);
+#   - NULL-workspace rows land in system0 (the default system_workspace);
+#   - a query inside ws-a's fabric store returns only ws-a objects;
+#   - InstinctStore(<per-ws-file>).verify_audit_chain() is intact=True AND hashed>0
+#     for each workspace (re-chain worked);
+#   - shared source files were NOT destroyed (renamed to .migrated);
+#   - re-running the migration is a strict no-op (skipped=True; counts show 0 new rows);
+#   - SOURCE-CHAIN GATE (captain hard requirement): a clean source records an
+#     intact verdict in the marker; a TAMPERED source ABORTS with the source
+#     left untouched (no laundering); force=True overrides + records the override.
+#
+# Mirrors the style of tests/test_instinct_workspace_isolation.py.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pocketpaw.stores as stores
+from pocketpaw.fabric.store import FabricStore
+from pocketpaw.instinct.models import ActionTrigger
+from pocketpaw.instinct.store import InstinctStore
+from pocketpaw.migrations.split_workspace_stores import (
+    SourceChainTamperedError,
+    migrate_shared_stores_to_workspaces,
+)
+
+WS_A = "wsa"
+WS_B = "wsb"
+# "system0" — must start with [A-Za-z0-9] to pass the path-traversal allowlist;
+# "__system__" (leading underscore) is rejected by _safe_workspace_dir.
+WS_SYS = "system0"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="test", reason="migration test")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the store factory at tmp_path; reset caches + env between tests."""
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+async def _seed_shared_fabric(data_dir: Path) -> dict[str, Any]:
+    """Create the shared fabric.db and seed rows across ws-a, ws-b, and NULL workspace.
+
+    Returns the row counts so tests can assert total-preservation.
+    """
+    shared_path = data_dir / "fabric.db"
+    store = FabricStore(shared_path)
+
+    # Define a type (global / NULL workspace)
+    obj_type = await store.define_type(
+        "TestWidget",
+        properties=[],
+        workspace_id=None,
+    )
+
+    # ws-a objects
+    await store.create_object(obj_type.id, {"name": "a1"}, workspace_id=WS_A)
+    await store.create_object(obj_type.id, {"name": "a2"}, workspace_id=WS_A)
+    # ws-b objects
+    await store.create_object(obj_type.id, {"name": "b1"}, workspace_id=WS_B)
+    # NULL-workspace object (pre-tenancy)
+    await store.create_object(obj_type.id, {"name": "null1"}, workspace_id=None)
+
+    # A link between ws-a objects
+    result_a = await store.query(
+        __import__("pocketpaw.fabric.models", fromlist=["FabricQuery"]).FabricQuery(
+            type_name="TestWidget"
+        ),
+        workspace_id=WS_A,
+    )
+    if len(result_a.objects) >= 2:
+        await store.link(
+            result_a.objects[0].id,
+            result_a.objects[1].id,
+            "related",
+            workspace_id=WS_A,
+        )
+
+    return {
+        "objects": {"wsa": 2, "wsb": 1, "null": 1},
+        "type_id": obj_type.id,
+    }
+
+
+async def _seed_shared_instinct(data_dir: Path) -> dict[str, Any]:
+    """Create the shared instinct.db and seed actions + audit rows across ws-a, ws-b, NULL.
+
+    Returns metadata (action ids, audit row expectations).
+    """
+    shared_path = data_dir / "instinct.db"
+    store = InstinctStore(shared_path)
+    trigger = _make_trigger()
+
+    action_ids: dict[str, list[str]] = {WS_A: [], WS_B: [], WS_SYS: []}
+
+    # ws-a: 2 actions, approve them (2 audit rows each → 4 hashed rows)
+    for i in range(2):
+        act = await store.propose(
+            pocket_id="pocket-a",
+            title=f"A-action-{i}",
+            description="",
+            recommendation="",
+            trigger=trigger,
+            workspace_id=WS_A,
+        )
+        await store.approve(act.id, approver="user")
+        action_ids[WS_A].append(act.id)
+
+    # ws-b: 2 actions, approve them
+    for i in range(2):
+        act = await store.propose(
+            pocket_id="pocket-b",
+            title=f"B-action-{i}",
+            description="",
+            recommendation="",
+            trigger=trigger,
+            workspace_id=WS_B,
+        )
+        await store.approve(act.id, approver="user")
+        action_ids[WS_B].append(act.id)
+
+    # NULL-workspace: 1 action (pre-tenancy)
+    null_act = await store.propose(
+        pocket_id="pocket-sys",
+        title="Sys-action",
+        description="",
+        recommendation="",
+        trigger=trigger,
+        workspace_id=None,
+    )
+    action_ids[WS_SYS].append(null_act.id)
+
+    return {"action_ids": action_ids}
+
+
+# ---------------------------------------------------------------------------
+# Core migration test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_per_workspace_files(tmp_path: Path) -> None:
+    """After migration, per-workspace db files exist for every workspace found."""
+    await _seed_shared_fabric(tmp_path)
+    await _seed_shared_instinct(tmp_path)
+
+    result = await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    assert result["skipped"] is False
+
+    # Fabric per-workspace files
+    for ws in (WS_A, WS_B, WS_SYS):
+        assert (tmp_path / "workspaces" / ws / "fabric.db").exists(), f"expected fabric.db for {ws}"
+        assert (tmp_path / "workspaces" / ws / "instinct.db").exists(), (
+            f"expected instinct.db for {ws}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_migration_preserves_shared_files_as_migrated(tmp_path: Path) -> None:
+    """Source files must NOT be destroyed — they are renamed to .migrated."""
+    await _seed_shared_fabric(tmp_path)
+    await _seed_shared_instinct(tmp_path)
+
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    assert (tmp_path / "fabric.db.migrated").exists(), (
+        "shared fabric.db should be renamed not deleted"
+    )
+    assert (tmp_path / "instinct.db.migrated").exists(), (
+        "shared instinct.db should be renamed not deleted"
+    )
+    assert not (tmp_path / "fabric.db").exists(), "original fabric.db should be gone (renamed)"
+    assert not (tmp_path / "instinct.db").exists(), "original instinct.db should be gone (renamed)"
+
+
+@pytest.mark.asyncio
+async def test_fabric_null_rows_land_in_system_workspace(tmp_path: Path) -> None:
+    """NULL-workspace fabric objects must end up in the __system__ workspace."""
+    await _seed_shared_fabric(tmp_path)
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path, system_workspace=WS_SYS)
+
+    sys_store = FabricStore(tmp_path / "workspaces" / WS_SYS / "fabric.db")
+
+    from pocketpaw.fabric.models import FabricQuery
+
+    # Unscoped query in the __system__ file — should contain the null-workspace object
+    result = await sys_store.query(FabricQuery(type_name="TestWidget"))
+    names = {obj.properties.get("name") for obj in result.objects}
+    assert "null1" in names, f"null-workspace object 'null1' not found in __system__; got {names}"
+
+
+@pytest.mark.asyncio
+async def test_fabric_workspace_isolation_after_migration(tmp_path: Path) -> None:
+    """ws-a's per-workspace store must only contain ws-a objects (not ws-b's)."""
+    await _seed_shared_fabric(tmp_path)
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    from pocketpaw.fabric.models import FabricQuery
+
+    store_a = FabricStore(tmp_path / "workspaces" / WS_A / "fabric.db")
+    result = await store_a.query(FabricQuery(type_name="TestWidget"))
+    names = {obj.properties.get("name") for obj in result.objects}
+
+    assert "a1" in names, "ws-a object 'a1' missing"
+    assert "a2" in names, "ws-a object 'a2' missing"
+    assert "b1" not in names, "ws-b object 'b1' must not appear in ws-a's store"
+    assert "null1" not in names, "null-ws object must not appear in ws-a's store"
+
+
+@pytest.mark.asyncio
+async def test_fabric_row_count_preserved(tmp_path: Path) -> None:
+    """Total objects across all per-workspace files must equal the shared total."""
+    import aiosqlite
+
+    await _seed_shared_fabric(tmp_path)
+    shared_path = tmp_path / "fabric.db"
+
+    # Count source rows before migration renames it.
+    async with aiosqlite.connect(str(shared_path)) as db:
+        async with db.execute("SELECT COUNT(*) FROM fabric_objects") as cur:
+            row = await cur.fetchone()
+            shared_count = row[0] if row else 0
+
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    # Sum across per-workspace files.
+    total = 0
+    ws_root = tmp_path / "workspaces"
+    for ws_dir in ws_root.iterdir():
+        ws_db = ws_dir / "fabric.db"
+        if ws_db.exists():
+            async with aiosqlite.connect(str(ws_db)) as db:
+                async with db.execute("SELECT COUNT(*) FROM fabric_objects") as cur:
+                    row = await cur.fetchone()
+                    total += row[0] if row else 0
+
+    assert total == shared_count, (
+        f"Row count mismatch: shared had {shared_count} fabric_objects, "
+        f"per-workspace total = {total}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Instinct audit re-chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_instinct_audit_chain_intact_per_workspace_after_migration(
+    tmp_path: Path,
+) -> None:
+    """verify_audit_chain() must return intact=True AND hashed>0 for EACH workspace."""
+    await _seed_shared_instinct(tmp_path)
+
+    result = await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+    assert result["skipped"] is False
+
+    for ws_id in (WS_A, WS_B):
+        ws_file = tmp_path / "workspaces" / ws_id / "instinct.db"
+        assert ws_file.exists(), f"instinct.db for {ws_id} should exist"
+
+        ws_store = InstinctStore(ws_file)
+        verdict = await ws_store.verify_audit_chain()
+
+        assert verdict["intact"] is True, (
+            f"audit chain broken for workspace {ws_id}: {verdict['broken_at']}"
+        )
+        assert verdict["hashed"] > 0, (
+            f"workspace {ws_id} has no hashed audit rows — re-chain did not fire"
+        )
+        assert verdict["checked"] == verdict["hashed"], (
+            f"workspace {ws_id}: not all hashed rows verified (checked={verdict['checked']}, "
+            f"hashed={verdict['hashed']})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_instinct_actions_isolated_per_workspace_after_migration(
+    tmp_path: Path,
+) -> None:
+    """ws-a's per-workspace store must only contain ws-a actions."""
+    await _seed_shared_instinct(tmp_path)
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    store_a = InstinctStore(tmp_path / "workspaces" / WS_A / "instinct.db")
+    actions_a = await store_a.list_actions()
+    titles = {a.title for a in actions_a}
+
+    assert all(t.startswith("A-") for t in titles), f"ws-a store contains non-A actions: {titles}"
+    assert not any(t.startswith("B-") for t in titles), "ws-b actions must not appear in ws-a"
+
+
+@pytest.mark.asyncio
+async def test_instinct_null_actions_land_in_system_workspace(tmp_path: Path) -> None:
+    """NULL-workspace instinct actions must end up in __system__."""
+    await _seed_shared_instinct(tmp_path)
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    sys_store = InstinctStore(tmp_path / "workspaces" / WS_SYS / "instinct.db")
+    actions = await sys_store.list_actions()
+    titles = {a.title for a in actions}
+
+    assert "Sys-action" in titles, (
+        f"null-ws action 'Sys-action' not found in __system__; got {titles}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — second run must be a no-op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent_marker_file(tmp_path: Path) -> None:
+    """A second run detects the .workspace_split_done marker and skips entirely."""
+    await _seed_shared_fabric(tmp_path)
+    await _seed_shared_instinct(tmp_path)
+
+    first = await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+    assert first["skipped"] is False
+
+    second = await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+    assert second["skipped"] is True, "second run should be skipped (marker present)"
+    assert second["fabric"] == {}, "second run fabric summary must be empty"
+    assert second["instinct"] == {}, "second run instinct summary must be empty"
+
+
+@pytest.mark.asyncio
+async def test_migration_no_double_insert_on_second_run(tmp_path: Path) -> None:
+    """Even without the marker, rows are not duplicated on a second run."""
+
+    await _seed_shared_fabric(tmp_path)
+    await _seed_shared_instinct(tmp_path)
+
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    # Remove marker to simulate a partial-failure re-run (sources already renamed).
+    marker = tmp_path / ".workspace_split_done"
+    marker.unlink()
+
+    # Fabric and instinct .migrated still exist; sources are gone.
+    # Second run should skip both (no source files, no marker).
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+    # skipped=False because the marker was absent, but nothing to copy.
+    # Verify the audit chain is still intact for each workspace (no duplicates).
+    for ws in (WS_A, WS_B, WS_SYS):
+        ws_idb = tmp_path / "workspaces" / ws / "instinct.db"
+        if ws_idb.exists() and ws in (WS_A, WS_B):
+            ws_store = InstinctStore(ws_idb)
+            verdict = await ws_store.verify_audit_chain()
+            assert verdict["intact"] is True, (
+                f"chain broken after idempotent re-run for {ws}: {verdict['broken_at']}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Marker written after migration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_marker_file_created_after_migration(tmp_path: Path) -> None:
+    """A .workspace_split_done marker file must exist after a successful migration."""
+    await _seed_shared_fabric(tmp_path)
+    await _seed_shared_instinct(tmp_path)
+
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    assert (tmp_path / ".workspace_split_done").exists()
+
+
+# ---------------------------------------------------------------------------
+# Source-chain integrity gate (captain hard requirement): re-chaining is only
+# sound over AUTHENTIC rows, so the shared instinct.db chain is verified intact
+# BEFORE re-chaining — abort on tamper unless force-overridden.
+# ---------------------------------------------------------------------------
+
+
+def _tamper_shared_instinct(data_dir: Path) -> None:
+    """Mutate a hashed row's content in the shared instinct.db, breaking the chain."""
+    import sqlite3
+
+    with sqlite3.connect(str(data_dir / "instinct.db")) as conn:
+        conn.execute(
+            "UPDATE instinct_audit SET description = 'TAMPERED' WHERE rowid = ("
+            "SELECT rowid FROM instinct_audit WHERE entry_hash IS NOT NULL "
+            "ORDER BY rowid LIMIT 1)"
+        )
+        conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_clean_source_records_intact_verdict_in_marker(tmp_path: Path) -> None:
+    """A clean source migrates AND the marker attests the source chain was intact."""
+    import json
+
+    await _seed_shared_instinct(tmp_path)
+
+    result = await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    assert result["skipped"] is False
+    assert result["source_chain"] is not None
+    assert result["source_chain"]["intact"] is True
+    # The marker is JSON recording the source-chain attestation.
+    marker_body = json.loads((tmp_path / ".workspace_split_done").read_text())
+    assert marker_body["source_chain_verified"]["intact"] is True
+    assert marker_body["forced"] is False
+    assert "migrated_at" in marker_body
+
+
+@pytest.mark.asyncio
+async def test_tampered_source_aborts_and_leaves_source_intact(tmp_path: Path) -> None:
+    """A broken source chain must ABORT the migration, untouched — no laundering."""
+    await _seed_shared_instinct(tmp_path)
+    _tamper_shared_instinct(tmp_path)
+
+    with pytest.raises(SourceChainTamperedError):
+        await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    # The source was NOT renamed/destroyed, NO per-workspace files were created,
+    # and NO marker was written — the abort is clean and reversible.
+    assert (tmp_path / "instinct.db").exists()
+    assert not (tmp_path / "instinct.db.migrated").exists()
+    assert not (tmp_path / "workspaces" / WS_A / "instinct.db").exists()
+    assert not (tmp_path / ".workspace_split_done").exists()
+
+
+@pytest.mark.asyncio
+async def test_force_overrides_tamper_gate_and_records_it(tmp_path: Path) -> None:
+    """force=True proceeds over a broken source and records the override in the marker."""
+    import json
+
+    await _seed_shared_instinct(tmp_path)
+    _tamper_shared_instinct(tmp_path)
+
+    result = await migrate_shared_stores_to_workspaces(data_dir=tmp_path, force=True)
+
+    assert result["skipped"] is False
+    assert result["source_chain"]["intact"] is False  # we knew it was broken
+    # Migration proceeded: per-workspace files exist and the source is renamed.
+    assert (tmp_path / "workspaces" / WS_A / "instinct.db").exists()
+    assert (tmp_path / "instinct.db.migrated").exists()
+    # The override is recorded in the marker (auditable).
+    marker_body = json.loads((tmp_path / ".workspace_split_done").read_text())
+    assert marker_body["forced"] is True
+    assert marker_body["source_chain_verified"]["intact"] is False
+    # Re-chained per-workspace files are themselves freshly VALID (the override's
+    # documented behavior — valid chains over possibly-tampered rows).
+    verdict = await InstinctStore(
+        str(tmp_path / "workspaces" / WS_A / "instinct.db")
+    ).verify_audit_chain()
+    assert verdict["intact"] is True


### PR DESCRIPTION
Stacks on #1554 (the ISO stack: #1550 ← #1551 ← #1554 ← this). Merge in order, each with `--rebase`. Last isolation slice.

## What this does

Three things that finish the per-tenant isolation:

1. A one-time migration (`split_workspace_stores.py`) that splits an existing shared `~/.pocketpaw/{fabric,instinct}.db` into per-workspace files. Fabric rows copy by workspace_id; pre-tenancy NULL rows go to a `system0` bucket. Reversible-safe (the source is renamed `.migrated`, never deleted) and idempotent (a per-file marker; a second run is a no-op).
2. An AST lint guard (`test_store_isolation_lint.py`) that fails the build if any code constructs `FabricStore(...)` / `InstinctStore(...)` directly outside the factory, so the isolation cannot silently regress. It carries a planted-violation self-test; only `stores.py` and the migration's source-read are allowlisted, with the justification in the file.
3. The audit-lock fix from the ISO-2 review: `_log_lock` is now keyed by db_path in a process-global registry instead of held on the store instance, so a workspace store evicted and rebuilt by the LRU shares one lock and concurrent audit appends across the eviction boundary cannot fork the chain.

## The Instinct audit chain survives the migration, with integrity

The shared Instinct file has one global hash chain across interleaved tenants. A naive split would orphan each file's hash links, so the migration re-chains each workspace's rows from genesis over their authentic data, giving every migrated tenant a valid `verify_audit_chain`.

Re-chaining is security-sensitive, so before it runs the migration verifies the source: it calls `verify_audit_chain` on the shared file (read-only, before any rename). If the source is intact it proceeds and records the verdict in the marker. If the source is tampered it aborts with `SourceChainTamperedError`, leaving the source untouched; it will not launder tampered rows into a fresh valid-looking chain. `force=True` overrides with a loud warning and records `forced` in the marker. The marker is a JSON attestation: `{migrated_at, source_chain_verified, forced}`.

## Tests

- 22 in the ISO-4 suite: migration (per-workspace chains intact, NULL→system0, row counts preserved, idempotent, source preserved); the 3 source-gate tests (clean records the verdict; tampered aborts and leaves the source untouched; force overrides and the per-workspace chains are still valid); the lint guard (clean scan + planted-violation self-test); and the lock (shares one lock per file, survives a real cap-1 LRU eviction with the chain intact under concurrent cross-eviction appends).
- ISO-1/2/3/4 regression slice: 482 passed; ruff clean; the OSS-cannot-import-EE import linter intact.

Independent security review covered the ISO-1/2 runtime primitives; this slice was verified against committed HEAD.