### PR TITLE
feat(model-catalog): LiteLLM-gateway model catalog + multi-modal media + provisioning + failover + caching (integration)

### DIFF
--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -95,10 +95,10 @@ POCKETPAW_LICENSE_KEY=
 # The catalog API (GET /api/v1/catalog/models[/{id}]) reads available models from
 # a self-hosted LiteLLM proxy. Point these at the running proxy; until it is
 # reachable the catalog endpoints return 502 (source of truth unreachable).
-#   LITELLM_PROXY_URL      — proxy base URL. Default http://localhost:4000.
-# LITELLM_PROXY_URL=http://localhost:4000
-#   LITELLM_PROXY_API_KEY  — proxy admin/virtual key (optional; sent as Bearer).
-# LITELLM_PROXY_API_KEY=
+#   POCKETPAW_LITELLM_API_BASE      — proxy base URL. Default http://localhost:4000.
+# POCKETPAW_LITELLM_API_BASE=http://localhost:4000
+#   POCKETPAW_LITELLM_API_KEY  — proxy admin/virtual key (optional; sent as Bearer).
+# POCKETPAW_LITELLM_API_KEY=
 #   CATALOG_CACHE_TTL_SECONDS  — in-process catalog cache TTL. Default 300.
 # CATALOG_CACHE_TTL_SECONDS=300
 #   CATALOG_MODELS_DEV_ENABLED — best-effort models.dev enrichment. Default true;

--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -90,3 +90,17 @@ POCKETPAW_LICENSE_KEY=
 # PAW_CF_API_TOKEN=
 # PAW_CF_ZONE_ID=
 # PAW_CF_DISPATCH_NAMESPACE=paw-sites
+
+# ── Model Catalog — LiteLLM proxy (MCG-1) ──────────────────────────────────────
+# The catalog API (GET /api/v1/catalog/models[/{id}]) reads available models from
+# a self-hosted LiteLLM proxy. Point these at the running proxy; until it is
+# reachable the catalog endpoints return 502 (source of truth unreachable).
+#   LITELLM_PROXY_URL      — proxy base URL. Default http://localhost:4000.
+# LITELLM_PROXY_URL=http://localhost:4000
+#   LITELLM_PROXY_API_KEY  — proxy admin/virtual key (optional; sent as Bearer).
+# LITELLM_PROXY_API_KEY=
+#   CATALOG_CACHE_TTL_SECONDS  — in-process catalog cache TTL. Default 300.
+# CATALOG_CACHE_TTL_SECONDS=300
+#   CATALOG_MODELS_DEV_ENABLED — best-effort models.dev enrichment. Default true;
+#                                set false to run LiteLLM-only (no outbound fetch).
+# CATALOG_MODELS_DEV_ENABLED=true

--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -95,6 +95,9 @@ POCKETPAW_LICENSE_KEY=
 # The catalog API (GET /api/v1/catalog/models[/{id}]) reads available models from
 # a self-hosted LiteLLM proxy. Point these at the running proxy; until it is
 # reachable the catalog endpoints return 502 (source of truth unreachable).
+# REQUIRED for media: /studio image/audio/video generation now routes through this
+# proxy too (the direct Google/Replicate fallback was removed). Without a reachable
+# proxy, media generation fails cleanly (no asset produced) — configure these to use it.
 #   POCKETPAW_LITELLM_API_BASE      — proxy base URL. Default http://localhost:4000.
 # POCKETPAW_LITELLM_API_BASE=http://localhost:4000
 #   POCKETPAW_LITELLM_API_KEY  — proxy admin/virtual key (optional; sent as Bearer).

--- a/docs/handoff/2026-06-26-mcg2-gateway-probe.md
+++ b/docs/handoff/2026-06-26-mcg2-gateway-probe.md
@@ -1,0 +1,143 @@
+<!--
+MCG-2 GATE findings note (NEW FILE, 2026-06-26).
+Records the live-proxy probe results for routing Claude Code through the
+LiteLLM proxy: prompt-cache survival, tool/stream fidelity, spend logging,
+and the captain-config gaps found. Durable deliverable for slice MCG-2.
+-->
+
+# MCG-2 — Claude Code through LiteLLM: gateway probe findings
+
+**Date:** 2026-06-26
+**Proxy:** `https://litellm.hzd.interacly.com` (key alias `paw-enterprise`, `sk-...2qyw`)
+**Slice:** MCG-2 (the GATE) — does routing the spawned `claude` CLI through the
+LiteLLM proxy preserve the economics (prompt cache) and fidelity (tools +
+streaming) we depend on, and does the proxy meter the spend?
+
+---
+
+## GATE answer (up front)
+
+**Does Anthropic prompt-cache survive the LiteLLM hop? → BLOCKED on a proxy-config
+gap, but the proxy itself preserves cache metadata (proven via DeepSeek).**
+
+- We could **not** measure Anthropic prompt cache through the proxy because
+  **every Anthropic model group on the proxy fails with `authentication_error:
+  invalid x-api-key`** — the error is raised by Anthropic's own API and relayed
+  through LiteLLM, i.e. the proxy's *upstream Anthropic credential is invalid or
+  expired*. This is a captain proxy-config gap, not a code or design problem.
+  Tested: `claude-3-haiku`, `claude-3-opus`, `anthropic/claude-3-5-haiku`,
+  `anthropic/claude-haiku-4-5`, and the `claude-sonnet-4-5` fallback — all 401.
+- **Fallback proof that caching survives the hop:** DeepSeek automatic caching
+  through `{BASE}/chat/completions` returned **`prompt_cache_hit_tokens: 2944`**
+  (of 3056 prompt tokens) on a repeated large prefix via model group
+  `deepseek/deepseek-chat`. The proxy passes the cache-usage fields through
+  faithfully — it does **not** strip cache metadata. So once a valid Anthropic
+  key is configured on the proxy, Anthropic `cache_creation_input_tokens` /
+  `cache_read_input_tokens` should survive the same way. (The proxy even records
+  the cache split in its spend log; see below.)
+- **Per-model-group caveat:** the bare alias `deepseek-chat` returned
+  `cached_tokens: 0` (routes to a non-native-DeepSeek deployment that doesn't
+  surface cache fields), while `deepseek/deepseek-chat` returned the hit.
+  Cache behaviour is per-deployment on this proxy, not universal — the model
+  group chosen matters.
+
+### What unblocks the Anthropic cache measurement
+Configure a **valid Anthropic API key** on the proxy for the `claude-*` /
+`anthropic/*` model groups, then re-run `scratchpad/probe_gate.py claude-3-haiku`
+(sends a >1024-token `cache_control: ephemeral` system block twice and reads
+`cache_creation_input_tokens` on call 1 / `cache_read_input_tokens` on call 2).
+
+---
+
+## Probe results
+
+### 1. Prompt cache (the GATE)
+| Path | Model group | Result |
+|------|-------------|--------|
+| Anthropic `/v1/messages` cache_control | `claude-3-haiku` & 4 others | **401 invalid x-api-key** (proxy upstream key bad) |
+| DeepSeek auto-cache `/chat/completions` | `deepseek/deepseek-chat` | **PASS — `prompt_cache_hit_tokens: 2944`** |
+| DeepSeek auto-cache `/chat/completions` | `deepseek-chat` (bare alias) | cached_tokens 0 (different deployment) |
+
+**Takeaway:** caching survives the proxy hop; the Anthropic-specific measurement
+is gated only by the missing/invalid upstream Anthropic key.
+
+### 2. Tool-calling + streaming fidelity — **PASS**
+`{BASE}/chat/completions` with a `tools` definition + `stream: true` on
+`deepseek/deepseek-chat`:
+- 12 streamed SSE chunks received.
+- A `tool_call` came back and assembled cleanly across chunks:
+  `get_weather({"city": "Paris"})`.
+- No format-translation issues observed on the OpenAI-compat surface.
+- `gpt-4o` could not be used as a second witness: the proxy's OpenAI group is
+  **quota-exhausted (429 "exceeded your current quota")** and its
+  `claude-sonnet-4-5` fallback hits the same invalid Anthropic key. Separate
+  config gaps; fidelity is already proven via DeepSeek.
+
+### 3. Spend logging — **PASS (fully working)**
+- `GET {BASE}/spend/logs?api_key=<key>` returns **per-call rows**. Our exact
+  DeepSeek probe call is logged with `model: deepseek/deepseek-chat`,
+  `total_tokens: 3082`, `prompt_cache_hit_tokens: 2944`, and a full
+  `cost_breakdown` (input/output/total cost). Cache metering is preserved in
+  the spend log too.
+- `GET {BASE}/key/info` shows cumulative spend for our key
+  (`spend: 0.00457…`, `last_active` updated to the probe time).
+- `GET {BASE}/global/spend` returns `{"spend": 0.000975…}`.
+- Note: `GET {BASE}/spend/logs` **without** the `?api_key=` filter times out
+  (it tries to dump all logs) — always pass the filter.
+
+---
+
+## Code: verified vs added
+
+**Verified (wiring already complete — no redundant code added):**
+The seam that routes the spawned `claude` CLI through the proxy is intact:
+- `src/pocketpaw/llm/providers/litellm.py` — `LiteLLMAdapter.resolve_config`
+  reads `settings.litellm_api_base` (→ `base_url`) and `settings.litellm_api_key`
+  (→ `api_key`); `build_env_dict` emits `ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY`.
+- `src/pocketpaw/llm/client.py` — `resolve_llm_client(force_provider="litellm")`
+  builds an `LLMClient` carrying the proxy base (stored in
+  `openai_compatible_base_url`) and key; `to_sdk_env()` → `build_env_dict`
+  produces the subprocess env.
+- `src/pocketpaw/agents/claude_sdk.py` — `_build_options` calls
+  `resolve_llm_client(force_provider=self.settings.claude_sdk_provider)`,
+  injects `llm.to_sdk_env()` into `options_kwargs["env"]` (the spawned
+  subprocess env), and — critically — when the provider is non-Anthropic
+  (`is_litellm` included) **smart routing is skipped** and the model is set
+  from `llm.model` (lines ~1215, 1547-1548, 1590). So `smart_routing_enabled`
+  does **not** clobber the litellm-chosen model. No gap.
+
+**Added (the genuine coverage gap):** two unit tests in
+`tests/test_llm_client.py` asserting the litellm-provider subprocess env points
+`ANTHROPIC_BASE_URL` at the configured base **and** carries the key:
+- `TestResolveLLMClient::test_resolve_litellm_routes_sdk_env_to_proxy` —
+  end-to-end `Settings → resolve_llm_client → to_sdk_env`.
+- `TestToSdkEnv::test_to_sdk_env_litellm` — direct `LLMClient` seam check.
+
+**Test run:**
+```
+uv run pytest tests/test_llm_client.py -q  →  25 passed
+uv run pytest <2 new tests> tests/test_provider_adapters.py -q  →  32 passed
+uv run ruff check tests/test_llm_client.py  →  All checks passed!
+```
+
+---
+
+## Captain-config gaps (action items, not code)
+1. **Proxy Anthropic upstream key is invalid/expired** — all `claude-*` /
+   `anthropic/*` model groups 401. Blocks the Anthropic prompt-cache GATE and
+   any production routing of Claude Code through this proxy. **Fix this to fully
+   close MCG-2.**
+2. **Proxy OpenAI key is quota-exhausted** — `gpt-4o` returns 429 "exceeded your
+   current quota". Lower priority (DeepSeek path works), but the OpenAI groups
+   are unusable until topped up.
+3. **`/spend/logs` (unfiltered) times out** — operational note: always query
+   with `?api_key=` (or a date filter) rather than dumping all logs.
+
+## How to re-run (probe scripts, in scratchpad — not committed)
+```
+export $(grep -v '^#' /Users/prakash-1/Documents/paw-workspace/.env | grep POCKETPAW_LITELLM | xargs)
+python3 scratchpad/probe_gate.py claude-3-haiku        # Anthropic cache GATE (after key fix)
+python3 scratchpad/probe_deepseek_cache.py deepseek/deepseek-chat   # cache-survives-hop proof
+python3 scratchpad/probe_tools_stream.py deepseek/deepseek-chat     # tool + stream fidelity
+# spend: curl "$BASE/spend/logs?api_key=$KEY" / "$BASE/key/info" / "$BASE/global/spend"
+```

--- a/ee/pocketpaw_ee/agent/mcp_servers/__init__.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/__init__.py
@@ -27,7 +27,8 @@ Server surfaces (module → server name → tools):
   ``instinct_audit`` (READ-ONLY gate visibility, workspace-scoped; proposing
   goes through ``pocketpaw_external_actions``)
 * ``loom.py`` → ``loom`` (stdio config) → codebase orientation reads
-* ``media.py`` → ``pocketpaw_media`` → ``image_generate`` / ``video_generate``
+* ``media.py`` → ``pocketpaw_media`` → ``image_generate`` / ``audio_generate`` /
+  ``audio_transcribe`` / ``video_generate`` (routed through the LiteLLM proxy)
 * ``meetings.py`` → ``pocketpaw_meetings`` → meeting queries
 * ``planner.py`` → ``pocketpaw_planner`` (opt-in) + ``pocketpaw_pocket_planner``
 * ``pockets.py`` → ``pocketpaw_pocket`` → pocket context + widget pinning

--- a/ee/pocketpaw_ee/agent/mcp_servers/media.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/media.py
@@ -23,6 +23,14 @@
 # via the OpenAI `user` field (the proxy keys per-end-customer spend off it) so
 # the existing proxy spend log attributes cost to the workspace; we do not block
 # on metering — the proxy already logs it.
+# 2026-06-26 (MCG-8): each proxy call now Bearers the workspace's PROVISIONED
+# per-tenant LiteLLM virtual key (resolved best-effort via
+# ee.cloud.llm_provisioning.service.get_tenant_key) instead of the deployment
+# master key, so the proxy enforces the tenant's budget + rate caps and attributes
+# spend to the tenant key. Falls back to the master key when a workspace has no
+# key yet (provisioning hasn't run) or the lookup fails — media never breaks on
+# key resolution, and the `user=workspace_id` tag still attributes spend either
+# way. See ``_resolve_auth_key``.
 #
 # What this file does: clones the sites.py / sites_create.py shape — a single
 # ``create_sdk_mcp_server`` with an SDK import-guard, ``SERVER_NAME`` /
@@ -229,18 +237,48 @@ def _proxy_base() -> str:
 
 
 def _proxy_key() -> str | None:
-    """The LiteLLM proxy admin/virtual key (or None), from catalog config."""
+    """The LiteLLM proxy admin/MASTER key (or None), from catalog config. The
+    fallback Bearer when a workspace has no provisioned per-tenant virtual key."""
     from pocketpaw_ee.catalog import config
 
     return config.litellm_proxy_api_key()
 
 
-def _proxy_headers(*, json_content: bool = True) -> dict[str, str]:
+async def _resolve_auth_key(workspace_id: str | None) -> str | None:
+    """Resolve the Bearer key for a tenant's media proxy call (MCG-8).
+
+    Prefer the workspace's PROVISIONED LiteLLM virtual key (so the proxy enforces
+    the tenant's budget + attributes spend to the key, not just the ``user`` tag);
+    fall back to the deployment master key when the workspace has no key yet (or
+    the lookup fails). Best-effort + non-fatal: media must keep working on the
+    master key when provisioning hasn't run — the ``user=workspace_id`` tag still
+    attributes spend in the proxy log either way. Importing the provisioning
+    service lazily keeps the agent MCP import graph free of Beanie at module load.
+    """
+    if workspace_id:
+        try:
+            from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+
+            tenant_key = await provisioning.get_tenant_key(workspace_id)
+            if tenant_key:
+                return tenant_key
+        except Exception:  # noqa: BLE001 — never let key resolution break a generation
+            logger.debug(
+                "media: tenant key lookup failed for workspace=%s; using master key",
+                workspace_id,
+                exc_info=True,
+            )
+    return _proxy_key()
+
+
+def _proxy_headers(*, json_content: bool = True, auth_key: str | None = None) -> dict[str, str]:
     """Bearer the proxy key (when set) the same way the catalog client does.
+    ``auth_key`` is the per-tenant virtual key resolved by ``_resolve_auth_key``;
+    when None we fall back to the deployment master key (the pre-MCG-8 behaviour).
     ``json_content`` adds the JSON content-type for the OpenAI-compatible JSON
     endpoints; multipart uploads (STT) let httpx set the boundary itself."""
     headers: dict[str, str] = {}
-    key = _proxy_key()
+    key = auth_key if auth_key is not None else _proxy_key()
     if key:
         headers["Authorization"] = f"Bearer {key}"
     if json_content:
@@ -429,7 +467,7 @@ async def _land_in_gallery(
 
 
 async def _proxy_image(
-    *, model: str, prompt: str, size: str | None, user: str
+    *, model: str, prompt: str, size: str | None, user: str, auth_key: str | None = None
 ) -> tuple[bytes | None, str | None]:
     """Generate an image via the proxy's OpenAI-compatible image endpoint.
 
@@ -454,7 +492,7 @@ async def _proxy_image(
         async with _proxy_client() as client:
             resp = await client.post(
                 f"{base}/v1/images/generations",
-                headers=_proxy_headers(),
+                headers=_proxy_headers(auth_key=auth_key),
                 json=payload,
             )
             resp.raise_for_status()
@@ -503,8 +541,9 @@ async def _image_generate_handler(args: dict) -> dict:
     if not model:
         model = _default_image_model()
 
+    auth_key = await _resolve_auth_key(workspace_id)
     image_bytes, err = await _proxy_image(
-        model=model, prompt=prompt, size=size, user=workspace_id
+        model=model, prompt=prompt, size=size, user=workspace_id, auth_key=auth_key
     )
     if err is not None or image_bytes is None:
         return _error_response(err or "image generation returned no data")
@@ -543,7 +582,13 @@ async def _image_generate_handler(args: dict) -> dict:
 
 
 async def _proxy_audio_speech(
-    *, model: str, text: str, voice: str, response_format: str, user: str
+    *,
+    model: str,
+    text: str,
+    voice: str,
+    response_format: str,
+    user: str,
+    auth_key: str | None = None,
 ) -> tuple[bytes | None, str | None]:
     """Synthesize speech via the proxy's OpenAI-compatible speech endpoint.
 
@@ -563,7 +608,7 @@ async def _proxy_audio_speech(
         async with _proxy_client() as client:
             resp = await client.post(
                 f"{base}/v1/audio/speech",
-                headers=_proxy_headers(),
+                headers=_proxy_headers(auth_key=auth_key),
                 json=payload,
             )
             resp.raise_for_status()
@@ -596,12 +641,14 @@ async def _audio_generate_handler(args: dict) -> dict:
     response_format = _str_arg(args, "response_format", "mp3")
     model = _str_arg(args, "model", _DEFAULT_AUDIO_TTS_MODEL)
 
+    auth_key = await _resolve_auth_key(workspace_id)
     audio_bytes, err = await _proxy_audio_speech(
         model=model,
         text=text,
         voice=voice,
         response_format=response_format,
         user=workspace_id,
+        auth_key=auth_key,
     )
     if err is not None or audio_bytes is None:
         return _error_response(err or "audio synthesis returned no data")
@@ -640,7 +687,7 @@ async def _audio_generate_handler(args: dict) -> dict:
 
 
 async def _proxy_audio_transcription(
-    *, model: str, audio_path: Path, user: str
+    *, model: str, audio_path: Path, user: str, auth_key: str | None = None
 ) -> tuple[str | None, str | None]:
     """Transcribe an audio file via the proxy's OpenAI-compatible transcription
     endpoint.
@@ -659,7 +706,7 @@ async def _proxy_audio_transcription(
         async with _proxy_client() as client:
             resp = await client.post(
                 f"{base}/v1/audio/transcriptions",
-                headers=_proxy_headers(json_content=False),
+                headers=_proxy_headers(json_content=False, auth_key=auth_key),
                 files={"file": (audio_path.name, data)},
                 data={"model": model, "user": user},
             )
@@ -700,8 +747,9 @@ async def _audio_transcribe_handler(args: dict) -> dict:
 
     model = _str_arg(args, "model", _DEFAULT_AUDIO_STT_MODEL)
 
+    auth_key = await _resolve_auth_key(workspace_id)
     text, err = await _proxy_audio_transcription(
-        model=model, audio_path=audio_path, user=workspace_id
+        model=model, audio_path=audio_path, user=workspace_id, auth_key=auth_key
     )
     if err is not None or text is None:
         return _error_response(err or "transcription returned no text")
@@ -715,7 +763,7 @@ async def _audio_transcribe_handler(args: dict) -> dict:
 
 
 async def _poll_proxy_video(
-    client: httpx.AsyncClient, base: str, job_id: str
+    client: httpx.AsyncClient, base: str, job_id: str, *, auth_key: str | None = None
 ) -> dict[str, Any]:
     """Poll ``GET {proxy}/videos/{job_id}`` until the job reaches a terminal
     status (``completed`` / ``succeeded`` / ``failed`` / ``cancelled``), bounded
@@ -724,7 +772,9 @@ async def _poll_proxy_video(
     waited = 0.0
     job: dict[str, Any] = {}
     while waited < _VIDEO_POLL_MAX_SECONDS:
-        resp = await client.get(f"{base}/videos/{job_id}", headers=_proxy_headers())
+        resp = await client.get(
+            f"{base}/videos/{job_id}", headers=_proxy_headers(auth_key=auth_key)
+        )
         resp.raise_for_status()
         job = resp.json()
         status = (job.get("status") or "").lower()
@@ -765,6 +815,7 @@ async def _proxy_video(
     size: str | None,
     aspect_ratio: str | None,
     user: str,
+    auth_key: str | None = None,
 ) -> tuple[str | None, str | None]:
     """Generate a video via the proxy's ``/videos`` endpoint.
 
@@ -790,7 +841,7 @@ async def _proxy_video(
         async with _proxy_client(timeout=_VIDEO_POLL_MAX_SECONDS + 30.0) as client:
             resp = await client.post(
                 f"{base}/videos",
-                headers=_proxy_headers(),
+                headers=_proxy_headers(auth_key=auth_key),
                 json=payload,
             )
             resp.raise_for_status()
@@ -799,7 +850,7 @@ async def _proxy_video(
             terminal = {"completed", "succeeded", "failed", "cancelled", "canceled", "error"}
             job_id = job.get("id")
             if status not in terminal and job_id:
-                job = await _poll_proxy_video(client, base, str(job_id))
+                job = await _poll_proxy_video(client, base, str(job_id), auth_key=auth_key)
             status = (job.get("status") or "").lower()
             if status not in ("completed", "succeeded"):
                 detail = job.get("error") or status or "unknown status"
@@ -842,6 +893,7 @@ async def _video_generate_handler(args: dict) -> dict:
 
     model = _str_arg(args, "model") or _default_video_model()
 
+    auth_key = await _resolve_auth_key(workspace_id)
     output_url, err = await _proxy_video(
         model=model,
         prompt=prompt,
@@ -849,6 +901,7 @@ async def _video_generate_handler(args: dict) -> dict:
         size=size,
         aspect_ratio=aspect_ratio,
         user=workspace_id,
+        auth_key=auth_key,
     )
     if err is not None or output_url is None:
         return _error_response(err or "video generation returned no output URL")

--- a/ee/pocketpaw_ee/agent/mcp_servers/media.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/media.py
@@ -1,6 +1,28 @@
 # media.py — in-process MCP server exposing the STUDIO media-generation actions
-# (image + video) to the claude_agent_sdk cloud chat backend. Created: 2026-06-10
-# (feat/studio-code-migration).
+# (image + audio + video) to the claude_agent_sdk cloud chat backend.
+#
+# Created: 2026-06-10 (feat/studio-code-migration).
+# 2026-06-26 (MCG-6 + MCG-7): media generation now routes through the self-hosted
+# LiteLLM proxy via its OpenAI-compatible endpoints instead of calling Google /
+# Replicate directly. One gateway means one credential path, one spend log, and
+# any model the proxy serves (gpt-image-1, dall-e-*, imagen-*, tts-1, whisper-*,
+# sora/veo/kling) is reachable by catalog model id with no per-provider code:
+#   * image → POST {proxy}/v1/images/generations  (no response_format param —
+#     gpt-image-1 / the newer dall-e API reject it; we accept either b64_json
+#     OR url in the response, confirmed against the live proxy 2026-06-26)
+#   * audio TTS → POST {proxy}/v1/audio/speech       (raw audio bytes back)
+#   * audio STT → POST {proxy}/v1/audio/transcriptions (multipart upload)
+#   * video → POST {proxy}/videos                    (async job, GET-poll)
+# The model id comes from the CALLER (a catalog model id passed as `model`), not a
+# hardcoded settings field. When the caller passes nothing we fall back to a
+# per-modality default (image keeps settings.image_model for backward-compat with
+# the existing studio skill / preamble, which pass only prompt + aspect_ratio).
+# Proxy base/key resolution + the httpx style are REUSED from the catalog entity
+# (ee.pocketpaw_ee.catalog.config + its LiteLLMClient header/transport shape) — we
+# do NOT re-resolve the proxy URL/key here. The tenant is tagged on every request
+# via the OpenAI `user` field (the proxy keys per-end-customer spend off it) so
+# the existing proxy spend log attributes cost to the workspace; we do not block
+# on metering — the proxy already logs it.
 #
 # What this file does: clones the sites.py / sites_create.py shape — a single
 # ``create_sdk_mcp_server`` with an SDK import-guard, ``SERVER_NAME`` /
@@ -8,45 +30,41 @@
 # ``current_workspace_id`` / ``current_user_id`` accessors in
 # ``ee.cloud.chat.agent_service`` the sites / pocket-specialist servers read),
 # and the ``_error_response`` / ``_success_response`` helpers. Tool ids namespace
-# as ``mcp__pocketpaw_media__image_generate`` / ``__video_generate`` so the
-# Claude Code allowlist machinery matches them.
+# as ``mcp__pocketpaw_media__image_generate`` / ``__audio_generate`` /
+# ``__audio_transcribe`` / ``__video_generate`` so the Claude Code allowlist
+# machinery matches them.
 #
-# Two SDK @tool defs:
-#   * image_generate — delegates to generate_image_file() in
-#     src/pocketpaw/tools/builtin/image_gen.py (2026-06-10: shared helper that
-#     routes gemini-*-image models via generateContent and imagen-* via the
-#     paid-tier predict endpoint), saves to get_config_dir()/generated/<uuid>.png.
-#     Missing key → clear error.
-#   * video_generate — calls the Replicate HTTP API with httpx (an EXISTING
-#     dep — the replicate package is NOT added). Reads settings.replicate_api_token
-#     + settings.video_model, POSTs a prediction, polls the GET until terminal
-#     (~120s cap, 3s sleep), returns the output URL. Missing token → clear error.
-#
-# Result contract: every successful generation lands the asset in a STUDIO
-# gallery pocket via the TRUSTED-CREATE path (``agent_create(... type_="studio",
-# pattern="gallery", engine="ripple", ripple_spec=<gallery spec>, trusted=True)``)
-# so the strict catalog gate is bypassed (image / video-player widgets lag the
-# published manifest), then binds the session + emits ``pocket_created`` exactly
-# like sites_create.py (``_bind_session_and_emit``). The gallery spec uses ONLY
-# existing widget types (grid / card / image / video-player / text) so it renders
-# today — a responsive grid of media tiles. Media accumulates across the session
-# (per-session state holds the gallery's media list); each generation re-creates
-# the gallery with the full list and emits the refreshed pocket, so the canvas
-# always shows every asset made this session.
+# Four SDK @tool defs (image / audio_generate (TTS) / audio_transcribe (STT) /
+# video). Generated assets (image bytes, TTS audio bytes, the video output URL)
+# land in a STUDIO gallery pocket via the TRUSTED-CREATE path
+# (``agent_create(... type_="studio", pattern="gallery", engine="ripple",
+# ripple_spec=<gallery spec>, trusted=True)``) so the strict catalog gate is
+# bypassed (image / video-player widgets lag the published manifest), then binds
+# the session + emits ``pocket_created`` exactly like sites_create.py
+# (``_bind_session_and_emit``). The gallery spec uses ONLY existing widget types
+# (grid / card / image / video-player / text). Transcription (STT) is an input
+# op, not a generated asset, so it returns the text directly and does NOT touch
+# the gallery. Media accumulates across the session (per-session state holds the
+# gallery's media list); each generation re-creates the gallery with the full
+# list and emits the refreshed pocket, so the canvas always shows every asset
+# made this session.
 #
 # EE→OSS boundary: this module lives in pocketpaw_ee; the surface service loads
 # MEDIA_TOOL_IDS as a plain frozenset[str] inside a try/except (never importing a
 # pocketpaw_ee symbol into src/pocketpaw).
-"""Agent-side MCP surface for STUDIO image + video generation."""
+"""Agent-side MCP surface for STUDIO image + audio + video generation."""
 
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 import uuid
 from pathlib import Path
 from typing import Any
+
+import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -54,16 +72,30 @@ SERVER_NAME = "pocketpaw_media"
 # Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
 # Allowlist entries must use this exact form.
 IMAGE_GENERATE_TOOL_ID = f"mcp__{SERVER_NAME}__image_generate"
+AUDIO_GENERATE_TOOL_ID = f"mcp__{SERVER_NAME}__audio_generate"
+AUDIO_TRANSCRIBE_TOOL_ID = f"mcp__{SERVER_NAME}__audio_transcribe"
 VIDEO_GENERATE_TOOL_ID = f"mcp__{SERVER_NAME}__video_generate"
 
-MEDIA_TOOL_IDS = (IMAGE_GENERATE_TOOL_ID, VIDEO_GENERATE_TOOL_ID)
+MEDIA_TOOL_IDS = (
+    IMAGE_GENERATE_TOOL_ID,
+    AUDIO_GENERATE_TOOL_ID,
+    AUDIO_TRANSCRIBE_TOOL_ID,
+    VIDEO_GENERATE_TOOL_ID,
+)
 
-# Replicate HTTP API polling bounds (video generation is async — POST a
-# prediction, then GET-poll until terminal). httpx is the existing transport;
-# the replicate package is intentionally NOT a dependency.
-_REPLICATE_BASE = "https://api.replicate.com/v1"
-_POLL_INTERVAL_SECONDS = 3.0
-_POLL_MAX_SECONDS = 120.0
+# Per-modality default model ids used when the caller passes no ``model``. Image
+# keeps ``settings.image_model`` (resolved at call time) for backward-compat with
+# the studio skill/preamble, which pass only prompt + aspect_ratio. Audio/video
+# defaults are sensible catalog ids the proxy is expected to front; an operator
+# can pick any served model by passing ``model`` explicitly.
+_DEFAULT_AUDIO_TTS_MODEL = "tts-1"
+_DEFAULT_AUDIO_STT_MODEL = "whisper-1"
+_DEFAULT_VIDEO_MODEL = "sora"
+
+# LiteLLM's async video endpoint returns a job; poll its status until terminal,
+# bounded so a stuck job can't hang the chat turn (video can be slow).
+_VIDEO_POLL_INTERVAL_SECONDS = 3.0
+_VIDEO_POLL_MAX_SECONDS = 180.0
 
 
 def _error_response(message: str) -> dict[str, Any]:
@@ -87,6 +119,16 @@ def _success_response(body: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _str_arg(args: dict, key: str, default: str | None = None) -> str | None:
+    """Return ``args[key]`` when it is a non-empty string, else ``default``.
+    Keeps the optional-string arg handling (model / voice / size / format)
+    uniform across the handlers."""
+    val = args.get(key)
+    if isinstance(val, str) and val.strip():
+        return val
+    return default
+
+
 def _identity() -> tuple[str | None, str | None]:
     """Resolve the active workspace + user id from the per-stream ContextVars set
     by the cloud chat agent runtime. Returns ``(workspace_id, user_id)``."""
@@ -96,6 +138,56 @@ def _identity() -> tuple[str | None, str | None]:
         return current_workspace_id(), current_user_id()
     except Exception:  # noqa: BLE001
         return None, None
+
+
+# ── LiteLLM proxy transport (REUSED from the catalog entity) ─────────────────
+# Proxy base + key resolution lives in ee.pocketpaw_ee.catalog.config; the header
+# + httpx style mirrors catalog.litellm_client.LiteLLMClient. We do NOT
+# re-implement proxy URL/key handling here — one config path for the whole
+# deployment. The ``user`` field on each request tags the tenant so the proxy's
+# spend log attributes cost to the workspace (meter-friendly; we never block on
+# metering — the proxy already logs spend).
+
+
+def _proxy_base() -> str:
+    """The LiteLLM proxy base URL (trailing slash trimmed), from catalog config."""
+    from pocketpaw_ee.catalog import config
+
+    return config.litellm_proxy_url()
+
+
+def _proxy_key() -> str | None:
+    """The LiteLLM proxy admin/virtual key (or None), from catalog config."""
+    from pocketpaw_ee.catalog import config
+
+    return config.litellm_proxy_api_key()
+
+
+def _proxy_headers(*, json_content: bool = True) -> dict[str, str]:
+    """Bearer the proxy key (when set) the same way the catalog client does.
+    ``json_content`` adds the JSON content-type for the OpenAI-compatible JSON
+    endpoints; multipart uploads (STT) let httpx set the boundary itself."""
+    headers: dict[str, str] = {}
+    key = _proxy_key()
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    if json_content:
+        headers["Content-Type"] = "application/json"
+    return headers
+
+
+def _proxy_client(timeout: float = 120.0) -> httpx.AsyncClient:
+    """An httpx.AsyncClient pointed at the proxy. Media generation is slow
+    (image/audio seconds, video much longer), so the default timeout is generous
+    relative to the catalog client's 15s reads. Tests inject a MockTransport via
+    ``_PROXY_TRANSPORT``."""
+    return httpx.AsyncClient(transport=_PROXY_TRANSPORT, timeout=timeout)
+
+
+# Tests set this to an httpx.MockTransport so the proxy HTTP calls are exercised
+# without a live proxy (the same injection seam catalog.litellm_client exposes as
+# the ``_transport`` ctor arg). Production leaves it None (real network).
+_PROXY_TRANSPORT: httpx.BaseTransport | None = None
 
 
 # ── Per-session gallery state ───────────────────────────────────────────────
@@ -123,8 +215,11 @@ def _build_gallery_spec(media: list[dict[str, Any]]) -> dict[str, Any]:
     Uses ONLY existing widget types (``grid`` / ``card`` / ``image`` /
     ``video-player`` / ``text``) so it renders today. Each media item becomes a
     card tile in a responsive grid; an ``image`` item carries a local file path,
-    a ``video`` item carries the provider output URL. A leading ``text`` node
-    titles the gallery. ``media`` items: ``{kind: "image"|"video", src, prompt}``.
+    a ``video`` item carries the provider output URL, an ``audio`` item carries a
+    text note with its local path (no audio widget exists yet — degrade to a
+    labelled text tile rather than introduce an unrendered widget). A leading
+    ``text`` node titles the gallery. ``media`` items:
+    ``{kind: "image"|"video"|"audio", src, prompt}``.
     """
     tiles: list[dict[str, Any]] = []
     for i, item in enumerate(media):
@@ -133,6 +228,10 @@ def _build_gallery_spec(media: list[dict[str, Any]]) -> dict[str, Any]:
         prompt = item.get("prompt", "")
         if kind == "video":
             inner = {"type": "video-player", "props": {"src": src, "controls": True}}
+        elif kind == "audio":
+            # No audio-player widget in the manifest yet — show the audio as a
+            # labelled text tile so the gallery still renders with known widgets.
+            inner = {"type": "text", "props": {"text": f"Audio: {src}"}}
         else:
             inner = {"type": "image", "props": {"src": src, "alt": prompt}}
         tiles.append(
@@ -254,13 +353,66 @@ async def _land_in_gallery(
     return {"pocket_id": new_pocket_id, "count": len(state["media"])}, None
 
 
+# ── Image (POST {proxy}/v1/images/generations) ──────────────────────────────
+
+
+async def _proxy_image(
+    *, model: str, prompt: str, size: str | None, user: str
+) -> tuple[bytes | None, str | None]:
+    """Generate an image via the proxy's OpenAI-compatible image endpoint.
+
+    POSTs ``{model, prompt, n:1, size?, user}`` to ``/v1/images/generations`` and
+    accepts EITHER return shape: ``data[0].b64_json`` (gpt-image-1 always returns
+    base64) or ``data[0].url`` (dall-e fetched and its bytes returned). We do NOT
+    send ``response_format`` — gpt-image-1 / the newer dall-e API reject it
+    ("Unknown parameter: 'response_format'"), confirmed against the live proxy —
+    so the caller always gets raw image bytes to save regardless of model.
+    Returns ``(bytes, None)`` or ``(None, error)``.
+    """
+    base = _proxy_base()
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "n": 1,
+        "user": user,
+    }
+    if size:
+        payload["size"] = size
+    try:
+        async with _proxy_client() as client:
+            resp = await client.post(
+                f"{base}/v1/images/generations",
+                headers=_proxy_headers(),
+                json=payload,
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            data = (body.get("data") or [{}])[0]
+            b64 = data.get("b64_json")
+            if b64:
+                return base64.b64decode(b64), None
+            url = data.get("url")
+            if url:
+                img_resp = await client.get(url)
+                img_resp.raise_for_status()
+                return img_resp.content, None
+            return None, "proxy returned no image data (no b64_json or url)"
+    except httpx.HTTPStatusError as exc:
+        return None, _http_error_detail("image generation", exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("media: proxy image generation failed", exc_info=True)
+        return None, f"image generation failed: {exc}"
+
+
 async def _image_generate_handler(args: dict) -> dict:
     """MCP handler for ``media__image_generate``.
 
-    Reuses the Gemini image logic from the OSS ImageGenerateTool: settings'
-    google_api_key + image_model, saves the PNG under get_config_dir()/generated,
-    then lands it in the STUDIO gallery. Sets ``is_error`` when identity or the
-    google key is missing, the genai package is absent, or generation fails.
+    Routes through the LiteLLM proxy's ``/v1/images/generations`` with the
+    catalog model id from ``args['model']`` (falling back to
+    ``settings.image_model`` when omitted, for backward-compat with the studio
+    skill which passes only prompt + aspect_ratio), saves the PNG under
+    get_config_dir()/generated, then lands it in the STUDIO gallery. Sets
+    ``is_error`` when identity is missing or the proxy call fails.
     """
     workspace_id, user_id = _identity()
     if not workspace_id or not user_id:
@@ -271,35 +423,28 @@ async def _image_generate_handler(args: dict) -> dict:
     prompt = args.get("prompt")
     if not isinstance(prompt, str) or not prompt.strip():
         return _error_response("image_generate requires a non-empty `prompt`.")
-    aspect_ratio = args.get("aspect_ratio") if isinstance(args.get("aspect_ratio"), str) else "1:1"
+    size = _str_arg(args, "size")
 
-    from pocketpaw.config import get_settings
+    model = _str_arg(args, "model")
+    if not model:
+        # Backward-compat: existing callers (studio skill/preamble) pass no model.
+        from pocketpaw.config import get_settings
 
-    settings = get_settings()
-    if not settings.google_api_key:
-        return _error_response(
-            "Set POCKETPAW_GOOGLE_API_KEY to enable image generation (Google Gemini)."
-        )
+        model = get_settings().image_model
 
-    try:
-        from google import genai
-    except ImportError:
-        return _error_response(
-            "google-genai package not installed. Install with: pip install 'pocketpaw[image]'."
-        )
-
-    from pocketpaw.tools.builtin.image_gen import generate_image_file
+    image_bytes, err = await _proxy_image(
+        model=model, prompt=prompt, size=size, user=workspace_id
+    )
+    if err is not None or image_bytes is None:
+        return _error_response(err or "image generation returned no data")
 
     try:
-        client = genai.Client(api_key=settings.google_api_key)
         out_path = _generated_dir() / f"{uuid.uuid4()}.png"
-        err = generate_image_file(client, settings.image_model, prompt, aspect_ratio, out_path)
-        if err:
-            return _error_response(err)
-        logger.info("media: generated image %s", out_path)
+        out_path.write_bytes(image_bytes)
+        logger.info("media: generated image %s via proxy model %s", out_path, model)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("media: image generation failed", exc_info=True)
-        return _error_response(f"image generation failed: {exc}")
+        logger.warning("media: writing generated image failed", exc_info=True)
+        return _error_response(f"could not save the generated image: {exc}")
 
     result, err = await _land_in_gallery(
         workspace_id=workspace_id,
@@ -315,6 +460,7 @@ async def _image_generate_handler(args: dict) -> dict:
         {
             "ok": True,
             "kind": "image",
+            "model": model,
             "path": str(out_path),
             "pocket_id": result["pocket_id"],
             "gallery_count": result["count"],
@@ -322,34 +468,280 @@ async def _image_generate_handler(args: dict) -> dict:
     )
 
 
-async def _poll_replicate(client: Any, token: str, get_url: str) -> dict[str, Any]:
-    """Poll a Replicate prediction GET until it reaches a terminal status,
-    bounded by ``_POLL_MAX_SECONDS``. Returns the final prediction dict (caller
-    inspects ``status`` / ``output`` / ``error``)."""
-    headers = {"Authorization": f"Bearer {token}"}
+# ── Audio TTS (POST {proxy}/v1/audio/speech) ─────────────────────────────────
+
+
+async def _proxy_audio_speech(
+    *, model: str, text: str, voice: str, response_format: str, user: str
+) -> tuple[bytes | None, str | None]:
+    """Synthesize speech via the proxy's OpenAI-compatible speech endpoint.
+
+    POSTs ``{model, input, voice, response_format, user}`` to
+    ``/v1/audio/speech``; the body is the raw audio bytes (not JSON). Returns
+    ``(bytes, None)`` or ``(None, error)``.
+    """
+    base = _proxy_base()
+    payload = {
+        "model": model,
+        "input": text,
+        "voice": voice,
+        "response_format": response_format,
+        "user": user,
+    }
+    try:
+        async with _proxy_client() as client:
+            resp = await client.post(
+                f"{base}/v1/audio/speech",
+                headers=_proxy_headers(),
+                json=payload,
+            )
+            resp.raise_for_status()
+            return resp.content, None
+    except httpx.HTTPStatusError as exc:
+        return None, _http_error_detail("audio synthesis", exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("media: proxy audio synthesis failed", exc_info=True)
+        return None, f"audio synthesis failed: {exc}"
+
+
+async def _audio_generate_handler(args: dict) -> dict:
+    """MCP handler for ``media__audio_generate`` (text-to-speech).
+
+    Routes through ``/v1/audio/speech`` with the catalog model id from
+    ``args['model']`` (default ``tts-1``), saves the audio under
+    get_config_dir()/generated, then lands it in the STUDIO gallery as an audio
+    tile. Sets ``is_error`` when identity is missing or the proxy call fails.
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "audio_generate requires workspace and user context (call from a cloud chat session)."
+        )
+
+    text = args.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return _error_response("audio_generate requires non-empty `text` to speak.")
+    voice = _str_arg(args, "voice", "alloy")
+    response_format = _str_arg(args, "response_format", "mp3")
+    model = _str_arg(args, "model", _DEFAULT_AUDIO_TTS_MODEL)
+
+    audio_bytes, err = await _proxy_audio_speech(
+        model=model,
+        text=text,
+        voice=voice,
+        response_format=response_format,
+        user=workspace_id,
+    )
+    if err is not None or audio_bytes is None:
+        return _error_response(err or "audio synthesis returned no data")
+
+    try:
+        out_path = _generated_dir() / f"{uuid.uuid4()}.{response_format}"
+        out_path.write_bytes(audio_bytes)
+        logger.info("media: generated audio %s via proxy model %s", out_path, model)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("media: writing generated audio failed", exc_info=True)
+        return _error_response(f"could not save the generated audio: {exc}")
+
+    result, err = await _land_in_gallery(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        kind="audio",
+        src=str(out_path),
+        prompt=text,
+    )
+    if err is not None or result is None:
+        return _error_response(err or "could not add the audio to the gallery")
+
+    return _success_response(
+        {
+            "ok": True,
+            "kind": "audio",
+            "model": model,
+            "path": str(out_path),
+            "pocket_id": result["pocket_id"],
+            "gallery_count": result["count"],
+        }
+    )
+
+
+# ── Audio STT (POST {proxy}/v1/audio/transcriptions) ─────────────────────────
+
+
+async def _proxy_audio_transcription(
+    *, model: str, audio_path: Path, user: str
+) -> tuple[str | None, str | None]:
+    """Transcribe an audio file via the proxy's OpenAI-compatible transcription
+    endpoint.
+
+    POSTs a multipart upload (``file`` + ``model`` + ``user``) to
+    ``/v1/audio/transcriptions`` and returns ``body['text']``. httpx sets the
+    multipart boundary, so the JSON content-type header is NOT sent. Returns
+    ``(text, None)`` or ``(None, error)``.
+    """
+    base = _proxy_base()
+    try:
+        data = audio_path.read_bytes()
+    except OSError as exc:
+        return None, f"could not read audio file {audio_path}: {exc}"
+    try:
+        async with _proxy_client() as client:
+            resp = await client.post(
+                f"{base}/v1/audio/transcriptions",
+                headers=_proxy_headers(json_content=False),
+                files={"file": (audio_path.name, data)},
+                data={"model": model, "user": user},
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            text = body.get("text")
+            if not isinstance(text, str):
+                return None, "transcription returned no text"
+            return text, None
+    except httpx.HTTPStatusError as exc:
+        return None, _http_error_detail("audio transcription", exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("media: proxy audio transcription failed", exc_info=True)
+        return None, f"audio transcription failed: {exc}"
+
+
+async def _audio_transcribe_handler(args: dict) -> dict:
+    """MCP handler for ``media__audio_transcribe`` (speech-to-text).
+
+    Routes through ``/v1/audio/transcriptions`` with the catalog model id from
+    ``args['model']`` (default ``whisper-1``). Transcription is an INPUT op (not a
+    generated asset), so it returns the text directly and does NOT touch the
+    gallery. ``args['path']`` is a local audio file path. Sets ``is_error`` when
+    identity is missing, the path is absent, or the proxy call fails.
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "audio_transcribe requires workspace and user context (call from a cloud chat session)."
+        )
+
+    path = args.get("path")
+    if not isinstance(path, str) or not path.strip():
+        return _error_response("audio_transcribe requires a `path` to a local audio file.")
+    audio_path = Path(path)
+    if not audio_path.is_file():
+        return _error_response(f"audio file not found: {path}")
+
+    model = _str_arg(args, "model", _DEFAULT_AUDIO_STT_MODEL)
+
+    text, err = await _proxy_audio_transcription(
+        model=model, audio_path=audio_path, user=workspace_id
+    )
+    if err is not None or text is None:
+        return _error_response(err or "transcription returned no text")
+
+    return _success_response(
+        {"ok": True, "kind": "transcription", "model": model, "text": text}
+    )
+
+
+# ── Video (POST {proxy}/videos) ──────────────────────────────────────────────
+
+
+async def _poll_proxy_video(
+    client: httpx.AsyncClient, base: str, job_id: str
+) -> dict[str, Any]:
+    """Poll ``GET {proxy}/videos/{job_id}`` until the job reaches a terminal
+    status (``completed`` / ``succeeded`` / ``failed`` / ``cancelled``), bounded
+    by ``_VIDEO_POLL_MAX_SECONDS``. Returns the final job dict (caller inspects
+    ``status`` / ``data`` / ``error``)."""
     waited = 0.0
-    prediction: dict[str, Any] = {}
-    while waited < _POLL_MAX_SECONDS:
-        resp = await client.get(get_url, headers=headers, timeout=30.0)
+    job: dict[str, Any] = {}
+    while waited < _VIDEO_POLL_MAX_SECONDS:
+        resp = await client.get(f"{base}/videos/{job_id}", headers=_proxy_headers())
         resp.raise_for_status()
-        prediction = resp.json()
-        status = prediction.get("status")
-        if status in ("succeeded", "failed", "canceled"):
-            return prediction
-        await asyncio.sleep(_POLL_INTERVAL_SECONDS)
-        waited += _POLL_INTERVAL_SECONDS
-    prediction["status"] = prediction.get("status") or "timed_out"
-    return prediction
+        job = resp.json()
+        status = (job.get("status") or "").lower()
+        if status in ("completed", "succeeded", "failed", "cancelled", "canceled", "error"):
+            return job
+        await asyncio.sleep(_VIDEO_POLL_INTERVAL_SECONDS)
+        waited += _VIDEO_POLL_INTERVAL_SECONDS
+    job["status"] = job.get("status") or "timed_out"
+    return job
+
+
+def _extract_video_url(job: dict[str, Any]) -> str | None:
+    """Pull the first output URL out of a (terminal) video job. LiteLLM/OpenAI
+    video jobs vary in shape; check the common fields: ``url`` / ``output`` /
+    ``data[].url``."""
+    if isinstance(job.get("url"), str):
+        return job["url"]
+    output = job.get("output")
+    if isinstance(output, str):
+        return output
+    if isinstance(output, list):
+        url = next((u for u in output if isinstance(u, str)), None)
+        if url:
+            return url
+    data = job.get("data")
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict) and isinstance(item.get("url"), str):
+                return item["url"]
+    return None
+
+
+async def _proxy_video(
+    *, model: str, prompt: str, seconds: int, size: str | None, user: str
+) -> tuple[str | None, str | None]:
+    """Generate a video via the proxy's ``/videos`` endpoint.
+
+    POSTs ``{model, prompt, seconds, size?, user}``; the response is an async job
+    (or, for a fast provider, an already-terminal job). If the job is pending it
+    is GET-polled to terminal. Returns the output URL or an error.
+    """
+    base = _proxy_base()
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "seconds": seconds,
+        "user": user,
+    }
+    if size:
+        payload["size"] = size
+    try:
+        async with _proxy_client(timeout=_VIDEO_POLL_MAX_SECONDS + 30.0) as client:
+            resp = await client.post(
+                f"{base}/videos",
+                headers=_proxy_headers(),
+                json=payload,
+            )
+            resp.raise_for_status()
+            job = resp.json()
+            status = (job.get("status") or "").lower()
+            terminal = {"completed", "succeeded", "failed", "cancelled", "canceled", "error"}
+            job_id = job.get("id")
+            if status not in terminal and job_id:
+                job = await _poll_proxy_video(client, base, str(job_id))
+            status = (job.get("status") or "").lower()
+            if status not in ("completed", "succeeded"):
+                detail = job.get("error") or status or "unknown status"
+                return None, f"video generation did not succeed: {detail}"
+            url = _extract_video_url(job)
+            if not url:
+                return None, "video generation succeeded but returned no output URL"
+            return url, None
+    except httpx.HTTPStatusError as exc:
+        return None, _http_error_detail("video generation", exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("media: proxy video generation failed", exc_info=True)
+        return None, f"video generation failed: {exc}"
 
 
 async def _video_generate_handler(args: dict) -> dict:
     """MCP handler for ``media__video_generate``.
 
-    Calls the Replicate HTTP API with httpx (no replicate package): POSTs a
-    prediction for ``settings.video_model`` with the prompt + duration +
-    aspect_ratio, polls the prediction GET until terminal (~120s cap, 3s sleep),
-    then lands the resulting output URL in the STUDIO gallery. Sets ``is_error``
-    when identity or the token is missing, the prediction fails, or it times out.
+    Routes through the LiteLLM proxy's ``/videos`` endpoint with the catalog
+    model id from ``args['model']`` (falling back to ``settings.video_model`` then
+    a built-in default, for backward-compat with the studio skill which passes
+    only prompt + duration + aspect_ratio). Lands the resulting output URL in the
+    STUDIO gallery. Sets ``is_error`` when identity is missing or the proxy call
+    fails / does not succeed.
     """
     workspace_id, user_id = _identity()
     if not workspace_id or not user_id:
@@ -361,62 +753,21 @@ async def _video_generate_handler(args: dict) -> dict:
     if not isinstance(prompt, str) or not prompt.strip():
         return _error_response("video_generate requires a non-empty `prompt`.")
     duration = args.get("duration") if isinstance(args.get("duration"), int) else 5
-    aspect_ratio = args.get("aspect_ratio") if isinstance(args.get("aspect_ratio"), str) else "16:9"
+    size = _str_arg(args, "size")
 
-    from pocketpaw.config import get_settings
+    model = _str_arg(args, "model")
+    if not model:
+        # Backward-compat: existing callers pass no model. Prefer the legacy
+        # settings.video_model if it looks like a proxy model id, else default.
+        from pocketpaw.config import get_settings
 
-    settings = get_settings()
-    if not settings.replicate_api_token:
-        return _error_response("Set POCKETPAW_REPLICATE_API_TOKEN to enable video generation.")
+        model = get_settings().video_model or _DEFAULT_VIDEO_MODEL
 
-    import httpx
-
-    token = settings.replicate_api_token
-    model = settings.video_model
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-    # Replicate runs a model by owner/name slug via the model-scoped predictions
-    # endpoint; the input shape is model-specific but prompt/duration/aspect_ratio
-    # are the common kling-style fields.
-    create_url = f"{_REPLICATE_BASE}/models/{model}/predictions"
-    payload = {
-        "input": {
-            "prompt": prompt,
-            "duration": duration,
-            "aspect_ratio": aspect_ratio,
-        }
-    }
-
-    try:
-        async with httpx.AsyncClient() as client:
-            create_resp = await client.post(create_url, headers=headers, json=payload, timeout=30.0)
-            create_resp.raise_for_status()
-            prediction = create_resp.json()
-            get_url = (prediction.get("urls") or {}).get("get")
-            if not get_url:
-                return _error_response("Replicate did not return a prediction poll URL.")
-            prediction = await _poll_replicate(client, token, get_url)
-    except httpx.HTTPStatusError as exc:
-        logger.warning("media: replicate HTTP error", exc_info=True)
-        return _error_response(f"video generation request failed: {exc.response.status_code}")
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("media: video generation failed", exc_info=True)
-        return _error_response(f"video generation failed: {exc}")
-
-    status = prediction.get("status")
-    if status != "succeeded":
-        detail = prediction.get("error") or status
-        return _error_response(f"video generation did not succeed: {detail}")
-
-    output = prediction.get("output")
-    # Replicate output is a URL or a list of URLs — take the first URL.
-    if isinstance(output, list):
-        output_url = next((u for u in output if isinstance(u, str)), None)
-    elif isinstance(output, str):
-        output_url = output
-    else:
-        output_url = None
-    if not output_url:
-        return _error_response("video generation succeeded but returned no output URL.")
+    output_url, err = await _proxy_video(
+        model=model, prompt=prompt, seconds=duration, size=size, user=workspace_id
+    )
+    if err is not None or output_url is None:
+        return _error_response(err or "video generation returned no output URL")
 
     result, err = await _land_in_gallery(
         workspace_id=workspace_id,
@@ -432,11 +783,33 @@ async def _video_generate_handler(args: dict) -> dict:
         {
             "ok": True,
             "kind": "video",
+            "model": model,
             "url": output_url,
             "pocket_id": result["pocket_id"],
             "gallery_count": result["count"],
         }
     )
+
+
+def _http_error_detail(what: str, exc: httpx.HTTPStatusError) -> str:
+    """A compact, user-relayable message for a proxy HTTP error. Surfaces the
+    status code and, when the proxy returned a JSON error body, its message —
+    so a missing-model / no-quota / bad-key proxy response is legible rather than
+    a bare 4xx/5xx."""
+    status = exc.response.status_code
+    detail: str | None = None
+    try:
+        body = exc.response.json()
+        if isinstance(body, dict):
+            err = body.get("error")
+            if isinstance(err, dict):
+                detail = err.get("message")
+            elif isinstance(err, str):
+                detail = err
+            detail = detail or body.get("message")
+    except Exception:  # noqa: BLE001
+        detail = None
+    return f"{what} request failed: {status}" + (f" — {detail}" if detail else "")
 
 
 def build_media_server() -> tuple[str, Any] | None:
@@ -456,15 +829,17 @@ def build_media_server() -> tuple[str, Any] | None:
     @tool(
         "image_generate",
         (
-            "Generate an IMAGE from a text prompt (Google Gemini) and add it to "
-            "the user's /studio gallery. Use this on the STUDIO surface when the "
-            "user describes an image / poster / illustration to create. Args: "
-            "`prompt` (required — describe the image), optional `aspect_ratio` "
-            "(e.g. '1:1', '16:9', '9:16') and `size`. Returns {ok, kind:'image', "
-            "path, pocket_id, gallery_count}; the image is laid out as a tile in "
-            "the gallery pocket and the canvas opens automatically. ok=false with "
-            "an error means relay the reason (e.g. the Google API key is not set) "
-            "— do NOT claim a phantom image."
+            "Generate an IMAGE from a text prompt (routed through the model "
+            "gateway) and add it to the user's /studio gallery. Use this on the "
+            "STUDIO surface when the user describes an image / poster / "
+            "illustration to create. Args: `prompt` (required — describe the "
+            "image), optional `model` (a catalog image-model id, e.g. "
+            "'openai/gpt-image-1' or 'google/imagen-4'; omit to use the "
+            "deployment default) and `size` (e.g. '1024x1024'). Returns {ok, "
+            "kind:'image', model, path, pocket_id, gallery_count}; the image is "
+            "laid out as a tile in the gallery pocket and the canvas opens "
+            "automatically. ok=false with an error means relay the reason — do "
+            "NOT claim a phantom image."
         ),
         {
             "type": "object",
@@ -474,13 +849,17 @@ def build_media_server() -> tuple[str, Any] | None:
                     "minLength": 1,
                     "description": "Text description of the image to generate.",
                 },
+                "model": {
+                    "type": "string",
+                    "description": "Catalog image-model id (optional; default = deployment model).",
+                },
                 "aspect_ratio": {
                     "type": "string",
-                    "description": "Aspect ratio (default '1:1'). e.g. '1:1', '16:9', '9:16'.",
+                    "description": "Aspect ratio hint (e.g. '1:1', '16:9', '9:16').",
                 },
                 "size": {
                     "type": "string",
-                    "description": "Output resolution hint (default '1K').",
+                    "description": "Output resolution (e.g. '1024x1024', '1792x1024').",
                 },
             },
             "required": ["prompt"],
@@ -491,18 +870,90 @@ def build_media_server() -> tuple[str, Any] | None:
         return await _image_generate_handler(args)
 
     @tool(
+        "audio_generate",
+        (
+            "Generate SPEECH AUDIO from text (text-to-speech, routed through the "
+            "model gateway) and add it to the user's /studio gallery. Use this on "
+            "the STUDIO surface when the user wants narration / a voiceover / "
+            "spoken audio. Args: `text` (required — what to say), optional `model` "
+            "(a catalog TTS model id, default 'tts-1'), `voice` (e.g. 'alloy', "
+            "default 'alloy') and `response_format` ('mp3' default, 'wav', "
+            "'opus'). Returns {ok, kind:'audio', model, path, pocket_id, "
+            "gallery_count}. ok=false with an error means relay the reason — do "
+            "NOT claim phantom audio."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The text to synthesize into speech.",
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Catalog TTS model id (optional; defaults to 'tts-1').",
+                },
+                "voice": {
+                    "type": "string",
+                    "description": "Voice name (optional; defaults to 'alloy').",
+                },
+                "response_format": {
+                    "type": "string",
+                    "description": "Audio format: 'mp3' (default), 'wav', 'opus'.",
+                },
+            },
+            "required": ["text"],
+            "additionalProperties": False,
+        },
+    )
+    async def audio_generate(args):  # type: ignore[no-untyped-def]
+        return await _audio_generate_handler(args)
+
+    @tool(
+        "audio_transcribe",
+        (
+            "Transcribe a local AUDIO file to text (speech-to-text, routed "
+            "through the model gateway). Use when the user has an audio file they "
+            "want transcribed. Args: `path` (required — path to a local audio "
+            "file) and optional `model` (a catalog STT model id, default "
+            "'whisper-1'). Returns {ok, kind:'transcription', model, text}. This "
+            "does NOT add anything to the gallery (it is text, not a generated "
+            "asset). ok=false with an error means relay the reason."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Local filesystem path to the audio file to transcribe.",
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Catalog STT model id (optional; defaults to 'whisper-1').",
+                },
+            },
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+    )
+    async def audio_transcribe(args):  # type: ignore[no-untyped-def]
+        return await _audio_transcribe_handler(args)
+
+    @tool(
         "video_generate",
         (
-            "Generate a VIDEO from a text prompt (Replicate) and add it to the "
-            "user's /studio gallery. Use this on the STUDIO surface when the user "
-            "describes a short video / clip / animation to create. Args: `prompt` "
-            "(required — describe the video), optional `duration` (seconds, "
-            "default 5) and `aspect_ratio` (e.g. '16:9', '9:16'). Generation is "
-            "async and may take up to ~2 minutes. Returns {ok, kind:'video', url, "
-            "pocket_id, gallery_count}; the video is laid out as a tile in the "
-            "gallery pocket and the canvas opens automatically. ok=false with an "
-            "error means relay the reason (e.g. POCKETPAW_REPLICATE_API_TOKEN is "
-            "not set) — do NOT claim a phantom video."
+            "Generate a VIDEO from a text prompt (routed through the model "
+            "gateway) and add it to the user's /studio gallery. Use this on the "
+            "STUDIO surface when the user describes a short video / clip / "
+            "animation to create. Args: `prompt` (required — describe the video), "
+            "optional `model` (a catalog video-model id, e.g. 'openai/sora' or a "
+            "Veo/Kling id; omit to use the deployment default), `duration` "
+            "(seconds, default 5) and `size` (e.g. '1280x720'). Generation is "
+            "async and may take a few minutes. Returns {ok, kind:'video', model, "
+            "url, pocket_id, gallery_count}. ok=false with an error means relay "
+            "the reason — do NOT claim a phantom video."
         ),
         {
             "type": "object",
@@ -512,13 +963,21 @@ def build_media_server() -> tuple[str, Any] | None:
                     "minLength": 1,
                     "description": "Text description of the video to generate.",
                 },
+                "model": {
+                    "type": "string",
+                    "description": "Catalog video-model id (optional; default = deployment model).",
+                },
                 "duration": {
                     "type": "integer",
                     "description": "Clip length in seconds (default 5).",
                 },
                 "aspect_ratio": {
                     "type": "string",
-                    "description": "Aspect ratio (default '16:9'). e.g. '16:9', '9:16'.",
+                    "description": "Aspect ratio hint (e.g. '16:9', '9:16').",
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Output resolution (e.g. '1280x720', '720x1280').",
                 },
             },
             "required": ["prompt"],
@@ -530,16 +989,18 @@ def build_media_server() -> tuple[str, Any] | None:
 
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
-        version="1.0.0",
-        tools=[image_generate, video_generate],
+        version="2.0.0",
+        tools=[image_generate, audio_generate, audio_transcribe, video_generate],
     )
     return SERVER_NAME, server
 
 
 __all__ = [
     "IMAGE_GENERATE_TOOL_ID",
+    "AUDIO_GENERATE_TOOL_ID",
+    "AUDIO_TRANSCRIBE_TOOL_ID",
+    "VIDEO_GENERATE_TOOL_ID",
     "MEDIA_TOOL_IDS",
     "SERVER_NAME",
-    "VIDEO_GENERATE_TOOL_ID",
     "build_media_server",
 ]

--- a/ee/pocketpaw_ee/agent/mcp_servers/media.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/media.py
@@ -83,14 +83,27 @@ MEDIA_TOOL_IDS = (
     VIDEO_GENERATE_TOOL_ID,
 )
 
-# Per-modality default model ids used when the caller passes no ``model``. Image
-# keeps ``settings.image_model`` (resolved at call time) for backward-compat with
-# the studio skill/preamble, which pass only prompt + aspect_ratio. Audio/video
-# defaults are sensible catalog ids the proxy is expected to front; an operator
-# can pick any served model by passing ``model`` explicitly.
+# Per-modality default model ids used when the caller passes no ``model``. THE
+# REAL PATH is the caller passing a catalog model id (the picker / studio skill
+# selects one) — these defaults are only a backward-compat floor for callers
+# that pass nothing, and they only route if the proxy actually serves that id.
+# Image prefers a known-served default and falls back to ``settings.image_model``
+# (resolved at call time); audio/video use proxy-style ids an operator is
+# expected to front. An operator can always pick any served model explicitly.
+_DEFAULT_IMAGE_MODEL = "gpt-image-1"  # an OpenAI-compatible id the proxy serves
 _DEFAULT_AUDIO_TTS_MODEL = "tts-1"
 _DEFAULT_AUDIO_STT_MODEL = "whisper-1"
-_DEFAULT_VIDEO_MODEL = "sora"
+_DEFAULT_VIDEO_MODEL = "sora"  # a proxy-style id; NOT a Replicate owner/name slug
+
+# Map the studio skill's aspect_ratio hint onto an OpenAI-compatible ``size``
+# (the images/generations + videos endpoints take ``size``, not aspect_ratio).
+# An explicit ``size`` arg always wins; this only fills the gap when the caller
+# passed aspect_ratio (the existing bundled-skill contract) and no size.
+_ASPECT_RATIO_TO_SIZE: dict[str, str] = {
+    "1:1": "1024x1024",
+    "16:9": "1792x1024",
+    "9:16": "1024x1792",
+}
 
 # LiteLLM's async video endpoint returns a job; poll its status until terminal,
 # bounded so a stuck job can't hang the chat turn (video can be slow).
@@ -127,6 +140,65 @@ def _str_arg(args: dict, key: str, default: str | None = None) -> str | None:
     if isinstance(val, str) and val.strip():
         return val
     return default
+
+
+def _resolve_size(args: dict) -> str | None:
+    """Resolve an OpenAI-compatible ``size`` from the request args. An explicit
+    ``size`` wins; otherwise the studio skill's ``aspect_ratio`` hint is mapped
+    via _ASPECT_RATIO_TO_SIZE so a user asking 16:9 doesn't silently get the
+    model default. Returns None when neither is usable (model picks its default).
+    """
+    size = _str_arg(args, "size")
+    if size:
+        return size
+    aspect = _str_arg(args, "aspect_ratio")
+    if aspect:
+        return _ASPECT_RATIO_TO_SIZE.get(aspect.strip())
+    return None
+
+
+def _looks_like_replicate_slug(model: str) -> bool:
+    """True when ``model`` looks like a Replicate ``owner/name`` slug rather than
+    a proxy catalog id. Used so the legacy ``settings.video_model`` default
+    (kwaivgi/kling-v2.0) is NOT POSTed to the proxy's /videos endpoint, which
+    won't serve a raw Replicate slug. Heuristic: a single '/' with non-empty
+    halves and no leading provider we recognise as proxy-style. Catalog ids are
+    bare (``sora``) or ``provider/model`` where provider is an LLM provider; a
+    Replicate slug is an account handle. We can't perfectly tell them apart, so
+    we treat ANY ``a/b`` as a slug here — proxy callers that want a namespaced id
+    should pass it explicitly via ``model`` rather than rely on the video_model
+    setting, which exists for the old direct-Replicate path."""
+    return model.count("/") == 1 and all(part.strip() for part in model.split("/"))
+
+
+def _default_image_model() -> str:
+    """The image model to use when the caller passes none. Prefer the known-served
+    default; honour ``settings.image_model`` ONLY if the operator deliberately
+    changed it from its field default (``gemini-2.5-flash-image``, which only
+    routes if the proxy aliases that exact id). Keeps the setting meaningful for
+    an operator who pointed it at a served id, without shipping the unroutable
+    field default as the de-facto proxy default."""
+    from pocketpaw.config import Settings, get_settings
+
+    configured = get_settings().image_model
+    field_default = Settings.model_fields["image_model"].default
+    if configured and configured != field_default:
+        return configured
+    return _DEFAULT_IMAGE_MODEL
+
+
+def _default_video_model() -> str:
+    """The video model to use when the caller passes none. The legacy
+    ``settings.video_model`` default is a Replicate ``owner/name`` slug
+    (kwaivgi/kling-v2.0) that the proxy's /videos endpoint won't serve, so we do
+    NOT forward a slug: prefer a proxy-style default, and use
+    ``settings.video_model`` only when an operator set it to a NON-slug proxy id."""
+    from pocketpaw.config import get_settings
+
+    configured = get_settings().video_model
+    if configured and not _looks_like_replicate_slug(configured):
+        return configured
+    return _DEFAULT_VIDEO_MODEL
 
 
 def _identity() -> tuple[str | None, str | None]:
@@ -407,12 +479,14 @@ async def _proxy_image(
 async def _image_generate_handler(args: dict) -> dict:
     """MCP handler for ``media__image_generate``.
 
-    Routes through the LiteLLM proxy's ``/v1/images/generations`` with the
-    catalog model id from ``args['model']`` (falling back to
-    ``settings.image_model`` when omitted, for backward-compat with the studio
-    skill which passes only prompt + aspect_ratio), saves the PNG under
-    get_config_dir()/generated, then lands it in the STUDIO gallery. Sets
-    ``is_error`` when identity is missing or the proxy call fails.
+    The REAL path is the caller passing a catalog model id in ``args['model']``
+    (the picker / studio skill selects one). Routes through the LiteLLM proxy's
+    ``/v1/images/generations``; ``aspect_ratio`` is mapped to ``size`` (an
+    explicit ``size`` wins) so the bundled skill's aspect hint is honoured rather
+    than silently dropped. Saves the PNG under get_config_dir()/generated, then
+    lands it in the STUDIO gallery. When no model is passed it falls back to a
+    known-served default, then ``settings.image_model``. Sets ``is_error`` when
+    identity is missing or the proxy call fails.
     """
     workspace_id, user_id = _identity()
     if not workspace_id or not user_id:
@@ -423,14 +497,11 @@ async def _image_generate_handler(args: dict) -> dict:
     prompt = args.get("prompt")
     if not isinstance(prompt, str) or not prompt.strip():
         return _error_response("image_generate requires a non-empty `prompt`.")
-    size = _str_arg(args, "size")
+    size = _resolve_size(args)
 
     model = _str_arg(args, "model")
     if not model:
-        # Backward-compat: existing callers (studio skill/preamble) pass no model.
-        from pocketpaw.config import get_settings
-
-        model = get_settings().image_model
+        model = _default_image_model()
 
     image_bytes, err = await _proxy_image(
         model=model, prompt=prompt, size=size, user=workspace_id
@@ -687,13 +758,22 @@ def _extract_video_url(job: dict[str, Any]) -> str | None:
 
 
 async def _proxy_video(
-    *, model: str, prompt: str, seconds: int, size: str | None, user: str
+    *,
+    model: str,
+    prompt: str,
+    seconds: int,
+    size: str | None,
+    aspect_ratio: str | None,
+    user: str,
 ) -> tuple[str | None, str | None]:
     """Generate a video via the proxy's ``/videos`` endpoint.
 
-    POSTs ``{model, prompt, seconds, size?, user}``; the response is an async job
-    (or, for a fast provider, an already-terminal job). If the job is pending it
-    is GET-polled to terminal. Returns the output URL or an error.
+    POSTs ``{model, prompt, seconds, size?, aspect_ratio?, user}``; the response
+    is an async job (or, for a fast provider, an already-terminal job). If the job
+    is pending it is GET-polled to terminal. Both ``size`` and ``aspect_ratio`` are
+    sent when present — different video models accept different shape params and
+    LiteLLM passes through what the model takes / ignores the rest. Returns the
+    output URL or an error.
     """
     base = _proxy_base()
     payload: dict[str, Any] = {
@@ -704,6 +784,8 @@ async def _proxy_video(
     }
     if size:
         payload["size"] = size
+    if aspect_ratio:
+        payload["aspect_ratio"] = aspect_ratio
     try:
         async with _proxy_client(timeout=_VIDEO_POLL_MAX_SECONDS + 30.0) as client:
             resp = await client.post(
@@ -736,12 +818,14 @@ async def _proxy_video(
 async def _video_generate_handler(args: dict) -> dict:
     """MCP handler for ``media__video_generate``.
 
-    Routes through the LiteLLM proxy's ``/videos`` endpoint with the catalog
-    model id from ``args['model']`` (falling back to ``settings.video_model`` then
-    a built-in default, for backward-compat with the studio skill which passes
-    only prompt + duration + aspect_ratio). Lands the resulting output URL in the
-    STUDIO gallery. Sets ``is_error`` when identity is missing or the proxy call
-    fails / does not succeed.
+    The REAL path is the caller passing a catalog model id in ``args['model']``.
+    Routes through the LiteLLM proxy's ``/videos`` endpoint; ``aspect_ratio`` is
+    both mapped to ``size`` and passed through (LiteLLM ignores params a model
+    doesn't take). When no model is passed it defaults to a proxy-style id — it
+    does NOT forward the legacy ``settings.video_model`` Replicate slug, which the
+    proxy won't serve. Lands the resulting output URL in the STUDIO gallery. Sets
+    ``is_error`` when identity is missing or the proxy call fails / does not
+    succeed.
     """
     workspace_id, user_id = _identity()
     if not workspace_id or not user_id:
@@ -753,18 +837,18 @@ async def _video_generate_handler(args: dict) -> dict:
     if not isinstance(prompt, str) or not prompt.strip():
         return _error_response("video_generate requires a non-empty `prompt`.")
     duration = args.get("duration") if isinstance(args.get("duration"), int) else 5
-    size = _str_arg(args, "size")
+    size = _resolve_size(args)
+    aspect_ratio = _str_arg(args, "aspect_ratio")
 
-    model = _str_arg(args, "model")
-    if not model:
-        # Backward-compat: existing callers pass no model. Prefer the legacy
-        # settings.video_model if it looks like a proxy model id, else default.
-        from pocketpaw.config import get_settings
-
-        model = get_settings().video_model or _DEFAULT_VIDEO_MODEL
+    model = _str_arg(args, "model") or _default_video_model()
 
     output_url, err = await _proxy_video(
-        model=model, prompt=prompt, seconds=duration, size=size, user=workspace_id
+        model=model,
+        prompt=prompt,
+        seconds=duration,
+        size=size,
+        aspect_ratio=aspect_ratio,
+        user=workspace_id,
     )
     if err is not None or output_url is None:
         return _error_response(err or "video generation returned no output URL")

--- a/ee/pocketpaw_ee/catalog/README.md
+++ b/ee/pocketpaw_ee/catalog/README.md
@@ -36,8 +36,8 @@ yet (see the MCG-1 note below).
 
 | Var | Default | Meaning |
 | --- | --- | --- |
-| `LITELLM_PROXY_URL` | `http://localhost:4000` | proxy base URL |
-| `LITELLM_PROXY_API_KEY` | _(unset)_ | proxy admin/virtual key (Bearer) |
+| `POCKETPAW_LITELLM_API_BASE` | `http://localhost:4000` | proxy base URL |
+| `POCKETPAW_LITELLM_API_KEY` | _(unset)_ | proxy admin/virtual key (Bearer) |
 | `CATALOG_CACHE_TTL_SECONDS` | `300` | assembled-catalog TTL |
 | `CATALOG_MODELS_DEV_ENABLED` | `true` | toggle models.dev enrichment |
 
@@ -61,7 +61,7 @@ yet (see the MCG-1 note below).
 This slice ships the **app-side catalog API** and a **reference proxy config**
 (`litellm.config.example.yaml`). Standing up the live LiteLLM proxy — wiring it
 into the Coolify deploy, supplying real provider keys + Postgres/Redis, and
-pointing `LITELLM_PROXY_URL` / `LITELLM_PROXY_API_KEY` at it — is a **captain
+pointing `POCKETPAW_LITELLM_API_BASE` / `POCKETPAW_LITELLM_API_KEY` at it — is a **captain
 handoff**; the controller has the box and the credentials. Until the live proxy
 is reachable, the catalog endpoints return `502` (source of truth unreachable),
 which is the intended behavior, not a bug.

--- a/ee/pocketpaw_ee/catalog/README.md
+++ b/ee/pocketpaw_ee/catalog/README.md
@@ -1,0 +1,52 @@
+<!-- ee/pocketpaw_ee/catalog/README.md — Model Catalog (MCG-1) overview +
+     live-deploy captain handoff. Created 2026-06-26 (feat/mcg-1-catalog-api). -->
+
+# Model Catalog (MCG-1)
+
+A thin, license-gated read API over a self-hosted **LiteLLM proxy**. It exposes
+the models the proxy serves, grouped by modality, to clients.
+
+## Endpoints
+
+- `GET /api/v1/catalog/models?modality=&provider=&q=&capability=` — filtered list
+  (`{models: [...], total: N}`).
+- `GET /api/v1/catalog/models/{id}` — one entry. `id` is the **URL-encoded**
+  canonical key `"<provider>/<model>"` (the slash is `%2F`).
+
+## How it works
+
+1. `litellm_client.py` reads the proxy: `GET /v1/models` (routable ids) +
+   `GET /model/info` (per-model metadata), and maps each row onto a
+   `ModelCatalogEntry` (`models.py`). LiteLLM's `mode` → our `modality`;
+   per-token cost → per-million-token `pricing`; `supports_*` flags →
+   `capabilities`.
+2. `models_dev_client.py` enriches `logo` / `description` / extra capabilities
+   from `https://models.dev/api.json` — **best-effort, fail-open**. Any failure
+   (or `CATALOG_MODELS_DEV_ENABLED=false`) falls back to LiteLLM-only data.
+3. `service.py` assembles + **TTL-caches** the catalog in-process
+   (`CATALOG_CACHE_TTL_SECONDS`, default 300s) and applies the filters.
+   `service.bust_cache()` invalidates on demand.
+
+**Catalog ⊇ routable:** the catalog is the union of `/model/info` and
+`/v1/models`, so a served-but-undescribed model is still listed. v1 marks every
+entry `status="available"` — `/model/info` exposes no per-model readiness signal
+yet (see the MCG-1 note below).
+
+## Configuration (env — see `.env.enterprise.example`)
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `LITELLM_PROXY_URL` | `http://localhost:4000` | proxy base URL |
+| `LITELLM_PROXY_API_KEY` | _(unset)_ | proxy admin/virtual key (Bearer) |
+| `CATALOG_CACHE_TTL_SECONDS` | `300` | assembled-catalog TTL |
+| `CATALOG_MODELS_DEV_ENABLED` | `true` | toggle models.dev enrichment |
+
+## Live deploy — CAPTAIN HANDOFF
+
+This slice ships the **app-side catalog API** and a **reference proxy config**
+(`litellm.config.example.yaml`). Standing up the live LiteLLM proxy — wiring it
+into the Coolify deploy, supplying real provider keys + Postgres/Redis, and
+pointing `LITELLM_PROXY_URL` / `LITELLM_PROXY_API_KEY` at it — is a **captain
+handoff**; the controller has the box and the credentials. Until the live proxy
+is reachable, the catalog endpoints return `502` (source of truth unreachable),
+which is the intended behavior, not a bug.

--- a/ee/pocketpaw_ee/catalog/README.md
+++ b/ee/pocketpaw_ee/catalog/README.md
@@ -41,6 +41,21 @@ yet (see the MCG-1 note below).
 | `CATALOG_CACHE_TTL_SECONDS` | `300` | assembled-catalog TTL |
 | `CATALOG_MODELS_DEV_ENABLED` | `true` | toggle models.dev enrichment |
 
+## Known gaps (carried forward)
+
+- **Non-text pricing is unmapped.** The mapper reads only per-token cost
+  (`input_cost_per_token`/`output_cost_per_token`), so image / audio / video
+  models report `pricing=None` even when the proxy knows a per-image or
+  per-second cost. Fails soft (the field is optional). Fix belongs with the
+  multi-modal execution slices (MCG-6/7), which must map the per-unit cost
+  fields into a richer `Pricing` before the picker surfaces non-text prices.
+- **Readiness/status.** `/model/info` exposes no per-model readiness signal, so
+  v1 marks every entry `status="available"`. The `status` field + the
+  catalog⊇routable union are in place for a future readiness probe to flip
+  un-keyed models to `"disabled"`.
+- **`streaming` capability is a heuristic** (assumed for all chat models), not
+  read from `/model/info`.
+
 ## Live deploy — CAPTAIN HANDOFF
 
 This slice ships the **app-side catalog API** and a **reference proxy config**

--- a/ee/pocketpaw_ee/catalog/__init__.py
+++ b/ee/pocketpaw_ee/catalog/__init__.py
@@ -1,0 +1,8 @@
+# ee/pocketpaw_ee/catalog/__init__.py — Model Catalog entity package marker
+# (MCG-1). The catalog reads the models a self-hosted LiteLLM proxy serves
+# (GET /v1/models + GET /model/info), maps each onto a ModelCatalogEntry grouped
+# by modality, optionally enriches logo/description from models.dev, TTL-caches
+# the assembled set in-process, and exposes it over GET /api/v1/catalog/models[/{id}].
+# Plain marker — the router is re-exported by ee.cloud.__init__:mount_cloud.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): new entity package.

--- a/ee/pocketpaw_ee/catalog/admin_client.py
+++ b/ee/pocketpaw_ee/catalog/admin_client.py
@@ -1,0 +1,186 @@
+# ee/pocketpaw_ee/catalog/admin_client.py — async ADMIN client over the LiteLLM
+# proxy's management API (MCG-8). The read-only catalog client lives in
+# ``litellm_client.py``; this is its MUTATING sibling — it mints per-tenant
+# virtual keys and reads per-key spend, authorized by the proxy MASTER key.
+#
+# Reuses the catalog's proxy base/key resolution (``catalog.config``) so the whole
+# deployment has ONE proxy config path — the admin key is the same
+# ``POCKETPAW_LITELLM_API_KEY`` (the master key) the read client already uses; it
+# is the only key authorized for ``/key/*`` and ``/spend/*``.
+#
+# Endpoints wrapped:
+#   * POST /key/generate     — mint a virtual key with max_budget / budget_duration
+#                              / rpm_limit / tpm_limit / models / metadata. Returns
+#                              the new ``key`` string (+ echoed fields).
+#   * GET  /key/info?key=    — read back a key's live config + spend.
+#   * GET  /spend/logs?api_key=<key> — the per-key spend rows (cost + token counts,
+#                              incl. cached tokens). MUST pass ``api_key`` — an
+#                              unfiltered /spend/logs scans the whole proxy and
+#                              times out (noted in the MCG-8 task brief).
+#   * POST /key/delete       — revoke keys (used by the live-check teardown so a
+#                              throwaway probe key never lingers on the proxy).
+#
+# httpx-based with an injectable ``_transport`` so tests stand in an
+# httpx.MockTransport (no live proxy) — the same seam ``LiteLLMClient`` exposes.
+# Fail-LOUD: a non-2xx raises ``LiteLLMAdminError`` so a broken provision surfaces
+# rather than silently minting nothing / billing nothing.
+#
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-8): the proxy admin client.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from pocketpaw_ee.catalog import config
+
+logger = logging.getLogger(__name__)
+
+
+class LiteLLMAdminError(Exception):
+    """A LiteLLM proxy management call failed (non-2xx or malformed body). Raised
+    so provisioning / spend ingestion fail loud rather than silently no-op."""
+
+
+class LiteLLMAdminClient:
+    """Thin async client over the LiteLLM proxy MANAGEMENT API (key + spend).
+
+    Authorized by the proxy master key (``catalog.config.litellm_proxy_api_key``).
+    Mutating sibling of the read-only ``LiteLLMClient`` — same base-URL + header +
+    transport shape, different (privileged) endpoints.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        _transport: httpx.BaseTransport | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self._base_url = (base_url or config.litellm_proxy_url()).rstrip("/")
+        # api_key explicitly passed wins; otherwise resolve the master key from env.
+        self._api_key = api_key if api_key is not None else config.litellm_proxy_api_key()
+        self._transport = _transport  # tests inject httpx.MockTransport
+        self._timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            headers=self._headers(),
+            transport=self._transport,
+            timeout=self._timeout,
+        )
+
+    @staticmethod
+    def _json_or_raise(resp: httpx.Response, what: str) -> dict[str, Any]:
+        """Return the JSON body of a 2xx response, or raise ``LiteLLMAdminError``.
+        A non-2xx surfaces the status + (when present) the proxy error message so a
+        bad-budget / bad-key / no-permission response is legible."""
+        if resp.status_code // 100 != 2:
+            detail = ""
+            try:
+                body = resp.json()
+                if isinstance(body, dict):
+                    err = body.get("error")
+                    if isinstance(err, dict):
+                        detail = str(err.get("message") or "")
+                    elif isinstance(err, str):
+                        detail = err
+                    detail = detail or str(body.get("detail") or body.get("message") or "")
+            except Exception:  # noqa: BLE001
+                detail = ""
+            raise LiteLLMAdminError(
+                f"LiteLLM admin {what} returned {resp.status_code}"
+                + (f" — {detail}" if detail else "")
+            )
+        try:
+            body = resp.json()
+        except ValueError as exc:
+            raise LiteLLMAdminError(f"LiteLLM admin {what} returned non-JSON") from exc
+        return body if isinstance(body, dict) else {"data": body}
+
+    async def generate_key(
+        self,
+        *,
+        key_alias: str | None = None,
+        max_budget: float | None = None,
+        budget_duration: str | None = None,
+        rpm_limit: int | None = None,
+        tpm_limit: int | None = None,
+        models: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """POST /key/generate — mint a virtual key. Returns the proxy's JSON body
+        (carries the new ``key`` string and echoes the budget / limit fields).
+
+        Only non-None fields are sent so the proxy applies its own defaults for
+        anything we leave unset. ``models=[]`` is sent as an explicit empty
+        allowlist (all models) only when ``models`` is the empty list, not None.
+        """
+        payload: dict[str, Any] = {}
+        if key_alias is not None:
+            payload["key_alias"] = key_alias
+        if max_budget is not None:
+            payload["max_budget"] = max_budget
+        if budget_duration is not None:
+            payload["budget_duration"] = budget_duration
+        if rpm_limit is not None:
+            payload["rpm_limit"] = rpm_limit
+        if tpm_limit is not None:
+            payload["tpm_limit"] = tpm_limit
+        if models is not None:
+            payload["models"] = models
+        if metadata is not None:
+            payload["metadata"] = metadata
+
+        async with self._client() as client:
+            resp = await client.post(f"{self._base_url}/key/generate", json=payload)
+        return self._json_or_raise(resp, "/key/generate")
+
+    async def key_info(self, key: str) -> dict[str, Any]:
+        """GET /key/info?key=<key> — read back a key's live config + spend."""
+        async with self._client() as client:
+            resp = await client.get(f"{self._base_url}/key/info", params={"key": key})
+        return self._json_or_raise(resp, "/key/info")
+
+    async def spend_logs(self, *, api_key: str) -> list[dict[str, Any]]:
+        """GET /spend/logs?api_key=<key> — the spend rows for ONE virtual key.
+
+        ``api_key`` is REQUIRED: an unfiltered /spend/logs scans the proxy's whole
+        spend table and times out (per the MCG-8 brief). Returns the list of rows
+        (each carries ``spend``, ``startTime``, token counts incl. cached, and a
+        ``request_id``). A proxy that returns a bare list yields it directly; a
+        dict-wrapped ``{"data": [...]}`` is unwrapped.
+        """
+        if not api_key:
+            raise LiteLLMAdminError("spend_logs requires api_key (unfiltered scan times out)")
+        async with self._client() as client:
+            resp = await client.get(f"{self._base_url}/spend/logs", params={"api_key": api_key})
+        body = self._json_or_raise(resp, "/spend/logs")
+        # /spend/logs returns a top-level JSON array; _json_or_raise wraps a bare
+        # list as {"data": [...]}. A dict response with a "data" list is handled
+        # the same way. Keep only dict rows.
+        data = body.get("data")
+        rows = data if isinstance(data, list) else []
+        return [r for r in rows if isinstance(r, dict)]
+
+    async def delete_keys(self, keys: list[str]) -> dict[str, Any]:
+        """POST /key/delete — revoke the given virtual keys. Used by the live-check
+        teardown so a throwaway probe key is never left on the proxy."""
+        async with self._client() as client:
+            resp = await client.post(f"{self._base_url}/key/delete", json={"keys": keys})
+        return self._json_or_raise(resp, "/key/delete")
+
+
+__all__ = [
+    "LiteLLMAdminClient",
+    "LiteLLMAdminError",
+]

--- a/ee/pocketpaw_ee/catalog/config.py
+++ b/ee/pocketpaw_ee/catalog/config.py
@@ -4,8 +4,10 @@
 # following the same env-helper pattern as the Recall provider client
 # (ee/pocketpaw_ee/cloud/meetings/providers/recall/client.py).
 #
-#   LITELLM_PROXY_URL      — proxy base URL. Default http://localhost:4000.
-#   LITELLM_PROXY_API_KEY  — proxy admin/virtual key (optional). When set it is
+#   POCKETPAW_LITELLM_API_BASE — proxy base URL. Default http://localhost:4000.
+#                            (Same env var as the pocketpaw Settings field
+#                            litellm_api_base, so one value configures both.)
+#   POCKETPAW_LITELLM_API_KEY  — proxy admin/virtual key (optional). When set it is
 #                            sent as a Bearer token on every proxy call so a
 #                            key-protected proxy authorizes the catalog reads.
 #   CATALOG_CACHE_TTL_SECONDS  — assembled-catalog in-process TTL. Default 300.
@@ -31,7 +33,7 @@ def litellm_proxy_url() -> str:
     ``/`` without producing a double slash. Falls back to ``http://localhost:4000``
     (a local proxy) when the env var is unset or blank.
     """
-    raw = os.environ.get("LITELLM_PROXY_URL", "").strip() or DEFAULT_PROXY_URL
+    raw = os.environ.get("POCKETPAW_LITELLM_API_BASE", "").strip() or DEFAULT_PROXY_URL
     return raw.rstrip("/")
 
 
@@ -41,7 +43,7 @@ def litellm_proxy_api_key() -> str | None:
     Optional: a proxy with no key requirement (e.g. a local dev proxy) needs no
     value. When present it becomes the Bearer token on every proxy request.
     """
-    key = os.environ.get("LITELLM_PROXY_API_KEY", "").strip()
+    key = os.environ.get("POCKETPAW_LITELLM_API_KEY", "").strip()
     return key or None
 
 

--- a/ee/pocketpaw_ee/catalog/config.py
+++ b/ee/pocketpaw_ee/catalog/config.py
@@ -1,0 +1,73 @@
+# ee/pocketpaw_ee/catalog/config.py — deployment-global config for the Model
+# Catalog (MCG-1). The catalog's source of truth is a self-hosted LiteLLM proxy;
+# its base URL + (optional) admin key come from the environment, NOT hardcoded,
+# following the same env-helper pattern as the Recall provider client
+# (ee/pocketpaw_ee/cloud/meetings/providers/recall/client.py).
+#
+#   LITELLM_PROXY_URL      — proxy base URL. Default http://localhost:4000.
+#   LITELLM_PROXY_API_KEY  — proxy admin/virtual key (optional). When set it is
+#                            sent as a Bearer token on every proxy call so a
+#                            key-protected proxy authorizes the catalog reads.
+#   CATALOG_CACHE_TTL_SECONDS  — assembled-catalog in-process TTL. Default 300.
+#   CATALOG_MODELS_DEV_ENABLED — best-effort models.dev enrichment toggle.
+#                                Default "true"; set "false"/"0" to run
+#                                LiteLLM-only (no outbound models.dev fetch).
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): new config module.
+
+from __future__ import annotations
+
+import os
+
+# Defaults — referenced by tests and the example deploy config.
+DEFAULT_PROXY_URL = "http://localhost:4000"
+DEFAULT_CACHE_TTL_SECONDS = 300
+
+
+def litellm_proxy_url() -> str:
+    """Resolve the LiteLLM proxy base URL for this deployment.
+
+    Trailing slashes are trimmed so callers can join paths with a leading
+    ``/`` without producing a double slash. Falls back to ``http://localhost:4000``
+    (a local proxy) when the env var is unset or blank.
+    """
+    raw = os.environ.get("LITELLM_PROXY_URL", "").strip() or DEFAULT_PROXY_URL
+    return raw.rstrip("/")
+
+
+def litellm_proxy_api_key() -> str | None:
+    """Resolve the LiteLLM proxy admin/virtual key, or None when unset.
+
+    Optional: a proxy with no key requirement (e.g. a local dev proxy) needs no
+    value. When present it becomes the Bearer token on every proxy request.
+    """
+    key = os.environ.get("LITELLM_PROXY_API_KEY", "").strip()
+    return key or None
+
+
+def cache_ttl_seconds() -> int:
+    """In-process TTL (seconds) for the assembled catalog. Default 300.
+
+    A non-numeric or non-positive value falls back to the default so a bad env
+    value can never disable caching or crash assembly.
+    """
+    raw = os.environ.get("CATALOG_CACHE_TTL_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_CACHE_TTL_SECONDS
+    try:
+        ttl = int(raw)
+    except ValueError:
+        return DEFAULT_CACHE_TTL_SECONDS
+    return ttl if ttl > 0 else DEFAULT_CACHE_TTL_SECONDS
+
+
+def models_dev_enabled() -> bool:
+    """Whether to attempt best-effort models.dev enrichment. Default True.
+
+    Enrichment is always non-blocking (a failed fetch falls back to LiteLLM-only
+    data); this flag lets an operator skip the outbound call entirely.
+    """
+    raw = os.environ.get("CATALOG_MODELS_DEV_ENABLED", "").strip().lower()
+    if not raw:
+        return True
+    return raw not in {"0", "false", "no", "off"}

--- a/ee/pocketpaw_ee/catalog/litellm.config.example.yaml
+++ b/ee/pocketpaw_ee/catalog/litellm.config.example.yaml
@@ -11,8 +11,8 @@
 #
 # Catalog wiring on the app side (set in the enterprise env, see
 # .env.enterprise.example):
-#   LITELLM_PROXY_URL=http://<proxy-host>:4000
-#   LITELLM_PROXY_API_KEY=<the master_key below, or a virtual key>
+#   POCKETPAW_LITELLM_API_BASE=http://<proxy-host>:4000
+#   POCKETPAW_LITELLM_API_KEY=<the master_key below, or a virtual key>
 #
 # Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): reference proxy config.
 
@@ -46,7 +46,7 @@ litellm_settings:
 
 general_settings:
   # The proxy admin key. The catalog sends this (or a virtual key minted from it)
-  # as LITELLM_PROXY_API_KEY. Reads from the proxy host's env — never inline.
+  # as POCKETPAW_LITELLM_API_KEY. Reads from the proxy host's env — never inline.
   master_key: os.environ/LITELLM_MASTER_KEY
   # Postgres backs the proxy's virtual-key / spend tables. Placeholder DSN —
   # point at the deploy's Postgres.

--- a/ee/pocketpaw_ee/catalog/litellm.config.example.yaml
+++ b/ee/pocketpaw_ee/catalog/litellm.config.example.yaml
@@ -1,0 +1,53 @@
+# ee/pocketpaw_ee/catalog/litellm.config.example.yaml — REFERENCE LiteLLM proxy
+# config for the Model Catalog (MCG-1). The catalog reads its source of truth
+# from a self-hosted LiteLLM proxy started with a config like this:
+#
+#     litellm --config litellm.config.yaml
+#
+# This file is a starting point — one chat model in model_list, a router_settings
+# stub, and Postgres + Redis placeholders. Wiring the LIVE proxy into the Coolify
+# deploy with real credentials is a CAPTAIN HANDOFF (the controller has the box +
+# creds). Do NOT commit real keys here; keys belong in the proxy host's env.
+#
+# Catalog wiring on the app side (set in the enterprise env, see
+# .env.enterprise.example):
+#   LITELLM_PROXY_URL=http://<proxy-host>:4000
+#   LITELLM_PROXY_API_KEY=<the master_key below, or a virtual key>
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): reference proxy config.
+
+model_list:
+  # The canonical model_name "<provider>/<model>" IS the catalog's id. The
+  # litellm_params point at the upstream; api_key reads from the proxy host's env
+  # so no secret is stored in this file.
+  - model_name: anthropic/claude-3-5-sonnet
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+    # model_info is OPTIONAL — LiteLLM derives most fields from its built-in
+    # model map. Override here only when the upstream metadata is wrong/missing.
+    model_info:
+      mode: chat
+
+router_settings:
+  # Stub — tune for the real deploy. routing_strategy controls how the proxy
+  # picks among duplicate deployments of the same model_name.
+  routing_strategy: simple-shuffle
+  num_retries: 2
+  # redis_* lets the router share rate-limit + cooldown state across proxy
+  # replicas. Placeholders — point at the deploy's Redis.
+  redis_host: os.environ/REDIS_HOST
+  redis_port: os.environ/REDIS_PORT
+  redis_password: os.environ/REDIS_PASSWORD
+
+litellm_settings:
+  # Response/prompt caching at the proxy. Off by default in this reference.
+  set_verbose: false
+
+general_settings:
+  # The proxy admin key. The catalog sends this (or a virtual key minted from it)
+  # as LITELLM_PROXY_API_KEY. Reads from the proxy host's env — never inline.
+  master_key: os.environ/LITELLM_MASTER_KEY
+  # Postgres backs the proxy's virtual-key / spend tables. Placeholder DSN —
+  # point at the deploy's Postgres.
+  database_url: os.environ/DATABASE_URL

--- a/ee/pocketpaw_ee/catalog/litellm_client.py
+++ b/ee/pocketpaw_ee/catalog/litellm_client.py
@@ -1,0 +1,271 @@
+# ee/pocketpaw_ee/catalog/litellm_client.py — async client + mapper for a
+# self-hosted LiteLLM proxy (MCG-1). The proxy is the catalog's source of truth.
+#
+# Two reads:
+#   * GET /v1/models      — the list of model ids the proxy currently serves
+#                           (OpenAI-compatible {"data": [{"id": ...}, ...]}).
+#   * GET /model/info     — per-model metadata {"data": [{"model_name": ...,
+#                           "model_info": {max_tokens, input_cost_per_token,
+#                           output_cost_per_token, mode, supports_*, ...},
+#                           "litellm_params": {...}}, ...]}.
+#
+# ``fetch_entries`` joins the two and maps each row onto a ModelCatalogEntry:
+# LiteLLM ``mode`` -> our Modality (MODE_TO_MODALITY), per-token cost -> per-mtok
+# Pricing, supports_* flags -> the capabilities list, and the provider parsed
+# from the canonical "<provider>/<model>" model_name (falling back to
+# litellm_provider). v1 marks everything status="available" — /model/info does
+# not expose per-model routability/readiness, so catalog ⊇ routable degrades to
+# "all listed entries are available" (noted in the entity README + MCG-1 report).
+#
+# httpx-based with an injectable ``_transport`` so tests stand in an
+# httpx.MockTransport (no live proxy). Fail-closed: a non-2xx raises
+# CatalogUpstreamError so a broken proxy never silently yields a partial catalog.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): the proxy client + mapper.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from pocketpaw_ee.catalog import config
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry, Pricing
+
+logger = logging.getLogger(__name__)
+
+# LiteLLM's per-model ``mode`` string -> our coarse Modality bucket. LiteLLM uses
+# several spellings for "text in / text out" (chat, completion, responses); all
+# collapse to CHAT. Anything we don't recognise is treated as CHAT by the mapper
+# (the safest default for the picker — see _modality_for).
+MODE_TO_MODALITY: dict[str, Modality] = {
+    "chat": Modality.CHAT,
+    "completion": Modality.CHAT,
+    "responses": Modality.CHAT,
+    "embedding": Modality.EMBEDDING,
+    "image_generation": Modality.IMAGE,
+    "audio_speech": Modality.AUDIO_TTS,
+    "audio_transcription": Modality.AUDIO_STT,
+    "video": Modality.VIDEO,
+}
+
+# LiteLLM model_info ``supports_<x>`` boolean -> the capability token we surface.
+# Only flags that are True on a model land in ModelCatalogEntry.capabilities.
+SUPPORTS_TO_CAPABILITY: dict[str, str] = {
+    "supports_function_calling": "tool_call",
+    "supports_tool_choice": "tool_call",
+    "supports_vision": "vision",
+    "supports_response_schema": "json_mode",
+    "supports_parallel_function_calling": "parallel_tool_call",
+    "supports_prompt_caching": "prompt_caching",
+    "supports_reasoning": "reasoning",
+    "supports_audio_input": "audio_input",
+    "supports_audio_output": "audio_output",
+}
+
+
+class CatalogUpstreamError(Exception):
+    """A LiteLLM proxy read failed (non-2xx or malformed body). Raised so the
+    service can fail closed rather than serve a partial / empty catalog as if it
+    were complete."""
+
+
+def _provider_from_model_name(model_name: str, litellm_provider: str | None) -> str:
+    """Provider for an entry. Prefer the prefix of the canonical
+    "<provider>/<model>" model_name; fall back to LiteLLM's ``litellm_provider``;
+    finally "unknown". This keeps the provider consistent with the id's prefix."""
+    if "/" in model_name:
+        prefix = model_name.split("/", 1)[0].strip()
+        if prefix:
+            return prefix
+    if litellm_provider:
+        return litellm_provider.strip()
+    return "unknown"
+
+
+def _modality_for(mode: str | None) -> Modality:
+    """Map a LiteLLM ``mode`` onto a Modality. Unknown / missing -> CHAT, the
+    dominant case and the safest default for the picker (a mis-bucketed chat
+    model is still usable; dropping it is not)."""
+    if not mode:
+        return Modality.CHAT
+    return MODE_TO_MODALITY.get(mode.strip().lower(), Modality.CHAT)
+
+
+def _per_mtok(cost_per_token: Any) -> float | None:
+    """LiteLLM exposes cost PER TOKEN; the catalog reports per MILLION tokens.
+    Returns None for missing / non-numeric values so unknown cost stays None."""
+    if cost_per_token is None:
+        return None
+    try:
+        return round(float(cost_per_token) * 1_000_000, 6)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pricing_for(model_info: dict[str, Any]) -> Pricing | None:
+    """Build Pricing from per-token costs, or None when neither side is known."""
+    inp = _per_mtok(model_info.get("input_cost_per_token"))
+    out = _per_mtok(model_info.get("output_cost_per_token"))
+    if inp is None and out is None:
+        return None
+    return Pricing(input_per_mtok=inp, output_per_mtok=out)
+
+
+def _capabilities_for(model_info: dict[str, Any]) -> list[str]:
+    """Derive the capability tokens from the model_info ``supports_*`` flags.
+    Deduped + sorted so the wire output is deterministic; ``streaming`` is added
+    for chat-family models (LiteLLM streams every chat model it proxies)."""
+    caps: set[str] = set()
+    for flag, token in SUPPORTS_TO_CAPABILITY.items():
+        if model_info.get(flag) is True:
+            caps.add(token)
+    return sorted(caps)
+
+
+def _display_name(model_name: str) -> str:
+    """Human label derived from the model portion of "<provider>/<model>"."""
+    tail = model_name.split("/", 1)[1] if "/" in model_name else model_name
+    return tail or model_name
+
+
+def map_model_info_row(row: dict[str, Any]) -> ModelCatalogEntry | None:
+    """Map ONE /model/info row onto a ModelCatalogEntry, or None if it has no
+    usable ``model_name`` (the canonical id). Pure + side-effect free so it is
+    unit-testable in isolation."""
+    model_name = (row.get("model_name") or "").strip()
+    if not model_name:
+        return None
+    info: dict[str, Any] = row.get("model_info") or {}
+    params: dict[str, Any] = row.get("litellm_params") or {}
+    litellm_provider = info.get("litellm_provider") or params.get("custom_llm_provider")
+
+    mode = info.get("mode")
+    modality = _modality_for(mode)
+    caps = _capabilities_for(info)
+    # Chat-family models stream; surface it as a capability so the picker can show it.
+    if modality == Modality.CHAT:
+        caps = sorted(set(caps) | {"streaming"})
+
+    return ModelCatalogEntry(
+        id=model_name,
+        display_name=_display_name(model_name),
+        provider=_provider_from_model_name(model_name, litellm_provider),
+        modality=modality,
+        context=info.get("max_input_tokens") or info.get("max_tokens"),
+        max_output_tokens=info.get("max_output_tokens"),
+        pricing=_pricing_for(info),
+        capabilities=caps,
+        logo=None,  # enriched best-effort from models.dev in the service layer
+        description=None,
+        # v1: /model/info carries no per-model readiness signal, so every listed
+        # model is "available". catalog ⊇ routable holds trivially here; a future
+        # readiness probe can flip un-keyed models to "disabled".
+        status="available",
+    )
+
+
+class LiteLLMClient:
+    """Thin async client over a LiteLLM proxy. Reads only — no mutation."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        _transport: httpx.BaseTransport | None = None,
+        timeout: float = 15.0,
+    ) -> None:
+        self._base_url = (base_url or config.litellm_proxy_url()).rstrip("/")
+        # api_key explicitly passed wins; otherwise resolve from env at init.
+        self._api_key = api_key if api_key is not None else config.litellm_proxy_api_key()
+        self._transport = _transport  # tests inject httpx.MockTransport
+        self._timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        if self._api_key:
+            return {"Authorization": f"Bearer {self._api_key}"}
+        return {}
+
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            headers=self._headers(),
+            transport=self._transport,
+            timeout=self._timeout,
+        )
+
+    @staticmethod
+    def _unwrap_data(resp: httpx.Response, what: str) -> list[dict[str, Any]]:
+        """Fail-closed extraction of the ``data`` list from a proxy response.
+        Non-2xx raises; a missing/!list ``data`` yields an empty list (the proxy
+        answered but served nothing)."""
+        if resp.status_code // 100 != 2:
+            raise CatalogUpstreamError(f"LiteLLM proxy {what} returned {resp.status_code}")
+        try:
+            body = resp.json()
+        except ValueError as exc:
+            raise CatalogUpstreamError(f"LiteLLM proxy {what} returned non-JSON") from exc
+        data = body.get("data") if isinstance(body, dict) else None
+        return [r for r in data if isinstance(r, dict)] if isinstance(data, list) else []
+
+    async def list_model_ids(self) -> list[str]:
+        """GET /v1/models -> the model ids the proxy currently serves."""
+        async with self._client() as client:
+            resp = await client.get(f"{self._base_url}/v1/models")
+        rows = self._unwrap_data(resp, "/v1/models")
+        return [str(r["id"]).strip() for r in rows if r.get("id")]
+
+    async def model_info(self) -> list[dict[str, Any]]:
+        """GET /model/info -> the raw per-model metadata rows."""
+        async with self._client() as client:
+            resp = await client.get(f"{self._base_url}/model/info")
+        return self._unwrap_data(resp, "/model/info")
+
+    async def fetch_entries(self) -> list[ModelCatalogEntry]:
+        """Assemble ModelCatalogEntry objects from /model/info, then reconcile
+        against /v1/models so the catalog ⊇ routable (an /v1/models id missing
+        from /model/info is still listed as a bare entry).
+
+        /model/info is the rich source. /v1/models is the routable set. The union
+        is the catalog: every routable id appears; entries the proxy describes but
+        can't currently serve are kept (not dropped). The two reads run; if
+        /model/info succeeds we map it; /v1/models is best-effort reconciliation —
+        a failure there does not blank an otherwise-good catalog.
+        """
+        info_rows = await self.model_info()
+        entries: dict[str, ModelCatalogEntry] = {}
+        for row in info_rows:
+            entry = map_model_info_row(row)
+            if entry is not None:
+                entries[entry.id] = entry
+
+        # Reconcile against the routable list. Best-effort: a /v1/models failure
+        # must not blank a good /model/info catalog.
+        try:
+            served_ids = await self.list_model_ids()
+        except CatalogUpstreamError:
+            logger.warning("LiteLLM /v1/models unavailable; catalog from /model/info only")
+            served_ids = []
+        for mid in served_ids:
+            if mid not in entries:
+                # Served but undescribed — list it as a minimal available entry so
+                # the routable set is never narrower than the catalog.
+                entries[mid] = ModelCatalogEntry(
+                    id=mid,
+                    display_name=_display_name(mid),
+                    provider=_provider_from_model_name(mid, None),
+                    modality=Modality.CHAT,
+                    status="available",
+                )
+
+        return list(entries.values())
+
+
+__all__ = [
+    "LiteLLMClient",
+    "CatalogUpstreamError",
+    "MODE_TO_MODALITY",
+    "SUPPORTS_TO_CAPABILITY",
+    "map_model_info_row",
+]

--- a/ee/pocketpaw_ee/catalog/litellm_client.py
+++ b/ee/pocketpaw_ee/catalog/litellm_client.py
@@ -135,7 +135,9 @@ def map_model_info_row(row: dict[str, Any]) -> ModelCatalogEntry | None:
     usable ``model_name`` (the canonical id). Pure + side-effect free so it is
     unit-testable in isolation."""
     model_name = (row.get("model_name") or "").strip()
-    if not model_name:
+    # Skip LiteLLM's "*" catch-all passthrough — a routing wildcard, not a real,
+    # selectable model.
+    if not model_name or model_name == "*":
         return None
     info: dict[str, Any] = row.get("model_info") or {}
     params: dict[str, Any] = row.get("litellm_params") or {}
@@ -248,6 +250,8 @@ class LiteLLMClient:
             logger.warning("LiteLLM /v1/models unavailable; catalog from /model/info only")
             served_ids = []
         for mid in served_ids:
+            if mid == "*":
+                continue  # routing wildcard, not a real model
             if mid not in entries:
                 # Served but undescribed — list it as a minimal available entry so
                 # the routable set is never narrower than the catalog.

--- a/ee/pocketpaw_ee/catalog/models.py
+++ b/ee/pocketpaw_ee/catalog/models.py
@@ -1,0 +1,82 @@
+# ee/pocketpaw_ee/catalog/models.py — the Model Catalog data contract (MCG-1).
+#
+# ModelCatalogEntry is the single shape clients consume for a model the platform
+# can route to. Its ``id`` is the canonical key == the LiteLLM ``model_name``
+# ("<provider>/<model>"). ``modality`` is the coarse capability bucket the picker
+# groups by (chat / embedding / image / audio_tts / audio_stt / video — music is
+# explicitly out of scope). Pricing is per-million-tokens for text modalities;
+# None whenever the proxy/models.dev don't expose a cost. ``status`` is
+# "available" unless the proxy signals the model can't currently be served.
+#
+# These are plain Pydantic models (no Beanie / Mongo) — the catalog is assembled
+# from upstream reads on demand and TTL-cached in-process, never persisted.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): the catalog DTOs.
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class Modality(StrEnum):
+    """Coarse capability bucket the catalog groups + filters by.
+
+    Maps from LiteLLM's per-model ``mode`` (see litellm_client.MODE_TO_MODALITY).
+    ``music`` is deliberately absent — out of scope for MCG-1.
+    """
+
+    CHAT = "chat"
+    EMBEDDING = "embedding"
+    IMAGE = "image"
+    AUDIO_TTS = "audio_tts"
+    AUDIO_STT = "audio_stt"
+    VIDEO = "video"
+
+
+class Pricing(BaseModel):
+    """Per-model cost. For text modalities these are USD per MILLION tokens
+    (LiteLLM exposes per-token cost; the mapper multiplies by 1e6). A field is
+    None when the upstream doesn't expose that side of the cost. The whole
+    Pricing object is None on the entry when nothing is known."""
+
+    input_per_mtok: float | None = None
+    output_per_mtok: float | None = None
+
+
+class ModelCatalogEntry(BaseModel):
+    """One routable (or known-but-disabled) model, grouped by modality.
+
+    ``id`` is the canonical key — the LiteLLM ``model_name`` "<provider>/<model>".
+    A client fetches one entry via GET /catalog/models/{id} with ``id``
+    URL-encoded (the slash becomes %2F).
+    """
+
+    id: str
+    display_name: str
+    provider: str
+    modality: Modality
+    context: int | None = None
+    max_output_tokens: int | None = None
+    pricing: Pricing | None = None
+    capabilities: list[str] = Field(default_factory=list)
+    logo: str | None = None
+    description: str | None = None
+    status: str = "available"  # "available" | "disabled"
+
+
+class ModelCatalogList(BaseModel):
+    """Envelope for the list endpoint — a flat, already-filtered list plus the
+    total count, so a client can render modality groups without a second call."""
+
+    models: list[ModelCatalogEntry]
+    total: int
+
+
+__all__ = [
+    "Modality",
+    "Pricing",
+    "ModelCatalogEntry",
+    "ModelCatalogList",
+]

--- a/ee/pocketpaw_ee/catalog/models_dev_client.py
+++ b/ee/pocketpaw_ee/catalog/models_dev_client.py
@@ -1,0 +1,95 @@
+# ee/pocketpaw_ee/catalog/models_dev_client.py — best-effort models.dev
+# enrichment for the Model Catalog (MCG-1). models.dev publishes an open metadata
+# index (https://models.dev/api.json) keyed by provider -> model -> {name, ...}.
+# We use it ONLY to fill gaps the LiteLLM proxy doesn't provide: a human
+# description and any capabilities not already derived. (logo is provider-level
+# and not reliably in the index, so we leave it None unless a model entry carries
+# one.)
+#
+# Hard rule: enrichment is non-blocking and fail-open. Any error — network,
+# timeout, non-2xx, malformed JSON — yields an EMPTY lookup, and the service then
+# serves LiteLLM-only data unchanged. A models.dev outage can never break the
+# catalog. The toggle CATALOG_MODELS_DEV_ENABLED (config.models_dev_enabled)
+# skips the fetch entirely.
+#
+# httpx-based with an injectable ``_transport`` so tests stand in an
+# httpx.MockTransport (and assert the fail-open fallback) with no network.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): best-effort enrichment.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+MODELS_DEV_URL = "https://models.dev/api.json"
+
+
+def _normalize_index(payload: Any) -> dict[str, dict[str, Any]]:
+    """Flatten the models.dev payload into ``{canonical_id: {description, logo,
+    capabilities}}`` where canonical_id is "<provider>/<model>".
+
+    The published shape is ``{provider: {"models": {model_id: {...}}}}`` (with the
+    provider object also carrying a top-level icon/logo). This is defensive: it
+    accepts either a ``models`` sub-dict or a provider object whose values are the
+    model entries directly, and tolerates missing fields — anything unparseable is
+    skipped, never raised."""
+    out: dict[str, dict[str, Any]] = {}
+    if not isinstance(payload, dict):
+        return out
+    for provider, pobj in payload.items():
+        if not isinstance(pobj, dict):
+            continue
+        provider_logo = pobj.get("logo") or pobj.get("icon")
+        models = pobj.get("models")
+        # Either {"models": {...}} or the provider object is itself the model map.
+        model_map = models if isinstance(models, dict) else pobj
+        for model_id, mobj in model_map.items():
+            if not isinstance(mobj, dict):
+                continue
+            caps = mobj.get("capabilities")
+            out[f"{provider}/{model_id}"] = {
+                "description": mobj.get("description") or mobj.get("name"),
+                "logo": mobj.get("logo") or provider_logo,
+                "capabilities": [str(c) for c in caps] if isinstance(caps, list) else [],
+            }
+    return out
+
+
+class ModelsDevClient:
+    """Fetches + flattens the models.dev index. Fail-open by contract."""
+
+    def __init__(
+        self,
+        *,
+        _transport: httpx.BaseTransport | None = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self._transport = _transport  # tests inject httpx.MockTransport
+        self._timeout = timeout
+
+    async def fetch_index(self) -> dict[str, dict[str, Any]]:
+        """Return the flattened enrichment index, or an EMPTY dict on ANY error.
+
+        Never raises — a models.dev problem degrades the catalog to LiteLLM-only,
+        it does not fail the request.
+        """
+        try:
+            async with httpx.AsyncClient(
+                transport=self._transport, timeout=self._timeout
+            ) as client:
+                resp = await client.get(MODELS_DEV_URL)
+            if resp.status_code // 100 != 2:
+                logger.warning("models.dev returned %s; skipping enrichment", resp.status_code)
+                return {}
+            return _normalize_index(resp.json())
+        except Exception:  # noqa: BLE001 — fail-open is the whole point
+            logger.warning("models.dev fetch failed; serving LiteLLM-only catalog", exc_info=True)
+            return {}
+
+
+__all__ = ["ModelsDevClient", "MODELS_DEV_URL"]

--- a/ee/pocketpaw_ee/catalog/router.py
+++ b/ee/pocketpaw_ee/catalog/router.py
@@ -1,0 +1,92 @@
+# ee/pocketpaw_ee/catalog/router.py — the Model Catalog read surface (MCG-1).
+#
+# Two tenant-independent reads (the available-models set is deployment-global, not
+# workspace-scoped — same shape as GET /billing/plans), license-gated:
+#   * GET /catalog/models?modality=&provider=&q=&capability=
+#       -> the filtered catalog (ModelCatalogList: models + total).
+#   * GET /catalog/models/{id}
+#       -> one entry. ``id`` is the URL-ENCODED canonical key "<provider>/<model>"
+#          (the slash arrives as %2F; FastAPI decodes it into the path value, so
+#          we capture the full remainder with a :path converter).
+#
+# THIN adapter per the EE "primitive = service + thin adapters" shape — assembly,
+# the TTL cache, and filtering all live in ``catalog.service``; the proxy read +
+# mapping live in ``catalog.litellm_client``. A LiteLLM proxy failure surfaces as
+# 502 (the catalog's source of truth is unreachable) rather than a misleading
+# empty 200. Mounted in ``mount_cloud()``.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): new entity router.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from pocketpaw_ee.catalog import service as catalog_service
+from pocketpaw_ee.catalog.litellm_client import CatalogUpstreamError
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry, ModelCatalogList
+from pocketpaw_ee.cloud.license import require_license
+
+router = APIRouter(prefix="/catalog", tags=["Catalog"], dependencies=[Depends(require_license)])
+
+
+@router.get("/models", response_model=ModelCatalogList)
+async def list_catalog_models(
+    modality: str | None = Query(
+        None,
+        description="Filter by modality bucket: chat | embedding | image | "
+        "audio_tts | audio_stt | video.",
+    ),
+    provider: str | None = Query(None, description="Filter by provider (exact, case-insensitive)."),
+    q: str | None = Query(
+        None, description="Substring search over id, display name, and description."
+    ),
+    capability: str | None = Query(
+        None,
+        description="Filter to models exposing this capability token "
+        "(e.g. tool_call, vision, streaming, json_mode).",
+    ),
+) -> ModelCatalogList:
+    """List catalog entries from the LiteLLM proxy, grouped by modality and
+    filtered by any supplied query params (all AND together).
+
+    The catalog is the UNION of what the proxy describes (/model/info) and what it
+    routes (/v1/models), so the catalog is never narrower than the routable set.
+    A proxy outage returns 502 — the source of truth is unreachable, which is an
+    upstream error, not an empty catalog.
+    """
+    # Validate the modality value early so a bad filter is a clear 422-style 400
+    # rather than a silent empty list.
+    if modality is not None and modality.strip().lower() not in {m.value for m in Modality}:
+        raise HTTPException(
+            400,
+            f"Unknown modality '{modality}'. Expected one of: "
+            f"{', '.join(m.value for m in Modality)}.",
+        )
+    try:
+        entries: list[ModelCatalogEntry] = await catalog_service.list_models(
+            modality=modality,
+            provider=provider,
+            q=q,
+            capability=capability,
+        )
+    except CatalogUpstreamError as exc:
+        raise HTTPException(502, f"Model catalog source unavailable: {exc}") from exc
+    return ModelCatalogList(models=entries, total=len(entries))
+
+
+@router.get("/models/{model_id:path}", response_model=ModelCatalogEntry)
+async def get_catalog_model(model_id: str) -> ModelCatalogEntry:
+    """Return one catalog entry by its canonical id.
+
+    ``model_id`` is the URL-encoded "<provider>/<model>" key; the ``:path``
+    converter captures the decoded value (including the slash) so e.g.
+    GET /catalog/models/anthropic%2Fclaude-3-5-sonnet resolves to the
+    ``anthropic/claude-3-5-sonnet`` entry.
+    """
+    try:
+        entry = await catalog_service.get_model(model_id)
+    except CatalogUpstreamError as exc:
+        raise HTTPException(502, f"Model catalog source unavailable: {exc}") from exc
+    if entry is None:
+        raise HTTPException(404, f"Model '{model_id}' not found in catalog")
+    return entry

--- a/ee/pocketpaw_ee/catalog/service.py
+++ b/ee/pocketpaw_ee/catalog/service.py
@@ -1,0 +1,178 @@
+# ee/pocketpaw_ee/catalog/service.py — assembly + cache + filtering for the Model
+# Catalog (MCG-1). The thin router delegates everything here.
+#
+# Assembly: read the LiteLLM proxy (litellm_client.fetch_entries), then, when
+# enabled and available, merge best-effort models.dev enrichment over the gaps
+# (description / logo / extra capabilities) — never overwriting a value LiteLLM
+# already provided. The assembled list is TTL-cached IN-PROCESS
+# (config.cache_ttl_seconds, default 300s) so a burst of requests hits the proxy
+# once; ``bust_cache`` clears it on demand.
+#
+# Filtering: ``list_models`` applies modality / provider / capability (exact,
+# case-insensitive) and ``q`` (substring over id + display_name + description),
+# all combinable. ``get_model`` returns one entry by canonical id or None.
+#
+# Concurrency: a single asyncio.Lock serializes assembly so N concurrent
+# cache-miss requests trigger exactly ONE upstream fetch (the rest await the lock
+# and then read the now-warm cache) — this is what the TTL-cache test asserts.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1): the catalog service.
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+
+from pocketpaw_ee.catalog import config
+from pocketpaw_ee.catalog.litellm_client import LiteLLMClient
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry
+from pocketpaw_ee.catalog.models_dev_client import ModelsDevClient
+
+
+@dataclass
+class _CacheState:
+    """In-process cache for the assembled catalog. ``expires_at`` is a monotonic
+    deadline; ``entries`` is None until the first successful assembly."""
+
+    entries: list[ModelCatalogEntry] | None = None
+    expires_at: float = 0.0
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+# Module-level singleton cache — the catalog is deployment-global (not
+# tenant-scoped), so one process-wide cache is correct.
+_cache = _CacheState()
+
+
+def bust_cache() -> None:
+    """Invalidate the in-process catalog cache. The next list/get re-assembles
+    from the proxy. Exposed for an admin/refresh path and for tests."""
+    _cache.entries = None
+    _cache.expires_at = 0.0
+
+
+def _merge_enrichment(
+    entries: list[ModelCatalogEntry],
+    enrichment: dict[str, dict],
+) -> list[ModelCatalogEntry]:
+    """Fill gaps on each entry from the models.dev index WITHOUT overwriting
+    anything LiteLLM already set. Only ``logo``/``description`` when currently
+    None, and capabilities are unioned (deduped, sorted, deterministic)."""
+    if not enrichment:
+        return entries
+    merged: list[ModelCatalogEntry] = []
+    for entry in entries:
+        extra = enrichment.get(entry.id)
+        if not extra:
+            merged.append(entry)
+            continue
+        patch: dict = {}
+        if entry.logo is None and extra.get("logo"):
+            patch["logo"] = extra["logo"]
+        if entry.description is None and extra.get("description"):
+            patch["description"] = extra["description"]
+        extra_caps = extra.get("capabilities") or []
+        if extra_caps:
+            patch["capabilities"] = sorted(set(entry.capabilities) | set(extra_caps))
+        merged.append(entry.model_copy(update=patch) if patch else entry)
+    return merged
+
+
+async def _assemble() -> list[ModelCatalogEntry]:
+    """Read the proxy + (optional) models.dev and produce the merged catalog.
+
+    LiteLLM is the source of truth (its failure propagates — the router maps it to
+    a 502). models.dev is best-effort: disabled by flag or failing yields an empty
+    index and the LiteLLM-only catalog passes through unchanged.
+    """
+    entries = await LiteLLMClient().fetch_entries()
+    if config.models_dev_enabled():
+        enrichment = await ModelsDevClient().fetch_index()
+        entries = _merge_enrichment(entries, enrichment)
+    # Stable order for deterministic output: by modality then id.
+    entries.sort(key=lambda e: (e.modality.value, e.id))
+    return entries
+
+
+async def _get_catalog(force_refresh: bool = False) -> list[ModelCatalogEntry]:
+    """Return the cached catalog, assembling (once) on miss/expiry.
+
+    The lock guarantees a single in-flight assembly: the first miss assembles and
+    warms the cache; concurrent callers await the lock, re-check the cache, and
+    return the warm copy without a second upstream call.
+    """
+    now = time.monotonic()
+    if not force_refresh and _cache.entries is not None and now < _cache.expires_at:
+        return _cache.entries
+
+    async with _cache.lock:
+        # Re-check under the lock — another coroutine may have just filled it.
+        now = time.monotonic()
+        if not force_refresh and _cache.entries is not None and now < _cache.expires_at:
+            return _cache.entries
+        entries = await _assemble()
+        _cache.entries = entries
+        _cache.expires_at = time.monotonic() + config.cache_ttl_seconds()
+        return entries
+
+
+def _matches(
+    entry: ModelCatalogEntry,
+    *,
+    modality: str | None,
+    provider: str | None,
+    q: str | None,
+    capability: str | None,
+) -> bool:
+    """Combined predicate for the list filters. All supplied filters must pass
+    (AND). modality/provider/capability are exact case-insensitive; q is a
+    case-insensitive substring over id + display_name + description."""
+    if modality and entry.modality.value != modality.strip().lower():
+        return False
+    if provider and entry.provider.lower() != provider.strip().lower():
+        return False
+    if capability and capability.strip().lower() not in {c.lower() for c in entry.capabilities}:
+        return False
+    if q:
+        needle = q.strip().lower()
+        haystack = " ".join(filter(None, [entry.id, entry.display_name, entry.description])).lower()
+        if needle not in haystack:
+            return False
+    return True
+
+
+async def list_models(
+    *,
+    modality: str | None = None,
+    provider: str | None = None,
+    q: str | None = None,
+    capability: str | None = None,
+    force_refresh: bool = False,
+) -> list[ModelCatalogEntry]:
+    """Return catalog entries matching every supplied filter (filters AND
+    together; omitted filters match all)."""
+    catalog = await _get_catalog(force_refresh=force_refresh)
+    return [
+        e
+        for e in catalog
+        if _matches(e, modality=modality, provider=provider, q=q, capability=capability)
+    ]
+
+
+async def get_model(model_id: str, *, force_refresh: bool = False) -> ModelCatalogEntry | None:
+    """Return the single entry whose canonical id matches, or None."""
+    catalog = await _get_catalog(force_refresh=force_refresh)
+    for entry in catalog:
+        if entry.id == model_id:
+            return entry
+    return None
+
+
+# Re-export so callers can ``from ...service import Modality`` for query validation.
+__all__ = [
+    "list_models",
+    "get_model",
+    "bust_cache",
+    "Modality",
+]

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -365,6 +365,16 @@ def mount_cloud(app: FastAPI) -> None:
     # (Cloudflare for SaaS) the Domains panel drives.
     app.include_router(sites_router, prefix="/api/v1")
 
+    # Model Catalog — MCG-1. License-gated, tenant-independent reads of the
+    # models a self-hosted LiteLLM proxy serves: GET /catalog/models (filtered by
+    # modality/provider/q/capability) and GET /catalog/models/{id}. The proxy is
+    # the source of truth (read via /v1/models + /model/info, mapped to
+    # ModelCatalogEntry, TTL-cached in-process); models.dev enriches logo/desc
+    # best-effort. Thin adapter over ee.catalog.service.
+    from pocketpaw_ee.catalog.router import router as catalog_router
+
+    app.include_router(catalog_router, prefix="/api/v1")
+
     # Temporal sweeps — RFC 03 v2 Wave 3d. Read-only inspect endpoint
     # for the persisted (trigger, row) state matrix; the actual sweep
     # is driven by the in-process scheduler at

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -43,6 +43,13 @@ terminal runs the prior worker left unbilled are charged on restart. The
 metering sweep is idempotent (billed flag + ``run:{run_id}`` ledger key), so it
 is safe even when the boot stale-run sweep is disabled — it just bills the
 already-terminal backlog.
+
+Updated: 2026-06-26 (feat/litellm-billing-cutover, WU-F) — the boot sweep also
+runs the per-tenant LiteLLM billing-cutover sweep (``run_cutover_sweep``): a
+no-op in ``off`` mode, a read-only reconciliation compare in ``shadow``, and a
+proxy-spend debit in ``live`` (where ``sweep_unbilled_runs`` self-gates off so
+exactly one meter charges). Idempotent + its own try so a cutover-sweep failure
+can't abort worker startup.
 """
 
 from __future__ import annotations
@@ -130,13 +137,24 @@ async def _startup(ctx: dict[str, Any]) -> None:
     # BC-3 metering: bill any terminal runs the prior worker left unbilled (the
     # boot sweep above just turned this boot's orphans terminal, and earlier
     # finished runs may never have been billed). Own try so a metering failure
-    # can't abort worker startup.
+    # can't abort worker startup. Self-gated OFF in the WU-F ``live`` cutover mode.
     try:
         billed = await sweep_unbilled_runs()
         if billed:
             logger.info("worker boot: billed %d unbilled terminal runs", billed)
     except Exception:
         logger.exception("worker boot: compute-cost metering sweep failed")
+    # WU-F billing cutover: per-tenant LiteLLM spend sweep on boot too (no-op in
+    # ``off``; shadow-compare in ``shadow``; debit proxy spend in ``live``). Own try
+    # so a cutover-sweep failure can't abort worker startup.
+    try:
+        from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
+
+        summary = await run_cutover_sweep()
+        if summary.get("processed"):
+            logger.info("worker boot: cutover sweep processed %d tenants", summary["processed"])
+    except Exception:
+        logger.exception("worker boot: LiteLLM billing-cutover sweep failed")
 
 
 async def _shutdown(ctx: dict[str, Any]) -> None:

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -105,6 +105,13 @@
 # report an accurate newly-billed count and skip a redundant insert-then-rollback
 # on the duplicate path. It does NOT weaken the exactly-once guard (grant/debit
 # stay idempotent via the unique index); it only saves the wasted round-trip.
+# Changed 2026-06-26 (WU-F billing cutover): added ``sum_debits_by_cause`` — a
+# read-only, tenant-filtered sum of credits debited under one ``cause`` over a
+# ``createdAt`` window (only ``applied`` entries counted). The shadow-compare phase
+# of the LiteLLM cutover uses it to total the BC-3 ``compute_spend`` debits for a
+# tenant's window so the llm_provisioning entity never reads the credit ledger doc
+# directly (the credits service owns reads of its own ``CreditLedgerEntry``). It
+# performs NO writes — shadow mode debits nothing.
 
 from __future__ import annotations
 
@@ -414,6 +421,56 @@ async def is_recorded(workspace: str, idempotency_key: str) -> bool:
     return existing is not None
 
 
+async def sum_debits_by_cause(
+    workspace: str,
+    cause: str,
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+) -> tuple[int, int]:
+    """Sum the credits debited under ``cause`` for ``workspace`` over a window.
+
+    Returns ``(credits, entry_count)`` where ``credits`` is the POSITIVE total
+    debited (the absolute value of the summed negative ``amount_delta`` over the
+    matching APPLIED entries) and ``entry_count`` is how many entries fed it.
+
+    The window is on ``createdAt``: ``since`` is inclusive (``>=``), ``until`` is
+    EXCLUSIVE (``<``) so adjacent windows never double-count a boundary entry; a
+    ``None`` bound is open on that side. Only ``applied is True`` entries are
+    counted — a committed-but-unapplied phantom never moved the wallet, so it must
+    not inflate the sum (the same rule ``reconcile`` enforces).
+
+    WU-F's shadow compare uses this to total the BC-3 ``compute_spend`` debits over
+    a tenant's window WITHOUT the llm_provisioning entity reaching into the credit
+    ledger doc directly — the credits service owns the read of its own
+    ``CreditLedgerEntry`` (EE entity-isolation), so the cross-entity compare goes
+    through this tenant-filtered helper. It performs NO writes.
+    """
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+
+    query: dict[str, Any] = {
+        "workspace": workspace,
+        "cause": cause,
+        "applied": True,
+    }
+    created_filter: dict[str, Any] = {}
+    if since is not None:
+        created_filter["$gte"] = since
+    if until is not None:
+        created_filter["$lt"] = until
+    if created_filter:
+        query["createdAt"] = created_filter
+
+    entries = await CreditLedgerEntry.find(query).to_list()
+    # A debit's ``amount_delta`` is negative; sum and flip the sign to a positive
+    # "credits debited" figure. A stray positive delta under this cause (there
+    # should be none — compute_spend is debit-only) is clamped out so a bad row
+    # can't make the spend total read as a refund.
+    total = sum(-int(e.amount_delta) for e in entries if int(e.amount_delta) < 0)
+    return total, len(entries)
+
+
 async def history(
     workspace: str,
     *,
@@ -619,4 +676,5 @@ __all__ = [
     "history",
     "is_recorded",
     "reconcile",
+    "sum_debits_by_cause",
 ]

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -99,6 +99,12 @@
 # (``new_balance == before + amount``) that is wrong under concurrency — a racing
 # grant could suppress a genuine emit or fire a spurious one. The created-flag is
 # the authoritative replay signal; callers gate the emit on it.
+# Changed 2026-06-26 (MCG-8): added ``is_recorded`` — a read-only check for whether
+# a ``(workspace, idempotency_key)`` movement already exists. MCG-8's LiteLLM
+# spend-log sweep ingests already-deduplicated external rows; it uses this to
+# report an accurate newly-billed count and skip a redundant insert-then-rollback
+# on the duplicate path. It does NOT weaken the exactly-once guard (grant/debit
+# stay idempotent via the unique index); it only saves the wasted round-trip.
 
 from __future__ import annotations
 
@@ -384,6 +390,30 @@ async def check_balance(workspace: str) -> None:
         raise InsufficientCredits(1, max(bal, 0))
 
 
+async def is_recorded(workspace: str, idempotency_key: str) -> bool:
+    """Whether a movement with this ``(workspace, idempotency_key)`` already exists.
+
+    A read-only pre-check for callers that ingest external, already-deduplicated
+    events (e.g. MCG-8's LiteLLM spend-log sweep) and want to know whether a given
+    source row was ALREADY recorded — so they can report an accurate
+    "newly billed" count and skip a redundant insert-then-rollback on the
+    duplicate path. This does NOT replace the exactly-once guard: ``grant`` /
+    ``debit`` remain idempotent via the unique index regardless, so a race between
+    this read and the write still resolves correctly (the write no-ops). It only
+    saves the wasted round-trip and lets the caller's bookkeeping stay honest.
+    Tenant-filtered (Rule 7).
+    """
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+    if not idempotency_key:
+        return False
+    existing = await CreditLedgerEntry.find_one(
+        CreditLedgerEntry.workspace == workspace,
+        CreditLedgerEntry.idempotency_key == idempotency_key,
+    )
+    return existing is not None
+
+
 async def history(
     workspace: str,
     *,
@@ -587,5 +617,6 @@ __all__ = [
     "debit",
     "grant",
     "history",
+    "is_recorded",
     "reconcile",
 ]

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/__init__.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/__init__.py
@@ -1,0 +1,19 @@
+# ee/pocketpaw_ee/cloud/llm_provisioning/__init__.py — LLM-provisioning entity
+# package marker (MCG-8).
+#
+# This entity owns the per-tenant LiteLLM virtual-key lifecycle: it mints a
+# budgeted, rate-limited virtual key per workspace on the proxy (POST
+# /key/generate), persists the workspace -> key mapping (the LiteLLMTenantKey
+# doc), and ingests that key's proxy spend (/spend/logs) into the EXISTING credit
+# ledger (credits.service.debit) — it does NOT own a ledger, it plugs into BC-1's.
+#
+# The 3-file shape (domain / service / this marker) lives here; the proxy admin
+# client it calls lives in the catalog entity (catalog.admin_client), reusing the
+# one deployment proxy-config path. Plain marker — nothing is imported eagerly so
+# importing this package never pulls FastAPI / Beanie.
+#
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-8): new entity.
+
+"""Per-tenant LiteLLM virtual-key provisioning + spend -> credits ingestion."""
+
+from __future__ import annotations

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
@@ -1,0 +1,140 @@
+# ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py — the durable
+# per-tenant LiteLLM billing-cutover sweep (WU-F).
+#
+# One system job that iterates every PROVISIONED tenant and runs the spend logic
+# for the current cutover mode (POCKETPAW_LITELLM_SPEND_MODE, honouring the legacy
+# INGEST bool via ``service.spend_mode()``):
+#
+#   * ``off``    — no-op. BC-3 per-run metering bills as today; nothing to sweep.
+#   * ``shadow`` — read-only compare. For each tenant, ``reconcile_tenant_spend``
+#                  reads proxy spend + the BC-3 ``compute_spend`` ledger over a
+#                  lookback window and records a reconciliation row. DEBITS NOTHING.
+#   * ``live``   — LiteLLM is the sole meter. For each tenant,
+#                  ``ingest_tenant_spend`` debits the proxy spend to the credit
+#                  ledger (the BC-3 sweep is gated OFF in ``metering.sweeper`` when
+#                  the mode is live, so exactly one meter charges).
+#
+# Runs on the SAME schedule as the BC-3 metering sweep — the in-process 5-minute
+# heartbeat (``ee.extensions._sweeper_loop``) and the Tier 2 worker boot
+# (``chat.runs.worker._startup``). Mirrors that sweep's shape: tenant-agnostic
+# iteration, every spend op workspace-scoped, idempotent + safe to run repeatedly.
+#
+# IDEMPOTENT BY CONSTRUCTION:
+#   * live   — ``ingest_tenant_spend`` is exactly-once per spend row (the
+#              ``litellm:{request_id}`` ledger key + the high-water mark), so a
+#              re-run bills nothing twice.
+#   * shadow — ``reconcile_tenant_spend`` writes an append-only audit row and moves
+#              no money, so a re-run only records another (consistent) compare. The
+#              window is a fixed lookback ending "now"; overlapping windows across
+#              ticks are harmless because shadow never debits.
+# A per-tenant failure (proxy blip, one bad key) is logged and skipped so one
+# tenant never wedges the whole sweep — the same isolation the BC-3 sweep uses.
+#
+# Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new entity.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning_service
+
+logger = logging.getLogger(__name__)
+
+# Shadow-compare lookback. Each shadow tick reconciles the trailing window ending
+# "now". Generous enough to overlap the sweep cadence (so no spend falls between
+# ticks) — overlap is safe because shadow debits nothing. Live mode ignores this
+# (its ingest is high-water-bounded, not window-bounded).
+_SHADOW_WINDOW = timedelta(hours=24)
+
+
+async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
+    """Run the LiteLLM billing-cutover spend logic for every provisioned tenant.
+
+    Resolves the cutover ``mode`` (defaulting to the deployment's
+    ``service.spend_mode()``) and dispatches per tenant:
+      * ``off``    — returns immediately, sweeps nothing.
+      * ``shadow`` — ``reconcile_tenant_spend`` per tenant (read-only compare).
+      * ``live``   — ``ingest_tenant_spend`` per tenant (debit proxy spend).
+
+    Returns a small summary dict ``{"tenants", "processed", "failed", "gaps",
+    "credits"}`` for the caller's log line (``gaps`` only meaningful in shadow,
+    ``credits`` only in live). Idempotent + safe to run repeatedly. A per-tenant
+    error is logged and skipped — never raised — so one tenant can't wedge the
+    sweep (it is retried next tick).
+    """
+    resolved = mode if mode is not None else provisioning_service.spend_mode()
+    summary = {"tenants": 0, "processed": 0, "failed": 0, "gaps": 0, "credits": 0}
+
+    if resolved == "off":
+        # Nothing to do — BC-3 bills as today.
+        return summary
+
+    workspaces = await provisioning_service.list_provisioned_workspaces()
+    summary["tenants"] = len(workspaces)
+    if not workspaces:
+        return summary
+
+    if resolved == "shadow":
+        until = datetime.now(UTC)
+        since = until - _SHADOW_WINDOW
+        for workspace in workspaces:
+            try:
+                rec = await provisioning_service.reconcile_tenant_spend(
+                    workspace, since=since, until=until
+                )
+                summary["processed"] += 1
+                if rec.coverage_gap:
+                    summary["gaps"] += 1
+            except Exception:
+                summary["failed"] += 1
+                logger.exception(
+                    "run_cutover_sweep[shadow]: reconcile failed for workspace=%s "
+                    "— will retry next tick",
+                    workspace,
+                )
+        logger.info(
+            "run_cutover_sweep[shadow]: reconciled %d/%d tenants over [%s,%s), "
+            "%d coverage gap(s), %d failed — NO debits",
+            summary["processed"],
+            summary["tenants"],
+            since.isoformat(),
+            until.isoformat(),
+            summary["gaps"],
+            summary["failed"],
+        )
+        return summary
+
+    if resolved == "live":
+        for workspace in workspaces:
+            try:
+                result = await provisioning_service.ingest_tenant_spend(workspace)
+                summary["processed"] += 1
+                summary["credits"] += result.credits_debited
+            except Exception:
+                summary["failed"] += 1
+                logger.exception(
+                    "run_cutover_sweep[live]: spend ingest failed for workspace=%s "
+                    "— will retry next tick",
+                    workspace,
+                )
+        logger.info(
+            "run_cutover_sweep[live]: ingested spend for %d/%d tenants -> %d credits, "
+            "%d failed (LiteLLM is the sole meter; BC-3 gated off)",
+            summary["processed"],
+            summary["tenants"],
+            summary["credits"],
+            summary["failed"],
+        )
+        return summary
+
+    # An unrecognised mode (mis-set env) — log loud and do nothing rather than
+    # guess. ``effective_spend_mode`` only ever returns off|shadow|live, so this is
+    # defensive against a hand-rolled caller passing a bad value.
+    logger.warning(
+        "run_cutover_sweep: unrecognised billing mode %r — sweeping nothing", resolved
+    )
+    return summary
+
+
+__all__ = ["run_cutover_sweep"]

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
@@ -1,0 +1,107 @@
+# ee/pocketpaw_ee/cloud/llm_provisioning/domain.py — frozen value objects + the
+# provisioning rate card for the LLM-provisioning entity (MCG-8).
+#
+# Framework-free shapes the service hands back across the entity boundary (never
+# the Beanie ``LiteLLMTenantKey`` doc, never raw proxy JSON):
+#
+#   * ``KeyBudget``       — the budget / rate-limit / allowlist a virtual key is
+#                           provisioned with, resolved from runtime settings. The
+#                           declarative knobs the proxy enforces per tenant.
+#   * ``ProvisionResult`` — the outcome of ``ensure_tenant_key``: the workspace,
+#                           its virtual key, and ``created`` (True only on a real
+#                           first mint, False on the idempotent already-exists
+#                           path) so callers can gate a one-time side effect on it.
+#   * ``SpendIngestResult`` — the outcome of one spend sweep for a tenant: how many
+#                           proxy spend rows were read, how many credits were
+#                           debited, the USD total + cached-token savings, and the
+#                           resulting wallet balance.
+#   * ``SpendCredits``    — the per-tenant spend rate card: USD-cost markup + the
+#                           per-credit USD denomination. Mirrors metering's
+#                           ``RateCard`` shape deliberately so proxy-spend and
+#                           per-run metering convert USD->credits identically.
+#
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-8): new entity.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class KeyBudget:
+    """The budget / limits a per-tenant virtual key is minted with.
+
+    All optional: ``None`` means "let the proxy apply no cap" for that knob. The
+    service resolves these from runtime settings (POCKETPAW_TENANT_* ) with sane
+    defaults, so budgets are config-driven, never hardcoded secrets. ``models`` is
+    the allowed-model allowlist (empty == all models the proxy serves).
+    """
+
+    max_budget_usd: float | None = None
+    budget_duration: str | None = None  # LiteLLM duration string, e.g. "30d"
+    rpm_limit: int | None = None
+    tpm_limit: int | None = None
+    models: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ProvisionResult:
+    """The outcome of ``ensure_tenant_key``.
+
+    ``litellm_key`` is the tenant's virtual key (minted now, or the one already on
+    file). ``created`` is True ONLY when this call newly minted the key on the
+    proxy; False on the idempotent already-provisioned path (no proxy call was
+    made). Callers gate a one-time side effect (e.g. an audit emit) on ``created``.
+    """
+
+    workspace_id: str
+    litellm_key: str
+    created: bool
+
+
+@dataclass(frozen=True)
+class SpendCredits:
+    """The per-tenant proxy-spend rate card (USD -> integer credits).
+
+    Deliberately the SAME conversion as metering's ``RateCard`` so a dollar of
+    proxy spend bills the same number of credits whether it is attributed via the
+    per-run meter (BC-3) or this proxy-spend sweep (MCG-8): a single price for
+    compute. ``markup`` is the flat multiplier; ``credit_usd`` is the USD value of
+    one credit (1 credit == $0.01).
+    """
+
+    markup: float
+    credit_usd: float
+
+    def to_credits(self, cost_usd: float) -> int:
+        """Convert a USD spend amount into integer credits.
+
+        ``round(cost_usd * markup / credit_usd)`` — identical to
+        ``metering.domain.RateCard.to_credits``. A non-positive cost yields 0
+        credits (no debit).
+        """
+        if cost_usd <= 0:
+            return 0
+        return round(cost_usd * self.markup / self.credit_usd)
+
+
+@dataclass(frozen=True)
+class SpendIngestResult:
+    """The outcome of one spend sweep for a tenant.
+
+    ``rows_read`` is how many /spend/logs rows the sweep examined; ``rows_billed``
+    how many produced a NEW ledger debit (a row already ingested — same
+    idempotency key — is counted in ``rows_read`` but not ``rows_billed``).
+    ``credits_debited`` is the total integer credits charged this sweep;
+    ``cost_usd`` the summed USD; ``cached_tokens`` the summed cached-input tokens
+    the proxy reported (the prompt-cache savings signal). ``balance_after`` is the
+    wallet balance once the sweep's debits landed.
+    """
+
+    workspace_id: str
+    rows_read: int
+    rows_billed: int
+    credits_debited: int
+    cost_usd: float
+    cached_tokens: int
+    balance_after: int

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
@@ -15,12 +15,21 @@
 #                           proxy spend rows were read, how many credits were
 #                           debited, the USD total + cached-token savings, and the
 #                           resulting wallet balance.
+#   * ``SpendReconciliation`` — the outcome of one SHADOW compare for a tenant (WU-F):
+#                           the litellm-vs-BC-3 credits over a window, their delta,
+#                           and the coverage-gap verdict. Carries NO debit — shadow
+#                           only reads + compares. The Beanie persistence twin is
+#                           ``models.spend_reconciliation.SpendReconciliation``.
 #   * ``SpendCredits``    — the per-tenant spend rate card: USD-cost markup + the
 #                           per-credit USD denomination. Mirrors metering's
 #                           ``RateCard`` shape deliberately so proxy-spend and
 #                           per-run metering convert USD->credits identically.
 #
 # Created 2026-06-26 (integration/model-catalog-v2, MCG-8): new entity.
+# Updated 2026-06-26 (feat/litellm-billing-cutover, WU-F): added
+# ``SpendReconciliation`` — the value object returned by the shadow-mode compare
+# (``service.reconcile_tenant_spend``). Distinct from the Beanie doc of the same
+# concept; this is the framework-free shape the sweep logs + the doc is built from.
 
 from __future__ import annotations
 
@@ -105,3 +114,35 @@ class SpendIngestResult:
     cost_usd: float
     cached_tokens: int
     balance_after: int
+
+
+@dataclass(frozen=True)
+class SpendReconciliation:
+    """The outcome of one SHADOW compare for a tenant (WU-F billing cutover).
+
+    Shadow mode reads the tenant's LiteLLM proxy spend over a window, converts it
+    to credits (the SAME rate card BC-3 uses), sums the workspace's BC-3
+    ``compute_spend`` ledger debits over that window, and records the two side by
+    side. This object is the framework-free result; it carries NO debit — the whole
+    point of shadow is to compare WITHOUT touching the wallet.
+
+    ``litellm_credits`` is the proxy spend in credits; ``bc3_credits`` is the summed
+    BC-3 metered debits in credits. ``delta = litellm_credits - bc3_credits``
+    (positive ⇒ the proxy saw MORE than BC-3 billed — traffic likely bypassing
+    per-run metering, or a conversion mismatch; negative ⇒ BC-3 billed more than the
+    proxy attributed). ``coverage_gap`` is True when ``abs(delta) > threshold`` — a
+    discrepancy big enough to resolve BEFORE flipping to live. ``window_start`` /
+    ``window_end`` bound the compare (ISO ``startTime`` strings, half-open).
+    ``litellm_rows`` / ``bc3_entries`` are the input counts (provenance).
+    """
+
+    workspace_id: str
+    window_start: str | None
+    window_end: str | None
+    litellm_credits: int
+    bc3_credits: int
+    delta: int
+    coverage_gap: bool
+    threshold: int
+    litellm_rows: int
+    bc3_entries: int

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -52,8 +52,11 @@
 # billing cutover from per-run metering (BC-3) to LiteLLM as the single meter,
 # done through a safe shadow-compare phase.
 #   1. ``spend_mode`` / ``reconcile_gap_threshold`` — read the 3-position cutover
-#      switch (POCKETPAW_LITELLM_SPEND_MODE off|shadow|live, honouring the legacy
-#      INGEST bool). ``spend_ingest_enabled`` is now a back-compat shim over it.
+#      switch (POCKETPAW_LITELLM_SPEND_MODE off|shadow|live). The legacy INGEST bool
+#      is honoured ONLY as far as ``shadow`` — ``live`` requires an EXPLICIT mode, so
+#      deploying WU-F never auto-flips an old bool-setter into live billing (a
+#      one-time deprecation notice fires when the legacy bool is seen).
+#      ``spend_ingest_enabled`` is now a back-compat shim over it.
 #   2. ``reconcile_tenant_spend`` — the SHADOW compare. Reads proxy spend + the
 #      BC-3 ``compute_spend`` ledger debits over the same window and records a
 #      reconciliation row (litellm vs bc3 + delta + coverage_gap). It DEBITS
@@ -87,6 +90,12 @@ from pocketpaw_ee.cloud.models.spend_reconciliation import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Once-per-process guard for the legacy-spend-bool deprecation notice (WU-F). The
+# warning is emitted the first time the mode is resolved while the deprecated bool
+# is the only thing set, so an operator is told their old flag now means ``shadow``
+# (NOT ``live``) and that billing requires an explicit POCKETPAW_LITELLM_SPEND_MODE.
+_legacy_bool_warned = False
 
 # Business cause stamped on the ledger movement for proxy-attributed spend. KEPT
 # DISTINCT from BC-3 metering's ``compute_spend`` so a dashboard / audit can tell
@@ -157,15 +166,50 @@ def load_spend_credits() -> SpendCredits:
     )
 
 
+def warn_legacy_spend_bool_once() -> None:
+    """Emit a ONE-TIME deprecation notice when the legacy spend bool is the only
+    cutover signal set (WU-F money-safety guard).
+
+    Fires at most once per process, the first time the mode is resolved while
+    ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` AND the new
+    ``POCKETPAW_LITELLM_SPEND_MODE`` is left at its ``off`` default. Tells the
+    operator the legacy bool now resolves to ``shadow`` (reads + compares, debits
+    NOTHING) and that to actually bill from proxy spend they must EXPLICITLY set
+    ``POCKETPAW_LITELLM_SPEND_MODE=live``. This is why deploying WU-F can never
+    auto-flip an old bool-setter into live billing — the bool can only ever reach
+    the safe shadow mode, loudly, with this notice.
+    """
+    global _legacy_bool_warned
+    if _legacy_bool_warned:
+        return
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    if settings.litellm_spend_mode == "off" and settings.litellm_spend_ingest_enabled:
+        _legacy_bool_warned = True
+        logger.warning(
+            "DEPRECATION (WU-F): POCKETPAW_LITELLM_SPEND_INGEST_ENABLED is set but "
+            "POCKETPAW_LITELLM_SPEND_MODE is unset — the legacy bool now resolves to "
+            "'shadow' (read-only reconciliation, NO debits), NOT live billing. "
+            "LiteLLM will NOT charge and BC-3 per-run metering keeps billing. To make "
+            "LiteLLM the sole meter you must EXPLICITLY set "
+            "POCKETPAW_LITELLM_SPEND_MODE=live."
+        )
+
+
 def spend_mode() -> str:
     """The LiteLLM billing-cutover mode for this deployment: ``off`` | ``shadow`` |
     ``live`` (WU-F).
 
-    Delegates to ``Settings.effective_spend_mode()`` so the legacy
-    ``POCKETPAW_LITELLM_SPEND_INGEST`` bool is honoured (an existing True maps to
-    ``live`` while the new mode is left at its ``off`` default). Provisioning is
-    unaffected by the mode (always on); only the spend SWEEP behaviour changes.
+    Delegates to ``Settings.effective_spend_mode()``. The legacy
+    ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED`` bool is honoured ONLY as far as
+    ``shadow`` — it never resolves to ``live`` (that requires an explicit
+    ``POCKETPAW_LITELLM_SPEND_MODE=live``), so merely deploying WU-F can never flip
+    an old bool-setter into live billing. The first resolution that sees the legacy
+    bool emits a one-time deprecation notice. Provisioning is unaffected by the mode
+    (always on); only the spend SWEEP behaviour changes.
     """
+    warn_legacy_spend_bool_once()
     from pocketpaw.config import get_settings
 
     return get_settings().effective_spend_mode()
@@ -716,4 +760,5 @@ __all__ = [
     "reconcile_tenant_spend",
     "spend_ingest_enabled",
     "spend_mode",
+    "warn_legacy_spend_bool_once",
 ]

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -48,6 +48,22 @@
 # exception) which a system-job caller logs + retries, never a bare HTTPException.
 #
 # Created 2026-06-26 (integration/model-catalog-v2, MCG-8): new entity.
+# Updated 2026-06-26 (feat/litellm-billing-cutover, WU-F): three changes for the
+# billing cutover from per-run metering (BC-3) to LiteLLM as the single meter,
+# done through a safe shadow-compare phase.
+#   1. ``spend_mode`` / ``reconcile_gap_threshold`` — read the 3-position cutover
+#      switch (POCKETPAW_LITELLM_SPEND_MODE off|shadow|live, honouring the legacy
+#      INGEST bool). ``spend_ingest_enabled`` is now a back-compat shim over it.
+#   2. ``reconcile_tenant_spend`` — the SHADOW compare. Reads proxy spend + the
+#      BC-3 ``compute_spend`` ledger debits over the same window and records a
+#      reconciliation row (litellm vs bc3 + delta + coverage_gap). It DEBITS
+#      NOTHING and never advances the high-water mark — BC-3 keeps billing during
+#      shadow. The cross-entity ledger read goes through the credits service's
+#      tenant-filtered ``sum_debits_by_cause`` (entity-isolation preserved).
+#   3. ``ingest_tenant_spend`` high-water boundary fix — the same-second skip was
+#      ``<=`` (dropped a distinct boundary row on a later sweep → under-bill); it
+#      is now strict ``<`` with the ``litellm:{request_id}`` ledger dedup as the
+#      exactly-once guard at the boundary. See the inline note at the loop.
 
 from __future__ import annotations
 
@@ -63,8 +79,12 @@ from pocketpaw_ee.cloud.llm_provisioning.domain import (
     ProvisionResult,
     SpendCredits,
     SpendIngestResult,
+    SpendReconciliation,
 )
 from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+from pocketpaw_ee.cloud.models.spend_reconciliation import (
+    SpendReconciliation as SpendReconciliationDoc,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +93,14 @@ logger = logging.getLogger(__name__)
 # proxy-gateway spend apart from per-run metered spend (and so the two paths can
 # coexist without their idempotency namespaces colliding).
 _LITELLM_SPEND_CAUSE = "litellm_spend"
+
+# The BC-3 per-run metering cause (``metering.service._COMPUTE_SPEND_CAUSE``). The
+# shadow compare sums the credit ledger's ``compute_spend`` debits to put BC-3 next
+# to LiteLLM. Duplicated as a literal here ON PURPOSE — metering is a SIBLING entity,
+# and importing its private constant would couple two cloud entities at module load
+# (and the import-linter forbids the cross-entity reach). If BC-3's cause string ever
+# changes, this literal + the matching test must change with it.
+_BC3_COMPUTE_SPEND_CAUSE = "compute_spend"
 
 # The key-alias prefix the proxy stamps on a tenant's virtual key, for operator
 # legibility in the proxy admin UI + spend logs.
@@ -129,15 +157,41 @@ def load_spend_credits() -> SpendCredits:
     )
 
 
-def spend_ingest_enabled() -> bool:
-    """Whether the proxy-spend -> credits sweep is enabled for this deployment.
+def spend_mode() -> str:
+    """The LiteLLM billing-cutover mode for this deployment: ``off`` | ``shadow`` |
+    ``live`` (WU-F).
 
-    Default FALSE — see the DOUBLE-BILL BOUNDARY note in the module header.
-    Provisioning is unaffected by this flag (always on); only ingestion is gated.
+    Delegates to ``Settings.effective_spend_mode()`` so the legacy
+    ``POCKETPAW_LITELLM_SPEND_INGEST`` bool is honoured (an existing True maps to
+    ``live`` while the new mode is left at its ``off`` default). Provisioning is
+    unaffected by the mode (always on); only the spend SWEEP behaviour changes.
     """
     from pocketpaw.config import get_settings
 
-    return bool(get_settings().litellm_spend_ingest_enabled)
+    return get_settings().effective_spend_mode()
+
+
+def spend_ingest_enabled() -> bool:
+    """DEPRECATED back-compat shim — whether the spend sweep DEBITS (mode == live).
+
+    Superseded by ``spend_mode()`` (WU-F). Kept so any caller still asking the old
+    yes/no question gets the right answer: only ``live`` mode debits proxy spend.
+    ``shadow`` returns False here (it reads + compares but never debits), matching
+    the original contract that True meant "ingestion debits the ledger".
+    """
+    return spend_mode() == "live"
+
+
+def reconcile_gap_threshold() -> int:
+    """The shadow-compare coverage-gap threshold in credits (WU-F).
+
+    Reads ``POCKETPAW_LITELLM_RECONCILE_GAP_THRESHOLD_CREDITS`` (default 10). A
+    reconciliation row is flagged ``coverage_gap`` when ``abs(delta)`` exceeds this.
+    Clamped to >= 0 so a negative config can't make every window read as a gap.
+    """
+    from pocketpaw.config import get_settings
+
+    return max(0, int(get_settings().litellm_reconcile_gap_threshold_credits))
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +233,20 @@ async def get_tenant_key(workspace: str) -> str | None:
     _require_workspace(workspace)
     doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
     return doc.litellm_key if doc is not None else None
+
+
+async def list_provisioned_workspaces() -> list[str]:
+    """Every workspace that has a live LiteLLM virtual key.
+
+    The cutover sweep iterates these to run the per-mode spend logic. A SYSTEM-job
+    read across tenants (no per-tenant scope) — but it only returns workspace IDs
+    that have a real key; an unprovisioned workspace has nothing to sweep. Reading
+    ``LiteLLMTenantKey`` stays inside THIS entity (only this module touches that
+    doc), so the cutover sweeper goes through this helper rather than querying the
+    doc itself.
+    """
+    docs = await LiteLLMTenantKey.find(LiteLLMTenantKey.litellm_key != None).to_list()  # noqa: E711
+    return [d.workspace for d in docs if d.litellm_key]
 
 
 async def ensure_tenant_key(
@@ -368,8 +436,17 @@ async def ingest_tenant_spend(
     # Oldest first so the high-water mark advances monotonically.
     for row in sorted(rows, key=lambda r: _row_start_time(r) or ""):
         start_ts = _row_start_time(row)
-        # Skip rows at/older than the high-water mark — already ingested.
-        if high_water is not None and start_ts is not None and start_ts <= high_water:
+        # WU-F boundary fix — skip rows STRICTLY older than the high-water mark
+        # only. The previous ``start_ts <= high_water`` dropped a DISTINCT row that
+        # shared the mark's exact ``startTime`` second when it first appeared on a
+        # LATER sweep (proxy spend rows are not strictly ordered, and second-grained
+        # timestamps collide), silently UNDER-BILLING it. Now a same-second row at
+        # the boundary is RE-EXAMINED and de-duplicated by its own
+        # ``litellm:{request_id}`` ledger key below (the ``is_recorded`` skip + BC-1's
+        # unique index), so an already-ingested boundary row no-ops while a new
+        # boundary row bills exactly once. The mark stays an optimisation that bounds
+        # the read; the per-row request_id is the real exactly-once guard.
+        if high_water is not None and start_ts is not None and start_ts < high_water:
             continue
 
         rows_read += 1
@@ -462,11 +539,181 @@ async def ingest_tenant_spend(
     )
 
 
+# ---------------------------------------------------------------------------
+# Shadow compare — read proxy spend + BC-3 ledger side by side, debit NOTHING.
+# ---------------------------------------------------------------------------
+
+
+def _as_aware(dt: datetime | None) -> datetime | None:
+    """Normalise a datetime to tz-aware UTC (a naive value is assumed UTC), or
+    pass None through. Used so window comparisons never mix naive + aware."""
+    if dt is None:
+        return None
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    """Parse a LiteLLM ``startTime`` ISO string to a datetime, or None.
+
+    Tolerant of the proxy's shapes: a trailing ``Z`` is normalised to ``+00:00``;
+    a naive (no-offset) string parses as naive. Returns None on anything
+    unparseable so a malformed row is excluded from a window rather than crashing
+    the compare.
+    """
+    if not ts:
+        return None
+    try:
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    # LiteLLM /spend/logs ``startTime`` is frequently NAIVE (no offset). The window
+    # bounds the sweep passes are tz-AWARE (UTC), and Python refuses to compare a
+    # naive datetime to an aware one. Normalise a naive timestamp to UTC (the proxy
+    # records UTC) so the window test never crashes on a real proxy row.
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _in_window(row_dt: datetime | None, since: datetime | None, until: datetime | None) -> bool:
+    """Half-open window test ``[since, until)`` on a row's parsed timestamp.
+
+    A row with NO parseable timestamp is INCLUDED (we'd rather over-count an
+    undated row into the compare than silently drop spend from the shadow check —
+    the compare is a safety net, so it errs toward surfacing discrepancies). An
+    open bound (``None``) passes that side. ``since`` / ``until`` are normalised to
+    tz-aware UTC alongside the row timestamp so a caller passing naive bounds (or a
+    proxy emitting naive timestamps) can't trip a naive-vs-aware comparison.
+    """
+    if row_dt is None:
+        return True
+    since = _as_aware(since)
+    until = _as_aware(until)
+    row_dt = _as_aware(row_dt)
+    if since is not None and row_dt < since:
+        return False
+    return not (until is not None and row_dt >= until)
+
+
+async def reconcile_tenant_spend(
+    workspace: str,
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    spend_card: SpendCredits | None = None,
+    threshold: int | None = None,
+    admin_client: LiteLLMAdminClient | None = None,
+) -> SpendReconciliation:
+    """SHADOW compare for ``workspace`` over ``[since, until)`` — debit NOTHING.
+
+    The safe cutover step. Reads the tenant's LiteLLM proxy spend, converts it to
+    credits via the SAME rate card BC-3 uses, sums the workspace's BC-3
+    ``compute_spend`` ledger debits over the same window, and records the two side
+    by side as a ``SpendReconciliation`` doc (and a structured log line). The
+    ``delta`` (litellm - bc3) and the ``coverage_gap`` verdict (``abs(delta)`` over
+    ``threshold``) tell an operator whether the two meters agree before flipping to
+    ``live``.
+
+    CRITICAL — this performs ZERO debits. It NEVER calls ``credits.service.debit``
+    and NEVER advances the spend high-water mark. BC-3 keeps billing untouched
+    during shadow. The credit ledger is read (via the credits service's own
+    tenant-filtered ``sum_debits_by_cause``) but never written. A workspace with no
+    provisioned key still produces a record (litellm_credits=0) so the operator
+    sees every tenant in the compare, not a silent gap.
+
+    ``since`` / ``until`` bound the window (datetimes; ``until`` exclusive). The
+    LiteLLM rows are filtered on their parsed ``startTime``; the BC-3 debits on
+    ``createdAt`` — the same window on both sides. ``spend_card`` / ``threshold``
+    are injectable for tests; they default to the settings-derived values.
+    """
+    _require_workspace(workspace)
+
+    card = spend_card if spend_card is not None else load_spend_credits()
+    gap_threshold = threshold if threshold is not None else reconcile_gap_threshold()
+
+    # --- LiteLLM side: proxy spend over the window -> credits. ---------------
+    litellm_credits = 0
+    litellm_rows = 0
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+    if doc is not None and doc.litellm_key:
+        client = admin_client if admin_client is not None else LiteLLMAdminClient()
+        rows = await client.spend_logs(api_key=doc.litellm_key)
+        for row in rows:
+            row_dt = _parse_iso(_row_start_time(row))
+            if not _in_window(row_dt, since, until):
+                continue
+            litellm_rows += 1
+            litellm_credits += card.to_credits(_num(row.get("spend")))
+
+    # --- BC-3 side: the metered compute_spend debits over the SAME window. ---
+    # Read through the credits service (entity-isolation: it owns its ledger doc).
+    # This is a READ — no debit, no write.
+    bc3_credits, bc3_entries = await credits_service.sum_debits_by_cause(
+        workspace, _BC3_COMPUTE_SPEND_CAUSE, since=since, until=until
+    )
+
+    delta = litellm_credits - bc3_credits
+    coverage_gap = abs(delta) > gap_threshold
+
+    window_start = since.isoformat() if since is not None else None
+    window_end = until.isoformat() if until is not None else None
+
+    # Persist the reconciliation row (append-only audit — NOT a ledger; recording
+    # one moves no money). One row per tenant per window.
+    record = SpendReconciliationDoc(
+        workspace=workspace,
+        window_start=window_start,
+        window_end=window_end,
+        litellm_credits=litellm_credits,
+        bc3_credits=bc3_credits,
+        delta=delta,
+        coverage_gap=coverage_gap,
+        threshold=gap_threshold,
+        litellm_rows=litellm_rows,
+        bc3_entries=bc3_entries,
+    )
+    await record.insert()
+
+    log = logger.warning if coverage_gap else logger.info
+    log(
+        "llm_provisioning.reconcile_tenant_spend: workspace=%s window=[%s,%s) "
+        "litellm=%d bc3=%d delta=%d coverage_gap=%s (threshold=%d, litellm_rows=%d, "
+        "bc3_entries=%d) — SHADOW, no debit",
+        workspace,
+        window_start,
+        window_end,
+        litellm_credits,
+        bc3_credits,
+        delta,
+        coverage_gap,
+        gap_threshold,
+        litellm_rows,
+        bc3_entries,
+    )
+
+    return SpendReconciliation(
+        workspace_id=workspace,
+        window_start=window_start,
+        window_end=window_end,
+        litellm_credits=litellm_credits,
+        bc3_credits=bc3_credits,
+        delta=delta,
+        coverage_gap=coverage_gap,
+        threshold=gap_threshold,
+        litellm_rows=litellm_rows,
+        bc3_entries=bc3_entries,
+    )
+
+
 __all__ = [
     "ensure_tenant_key",
     "get_tenant_key",
     "ingest_tenant_spend",
+    "list_provisioned_workspaces",
     "load_key_budget",
     "load_spend_credits",
+    "reconcile_gap_threshold",
+    "reconcile_tenant_spend",
     "spend_ingest_enabled",
+    "spend_mode",
 ]

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -1,0 +1,472 @@
+# ee/pocketpaw_ee/cloud/llm_provisioning/service.py — the per-tenant LiteLLM
+# virtual-key lifecycle (MCG-8). Module-level ``async def`` API (NOT a class, per
+# the EE cloud rule, mirroring ``credits.service`` / ``metering.service``). Sole
+# owner of writes to the ``LiteLLMTenantKey`` doc (entity isolation — only THIS
+# module imports ``models.litellm_key``).
+#
+# Two jobs:
+#
+#   1. PROVISIONING (``ensure_tenant_key``) — idempotently ensure a budgeted,
+#      rate-limited LiteLLM virtual key exists for a workspace. Mints one via the
+#      proxy admin API (POST /key/generate, with metadata={workspace_id}) the
+#      FIRST time, persists the workspace -> key mapping (upsert on the unique
+#      ``workspace`` index), and on every later call returns the stored key
+#      WITHOUT a second proxy call. The budget / rpm / tpm / allowed-models come
+#      from runtime settings (``load_key_budget``) — config-driven, never
+#      hardcoded. ``get_tenant_key`` reads the key back for spend attribution on
+#      the tenant's proxy calls.
+#
+#   2. SPEND INGESTION (``ingest_tenant_spend``) — read the tenant key's proxy
+#      spend (GET /spend/logs?api_key=<key>) and feed it into the EXISTING credit
+#      ledger via ``credits.service.debit``. This entity does NOT own a ledger; it
+#      plugs into BC-1's. Each spend row is debited EXACTLY ONCE: the debit is
+#      keyed ``litellm:{request_id}`` against BC-1's unique
+#      ``(workspace, idempotency_key)`` index (the real guard), and the
+#      ``last_spend_ingest_ts`` high-water mark bounds the read so a re-sweep
+#      doesn't re-read settled rows. ``allow_negative=True`` + a DISTINCT cause
+#      (``litellm_spend``) — proxy compute already happened, so it bills fully,
+#      and the distinct cause keeps these movements separable from BC-3's
+#      ``compute_spend`` rows on the dashboard.
+#
+# DOUBLE-BILL BOUNDARY (read this before enabling ingestion): the proxy's
+# /spend/logs includes EVERY call routed through the proxy — including the text
+# chat runs BC-3 metering already bills per ``ChatRunDoc`` (keyed ``run:{run_id}``,
+# cause ``compute_spend``). Running BOTH unconditionally would double-bill text
+# chat. So spend ingestion is GATED OFF by default behind
+# ``settings.litellm_spend_ingest_enabled`` (POCKETPAW_LITELLM_SPEND_INGEST,
+# default False). It is the future single-source-of-truth path — bill ALL compute
+# from proxy spend and retire per-run metering — but flipping that seam (and the
+# row-level dedup against BC-3, e.g. skipping rows whose metadata carries a
+# ``run_id`` already billed) is a deliberate product decision, NOT a default. The
+# PROVISIONING half is always-on and unconditional; only the ingestion half is
+# gated. Today's live, attributed path is media (it tags ``user=workspace_id`` so
+# the proxy logs spend per tenant) once provisioning hands media the tenant key.
+#
+# Rule 6 — validate at entry (a workspace id is required). Rule 7 — every read is
+# tenant-filtered on ``workspace``. Rule 10 — only ``CloudError`` subclasses
+# propagate to HTTP; a proxy admin failure raises ``LiteLLMAdminError`` (a plain
+# exception) which a system-job caller logs + retries, never a bare HTTPException.
+#
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-8): new entity.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from pocketpaw_ee.catalog.admin_client import LiteLLMAdminClient, LiteLLMAdminError
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.credits import service as credits_service
+from pocketpaw_ee.cloud.llm_provisioning.domain import (
+    KeyBudget,
+    ProvisionResult,
+    SpendCredits,
+    SpendIngestResult,
+)
+from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+
+logger = logging.getLogger(__name__)
+
+# Business cause stamped on the ledger movement for proxy-attributed spend. KEPT
+# DISTINCT from BC-3 metering's ``compute_spend`` so a dashboard / audit can tell
+# proxy-gateway spend apart from per-run metered spend (and so the two paths can
+# coexist without their idempotency namespaces colliding).
+_LITELLM_SPEND_CAUSE = "litellm_spend"
+
+# The key-alias prefix the proxy stamps on a tenant's virtual key, for operator
+# legibility in the proxy admin UI + spend logs.
+_KEY_ALIAS_PREFIX = "ws-"
+
+
+# ---------------------------------------------------------------------------
+# Config — budgets + the spend rate card from runtime settings (NEVER hardcoded).
+# ---------------------------------------------------------------------------
+
+
+def load_key_budget() -> KeyBudget:
+    """Build the per-tenant key budget from runtime settings.
+
+    Reads (all with sane defaults so a fresh deploy provisions a sensible key):
+      * POCKETPAW_TENANT_MAX_BUDGET_USD  — USD ceiling per ``budget_duration``.
+      * POCKETPAW_TENANT_BUDGET_DURATION — reset window (LiteLLM duration string).
+      * POCKETPAW_TENANT_RPM_LIMIT       — requests-per-minute cap (0 == unset).
+      * POCKETPAW_TENANT_TPM_LIMIT       — tokens-per-minute cap (0 == unset).
+
+    The allowed-models allowlist defaults to empty (all models the proxy serves) —
+    a deployment that wants to restrict a tenant can layer that on later without
+    changing the mint path. Lazy import so the entity has no import-time dependency
+    on the settings singleton.
+    """
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    rpm = int(settings.tenant_rpm_limit)
+    tpm = int(settings.tenant_tpm_limit)
+    budget = float(settings.tenant_max_budget_usd)
+    return KeyBudget(
+        max_budget_usd=budget if budget > 0 else None,
+        budget_duration=settings.tenant_budget_duration or None,
+        rpm_limit=rpm if rpm > 0 else None,
+        tpm_limit=tpm if tpm > 0 else None,
+        models=[],
+    )
+
+
+def load_spend_credits() -> SpendCredits:
+    """Build the proxy-spend rate card from runtime settings.
+
+    Reuses the SAME ``billing_markup`` / ``credit_usd`` settings the BC-3 meter
+    uses (``metering.service.load_rate_card``) so a dollar of compute bills the
+    same credits regardless of which path attributes it. Lazy import for the same
+    reason as above.
+    """
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    return SpendCredits(
+        markup=float(settings.billing_markup), credit_usd=float(settings.credit_usd)
+    )
+
+
+def spend_ingest_enabled() -> bool:
+    """Whether the proxy-spend -> credits sweep is enabled for this deployment.
+
+    Default FALSE — see the DOUBLE-BILL BOUNDARY note in the module header.
+    Provisioning is unaffected by this flag (always on); only ingestion is gated.
+    """
+    from pocketpaw.config import get_settings
+
+    return bool(get_settings().litellm_spend_ingest_enabled)
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_workspace(workspace: str) -> None:
+    if not workspace:
+        raise ValidationError("llm_provisioning.invalid_workspace", "workspace is required")
+
+
+def _num(value: Any) -> float:
+    """Coerce a proxy spend value to a float, tolerating None / strings."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _int(value: Any) -> int:
+    """Coerce a token count to a non-negative int, tolerating None / strings."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+# ---------------------------------------------------------------------------
+# Provisioning — idempotently ensure a tenant has a budgeted virtual key.
+# ---------------------------------------------------------------------------
+
+
+async def get_tenant_key(workspace: str) -> str | None:
+    """Return the workspace's LiteLLM virtual key, or None when not yet
+    provisioned. Tenant-filtered read (Rule 7). The proxy-calling paths (media /
+    the harness) use this to attribute spend + enforce the tenant budget."""
+    _require_workspace(workspace)
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+    return doc.litellm_key if doc is not None else None
+
+
+async def ensure_tenant_key(
+    workspace: str,
+    *,
+    budget: KeyBudget | None = None,
+    admin_client: LiteLLMAdminClient | None = None,
+) -> ProvisionResult:
+    """Ensure a LiteLLM virtual key exists for ``workspace``. Idempotent.
+
+    First call: mint a key via the proxy admin API (POST /key/generate) carrying
+    the budget / rpm / tpm / allowed-models from ``budget`` (default:
+    ``load_key_budget()``) and ``metadata={"workspace_id": workspace}`` so the
+    proxy attributes the key to the tenant, then persist the workspace -> key
+    mapping. Returns ``ProvisionResult(..., created=True)``.
+
+    Every later call: the mapping already exists, so return the stored key with
+    ``created=False`` and NO proxy call (the idempotency guarantee — a workspace
+    never gets two proxy keys, even under a concurrent double-provision: the
+    unique ``workspace`` index makes the second insert collide and we re-read the
+    winner).
+
+    ``admin_client`` is injectable for tests (an ``httpx.MockTransport``-backed
+    client); production builds one bound to the deployment master key.
+    """
+    _require_workspace(workspace)
+
+    # Fast path — already provisioned. No proxy call.
+    existing = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+    if existing is not None and existing.litellm_key:
+        return ProvisionResult(
+            workspace_id=workspace, litellm_key=existing.litellm_key, created=False
+        )
+
+    card = budget if budget is not None else load_key_budget()
+    client = admin_client if admin_client is not None else LiteLLMAdminClient()
+    alias = f"{_KEY_ALIAS_PREFIX}{workspace}"
+
+    # Mint the key on the proxy. A failure here raises LiteLLMAdminError — we do
+    # NOT persist a half-row, so a retry re-attempts the mint cleanly.
+    body = await client.generate_key(
+        key_alias=alias,
+        max_budget=card.max_budget_usd,
+        budget_duration=card.budget_duration,
+        rpm_limit=card.rpm_limit,
+        tpm_limit=card.tpm_limit,
+        models=card.models or None,
+        metadata={"workspace_id": workspace},
+    )
+    key = body.get("key")
+    if not isinstance(key, str) or not key:
+        raise LiteLLMAdminError("LiteLLM /key/generate returned no key")
+
+    # Persist the mapping. Upsert-on-insert with the unique ``workspace`` index as
+    # the concurrency guard: if a racing call minted + inserted first, our insert
+    # collides — we swallow it and re-read the winner so we never store two rows
+    # (the loser's freshly-minted proxy key is orphaned but harmless: unused, and
+    # the proxy budget bounds its blast radius; revoking orphans is a noted
+    # follow-up).
+    doc = LiteLLMTenantKey(
+        workspace=workspace,
+        litellm_key=key,
+        key_alias=alias,
+        max_budget_usd=card.max_budget_usd,
+        budget_duration=card.budget_duration,
+        rpm_limit=card.rpm_limit,
+        tpm_limit=card.tpm_limit,
+        models=list(card.models),
+    )
+    try:
+        await doc.insert()
+    except Exception as exc:  # noqa: BLE001 — Beanie raises DuplicateKeyError here
+        winner = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+        if winner is not None and winner.litellm_key:
+            logger.info(
+                "llm_provisioning.ensure_tenant_key: workspace=%s lost mint race; "
+                "using existing key (orphaned a fresh proxy key)",
+                workspace,
+            )
+            return ProvisionResult(
+                workspace_id=workspace, litellm_key=winner.litellm_key, created=False
+            )
+        # Not a duplicate-key collision — re-raise so the caller sees the real error.
+        raise LiteLLMAdminError(f"persisting tenant key failed: {exc}") from exc
+
+    logger.info(
+        "llm_provisioning.ensure_tenant_key: workspace=%s provisioned a LiteLLM key "
+        "(alias=%s, budget=%s/%s, rpm=%s, tpm=%s)",
+        workspace,
+        alias,
+        card.max_budget_usd,
+        card.budget_duration,
+        card.rpm_limit,
+        card.tpm_limit,
+    )
+    return ProvisionResult(workspace_id=workspace, litellm_key=key, created=True)
+
+
+# ---------------------------------------------------------------------------
+# Spend ingestion — read the tenant key's proxy spend -> the EXISTING ledger.
+# ---------------------------------------------------------------------------
+
+
+def _row_id(row: dict[str, Any]) -> str | None:
+    """The stable per-row id used as the ledger idempotency key. LiteLLM spend
+    rows carry ``request_id`` (the canonical id); fall back to ``id``. None when
+    neither is present (such a row can't be deduped safely, so it is skipped)."""
+    rid = row.get("request_id") or row.get("id")
+    return str(rid) if rid else None
+
+
+def _row_start_time(row: dict[str, Any]) -> str | None:
+    """The row's ISO ``startTime`` (the high-water-mark field). None when absent."""
+    ts = row.get("startTime") or row.get("startTimeStamp")
+    return str(ts) if ts else None
+
+
+def _cached_tokens(row: dict[str, Any]) -> int:
+    """The cached-input token count a spend row reports (the prompt-cache savings
+    signal). LiteLLM nests it under ``prompt_tokens_details.cached_tokens``; some
+    rows expose a flat ``cache_read_input_tokens``. Best-effort across shapes."""
+    details = row.get("prompt_tokens_details")
+    if isinstance(details, dict):
+        cached = _int(details.get("cached_tokens"))
+        if cached:
+            return cached
+    return _int(row.get("cache_read_input_tokens") or row.get("cached_tokens"))
+
+
+async def ingest_tenant_spend(
+    workspace: str,
+    *,
+    spend_card: SpendCredits | None = None,
+    admin_client: LiteLLMAdminClient | None = None,
+) -> SpendIngestResult:
+    """Read ``workspace``'s LiteLLM proxy spend and debit it to the EXISTING credit
+    ledger, exactly once per spend row.
+
+    Reads GET /spend/logs?api_key=<tenant key>, keeps only rows NEWER than the
+    stored ``last_spend_ingest_ts`` high-water mark, converts each row's USD
+    ``spend`` to integer credits via the rate card, and debits the wallet with
+    ``credits.service.debit(..., cause="litellm_spend",
+    idempotency_key="litellm:{request_id}", allow_negative=True)``. BC-1's unique
+    ``(workspace, idempotency_key)`` index makes a re-ingested row a ledger no-op
+    (the real exactly-once guard); the high-water mark merely bounds the read.
+
+    Advances ``last_spend_ingest_ts`` to the newest row's ``startTime`` after the
+    sweep. Returns a ``SpendIngestResult`` (rows read / billed, credits + USD +
+    cached-token totals, resulting balance).
+
+    NOTE: this is the GATED half (see the module header's double-bill boundary).
+    The caller decides whether to run it — this function does NOT check the flag,
+    so it stays reusable by an explicit admin trigger even when the periodic sweep
+    is off. A workspace with no provisioned key returns a zero result (nothing to
+    ingest) rather than raising.
+    """
+    _require_workspace(workspace)
+
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+    if doc is None or not doc.litellm_key:
+        # Not provisioned — nothing to ingest. Return the current balance so the
+        # caller has a consistent shape.
+        return SpendIngestResult(
+            workspace_id=workspace,
+            rows_read=0,
+            rows_billed=0,
+            credits_debited=0,
+            cost_usd=0.0,
+            cached_tokens=0,
+            balance_after=await credits_service.balance(workspace),
+        )
+
+    card = spend_card if spend_card is not None else load_spend_credits()
+    client = admin_client if admin_client is not None else LiteLLMAdminClient()
+
+    rows = await client.spend_logs(api_key=doc.litellm_key)
+
+    high_water = doc.last_spend_ingest_ts
+    newest_ts = high_water
+
+    rows_read = 0
+    rows_billed = 0
+    credits_debited = 0
+    cost_usd_total = 0.0
+    cached_total = 0
+
+    # Oldest first so the high-water mark advances monotonically.
+    for row in sorted(rows, key=lambda r: _row_start_time(r) or ""):
+        start_ts = _row_start_time(row)
+        # Skip rows at/older than the high-water mark — already ingested.
+        if high_water is not None and start_ts is not None and start_ts <= high_water:
+            continue
+
+        rows_read += 1
+        if newest_ts is None or (start_ts is not None and start_ts > newest_ts):
+            newest_ts = start_ts
+
+        cost_usd = _num(row.get("spend"))
+        cached_total += _cached_tokens(row)
+        cost_usd_total += cost_usd
+
+        credits = card.to_credits(cost_usd)
+        if credits <= 0:
+            continue  # sub-credit / zero-cost row — nothing to debit
+
+        rid = _row_id(row)
+        if rid is None:
+            # No stable id — we can't dedup it, so skip rather than risk a
+            # double-debit on the next sweep.
+            logger.warning(
+                "llm_provisioning.ingest_tenant_spend: workspace=%s skipping a spend "
+                "row with no request_id (cost_usd=%.6f)",
+                workspace,
+                cost_usd,
+            )
+            continue
+
+        ledger_key = f"litellm:{rid}"
+        # Skip a row already recorded (the high-water mark normally prevents this,
+        # but a reset / a row predating the mark could re-surface). The debit would
+        # no-op on the unique index anyway — this keeps ``rows_billed`` honest and
+        # avoids the wasted insert-then-rollback. NOT the exactly-once guard (that
+        # is BC-1's unique index); just accurate bookkeeping.
+        if await credits_service.is_recorded(workspace, ledger_key):
+            continue
+
+        balance_after = await credits_service.debit(
+            workspace=workspace,
+            amount=credits,
+            cause=_LITELLM_SPEND_CAUSE,
+            idempotency_key=ledger_key,
+            ref={
+                "request_id": rid,
+                "cost_usd": cost_usd,
+                "model": row.get("model"),
+                "cached_tokens": _cached_tokens(row),
+                "source": "litellm_spend_log",
+            },
+            allow_negative=True,
+        )
+        credits_debited += credits
+        rows_billed += 1
+        logger.debug(
+            "llm_provisioning.ingest_tenant_spend: workspace=%s billed %d credits "
+            "(request_id=%s, cost_usd=%.6f) -> balance=%d",
+            workspace,
+            credits,
+            rid,
+            cost_usd,
+            balance_after,
+        )
+
+    # Advance the high-water mark so a re-sweep doesn't re-read settled rows. Only
+    # write when it actually moved (avoid a no-op save).
+    if newest_ts is not None and newest_ts != doc.last_spend_ingest_ts:
+        doc.last_spend_ingest_ts = newest_ts
+        doc.updatedAt = datetime.now(UTC)
+        await doc.save()
+
+    balance_after = await credits_service.balance(workspace)
+    if rows_billed:
+        logger.info(
+            "llm_provisioning.ingest_tenant_spend: workspace=%s ingested %d/%d new "
+            "spend rows -> %d credits (cost_usd=%.6f, cached_tokens=%d), balance=%d",
+            workspace,
+            rows_billed,
+            rows_read,
+            credits_debited,
+            cost_usd_total,
+            cached_total,
+            balance_after,
+        )
+    return SpendIngestResult(
+        workspace_id=workspace,
+        rows_read=rows_read,
+        rows_billed=rows_billed,
+        credits_debited=credits_debited,
+        cost_usd=cost_usd_total,
+        cached_tokens=cached_total,
+        balance_after=balance_after,
+    )
+
+
+__all__ = [
+    "ensure_tenant_key",
+    "get_tenant_key",
+    "ingest_tenant_spend",
+    "load_key_budget",
+    "load_spend_credits",
+    "spend_ingest_enabled",
+]

--- a/ee/pocketpaw_ee/cloud/metering/sweeper.py
+++ b/ee/pocketpaw_ee/cloud/metering/sweeper.py
@@ -20,7 +20,21 @@
 # racing it — bills each run once: the second debit collides on the key and is a
 # no-op, and the ``billed`` flag short-circuits the run out of later sweeps.
 #
+# THE BC-3 OFF-SWITCH (WU-F): this sweep is the ONLY place BC-3 actually charges —
+# ``bill_run`` is never called inline in the chat run lifecycle, only from here (the
+# ee/extensions heartbeat + the Tier 2 worker boot). When the billing cutover is in
+# ``live`` mode (POCKETPAW_LITELLM_SPEND_MODE=live) LiteLLM is the sole meter, so
+# this sweep MUST NOT run — otherwise the same usage is billed twice (once by the
+# proxy-spend sweep, once here). ``sweep_unbilled_runs`` therefore checks the mode
+# and no-ops in ``live``. In ``off`` and ``shadow`` it bills as today (shadow is a
+# read-only compare layered ON TOP of unchanged BC-3 billing). Runs that go unbilled
+# while ``live`` is in effect simply stay ``billed=False`` and are billed by LiteLLM
+# instead — they are NOT back-billed by BC-3 if the mode is later turned off, which
+# is the correct behaviour (the proxy already charged them).
+#
 # Created 2026-06-24 (integration/billing-credits, BC-3): new entity.
+# Updated 2026-06-26 (feat/litellm-billing-cutover, WU-F): gated OFF in ``live`` mode
+# — the single-meter guarantee. See "THE BC-3 OFF-SWITCH" above.
 
 from __future__ import annotations
 
@@ -46,6 +60,7 @@ async def sweep_unbilled_runs(
     *,
     batch_limit: int = _SWEEP_BATCH_LIMIT,
     rate_card: RateCard | None = None,
+    mode: str | None = None,
 ) -> int:
     """Bill every unbilled terminal chat run's compute cost, exactly once.
 
@@ -59,7 +74,28 @@ async def sweep_unbilled_runs(
     ``rate_card`` is resolved ONCE for the whole batch (a single settings read)
     and passed into each ``bill_run`` so a 200-run sweep doesn't re-read settings
     200 times. Tests inject a card here to pin the rate.
+
+    WU-F single-meter gate: when the billing-cutover ``mode`` is ``live`` LiteLLM
+    is the sole meter, so this BC-3 sweep MUST NOT charge — it returns 0 WITHOUT
+    touching any wallet or flipping any ``billed`` flag (the off-switch that keeps
+    exactly one meter charging; see the module header). ``off`` and ``shadow`` bill
+    as today. ``mode`` defaults to the resolved deployment mode
+    (``llm_provisioning.service.spend_mode()``, which honours the legacy bool);
+    tests pass it explicitly so they don't depend on ambient settings.
     """
+    if mode is None:
+        # Lazy import — avoids a metering<->llm_provisioning module-load cycle and
+        # mirrors the lazy settings reads elsewhere in the metering entity.
+        from pocketpaw_ee.cloud.llm_provisioning import service as provisioning_service
+
+        mode = provisioning_service.spend_mode()
+    if mode == "live":
+        logger.debug(
+            "sweep_unbilled_runs: billing mode is 'live' — LiteLLM is the sole "
+            "meter, BC-3 per-run metering is gated OFF (no debit, no flag write)"
+        )
+        return 0
+
     unbilled = (
         await ChatRunDoc.find(
             {"status": {"$in": _TERMINAL_STATES}},

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -116,6 +116,7 @@ from pocketpaw_ee.cloud.models.sense_preference import WorkspaceSensePreference
 from pocketpaw_ee.cloud.models.session import Session
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
+from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
 from pocketpaw_ee.cloud.models.subscription import Subscription
 from pocketpaw_ee.cloud.models.task import Task, TaskAssignee, TaskSource
 from pocketpaw_ee.cloud.models.task_attachment import TaskAttachment
@@ -254,6 +255,7 @@ __all__ = [
     "Site",
     "SiteDomain",
     "SiteRateCounter",
+    "SpendReconciliation",
     "Subscription",
     "WorkspaceSensePreference",
     "Task",
@@ -312,6 +314,9 @@ def get_all_documents():
         InstinctApproval,
         Message,
         ReadState,
+        # Shadow-compare reconciliation rows (WU-F). One per tenant per window
+        # during shadow mode. Only ``ee.cloud.llm_provisioning.service`` writes it.
+        SpendReconciliation,
         Task,
         TaskAttachment,
         TemporalSweepStateDoc,

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -96,6 +96,7 @@ from pocketpaw_ee.cloud.models.group import Group, GroupAgent
 from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval
 from pocketpaw_ee.cloud.models.invite import Invite
 from pocketpaw_ee.cloud.models.lead import Lead, LeadSource
+from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
 from pocketpaw_ee.cloud.models.meeting import (
     Meeting,
     MeetingProviderCredentials,
@@ -231,6 +232,7 @@ __all__ = [
     "Invite",
     "Lead",
     "LeadSource",
+    "LiteLLMTenantKey",
     "Meeting",
     "MeetingProviderCredentials",
     "MeetingsSettings",
@@ -302,6 +304,9 @@ def get_all_documents():
         # captured via verified ``subscription.*`` webhooks. Only
         # ``ee.cloud.billing.service`` writes this.
         Subscription,
+        # LiteLLM per-tenant virtual-key mapping (MCG-8). Only
+        # ``ee.cloud.llm_provisioning.service`` writes this.
+        LiteLLMTenantKey,
         Invite,
         Group,
         InstinctApproval,

--- a/ee/pocketpaw_ee/cloud/models/litellm_key.py
+++ b/ee/pocketpaw_ee/cloud/models/litellm_key.py
@@ -1,0 +1,86 @@
+# ee/pocketpaw_ee/cloud/models/litellm_key.py — the per-tenant LiteLLM virtual-key
+# mapping document (MCG-8, the per-tenant key + budget provisioning seam).
+#
+# One Beanie document backs the workspace -> LiteLLM virtual-key mapping:
+#
+#   * ``LiteLLMTenantKey`` — exactly one row per workspace (the ``workspace``
+#     index is UNIQUE). Records the virtual key the LiteLLM proxy minted for the
+#     tenant (via ``POST /key/generate``), plus the budget / rpm / tpm / allowed
+#     models the key was provisioned with, and the high-water mark of the last
+#     spend log row already ingested into the credit ledger (so spend ingestion
+#     never re-reads the same rows). The provisioning service is idempotent: it
+#     upserts on ``workspace`` and skips the proxy ``/key/generate`` call when a
+#     row with a live key already exists, so a double-provision is a no-op.
+#
+# WHY a separate doc (not a field on Workspace / WorkspaceSettings): RFC 03 keeps
+# domain-specific config in domain-owned docs. Only ``ee.cloud.llm_provisioning.
+# service`` reads/writes this document — the same entity-isolation boundary the
+# credit / foresight docs use (one service owns one doc family). The key itself
+# is a proxy-scoped virtual key (NOT a provider API key) — its blast radius is the
+# budget + allowed-models the proxy enforces, so it is stored as-is rather than
+# encrypted-at-rest like a raw provider credential; tightening this to the
+# secret-store path is a noted follow-up.
+#
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-8): new entity. Registered
+# in ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``litellm_tenant_keys`` collection.
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class LiteLLMTenantKey(TimestampedDocument):
+    """The LiteLLM virtual key minted for one workspace (tenant).
+
+    Exactly one row per workspace (the ``workspace`` index is UNIQUE). The
+    provisioning service upserts on this key and short-circuits when a live key
+    already exists, so provisioning is idempotent — a workspace never gets two
+    proxy keys.
+
+    ``litellm_key`` is the proxy virtual key (the ``key`` field returned by
+    ``POST /key/generate``); ``key_alias`` is the human-readable alias we asked
+    the proxy to stamp on it (``ws-<workspace>``). The budget / limit columns
+    record what the key was provisioned WITH (so a later re-provision can detect
+    drift); they are NOT the live proxy state — the proxy is the source of truth
+    for current spend, read back via ``GET /key/info``.
+
+    ``last_spend_ingest_ts`` is the high-water mark: the ``startTime`` of the most
+    recent ``/spend/logs`` row already debited to the credit ledger. The spend
+    sweep reads only rows newer than this, then advances it — so each spend row is
+    ingested at most once even before BC-1's idempotency key is consulted (the key
+    is the real exactly-once guard; the high-water mark just bounds the read).
+    """
+
+    # UNIQUE — one virtual key per workspace. The provisioning upsert keys on it.
+    workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
+    # The proxy virtual key (the ``key`` from POST /key/generate). Sent as the
+    # Bearer token on this tenant's proxy calls so the proxy attributes spend +
+    # enforces the budget.
+    litellm_key: str
+    # The alias the proxy stamped on the key (``ws-<workspace>``) — for operator
+    # legibility in the proxy admin UI / spend logs.
+    key_alias: str | None = None
+    # What the key was provisioned WITH (provenance, NOT the live proxy state):
+    #   * ``max_budget_usd`` — the USD budget ceiling the proxy enforces over
+    #     ``budget_duration`` (None == unlimited; we always set one from config).
+    #   * ``budget_duration`` — the reset window, a LiteLLM duration string
+    #     (e.g. "30d", "1mo"). None == no reset.
+    #   * ``rpm_limit`` / ``tpm_limit`` — requests / tokens-per-minute caps
+    #     (None == unlimited).
+    #   * ``models`` — the allowed-model allowlist the key may route to (empty ==
+    #     all models the proxy serves).
+    max_budget_usd: float | None = None
+    budget_duration: str | None = None
+    rpm_limit: int | None = None
+    tpm_limit: int | None = None
+    models: list[str] = []  # noqa: RUF012 — Beanie field default, not a shared mutable
+    # High-water mark for spend ingestion: the ISO ``startTime`` of the newest
+    # /spend/logs row already debited to the ledger. The sweep reads rows AFTER
+    # this and advances it; None means nothing has been ingested yet.
+    last_spend_ingest_ts: str | None = None
+
+    class Settings:
+        name = "litellm_tenant_keys"

--- a/ee/pocketpaw_ee/cloud/models/spend_reconciliation.py
+++ b/ee/pocketpaw_ee/cloud/models/spend_reconciliation.py
@@ -1,0 +1,78 @@
+# ee/pocketpaw_ee/cloud/models/spend_reconciliation.py — the per-tenant
+# shadow-compare reconciliation record (WU-F billing cutover).
+#
+# One Beanie document per tenant per shadow sweep window. The shadow mode of the
+# billing cutover (POCKETPAW_LITELLM_SPEND_MODE=shadow) reads a tenant's LiteLLM
+# proxy spend, converts it to credits, sums the BC-3 ``compute_spend`` ledger
+# debits over the SAME window, and records the two side by side plus their delta
+# and a ``coverage_gap`` flag. It is the audit trail that lets an operator confirm
+# the two meters AGREE before cutting over to LiteLLM as the single meter (live
+# mode). Writing this row performs ZERO debits — shadow only reads + compares.
+#
+#   * ``SpendReconciliation`` — ``{workspace, window_start, window_end,
+#     litellm_credits, bc3_credits, delta, coverage_gap, threshold}``. ``delta`` is
+#     ``litellm_credits - bc3_credits`` (positive ⇒ the proxy saw MORE spend than
+#     BC-3 billed — traffic likely bypassing per-run metering, or a conversion
+#     mismatch; negative ⇒ BC-3 billed more than the proxy attributed).
+#     ``coverage_gap`` is True when ``abs(delta)`` exceeds ``threshold`` credits.
+#
+# WHY a separate doc (not a field on LiteLLMTenantKey / the credit ledger): RFC 03
+# keeps domain-specific records in domain-owned docs, and this is an append-only
+# audit series (one row per window per tenant), not per-key state. Only
+# ``ee.cloud.llm_provisioning.service`` writes it — the same entity-isolation
+# boundary the credit / litellm-key docs use. It is NOT a ledger: it never moves
+# money, so it carries no idempotency key and no ``applied`` flag.
+#
+# Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new entity. Registered
+# in ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``spend_reconciliations`` collection.
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class SpendReconciliation(TimestampedDocument):
+    """One shadow-compare row: LiteLLM proxy spend vs BC-3 metering for a tenant
+    over a window.
+
+    Append-only audit, NOT a ledger — recording one performs no debit. The shadow
+    sweep writes one per provisioned tenant per window; an operator (or a future
+    dashboard) reads them to confirm the two meters agree before flipping to live.
+
+    ``litellm_credits`` is the proxy spend over ``[window_start, window_end)``
+    converted to integer credits via the SAME rate card BC-3 uses; ``bc3_credits``
+    is the sum of the workspace's ``compute_spend`` ledger debits whose timestamps
+    fall in that window. ``delta = litellm_credits - bc3_credits``. ``coverage_gap``
+    is True when ``abs(delta) > threshold`` — a likely proxy-bypass or conversion
+    mismatch that must be resolved before live cutover.
+    """
+
+    # The tenant this row reconciles. Indexed (NOT unique — many windows per
+    # workspace) so an operator query for one workspace's history is cheap.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The compare window, as ISO ``startTime`` strings (the same field shape the
+    # LiteLLM /spend/logs rows carry, so window math compares like-for-like).
+    # Half-open ``[window_start, window_end)``.
+    window_start: str | None = None
+    window_end: str | None = None
+    # The two meters, in integer credits.
+    litellm_credits: int = 0
+    bc3_credits: int = 0
+    # ``litellm_credits - bc3_credits``. Positive ⇒ proxy saw more than BC-3 billed.
+    delta: int = 0
+    # True when ``abs(delta)`` exceeds ``threshold`` — a coverage gap to resolve
+    # before cutting over.
+    coverage_gap: bool = False
+    # The credit threshold the gap was judged against (recorded for provenance so a
+    # later threshold change doesn't retro-reinterpret old rows).
+    threshold: int = 0
+    # How many proxy spend rows + ledger debits fed this compare (provenance for an
+    # operator triaging a flagged gap).
+    litellm_rows: int = 0
+    bc3_entries: int = 0
+
+    class Settings:
+        name = "spend_reconciliations"

--- a/ee/pocketpaw_ee/cloud/surface/handlers/studio.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/studio.py
@@ -1,17 +1,21 @@
 # studio.py — /studio surface preamble.
 #
 # Created: 2026-06-10 (feat/studio-code-migration) — Orients the chat agent when
-# the user is on the /studio surface (describe→generate media: image + video).
-# Without it the surface falls back to GENERIC and the agent builds a dashboard
-# pocket instead of generating media — the same drift the /sites preamble was
-# created to fix. Static orientation — no live data to fake.
+# the user is on the /studio surface (describe→generate media). Without it the
+# surface falls back to GENERIC and the agent builds a dashboard pocket instead
+# of generating media — the same drift the /sites preamble was created to fix.
+# Static orientation — no live data to fake.
+# 2026-06-26 (MCG-6 + MCG-7): media routes through the LiteLLM proxy, so the
+# fallback now lists the audio tools too and notes the optional `model` arg (a
+# catalog model id); generation errors are now proxy errors, relayed plainly.
 #
 # Mirrors the layout of handlers/sites.py: an async ``build_preamble`` returning
 # an XML-ish ``<surface>`` + ``<orientation>`` + ``<procedure>`` block. The
 # procedure PREFERS the bundled ``studio`` skill (invoked by intent — no slash
 # command), and points the fallback at the in-process media MCP tools
-# (``mcp__pocketpaw_media__image_generate`` / ``__video_generate``). Provider /
-# key errors are relayed plainly so the agent never fakes a generated asset.
+# (``image_generate`` / ``audio_generate`` / ``audio_transcribe`` /
+# ``video_generate``). Provider / proxy errors are relayed plainly so the agent
+# never fakes a generated asset.
 #
 # The /studio SurfaceProfile sets ``ripple_mode="off"`` (see service.py) so the
 # agent does not inherit the ~20k-char "default to ui-spec" ripple LAW and build
@@ -44,17 +48,19 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         "vs video by the request. If that skill is unavailable, fall back "
         "directly to the media MCP tools: call "
         "`mcp__pocketpaw_media__image_generate` for an image / poster / "
-        "illustration (args: `prompt`, optional `aspect_ratio`), or "
+        "illustration (args: `prompt`, optional `model`, `aspect_ratio`, `size`), "
+        "`mcp__pocketpaw_media__audio_generate` for spoken audio / a voiceover "
+        "(args: `text`, optional `model`, `voice`), or "
         "`mcp__pocketpaw_media__video_generate` for a short video / clip / "
-        "animation (args: `prompt`, optional `duration`, `aspect_ratio`). Each "
-        "tool produces the asset and adds it to the gallery pocket; the canvas "
-        "opens automatically. Video generation is async and may take up to ~2 "
-        "minutes — tell the user it is rendering.\n"
-        "Relay any provider or key error PLAINLY (e.g. 'Set "
-        "POCKETPAW_GOOGLE_API_KEY to enable image generation' or 'Set "
-        "POCKETPAW_REPLICATE_API_TOKEN to enable video generation') — NEVER "
-        "claim a phantom image or video. After it succeeds, briefly say what was "
-        "added to the gallery.\n"
+        "animation (args: `prompt`, optional `model`, `duration`). The optional "
+        "`model` is a catalog model id — omit it to use the deployment default. "
+        "Each tool produces the asset and adds it to the gallery pocket; the "
+        "canvas opens automatically. Video generation is async and may take a "
+        "few minutes — tell the user it is rendering.\n"
+        "If a tool returns ok=false, relay its error message PLAINLY (e.g. an "
+        "unknown model id, or the model gateway being unreachable) — NEVER claim "
+        "a phantom image, audio clip, or video. After it succeeds, briefly say "
+        "what was added to the gallery.\n"
         "</studio-procedure>"
     )
 

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -61,6 +61,12 @@ general update() path on purpose (a non-ASK level enables auto-approval of
 agent writes), and emits a WARNING-severity append-only audit event with the
 old→new level. The write goes through this service per the import-linter
 Beanie-writes-only-from-service contract.
+2026-06-26 (feat/litellm-billing-cutover, WU-F): create() now also fires the
+per-tenant LiteLLM key provisioning trigger — a BEST-EFFORT, NON-BLOCKING
+ensure_tenant_key(workspace) call. A proxy outage / mint failure is logged and
+swallowed (workspace creation NEVER fails on a provisioning error); the call is
+idempotent, so the billing-cutover sweep and any later workspace touch back-fill
+a key that didn't mint here. Mirrors the best-effort seed_default_agent step.
 """
 
 from __future__ import annotations
@@ -342,6 +348,24 @@ async def create(ctx: RequestContext, body: CreateWorkspaceRequest) -> Workspace
         await agents_service.seed_default_agent(str(doc.id), ctx.user_id)
     except Exception as exc:
         logger.warning("Failed to seed default agent for workspace %s (non-fatal): %s", doc.id, exc)
+
+    # Provision the per-tenant LiteLLM virtual key (WU-F / MCG-8). BEST-EFFORT and
+    # NON-BLOCKING: if the proxy is unreachable or the mint fails, log + continue —
+    # workspace creation must NEVER fail on a provisioning error. ``ensure_tenant_key``
+    # is idempotent, so the cutover sweep (which iterates provisioned tenants) and a
+    # later workspace touch both back-fill a key that didn't get minted here. Lazy
+    # import keeps the workspace service free of an llm_provisioning dependency at
+    # module load.
+    try:
+        from pocketpaw_ee.cloud.llm_provisioning import service as llm_provisioning_service
+
+        await llm_provisioning_service.ensure_tenant_key(str(doc.id))
+    except Exception as exc:  # noqa: BLE001 — provisioning is best-effort, never fatal
+        logger.warning(
+            "Failed to provision LiteLLM tenant key for workspace %s (non-fatal): %s",
+            doc.id,
+            exc,
+        )
 
     await emit(
         WorkspaceMemberAdded(

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -91,6 +91,7 @@ _xproc_consumer_task: asyncio.Task[None] | None = None
 
 async def _sweeper_loop() -> None:
     from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
+    from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
     from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
     from pocketpaw_ee.sites.pending_sweeper import sweep_pending_sites
 
@@ -104,11 +105,20 @@ async def _sweeper_loop() -> None:
             _run_sweeper_logger.exception("sweep_stale_runs tick failed")
         # BC-3 metering: bill every newly-terminal run's compute cost on the same
         # heartbeat. Kept in its own try so a metering failure can't suppress the
-        # stale-run sweep (or vice versa) on the next tick.
+        # stale-run sweep (or vice versa) on the next tick. Self-gated OFF in the
+        # WU-F ``live`` cutover mode (LiteLLM is then the sole meter).
         try:
             await sweep_unbilled_runs()
         except Exception:
             _run_sweeper_logger.exception("sweep_unbilled_runs tick failed")
+        # WU-F billing cutover: per-tenant LiteLLM spend sweep. No-op in ``off``;
+        # a read-only reconciliation compare in ``shadow``; debits proxy spend in
+        # ``live``. Own try so a cutover-sweep failure can't suppress the other
+        # sweeps (or vice versa) on the next tick.
+        try:
+            await run_cutover_sweep()
+        except Exception:
+            _run_sweeper_logger.exception("run_cutover_sweep tick failed")
         # Charge-first (review fix C): surface PAID sites stuck pending past the
         # threshold (a lost/delayed subscription.active webhook). VISIBILITY ONLY —
         # logs at WARNING, never auto-deploys or auto-cancels. Its own try so a
@@ -123,11 +133,13 @@ async def start_run_sweeper() -> None:
     """Sweep once on boot, then tick every 5 minutes until shutdown.
 
     Boot runs the stale-run sweep (interrupt orphaned runs), the BC-3 compute-cost
-    metering sweep (bill any terminal runs left unbilled by the prior process), and
-    the charge-first pending-site reconciliation sweep (surface paid sites stuck
-    pending); the 5-minute loop then ticks all three.
+    metering sweep (bill any terminal runs left unbilled by the prior process), the
+    WU-F LiteLLM billing-cutover sweep (no-op / shadow-compare / live-ingest per the
+    cutover mode), and the charge-first pending-site reconciliation sweep (surface
+    paid sites stuck pending); the 5-minute loop then ticks all four.
     """
     from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
+    from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
     from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
     from pocketpaw_ee.sites.pending_sweeper import sweep_pending_sites
 
@@ -136,6 +148,8 @@ async def start_run_sweeper() -> None:
         await sweep_stale_runs()
     with suppress(Exception):
         await sweep_unbilled_runs()
+    with suppress(Exception):
+        await run_cutover_sweep()
     with suppress(Exception):
         await sweep_pending_sites()
     _sweeper_task = asyncio.create_task(_sweeper_loop())

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -552,6 +552,21 @@ source_modules = [
 forbidden_modules = ["pocketpaw_ee.cloud.models.cycle"]
 
 [[tool.importlinter.contracts]]
+name = "LLM provisioning — Beanie writes only from service.py"
+# MCG-8: the per-tenant LiteLLM virtual-key mapping (LiteLLMTenantKey) is written
+# only by llm_provisioning.service. The domain layer carries framework-free value
+# objects and must never import the Beanie doc (same entity-isolation boundary the
+# credit / foresight entities use).
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.llm_provisioning.domain",
+]
+forbidden_modules = [
+    "pocketpaw_ee.cloud.models.litellm_key",
+]
+
+[[tool.importlinter.contracts]]
 name = "Foresight — Beanie writes only from service.py"
 type = "forbidden"
 allow_indirect_imports = "true"

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,12 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-06-26 (integration/model-catalog-v2, MCG-11) — the ResultMessage
+  token-usage path now runs ``pocketpaw.llm.caching.report_savings`` over the SDK
+  usage to surface STRUCTURED prompt-cache telemetry (cache_read_tokens,
+  cache_write_tokens, cache_hit_rate, cache_est_tokens_saved) on the
+  ``token_usage`` AgentEvent metadata and log the per-turn margin. This is the
+  measurement hook for the byte-stable cached prefix used by site/pocket-gen;
+  the existing ``cached_input_tokens`` field is unchanged for back-compat.
 Updated: 2026-06-13 (feat/claude-sdk-prewarm) — added ``prewarm``: eagerly
   ``connect()`` the warm CLI subprocess for a session BEFORE its first turn so
   the first real ``run`` reuses it instead of paying the ~12s cold connect. To
@@ -2069,6 +2076,23 @@ class ClaudeSDKBackend(BaseAgentBackend):
                         usage = getattr(event, "usage", None) or {}
                         if isinstance(usage, dict) and (usage or total_cost):
                             _model_name = options_kwargs.get("model", "claude")
+                            # MCG-11 — read prompt-cache effectiveness off the
+                            # SDK usage via the universal helper so the margin
+                            # from the byte-stable cached prefix (site/pocket-gen)
+                            # is MEASURABLE: hit-rate + est. input-token-equivalents
+                            # saved, surfaced to metering alongside the raw counts.
+                            from pocketpaw.llm.caching import report_savings
+
+                            savings = report_savings(usage)
+                            if savings.cache_read_tokens or savings.cache_write_tokens:
+                                logger.info(
+                                    "[claude_sdk] prompt-cache: read=%d write=%d "
+                                    "hit_rate=%.1f%% est_saved=%.0f input-tok-equiv",
+                                    savings.cache_read_tokens,
+                                    savings.cache_write_tokens,
+                                    savings.hit_rate * 100,
+                                    savings.est_tokens_saved,
+                                )
                             yield AgentEvent(
                                 type="token_usage",
                                 content="",
@@ -2077,6 +2101,12 @@ class ClaudeSDKBackend(BaseAgentBackend):
                                     "output_tokens": usage.get("output_tokens", 0),
                                     "cached_input_tokens": usage.get("cache_read_input_tokens", 0)
                                     + usage.get("cache_creation_input_tokens", 0),
+                                    # Structured cache telemetry (MCG-11) — metering
+                                    # can attribute the margin without re-parsing.
+                                    "cache_read_tokens": savings.cache_read_tokens,
+                                    "cache_write_tokens": savings.cache_write_tokens,
+                                    "cache_hit_rate": savings.hit_rate,
+                                    "cache_est_tokens_saved": savings.est_tokens_saved,
                                     "total_cost_usd": total_cost,
                                     "model": _model_name
                                     if isinstance(_model_name, str)

--- a/src/pocketpaw/agents/deep_agents.py
+++ b/src/pocketpaw/agents/deep_agents.py
@@ -7,6 +7,12 @@ Uses the Deep Agents SDK (pip install deepagents) which provides:
 - Pluggable virtual filesystem backends
 
 Requires: pip install deepagents
+
+Updated 2026-06-26 (integration/model-catalog-v2, MCG-11): the Anthropic
+prompt-cache monkey-patch now sources its ``cache_control`` marker from the
+universal ``pocketpaw.llm.caching._cache_control`` helper (single source of
+truth for the 5m/1h ephemeral shape) instead of an inline literal, so this
+patch and the structured ``build_cacheable`` path can never drift.
 """
 
 import logging
@@ -257,6 +263,11 @@ def _patch_anthropic_message_serializer() -> None:
 
     original = _ac._format_messages
 
+    # Single source of truth for the ephemeral marker shape (MCG-11) — the
+    # universal caching module owns the 5m/1h ``cache_control`` dict so this
+    # patch and the structured ``build_cacheable`` path can never diverge.
+    from pocketpaw.llm.caching import _cache_control as _cc
+
     def patched(messages):  # type: ignore[no-untyped-def]
         system, formatted = original(messages)
         if isinstance(system, str) and len(system) >= _ANTHROPIC_CACHE_MIN_CHARS:
@@ -264,7 +275,7 @@ def _patch_anthropic_message_serializer() -> None:
                 {
                     "type": "text",
                     "text": system,
-                    "cache_control": {"type": "ephemeral"},
+                    "cache_control": _cc("5m"),
                 }
             ]
         elif isinstance(system, list) and system:
@@ -280,7 +291,7 @@ def _patch_anthropic_message_serializer() -> None:
             if total_chars >= _ANTHROPIC_CACHE_MIN_CHARS and not already_cached:
                 for block in reversed(system):
                     if isinstance(block, dict) and block.get("type") == "text":
-                        block["cache_control"] = {"type": "ephemeral"}
+                        block["cache_control"] = _cc("5m")
                         break
         return system, formatted
 

--- a/src/pocketpaw/agents/deep_agents.py
+++ b/src/pocketpaw/agents/deep_agents.py
@@ -8,11 +8,20 @@ Uses the Deep Agents SDK (pip install deepagents) which provides:
 
 Requires: pip install deepagents
 
-Updated 2026-06-26 (integration/model-catalog-v2, MCG-11): the Anthropic
-prompt-cache monkey-patch now sources its ``cache_control`` marker from the
-universal ``pocketpaw.llm.caching._cache_control`` helper (single source of
-truth for the 5m/1h ephemeral shape) instead of an inline literal, so this
-patch and the structured ``build_cacheable`` path can never drift.
+Updated 2026-06-26 (integration/model-catalog-v2, MCG-11):
+  * The Anthropic prompt-cache patch sources its ``cache_control`` marker from
+    the universal ``pocketpaw.llm.caching._cache_control`` helper (single source
+    of truth for the 5m/1h ephemeral shape) instead of an inline literal.
+  * It now picks the TTL by content: the pocket/site-GENERATOR prefix (detected
+    by the byte-stable ``<pocket-scope>`` sentinel via ``_cache_ttl_for_system``)
+    gets a **1h** window because it recurs across back-to-back briefs; every
+    other long prompt keeps the 5m default. This is where the live site-gen
+    margin actually lands — the specialist runs on this backend by default and
+    its system prompt is a string the patch wraps + marks.
+  * Added prompt-cache TELEMETRY: the stream accumulates per-turn cache token
+    counts (``_accumulate_cache_usage``) and emits a ``token_usage`` AgentEvent
+    (via ``report_savings``) before ``done``, so the margin is measurable on this
+    backend (mirrors the claude_sdk hook).
 """
 
 import logging
@@ -47,6 +56,27 @@ _ANTHROPIC_PATCHED = False
 # prompts the chat agent uses for greetings / one-shot facts. Tuned
 # conservatively — false positives only cost the cache-write overhead.
 _ANTHROPIC_CACHE_MIN_CHARS = 4000
+
+# MCG-11 — byte-stable sentinel that identifies the pocket/site-GENERATOR
+# prefix (``POCKET_SPECIALIST_PROMPT`` and the edit-specialist variants all open
+# with ``_SCOPE_BLOCK``, whose first line is ``<pocket-scope>``). That prefix is
+# huge (~17k tokens) and recurs across BACK-TO-BACK briefs, so it earns the 1h
+# cache window (≥3 reads/hour beats the 5m default and amortises the 2x write).
+# Every OTHER long prompt (chat / home / one-shot) keeps the 5m default — a
+# blanket 1h would 2x the write cost for prompts that never recur within the
+# hour. The gate is a substring test on byte-stable prompt text, so it stays
+# correct regardless of which backend assembled the string.
+_SPECIALIST_PREFIX_SENTINEL = "<pocket-scope>"
+
+
+def _cache_ttl_for_system(text: str) -> str:
+    """Pick the cache TTL for a system prompt by its content.
+
+    Returns ``"1h"`` for the pocket/site-generator prefix (detected by the
+    byte-stable ``<pocket-scope>`` sentinel) — it recurs across briefs so the
+    longer window pays off — and ``"5m"`` for everything else.
+    """
+    return "1h" if _SPECIALIST_PREFIX_SENTINEL in text else "5m"
 
 
 def _patch_openai_message_serializer() -> None:
@@ -271,27 +301,29 @@ def _patch_anthropic_message_serializer() -> None:
     def patched(messages):  # type: ignore[no-untyped-def]
         system, formatted = original(messages)
         if isinstance(system, str) and len(system) >= _ANTHROPIC_CACHE_MIN_CHARS:
+            # The pocket/site-generator prefix gets the 1h window (it recurs
+            # across briefs); every other long prompt keeps 5m.
             system = [
                 {
                     "type": "text",
                     "text": system,
-                    "cache_control": _cc("5m"),
+                    "cache_control": _cc(_cache_ttl_for_system(system)),
                 }
             ]
         elif isinstance(system, list) and system:
             # Already a block list. Tag the last text block whose total
             # text size pushes the system payload over the threshold —
             # short text-only systems and pure-image systems are skipped.
-            total_chars = sum(
-                len(b.get("text", ""))
-                for b in system
-                if isinstance(b, dict) and b.get("type") == "text"
-            )
+            text_blocks = [b for b in system if isinstance(b, dict) and b.get("type") == "text"]
+            total_chars = sum(len(b.get("text", "")) for b in text_blocks)
             already_cached = any(isinstance(b, dict) and b.get("cache_control") for b in system)
             if total_chars >= _ANTHROPIC_CACHE_MIN_CHARS and not already_cached:
+                # TTL keys off the WHOLE system text so the generator prefix is
+                # recognised even when split across blocks.
+                ttl = _cache_ttl_for_system("".join(b.get("text", "") for b in text_blocks))
                 for block in reversed(system):
                     if isinstance(block, dict) and block.get("type") == "text":
-                        block["cache_control"] = _cc("5m")
+                        block["cache_control"] = _cc(ttl)
                         break
         return system, formatted
 
@@ -313,6 +345,36 @@ def _unwrap(value: Any) -> Any:
     if hasattr(value, "value"):
         return value.value
     return value
+
+
+def _accumulate_cache_usage(msg_chunk: Any, acc: dict[str, int]) -> None:
+    """Fold a LangChain ``AIMessageChunk``'s cache token counts into ``acc``
+    (MCG-11 telemetry).
+
+    LangChain normalises provider usage onto ``usage_metadata``:
+    ``input_tokens`` is the TOTAL input (cached + uncached) and the cache split
+    lives under ``input_token_details.{cache_read, cache_creation}``. A tool
+    loop yields several AI turns, each with its own ``usage_metadata``, so we
+    SUM across chunks. ``acc`` carries Anthropic-NATIVE keys (read / write /
+    total) so it can be handed straight to ``report_savings`` — which expects
+    ``input_tokens`` to be the UNCACHED remainder, hence we store
+    ``uncached = total - read - write``.
+    """
+    um = getattr(msg_chunk, "usage_metadata", None)
+    if not isinstance(um, dict):
+        return
+    total_input = um.get("input_tokens") or 0
+    details = um.get("input_token_details") or {}
+    read = details.get("cache_read") or 0
+    write = details.get("cache_creation") or 0
+    try:
+        total_input, read, write = int(total_input), int(read), int(write)
+    except (TypeError, ValueError):
+        return
+    uncached = max(0, total_input - read - write)
+    acc["cache_read_input_tokens"] += max(0, read)
+    acc["cache_creation_input_tokens"] += max(0, write)
+    acc["input_tokens"] += uncached
 
 
 def _extract_content_text(content: Any) -> str:
@@ -871,6 +933,17 @@ class DeepAgentsBackend:
             # path emits the final args. Same tool_call_id → emit once.
             announced_tool_ids: set[str] = set()
 
+            # MCG-11 — accumulate prompt-cache token usage across the stream's
+            # AI turns (Anthropic-native keys, so report_savings consumes it
+            # directly). Emitted as a token_usage event before "done" so the
+            # margin from the 1h-cached specialist prefix is MEASURABLE on this
+            # backend (the pocket specialist's default).
+            cache_usage: dict[str, int] = {
+                "input_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+            }
+
             # Stream using LangGraph's async streaming. Hold the stream in
             # a variable so the ``finally`` block below can call
             # ``aclose()`` on it. LangGraph's astream is backed by
@@ -899,6 +972,9 @@ class DeepAgentsBackend:
                         continue
                     # v2 format: data is (AIMessageChunk, metadata_dict) tuple
                     msg_chunk = data[0] if isinstance(data, tuple | list) else data
+                    # Fold this turn's cache token counts into the accumulator
+                    # (no-op when the chunk carries no usage_metadata).
+                    _accumulate_cache_usage(msg_chunk, cache_usage)
                     text, thinking = _split_content_text_and_thinking(
                         getattr(msg_chunk, "content", "")
                     )
@@ -979,6 +1055,34 @@ class DeepAgentsBackend:
                                     content=tool_content,
                                     metadata={"name": tool_name},
                                 )
+
+            # MCG-11 — emit prompt-cache telemetry before "done" so the margin
+            # from the 1h-cached specialist prefix is observable on this backend
+            # (the pocket specialist's default). Mirrors the claude_sdk hook.
+            if cache_usage["cache_read_input_tokens"] or cache_usage["cache_creation_input_tokens"]:
+                from pocketpaw.llm.caching import report_savings
+
+                savings = report_savings(cache_usage)
+                logger.info(
+                    "[deep_agents] prompt-cache: read=%d write=%d "
+                    "hit_rate=%.1f%% est_saved=%.0f input-tok-equiv",
+                    savings.cache_read_tokens,
+                    savings.cache_write_tokens,
+                    savings.hit_rate * 100,
+                    savings.est_tokens_saved,
+                )
+                yield AgentEvent(
+                    type="token_usage",
+                    content="",
+                    metadata={
+                        "input_tokens": cache_usage["input_tokens"],
+                        "cache_read_tokens": savings.cache_read_tokens,
+                        "cache_write_tokens": savings.cache_write_tokens,
+                        "cache_hit_rate": savings.hit_rate,
+                        "cache_est_tokens_saved": savings.est_tokens_saved,
+                        "backend": "deep_agents",
+                    },
+                )
 
             yield AgentEvent(type="done", content="")
 

--- a/src/pocketpaw/agents/failover.py
+++ b/src/pocketpaw/agents/failover.py
@@ -1,0 +1,392 @@
+# pocketpaw/agents/failover.py — L2 cross-backend (harness) failover (MCG-10).
+#
+# Created: 2026-06-26 (integration/model-catalog-v2, WU-D / MCG-10).
+#
+# What this is: the MECHANISM for failing over between agent HARNESSES when a
+# whole backend lane is down. This is the *second* failover level:
+#   * L1 (model / account) is owned by LiteLLM (multi-account weighted failover
+#     + cross-group fallback to another provider). NOT here.
+#   * L2 (harness / backend) is paw's job and LiteLLM CANNOT do it: when the
+#     entire Claude Code lane is down (an Anthropic-wide overload), Claude
+#     Code's own ``--fallback-model`` stays in Anthropic's capacity pool, so it
+#     can't escape. We switch to a DIFFERENT harness instead:
+#     claude_agent_sdk -> codex_cli -> opencode.
+#
+# Two hard rules that make this safe:
+#   1. We only fail over on a LANE-LEVEL failure — an overload / unavailable /
+#      auth error from the provider that persists AFTER the backend's own
+#      retries. A normal task error (the model answered, but wrongly) does NOT
+#      trigger a switch. See ``classify_lane_failure``.
+#   2. We only fail over if NOTHING was streamed to the user yet. A half-
+#      streamed turn cannot be replayed on another harness without duplicating
+#      tokens, so once a user-visible event has been yielded we surface the
+#      error instead of silently restarting. See the ``_streamed`` guard.
+#
+# Each harness in the chain is tried at most once; when the chain is exhausted
+# the LAST error is surfaced. Every switch is audit-logged (which harness, why,
+# the error class) via the shared OSS audit logger.
+#
+# OSS-pure: no ``pocketpaw_ee`` import. The EE cloud run path (``run_core``)
+# wiring to actually CALL ``AgentRouter.run_with_failover`` is a follow-up
+# (the IGW-seam pattern) — this slice ships the mechanism + the OSS hook.
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+from pocketpaw.agents.protocol import AgentEvent
+
+logger = logging.getLogger(__name__)
+
+# Event types that are USER-VISIBLE: once one of these is yielded we have
+# committed output to the user and can no longer fail over (no-replay rule).
+# "thinking"/"thinking_done" go to the Activity panel only, but they are still
+# emitted content we cannot cleanly replay on a different harness, so they also
+# latch the no-replay guard. "token_usage" is bookkeeping (no visible content)
+# and "done" is terminal, so neither latches the guard on its own — though in
+# practice a clean "done" ends the run before failover is considered.
+_STREAMED_EVENT_TYPES: frozenset[str] = frozenset(
+    {"message", "tool_use", "tool_result", "thinking", "thinking_done"}
+)
+
+# Substrings that mark a provider LANE-DOWN condition: capacity exhaustion,
+# service unavailability, or a credential/authorization failure that the
+# backend could not recover from on its own. Matched case-insensitively against
+# the error text (an exception's str() or an error AgentEvent's content). These
+# are deliberately conservative — a generic "error" with none of these markers
+# is treated as a normal task error and does NOT trigger a harness switch.
+_LANE_DOWN_PATTERNS: tuple[str, ...] = (
+    # Capacity / overload (Anthropic 529 "Overloaded", OpenAI/others rate limit)
+    "overloaded",
+    "overload",
+    "rate limit",
+    "rate_limit",
+    "ratelimit",
+    "too many requests",
+    "too_many_requests",
+    "429",
+    "529",
+    "capacity",
+    "quota",
+    "usage limit",
+    "usage_limit",
+    "insufficient_quota",
+    # Service unavailable / outage
+    "service unavailable",
+    "service_unavailable",
+    "temporarily unavailable",
+    "unavailable",
+    "503",
+    "502",
+    "504",
+    "bad gateway",
+    "gateway timeout",
+    "upstream",
+    "overloaded_error",
+    "api_error",
+    "internal server error",
+    # Auth / credential failures (lane is unusable for this harness)
+    "authentication",
+    "unauthorized",
+    "invalid api key",
+    "invalid_api_key",
+    "permission denied",
+    "permission_error",
+    "forbidden",
+    "401",
+    "403",
+)
+
+# Compiled once. Word-ish boundaries are not used because the markers appear
+# inside longer provider strings (e.g. "anthropic.APIStatusError: 529
+# {'type': 'overloaded_error'}"); a plain case-insensitive substring scan is
+# the right tool and avoids false negatives from punctuation.
+_LANE_DOWN_RE = re.compile("|".join(re.escape(p) for p in _LANE_DOWN_PATTERNS), re.IGNORECASE)
+
+
+def classify_lane_failure(error_text: str | None) -> bool:
+    """Return True if *error_text* looks like a LANE-DOWN failure.
+
+    A lane-down failure is a provider capacity / availability / credential
+    error that persists after the backend's own retries — the signal that the
+    *whole harness lane* is unusable right now, so switching to a different
+    harness is worth trying. A normal task error (the model ran but produced a
+    bad answer, a tool failed, the prompt was rejected on content grounds)
+    returns False: another harness would hit the same wall, so we must not
+    burn the chain on it.
+
+    Empty / None text returns False (nothing to classify as lane-down).
+    """
+    if not error_text:
+        return False
+    return bool(_LANE_DOWN_RE.search(error_text))
+
+
+# A factory that builds (or fetches a cached) backend instance for a given
+# harness name, or returns None if that harness is unavailable (missing deps,
+# failed init). The router supplies this; tests supply a fake.
+BackendFactory = Callable[[str], Any]
+
+
+class BackendFailoverRunner:
+    """Drives an agent run across an ordered chain of HARNESSES (L2 failover).
+
+    Construction is cheap and stateless apart from the injected factory; build
+    one per logical run (or reuse — it holds no per-run state across calls).
+
+    Usage::
+
+        runner = BackendFailoverRunner(chain, get_backend)
+        async for event in runner.run(message, system_prompt=..., ...):
+            yield event
+
+    Behavior:
+      * Try each harness in ``chain`` in order. The first harness is the
+        primary lane; the rest are the escape hatches.
+      * If a harness raises or yields a ``type="error"`` event whose text is
+        classified lane-down BEFORE any user-visible event was streamed, audit-
+        log the switch and move to the next harness.
+      * If output was already streamed, surface the error as-is (no replay) and
+        stop — we never silently restart a half-streamed turn.
+      * If an error is NOT lane-down (a normal task error), surface it and stop
+        — another harness would hit the same wall.
+      * Each harness is tried at most once. When the chain is exhausted, the
+        last error is surfaced.
+    """
+
+    def __init__(
+        self,
+        chain: list[str],
+        get_backend: BackendFactory,
+        *,
+        audit_actor: str = "agent",
+    ) -> None:
+        self._chain = list(chain)
+        self._get_backend = get_backend
+        self._audit_actor = audit_actor
+
+    async def run(
+        self,
+        message: str,
+        **run_kwargs: Any,
+    ) -> AsyncIterator[AgentEvent]:
+        """Run *message* across the harness chain. Yields ``AgentEvent``s.
+
+        ``run_kwargs`` (system_prompt / history / session_key / the optional
+        per-surface frozensets) are forwarded verbatim to each backend's
+        ``run`` — the runner does not interpret them.
+        """
+        last_error: str | None = "All configured harnesses failed"
+        tried_any = False
+
+        for index, backend_name in enumerate(self._chain):
+            backend = self._get_backend(backend_name)
+            if backend is None:
+                logger.warning("Harness '%s' unavailable — skipping", backend_name)
+                continue
+
+            tried_any = True
+            is_primary = index == 0
+            # Per-attempt streaming latch: flips True the instant a user-visible
+            # event leaves this harness. Once True we can no longer fail over.
+            streamed = False
+            attempt_error: str | None = None
+
+            # ``failed_over`` records that THIS harness hit a pre-stream lane-
+            # down condition and we should advance to the next harness. We set
+            # it instead of ``continue``-ing from inside the ``async for`` so
+            # the generator is fully exhausted/closed before we move on.
+            failed_over = False
+
+            try:
+                async for event in backend.run(message, **run_kwargs):
+                    etype = getattr(event, "type", None)
+
+                    # An error event: decide failover BEFORE forwarding it, so a
+                    # lane-down error pre-stream is swallowed (we retry on the
+                    # next harness) rather than shown to the user.
+                    if etype == "error":
+                        attempt_error = _event_text(event)
+                        if not streamed and classify_lane_failure(attempt_error):
+                            # Lane down, nothing streamed yet → fail over. Do
+                            # NOT yield this error event; stop consuming this
+                            # harness and advance to the next one.
+                            last_error = attempt_error
+                            failed_over = True
+                            self._audit_switch(
+                                from_backend=backend_name,
+                                to_backend=self._next_available(index),
+                                error_text=attempt_error,
+                                error_class="error_event",
+                                via="error_event",
+                            )
+                            break
+                        # Output already streamed (no replay) OR a normal task
+                        # error → surface it and stop entirely.
+                        self._audit_no_failover(
+                            backend_name,
+                            attempt_error,
+                            streamed=streamed,
+                            reason="streamed" if streamed else "not_lane_down",
+                        )
+                        yield event
+                        continue
+
+                    # Normal event. Latch the no-replay guard on first user-
+                    # visible output, then forward.
+                    if etype in _STREAMED_EVENT_TYPES:
+                        streamed = True
+                    yield event
+
+                    if etype == "done":
+                        # Clean completion on this harness.
+                        if not is_primary:
+                            logger.info("Harness failover succeeded on '%s'", backend_name)
+                        return
+
+            except Exception as exc:  # noqa: BLE001 — classify, don't crash.
+                attempt_error = str(exc)
+                last_error = attempt_error
+                if not streamed and classify_lane_failure(attempt_error):
+                    logger.warning(
+                        "Harness '%s' lane-down (raised): %s",
+                        backend_name,
+                        attempt_error,
+                    )
+                    self._audit_switch(
+                        from_backend=backend_name,
+                        to_backend=self._next_available(index),
+                        error_text=attempt_error,
+                        error_class=type(exc).__name__,
+                        via="exception",
+                    )
+                    failed_over = True
+                else:
+                    # Streamed already, or not a lane-down error → surface + stop.
+                    logger.warning(
+                        "Harness '%s' failed (no failover: streamed=%s lane_down=%s): %s",
+                        backend_name,
+                        streamed,
+                        classify_lane_failure(attempt_error),
+                        attempt_error,
+                    )
+                    self._audit_no_failover(
+                        backend_name,
+                        attempt_error,
+                        streamed=streamed,
+                        reason="streamed" if streamed else "not_lane_down",
+                    )
+                    yield AgentEvent(type="error", content=attempt_error)
+                    yield AgentEvent(type="done", content="")
+                    return
+
+            if failed_over:
+                # Advance to the next harness in the chain.
+                continue
+
+            # Generator finished without a terminal "done" and without an error
+            # we acted on. Treat as a soft completion: nothing left to yield.
+            if attempt_error is None:
+                return
+            # An error event was surfaced (not lane-down / post-stream) and the
+            # backend's generator ended without its own "done" — close cleanly.
+            yield AgentEvent(type="done", content="")
+            return
+
+        # Chain exhausted (or nothing was runnable). Surface the last error.
+        if not tried_any:
+            logger.error("No harness in the failover chain was available")
+        yield AgentEvent(
+            type="error",
+            content=last_error or "All configured harnesses failed",
+        )
+        yield AgentEvent(type="done", content="")
+
+    # ── internals ────────────────────────────────────────────────────────
+
+    def _next_available(self, index: int) -> str | None:
+        """Name of the next harness AFTER *index* that resolves, or None."""
+        for name in self._chain[index + 1 :]:
+            if self._get_backend(name) is not None:
+                return name
+        return None
+
+    def _audit_switch(
+        self,
+        *,
+        from_backend: str,
+        to_backend: str | None,
+        error_text: str | None,
+        error_class: str,
+        via: str,
+    ) -> None:
+        """Audit-log a harness switch (which, why, error class). Best-effort."""
+        try:
+            from pocketpaw.security.audit import (
+                AuditEvent,
+                AuditSeverity,
+                get_audit_logger,
+            )
+
+            get_audit_logger().log(
+                AuditEvent.create(
+                    severity=AuditSeverity.WARNING,
+                    actor=self._audit_actor,
+                    action="backend_failover",
+                    target=f"{from_backend} -> {to_backend or '(chain exhausted)'}",
+                    status="switch",
+                    from_backend=from_backend,
+                    to_backend=to_backend,
+                    error_class=error_class,
+                    detected_via=via,
+                    # Truncate so a giant provider stack trace can't bloat the
+                    # audit line; the class + a snippet is enough to triage.
+                    error=(error_text or "")[:500],
+                    level="L2_harness",
+                )
+            )
+        except Exception:  # noqa: BLE001 — audit must never break a run.
+            logger.exception("Failed to write backend-failover audit log")
+
+    def _audit_no_failover(
+        self,
+        backend_name: str,
+        error_text: str | None,
+        *,
+        streamed: bool,
+        reason: str,
+    ) -> None:
+        """Audit-log that an error was SURFACED without a switch. Best-effort."""
+        try:
+            from pocketpaw.security.audit import (
+                AuditEvent,
+                AuditSeverity,
+                get_audit_logger,
+            )
+
+            get_audit_logger().log(
+                AuditEvent.create(
+                    severity=AuditSeverity.INFO,
+                    actor=self._audit_actor,
+                    action="backend_failover",
+                    target=backend_name,
+                    status="no_switch",
+                    reason=reason,
+                    streamed=streamed,
+                    error=(error_text or "")[:500],
+                    level="L2_harness",
+                )
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to write backend-failover audit log")
+
+
+def _event_text(event: AgentEvent) -> str:
+    """Extract a string from an error event's content for classification."""
+    content = getattr(event, "content", "")
+    if isinstance(content, str):
+        return content
+    return str(content)

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -50,6 +50,19 @@ Updated: 2026-06-13 (feat/claude-sdk-prewarm) — added ``prewarm``, which eager
   digest matches too. Fire-and-forget: never raises (the backend's ``prewarm``
   swallows its own errors; this guards instance load + prompt assembly). The EE
   trigger fires it as a background task in ``run_core.execute_run``.
+Updated: 2026-06-26 (feat/mcg-3-pool-route-model) — ``_build`` now routes the
+  per-agent ``config.model`` onto the correct backend Settings field via
+  ``pocketpaw.llm.providers.base.route_model`` instead of the old brittle
+  ``"claude" in backend`` / ``"openai" in backend`` / ``"google" in backend``
+  substring chain. That chain silently dropped the per-agent model for
+  ``codex_cli``, ``opencode``, ``deep_agents``, ``copilot_sdk`` and
+  ``langchain_react`` (and even wrote OpenAI Agents' model to the wrong field,
+  ``openai_model`` instead of ``openai_agents_model``). ``route_model`` is
+  driven by ``_BACKEND_MODEL_ATTR`` (+ the langchain_react->deep_agents_model
+  alias) so it covers every registered backend and preserves the composite
+  ``provider:model`` / ``provider/model`` formats verbatim. Legacy backend names
+  are resolved through ``_LEGACY_BACKENDS`` before routing so old agent docs
+  still map to the right field. Empty model stays a no-op (backend default).
 """
 
 from __future__ import annotations
@@ -524,8 +537,9 @@ class AgentPool:
     async def _build(self, agent_doc: Any) -> AgentInstance:
         """Build a new AgentInstance from an Agent document."""
         from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
-        from pocketpaw.agents.registry import get_backend_class
+        from pocketpaw.agents.registry import _LEGACY_BACKENDS, get_backend_class
         from pocketpaw.config import Settings
+        from pocketpaw.llm.providers.base import route_model
         from pocketpaw.tools.policy import OPT_IN_MCP_SERVERS, ToolPolicy
 
         agent_id = str(agent_doc.id)
@@ -535,15 +549,21 @@ class AgentPool:
         settings = Settings.load()
         settings.agent_backend = config.get("backend", "claude_agent_sdk")
 
-        # Map model to the correct settings field based on backend
+        # Map the per-agent model onto the Settings field the chosen backend
+        # actually reads, for EVERY registered backend — the old ``"claude" in
+        # backend`` substring routing silently dropped the model for codex_cli /
+        # opencode / deep_agents / copilot_sdk / langchain_react. ``route_model``
+        # is the single source of truth (driven by ``_BACKEND_MODEL_ATTR`` +
+        # the langchain_react->deep_agents alias) and preserves the composite
+        # ``provider:model`` / ``provider/model`` formats verbatim. An empty
+        # model is a no-op, so the backend falls through to its own default.
+        # Catalog existence-validation is NOT done here — it lives upstream in
+        # the picker / EE catalog layer (MCG-1/4); OSS can't import EE.
+        # Resolve legacy backend names to their canonical key first so an old
+        # agent doc (e.g. ``claude_code``) still routes to the right field.
         model = config.get("model", "")
-        if model:
-            if "claude" in settings.agent_backend:
-                settings.claude_sdk_model = model
-            elif "openai" in settings.agent_backend:
-                settings.openai_model = model
-            elif "google" in settings.agent_backend:
-                settings.google_adk_model = model
+        canonical_backend = _LEGACY_BACKENDS.get(settings.agent_backend, settings.agent_backend)
+        route_model(settings, canonical_backend, model)
 
         # Instantiate backend
         backend_cls = get_backend_class(settings.agent_backend)

--- a/src/pocketpaw/agents/router.py
+++ b/src/pocketpaw/agents/router.py
@@ -3,6 +3,17 @@
 Uses the backend registry to lazily discover and instantiate the
 configured agent backend. Supports optional user-configured fallback
 backends if the primary backend fails.
+
+Changes:
+  - 2026-06-26 (MCG-10): Added ``run_with_failover`` — the OSS hook for L2
+    cross-backend HARNESS failover. When ``settings.backend_failover_enabled``
+    is True it drives the run through ``BackendFailoverRunner`` over
+    ``settings.backend_failover_chain`` (Claude Code -> Codex -> opencode),
+    switching harnesses only on a pre-stream lane-down failure and audit-
+    logging each switch. When the flag is False it is a thin pass-through to
+    ``run`` (behavior unchanged). Distinct from the generic ``fallback_backends``
+    path in ``run`` (which trips on ANY failure, with no streaming guard). The
+    EE cloud run path wiring is a follow-up.
 """
 
 import asyncio
@@ -12,6 +23,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from pocketpaw.agents.backend import BackendInfo
+from pocketpaw.agents.failover import BackendFailoverRunner
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.agents.registry import get_backend_class
 from pocketpaw.config import Settings
@@ -210,6 +222,59 @@ class AgentRouter:
             content=last_error or "All configured backends failed",
         )
         yield AgentEvent(type="done", content="")
+
+    def _failover_backend_factory(self, backend_name: str) -> Any:
+        """Resolve a harness name to a (cached) backend instance for failover.
+
+        Reuses the already-initialized primary instance when the name matches
+        the active backend, otherwise reuses/creates a cached instance via the
+        same path the generic fallback uses — so the failover chain shares warm
+        subprocesses with the rest of the router instead of spawning a fresh
+        one per attempt. Returns None if the harness is unavailable.
+        """
+        if backend_name == self._active_backend_name and self._backend is not None:
+            return self._backend
+        return self._get_fallback_backend(backend_name)
+
+    async def run_with_failover(
+        self,
+        message: str,
+        *,
+        system_prompt: str | None = None,
+        history: list[dict] | None = None,
+        session_key: str | None = None,
+    ) -> AsyncIterator[AgentEvent]:
+        """Run with L2 cross-backend (harness) failover when enabled.
+
+        This is the MCG-10 hook. When ``backend_failover_enabled`` is False it
+        delegates to :meth:`run` (identical behavior, including the generic
+        ``fallback_backends`` path). When True it drives the run through
+        :class:`BackendFailoverRunner` over ``backend_failover_chain``, which
+        switches HARNESSES only on a pre-stream lane-down failure (overload /
+        unavailable / auth) and audit-logs every switch.
+
+        The EE cloud run path (``run_core``) calling this is a follow-up; the
+        mechanism + this hook ship in the OSS slice.
+        """
+        if not self.settings.backend_failover_enabled:
+            async for event in self.run(
+                message,
+                system_prompt=system_prompt,
+                history=history,
+                session_key=session_key,
+            ):
+                yield event
+            return
+
+        chain = self.settings.backend_failover_chain or [self.settings.agent_backend]
+        runner = BackendFailoverRunner(chain, self._failover_backend_factory)
+        async for event in runner.run(
+            message,
+            system_prompt=system_prompt,
+            history=history,
+            session_key=session_key,
+        ):
+            yield event
 
     async def stop(self) -> None:
         """Stop all backend instances."""

--- a/src/pocketpaw/bundled_skills/_bundled/skills/studio/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/studio/SKILL.md
@@ -45,12 +45,18 @@ enrich it from the request.
 
 ## STEP 2 — Call the media tool
 
+Generation runs through the model gateway, so you can target any image or
+video model the deployment serves by passing its catalog id as `model`.
+Leave `model` off to use the deployment default.
+
 **Image:**
 
 ```
 mcp__pocketpaw_media__image_generate(
   prompt = "<the vivid image prompt>",
-  aspect_ratio = "16:9"      // optional: "1:1" | "16:9" | "9:16"
+  model = "gpt-image-1",     // optional: a catalog image-model id
+  aspect_ratio = "16:9",     // optional: "1:1" | "16:9" | "9:16" (mapped to size)
+  size = "1792x1024"         // optional: explicit size wins over aspect_ratio
 )
 ```
 
@@ -59,27 +65,28 @@ mcp__pocketpaw_media__image_generate(
 ```
 mcp__pocketpaw_media__video_generate(
   prompt = "<the vivid video prompt>",
+  model = "sora",            // optional: a catalog video-model id
   duration = 5,              // optional: seconds
   aspect_ratio = "16:9"      // optional: "16:9" | "9:16"
 )
 ```
 
 Each tool **produces the asset and adds it to the gallery pocket**, then
-returns `{ ok, kind, path|url, pocket_id, gallery_count }`. The canvas opens
-the gallery automatically — you don't create or merge a pocket yourself.
+returns `{ ok, kind, model, path|url, pocket_id, gallery_count }`. The canvas
+opens the gallery automatically — you don't create or merge a pocket yourself.
 
-Video generation is **async** and may take up to ~2 minutes. Tell the user
+Video generation is **async** and may take a few minutes. Tell the user
 it's rendering before you wait on it.
 
 ## STEP 3 — Relay the result (or the error)
 
 - On success: briefly say what was added to the gallery (e.g. "Added your
   poster to the gallery — 3 items now"). Don't dump the file path.
-- On `ok: false`: **relay the error plainly** and do **not** claim a
-  phantom asset. Common errors are missing provider keys:
-  - image → "Set `POCKETPAW_GOOGLE_API_KEY` to enable image generation."
-  - video → "Set `POCKETPAW_REPLICATE_API_TOKEN` to enable video
-    generation."
+- On `ok: false`: **relay the error message plainly** and do **not** claim a
+  phantom asset. The error comes back from the model gateway — common causes
+  are an unknown model id, a model the gateway isn't serving yet, or an
+  upstream quota/billing limit. Pass the message through as-is; don't invent
+  a fix.
 
 ## Accumulating a gallery
 
@@ -90,9 +97,17 @@ tool per request.
 
 ## Related tools (via MCP)
 
-- `mcp__pocketpaw_media__image_generate` — generate an image (Google
-  Gemini) and add it to the gallery. Returns `{ok, kind:'image', path,
-  pocket_id, gallery_count}`.
-- `mcp__pocketpaw_media__video_generate` — generate a short video
-  (Replicate) and add it to the gallery. Returns `{ok, kind:'video', url,
-  pocket_id, gallery_count}`.
+All four route through the model gateway:
+
+- `mcp__pocketpaw_media__image_generate` — generate an image and add it to
+  the gallery. Returns `{ok, kind:'image', model, path, pocket_id,
+  gallery_count}`.
+- `mcp__pocketpaw_media__audio_generate` — synthesize speech (text-to-speech)
+  and add it to the gallery. Args: `text`, optional `model`, `voice`.
+  Returns `{ok, kind:'audio', model, path, pocket_id, gallery_count}`.
+- `mcp__pocketpaw_media__audio_transcribe` — transcribe a local audio file
+  (speech-to-text). Args: `path`, optional `model`. Returns `{ok,
+  kind:'transcription', model, text}`. Does NOT touch the gallery.
+- `mcp__pocketpaw_media__video_generate` — generate a short video and add it
+  to the gallery. Returns `{ok, kind:'video', model, url, pocket_id,
+  gallery_count}`.

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,16 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-26 (WU-F billing cutover): Added ``litellm_spend_mode``
+    (Literal off|shadow|live, default 'off'; POCKETPAW_LITELLM_SPEND_MODE) — the
+    three-position billing-cutover switch that supersedes the
+    ``litellm_spend_ingest_enabled`` bool. 'off' keeps BC-3 per-run metering as
+    today; 'shadow' runs a read-only per-tenant compare (litellm spend vs BC-3
+    ledger, ZERO debits) that records a reconciliation row; 'live' makes LiteLLM
+    the sole meter (proxy-spend sweep debits + BC-3 sweep gated off). The legacy
+    bool is kept for back-compat and resolved by ``effective_spend_mode()`` — an
+    existing ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` maps to 'live' only
+    while the new mode is left at 'off'.
   - 2026-06-26: Added the L2 cross-backend harness-failover settings (MCG-10) —
     ``backend_failover_enabled`` (default False; kill-switch — when False the
     new ``AgentRouter.run_with_failover`` behaves exactly like ``run`` and no
@@ -1596,14 +1606,49 @@ class Settings(BaseSettings):
     litellm_spend_ingest_enabled: bool = Field(
         default=False,
         description=(
-            "Whether the LiteLLM proxy-spend -> credits sweep (MCG-8) runs. Default "
-            "FALSE: the proxy's /spend/logs includes the text chat runs BC-3 "
-            "metering already bills per ChatRunDoc, so enabling this alongside "
-            "per-run metering would double-bill text chat. It is the future "
-            "single-source-of-truth path (bill all compute from proxy spend, retire "
-            "per-run metering) — flip it (with row-level dedup against BC-3) as a "
-            "deliberate migration. Provisioning the per-tenant key is unaffected by "
-            "this flag. Set via POCKETPAW_LITELLM_SPEND_INGEST."
+            "DEPRECATED back-compat flag for the MCG-8 spend sweep — superseded by "
+            "POCKETPAW_LITELLM_SPEND_MODE (WU-F). Left in place so an existing "
+            "deployment that set POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true keeps "
+            "billing from proxy spend: when the new mode is left at its 'off' default "
+            "and this bool is True, ``effective_spend_mode()`` resolves to 'live' "
+            "(the old bool meant 'ingest + single meter'). Prefer setting "
+            "POCKETPAW_LITELLM_SPEND_MODE explicitly; this flag is ignored once the "
+            "mode is set to any non-'off' value. Set via "
+            "POCKETPAW_LITELLM_SPEND_INGEST_ENABLED."
+        ),
+    )
+    litellm_spend_mode: Literal["off", "shadow", "live"] = Field(
+        default="off",
+        description=(
+            "The billing-cutover mode for LiteLLM proxy spend (WU-F). Replaces the "
+            "POCKETPAW_LITELLM_SPEND_INGEST bool with a three-position switch so the "
+            "cutover to LiteLLM as the single meter happens through a SAFE "
+            "shadow-compare phase:\n"
+            "  * 'off'    (default) — nothing changes; BC-3 per-run metering bills "
+            "as today, no proxy-spend sweep runs.\n"
+            "  * 'shadow' — the safe compare. A per-tenant sweep reads /spend/logs, "
+            "converts cost->credits, sums the BC-3 compute_spend ledger debits over "
+            "the same window, and records a reconciliation row (litellm vs bc3 + "
+            "delta + coverage_gap). It performs ZERO debits — BC-3 keeps billing — "
+            "so an operator can confirm the two meters agree BEFORE cutting over.\n"
+            "  * 'live'   — LiteLLM is the sole meter: the proxy-spend sweep debits "
+            "litellm_spend AND BC-3's per-run metering sweep is gated OFF, so "
+            "exactly one meter charges each unit of usage (no double-bill window).\n"
+            "Provisioning the per-tenant key is unaffected by this mode (always on). "
+            "Set via POCKETPAW_LITELLM_SPEND_MODE."
+        ),
+    )
+    litellm_reconcile_gap_threshold_credits: int = Field(
+        default=10,
+        description=(
+            "Shadow-compare coverage-gap threshold in CREDITS (WU-F). During "
+            "POCKETPAW_LITELLM_SPEND_MODE=shadow, a reconciliation row is flagged "
+            "``coverage_gap=true`` when |litellm_credits - bc3_credits| exceeds this "
+            "many credits — a discrepancy big enough to mean traffic is bypassing "
+            "the proxy OR the USD->credits conversion disagrees, which must be "
+            "resolved before flipping to 'live'. 1 credit == $0.01, so the default "
+            "10 ≈ $0.10 of tolerated per-tenant-per-window drift (rounding noise). "
+            "Set via POCKETPAW_LITELLM_RECONCILE_GAP_THRESHOLD_CREDITS."
         ),
     )
     site_pending_alert_hours: float = Field(
@@ -1904,6 +1949,25 @@ class Settings(BaseSettings):
             )
             self.kb_scopes = [self.kb_scope]
         return self
+
+    def effective_spend_mode(self) -> Literal["off", "shadow", "live"]:
+        """Resolve the LiteLLM billing-cutover mode, honouring the legacy bool.
+
+        WU-F replaced the ``litellm_spend_ingest_enabled`` bool with the
+        three-position ``litellm_spend_mode`` switch. To keep an existing
+        deployment that set ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` billing
+        from proxy spend, the bool is treated as a 'live'-intent fallback: when the
+        new mode is still at its 'off' default AND the old bool is True, the
+        effective mode is 'live' (the bool meant "ingest proxy spend as the
+        single meter"). Once the mode is set to ANY non-'off' value it wins
+        outright and the bool is ignored — so an explicit 'shadow' is never
+        silently upgraded to 'live' by a stale bool.
+        """
+        if self.litellm_spend_mode != "off":
+            return self.litellm_spend_mode
+        if self.litellm_spend_ingest_enabled:
+            return "live"
+        return "off"
 
     def save(self) -> None:
         """Save settings to config file.

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1516,6 +1516,56 @@ class Settings(BaseSettings):
             "POCKETPAW_BILLING_ENFORCED."
         ),
     )
+
+    # Per-tenant LiteLLM virtual-key provisioning (MCG-8). The cloud mints a
+    # budgeted, rate-limited virtual key per workspace on the LiteLLM proxy so the
+    # proxy enforces a spend ceiling + rate caps per tenant and attributes spend
+    # to the workspace. These knobs are the key's provisioning defaults — NOT
+    # secrets; the proxy master key stays in POCKETPAW_LITELLM_API_KEY.
+    tenant_max_budget_usd: float = Field(
+        default=0.0,
+        description=(
+            "USD budget ceiling minted onto each tenant's LiteLLM virtual key, "
+            "enforced by the proxy over POCKETPAW_TENANT_BUDGET_DURATION. 0 == no "
+            "budget cap (the proxy applies no ceiling). Set via "
+            "POCKETPAW_TENANT_MAX_BUDGET_USD."
+        ),
+    )
+    tenant_budget_duration: str = Field(
+        default="30d",
+        description=(
+            "Reset window for a tenant key's budget — a LiteLLM duration string "
+            "(e.g. '30d', '1mo'). Empty == the budget never resets. Set via "
+            "POCKETPAW_TENANT_BUDGET_DURATION."
+        ),
+    )
+    tenant_rpm_limit: int = Field(
+        default=0,
+        description=(
+            "Requests-per-minute cap minted onto each tenant's LiteLLM virtual key. "
+            "0 == no RPM cap. Set via POCKETPAW_TENANT_RPM_LIMIT."
+        ),
+    )
+    tenant_tpm_limit: int = Field(
+        default=0,
+        description=(
+            "Tokens-per-minute cap minted onto each tenant's LiteLLM virtual key. "
+            "0 == no TPM cap. Set via POCKETPAW_TENANT_TPM_LIMIT."
+        ),
+    )
+    litellm_spend_ingest_enabled: bool = Field(
+        default=False,
+        description=(
+            "Whether the LiteLLM proxy-spend -> credits sweep (MCG-8) runs. Default "
+            "FALSE: the proxy's /spend/logs includes the text chat runs BC-3 "
+            "metering already bills per ChatRunDoc, so enabling this alongside "
+            "per-run metering would double-bill text chat. It is the future "
+            "single-source-of-truth path (bill all compute from proxy spend, retire "
+            "per-run metering) — flip it (with row-level dedup against BC-3) as a "
+            "deliberate migration. Provisioning the per-tenant key is unaffected by "
+            "this flag. Set via POCKETPAW_LITELLM_SPEND_INGEST."
+        ),
+    )
     site_pending_alert_hours: float = Field(
         default=24.0,
         description=(

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -9,8 +9,10 @@ Changes:
     ledger, ZERO debits) that records a reconciliation row; 'live' makes LiteLLM
     the sole meter (proxy-spend sweep debits + BC-3 sweep gated off). The legacy
     bool is kept for back-compat and resolved by ``effective_spend_mode()`` — an
-    existing ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` maps to 'live' only
-    while the new mode is left at 'off'.
+    existing ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` maps to 'shadow' (NOT
+    'live') while the new mode is left at 'off', so deploying WU-F can never
+    auto-flip an old bool-setter into live billing; 'live' requires an explicit
+    POCKETPAW_LITELLM_SPEND_MODE=live.
   - 2026-06-26: Added the L2 cross-backend harness-failover settings (MCG-10) —
     ``backend_failover_enabled`` (default False; kill-switch — when False the
     new ``AgentRouter.run_with_failover`` behaves exactly like ``run`` and no
@@ -1608,13 +1610,15 @@ class Settings(BaseSettings):
         description=(
             "DEPRECATED back-compat flag for the MCG-8 spend sweep — superseded by "
             "POCKETPAW_LITELLM_SPEND_MODE (WU-F). Left in place so an existing "
-            "deployment that set POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true keeps "
-            "billing from proxy spend: when the new mode is left at its 'off' default "
-            "and this bool is True, ``effective_spend_mode()`` resolves to 'live' "
-            "(the old bool meant 'ingest + single meter'). Prefer setting "
-            "POCKETPAW_LITELLM_SPEND_MODE explicitly; this flag is ignored once the "
-            "mode is set to any non-'off' value. Set via "
-            "POCKETPAW_LITELLM_SPEND_INGEST_ENABLED."
+            "deployment that set POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true is not "
+            "silently flipped into live billing by deploying WU-F: when the new mode "
+            "is left at its 'off' default and this bool is True, "
+            "``effective_spend_mode()`` resolves to 'shadow' (read-only "
+            "reconciliation, ZERO debits) — NOT 'live'. Making LiteLLM the sole meter "
+            "requires an EXPLICIT POCKETPAW_LITELLM_SPEND_MODE=live (a money-meter "
+            "flip must be a conscious operator choice). A one-time deprecation notice "
+            "is logged when this bool is seen. The flag is ignored once the mode is "
+            "set to any non-'off' value. Set via POCKETPAW_LITELLM_SPEND_INGEST_ENABLED."
         ),
     )
     litellm_spend_mode: Literal["off", "shadow", "live"] = Field(
@@ -1954,19 +1958,30 @@ class Settings(BaseSettings):
         """Resolve the LiteLLM billing-cutover mode, honouring the legacy bool.
 
         WU-F replaced the ``litellm_spend_ingest_enabled`` bool with the
-        three-position ``litellm_spend_mode`` switch. To keep an existing
-        deployment that set ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` billing
-        from proxy spend, the bool is treated as a 'live'-intent fallback: when the
-        new mode is still at its 'off' default AND the old bool is True, the
-        effective mode is 'live' (the bool meant "ingest proxy spend as the
-        single meter"). Once the mode is set to ANY non-'off' value it wins
-        outright and the bool is ignored — so an explicit 'shadow' is never
-        silently upgraded to 'live' by a stale bool.
+        three-position ``litellm_spend_mode`` switch. Resolution, in order:
+
+          1. An EXPLICIT ``POCKETPAW_LITELLM_SPEND_MODE`` (any non-'off' value)
+             wins outright — ``shadow`` and ``live`` are taken as set.
+          2. Mode unset / 'off' + the legacy bool True → ``shadow`` (NOT ``live``).
+          3. Mode unset / 'off' + the legacy bool False/unset → ``off``.
+
+        WHY the legacy bool maps to ``shadow`` and NEVER ``live`` (money safety):
+        WU-F adds the FIRST periodic ingestion caller (the cutover sweep on the
+        heartbeat + worker boot). Under WU-C the bool toggled an ingestion path
+        that had NO periodic caller, so a deployment could carry
+        ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` harmlessly. If WU-F resolved
+        that bool to ``live``, merely DEPLOYING WU-F would start LiteLLM debiting AND
+        gate BC-3 off — a billing-meter flip with no operator decision. So ``live``
+        requires an EXPLICIT ``POCKETPAW_LITELLM_SPEND_MODE=live`` and is never
+        inferred. The legacy bool resolves to ``shadow`` — it reads + compares but
+        debits nothing — so an old deployment gets the (safe) reconciliation signal
+        and the operator must consciously set the mode to ``live`` to bill. See
+        ``warn_legacy_spend_bool_once`` for the one-time startup notice.
         """
         if self.litellm_spend_mode != "off":
             return self.litellm_spend_mode
         if self.litellm_spend_ingest_enabled:
-            return "live"
+            return "shadow"
         return "off"
 
     def save(self) -> None:

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,19 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-26: Added the L2 cross-backend harness-failover settings (MCG-10) —
+    ``backend_failover_enabled`` (default False; kill-switch — when False the
+    new ``AgentRouter.run_with_failover`` behaves exactly like ``run`` and no
+    harness switch ever happens) and ``backend_failover_chain`` (default
+    ["claude_agent_sdk", "codex_cli", "opencode"]; the ordered list of agent
+    HARNESSES to try when the whole primary lane is down — distinct from L1's
+    LiteLLM model/account failover, which cannot escape a provider-wide
+    outage). Only a lane-level failure (overload/unavailable/auth that
+    persists after the backend's own retries) before any token is streamed
+    triggers a switch; each harness is tried at most once. Env:
+    POCKETPAW_BACKEND_FAILOVER_ENABLED / POCKETPAW_BACKEND_FAILOVER_CHAIN
+    (JSON list). The EE cloud run path wiring is a follow-up — this ships the
+    mechanism + the OSS hook only.
   - 2026-06-24: Added ``dodo_plan_products`` (default {}, env
     POCKETPAW_DODO_PLAN_PRODUCTS as a JSON object) — the BC-7 mapping of plan
     tier key -> Dodo recurring product id. ``subscribe`` reads it to open a
@@ -247,6 +260,33 @@ class Settings(BaseSettings):
     fallback_backends: list[str] = Field(
         default_factory=list,
         description=("Ordered list of fallback backends to try if the primary backend fails"),
+    )
+
+    # L2 cross-backend harness failover (MCG-10) — distinct from the generic
+    # ``fallback_backends`` above. This is the harness-level escape hatch for a
+    # provider-wide outage: when the whole Claude Code lane is down (an
+    # Anthropic-wide overload that Claude Code's own ``--fallback-model`` cannot
+    # escape, because that stays in Anthropic's capacity pool), switch to a
+    # DIFFERENT backend harness. Only fires on a lane-level failure (overload /
+    # unavailable / auth that survives the backend's own retries) AND only if
+    # nothing was streamed to the user yet (a half-streamed turn can't be
+    # replayed). Off by default so behavior is unchanged unless opted in.
+    backend_failover_enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable L2 cross-backend (harness) failover. When True, "
+            "AgentRouter.run_with_failover switches to the next harness in "
+            "backend_failover_chain if the primary lane is down before any "
+            "token is streamed. Off by default."
+        ),
+    )
+    backend_failover_chain: list[str] = Field(
+        default_factory=lambda: ["claude_agent_sdk", "codex_cli", "opencode"],
+        description=(
+            "Ordered list of agent HARNESSES to try on a lane-level failure "
+            "(Claude Code -> Codex -> opencode). Each harness is tried at most "
+            "once; the chain is consulted only when backend_failover_enabled."
+        ),
     )
 
     # Claude Agent SDK Settings

--- a/src/pocketpaw/llm/__init__.py
+++ b/src/pocketpaw/llm/__init__.py
@@ -1,6 +1,24 @@
-"""LLM package for PocketPaw."""
+"""LLM package for PocketPaw.
 
+Updated 2026-06-26 (MCG-11): exports the universal prompt-caching helper
+(``build_cacheable`` / ``report_savings`` / ``CacheSavings``) from
+``pocketpaw.llm.caching`` so any backend — OSS or EE — can build a
+provider-correct cacheable prefix and measure the savings.
+"""
+
+from pocketpaw.llm.caching import (
+    CacheSavings,
+    build_cacheable,
+    report_savings,
+)
 from pocketpaw.llm.client import LLMClient, resolve_llm_client
 from pocketpaw.llm.router import LLMRouter
 
-__all__ = ["LLMClient", "LLMRouter", "resolve_llm_client"]
+__all__ = [
+    "CacheSavings",
+    "LLMClient",
+    "LLMRouter",
+    "build_cacheable",
+    "report_savings",
+    "resolve_llm_client",
+]

--- a/src/pocketpaw/llm/caching.py
+++ b/src/pocketpaw/llm/caching.py
@@ -1,0 +1,326 @@
+# src/pocketpaw/llm/caching.py — universal LLM prompt-caching helper (MCG-11).
+#
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-11): generalizes the
+# ad-hoc Anthropic cache-control monkey-patch in
+# ``src/pocketpaw/agents/deep_agents.py`` into a reusable, provider-agnostic,
+# OSS-importable module. Two pure functions, no I/O, no ``ee/`` imports:
+#
+#   * ``build_cacheable(prefix_parts, variable_parts, *, ttl, breakpoints)``
+#       Assembles a content-block list (the shape LiteLLM/Anthropic accept for
+#       the ``system`` parameter or a message ``content``) with
+#       ``cache_control`` markers placed ONLY on the STABLE prefix. The stable
+#       content goes first, the variable suffix last, so the cached
+#       longest-common-prefix is maximised. Marker placement respects
+#       Anthropic's 4-breakpoint hard cap. For automatic-caching providers
+#       (OpenAI/DeepSeek cache >=1024 tokens with no markup) the structure is
+#       still correct — the markers are simply ignored.
+#
+#   * ``report_savings(usage)``
+#       Reads ``cache_creation_input_tokens`` / ``cache_read_input_tokens``
+#       (Anthropic), ``cached_tokens`` / ``prompt_tokens_details.cached_tokens``
+#       (OpenAI), and ``prompt_cache_hit_tokens`` / ``prompt_cache_miss_tokens``
+#       (DeepSeek) off a response ``usage`` object (dict or attr-style) and
+#       returns a small ``CacheSavings`` struct: cached-read tokens, cache-write
+#       tokens, total prompt tokens, hit-rate, and an estimated cost saved (a
+#       cached read costs ~10% of a fresh input token, so each cached-read token
+#       saves ~90% of one input token).
+#
+# Guardrails (see ``CACHE_MIN_TOKENS`` / docstrings):
+#   * The prefix MUST be byte-stable. ANY per-call drift (a timestamp, a uuid, a
+#     trailing-whitespace difference) busts the cache for every downstream call.
+#     ``build_cacheable`` therefore never mutates the prefix text and keeps every
+#     variable part strictly after the last cache breakpoint.
+#   * Min-token thresholds: 1024 tokens (most models), 2048 (Anthropic Sonnet),
+#     4096 (Anthropic Haiku / Opus 4.5+). Below the floor the provider declines
+#     to cache and the write is wasted — callers should gate on prefix size.
+#   * 1h TTL costs 2x a 5m write on the create call; only worth it when the same
+#     prefix recurs within the hour (the site-gen / pocket-gen case). 5m is the
+#     default.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants / guardrails
+# ---------------------------------------------------------------------------
+
+# Anthropic allows at most 4 cache breakpoints (``cache_control`` blocks) per
+# request. Markers beyond this are rejected by the API, so ``build_cacheable``
+# clamps to it.
+MAX_CACHE_BREAKPOINTS = 4
+
+# Per-model minimum cacheable prefix sizes (tokens). Below the floor the
+# provider silently declines to cache and the write is wasted. These are the
+# documented Anthropic floors; the 1024 default also covers OpenAI/DeepSeek
+# automatic caching. Keyed by a coarse model family the caller can look up.
+CACHE_MIN_TOKENS: dict[str, int] = {
+    "default": 1024,
+    "anthropic-sonnet": 2048,
+    "anthropic-haiku": 4096,
+    "anthropic-opus": 4096,  # Opus 4.5+ raised the floor to 4096
+    "openai": 1024,
+    "deepseek": 1024,
+}
+
+# Valid Anthropic ``cache_control`` TTL strings. "5m" is the free default;
+# "1h" extends the window at 2x the write cost.
+_VALID_TTLS = ("5m", "1h")
+
+# The ephemeral cache_control marker LiteLLM translates per provider. For a 5m
+# TTL Anthropic accepts the bare ``{"type": "ephemeral"}`` (no ttl key); a 1h
+# window needs the explicit ``ttl`` field (extended-cache-ttl beta).
+_EPHEMERAL_5M: dict[str, str] = {"type": "ephemeral"}
+
+
+def _cache_control(ttl: str) -> dict[str, str]:
+    """Return the ``cache_control`` marker dict for a TTL.
+
+    5m → the bare ``{"type": "ephemeral"}`` (the universally-accepted form).
+    1h → ``{"type": "ephemeral", "ttl": "1h"}`` (extended-cache-ttl). LiteLLM
+    passes the ttl through to Anthropic and ignores it for providers that cache
+    automatically, so the structure stays correct everywhere.
+    """
+    if ttl == "1h":
+        return {"type": "ephemeral", "ttl": "1h"}
+    return dict(_EPHEMERAL_5M)
+
+
+# ---------------------------------------------------------------------------
+# build_cacheable
+# ---------------------------------------------------------------------------
+
+
+def _as_text_block(part: Any) -> dict[str, Any]:
+    """Normalise one input part into a ``{"type": "text", "text": ...}`` block.
+
+    A plain ``str`` is wrapped. A dict is taken as a pre-shaped content block
+    and passed through (a SHALLOW COPY so we never mutate the caller's object —
+    important for byte-stability: the same input must always yield an equal,
+    independent structure). Any pre-existing ``cache_control`` on a passed-in
+    block is stripped here; placement is decided centrally by ``build_cacheable``
+    so the breakpoint count and position are deterministic.
+    """
+    if isinstance(part, str):
+        return {"type": "text", "text": part}
+    if isinstance(part, dict):
+        block = dict(part)
+        block.pop("cache_control", None)
+        return block
+    # Anything else (numbers, etc.) — stringify so the structure stays valid.
+    return {"type": "text", "text": str(part)}
+
+
+def build_cacheable(
+    prefix_parts: list[Any],
+    variable_parts: list[Any] | None = None,
+    *,
+    ttl: str = "5m",
+    breakpoints: int = 1,
+) -> list[dict[str, Any]]:
+    """Build a cacheable content-block list: STABLE prefix first (marked with
+    ``cache_control``), VARIABLE suffix last (never marked).
+
+    Args:
+        prefix_parts: The byte-stable prefix — strings and/or pre-shaped content
+            blocks. This is what gets cached. It MUST be identical across calls
+            for a cache hit; any drift (timestamp, uuid, whitespace) busts it.
+        variable_parts: The per-call suffix (e.g. the customer brief, the pocket
+            id). Always placed AFTER the last cache breakpoint, never marked, so
+            it can vary freely without disturbing the cached prefix.
+        ttl: ``"5m"`` (default, free) or ``"1h"`` (2x write cost; worth it only
+            when the prefix recurs within the hour).
+        breakpoints: How many ``cache_control`` markers to place on the prefix
+            (1–4). With N>1 the markers are spread across the prefix blocks so a
+            partially-changed prefix can still hit the earlier breakpoints.
+            Clamped to ``[1, MAX_CACHE_BREAKPOINTS]`` and to the number of prefix
+            blocks. Most callers want 1 (a single stable prefix → one marker on
+            its last block).
+
+    Returns:
+        A list of content blocks. Block ordering is deterministic and the prefix
+        blocks are byte-identical for identical ``prefix_parts`` regardless of
+        ``variable_parts`` — this is the property the cache relies on.
+
+    Raises:
+        ValueError: on an unknown ``ttl`` or an empty ``prefix_parts``.
+
+    Byte-stability contract: ``build_cacheable(P, V1) == build_cacheable(P, V2)``
+    for the prefix slice ``[: len(P)]`` whenever the prefix ``P`` is the same.
+    The test-suite asserts this directly.
+    """
+    if ttl not in _VALID_TTLS:
+        raise ValueError(f"ttl must be one of {_VALID_TTLS}, got {ttl!r}")
+    if not prefix_parts:
+        raise ValueError("prefix_parts must be non-empty — there is nothing to cache")
+
+    prefix_blocks = [_as_text_block(p) for p in prefix_parts]
+    variable_blocks = [_as_text_block(v) for v in (variable_parts or [])]
+
+    # Clamp the breakpoint count: at least 1, at most the Anthropic cap, and
+    # never more than the number of prefix blocks (you can't mark a block that
+    # isn't there).
+    n_breakpoints = max(1, min(breakpoints, MAX_CACHE_BREAKPOINTS, len(prefix_blocks)))
+
+    marker = _cache_control(ttl)
+
+    # Choose which prefix-block indices carry a breakpoint. The LAST block
+    # always gets one (it terminates the longest cacheable prefix). For N>1 we
+    # also mark evenly-spaced earlier blocks so a prefix that diverges late can
+    # still reuse the earlier cached segments. Indices are computed from block
+    # COUNT only (not content), so placement is deterministic and byte-stable.
+    last = len(prefix_blocks) - 1
+    marked: set[int] = {last}
+    if n_breakpoints > 1:
+        # Spread the remaining (n_breakpoints - 1) markers across [0, last).
+        step = len(prefix_blocks) / n_breakpoints
+        for k in range(1, n_breakpoints):
+            idx = min(int(round(k * step)) - 1, last - 1)
+            if idx >= 0:
+                marked.add(idx)
+
+    for i, block in enumerate(prefix_blocks):
+        if i in marked:
+            # Fresh dict each time so two calls never share a marker object.
+            block["cache_control"] = dict(marker)
+
+    # Variable blocks are appended untouched — no cache_control ever lands here.
+    return prefix_blocks + variable_blocks
+
+
+# ---------------------------------------------------------------------------
+# report_savings
+# ---------------------------------------------------------------------------
+
+# A cached input-token READ is billed at ~10% of a fresh input token across
+# Anthropic / OpenAI / DeepSeek. So each cached-read token SAVES ~90% of one
+# input token. A cache WRITE (first call) costs ~125% (Anthropic 5m) — captured
+# separately so callers can see the amortisation, not folded into "saved".
+_CACHE_READ_DISCOUNT = 0.90  # fraction of an input token saved per cached read
+
+
+@dataclass(frozen=True)
+class CacheSavings:
+    """Outcome of reading a response ``usage`` object for cache effectiveness.
+
+    All token counts are ints; ``hit_rate`` and ``est_tokens_saved`` are floats.
+    ``est_tokens_saved`` is in *input-token-equivalents* (cached reads * the
+    ~90% discount) — multiply by the model's input $/token to get dollars.
+    Pure data; no I/O.
+    """
+
+    cache_read_tokens: int  # tokens served from cache (the win)
+    cache_write_tokens: int  # tokens written to cache this call (the create cost)
+    prompt_tokens: int  # total prompt/input tokens for the call
+    hit_rate: float  # cache_read / prompt_tokens, in [0, 1]
+    est_tokens_saved: float  # input-token-equivalents saved by the cached reads
+    provider: str  # which usage shape matched: anthropic|openai|deepseek|none
+
+    def est_cost_saved(self, input_cost_per_token: float) -> float:
+        """Dollars saved, given the model's input $/token. Convenience over
+        ``est_tokens_saved`` so metering can attach a real figure."""
+        return self.est_tokens_saved * input_cost_per_token
+
+
+def _get(usage: Any, key: str) -> Any:
+    """Read ``key`` off a usage object that may be a dict OR an attr-style
+    object (Anthropic SDK ``Usage``, OpenAI ``CompletionUsage``). Returns None
+    when absent."""
+    if usage is None:
+        return None
+    if isinstance(usage, dict):
+        return usage.get(key)
+    return getattr(usage, key, None)
+
+
+def _int(value: Any) -> int:
+    """Coerce a usage field to a non-negative int; None/garbage → 0."""
+    if value is None:
+        return 0
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def report_savings(usage: Any) -> CacheSavings:
+    """Read cache effectiveness off a response ``usage`` object.
+
+    Handles all three provider shapes (dict or attr-style):
+
+      * Anthropic — ``cache_read_input_tokens`` (the win) +
+        ``cache_creation_input_tokens`` (the write); ``input_tokens`` is the
+        UNCACHED remainder, so total prompt = input + read + write.
+      * OpenAI — ``prompt_tokens`` total with ``cached_tokens`` (a subset)
+        either top-level or under ``prompt_tokens_details``. No separate write
+        line (writes are free / implicit).
+      * DeepSeek — ``prompt_cache_hit_tokens`` + ``prompt_cache_miss_tokens``;
+        their sum is the prompt total. (This is the shape the live proxy probe
+        confirmed: hit 2944 / 3056.)
+
+    Unknown / empty usage → an all-zero ``CacheSavings`` with provider="none".
+    Pure + deterministic.
+    """
+    # --- DeepSeek: most specific keys, check first ---
+    ds_hit = _get(usage, "prompt_cache_hit_tokens")
+    ds_miss = _get(usage, "prompt_cache_miss_tokens")
+    if ds_hit is not None or ds_miss is not None:
+        read = _int(ds_hit)
+        miss = _int(ds_miss)
+        total = read + miss
+        return _build(read, 0, total, "deepseek")
+
+    # --- Anthropic: cache_creation / cache_read present ---
+    a_read = _get(usage, "cache_read_input_tokens")
+    a_write = _get(usage, "cache_creation_input_tokens")
+    if a_read is not None or a_write is not None:
+        read = _int(a_read)
+        write = _int(a_write)
+        # Anthropic's input_tokens is the UNCACHED portion; total prompt is the
+        # sum of uncached + cached-read + cache-write.
+        uncached = _int(_get(usage, "input_tokens"))
+        total = uncached + read + write
+        return _build(read, write, total, "anthropic")
+
+    # --- OpenAI: cached_tokens (subset of prompt_tokens) ---
+    o_cached = _get(usage, "cached_tokens")
+    if o_cached is None:
+        details = _get(usage, "prompt_tokens_details")
+        o_cached = _get(details, "cached_tokens") if details is not None else None
+    o_prompt = _get(usage, "prompt_tokens")
+    if o_cached is not None or o_prompt is not None:
+        read = _int(o_cached)
+        total = _int(o_prompt)
+        # cached_tokens is a SUBSET of prompt_tokens; no extra write line.
+        return _build(read, 0, total, "openai")
+
+    return _build(0, 0, 0, "none")
+
+
+def _build(read: int, write: int, total: int, provider: str) -> CacheSavings:
+    """Assemble a CacheSavings, computing hit-rate + estimated saved tokens.
+
+    hit_rate divides cached reads by the total prompt tokens (0 when there are
+    none). est_tokens_saved discounts the cached reads by ~90% (a cached read
+    costs ~10% of a fresh input token, so it saves ~90%).
+    """
+    hit_rate = (read / total) if total > 0 else 0.0
+    est_saved = read * _CACHE_READ_DISCOUNT
+    return CacheSavings(
+        cache_read_tokens=read,
+        cache_write_tokens=write,
+        prompt_tokens=total,
+        hit_rate=round(hit_rate, 4),
+        est_tokens_saved=round(est_saved, 2),
+        provider=provider,
+    )
+
+
+__all__ = [
+    "MAX_CACHE_BREAKPOINTS",
+    "CACHE_MIN_TOKENS",
+    "CacheSavings",
+    "build_cacheable",
+    "report_savings",
+]

--- a/src/pocketpaw/llm/providers/base.py
+++ b/src/pocketpaw/llm/providers/base.py
@@ -1,4 +1,14 @@
-"""Base types for the provider adapter pattern."""
+"""Base types for the provider adapter pattern.
+
+Updated: 2026-06-26 (feat/mcg-3-pool-route-model) — added ``route_model``, the
+  single writer that maps a per-agent ``model`` string onto the correct
+  ``Settings`` field for ANY registered agent backend, driven by
+  ``_BACKEND_MODEL_ATTR`` (plus ``_BACKEND_MODEL_ATTR_ALIASES`` for backends
+  that read another backend's field, e.g. ``langchain_react`` reads
+  ``deep_agents_model``). Replaces the brittle ``"claude" in backend`` substring
+  routing in ``AgentPool._build`` that silently dropped the per-agent model for
+  ``codex_cli``/``opencode``/``deep_agents``/``copilot_sdk``/``langchain_react``.
+"""
 
 from __future__ import annotations
 
@@ -42,6 +52,18 @@ _BACKEND_MODEL_ATTR: dict[str, str] = {
     "deep_agents": "deep_agents_model",
 }
 
+# -- Backends that read another backend's model field instead of their own --
+# ``langchain_react`` subclasses ``DeepAgentsBackend`` and reads
+# ``settings.deep_agents_model`` directly (it has no ``langchain_react_model``
+# field), so it shares deep_agents' slot. Kept SEPARATE from
+# ``_BACKEND_MODEL_ATTR`` so that map stays a 1:1 backend->own-field registry;
+# ``route_model`` consults this alias map only when a backend isn't a primary
+# key. ``resolve_model``'s backend lookup is unaffected (langchain_react resolves
+# via the deep_agents path in the backend itself, not through this table).
+_BACKEND_MODEL_ATTR_ALIASES: dict[str, str] = {
+    "langchain_react": "deep_agents_model",
+}
+
 # -- Maps provider name -> settings attribute for provider-level model --
 _PROVIDER_MODEL_ATTR: dict[str, str] = {
     "anthropic": "anthropic_model",
@@ -78,6 +100,47 @@ def resolve_model(settings: Settings, backend: str, provider: str) -> str:
 
     # 3. Provider default
     return PROVIDER_DEFAULT_MODELS.get(provider, "")
+
+
+def route_model(settings: Settings, backend: str, model: str) -> bool:
+    """Write a per-agent ``model`` onto the ``Settings`` field that ``backend``
+    actually reads, for EVERY registered agent backend.
+
+    This is the inverse of ``resolve_model``'s backend-specific lookup: given a
+    model string chosen for one agent, it sets the single backend-model attribute
+    so the backend instantiated from these settings picks it up. The field is
+    chosen from ``_BACKEND_MODEL_ATTR`` (the 1:1 backend->own-field registry),
+    falling back to ``_BACKEND_MODEL_ATTR_ALIASES`` for backends that read a
+    sibling's field (``langchain_react`` -> ``deep_agents_model``).
+
+    The model string is written VERBATIM. Backends whose field carries a
+    composite format keep it intact — ``deep_agents``/``langchain_react`` expect
+    ``provider:model`` and ``opencode`` expects ``provider/model``; this helper
+    does NOT split or reformat, so those round-trip exactly as supplied by the
+    upstream picker.
+
+    Catalog/existence validation of the model is NOT done here — that lives
+    upstream in the picker / EE catalog layer (MCG-1/4); OSS cannot import EE.
+    This is the field-routing seam only.
+
+    Args:
+        settings: the per-agent ``Settings`` clone to mutate in place.
+        backend: the registered backend name (e.g. ``"codex_cli"``).
+        model: the per-agent model string. Empty/blank is a no-op — the backend
+            then falls through to its own default via ``resolve_model``.
+
+    Returns:
+        ``True`` if a Settings field was written; ``False`` if the model was
+        empty or the backend has no known model field (unknown backend — the
+        caller leaves defaults untouched, matching legacy fall-through).
+    """
+    if not model:
+        return False
+    attr = _BACKEND_MODEL_ATTR.get(backend) or _BACKEND_MODEL_ATTR_ALIASES.get(backend)
+    if not attr:
+        return False
+    setattr(settings, attr, model)
+    return True
 
 
 @runtime_checkable

--- a/src/pocketpaw/ripple/__init__.py
+++ b/src/pocketpaw/ripple/__init__.py
@@ -48,6 +48,7 @@ from pocketpaw.ripple._pockets import (
     POCKET_INTERACTION_PROMPT_CLI,
     POCKET_INTERACTION_PROMPT_MCP,
     POCKET_SPECIALIST_PROMPT,
+    build_specialist_cacheable,
     fill_current_pocket,
     get_pocket_prompts,
 )
@@ -68,6 +69,7 @@ __all__ = [
     "POCKET_INTERACTION_PROMPT_MCP",
     "POCKET_SPECIALIST_PROMPT",
     "RIPPLE_DESIGN_RULES",
+    "build_specialist_cacheable",
     "fill_current_pocket",
     "get_pocket_prompts",
 ]

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,5 +1,13 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
+# Changes: 2026-06-26 (integration/model-catalog-v2, MCG-11) — added
+# `build_specialist_cacheable()`: structures the byte-stable site/pocket-gen
+# system prompt (POCKET_SPECIALIST_PROMPT) into a `cache_control`-marked prefix
+# block ⊕ an unmarked per-brief variable suffix, via the universal
+# `pocketpaw.llm.caching.build_cacheable`. Defaults to a 1h TTL so the
+# generator's shared prefix stays warm across briefs (the Nth site pays ~10% on
+# the prefix → margin on paw-managed keys). No prompt TEXT changed.
+#
 # Changes: 2026-05-31 (feat/home-agent-source-authoring) — `HOME_POCKET_PROMPT`
 # now (1) carries the `__BACKEND_SUMMARY__` token in its intro (filled via
 # `fill_current_pocket` from the resolved scope) so the home agent SEES
@@ -2430,6 +2438,66 @@ POCKET_SPECIALIST_PROMPT = _assemble_specialist()
 # tool surface explicitly; CLI callers should switch to the selector.
 POCKET_CREATION_PROMPT = POCKET_CREATION_PROMPT_MCP
 POCKET_INTERACTION_PROMPT = POCKET_INTERACTION_PROMPT_MCP
+
+
+# ---------------------------------------------------------------------------
+# Prompt-cache structuring (MCG-11).
+#
+# ``POCKET_SPECIALIST_PROMPT`` (and the interaction/edit variants) are the
+# BYTE-STABLE prefix the site/pocket generator pays for on every brief: the
+# widget catalog + canonical shapes + workflow + design rules. The ONLY
+# per-call variation lives in (a) the trailing ``<current-pocket>`` block (a
+# pocket id + a non-secret backend summary) and (b) the caller's hints
+# (name / purpose / layout / template / API-skill) that ``runtime`` appends.
+#
+# Anthropic and DeepSeek both cache by longest-common-prefix, so the win is to
+# keep that stable text in ONE marked block and shove every variable byte into
+# a SEPARATE trailing block. ``build_specialist_cacheable`` does exactly that
+# via the universal ``pocketpaw.llm.caching.build_cacheable`` helper: the stable
+# prompt carries the ``cache_control`` breakpoint, the variable suffix never
+# does. The Nth site then pays ~10% on the (huge) prefix — that is the margin
+# on paw-managed keys.
+#
+# This returns the Anthropic/LiteLLM ``system``-block shape. Backends that take
+# a structured system (LiteLLM/langchain via the deep_agents cache path) consume
+# it directly; the Claude-Agent-SDK backend takes a string system_prompt, so it
+# relies on the deep_agents ``_format_messages`` patch to place the same
+# breakpoint — both paths agree on "stable prefix marked, variable suffix not".
+# ---------------------------------------------------------------------------
+
+
+def build_specialist_cacheable(
+    variable_suffix: str | list[str] | None = None,
+    *,
+    base_prompt: str = POCKET_SPECIALIST_PROMPT,
+    ttl: str = "1h",
+):
+    """Structure a site/pocket-gen system prompt as a CACHEABLE block list.
+
+    ``base_prompt`` (default the byte-stable ``POCKET_SPECIALIST_PROMPT``) is
+    the cached prefix and carries the ``cache_control`` marker; ``variable_suffix``
+    (the per-brief hints / current-pocket block) is appended as a SEPARATE,
+    UNMARKED trailing block so it can vary freely without busting the prefix
+    cache.
+
+    ``ttl`` defaults to ``"1h"`` — the generator reuses this exact prefix across
+    back-to-back briefs, so the 2x write cost amortises fast and the 1h window
+    keeps the prefix warm between sites.
+
+    Returns the LiteLLM/Anthropic ``system``-parameter block list (see
+    ``pocketpaw.llm.caching.build_cacheable``). Byte-stable: the prefix block is
+    identical for the same ``base_prompt`` no matter what ``variable_suffix`` is.
+    """
+    from pocketpaw.llm.caching import build_cacheable
+
+    if variable_suffix is None:
+        variables: list[str] = []
+    elif isinstance(variable_suffix, str):
+        variables = [variable_suffix] if variable_suffix else []
+    else:
+        variables = [v for v in variable_suffix if v]
+
+    return build_cacheable([base_prompt], variables, ttl=ttl)
 
 
 # ---------------------------------------------------------------------------

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,12 +1,14 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
 # Changes: 2026-06-26 (integration/model-catalog-v2, MCG-11) — added
-# `build_specialist_cacheable()`: structures the byte-stable site/pocket-gen
-# system prompt (POCKET_SPECIALIST_PROMPT) into a `cache_control`-marked prefix
-# block ⊕ an unmarked per-brief variable suffix, via the universal
-# `pocketpaw.llm.caching.build_cacheable`. Defaults to a 1h TTL so the
-# generator's shared prefix stays warm across briefs (the Nth site pays ~10% on
-# the prefix → margin on paw-managed keys). No prompt TEXT changed.
+# `build_specialist_cacheable()`: the STRUCTURED-system cache helper that wraps
+# the byte-stable POCKET_SPECIALIST_PROMPT into a `cache_control`-marked prefix
+# block ⊕ an unmarked per-brief variable suffix (1h TTL), via the universal
+# `pocketpaw.llm.caching.build_cacheable`. It is NOT yet on the live run — every
+# shipped backend.run takes a STRING system_prompt, so the live margin is
+# delivered by the `deep_agents` _format_messages patch, which now marks this
+# same prefix at 1h (gated on the `<pocket-scope>` sentinel). This helper is the
+# ready-made path for a future structured/LiteLLM caller. No prompt TEXT changed.
 #
 # Changes: 2026-05-31 (feat/home-agent-source-authoring) — `HOME_POCKET_PROMPT`
 # now (1) carries the `__BACKEND_SUMMARY__` token in its intro (filled via
@@ -2458,11 +2460,25 @@ POCKET_INTERACTION_PROMPT = POCKET_INTERACTION_PROMPT_MCP
 # does. The Nth site then pays ~10% on the (huge) prefix — that is the margin
 # on paw-managed keys.
 #
-# This returns the Anthropic/LiteLLM ``system``-block shape. Backends that take
-# a structured system (LiteLLM/langchain via the deep_agents cache path) consume
-# it directly; the Claude-Agent-SDK backend takes a string system_prompt, so it
-# relies on the deep_agents ``_format_messages`` patch to place the same
-# breakpoint — both paths agree on "stable prefix marked, variable suffix not".
+# Two delivery paths, and what actually runs today:
+#
+#   * The LIVE path (what every shipped backend uses): the assembled prompt is a
+#     STRING — ``runtime._build_system_prompt`` returns ``POCKET_SPECIALIST_PROMPT``
+#     (the stable prefix) with the variable hints concatenated AFTER it, and
+#     passes it as ``system_prompt=`` to ``backend.run``. The cache marker is
+#     placed by the ``deep_agents._format_messages`` patch, which wraps the whole
+#     string in one ``cache_control`` block. That patch now picks a **1h** TTL for
+#     this prefix (it carries the ``<pocket-scope>`` sentinel — see
+#     ``deep_agents._cache_ttl_for_system``); other prompts stay at 5m. So the
+#     live margin is real and runs at 1h.
+#
+#   * The STRUCTURED path (this helper): ``build_specialist_cacheable`` returns the
+#     Anthropic/LiteLLM ``system``-BLOCK shape — stable prefix as a marked block,
+#     variable suffix as a separate unmarked block — at 1h by default. No shipped
+#     backend.run takes a structured ``system`` today (they take a string), so this
+#     is the ready-made helper for a future LiteLLM/structured-system caller; it is
+#     NOT yet on the live specialist path. Both paths now agree at 1h, and on
+#     "stable prefix marked, variable suffix not".
 # ---------------------------------------------------------------------------
 
 
@@ -2472,7 +2488,8 @@ def build_specialist_cacheable(
     base_prompt: str = POCKET_SPECIALIST_PROMPT,
     ttl: str = "1h",
 ):
-    """Structure a site/pocket-gen system prompt as a CACHEABLE block list.
+    """Structure a site/pocket-gen system prompt as a CACHEABLE block list
+    (the STRUCTURED-system path — see the module comment above).
 
     ``base_prompt`` (default the byte-stable ``POCKET_SPECIALIST_PROMPT``) is
     the cached prefix and carries the ``cache_control`` marker; ``variable_suffix``
@@ -2482,11 +2499,17 @@ def build_specialist_cacheable(
 
     ``ttl`` defaults to ``"1h"`` — the generator reuses this exact prefix across
     back-to-back briefs, so the 2x write cost amortises fast and the 1h window
-    keeps the prefix warm between sites.
+    keeps the prefix warm between sites. This matches the TTL the live string
+    path now uses for the same prefix (``deep_agents._cache_ttl_for_system``).
 
     Returns the LiteLLM/Anthropic ``system``-parameter block list (see
     ``pocketpaw.llm.caching.build_cacheable``). Byte-stable: the prefix block is
     identical for the same ``base_prompt`` no matter what ``variable_suffix`` is.
+
+    NOTE: no shipped ``backend.run`` accepts a structured ``system`` today (they
+    take a string), so this helper is the ready-made path for a future
+    LiteLLM/structured-system caller — it is NOT yet wired into the live
+    specialist run. The live margin comes from the ``deep_agents`` cache patch.
     """
     from pocketpaw.llm.caching import build_cacheable
 

--- a/tests/cloud/catalog/__init__.py
+++ b/tests/cloud/catalog/__init__.py
@@ -1,0 +1,2 @@
+# tests/cloud/catalog/ — Model Catalog (MCG-1) test package marker.
+# Created 2026-06-26 (feat/mcg-1-catalog-api).

--- a/tests/cloud/catalog/test_admin_client.py
+++ b/tests/cloud/catalog/test_admin_client.py
@@ -1,0 +1,150 @@
+# tests/cloud/catalog/test_admin_client.py — proves the LiteLLM proxy ADMIN client
+# (MCG-8) wraps the management API correctly. httpx.MockTransport stands in for a
+# live proxy (no network). Asserts:
+#   * generate_key POSTs /key/generate with only the non-None budget / limit /
+#     models / metadata fields and returns the proxy's body (incl. the new key).
+#   * key_info GETs /key/info?key=.
+#   * spend_logs GETs /spend/logs?api_key= (the required filter) and unwraps both
+#     a bare-list and a {"data": [...]} response; an empty api_key raises.
+#   * delete_keys POSTs /key/delete with the keys list.
+#   * the master key rides as a Bearer header.
+#   * a non-2xx surfaces LiteLLMAdminError with the proxy's error message.
+#
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-8).
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from pocketpaw_ee.catalog.admin_client import LiteLLMAdminClient, LiteLLMAdminError
+
+_BASE = "http://proxy.test:4000"
+
+
+def _client(handler, *, api_key: str | None = None) -> LiteLLMAdminClient:
+    return LiteLLMAdminClient(
+        base_url=_BASE, api_key=api_key, _transport=httpx.MockTransport(handler)
+    )
+
+
+async def test_generate_key_posts_only_supplied_fields():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["method"] = request.method
+        captured["body"] = json.loads(request.content)
+        captured["auth"] = request.headers.get("Authorization")
+        return httpx.Response(200, json={"key": "sk-tenant-abc", "max_budget": 25.0})
+
+    client = _client(handler, api_key="sk-master")
+    body = await client.generate_key(
+        key_alias="ws-w1",
+        max_budget=25.0,
+        budget_duration="30d",
+        rpm_limit=60,
+        models=["anthropic/claude-3-5-sonnet"],
+        metadata={"workspace_id": "w1"},
+    )
+
+    assert body["key"] == "sk-tenant-abc"
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/key/generate")
+    # The master key Bearers the privileged call.
+    assert captured["auth"] == "Bearer sk-master"
+    # Only the supplied fields are present (tpm_limit was omitted -> absent).
+    assert captured["body"] == {
+        "key_alias": "ws-w1",
+        "max_budget": 25.0,
+        "budget_duration": "30d",
+        "rpm_limit": 60,
+        "models": ["anthropic/claude-3-5-sonnet"],
+        "metadata": {"workspace_id": "w1"},
+    }
+    assert "tpm_limit" not in captured["body"]
+
+
+async def test_generate_key_omits_none_budget():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"key": "sk-tenant-xyz"})
+
+    client = _client(handler)
+    await client.generate_key(key_alias="ws-w2", metadata={"workspace_id": "w2"})
+    # No budget / limits passed -> the proxy applies its own defaults; we send none.
+    assert captured["body"] == {"key_alias": "ws-w2", "metadata": {"workspace_id": "w2"}}
+
+
+async def test_key_info_gets_with_key_param():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json={"info": {"spend": 1.23, "max_budget": 25.0}})
+
+    client = _client(handler)
+    body = await client.key_info("sk-tenant-abc")
+    assert "/key/info" in captured["url"]
+    assert "key=sk-tenant-abc" in captured["url"]
+    assert body["info"]["spend"] == 1.23
+
+
+async def test_spend_logs_requires_api_key():
+    client = _client(lambda r: httpx.Response(200, json=[]))
+    with pytest.raises(LiteLLMAdminError):
+        await client.spend_logs(api_key="")
+
+
+async def test_spend_logs_unwraps_bare_list():
+    rows = [
+        {"request_id": "r1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"},
+        {"request_id": "r2", "spend": 0.01, "startTime": "2026-06-26T10:01:00"},
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "api_key=sk-tenant-abc" in str(request.url)
+        return httpx.Response(200, json=rows)
+
+    client = _client(handler)
+    out = await client.spend_logs(api_key="sk-tenant-abc")
+    assert out == rows
+
+
+async def test_spend_logs_unwraps_data_envelope():
+    rows = [{"request_id": "r1", "spend": 0.04}]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": rows})
+
+    client = _client(handler)
+    out = await client.spend_logs(api_key="sk-tenant-abc")
+    assert out == rows
+
+
+async def test_delete_keys_posts_keys_list():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"deleted_keys": ["sk-tenant-abc"]})
+
+    client = _client(handler)
+    await client.delete_keys(["sk-tenant-abc"])
+    assert captured["url"].endswith("/key/delete")
+    assert captured["body"] == {"keys": ["sk-tenant-abc"]}
+
+
+async def test_non_2xx_raises_admin_error_with_detail():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": {"message": "Invalid master key"}})
+
+    client = _client(handler)
+    with pytest.raises(LiteLLMAdminError) as exc:
+        await client.generate_key(key_alias="ws-w1")
+    assert "401" in str(exc.value)
+    assert "Invalid master key" in str(exc.value)

--- a/tests/cloud/catalog/test_litellm_client.py
+++ b/tests/cloud/catalog/test_litellm_client.py
@@ -1,0 +1,187 @@
+# tests/cloud/catalog/test_litellm_client.py — Model Catalog (MCG-1) proxy
+# client + mapper tests. httpx.MockTransport stands in for a live LiteLLM proxy
+# (no network). Asserts:
+#   * map_model_info_row produces a correct ModelCatalogEntry (id/provider/
+#     modality/context/max_output/pricing-per-mtok/capabilities).
+#   * LiteLLM ``mode`` -> our Modality across every bucket (chat family, embedding,
+#     image, audio_tts, audio_stt, video) + unknown -> chat default.
+#   * fetch_entries joins /model/info + /v1/models so catalog ⊇ routable (a served
+#     id missing from /model/info is still listed).
+#   * a non-2xx proxy read fails closed (CatalogUpstreamError).
+#   * the proxy api key rides as a Bearer header when configured.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1).
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pocketpaw_ee.catalog.litellm_client import (
+    CatalogUpstreamError,
+    LiteLLMClient,
+    map_model_info_row,
+)
+from pocketpaw_ee.catalog.models import Modality
+
+# A representative /model/info row (the rich anthropic chat model).
+_SONNET_ROW = {
+    "model_name": "anthropic/claude-3-5-sonnet",
+    "litellm_params": {"model": "anthropic/claude-3-5-sonnet-20241022"},
+    "model_info": {
+        "litellm_provider": "anthropic",
+        "mode": "chat",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000003,  # $3 / Mtok
+        "output_cost_per_token": 0.000015,  # $15 / Mtok
+        "supports_function_calling": True,
+        "supports_vision": True,
+        "supports_response_schema": True,
+        "supports_prompt_caching": True,
+    },
+}
+
+
+def _client(handler) -> LiteLLMClient:
+    return LiteLLMClient(
+        base_url="http://proxy.test:4000",
+        api_key=None,
+        _transport=httpx.MockTransport(handler),
+    )
+
+
+def test_map_model_info_row_builds_entry():
+    entry = map_model_info_row(_SONNET_ROW)
+    assert entry is not None
+    assert entry.id == "anthropic/claude-3-5-sonnet"
+    assert entry.provider == "anthropic"
+    assert entry.display_name == "claude-3-5-sonnet"
+    assert entry.modality is Modality.CHAT
+    assert entry.context == 200000
+    assert entry.max_output_tokens == 8192
+    # per-token -> per-MILLION-token.
+    assert entry.pricing is not None
+    assert entry.pricing.input_per_mtok == 3.0
+    assert entry.pricing.output_per_mtok == 15.0
+    # supports_* -> capability tokens; chat models also get "streaming".
+    assert "tool_call" in entry.capabilities
+    assert "vision" in entry.capabilities
+    assert "json_mode" in entry.capabilities
+    assert "prompt_caching" in entry.capabilities
+    assert "streaming" in entry.capabilities
+    assert entry.status == "available"
+
+
+def test_map_model_info_row_no_model_name_dropped():
+    assert map_model_info_row({"model_info": {"mode": "chat"}}) is None
+
+
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        ("chat", Modality.CHAT),
+        ("completion", Modality.CHAT),
+        ("responses", Modality.CHAT),
+        ("embedding", Modality.EMBEDDING),
+        ("image_generation", Modality.IMAGE),
+        ("audio_speech", Modality.AUDIO_TTS),
+        ("audio_transcription", Modality.AUDIO_STT),
+        ("video", Modality.VIDEO),
+        ("something_new", Modality.CHAT),  # unknown -> chat default
+        (None, Modality.CHAT),
+    ],
+)
+def test_mode_maps_to_modality(mode, expected):
+    row = {"model_name": "p/m", "model_info": {"mode": mode} if mode is not None else {}}
+    entry = map_model_info_row(row)
+    assert entry is not None
+    assert entry.modality is expected
+
+
+def test_unknown_cost_yields_no_pricing():
+    row = {"model_name": "p/m", "model_info": {"mode": "embedding"}}
+    entry = map_model_info_row(row)
+    assert entry is not None
+    assert entry.pricing is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_entries_maps_model_info():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/model/info":
+            return httpx.Response(200, json={"data": [_SONNET_ROW]})
+        if request.url.path == "/v1/models":
+            return httpx.Response(200, json={"data": [{"id": "anthropic/claude-3-5-sonnet"}]})
+        return httpx.Response(404)
+
+    entries = await _client(handler).fetch_entries()
+    assert len(entries) == 1
+    assert entries[0].id == "anthropic/claude-3-5-sonnet"
+
+
+@pytest.mark.asyncio
+async def test_fetch_entries_catalog_superset_of_routable():
+    """A model served by /v1/models but absent from /model/info is STILL listed
+    (catalog ⊇ routable) as a minimal available entry."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/model/info":
+            return httpx.Response(200, json={"data": [_SONNET_ROW]})
+        if request.url.path == "/v1/models":
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"id": "anthropic/claude-3-5-sonnet"},
+                        {"id": "openai/gpt-4o"},  # served but undescribed
+                    ]
+                },
+            )
+        return httpx.Response(404)
+
+    entries = await _client(handler).fetch_entries()
+    ids = {e.id for e in entries}
+    assert ids == {"anthropic/claude-3-5-sonnet", "openai/gpt-4o"}
+    gpt = next(e for e in entries if e.id == "openai/gpt-4o")
+    assert gpt.provider == "openai"
+    assert gpt.status == "available"
+
+
+@pytest.mark.asyncio
+async def test_model_info_non_2xx_fails_closed():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"error": "down"})
+
+    with pytest.raises(CatalogUpstreamError):
+        await _client(handler).fetch_entries()
+
+
+@pytest.mark.asyncio
+async def test_v1_models_failure_does_not_blank_catalog():
+    """If /model/info succeeds but /v1/models fails, the catalog still serves the
+    described entries (reconciliation is best-effort, not blocking)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/model/info":
+            return httpx.Response(200, json={"data": [_SONNET_ROW]})
+        return httpx.Response(500)  # /v1/models down
+
+    entries = await _client(handler).fetch_entries()
+    assert {e.id for e in entries} == {"anthropic/claude-3-5-sonnet"}
+
+
+@pytest.mark.asyncio
+async def test_api_key_sent_as_bearer():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"data": []})
+
+    client = LiteLLMClient(
+        base_url="http://proxy.test:4000",
+        api_key="sk-proxy-123",
+        _transport=httpx.MockTransport(handler),
+    )
+    await client.model_info()
+    assert seen["auth"] == "Bearer sk-proxy-123"

--- a/tests/cloud/catalog/test_models_dev_client.py
+++ b/tests/cloud/catalog/test_models_dev_client.py
@@ -1,0 +1,61 @@
+# tests/cloud/catalog/test_models_dev_client.py — Model Catalog (MCG-1)
+# best-effort models.dev enrichment client. httpx.MockTransport stands in for
+# models.dev (no network). Asserts:
+#   * a well-formed api.json flattens to {"<provider>/<model>": {description,
+#     logo, capabilities}}.
+#   * a non-2xx response fails OPEN (empty dict, no raise).
+#   * a transport error fails OPEN (empty dict, no raise) — a models.dev outage
+#     can never break the catalog.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1).
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pocketpaw_ee.catalog.models_dev_client import ModelsDevClient
+
+_API_JSON = {
+    "anthropic": {
+        "logo": "https://models.dev/logos/anthropic.svg",
+        "models": {
+            "claude-3-5-sonnet": {
+                "name": "Claude 3.5 Sonnet",
+                "description": "Anthropic's mid-tier chat model",
+                "capabilities": ["vision", "tool_call"],
+            }
+        },
+    }
+}
+
+
+@pytest.mark.asyncio
+async def test_fetch_index_flattens_payload():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_API_JSON)
+
+    client = ModelsDevClient(_transport=httpx.MockTransport(handler))
+    index = await client.fetch_index()
+    assert "anthropic/claude-3-5-sonnet" in index
+    entry = index["anthropic/claude-3-5-sonnet"]
+    assert entry["description"] == "Anthropic's mid-tier chat model"
+    assert entry["logo"] == "https://models.dev/logos/anthropic.svg"  # provider-level fallback
+    assert set(entry["capabilities"]) == {"vision", "tool_call"}
+
+
+@pytest.mark.asyncio
+async def test_non_2xx_fails_open():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    client = ModelsDevClient(_transport=httpx.MockTransport(handler))
+    assert await client.fetch_index() == {}
+
+
+@pytest.mark.asyncio
+async def test_transport_error_fails_open():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("dns fail")
+
+    client = ModelsDevClient(_transport=httpx.MockTransport(handler))
+    assert await client.fetch_index() == {}

--- a/tests/cloud/catalog/test_router.py
+++ b/tests/cloud/catalog/test_router.py
@@ -1,0 +1,109 @@
+# tests/cloud/catalog/test_router.py — Model Catalog (MCG-1) HTTP-layer tests.
+# A FastAPI app mounts the catalog router with the license dep waived; the catalog
+# SERVICE is patched (the router is a thin adapter, so the service is the seam).
+# Asserts:
+#   * GET /catalog/models returns {models, total} and forwards filter params.
+#   * an unknown modality value is a 400 (clear error, not a silent empty list).
+#   * GET /catalog/models/{id} resolves the URL-ENCODED "<provider>/<model>" id
+#     (the %2F-encoded slash) to one entry; a miss is 404.
+#   * a LiteLLM upstream failure (CatalogUpstreamError) surfaces as 502.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1).
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.catalog import service as catalog_service
+from pocketpaw_ee.catalog.litellm_client import CatalogUpstreamError
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry, Pricing
+from pocketpaw_ee.catalog.router import router as catalog_router
+from pocketpaw_ee.cloud.license import require_license
+
+_SONNET = ModelCatalogEntry(
+    id="anthropic/claude-3-5-sonnet",
+    display_name="claude-3-5-sonnet",
+    provider="anthropic",
+    modality=Modality.CHAT,
+    context=200000,
+    max_output_tokens=8192,
+    pricing=Pricing(input_per_mtok=3.0, output_per_mtok=15.0),
+    capabilities=["tool_call", "vision", "streaming"],
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(catalog_router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_list_models_returns_envelope(client, monkeypatch):
+    seen: dict = {}
+
+    async def _list(**kwargs):
+        seen.update(kwargs)
+        return [_SONNET]
+
+    monkeypatch.setattr(catalog_service, "list_models", _list)
+
+    resp = client.get(
+        "/api/v1/catalog/models",
+        params={"modality": "chat", "provider": "anthropic", "q": "son", "capability": "vision"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["models"][0]["id"] == "anthropic/claude-3-5-sonnet"
+    assert body["models"][0]["pricing"]["input_per_mtok"] == 3.0
+    # filters forwarded to the service.
+    assert seen == {
+        "modality": "chat",
+        "provider": "anthropic",
+        "q": "son",
+        "capability": "vision",
+    }
+
+
+def test_list_models_unknown_modality_is_400(client):
+    resp = client.get("/api/v1/catalog/models", params={"modality": "music"})
+    assert resp.status_code == 400
+    assert "Unknown modality" in resp.json()["detail"]
+
+
+def test_list_models_upstream_failure_is_502(client, monkeypatch):
+    async def _boom(**kwargs):
+        raise CatalogUpstreamError("proxy down")
+
+    monkeypatch.setattr(catalog_service, "list_models", _boom)
+    resp = client.get("/api/v1/catalog/models")
+    assert resp.status_code == 502
+
+
+def test_get_model_url_encoded_id(client, monkeypatch):
+    seen: dict = {}
+
+    async def _get(model_id, **kwargs):
+        seen["id"] = model_id
+        return _SONNET
+
+    monkeypatch.setattr(catalog_service, "get_model", _get)
+
+    # The "/" in the canonical id is URL-encoded as %2F by the client.
+    resp = client.get("/api/v1/catalog/models/anthropic%2Fclaude-3-5-sonnet")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "anthropic/claude-3-5-sonnet"
+    # The router decoded it back to the canonical "<provider>/<model>" key.
+    assert seen["id"] == "anthropic/claude-3-5-sonnet"
+
+
+def test_get_model_not_found_is_404(client, monkeypatch):
+    async def _none(model_id, **kwargs):
+        return None
+
+    monkeypatch.setattr(catalog_service, "get_model", _none)
+    resp = client.get("/api/v1/catalog/models/nope%2Fnone")
+    assert resp.status_code == 404

--- a/tests/cloud/catalog/test_service.py
+++ b/tests/cloud/catalog/test_service.py
@@ -1,0 +1,215 @@
+# tests/cloud/catalog/test_service.py — Model Catalog (MCG-1) service tests:
+# filtering, TTL cache, and best-effort models.dev enrichment merge.
+# The upstream clients (LiteLLMClient / ModelsDevClient) are replaced with fakes
+# injected via monkeypatch so no network is touched. Asserts:
+#   * modality / provider / capability / q filters (each + combined).
+#   * the TTL cache: a second request inside the window does NOT re-hit the proxy
+#     (the fetch counter stays at 1), and bust_cache forces a re-fetch.
+#   * models.dev enrichment fills gaps WITHOUT overwriting LiteLLM values.
+#   * enrichment is fail-open: an empty index leaves the catalog unchanged.
+#   * the models.dev toggle (CATALOG_MODELS_DEV_ENABLED=false) skips enrichment.
+#
+# Created 2026-06-26 (feat/mcg-1-catalog-api, MCG-1).
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.catalog import service
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry, Pricing
+
+
+def _entry(
+    id_: str,
+    *,
+    provider: str,
+    modality: Modality,
+    caps: list[str] | None = None,
+    description: str | None = None,
+    logo: str | None = None,
+) -> ModelCatalogEntry:
+    return ModelCatalogEntry(
+        id=id_,
+        display_name=id_.split("/", 1)[-1],
+        provider=provider,
+        modality=modality,
+        pricing=Pricing(input_per_mtok=1.0, output_per_mtok=2.0),
+        capabilities=caps or [],
+        description=description,
+        logo=logo,
+    )
+
+
+_CATALOG = [
+    _entry(
+        "anthropic/claude-3-5-sonnet",
+        provider="anthropic",
+        modality=Modality.CHAT,
+        caps=["tool_call", "vision", "streaming"],
+    ),
+    _entry(
+        "openai/gpt-4o", provider="openai", modality=Modality.CHAT, caps=["tool_call", "streaming"]
+    ),
+    _entry("openai/text-embedding-3-small", provider="openai", modality=Modality.EMBEDDING),
+    _entry("google/imagen-3", provider="google", modality=Modality.IMAGE),
+]
+
+
+class _FakeLiteLLM:
+    """Counts fetches so the TTL-cache test can assert a single upstream call."""
+
+    calls = 0
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+        pass
+
+    async def fetch_entries(self) -> list[ModelCatalogEntry]:
+        type(self).calls += 1
+        # Return fresh copies so the service's in-place sort never mutates _CATALOG.
+        return [e.model_copy(deep=True) for e in _CATALOG]
+
+
+class _FakeModelsDev:
+    """Returns a fixed enrichment index (overridable per-test)."""
+
+    index: dict = {}
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def fetch_index(self) -> dict:
+        return dict(type(self).index)
+
+
+@pytest.fixture(autouse=True)
+def wire_fakes(monkeypatch: pytest.MonkeyPatch):
+    """Inject the fakes, reset counters + cache, and default enrichment off so a
+    test opts INTO models.dev explicitly."""
+    _FakeLiteLLM.calls = 0
+    _FakeModelsDev.index = {}
+    monkeypatch.setattr(service, "LiteLLMClient", _FakeLiteLLM)
+    monkeypatch.setattr(service, "ModelsDevClient", _FakeModelsDev)
+    monkeypatch.setenv("CATALOG_MODELS_DEV_ENABLED", "false")
+    monkeypatch.setenv("CATALOG_CACHE_TTL_SECONDS", "300")
+    service.bust_cache()
+    yield
+    service.bust_cache()
+
+
+# --- filtering --------------------------------------------------------------
+
+
+async def test_no_filter_returns_all():
+    entries = await service.list_models()
+    assert len(entries) == len(_CATALOG)
+
+
+async def test_filter_by_modality():
+    chat = await service.list_models(modality="chat")
+    assert {e.id for e in chat} == {"anthropic/claude-3-5-sonnet", "openai/gpt-4o"}
+    emb = await service.list_models(modality="embedding")
+    assert {e.id for e in emb} == {"openai/text-embedding-3-small"}
+
+
+async def test_filter_by_provider_case_insensitive():
+    res = await service.list_models(provider="OpenAI")
+    assert {e.id for e in res} == {"openai/gpt-4o", "openai/text-embedding-3-small"}
+
+
+async def test_filter_by_capability():
+    res = await service.list_models(capability="vision")
+    assert {e.id for e in res} == {"anthropic/claude-3-5-sonnet"}
+
+
+async def test_filter_by_q_substring():
+    res = await service.list_models(q="sonnet")
+    assert {e.id for e in res} == {"anthropic/claude-3-5-sonnet"}
+
+
+async def test_filters_combine_and():
+    # chat AND provider=openai -> gpt-4o only (embedding is openai but not chat).
+    res = await service.list_models(modality="chat", provider="openai")
+    assert {e.id for e in res} == {"openai/gpt-4o"}
+
+
+async def test_get_model_by_id():
+    entry = await service.get_model("google/imagen-3")
+    assert entry is not None
+    assert entry.modality is Modality.IMAGE
+    assert await service.get_model("nope/none") is None
+
+
+# --- TTL cache --------------------------------------------------------------
+
+
+async def test_cache_avoids_second_upstream_call():
+    await service.list_models()
+    await service.list_models(modality="chat")
+    await service.get_model("openai/gpt-4o")
+    # Three service reads, ONE upstream fetch — the TTL cache served the rest.
+    assert _FakeLiteLLM.calls == 1
+
+
+async def test_bust_cache_forces_refetch():
+    await service.list_models()
+    assert _FakeLiteLLM.calls == 1
+    service.bust_cache()
+    await service.list_models()
+    assert _FakeLiteLLM.calls == 2
+
+
+async def test_expired_ttl_refetches(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CATALOG_CACHE_TTL_SECONDS", "300")
+    service.bust_cache()
+
+    # Drive a controllable monotonic clock.
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(service.time, "monotonic", lambda: clock["t"])
+
+    await service.list_models()
+    assert _FakeLiteLLM.calls == 1
+    clock["t"] += 301  # past the 300s TTL
+    await service.list_models()
+    assert _FakeLiteLLM.calls == 2
+
+
+# --- models.dev enrichment --------------------------------------------------
+
+
+async def test_enrichment_fills_gaps_without_overwrite(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CATALOG_MODELS_DEV_ENABLED", "true")
+    _FakeModelsDev.index = {
+        "openai/gpt-4o": {
+            "description": "GPT-4o omni model",
+            "logo": "https://logos.test/openai.svg",
+            "capabilities": ["json_mode"],  # not in the LiteLLM-derived set
+        },
+        "anthropic/claude-3-5-sonnet": {
+            "description": "should NOT overwrite — but LiteLLM left it None",
+            "capabilities": [],
+        },
+    }
+    service.bust_cache()
+    gpt = await service.get_model("openai/gpt-4o")
+    assert gpt is not None
+    assert gpt.description == "GPT-4o omni model"
+    assert gpt.logo == "https://logos.test/openai.svg"
+    # union of LiteLLM caps + the enrichment cap.
+    assert "json_mode" in gpt.capabilities
+    assert "tool_call" in gpt.capabilities
+
+
+async def test_enrichment_disabled_by_flag(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CATALOG_MODELS_DEV_ENABLED", "false")
+    _FakeModelsDev.index = {"openai/gpt-4o": {"description": "ignored"}}
+    service.bust_cache()
+    gpt = await service.get_model("openai/gpt-4o")
+    assert gpt is not None
+    assert gpt.description is None  # enrichment was skipped
+
+
+async def test_enrichment_empty_index_is_noop(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CATALOG_MODELS_DEV_ENABLED", "true")
+    _FakeModelsDev.index = {}  # models.dev down -> fail-open empty
+    service.bust_cache()
+    entries = await service.list_models()
+    assert len(entries) == len(_CATALOG)  # unchanged, LiteLLM-only

--- a/tests/cloud/llm_provisioning/test_billing_cutover.py
+++ b/tests/cloud/llm_provisioning/test_billing_cutover.py
@@ -422,20 +422,88 @@ def test_mode_default_is_off(monkeypatch):
     assert _mode_for(monkeypatch, mode_env=None, ingest_env=None) == "off"
 
 
-def test_legacy_ingest_bool_maps_to_live(monkeypatch):
-    # Old deployments set only POCKETPAW_LITELLM_SPEND_INGEST=true.
-    assert _mode_for(monkeypatch, mode_env=None, ingest_env="true") == "live"
+def test_legacy_ingest_bool_maps_to_shadow_not_live(monkeypatch):
+    # MONEY SAFETY: an old deployment that set only the legacy bool must resolve to
+    # 'shadow' (read-only compare, ZERO debits) — NEVER 'live'. Deploying WU-F (which
+    # adds the first periodic ingestion caller) must not auto-start LiteLLM billing.
+    assert _mode_for(monkeypatch, mode_env=None, ingest_env="true") == "shadow"
+
+
+def test_live_is_never_inferred_from_legacy_bool(monkeypatch):
+    # 'live' requires an EXPLICIT POCKETPAW_LITELLM_SPEND_MODE=live. The legacy bool
+    # alone can only ever reach 'shadow' — there is no value of the bool that yields
+    # 'live'. This is the core anti-silent-flip guarantee.
+    assert _mode_for(monkeypatch, mode_env=None, ingest_env="true") == "shadow"
+    assert _mode_for(monkeypatch, mode_env="off", ingest_env="true") == "shadow"
+    # The ONLY path to live is the explicit mode.
+    assert _mode_for(monkeypatch, mode_env="live", ingest_env=None) == "live"
 
 
 def test_explicit_shadow_overrides_legacy_bool(monkeypatch):
-    # A new explicit 'shadow' is NOT silently upgraded to 'live' by a stale bool.
+    # A new explicit 'shadow' is taken as-is alongside a stale bool.
     assert _mode_for(monkeypatch, mode_env="shadow", ingest_env="true") == "shadow"
+
+
+def test_explicit_live_overrides_legacy_bool(monkeypatch):
+    # An explicit 'live' wins (the operator consciously chose to bill), bool or not.
+    assert _mode_for(monkeypatch, mode_env="live", ingest_env="true") == "live"
 
 
 def test_explicit_modes_resolve(monkeypatch):
     assert _mode_for(monkeypatch, mode_env="off", ingest_env=None) == "off"
     assert _mode_for(monkeypatch, mode_env="shadow", ingest_env=None) == "shadow"
     assert _mode_for(monkeypatch, mode_env="live", ingest_env=None) == "live"
+
+
+def test_legacy_bool_emits_one_time_deprecation_warning(monkeypatch, caplog):
+    # When the legacy bool is the only signal, the first mode resolution logs a
+    # one-time deprecation notice telling the operator it now means 'shadow' and
+    # that billing needs an explicit mode. Fires at most once per process.
+    import logging
+
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    from pocketpaw.config import get_settings
+
+    monkeypatch.setattr(svc, "_legacy_bool_warned", False)  # reset the once-guard
+    monkeypatch.delenv("POCKETPAW_LITELLM_SPEND_MODE", raising=False)
+    monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_INGEST_ENABLED", "true")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        with caplog.at_level(logging.WARNING, logger=svc.logger.name):
+            assert svc.spend_mode() == "shadow"
+            # Resolve again — the warning must NOT fire a second time.
+            assert svc.spend_mode() == "shadow"
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+    dep = [r for r in caplog.records if "DEPRECATION (WU-F)" in r.getMessage()]
+    assert len(dep) == 1, "the deprecation notice must fire exactly once"
+    msg = dep[0].getMessage()
+    assert "'shadow'" in msg
+    assert "POCKETPAW_LITELLM_SPEND_MODE=live" in msg
+
+
+def test_no_warning_when_mode_explicit(monkeypatch, caplog):
+    # With an explicit mode set, the legacy-bool notice never fires (the operator
+    # already made a conscious choice).
+    import logging
+
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    from pocketpaw.config import get_settings
+
+    monkeypatch.setattr(svc, "_legacy_bool_warned", False)
+    monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_MODE", "live")
+    monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_INGEST_ENABLED", "true")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        with caplog.at_level(logging.WARNING, logger=svc.logger.name):
+            assert svc.spend_mode() == "live"
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+    assert not [r for r in caplog.records if "DEPRECATION (WU-F)" in r.getMessage()]
 
 
 def test_spend_ingest_enabled_shim_true_only_in_live(monkeypatch):

--- a/tests/cloud/llm_provisioning/test_billing_cutover.py
+++ b/tests/cloud/llm_provisioning/test_billing_cutover.py
@@ -1,0 +1,503 @@
+# tests/cloud/llm_provisioning/test_billing_cutover.py — proves the WU-F billing
+# cutover from BC-3 per-run metering to LiteLLM as the SINGLE meter, via the safe
+# shadow-compare phase. This touches MONEY, so every mode is proven at the ledger:
+#
+# SHADOW (the safe compare — ZERO debits):
+#   * reconcile_tenant_spend records a reconciliation row with the right
+#     litellm/bc3/delta and the coverage_gap verdict, AND leaves the credit ledger
+#     COMPLETELY UNCHANGED (the critical invariant — shadow never debits).
+#   * a coverage-gap case (LiteLLM spend >> BC-3) flips coverage_gap=True.
+#   * the cutover sweep in shadow mode reconciles every provisioned tenant and
+#     still moves no money.
+#
+# LIVE (LiteLLM is the sole meter — exactly ONE meter charges):
+#   * the BC-3 metering sweep (sweep_unbilled_runs) is GATED OFF in live mode:
+#     it returns 0, debits nothing, and does NOT flip the run's billed flag.
+#   * the cutover sweep in live mode debits the proxy spend exactly once.
+#   * end-to-end: with the same usage present as a chat run AND a proxy spend row,
+#     live mode charges it once (LiteLLM), never twice.
+#
+# MODE TRANSITIONS + BACK-COMPAT:
+#   * effective_spend_mode resolves off/shadow/live and honours the legacy
+#     POCKETPAW_LITELLM_SPEND_INGEST bool (True -> live while mode is 'off').
+#
+# BOUNDARY FIX (WU-C high-water under-bill regression):
+#   * two DISTINCT spend rows sharing one startTime, arriving across two sweeps,
+#     are both billed EXACTLY once (the old start_ts <= high_water dropped the
+#     second one -> under-bill).
+#
+# Uses the shared ``mongo_db`` + autouse ``recording_bus`` fixtures from
+# tests/cloud/conftest.py. A FAKE admin client stands in for the proxy.
+#
+# Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.llm_provisioning import cutover_sweeper
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
+from pocketpaw_ee.cloud.metering.domain import RateCard
+from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
+from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
+
+WS = "ws_cutover_test"
+
+# Pin both rate cards so credits don't depend on ambient settings: round(usd*250).
+SPEND = SpendCredits(markup=2.5, credit_usd=0.01)
+RATE = RateCard(markup=2.5, credit_usd=0.01)
+
+
+class FakeAdmin:
+    """In-memory stand-in for LiteLLMAdminClient (no HTTP).
+
+    ``generate_key`` mints a deterministic key; ``spend_logs`` returns scripted
+    rows. ``raise_on_generate`` simulates a proxy-down provision failure.
+    """
+
+    def __init__(
+        self, *, spend_rows: list[dict] | None = None, raise_on_generate: bool = False
+    ) -> None:
+        self.generate_calls = 0
+        self._spend_rows = spend_rows or []
+        self._raise_on_generate = raise_on_generate
+
+    async def generate_key(self, **kwargs):
+        self.generate_calls += 1
+        if self._raise_on_generate:
+            from pocketpaw_ee.catalog.admin_client import LiteLLMAdminError
+
+            raise LiteLLMAdminError("proxy unreachable (simulated)")
+        return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **kwargs}
+
+    async def spend_logs(self, *, api_key: str):
+        return list(self._spend_rows)
+
+
+async def _make_run(
+    *, run_id: str, status: str = "completed", usage: dict | None = None, billed: bool = False
+) -> ChatRunDoc:
+    doc = ChatRunDoc(
+        run_id=run_id,
+        workspace=WS,
+        context_type="dm",
+        scope_id="scope-1",
+        session_key="sk-1",
+        user_id="u1",
+        agent_id="a1",
+        client_message_id=f"cmid-{run_id}",
+        user_message_id=f"umid-{run_id}",
+        status=status,  # type: ignore[arg-type]
+        usage=usage if usage is not None else {},
+        billed=billed,
+    )
+    await doc.insert()
+    return doc
+
+
+async def _ledger_snapshot(workspace: str) -> tuple[int, int]:
+    """(#ledger entries, balance) — the two things shadow must NOT change."""
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == workspace).to_list()
+    return len(entries), await credits.balance(workspace)
+
+
+# ===========================================================================
+# SHADOW — the safe compare. ZERO debits. Reconciliation record produced.
+# ===========================================================================
+
+
+async def test_shadow_records_reconciliation_and_never_debits(mongo_db):
+    # Seed a wallet and a BC-3 compute_spend debit (what BC-3 already billed).
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    # BC-3 billed 10 credits of compute for this workspace.
+    await credits.debit(
+        WS, 10, cause="compute_spend", idempotency_key="run:r1", allow_negative=True
+    )
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    # The proxy attributes 0.04 USD == 10 credits for the SAME window -> they agree.
+    admin = FakeAdmin(
+        spend_rows=[{"request_id": "req-1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"}]
+    )
+
+    before_entries, before_balance = await _ledger_snapshot(WS)
+
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+
+    # The compare: litellm 10 == bc3 10, delta 0, no gap.
+    assert rec.litellm_credits == 10
+    assert rec.bc3_credits == 10
+    assert rec.delta == 0
+    assert rec.coverage_gap is False
+    assert rec.litellm_rows == 1
+    assert rec.bc3_entries == 1
+
+    # CRITICAL — shadow performed ZERO debits: ledger entry count AND balance are
+    # byte-for-byte unchanged (no litellm_spend row was written).
+    after_entries, after_balance = await _ledger_snapshot(WS)
+    assert after_entries == before_entries
+    assert after_balance == before_balance
+    litellm_debits = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.cause == "litellm_spend",
+    ).to_list()
+    assert litellm_debits == []  # shadow NEVER writes a litellm_spend debit
+
+    # The reconciliation record was persisted (the audit trail).
+    records = await SpendReconciliation.find(SpendReconciliation.workspace == WS).to_list()
+    assert len(records) == 1
+    assert records[0].litellm_credits == 10
+    assert records[0].bc3_credits == 10
+    assert records[0].delta == 0
+    assert records[0].coverage_gap is False
+
+
+async def test_shadow_coverage_gap_when_litellm_exceeds_bc3(mongo_db):
+    # BC-3 billed only 2 credits, but the proxy saw 0.40 USD == 100 credits of
+    # spend -> a coverage gap (traffic bypassing per-run metering).
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await credits.debit(WS, 2, cause="compute_spend", idempotency_key="run:r1", allow_negative=True)
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    admin = FakeAdmin(
+        spend_rows=[{"request_id": "req-1", "spend": 0.40, "startTime": "2026-06-26T10:00:00"}]
+    )
+
+    before_entries, before_balance = await _ledger_snapshot(WS)
+
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, spend_card=SPEND, threshold=10, admin_client=admin
+    )
+
+    assert rec.litellm_credits == 100
+    assert rec.bc3_credits == 2
+    assert rec.delta == 98  # litellm - bc3
+    assert rec.coverage_gap is True  # |98| > 10
+
+    # Still ZERO debits — even a gap only RECORDS, never charges.
+    after_entries, after_balance = await _ledger_snapshot(WS)
+    assert after_entries == before_entries
+    assert after_balance == before_balance
+
+    records = await SpendReconciliation.find(SpendReconciliation.workspace == WS).to_list()
+    assert len(records) == 1
+    assert records[0].coverage_gap is True
+    assert records[0].delta == 98
+
+
+async def test_shadow_window_filters_bc3_and_litellm(mongo_db):
+    # A BC-3 debit and a proxy row INSIDE the window count; ones outside don't.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    # One in-window BC-3 debit (createdAt ~ now), recorded just before the sweep.
+    await credits.debit(WS, 5, cause="compute_spend", idempotency_key="run:in", allow_negative=True)
+
+    since = datetime(2000, 1, 1, tzinfo=UTC)  # wide-open past
+    until = datetime(2999, 1, 1, tzinfo=UTC)  # wide-open future
+    admin = FakeAdmin(
+        spend_rows=[
+            {"request_id": "req-in", "spend": 0.02, "startTime": "2026-06-26T10:00:00"},  # 5 cr
+        ]
+    )
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, since=since, until=until, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+    assert rec.litellm_credits == 5
+    assert rec.bc3_credits == 5
+    assert rec.delta == 0
+    assert rec.window_start == since.isoformat()
+    assert rec.window_end == until.isoformat()
+
+
+# ===========================================================================
+# LIVE — LiteLLM is the sole meter. Exactly ONE meter charges.
+# ===========================================================================
+
+
+async def test_live_gates_bc3_sweep_off(mongo_db):
+    # A terminal, unbilled run that BC-3 WOULD bill in off/shadow.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    run = await _make_run(run_id="run-live", usage={"total_cost_usd": 0.04, "model": "gpt-4o"})
+    before = await credits.balance(WS)
+
+    # In LIVE mode the BC-3 sweep MUST NOT charge.
+    billed = await sweep_unbilled_runs(rate_card=RATE, mode="live")
+
+    assert billed == 0  # gated off — nothing billed
+    assert await credits.balance(WS) == before  # NO debit
+    # And it did NOT flip the billed flag (so LiteLLM still owns this usage).
+    reloaded = await ChatRunDoc.find_one(ChatRunDoc.run_id == "run-live")
+    assert reloaded is not None
+    assert reloaded.billed is False
+    # No compute_spend ledger row was written.
+    bc3 = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.cause == "compute_spend",
+    ).to_list()
+    assert bc3 == []
+    _ = run  # silence unused
+
+
+async def test_off_and_shadow_modes_still_bill_bc3(mongo_db):
+    # Sanity: the gate is LIVE-only. In off + shadow, BC-3 bills as today.
+    for mode in ("off", "shadow"):
+        ws = f"{WS}_{mode}"
+        await credits.grant(ws, 1000, cause="top_up", idempotency_key=f"seed-{mode}")
+        doc = ChatRunDoc(
+            run_id=f"run-{mode}",
+            workspace=ws,
+            context_type="dm",
+            scope_id="s",
+            session_key="sk",
+            user_id="u1",
+            agent_id="a1",
+            client_message_id=f"cmid-{mode}",
+            user_message_id=f"umid-{mode}",
+            status="completed",  # type: ignore[arg-type]
+            usage={"total_cost_usd": 0.04, "model": "gpt-4o"},
+            billed=False,
+        )
+        await doc.insert()
+
+        billed = await sweep_unbilled_runs(rate_card=RATE, mode=mode)
+        assert billed == 1, f"BC-3 must bill in {mode} mode"
+        assert await credits.balance(ws) == 990, f"BC-3 debit must land in {mode} mode"
+
+
+async def test_live_cutover_sweep_debits_proxy_spend_once(mongo_db):
+    # In live mode the cutover sweep ingests proxy spend exactly once.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    rows = [{"request_id": "req-1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"}]
+
+    # Patch the admin client the service constructs (the sweep calls
+    # ingest_tenant_spend without an injected client), and pin the mode.
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    orig = svc.LiteLLMAdminClient
+    svc.LiteLLMAdminClient = lambda *a, **k: FakeAdmin(spend_rows=rows)  # type: ignore[assignment]
+    # Pin the rate card the same way so credits are deterministic.
+    orig_load = svc.load_spend_credits
+    svc.load_spend_credits = lambda: SPEND  # type: ignore[assignment]
+    try:
+        first = await cutover_sweeper.run_cutover_sweep(mode="live")
+        assert first["processed"] == 1
+        assert first["credits"] == 10
+        assert await credits.balance(WS) == 990  # 1000 - 10
+
+        # Re-run: the ledger key + high-water mark make it a no-op.
+        second = await cutover_sweeper.run_cutover_sweep(mode="live")
+        assert second["credits"] == 0
+        assert await credits.balance(WS) == 990  # never moved twice
+    finally:
+        svc.LiteLLMAdminClient = orig  # type: ignore[assignment]
+        svc.load_spend_credits = orig_load  # type: ignore[assignment]
+
+    # Exactly one litellm_spend ledger row.
+    entries = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "litellm:req-1",
+    ).to_list()
+    assert len(entries) == 1
+    assert entries[0].amount_delta == -10
+
+
+async def test_no_double_charge_same_usage_live(mongo_db):
+    # The single-meter guarantee end-to-end: the SAME unit of usage exists both as
+    # a terminal chat run (BC-3's input) AND as a proxy spend row (LiteLLM's input).
+    # In live mode it must be charged EXACTLY once, by LiteLLM only.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+    await _make_run(run_id="run-x", usage={"total_cost_usd": 0.04, "model": "gpt-4o"})
+
+    rows = [{"request_id": "req-x", "spend": 0.04, "startTime": "2026-06-26T10:00:00"}]
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    orig = svc.LiteLLMAdminClient
+    orig_load = svc.load_spend_credits
+    svc.LiteLLMAdminClient = lambda *a, **k: FakeAdmin(spend_rows=rows)  # type: ignore[assignment]
+    svc.load_spend_credits = lambda: SPEND  # type: ignore[assignment]
+    try:
+        # BC-3 sweep (gated off in live) + cutover sweep (live ingest).
+        bc3_billed = await sweep_unbilled_runs(rate_card=RATE, mode="live")
+        cut = await cutover_sweeper.run_cutover_sweep(mode="live")
+    finally:
+        svc.LiteLLMAdminClient = orig  # type: ignore[assignment]
+        svc.load_spend_credits = orig_load  # type: ignore[assignment]
+
+    assert bc3_billed == 0  # BC-3 charged nothing
+    assert cut["credits"] == 10  # LiteLLM charged the 10 credits
+
+    # Net: exactly 10 credits charged total (1000 -> 990), via litellm_spend only.
+    assert await credits.balance(WS) == 990
+    bc3_rows = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS, CreditLedgerEntry.cause == "compute_spend"
+    ).to_list()
+    litellm_rows = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS, CreditLedgerEntry.cause == "litellm_spend"
+    ).to_list()
+    assert bc3_rows == []  # BC-3 never charged this usage
+    assert len(litellm_rows) == 1  # LiteLLM charged it once
+
+
+# ===========================================================================
+# CUTOVER SWEEP — off no-ops; shadow reconciles every tenant, moves no money.
+# ===========================================================================
+
+
+async def test_cutover_sweep_off_is_noop(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+    before = await credits.balance(WS)
+
+    summary = await cutover_sweeper.run_cutover_sweep(mode="off")
+
+    assert summary["processed"] == 0
+    assert await credits.balance(WS) == before
+    assert await SpendReconciliation.find(SpendReconciliation.workspace == WS).to_list() == []
+
+
+async def test_cutover_sweep_shadow_reconciles_tenants_without_debit(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await credits.debit(
+        WS, 10, cause="compute_spend", idempotency_key="run:r1", allow_negative=True
+    )
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    rows = [{"request_id": "req-1", "spend": 0.04, "startTime": datetime.now(UTC).isoformat()}]
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    orig = svc.LiteLLMAdminClient
+    orig_load = svc.load_spend_credits
+    svc.LiteLLMAdminClient = lambda *a, **k: FakeAdmin(spend_rows=rows)  # type: ignore[assignment]
+    svc.load_spend_credits = lambda: SPEND  # type: ignore[assignment]
+    before_entries, before_balance = await _ledger_snapshot(WS)
+    try:
+        summary = await cutover_sweeper.run_cutover_sweep(mode="shadow")
+    finally:
+        svc.LiteLLMAdminClient = orig  # type: ignore[assignment]
+        svc.load_spend_credits = orig_load  # type: ignore[assignment]
+
+    assert summary["processed"] == 1
+    # ZERO debits even via the sweep path.
+    after_entries, after_balance = await _ledger_snapshot(WS)
+    assert after_entries == before_entries
+    assert after_balance == before_balance
+    # A reconciliation row was recorded for the tenant.
+    assert len(await SpendReconciliation.find(SpendReconciliation.workspace == WS).to_list()) == 1
+
+
+# ===========================================================================
+# MODE TRANSITIONS + BACK-COMPAT of the legacy POCKETPAW_LITELLM_SPEND_INGEST bool.
+# ===========================================================================
+
+
+def _mode_for(monkeypatch, *, mode_env: str | None, ingest_env: str | None) -> str:
+    from pocketpaw.config import get_settings
+
+    if mode_env is None:
+        monkeypatch.delenv("POCKETPAW_LITELLM_SPEND_MODE", raising=False)
+    else:
+        monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_MODE", mode_env)
+    if ingest_env is None:
+        monkeypatch.delenv("POCKETPAW_LITELLM_SPEND_INGEST_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_INGEST_ENABLED", ingest_env)
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        return provisioning.spend_mode()
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def test_mode_default_is_off(monkeypatch):
+    assert _mode_for(monkeypatch, mode_env=None, ingest_env=None) == "off"
+
+
+def test_legacy_ingest_bool_maps_to_live(monkeypatch):
+    # Old deployments set only POCKETPAW_LITELLM_SPEND_INGEST=true.
+    assert _mode_for(monkeypatch, mode_env=None, ingest_env="true") == "live"
+
+
+def test_explicit_shadow_overrides_legacy_bool(monkeypatch):
+    # A new explicit 'shadow' is NOT silently upgraded to 'live' by a stale bool.
+    assert _mode_for(monkeypatch, mode_env="shadow", ingest_env="true") == "shadow"
+
+
+def test_explicit_modes_resolve(monkeypatch):
+    assert _mode_for(monkeypatch, mode_env="off", ingest_env=None) == "off"
+    assert _mode_for(monkeypatch, mode_env="shadow", ingest_env=None) == "shadow"
+    assert _mode_for(monkeypatch, mode_env="live", ingest_env=None) == "live"
+
+
+def test_spend_ingest_enabled_shim_true_only_in_live(monkeypatch):
+    # The deprecated shim: True ONLY when the effective mode is live.
+    assert _mode_for(monkeypatch, mode_env="off", ingest_env=None) == "off"
+    from pocketpaw.config import get_settings
+
+    monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_MODE", "shadow")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        assert provisioning.spend_ingest_enabled() is False  # shadow does NOT debit
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+    monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_MODE", "live")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        assert provisioning.spend_ingest_enabled() is True
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+# ===========================================================================
+# BOUNDARY FIX — two distinct same-startTime rows across two sweeps bill once each.
+# ===========================================================================
+
+
+async def test_high_water_boundary_same_second_rows_both_billed_once(mongo_db):
+    # The WU-C under-bill bug: with start_ts <= high_water, a DISTINCT row sharing
+    # the prior sweep's exact startTime second is dropped on the later sweep. With
+    # the strict-< fix + the litellm:{request_id} dedup, BOTH same-second rows bill
+    # exactly once across two sweeps.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    SAME_TS = "2026-06-26T10:00:00"
+
+    # Sweep 1 sees only req-1 at SAME_TS (0.04 USD -> 10 credits). Mark advances to
+    # SAME_TS.
+    admin = FakeAdmin(spend_rows=[{"request_id": "req-1", "spend": 0.04, "startTime": SAME_TS}])
+    first = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+    assert first.rows_billed == 1
+    assert first.credits_debited == 10
+    assert await credits.balance(WS) == 990
+
+    # Sweep 2: req-2 ALSO carries SAME_TS (a distinct row that arrived/settled at
+    # the same second) plus the already-billed req-1. The fix must bill req-2 (the
+    # old <= would have skipped it -> under-bill) while req-1 no-ops on its key.
+    admin._spend_rows = [
+        {"request_id": "req-1", "spend": 0.04, "startTime": SAME_TS},
+        {"request_id": "req-2", "spend": 0.06, "startTime": SAME_TS},  # -> 15 credits
+    ]
+    second = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    assert second.rows_billed == 1  # only req-2 is newly billed
+    assert second.credits_debited == 15
+    assert await credits.balance(WS) == 975  # 990 - 15
+
+    # Exactly one ledger row per request — neither double-billed.
+    for rid, delta in (("req-1", -10), ("req-2", -15)):
+        entries = await CreditLedgerEntry.find(
+            CreditLedgerEntry.workspace == WS,
+            CreditLedgerEntry.idempotency_key == f"litellm:{rid}",
+        ).to_list()
+        assert len(entries) == 1, f"{rid} must have exactly one ledger row"
+        assert entries[0].amount_delta == delta

--- a/tests/cloud/llm_provisioning/test_provisioning.py
+++ b/tests/cloud/llm_provisioning/test_provisioning.py
@@ -1,0 +1,299 @@
+# tests/cloud/llm_provisioning/test_provisioning.py — proves the MCG-8 per-tenant
+# LiteLLM virtual-key provisioning + spend->credits ingestion seam.
+#
+# PROVISIONING:
+#   1. ensure_tenant_key mints a key via the admin API with the budget / rpm / tpm
+#      / metadata={workspace_id} and stores the workspace -> key mapping.
+#   2. A second ensure_tenant_key is idempotent — returns the SAME key, makes NO
+#      second proxy call (created=False), and never stores a second row.
+#   3. get_tenant_key reads the stored key back (None when unprovisioned).
+#
+# SPEND INGESTION (the real seam — plugs into the EXISTING credits ledger):
+#   4. ingest_tenant_spend reads /spend/logs and debits the EXISTING credit ledger
+#      (credits.service) with the right workspace + credits + cause + a
+#      litellm:{request_id} idempotency key; cached tokens are captured.
+#   5. Re-ingest is idempotent — the BC-1 ledger key blocks a second debit even
+#      when the high-water mark is reset, so the balance never moves twice.
+#   6. The high-water mark advances so a re-sweep skips settled rows.
+#   7. An unprovisioned workspace returns a zero result (no raise).
+#   8. allow_negative: spend beyond the wallet still bills fully (metered compute).
+#
+# Uses the shared ``mongo_db`` fixture (mongomock-motor + Beanie over
+# ALL_DOCUMENTS) + the autouse ``recording_bus`` from tests/cloud/conftest.py —
+# the same DB-fixture pattern the credits / metering tests use. A FAKE admin
+# client (no HTTP) stands in for the proxy so provisioning + ingestion are tested
+# without a live proxy; the admin client's own HTTP wiring is covered separately
+# in tests/cloud/catalog/test_admin_client.py.
+#
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-8): new test module.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+
+WS = "ws_prov_test"
+
+# Pin the spend rate card so credits don't depend on ambient POCKETPAW_* settings:
+# credits = round(cost_usd * 250).
+SPEND = SpendCredits(markup=2.5, credit_usd=0.01)
+
+# A budget the FakeAdmin echoes back; values are config-shaped, not secrets.
+BUDGET = KeyBudget(
+    max_budget_usd=25.0, budget_duration="30d", rpm_limit=60, tpm_limit=10_000, models=[]
+)
+
+
+class FakeAdmin:
+    """In-memory stand-in for LiteLLMAdminClient.
+
+    ``generate_key`` mints a deterministic key + records the payload it was called
+    with so the test can assert the budget / metadata round-tripped. ``spend_logs``
+    returns a scripted list of rows. ``generate_calls`` counts mints so the
+    idempotency test can prove the proxy is NOT hit twice.
+    """
+
+    def __init__(self, *, spend_rows: list[dict] | None = None) -> None:
+        self.generate_calls = 0
+        self.last_generate_kwargs: dict | None = None
+        self._spend_rows = spend_rows or []
+        self.spend_log_calls: list[str] = []
+
+    async def generate_key(self, **kwargs):
+        self.generate_calls += 1
+        self.last_generate_kwargs = kwargs
+        return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **{k: v for k, v in kwargs.items()}}
+
+    async def spend_logs(self, *, api_key: str):
+        self.spend_log_calls.append(api_key)
+        return list(self._spend_rows)
+
+
+# ---------------------------------------------------------------------------
+# Provisioning
+# ---------------------------------------------------------------------------
+
+
+async def test_ensure_tenant_key_mints_with_budget_and_stores_mapping(mongo_db):
+    admin = FakeAdmin()
+    result = await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=admin)
+
+    assert result.created is True
+    assert result.workspace_id == WS
+    assert result.litellm_key == "sk-ws-ws_prov_test"
+    assert admin.generate_calls == 1
+
+    # The mint carried the budget / limits + metadata={workspace_id}.
+    kw = admin.last_generate_kwargs
+    assert kw["key_alias"] == "ws-ws_prov_test"
+    assert kw["max_budget"] == 25.0
+    assert kw["budget_duration"] == "30d"
+    assert kw["rpm_limit"] == 60
+    assert kw["tpm_limit"] == 10_000
+    assert kw["metadata"] == {"workspace_id": WS}
+
+    # The workspace -> key mapping is persisted (exactly one row).
+    rows = await LiteLLMTenantKey.find(LiteLLMTenantKey.workspace == WS).to_list()
+    assert len(rows) == 1
+    assert rows[0].litellm_key == "sk-ws-ws_prov_test"
+    assert rows[0].max_budget_usd == 25.0
+    assert rows[0].rpm_limit == 60
+
+
+async def test_ensure_tenant_key_is_idempotent(mongo_db):
+    admin = FakeAdmin()
+    first = await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=admin)
+    second = await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=admin)
+
+    # Same key, no second proxy mint, created=False on the replay.
+    assert first.litellm_key == second.litellm_key
+    assert second.created is False
+    assert admin.generate_calls == 1  # NOT 2 — the proxy is not hit again
+
+    # Still exactly one mapping row.
+    rows = await LiteLLMTenantKey.find(LiteLLMTenantKey.workspace == WS).to_list()
+    assert len(rows) == 1
+
+
+async def test_get_tenant_key_reads_back_or_none(mongo_db):
+    assert await provisioning.get_tenant_key(WS) is None  # unprovisioned
+    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=FakeAdmin())
+    assert await provisioning.get_tenant_key(WS) == "sk-ws-ws_prov_test"
+
+
+# ---------------------------------------------------------------------------
+# Spend ingestion — the seam into the EXISTING credits ledger.
+# ---------------------------------------------------------------------------
+
+
+async def test_ingest_spend_debits_existing_credit_ledger(mongo_db):
+    # Seed a wallet via the EXISTING credits service (the ledger we plug into).
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=FakeAdmin())
+
+    # Two proxy spend rows: 0.04 USD (-> 10 credits) + 0.02 USD (-> 5 credits).
+    rows = [
+        {
+            "request_id": "req-1",
+            "spend": 0.04,
+            "startTime": "2026-06-26T10:00:00",
+            "model": "anthropic/claude-3-5-sonnet",
+            "prompt_tokens_details": {"cached_tokens": 128},
+        },
+        {
+            "request_id": "req-2",
+            "spend": 0.02,
+            "startTime": "2026-06-26T10:05:00",
+            "model": "anthropic/claude-3-5-sonnet",
+        },
+    ]
+    admin = FakeAdmin(spend_rows=rows)
+
+    result = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    # Debited via the EXISTING ledger: 10 + 5 = 15 credits; balance 1000 -> 985.
+    assert result.rows_read == 2
+    assert result.rows_billed == 2
+    assert result.credits_debited == 15
+    assert result.cached_tokens == 128
+    assert result.balance_after == 985
+    assert await credits.balance(WS) == 985
+
+    # The ledger rows are keyed litellm:{request_id} with the litellm_spend cause —
+    # i.e. they live in the SAME CreditLedgerEntry collection BC-3 uses, not a fork.
+    spend_entries = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.cause == "litellm_spend",
+    ).to_list()
+    assert {e.idempotency_key for e in spend_entries} == {"litellm:req-1", "litellm:req-2"}
+    by_key = {e.idempotency_key: e for e in spend_entries}
+    assert by_key["litellm:req-1"].amount_delta == -10
+    assert by_key["litellm:req-1"].ref.get("cached_tokens") == 128
+    assert by_key["litellm:req-2"].amount_delta == -5
+
+
+async def test_reingest_is_idempotent_even_if_high_water_reset(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=FakeAdmin())
+
+    rows = [{"request_id": "req-1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"}]
+    admin = FakeAdmin(spend_rows=rows)
+
+    first = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+    assert first.credits_debited == 10
+    assert await credits.balance(WS) == 990
+
+    # Force the high-water mark back so the row is re-read — the BC-1 ledger key
+    # must still block the second debit (the real exactly-once guard).
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
+    assert doc is not None
+    doc.last_spend_ingest_ts = None
+    await doc.save()
+
+    second = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+    assert second.rows_read == 1  # the row WAS re-read...
+    assert second.rows_billed == 0  # ...but produced no NEW ledger debit
+    assert await credits.balance(WS) == 990  # balance never moved twice
+
+    # Still exactly one ledger row for that request.
+    entries = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "litellm:req-1",
+    ).to_list()
+    assert len(entries) == 1
+
+
+async def test_high_water_mark_skips_settled_rows(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=FakeAdmin())
+
+    admin = FakeAdmin(
+        spend_rows=[{"request_id": "req-1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"}]
+    )
+    await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    # The high-water mark advanced to the row's startTime.
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
+    assert doc is not None
+    assert doc.last_spend_ingest_ts == "2026-06-26T10:00:00"
+
+    # A re-sweep with the SAME (now-settled) row reads nothing new.
+    again = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+    assert again.rows_read == 0
+    assert again.rows_billed == 0
+
+    # A NEWER row gets ingested.
+    admin._spend_rows = [
+        {"request_id": "req-1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"},
+        {"request_id": "req-2", "spend": 0.08, "startTime": "2026-06-26T11:00:00"},
+    ]
+    newer = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+    assert newer.rows_read == 1  # only the new row
+    assert newer.rows_billed == 1
+    assert newer.credits_debited == 20  # round(0.08 * 250)
+    assert await credits.balance(WS) == 1000 - 10 - 20  # 970
+
+
+async def test_ingest_unprovisioned_workspace_returns_zero(mongo_db):
+    # No key provisioned, no wallet — ingestion is a no-op, not a raise.
+    result = await provisioning.ingest_tenant_spend(
+        "ws_never_provisioned", spend_card=SPEND, admin_client=FakeAdmin()
+    )
+    assert result.rows_read == 0
+    assert result.rows_billed == 0
+    assert result.credits_debited == 0
+    assert result.balance_after == 0
+
+
+async def test_ingest_overage_drives_balance_negative(mongo_db):
+    # Tiny wallet: 5 credits, but a 0.04 USD row bills 10 credits.
+    await credits.grant(WS, 5, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=FakeAdmin())
+
+    admin = FakeAdmin(
+        spend_rows=[{"request_id": "req-1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"}]
+    )
+    result = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    # Metered compute is always billed — the overage is a legitimate negative.
+    assert result.credits_debited == 10
+    assert result.balance_after == -5
+    assert await credits.balance(WS) == -5
+
+
+# ---------------------------------------------------------------------------
+# Config — budgets resolve from settings (never hardcoded secrets).
+# ---------------------------------------------------------------------------
+
+
+def test_load_key_budget_reads_settings(monkeypatch):
+    monkeypatch.setenv("POCKETPAW_TENANT_MAX_BUDGET_USD", "50")
+    monkeypatch.setenv("POCKETPAW_TENANT_BUDGET_DURATION", "7d")
+    monkeypatch.setenv("POCKETPAW_TENANT_RPM_LIMIT", "120")
+    monkeypatch.setenv("POCKETPAW_TENANT_TPM_LIMIT", "0")  # 0 -> unset
+    from pocketpaw.config import get_settings
+
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        budget = provisioning.load_key_budget()
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+    assert budget.max_budget_usd == 50.0
+    assert budget.budget_duration == "7d"
+    assert budget.rpm_limit == 120
+    assert budget.tpm_limit is None  # 0 mapped to "no cap"
+
+
+def test_spend_ingest_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("POCKETPAW_LITELLM_SPEND_INGEST", raising=False)
+    from pocketpaw.config import get_settings
+
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        assert provisioning.spend_ingest_enabled() is False
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]

--- a/tests/cloud/llm_provisioning/test_provisioning.py
+++ b/tests/cloud/llm_provisioning/test_provisioning.py
@@ -220,19 +220,28 @@ async def test_high_water_mark_skips_settled_rows(mongo_db):
     assert doc is not None
     assert doc.last_spend_ingest_ts == "2026-06-26T10:00:00"
 
-    # A re-sweep with the SAME (now-settled) row reads nothing new.
+    # A re-sweep with the SAME (now-settled) row bills NOTHING new. After the WU-F
+    # boundary fix the high-water skip is strict ``<`` (not ``<=``), so a row whose
+    # startTime EQUALS the mark is RE-EXAMINED (rows_read==1) and de-duplicated by
+    # its litellm:{request_id} ledger key — it must not re-bill. (The old ``<=``
+    # skipped it outright, rows_read==0, but that same skip silently DROPPED a
+    # distinct same-second row on a later sweep — the under-bill this fix closes;
+    # see test_high_water_boundary_same_second_rows_both_billed_once.)
+    before_balance = await credits.balance(WS)
     again = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
-    assert again.rows_read == 0
-    assert again.rows_billed == 0
+    assert again.rows_read == 1  # the boundary row is re-examined...
+    assert again.rows_billed == 0  # ...but never re-billed (deduped on its key)
+    assert await credits.balance(WS) == before_balance  # balance never moved twice
 
-    # A NEWER row gets ingested.
+    # A NEWER row gets ingested (the boundary row is re-examined + deduped, the
+    # newer row bills).
     admin._spend_rows = [
         {"request_id": "req-1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"},
         {"request_id": "req-2", "spend": 0.08, "startTime": "2026-06-26T11:00:00"},
     ]
     newer = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
-    assert newer.rows_read == 1  # only the new row
-    assert newer.rows_billed == 1
+    assert newer.rows_read == 2  # the boundary row (re-examined) + the new row
+    assert newer.rows_billed == 1  # only the new row produces a debit
     assert newer.credits_debited == 20  # round(0.08 * 250)
     assert await credits.balance(WS) == 1000 - 10 - 20  # 970
 

--- a/tests/cloud/test_media_mcp.py
+++ b/tests/cloud/test_media_mcp.py
@@ -1,19 +1,24 @@
 # tests/cloud/test_media_mcp.py — STUDIO media-generation in-process MCP server.
 #
-# Created: 2026-06-10 (feat/studio-code-migration) — Guards the media MCP server
-# the cloud chat (claude_agent_sdk) backend uses on the /studio surface:
-#   * MEDIA_TOOL_IDS — the two namespaced tool ids the surface allow-list + the
-#     SDK allowlist machinery key on.
-#   * image_generate — happy path (mock the google genai client + agent_create →
-#     asserts the asset lands in a trusted-create gallery and the success body
-#     carries the pocket_id) and the error path when no google key is set.
-#     2026-06-10: happy path mocks generate_content (the gemini-2.5-flash-image
-#     default route in generate_image_file); the imagen/generate_images route is
-#     covered in tests/test_image_gen.py.
-#   * video_generate — the error path when no Replicate token is set (mock the
-#     settings; httpx must not even be reached). The happy path needs a live
-#     Replicate poll, so it is covered structurally by the no-token guard + the
-#     output-URL parsing being exercised in the handler.
+# Created: 2026-06-10 (feat/studio-code-migration).
+# 2026-06-26 (MCG-6 + MCG-7): media generation now routes through the LiteLLM
+# proxy's OpenAI-compatible endpoints, so the tests mock the PROXY HTTP calls
+# (httpx.MockTransport injected via media._PROXY_TRANSPORT — the same seam the
+# catalog client exposes) instead of mocking Google genai / Replicate. They
+# assert each modality POSTs to the correct proxy path with the catalog-selected
+# model AND the Bearer proxy key, and that the OpenAI `user` field carries the
+# tenant (the proxy keys spend off it). Coverage:
+#   * MEDIA_TOOL_IDS — the four namespaced tool ids the surface allow-list keys on.
+#   * image_generate — happy path (POST /v1/images/generations, decodes b64_json,
+#     saves a PNG, lands in a trusted-create gallery), the backward-compat path
+#     (no `model` arg → settings.image_model), and identity / proxy-error guards.
+#   * audio_generate (TTS) — happy path (POST /v1/audio/speech, raw bytes saved,
+#     lands in the gallery), default model when none passed.
+#   * audio_transcribe (STT) — happy path (POST /v1/audio/transcriptions multipart,
+#     returns text, does NOT touch the gallery), missing-file guard.
+#   * video_generate — happy path (POST /videos terminal job, lands the URL in the
+#     gallery) and the async poll path (pending → GET /videos/{id} → completed).
+#   * gallery spec still uses only existing widget types (now incl. audio tiles).
 #
 # All tests mock the per-stream ContextVar identity (``_identity``) and the
 # session-bind/SSE side effects (``_bind_session_and_emit``) so they run without
@@ -21,40 +26,61 @@
 
 from __future__ import annotations
 
+import base64
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pocketpaw_ee.agent.mcp_servers.media as media
+import pytest
 
 # pytest-asyncio runs in auto mode (see pyproject [tool.pytest] asyncio_mode),
 # so async tests are detected automatically — no module-level mark needed (a
 # module mark would wrongly tag the sync util tests below).
 
+_PROXY_BASE = "https://proxy.test:4000"
+_PROXY_KEY = "sk-proxy-abc"
+
+
+@pytest.fixture
+def proxy_env(monkeypatch):
+    """Point the catalog proxy config (which media reuses) at a fake proxy with a
+    key, so the Bearer header is exercised end-to-end through catalog.config."""
+    monkeypatch.setenv("POCKETPAW_LITELLM_API_BASE", _PROXY_BASE)
+    monkeypatch.setenv("POCKETPAW_LITELLM_API_KEY", _PROXY_KEY)
+
+
+def _install_transport(monkeypatch, handler) -> dict:
+    """Install an httpx.MockTransport on media._PROXY_TRANSPORT and capture every
+    request the handler sees. Returns a dict the test inspects (``requests``)."""
+    captured: dict = {"requests": []}
+
+    def _wrapped(request: httpx.Request) -> httpx.Response:
+        captured["requests"].append(request)
+        return handler(request)
+
+    monkeypatch.setattr(media, "_PROXY_TRANSPORT", httpx.MockTransport(_wrapped))
+    return captured
+
 
 def test_media_tool_ids_are_namespaced() -> None:
     """The tool ids use the ``mcp__<server>__<tool>`` form the Claude Code
-    allowlist machinery matches."""
+    allowlist machinery matches — now four tools (image / audio TTS / audio STT /
+    video)."""
     assert media.SERVER_NAME == "pocketpaw_media"
     assert media.IMAGE_GENERATE_TOOL_ID == "mcp__pocketpaw_media__image_generate"
+    assert media.AUDIO_GENERATE_TOOL_ID == "mcp__pocketpaw_media__audio_generate"
+    assert media.AUDIO_TRANSCRIBE_TOOL_ID == "mcp__pocketpaw_media__audio_transcribe"
     assert media.VIDEO_GENERATE_TOOL_ID == "mcp__pocketpaw_media__video_generate"
     assert media.MEDIA_TOOL_IDS == (
         media.IMAGE_GENERATE_TOOL_ID,
+        media.AUDIO_GENERATE_TOOL_ID,
+        media.AUDIO_TRANSCRIBE_TOOL_ID,
         media.VIDEO_GENERATE_TOOL_ID,
     )
 
 
 # --- image_generate ---
-
-
-async def test_image_generate_error_when_no_google_key() -> None:
-    """No google key → a clear error response, no asset, no gallery write."""
-    with (
-        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
-        patch("pocketpaw.config.get_settings", return_value=MagicMock(google_api_key=None)),
-    ):
-        result = await media._image_generate_handler({"prompt": "a red bicycle"})
-
-    assert result.get("is_error") is True
-    assert "POCKETPAW_GOOGLE_API_KEY" in result["content"][0]["text"]
 
 
 async def test_image_generate_error_when_no_identity() -> None:
@@ -66,41 +92,30 @@ async def test_image_generate_error_when_no_identity() -> None:
     assert "workspace and user context" in result["content"][0]["text"]
 
 
-async def test_image_generate_happy_path_lands_in_gallery(tmp_path, monkeypatch) -> None:
-    """A successful Gemini generation saves a PNG and lands it in a trusted-create
-    STUDIO gallery; the success body carries the gallery pocket_id."""
-    import sys
-
-    # Fresh per-session state so the gallery count is deterministic.
+async def test_image_generate_routes_to_proxy_with_model_and_bearer(
+    tmp_path, monkeypatch, proxy_env
+) -> None:
+    """A successful image generation POSTs the catalog model id to the proxy's
+    /v1/images/generations with the Bearer key + the tenant in `user`, decodes
+    b64_json, saves a PNG, and lands it in a trusted-create gallery."""
     monkeypatch.setattr(media, "_GALLERY_STATE", {})
+    b64 = base64.b64encode(b"png-bytes").decode()
 
-    # Mock the google genai module (`from google import genai`). The default
-    # image model is now gemini-2.5-flash-image, which routes through
-    # generate_content (free-tier path) — see generate_image_file().
-    mock_part = MagicMock()
-    mock_part.inline_data = MagicMock(mime_type="image/png", data=b"png-bytes")
-    mock_candidate = MagicMock()
-    mock_candidate.content.parts = [mock_part]
-    mock_response = MagicMock(candidates=[mock_candidate])
-    mock_client = MagicMock()
-    mock_client.models.generate_content.return_value = mock_response
-    mock_genai = MagicMock()
-    mock_genai.Client.return_value = mock_client
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/images/generations"
+        body = json.loads(request.content)
+        assert body["model"] == "openai/gpt-image-1"
+        assert body["prompt"] == "a red bicycle"
+        assert body["user"] == "ws-1"  # tenant tag (workspace id)
+        return httpx.Response(200, json={"data": [{"b64_json": b64}]})
 
-    # agent_create returns (view, pocket_id, err).
+    captured = _install_transport(monkeypatch, handler)
     fake_view = {"name": "Studio gallery", "type": "studio", "pattern": "gallery"}
     agent_create = AsyncMock(return_value=(fake_view, "pkt-gallery-1", None))
 
     with (
         patch.object(media, "_identity", return_value=("ws-1", "u-1")),
-        patch(
-            "pocketpaw.config.get_settings",
-            return_value=MagicMock(google_api_key="k", image_model="gemini-2.5-flash-image"),
-        ),
         patch.object(media, "_generated_dir", return_value=tmp_path),
-        patch.dict(
-            sys.modules, {"google": MagicMock(genai=mock_genai), "google.genai": mock_genai}
-        ),
         patch(
             "pocketpaw_ee.cloud.chat.agent_service.current_session_mongo_id",
             return_value="sess-1",
@@ -109,19 +124,19 @@ async def test_image_generate_happy_path_lands_in_gallery(tmp_path, monkeypatch)
         patch.object(media, "_bind_session_and_emit", AsyncMock()),
     ):
         result = await media._image_generate_handler(
-            {"prompt": "a red bicycle", "aspect_ratio": "16:9"}
+            {"prompt": "a red bicycle", "model": "openai/gpt-image-1", "size": "1024x1024"}
         )
 
-    # No is_error — a success body with the gallery pocket id.
     assert result.get("is_error") is not True
-    import json
-
     body = json.loads(result["content"][0]["text"])
     assert body["ok"] is True
     assert body["kind"] == "image"
+    assert body["model"] == "openai/gpt-image-1"
     assert body["pocket_id"] == "pkt-gallery-1"
     assert body["gallery_count"] == 1
-    # The PNG was written under the generated dir with the inline image bytes.
+    # The Bearer proxy key rode on the request.
+    assert captured["requests"][0].headers.get("authorization") == f"Bearer {_PROXY_KEY}"
+    # The PNG was written with the decoded image bytes.
     pngs = list(tmp_path.glob("*.png"))
     assert len(pngs) == 1
     assert pngs[0].read_bytes() == b"png-bytes"
@@ -133,29 +148,312 @@ async def test_image_generate_happy_path_lands_in_gallery(tmp_path, monkeypatch)
     assert kwargs["ripple_spec"] is not None
 
 
+async def test_image_generate_backward_compat_default_model(
+    tmp_path, monkeypatch, proxy_env
+) -> None:
+    """No `model` arg (the existing studio skill/preamble call shape) →
+    settings.image_model is used as the catalog model id."""
+    monkeypatch.setattr(media, "_GALLERY_STATE", {})
+    b64 = base64.b64encode(b"img").decode()
+    seen_model: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_model["model"] = json.loads(request.content)["model"]
+        return httpx.Response(200, json={"data": [{"b64_json": b64}]})
+
+    _install_transport(monkeypatch, handler)
+    agent_create = AsyncMock(return_value=({"x": 1}, "pkt-1", None))
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch.object(media, "_generated_dir", return_value=tmp_path),
+        patch(
+            "pocketpaw.config.get_settings",
+            return_value=MagicMock(image_model="google/imagen-4"),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_session_mongo_id",
+            return_value="sess-1",
+        ),
+        patch("pocketpaw_ee.cloud.pockets.service.agent_create", agent_create),
+        patch.object(media, "_bind_session_and_emit", AsyncMock()),
+    ):
+        result = await media._image_generate_handler({"prompt": "a cat"})
+
+    assert result.get("is_error") is not True
+    assert seen_model["model"] == "google/imagen-4"
+
+
+async def test_image_generate_relays_proxy_error(tmp_path, monkeypatch, proxy_env) -> None:
+    """A proxy 4xx (e.g. unknown model) is relayed plainly, no asset, no gallery
+    write."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": {"message": "model not found"}})
+
+    _install_transport(monkeypatch, handler)
+    agent_create = AsyncMock()
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch.object(media, "_generated_dir", return_value=tmp_path),
+        patch("pocketpaw_ee.cloud.pockets.service.agent_create", agent_create),
+    ):
+        result = await media._image_generate_handler(
+            {"prompt": "x", "model": "openai/does-not-exist"}
+        )
+
+    assert result.get("is_error") is True
+    text = result["content"][0]["text"]
+    assert "400" in text
+    assert "model not found" in text
+    agent_create.assert_not_called()
+
+
+# --- audio_generate (TTS) ---
+
+
+async def test_audio_generate_routes_to_speech_endpoint(tmp_path, monkeypatch, proxy_env) -> None:
+    """A successful TTS POSTs to /v1/audio/speech with the model + Bearer + tenant,
+    saves the raw audio bytes, and lands an audio tile in the gallery."""
+    monkeypatch.setattr(media, "_GALLERY_STATE", {})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/audio/speech"
+        body = json.loads(request.content)
+        assert body["model"] == "openai/tts-1-hd"
+        assert body["input"] == "hello world"
+        assert body["voice"] == "nova"
+        assert body["user"] == "ws-1"
+        return httpx.Response(200, content=b"mp3-bytes")
+
+    captured = _install_transport(monkeypatch, handler)
+    agent_create = AsyncMock(return_value=({"x": 1}, "pkt-audio-1", None))
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch.object(media, "_generated_dir", return_value=tmp_path),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_session_mongo_id",
+            return_value="sess-1",
+        ),
+        patch("pocketpaw_ee.cloud.pockets.service.agent_create", agent_create),
+        patch.object(media, "_bind_session_and_emit", AsyncMock()),
+    ):
+        result = await media._audio_generate_handler(
+            {"text": "hello world", "model": "openai/tts-1-hd", "voice": "nova"}
+        )
+
+    assert result.get("is_error") is not True
+    body = json.loads(result["content"][0]["text"])
+    assert body["ok"] is True
+    assert body["kind"] == "audio"
+    assert body["model"] == "openai/tts-1-hd"
+    assert body["pocket_id"] == "pkt-audio-1"
+    assert captured["requests"][0].headers.get("authorization") == f"Bearer {_PROXY_KEY}"
+    mp3s = list(tmp_path.glob("*.mp3"))
+    assert len(mp3s) == 1
+    assert mp3s[0].read_bytes() == b"mp3-bytes"
+    _, kwargs = agent_create.call_args
+    assert kwargs["trusted"] is True
+
+
+async def test_audio_generate_default_model(tmp_path, monkeypatch, proxy_env) -> None:
+    """No `model` → the built-in TTS default (tts-1)."""
+    monkeypatch.setattr(media, "_GALLERY_STATE", {})
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["model"] = json.loads(request.content)["model"]
+        return httpx.Response(200, content=b"a")
+
+    _install_transport(monkeypatch, handler)
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch.object(media, "_generated_dir", return_value=tmp_path),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_session_mongo_id",
+            return_value="sess-1",
+        ),
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.agent_create",
+            AsyncMock(return_value=({"x": 1}, "p", None)),
+        ),
+        patch.object(media, "_bind_session_and_emit", AsyncMock()),
+    ):
+        result = await media._audio_generate_handler({"text": "hi"})
+
+    assert result.get("is_error") is not True
+    assert seen["model"] == media._DEFAULT_AUDIO_TTS_MODEL
+
+
+async def test_audio_generate_error_when_no_identity() -> None:
+    with patch.object(media, "_identity", return_value=(None, None)):
+        result = await media._audio_generate_handler({"text": "hi"})
+    assert result.get("is_error") is True
+    assert "workspace and user context" in result["content"][0]["text"]
+
+
+# --- audio_transcribe (STT) ---
+
+
+async def test_audio_transcribe_routes_to_transcriptions_endpoint(
+    tmp_path, monkeypatch, proxy_env
+) -> None:
+    """A successful STT POSTs a multipart upload to /v1/audio/transcriptions with
+    the model + Bearer, returns the text, and does NOT touch the gallery."""
+    audio_file = tmp_path / "clip.mp3"
+    audio_file.write_bytes(b"fake-audio")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/audio/transcriptions"
+        # multipart upload — the boundary content-type is set by httpx, not the
+        # JSON content-type, and the model + file ride in the body.
+        ctype = request.headers.get("content-type", "")
+        assert ctype.startswith("multipart/form-data")
+        raw = request.content
+        assert b"whisper-1" in raw
+        assert b"fake-audio" in raw
+        return httpx.Response(200, json={"text": "transcribed words"})
+
+    captured = _install_transport(monkeypatch, handler)
+    agent_create = AsyncMock()
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        # If transcription wrongly tried to write the gallery, this would be hit.
+        patch("pocketpaw_ee.cloud.pockets.service.agent_create", agent_create),
+    ):
+        result = await media._audio_transcribe_handler({"path": str(audio_file)})
+
+    assert result.get("is_error") is not True
+    body = json.loads(result["content"][0]["text"])
+    assert body["ok"] is True
+    assert body["kind"] == "transcription"
+    assert body["text"] == "transcribed words"
+    assert body["model"] == "whisper-1"
+    assert captured["requests"][0].headers.get("authorization") == f"Bearer {_PROXY_KEY}"
+    # STT is an input op — it must NOT create a gallery pocket.
+    agent_create.assert_not_called()
+
+
+async def test_audio_transcribe_missing_file() -> None:
+    with patch.object(media, "_identity", return_value=("ws-1", "u-1")):
+        result = await media._audio_transcribe_handler({"path": "/no/such/file.mp3"})
+    assert result.get("is_error") is True
+    assert "not found" in result["content"][0]["text"]
+
+
 # --- video_generate ---
 
 
-async def test_video_generate_error_when_no_replicate_token() -> None:
-    """No Replicate token → a clear error response; httpx is never reached."""
+async def test_video_generate_terminal_job_lands_in_gallery(monkeypatch, proxy_env) -> None:
+    """A /videos POST that returns an already-terminal job lands the output URL in
+    the gallery with the catalog model id + Bearer + tenant."""
+    monkeypatch.setattr(media, "_GALLERY_STATE", {})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/videos"
+        body = json.loads(request.content)
+        assert body["model"] == "openai/sora-2"
+        assert body["prompt"] == "a drone shot of a city"
+        assert body["seconds"] == 8
+        assert body["user"] == "ws-1"
+        return httpx.Response(
+            200,
+            json={"id": "vid-1", "status": "completed", "url": "https://cdn/v.mp4"},
+        )
+
+    captured = _install_transport(monkeypatch, handler)
+    agent_create = AsyncMock(return_value=({"x": 1}, "pkt-video-1", None))
+
     with (
         patch.object(media, "_identity", return_value=("ws-1", "u-1")),
         patch(
-            "pocketpaw.config.get_settings",
-            return_value=MagicMock(replicate_api_token=None, video_model="kwaivgi/kling-v2.0"),
+            "pocketpaw_ee.cloud.chat.agent_service.current_session_mongo_id",
+            return_value="sess-1",
         ),
+        patch("pocketpaw_ee.cloud.pockets.service.agent_create", agent_create),
+        patch.object(media, "_bind_session_and_emit", AsyncMock()),
     ):
-        result = await media._video_generate_handler({"prompt": "a drone shot of a city"})
+        result = await media._video_generate_handler(
+            {"prompt": "a drone shot of a city", "model": "openai/sora-2", "duration": 8}
+        )
+
+    assert result.get("is_error") is not True
+    body = json.loads(result["content"][0]["text"])
+    assert body["ok"] is True
+    assert body["kind"] == "video"
+    assert body["model"] == "openai/sora-2"
+    assert body["url"] == "https://cdn/v.mp4"
+    assert body["pocket_id"] == "pkt-video-1"
+    assert captured["requests"][0].headers.get("authorization") == f"Bearer {_PROXY_KEY}"
+
+
+async def test_video_generate_polls_pending_job(monkeypatch, proxy_env) -> None:
+    """A pending /videos job is GET-polled at /videos/{id} until completed, then
+    the output URL is landed in the gallery. asyncio.sleep is patched out so the
+    poll loop runs instantly."""
+    monkeypatch.setattr(media, "_GALLERY_STATE", {})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/videos":
+            return httpx.Response(200, json={"id": "vid-9", "status": "queued"})
+        if request.method == "GET" and request.url.path == "/videos/vid-9":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "vid-9",
+                    "status": "completed",
+                    "data": [{"url": "https://cdn/poll.mp4"}],
+                },
+            )
+        return httpx.Response(404)
+
+    _install_transport(monkeypatch, handler)
+    agent_create = AsyncMock(return_value=({"x": 1}, "pkt-v9", None))
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch("pocketpaw_ee.agent.mcp_servers.media.asyncio.sleep", AsyncMock()),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_session_mongo_id",
+            return_value="sess-1",
+        ),
+        patch("pocketpaw_ee.cloud.pockets.service.agent_create", agent_create),
+        patch.object(media, "_bind_session_and_emit", AsyncMock()),
+    ):
+        result = await media._video_generate_handler({"prompt": "x", "model": "openai/sora-2"})
+
+    assert result.get("is_error") is not True
+    body = json.loads(result["content"][0]["text"])
+    assert body["url"] == "https://cdn/poll.mp4"
+
+
+async def test_video_generate_failed_job_relays_error(monkeypatch, proxy_env) -> None:
+    """A terminal job with status=failed relays the error; no gallery write."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id": "v", "status": "failed", "error": "content policy"})
+
+    _install_transport(monkeypatch, handler)
+    agent_create = AsyncMock()
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch("pocketpaw_ee.cloud.pockets.service.agent_create", agent_create),
+    ):
+        result = await media._video_generate_handler({"prompt": "x", "model": "openai/sora-2"})
 
     assert result.get("is_error") is True
-    assert "POCKETPAW_REPLICATE_API_TOKEN" in result["content"][0]["text"]
+    assert "content policy" in result["content"][0]["text"]
+    agent_create.assert_not_called()
 
 
 async def test_video_generate_error_when_no_identity() -> None:
-    """No workspace/user context → a clear error."""
     with patch.object(media, "_identity", return_value=(None, None)):
-        result = await media._video_generate_handler({"prompt": "a drone shot"})
-
+        result = await media._video_generate_handler({"prompt": "x"})
     assert result.get("is_error") is True
     assert "workspace and user context" in result["content"][0]["text"]
 
@@ -165,14 +463,14 @@ async def test_video_generate_error_when_no_identity() -> None:
 
 def test_gallery_spec_uses_only_existing_widget_types() -> None:
     """The assembled gallery spec uses ONLY container / grid / card / image /
-    video-player / text so it renders today, and carries version + a
-    non-dashboard intent so toRippleEnvelope passes it through untouched and
-    Ripple renders it in node mode (2026-06-10 — a bare {ui: [...]} got
-    intent=dashboard stamped on and rendered "No widgets yet")."""
+    video-player / text so it renders today (audio degrades to a text tile), and
+    carries version + a non-dashboard intent so toRippleEnvelope passes it through
+    untouched and Ripple renders it in node mode."""
     spec = media._build_gallery_spec(
         [
             {"kind": "image", "src": "/tmp/a.png", "prompt": "a"},
             {"kind": "video", "src": "https://x/v.mp4", "prompt": "b"},
+            {"kind": "audio", "src": "/tmp/c.mp3", "prompt": "c"},
         ]
     )
     assert spec["version"] == "2.0"
@@ -190,4 +488,4 @@ def test_gallery_spec_uses_only_existing_widget_types() -> None:
     _walk([root])
     # The grid holds one tile per media item.
     grid = next(n for n in root["children"] if n["type"] == "grid")
-    assert len(grid["children"]) == 2
+    assert len(grid["children"]) == 3

--- a/tests/cloud/test_media_mcp.py
+++ b/tests/cloud/test_media_mcp.py
@@ -23,6 +23,11 @@
 # All tests mock the per-stream ContextVar identity (``_identity``) and the
 # session-bind/SSE side effects (``_bind_session_and_emit``) so they run without
 # a live SSE chat stream.
+#
+# 2026-06-26 (MCG-8): added coverage for ``_resolve_auth_key`` — media now Bearers
+# the workspace's provisioned per-tenant LiteLLM virtual key (resolved best-effort
+# via llm_provisioning.get_tenant_key), falling back to the deployment master key
+# when none is provisioned or the lookup fails.
 
 from __future__ import annotations
 
@@ -599,3 +604,51 @@ def test_gallery_spec_uses_only_existing_widget_types() -> None:
     # The grid holds one tile per media item.
     grid = next(n for n in root["children"] if n["type"] == "grid")
     assert len(grid["children"]) == 3
+
+
+# --- MCG-8: per-tenant LiteLLM virtual-key resolution on proxy calls ---
+
+
+async def test_resolve_auth_key_prefers_provisioned_tenant_key(monkeypatch, proxy_env) -> None:
+    """When the workspace has a provisioned virtual key, media Bearers THAT key
+    (so the proxy enforces the tenant budget + attributes spend), not the master
+    key. ``get_tenant_key`` is patched to stand in for the provisioning lookup so
+    this test needs no Mongo."""
+    with patch(
+        "pocketpaw_ee.cloud.llm_provisioning.service.get_tenant_key",
+        new=AsyncMock(return_value="sk-tenant-w1"),
+    ):
+        key = await media._resolve_auth_key("ws-1")
+    assert key == "sk-tenant-w1"  # the tenant key, NOT _PROXY_KEY (the master key)
+
+
+async def test_resolve_auth_key_falls_back_to_master_when_unprovisioned(
+    monkeypatch, proxy_env
+) -> None:
+    """No provisioned key -> fall back to the deployment master key (pre-MCG-8
+    behaviour), so media keeps working before provisioning has run."""
+    with patch(
+        "pocketpaw_ee.cloud.llm_provisioning.service.get_tenant_key",
+        new=AsyncMock(return_value=None),
+    ):
+        key = await media._resolve_auth_key("ws-1")
+    assert key == _PROXY_KEY  # the master key from proxy_env
+
+
+async def test_resolve_auth_key_falls_back_to_master_on_lookup_error(
+    monkeypatch, proxy_env
+) -> None:
+    """A failing tenant-key lookup must NEVER break media — it falls back to the
+    master key rather than raising."""
+    with patch(
+        "pocketpaw_ee.cloud.llm_provisioning.service.get_tenant_key",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
+        key = await media._resolve_auth_key("ws-1")
+    assert key == _PROXY_KEY
+
+
+async def test_resolve_auth_key_no_workspace_uses_master(monkeypatch, proxy_env) -> None:
+    """No workspace id (e.g. identity missing) -> the master key, no lookup."""
+    key = await media._resolve_auth_key(None)
+    assert key == _PROXY_KEY

--- a/tests/cloud/test_media_mcp.py
+++ b/tests/cloud/test_media_mcp.py
@@ -210,6 +210,114 @@ async def test_image_generate_relays_proxy_error(tmp_path, monkeypatch, proxy_en
     agent_create.assert_not_called()
 
 
+async def test_image_generate_url_return_shape(tmp_path, monkeypatch, proxy_env) -> None:
+    """When the proxy returns a URL instead of b64_json (dall-e-style), the bytes
+    are fetched from the CDN — and the proxy Bearer key must NOT ride the CDN GET
+    (the key is for the proxy, not arbitrary asset hosts)."""
+    monkeypatch.setattr(media, "_GALLERY_STATE", {})
+    cdn_url = "https://cdn.example.test/img/abc.png"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/images/generations":
+            # The generations call carries the Bearer proxy key.
+            assert request.headers.get("authorization") == f"Bearer {_PROXY_KEY}"
+            return httpx.Response(200, json={"data": [{"url": cdn_url}]})
+        if str(request.url) == cdn_url:
+            # The CDN GET must NOT leak the proxy key.
+            assert request.headers.get("authorization") is None
+            return httpx.Response(200, content=b"cdn-png-bytes")
+        return httpx.Response(404)
+
+    _install_transport(monkeypatch, handler)
+    agent_create = AsyncMock(return_value=({"x": 1}, "pkt-url-1", None))
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch.object(media, "_generated_dir", return_value=tmp_path),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_session_mongo_id",
+            return_value="sess-1",
+        ),
+        patch("pocketpaw_ee.cloud.pockets.service.agent_create", agent_create),
+        patch.object(media, "_bind_session_and_emit", AsyncMock()),
+    ):
+        result = await media._image_generate_handler({"prompt": "a cat", "model": "dall-e-3"})
+
+    assert result.get("is_error") is not True
+    pngs = list(tmp_path.glob("*.png"))
+    assert len(pngs) == 1
+    assert pngs[0].read_bytes() == b"cdn-png-bytes"
+
+
+async def test_image_generate_aspect_ratio_maps_to_size(tmp_path, monkeypatch, proxy_env) -> None:
+    """The bundled skill passes `aspect_ratio` (not `size`); it must be mapped to
+    an OpenAI-compatible size rather than silently dropped. 16:9 → 1792x1024."""
+    monkeypatch.setattr(media, "_GALLERY_STATE", {})
+    b64 = base64.b64encode(b"png").decode()
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["size"] = json.loads(request.content).get("size")
+        return httpx.Response(200, json={"data": [{"b64_json": b64}]})
+
+    _install_transport(monkeypatch, handler)
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch.object(media, "_generated_dir", return_value=tmp_path),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_session_mongo_id",
+            return_value="sess-1",
+        ),
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.agent_create",
+            AsyncMock(return_value=({"x": 1}, "p", None)),
+        ),
+        patch.object(media, "_bind_session_and_emit", AsyncMock()),
+    ):
+        result = await media._image_generate_handler(
+            {"prompt": "x", "model": "gpt-image-1", "aspect_ratio": "16:9"}
+        )
+
+    assert result.get("is_error") is not True
+    assert seen["size"] == "1792x1024"
+
+
+async def test_image_generate_explicit_size_wins_over_aspect_ratio(
+    tmp_path, monkeypatch, proxy_env
+) -> None:
+    """When both `size` and `aspect_ratio` are given, the explicit `size` wins."""
+    monkeypatch.setattr(media, "_GALLERY_STATE", {})
+    b64 = base64.b64encode(b"png").decode()
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["size"] = json.loads(request.content).get("size")
+        return httpx.Response(200, json={"data": [{"b64_json": b64}]})
+
+    _install_transport(monkeypatch, handler)
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch.object(media, "_generated_dir", return_value=tmp_path),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_session_mongo_id",
+            return_value="sess-1",
+        ),
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.agent_create",
+            AsyncMock(return_value=({"x": 1}, "p", None)),
+        ),
+        patch.object(media, "_bind_session_and_emit", AsyncMock()),
+    ):
+        result = await media._image_generate_handler(
+            {"prompt": "x", "model": "gpt-image-1", "aspect_ratio": "16:9", "size": "512x512"}
+        )
+
+    assert result.get("is_error") is not True
+    assert seen["size"] == "512x512"
+
+
 # --- audio_generate (TTS) ---
 
 
@@ -315,6 +423,8 @@ async def test_audio_transcribe_routes_to_transcriptions_endpoint(
         raw = request.content
         assert b"whisper-1" in raw
         assert b"fake-audio" in raw
+        # The tenant rides the multipart body via the `user` field.
+        assert b"ws-1" in raw
         return httpx.Response(200, json={"text": "transcribed words"})
 
     captured = _install_transport(monkeypatch, handler)

--- a/tests/cloud/workspace/test_provisioning_trigger.py
+++ b/tests/cloud/workspace/test_provisioning_trigger.py
@@ -1,0 +1,117 @@
+# tests/cloud/workspace/test_provisioning_trigger.py — proves the WU-F workspace
+# provisioning trigger is BEST-EFFORT and NON-BLOCKING.
+#
+#   1. Happy path — creating a workspace fires ensure_tenant_key(workspace_id) so
+#      a per-tenant LiteLLM key is provisioned for the new workspace.
+#   2. Proxy-down — if ensure_tenant_key RAISES (proxy unreachable / mint failure),
+#      workspace creation STILL SUCCEEDS (the workspace + owner membership land);
+#      the provisioning error is swallowed + logged, never fatal.
+#
+# Uses the shared ``mongo_db`` + autouse ``recording_bus`` fixtures. The resolver
+# is mocked (the realtime resolver isn't initialised in unit tests).
+#
+# Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.workspace import service as workspace_service
+from pocketpaw_ee.cloud.workspace.dto import CreateWorkspaceRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(user_id: str) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=None,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_user(email: str = "owner@x.c") -> _UserDoc:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="Owner",
+        workspaces=[],
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture(autouse=True)
+def resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock = MagicMock()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.get_resolver", lambda: mock)
+    return mock
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def stub_proxy(monkeypatch):
+    """Stub the LiteLLM admin client so ensure_tenant_key never hits the network.
+
+    By default the mint succeeds with a deterministic key; a test that wants the
+    proxy-down path patches ensure_tenant_key to raise instead.
+    """
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    class _FakeAdmin:
+        async def generate_key(self, **kwargs):
+            return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **kwargs}
+
+    monkeypatch.setattr(svc, "LiteLLMAdminClient", lambda *a, **k: _FakeAdmin())
+    yield
+
+
+async def test_create_workspace_provisions_tenant_key() -> None:
+    owner = await _seed_user()
+
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="Acme", slug="acme")
+    )
+
+    # The provisioning trigger fired: a per-tenant key row exists for the new ws.
+    row = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == ws.id)
+    assert row is not None
+    assert row.litellm_key  # a key was minted
+    assert row.key_alias == f"ws-{ws.id}"
+
+
+async def test_create_workspace_survives_proxy_down(monkeypatch) -> None:
+    # Simulate the proxy being unreachable: ensure_tenant_key raises.
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    async def _boom(workspace, **kwargs):
+        raise RuntimeError("proxy unreachable (simulated)")
+
+    monkeypatch.setattr(svc, "ensure_tenant_key", _boom)
+
+    owner = await _seed_user()
+
+    # Creation MUST NOT raise even though provisioning blew up.
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="Acme", slug="acme")
+    )
+
+    # The workspace + owner membership landed (creation fully succeeded)...
+    assert ws.id
+    assert ws.name == "Acme"
+    reloaded = await _UserDoc.find_one(_UserDoc.email == "owner@x.c")
+    assert reloaded is not None
+    assert any(m.workspace == ws.id and m.role == "owner" for m in reloaded.workspaces)
+
+    # ...but no key row was provisioned (the failure was swallowed, not retried here).
+    row = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == ws.id)
+    assert row is None

--- a/tests/llm/__init__.py
+++ b/tests/llm/__init__.py
@@ -1,0 +1,4 @@
+# tests/llm/__init__.py
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-11): package marker for
+# the pocketpaw.llm test suite (matches the import-mode convention used by the
+# sibling tests/cloud, tests/ee packages).

--- a/tests/llm/test_caching.py
+++ b/tests/llm/test_caching.py
@@ -1,0 +1,315 @@
+# tests/llm/test_caching.py
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-11): unit tests for the
+# universal prompt-caching helper ``pocketpaw.llm.caching``.
+#
+# Covers ``build_cacheable`` (stable-prefix-first ordering, cache_control on the
+# prefix ONLY, the 4-breakpoint cap, 5m vs 1h TTL markup, and the byte-stability
+# contract that a changed variable suffix never disturbs the cached prefix) and
+# ``report_savings`` across the three provider usage shapes (Anthropic
+# cache_creation/cache_read, OpenAI cached_tokens incl. the nested
+# prompt_tokens_details form, DeepSeek prompt_cache_hit_tokens), for both dict
+# and attribute-style usage objects.
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.llm.caching import (
+    CACHE_MIN_TOKENS,
+    MAX_CACHE_BREAKPOINTS,
+    CacheSavings,
+    build_cacheable,
+    report_savings,
+)
+
+# ---------------------------------------------------------------------------
+# build_cacheable
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCacheable:
+    def test_stable_prefix_comes_first_variable_last(self):
+        """Block ordering is prefix-then-variable so the cached LCP is the
+        whole stable prefix."""
+        out = build_cacheable(["SCHEMA", "CATALOG", "RULES"], ["customer brief"])
+        texts = [b["text"] for b in out]
+        assert texts == ["SCHEMA", "CATALOG", "RULES", "customer brief"]
+
+    def test_cache_control_on_prefix_only_not_variable(self):
+        """The single default breakpoint lands on the LAST prefix block; the
+        variable suffix never carries cache_control."""
+        out = build_cacheable(["SCHEMA", "CATALOG", "RULES"], ["brief"])
+        # Last prefix block (index 2) is marked.
+        assert out[2]["cache_control"] == {"type": "ephemeral"}
+        # Earlier prefix blocks are NOT marked (single breakpoint).
+        assert "cache_control" not in out[0]
+        assert "cache_control" not in out[1]
+        # Variable suffix (index 3) is NOT marked.
+        assert "cache_control" not in out[3]
+
+    def test_no_variable_parts_marks_last_prefix_block(self):
+        """``variable_parts`` is optional — a prefix-only call still marks the
+        tail of the prefix."""
+        out = build_cacheable(["A", "B"])
+        assert len(out) == 2
+        assert "cache_control" not in out[0]
+        assert out[1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_5m_ttl_is_bare_ephemeral(self):
+        out = build_cacheable(["stable"], ["var"], ttl="5m")
+        assert out[0]["cache_control"] == {"type": "ephemeral"}
+        assert "ttl" not in out[0]["cache_control"]
+
+    def test_1h_ttl_carries_ttl_field(self):
+        """1h TTL emits the extended-cache-ttl markup LiteLLM forwards to
+        Anthropic."""
+        out = build_cacheable(["stable"], ["var"], ttl="1h")
+        assert out[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_invalid_ttl_raises(self):
+        with pytest.raises(ValueError, match="ttl must be one of"):
+            build_cacheable(["x"], ttl="2h")
+
+    def test_empty_prefix_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            build_cacheable([], ["var"])
+
+    def test_breakpoint_cap_respected(self):
+        """Requesting more than 4 breakpoints clamps to MAX_CACHE_BREAKPOINTS —
+        the Anthropic hard limit."""
+        prefix = [f"part{i}" for i in range(10)]
+        out = build_cacheable(prefix, ["var"], breakpoints=8)
+        n_marked = sum(1 for b in out if "cache_control" in b)
+        assert n_marked == MAX_CACHE_BREAKPOINTS == 4
+
+    def test_multiple_breakpoints_include_last_block(self):
+        """With N breakpoints the LAST prefix block is always one of them
+        (terminates the longest cacheable prefix)."""
+        prefix = [f"part{i}" for i in range(8)]
+        out = build_cacheable(prefix, ["var"], breakpoints=3)
+        prefix_blocks = out[:-1]  # drop the variable suffix
+        n_marked = sum(1 for b in prefix_blocks if "cache_control" in b)
+        assert n_marked == 3
+        assert "cache_control" in prefix_blocks[-1]  # last prefix block marked
+
+    def test_breakpoints_clamped_to_prefix_block_count(self):
+        """Can't place more breakpoints than there are prefix blocks."""
+        out = build_cacheable(["only-one"], ["var"], breakpoints=4)
+        n_marked = sum(1 for b in out if "cache_control" in b)
+        assert n_marked == 1
+
+    def test_breakpoints_never_land_on_variable_block(self):
+        """Even at the 4-breakpoint cap, markers stay on prefix blocks; the
+        variable suffix is always clean."""
+        prefix = [f"p{i}" for i in range(6)]
+        variables = ["v0", "v1"]
+        out = build_cacheable(prefix, variables, breakpoints=4)
+        var_blocks = out[len(prefix) :]
+        assert all("cache_control" not in b for b in var_blocks)
+
+    def test_dict_prefix_part_passthrough_with_marker(self):
+        """A pre-shaped content-block dict is preserved (its non-cache keys)
+        and the marker is added by us."""
+        block = {"type": "text", "text": "RULES", "extra": "kept"}
+        out = build_cacheable([block], ["var"])
+        assert out[0]["text"] == "RULES"
+        assert out[0]["extra"] == "kept"
+        assert out[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_caller_block_not_mutated(self):
+        """build_cacheable must not mutate the caller's input dicts (shared
+        module-level prompt constants would otherwise accrete cache_control)."""
+        block = {"type": "text", "text": "RULES"}
+        build_cacheable([block], ["var"])
+        assert "cache_control" not in block  # original untouched
+
+    def test_preexisting_cache_control_on_input_is_normalised(self):
+        """A caller block that already carries cache_control doesn't get
+        double-counted — placement is decided centrally."""
+        # This block is NOT the last prefix block, so after normalisation it
+        # should end up WITHOUT a marker (only the last block gets one at
+        # breakpoints=1).
+        tagged = {"type": "text", "text": "early", "cache_control": {"type": "ephemeral"}}
+        out = build_cacheable([tagged, "late"], ["var"])
+        assert "cache_control" not in out[0]
+        assert out[1]["cache_control"] == {"type": "ephemeral"}
+
+    # --- byte-stability contract ---
+
+    def test_byte_stability_same_prefix_different_suffix(self):
+        """THE core cache property: identical prefix + DIFFERENT variable
+        suffix → byte-identical prefix blocks. Any drift here busts the cache
+        for every downstream call."""
+        prefix = ["SCHEMA", "CATALOG", "RULES"]
+        out_a = build_cacheable(prefix, ["customer A brief"], ttl="1h")
+        out_b = build_cacheable(prefix, ["a totally different customer B brief"], ttl="1h")
+        # The prefix slice (everything but the trailing variable block) is equal.
+        assert out_a[: len(prefix)] == out_b[: len(prefix)]
+        # ... while the variable suffix legitimately differs.
+        assert out_a[-1] != out_b[-1]
+
+    def test_byte_stability_repeated_identical_calls(self):
+        """Same inputs → equal (and independent) structures every time."""
+        prefix = ["A", "B", "C"]
+        out_1 = build_cacheable(prefix, ["v"])
+        out_2 = build_cacheable(prefix, ["v"])
+        assert out_1 == out_2
+        # Independent objects — mutating one must not touch the other.
+        out_1[0]["text"] = "MUTATED"
+        assert out_2[0]["text"] == "A"
+
+    def test_marker_objects_are_independent(self):
+        """Each marked block gets its own cache_control dict (no shared
+        reference that a downstream mutation could corrupt across blocks)."""
+        out = build_cacheable(["a", "b", "c", "d"], ["v"], breakpoints=4)
+        markers = [b["cache_control"] for b in out if "cache_control" in b]
+        ids = {id(m) for m in markers}
+        assert len(ids) == len(markers)  # all distinct objects
+
+
+# ---------------------------------------------------------------------------
+# report_savings
+# ---------------------------------------------------------------------------
+
+
+class _AttrUsage:
+    """Attribute-style usage stand-in (mimics the Anthropic/OpenAI SDK usage
+    objects, which expose fields as attributes, not dict keys)."""
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class TestReportSavingsAnthropic:
+    def test_anthropic_dict_shape(self):
+        usage = {
+            "input_tokens": 100,  # uncached remainder
+            "cache_read_input_tokens": 2000,
+            "cache_creation_input_tokens": 500,
+        }
+        s = report_savings(usage)
+        assert s.provider == "anthropic"
+        assert s.cache_read_tokens == 2000
+        assert s.cache_write_tokens == 500
+        assert s.prompt_tokens == 2600  # 100 + 2000 + 500
+        assert s.hit_rate == pytest.approx(2000 / 2600, abs=1e-4)
+        assert s.est_tokens_saved == pytest.approx(2000 * 0.90)
+
+    def test_anthropic_attr_shape(self):
+        usage = _AttrUsage(
+            input_tokens=0,
+            cache_read_input_tokens=3000,
+            cache_creation_input_tokens=0,
+        )
+        s = report_savings(usage)
+        assert s.provider == "anthropic"
+        assert s.cache_read_tokens == 3000
+        assert s.prompt_tokens == 3000
+        assert s.hit_rate == 1.0
+
+    def test_anthropic_cost_saved_helper(self):
+        usage = {"input_tokens": 0, "cache_read_input_tokens": 1000}
+        s = report_savings(usage)
+        # 1000 cached reads * 0.90 discount = 900 input-token-equivalents.
+        # At $3/Mtok input → $0.0027 saved.
+        assert s.est_cost_saved(3e-6) == pytest.approx(900 * 3e-6)
+
+
+class TestReportSavingsOpenAI:
+    def test_openai_top_level_cached_tokens(self):
+        usage = {"prompt_tokens": 5000, "cached_tokens": 4096}
+        s = report_savings(usage)
+        assert s.provider == "openai"
+        assert s.cache_read_tokens == 4096
+        assert s.cache_write_tokens == 0
+        assert s.prompt_tokens == 5000
+        assert s.hit_rate == pytest.approx(4096 / 5000, abs=1e-4)
+
+    def test_openai_nested_prompt_tokens_details(self):
+        """OpenAI's real shape nests cached_tokens under
+        prompt_tokens_details."""
+        usage = {
+            "prompt_tokens": 5000,
+            "prompt_tokens_details": {"cached_tokens": 2048},
+        }
+        s = report_savings(usage)
+        assert s.provider == "openai"
+        assert s.cache_read_tokens == 2048
+        assert s.prompt_tokens == 5000
+
+    def test_openai_attr_shape_nested(self):
+        usage = _AttrUsage(
+            prompt_tokens=4000,
+            prompt_tokens_details=_AttrUsage(cached_tokens=1024),
+        )
+        s = report_savings(usage)
+        assert s.provider == "openai"
+        assert s.cache_read_tokens == 1024
+
+
+class TestReportSavingsDeepSeek:
+    def test_deepseek_dict_shape_matches_live_probe(self):
+        """The shape the live proxy probe confirmed: hit 2944 / miss 112,
+        total 3056."""
+        usage = {"prompt_cache_hit_tokens": 2944, "prompt_cache_miss_tokens": 112}
+        s = report_savings(usage)
+        assert s.provider == "deepseek"
+        assert s.cache_read_tokens == 2944
+        assert s.cache_write_tokens == 0
+        assert s.prompt_tokens == 3056  # hit + miss
+        assert s.hit_rate == pytest.approx(2944 / 3056, abs=1e-4)
+        assert s.est_tokens_saved == pytest.approx(2944 * 0.90)
+
+    def test_deepseek_attr_shape(self):
+        usage = _AttrUsage(prompt_cache_hit_tokens=1000, prompt_cache_miss_tokens=0)
+        s = report_savings(usage)
+        assert s.provider == "deepseek"
+        assert s.hit_rate == 1.0
+
+
+class TestReportSavingsEdgeCases:
+    def test_none_usage_is_all_zero(self):
+        s = report_savings(None)
+        assert s == CacheSavings(0, 0, 0, 0.0, 0.0, "none")
+
+    def test_empty_dict_is_none_provider(self):
+        s = report_savings({})
+        assert s.provider == "none"
+        assert s.cache_read_tokens == 0
+        assert s.hit_rate == 0.0
+
+    def test_unrecognised_keys_are_none_provider(self):
+        s = report_savings({"total_tokens": 99, "completion_tokens": 10})
+        assert s.provider == "none"
+
+    def test_garbage_values_coerce_to_zero(self):
+        usage = {"input_tokens": "oops", "cache_read_input_tokens": None}
+        s = report_savings(usage)
+        assert s.cache_read_tokens == 0
+        assert s.prompt_tokens == 0
+
+    def test_zero_prompt_tokens_no_div_by_zero(self):
+        usage = {"prompt_cache_hit_tokens": 0, "prompt_cache_miss_tokens": 0}
+        s = report_savings(usage)
+        assert s.hit_rate == 0.0
+
+    def test_deepseek_precedence_over_others(self):
+        """If a payload somehow carried both DeepSeek and OpenAI keys, the
+        DeepSeek shape (most specific) wins deterministically."""
+        usage = {
+            "prompt_cache_hit_tokens": 500,
+            "prompt_cache_miss_tokens": 500,
+            "cached_tokens": 999,
+            "prompt_tokens": 9999,
+        }
+        s = report_savings(usage)
+        assert s.provider == "deepseek"
+        assert s.cache_read_tokens == 500
+
+
+class TestConstants:
+    def test_min_token_floors_present(self):
+        assert CACHE_MIN_TOKENS["default"] == 1024
+        assert CACHE_MIN_TOKENS["anthropic-haiku"] == 4096
+        assert CACHE_MIN_TOKENS["anthropic-opus"] == 4096

--- a/tests/llm/test_sitegen_cacheable.py
+++ b/tests/llm/test_sitegen_cacheable.py
@@ -1,0 +1,95 @@
+# tests/llm/test_sitegen_cacheable.py
+# Created 2026-06-26 (integration/model-catalog-v2, MCG-11): proves the site/
+# pocket-generation system prompt is now structured as a BYTE-STABLE cached
+# prefix ⊕ a varying suffix via ``ripple.build_specialist_cacheable`` (the
+# concrete site-gen application of the universal ``build_cacheable`` helper).
+#
+# The win this guards: the generator's huge near-identical prefix (widget
+# catalog + canonical shapes + workflow + design rules) is cached, so the Nth
+# site pays ~10% on it. These tests assert (a) the cache_control breakpoint sits
+# on the STABLE prefix only, (b) the per-brief variable suffix is a separate,
+# UNMARKED trailing block, and (c) two different briefs yield a byte-identical
+# prefix block — the property the provider cache keys on.
+
+from __future__ import annotations
+
+from pocketpaw.ripple import POCKET_SPECIALIST_PROMPT, build_specialist_cacheable
+
+
+class TestSiteGenCacheablePrefix:
+    def test_prefix_is_the_byte_stable_specialist_prompt(self):
+        """The cached prefix block carries the full POCKET_SPECIALIST_PROMPT —
+        the stable widget-catalog + design-rules text the generator reuses."""
+        blocks = build_specialist_cacheable("brief: a dentist landing page")
+        assert blocks[0]["text"] == POCKET_SPECIALIST_PROMPT
+        assert blocks[0]["type"] == "text"
+
+    def test_cache_control_on_prefix_only(self):
+        """The stable prefix block is marked; the variable suffix is not."""
+        blocks = build_specialist_cacheable("brief: a bakery site")
+        assert blocks[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+        # The trailing variable suffix block is never marked.
+        assert "cache_control" not in blocks[-1]
+
+    def test_default_ttl_is_one_hour(self):
+        """Site-gen defaults to a 1h TTL — the generator reuses this prefix
+        across back-to-back briefs, so the 2x write cost amortises."""
+        blocks = build_specialist_cacheable("brief")
+        assert blocks[0]["cache_control"]["ttl"] == "1h"
+
+    def test_variable_suffix_is_separate_trailing_block(self):
+        """The per-brief content is appended as its own block AFTER the prefix
+        — not concatenated into the cached text."""
+        blocks = build_specialist_cacheable("brief: a SaaS pricing page")
+        assert len(blocks) == 2
+        assert blocks[1]["text"] == "brief: a SaaS pricing page"
+
+    def test_empty_suffix_yields_prefix_only(self):
+        """No variable suffix → just the marked prefix block (still cacheable)."""
+        blocks = build_specialist_cacheable(None)
+        assert len(blocks) == 1
+        assert blocks[0]["text"] == POCKET_SPECIALIST_PROMPT
+        assert blocks[0]["cache_control"]["type"] == "ephemeral"
+
+    def test_list_suffix_parts_each_become_a_block(self):
+        """Callers can pass multiple variable parts (hints + current-pocket
+        block); each lands as its own unmarked trailing block."""
+        blocks = build_specialist_cacheable(
+            ["CALLER METADATA: name=Acme", "<current-pocket>id: p_123</current-pocket>"]
+        )
+        assert len(blocks) == 3
+        assert blocks[1]["text"].startswith("CALLER METADATA")
+        assert blocks[2]["text"].startswith("<current-pocket>")
+        assert all("cache_control" not in b for b in blocks[1:])
+
+    # --- the load-bearing property: byte-stable prefix across briefs ---
+
+    def test_two_different_briefs_share_byte_identical_prefix(self):
+        """THE margin property: customer A and customer B get DIFFERENT
+        suffixes but a BYTE-IDENTICAL cached prefix block — so the provider
+        cache hits on the 2nd (and Nth) site."""
+        a = build_specialist_cacheable("brief: a dentist in Austin, blue theme")
+        b = build_specialist_cacheable("brief: a law firm in NYC, dark theme, 4 services")
+        # The cached prefix block (text + marker) is identical.
+        assert a[0] == b[0]
+        # ... while the variable suffix legitimately differs.
+        assert a[-1] != b[-1]
+
+    def test_prefix_stable_regardless_of_suffix_count(self):
+        """Whether the caller passes one suffix part or several, the prefix
+        block is unchanged."""
+        one = build_specialist_cacheable("just a brief")
+        many = build_specialist_cacheable(["a", "b", "c"])
+        assert one[0] == many[0]
+
+    def test_prefix_blocks_are_independent_objects(self):
+        """Two builds don't share the prefix dict — a downstream mutation of
+        one call's structure can't corrupt another's (or the module-level
+        POCKET_SPECIALIST_PROMPT constant)."""
+        a = build_specialist_cacheable("x")
+        b = build_specialist_cacheable("y")
+        a[0]["text"] = "MUTATED"
+        assert b[0]["text"] == POCKET_SPECIALIST_PROMPT
+        # The module constant itself is a str, never mutated.
+        assert isinstance(POCKET_SPECIALIST_PROMPT, str)
+        assert "MUTATED" not in POCKET_SPECIALIST_PROMPT

--- a/tests/test_agent_failover.py
+++ b/tests/test_agent_failover.py
@@ -1,0 +1,477 @@
+# tests/test_agent_failover.py — L2 cross-backend harness failover (MCG-10).
+#
+# Created: 2026-06-26 (integration/model-catalog-v2, WU-D / MCG-10).
+#
+# Covers the harness-failover MECHANISM in ``pocketpaw.agents.failover`` and its
+# OSS hook ``AgentRouter.run_with_failover``:
+#   * lane-down BEFORE streaming → next harness tried, run completes, switch
+#     audit-logged;
+#   * error AFTER streaming → NO failover (error surfaced, no replay);
+#   * a normal (non-lane-down) error → NO failover (surfaced);
+#   * chain exhausted → last error surfaced;
+#   * disabled-by-default → delegates to ``run`` (no harness switch);
+#   * lane-down classification table (overload / unavailable / auth vs a normal
+#     task error);
+#   * both signal shapes — a RAISED exception and an error AgentEvent.
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.agents.failover import (
+    BackendFailoverRunner,
+    classify_lane_failure,
+)
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.agents.router import AgentRouter
+from pocketpaw.config import Settings
+
+# ── Fake backends ────────────────────────────────────────────────────────
+
+
+class _RaisesLaneDown:
+    """Harness whose lane is down — raises an overload error before streaming."""
+
+    def __init__(self, settings=None):
+        pass
+
+    async def run(self, message, **kwargs):
+        raise RuntimeError("anthropic.APIStatusError: 529 {'type': 'overloaded_error'}")
+        yield  # pragma: no cover — makes this an async generator.
+
+
+class _ErrorEventLaneDown:
+    """Harness that EMITS a lane-down error event (the common path) pre-stream."""
+
+    def __init__(self, settings=None):
+        pass
+
+    async def run(self, message, **kwargs):
+        yield AgentEvent(type="error", content="503 Service Unavailable (upstream)")
+        yield AgentEvent(type="done", content="")
+
+
+class _NormalTaskError:
+    """Harness that fails with a NORMAL task error (not lane-down)."""
+
+    def __init__(self, settings=None):
+        pass
+
+    async def run(self, message, **kwargs):
+        yield AgentEvent(type="error", content="the tool returned an invalid result")
+        yield AgentEvent(type="done", content="")
+
+
+class _StreamsThenLaneDown:
+    """Harness that streams a token, THEN hits a lane-down error.
+
+    The no-replay guard must prevent failover here even though the error text
+    is lane-down — output already went to the user.
+    """
+
+    def __init__(self, settings=None):
+        pass
+
+    async def run(self, message, **kwargs):
+        yield AgentEvent(type="message", content="partial answer...")
+        raise RuntimeError("429 rate limit exceeded")
+        yield  # pragma: no cover
+
+
+class _StreamsThenErrorEvent:
+    """Streams a token, then emits a lane-down ERROR EVENT (no raise)."""
+
+    def __init__(self, settings=None):
+        pass
+
+    async def run(self, message, **kwargs):
+        yield AgentEvent(type="message", content="partial answer...")
+        yield AgentEvent(type="error", content="529 overloaded_error")
+        yield AgentEvent(type="done", content="")
+
+
+class _Succeeds:
+    """Healthy harness — streams a message and completes."""
+
+    def __init__(self, settings=None):
+        pass
+
+    async def run(self, message, **kwargs):
+        yield AgentEvent(type="message", content="recovered on fallback harness")
+        yield AgentEvent(type="done", content="")
+
+
+class _RecordsKwargs:
+    """Healthy harness that records the kwargs it was called with."""
+
+    seen: dict = {}
+
+    def __init__(self, settings=None):
+        pass
+
+    async def run(self, message, **kwargs):
+        _RecordsKwargs.seen = {"message": message, **kwargs}
+        yield AgentEvent(type="message", content="ok")
+        yield AgentEvent(type="done", content="")
+
+
+def _factory(mapping):
+    """Build a get_backend(name) factory from a {name: instance} mapping."""
+
+    def _get(name):
+        return mapping.get(name)
+
+    return _get
+
+
+async def _collect(runner, message="hi", **kw):
+    return [e async for e in runner.run(message, **kw)]
+
+
+# ── classify_lane_failure ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Overload / capacity
+        ("anthropic.APIStatusError: 529 overloaded_error", True),
+        ("Overloaded", True),
+        ("429 Too Many Requests", True),
+        ("rate limit exceeded", True),
+        ("you have exceeded your quota", True),
+        ("usage limit reached for this account", True),
+        # Service unavailable / outage
+        ("503 Service Unavailable", True),
+        ("502 Bad Gateway", True),
+        ("upstream connect error", True),
+        ("the service is temporarily unavailable", True),
+        # Auth / credential
+        ("401 Unauthorized", True),
+        ("invalid api key", True),
+        ("403 Forbidden: permission denied", True),
+        # NOT lane-down — normal task errors
+        ("the model produced an invalid JSON response", False),
+        ("tool 'search' raised ValueError", False),
+        ("I cannot help with that request", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_classify_lane_failure(text, expected):
+    assert classify_lane_failure(text) is expected
+
+
+# ── failover happy path: raised lane-down → next harness ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_failover_on_raised_lane_down(monkeypatch):
+    """Primary raises a lane-down error pre-stream → next harness completes."""
+    audited = []
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: audited.append(kw),
+    )
+
+    mapping = {"primary": _RaisesLaneDown(), "secondary": _Succeeds()}
+    runner = BackendFailoverRunner(["primary", "secondary"], _factory(mapping))
+
+    events = await _collect(runner)
+
+    # The run completed on the SECOND harness.
+    assert any(e.type == "message" and e.content == "recovered on fallback harness" for e in events)
+    assert events[-1].type == "done"
+    # No error event leaked from the failed primary.
+    assert not any(e.type == "error" for e in events)
+    # The switch was audit-logged with the right from/to + error class.
+    assert audited and audited[0]["from_backend"] == "primary"
+    assert audited[0]["to_backend"] == "secondary"
+    assert audited[0]["via"] == "exception"
+
+
+@pytest.mark.asyncio
+async def test_failover_on_error_event_lane_down(monkeypatch):
+    """Primary EMITS a lane-down error event pre-stream → next harness completes."""
+    audited = []
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: audited.append(kw),
+    )
+
+    mapping = {"primary": _ErrorEventLaneDown(), "secondary": _Succeeds()}
+    runner = BackendFailoverRunner(["primary", "secondary"], _factory(mapping))
+
+    events = await _collect(runner)
+
+    assert any(e.content == "recovered on fallback harness" for e in events)
+    # The primary's error event must NOT have been forwarded.
+    assert not any(e.type == "error" and "Service Unavailable" in str(e.content) for e in events)
+    # ``_audit_switch`` is called with via="error_event" for the error-event path.
+    assert audited and audited[0]["via"] == "error_event"
+    assert audited[0]["from_backend"] == "primary"
+
+
+# ── no-replay guard: streamed already → NO failover ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_failover_after_streaming_raise(monkeypatch):
+    """A lane-down RAISE after a token was streamed → surface error, NO replay."""
+    switched = []
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: switched.append(kw),
+    )
+
+    mapping = {"primary": _StreamsThenLaneDown(), "secondary": _Succeeds()}
+    runner = BackendFailoverRunner(["primary", "secondary"], _factory(mapping))
+
+    events = await _collect(runner)
+
+    # The partial token was delivered.
+    assert any(e.type == "message" and e.content == "partial answer..." for e in events)
+    # The error was surfaced (NOT swallowed) ...
+    assert any(e.type == "error" for e in events)
+    # ... and the secondary harness was NEVER tried.
+    assert not any(e.content == "recovered on fallback harness" for e in events)
+    assert switched == []
+
+
+@pytest.mark.asyncio
+async def test_no_failover_after_streaming_error_event(monkeypatch):
+    """A lane-down ERROR EVENT after a streamed token → surface it, NO replay."""
+    switched = []
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: switched.append(kw),
+    )
+
+    mapping = {"primary": _StreamsThenErrorEvent(), "secondary": _Succeeds()}
+    runner = BackendFailoverRunner(["primary", "secondary"], _factory(mapping))
+
+    events = await _collect(runner)
+
+    assert any(e.type == "message" and e.content == "partial answer..." for e in events)
+    # The error event IS forwarded once output has streamed.
+    assert any(e.type == "error" and "overloaded" in str(e.content) for e in events)
+    assert not any(e.content == "recovered on fallback harness" for e in events)
+    assert switched == []
+
+
+# ── normal task error → NO failover ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_failover_on_normal_task_error(monkeypatch):
+    """A non-lane-down error (normal task failure) → surfaced, no harness switch."""
+    switched = []
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: switched.append(kw),
+    )
+
+    mapping = {"primary": _NormalTaskError(), "secondary": _Succeeds()}
+    runner = BackendFailoverRunner(["primary", "secondary"], _factory(mapping))
+
+    events = await _collect(runner)
+
+    # The task error was surfaced from the primary ...
+    assert any(e.type == "error" and "invalid result" in str(e.content) for e in events)
+    # ... and we did NOT fall through to the healthy secondary.
+    assert not any(e.content == "recovered on fallback harness" for e in events)
+    assert switched == []
+
+
+# ── chain exhausted → last error surfaced ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_chain_exhausted_surfaces_last_error(monkeypatch):
+    """Every harness is lane-down → last error surfaced after the chain ends."""
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: None,
+    )
+
+    mapping = {
+        "a": _RaisesLaneDown(),
+        "b": _ErrorEventLaneDown(),
+    }
+    runner = BackendFailoverRunner(["a", "b"], _factory(mapping))
+
+    events = await _collect(runner)
+
+    # Exactly one error event at the end, carrying the LAST harness's error.
+    errors = [e for e in events if e.type == "error"]
+    assert len(errors) == 1
+    assert "503" in str(errors[0].content) or "Unavailable" in str(errors[0].content)
+    assert events[-1].type == "done"
+
+
+@pytest.mark.asyncio
+async def test_each_harness_tried_at_most_once(monkeypatch):
+    """The chain is consulted once per harness — no infinite loop."""
+    calls = {"n": 0}
+
+    class _CountingLaneDown:
+        def __init__(self, settings=None):
+            pass
+
+        async def run(self, message, **kwargs):
+            calls["n"] += 1
+            raise RuntimeError("529 overloaded")
+            yield  # pragma: no cover
+
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: None,
+    )
+
+    inst = _CountingLaneDown()
+    mapping = {"a": inst, "b": inst, "c": inst}
+    runner = BackendFailoverRunner(["a", "b", "c"], _factory(mapping))
+
+    await _collect(runner)
+    # Three distinct chain slots, each tried exactly once.
+    assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_unavailable_harness_is_skipped(monkeypatch):
+    """A None (unavailable) harness in the chain is skipped, not fatal."""
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: None,
+    )
+    # 'missing' resolves to None; the run should still complete on 'good'.
+    mapping = {"missing": None, "good": _Succeeds()}
+    runner = BackendFailoverRunner(["missing", "good"], _factory(mapping))
+
+    events = await _collect(runner)
+    assert any(e.content == "recovered on fallback harness" for e in events)
+
+
+# ── kwargs are forwarded verbatim ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_kwargs_forwarded():
+    """system_prompt / history / session_key reach the backend unchanged."""
+    mapping = {"only": _RecordsKwargs()}
+    runner = BackendFailoverRunner(["only"], _factory(mapping))
+
+    await _collect(
+        runner,
+        message="hello",
+        system_prompt="be terse",
+        history=[{"role": "user", "content": "x"}],
+        session_key="sess-1",
+    )
+
+    seen = _RecordsKwargs.seen
+    assert seen["message"] == "hello"
+    assert seen["system_prompt"] == "be terse"
+    assert seen["session_key"] == "sess-1"
+    assert seen["history"] == [{"role": "user", "content": "x"}]
+
+
+# ── audit log actually fires through the real logger ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_switch_writes_audit_event(monkeypatch):
+    """The switch goes through the real audit logger (action=backend_failover)."""
+    logged = []
+
+    class _FakeAuditLogger:
+        def log(self, event):
+            logged.append(event)
+
+    monkeypatch.setattr(
+        "pocketpaw.security.audit.get_audit_logger",
+        lambda: _FakeAuditLogger(),
+    )
+
+    mapping = {"primary": _RaisesLaneDown(), "secondary": _Succeeds()}
+    runner = BackendFailoverRunner(["primary", "secondary"], _factory(mapping))
+    await _collect(runner)
+
+    switch_events = [e for e in logged if e.action == "backend_failover" and e.status == "switch"]
+    assert switch_events, "expected a backend_failover switch audit event"
+    ctx = switch_events[0].context
+    assert ctx["from_backend"] == "primary"
+    assert ctx["to_backend"] == "secondary"
+    assert ctx["level"] == "L2_harness"
+
+
+# ── AgentRouter.run_with_failover hook ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_router_failover_disabled_by_default(monkeypatch):
+    """Flag OFF (default) → run_with_failover delegates to run, NO harness switch.
+
+    Primary raises a lane-down error; because failover is disabled and no
+    ``fallback_backends`` are set, the router surfaces the error from ``run``
+    rather than switching to the chain's healthy harnesses.
+    """
+    from pocketpaw.agents import registry
+
+    monkeypatch.setitem(
+        registry._BACKEND_REGISTRY,
+        "raises_lane_down",
+        ("tests.test_agent_failover", "_RaisesLaneDown"),
+    )
+    monkeypatch.setitem(
+        registry._BACKEND_REGISTRY,
+        "healthy",
+        ("tests.test_agent_failover", "_Succeeds"),
+    )
+
+    settings = Settings(
+        agent_backend="raises_lane_down",
+        # Chain names a healthy harness, but the flag is OFF so it's ignored.
+        backend_failover_chain=["raises_lane_down", "healthy"],
+        backend_failover_enabled=False,
+    )
+    router = AgentRouter(settings)
+
+    events = [e async for e in router.run_with_failover("hi")]
+
+    # No switch happened: the healthy harness was never reached.
+    assert not any(e.content == "recovered on fallback harness" for e in events)
+    assert any(e.type == "error" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_router_failover_enabled_switches_harness(monkeypatch):
+    """Flag ON → run_with_failover switches from a lane-down primary to the chain."""
+    from pocketpaw.agents import registry
+
+    monkeypatch.setitem(
+        registry._BACKEND_REGISTRY,
+        "raises_lane_down",
+        ("tests.test_agent_failover", "_RaisesLaneDown"),
+    )
+    monkeypatch.setitem(
+        registry._BACKEND_REGISTRY,
+        "healthy",
+        ("tests.test_agent_failover", "_Succeeds"),
+    )
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: None,
+    )
+
+    settings = Settings(
+        agent_backend="raises_lane_down",
+        backend_failover_chain=["raises_lane_down", "healthy"],
+        backend_failover_enabled=True,
+    )
+    router = AgentRouter(settings)
+
+    events = [e async for e in router.run_with_failover("hi")]
+
+    assert any(e.content == "recovered on fallback harness" for e in events)
+    assert events[-1].type == "done"

--- a/tests/test_deep_agents_anthropic_cache.py
+++ b/tests/test_deep_agents_anthropic_cache.py
@@ -5,6 +5,15 @@
 # this, the pocket specialist's ~12k-token design-rules prompt is
 # re-tokenized on every spec generation; the patch unlocks Anthropic's
 # prompt cache so warm calls reuse the prefix at ~10% of the cost.
+#
+# Updated 2026-06-26 (integration/model-catalog-v2, MCG-11): added
+# ``TestSpecialistLivePathTTL`` — exercises the patch on the ACTUAL
+# ``POCKET_SPECIALIST_PROMPT`` (the string the live site/pocket-gen run passes
+# as system_prompt) and asserts the stable prefix is byte-stable across two
+# different briefs AND carries the **1h** cache_control marker. Also covers
+# ``_cache_ttl_for_system`` (1h for the ``<pocket-scope>`` prefix, 5m otherwise)
+# and ``_accumulate_cache_usage`` (the LangChain→native usage fold the
+# token_usage telemetry consumes).
 """Tests for the Anthropic prompt-cache monkey-patch in deep_agents.
 
 The patch wraps ``langchain_anthropic.chat_models._format_messages`` to
@@ -165,3 +174,140 @@ class TestAnthropicCachePatch:
         # Exactly one user message in the conversation.
         assert len(formatted) == 1
         assert formatted[0]["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# MCG-11 — the LIVE path. The pocket/site generator passes a STRING system
+# prompt (POCKET_SPECIALIST_PROMPT + appended hints) to backend.run; the patch
+# below is what actually places the cache marker on production traffic. These
+# tests assert the margin lands at 1h on the real prefix, across briefs.
+# ---------------------------------------------------------------------------
+
+
+class TestSpecialistTTLSelector:
+    """``_cache_ttl_for_system`` — the byte-stable content gate."""
+
+    def test_specialist_prefix_gets_1h(self):
+        from pocketpaw.ripple import POCKET_SPECIALIST_PROMPT
+
+        assert deep_agents._cache_ttl_for_system(POCKET_SPECIALIST_PROMPT) == "1h"
+
+    def test_pocket_scope_sentinel_triggers_1h(self):
+        assert deep_agents._cache_ttl_for_system("...<pocket-scope>...") == "1h"
+
+    def test_generic_prompt_stays_5m(self):
+        """A long non-specialist prompt (chat / home / one-shot) keeps the 5m
+        default so its first-call write cost isn't doubled."""
+        assert deep_agents._cache_ttl_for_system("You are a helpful assistant. " * 50) == "5m"
+
+
+class TestSpecialistLivePathTTL:
+    """Exercise the real patch on the real specialist prompt — the string the
+    live run actually hands to backend.run."""
+
+    def _make_specialist_system(self, brief: str) -> str:
+        """Mirror the live assembly: stable POCKET_SPECIALIST_PROMPT prefix +
+        a per-brief variable suffix appended AFTER it (as
+        runtime._build_system_prompt does)."""
+        from pocketpaw.ripple import POCKET_SPECIALIST_PROMPT
+
+        return POCKET_SPECIALIST_PROMPT + "\n\nCALLER METADATA:\n  brief: " + brief
+
+    def test_specialist_prefix_marked_at_1h(self, fresh_patch):
+        """The live specialist system string is wrapped into one block carrying
+        the 1h cache_control marker (not 5m)."""
+        deep_agents._patch_anthropic_message_serializer()
+        from langchain_anthropic.chat_models import _format_messages
+
+        sys_str = self._make_specialist_system("a dentist landing page")
+        system, _ = _format_messages([SystemMessage(content=sys_str), HumanMessage(content="go")])
+        assert isinstance(system, list)
+        assert len(system) == 1
+        assert system[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_prefix_byte_stable_across_two_briefs(self, fresh_patch):
+        """THE live margin property: two DIFFERENT briefs produce system blocks
+        whose cached PREFIX (POCKET_SPECIALIST_PROMPT) is byte-identical, so the
+        provider cache hits on the 2nd brief. The marker is the same 1h block."""
+        from pocketpaw.ripple import POCKET_SPECIALIST_PROMPT
+
+        deep_agents._patch_anthropic_message_serializer()
+        from langchain_anthropic.chat_models import _format_messages
+
+        a_str = self._make_specialist_system("a dentist in Austin, blue theme")
+        b_str = self._make_specialist_system("a law firm in NYC, dark theme, 4 services")
+        sys_a, _ = _format_messages([SystemMessage(content=a_str), HumanMessage(content="go")])
+        sys_b, _ = _format_messages([SystemMessage(content=b_str), HumanMessage(content="go")])
+
+        # Both wrap to a single block; the marker is identical (1h).
+        assert (
+            sys_a[0]["cache_control"]
+            == sys_b[0]["cache_control"]
+            == {
+                "type": "ephemeral",
+                "ttl": "1h",
+            }
+        )
+        # The cached prefix — the stable specialist prompt — is a byte-identical
+        # leading slice of both system texts (only the trailing brief differs).
+        text_a = sys_a[0]["text"]
+        text_b = sys_b[0]["text"]
+        assert text_a.startswith(POCKET_SPECIALIST_PROMPT)
+        assert text_b.startswith(POCKET_SPECIALIST_PROMPT)
+        assert text_a[: len(POCKET_SPECIALIST_PROMPT)] == text_b[: len(POCKET_SPECIALIST_PROMPT)]
+        # ... and the variable tails legitimately differ.
+        assert text_a != text_b
+
+
+class TestAccumulateCacheUsage:
+    """``_accumulate_cache_usage`` — the LangChain usage_metadata → Anthropic-
+    native fold the deep_agents token_usage telemetry consumes."""
+
+    class _Chunk:
+        def __init__(self, usage_metadata):
+            self.usage_metadata = usage_metadata
+
+    def _fresh_acc(self):
+        return {
+            "input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+        }
+
+    def test_folds_cache_read_and_creation(self):
+        """LangChain's input_tokens is the TOTAL (cached+uncached); the fold
+        derives the uncached remainder and stores native keys."""
+        acc = self._fresh_acc()
+        chunk = self._Chunk(
+            {
+                "input_tokens": 5000,  # total incl. cache
+                "input_token_details": {"cache_read": 4000, "cache_creation": 500},
+            }
+        )
+        deep_agents._accumulate_cache_usage(chunk, acc)
+        assert acc["cache_read_input_tokens"] == 4000
+        assert acc["cache_creation_input_tokens"] == 500
+        assert acc["input_tokens"] == 500  # 5000 - 4000 - 500 uncached remainder
+
+        # And report_savings reads the accumulated native dict correctly:
+        from pocketpaw.llm.caching import report_savings
+
+        s = report_savings(acc)
+        assert s.provider == "anthropic"
+        assert s.cache_read_tokens == 4000
+        assert s.prompt_tokens == 5000  # uncached(500) + read(4000) + write(500)
+
+    def test_sums_across_multiple_turns(self):
+        """A tool loop yields several AI turns; usage SUMS."""
+        acc = self._fresh_acc()
+        for _ in range(3):
+            chunk = self._Chunk({"input_tokens": 1000, "input_token_details": {"cache_read": 900}})
+            deep_agents._accumulate_cache_usage(chunk, acc)
+        assert acc["cache_read_input_tokens"] == 2700
+        assert acc["input_tokens"] == 300  # 3 * (1000 - 900)
+
+    def test_no_usage_metadata_is_noop(self):
+        acc = self._fresh_acc()
+        deep_agents._accumulate_cache_usage(self._Chunk(None), acc)
+        deep_agents._accumulate_cache_usage(object(), acc)  # no attr at all
+        assert acc == self._fresh_acc()

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,4 +1,12 @@
-"""Tests for the centralized LLMClient abstraction."""
+"""Tests for the centralized LLMClient abstraction.
+
+MCG-2: added TestToSdkEnv.test_to_sdk_env_litellm and
+TestResolveLLMClient.test_resolve_litellm_routes_sdk_env_to_proxy — assert that
+selecting the ``litellm`` provider produces a subprocess env whose
+``ANTHROPIC_BASE_URL`` points at the configured ``litellm_api_base`` and whose
+``ANTHROPIC_API_KEY`` carries ``litellm_api_key``. This is the seam that routes
+the spawned ``claude`` CLI's model calls through the LiteLLM proxy.
+"""
 
 import dataclasses
 from unittest.mock import patch
@@ -94,6 +102,28 @@ class TestResolveLLMClient:
         assert llm.openai_compatible_base_url == "https://openrouter.ai/api/v1"
         assert llm.api_key == "sk-or-v1-test"
         assert llm.model == "meta-llama/llama-4-maverick"
+
+    def test_resolve_litellm_routes_sdk_env_to_proxy(self):
+        """MCG-2 GATE seam: selecting the litellm provider routes the Claude SDK
+        subprocess env at the configured proxy base + carries the proxy key.
+
+        End-to-end path: Settings → resolve_llm_client(force_provider="litellm")
+        → to_sdk_env(). This is what points the spawned ``claude`` CLI's model
+        calls at the LiteLLM proxy instead of api.anthropic.com.
+        """
+        settings = Settings(
+            litellm_api_base="https://litellm.example.com",
+            litellm_api_key="sk-proxy-123",
+            litellm_model="claude-3-haiku",
+        )
+        llm = resolve_llm_client(settings, force_provider="litellm")
+        assert llm.is_litellm
+        assert llm.api_key == "sk-proxy-123"
+
+        env = llm.to_sdk_env()
+        # Trailing slash is stripped by LiteLLMAdapter.resolve_config.
+        assert env["ANTHROPIC_BASE_URL"] == "https://litellm.example.com"
+        assert env["ANTHROPIC_API_KEY"] == "sk-proxy-123"
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +274,26 @@ class TestToSdkEnv:
         env = llm.to_sdk_env()
         assert env["ANTHROPIC_API_KEY"] == "my-key"
         assert "ANTHROPIC_AUTH_TOKEN" not in env
+
+    def test_to_sdk_env_litellm(self):
+        """MCG-2 GATE seam: the litellm provider points the Claude SDK subprocess
+        at the proxy base and forwards the proxy key as ANTHROPIC_API_KEY.
+
+        The litellm base URL travels via ``openai_compatible_base_url`` on the
+        LLMClient (how resolve_llm_client stores adapter base_urls) and must
+        emerge as ANTHROPIC_BASE_URL so the spawned ``claude`` CLI calls the
+        proxy. Both the base URL AND the key must be present.
+        """
+        llm = LLMClient(
+            provider="litellm",
+            model="claude-3-haiku",
+            api_key="sk-proxy-key",
+            ollama_host="http://localhost:11434",
+            openai_compatible_base_url="https://litellm.example.com",
+        )
+        env = llm.to_sdk_env()
+        assert env["ANTHROPIC_BASE_URL"] == "https://litellm.example.com"
+        assert env["ANTHROPIC_API_KEY"] == "sk-proxy-key"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pool_route_model.py
+++ b/tests/test_pool_route_model.py
@@ -1,0 +1,199 @@
+# tests/test_pool_route_model.py
+# Created: 2026-06-26 (feat/mcg-3-pool-route-model) — regression coverage for the
+# AgentPool model-routing seam (MCG-3). The old ``AgentPool._build`` mapped a
+# per-agent model onto a Settings field with a brittle ``"claude"/"openai"/
+# "google" in backend`` substring chain that SILENTLY DROPPED the per-agent
+# model for codex_cli / opencode / deep_agents / copilot_sdk / langchain_react
+# (and wrote OpenAI Agents' model to the wrong field). These tests pin:
+#   1. ``route_model`` writes the model to the correct Settings field for EVERY
+#      registered backend (including the langchain_react -> deep_agents_model
+#      alias), preserves the composite provider:model / provider/model formats
+#      verbatim, and no-ops on an empty model.
+#   2. A thin ``_build`` integration check drives the real build path with a fake
+#      backend class and asserts the per-agent model reaches the right Settings
+#      field for the previously-dropped backends — i.e. it is NOT dropped.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from pocketpaw.agents.registry import list_backends
+from pocketpaw.config import Settings
+from pocketpaw.llm.providers.base import (
+    _BACKEND_MODEL_ATTR,
+    _BACKEND_MODEL_ATTR_ALIASES,
+    route_model,
+)
+
+# ---------------------------------------------------------------------------
+# 1. route_model — the single source of truth for backend -> Settings field
+# ---------------------------------------------------------------------------
+
+# (backend name, model string, the Settings attr it must land in)
+_ROUTING_CASES = [
+    ("claude_agent_sdk", "claude-opus-4-8", "claude_sdk_model"),
+    ("openai_agents", "gpt-5.2", "openai_agents_model"),
+    ("google_adk", "gemini-3-pro-preview", "google_adk_model"),
+    ("codex_cli", "gpt-5.3-codex", "codex_cli_model"),
+    ("copilot_sdk", "gpt-5.2", "copilot_sdk_model"),
+    ("opencode", "anthropic/claude-sonnet-4-6", "opencode_model"),
+    ("deep_agents", "anthropic:claude-sonnet-4-6", "deep_agents_model"),
+    # langchain_react has no field of its own — it reads deep_agents_model.
+    ("langchain_react", "ollama:llama3.2", "deep_agents_model"),
+]
+
+
+@pytest.mark.parametrize(("backend", "model", "attr"), _ROUTING_CASES)
+def test_route_model_writes_correct_field(backend: str, model: str, attr: str) -> None:
+    settings = Settings.load()
+    wrote = route_model(settings, backend, model)
+    assert wrote is True
+    # The model landed in the right field, byte-for-byte (composite formats kept).
+    assert getattr(settings, attr) == model
+
+
+def test_route_model_covers_every_registered_backend() -> None:
+    """Every backend in the registry must route — otherwise its per-agent model
+    is silently dropped (the exact bug MCG-3 fixes)."""
+    for backend in list_backends():
+        settings = Settings.load()
+        assert route_model(settings, backend, "some-model:value") is True, (
+            f"backend {backend!r} does not route a per-agent model -> it would be dropped"
+        )
+
+
+def test_route_model_previously_dropped_backends_not_silently_dropped() -> None:
+    """Focused guard on the five backends the substring chain dropped."""
+    dropped = {
+        "codex_cli": "codex_cli_model",
+        "opencode": "opencode_model",
+        "deep_agents": "deep_agents_model",
+        "copilot_sdk": "copilot_sdk_model",
+        "langchain_react": "deep_agents_model",
+    }
+    for backend, attr in dropped.items():
+        settings = Settings.load()
+        # Field starts unset (or default) — prove the model actually arrives.
+        route_model(settings, backend, "mymodel:tag")
+        assert getattr(settings, attr) == "mymodel:tag", f"{backend!r} dropped its per-agent model"
+
+
+def test_route_model_preserves_provider_model_for_deep_agents() -> None:
+    """deep_agents / langchain_react take a single ``provider:model`` string in
+    deep_agents_model — route_model must NOT split it into provider/model."""
+    settings = Settings.load()
+    route_model(settings, "deep_agents", "anthropic:claude-sonnet-4-6")
+    assert settings.deep_agents_model == "anthropic:claude-sonnet-4-6"
+
+    settings2 = Settings.load()
+    route_model(settings2, "langchain_react", "ollama:llama3.2")
+    # langchain_react inherits the deep_agents slot, single composite string.
+    assert settings2.deep_agents_model == "ollama:llama3.2"
+
+
+def test_route_model_empty_model_is_noop() -> None:
+    """Empty model leaves the default untouched (fall-through to resolve_model)."""
+    settings = Settings.load()
+    default = settings.deep_agents_model  # "anthropic:claude-sonnet-4-6"
+    assert route_model(settings, "deep_agents", "") is False
+    assert settings.deep_agents_model == default
+
+    # codex_cli keeps its own default too.
+    codex_default = settings.codex_cli_model
+    assert route_model(settings, "codex_cli", "") is False
+    assert settings.codex_cli_model == codex_default
+
+
+def test_route_model_unknown_backend_is_noop() -> None:
+    settings = Settings.load()
+    assert route_model(settings, "no_such_backend", "x") is False
+
+
+def test_alias_map_targets_a_real_settings_field() -> None:
+    """The langchain_react alias must point at a field that exists on Settings."""
+    settings = Settings.load()
+    for backend, attr in _BACKEND_MODEL_ATTR_ALIASES.items():
+        assert hasattr(settings, attr), (
+            f"alias for {backend!r} -> {attr!r} is not a real Settings field"
+        )
+
+
+def test_backend_model_attr_fields_exist_on_settings() -> None:
+    """Sanity: every primary backend->field mapping names a real Settings field."""
+    settings = Settings.load()
+    for backend, attr in _BACKEND_MODEL_ATTR.items():
+        assert hasattr(settings, attr), f"{backend!r} -> {attr!r} is not a real Settings field"
+
+
+# ---------------------------------------------------------------------------
+# 2. _build integration — the real pool path routes the model end-to-end
+# ---------------------------------------------------------------------------
+
+
+class _CapturingBackend:
+    """Stand-in backend that records the Settings it was built with."""
+
+    last_settings = None  # class attr — read after _build
+
+    def __init__(self, settings, **_kwargs) -> None:
+        type(self).last_settings = settings
+
+    async def stop(self) -> None:  # pragma: no cover — teardown path
+        pass
+
+
+def _fake_agent_doc(backend: str, model: str):
+    """A minimal Agent-doc stand-in for ``_build`` (soul disabled to skip I/O)."""
+    cfg = {
+        "backend": backend,
+        "model": model,
+        "soul_enabled": False,
+        "tools": [],
+    }
+    return SimpleNamespace(
+        id="64b7f0000000000000000001",
+        name=f"agent-{backend}",
+        slug=f"agent-{backend}",
+        workspace="ws-test",
+        updatedAt=datetime.now(UTC),
+        config=SimpleNamespace(model_dump=lambda: dict(cfg)),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("backend", "model", "attr"),
+    [
+        ("codex_cli", "gpt-5.3-codex", "codex_cli_model"),
+        ("opencode", "anthropic/claude-sonnet-4-6", "opencode_model"),
+        ("deep_agents", "anthropic:claude-sonnet-4-6", "deep_agents_model"),
+        ("langchain_react", "ollama:llama3.2", "deep_agents_model"),
+    ],
+)
+async def test_build_routes_model_to_backend_settings(
+    monkeypatch, backend: str, model: str, attr: str
+) -> None:
+    """The real ``_build`` must land the per-agent model on the right Settings
+    field for backends the old substring chain dropped."""
+    from pocketpaw.agents import pool as pool_mod
+    from pocketpaw.agents import registry as registry_mod
+
+    _CapturingBackend.last_settings = None
+    # ``_build`` imports ``get_backend_class`` locally from the registry module,
+    # so patch it at its source. Stubs backend resolution so the test doesn't
+    # import optional SDKs or hit a network.
+    monkeypatch.setattr(registry_mod, "get_backend_class", lambda _name: _CapturingBackend)
+
+    p = pool_mod.AgentPool()
+    instance = await p._build(_fake_agent_doc(backend, model))
+
+    settings = _CapturingBackend.last_settings
+    assert settings is not None, "_build never instantiated the backend"
+    assert settings.agent_backend == backend
+    # The proof: the per-agent model reached the field the backend reads.
+    assert getattr(settings, attr) == model
+    # And it's the same Settings the instance carries downstream.
+    assert instance.config["model"] == model


### PR DESCRIPTION
The full pocketpaw side of the model-catalog + LiteLLM-gateway work, assembled on one integration branch so it can be smoke-tested as a whole before merge. **Supersedes #1552, #1553, #1557** (folded in here).

## What's in it

**Catalog + gateway foundation**
- **MCG-1** — catalog API over the LiteLLM proxy (`/api/v1/catalog/models`), verified against the live proxy (105 models, env aligned to `POCKETPAW_LITELLM_API_BASE/_API_KEY`, `*` wildcard filtered).
- **MCG-3** — route a per-agent model to *every* backend's settings field (fixes the silent drop for codex/opencode/deep_agents/copilot; also fixed a latent `openai_model` vs `openai_agents_model` bug).
- **MCG-2** — Claude Code → LiteLLM routing verified + tested; gateway probe confirmed the proxy preserves prompt-cache and relays tools/streaming/spend.

**Deferred wave**
- **MCG-6+7** — image / audio (TTS+STT) / video generation routed through the proxy with catalog-selected models (live-proven: real imagen PNGs through the proxy, incl. aspect-ratio → size).
- **MCG-8** — per-tenant LiteLLM virtual-key + budget provisioning, and a spend→credits ingestion path that reuses the existing credit ledger. **Opt-in / dormant**: provisioning + ingestion are built and tested, but activation (a workspace-creation trigger + a periodic sweep) is a follow-up, and ingestion is **off by default** to avoid double-billing the text-chat the BC-3 metering already bills.
- **MCG-10** — L2 cross-backend harness failover (Claude Code → Codex → opencode) for when a whole lane is down. **Opt-in, default-off**; the EE `run_core` wiring is the activation follow-up.
- **MCG-11** — a universal prompt-caching module, applied to the ~17k-token pocket-specialist prefix at a content-gated **1h TTL** (the site-gen margin), with savings telemetry on the live `deep_agents` backend.

## Verification

- **Integration smoke: 204 tests pass** across catalog / media / provisioning / credits / metering / failover / route-model / caching.
- EE→OSS import contract kept (`OSS core may not import from EE`).
- Every slice was distrust-reviewed; review caught and fixed: a half-null-pricing crash, an `aspect_ratio` regression, a billing double-count (gated off), and an unwired caching path (now wired to the live backend).

## Captain action items (proxy config, not code)

- **Fix the proxy's Anthropic upstream key** (currently 401) — unblocks Claude-through-proxy + the Anthropic cache number, and gates the destructive IGW collapse.
- OpenAI key quota (429); add Replicate/FAL keys for video/image gen.

## Deliberately deferred (follow-ups)

- Activate provisioning (workspace trigger) + a spend-sweep job; fix the same-second high-water-mark boundary before enabling ingestion.
- Wire failover into the EE `run_core` path; treat an uninstalled middle harness as lane-down so the chain doesn't dead-end.
- The **destructive** IGW collapse (removing the superseded router/budget/metering) — gated on a green Anthropic smoke. See the inference-gateway `MIGRATION.md` + the RFC 11 amendment.

The paw-enterprise picker is a separate stack (#486 → #487).
