### PR TITLE
fix(sites): bound build subprocesses with a timeout + process-group kill

### DIFF
--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -8,6 +8,31 @@
 # behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-06-26 (fix/sites-build-subprocess-timeout — stop-gap: bound the build
+# subprocesses): all THREE _SubprocessRunner subprocesses (the generator, `bun
+# install`, and the `bun run build` static build) ran a bare ``await
+# proc.communicate()`` with NO timeout. When adapter-cloudflare's workerd prerender
+# wedges (known upstream SvelteKit hang) the `bun run build` step ran forever, so
+# /editable and publish hung unbounded (tens of minutes). The existing
+# ``reap_build_workerd`` only runs AFTER communicate() returns, so it could not
+# rescue a wedged build.
+#   * Each subprocess is now launched with ``start_new_session=True`` (its own
+#     process group) and run through ``_communicate_bounded(proc, timeout_s, label)``,
+#     which ``asyncio.wait_for``-bounds communicate() and, on timeout, SIGKILLs the
+#     whole process GROUP (``_kill_process_group`` → ``os.killpg`` — kills the leaked
+#     workerd CHILD too, not just the bun parent), reaps the parent, and raises the
+#     internal ``_BuildTimeout``.
+#   * Timeout is ``PAW_SITES_BUILD_TIMEOUT_SEC`` (int, default 120s — a legit build is
+#     ~45-60s, a wedged one runs for minutes, so 120s cleanly separates them); read
+#     once per call via ``_build_timeout_sec()`` with an int-parse-or-fallback.
+#   * Each call site converts ``_BuildTimeout`` into its EXISTING failure contract
+#     (callers unchanged): ``install``/``build_static`` return ``(False, "<step> timed
+#     out after Ns ...")`` — the same ``(ok, msg)`` shape the non-zero-exit path
+#     returns, so build() raises SmokeGateFailed and the caller maps it to a CloudError
+#     (FE degrades to view-only); ``generate`` raises ``RuntimeError`` (its existing
+#     raise-on-failure). ``reap_build_workerd`` is kept (success-path + on a build
+#     timeout, as defensive straggler cleanup).
+#
 # Updated 2026-06-21 (DSV-5 — dynamic svelte sites write-side): build() now SPLITS
 # a svelte pocket's ``source`` content envelope before sending it to the generator.
 # A DYNAMIC svelte pocket stores its live-data bindings
@@ -142,17 +167,105 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import logging
 import os
 import shlex
+import signal
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
+
+# Stop-gap timeout that bounds each build subprocess (the generator, `bun install`,
+# and the `bun run build` static build) so a wedged step fails FAST instead of
+# hanging the request unbounded. The static build runs adapter-cloudflare's workerd
+# prerender, which can hang forever on a known upstream SvelteKit bug; without a
+# timeout `/editable` and publish hang for tens of minutes. A legit build is
+# ~45-60s and a wedged one runs for minutes, so the 120s default cleanly separates
+# them. Override with PAW_SITES_BUILD_TIMEOUT_SEC (int seconds). Read once per call
+# via _build_timeout_sec() with an int-parse-or-fallback so a malformed value can
+# never crash the build.
+_DEFAULT_BUILD_TIMEOUT_SEC = 120
+
+
+def _build_timeout_sec() -> int:
+    """Per-subprocess build timeout in seconds (PAW_SITES_BUILD_TIMEOUT_SEC, int,
+    default 120). A malformed/empty value falls back to the default rather than
+    raising — the timeout is a safety net and must never itself break a build."""
+    raw = os.environ.get("PAW_SITES_BUILD_TIMEOUT_SEC")
+    if raw is None:
+        return _DEFAULT_BUILD_TIMEOUT_SEC
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "sites: ignoring non-int PAW_SITES_BUILD_TIMEOUT_SEC=%r, using default %ds",
+            raw,
+            _DEFAULT_BUILD_TIMEOUT_SEC,
+        )
+        return _DEFAULT_BUILD_TIMEOUT_SEC
+
+
+class _BuildTimeout(RuntimeError):
+    """Raised by ``_communicate_bounded`` when a build subprocess exceeds the
+    timeout and is killed. Carries the step ``label`` and the elapsed ``timeout_s``
+    so each call site can convert it into that step's existing failure contract
+    (``install``/``smoke`` → a ``(False, msg)`` tuple; ``generate`` → a
+    ``RuntimeError``). Internal — never surfaces to callers raw."""
+
+    def __init__(self, label: str, timeout_s: int) -> None:
+        self.label = label
+        self.timeout_s = timeout_s
+        super().__init__(f"{label} timed out after {timeout_s}s")
+
+
+def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
+    """SIGKILL the entire process GROUP of a launched subprocess so leaked workerd
+    CHILDREN die too, not just the parent.
+
+    The build subprocesses are launched with ``start_new_session=True``, so each is
+    its own process-group leader (pgid == pid). ``adapter-cloudflare``'s prerender
+    boots a workerd child that the bun parent never reaps; killing only the parent
+    would leave that child wedged. ``os.killpg(os.getpgid(pid), SIGKILL)`` takes out
+    the whole group. Guards ``ProcessLookupError`` (the proc/group already exited)
+    and ``PermissionError`` (can't signal — nothing we can do) so a best-effort kill
+    never raises into the build path."""
+    pid = proc.pid
+    if pid is None:
+        return
+    try:
+        os.killpg(os.getpgid(pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        # Already dead, or not allowed to signal it — nothing further to do.
+        pass
+
+
+async def _communicate_bounded(
+    proc: asyncio.subprocess.Process, timeout_s: int, label: str
+) -> tuple[bytes, bytes]:
+    """Run ``proc.communicate()`` but bound it by ``timeout_s``. On timeout, kill
+    the proc's whole process group (so leaked workerd children die too), reap the
+    parent, and raise ``_BuildTimeout(label, timeout_s)``.
+
+    Each build subprocess is launched with ``start_new_session=True`` so it leads
+    its own process group; ``_kill_process_group`` SIGKILLs the group. After the
+    kill we ``await proc.wait()`` to REAP the parent (avoid a zombie / a lingering
+    transport) — suppressing any error there since the proc is being torn down
+    anyway. The raised ``_BuildTimeout`` is caught at each call site and converted
+    into that step's existing failure contract."""
+    try:
+        return await asyncio.wait_for(proc.communicate(), timeout_s)
+    except TimeoutError as exc:  # asyncio.TimeoutError IS builtin TimeoutError (3.11+)
+        _kill_process_group(proc)
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        raise _BuildTimeout(label, timeout_s) from exc
+
 
 # Sentinel file (in the per-pocket build dir) recording the install-input
 # fingerprint of the last SUCCESSFUL `bun install`. build() skips install when the
@@ -390,7 +503,10 @@ class _SubprocessRunner:
         with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
             json.dump(input_json, fh)
             input_path = fh.name
+        timeout_s = _build_timeout_sec()
         try:
+            # start_new_session=True: own process group so a wedged generator (and
+            # any children it leaked) can be killed as a group on timeout.
             proc = await asyncio.create_subprocess_exec(
                 *self._gen_cmd,
                 "build",
@@ -400,8 +516,14 @@ class _SubprocessRunner:
                 out_dir,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
             )
-            stdout, stderr = await proc.communicate()
+            try:
+                stdout, stderr = await _communicate_bounded(proc, timeout_s, "generator")
+            except _BuildTimeout as exc:
+                # Preserve generate()'s raise-on-failure contract: a timed-out
+                # generator is a failed generate.
+                raise RuntimeError(f"generator timed out after {exc.timeout_s}s") from exc
             if proc.returncode != 0:
                 raise RuntimeError(f"generator failed: {stderr.decode()}")
             return json.loads(stdout.decode().strip().splitlines()[-1])
@@ -418,6 +540,9 @@ class _SubprocessRunner:
         # The deps are already made resolvable by build() (_rewrite_ripple_dep runs
         # before the install decision so the dep-hash reflects the final inputs).
         # This just runs `bun install` on the prepared dir.
+        timeout_s = _build_timeout_sec()
+        # start_new_session=True: own process group so a wedged install is killable
+        # as a group on timeout.
         proc = await asyncio.create_subprocess_exec(
             "bun",
             "install",
@@ -425,8 +550,19 @@ class _SubprocessRunner:
             cwd=project_dir,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
         )
-        stdout, stderr = await proc.communicate()
+        try:
+            stdout, stderr = await _communicate_bounded(proc, timeout_s, "bun install")
+        except _BuildTimeout as exc:
+            # Preserve install()'s (ok, msg) contract: a timeout is a build failure,
+            # so build() raises SmokeGateFailed → the publish/editable caller maps it
+            # to a CloudError and the FE degrades to view-only (same as a non-zero exit).
+            return (
+                False,
+                f"bun install timed out after {exc.timeout_s}s — killed the build "
+                "(likely a wedged workerd prerender)",
+            )
         if proc.returncode != 0:
             return False, f"bun install failed (exit {proc.returncode}): {stderr.decode()[-500:]}"
         return True, "ok"
@@ -443,6 +579,11 @@ class _SubprocessRunner:
         #     LIVE publish path). A preview build tolerates a would-fail SSR render
         #     (the live publish still gates + rolls back, so a broken edit can't go
         #     live) but still BUILDS so the served preview is fresh + anchored.
+        timeout_s = _build_timeout_sec()
+        # start_new_session=True: own process group. This is the step that wedges —
+        # adapter-cloudflare's workerd prerender can hang forever (upstream SvelteKit
+        # bug). The group kill on timeout takes out the leaked workerd CHILD too, not
+        # just the bun parent.
         proc = await asyncio.create_subprocess_exec(
             "bun",
             "run",
@@ -450,8 +591,21 @@ class _SubprocessRunner:
             cwd=project_dir,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
         )
-        stdout, stderr = await proc.communicate()
+        try:
+            stdout, stderr = await _communicate_bounded(proc, timeout_s, "build")
+        except _BuildTimeout as exc:
+            # A wedged build (typically the hung workerd prerender) is killed as a
+            # group; still run the defensive reap below for any straggler, then return
+            # the same (False, msg) shape a non-zero exit returns so build() treats it
+            # as a normal build failure (→ SmokeGateFailed → CloudError → view-only FE).
+            reap_build_workerd(project_dir)
+            return (
+                False,
+                f"build timed out after {exc.timeout_s}s — killed the build "
+                "(likely a wedged workerd prerender)",
+            )
         # P1a: reap the prerender-spawned workerd after EVERY build (the leak is
         # independent of the gate), scoped to this build's project dir.
         reap_build_workerd(project_dir)

--- a/tests/ee/sites/test_generator_client_timeout.py
+++ b/tests/ee/sites/test_generator_client_timeout.py
@@ -1,0 +1,186 @@
+# tests/ee/sites/test_generator_client_timeout.py
+# Created: 2026-06-26 (fix/sites-build-subprocess-timeout — stop-gap: bound the
+# build subprocesses with a timeout + process-group kill).
+#
+# Reproduce-first tests for the build-subprocess timeout. They exercise the REAL
+# _SubprocessRunner methods (install / build_static / generate) but make the
+# subprocess HANG by patching asyncio.create_subprocess_exec to spawn a Python
+# `time.sleep(999)` instead of bun — so no bun/node/workerd is ever required and the
+# test is fast + deterministic. With PAW_SITES_BUILD_TIMEOUT_SEC=1 each method must:
+#   * return / raise in WELL under 999s (the would-hang sleep) — proving the hang is
+#     bounded,
+#   * return its existing failure contract: install/build_static → (False, "<step>
+#     timed out ...") tuple; generate → RuntimeError("generator timed out ..."),
+#   * actually REAP the spawned process (proc.returncode is not None — the pid is
+#     gone, not a lingering child), and SIGKILL its whole process GROUP.
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import sys
+import time
+
+import pytest
+from pocketpaw_ee.sites.generator_client import _SubprocessRunner
+
+# A child that would hang far longer than any test timeout. The real `bun run build`
+# wedges on a hung workerd prerender the same way — an unbounded communicate().
+_HANG_ARGV = [sys.executable, "-c", "import time; time.sleep(999)"]
+
+
+def _patch_hang(monkeypatch) -> dict[str, object]:
+    """Replace asyncio.create_subprocess_exec so any command the runner launches
+    becomes a real, hanging child (a Python `time.sleep(999)`), launched with the
+    SAME kwargs the runner passed (notably start_new_session=True). Records the
+    spawned proc so the test can assert it gets reaped."""
+    spawned: dict[str, object] = {}
+    real_exec = asyncio.create_subprocess_exec
+
+    async def _fake_exec(*_args, **kwargs):
+        proc = await real_exec(*_HANG_ARGV, **kwargs)
+        spawned["proc"] = proc
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    return spawned
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if pid is still a live process (signal 0 probes without killing)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — alive for our purposes.
+        return True
+    return True
+
+
+@pytest.mark.asyncio
+async def test_build_static_bounds_a_wedged_build(tmp_path, monkeypatch):
+    """The #1 wedge: `bun run build` hangs on a stuck workerd prerender. With a 1s
+    timeout, build_static must return (False, <"timed out">) in seconds — NOT 999s —
+    and the spawned process must be reaped."""
+    monkeypatch.setenv("PAW_SITES_BUILD_TIMEOUT_SEC", "1")
+    spawned = _patch_hang(monkeypatch)
+    runner = _SubprocessRunner()
+
+    started = time.monotonic()
+    ok, msg = await asyncio.wait_for(runner.build_static(str(tmp_path), gate=True), timeout=10)
+    elapsed = time.monotonic() - started
+
+    # The hang was bounded: well under the 999s sleep (and under a few seconds).
+    assert elapsed < 5, f"build_static did not bound the hang (took {elapsed:.1f}s)"
+    # Existing (ok, msg) contract: a timeout looks like a normal build failure so
+    # build() raises SmokeGateFailed → CloudError → view-only FE.
+    assert ok is False
+    assert "timed out" in msg
+
+    # The spawned process was actually reaped — not left lingering.
+    proc = spawned["proc"]
+    assert proc.returncode is not None, "wedged build process was not reaped"
+    assert not _pid_alive(proc.pid), "wedged build process is still alive"
+
+
+@pytest.mark.asyncio
+async def test_install_bounds_a_wedged_install(tmp_path, monkeypatch):
+    """`bun install` is bounded the same way: on timeout it returns the (False,
+    <"timed out">) tuple (its existing non-zero-exit contract) and the process is
+    reaped."""
+    monkeypatch.setenv("PAW_SITES_BUILD_TIMEOUT_SEC", "1")
+    spawned = _patch_hang(monkeypatch)
+    runner = _SubprocessRunner()
+
+    started = time.monotonic()
+    ok, msg = await asyncio.wait_for(runner.install(str(tmp_path)), timeout=10)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5, f"install did not bound the hang (took {elapsed:.1f}s)"
+    assert ok is False
+    assert "timed out" in msg
+
+    proc = spawned["proc"]
+    assert proc.returncode is not None, "wedged install process was not reaped"
+    assert not _pid_alive(proc.pid), "wedged install process is still alive"
+
+
+@pytest.mark.asyncio
+async def test_generate_bounds_a_wedged_generator(tmp_path, monkeypatch):
+    """The generator preserves its raise-on-failure contract: a timeout raises
+    RuntimeError("generator timed out ..."), bounded well under the would-hang
+    sleep, and the process is reaped."""
+    monkeypatch.setenv("PAW_SITES_BUILD_TIMEOUT_SEC", "1")
+    spawned = _patch_hang(monkeypatch)
+    runner = _SubprocessRunner()
+
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match="generator timed out"):
+        await asyncio.wait_for(runner.generate({"engine": "ripple"}, str(tmp_path)), timeout=10)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5, f"generate did not bound the hang (took {elapsed:.1f}s)"
+
+    proc = spawned["proc"]
+    assert proc.returncode is not None, "wedged generator process was not reaped"
+    assert not _pid_alive(proc.pid), "wedged generator process is still alive"
+
+
+@pytest.mark.asyncio
+async def test_process_group_kill_reaps_a_leaked_child(tmp_path, monkeypatch):
+    """Group-kill proof: start_new_session=True + os.killpg means a CHILD the
+    wedged build leaked (the workerd analogue) dies too, not just the parent.
+
+    The faked parent spawns a grandchild that ignores SIGTERM and sleeps; only a
+    process-GROUP SIGKILL takes it down. After the timeout fires, the grandchild's
+    pid must be gone."""
+    monkeypatch.setenv("PAW_SITES_BUILD_TIMEOUT_SEC", "1")
+
+    # A child that forks a grandchild (the leaked-workerd analogue), prints the
+    # grandchild pid, then both sleep. The grandchild ignores SIGTERM, so only a
+    # SIGKILL to the whole group reaps it.
+    child_src = (
+        "import os, sys, time, signal\n"
+        "pid = os.fork()\n"
+        "if pid == 0:\n"
+        "    signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "    time.sleep(999)\n"
+        "else:\n"
+        "    sys.stdout.write(str(pid) + '\\n'); sys.stdout.flush()\n"
+        "    time.sleep(999)\n"
+    )
+    child_argv = [sys.executable, "-c", child_src]
+
+    grandchild_pid: dict[str, int] = {}
+    real_exec = asyncio.create_subprocess_exec
+
+    async def _fake_exec(*_args, **kwargs):
+        proc = await real_exec(
+            *child_argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=kwargs.get("stderr", asyncio.subprocess.PIPE),
+            cwd=kwargs.get("cwd"),
+            start_new_session=kwargs.get("start_new_session", False),
+        )
+        # Read the grandchild pid the child prints before either sleeps.
+        line = await asyncio.wait_for(proc.stdout.readline(), timeout=5)
+        grandchild_pid["pid"] = int(line.decode().strip())
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    runner = _SubprocessRunner()
+
+    ok, msg = await asyncio.wait_for(runner.build_static(str(tmp_path), gate=False), timeout=10)
+    assert ok is False
+    assert "timed out" in msg
+
+    gc_pid = grandchild_pid["pid"]
+    # Give the group SIGKILL a beat to land, then confirm the leaked child is gone.
+    deadline = time.monotonic() + 5
+    while _pid_alive(gc_pid) and time.monotonic() < deadline:
+        await asyncio.sleep(0.05)
+    assert not _pid_alive(gc_pid), "leaked child survived — process-group kill failed"
+    # Reap the now-dead grandchild's zombie if it became ours (best-effort).
+    with contextlib.suppress(ChildProcessError, OSError):
+        os.waitpid(gc_pid, os.WNOHANG)


### PR DESCRIPTION
## What was wrong

A Paw Sites build — publish, and especially click-to-edit `/editable` — runs `bun run build` + the `@sveltejs/adapter-cloudflare` workerd prerender. That prerender can **wedge** (a known upstream SvelteKit bug: builds that should take ~50s hang for 30+ minutes), and the three build subprocesses in `generator_client.py` ran with bare `await proc.communicate()` and **no timeout** — so the request hung unbounded. The existing `reap_build_workerd` only runs *after* `communicate()` returns, so it couldn't rescue a wedged build.

## The fix (stop-gap)

- All three build subprocesses (`generate` / `install` / `build_static`) now launch with `start_new_session=True` (own process group) and run through `_communicate_bounded`, which bounds `communicate()` with `asyncio.wait_for` and, on timeout, **SIGKILLs the whole process group** — so leaked workerd children die too, not just the bun parent — reaps the parent, and fails the build cleanly.
- Timeout is `PAW_SITES_BUILD_TIMEOUT_SEC` (default **120s** — a real build is ~45-60s, a wedged one runs for minutes, so it cleanly separates them; a malformed value falls back, never breaks a build).
- Each site keeps its existing failure contract: `install` / `build_static` return the same `(False, msg)` tuple (so `build()` → `SmokeGateFailed` → CloudError → the FE degrades to view-only); `generate` raises. `reap_build_workerd` stays as defensive cleanup.

## Result

A wedged build now fails fast (≤ the timeout) instead of hanging `/editable` (and publish) indefinitely. Pairs with the FE change (#488) that already degrades the preview to view-only on a build error.

## Tests

`tests/ee/sites/test_generator_client_timeout.py` (4): patches the subprocess to `sleep(999)` with a 1s timeout → asserts the call returns/raises in **seconds** (not 999s), the right failure contract per step, and the process is reaped — including a SIGTERM-ignoring grandchild that proves only the **group** kill reaps a leaked-workerd analogue. Reverting to unbounded `communicate()` makes the test hang (regression-proof). Full sites suite green (279 passed, 1 pre-existing skip).

## Follow-up

This is the stop-gap (fail-fast). The real speedup — dev-server HMR via `BRIDGE_IN_DEV` — is captured in `docs/design/drafts/2026-06-26-editable-preview-speedup.md`.
