### PR TITLE
Cloud paw-OS backend: per-tenant store isolation, GA gate, and the Dodo billing fix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,11 @@
 # Updated: 2026-05-25 — Triggers added for feat/*-integration branches so
 # sub-PRs in a multi-PR RFC rollout get full CI coverage during integration.
 # Stale `ee` branch reference dropped (the ee branch was deprecated 2026-05-21).
+# Updated: 2026-06-26 — Added the `pytest-flag-mode` job (FU-4): the OSS pytest
+# lane above runs WITHOUT POCKETPAW_REQUIRE_WORKSPACE_SCOPE, so cloud fail-closed
+# (per-workspace physical isolation) regressions pass green. The new job re-runs
+# the isolation subset WITH the flag set so the whole bug class the C1 fix closed
+# stays caught. Both jobs are required.
 name: Tests
 
 on:
@@ -60,5 +65,56 @@ jobs:
             --deselect tests/test_context_budget.py::TestKbContext::test_successful_kb_fetch \
             -q --tb=short
         env:
+          POCKETPAW_LLM_PROVIDER: "ollama"
+          POCKETPAW_OLLAMA_HOST: "http://localhost:11434"
+
+  pytest-flag-mode:
+    # FU-4 — the cloud paw-OS deployment runs EVERY store path with
+    # POCKETPAW_REQUIRE_WORKSPACE_SCOPE=1 (fail-closed per-workspace physical
+    # isolation). The `pytest` job above runs WITHOUT the flag, so a store call
+    # that regresses to the legacy shared file (or that raises under the flag
+    # after an action is already approved) still passes there. This job re-runs
+    # the ISOLATION subset WITH the flag exported so flag-mode regressions are
+    # caught. Required, and green today (the C1 fix passes under the flag).
+    #
+    # Explicit subset — NOT the whole suite — because many non-isolation tests
+    # legitimately run unscoped (single-tenant OSS back-compat) and would
+    # fail-closed under the flag. Two known flag-broken paths are deliberately
+    # EXCLUDED until their fixes land (see
+    # docs/design/drafts/2026-06-26-cloud-iso-flag-mode-followups.md):
+    #   FU-2 — the abandon-sweeper scans all tenants from one store
+    #          (tests/cloud/test_action_sweeper.py is multi-tenant under the flag)
+    #   FU-3 — paw_print's colon-qualified owner is not a path-safe workspace id
+    #          (tests/cloud/test_paw_print_decision_loop.py)
+    # Add each to the list below once it's fixed; then this lane covers the whole
+    # cloud surface and the class stops slipping past CI.
+    name: pytest (flag mode)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set Python version
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --dev --all-extras --group ee
+
+      - name: Run isolation subset under POCKETPAW_REQUIRE_WORKSPACE_SCOPE=1
+        run: |
+          uv run pytest \
+            tests/cloud/test_executor_workspace_iso.py \
+            tests/cloud/test_instinct_empty_workspace_failclosed.py \
+            tests/cloud/test_ga_two_tenant_pentest.py \
+            tests/test_instinct_workspace_isolation.py \
+            tests/test_fabric_workspace_isolation.py \
+            tests/test_store_isolation_lint.py \
+            --ignore=tests/e2e \
+            -q --tb=short
+        env:
+          POCKETPAW_REQUIRE_WORKSPACE_SCOPE: "1"
           POCKETPAW_LLM_PROVIDER: "ollama"
           POCKETPAW_OLLAMA_HOST: "http://localhost:11434"

--- a/docs/runbooks/cloud-ga-two-tenant-smoke.md
+++ b/docs/runbooks/cloud-ga-two-tenant-smoke.md
@@ -1,0 +1,190 @@
+<!-- Runbook: GA acceptance — two-tenant isolation + live provision smoke for the
+     Cloud Paw-OS multi-tenant offering. Created 2026-06-26 (GA-1).
+     The AUTOMATED proof is tests/cloud/test_ga_two_tenant_pentest.py (9 tests,
+     no creds, signed-webhook sim). THIS runbook is the captain's LIVE acceptance
+     pass on the real Coolify box with real Dodo checkouts. Grounded against the
+     shipped ISO-1..4 stack + the billing/credits/entitlements services. -->
+
+# Cloud Paw-OS — Two-Tenant GA Smoke (live acceptance)
+
+The final gate before the multi-tenant offering is sold: prove that **two paying
+tenants on one shared backend are isolated end to end**, and that the
+**signup → pay → provision → isolated** path works with a **real Dodo checkout**.
+
+The automated half is already green and needs no credentials. This runbook is the
+**live half** — the captain's manual acceptance on the deployed box.
+
+---
+
+## 0. What's already proven (automated, no creds)
+
+Run the GA pen-test from the repo. It boots the cloud services in-process
+(mongomock + the per-workspace SQLite stores), drives two tenants, and signs the
+provision webhook with the real `standardwebhooks` library — so the verification
+path is exercised exactly as production, with no live Dodo call.
+
+```bash
+uv run --group ee pytest tests/cloud/test_ga_two_tenant_pentest.py -v
+# 9 passed — the GA gate:
+#   Fabric / Instinct / Pockets / KB  → zero cross-leak between tenant A and B
+#   fail-closed on every store path    → no-workspace under required-scope RAISES
+#   entitlement                        → plan resolves to its feature set; isolated
+#   credit 402                         → balance<=0 hard-blocks; isolated
+#   provision (sim)                    → signed subscription.active stamps the plan
+#                                        + grants monthly credits; tampered sig rejected
+```
+
+If that is not green, STOP — do not proceed to the live run.
+
+The full isolation stack it exercises (ISO-1..4) must be merged first — see step 1.
+
+---
+
+## 1. Merge the isolation stack + redeploy `pocketpaw@dev`
+
+The pen-test depends on the ISO-1..4 stack. Merge the stacked PRs in order
+(base-first; the stack uses `--rebase` merges per the stacked-PR rule), then
+redeploy.
+
+PR stack (pocketpaw, all targeting `dev`):
+
+| Order | PR | What | Merge |
+|-------|----|------|-------|
+| 1 | #1550 | ISO-1 — workspace-keyed store factory + Fabric isolation | `--rebase` (has stacked dependents) |
+| 2 | #1551 | ISO-2 — Instinct isolation + per-workspace audit chains (+ test-double fix) | `--rebase` |
+| 3 | #1554 | ISO-3 — ContextVar bridge + EE store provider | `--rebase` |
+| 4 | #1555 | ISO-4 — migration + isolation lint guard + audit-lock fix | `--squash` (top of stack) |
+| 5 | (this) | GA-1 — two-tenant pen-test + this runbook | `--squash` |
+
+After merge, redeploy `pocketpaw@dev` to the Coolify box (the per-tenant
+dedicated server / micro tier, per the deployment topology). The deploy must:
+
+- **Enable fail-closed scoping**: set `POCKETPAW_REQUIRE_WORKSPACE_SCOPE=1` as a
+  Coolify **runtime** var so a store call that ever loses its workspace context
+  raises instead of reading a shared file. (The cloud bootstrap should also set
+  this; the env var is the belt-and-suspenders.)
+- **Run the one-time store migration** if this box already has shared-store data
+  from before isolation (a box that only ever ran the isolated build can skip it):
+
+  ```python
+  # one-time, idempotent, reversible-safe (renames the shared files to .migrated)
+  from pocketpaw.migrations.split_workspace_stores import migrate_shared_stores_to_workspaces
+  import asyncio
+  print(asyncio.run(migrate_shared_stores_to_workspaces()))
+  ```
+
+  It verifies the shared Instinct audit chain BEFORE re-chaining and ABORTS on
+  tamper (pass `force=True` only after inspecting the breakage). Confirm the
+  returned summary shows the expected per-workspace row counts and
+  `source_chain_verified.intact == true`.
+
+---
+
+## 2. Wire Dodo creds + products (PAY-1) as Coolify RUNTIME vars
+
+The live checkout needs real Dodo configuration. Set these as Coolify **runtime**
+environment variables — NOT build vars (the 128 KB build-secret limit; and the
+key must be present when the app serves requests, not just at build):
+
+- `POCKETPAW_DODO_API_KEY` — the live Dodo API key.
+- `POCKETPAW_DODO_WEBHOOK_SECRET` — the `whsec_…` signing secret for the Dodo
+  webhook endpoint (the app verifies every inbound webhook against this).
+- `POCKETPAW_DODO_PLAN_PRODUCTS` — the plan→product map, one real Dodo
+  **recurring** product id per tier (e.g. `go=prod_…,pro=prod_…,pro_max=prod_…`).
+  This is the PAY-1 deliverable; create one subscription product per tier in the
+  Dodo dashboard first.
+- `POCKETPAW_DODO_ENVIRONMENT` — `live_mode` (or `test_mode` for a dry run with
+  Dodo test cards).
+
+Point the Dodo webhook (in the Dodo dashboard) at the deployed
+`POST /api/v1/billing/webhook` endpoint.
+
+Verify config resolves before touching the UI:
+
+```bash
+# on the box / via the API — every tier returns a non-empty Dodo product id
+curl -s "$BASE/api/v1/billing/plans" | jq '.[] | {key, dodo_product_id}'
+```
+
+If any tier's `dodo_product_id` is null, PAY-1 isn't finished — fix the product
+map before continuing.
+
+---
+
+## 3. Live two-tenant walkthrough
+
+Register **two real cloud users in two separate workspaces** (tenant A, tenant B)
+and run the funnel for each. Use the self-serve onboarding (FE-1).
+
+### 3a. Provision each tenant (signup → pay → provision)
+
+For EACH tenant (A, then B), in a fresh browser session:
+
+1. Register a new user → create the first workspace (`POST /api/v1/workspace`).
+2. Pick a plan in the plan-picker (`GET /api/v1/billing/plans`).
+3. `POST /api/v1/billing/subscribe` → follow the returned `checkout_url` to the
+   **real Dodo hosted checkout** and complete payment (a real card, or a Dodo
+   test card in `test_mode`).
+4. Dodo fires `subscription.active` → the app's webhook stamps the workspace to
+   the plan and grants the monthly credit allotment. Confirm on the box:
+   - the workspace's plan flipped to the chosen tier (`GET /api/v1/workspace` or
+     the billing panel, FE-2);
+   - the credit balance shows the tier's monthly allotment
+     (`GET /api/v1/credits/balance`).
+
+Give A and B **different** plans (e.g. A=go, B=pro) so the entitlement check in
+3c has a visible difference.
+
+### 3b. Cross-leak probe (the core acceptance)
+
+As **tenant A**, create distinctive data on each surface, then log in as
+**tenant B** and confirm none of A's data is visible (and vice-versa):
+
+- **Pockets** — A creates a pocket "A-SECRET"; B's pocket list must not show it.
+- **Fabric** — A's agent/UI writes a Fabric object; B's Fabric query returns zero
+  of A's objects. (Physically: A's rows live in
+  `~/.pocketpaw/workspaces/<A>/fabric.db`, B's in `<B>/fabric.db` — verify the two
+  files exist and are distinct on the box.)
+- **Instinct** — A proposes an action; B's pending list + audit export must not
+  contain it. `GET /api/v1/instinct/audit/verify` for each tenant verifies that
+  tenant's OWN per-workspace chain (not a global one).
+- **KB** — A ingests a document into a pocket scope; B's KB search must not
+  surface it. A cross-workspace `search` for A's scope as B returns empty / 403.
+
+Any single leak here is a **GA blocker**.
+
+### 3c. Entitlement + credit enforcement
+
+- **Plan gate** — exercise a feature gated to a higher tier from the lower-tier
+  tenant; it must be denied (the per-plan ABAC feature set, resolved from
+  `Workspace.plan`).
+- **402 at zero** — drain one tenant's wallet (or use a fresh tenant with no
+  allotment) and start a chat run; it must hard-block with a 402
+  `credits.insufficient`. The OTHER tenant, with balance, is unaffected.
+
+### 3d. Fail-closed spot check
+
+Confirm `POCKETPAW_REQUIRE_WORKSPACE_SCOPE=1` is live: any code path that reaches
+a store without a resolved workspace must error, never read a shared file. (This
+is asserted automatically in the pen-test; on the box, a request that loses
+tenancy returns an error rather than another tenant's data.)
+
+---
+
+## 4. Sign-off
+
+GA is accepted when:
+
+- [ ] the automated pen-test is green (`test_ga_two_tenant_pentest.py`, 9 passed);
+- [ ] the ISO stack (#1550–#1555) is merged + `pocketpaw@dev` redeployed with
+      `POCKETPAW_REQUIRE_WORKSPACE_SCOPE=1` and (if needed) the store migration run;
+- [ ] Dodo creds + per-tier products are live runtime vars and
+      `GET /billing/plans` returns a product id for every tier;
+- [ ] both tenants provisioned via a **real Dodo checkout** (plan stamped +
+      credits granted);
+- [ ] **zero cross-leak** across Pockets, Fabric, Instinct, KB (3b);
+- [ ] entitlement gate + 402-at-zero enforced and tenant-isolated (3c);
+- [ ] fail-closed confirmed (3d).
+
+When all boxes are checked, the offering is build-complete and smoke-passed for
+sale to multiple paying tenants on one backend.

--- a/ee/pocketpaw_ee/cloud/belt/executor.py
+++ b/ee/pocketpaw_ee/cloud/belt/executor.py
@@ -480,14 +480,14 @@ async def execute_approved_change(
     """
     from pocketpaw.stores import get_instinct_store
 
-    store = get_instinct_store()
     opener: PrOpener = pr_opener or GhCliPrOpener()
 
     params = getattr(action, "parameters", None) or {}
     blob = params.get(_CODE_CHANGE_PARAM_KEY)
     if not isinstance(blob, dict):
         # Not a Belt code-change Action at all — no chain was ever opened for
-        # it, so there is nothing to close. Return without a terminal emit.
+        # it, so there is nothing to close. We can't resolve the store's
+        # workspace either (the blob carries it), so bail before opening one.
         logger.warning("approved action %s carries no _code_change blob", action.id)
         return
 
@@ -497,6 +497,10 @@ async def execute_approved_change(
     # no-ops (the Slice 4 abandon-sweeper closes any chain left open).
     correlation_id = _blob_correlation_id(blob)
     workspace_id = str(blob.get("workspace_id") or "")
+    # ISO: this runs on the HTTP approve path (no ``current_workspace``
+    # ContextVar), so the store MUST be scoped to the blob's workspace or it
+    # split-brains onto the shared file (flag unset) / raises (flag set).
+    store = get_instinct_store(workspace_id=workspace_id or None)
     requested_by = str(blob.get("requested_by") or "")
     causation = _coerce_uuid(human_event_id)
 

--- a/ee/pocketpaw_ee/cloud/belt/headless.py
+++ b/ee/pocketpaw_ee/cloud/belt/headless.py
@@ -114,16 +114,22 @@ class HeadlessDevelopRunner:
 
     develop_fn: DevelopFn
 
-    async def run(self, action_id: str) -> str:
+    async def run(self, action_id: str, *, workspace_id: str | None = None) -> str:
         """Produce a diff for a queued ``code_change`` action and attach it.
 
         Returns the action id (a run reference) in every case — success or
         handled failure. Never raises: a develop-loop crash or an empty diff
         leaves the run queued and records ``headless_error`` on the blob so a
-        human can still drive the station or the dispatcher can retry."""
+        human can still drive the station or the dispatcher can retry.
+
+        ``workspace_id`` scopes the store: this runs on a background dispatch
+        path (no ``current_workspace`` ContextVar), so the caller threads the
+        tenant in. Under ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` a missing one
+        fail-closes — the blob (which also carries it) can't be read until the
+        store is open, so the explicit arg is the only safe source here."""
         from pocketpaw.stores import get_instinct_store
 
-        store = get_instinct_store()
+        store = get_instinct_store(workspace_id=workspace_id or None)
         action = await store.get_action(action_id)
         if action is None:
             logger.warning("headless: action %s not found — nothing to develop", action_id)
@@ -395,8 +401,9 @@ class HeadlessTaskDispatcher:
         )
         # 2. Produce the diff headlessly and attach it (the run becomes a real
         #    pending diff). Never raises — a miss leaves the queued run for a
-        #    human to drive.
-        await self.runner.run(run_ref)
+        #    human to drive. Thread the workspace so the runner's store is scoped
+        #    to the tenant (no ContextVar on this background path — ISO).
+        await self.runner.run(run_ref, workspace_id=workspace_id)
         return run_ref
 
 

--- a/ee/pocketpaw_ee/cloud/belt/service.py
+++ b/ee/pocketpaw_ee/cloud/belt/service.py
@@ -720,7 +720,9 @@ async def list_runs(workspace_id: str) -> dict[str, Any]:
     """
     from pocketpaw.stores import get_instinct_store
 
-    store = get_instinct_store()
+    # ISO: HTTP console path (no ``current_workspace`` ContextVar) — scope the
+    # store to the caller's workspace so the listing reads the tenant's file.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     actions = await store.list_actions(pocket_id=workspace_id, limit=200)
     runs: list[dict[str, Any]] = []
     for action in actions:
@@ -742,7 +744,10 @@ async def get_run(workspace_id: str, action_id: str) -> dict[str, Any]:
     """
     from pocketpaw.stores import get_instinct_store
 
-    store = get_instinct_store()
+    # ISO: HTTP console path (no ``current_workspace`` ContextVar) — scope the
+    # store to the caller's workspace so a foreign action is never read from the
+    # shared file (the blob-workspace 404 below stays as belt-and-braces).
+    store = get_instinct_store(workspace_id=workspace_id or None)
     action = await store.get_action(action_id)
     blob = _code_change_blob(action) if action is not None else None
     if action is None or blob is None:

--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -109,6 +109,20 @@ _DEFAULT_BILLING_COUNTRY = "US"
 _PLACEHOLDER_EMAIL = "billing@pocketpaw.local"
 
 
+def _customer_param(email: str | None) -> dict[str, str]:
+    """Build Dodo's ``CustomerRequest`` (new-customer variant).
+
+    Dodo's ``customer`` is an untagged enum: ``{customer_id}`` (attach existing) OR
+    ``{email, name}`` (new customer). Sending ``{email}`` alone fails the server-side
+    variant match with a 422 (``did not match any variant of untagged enum
+    CustomerRequest``) — a NAME is required too. Derive a display name from the email
+    local-part when the caller has none; Dodo collects the real details on the hosted
+    page either way.
+    """
+    e = email or _PLACEHOLDER_EMAIL
+    return {"email": e, "name": e.split("@", 1)[0] or "Customer"}
+
+
 class DodoProvider:
     """Dodo Payments gateway adapter. Implements ``IPaymentsProvider``."""
 
@@ -213,7 +227,7 @@ class DodoProvider:
         client = self._client()
         response = await client.payments.create(
             billing={"country": _DEFAULT_BILLING_COUNTRY},
-            customer={"email": customer_email or _PLACEHOLDER_EMAIL},
+            customer=_customer_param(customer_email),
             product_cart=[
                 {
                     "product_id": self._credit_product_id,
@@ -272,7 +286,7 @@ class DodoProvider:
         client = self._client()
         response = await client.subscriptions.create(
             billing={"country": _DEFAULT_BILLING_COUNTRY},
-            customer={"email": customer_email or _PLACEHOLDER_EMAIL},
+            customer=_customer_param(customer_email),
             product_id=product_id,
             quantity=1,
             payment_link=True,

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -168,6 +168,7 @@ from pocketpaw.ripple import (
     get_pocket_prompts,
 )
 from pocketpaw.ripple._pockets import _MCP_POCKET_BACKENDS
+from pocketpaw.stores import current_workspace as _oss_current_workspace
 from pocketpaw_ee.cloud.shared.errors import CloudError, Forbidden, NotFound
 from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceProfile
 
@@ -216,7 +217,7 @@ def attach_agent_identity(
     user_id: str,
     session_mongo_id: str | None = None,
     pocket_id: str | None = None,
-) -> tuple[Token, Token, Token, Token]:
+) -> tuple[Token, Token, Token, Token, Token]:
     """Bind workspace / user / session / pocket identity for the active
     stream's MCP tools. ``session_mongo_id`` is the ``Session._id`` the chat
     is streaming through — used by ``create_pocket`` to link the active
@@ -232,7 +233,19 @@ def attach_agent_identity(
     that lost the id. Failing loudly at the bind makes any future caller that
     drops tenancy break at the source instead. Every real caller (the SSE chat
     path, the group/DM bridge, the in-process test harnesses) already passes
-    non-empty ids, so this is a guard, not a behavior change for them."""
+    non-empty ids, so this is a guard, not a behavior change for them.
+
+    ISO-3 (workspace store bridge): the same bind also sets the OSS-core
+    ``pocketpaw.stores.current_workspace`` ContextVar, so the NON-router store
+    callers inside an agent run — the agent Fabric tools, the Fabric/Instinct
+    MCP servers, connector ingest — that call ``get_fabric_store()`` /
+    ``get_instinct_store()`` WITHOUT an explicit ``workspace_id`` resolve to THIS
+    stream's workspace and land in its per-workspace file (ISO-1/ISO-2). The
+    EE router path keeps passing ``workspace_id`` explicitly (it has the request
+    scope); this bridges the agent path that doesn't. The OSS token is returned
+    as a FIFTH tuple element — callers treat the tuple opaquely (only
+    ``detach_agent_identity`` unpacks it), so the wider shape is invisible to
+    them. ``detach`` resets it."""
     if not workspace_id or not user_id:
         raise ValueError(
             "attach_agent_identity requires a non-empty workspace_id and user_id "
@@ -243,15 +256,19 @@ def attach_agent_identity(
         _active_user_id.set(user_id),
         _active_session_mongo_id.set(session_mongo_id),
         _active_pocket_id.set(pocket_id),
+        # ISO-3: bridge the EE per-stream workspace onto the OSS store ContextVar.
+        _oss_current_workspace.set(workspace_id),
     )
 
 
-def detach_agent_identity(tokens: tuple[Token, Token, Token, Token]) -> None:
-    ws_token, user_token, session_token, pocket_token = tokens
+def detach_agent_identity(tokens: tuple[Token, Token, Token, Token, Token]) -> None:
+    ws_token, user_token, session_token, pocket_token, oss_ws_token = tokens
     _active_workspace_id.reset(ws_token)
     _active_user_id.reset(user_token)
     _active_session_mongo_id.reset(session_token)
     _active_pocket_id.reset(pocket_token)
+    # ISO-3: clear the OSS store ContextVar bridged in attach_agent_identity.
+    _oss_current_workspace.reset(oss_ws_token)
 
 
 def current_workspace_id() -> str | None:

--- a/ee/pocketpaw_ee/cloud/external_actions/executor.py
+++ b/ee/pocketpaw_ee/cloud/external_actions/executor.py
@@ -316,12 +316,12 @@ async def execute_approved_external_action(
     """
     from pocketpaw.stores import get_instinct_store
 
-    store = get_instinct_store()
     params = getattr(action, "parameters", None) or {}
     blob = params.get(EXTERNAL_ACTION_PARAM_KEY)
     if not isinstance(blob, dict):
         # Not an external-action Action at all — no chain was opened for it, so
-        # there is nothing to close. Return without a terminal emit.
+        # there is nothing to close. We can't resolve the store's workspace
+        # either (the blob carries it), so bail before opening one.
         logger.warning("approved action %s carries no _external_action blob", action.id)
         return
 
@@ -330,6 +330,10 @@ async def execute_approved_external_action(
     # (the Slice 4 abandon-sweeper closes any chain left open).
     correlation_id = _coerce_uuid(blob.get("correlation_id"))
     workspace_id = str(blob.get("workspace_id") or "")
+    # ISO: HTTP approve path (no ``current_workspace`` ContextVar) — scope the
+    # store to the blob's workspace so the terminal audit row + chain-close land
+    # in the tenant's file, not the shared ledger (and don't raise under the flag).
+    store = get_instinct_store(workspace_id=workspace_id or None)
     requested_by = str(blob.get("requested_by") or "")
     approver = str(getattr(action, "approved_by", "") or "") or requested_by or "system"
     causation = _coerce_uuid(human_event_id)

--- a/ee/pocketpaw_ee/cloud/external_actions/propose.py
+++ b/ee/pocketpaw_ee/cloud/external_actions/propose.py
@@ -314,7 +314,10 @@ async def propose_external_action(
         reason=f"external action '{action}' on connector '{connector_name}' requires approval",
     )
 
-    store = get_instinct_store()
+    # ISO: scope the store to the caller's workspace (validated non-empty above)
+    # so the proposal lands in the tenant's file — this propose path has no
+    # ``current_workspace`` ContextVar set.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     action_obj = await store.propose(
         # ``pocket_id`` carries the workspace for external actions — they aren't
         # bound to a pocket the way Mission Control items are (mirrors belt.py).

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -172,7 +172,9 @@ async def ingest_collection(
             "errors": [f"no mapping for collection {source_id!r}"],
         }
 
-    store = store or _default_store()
+    # ISO: thread the caller's workspace so the default store is tenant-scoped
+    # (an injected test store is used as-is).
+    store = store or _default_store(workspace_id)
     state = await _load_or_create_state(workspace_id, source_id)
     mode = "backfill" if not state.backfill_done else "incremental"
     state.status = "running"
@@ -508,12 +510,16 @@ async def _apply_link_rules(
 # --------------------------------------------------------------------------
 
 
-def _default_store() -> StoreLike:
-    """The process-wide OSS FabricStore singleton. Imported lazily so a unit
-    test passing a fake store never pulls the OSS store stack."""
+def _default_store(workspace_id: str | None = None) -> StoreLike:
+    """The OSS FabricStore for ``workspace_id``. Imported lazily so a unit test
+    passing a fake store never pulls the OSS store stack.
+
+    ISO: ingest runs on a background/HTTP path with no ``current_workspace``
+    ContextVar, so the caller threads its workspace in. Under
+    ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` a missing one fail-closes."""
     from pocketpaw.stores import get_fabric_store
 
-    return get_fabric_store()
+    return get_fabric_store(workspace_id=workspace_id or None)
 
 
 def _default_reader() -> FirestoreReader:

--- a/ee/pocketpaw_ee/cloud/fabric_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/fabric_proposals/executor.py
@@ -373,12 +373,12 @@ async def execute_approved_fabric_objects(
     """
     from pocketpaw.stores import get_fabric_store, get_instinct_store
 
-    store = get_instinct_store()
     params = getattr(action, "parameters", None) or {}
     blob = params.get(FABRIC_OBJECTS_PARAM_KEY)
     if not isinstance(blob, dict):
         # Not a fabric-objects Action at all — no chain was opened for it, so
-        # there is nothing to close. Return without a terminal emit.
+        # there is nothing to close. We can't resolve the store's workspace
+        # without the blob either, so bail before opening one.
         logger.warning("approved action %s carries no _fabric_objects blob", action.id)
         return
 
@@ -388,6 +388,10 @@ async def execute_approved_fabric_objects(
     correlation_id = _coerce_uuid(blob.get("correlation_id"))
     workspace_id = str(blob.get("workspace_id") or "")
     requested_by = str(blob.get("requested_by") or "")
+    # ISO: HTTP approve path (no ``current_workspace`` ContextVar) — scope the
+    # store to the blob's workspace BEFORE ``_fail`` (which calls mark_failed)
+    # so every terminal lands in the tenant's file, not the shared ledger.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     approver = str(getattr(action, "approved_by", "") or "") or requested_by or "system"
     causation = _coerce_uuid(human_event_id)
 
@@ -461,7 +465,9 @@ async def execute_approved_fabric_objects(
     try:
         from pocketpaw.connectors.fabric_ingest import ingest_records
 
-        fabric = get_fabric_store()
+        # ISO: scope the fabric store to the blob's workspace (guaranteed
+        # non-empty by the tenancy guard above) — no ContextVar on this path.
+        fabric = get_fabric_store(workspace_id=workspace_id or None)
         batches = _build_ingest_batches(object_types, objects)
 
         total_created = 0

--- a/ee/pocketpaw_ee/cloud/fabric_proposals/propose.py
+++ b/ee/pocketpaw_ee/cloud/fabric_proposals/propose.py
@@ -383,7 +383,9 @@ async def propose_fabric_objects(
         reason="proposed Fabric ontology requires approval",
     )
 
-    store = get_instinct_store()
+    # ISO: scope the store to the caller's workspace (validated non-empty above)
+    # — this propose path has no ``current_workspace`` ContextVar set.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     action_obj = await store.propose(
         # ``pocket_id`` carries the workspace for Fabric-objects writes — they
         # aren't bound to a pocket the way Mission Control items are (mirrors the

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -2106,7 +2106,10 @@ async def _fan_to_instinct_proposal(
     )
     dedupe_key = proposal.parameters.get("_foresight", {}).get("dedupe_key", "")
 
-    store = get_instinct_store()
+    # ISO: the foresight engine runs inline inside the HTTP run handler (no
+    # ``current_workspace`` ContextVar) — scope the store file to the run's
+    # tenant (the W4c in-row filter below is additive).
+    store = get_instinct_store(workspace_id=domain_pd.workspace_id or None)
     # W4c — scope the dedupe read to the run's tenant so the idempotence check
     # only sees this workspace's rows (plus legacy NULL) on the shared store.
     existing = await _existing_dedupe_keys(
@@ -2251,7 +2254,9 @@ async def list_instinct_proposals_for_run(
     # at module top would touch the disk on every cloud module load.
     from pocketpaw.stores import get_instinct_store
 
-    store = get_instinct_store()
+    # ISO: HTTP path (no ContextVar) — scope the store to the caller (the W4c
+    # in-row filter below is additive).
+    store = get_instinct_store(workspace_id=workspace_id or None)
     pocket_id = _foresight_pocket_id(run_id)
     # Pull a generous slice (Instinct's max page size is 500) and
     # filter to the rows our own provenance stamped, in case a future

--- a/ee/pocketpaw_ee/cloud/mandates/executor.py
+++ b/ee/pocketpaw_ee/cloud/mandates/executor.py
@@ -192,7 +192,10 @@ class StationTaskDispatcher:
         from pocketpaw.stores import get_instinct_store
         from pocketpaw_ee.cloud.belt import service as belt_service
 
-        store = get_instinct_store()
+        # ISO: background/dispatch path (no ``current_workspace`` ContextVar) —
+        # scope the store to the caller's workspace so the queued run lands in
+        # the tenant's file.
+        store = get_instinct_store(workspace_id=workspace_id or None)
 
         title = str(task.get("title") or "Belt station task")
         why = str(task.get("why") or "")
@@ -443,18 +446,23 @@ async def execute_approved_plan(
     chokepoint (emit + return), success via the single close at the end."""
     from pocketpaw.stores import get_instinct_store
 
-    store = get_instinct_store()
     dispatch: TaskDispatcher = dispatcher or resolve_dispatcher()
 
     params = getattr(action, "parameters", None) or {}
     blob = params.get(BELT_PLAN_PARAM_KEY)
     if not isinstance(blob, dict):
-        # Not a belt_plan Action — no chain was opened for it here.
+        # Not a belt_plan Action — no chain was opened for it here. We can't
+        # resolve the store's workspace without the blob either, so bail before
+        # opening one.
         logger.warning("approved action %s carries no _belt_plan blob", action.id)
         return
 
     correlation_id = _coerce_uuid(blob.get("correlation_id"))
     workspace_id = str(blob.get("workspace_id") or "")
+    # ISO: HTTP approve path (no ``current_workspace`` ContextVar) — scope the
+    # store to the blob's workspace BEFORE ``_fail`` (which calls mark_failed)
+    # so every terminal lands in the tenant's file, not the shared ledger.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     requested_by = str(blob.get("requested_by") or "")
     mandate_id = str(blob.get("mandate_id") or "")
     shift_id = str(blob.get("shift_id") or "")

--- a/ee/pocketpaw_ee/cloud/mandates/service.py
+++ b/ee/pocketpaw_ee/cloud/mandates/service.py
@@ -745,7 +745,8 @@ async def trigger_shift(workspace_id: str, user_id: str, mandate_id: str) -> dic
         source="belt:mandate-foreman",
         reason="shift plan proposed by the mandate foreman — requires human approval",
     )
-    store = get_instinct_store()
+    # ISO: HTTP path (no ``current_workspace`` ContextVar) — scope to the caller.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     try:
         action = await store.propose(
             pocket_id=workspace_id,
@@ -1032,7 +1033,8 @@ async def prepare_plan_resolution(
             f"shift {body.shift_no} is {shift.state!r} — only an in_gate shift can be resolved",
         )
 
-    store = get_instinct_store()
+    # ISO: HTTP path (no ``current_workspace`` ContextVar) — scope to the caller.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     action = await store.get_action(shift.plan_action_id)
     params = dict(getattr(action, "parameters", None) or {}) if action else {}
     blob = params.get(BELT_PLAN_PARAM_KEY)
@@ -1149,7 +1151,9 @@ async def shift_wire(workspace_id: str, shift_id: str) -> dict[str, Any]:
         from pocketpaw_ee.cloud.mandates.executor import BELT_PLAN_PARAM_KEY
 
         try:
-            action = await get_instinct_store().get_action(doc.plan_action_id)
+            # ISO: HTTP path (no ContextVar) — scope to the caller's workspace.
+            _store = get_instinct_store(workspace_id=workspace_id or None)
+            action = await _store.get_action(doc.plan_action_id)
             blob = (getattr(action, "parameters", None) or {}).get(BELT_PLAN_PARAM_KEY)
             if isinstance(blob, dict):
                 task_count = len((blob.get("plan") or {}).get("tasks") or [])
@@ -1202,7 +1206,8 @@ async def get_pawprints(workspace_id: str, user_id: str, mandate_id: str) -> dic
     from pocketpaw.stores import get_instinct_store
     from pocketpaw_ee.cloud.mandates.executor import BELT_PLAN_PARAM_KEY
 
-    store = get_instinct_store()
+    # ISO: HTTP path (no ``current_workspace`` ContextVar) — scope to the caller.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     prints: list[dict[str, Any]] = []
 
     def _item(shift: Any, kind: str, summary: str, refs: list[str], ts: Any) -> dict[str, Any]:

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -410,7 +410,9 @@ async def agent_list_work_items(
     # block must run even when the workspace has zero visible pockets. Tasks
     # below have their own workspace-level tenancy and are NOT gated by
     # pocket visibility.
-    store = get_instinct_store()
+    # ISO: HTTP path (no ``current_workspace`` ContextVar) — scope the store
+    # file to the caller's workspace (the W4c in-row filter below is additive).
+    store = get_instinct_store(workspace_id=workspace_id or None)
     # W4c — scope the instinct reads to the caller's workspace (plus legacy
     # NULL rows) at the store/SQL layer so a tenant never reads another
     # tenant's Nudges off the shared DB. The pocket-visibility filter below
@@ -592,7 +594,7 @@ async def agent_bulk_approve(
     from uuid import uuid4
 
     body = BulkActionRequest.model_validate(body)
-    _require_workspace(ctx)
+    workspace_id = _require_workspace(ctx)
 
     bulk_id = uuid4().hex
     approved: list[dict] = []
@@ -638,7 +640,8 @@ async def agent_bulk_approve(
     # Handle nudges via Instinct store
     if nudge_store_ids:
         visible = await _visible_pocket_ids(ctx)
-        store = get_instinct_store()
+        # ISO: HTTP path (no ContextVar) — scope the store to the caller.
+        store = get_instinct_store(workspace_id=workspace_id or None)
         eligible, blocked = await _split_ids_by_tenancy(store, nudge_store_ids, visible)
         nudge_approved, nudge_missing, _ = await store.bulk_approve(
             eligible, approver=ctx.user_id, note=body.note
@@ -683,7 +686,7 @@ async def agent_bulk_reject(
             "mission_control.reason_required",
             "bulk-reject requires a reason — pass a non-empty string in ``reason``.",
         )
-    _require_workspace(ctx)
+    workspace_id = _require_workspace(ctx)
 
     from uuid import uuid4
 
@@ -727,7 +730,8 @@ async def agent_bulk_reject(
     # Handle nudges via Instinct store
     if nudge_store_ids:
         visible = await _visible_pocket_ids(ctx)
-        store = get_instinct_store()
+        # ISO: HTTP path (no ContextVar) — scope the store to the caller.
+        store = get_instinct_store(workspace_id=workspace_id or None)
         eligible, blocked = await _split_ids_by_tenancy(store, nudge_store_ids, visible)
         nudge_rejected, nudge_missing, _ = await store.bulk_reject(
             eligible, reason=body.reason, rejector=ctx.user_id
@@ -786,7 +790,8 @@ async def agent_outcomes_summary(
     body = OutcomesQueryRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
     visible = await _visible_pocket_ids(ctx)
-    store = get_instinct_store()
+    # ISO: HTTP path (no ContextVar) — scope the store to the caller.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     cutoff = datetime.now() - _window_to_delta(body.window)
 
     # Pull a generous slice and filter in Python. ``list_actions`` does

--- a/ee/pocketpaw_ee/cloud/pocket_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/pocket_proposals/executor.py
@@ -237,12 +237,12 @@ async def execute_approved_pocket_create(
     """
     from pocketpaw.stores import get_instinct_store
 
-    store = get_instinct_store()
     params = getattr(action, "parameters", None) or {}
     blob = params.get(POCKET_CREATE_PARAM_KEY)
     if not isinstance(blob, dict):
         # Not a pocket-create Action at all — no chain was opened for it, so there
-        # is nothing to close. Return without a terminal emit.
+        # is nothing to close. We can't resolve the store's workspace without the
+        # blob either, so bail before opening one.
         logger.warning("approved action %s carries no _pocket_create blob", action.id)
         return
 
@@ -253,6 +253,10 @@ async def execute_approved_pocket_create(
     # Slice 4 abandon-sweeper closes any chain left open).
     correlation_id = _coerce_uuid(blob.get("correlation_id"))
     workspace_id = str(blob.get("workspace_id") or "")
+    # ISO: HTTP approve path (no ``current_workspace`` ContextVar) — scope the
+    # store to the blob's workspace BEFORE ``_fail`` (which calls mark_failed)
+    # so every terminal lands in the tenant's file, not the shared ledger.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     owner_user_id = str(blob.get("user_id") or "")
     approver = str(getattr(action, "approved_by", "") or "") or owner_user_id or "system"
     causation = _coerce_uuid(human_event_id)

--- a/ee/pocketpaw_ee/cloud/pocket_proposals/propose.py
+++ b/ee/pocketpaw_ee/cloud/pocket_proposals/propose.py
@@ -327,7 +327,9 @@ async def propose_pocket(
         reason="proposed starter Pocket requires approval",
     )
 
-    store = get_instinct_store()
+    # ISO: scope the store to the caller's workspace (validated non-empty above)
+    # — this propose path has no ``current_workspace`` ContextVar set.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     action_obj = await store.propose(
         # ``pocket_id`` carries the workspace for Pocket-create proposals — they
         # aren't bound to an EXISTING pocket the way Mission Control items are

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
@@ -222,7 +222,12 @@ async def propose_pocket_write(
 
     approver = _resolve_approver(pocket, backend_config)
 
-    store = get_instinct_store()
+    # ISO: this propose path is reached from BOTH the agent stream (ContextVar
+    # set) AND the REST run_action endpoint (FastAPI Depends, no ContextVar) —
+    # so scope the store to the pocket's workspace explicitly. When the
+    # ContextVar IS set it equals this id (harmless); on the REST path it's the
+    # only correct source.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     action = await store.propose(
         pocket_id=pocket_id,
         title=title or action_name or "Pocket write",
@@ -428,12 +433,20 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
     from pocketpaw_ee.cloud.pockets import action_executor
     from pocketpaw_ee.cloud.pockets import service as pockets_service
 
-    store = get_instinct_store()
     params = getattr(action, "parameters", None) or {}
     blob = params.get("_pocket_write")
     if not isinstance(blob, dict):
+        # Can't resolve the store's workspace without the blob either, so bail
+        # before opening one.
         logger.warning("approved action %s carries no _pocket_write blob", action.id)
         return
+
+    pocket_id = str(action.pocket_id or "")
+    workspace_id = str(blob.get("workspace_id") or "")
+    # ISO: this runs on the HTTP approve path (no ``current_workspace``
+    # ContextVar) — scope the store to the blob's workspace so the
+    # executed/failed mark lands in the tenant's file, not the shared ledger.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     if blob.get("schema") != _POCKET_WRITE_SCHEMA:
         await store.mark_failed(
             action.id,
@@ -441,9 +454,6 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
             "incompatible build and cannot be executed",
         )
         return
-
-    pocket_id = str(action.pocket_id or "")
-    workspace_id = str(blob.get("workspace_id") or "")
     action_name = str(blob.get("action") or "")
     requested_by = str(blob.get("requested_by") or "")
     approver = str(getattr(action, "approved_by", "") or "") or "system"

--- a/ee/pocketpaw_ee/cloud/ripple_sources.py
+++ b/ee/pocketpaw_ee/cloud/ripple_sources.py
@@ -211,7 +211,11 @@ async def _resolve_fabric_objects(
     from pocketpaw.fabric.models import FabricQuery
     from pocketpaw.stores import get_fabric_store
 
-    store = get_fabric_store()
+    # ISO: the ripple resolver runs server-side off a built ctx, not the agent
+    # stream — no ``current_workspace`` ContextVar — so scope the store to
+    # ``ctx.workspace_id`` (validated non-empty above). The store's own W4a row
+    # guard below is then a second, in-file scope.
+    store = get_fabric_store(workspace_id=ctx.workspace_id or None)
     q = FabricQuery(
         type_id=type_id,
         type_name=type_name,

--- a/ee/pocketpaw_ee/discovery/orchestrate.py
+++ b/ee/pocketpaw_ee/discovery/orchestrate.py
@@ -399,7 +399,10 @@ async def run_discovery_and_propose(
 
     from pocketpaw.stores import get_instinct_store
 
-    store = get_instinct_store()
+    # ISO: this can run on a background/HTTP path with no ``current_workspace``
+    # ContextVar — scope the store to the caller's workspace (validated non-empty
+    # above) so the proposals land in the tenant's file.
+    store = get_instinct_store(workspace_id=workspace_id or None)
 
     # 1) Supersede the prior open pair BEFORE filing the new one (so the new pair
     #    is never itself collapsed and the queue never shows two open pairs).

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -75,6 +75,17 @@ only MCP servers do — so without these the cloud chat agent had no path to the
 Fabric ontology or Instinct gate visibility. Both are READ-ONLY and
 workspace-scoped via the chat ContextVars. Gated proposing stays on
 ``pocketpaw_external_actions``. Ambient (not opt-in).
+
+Updated: 2026-06-26 (ISO-3 — workspace store bridge) — added ``CloudStoreProvider``
+(``pocketpaw.stores`` entry-point) so the dormant ``StoreProvider`` seam ISO-1 lit
+up is now live under EE. It returns the standard per-workspace SQLite file store
+(Fabric / Instinct at ``~/.pocketpaw/workspaces/<id>/<name>.db``) by delegating to
+the OSS helper ``pocketpaw.stores.build_workspace_store`` — so the path + the
+path-traversal allowlist stay authoritative in OSS and the provider can never drift
+from or weaken them. It returns ``None`` for the legacy (no-workspace) path, leaving
+the OSS factory's shared singleton in place. This activates the entry-point end to
+end and gives EE the single hook to later swap in a cloud-backed store without
+touching core.
 """
 
 from __future__ import annotations
@@ -1014,3 +1025,36 @@ class CloudComposioMcpProvider:
         # ``mcp__composio`` is the server-level allowlist entry — it
         # permits every tool the in-process ``composio`` server exposes.
         return ["mcp__composio"]
+
+
+class CloudStoreProvider:
+    """``pocketpaw.stores`` — the workspace-keyed store provider (ISO-3).
+
+    Activates the ``StoreProvider`` seam ISO-1 added but left dormant. The OSS
+    factory consults this provider FIRST when building a workspace-keyed store;
+    we return the standard per-workspace SQLite file store (Fabric / Instinct
+    under ``~/.pocketpaw/workspaces/<id>/<name>.db``) by delegating to the OSS
+    helper ``build_workspace_store``, so:
+
+    * the file path AND the strict path-traversal allowlist stay defined ONCE,
+      in OSS core — a provider can't drift from or weaken the guard; and
+    * delegation is recursion-safe (``build_workspace_store`` never re-enters
+      the provider seam).
+
+    We return ``None`` for the legacy / no-workspace path (``workspace_id`` is
+    ``None``) so the OSS factory keeps using its shared single-tenant singleton
+    there — the cloud always carries a workspace, so on cloud this provider only
+    ever serves the per-workspace branch. This is the one hook a future task
+    swaps to back stores with a cloud DB or a per-tenant server, without
+    touching core.
+    """
+
+    def get_store(self, name: str, *, workspace_id: str | None = None) -> Any:
+        if workspace_id is None:
+            # No workspace → let the OSS factory use its legacy shared singleton
+            # (or fail closed under POCKETPAW_REQUIRE_WORKSPACE_SCOPE, which the
+            # factory enforces before it ever consults a provider).
+            return None
+        from pocketpaw.stores import build_workspace_store
+
+        return build_workspace_store(name, workspace_id)

--- a/ee/pocketpaw_ee/fabric/router.py
+++ b/ee/pocketpaw_ee/fabric/router.py
@@ -43,11 +43,19 @@
 #   scoped on the type's own ``workspace_id`` now). This supersedes the W4a /
 #   fix/fabric-stats note above that called definitions "global in the schema"
 #   — they carry their own workspace column as of SZD-2.
+# Updated: 2026-06-26 (ISO-1 — physical per-workspace isolation) — the store is
+#   no longer a single shared ``~/.pocketpaw/fabric.db``. ``_store`` now takes
+#   the caller's ``workspace_id`` and routes through
+#   ``pocketpaw.stores.get_fabric_store(workspace_id=...)``, so every read/write
+#   in this router hits that tenant's OWN
+#   ``~/.pocketpaw/workspaces/<id>/fabric.db`` file. The per-endpoint W4a
+#   ``workspace_id`` filter args are UNCHANGED — physical file isolation is
+#   additive defense-in-depth, kept alongside the in-row WHERE-filter, not a
+#   replacement for it.
 
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -62,6 +70,7 @@ from pocketpaw.fabric.models import (
     PropertyDef,
 )
 from pocketpaw.fabric.store import FabricStore
+from pocketpaw.stores import get_fabric_store
 from pocketpaw_ee.cloud._core.deps import current_workspace_id, require_plan_feature
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import require_action_any_workspace
@@ -73,11 +82,18 @@ router = APIRouter(
     dependencies=[Depends(require_license), Depends(require_plan_feature("fabric"))],
 )
 
-_DB_PATH = Path.home() / ".pocketpaw" / "fabric.db"
 
+def _store(workspace_id: str) -> FabricStore:
+    """Return the FabricStore for ``workspace_id`` (ISO-1 — physical isolation).
 
-def _store() -> FabricStore:
-    return FabricStore(_DB_PATH)
+    Routes through the workspace-keyed factory so every Fabric read/write in
+    this router hits the caller's OWN ``~/.pocketpaw/workspaces/<id>/fabric.db``
+    file, not the shared one. ``workspace_id`` is the caller's active workspace,
+    already resolved by ``current_workspace_id`` on each endpoint. The W4a
+    in-row ``workspace_id`` WHERE-filter the endpoints already pass STAYS — the
+    physical file split is additive defense-in-depth on top of it.
+    """
+    return get_fabric_store(workspace_id=workspace_id)
 
 
 # ---------------------------------------------------------------------------
@@ -124,7 +140,7 @@ async def list_types(workspace_id: str = Depends(current_workspace_id)):
     object row visible to the workspace — type names are tenant metadata on a
     shared deployment.
     """
-    return await _store().list_types(workspace_id=workspace_id)
+    return await _store(workspace_id).list_types(workspace_id=workspace_id)
 
 
 @router.post(
@@ -138,7 +154,7 @@ async def define_type(
     workspace_id: str = Depends(current_workspace_id),
 ):
     """Define an object type stamped with the caller's active workspace (SZD-2)."""
-    return await _store().define_type(
+    return await _store(workspace_id).define_type(
         name=req.name,
         properties=req.properties,
         description=req.description,
@@ -181,7 +197,7 @@ async def list_objects(
     workspace so a tenant never sees another tenant's objects.
     """
     q = FabricQuery(type_id=type_id, type_name=type_name, limit=limit, offset=offset)
-    result = await _store().query(q, workspace_id=workspace_id)
+    result = await _store(workspace_id).query(q, workspace_id=workspace_id)
     return ObjectsListResponse(objects=result.objects, total=result.total)
 
 
@@ -203,7 +219,7 @@ async def list_links(
     W4a — scoped to the caller's active workspace (plus legacy NULL-workspace
     links) so a tenant cannot enumerate another tenant's relationships.
     """
-    links, total = await _store().list_links(
+    links, total = await _store(workspace_id).list_links(
         from_id=from_id,
         to_id=to_id,
         link_type=link_type,
@@ -225,7 +241,7 @@ async def create_object(
     workspace_id: str = Depends(current_workspace_id),
 ):
     """Create an object stamped with the caller's active workspace (W4a)."""
-    return await _store().create_object(
+    return await _store(workspace_id).create_object(
         type_id=req.type_id,
         properties=req.properties,
         source_connector=req.source_connector,
@@ -248,7 +264,7 @@ async def get_object(
     A 404 — not a 403 — is returned for another tenant's object so the
     endpoint never leaks the existence of cross-workspace ids.
     """
-    obj = await _store().get_object(obj_id, workspace_id=workspace_id)
+    obj = await _store(workspace_id).get_object(obj_id, workspace_id=workspace_id)
     if not obj:
         raise HTTPException(404, "Object not found")
     return obj
@@ -264,7 +280,7 @@ async def query_fabric(
     workspace_id: str = Depends(current_workspace_id),
 ):
     """Run an arbitrary FabricQuery, scoped to the caller's workspace (W4a)."""
-    return await _store().query(q, workspace_id=workspace_id)
+    return await _store(workspace_id).query(q, workspace_id=workspace_id)
 
 
 @router.post(
@@ -277,7 +293,7 @@ async def create_link(
     workspace_id: str = Depends(current_workspace_id),
 ):
     """Create a link stamped with the caller's active workspace (W4a)."""
-    return await _store().link(
+    return await _store(workspace_id).link(
         from_id=req.from_id,
         to_id=req.to_id,
         link_type=req.link_type,
@@ -299,4 +315,4 @@ async def fabric_stats(workspace_id: str = Depends(current_workspace_id)):
     names are tenant metadata on a shared deployment, so an unscoped stats here
     leaked another tenant's experimental type names into chat.
     """
-    return await _store().stats(workspace_id=workspace_id)
+    return await _store(workspace_id).stats(workspace_id=workspace_id)

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,20 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-06-26 (ISO-2 — physical per-workspace isolation) — the store is
+#   no longer one shared ``~/.pocketpaw/instinct.db``. ``_store`` now takes the
+#   caller's ``workspace_id`` and routes through
+#   ``pocketpaw.stores.get_instinct_store(workspace_id=...)``, so every action +
+#   audit read/write hits that tenant's OWN
+#   ``~/.pocketpaw/workspaces/<id>/instinct.db`` — and therefore that tenant's
+#   own audit hash-chain. The audit ``verify`` and ``corrections`` endpoints,
+#   which previously took no workspace, now resolve ``current_workspace_id`` so
+#   ``verify_audit_chain`` checks the CALLER'S per-tenant chain (not a global
+#   chain spanning tenants — the correct multi-tenant model). The internal
+#   helpers ``_forward_to_soul`` and ``_fetch_current_fabric`` take
+#   ``workspace_id`` from their endpoint callers (the latter also threads it into
+#   the per-workspace Fabric store so it doesn't fail closed on a cloud path).
+#   The per-endpoint W4a ``workspace_id`` filter args are UNCHANGED — physical
+#   file isolation is additive defense-in-depth on top of the in-row filter.
 # Updated: 2026-06-19 (SZD-5b — _pocket_create proposal type) — added a gated
 #   starter-Pocket-create proposal kind (TENANCY GATE). ``_pocket_create_blob`` +
 #   ``_assert_pocket_create_workspace`` are the peers of the existing blob
@@ -422,7 +437,7 @@ async def _run_auto_triage(action: Any, workspace_id: str) -> Any:
         )
 
         outcome = await maybe_auto_approve(
-            store=_store(),
+            store=_store(workspace_id),
             action=action,
             context=context,
             level=level,
@@ -808,10 +823,20 @@ router = APIRouter(
 )
 
 
-def _store():
-    from pocketpaw_ee.api import get_instinct_store
+def _store(workspace_id: str):
+    """Return the InstinctStore for ``workspace_id`` (ISO-2 — physical isolation).
 
-    return get_instinct_store()
+    Routes through the workspace-keyed factory so every Instinct action +
+    audit-ledger read/write in this router hits the caller's OWN
+    ``~/.pocketpaw/workspaces/<id>/instinct.db`` file — and therefore that
+    tenant's own audit hash-chain. ``workspace_id`` is the caller's active
+    workspace, already resolved by ``current_workspace_id`` on each endpoint. The
+    W4a in-row ``workspace_id`` read-filter the endpoints already pass STAYS — the
+    physical file split is additive defense-in-depth on top of it.
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    return get_instinct_store(workspace_id=workspace_id)
 
 
 # ---------------------------------------------------------------------------
@@ -984,7 +1009,7 @@ async def propose_action(
     triager failure escalates to the human, and a wiring failure can never
     break this propose response.
     """
-    action = await _store().propose(
+    action = await _store(workspace_id).propose(
         pocket_id=req.pocket_id,
         title=req.title,
         description=req.description,
@@ -1024,7 +1049,9 @@ async def pending_actions(
     W4a — scoped to the caller's active workspace (plus legacy NULL-workspace
     rows) so The Tray for tenant A never surfaces tenant B's pending decisions.
     """
-    return await _store().pending(pocket_id=pocket_id, assignee=assignee, workspace_id=workspace_id)
+    return await _store(workspace_id).pending(
+        pocket_id=pocket_id, assignee=assignee, workspace_id=workspace_id
+    )
 
 
 @router.get(
@@ -1045,7 +1072,7 @@ async def list_actions(
     W4a — scoped to the caller's active workspace (plus legacy NULL-workspace
     rows) so a tenant can't enumerate another tenant's actions.
     """
-    store = _store()
+    store = _store(workspace_id)
     status_enum = ActionStatus(status) if status else None
     actions = await store.list_actions(
         pocket_id=pocket_id,
@@ -1093,7 +1120,7 @@ async def bulk_approve_actions(
       * SHOULD-FIX 1 — the audit actor is the authenticated user id, not
         the free-text ``req.approver`` field.
     """
-    store = _store()
+    store = _store(workspace_id)
     approver_id = str(user.id)
 
     # BLOCKER 1 — verify tenancy on every requested action up front. A
@@ -1380,7 +1407,7 @@ async def bulk_reject_actions(
     item would hide a cross-tenant rejection-escalation attempt
     (mirror of bulk-approve's BLOCKER 1 behaviour).
     """
-    store = _store()
+    store = _store(workspace_id)
     rejector_id = str(user.id)
 
     # Touch-time security fix — verify tenancy on every requested
@@ -1618,7 +1645,7 @@ async def approve_action(
       * SHOULD-FIX 1 — the audit actor + outcome actor are the
         authenticated user id, never the free-text ``req.approver``.
     """
-    store = _store()
+    store = _store(workspace_id)
     before = await store.get_action(action_id)
     if not before:
         raise HTTPException(404, "Action not found")
@@ -1673,7 +1700,7 @@ async def approve_action(
             )
             await store.record_correction(correction)
             await _persist_edits(store, after, edited_fields)
-            await _forward_to_soul(correction, after)
+            await _forward_to_soul(correction, after, workspace_id)
 
     approved = await store.approve(action_id, approver=approver_id)
     if not approved:
@@ -1963,8 +1990,12 @@ async def approve_action(
     return ApproveResponse(action=approved, correction=correction)
 
 
-async def _forward_to_soul(correction: Correction, action: Action) -> None:
-    """Hand off to the soul bridge — always best-effort, never breaks approval."""
+async def _forward_to_soul(correction: Correction, action: Action, workspace_id: str) -> None:
+    """Hand off to the soul bridge — always best-effort, never breaks approval.
+
+    ISO-2: takes the caller's ``workspace_id`` so the bridge's InstinctStore is
+    the tenant's own per-workspace file, not the shared one.
+    """
     try:
         from pocketpaw.instinct.correction_soul_bridge import CorrectionSoulBridge
         from pocketpaw.soul import get_soul_manager
@@ -1972,7 +2003,7 @@ async def _forward_to_soul(correction: Correction, action: Action) -> None:
         manager = get_soul_manager()
         if manager is None:
             return
-        bridge = CorrectionSoulBridge(soul_manager=manager, store=_store())
+        bridge = CorrectionSoulBridge(soul_manager=manager, store=_store(workspace_id))
         await bridge.record(correction, action)
     except Exception:
         logger.exception("Correction soul-bridge failed (non-fatal)")
@@ -2012,7 +2043,7 @@ async def reject_action(
          scope. The bridge is NOT invoked on reject so the router owns
          the chain close.
     """
-    store = _store()
+    store = _store(workspace_id)
     before = await store.get_action(action_id)
     if not before:
         raise HTTPException(404, "Action not found")
@@ -2332,9 +2363,14 @@ async def list_corrections(
     pocket_id: str | None = Query(None, description="Filter by pocket ID"),
     action_id: str | None = Query(None, description="Filter by action ID"),
     limit: int = Query(100, ge=1, le=500),
+    workspace_id: str = Depends(current_workspace_id),
 ):
-    """List corrections captured when humans edited proposed actions."""
-    store = _store()
+    """List corrections captured when humans edited proposed actions.
+
+    ISO-2: corrections live in the tenant's own ``instinct.db``, so resolving the
+    store by ``workspace_id`` keeps one tenant's corrections out of another's.
+    """
+    store = _store(workspace_id)
     if action_id:
         corrections = await store.get_corrections_for_action(action_id)
     elif pocket_id:
@@ -2388,7 +2424,7 @@ async def query_audit(
     """
     response.headers["Deprecation"] = "true"
     response.headers["Link"] = '</api/v1/runtime/audit>; rel="successor-version"'
-    entries = await _store().query_audit(
+    entries = await _store(workspace_id).query_audit(
         pocket_id=pocket_id,
         category=category,
         event=event,
@@ -2458,7 +2494,7 @@ async def export_audit(
     the ledger verified at export time. Call ``GET /instinct/audit/verify`` for
     the full break-point detail.
     """
-    store = _store()
+    store = _store(workspace_id)
     data = await store.export_audit(pocket_id=pocket_id, workspace_id=workspace_id)
     verdict = await store.verify_audit_chain()
     return Response(
@@ -2476,21 +2512,27 @@ async def export_audit(
     response_model=AuditVerifyResponse,
     dependencies=[Depends(require_action_any_workspace("instinct.audit"))],
 )
-async def verify_audit_chain():
+async def verify_audit_chain(workspace_id: str = Depends(current_workspace_id)):
     """Verify the tamper-evident audit hash chain end to end.
 
-    Walks the entire ``instinct_audit`` ledger in insertion order, recomputes
-    each row's hash from its canonical content + the running previous hash, and
-    reports whether the chain is intact. Any insertion, edit, or deletion of a
-    hashed row surfaces as ``intact=false`` with ``broken_at`` pointing at the
-    first failing row — proof an auditor or insurer can run themselves.
+    Walks this workspace's ``instinct_audit`` ledger in insertion order,
+    recomputes each row's hash from its canonical content + the running previous
+    hash, and reports whether the chain is intact. Any insertion, edit, or
+    deletion of a hashed row surfaces as ``intact=false`` with ``broken_at``
+    pointing at the first failing row — proof an auditor or insurer can run
+    themselves.
 
-    The chain is global (not pocket-scoped), so this endpoint takes no filter:
-    integrity is a property of the whole ledger. Pre-W2b rows without a hash
-    are counted under ``legacy_unhashed`` and are not enforced — see the store
-    docstring for the genesis/legacy boundary.
+    ISO-2: the chain is now PER WORKSPACE. Each tenant has its own
+    ``instinct.db`` with its own genesis→…→head chain, so this endpoint verifies
+    the CALLER'S chain (resolved via ``current_workspace_id``), not a global
+    chain mixing tenants. That is the correct multi-tenant model — a tenant's
+    auditor verifies only that tenant's ledger, and one tenant's tampering can
+    never flip another tenant's verdict. The chain spans the whole (per-tenant)
+    file rather than a single pocket, so there is no pocket filter. Pre-W2b rows
+    without a hash are counted under ``legacy_unhashed`` and are not enforced —
+    see the store docstring for the genesis/legacy boundary.
     """
-    verdict = await _store().verify_audit_chain()
+    verdict = await _store(workspace_id).verify_audit_chain()
     return AuditVerifyResponse(**verdict)
 
 
@@ -2521,7 +2563,7 @@ async def get_audit_entry(
     the prior path paged the most-recent rows and matched in Python, 404-ing on
     valid ids past that window for a tenant with a large ledger.
     """
-    store = _store()
+    store = _store(workspace_id)
     entry = await store.get_audit_entry(audit_id, workspace_id=workspace_id)
     if entry is None:
         raise HTTPException(404, "Audit entry not found")
@@ -2534,7 +2576,7 @@ async def get_audit_entry(
     current: list[dict[str, Any]] = []
     if trace is not None:
         snapshots = await store.get_snapshots_for_audit(audit_id)
-        current = await _fetch_current_fabric(trace.fabric_queries)
+        current = await _fetch_current_fabric(trace.fabric_queries, workspace_id)
 
     return HydratedAuditEntry(
         entry=entry,
@@ -2555,21 +2597,27 @@ def _decode_trace(entry: AuditEntry) -> ReasoningTrace | None:
         return None
 
 
-async def _fetch_current_fabric(object_ids: list[str]) -> list[dict[str, Any]]:
-    """Look up live Fabric objects by ID, tolerating a missing ee module."""
+async def _fetch_current_fabric(object_ids: list[str], workspace_id: str) -> list[dict[str, Any]]:
+    """Look up live Fabric objects by ID, tolerating a missing ee module.
+
+    ISO-2: takes the caller's ``workspace_id`` so the Fabric store is the
+    tenant's own per-workspace file (ISO-1). Passing it is also REQUIRED on a
+    cloud path — an unscoped Fabric-store fetch there now fails closed — and it
+    keeps the W4a in-row filter on ``get_object``.
+    """
     if not object_ids:
         return []
     try:
-        from pocketpaw_ee.api import get_fabric_store
+        from pocketpaw.stores import get_fabric_store
 
-        fabric = get_fabric_store()
+        fabric = get_fabric_store(workspace_id=workspace_id)
     except ImportError:
         return []
 
     results: list[dict[str, Any]] = []
     for oid in object_ids:
         try:
-            obj = await fabric.get_object(oid)
+            obj = await fabric.get_object(oid, workspace_id=workspace_id)
         except Exception:
             obj = None
         if obj is None:

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -607,7 +607,16 @@ def _assert_belt_plan_workspace(action: Any, current_workspace: str) -> None:
     if blob is None:
         return
     blob_workspace = str(blob.get("workspace_id") or "")
-    if blob_workspace and blob_workspace != current_workspace:
+    # LOW-1 — an absent/empty workspace claim is a HARD 403, never a
+    # pass-through (matches _assert_artifact_change_workspace). Now that the
+    # executors resolve the store from the blob's workspace_id, an empty claim
+    # would otherwise approve-then-misfile onto the shared ledger / raise.
+    if not blob_workspace:
+        raise Forbidden(
+            "instinct.missing_workspace_in_blob",
+            "This shift plan has no workspace claim — cannot verify tenancy",
+        )
+    if blob_workspace != current_workspace:
         raise Forbidden(
             "instinct.cross_workspace_approval",
             "This shift plan belongs to a different workspace",
@@ -673,7 +682,14 @@ def _assert_code_change_workspace(action: Any, current_workspace: str) -> None:
     if blob is None:
         return
     blob_workspace = str(blob.get("workspace_id") or "")
-    if blob_workspace and blob_workspace != current_workspace:
+    # LOW-1 — empty workspace claim fails closed (the executor resolves its
+    # store from this field; an empty one would misfile onto the shared ledger).
+    if not blob_workspace:
+        raise Forbidden(
+            "instinct.missing_workspace_in_blob",
+            "This code change has no workspace claim — cannot verify tenancy",
+        )
+    if blob_workspace != current_workspace:
         raise Forbidden(
             "instinct.cross_workspace_approval",
             "This code change belongs to a different workspace",
@@ -695,7 +711,14 @@ def _assert_external_action_workspace(action: Any, current_workspace: str) -> No
     if blob is None:
         return
     blob_workspace = str(blob.get("workspace_id") or "")
-    if blob_workspace and blob_workspace != current_workspace:
+    # LOW-1 — empty workspace claim fails closed (the executor resolves its
+    # store from this field; an empty one would misfile onto the shared ledger).
+    if not blob_workspace:
+        raise Forbidden(
+            "instinct.missing_workspace_in_blob",
+            "This external action has no workspace claim — cannot verify tenancy",
+        )
+    if blob_workspace != current_workspace:
         raise Forbidden(
             "instinct.cross_workspace_approval",
             "This external action belongs to a different workspace",
@@ -737,7 +760,14 @@ def _assert_fabric_objects_workspace(action: Any, current_workspace: str) -> Non
     if blob is None:
         return
     blob_workspace = str(blob.get("workspace_id") or "")
-    if blob_workspace and blob_workspace != current_workspace:
+    # LOW-1 — empty workspace claim fails closed (the executor resolves its
+    # store from this field; an empty one would misfile onto the shared ledger).
+    if not blob_workspace:
+        raise Forbidden(
+            "instinct.missing_workspace_in_blob",
+            "This fabric-objects write has no workspace claim — cannot verify tenancy",
+        )
+    if blob_workspace != current_workspace:
         raise Forbidden(
             "instinct.cross_workspace_approval",
             "This fabric-objects write belongs to a different workspace",
@@ -780,7 +810,14 @@ def _assert_pocket_create_workspace(action: Any, current_workspace: str) -> None
     if blob is None:
         return
     blob_workspace = str(blob.get("workspace_id") or "")
-    if blob_workspace and blob_workspace != current_workspace:
+    # LOW-1 — empty workspace claim fails closed (the executor resolves its
+    # store from this field; an empty one would misfile onto the shared ledger).
+    if not blob_workspace:
+        raise Forbidden(
+            "instinct.missing_workspace_in_blob",
+            "This pocket create has no workspace claim — cannot verify tenancy",
+        )
+    if blob_workspace != current_workspace:
         raise Forbidden(
             "instinct.cross_workspace_approval",
             "This pocket create belongs to a different workspace",
@@ -810,7 +847,14 @@ def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
     if blob is None:
         return
     blob_workspace = str(blob.get("workspace_id") or "")
-    if blob_workspace and blob_workspace != current_workspace:
+    # LOW-1 — empty workspace claim fails closed (the executor resolves its
+    # store from this field; an empty one would misfile onto the shared ledger).
+    if not blob_workspace:
+        raise Forbidden(
+            "instinct.missing_workspace_in_blob",
+            "This action's pocket write has no workspace claim — cannot verify tenancy",
+        )
+    if blob_workspace != current_workspace:
         raise Forbidden(
             "instinct.cross_workspace_approval",
             "This action's pocket write belongs to a different workspace",

--- a/ee/pocketpaw_ee/paw_print/decision_loop.py
+++ b/ee/pocketpaw_ee/paw_print/decision_loop.py
@@ -193,6 +193,13 @@ async def propose_customer_decision(
             "payload_summary": summary,
         }
 
+        # ISO note: paw-print's tenant key is the widget OWNER, which is a
+        # logical, possibly colon-qualified string (``user:maya``) used for the
+        # in-row W4a ``workspace_id`` filter on ``store.propose`` below — NOT a
+        # physical-store-path workspace id (those must pass the strict
+        # path-traversal allowlist, which rejects a ``:``). So this path keeps
+        # the BARE store + in-row scoping; it does NOT thread the owner into the
+        # store factory (that would ValueError on a colon-qualified owner).
         store = get_instinct_store()
         action = await store.propose(
             pocket_id=pocket_id or widget_id,

--- a/ee/pocketpaw_ee/paw_print/router.py
+++ b/ee/pocketpaw_ee/paw_print/router.py
@@ -547,6 +547,12 @@ async def _apply_event_mapping(widget: PawPrintWidget, event: PawPrintEvent) -> 
     except ImportError:
         return None
 
+    # ISO note: paw-print's tenant key is the widget OWNER, a logical, possibly
+    # colon-qualified string (``user:maya``) — NOT a physical-store-path
+    # workspace id (a ``:`` fails the path-traversal allowlist). The Fabric
+    # write is scoped by the object's ``source_*`` provenance + the store's own
+    # in-row guard, not by a per-owner store file, so this keeps the BARE store
+    # rather than threading the owner into the factory (which would ValueError).
     fabric = get_fabric_store()
     if fabric is None:
         return None

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2833,7 +2833,10 @@ async def request_publish_pocket(
         "proposed_event_id": None,
     }
 
-    store = get_instinct_store()
+    # ISO: scope the store to the caller's workspace (this can run on an HTTP
+    # path with no ``current_workspace`` ContextVar) so the publish proposal
+    # lands in the tenant's file.
+    store = get_instinct_store(workspace_id=workspace_id or None)
     action = await store.propose(
         pocket_id=pocket_id,
         title="Publish site changes",

--- a/ee/pocketpaw_ee/versions/instinct_executor.py
+++ b/ee/pocketpaw_ee/versions/instinct_executor.py
@@ -98,15 +98,20 @@ async def execute_approved_change(action: Any, *, human_event_id: Any | None = N
     """
     from pocketpaw.stores import get_instinct_store
 
-    store = get_instinct_store()
     blob = artifact_change_blob(action)
     if blob is None:
-        # Defensive — the router only calls this when the blob is present.
+        # Defensive — the router only calls this when the blob is present. We
+        # can't resolve the store's workspace without the blob either, so bail
+        # before opening one.
         return
 
     scope_type = str(blob.get("scope_type") or "")
     scope_id = str(blob.get("scope_id") or "")
     workspace_id = str(blob.get("workspace") or blob.get("workspace_id") or "")
+    # ISO: HTTP approve path (no ``current_workspace`` ContextVar) — scope the
+    # store to the blob's workspace so the merge's executed/failed mark lands in
+    # the tenant's file, not the shared ledger (and doesn't raise under the flag).
+    store = get_instinct_store(workspace_id=workspace_id or None)
     to_version_id = str(blob.get("to_version_id") or "")
     author = blob.get("user_id")
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -177,6 +177,11 @@ cloud = "pocketpaw_ee.extensions:CloudEmbeddingProvider"
 [project.entry-points."pocketpaw.memory_backends"]
 mongodb = "pocketpaw_ee.extensions:MongoMemoryBackendProvider"
 
+# ISO-3: the workspace-keyed store provider. Activates the StoreProvider seam
+# ISO-1 added; returns the per-workspace file store via the OSS helper.
+[project.entry-points."pocketpaw.stores"]
+cloud = "pocketpaw_ee.extensions:CloudStoreProvider"
+
 [project.entry-points."pocketpaw.capabilities"]
 cloud = "pocketpaw_ee.extensions:CloudCapabilityProvider"
 

--- a/src/pocketpaw/_store_locks.py
+++ b/src/pocketpaw/_store_locks.py
@@ -1,0 +1,61 @@
+# src/pocketpaw/_store_locks.py
+# Created: 2026-06-26 (ISO-4 — audit-lock carry from the ISO-2 security review).
+#
+# Process-global registry of per-db-file asyncio locks, keyed by db_path. The
+# Instinct audit hash-chain is serialized by a lock held across the chain
+# read-head + insert in InstinctStore._log: without it, two concurrent _log
+# calls could both read the same prev_hash before either inserts, forking the
+# chain. Until ISO-4 that lock lived on the STORE INSTANCE (self._log_lock).
+#
+# The ISO-2 security review flagged the gap that motivates this module: under
+# the workspace-keyed factory's bounded LRU (ISO-1/2), a workspace's
+# InstinctStore can be EVICTED and a NEW instance built for the same file while
+# an async _log on the old instance is still in flight. Two instances for the
+# same db_path each held their OWN per-instance lock, so they did NOT mutually
+# exclude — re-opening the within-tenant chain-fork window the lock exists to
+# close. Keying the lock by db_path here (OUTSIDE any evictable store instance)
+# means every instance that targets the same file shares ONE lock, so eviction
+# can never split it. Different files (different tenants) still get different
+# locks and never contend — the property the old per-instance design wanted,
+# now without the eviction hole.
+
+from __future__ import annotations
+
+import asyncio
+
+# (db_path, running-loop id) -> the lock guarding that file's audit-chain
+# append. Module-global so it survives store eviction/recreation.
+#
+# Why the loop id is part of the key: an ``asyncio.Lock`` bound to one running
+# loop cannot be awaited under a different loop (it raises "bound to a different
+# event loop"). Production runs a single long-lived loop, so this degenerates to
+# "one lock per db file" — exactly what we want. The pytest-asyncio suite runs a
+# FRESH loop per test, so without the loop in the key a lock cached under test
+# A's loop would blow up in test B. Scoping by loop gives each loop its own lock
+# per file with zero introspection of private Lock internals, and never weakens
+# isolation: a brand-new loop has no in-flight appends from the old one to
+# serialize against, and within ANY single loop every instance for the same file
+# still shares one lock (the eviction-hole fix).
+_locks: dict[tuple[str, int], asyncio.Lock] = {}
+
+
+def audit_lock_for(db_path: str) -> asyncio.Lock:
+    """Return the process-global audit-append lock for ``db_path``.
+
+    All InstinctStore instances pointing at the same file (under the same event
+    loop) get the SAME lock, so a store evicted+rebuilt mid-append still
+    serializes against its replacement. Must be called with a running event
+    loop (it always is — it is invoked from inside an ``async`` append).
+    """
+    loop = asyncio.get_running_loop()
+    key = (db_path, id(loop))
+    lock = _locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _locks[key] = lock
+    return lock
+
+
+def reset_audit_locks() -> None:
+    """Drop every cached lock. For tests that need a clean registry."""
+    _locks.clear()

--- a/src/pocketpaw/extensions.py
+++ b/src/pocketpaw/extensions.py
@@ -15,6 +15,12 @@ Updated: 2026-06-12 (connector-store-unification CS-3) — added
 ``ConnectorStateStoreProvider`` (group ``pocketpaw.connector_state_stores``)
 so EE can back the ConnectorRegistry's durable state with the cloud DB
 instead of the file store.
+
+Updated: 2026-06-26 (ISO-1 — workspace-keyed store factory) — activated the
+previously-dormant ``StoreProvider`` seam: ``pocketpaw.stores.get_fabric_store``
+now consults it, and ``get_store`` gained a ``workspace_id`` keyword so a future
+EE provider can return a per-workspace / cloud-backed Fabric store. The EE
+registration is a later task; core only consults the seam here.
 """
 
 from __future__ import annotations
@@ -82,11 +88,24 @@ class AuthProvider(Protocol):
 class StoreProvider(Protocol):
     """Entry-point group: ``pocketpaw.stores``
 
-    Overrides the default singleton store factories (instinct, fabric, …).
-    Core ships local SQLite-backed defaults; EE swaps in cloud-backed ones.
+    Overrides the default store factories (instinct, fabric, …). Core ships
+    local SQLite-backed defaults; EE swaps in cloud-backed ones.
+
+    Activated by ISO-1 (2026-06-26): ``pocketpaw.stores.get_fabric_store``
+    consults this seam before building its own store, so EE can later register a
+    workspace-keyed / cloud-backed Fabric store without core importing EE. The
+    EE registration itself is a LATER task — core merely consults the seam now.
+
+    ``get_store`` takes the logical store *name* (``"fabric"``, ``"instinct"``,
+    …) and the resolved ``workspace_id`` (``None`` for the single-tenant /
+    unscoped path). A provider returns the store it wants core to use, or
+    ``None`` to decline that name (core then builds its local default).
+    Implementations should accept ``workspace_id`` as a keyword so the core
+    factory can pass it; the factory tolerates a legacy no-``workspace_id``
+    signature for back-compat.
     """
 
-    def get_store(self, name: str) -> Any: ...
+    def get_store(self, name: str, *, workspace_id: str | None = None) -> Any: ...
 
 
 @runtime_checkable

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -135,6 +135,14 @@
 #        match. ``ensure_type`` / ``ingest_records`` (connectors/fabric_ingest.py)
 #        thread ``workspace_id`` so existing ingestion keeps working and minted
 #        types land in the caller's tenant.
+# Updated: 2026-06-26 (ISO-1 — physical per-workspace isolation) — added
+#   aclose(): a best-effort WAL-checkpoint + state reset the new workspace-keyed
+#   store factory (src/pocketpaw/stores.py) runs when it evicts a per-workspace
+#   FabricStore from its bounded LRU. The store still holds no long-lived
+#   connection; aclose exists only so an idle tenant's write-ahead-log sidecar
+#   gets truncated instead of growing unbounded across 128+ cached tenants. The
+#   W4a in-row workspace_id WHERE-filter is UNCHANGED — physical file isolation
+#   is ADDITIVE defense-in-depth layered on top of it, never a replacement.
 
 
 from __future__ import annotations
@@ -530,6 +538,29 @@ class FabricStore:
     def _conn(self) -> aiosqlite.Connection:
         """Return a new connection context manager. Use with `async with`."""
         return aiosqlite.connect(self._db_path)
+
+    async def aclose(self) -> None:
+        """Release this store's on-disk resources (ISO-1).
+
+        ``FabricStore`` holds NO long-lived connection — every method opens and
+        closes its own ``aiosqlite.connect()`` per call — so there is no socket
+        or cursor to close. What CAN accumulate is a write-ahead-log sidecar
+        (``fabric.db-wal`` / ``-shm``) that grows until a checkpoint folds it
+        back into the main file. Under per-workspace physical isolation the
+        store factory caches up to 128 of these and evicts the least-recently
+        used; ``aclose`` is what the factory runs on eviction so an idle
+        tenant's WAL is truncated rather than left to grow unbounded, and the
+        next ``_ensure_schema`` re-runs cleanly on the cold handle.
+
+        Best-effort and idempotent: a checkpoint failure (DB never created,
+        WAL not in use, file vanished) is swallowed — eviction must never raise.
+        """
+        self._initialized = False
+        try:
+            async with aiosqlite.connect(self._db_path) as db:
+                await db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except Exception:  # noqa: BLE001 — eviction cleanup is best-effort
+            logger.debug("FabricStore.aclose checkpoint skipped", exc_info=True)
 
     # --- Object Types ---
 

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,17 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-06-26 (ISO-4 — audit-lock keyed outside the evictable instance)
+#   — the audit-append lock (``_log_lock``, which serializes the chain
+#   read-head + insert in ``_log``) is no longer a per-instance
+#   ``asyncio.Lock`` set in ``__init__``. It is now a PROPERTY that fetches a
+#   process-global lock keyed by ``db_path`` from ``pocketpaw._store_locks``.
+#   The ISO-2 security review flagged the hole: under the ISO-1/2 bounded-LRU
+#   store factory, a workspace's store can be evicted and rebuilt for the same
+#   file while an append is in flight, so two instances with two per-instance
+#   locks let their appends race and fork the chain. A db_path-keyed lock makes
+#   every instance for the same file share ONE lock; different tenants (files)
+#   still never contend. The two ``async with self._log_lock`` call sites are
+#   unchanged — the property is transparent.
 # Updated: 2026-06-26 (ISO-2 — physical per-workspace isolation) — added
 #   aclose(): a best-effort WAL-checkpoint + state reset the workspace-keyed
 #   store factory (src/pocketpaw/stores.py) runs when it evicts a per-workspace
@@ -384,13 +396,29 @@ class InstinctStore:
     def __init__(self, db_path: str | Path) -> None:
         self._db_path = str(db_path)
         self._initialized = False
-        # Serializes the audit-chain read-head + insert in _log (REVIEW-1):
-        # each _log opens its own connection, so without this lock two
-        # concurrent _log calls could both read the same prev_hash before
-        # either inserts, forking the chain and producing false-positive
-        # tamper reports in verify_audit_chain. Per-instance (not module-level)
-        # so separate tenants/stores don't contend.
-        self._log_lock = asyncio.Lock()
+
+    @property
+    def _log_lock(self) -> asyncio.Lock:
+        """The lock serializing this file's audit-chain read-head + insert.
+
+        Held across the prev_hash read + the append in ``_log``: each ``_log``
+        opens its own connection, so without it two concurrent appends could
+        both read the same prev_hash before either inserts, forking the chain
+        and producing false-positive tamper reports in ``verify_audit_chain``.
+
+        ISO-4: the lock is now keyed by ``db_path`` in a PROCESS-GLOBAL registry
+        (``pocketpaw._store_locks``), not stored on this instance. The ISO-2
+        security review flagged that a per-instance lock does NOT cover the
+        bounded-LRU eviction window: when the store factory evicts a workspace's
+        InstinctStore and builds a fresh one for the same file, two instances
+        briefly coexist, and per-instance locks let their appends race and fork
+        that tenant's chain. A db_path-keyed lock makes every instance for the
+        same file share ONE lock, closing that window. Different tenants (files)
+        still get different locks and never contend.
+        """
+        from pocketpaw._store_locks import audit_lock_for
+
+        return audit_lock_for(self._db_path)
 
     async def _ensure_schema(self) -> None:
         if self._initialized:

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,19 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-06-26 (ISO-2 — physical per-workspace isolation) — added
+#   aclose(): a best-effort WAL-checkpoint + state reset the workspace-keyed
+#   store factory (src/pocketpaw/stores.py) runs when it evicts a per-workspace
+#   InstinctStore from its bounded LRU. The store still holds no long-lived
+#   connection; aclose exists only so an idle tenant's write-ahead-log sidecar
+#   gets truncated instead of growing across 128+ cached tenants. ISO-2 gives
+#   each workspace its OWN instinct.db (~/.pocketpaw/workspaces/<id>/instinct.db),
+#   so the W2b audit hash-chain below is now PER-FILE: each tenant's chain has its
+#   own genesis→…→head and ``verify_audit_chain`` runs PER WORKSPACE (a tenant's
+#   auditor verifies only that tenant's chain — the correct multi-tenant model).
+#   The W4a in-row ``workspace_id`` read-filter is UNCHANGED — physical file
+#   isolation is ADDITIVE defense-in-depth layered on top of it. The store class
+#   itself is workspace-agnostic; isolation is entirely in which file the factory
+#   hands it.
 # Updated: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — ADDITIVE
 #   generic scope on the actions table. ``instinct_actions`` now carries a
 #   nullable ``scope_type`` column (additive ALTER, mirrors the assignee /
@@ -102,6 +116,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -121,6 +136,8 @@ from pocketpaw.instinct.models import (
     OutcomeVerdict,
 )
 from pocketpaw.instinct.trace import FabricObjectSnapshot, ReasoningTrace
+
+logger = logging.getLogger(__name__)
 
 
 def _serialize_outcome(outcome: str | OutcomeVerdict | None) -> str | None:
@@ -427,6 +444,29 @@ class InstinctStore:
     def _conn(self) -> aiosqlite.Connection:
         """Return a new connection context manager."""
         return aiosqlite.connect(self._db_path)
+
+    async def aclose(self) -> None:
+        """Release this store's on-disk resources (ISO-2).
+
+        Like ``FabricStore``, ``InstinctStore`` holds NO long-lived connection —
+        every method opens and closes its own ``aiosqlite.connect()`` per call —
+        so there is no socket or cursor to close. What CAN accumulate is a
+        write-ahead-log sidecar (``instinct.db-wal`` / ``-shm``). Under
+        per-workspace physical isolation (ISO-2) the store factory caches up to
+        128 per-workspace handles and evicts the least-recently-used; ``aclose``
+        is what the factory runs on eviction so an idle tenant's WAL is truncated
+        rather than left to grow, and the next ``_ensure_schema`` re-runs cleanly
+        on the cold handle.
+
+        Best-effort and idempotent: a checkpoint failure (DB never created, WAL
+        not in use, file vanished) is swallowed — eviction must never raise.
+        """
+        self._initialized = False
+        try:
+            async with aiosqlite.connect(self._db_path) as db:
+                await db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except Exception:  # noqa: BLE001 — eviction cleanup is best-effort
+            logger.debug("InstinctStore.aclose checkpoint skipped", exc_info=True)
 
     # --- Actions ---
 
@@ -1144,14 +1184,22 @@ class InstinctStore:
     async def verify_audit_chain(self) -> dict[str, Any]:
         """Walk the audit hash chain and report whether it is intact.
 
-        The chain is GLOBAL (each row's ``prev_hash`` links to the previous
-        *hashed* row across the whole ledger, not within a pocket), so
+        The chain spans the WHOLE FILE (each row's ``prev_hash`` links to the
+        previous *hashed* row in this ledger, not within a pocket), so
         verification always runs over the entire table in insertion order
         (``rowid``). It recomputes each row's ``entry_hash`` from the row's
         canonical content + the recomputed running ``prev_hash`` and compares
         against the stored value. The first row that fails to match is the
         break point — any insertion, edit, or deletion of a hashed row shifts
         or invalidates every subsequent link.
+
+        ISO-2: under per-workspace physical isolation each workspace has its OWN
+        ``instinct.db``, so "the whole ledger" here is exactly ONE tenant's
+        ledger — the chain is per-workspace, with its own genesis→…→head, and
+        this verifies that tenant's chain independently. (On a single-tenant OSS
+        install, or the legacy shared file, it verifies the one shared chain, as
+        before. The method is workspace-agnostic — isolation is entirely in which
+        file the factory opened.)
 
         Legacy boundary: rows written before W2b have a NULL ``entry_hash``.
         They are counted as ``legacy_unhashed`` and skipped — the chain is

--- a/src/pocketpaw/migrations/__init__.py
+++ b/src/pocketpaw/migrations/__init__.py
@@ -1,0 +1,2 @@
+# pocketpaw/migrations/__init__.py — Migration utilities for PocketPaw data stores.
+# Created: 2026-06-26 — Package init for one-time, idempotent data migrations.

--- a/src/pocketpaw/migrations/split_workspace_stores.py
+++ b/src/pocketpaw/migrations/split_workspace_stores.py
@@ -455,8 +455,6 @@ async def _migrate_instinct(
             ws = _effective_ws(row, system_workspace)
             by_ws_audit.setdefault(ws, []).append(row)
 
-        import json as _json
-
         for ws_id, ws_audit_rows in by_ws_audit.items():
             store = build_workspace_store("instinct", ws_id)
             await store._ensure_schema()
@@ -487,8 +485,6 @@ async def _migrate_instinct(
 
                 count = 0
                 for row in new_rows:
-                    import json
-
                     context_raw = row["context"]
                     try:
                         context_obj = json.loads(context_raw) if context_raw else {}
@@ -522,7 +518,7 @@ async def _migrate_instinct(
                         new_prev_hash = None
                         new_entry_hash = None
 
-                    context_json = _json.dumps(context_obj) if not context_raw else context_raw
+                    context_json = json.dumps(context_obj) if not context_raw else context_raw
 
                     await dest.execute(
                         "INSERT OR IGNORE INTO instinct_audit"

--- a/src/pocketpaw/migrations/split_workspace_stores.py
+++ b/src/pocketpaw/migrations/split_workspace_stores.py
@@ -1,0 +1,583 @@
+# pocketpaw/migrations/split_workspace_stores.py — One-time migration that splits
+# the shared per-process SQLite stores (fabric.db, instinct.db) into per-workspace
+# files under ~/.pocketpaw/workspaces/<workspace_id>/<name>.db.
+#
+# Created: 2026-06-26 (ISO-4) — Companion to ISO-1/2/3 physical isolation work.
+#
+# Background
+# ----------
+# ISO-1 and ISO-2 introduced per-workspace physical isolation: new writes land in
+# ~/.pocketpaw/workspaces/<workspace_id>/fabric.db (or instinct.db). But existing
+# rows were written to the SHARED ~/.pocketpaw/fabric.db and instinct.db files.
+# This migration reads those shared files and copies each row into the correct
+# per-workspace file (grouping by the ``workspace_id`` column; NULL rows go to the
+# ``system_workspace`` bucket, default ``"system0"``).
+#
+# Why "system0" not "__system__": the path-traversal allowlist in
+# pocketpaw.stores._safe_workspace_dir requires the first character to be
+# alphanumeric ([A-Za-z0-9][A-Za-z0-9_-]*). A leading underscore is rejected
+# by that guard, so "__system__" is not a valid workspace dir name. "system0"
+# satisfies the allowlist and is unambiguous.
+#
+# Idempotency
+# -----------
+# We use a marker file: after a successful migration we rename each shared file to
+# <name>.db.migrated. Re-running detects the .migrated files and skips gracefully,
+# returning a summary with skipped=True. The original shared data is therefore
+# preserved (in .migrated form) for rollback; we NEVER delete it.
+#
+# Instinct audit re-chain (+ source-integrity gate)
+# --------------------------------------------------
+# The shared instinct_audit ledger has a GLOBAL hash chain whose prev_hash links
+# span all workspaces interleaved. After splitting into per-workspace files, each
+# workspace's chain must be RE-COMPUTED from genesis (prev_hash="") in rowid order
+# within that workspace, using the existing _canonical_audit_payload + compute_audit_hash
+# helpers. Non-audit tables are plain row copies.
+#
+# SECURITY GATE: re-chaining is only sound over AUTHENTIC rows, so BEFORE we
+# re-chain we ``verify_audit_chain`` on the SHARED instinct.db. If the source
+# chain is broken/tampered we ABORT (SourceChainTamperedError) — a clean
+# re-chain over tampered rows would launder them into fresh valid-looking
+# per-tenant chains, blessing exactly what tamper-evidence exists to catch.
+# ``force=True`` overrides (logs LOUD at WARNING). The source verdict is recorded
+# in the marker (see below) so the migration leaves an auditable attestation of
+# what it re-chained over. The verify is read-only and runs before the rename, so
+# an abort leaves the source intact.
+#
+# Safety contract
+# ---------------
+# * build_workspace_store() applies the path-traversal allowlist — no traversal possible.
+# * Source instinct chain is verified intact before any re-chain (abort on tamper unless force).
+# * No DELETE on source files — only rename to .migrated AFTER all rows land.
+# * Idempotent: a second call is a no-op (detects .migrated marker or .workspace_split_done).
+# * The marker is JSON recording the source-chain verdict + timestamp + force flag.
+# * Returns a structured summary dict: per-store row counts, skipped flag, source_chain verdict.
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from pocketpaw.instinct.store import (
+    InstinctStore,
+    _canonical_audit_payload,
+    compute_audit_hash,
+)
+from pocketpaw.stores import build_workspace_store
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DATA_DIR = Path.home() / ".pocketpaw"
+
+# Marker written in data_dir after a successful migration so a second run is a no-op.
+_MARKER_FILENAME = ".workspace_split_done"
+
+
+class SourceChainTamperedError(RuntimeError):
+    """Raised when the shared instinct.db audit chain is NOT intact at migration.
+
+    Re-chaining the per-workspace ledgers is only sound over authentic rows. If
+    the source global chain is broken/tampered, the migration aborts with this
+    rather than silently re-chain — a clean re-chain over tampered rows would
+    launder them into fresh valid-looking per-tenant chains, blessing exactly
+    what the tamper-evidence exists to catch. Pass ``force=True`` to override.
+    """
+
+
+async def _verify_source_instinct_chain(src: Path) -> dict[str, Any]:
+    """Run verify_audit_chain on the SHARED instinct.db before any re-chain.
+
+    Returns the verdict dict (intact / broken_at / hashed / …). Read-only — it
+    never mutates the source — so it is safe to call before the rename.
+    """
+    return await InstinctStore(str(src)).verify_audit_chain()
+
+
+def _write_marker(marker: Path, *, source_chain: dict[str, Any] | None, forced: bool) -> None:
+    """Write the idempotency marker, recording the source-chain attestation.
+
+    The marker doubles as an audit record of what the migration re-chained over:
+    the source ``verify_audit_chain`` verdict + a timestamp + whether the tamper
+    gate was force-overridden. ``source_chain`` is ``None`` when there was no
+    instinct.db to migrate (nothing was re-chained). Best-effort on the body —
+    if JSON serialization somehow fails we still create the marker (an empty
+    marker is enough for idempotency), so a write hiccup can't break re-run
+    safety.
+    """
+    payload: dict[str, Any] = {
+        "migrated_at": datetime.now(UTC).isoformat(),
+        "source_chain_verified": source_chain,
+        "forced": forced,
+    }
+    try:
+        marker.write_text(json.dumps(payload, indent=2))
+    except Exception:  # noqa: BLE001 — marker presence is what matters for idempotency
+        logger.warning("split_workspace_stores: could not write marker body", exc_info=True)
+        marker.touch()
+
+
+# Tables belonging to the Fabric store.
+_FABRIC_TABLES = ("fabric_object_types", "fabric_objects", "fabric_links")
+
+# Tables belonging to the Instinct store; the audit table is treated specially
+# (re-chain); all others are plain copies.
+_INSTINCT_NON_AUDIT_TABLES = (
+    "instinct_actions",
+    "instinct_corrections",
+    "instinct_fabric_snapshots",
+)
+_INSTINCT_AUDIT_TABLE = "instinct_audit"
+
+
+async def migrate_shared_stores_to_workspaces(
+    data_dir: Path | None = None,
+    *,
+    system_workspace: str = "system0",
+    force: bool = False,
+) -> dict[str, Any]:
+    """Split shared fabric.db and instinct.db into per-workspace files.
+
+    Parameters
+    ----------
+    data_dir:
+        Root of the PocketPaw data directory (where fabric.db and instinct.db
+        live). Defaults to ``~/.pocketpaw`` when ``None``.
+    system_workspace:
+        The workspace id to assign to rows whose ``workspace_id`` column is
+        NULL (pre-tenancy rows written before W4a). Defaults to ``"system0"``.
+        Must satisfy the path-traversal allowlist: start with [A-Za-z0-9],
+        followed only by [A-Za-z0-9_-]. Leading underscores (e.g. "__system__")
+        are rejected by the allowlist guard in pocketpaw.stores.
+    force:
+        Security override for the source-chain integrity gate. Re-chaining the
+        Instinct audit ledger per workspace is only safe over AUTHENTIC rows, so
+        before re-chaining we ``verify_audit_chain`` on the SHARED instinct.db.
+        If the source chain is BROKEN/tampered we ABORT
+        (:class:`SourceChainTamperedError`) rather than silently re-chain — a
+        clean re-chain over tampered rows would launder them into fresh
+        valid-looking per-tenant chains, blessing exactly what tamper-evidence
+        exists to catch. ``force=True`` overrides the abort, logs LOUD at
+        WARNING, and proceeds anyway (for a deliberate operator who has
+        inspected the breakage). The source-verify result is recorded in the
+        migration marker either way.
+
+    Returns
+    -------
+    dict with keys:
+        - ``skipped`` (bool) — True when already migrated (no-op run).
+        - ``fabric`` (dict) — per-workspace row counts migrated, keyed by table.
+        - ``instinct`` (dict) — same for the instinct store.
+
+    Raises
+    ------
+    ValueError
+        If a workspace_id read from the shared DB is unsafe (would fail
+        build_workspace_store's path-traversal allowlist). This is loud by
+        design: a hostile id in the source data must be flagged, not silently
+        dropped. The system_workspace arg is the escape hatch for NULL rows.
+    """
+    root = data_dir if data_dir is not None else _DEFAULT_DATA_DIR
+    marker = root / _MARKER_FILENAME
+
+    if marker.exists():
+        logger.info(
+            "split_workspace_stores: marker %s exists — skipping (already migrated)", marker
+        )
+        return {"skipped": True, "fabric": {}, "instinct": {}}
+
+    fabric_src = root / "fabric.db"
+    instinct_src = root / "instinct.db"
+
+    # Both migrated files may already exist from a partial run; treat the marker
+    # as the definitive idempotency signal so we always finish the rename pair.
+    fabric_already_done = (root / "fabric.db.migrated").exists()
+    instinct_already_done = (root / "instinct.db.migrated").exists()
+
+    fabric_summary: dict[str, dict[str, int]] = {}
+    instinct_summary: dict[str, dict[str, int]] = {}
+
+    if fabric_src.exists() and not fabric_already_done:
+        fabric_summary = await _migrate_fabric(fabric_src, root, system_workspace=system_workspace)
+        # Rename AFTER success; any exception before this line leaves the source intact.
+        fabric_src.rename(root / "fabric.db.migrated")
+        logger.info(
+            "split_workspace_stores: fabric migration done, source renamed to fabric.db.migrated"
+        )
+    else:
+        if not fabric_src.exists():
+            logger.info("split_workspace_stores: fabric.db not found — nothing to migrate")
+        else:
+            logger.info(
+                "split_workspace_stores: fabric.db.migrated already present — skipping fabric"
+            )
+
+    source_chain: dict[str, Any] | None = None
+    if instinct_src.exists() and not instinct_already_done:
+        # SECURITY GATE (captain hard requirement): re-chaining the audit ledger
+        # is only sound over AUTHENTIC rows. Verify the SHARED chain is intact
+        # BEFORE we re-chain; abort on tamper unless force-overridden — never
+        # launder a broken chain into fresh valid-looking per-tenant chains. This
+        # runs before the rename, so an abort leaves the source untouched.
+        source_chain = await _verify_source_instinct_chain(instinct_src)
+        if not source_chain["intact"]:
+            if not force:
+                raise SourceChainTamperedError(
+                    "split_workspace_stores: the shared instinct.db audit chain is "
+                    f"NOT intact (broken_at={source_chain.get('broken_at')!r}). "
+                    "Refusing to re-chain tampered history into per-workspace files. "
+                    "Inspect the breakage; pass force=True to override deliberately."
+                )
+            logger.warning(
+                "split_workspace_stores: source instinct.db audit chain is BROKEN "
+                "(broken_at=%r) — proceeding under force=True. The migrated "
+                "per-workspace chains will be freshly valid over POSSIBLY-TAMPERED "
+                "rows; this override has been recorded in the marker.",
+                source_chain.get("broken_at"),
+            )
+        instinct_summary = await _migrate_instinct(
+            instinct_src, root, system_workspace=system_workspace
+        )
+        instinct_src.rename(root / "instinct.db.migrated")
+        logger.info(
+            "split_workspace_stores: instinct migration done,"
+            " source renamed to instinct.db.migrated"
+        )
+    else:
+        if not instinct_src.exists():
+            logger.info("split_workspace_stores: instinct.db not found — nothing to migrate")
+        else:
+            logger.info(
+                "split_workspace_stores: instinct.db.migrated already present — skipping instinct"
+            )
+
+    # Write the marker so re-runs are instant no-ops. Record the source-chain
+    # verify result (the captain hard requirement) so the migration leaves an
+    # auditable attestation of what it re-chained over.
+    _write_marker(marker, source_chain=source_chain, forced=force)
+    logger.info("split_workspace_stores: marker written at %s", marker)
+
+    return {
+        "skipped": False,
+        "fabric": fabric_summary,
+        "instinct": instinct_summary,
+        "source_chain": source_chain,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fabric migration — plain row copy, no hash chain
+# ---------------------------------------------------------------------------
+
+
+async def _migrate_fabric(
+    src: Path,
+    root: Path,
+    *,
+    system_workspace: str,
+) -> dict[str, dict[str, int]]:
+    """Copy every fabric table row into the correct per-workspace file."""
+    summary: dict[str, dict[str, int]] = {t: {} for t in _FABRIC_TABLES}
+
+    async with aiosqlite.connect(str(src)) as db:
+        db.row_factory = aiosqlite.Row
+
+        for table in _FABRIC_TABLES:
+            # Check the table exists in the source DB (a very old DB may lack some).
+            async with db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ) as cur:
+                if await cur.fetchone() is None:
+                    logger.debug(
+                        "split_workspace_stores: table %s not found in fabric.db — skipping", table
+                    )
+                    continue
+
+            # Read all rows.
+            async with db.execute(f"SELECT * FROM {table} ORDER BY rowid ASC") as cur:  # noqa: S608
+                rows = await cur.fetchall()
+
+            # Group rows by effective workspace_id.
+            by_ws: dict[str, list[Any]] = {}
+            for row in rows:
+                ws = _effective_ws(row, system_workspace)
+                by_ws.setdefault(ws, []).append(row)
+
+            for ws_id, ws_rows in by_ws.items():
+                store = build_workspace_store("fabric", ws_id)
+                # Ensure schema exists in the target file before writing.
+                await store._ensure_schema()
+
+                dest_path = store._db_path
+                columns = [description[0] for description in (await _get_columns(db, table))]
+
+                async with aiosqlite.connect(dest_path) as dest:
+                    count = 0
+                    for row in ws_rows:
+                        row_dict = dict(zip(columns, [row[c] for c in columns], strict=False))
+                        # Stamp workspace_id where it was NULL.
+                        if "workspace_id" in row_dict and row_dict["workspace_id"] is None:
+                            row_dict["workspace_id"] = ws_id
+
+                        # Idempotent insert: skip if primary key already exists.
+                        pk = row_dict.get("id")
+                        if pk is not None:
+                            async with dest.execute(
+                                f"SELECT 1 FROM {table} WHERE id = ?",
+                                (pk,),  # noqa: S608
+                            ) as check:
+                                if await check.fetchone() is not None:
+                                    continue
+
+                        placeholders = ", ".join(["?"] * len(row_dict))
+                        col_names = ", ".join(row_dict.keys())
+                        await dest.execute(
+                            f"INSERT OR IGNORE INTO {table} ({col_names}) VALUES ({placeholders})",  # noqa: S608
+                            list(row_dict.values()),
+                        )
+                        count += 1
+                    await dest.commit()
+
+                summary[table][ws_id] = summary[table].get(ws_id, 0) + count
+                logger.debug(
+                    "split_workspace_stores: fabric/%s -> ws=%s count=%d", table, ws_id, count
+                )
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Instinct migration — plain row copy + audit re-chain
+# ---------------------------------------------------------------------------
+
+
+async def _migrate_instinct(
+    src: Path,
+    root: Path,
+    *,
+    system_workspace: str,
+) -> dict[str, dict[str, int]]:
+    """Copy every instinct table row into the correct per-workspace file.
+
+    Non-audit tables: plain row copy (grouped by workspace_id).
+    instinct_audit: re-chain each per-workspace file's rows from genesis (prev_hash="")
+    in original rowid order, using the canonical hash helpers from instinct.store.
+    """
+    summary: dict[str, dict[str, int]] = {}
+    for t in (*_INSTINCT_NON_AUDIT_TABLES, _INSTINCT_AUDIT_TABLE):
+        summary[t] = {}
+
+    async with aiosqlite.connect(str(src)) as db:
+        db.row_factory = aiosqlite.Row
+
+        # --- Non-audit tables: plain copy ---
+        for table in _INSTINCT_NON_AUDIT_TABLES:
+            async with db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ) as cur:
+                if await cur.fetchone() is None:
+                    logger.debug(
+                        "split_workspace_stores: table %s not found in instinct.db — skipping",
+                        table,
+                    )
+                    continue
+
+            async with db.execute(f"SELECT * FROM {table} ORDER BY rowid ASC") as cur:  # noqa: S608
+                rows = await cur.fetchall()
+
+            by_ws: dict[str, list[Any]] = {}
+            for row in rows:
+                ws = _effective_ws(row, system_workspace)
+                by_ws.setdefault(ws, []).append(row)
+
+            for ws_id, ws_rows in by_ws.items():
+                store = build_workspace_store("instinct", ws_id)
+                await store._ensure_schema()
+                dest_path = store._db_path
+                columns = [d[0] for d in (await _get_columns(db, table))]
+
+                async with aiosqlite.connect(dest_path) as dest:
+                    count = 0
+                    for row in ws_rows:
+                        row_dict = dict(zip(columns, [row[c] for c in columns], strict=False))
+                        if "workspace_id" in row_dict and row_dict["workspace_id"] is None:
+                            row_dict["workspace_id"] = ws_id
+
+                        pk = row_dict.get("id")
+                        if pk is not None:
+                            async with dest.execute(
+                                f"SELECT 1 FROM {table} WHERE id = ?",
+                                (pk,),  # noqa: S608
+                            ) as check:
+                                if await check.fetchone() is not None:
+                                    continue
+
+                        placeholders = ", ".join(["?"] * len(row_dict))
+                        col_names = ", ".join(row_dict.keys())
+                        await dest.execute(
+                            f"INSERT OR IGNORE INTO {table} ({col_names}) VALUES ({placeholders})",  # noqa: S608
+                            list(row_dict.values()),
+                        )
+                        count += 1
+                    await dest.commit()
+
+                summary[table][ws_id] = summary[table].get(ws_id, 0) + count
+
+        # --- Audit table: read all rows, group by ws, re-chain per-ws ---
+        table = _INSTINCT_AUDIT_TABLE
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ) as cur:
+            if await cur.fetchone() is None:
+                logger.debug(
+                    "split_workspace_stores: instinct_audit not found in instinct.db — skipping"
+                )
+                return summary
+
+        # Read ALL audit rows in original insertion order (rowid ASC).
+        # We need EVERY column including prev_hash/entry_hash from the source,
+        # because we'll DISCARD them and recompute per-workspace chain links.
+        async with db.execute(
+            "SELECT rowid, id, action_id, pocket_id, timestamp, actor, event,"
+            " category, description, context, ai_recommendation, outcome,"
+            " prev_hash, entry_hash, workspace_id"
+            " FROM instinct_audit ORDER BY rowid ASC"
+        ) as cur:
+            audit_rows = await cur.fetchall()
+
+        # Group by effective workspace, PRESERVING original rowid order within each group.
+        by_ws_audit: dict[str, list[Any]] = {}
+        for row in audit_rows:
+            ws = _effective_ws(row, system_workspace)
+            by_ws_audit.setdefault(ws, []).append(row)
+
+        import json as _json
+
+        for ws_id, ws_audit_rows in by_ws_audit.items():
+            store = build_workspace_store("instinct", ws_id)
+            await store._ensure_schema()
+            dest_path = store._db_path
+
+            async with aiosqlite.connect(dest_path) as dest:
+                # Check which row ids are already present (idempotent).
+                async with dest.execute("SELECT id FROM instinct_audit") as existing_cur:
+                    existing_ids = {r[0] async for r in existing_cur}
+
+                # Separate new rows from already-migrated ones.
+                new_rows = [r for r in ws_audit_rows if r["id"] not in existing_ids]
+
+                if not new_rows:
+                    summary[table][ws_id] = 0
+                    continue
+
+                # RE-CHAIN: find the current chain head in the destination file
+                # (there may be pre-existing hashed rows if schema was already
+                # bootstrapped with audit entries). Start prev_hash from the
+                # current chain head so we extend it correctly.
+                async with dest.execute(
+                    "SELECT entry_hash FROM instinct_audit"
+                    " WHERE entry_hash IS NOT NULL ORDER BY rowid DESC LIMIT 1"
+                ) as head_cur:
+                    head_row = await head_cur.fetchone()
+                running_prev = head_row[0] if head_row else ""
+
+                count = 0
+                for row in new_rows:
+                    import json
+
+                    context_raw = row["context"]
+                    try:
+                        context_obj = json.loads(context_raw) if context_raw else {}
+                    except (json.JSONDecodeError, ValueError):
+                        context_obj = {}
+
+                    timestamp = row["timestamp"] or ""
+                    ws_col = ws_id  # stamp the resolved workspace
+
+                    # Only re-chain rows that originally had an entry_hash (hashed rows).
+                    # Legacy NULL-hash rows stay un-chained (NULL prev_hash, NULL entry_hash).
+                    if row["entry_hash"] is not None:
+                        canonical = _canonical_audit_payload(
+                            id=row["id"],
+                            action_id=row["action_id"],
+                            pocket_id=row["pocket_id"],
+                            timestamp=timestamp,
+                            actor=row["actor"],
+                            event=row["event"],
+                            category=row["category"],
+                            description=row["description"],
+                            context=context_obj,
+                            ai_recommendation=row["ai_recommendation"],
+                            outcome=row["outcome"],
+                        )
+                        new_entry_hash = compute_audit_hash(canonical, running_prev)
+                        new_prev_hash = running_prev
+                        running_prev = new_entry_hash
+                    else:
+                        # Legacy un-hashed row: preserve NULL hashes.
+                        new_prev_hash = None
+                        new_entry_hash = None
+
+                    context_json = _json.dumps(context_obj) if not context_raw else context_raw
+
+                    await dest.execute(
+                        "INSERT OR IGNORE INTO instinct_audit"
+                        " (id, action_id, pocket_id, timestamp, actor, event,"
+                        " category, description, context, ai_recommendation,"
+                        " outcome, prev_hash, entry_hash, workspace_id)"
+                        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            row["id"],
+                            row["action_id"],
+                            row["pocket_id"],
+                            timestamp,
+                            row["actor"],
+                            row["event"],
+                            row["category"] or "decision",
+                            row["description"],
+                            context_json,
+                            row["ai_recommendation"],
+                            row["outcome"],
+                            new_prev_hash,
+                            new_entry_hash,
+                            ws_col,
+                        ),
+                    )
+                    count += 1
+
+                await dest.commit()
+
+            summary[table][ws_id] = count
+            logger.debug(
+                "split_workspace_stores: instinct_audit -> ws=%s count=%d (re-chained)",
+                ws_id,
+                count,
+            )
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _effective_ws(row: Any, system_workspace: str) -> str:
+    """Return the effective workspace id for a row, substituting NULL with system_workspace."""
+    try:
+        ws = row["workspace_id"]
+    except (IndexError, KeyError):
+        ws = None
+    return ws if (ws is not None and ws != "") else system_workspace
+
+
+async def _get_columns(db: aiosqlite.Connection, table: str) -> list[tuple[str, ...]]:
+    """Return column descriptions for a table via PRAGMA table_info."""
+    async with db.execute(f"PRAGMA table_info({table})") as cur:  # noqa: S608
+        infos = await cur.fetchall()
+    # PRAGMA table_info columns: cid, name, type, notnull, dflt_value, pk
+    return [(info[1],) for info in infos]

--- a/src/pocketpaw/stores.py
+++ b/src/pocketpaw/stores.py
@@ -1,27 +1,198 @@
-"""Process-wide singletons for the local SQLite-backed runtime stores.
+"""Process-wide store factories for the local SQLite-backed runtime stores.
 
-Instinct, Fabric and Paw Print all keep their state in SQLite under
-``~/.pocketpaw/``. These factories return a lazily-created singleton each so
-agent tools, automations and routers share one instance per process.
+Instinct, Fabric and Paw Print keep their state in SQLite under
+``~/.pocketpaw/``. These factories return a lazily-created handle so agent
+tools, automations and routers share one instance per process (or, for Fabric,
+one instance per WORKSPACE — see below).
 
-This is plain core infrastructure — there is no cloud-backed override. The
-factories moved here from ``pocketpaw_ee/api.py`` in the OSS-EE split
-(Phase 3); ``pocketpaw_ee.api`` now re-exports from this module for the
-enterprise routers that still import via that path.
+ISO-1 (2026-06-26 — physical per-workspace isolation): Fabric is no longer a
+single process-wide singleton on a SHARED ``~/.pocketpaw/fabric.db``. On a
+shared cloud box every tenant used to read and write the same file, with only
+the W4a in-row ``workspace_id`` WHERE-filter standing between them. ISO-1 adds
+PHYSICAL isolation: each workspace gets its OWN file at
+``~/.pocketpaw/workspaces/<workspace_id>/fabric.db`` — mirroring how KB
+(``~/.knowledge-base/{scope}/``) and Soul (one ``.soul`` per entity) already
+isolate by directory. The W4a WHERE-filter STAYS; physical isolation is
+ADDITIVE defense-in-depth, not a replacement.
+
+``get_fabric_store`` resolves the target workspace in this order:
+
+    explicit ``workspace_id=`` arg  →  the ``current_workspace`` ContextVar  →  None
+
+When a workspace resolves, a per-workspace ``FabricStore`` is returned (and the
+directory is created), cached in a bounded LRU that ``aclose()``s the handle it
+evicts. When NO workspace resolves:
+
+  * if ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` is truthy (cloud mode — set by the
+    EE cloud bootstrap, mirroring the ``POCKETPAW_MEMORY_BACKEND`` precedent),
+    we RAISE ``WorkspaceScopeRequired`` (fail-closed). A missing workspace on a
+    cloud path must NEVER silently fall back to a shared store.
+  * otherwise (single-tenant OSS) we return the legacy
+    ``~/.pocketpaw/fabric.db`` singleton, so a self-hosted install keeps working
+    exactly as before.
+
+The ``current_workspace`` ContextVar lives HERE in OSS core (``pocketpaw``) on
+purpose: EE imports from OSS, never the reverse. ISO-3 (a later task) wires the
+non-router callers — the agent-tool path, the MCP servers — to SET this
+ContextVar per request/stream so they too land in the right file; THIS task only
+creates and consults it and wires the EE Fabric router (which already resolves
+the workspace) to pass it explicitly.
+
+The factory consults the previously-dormant ``pocketpaw.stores`` entry-point
+seam (``StoreProvider``): if EE (or a third party) registers a provider, it gets
+first refusal on building the store, so a later task can swap in a cloud-backed
+implementation without touching core. An OSS-only install finds no provider and
+uses the local SQLite default.
+
+Instinct and Paw Print are UNCHANGED here — still process-wide singletons on the
+shared file. Per-workspace Instinct isolation is a separate later task (ISO-2);
+the workspace-keyed machinery below is written generically so it can be reused.
+
+The factories moved here from ``pocketpaw_ee/api.py`` in the OSS-EE split
+(Phase 3); ``pocketpaw_ee.api`` re-exports from this module for the enterprise
+routers that still import via that path.
 """
 
 from __future__ import annotations
 
+import logging
+import os
+import re
+from collections import OrderedDict
+from contextvars import ContextVar
 from pathlib import Path
 
+from pocketpaw._registry import first
 from pocketpaw.fabric.store import FabricStore
 from pocketpaw.instinct.store import InstinctStore
 from pocketpaw.paw_print.store import PawPrintStore
 
+logger = logging.getLogger(__name__)
+
 _DATA_DIR = Path.home() / ".pocketpaw"
 
+# Entry-point group that supplies a `StoreProvider` (see pocketpaw.extensions).
+# EE registers a provider to back stores with cloud-native implementations; an
+# OSS install registers none and the local SQLite defaults below are used.
+_STORE_PROVIDER_GROUP = "pocketpaw.stores"
+
+# Env flag that turns on fail-closed workspace scoping. Set by the EE cloud
+# bootstrap (a later task), mirroring the POCKETPAW_MEMORY_BACKEND precedent in
+# ee/pocketpaw_ee/cloud/memory/bootstrap.py. When truthy, a Fabric store request
+# that resolves to NO workspace raises instead of returning the shared file.
+_REQUIRE_WORKSPACE_SCOPE_ENV = "POCKETPAW_REQUIRE_WORKSPACE_SCOPE"
+
+# Bounded cap on the per-workspace FabricStore handle cache. A FabricStore is a
+# cheap object (a path string + an `_initialized` bool; it opens/closes a
+# connection per call), so 128 live handles is light — but unbounded growth
+# across thousands of tenants on a long-lived process would still leak WAL
+# sidecars and handle objects, so we cap and evict LRU, aclose()-ing the victim.
+_WORKSPACE_STORE_CACHE_CAP = 128
+
+# STRICT allowlist for a workspace id that is about to name a directory under
+# ``workspaces/``. A real workspace id is either a 24-hex Mongo ObjectId
+# (e.g. ``69e4f93b57ff64b3903868e3``) or a slug (``ws-acme``, ``w_1``) — all of
+# which START with an alphanumeric and then carry only ``[A-Za-z0-9_-]``. We
+# validate POSITIVELY against that shape and FAIL CLOSED (raise) on anything
+# else, rather than trying to sanitize a hostile id into something "safe". An
+# allowlist can't be out-thought by a novel traversal encoding the way a
+# denylist can.
+#
+# The FIRST char must be alphanumeric: this rejects a leading ``-`` (which the
+# charset would otherwise allow) so a workspace dir name can never be mistaken
+# for an argv flag (``-rf``, ``--force``) if the path is ever handed to a
+# subprocess / CLI as a bare argument — a defense-in-depth concern even though a
+# leading-dash id stays inside ``workspaces/`` and doesn't itself escape.
+#
+# Security-critical: this is the load-bearing guard that keeps one tenant's id
+# from ever resolving to another tenant's (or the OS's) files, and it governs
+# the GENERIC factory so ISO-2's Instinct path inherits it.
+_WORKSPACE_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_-]*\Z")
+
+
+# ---------------------------------------------------------------------------
+# Workspace context + fail-closed error
+# ---------------------------------------------------------------------------
+
+
+class WorkspaceScopeRequired(RuntimeError):
+    """Raised when a workspace-scoped store is required but none resolved.
+
+    Fail-closed guard for the cloud path: with
+    ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` set, a store request that carries no
+    explicit ``workspace_id`` and finds no ``current_workspace`` ContextVar
+    value raises this rather than silently reading the shared store — which
+    would re-open the very cross-tenant leak physical isolation closes.
+    """
+
+
+# The active workspace for the current execution context. OSS core owns this so
+# EE (and the agent-tool / MCP callers wired in ISO-3) can SET it without core
+# ever importing EE. ``None`` means "no workspace in context" — the resolution
+# in get_fabric_store then falls through to the env-flag decision.
+current_workspace: ContextVar[str | None] = ContextVar("current_workspace", default=None)
+
+
+def _resolve_workspace_id(explicit: str | None) -> str | None:
+    """Resolve the effective workspace: explicit arg → ContextVar → None.
+
+    A blank / whitespace-only value (from either source) is treated as "no
+    workspace" so an empty string can never name a real per-workspace directory
+    NOR satisfy the fail-closed required-scope check.
+    """
+    candidate = explicit if explicit is not None else current_workspace.get()
+    if candidate is None:
+        return None
+    candidate = candidate.strip()
+    return candidate or None
+
+
+def _require_workspace_scope() -> bool:
+    """True when the env flag mandates fail-closed workspace scoping."""
+    return os.environ.get(_REQUIRE_WORKSPACE_SCOPE_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _safe_workspace_dir(workspace_id: str) -> Path:
+    """Map a workspace id to its data dir, FAILING CLOSED on a non-token id.
+
+    Security-critical (ISO-1 physically isolates tenants): the id is about to
+    become a directory name under ``workspaces/``, so it must be a single, safe
+    path segment. We validate it POSITIVELY against ``_WORKSPACE_ID_RE``
+    (``[A-Za-z0-9_-]+`` — covers a 24-hex ObjectId and every slug form) and
+    RAISE ``ValueError`` on anything else: empty, a ``/`` or ``\\`` separator,
+    ``.`` / ``..``, a space, a null byte, a leading dash that argv could read as
+    a flag, any non-ASCII. We do NOT sanitize-and-continue — a hostile id is
+    refused outright. The resolved-path containment check below is kept as
+    defense-in-depth (a second, independent line) but the allowlist is the
+    primary guard, because a denylist can be defeated by a novel encoding.
+    """
+    if not isinstance(workspace_id, str) or not _WORKSPACE_ID_RE.match(workspace_id):
+        raise ValueError(
+            f"unsafe workspace_id for store path: {workspace_id!r} "
+            "(must match [A-Za-z0-9][A-Za-z0-9_-]*)"
+        )
+
+    root = (_DATA_DIR / "workspaces").resolve()
+    target = (root / workspace_id).resolve()
+    # Defense-in-depth: even though the allowlist already forbids separators and
+    # dots, re-assert that the resolved real path sits DIRECTLY under the
+    # workspaces root. A future loosening of the regex, or a symlinked root,
+    # cannot silently let an id escape without tripping this check too.
+    if target.parent != root:
+        raise ValueError(f"workspace_id escapes workspaces dir: {workspace_id!r}")
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Instinct / Paw Print — process-wide singletons (UNCHANGED by ISO-1)
+# ---------------------------------------------------------------------------
+
 _instinct_store: InstinctStore | None = None
-_fabric_store: FabricStore | None = None
 _paw_print_store: PawPrintStore | None = None
 
 
@@ -33,17 +204,194 @@ def get_instinct_store() -> InstinctStore:
     return _instinct_store
 
 
-def get_fabric_store() -> FabricStore:
-    """Return the global FabricStore singleton (``~/.pocketpaw/fabric.db``)."""
-    global _fabric_store
-    if _fabric_store is None:
-        _fabric_store = FabricStore(_DATA_DIR / "fabric.db")
-    return _fabric_store
-
-
 def get_paw_print_store() -> PawPrintStore:
     """Return the global PawPrintStore singleton (``~/.pocketpaw/paw_print.db``)."""
     global _paw_print_store
     if _paw_print_store is None:
         _paw_print_store = PawPrintStore(_DATA_DIR / "paw_print.db")
     return _paw_print_store
+
+
+# ---------------------------------------------------------------------------
+# Fabric — workspace-keyed physical isolation (ISO-1)
+# ---------------------------------------------------------------------------
+
+# Legacy shared singleton (single-tenant OSS / unscoped, non-required path).
+_fabric_store: FabricStore | None = None
+
+# Per-workspace handle cache: workspace_id -> FabricStore, ordered by recency so
+# we can evict the least-recently-used past the cap. Bounded by
+# _WORKSPACE_STORE_CACHE_CAP; the evicted handle is aclose()d.
+_workspace_fabric_stores: OrderedDict[str, FabricStore] = OrderedDict()
+
+
+def _provider_fabric_store(workspace_id: str | None) -> FabricStore | None:
+    """Ask the StoreProvider seam for a Fabric store, if one is registered.
+
+    Returns the provider's store, or ``None`` when no provider is installed
+    (the OSS case) or the provider declines (returns ``None`` / lacks Fabric).
+    A provider that raises is isolated: we log and fall back to the local store
+    rather than take the factory down — a broken EE plugin must not break core.
+    """
+    provider = first(_STORE_PROVIDER_GROUP)
+    if provider is None:
+        return None
+    try:
+        store = provider.get_store("fabric", workspace_id=workspace_id)
+    except TypeError:
+        # Back-compat for a provider whose get_store predates the workspace_id
+        # keyword: call it the old way. (Core ships no such provider; this just
+        # keeps the seam tolerant.)
+        try:
+            store = provider.get_store("fabric")
+        except Exception:  # noqa: BLE001
+            logger.warning("StoreProvider.get_store('fabric') failed", exc_info=True)
+            return None
+    except Exception:  # noqa: BLE001 — isolate plugin failures
+        logger.warning("StoreProvider.get_store('fabric', ...) failed", exc_info=True)
+        return None
+    if store is not None and not isinstance(store, FabricStore):
+        logger.warning(
+            "StoreProvider returned a %s for 'fabric', expected FabricStore — ignoring",
+            type(store).__name__,
+        )
+        return None
+    return store
+
+
+def _cache_workspace_store(workspace_id: str, store: FabricStore) -> None:
+    """Insert ``store`` as most-recently-used, evicting + closing LRU past cap."""
+    _workspace_fabric_stores[workspace_id] = store
+    _workspace_fabric_stores.move_to_end(workspace_id)
+    while len(_workspace_fabric_stores) > _WORKSPACE_STORE_CACHE_CAP:
+        _evict_key, evicted = _workspace_fabric_stores.popitem(last=False)
+        _schedule_aclose(evicted)
+
+
+def _schedule_aclose(store: FabricStore) -> None:
+    """Best-effort release of an evicted store's on-disk resources.
+
+    The evicted store holds no live connection, so the only cleanup is a WAL
+    checkpoint (see ``FabricStore.aclose``). How we run it depends on the caller:
+
+    * A running event loop is present (the common case — eviction fires from an
+      async request building another store): fire-and-forget the async
+      ``aclose`` as a task on that loop, so we don't block the request and we
+      reuse the live loop's aiosqlite worker.
+    * No running loop (a sync caller, or test teardown via
+      ``reset_store_caches``): do the checkpoint SYNCHRONOUSLY with stdlib
+      ``sqlite3`` instead of spinning up a throwaway ``asyncio.run`` loop. A
+      short-lived loop would start an aiosqlite worker thread that races process
+      teardown and emits noisy "Event loop is closed" warnings; a plain
+      ``sqlite3`` checkpoint is faster and side-effect-free.
+
+    Any failure is swallowed — eviction cleanup must never raise into the caller
+    building a DIFFERENT store.
+    """
+    import asyncio
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None and loop.is_running():
+        loop.create_task(_safe_aclose(store))
+    else:
+        _sync_checkpoint(store)
+
+
+def _sync_checkpoint(store: FabricStore) -> None:
+    """Synchronously checkpoint a store's WAL via stdlib sqlite3 (no event loop).
+
+    Resets the store's ``_initialized`` flag to mirror ``aclose`` so a later
+    re-fetch of the same path re-runs ``_ensure_schema`` cleanly. Best-effort:
+    a missing DB / WAL is fine and is swallowed.
+    """
+    import sqlite3
+
+    store._initialized = False
+    try:
+        with sqlite3.connect(store._db_path) as conn:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    except Exception:  # noqa: BLE001 — eviction cleanup is best-effort
+        logger.debug("evicted FabricStore sync checkpoint skipped", exc_info=True)
+
+
+async def _safe_aclose(store: FabricStore) -> None:
+    try:
+        await store.aclose()
+    except Exception:  # noqa: BLE001
+        logger.debug("evicted FabricStore aclose failed", exc_info=True)
+
+
+def get_fabric_store(*, workspace_id: str | None = None) -> FabricStore:
+    """Return the FabricStore for the resolved workspace (ISO-1).
+
+    Resolution order: explicit ``workspace_id`` arg → ``current_workspace``
+    ContextVar → ``None``. See the module docstring for the full contract.
+
+    * A resolved workspace returns a per-workspace store at
+      ``~/.pocketpaw/workspaces/<workspace_id>/fabric.db`` (directory created),
+      cached in a bounded LRU.
+    * No workspace + ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` truthy → raises
+      :class:`WorkspaceScopeRequired` (fail-closed; never a shared read).
+    * No workspace + flag unset → the legacy shared ``~/.pocketpaw/fabric.db``
+      singleton (single-tenant OSS back-compat).
+
+    A registered ``StoreProvider`` (entry-point group ``pocketpaw.stores``) gets
+    first refusal in every branch, so EE can later supply a cloud-backed store.
+    """
+    resolved = _resolve_workspace_id(workspace_id)
+
+    if resolved is None:
+        if _require_workspace_scope():
+            # Fail-closed: a cloud deployment must carry a workspace. Never fall
+            # back to the shared store — that is the exact cross-tenant leak
+            # physical isolation exists to close.
+            raise WorkspaceScopeRequired(
+                "A workspace-scoped Fabric store is required "
+                f"(${_REQUIRE_WORKSPACE_SCOPE_ENV} is set) but no workspace was "
+                "resolved from the explicit argument or the current_workspace "
+                "context. Refusing to fall back to the shared store."
+            )
+        # Single-tenant OSS path: legacy shared singleton.
+        global _fabric_store
+        if _fabric_store is None:
+            provided = _provider_fabric_store(None)
+            _fabric_store = (
+                provided if provided is not None else FabricStore(_DATA_DIR / "fabric.db")
+            )
+        return _fabric_store
+
+    # Workspace resolved: per-workspace physically-isolated store.
+    cached = _workspace_fabric_stores.get(resolved)
+    if cached is not None:
+        _workspace_fabric_stores.move_to_end(resolved)  # mark MRU
+        return cached
+
+    provided = _provider_fabric_store(resolved)
+    if provided is not None:
+        store = provided
+    else:
+        ws_dir = _safe_workspace_dir(resolved)
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        store = FabricStore(ws_dir / "fabric.db")
+    _cache_workspace_store(resolved, store)
+    return store
+
+
+def reset_store_caches() -> None:
+    """Drop every cached store handle (legacy singletons + per-workspace LRU).
+
+    For tests that install/remove providers, swap the data dir, or need a clean
+    factory between cases. Evicted per-workspace handles are aclose()d
+    best-effort so a checkpoint runs and no WAL sidecar is left behind.
+    """
+    global _fabric_store, _instinct_store, _paw_print_store
+    _fabric_store = None
+    _instinct_store = None
+    _paw_print_store = None
+    while _workspace_fabric_stores:
+        _key, store = _workspace_fabric_stores.popitem(last=False)
+        _schedule_aclose(store)

--- a/src/pocketpaw/stores.py
+++ b/src/pocketpaw/stores.py
@@ -236,6 +236,7 @@ class _StoreKind:
 _FABRIC_KIND = _StoreKind(name="fabric", cls=FabricStore)
 _INSTINCT_KIND = _StoreKind(name="instinct", cls=InstinctStore)
 _STORE_KINDS: tuple[_StoreKind, ...] = (_FABRIC_KIND, _INSTINCT_KIND)
+_KIND_BY_NAME: dict[str, _StoreKind] = {k.name: k for k in _STORE_KINDS}
 
 
 def _provider_store(kind: _StoreKind, workspace_id: str | None) -> Any | None:
@@ -384,11 +385,45 @@ def _get_workspace_store(kind: _StoreKind, workspace_id: str | None) -> Any:
     if provided is not None:
         store = provided
     else:
-        ws_dir = _safe_workspace_dir(resolved)
-        ws_dir.mkdir(parents=True, exist_ok=True)
-        store = kind.cls(ws_dir / kind.filename)
+        store = _build_local_workspace_store(kind.name, resolved)
     _cache_workspace_store(kind, resolved, store)
     return store
+
+
+def _build_local_workspace_store(name: str, workspace_id: str) -> Any:
+    """Construct the LOCAL per-workspace store for ``name`` at its file path.
+
+    The single authority for "where does workspace ``X``'s ``name`` store live
+    and how is its id validated": resolves the directory via the
+    path-traversal allowlist (``_safe_workspace_dir``), creates it, and
+    constructs the OSS store class on ``<dir>/<name>.db``.
+
+    IMPORTANT: this does NOT consult the StoreProvider seam — it is the local
+    default, and is ALSO what a registered provider should delegate to when it
+    just wants the standard per-workspace file store (see
+    ``build_workspace_store``). Routing a provider back through the seam would
+    recurse. ``name`` must be a known workspace-keyed kind.
+    """
+    kind = _KIND_BY_NAME.get(name)
+    if kind is None:
+        raise ValueError(f"unknown workspace-keyed store kind: {name!r}")
+    ws_dir = _safe_workspace_dir(workspace_id)
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    return kind.cls(ws_dir / kind.filename)
+
+
+def build_workspace_store(name: str, workspace_id: str) -> Any:
+    """Public helper: build the standard per-workspace file store for ``name``.
+
+    The seam an EE ``StoreProvider`` delegates to when it wants the normal
+    per-workspace SQLite file store (Fabric / Instinct at
+    ``~/.pocketpaw/workspaces/<id>/<name>.db``) rather than a bespoke
+    implementation. Keeping the path + the path-traversal allowlist here means
+    the provider can't drift from — or weaken — the OSS guard, and it is
+    recursion-safe (it never re-enters the provider seam). ``workspace_id`` is
+    validated by the same strict allowlist every other store path uses.
+    """
+    return _build_local_workspace_store(name, workspace_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/pocketpaw/stores.py
+++ b/src/pocketpaw/stores.py
@@ -2,8 +2,8 @@
 
 Instinct, Fabric and Paw Print keep their state in SQLite under
 ``~/.pocketpaw/``. These factories return a lazily-created handle so agent
-tools, automations and routers share one instance per process (or, for Fabric,
-one instance per WORKSPACE — see below).
+tools, automations and routers share one instance per process (or, for Fabric
+and Instinct, one instance per WORKSPACE — see below).
 
 ISO-1 (2026-06-26 — physical per-workspace isolation): Fabric is no longer a
 single process-wide singleton on a SHARED ``~/.pocketpaw/fabric.db``. On a
@@ -31,12 +31,21 @@ evicts. When NO workspace resolves:
     ``~/.pocketpaw/fabric.db`` singleton, so a self-hosted install keeps working
     exactly as before.
 
+ISO-2 (2026-06-26 — Instinct isolation) extends the SAME machinery to Instinct:
+``get_instinct_store(*, workspace_id=...)`` returns a per-workspace
+``~/.pocketpaw/workspaces/<id>/instinct.db``. Because each workspace gets its own
+file, its W2b audit hash-chain (genesis→…→head) is INDEPENDENT and
+``verify_audit_chain`` runs PER WORKSPACE — the correct multi-tenant model (a
+tenant's auditor verifies only that tenant's chain, never a global chain mixing
+tenants). The generic ``_StoreKind`` + ``_get_workspace_store`` engine below
+drives both stores; adding a third is a one-liner.
+
 The ``current_workspace`` ContextVar lives HERE in OSS core (``pocketpaw``) on
 purpose: EE imports from OSS, never the reverse. ISO-3 (a later task) wires the
 non-router callers — the agent-tool path, the MCP servers — to SET this
-ContextVar per request/stream so they too land in the right file; THIS task only
-creates and consults it and wires the EE Fabric router (which already resolves
-the workspace) to pass it explicitly.
+ContextVar per request/stream so they too land in the right file; ISO-1/ISO-2
+create and consult it and wire the EE Fabric + Instinct routers (which already
+resolve the workspace) to pass it explicitly.
 
 The factory consults the previously-dormant ``pocketpaw.stores`` entry-point
 seam (``StoreProvider``): if EE (or a third party) registers a provider, it gets
@@ -44,9 +53,8 @@ first refusal on building the store, so a later task can swap in a cloud-backed
 implementation without touching core. An OSS-only install finds no provider and
 uses the local SQLite default.
 
-Instinct and Paw Print are UNCHANGED here — still process-wide singletons on the
-shared file. Per-workspace Instinct isolation is a separate later task (ISO-2);
-the workspace-keyed machinery below is written generically so it can be reused.
+Paw Print is UNCHANGED — still a plain process-wide singleton on the shared file
+(not tenant-isolated yet).
 
 The factories moved here from ``pocketpaw_ee/api.py`` in the OSS-EE split
 (Phase 3); ``pocketpaw_ee.api`` re-exports from this module for the enterprise
@@ -60,7 +68,9 @@ import os
 import re
 from collections import OrderedDict
 from contextvars import ContextVar
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from pocketpaw._registry import first
 from pocketpaw.fabric.store import FabricStore
@@ -189,90 +199,96 @@ def _safe_workspace_dir(workspace_id: str) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# Instinct / Paw Print — process-wide singletons (UNCHANGED by ISO-1)
+# Generic workspace-keyed store machinery (ISO-1 built it; ISO-2 generalized it)
 # ---------------------------------------------------------------------------
-
-_instinct_store: InstinctStore | None = None
-_paw_print_store: PawPrintStore | None = None
-
-
-def get_instinct_store() -> InstinctStore:
-    """Return the global InstinctStore singleton (``~/.pocketpaw/instinct.db``)."""
-    global _instinct_store
-    if _instinct_store is None:
-        _instinct_store = InstinctStore(_DATA_DIR / "instinct.db")
-    return _instinct_store
+#
+# Both Fabric (ISO-1) and Instinct (ISO-2) need the SAME per-workspace plumbing:
+# resolve workspace -> fail-closed-or-legacy when absent -> per-workspace file
+# under workspaces/<id>/<name>.db -> bounded LRU that aclose()s the evicted
+# handle -> StoreProvider-seam first-refusal. Rather than duplicate that for each
+# store, a ``_StoreKind`` captures the few things that differ (the store class,
+# the file/provider name, the db filename) and one set of generic functions
+# drives every kind. Adding a third workspace-keyed store later is a one-liner.
 
 
-def get_paw_print_store() -> PawPrintStore:
-    """Return the global PawPrintStore singleton (``~/.pocketpaw/paw_print.db``)."""
-    global _paw_print_store
-    if _paw_print_store is None:
-        _paw_print_store = PawPrintStore(_DATA_DIR / "paw_print.db")
-    return _paw_print_store
+@dataclass
+class _StoreKind:
+    """Per-store-type config for the generic workspace-keyed factory.
+
+    ``name`` is BOTH the StoreProvider ``get_store(name=...)`` key and the on-disk
+    db filename stem (``fabric`` -> ``fabric.db``). ``cls`` is the concrete store
+    class the local default constructs. ``legacy`` holds the single-tenant shared
+    singleton; ``cache`` is the bounded per-workspace LRU (workspace_id -> store).
+    """
+
+    name: str
+    cls: type
+    legacy: Any = None  # the lazily-built shared singleton (legacy / OSS path)
+    cache: OrderedDict[str, Any] = field(default_factory=OrderedDict)
+
+    @property
+    def filename(self) -> str:
+        return f"{self.name}.db"
 
 
-# ---------------------------------------------------------------------------
-# Fabric — workspace-keyed physical isolation (ISO-1)
-# ---------------------------------------------------------------------------
-
-# Legacy shared singleton (single-tenant OSS / unscoped, non-required path).
-_fabric_store: FabricStore | None = None
-
-# Per-workspace handle cache: workspace_id -> FabricStore, ordered by recency so
-# we can evict the least-recently-used past the cap. Bounded by
-# _WORKSPACE_STORE_CACHE_CAP; the evicted handle is aclose()d.
-_workspace_fabric_stores: OrderedDict[str, FabricStore] = OrderedDict()
+# The registry of workspace-keyed store kinds. Fabric is wired by ISO-1, Instinct
+# by ISO-2. Paw Print stays a plain shared singleton (not tenant-isolated yet).
+_FABRIC_KIND = _StoreKind(name="fabric", cls=FabricStore)
+_INSTINCT_KIND = _StoreKind(name="instinct", cls=InstinctStore)
+_STORE_KINDS: tuple[_StoreKind, ...] = (_FABRIC_KIND, _INSTINCT_KIND)
 
 
-def _provider_fabric_store(workspace_id: str | None) -> FabricStore | None:
-    """Ask the StoreProvider seam for a Fabric store, if one is registered.
+def _provider_store(kind: _StoreKind, workspace_id: str | None) -> Any | None:
+    """Ask the StoreProvider seam for a store of ``kind``, if one is registered.
 
-    Returns the provider's store, or ``None`` when no provider is installed
-    (the OSS case) or the provider declines (returns ``None`` / lacks Fabric).
-    A provider that raises is isolated: we log and fall back to the local store
+    Returns the provider's store, or ``None`` when no provider is installed (the
+    OSS case) or the provider declines (returns ``None`` / lacks this kind). A
+    provider that raises is isolated: we log and fall back to the local store
     rather than take the factory down — a broken EE plugin must not break core.
+    The returned store must be an instance of ``kind.cls`` or it is ignored.
     """
     provider = first(_STORE_PROVIDER_GROUP)
     if provider is None:
         return None
     try:
-        store = provider.get_store("fabric", workspace_id=workspace_id)
+        store = provider.get_store(kind.name, workspace_id=workspace_id)
     except TypeError:
         # Back-compat for a provider whose get_store predates the workspace_id
         # keyword: call it the old way. (Core ships no such provider; this just
         # keeps the seam tolerant.)
         try:
-            store = provider.get_store("fabric")
+            store = provider.get_store(kind.name)
         except Exception:  # noqa: BLE001
-            logger.warning("StoreProvider.get_store('fabric') failed", exc_info=True)
+            logger.warning("StoreProvider.get_store(%r) failed", kind.name, exc_info=True)
             return None
     except Exception:  # noqa: BLE001 — isolate plugin failures
-        logger.warning("StoreProvider.get_store('fabric', ...) failed", exc_info=True)
+        logger.warning("StoreProvider.get_store(%r, ...) failed", kind.name, exc_info=True)
         return None
-    if store is not None and not isinstance(store, FabricStore):
+    if store is not None and not isinstance(store, kind.cls):
         logger.warning(
-            "StoreProvider returned a %s for 'fabric', expected FabricStore — ignoring",
+            "StoreProvider returned a %s for %r, expected %s — ignoring",
             type(store).__name__,
+            kind.name,
+            kind.cls.__name__,
         )
         return None
     return store
 
 
-def _cache_workspace_store(workspace_id: str, store: FabricStore) -> None:
+def _cache_workspace_store(kind: _StoreKind, workspace_id: str, store: Any) -> None:
     """Insert ``store`` as most-recently-used, evicting + closing LRU past cap."""
-    _workspace_fabric_stores[workspace_id] = store
-    _workspace_fabric_stores.move_to_end(workspace_id)
-    while len(_workspace_fabric_stores) > _WORKSPACE_STORE_CACHE_CAP:
-        _evict_key, evicted = _workspace_fabric_stores.popitem(last=False)
+    kind.cache[workspace_id] = store
+    kind.cache.move_to_end(workspace_id)
+    while len(kind.cache) > _WORKSPACE_STORE_CACHE_CAP:
+        _evict_key, evicted = kind.cache.popitem(last=False)
         _schedule_aclose(evicted)
 
 
-def _schedule_aclose(store: FabricStore) -> None:
+def _schedule_aclose(store: Any) -> None:
     """Best-effort release of an evicted store's on-disk resources.
 
     The evicted store holds no live connection, so the only cleanup is a WAL
-    checkpoint (see ``FabricStore.aclose``). How we run it depends on the caller:
+    checkpoint (see the store's ``aclose``). How we run it depends on the caller:
 
     * A running event loop is present (the common case — eviction fires from an
       async request building another store): fire-and-forget the async
@@ -301,7 +317,7 @@ def _schedule_aclose(store: FabricStore) -> None:
         _sync_checkpoint(store)
 
 
-def _sync_checkpoint(store: FabricStore) -> None:
+def _sync_checkpoint(store: Any) -> None:
     """Synchronously checkpoint a store's WAL via stdlib sqlite3 (no event loop).
 
     Resets the store's ``_initialized`` flag to mirror ``aclose`` so a later
@@ -315,14 +331,69 @@ def _sync_checkpoint(store: FabricStore) -> None:
         with sqlite3.connect(store._db_path) as conn:
             conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
     except Exception:  # noqa: BLE001 — eviction cleanup is best-effort
-        logger.debug("evicted FabricStore sync checkpoint skipped", exc_info=True)
+        logger.debug("evicted %s sync checkpoint skipped", type(store).__name__, exc_info=True)
 
 
-async def _safe_aclose(store: FabricStore) -> None:
+async def _safe_aclose(store: Any) -> None:
     try:
         await store.aclose()
     except Exception:  # noqa: BLE001
-        logger.debug("evicted FabricStore aclose failed", exc_info=True)
+        logger.debug("evicted %s aclose failed", type(store).__name__, exc_info=True)
+
+
+def _get_workspace_store(kind: _StoreKind, workspace_id: str | None) -> Any:
+    """Resolve + return the per-workspace (or legacy) store for ``kind``.
+
+    The shared engine behind ``get_fabric_store`` / ``get_instinct_store``.
+    Resolution order: explicit ``workspace_id`` -> ``current_workspace``
+    ContextVar -> ``None``. With a workspace, returns a per-workspace store at
+    ``~/.pocketpaw/workspaces/<id>/<kind>.db`` (dir created), cached in a bounded
+    LRU. Without one: fail-closed (``WorkspaceScopeRequired``) under
+    ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE``, else the legacy shared singleton. A
+    registered ``StoreProvider`` gets first refusal in every branch.
+
+    The path-traversal allowlist (``_safe_workspace_dir``) is applied to EVERY
+    kind, so Instinct inherits the exact ISO-1 guard for free.
+    """
+    resolved = _resolve_workspace_id(workspace_id)
+
+    if resolved is None:
+        if _require_workspace_scope():
+            # Fail-closed: a cloud deployment must carry a workspace. Never fall
+            # back to the shared store — that is the exact cross-tenant leak
+            # physical isolation exists to close.
+            raise WorkspaceScopeRequired(
+                f"A workspace-scoped {kind.name} store is required "
+                f"(${_REQUIRE_WORKSPACE_SCOPE_ENV} is set) but no workspace was "
+                "resolved from the explicit argument or the current_workspace "
+                "context. Refusing to fall back to the shared store."
+            )
+        # Single-tenant OSS path: legacy shared singleton.
+        if kind.legacy is None:
+            provided = _provider_store(kind, None)
+            kind.legacy = provided if provided is not None else kind.cls(_DATA_DIR / kind.filename)
+        return kind.legacy
+
+    # Workspace resolved: per-workspace physically-isolated store.
+    cached = kind.cache.get(resolved)
+    if cached is not None:
+        kind.cache.move_to_end(resolved)  # mark MRU
+        return cached
+
+    provided = _provider_store(kind, resolved)
+    if provided is not None:
+        store = provided
+    else:
+        ws_dir = _safe_workspace_dir(resolved)
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        store = kind.cls(ws_dir / kind.filename)
+    _cache_workspace_store(kind, resolved, store)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Public factories
+# ---------------------------------------------------------------------------
 
 
 def get_fabric_store(*, workspace_id: str | None = None) -> FabricStore:
@@ -342,56 +413,59 @@ def get_fabric_store(*, workspace_id: str | None = None) -> FabricStore:
     A registered ``StoreProvider`` (entry-point group ``pocketpaw.stores``) gets
     first refusal in every branch, so EE can later supply a cloud-backed store.
     """
-    resolved = _resolve_workspace_id(workspace_id)
+    return _get_workspace_store(_FABRIC_KIND, workspace_id)
 
-    if resolved is None:
-        if _require_workspace_scope():
-            # Fail-closed: a cloud deployment must carry a workspace. Never fall
-            # back to the shared store — that is the exact cross-tenant leak
-            # physical isolation exists to close.
-            raise WorkspaceScopeRequired(
-                "A workspace-scoped Fabric store is required "
-                f"(${_REQUIRE_WORKSPACE_SCOPE_ENV} is set) but no workspace was "
-                "resolved from the explicit argument or the current_workspace "
-                "context. Refusing to fall back to the shared store."
-            )
-        # Single-tenant OSS path: legacy shared singleton.
-        global _fabric_store
-        if _fabric_store is None:
-            provided = _provider_fabric_store(None)
-            _fabric_store = (
-                provided if provided is not None else FabricStore(_DATA_DIR / "fabric.db")
-            )
-        return _fabric_store
 
-    # Workspace resolved: per-workspace physically-isolated store.
-    cached = _workspace_fabric_stores.get(resolved)
-    if cached is not None:
-        _workspace_fabric_stores.move_to_end(resolved)  # mark MRU
-        return cached
+def get_instinct_store(*, workspace_id: str | None = None) -> InstinctStore:
+    """Return the InstinctStore for the resolved workspace (ISO-2).
 
-    provided = _provider_fabric_store(resolved)
-    if provided is not None:
-        store = provided
-    else:
-        ws_dir = _safe_workspace_dir(resolved)
-        ws_dir.mkdir(parents=True, exist_ok=True)
-        store = FabricStore(ws_dir / "fabric.db")
-    _cache_workspace_store(resolved, store)
-    return store
+    Physically isolates Instinct per workspace through the SAME generic factory
+    Fabric uses: explicit ``workspace_id`` arg → ``current_workspace`` ContextVar
+    → ``None``.
+
+    * A resolved workspace returns a per-workspace store at
+      ``~/.pocketpaw/workspaces/<workspace_id>/instinct.db`` — its OWN file, so
+      its W2b audit hash-chain (genesis→…→head) is independent and
+      ``verify_audit_chain`` runs PER WORKSPACE. That is the correct multi-tenant
+      model: a tenant's auditor verifies only that tenant's chain.
+    * No workspace + ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` truthy → raises
+      :class:`WorkspaceScopeRequired` (fail-closed; never a shared read).
+    * No workspace + flag unset → the legacy shared ``~/.pocketpaw/instinct.db``
+      singleton (single-tenant OSS back-compat).
+
+    The W4a in-row ``workspace_id`` read-filter STAYS as a second layer; physical
+    file isolation is additive defense-in-depth. The path-traversal allowlist is
+    inherited from the generic factory.
+    """
+    return _get_workspace_store(_INSTINCT_KIND, workspace_id)
+
+
+# ---------------------------------------------------------------------------
+# Paw Print — plain process-wide singleton (NOT workspace-isolated yet)
+# ---------------------------------------------------------------------------
+
+_paw_print_store: PawPrintStore | None = None
+
+
+def get_paw_print_store() -> PawPrintStore:
+    """Return the global PawPrintStore singleton (``~/.pocketpaw/paw_print.db``)."""
+    global _paw_print_store
+    if _paw_print_store is None:
+        _paw_print_store = PawPrintStore(_DATA_DIR / "paw_print.db")
+    return _paw_print_store
 
 
 def reset_store_caches() -> None:
-    """Drop every cached store handle (legacy singletons + per-workspace LRU).
+    """Drop every cached store handle (legacy singletons + per-workspace LRUs).
 
     For tests that install/remove providers, swap the data dir, or need a clean
     factory between cases. Evicted per-workspace handles are aclose()d
     best-effort so a checkpoint runs and no WAL sidecar is left behind.
     """
-    global _fabric_store, _instinct_store, _paw_print_store
-    _fabric_store = None
-    _instinct_store = None
+    global _paw_print_store
     _paw_print_store = None
-    while _workspace_fabric_stores:
-        _key, store = _workspace_fabric_stores.popitem(last=False)
-        _schedule_aclose(store)
+    for kind in _STORE_KINDS:
+        kind.legacy = None
+        while kind.cache:
+            _key, store = kind.cache.popitem(last=False)
+            _schedule_aclose(store)

--- a/tests/cloud/billing/test_dodo_webhook.py
+++ b/tests/cloud/billing/test_dodo_webhook.py
@@ -277,6 +277,15 @@ async def test_create_topup_returns_checkout_url(mongo_db, monkeypatch):
     assert kwargs["metadata"]["workspace_id"] == WS
     assert kwargs["product_cart"][0]["product_id"] == PRODUCT_ID
     assert kwargs["product_cart"][0]["amount"] == 1000
+    # H1 — the one-time payment's new-customer object MUST carry a non-empty
+    # ``name`` alongside ``email`` (Dodo rejects ``{email}`` alone). Reverting
+    # _customer_param to ``{email}`` must fail this assertion.
+    customer = kwargs["customer"]
+    assert customer.get("email"), customer
+    assert customer.get("name"), (
+        "Dodo new-customer object is missing a non-empty 'name' — "
+        f"{customer!r} would be rejected server-side"
+    )
 
 
 async def test_create_topup_rejects_non_positive_amount(mongo_db):

--- a/tests/cloud/billing/test_subscriptions.py
+++ b/tests/cloud/billing/test_subscriptions.py
@@ -169,6 +169,15 @@ async def test_subscribe_creates_dodo_subscription_with_product_and_metadata(
     assert kwargs["payment_link"] is True
     assert kwargs["metadata"]["workspace_id"] == ws
     assert kwargs["metadata"]["plan_key"] == "pro"
+    # H1 — the new-customer object MUST carry a non-empty ``name`` alongside
+    # ``email``. Dodo's CustomerRequest rejects ``{email}`` alone (NewCustomer
+    # requires a name); reverting _customer_param to ``{email}`` must fail here.
+    customer = kwargs["customer"]
+    assert customer.get("email"), customer
+    assert customer.get("name"), (
+        "Dodo new-customer object is missing a non-empty 'name' — "
+        f"{customer!r} would be rejected server-side"
+    )
 
 
 async def test_subscribe_rejects_unknown_plan(mongo_db, patch_plan_products):

--- a/tests/cloud/pockets/test_tools_run_v2_instinct.py
+++ b/tests/cloud/pockets/test_tools_run_v2_instinct.py
@@ -100,7 +100,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     """Isolated InstinctStore on a tmp file, wired where the propose helper and
     the executor both read it (`pocketpaw.stores.get_instinct_store`)."""
     st = InstinctStore(tmp_path / "instinct_tools_run_v2.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_belt_autopilot.py
+++ b/tests/cloud/test_belt_autopilot.py
@@ -102,8 +102,8 @@ def graph(tmp_path: Path) -> DecisionGraph:
 @pytest.fixture
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     st = InstinctStore(tmp_path / "instinct_autopilot.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_belt_console.py
+++ b/tests/cloud/test_belt_console.py
@@ -121,7 +121,7 @@ def settings_allowlist(roots: Path, monkeypatch) -> Path:
 @pytest.fixture
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     st = InstinctStore(tmp_path / "instinct_console.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 
@@ -720,7 +720,7 @@ async def test_executor_emits_landed_and_persists_pr_result(
     monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
 
     st = InstinctStore(tmp_path / "exec.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
 
     action = await _propose_run(
         st,
@@ -784,7 +784,7 @@ async def test_executor_local_only_emits_landed_without_pr_url(
     monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
 
     st = InstinctStore(tmp_path / "exec_local.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
 
     action = await _propose_run(
         st,
@@ -856,7 +856,7 @@ async def test_executor_emits_failed_on_apply_conflict(monkeypatch, recording_bu
     monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
 
     st = InstinctStore(tmp_path / "exec_fail.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
 
     action = await _propose_run(
         st,

--- a/tests/cloud/test_belt_gate.py
+++ b/tests/cloud/test_belt_gate.py
@@ -34,6 +34,15 @@
 # identity through ee.cloud.chat.agent_service ContextVars (set in-test via
 # attach_agent_identity) and the store through pocketpaw.stores.get_instinct_store
 # (patched to a tmp-file store so nothing touches ~/.pocketpaw/instinct.db).
+#
+# Updated: 2026-06-26 (fix/cloud-iso-executor-scope) — the ``store`` fixture's
+# factory mock is now WORKSPACE-FAITHFUL (resolves explicit workspace_id →
+# current_workspace ContextVar → "", seeded store for "w1" only). The old
+# arg-swallowing mock hid C1: the approve-path executor's bare/unscoped store
+# call (run OUTSIDE _identity, no ContextVar) still reached the seeded store, so
+# split-brain isolation passed. The end-to-end test below now approves+executes
+# outside _identity, so it only stays green because the executor threads the
+# blob's workspace_id.
 
 from __future__ import annotations
 
@@ -140,9 +149,30 @@ def local_repo(tmp_path: Path) -> Path:
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     """Isolated InstinctStore on a tmp file, wired in everywhere the gate
     reads it (the MCP handler + the executor both lazy-import
-    ``pocketpaw.stores.get_instinct_store``)."""
+    ``pocketpaw.stores.get_instinct_store``).
+
+    WORKSPACE-FAITHFUL mock (fix/cloud-iso-executor-scope): the factory resolves
+    the workspace exactly like the real one — explicit ``workspace_id`` arg →
+    ``current_workspace`` ContextVar → "" — and returns the seeded store ONLY
+    for ``w1`` (the blob/identity workspace). Any other workspace gets a fresh,
+    empty store on a sibling tmp file. The old ``lambda *a, **k: st`` ignored
+    the workspace entirely, so the executor's BARE (pre-fix, no-ContextVar)
+    approve-path call still hit the seeded store and the isolation bug (C1) went
+    green. Now the MCP handler (bare call INSIDE _identity → ContextVar=w1)
+    still resolves to ``st``, but the executor (run OUTSIDE _identity) only does
+    so once it threads the blob's workspace — which is exactly the fix."""
+    from pocketpaw.stores import current_workspace
+
     st = InstinctStore(tmp_path / "instinct_belt_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    others: dict[str, InstinctStore] = {}
+
+    def _factory(*_a, workspace_id: str | None = None, **_k) -> InstinctStore:
+        ws = str((workspace_id if workspace_id is not None else current_workspace.get()) or "")
+        if ws == "w1":
+            return st
+        return others.setdefault(ws, InstinctStore(tmp_path / f"instinct_other_{ws or 'none'}.db"))
+
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", _factory)
     return st
 
 

--- a/tests/cloud/test_belt_gate.py
+++ b/tests/cloud/test_belt_gate.py
@@ -142,7 +142,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     reads it (the MCP handler + the executor both lazy-import
     ``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_belt_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_belt_headless.py
+++ b/tests/cloud/test_belt_headless.py
@@ -62,7 +62,7 @@ index e69de29..3b18e51 100644
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     """Isolated InstinctStore wired into the global resolver the runner reads."""
     st = InstinctStore(tmp_path / "instinct_headless.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_belt_mandates.py
+++ b/tests/cloud/test_belt_mandates.py
@@ -105,8 +105,8 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     service, the instinct router, and the plan executor all resolve through
     ``pocketpaw.stores.get_instinct_store`` or the router indirection)."""
     st = InstinctStore(tmp_path / "instinct_mandates.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_belt_trace.py
+++ b/tests/cloud/test_belt_trace.py
@@ -175,8 +175,8 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     handler, the router's ``_store``, and the executor all resolve through
     ``pocketpaw.stores.get_instinct_store`` or the router indirection)."""
     st = InstinctStore(tmp_path / "instinct.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_correction_soul_bridge.py
+++ b/tests/cloud/test_correction_soul_bridge.py
@@ -272,7 +272,7 @@ class TestInstinctCorrectionsTool:
         empty_store = InstinctStore(tmp_path / "empty.db")
         monkeypatch.setattr(
             "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
-            lambda: empty_store,
+            lambda *a, **k: empty_store,
         )
 
         tool = InstinctCorrectionsTool()
@@ -297,7 +297,7 @@ class TestInstinctCorrectionsTool:
         )
         monkeypatch.setattr(
             "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
-            lambda: store,
+            lambda *a, **k: store,
         )
 
         tool = InstinctCorrectionsTool()
@@ -316,7 +316,7 @@ class TestInstinctCorrectionsTool:
 
         monkeypatch.setattr(
             "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
-            lambda: None,
+            lambda *a, **k: None,
         )
 
         tool = InstinctCorrectionsTool()

--- a/tests/cloud/test_ee_fabric_list_endpoints.py
+++ b/tests/cloud/test_ee_fabric_list_endpoints.py
@@ -11,6 +11,12 @@
 #   stays gated on require_plan_feature("fabric"), which is now ENTERPRISE-ONLY
 #   (Sites/Leads were decoupled onto the "sites" flag). The fixture therefore
 #   patches get_workspace_plan to "enterprise" so the ontology gate passes.
+# Updated: 2026-06-26 (ISO-1 — physical per-workspace isolation) — the router
+#   dropped its module-level _DB_PATH and now routes through
+#   pocketpaw.stores.get_fabric_store(workspace_id=...). The client fixture
+#   therefore isolates by patching stores._DATA_DIR to tmp_path and resetting the
+#   factory caches (so the router's store lands in tmp_path/workspaces/ws-test/
+#   fabric.db) instead of patching the removed _DB_PATH.
 
 from __future__ import annotations
 
@@ -56,10 +62,17 @@ def client(tmp_path: Path, monkeypatch) -> TestClient:
         ENTERPRISE-only feature in PLAN_FEATURES after Sites/Leads were
         decoupled onto the 'sites' flag).
     """
-    # Point the module-level store at the tmp db. The router always calls
-    # _store() lazily so setattr is enough.
-    test_db = tmp_path / "fabric-test.db"
-    monkeypatch.setattr(fabric_router_module, "_DB_PATH", test_db)
+    # ISO-1: the router no longer holds a module-level _DB_PATH — it routes
+    # through pocketpaw.stores.get_fabric_store(workspace_id=...), which builds a
+    # per-workspace file under <_DATA_DIR>/workspaces/<id>/fabric.db. Point the
+    # factory's data dir at tmp and reset its caches so this client's store lands
+    # in tmp_path/workspaces/ws-test/fabric.db, fully isolated from ~/.pocketpaw
+    # and from any handle a prior test cached. Imported locally so the import
+    # sorter can't drop it as "unused" (it's only referenced in this fixture).
+    import pocketpaw.stores as stores
+
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    stores.reset_store_caches()
 
     import pocketpaw_ee.cloud.workspace.service as ws_svc
 

--- a/tests/cloud/test_executor_workspace_iso.py
+++ b/tests/cloud/test_executor_workspace_iso.py
@@ -1,5 +1,8 @@
 # tests/cloud/test_executor_workspace_iso.py
 # Created: 2026-06-26 (fix/cloud-iso-executor-scope) — C1 regression.
+# Updated: 2026-06-26 (FU-1) — parametrized across EVERY approve-path executor
+# (and the discovery propose flow) that was threaded, not just Belt. No
+# executor's per-workspace isolation may rest on an over-mocked store anymore.
 #
 # Pins the per-workspace store isolation of the Instinct APPROVAL executors and
 # the background/HTTP store paths that run OUTSIDE the agent chat stream (where
@@ -13,13 +16,31 @@
 #
 # These tests DO NOT mock the store seam — they drive the REAL workspace-keyed
 # factory against tmp store files and assert (a) the executor's store resolves
-# to the SAME per-workspace file the router wrote the action to, and (b) the
-# executor does not crash under the fail-closed flag. They FAIL on the pre-fix
-# code (bare call) and PASS after threading the blob's workspace_id.
+# to the SAME per-workspace file the router wrote the action to (terminal status
+# lands there; the legacy shared file is never created), and (b) the executor
+# does not crash under the fail-closed flag. They FAIL on the pre-fix code (bare
+# call) and PASS after threading the blob's workspace_id.
+#
+# Coverage map (executor → blob kind → store(s) scoped):
+#   belt/executor.execute_approved_change            _code_change      instinct
+#   external_actions/…execute_approved_external_action _external_action instinct
+#   pocket_proposals/…execute_approved_pocket_create  _pocket_create    instinct
+#   versions/instinct_executor.execute_approved_change _artifact_change instinct
+#   fabric_proposals/…execute_approved_fabric_objects _fabric_objects  instinct+fabric
+#   discovery/orchestrate.run_discovery_and_propose   (propose flow)   instinct
+#
+# Most cases drive the executor's EARLY validation-fail path (a correct
+# workspace_id but an intentionally-bad blob), which still calls
+# ``store.mark_failed`` on the resolved store — enough to prove WHICH file it
+# opened without standing up connectors/git/beanie. fabric_objects uses a VALID
+# blob so the SECOND scoped store (get_fabric_store) is exercised too.
 from __future__ import annotations
 
+import os
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -35,7 +56,11 @@ WS = "ws-tenant-a"
 def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Point the store data dir at a tmp path, clear the fail-closed flag and the
     ContextVar, and reset the bounded LRU between tests so a per-workspace store
-    from one test never leaks into the next."""
+    from one test never leaks into the next.
+
+    NOTE the flag is cleared even when the flag-mode CI lane exports it process
+    wide — these resolution tests set/clear it per-case so they assert the same
+    way under either lane."""
     monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
     monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
     stores.reset_store_caches()
@@ -54,107 +79,293 @@ def _trig() -> ActionTrigger:
     return ActionTrigger(type="agent", source="claude", reason="iso regression")
 
 
-def _belt_action(action_id: str, *, workspace_id: str) -> SimpleNamespace:
-    """An approved Belt code-change Action whose blob carries ``workspace_id`` —
-    the exact shape ``belt/executor.execute_approved_change`` reads."""
-    return SimpleNamespace(
-        id=action_id,
-        pocket_id=workspace_id,
-        parameters={
-            "_code_change": {
-                "schema": 2,
-                "kind": "code_change",
-                "workspace_id": workspace_id,
-                "requested_by": "u1",
-                # No diff / repo: the executor bails after the chain bookkeeping,
-                # which is all this test needs — the store resolution happens
-                # BEFORE any git work.
-                "base_branch": "main",
-                "correlation_id": None,
-            }
-        },
-    )
+class _NoopOpener:
+    """A PrOpener that never touches git/GitHub — the belt executor bails before
+    it on the no-diff blob, but the signature must be satisfied."""
+
+    async def open_pr(self, **_kwargs) -> str:  # pragma: no cover - not reached
+        return "https://example.invalid/pr/0"
 
 
-async def test_belt_executor_resolves_to_per_workspace_file(tmp_path: Path) -> None:
-    """The router writes + approves on the per-workspace instinct file; the belt
-    executor (HTTP approve path, no ContextVar) must mark that SAME action
-    executed/failed on the SAME file — never the shared one."""
+# ---------------------------------------------------------------------------
+# Per-executor specs. Each builds the Action ``parameters`` (CORRECT
+# workspace_id, kind-specific blob) and an awaitable that runs the executor
+# OUTSIDE any identity. ``terminal`` is True when the executor marks the Action
+# executed/failed on the resolved instinct store (everything except the
+# discovery propose flow).
+# ---------------------------------------------------------------------------
+
+
+def _belt_params(ws: str) -> dict:
+    # Valid schema but no diff/repo → the executor closes the chain and bails
+    # AFTER opening the instinct store; the action ends terminal on it.
+    return {
+        "_code_change": {
+            "schema": 2,
+            "kind": "code_change",
+            "workspace_id": ws,
+            "requested_by": "u1",
+            "base_branch": "main",
+            "correlation_id": None,
+        }
+    }
+
+
+async def _run_belt(action: Any) -> None:
     from pocketpaw_ee.cloud.belt import executor as belt_executor
 
-    # ROUTER PATH — scoped store, exactly as ee/.../instinct/router.py::_store(ws).
+    await belt_executor.execute_approved_change(action, pr_opener=_NoopOpener())
+
+
+def _external_params(ws: str) -> dict:
+    # Wrong schema → the executor's schema guard marks_failed on the instinct
+    # store it just resolved.
+    return {
+        "_external_action": {
+            "schema": 999,  # mismatch → early _fail (mark_failed)
+            "workspace_id": ws,
+            "connector_name": "crm",
+            "action": "noop",
+            "params": {},
+            "requested_by": "u1",
+            "correlation_id": None,
+        }
+    }
+
+
+async def _run_external(action: Any) -> None:
+    from pocketpaw_ee.cloud.external_actions import executor as ext_executor
+
+    await ext_executor.execute_approved_external_action(action)
+
+
+def _pocket_create_params(ws: str) -> dict:
+    return {
+        "_pocket_create": {
+            "schema": 999,  # mismatch → early _fail (mark_failed)
+            "workspace_id": ws,
+            "user_id": "u1",
+            "pocket_spec": {"name": "x"},
+            "correlation_id": None,
+        }
+    }
+
+
+async def _run_pocket_create(action: Any) -> None:
+    from pocketpaw_ee.cloud.pocket_proposals import executor as pc_executor
+
+    await pc_executor.execute_approved_pocket_create(action)
+
+
+def _artifact_change_params(ws: str) -> dict:
+    # ``workspace`` set (the executor's tenant key) but ``to_version_id`` missing
+    # → mark_failed on the resolved instinct store, before any beanie work.
+    return {
+        "_artifact_change": {
+            "schema": 1,
+            "scope_type": "pocket",
+            "scope_id": "pocket-art",
+            "branch": "main",
+            "from_version_id": "ver-from",
+            "to_version_id": "",  # missing → mark_failed
+            "workspace": ws,
+            "user_id": "u1",
+        }
+    }
+
+
+async def _run_artifact_change(action: Any) -> None:
+    from pocketpaw_ee.versions import instinct_executor as ver_executor
+
+    await ver_executor.execute_approved_change(action)
+
+
+def _fabric_objects_params(ws: str) -> dict:
+    # VALID blob (schema 1, one type + one object) so the executor passes its
+    # guards and reaches the SECOND scoped store, get_fabric_store(workspace_id).
+    return {
+        "_fabric_objects": {
+            "schema": 1,
+            "workspace_id": ws,
+            "object_types": [
+                {
+                    "type_name": "Customer",
+                    "properties": [{"name": "name", "type": "string"}],
+                }
+            ],
+            "objects": [
+                {
+                    "type_name": "Customer",
+                    "properties": {"name": "Acme Inc"},
+                    "source_connector": "crm",
+                    "source_id": "cust-1",
+                }
+            ],
+            "links": [],
+            "requested_by": "u1",
+            "correlation_id": None,
+        }
+    }
+
+
+async def _run_fabric_objects(action: Any) -> None:
+    from pocketpaw_ee.cloud.fabric_proposals import executor as fo_executor
+
+    await fo_executor.execute_approved_fabric_objects(action)
+
+
+# (id, blob_params_builder, run_coro, asserts_instinct_terminal)
+_EXECUTOR_CASES: list[tuple[str, Callable[[str], dict], Callable[[Any], Awaitable[None]], bool]] = [
+    ("belt", _belt_params, _run_belt, True),
+    ("external_action", _external_params, _run_external, True),
+    ("pocket_create", _pocket_create_params, _run_pocket_create, True),
+    ("artifact_change", _artifact_change_params, _run_artifact_change, True),
+    ("fabric_objects", _fabric_objects_params, _run_fabric_objects, True),
+]
+
+
+async def _propose_and_approve(params: dict) -> Any:
+    """ROUTER PATH — open the scoped instinct store exactly as
+    ee/.../instinct/router.py::_store(ws) does, file the action carrying the
+    blob, and approve it. Returns the approved Action."""
     router_store = stores.get_instinct_store(workspace_id=WS)
     act = await router_store.propose(
         pocket_id=WS,
-        title="belt-change",
+        title="iso-case",
         description="",
         recommendation="",
         trigger=_trig(),
         workspace_id=WS,
-        parameters=_belt_action("ignored", workspace_id=WS).parameters,
+        parameters=params,
     )
     await router_store.approve(act.id, approver="u1")
+    return act
+
+
+@pytest.mark.parametrize("case_id, build_params, run_executor, terminal", _EXECUTOR_CASES)
+async def test_executor_resolves_to_per_workspace_file(
+    case_id: str,
+    build_params: Callable[[str], dict],
+    run_executor: Callable[[Any], Awaitable[None]],
+    terminal: bool,
+    tmp_path: Path,
+) -> None:
+    """The router proposes+approves on the per-workspace instinct file; the
+    executor (HTTP approve path, no ContextVar) must mark that SAME action
+    terminal on the SAME file — never the shared one."""
+    params = build_params(WS)
+    act = await _propose_and_approve(params)
 
     # EXECUTOR PATH — run OUTSIDE any identity (no ContextVar). With the fix the
-    # executor threads the blob's workspace_id, so it opens the SAME file.
-    await belt_executor.execute_approved_change(
-        _belt_action(act.id, workspace_id=WS), pr_opener=_NoopOpener()
-    )
+    # executor threads the blob's workspace, so it opens the SAME file.
+    await run_executor(SimpleNamespace(id=act.id, pocket_id=WS, parameters=params))
 
-    # The action the router approved is now terminal (executed OR failed) ON THE
-    # PER-WORKSPACE FILE. Pre-fix the executor's bare store opened the SHARED
-    # file, so this row stayed 'approved' here.
-    refreshed = await router_store.get_action(act.id)
-    assert refreshed is not None
-    assert refreshed.status.value in {"executed", "failed"}, refreshed.status
+    if terminal:
+        refreshed = await stores.get_instinct_store(workspace_id=WS).get_action(act.id)
+        assert refreshed is not None
+        assert refreshed.status.value in {"executed", "failed"}, (
+            f"[{case_id}] executor left the action {refreshed.status.value!r} on the "
+            "per-workspace file — its store resolved elsewhere"
+        )
 
-    # And the executor must NOT have created the legacy shared file.
+    # The executor must NOT have created the legacy SHARED instinct file.
     assert not (tmp_path / "instinct.db").exists(), (
-        "executor opened the SHARED instinct.db instead of the per-workspace file"
+        f"[{case_id}] executor opened the SHARED instinct.db instead of the per-workspace file"
     )
+    # fabric_objects also opens a fabric store — it must be the per-workspace one,
+    # never the legacy shared fabric.db.
+    if case_id == "fabric_objects":
+        assert not (tmp_path / "fabric.db").exists(), (
+            "fabric_objects executor opened the SHARED fabric.db instead of the "
+            "per-workspace fabric file"
+        )
+        assert (tmp_path / "workspaces" / WS / "fabric.db").exists(), (
+            "fabric_objects executor never opened the per-workspace fabric file"
+        )
 
 
-async def test_belt_executor_does_not_crash_under_failclosed_flag(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("case_id, build_params, run_executor, terminal", _EXECUTOR_CASES)
+async def test_executor_does_not_crash_under_failclosed_flag(
+    case_id: str,
+    build_params: Callable[[str], dict],
+    run_executor: Callable[[Any], Awaitable[None]],
+    terminal: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Under the cloud fail-closed flag the executor must still resolve the
     tenant's file from the blob (not raise WorkspaceScopeRequired and leave the
     action approved-but-never-executed)."""
-    from pocketpaw_ee.cloud.belt import executor as belt_executor
-
-    router_store = stores.get_instinct_store(workspace_id=WS)
-    act = await router_store.propose(
-        pocket_id=WS,
-        title="belt-change",
-        description="",
-        recommendation="",
-        trigger=_trig(),
-        workspace_id=WS,
-        parameters=_belt_action("ignored", workspace_id=WS).parameters,
-    )
-    await router_store.approve(act.id, approver="u1")
+    params = build_params(WS)
+    act = await _propose_and_approve(params)
 
     monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
     stores.reset_store_caches()  # force re-resolution under the flag
 
-    # Must NOT raise — the executor never re-raises into the router, but pre-fix
+    # Must NOT raise — the executors never re-raise into the router, but pre-fix
     # the bare store call raised internally and the action stayed approved.
-    await belt_executor.execute_approved_change(
-        _belt_action(act.id, workspace_id=WS), pr_opener=_NoopOpener()
+    await run_executor(SimpleNamespace(id=act.id, pocket_id=WS, parameters=params))
+
+    if terminal:
+        refreshed = await stores.get_instinct_store(workspace_id=WS).get_action(act.id)
+        assert refreshed is not None
+        assert refreshed.status.value in {"executed", "failed"}, (
+            f"[{case_id}] under the fail-closed flag the executor left the action "
+            f"{refreshed.status.value!r} — it could not resolve the tenant store"
+        )
+
+
+# ---------------------------------------------------------------------------
+# discovery/orchestrate.run_discovery_and_propose — a PROPOSE flow (not an
+# approve-time executor), but it opens the scoped instinct store on the same
+# no-ContextVar path. A fake DiscoveryRun yields an EMPTY ontology so the run
+# opens the per-workspace store, runs the supersede sweep against it, and
+# returns cleanly — proving resolution without standing up connectors.
+# ---------------------------------------------------------------------------
+
+
+class _EmptyDiscoveryRun:
+    async def run(self, *_a: Any, **_k: Any):
+        from pocketpaw_ee.discovery.models import OntologyDraft
+
+        return OntologyDraft()
+
+
+async def test_discovery_propose_resolves_to_per_workspace_file(tmp_path: Path) -> None:
+    from pocketpaw_ee.discovery.orchestrate import run_discovery_and_propose
+
+    result = await run_discovery_and_propose(
+        workspace_id=WS,
+        user_id="u1",
+        connector_ids=[],
+        discovery_run=_EmptyDiscoveryRun(),
+    )
+    # Empty draft → no proposals filed, but the scoped store WAS opened + swept.
+    assert result.fabric_objects_action_id is None
+    assert result.pocket_action_id is None
+    # The per-workspace instinct file was used; the legacy shared one was not.
+    assert (tmp_path / "workspaces" / WS / "instinct.db").exists(), (
+        "discovery never opened the per-workspace instinct file"
+    )
+    assert not (tmp_path / "instinct.db").exists(), (
+        "discovery opened the SHARED instinct.db instead of the per-workspace file"
     )
 
-    # Re-read under the flag with the explicit workspace (the router's own path).
-    refreshed = await stores.get_instinct_store(workspace_id=WS).get_action(act.id)
-    assert refreshed is not None
-    assert refreshed.status.value in {"executed", "failed"}, (
-        "under the fail-closed flag the executor left the action "
-        f"{refreshed.status.value!r} — it could not resolve the tenant store"
+
+async def test_discovery_propose_does_not_crash_under_failclosed_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pocketpaw_ee.discovery.orchestrate import run_discovery_and_propose
+
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    stores.reset_store_caches()
+
+    # Must NOT raise WorkspaceScopeRequired — discovery threads its workspace_id.
+    result = await run_discovery_and_propose(
+        workspace_id=WS,
+        user_id="u1",
+        connector_ids=[],
+        discovery_run=_EmptyDiscoveryRun(),
     )
-
-
-class _NoopOpener:
-    """A PrOpener that never touches git/GitHub — the executor bails before it
-    on the no-diff blob, but the signature must be satisfied."""
-
-    async def open_pr(self, **_kwargs) -> str:  # pragma: no cover - not reached
-        return "https://example.invalid/pr/0"
+    assert result.run_id  # the run completed and minted an id
+    assert os.environ["POCKETPAW_REQUIRE_WORKSPACE_SCOPE"] == "1"  # flag was live

--- a/tests/cloud/test_executor_workspace_iso.py
+++ b/tests/cloud/test_executor_workspace_iso.py
@@ -1,0 +1,160 @@
+# tests/cloud/test_executor_workspace_iso.py
+# Created: 2026-06-26 (fix/cloud-iso-executor-scope) — C1 regression.
+#
+# Pins the per-workspace store isolation of the Instinct APPROVAL executors and
+# the background/HTTP store paths that run OUTSIDE the agent chat stream (where
+# the ``current_workspace`` ContextVar is NEVER set). Before the fix these all
+# called BARE ``get_instinct_store()`` / ``get_fabric_store()`` with no
+# workspace, so on CLOUD (``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` set) the bare
+# call RAISED ``WorkspaceScopeRequired`` after the action was already flipped
+# APPROVED (approved-but-never-executed), and on OSS (flag unset) it silently
+# resolved to the legacy SHARED store while the proposal+approval lived in the
+# per-workspace file → split-brain ledger.
+#
+# These tests DO NOT mock the store seam — they drive the REAL workspace-keyed
+# factory against tmp store files and assert (a) the executor's store resolves
+# to the SAME per-workspace file the router wrote the action to, and (b) the
+# executor does not crash under the fail-closed flag. They FAIL on the pre-fix
+# code (bare call) and PASS after threading the blob's workspace_id.
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import pocketpaw.stores as stores
+from pocketpaw.instinct.models import ActionTrigger
+
+pytestmark = pytest.mark.asyncio
+
+WS = "ws-tenant-a"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the store data dir at a tmp path, clear the fail-closed flag and the
+    ContextVar, and reset the bounded LRU between tests so a per-workspace store
+    from one test never leaks into the next."""
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+def _trig() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="iso regression")
+
+
+def _belt_action(action_id: str, *, workspace_id: str) -> SimpleNamespace:
+    """An approved Belt code-change Action whose blob carries ``workspace_id`` —
+    the exact shape ``belt/executor.execute_approved_change`` reads."""
+    return SimpleNamespace(
+        id=action_id,
+        pocket_id=workspace_id,
+        parameters={
+            "_code_change": {
+                "schema": 2,
+                "kind": "code_change",
+                "workspace_id": workspace_id,
+                "requested_by": "u1",
+                # No diff / repo: the executor bails after the chain bookkeeping,
+                # which is all this test needs — the store resolution happens
+                # BEFORE any git work.
+                "base_branch": "main",
+                "correlation_id": None,
+            }
+        },
+    )
+
+
+async def test_belt_executor_resolves_to_per_workspace_file(tmp_path: Path) -> None:
+    """The router writes + approves on the per-workspace instinct file; the belt
+    executor (HTTP approve path, no ContextVar) must mark that SAME action
+    executed/failed on the SAME file — never the shared one."""
+    from pocketpaw_ee.cloud.belt import executor as belt_executor
+
+    # ROUTER PATH — scoped store, exactly as ee/.../instinct/router.py::_store(ws).
+    router_store = stores.get_instinct_store(workspace_id=WS)
+    act = await router_store.propose(
+        pocket_id=WS,
+        title="belt-change",
+        description="",
+        recommendation="",
+        trigger=_trig(),
+        workspace_id=WS,
+        parameters=_belt_action("ignored", workspace_id=WS).parameters,
+    )
+    await router_store.approve(act.id, approver="u1")
+
+    # EXECUTOR PATH — run OUTSIDE any identity (no ContextVar). With the fix the
+    # executor threads the blob's workspace_id, so it opens the SAME file.
+    await belt_executor.execute_approved_change(
+        _belt_action(act.id, workspace_id=WS), pr_opener=_NoopOpener()
+    )
+
+    # The action the router approved is now terminal (executed OR failed) ON THE
+    # PER-WORKSPACE FILE. Pre-fix the executor's bare store opened the SHARED
+    # file, so this row stayed 'approved' here.
+    refreshed = await router_store.get_action(act.id)
+    assert refreshed is not None
+    assert refreshed.status.value in {"executed", "failed"}, refreshed.status
+
+    # And the executor must NOT have created the legacy shared file.
+    assert not (tmp_path / "instinct.db").exists(), (
+        "executor opened the SHARED instinct.db instead of the per-workspace file"
+    )
+
+
+async def test_belt_executor_does_not_crash_under_failclosed_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Under the cloud fail-closed flag the executor must still resolve the
+    tenant's file from the blob (not raise WorkspaceScopeRequired and leave the
+    action approved-but-never-executed)."""
+    from pocketpaw_ee.cloud.belt import executor as belt_executor
+
+    router_store = stores.get_instinct_store(workspace_id=WS)
+    act = await router_store.propose(
+        pocket_id=WS,
+        title="belt-change",
+        description="",
+        recommendation="",
+        trigger=_trig(),
+        workspace_id=WS,
+        parameters=_belt_action("ignored", workspace_id=WS).parameters,
+    )
+    await router_store.approve(act.id, approver="u1")
+
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    stores.reset_store_caches()  # force re-resolution under the flag
+
+    # Must NOT raise — the executor never re-raises into the router, but pre-fix
+    # the bare store call raised internally and the action stayed approved.
+    await belt_executor.execute_approved_change(
+        _belt_action(act.id, workspace_id=WS), pr_opener=_NoopOpener()
+    )
+
+    # Re-read under the flag with the explicit workspace (the router's own path).
+    refreshed = await stores.get_instinct_store(workspace_id=WS).get_action(act.id)
+    assert refreshed is not None
+    assert refreshed.status.value in {"executed", "failed"}, (
+        "under the fail-closed flag the executor left the action "
+        f"{refreshed.status.value!r} — it could not resolve the tenant store"
+    )
+
+
+class _NoopOpener:
+    """A PrOpener that never touches git/GitHub — the executor bails before it
+    on the no-diff blob, but the signature must be satisfied."""
+
+    async def open_pr(self, **_kwargs) -> str:  # pragma: no cover - not reached
+        return "https://example.invalid/pr/0"

--- a/tests/cloud/test_external_action_gate.py
+++ b/tests/cloud/test_external_action_gate.py
@@ -114,7 +114,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     (the propose helper + the executor both lazy-import
     ``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_external_action_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 
@@ -449,7 +449,7 @@ async def test_production_path_approve_runs_executor_one_terminal(
     # executor). The router's _store indirection points at our tmp store.
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 200, resp.text
 
@@ -497,7 +497,7 @@ async def test_production_path_reject_router_closes_executor_never_called(
 
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
     assert resp.status_code == 200, resp.text
 
@@ -539,7 +539,7 @@ async def test_router_cross_workspace_approval_forbidden(store, journal, graph, 
     # Caller is in w1 but the action belongs to w-OTHER.
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 403, resp.text
     # Nothing fired.

--- a/tests/cloud/test_external_action_mcp.py
+++ b/tests/cloud/test_external_action_mcp.py
@@ -52,7 +52,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     """Isolated InstinctStore on a tmp file, wired in everywhere the propose
     helper reads it (``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_ea_mcp_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/cloud/test_fabric_objects_gate.py
+++ b/tests/cloud/test_fabric_objects_gate.py
@@ -72,7 +72,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     (the propose helper + the executor both lazy-import
     ``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_fabric_objects_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 
@@ -402,7 +402,7 @@ async def test_production_path_approve_runs_executor_one_terminal(
 
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 200, resp.text
 
@@ -441,7 +441,7 @@ async def test_production_path_reject_router_closes_executor_never_runs(
 
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
     assert resp.status_code == 200, resp.text
 
@@ -480,7 +480,7 @@ async def test_cross_workspace_single_approve_forbidden(store, fabric, journal, 
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 403, resp.text
@@ -496,7 +496,7 @@ async def test_cross_workspace_single_reject_forbidden(store, fabric, journal, g
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "no"})
     assert resp.status_code == 403, resp.text
@@ -510,7 +510,7 @@ async def test_cross_workspace_bulk_approve_forbidden(store, fabric, journal, gr
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post("/instinct/actions/bulk-approve", json={"ids": [action_id]})
     assert resp.status_code == 403, resp.text
@@ -525,7 +525,7 @@ async def test_cross_workspace_bulk_reject_forbidden(store, fabric, journal, gra
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post("/instinct/actions/bulk-reject", json={"ids": [action_id], "reason": "no"})
     assert resp.status_code == 403, resp.text

--- a/tests/cloud/test_fabric_objects_gate.py
+++ b/tests/cloud/test_fabric_objects_gate.py
@@ -70,18 +70,38 @@ from pocketpaw.instinct.store import InstinctStore  # noqa: E402
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     """Isolated InstinctStore on a tmp file, wired everywhere the gate reads it
     (the propose helper + the executor both lazy-import
-    ``pocketpaw.stores.get_instinct_store``)."""
+    ``pocketpaw.stores.get_instinct_store``).
+
+    SINGLE-store, accept-and-ignore ``workspace_id`` (fix/cloud-iso-executor-scope):
+    these gate tests — especially the cross-workspace 403 cases — drive ONE
+    physical store and rely on the IN-ROW ``workspace_id`` filter for tenancy
+    (a "w1" propose and a "w-OTHER" propose must coexist in the same file so the
+    router's cross-workspace assertion is what forbids the approve). The factory
+    therefore returns the one store regardless of workspace; it only has to
+    TOLERATE the explicit ``workspace_id`` the propose/executor now thread
+    through. The executor's per-file isolation is proven separately in
+    tests/cloud/test_executor_workspace_iso.py and test_belt_gate.py."""
     st = InstinctStore(tmp_path / "instinct_fabric_objects_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    monkeypatch.setattr(
+        "pocketpaw.stores.get_instinct_store",
+        lambda *a, workspace_id=None, **k: st,
+    )
     return st
 
 
 @pytest.fixture
 def fabric(tmp_path: Path, monkeypatch) -> FabricStore:
     """Isolated FabricStore on a tmp file, wired into ``get_fabric_store`` so the
-    executor writes real (but isolated) typed objects + links."""
+    executor writes real (but isolated) typed objects + links.
+
+    Single-store, accept-and-ignore ``workspace_id`` — the old ``lambda: fs``
+    TypeError'd once the executor threaded the blob's workspace into the fabric
+    factory (fix/cloud-iso-executor-scope); the in-row filter handles tenancy."""
     fs = FabricStore(tmp_path / "fabric_objects_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda: fs)
+    monkeypatch.setattr(
+        "pocketpaw.stores.get_fabric_store",
+        lambda *a, workspace_id=None, **k: fs,
+    )
     return fs
 
 

--- a/tests/cloud/test_foresight_service_instinct.py
+++ b/tests/cloud/test_foresight_service_instinct.py
@@ -90,7 +90,13 @@ def isolated_instinct_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     test_store = InstinctStore(tmp_path / "instinct-test.db")
 
-    def _factory() -> InstinctStore:
+    # Accept (and ignore) ``workspace_id`` — these tests exercise the W4c IN-ROW
+    # workspace filter on a SINGLE physical store (the W4cWorkspaceScoping class
+    # queries this very store with explicit workspace_id), so the factory must
+    # return the one store regardless of the arg. The signature just has to
+    # tolerate the explicit ``workspace_id`` the service now threads through
+    # (fix/cloud-iso-executor-scope) instead of TypeError-ing.
+    def _factory(*_a, workspace_id: str | None = None, **_k) -> InstinctStore:
         return test_store
 
     monkeypatch.setattr(stores_mod, "get_instinct_store", _factory)

--- a/tests/cloud/test_ga_two_tenant_pentest.py
+++ b/tests/cloud/test_ga_two_tenant_pentest.py
@@ -1,0 +1,465 @@
+# tests/cloud/test_ga_two_tenant_pentest.py
+# Created: 2026-06-26 (GA-1) — the GA gate: an automated two-tenant isolation
+# pen-test + sim-provision e2e for the cloud multi-tenant offering.
+#
+# This is the build-complete proof that two paying tenants on ONE shared backend
+# are physically + logically isolated end to end. It exercises the full ISO-1..4
+# stack (per-workspace Fabric/Instinct files + fail-closed factory + ContextVar
+# bridge + the migration/lint/lock guards) plus the billing provision path.
+#
+# Five proofs (the captain's GA gate):
+#   1. CROSS-LEAK — write data in BOTH tenants across Fabric, Instinct, KB,
+#      Pockets; assert tenant A's reads return ZERO of tenant B's rows on every
+#      surface (and vice-versa).
+#   2. FAIL-CLOSED — under POCKETPAW_REQUIRE_WORKSPACE_SCOPE, a store call with
+#      no workspace context RAISES (never silently reads a shared store).
+#   3. ENTITLEMENT — a workspace's plan resolves to the right feature set; the
+#      402-at-balance<=0 credit guard fires.
+#   4. PROVISION (sim) — subscribe -> a REAL standardwebhooks-signed
+#      subscription.active webhook -> the workspace is stamped to the plan +
+#      monthly credits granted + lands isolated. Proven at BOTH the service layer
+#      and end-to-end through the real HTTP route POST /billing/webhooks/dodo
+#      (raw-byte read + signature verify + provision). No live Dodo creds — the
+#      signed sim is the proof; ONLY the OUTBOUND /billing/subscribe -> real Dodo
+#      hosted-checkout call is creds-gated, and that is the captain's runbook step.
+#
+# The signed-webhook technique mirrors tests/cloud/billing/test_subscriptions.py
+# (the 2026-06-24 billing-preview recipe); the cross-leak assertions mirror the
+# per-surface isolation tests (test_ee_fabric, test_ee_instinct, kb, pockets).
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import pocketpaw.stores as stores
+from pocketpaw.fabric.models import FabricQuery
+from pocketpaw.instinct.models import ActionTrigger
+
+# Two tenants on one backend.
+WS_A = "wsAlpha"
+WS_B = "wsBravo"
+
+# A valid Standard-Webhooks secret (whsec_ + base64 of a 32-byte key).
+SECRET = "whsec_" + base64.b64encode(b"ga-pentest-secret-key-32-bytes!!").decode()
+PLAN_PRODUCTS = {"go": "prod_go_recurring", "pro": "prod_pro_recurring"}
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the per-workspace store factory at a tmp data dir; reset caches.
+
+    This is the local-file side of isolation (Fabric/Instinct). The required-
+    scope flag is OFF here so the cross-leak/provision tests can resolve stores
+    by explicit workspace; the dedicated fail-closed test sets it ON.
+    """
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    token = stores.current_workspace.set(None)
+    try:
+        yield tmp_path
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+def _trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="ga pen-test")
+
+
+def _provider():
+    from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+
+    return DodoProvider(
+        api_key="dodo_test_key",
+        environment="test_mode",
+        webhook_secret=SECRET,
+        credit_product_id="prod_credits_sku",
+        plan_products=PLAN_PRODUCTS,
+    )
+
+
+def _sign(body: str, *, msg_id: str) -> dict[str, str]:
+    from standardwebhooks import Webhook
+
+    ts = datetime.now(UTC)
+    sig = Webhook(SECRET).sign(msg_id=msg_id, timestamp=ts, data=body)
+    return {
+        "webhook-id": msg_id,
+        "webhook-timestamp": str(int(ts.timestamp())),
+        "webhook-signature": sig,
+    }
+
+
+def _subscription_body(*, workspace_id: str, plan_key: str = "pro") -> str:
+    return json.dumps(
+        {
+            "business_id": "biz_ga",
+            "type": "subscription.active",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "subscription_id": f"sub_{workspace_id}",
+                "product_id": PLAN_PRODUCTS[plan_key],
+                "metadata": {"workspace_id": workspace_id, "plan_key": plan_key},
+            },
+        }
+    )
+
+
+# ===========================================================================
+# PROOF 1 — CROSS-LEAK across Fabric + Instinct (the physically-isolated stores)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fabric_two_tenant_zero_cross_leak(store_dir: Path) -> None:
+    a = stores.get_fabric_store(workspace_id=WS_A)
+    b = stores.get_fabric_store(workspace_id=WS_B)
+
+    ta = await a.define_type(name="Customer", properties=[], workspace_id=WS_A)
+    await a.create_object(ta.id, {"name": "AcmeSecret"}, workspace_id=WS_A)
+    tb = await b.define_type(name="Customer", properties=[], workspace_id=WS_B)
+    await b.create_object(tb.id, {"name": "GlobexSecret"}, workspace_id=WS_B)
+
+    # Separate files on disk.
+    assert (store_dir / "workspaces" / WS_A / "fabric.db").exists()
+    assert (store_dir / "workspaces" / WS_B / "fabric.db").exists()
+    assert not (store_dir / "fabric.db").exists()
+
+    # A's query (even unscoped at the store level) returns ZERO of B's rows.
+    a_names = {o.properties.get("name") for o in (await a.query(FabricQuery())).objects}
+    b_names = {o.properties.get("name") for o in (await b.query(FabricQuery())).objects}
+    assert a_names == {"AcmeSecret"}
+    assert b_names == {"GlobexSecret"}
+    assert "GlobexSecret" not in a_names
+    assert "AcmeSecret" not in b_names
+
+
+@pytest.mark.asyncio
+async def test_instinct_two_tenant_zero_cross_leak(store_dir: Path) -> None:
+    a = stores.get_instinct_store(workspace_id=WS_A)
+    b = stores.get_instinct_store(workspace_id=WS_B)
+
+    await a.propose("p", "A-secret-action", "", "", _trigger(), workspace_id=WS_A)
+    await b.propose("p", "B-secret-action", "", "", _trigger(), workspace_id=WS_B)
+
+    assert (store_dir / "workspaces" / WS_A / "instinct.db").exists()
+    assert (store_dir / "workspaces" / WS_B / "instinct.db").exists()
+    assert not (store_dir / "instinct.db").exists()
+
+    a_pending = {x.title for x in await a.pending()}
+    b_pending = {x.title for x in await b.pending()}
+    assert a_pending == {"A-secret-action"}
+    assert b_pending == {"B-secret-action"}
+
+    # The audit ledgers are independent + each intact (per-tenant chains).
+    assert (await a.verify_audit_chain())["intact"] is True
+    assert (await b.verify_audit_chain())["intact"] is True
+
+
+@pytest.mark.asyncio
+async def test_pockets_two_tenant_zero_cross_leak(mongo_db) -> None:
+    """Pocket created in tenant A is invisible to tenant B's list (Mongo-backed)."""
+    from pocketpaw_ee.cloud.pockets import service as pockets
+    from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+    p_a = await pockets.create(WS_A, "u-a", CreatePocketRequest(name="A-Secret-Pocket"))
+    p_b = await pockets.create(WS_B, "u-b", CreatePocketRequest(name="B-Secret-Pocket"))
+
+    a_list = {p["name"] for p in await pockets.list_pockets(WS_A, "u-a")}
+    b_list = {p["name"] for p in await pockets.list_pockets(WS_B, "u-b")}
+    assert "A-Secret-Pocket" in a_list
+    assert "B-Secret-Pocket" in b_list
+    # Neither tenant's list contains the other's pocket.
+    assert "B-Secret-Pocket" not in a_list
+    assert "A-Secret-Pocket" not in b_list
+    # And the pocket ids differ (distinct docs, distinct tenants).
+    assert p_a["_id"] != p_b["_id"]
+
+
+async def _seed_user(email: str, workspace: str) -> str:
+    """Insert a real User doc anchored to ``workspace`` and return its id."""
+    from pocketpaw_ee.cloud.models.user import User
+
+    doc = User(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="GA User",
+        active_workspace=workspace,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+def _kb_list_with(populated: set[str]):
+    """Per-scope kb-list shim: a scope in ``populated`` carries one article row.
+
+    Matches the kb-go subprocess contract list_scopes uses — it keeps a candidate
+    scope only when its list is non-empty. Mirrors the existing KB test's shim.
+    """
+
+    def _shim(scope: str) -> list[dict]:
+        return [{"id": f"art-{scope}", "title": "x"}] if scope in populated else []
+
+    return _shim
+
+
+@pytest.mark.asyncio
+async def test_kb_scopes_zero_cross_workspace_leak(mongo_db) -> None:
+    """KB scope listing for one workspace never surfaces another's pocket scope.
+
+    The SAME user owns a pocket in WS_A. Even with a shim that says WS_A's pocket
+    scope HAS content, listing KB scopes stamped with WS_B must not surface it —
+    the pockets workspace filter is the gate; KB relies on it. Mirrors the
+    existing test_list_scopes_blocks_cross_workspace_pocket_reads.
+    """
+    from pocketpaw_ee.cloud.kb import service as kb
+    from pocketpaw_ee.cloud.pockets import service as pockets
+    from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+    user_id = await _seed_user("ga-kb@tenant.test", WS_A)
+    pocket_a = await pockets.create(WS_A, user_id, CreatePocketRequest(name="A-KB-Pocket"))
+    a_pocket_scope = f"pocket:{pocket_a['_id']}"
+
+    # The shim claims A's pocket scope AND both workspace scopes are populated, so
+    # the ONLY thing that can keep A's pocket scope out of WS_B's listing is the
+    # workspace filter inside list_scopes.
+    populated = {a_pocket_scope, f"workspace:{WS_A}", f"workspace:{WS_B}"}
+    a_scopes = await kb.list_scopes(WS_A, user_id, kb_list=_kb_list_with(populated))
+    b_scopes = await kb.list_scopes(WS_B, user_id, kb_list=_kb_list_with(populated))
+
+    # WS_A sees its own pocket scope; WS_B — same user — does NOT.
+    assert a_pocket_scope in a_scopes
+    assert a_pocket_scope not in b_scopes
+
+
+# ===========================================================================
+# PROOF 2 — FAIL-CLOSED on every store path under required-scope
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_no_workspace_under_required_scope(
+    store_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    # Neither store may fall back to a shared file when no workspace resolves.
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_fabric_store()
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_instinct_store()
+
+
+# ===========================================================================
+# Mongo-backed proofs (entitlement + credit ledger + provision). These use the
+# in-memory Beanie (mongomock) `mongo_db` fixture from tests/cloud/conftest.py —
+# the same harness the billing-preview recipe uses.
+# ===========================================================================
+
+
+async def _make_workspace(plan: str = "free", *, slug: str | None = None) -> str:
+    """Insert a real Workspace doc and return its id string (the wallet key)."""
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(name="Tenant", slug=slug or f"tenant-{plan}", owner="u-owner", plan=plan)
+    await ws.insert()
+    return str(ws.id)
+
+
+# ---------------------------------------------------------------------------
+# PROOF 3 — ENTITLEMENT: plan resolves to the right features; the 402-at-zero
+# credit guard fires; both are tenant-isolated.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_entitlements_resolve_per_plan_and_isolate_tenants(mongo_db) -> None:
+    from pocketpaw_ee.cloud.entitlements import service as entitlements
+
+    ws_free = await _make_workspace(plan="free", slug="ent-free")
+    ws_pro = await _make_workspace(plan="pro", slug="ent-pro")
+
+    ent_free = await entitlements.resolve_entitlements(ws_free)
+    ent_pro = await entitlements.resolve_entitlements(ws_pro)
+
+    # Each workspace resolves to ITS OWN plan — no cross-tenant bleed of the
+    # paid feature set into the free tenant.
+    assert ent_free.plan == "free"
+    assert ent_pro.plan == "pro"
+    assert ent_free.features != ent_pro.features
+    # The pro tier is a strict superset of free (it's a higher tier).
+    assert set(ent_free.features).issubset(set(ent_pro.features))
+    # An unknown/absent workspace fails SAFE to the free base tier, never a leak.
+    ent_unknown = await entitlements.resolve_entitlements("ws-does-not-exist")
+    assert ent_unknown.plan == "free"
+
+
+@pytest.mark.asyncio
+async def test_credit_402_guard_fires_at_zero_and_is_tenant_isolated(mongo_db) -> None:
+    from pocketpaw_ee.cloud._core.errors import InsufficientCredits
+    from pocketpaw_ee.cloud.credits import service as credits
+
+    ws_a = await _make_workspace(plan="pro", slug="cred-a")
+    ws_b = await _make_workspace(plan="pro", slug="cred-b")
+
+    # Grant A 500 credits; B gets nothing.
+    await credits.grant(ws_a, 500, cause="test", idempotency_key="ga-grant-a")
+
+    # Balances are isolated: A has its grant, B is at zero.
+    assert await credits.balance(ws_a) == 500
+    assert await credits.balance(ws_b) == 0
+
+    # A (positive balance) passes the run-start guard; B (zero) gets a 402.
+    await credits.check_balance(ws_a)  # no raise
+    with pytest.raises(InsufficientCredits):
+        await credits.check_balance(ws_b)
+
+    # Spending A's wallet to zero does NOT touch B, and then A also 402s.
+    await credits.debit(ws_a, 500, cause="test", idempotency_key="ga-debit-a")
+    assert await credits.balance(ws_a) == 0
+    assert await credits.balance(ws_b) == 0
+    with pytest.raises(InsufficientCredits):
+        await credits.check_balance(ws_a)
+
+
+# ---------------------------------------------------------------------------
+# PROOF 4 — PROVISION (sim): subscribe -> SIGNED subscription.active webhook ->
+# workspace stamped to the plan + monthly credits granted + lands isolated.
+# No live Dodo creds: the standardwebhooks-signed sim is the proof.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_signed_webhook_provisions_plan_and_credits_isolated(
+    mongo_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pocketpaw_ee.cloud.billing import plans
+    from pocketpaw_ee.cloud.billing import service as billing
+    from pocketpaw_ee.cloud.credits import service as credits
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    monkeypatch.setattr(plans, "_dodo_product_for", lambda key: PLAN_PRODUCTS.get(key))
+
+    ws_a = await _make_workspace(plan="free", slug="prov-a")
+    ws_b = await _make_workspace(plan="free", slug="prov-b")
+
+    # --- the signup->subscribe leg: subscribe opens a (mocked) Dodo checkout ---
+    fake_resp = MagicMock()
+    fake_resp.payment_link = "https://checkout.dodopayments.test/sub/ga"
+    fake_resp.subscription_id = "sub_ga_a"
+    fake_client = MagicMock()
+    fake_client.subscriptions.create = AsyncMock(return_value=fake_resp)
+    import pocketpaw_ee.cloud.billing.providers.dodo as dodo_mod
+
+    monkeypatch.setattr(dodo_mod, "AsyncDodoPayments", MagicMock(return_value=fake_client))
+
+    sub = await billing.subscribe(
+        workspace_id=ws_a, user_id="u1", plan_key="pro", provider=_provider()
+    )
+    assert sub["checkout_url"] == "https://checkout.dodopayments.test/sub/ga"
+
+    # --- the provision leg: a REAL signed subscription.active for ws_a only ---
+    body = _subscription_body(workspace_id=ws_a, plan_key="pro")
+    headers = _sign(body, msg_id="evt_ga_prov_a")
+    result = await billing.handle_webhook(
+        payload=body.encode(), headers=headers, provider=_provider()
+    )
+    assert result is not None
+
+    # ws_a is now stamped to the plan + has its monthly allotment; ws_b is untouched.
+    a_doc = await Workspace.get(ws_a)
+    b_doc = await Workspace.get(ws_b)
+    assert a_doc.plan == "pro"
+    assert b_doc.plan == "free"  # provision did NOT leak to the other tenant
+    assert await credits.balance(ws_a) > 0  # monthly allotment granted
+    assert await credits.balance(ws_b) == 0  # B got nothing
+
+
+@pytest.mark.asyncio
+async def test_tampered_provision_webhook_is_rejected(mongo_db) -> None:
+    """A bad-signature provision webhook grants nothing — the gate holds."""
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.billing import service as billing
+
+    ws = await _make_workspace(plan="free", slug="prov-tamper")
+    body = _subscription_body(workspace_id=ws, plan_key="pro")
+    headers = _sign(body, msg_id="evt_tamper")
+    # Tamper the body AFTER signing — the signature no longer matches.
+    tampered = body.replace(ws, ws).encode() + b" "
+    with pytest.raises(CloudError):
+        await billing.handle_webhook(payload=tampered, headers=headers, provider=_provider())
+
+
+@pytest.mark.asyncio
+async def test_provision_through_the_http_webhook_route_end_to_end(
+    mongo_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The FULL inbound seam: POST a signed subscription.active to the REAL route.
+
+    Proves the HTTP layer end-to-end — POST /billing/webhooks/dodo reads the raw
+    bytes, verifies the Standard-Webhooks signature, and provisions — one layer
+    above the service-fn test. This is the exact path a live Dodo delivery hits;
+    only the OUTBOUND checkout call (the runbook's live step) needs real creds.
+    The inbound webhook needs none — we sign it ourselves.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.billing import service as billing
+    from pocketpaw_ee.cloud.billing.webhooks import router as webhook_router
+    from pocketpaw_ee.cloud.credits import service as credits
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    # The route calls handle_webhook with NO explicit provider, so it resolves
+    # the DEFAULT provider — point that at our test provider so the signature
+    # (signed with our SECRET) verifies, exactly as a real deploy's configured
+    # POCKETPAW_DODO_WEBHOOK_SECRET would.
+    monkeypatch.setattr(billing, "_default_provider", _provider)
+
+    ws_a = await _make_workspace(plan="free", slug="route-a")
+    ws_b = await _make_workspace(plan="free", slug="route-b")
+
+    app = FastAPI()
+    add_error_handler(app)  # so a bad-signature CloudError maps to its HTTP 400
+    app.include_router(webhook_router, prefix="/api/v1")
+    client = TestClient(app)
+
+    body = _subscription_body(workspace_id=ws_a, plan_key="pro")
+    headers = _sign(body, msg_id="evt_route_a")
+
+    resp = client.post("/api/v1/billing/webhooks/dodo", content=body.encode(), headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ok"] is True
+
+    # Provisioned through the HTTP route: ws_a stamped + credited; ws_b untouched.
+    a_doc = await Workspace.get(ws_a)
+    b_doc = await Workspace.get(ws_b)
+    assert a_doc.plan == "pro"
+    assert b_doc.plan == "free"
+    assert await credits.balance(ws_a) > 0
+    assert await credits.balance(ws_b) == 0
+
+    # A bad signature to the SAME route is a 400 (no provision).
+    bad_headers = _sign(body, msg_id="evt_route_bad")
+    bad = client.post(
+        "/api/v1/billing/webhooks/dodo",
+        content=body.encode() + b" ",  # body changed after signing
+        headers=bad_headers,
+    )
+    assert bad.status_code == 400

--- a/tests/cloud/test_instinct_approval_security.py
+++ b/tests/cloud/test_instinct_approval_security.py
@@ -404,7 +404,7 @@ class TestBlocker2BulkApproveFiresWrites:
         monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
         # The bridge lazy-imports get_instinct_store from pocketpaw.stores —
         # point it at the same router_store so propose + execute share state.
-        monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+        monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: router_store)
 
         with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
             action_id = _propose(

--- a/tests/cloud/test_instinct_empty_workspace_failclosed.py
+++ b/tests/cloud/test_instinct_empty_workspace_failclosed.py
@@ -1,0 +1,204 @@
+# tests/cloud/test_instinct_empty_workspace_failclosed.py
+# Created: 2026-06-26 (fix/cloud-iso-executor-scope, LOW-1) — fail-closed gate
+# for an EMPTY blob-workspace claim across ALL six gated Instinct proposal kinds.
+#
+# Before LOW-1 only ``_artifact_change`` hard-403'd on an empty blob workspace
+# (its own regression lives in test_artifact_change_gate.py). The other six
+# kinds — _belt_plan, _code_change, _external_action, _fabric_objects,
+# _pocket_create, _pocket_write — used the ``if blob_workspace and
+# blob_workspace != current`` short-circuit, i.e. an EMPTY claim PASSED THROUGH
+# the tenancy check. Now that the approve-time executors resolve their store
+# FROM the blob's workspace_id (C1), an empty claim is a real hole: it would let
+# any operator approve a no-workspace blob whose action then misfiles onto the
+# shared ledger. This pins that every kind fails closed (403
+# ``instinct.missing_workspace_in_blob``) on BOTH approve and reject, with NO
+# state mutation — so reverting any one ``if not blob_workspace: raise`` guard
+# back to the short-circuit fails here.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+TRIGGER = {"type": "agent", "source": "claude", "reason": "low-1 fail-closed test"}
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "user-A", workspace_id: str = "ws-A") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+# Each gated kind -> an Action ``parameters`` payload whose blob carries NO
+# workspace claim (empty string; the alias key absent). The blob bodies are
+# otherwise minimal — the gate runs BEFORE the executor, so only the workspace
+# field matters for this assertion.
+def _empty_blob_params(kind: str) -> dict:
+    bodies: dict[str, dict] = {
+        "_belt_plan": {
+            "schema": 1,
+            "workspace_id": "",
+            "mandate_id": "m-1",
+            "shift_no": 0,
+            "plan": {"tasks": []},
+            "correlation_id": None,
+        },
+        "_code_change": {
+            "schema": 2,
+            "kind": "code_change",
+            "workspace_id": "",
+            "requested_by": "attacker-1",
+            "base_branch": "main",
+            "diff": "",
+            "correlation_id": None,
+        },
+        "_external_action": {
+            "schema": 1,
+            "workspace_id": "",
+            "connector_name": "crm",
+            "action": "noop",
+            "params": {},
+            "requested_by": "attacker-1",
+            "correlation_id": None,
+        },
+        "_fabric_objects": {
+            "schema": 1,
+            "workspace_id": "",
+            "object_types": [],
+            "objects": [],
+            "links": [],
+            "requested_by": "attacker-1",
+            "correlation_id": None,
+        },
+        "_pocket_create": {
+            "schema": 1,
+            "workspace_id": "",
+            "user_id": "attacker-1",
+            "pocket_spec": {"name": "x"},
+            "correlation_id": None,
+        },
+        "_pocket_write": {
+            "schema": 2,
+            "action": "mark_renewed",
+            "method": "POST",
+            "path": "/victim/renew",
+            "params": {},
+            "workspace_id": "",
+            "requested_by": "attacker-1",
+            "correlation_id": None,
+        },
+    }
+    return {kind: bodies[kind]}
+
+
+@pytest.fixture
+def router_store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "low1_gate.db")
+
+
+def _make_client(router_store: InstinctStore, user: _FakeUser, monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _propose(client: TestClient, *, pocket_id: str, parameters: dict) -> str:
+    payload = {
+        "pocket_id": pocket_id,
+        "title": "empty-workspace blob",
+        "trigger": TRIGGER,
+        "parameters": parameters,
+    }
+    resp = client.post("/instinct/actions", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _status_of(client: TestClient, action_id: str) -> str:
+    resp = client.get("/instinct/actions", params={"limit": 500})
+    assert resp.status_code == 200, resp.text
+    for action in resp.json()["actions"]:
+        if action["id"] == action_id:
+            return action["status"]
+    raise AssertionError(f"action {action_id} not found")
+
+
+GATED_KINDS = [
+    "_belt_plan",
+    "_code_change",
+    "_external_action",
+    "_fabric_objects",
+    "_pocket_create",
+    "_pocket_write",
+]
+
+
+@pytest.mark.parametrize("kind", GATED_KINDS)
+def test_approve_of_empty_workspace_blob_is_403(kind: str, router_store, monkeypatch) -> None:
+    """APPROVE of an empty-workspace blob → 403 missing_workspace_in_blob, no
+    state mutation. Reverting the kind's ``if not blob_workspace`` guard to the
+    ``if blob_workspace and ...`` short-circuit makes this approve succeed."""
+    client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+        action_id = _propose(client, pocket_id="victim", parameters=_empty_blob_params(kind))
+        resp = client.post(f"/instinct/actions/{action_id}/approve")
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "instinct.missing_workspace_in_blob"
+        assert _status_of(client, action_id) == "pending"
+
+
+@pytest.mark.parametrize("kind", GATED_KINDS)
+def test_reject_of_empty_workspace_blob_is_403(kind: str, router_store, monkeypatch) -> None:
+    """REJECT of an empty-workspace blob → 403 too (asymmetric scope is no
+    scope): a cross/empty-workspace reject would discard another tenant's row."""
+    client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+        action_id = _propose(client, pocket_id="victim", parameters=_empty_blob_params(kind))
+        resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "nope"})
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "instinct.missing_workspace_in_blob"
+        assert _status_of(client, action_id) == "pending"
+
+
+@pytest.mark.parametrize("kind", GATED_KINDS)
+def test_empty_blob_403_even_from_matching_empty_caller(
+    kind: str, router_store, monkeypatch
+) -> None:
+    """Even a caller whose OWN active workspace resolves empty cannot approve an
+    empty-workspace blob — empty must ALWAYS 403, never match-through (the exact
+    bypass the short-circuit allowed: empty blob == empty caller → passed)."""
+    client = _make_client(router_store, _FakeUser("user-X", ""), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+        action_id = _propose(client, pocket_id="victim", parameters=_empty_blob_params(kind))
+        resp = client.post(f"/instinct/actions/{action_id}/approve")
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "instinct.missing_workspace_in_blob"
+        assert _status_of(client, action_id) == "pending"

--- a/tests/cloud/test_instinct_mcp.py
+++ b/tests/cloud/test_instinct_mcp.py
@@ -55,7 +55,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     """Isolated InstinctStore on a tmp file, wired in where the handlers read
     it (``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_mcp_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 
@@ -300,7 +300,7 @@ async def test_store_error_is_relayed(store, monkeypatch):
         async def pending(self, pocket_id=None, workspace_id=None):
             raise RuntimeError("instinct db is locked")
 
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: _Boom())
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: _Boom())
     with _identity(workspace="w1"):
         res = await instinct_mcp._instinct_pending_handler({})
     assert res.get("is_error") is True

--- a/tests/cloud/test_mission_control_bulk_reassign.py
+++ b/tests/cloud/test_mission_control_bulk_reassign.py
@@ -45,7 +45,7 @@ def store(tmp_path: Path) -> InstinctStore:
 @pytest.fixture(autouse=True)
 def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
     """Same test doubles as the other Mission Control suites."""
-    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda *a, **k: store)
     monkeypatch.setattr(
         mc_service.pockets_service,
         "list_pockets",

--- a/tests/cloud/test_mission_control_bulk_snooze.py
+++ b/tests/cloud/test_mission_control_bulk_snooze.py
@@ -42,7 +42,7 @@ def store(tmp_path: Path) -> InstinctStore:
 
 @pytest.fixture(autouse=True)
 def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
-    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda *a, **k: store)
     monkeypatch.setattr(
         mc_service.pockets_service,
         "list_pockets",

--- a/tests/cloud/test_mission_control_project_filter.py
+++ b/tests/cloud/test_mission_control_project_filter.py
@@ -43,7 +43,7 @@ def store(tmp_path: Path) -> InstinctStore:
 def _patch_store(monkeypatch, store: InstinctStore):
     from unittest.mock import AsyncMock
 
-    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda *a, **k: store)
     # Façade composes Tasks alongside Nudges; stub the Tasks read so the
     # Instinct-only project-filter tests don't need a Beanie test DB.
     monkeypatch.setattr(

--- a/tests/cloud/test_mission_control_router.py
+++ b/tests/cloud/test_mission_control_router.py
@@ -37,7 +37,7 @@ def store(tmp_path: Path) -> InstinctStore:
 @pytest.fixture(autouse=True)
 def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
     """Same test doubles as the service tests — the router delegates."""
-    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda *a, **k: store)
     monkeypatch.setattr(
         mc_service.pockets_service,
         "list_pockets",

--- a/tests/cloud/test_mission_control_service.py
+++ b/tests/cloud/test_mission_control_service.py
@@ -122,7 +122,7 @@ def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
       forcing every façade test to initialize Beanie. Tests that
       exercise the Tasks branch override this with their own patch.
     """
-    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda *a, **k: store)
     monkeypatch.setattr(
         mc_service.pockets_service,
         "list_pockets",
@@ -427,7 +427,7 @@ class TestBulkApproveExecutesWrites:
             _get_creds,
         )
         monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", run_action)
-        monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+        monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     @pytest.mark.asyncio
     async def test_bulk_approve_executes_each_parked_write_and_reaches_executed(

--- a/tests/cloud/test_paw_print_decision_loop.py
+++ b/tests/cloud/test_paw_print_decision_loop.py
@@ -74,7 +74,7 @@ def stores(tmp_path: Path, monkeypatch):
     """
     pp_store = PawPrintStore(tmp_path / "paw_print_loop.db")
     instinct_store = InstinctStore(tmp_path / "instinct_loop.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: instinct_store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: instinct_store)
     monkeypatch.setattr("pocketpaw.stores.get_paw_print_store", lambda: pp_store)
     return pp_store, instinct_store
 
@@ -84,7 +84,7 @@ def client(stores, monkeypatch):
     pp_store, _ = stores
     app = FastAPI()
     app.include_router(router)
-    monkeypatch.setattr("pocketpaw_ee.paw_print.router._store", lambda: pp_store)
+    monkeypatch.setattr("pocketpaw_ee.paw_print.router._store", lambda *a, **k: pp_store)
     return TestClient(app)
 
 

--- a/tests/cloud/test_pocket_create_gate.py
+++ b/tests/cloud/test_pocket_create_gate.py
@@ -82,7 +82,7 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     (the propose helper + the executor both lazy-import
     ``pocketpaw.stores.get_instinct_store``)."""
     st = InstinctStore(tmp_path / "instinct_pocket_create_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 
@@ -391,7 +391,7 @@ async def test_production_path_approve_runs_executor_one_terminal(
 
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 200, resp.text
 
@@ -429,7 +429,7 @@ async def test_production_path_reject_router_closes_executor_never_runs(
 
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
     resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
     assert resp.status_code == 200, resp.text
 
@@ -464,7 +464,7 @@ async def test_cross_workspace_single_approve_forbidden(
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post(f"/instinct/actions/{action_id}/approve")
     assert resp.status_code == 403, resp.text
@@ -483,7 +483,7 @@ async def test_cross_workspace_single_reject_forbidden(
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "no"})
     assert resp.status_code == 403, resp.text
@@ -497,7 +497,7 @@ async def test_cross_workspace_bulk_approve_forbidden(store, mongo_db, journal, 
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post("/instinct/actions/bulk-approve", json={"ids": [action_id]})
     assert resp.status_code == 403, resp.text
@@ -512,7 +512,7 @@ async def test_cross_workspace_bulk_reject_forbidden(store, mongo_db, journal, g
     action_id = await _propose(store, workspace_id="w-OTHER")
     user = _FakeUser("u1", "w1")
     client = _make_client(user, monkeypatch)
-    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
 
     resp = client.post("/instinct/actions/bulk-reject", json={"ids": [action_id], "reason": "no"})
     assert resp.status_code == 403, resp.text

--- a/tests/cloud/test_pocket_instinct_bridge.py
+++ b/tests/cloud/test_pocket_instinct_bridge.py
@@ -37,7 +37,7 @@ def store(tmp_path, monkeypatch):
     temp-backed store and never touch ``~/.pocketpaw/instinct.db``.
     """
     st = InstinctStore(tmp_path / "instinct_bridge_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/ee/agent/test_pocket_router/test_router.py
+++ b/tests/ee/agent/test_pocket_router/test_router.py
@@ -535,7 +535,7 @@ def _isolated_instinct_store(monkeypatch, tmp_path):
     from pocketpaw.instinct.store import InstinctStore
 
     st = InstinctStore(tmp_path / "w2c_router_instinct.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/ee/sites/test_edit_draft_not_publish.py
+++ b/tests/ee/sites/test_edit_draft_not_publish.py
@@ -99,7 +99,7 @@ def instinct_store(tmp_path, monkeypatch):
     """A throwaway InstinctStore wired into the accessor the sites service reads so
     request_publish_pocket() can actually create the review Action."""
     store = InstinctStore(tmp_path / "edit_draft_instinct.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
     return store
 
 

--- a/tests/ee/sites/test_pipeline_regression_gate.py
+++ b/tests/ee/sites/test_pipeline_regression_gate.py
@@ -148,7 +148,7 @@ async def test_sites_pipeline_regression_gate(beanie_test_db, tmp_path, monkeypa
     from pocketpaw.instinct.store import InstinctStore
 
     store = InstinctStore(tmp_path / "gate_instinct.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     from pocketpaw_ee.versions import service as versions
 

--- a/tests/ee/sites/test_request_publish.py
+++ b/tests/ee/sites/test_request_publish.py
@@ -34,7 +34,7 @@ def instinct_store(tmp_path, monkeypatch):
     executor (same accessor). Returns the store so a test can read the Action
     back."""
     store = InstinctStore(tmp_path / "rp_instinct.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
     return store
 
 

--- a/tests/ee/test_action_sweeper.py
+++ b/tests/ee/test_action_sweeper.py
@@ -81,8 +81,23 @@ def instinct_store(tmp_path: Path) -> InstinctStore:
 @pytest.fixture(autouse=True)
 def patch_instinct_store(monkeypatch, instinct_store: InstinctStore):
     """Patch the sweeper's lazy ``ee.api.get_instinct_store`` lookup so
-    the test's fixture wins."""
-    monkeypatch.setattr("pocketpaw_ee.api.get_instinct_store", lambda *a, **k: instinct_store)
+    the test's fixture wins.
+
+    NOTE (fix/cloud-iso-executor-scope): unlike the executor/propose mocks,
+    this one is INTENTIONALLY workspace-agnostic. The abandon-sweeper
+    (``decisions/_action_sweeper.py``) reads ALL pending parked Actions from a
+    SINGLE store via direct SQL with no per-tenant filter — it is multi-tenant
+    by design and calls ``get_instinct_store()`` bare. Per-workspace store
+    isolation (ISO) is NOT yet threaded through the sweeper; doing so means
+    enumerating each workspace's store file and sweeping each, which is tracked
+    as a follow-up beyond the C1 approval-executor scope. So we still return the
+    one seeded store here (all sweeper tests seed a single workspace, ``ws-A``)
+    and the factory accepts — but ignores — an explicit ``workspace_id`` so it
+    won't TypeError if the resolution path ever passes one."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.api.get_instinct_store",
+        lambda *a, workspace_id=None, **k: instinct_store,
+    )
 
 
 async def _seed_pending_action(

--- a/tests/ee/test_action_sweeper.py
+++ b/tests/ee/test_action_sweeper.py
@@ -82,7 +82,7 @@ def instinct_store(tmp_path: Path) -> InstinctStore:
 def patch_instinct_store(monkeypatch, instinct_store: InstinctStore):
     """Patch the sweeper's lazy ``ee.api.get_instinct_store`` lookup so
     the test's fixture wins."""
-    monkeypatch.setattr("pocketpaw_ee.api.get_instinct_store", lambda: instinct_store)
+    monkeypatch.setattr("pocketpaw_ee.api.get_instinct_store", lambda *a, **k: instinct_store)
 
 
 async def _seed_pending_action(

--- a/tests/ee/test_discovery_propose.py
+++ b/tests/ee/test_discovery_propose.py
@@ -150,7 +150,7 @@ def recording_bus():
 @pytest.fixture
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
     st = InstinctStore(tmp_path / "instinct_discovery_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
     return st
 
 

--- a/tests/ee/test_discovery_propose.py
+++ b/tests/ee/test_discovery_propose.py
@@ -149,15 +149,40 @@ def recording_bus():
 
 @pytest.fixture
 def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    # WORKSPACE-KEYED (fix/cloud-iso-executor-scope): discovery runs OUTSIDE the
+    # agent stream (no current_workspace ContextVar), so run_discovery_and_propose
+    # + the propose sites MUST thread the explicit workspace_id ("w1"). The old
+    # arg-swallowing mock returned ``st`` for any workspace, hiding an unscoped
+    # call. Now a bare/wrong-workspace call gets a DISTINCT empty store and the
+    # "PENDING action exists in w1" assertions fail.
     st = InstinctStore(tmp_path / "instinct_discovery_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    others: dict[str, InstinctStore] = {}
+
+    def _factory(*_a, workspace_id: str | None = None, **_k) -> InstinctStore:
+        ws = str(workspace_id or "")
+        if ws == "w1":
+            return st
+        return others.setdefault(ws, InstinctStore(tmp_path / f"instinct_other_{ws or 'none'}.db"))
+
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", _factory)
     return st
 
 
 @pytest.fixture
 def fabric(tmp_path: Path, monkeypatch) -> FabricStore:
+    # WORKSPACE-KEYED, mirroring ``store`` — and the signature now accepts
+    # ``workspace_id`` (the old ``lambda: fs`` would TypeError once the fabric
+    # factory is called with a workspace, which the executor path now does).
     fs = FabricStore(tmp_path / "fabric_discovery_test.db")
-    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda: fs)
+    others: dict[str, FabricStore] = {}
+
+    def _factory(*_a, workspace_id: str | None = None, **_k) -> FabricStore:
+        ws = str(workspace_id or "")
+        if ws == "w1":
+            return fs
+        return others.setdefault(ws, FabricStore(tmp_path / f"fabric_other_{ws or 'none'}.db"))
+
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", _factory)
     return fs
 
 

--- a/tests/ee/test_instinct_decision_events.py
+++ b/tests/ee/test_instinct_decision_events.py
@@ -243,7 +243,7 @@ async def test_propose_emits_policy_evaluated_and_persists_event_id(
     onto the parked blob's ``parked_policy_event_id`` field so the
     eventual ``human.corrected`` can chain its ``causation_id`` back."""
     corr = uuid4()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: router_store)
 
     park_blob = {
         "action": "mark_renewed",
@@ -294,7 +294,7 @@ async def test_propose_without_correlation_id_skips_policy_emit(
     parks without minting one) skips the policy.evaluated emit — the
     Slice 4 abandon sweeper will eventually close the chain. The
     propose call still succeeds."""
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: router_store)
 
     park_blob = {
         "action": "mark_renewed",
@@ -613,7 +613,7 @@ async def test_full_chain_causation_wires_policy_to_human(
     propose-side emits this test cares about."""
     user = _FakeUser("user-A", "ws-A")
     client = _make_client(router_store, user, monkeypatch)
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: router_store)
 
     async def _noop_execute(_action):
         return None
@@ -803,7 +803,7 @@ async def test_full_chain_via_graph_with_real_proposed_event(
 
     user = _FakeUser("user-A", "ws-A")
     client = _make_client(router_store, user, monkeypatch)
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: router_store)
 
     def _fake_getaddrinfo(host, *_args, **_kwargs):
         return [(2, 1, 6, "", ("8.8.8.8", 0))]

--- a/tests/ee/test_pocket_runtime_decision_events.py
+++ b/tests/ee/test_pocket_runtime_decision_events.py
@@ -623,7 +623,7 @@ async def test_parked_blob_carries_correlation_id_and_event_id_placeholder(
 
             return _A()
 
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: _StubStore())
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: _StubStore())
 
     pocket = {"_id": "p1", "workspace": "w1", "owner": "u_alice", "name": "Lease 42"}
     await instinct_bridge_module.propose_pocket_write(
@@ -714,7 +714,7 @@ async def test_schema_1_parked_blob_marked_failed_on_post_deploy_approval(
         async def mark_executed(self, action_id: str, reason: str) -> None:  # noqa: ARG002
             pytest.fail("should not have executed a schema-1 blob")
 
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: _StubStore())
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: _StubStore())
 
     # Schema-1 blob — pre-Slice-2 shape, no correlation_id field.
     schema_1_blob = {

--- a/tests/ee/versions/test_instinct_executor.py
+++ b/tests/ee/versions/test_instinct_executor.py
@@ -73,7 +73,7 @@ async def test_approve_merges_publishes_and_deploys(
     """APPROVE = MERGE: the candidate is promoted to published, the site deploy
     fires, and the Action is marked executed."""
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     deploys: list[dict] = []
 
@@ -117,7 +117,7 @@ async def test_approve_merge_marks_failed_when_deploy_raises(
     """If the deploy raises, the Action is marked FAILED — the version is still
     published (published != live, the BP-2 invariant)."""
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     async def _boom_deploy(**kwargs):
         raise RuntimeError("workerd smoke gate failed")
@@ -147,7 +147,7 @@ async def test_reject_discards_candidate_and_leaves_published(
     """REJECT = DISCARD: the candidate is reverted, the published pointer is
     untouched."""
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     # A live published version, plus a candidate draft.
     live = await versions.write_draft(
@@ -190,7 +190,7 @@ async def test_reject_clears_all_accumulated_drafts(
     so the other accumulated drafts remain → get_draft is non-None → fails.
     """
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
 
     # A live published version.
     live = await versions.write_draft(

--- a/tests/ee/versions/test_instinct_executor.py
+++ b/tests/ee/versions/test_instinct_executor.py
@@ -2,6 +2,13 @@
 # Created: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — behaviour
 # coverage for the artifact-change merge/discard EXECUTOR against real
 # ArtifactVersion rows (beanie), with the Instinct store + site deploy mocked.
+# Updated: 2026-06-26 (fix/cloud-iso-executor-scope) — the store factory mock
+# is now WORKSPACE-KEYED. The old `lambda *a, **k: store` swallowed
+# ``workspace_id`` so the executor's BARE (pre-fix, unscoped) call and the
+# router's scoped call both returned the SAME store — hiding the per-workspace
+# isolation bug (C1). `_install_workspace_store` returns the seeded store ONLY
+# when asked for WS, and a DISTINCT empty store otherwise, so an unscoped
+# executor call lands on the wrong store and the terminal assertions fail.
 #
 # What this pins (the BP-3 done-when behaviour):
 #   * execute_approved_change MERGES: the candidate draft (to_version_id) is
@@ -42,6 +49,25 @@ class _FakeStore:
         self.failed[action_id] = error
 
 
+def _install_workspace_store(monkeypatch, store: _FakeStore, ws: str = WS) -> dict[str, _FakeStore]:
+    """Patch ``get_instinct_store`` with a WORKSPACE-KEYED factory.
+
+    The factory returns ``store`` ONLY when called with ``workspace_id == ws``;
+    any other (or missing) workspace gets a fresh, empty ``_FakeStore``. This is
+    the anti-over-mock: a BARE ``get_instinct_store()`` (no workspace) can no
+    longer reach the seeded store, so the executor MUST resolve the blob's
+    workspace and pass it — proving the isolation fix rather than masking it.
+    Returns the registry so a test can assert which workspaces were opened."""
+    registry: dict[str, _FakeStore] = {ws: store}
+
+    def _factory(*_a: Any, workspace_id: str | None = None, **_k: Any) -> _FakeStore:
+        key = str(workspace_id or "")
+        return registry.setdefault(key, store if key == ws else _FakeStore())
+
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", _factory)
+    return registry
+
+
 def _action(to_version_id: str) -> SimpleNamespace:
     """A minimal Action stand-in carrying an ``_artifact_change`` blob.
 
@@ -73,7 +99,7 @@ async def test_approve_merges_publishes_and_deploys(
     """APPROVE = MERGE: the candidate is promoted to published, the site deploy
     fires, and the Action is marked executed."""
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
+    _install_workspace_store(monkeypatch, store)
 
     deploys: list[dict] = []
 
@@ -117,7 +143,7 @@ async def test_approve_merge_marks_failed_when_deploy_raises(
     """If the deploy raises, the Action is marked FAILED — the version is still
     published (published != live, the BP-2 invariant)."""
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
+    _install_workspace_store(monkeypatch, store)
 
     async def _boom_deploy(**kwargs):
         raise RuntimeError("workerd smoke gate failed")
@@ -147,7 +173,7 @@ async def test_reject_discards_candidate_and_leaves_published(
     """REJECT = DISCARD: the candidate is reverted, the published pointer is
     untouched."""
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
+    _install_workspace_store(monkeypatch, store)
 
     # A live published version, plus a candidate draft.
     live = await versions.write_draft(
@@ -190,7 +216,7 @@ async def test_reject_clears_all_accumulated_drafts(
     so the other accumulated drafts remain → get_draft is non-None → fails.
     """
     store = _FakeStore()
-    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
+    _install_workspace_store(monkeypatch, store)
 
     # A live published version.
     live = await versions.write_draft(

--- a/tests/test_audit_lock_survives_eviction.py
+++ b/tests/test_audit_lock_survives_eviction.py
@@ -1,0 +1,145 @@
+# tests/test_audit_lock_survives_eviction.py
+# Created: 2026-06-26 (ISO-4 — audit-lock keyed outside the evictable store instance).
+#
+# Proves the ISO-4 fix for the chain-fork window the ISO-2 security review
+# flagged: the Instinct audit-append lock is keyed by db_path in a process-global
+# registry (pocketpaw._store_locks), NOT stored on the evictable store instance.
+# So when the bounded-LRU store factory evicts a workspace's InstinctStore and
+# builds a fresh one for the same file, BOTH instances share ONE lock and their
+# concurrent appends still serialize — the chain cannot fork.
+#
+# Covers:
+#   * two InstinctStore instances for the same file share the same lock object;
+#   * different files get different locks (tenants never contend);
+#   * the lock survives a real factory eviction (cap-1 LRU): a store fetched,
+#     evicted, and re-fetched yields a handle whose lock matches the original's;
+#   * end-to-end: interleaved appends across an eviction boundary keep the chain
+#     intact (verify_audit_chain stays intact=True, no fork).
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import pocketpaw.stores as stores
+from pocketpaw._store_locks import audit_lock_for, reset_audit_locks
+from pocketpaw.instinct.models import ActionTrigger
+from pocketpaw.instinct.store import InstinctStore
+
+WS = "ws-lock"
+
+
+def _trig() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="iso-4 lock test")
+
+
+async def _drain_pending_tasks() -> None:
+    """Run fire-and-forget eviction tasks (aclose) to completion before the test
+    loop closes, so the aiosqlite worker doesn't race teardown."""
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    reset_audit_locks()
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+        reset_audit_locks()
+
+
+@pytest.mark.asyncio
+async def test_same_file_two_instances_share_one_lock(tmp_path: Path) -> None:
+    db = str(tmp_path / "instinct.db")
+    a = InstinctStore(db)
+    b = InstinctStore(db)
+    # Distinct instances, SAME lock — the eviction-hole fix.
+    assert a is not b
+    assert a._log_lock is b._log_lock
+    # And it's the registry's lock for that path.
+    assert a._log_lock is audit_lock_for(db)
+
+
+@pytest.mark.asyncio
+async def test_different_files_get_different_locks(tmp_path: Path) -> None:
+    a = InstinctStore(str(tmp_path / "a.db"))
+    b = InstinctStore(str(tmp_path / "b.db"))
+    assert a._log_lock is not b._log_lock  # tenants never contend
+
+
+@pytest.mark.asyncio
+async def test_lock_survives_a_real_factory_eviction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Evict a workspace's store via the cap-1 LRU; the rebuilt one keeps the lock."""
+    monkeypatch.setattr(stores, "_WORKSPACE_STORE_CACHE_CAP", 1)
+    stores.reset_store_caches()
+
+    first = stores.get_instinct_store(workspace_id=WS)
+    lock_before = first._log_lock
+
+    # A second distinct workspace evicts WS (cap is 1).
+    stores.get_instinct_store(workspace_id="ws-other")
+
+    # Re-fetch WS → a NEW instance (it was evicted), but the SAME db file.
+    rebuilt = stores.get_instinct_store(workspace_id=WS)
+    assert rebuilt is not first  # genuinely evicted + rebuilt
+    assert rebuilt._db_path == first._db_path
+    # The audit lock is the SAME object across the eviction boundary — proof the
+    # fork window is closed: an in-flight append on `first` and a new append on
+    # `rebuilt` would contend on one lock.
+    assert rebuilt._log_lock is lock_before
+    await _drain_pending_tasks()
+
+
+@pytest.mark.asyncio
+async def test_chain_stays_intact_across_eviction_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Concurrent appends straddling an eviction keep the chain intact (no fork)."""
+    monkeypatch.setattr(stores, "_WORKSPACE_STORE_CACHE_CAP", 1)
+    stores.reset_store_caches()
+
+    first = stores.get_instinct_store(workspace_id=WS)
+    # Seed one action on the original instance.
+    a0 = await first.propose("p", "a0", "", "", _trig())
+    await first.approve(a0.id)
+
+    # Evict WS, then re-fetch a fresh instance for the same file.
+    stores.get_instinct_store(workspace_id="ws-other")
+    rebuilt = stores.get_instinct_store(workspace_id=WS)
+    assert rebuilt is not first
+
+    # Fire concurrent appends from BOTH the stale and the rebuilt instance at the
+    # same file. With a per-instance lock these could interleave their prev_hash
+    # reads and fork; with the db_path-keyed lock they serialize.
+    async def append(store: InstinctStore, n: int) -> None:
+        act = await store.propose("p", f"t{n}", "", "", _trig())
+        await store.approve(act.id)
+
+    await asyncio.gather(
+        append(first, 1),
+        append(rebuilt, 2),
+        append(first, 3),
+        append(rebuilt, 4),
+    )
+
+    verdict = await rebuilt.verify_audit_chain()
+    assert verdict["intact"] is True, verdict
+    assert verdict["broken_at"] is None
+    assert verdict["hashed"] == verdict["checked"]
+    assert verdict["hashed"] > 0
+    await _drain_pending_tasks()

--- a/tests/test_fabric_workspace_isolation.py
+++ b/tests/test_fabric_workspace_isolation.py
@@ -1,0 +1,387 @@
+# tests/test_fabric_workspace_isolation.py
+# Created: 2026-06-26 (ISO-1 — workspace-keyed store factory + physical Fabric isolation).
+#
+# Proves ISO-1's new invariant: each workspace gets its OWN fabric.db file under
+# ~/.pocketpaw/workspaces/<workspace_id>/, layered ON TOP of W4a's in-row
+# workspace_id WHERE-filter (physical isolation is additive defense-in-depth).
+#
+# Covers:
+#   * two-workspace physical isolation — objects created in A and B land in two
+#     SEPARATE db files on disk, and a query in A returns ZERO of B's objects;
+#   * fail-closed — POCKETPAW_REQUIRE_WORKSPACE_SCOPE set + no workspace resolves
+#     to a hard error, never a silent shared-store read;
+#   * back-compat — with the flag unset and no workspace, the factory returns the
+#     legacy ~/.pocketpaw/fabric.db so single-tenant OSS keeps working;
+#   * ContextVar resolution — the current_workspace ContextVar is consulted when
+#     no explicit workspace_id is passed, and the explicit arg wins over it;
+#   * the bounded LRU caches handles and evicts (aclose) past the cap;
+#   * path-traversal safety — a hostile workspace_id (incl. ../../../tmp/pwn,
+#     url-encoded traversal, null bytes, leading-dash flag-injection, non-ASCII)
+#     is rejected by a STRICT positive allowlist ([A-Za-z0-9][A-Za-z0-9_-]*),
+#     fails closed (raises), and leaves the filesystem untouched (writes nothing
+#     outside workspaces/).
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import pocketpaw.stores as stores
+from pocketpaw.fabric.models import FabricQuery
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the store factory at a tmp data dir and reset module + LRU state.
+
+    Every test gets a clean ~/.pocketpaw equivalent, an empty cache, and the
+    required-scope flag unset, so tests can't leak db files or cached handles
+    into one another.
+    """
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    # Make sure no ContextVar value bleeds in from another test.
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            # A test that reloads the module replaces the ContextVar object, so
+            # the token no longer matches. Fall back to clearing the (new) var.
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+# ---------------------------------------------------------------------------
+# Core ISO-1 invariant: two workspaces => two physical files, no cross-read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_workspaces_get_separate_files_and_no_cross_read(
+    tmp_path: Path,
+) -> None:
+    store_a = stores.get_fabric_store(workspace_id=WS_A)
+    store_b = stores.get_fabric_store(workspace_id=WS_B)
+
+    # Distinct handles backed by distinct paths under workspaces/.
+    assert store_a is not store_b
+    assert store_a._db_path != store_b._db_path
+
+    # A defines a type + object; B defines its own.
+    type_a = await store_a.define_type(name="Customer", properties=[], workspace_id=WS_A)
+    await store_a.create_object(type_a.id, {"name": "Acme"}, workspace_id=WS_A)
+
+    type_b = await store_b.define_type(name="Customer", properties=[], workspace_id=WS_B)
+    await store_b.create_object(type_b.id, {"name": "Globex"}, workspace_id=WS_B)
+
+    # (a) Two SEPARATE db files exist on disk.
+    db_a = tmp_path / "workspaces" / WS_A / "fabric.db"
+    db_b = tmp_path / "workspaces" / WS_B / "fabric.db"
+    assert db_a.exists(), "workspace A fabric.db should exist on disk"
+    assert db_b.exists(), "workspace B fabric.db should exist on disk"
+    assert db_a != db_b
+
+    # The shared legacy file must NOT have been created by a scoped call.
+    assert not (tmp_path / "fabric.db").exists()
+
+    # (b) A query in A returns ZERO of B's objects — even unscoped at the store
+    # level (workspace_id=None), because B's row physically isn't in A's file.
+    res_a = await store_a.query(FabricQuery(type_name="Customer"))
+    names_a = {o.properties.get("name") for o in res_a.objects}
+    assert names_a == {"Acme"}
+    assert "Globex" not in names_a
+
+    res_b = await store_b.query(FabricQuery(type_name="Customer"))
+    names_b = {o.properties.get("name") for o in res_b.objects}
+    assert names_b == {"Globex"}
+    assert "Acme" not in names_b
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: required-scope mode + no workspace => raise, never shared read
+# ---------------------------------------------------------------------------
+
+
+def test_fail_closed_when_scope_required_and_no_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_fabric_store()  # no workspace, no ContextVar
+
+
+def test_fail_closed_ignores_blank_contextvar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blank/whitespace ContextVar must not satisfy required-scope mode."""
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    token = stores.current_workspace.set("   ")
+    try:
+        with pytest.raises(stores.WorkspaceScopeRequired):
+            stores.get_fabric_store()
+    finally:
+        stores.current_workspace.reset(token)
+
+
+def test_required_scope_with_workspace_returns_scoped_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Required-scope mode is satisfied by an explicit workspace_id."""
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    store = stores.get_fabric_store(workspace_id=WS_A)
+    assert str(tmp_path / "workspaces" / WS_A) in store._db_path
+
+
+# ---------------------------------------------------------------------------
+# Back-compat: flag unset + no workspace => legacy shared file
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_shared_store_when_unscoped_and_not_required(
+    tmp_path: Path,
+) -> None:
+    store = stores.get_fabric_store()  # no workspace, flag unset
+    assert store._db_path == str(tmp_path / "fabric.db")
+    # Same handle is returned on a second unscoped call (singleton preserved).
+    assert stores.get_fabric_store() is store
+
+
+# ---------------------------------------------------------------------------
+# ContextVar resolution + precedence
+# ---------------------------------------------------------------------------
+
+
+def test_contextvar_is_consulted_when_no_explicit_arg(tmp_path: Path) -> None:
+    token = stores.current_workspace.set(WS_A)
+    try:
+        store = stores.get_fabric_store()
+        assert str(tmp_path / "workspaces" / WS_A) in store._db_path
+    finally:
+        stores.current_workspace.reset(token)
+
+
+def test_explicit_arg_wins_over_contextvar(tmp_path: Path) -> None:
+    token = stores.current_workspace.set(WS_B)
+    try:
+        store = stores.get_fabric_store(workspace_id=WS_A)
+        assert str(tmp_path / "workspaces" / WS_A) in store._db_path
+        assert WS_B not in store._db_path
+    finally:
+        stores.current_workspace.reset(token)
+
+
+def test_same_workspace_returns_cached_handle(tmp_path: Path) -> None:
+    first = stores.get_fabric_store(workspace_id=WS_A)
+    second = stores.get_fabric_store(workspace_id=WS_A)
+    assert first is second
+
+
+# ---------------------------------------------------------------------------
+# Bounded LRU: evicts past the cap and closes the evicted handle
+# ---------------------------------------------------------------------------
+
+
+async def _drain_pending_tasks() -> None:
+    """Run every fire-and-forget eviction task this test started to completion.
+
+    Eviction from inside a running loop schedules ``aclose`` via
+    ``loop.create_task``. Draining those tasks before the test's loop closes
+    keeps the aiosqlite worker from racing teardown (the source of spurious
+    "Event loop is closed" warnings).
+    """
+    import asyncio
+
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_lru_evicts_past_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Shrink the cap so the test stays fast and deterministic.
+    monkeypatch.setattr(stores, "_WORKSPACE_STORE_CACHE_CAP", 3)
+    stores.reset_store_caches()
+
+    handles = [stores.get_fabric_store(workspace_id=f"ws-{i}") for i in range(3)]
+    # Touch ws-0 so it becomes most-recently-used; ws-1 is now the LRU victim.
+    again_0 = stores.get_fabric_store(workspace_id="ws-0")
+    assert again_0 is handles[0]
+
+    # A 4th distinct workspace evicts the least-recently-used (ws-1).
+    stores.get_fabric_store(workspace_id="ws-3")
+    # ws-1 was evicted: a fresh fetch builds a NEW handle, not the old one.
+    new_1 = stores.get_fabric_store(workspace_id="ws-1")
+    assert new_1 is not handles[1]
+    # ws-0 survived (it was touched), so it's still the same handle.
+    assert stores.get_fabric_store(workspace_id="ws-0") is handles[0]
+
+    await _drain_pending_tasks()
+
+
+@pytest.mark.asyncio
+async def test_eviction_closes_handle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On eviction the factory calls the store's aclose() (best-effort)."""
+    monkeypatch.setattr(stores, "_WORKSPACE_STORE_CACHE_CAP", 1)
+    stores.reset_store_caches()
+
+    closed: list[str] = []
+
+    victim = stores.get_fabric_store(workspace_id="ws-victim")
+    # Wrap the real aclose so we can observe it firing on eviction.
+    real_aclose = victim.aclose
+
+    async def _spy() -> None:
+        closed.append("ws-victim")
+        await real_aclose()
+
+    monkeypatch.setattr(victim, "aclose", _spy)
+
+    # A second distinct workspace evicts ws-victim (cap is 1).
+    stores.get_fabric_store(workspace_id="ws-next")
+
+    # Eviction schedules aclose as a task on this loop; drain it to completion
+    # (deterministic — no bare sleep) and assert the spy fired.
+    await _drain_pending_tasks()
+    assert closed == ["ws-victim"]
+
+
+# ---------------------------------------------------------------------------
+# Path-traversal safety (security-critical isolation code)
+# ---------------------------------------------------------------------------
+
+
+_HOSTILE_IDS = [
+    "../../../tmp/pwn",  # the captain's canonical payload
+    "../../etc",
+    "..",
+    "a/b",
+    "a/../../b",
+    "with space/../escape",
+    "/abs/path",
+    "\\windows\\path",
+    "x\x00y",  # null byte
+    ".",  # non-empty, would resolve to CWD if not refused
+    "-rf",  # leading dash — rejected so it can't be read as an argv flag
+    "--force",  # leading double-dash — same flag-injection concern
+    "..%2f..%2fetc",  # url-encoded traversal — must NOT be decoded into a slash
+    "ws\tname",  # embedded control char
+    "wörkspace",  # non-ASCII
+    "a.b",  # a dot in the middle — not in the allowlist
+]
+
+
+@pytest.mark.parametrize("hostile", _HOSTILE_IDS)
+def test_traversal_workspace_id_is_rejected(hostile: str) -> None:
+    """A non-token id that could escape ``workspaces/`` must RAISE, never build.
+
+    These ids are non-empty after strip, so they reach ``_safe_workspace_dir``
+    and MUST be rejected outright (fail closed) — the factory must never hand
+    back a store on a traversal-laden / non-allowlisted id. The guard is a
+    POSITIVE allowlist (``[A-Za-z0-9_-]+``), so even a novel encoding that a
+    denylist might miss is refused because it simply isn't on the allowlist.
+    """
+    with pytest.raises(ValueError):
+        stores.get_fabric_store(workspace_id=hostile)
+
+
+@pytest.mark.parametrize("hostile", _HOSTILE_IDS)
+def test_hostile_workspace_id_writes_nothing_outside_workspaces_dir(
+    tmp_path: Path, hostile: str
+) -> None:
+    """A rejected hostile id must leave the filesystem untouched.
+
+    The captain's explicit requirement: assert the call raises AND that NOTHING
+    was created outside ``~/.pocketpaw/workspaces/`` (here: the tmp data dir). We
+    snapshot the data dir before, attempt the build, and assert (a) it raised and
+    (b) the data-dir tree is byte-for-byte unchanged — no escape file, no stray
+    ``workspaces/<hostile>`` dir, no ``/tmp/pwn``.
+    """
+    data_dir = tmp_path  # the autouse fixture points stores._DATA_DIR here
+
+    def _snapshot() -> set[Path]:
+        return set(data_dir.rglob("*")) if data_dir.exists() else set()
+
+    before = _snapshot()
+    with pytest.raises(ValueError):
+        stores.get_fabric_store(workspace_id=hostile)
+    after = _snapshot()
+
+    assert after == before, (
+        f"hostile workspace_id {hostile!r} created filesystem entries: "
+        f"{sorted(str(p) for p in (after - before))}"
+    )
+    # And specifically: no escape artifact landed at the obvious target.
+    assert not Path("/tmp/pwn").exists()
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t", None])
+def test_blank_workspace_id_falls_back_to_legacy_not_escape(
+    tmp_path: Path, blank: str | None
+) -> None:
+    """Empty / whitespace / None = 'no workspace' → OSS legacy shared file.
+
+    A blank id is NOT a traversal payload; it means the caller carries no
+    workspace. In OSS mode (flag unset) that is the documented back-compat: the
+    shared ``~/.pocketpaw/fabric.db``. The one thing it must never do is land
+    somewhere OTHER than that legacy file (e.g. escape to CWD or to a stray
+    ``workspaces/`` entry).
+    """
+    store = stores.get_fabric_store(workspace_id=blank)
+    assert store._db_path == str(tmp_path / "fabric.db")
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_blank_workspace_id_fails_closed_under_required_scope(
+    blank: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same blank ids must FAIL CLOSED, not read the shared store, on cloud.
+
+    AC#3: a missing workspace on a cloud path must never silently read a shared
+    store. A blank id is a missing workspace, so under the required-scope flag
+    it raises rather than returning the legacy file.
+    """
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_fabric_store(workspace_id=blank)
+
+
+def test_reset_helper_clears_caches(tmp_path: Path) -> None:
+    """reset_store_caches drops both the legacy singleton and the LRU."""
+    legacy = stores.get_fabric_store()
+    scoped = stores.get_fabric_store(workspace_id=WS_A)
+    stores.reset_store_caches()
+    assert stores.get_fabric_store() is not legacy
+    assert stores.get_fabric_store(workspace_id=WS_A) is not scoped
+
+
+def test_fresh_import_has_no_side_effects(tmp_path: Path) -> None:
+    """Importing the module creates no DB and no dirs at import time.
+
+    Loaded under an INDEPENDENT module object (not ``importlib.reload(stores)``,
+    which would swap the shared module's ContextVar out from under the autouse
+    fixture). We point its data dir at an empty tmp dir and assert importing it
+    touched nothing on disk — the factory must be lazy.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_stores_probe", stores.__file__)
+    assert spec and spec.loader
+    probe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probe)
+
+    probe._DATA_DIR = tmp_path
+    # Nothing should exist yet — import alone must not create files/dirs.
+    assert list(tmp_path.iterdir()) == []
+    # And the module exposes the ISO-1 surface.
+    assert hasattr(probe, "get_fabric_store")
+    assert hasattr(probe, "current_workspace")
+    assert hasattr(probe, "WorkspaceScopeRequired")
+    assert hasattr(probe, "reset_store_caches")

--- a/tests/test_fabric_workspace_isolation.py
+++ b/tests/test_fabric_workspace_isolation.py
@@ -371,11 +371,22 @@ def test_fresh_import_has_no_side_effects(tmp_path: Path) -> None:
     touched nothing on disk — the factory must be lazy.
     """
     import importlib.util
+    import sys
 
-    spec = importlib.util.spec_from_file_location("_stores_probe", stores.__file__)
+    name = "_stores_probe"
+    spec = importlib.util.spec_from_file_location(name, stores.__file__)
     assert spec and spec.loader
     probe = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(probe)
+    # Register in sys.modules BEFORE exec: the module defines an @dataclass
+    # (``_StoreKind``), and the dataclasses machinery resolves the owning module
+    # via ``sys.modules[cls.__module__]`` to look up annotations — an unregistered
+    # module makes that lookup return None and raise. Clean it up afterward so the
+    # probe never leaks into other tests.
+    sys.modules[name] = probe
+    try:
+        spec.loader.exec_module(probe)
+    finally:
+        sys.modules.pop(name, None)
 
     probe._DATA_DIR = tmp_path
     # Nothing should exist yet — import alone must not create files/dirs.

--- a/tests/test_instinct_workspace_isolation.py
+++ b/tests/test_instinct_workspace_isolation.py
@@ -1,0 +1,268 @@
+# tests/test_instinct_workspace_isolation.py
+# Created: 2026-06-26 (ISO-2 — Instinct physically isolated + per-workspace audit chain).
+#
+# Proves ISO-2's invariant: each workspace gets its OWN instinct.db file under
+# ~/.pocketpaw/workspaces/<workspace_id>/, with its OWN W2b audit hash-chain
+# (genesis→…→head). Physical isolation is layered ON TOP of the W4a in-row
+# workspace_id read-filter (additive defense-in-depth), and reuses the generic
+# workspace-keyed factory ISO-1 built (so the path-traversal guard + fail-closed
+# + bounded LRU are inherited).
+#
+# Covers:
+#   * two-workspace physical isolation — actions proposed in A and B land in two
+#     SEPARATE db files on disk; pending() and query_audit() in A return ZERO of
+#     B's rows (even unscoped at the store level, because B's rows physically
+#     aren't in A's file);
+#   * per-workspace audit chain — verify_audit_chain() passes INDEPENDENTLY for
+#     each workspace's file, each with its own genesis (prev_hash="");
+#   * fail-closed — POCKETPAW_REQUIRE_WORKSPACE_SCOPE + no workspace → raises,
+#     never a silent shared-store read;
+#   * back-compat — flag unset + no workspace → legacy ~/.pocketpaw/instinct.db;
+#   * inherited hostile-id guard — a traversal workspace_id is rejected by the
+#     same strict allowlist Fabric uses, and writes nothing outside workspaces/.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import pocketpaw.stores as stores
+from pocketpaw.instinct.models import ActionTrigger
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+def make_trigger() -> ActionTrigger:
+    """Minimal ActionTrigger for a proposed action (matches test_ee_instinct)."""
+    return ActionTrigger(type="agent", source="claude", reason="iso-2 unit test")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the store factory at a tmp data dir; reset module + LRU state.
+
+    Every test gets a clean ~/.pocketpaw equivalent, empty caches, the
+    required-scope flag unset, and a cleared ContextVar so nothing leaks between
+    tests.
+    """
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+async def _propose(store, *, pocket: str, title: str, workspace_id: str):
+    return await store.propose(
+        pocket_id=pocket,
+        title=title,
+        description="",
+        recommendation="",
+        trigger=make_trigger(),
+        workspace_id=workspace_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core ISO-2 invariant: two workspaces => two files, no cross-read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_workspaces_get_separate_files_and_no_cross_read(
+    tmp_path: Path,
+) -> None:
+    store_a = stores.get_instinct_store(workspace_id=WS_A)
+    store_b = stores.get_instinct_store(workspace_id=WS_B)
+
+    assert store_a is not store_b
+    assert store_a._db_path != store_b._db_path
+
+    await _propose(store_a, pocket="p", title="A-task", workspace_id=WS_A)
+    await _propose(store_b, pocket="p", title="B-task", workspace_id=WS_B)
+
+    # (a) Two SEPARATE db files exist on disk under workspaces/.
+    db_a = tmp_path / "workspaces" / WS_A / "instinct.db"
+    db_b = tmp_path / "workspaces" / WS_B / "instinct.db"
+    assert db_a.exists(), "workspace A instinct.db should exist"
+    assert db_b.exists(), "workspace B instinct.db should exist"
+    # The shared legacy file must NOT have been created by a scoped call.
+    assert not (tmp_path / "instinct.db").exists()
+
+    # (b) pending() in A returns ZERO of B's actions — even UNSCOPED at the store
+    # level (workspace_id=None), because B's row physically isn't in A's file.
+    a_pending = await store_a.pending()
+    b_pending = await store_b.pending()
+    assert {a.title for a in a_pending} == {"A-task"}
+    assert {a.title for a in b_pending} == {"B-task"}
+
+    # (c) query_audit() is likewise physically isolated.
+    a_audit = await store_a.query_audit(pocket_id="p")
+    b_audit = await store_b.query_audit(pocket_id="p")
+    a_titles = {e.description for e in a_audit}
+    # B's "Proposed: B-task" audit line can't appear in A's file.
+    assert not any("B-task" in d for d in a_titles)
+    assert any("A-task" in (e.description or "") for e in a_audit)
+    assert any("B-task" in (e.description or "") for e in b_audit)
+
+
+# ---------------------------------------------------------------------------
+# Per-workspace audit hash chain: each file verifies independently
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_each_workspace_has_its_own_verifiable_chain(tmp_path: Path) -> None:
+    store_a = stores.get_instinct_store(workspace_id=WS_A)
+    store_b = stores.get_instinct_store(workspace_id=WS_B)
+
+    # Build a few hashed rows in each tenant's file (propose + approve both write
+    # audit rows, extending that file's chain).
+    for i in range(3):
+        act = await _propose(store_a, pocket="p", title=f"a{i}", workspace_id=WS_A)
+        await store_a.approve(act.id)
+    for i in range(2):
+        act = await _propose(store_b, pocket="p", title=f"b{i}", workspace_id=WS_B)
+        await store_b.approve(act.id)
+
+    # Each chain verifies INDEPENDENTLY and intact — its own genesis→…→head.
+    verdict_a = await store_a.verify_audit_chain()
+    verdict_b = await store_b.verify_audit_chain()
+
+    assert verdict_a["intact"] is True
+    assert verdict_a["broken_at"] is None
+    assert verdict_a["hashed"] == verdict_a["checked"]
+    assert verdict_a["hashed"] > 0
+
+    assert verdict_b["intact"] is True
+    assert verdict_b["broken_at"] is None
+    assert verdict_b["hashed"] == verdict_b["checked"]
+    assert verdict_b["hashed"] > 0
+
+    # The chains are independent: A has more hashed rows than B (3 vs 2 actions,
+    # each ~2 audit rows), so they are NOT one shared global chain.
+    assert verdict_a["hashed"] != verdict_b["hashed"]
+
+
+@pytest.mark.asyncio
+async def test_tampering_one_workspace_does_not_break_the_other(tmp_path: Path) -> None:
+    """A tampered row in A's file must not flip B's verdict (independent chains)."""
+    import sqlite3
+
+    store_a = stores.get_instinct_store(workspace_id=WS_A)
+    store_b = stores.get_instinct_store(workspace_id=WS_B)
+
+    a_act = await _propose(store_a, pocket="p", title="a", workspace_id=WS_A)
+    await store_a.approve(a_act.id)
+    b_act = await _propose(store_b, pocket="p", title="b", workspace_id=WS_B)
+    await store_b.approve(b_act.id)
+
+    # Both intact to start.
+    assert (await store_a.verify_audit_chain())["intact"] is True
+    assert (await store_b.verify_audit_chain())["intact"] is True
+
+    # Tamper with A's ledger directly on disk (mutate a hashed row's content).
+    # Target the lowest-rowid hashed row via a subquery — this SQLite build does
+    # not support UPDATE ... ORDER BY ... LIMIT (needs a compile-time flag).
+    with sqlite3.connect(store_a._db_path) as conn:
+        conn.execute(
+            "UPDATE instinct_audit SET description = 'TAMPERED' WHERE rowid = ("
+            "SELECT rowid FROM instinct_audit WHERE entry_hash IS NOT NULL "
+            "ORDER BY rowid LIMIT 1)"
+        )
+        conn.commit()
+
+    # A is now broken; B is untouched and still intact — proof the chains are
+    # per-tenant, not one global chain whose break would implicate every tenant.
+    assert (await store_a.verify_audit_chain())["intact"] is False
+    assert (await store_b.verify_audit_chain())["intact"] is True
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed + back-compat + ContextVar (mirrors the ISO-1 guards)
+# ---------------------------------------------------------------------------
+
+
+def test_fail_closed_when_scope_required_and_no_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_instinct_store()  # no workspace, no ContextVar
+
+
+def test_legacy_shared_store_when_unscoped_and_not_required(tmp_path: Path) -> None:
+    store = stores.get_instinct_store()  # no workspace, flag unset
+    assert store._db_path == str(tmp_path / "instinct.db")
+    assert stores.get_instinct_store() is store  # singleton preserved
+
+
+def test_contextvar_is_consulted_and_explicit_arg_wins(tmp_path: Path) -> None:
+    token = stores.current_workspace.set(WS_B)
+    try:
+        # No explicit arg → ContextVar (WS_B).
+        from_ctx = stores.get_instinct_store()
+        assert str(tmp_path / "workspaces" / WS_B) in from_ctx._db_path
+        # Explicit arg wins over the ContextVar.
+        explicit = stores.get_instinct_store(workspace_id=WS_A)
+        assert str(tmp_path / "workspaces" / WS_A) in explicit._db_path
+        assert WS_B not in explicit._db_path
+    finally:
+        stores.current_workspace.reset(token)
+
+
+def test_same_workspace_returns_cached_handle(tmp_path: Path) -> None:
+    first = stores.get_instinct_store(workspace_id=WS_A)
+    second = stores.get_instinct_store(workspace_id=WS_A)
+    assert first is second
+
+
+def test_fabric_and_instinct_caches_are_independent(tmp_path: Path) -> None:
+    """The two store kinds keep separate LRUs — same workspace, different files."""
+    fab = stores.get_fabric_store(workspace_id=WS_A)
+    inst = stores.get_instinct_store(workspace_id=WS_A)
+    assert fab is not inst
+    assert fab._db_path.endswith("fabric.db")
+    assert inst._db_path.endswith("instinct.db")
+    # Both under the SAME workspace dir.
+    assert str(tmp_path / "workspaces" / WS_A) in fab._db_path
+    assert str(tmp_path / "workspaces" / WS_A) in inst._db_path
+
+
+# ---------------------------------------------------------------------------
+# Inherited hostile-id guard (the generic factory governs Instinct too)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "../../../tmp/pwn",
+        "..",
+        "a/b",
+        "/abs/path",
+        "-rf",
+        "x\x00y",
+        ".",
+    ],
+)
+def test_hostile_workspace_id_rejected_and_writes_nothing(tmp_path: Path, hostile: str) -> None:
+    """Instinct inherits ISO-1's strict-allowlist guard: reject + FS untouched."""
+
+    def _snapshot() -> set[Path]:
+        return set(tmp_path.rglob("*")) if tmp_path.exists() else set()
+
+    before = _snapshot()
+    with pytest.raises(ValueError):
+        stores.get_instinct_store(workspace_id=hostile)
+    assert _snapshot() == before
+    assert not Path("/tmp/pwn").exists()

--- a/tests/test_store_isolation_lint.py
+++ b/tests/test_store_isolation_lint.py
@@ -1,0 +1,306 @@
+# tests/test_store_isolation_lint.py
+# Created: 2026-06-26 (ISO-4 — store-isolation lint guard)
+#
+# AST-based regression guard: ensures no code in src/pocketpaw/ or
+# ee/pocketpaw_ee/ directly constructs FabricStore(...) or
+# InstinctStore(...) outside the approved factory seam.
+#
+# WORKSPACE RULE: all store access MUST go through the factories in
+# pocketpaw.stores — get_fabric_store() and get_instinct_store(). Direct
+# construction bypasses workspace resolution, the fail-closed scope check,
+# the bounded LRU cache, and the StoreProvider seam, silently re-opening a
+# shared store that breaks per-tenant physical isolation (ISO-1 / ISO-2).
+#
+# CHECKS IMPLEMENTED:
+#   (a) Direct construction guard — ACTIVE.
+#       Flags any ast.Call whose func is a Name or Attribute with id/attr
+#       equal to "FabricStore" or "InstinctStore". This is the load-bearing
+#       guard. The current factory in stores.py uses kind.cls(path) — an
+#       Attribute on a dataclass field — which the AST represents as
+#       Attribute(value=Name(id='kind'), attr='cls'), NOT as a Name/Attribute
+#       ending in FabricStore/InstinctStore. So the factory is correctly
+#       transparent to the guard without needing an allowlist exception.
+#
+#   (b) Bare get_fabric_store() / get_instinct_store() call without
+#       workspace_id keyword — DROPPED.
+#       The OSS agent-tool path legitimately calls these bare and relies on
+#       the current_workspace ContextVar (ISO-3). Distinguishing that
+#       legitimate bare call from a bug requires cross-module dataflow
+#       analysis that an AST-only pass cannot reliably do. The
+#       fail-closed POCKETPAW_REQUIRE_WORKSPACE_SCOPE env flag provides
+#       the runtime guard for the cloud path; check (b) would produce
+#       too many false positives to be useful as a CI gate.
+#
+# ALLOWLIST (construction guard):
+#   Two files are excluded, each for a precise reason; everything else is
+#   protected (a direct FabricStore(...)/InstinctStore(...) anywhere else fails
+#   the guard and points the dev at the factory).
+#     - the factory implementation (stores.py) — the legitimate construction site.
+#     - the ISO-4 migration — its WRITES go through build_workspace_store (the
+#       approved seam), but it must also READ the SHARED {fabric,instinct}.db and
+#       verify the source audit chain before re-chaining, and the shared file is
+#       NOT a workspace path, so no factory call can open it. Direct construction
+#       on the shared path is legitimate there and only there.
+#
+#   ALLOWLIST_PATHS (relative to the worktree root):
+#     src/pocketpaw/stores.py
+#         The factory module — the ONLY place direct construction is a
+#         legitimate implementation choice (today the factory uses kind.cls
+#         indirection, not a bare Name call, so it would not be flagged anyway;
+#         the exemption future-proofs an explicit refactor).
+#     src/pocketpaw/migrations/split_workspace_stores.py
+#         The shared->per-workspace migration — must construct a store on the
+#         SHARED db path (not a workspace path) to read it + verify its audit
+#         chain, which no factory call can do.
+#
+# NO pytest-asyncio needed — pure synchronous AST walk.
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+_SOURCE_ROOTS = [
+    _REPO_ROOT / "src" / "pocketpaw",
+    _REPO_ROOT / "ee" / "pocketpaw_ee",
+]
+
+# Relative-to-repo-root paths that are ALLOWED to contain direct FabricStore /
+# InstinctStore construction calls.
+_ALLOWLIST_REL: frozenset[str] = frozenset(
+    [
+        # The factory module IS the legitimate construction site (the _StoreKind
+        # registry + _build_local_workspace_store).
+        "src/pocketpaw/stores.py",
+        # The ISO-4 migration is the one place that bridges the SHARED stores to
+        # the per-workspace ones. Its WRITES go through build_workspace_store (the
+        # approved seam), but it must also READ the shared ~/.pocketpaw/{fabric,
+        # instinct}.db files + verify the source audit chain before re-chaining —
+        # and the shared file is, by definition, NOT a workspace path, so NO
+        # factory call can open it. Constructing the store on the shared path
+        # directly is therefore legitimate HERE and only here. Exempted with that
+        # narrow justification; the guard still protects every other module.
+        "src/pocketpaw/migrations/split_workspace_stores.py",
+    ]
+)
+
+# Store class names whose direct construction is forbidden outside the allowlist.
+_FORBIDDEN_NAMES: frozenset[str] = frozenset(["FabricStore", "InstinctStore"])
+
+# ---------------------------------------------------------------------------
+# Core checker (reusable — called by both the real-tree test and the self-test)
+# ---------------------------------------------------------------------------
+
+
+def find_store_construction_violations(
+    tree: ast.AST,
+    filename: str,
+    allowlist: frozenset[str],
+) -> list[str]:
+    """Walk ``tree`` and return a list of violation strings.
+
+    A violation is any ``ast.Call`` whose ``func`` is:
+      * an ``ast.Name`` with ``id`` in _FORBIDDEN_NAMES, OR
+      * an ``ast.Attribute`` with ``attr`` in _FORBIDDEN_NAMES.
+
+    Each string in the returned list is formatted as::
+
+        path/to/file.py:LINE — FabricStore() called directly; use get_fabric_store()
+
+    ``filename`` is the string used in the violation message (and matched
+    against ``allowlist``).  ``allowlist`` is a frozenset of filenames /
+    relative paths to skip.
+    """
+    if filename in allowlist:
+        return []
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name: str | None = None
+        if isinstance(func, ast.Name):
+            name = func.id
+        elif isinstance(func, ast.Attribute):
+            name = func.attr
+        if name in _FORBIDDEN_NAMES:
+            violations.append(
+                f"{filename}:{node.lineno} — {name}() called directly; "
+                f"use get_{name[0].lower() + name[1:]}() from pocketpaw.stores"
+            )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_source_files() -> list[pathlib.Path]:
+    """Return all .py files under the source roots, excluding noise."""
+    files: list[pathlib.Path] = []
+    for root in _SOURCE_ROOTS:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            parts = path.parts
+            # Skip bytecode cache and virtual environments.
+            if any(segment in ("__pycache__", ".venv") for segment in parts):
+                continue
+            files.append(path)
+    return files
+
+
+def _rel(path: pathlib.Path) -> str:
+    """Return a repo-root-relative POSIX string for ``path``."""
+    try:
+        return path.relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Real-tree scan test
+# ---------------------------------------------------------------------------
+
+
+def test_no_direct_store_construction_in_source() -> None:
+    """Fail if any source file directly constructs FabricStore or InstinctStore.
+
+    Scans src/pocketpaw/ and ee/pocketpaw_ee/ via the Python AST.  The
+    allowlisted files (the factory implementation + the ISO-4 migration) are
+    exempted.  The test reports every violation with file and line number so
+    a developer knows exactly where to fix the regression.
+    """
+    source_files = _iter_source_files()
+    assert source_files, (
+        "No source files found under the expected roots — "
+        "check that _SOURCE_ROOTS point to the right directories."
+    )
+
+    all_violations: list[str] = []
+    parse_errors: list[str] = []
+
+    for path in source_files:
+        rel = _rel(path)
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError as exc:
+            parse_errors.append(f"{rel}: {exc}")
+            continue
+
+        violations = find_store_construction_violations(tree, rel, _ALLOWLIST_REL)
+        all_violations.extend(violations)
+
+    if parse_errors:
+        pytest.fail(
+            "Syntax errors prevented full scan — fix these files first:\n"
+            + "\n".join(f"  {e}" for e in parse_errors)
+        )
+
+    if all_violations:
+        lines = "\n".join(f"  {v}" for v in all_violations)
+        pytest.fail(
+            f"Store isolation violation(s) detected ({len(all_violations)} total).\n"
+            "Direct FabricStore/InstinctStore construction bypasses the factory,\n"
+            "workspace resolution, the fail-closed scope check, and the LRU cache.\n"
+            "Use get_fabric_store() / get_instinct_store() from pocketpaw.stores.\n"
+            f"\nViolations:\n{lines}\n"
+            f"\nAllowlisted paths (exempt from this check):\n"
+            + "\n".join(f"  {p}" for p in sorted(_ALLOWLIST_REL))
+        )
+
+
+# ---------------------------------------------------------------------------
+# Self-test — planted violation must be caught
+# ---------------------------------------------------------------------------
+
+
+def test_checker_catches_planted_violation() -> None:
+    """Self-test: the checker must flag a synthetic FabricStore() construction.
+
+    Feeds a small snippet of code containing a forbidden direct construction
+    call (parsed in-memory) to find_store_construction_violations and asserts
+    at least one violation is returned.  This proves the guard is not vacuously
+    passing — it actually detects the pattern it is supposed to catch.
+    """
+    snippet = """
+from pocketpaw.fabric.store import FabricStore
+
+def bad_function(db_path):
+    # BUG: direct construction bypasses the factory
+    store = FabricStore(db_path)
+    return store
+"""
+    tree = ast.parse(snippet)
+    violations = find_store_construction_violations(
+        tree,
+        filename="hypothetical/bad_module.py",
+        allowlist=frozenset(),  # no exemptions — violation must be reported
+    )
+    assert violations, (
+        "Self-test FAILED: find_store_construction_violations did not catch a "
+        "planted FabricStore() direct-construction call.  The guard is broken."
+    )
+    # Confirm the violation message mentions the right class and line.
+    assert any("FabricStore" in v for v in violations), (
+        f"Expected 'FabricStore' in violation messages, got: {violations}"
+    )
+
+
+def test_checker_catches_planted_instinct_violation() -> None:
+    """Self-test: the checker must flag a synthetic InstinctStore() construction.
+
+    Same pattern as the FabricStore self-test but for InstinctStore, ensuring
+    both forbidden names are live in the guard.
+    """
+    snippet = """
+from pocketpaw.instinct.store import InstinctStore
+
+class BadService:
+    def __init__(self, path):
+        # BUG: should call get_instinct_store() instead
+        self.store = InstinctStore(path)
+"""
+    tree = ast.parse(snippet)
+    violations = find_store_construction_violations(
+        tree,
+        filename="hypothetical/bad_service.py",
+        allowlist=frozenset(),
+    )
+    assert violations, (
+        "Self-test FAILED: find_store_construction_violations did not catch a "
+        "planted InstinctStore() direct-construction call.  The guard is broken."
+    )
+    assert any("InstinctStore" in v for v in violations), (
+        f"Expected 'InstinctStore' in violation messages, got: {violations}"
+    )
+
+
+def test_allowlisted_file_is_not_flagged() -> None:
+    """Self-test: files in the allowlist must not produce violations.
+
+    Feeds the same forbidden snippet but uses 'src/pocketpaw/stores.py'
+    as the filename, which IS in the allowlist.  Confirms exemptions work
+    correctly and the factory file can legitimately contain construction calls.
+    """
+    snippet = """
+from pocketpaw.fabric.store import FabricStore
+store = FabricStore('/some/path/fabric.db')
+"""
+    tree = ast.parse(snippet)
+    violations = find_store_construction_violations(
+        tree,
+        filename="src/pocketpaw/stores.py",
+        allowlist=_ALLOWLIST_REL,
+    )
+    assert not violations, f"Allowlisted file should not produce violations, but got: {violations}"

--- a/tests/test_workspace_ctxvar_bridge.py
+++ b/tests/test_workspace_ctxvar_bridge.py
@@ -1,0 +1,307 @@
+# tests/test_workspace_ctxvar_bridge.py
+# Created: 2026-06-26 (ISO-3 — ContextVar bridge for non-router store callers).
+#
+# Proves the ISO-3 invariant: the NON-router store callers (agent tools, MCP
+# servers, connector ingest) that call get_fabric_store() / get_instinct_store()
+# WITHOUT an explicit workspace_id land in the caller's per-workspace file,
+# because EE's attach_agent_identity bridges the per-stream workspace onto the
+# OSS-core `current_workspace` ContextVar that the factory resolves through.
+#
+# Covers:
+#   * the bridge — attach_agent_identity sets the OSS current_workspace; a bare
+#     get_fabric_store()/get_instinct_store() then resolves to that workspace's
+#     file; detach clears it;
+#   * a REAL agent tool (FabricCreateTool, which calls the bare factory
+#     internally) writes through the bridge → the object lands in the caller's
+#     workspace file, not the shared one, and is invisible to another workspace;
+#   * fail-closed — under POCKETPAW_REQUIRE_WORKSPACE_SCOPE, a non-router store
+#     call with NO identity attached (ContextVar unset) raises, never a shared
+#     read;
+#   * the EE StoreProvider seam (pocketpaw.stores entry-point) is registered and
+#     returns the per-workspace store for both kinds (and None for no-workspace).
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.chat.agent_service import (
+    attach_agent_identity,
+    detach_agent_identity,
+)
+
+import pocketpaw.stores as stores
+from pocketpaw.fabric.models import FabricQuery
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the factory at a tmp data dir; reset caches + flag + ContextVar."""
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+# ---------------------------------------------------------------------------
+# The bridge itself: attach sets the OSS ContextVar; bare factory resolves it
+# ---------------------------------------------------------------------------
+
+
+def test_attach_identity_bridges_workspace_to_oss_contextvar(tmp_path: Path) -> None:
+    assert stores.current_workspace.get() is None
+
+    tokens = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+    try:
+        # The OSS ContextVar now carries the stream's workspace.
+        assert stores.current_workspace.get() == WS_A
+        # A bare (no-arg) factory call — exactly what the agent tools / MCP
+        # servers do — resolves to that workspace's file.
+        fab = stores.get_fabric_store()
+        inst = stores.get_instinct_store()
+        assert str(tmp_path / "workspaces" / WS_A) in fab._db_path
+        assert str(tmp_path / "workspaces" / WS_A) in inst._db_path
+    finally:
+        detach_agent_identity(tokens)
+
+    # detach clears it — back to no workspace.
+    assert stores.current_workspace.get() is None
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_write_lands_in_callers_workspace_file(tmp_path: Path) -> None:
+    """A REAL agent tool writing through the bare factory lands in the right file.
+
+    Drives the non-router path end to end: attach identity for WS_A, write a
+    Fabric object via the SAME bare get_fabric_store() the agent FabricCreateTool
+    uses, and assert it lands in WS_A's file and is invisible from WS_B.
+    """
+    # Write as WS_A through the bridged bare factory.
+    tokens_a = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+    try:
+        store_a = stores.get_fabric_store()  # no explicit workspace arg
+        t = await store_a.define_type(name="Customer", properties=[], workspace_id=WS_A)
+        await store_a.create_object(t.id, {"name": "Acme"}, workspace_id=WS_A)
+    finally:
+        detach_agent_identity(tokens_a)
+
+    # The object physically lives in WS_A's file.
+    db_a = tmp_path / "workspaces" / WS_A / "fabric.db"
+    assert db_a.exists()
+    assert not (tmp_path / "fabric.db").exists()  # never the shared file
+
+    # WS_B, through the same bare path, sees ZERO of WS_A's objects.
+    tokens_b = attach_agent_identity(workspace_id=WS_B, user_id="u2")
+    try:
+        store_b = stores.get_fabric_store()
+        res_b = await store_b.query(FabricQuery(type_name="Customer"))
+        assert res_b.objects == []
+    finally:
+        detach_agent_identity(tokens_b)
+
+    # WS_A still sees its own object.
+    tokens_a2 = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+    try:
+        res_a = await stores.get_fabric_store().query(FabricQuery(type_name="Customer"))
+        assert {o.properties.get("name") for o in res_a.objects} == {"Acme"}
+    finally:
+        detach_agent_identity(tokens_a2)
+
+
+@pytest.mark.asyncio
+async def test_instinct_write_through_bridge_is_isolated(tmp_path: Path) -> None:
+    """The Instinct non-router path is bridged + isolated the same way."""
+    from pocketpaw.instinct.models import ActionTrigger
+
+    def trig() -> ActionTrigger:
+        return ActionTrigger(type="agent", source="claude", reason="iso-3")
+
+    tokens_a = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+    try:
+        await stores.get_instinct_store().propose(
+            pocket_id="p",
+            title="A-task",
+            description="",
+            recommendation="",
+            trigger=trig(),
+            workspace_id=WS_A,
+        )
+    finally:
+        detach_agent_identity(tokens_a)
+
+    tokens_b = attach_agent_identity(workspace_id=WS_B, user_id="u2")
+    try:
+        b_pending = await stores.get_instinct_store().pending()
+        assert b_pending == []  # WS_B's file has none of WS_A's actions
+    finally:
+        detach_agent_identity(tokens_b)
+
+    assert (tmp_path / "workspaces" / WS_A / "instinct.db").exists()
+    assert not (tmp_path / "instinct.db").exists()
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: a cloud non-router call with no identity attached must raise
+# ---------------------------------------------------------------------------
+
+
+def test_fail_closed_when_required_and_no_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No attach_agent_identity in scope + required-scope flag → raise, not share."""
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    # No identity attached → ContextVar is None → fail closed for BOTH kinds.
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_fabric_store()
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_instinct_store()
+
+
+def test_detach_restores_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After detach, a required-scope non-router call fails closed again.
+
+    Guards against a leaked ContextVar keeping a later, identity-less call
+    resolving to a stale workspace.
+    """
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    tokens = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+    # Inside the scope it resolves fine.
+    assert stores.get_fabric_store() is not None
+    detach_agent_identity(tokens)
+    # Outside it, the same call fails closed.
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_fabric_store()
+
+
+# ---------------------------------------------------------------------------
+# AC#2: the EE StoreProvider seam is live
+# ---------------------------------------------------------------------------
+
+
+def test_ee_store_provider_is_registered_and_serves_both_kinds(
+    tmp_path: Path,
+) -> None:
+    from pocketpaw._registry import clear_cache, first
+
+    clear_cache()
+    provider = first("pocketpaw.stores")
+    assert provider is not None, "EE CloudStoreProvider should be registered"
+    assert type(provider).__name__ == "CloudStoreProvider"
+
+    # No-workspace → None (factory falls back to its shared singleton / fail-closed).
+    assert provider.get_store("fabric", workspace_id=None) is None
+
+    # Per-workspace → the right store on the right file, for both kinds.
+    fab = provider.get_store("fabric", workspace_id=WS_A)
+    inst = provider.get_store("instinct", workspace_id=WS_A)
+    assert type(fab).__name__ == "FabricStore"
+    assert type(inst).__name__ == "InstinctStore"
+    assert str(tmp_path / "workspaces" / WS_A / "fabric.db") == fab._db_path
+    assert str(tmp_path / "workspaces" / WS_A / "instinct.db") == inst._db_path
+
+
+def test_provider_delegation_inherits_hostile_id_guard() -> None:
+    """The provider delegates to the OSS helper, so the allowlist still bites."""
+    from pocketpaw._registry import clear_cache, first
+
+    clear_cache()
+    provider = first("pocketpaw.stores")
+    with pytest.raises(ValueError):
+        provider.get_store("fabric", workspace_id="../../../tmp/pwn")
+
+
+def test_factory_routes_through_a_registered_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The FACTORY must actually consult a registered StoreProvider (AC#2).
+
+    The end-to-end proof that the ``pocketpaw.stores`` entry-point contract
+    works: register a provider, then assert ``get_fabric_store`` /
+    ``get_instinct_store`` return EXACTLY what that provider produced — not a
+    store the factory built itself. This is the seam a future per-tier backend
+    swap relies on, so it must be a real, tested contract, not just a dormant
+    hook. We inject a sentinel provider by patching the registry lookup the
+    factory uses (``pocketpaw.stores.first``).
+    """
+    sentinel_fabric = stores.FabricStore(":memory:")
+    sentinel_instinct = stores.InstinctStore(":memory:")
+
+    class _FakeProvider:
+        calls: list[tuple[str, str | None]] = []
+
+        def get_store(self, name: str, *, workspace_id: str | None = None):
+            self.calls.append((name, workspace_id))
+            if name == "fabric":
+                return sentinel_fabric
+            if name == "instinct":
+                return sentinel_instinct
+            return None
+
+    fake = _FakeProvider()
+    # The factory resolves the provider via ``first(_STORE_PROVIDER_GROUP)``;
+    # patch that name in the stores module so our fake is what it sees.
+    monkeypatch.setattr(stores, "first", lambda group: fake)
+    stores.reset_store_caches()
+
+    # A per-workspace fetch must return the PROVIDER'S store, proving the factory
+    # routed through the seam rather than constructing its own.
+    got_fab = stores.get_fabric_store(workspace_id=WS_A)
+    got_inst = stores.get_instinct_store(workspace_id=WS_A)
+    assert got_fab is sentinel_fabric
+    assert got_inst is sentinel_instinct
+    # And it asked the provider with the resolved workspace.
+    assert ("fabric", WS_A) in fake.calls
+    assert ("instinct", WS_A) in fake.calls
+
+
+@pytest.mark.asyncio
+async def test_contextvar_is_reset_when_the_run_body_raises(tmp_path: Path) -> None:
+    """HARD requirement (AC#1): a failed run must NOT leak a workspace.
+
+    The OSS ContextVar token rides the SAME identity-token tuple the existing
+    workspace/user tokens use and is reset in the SAME ``detach_agent_identity``
+    call — and both production seams (run_core, agent_bridge) run that detach in
+    a guaranteed ``finally``. This test pins that contract at the seam: simulate
+    a run that attaches identity, then throws, with detach in a finally — and
+    assert the OSS ``current_workspace`` is back to ``None`` afterwards, so the
+    next task on this loop can't inherit the failed run's workspace.
+    """
+    assert stores.current_workspace.get() is None
+
+    class _Boom(RuntimeError):
+        pass
+
+    with pytest.raises(_Boom):
+        tokens = attach_agent_identity(workspace_id=WS_A, user_id="u1")
+        try:
+            assert stores.current_workspace.get() == WS_A  # bound during the run
+            raise _Boom("run blew up mid-flight")
+        finally:
+            detach_agent_identity(tokens)
+
+    # The exception propagated, but the workspace did NOT leak.
+    assert stores.current_workspace.get() is None
+    # A subsequent identity-less required-scope call therefore fails closed, not
+    # silently resolving to the dead run's WS_A.
+    import os
+
+    os.environ["POCKETPAW_REQUIRE_WORKSPACE_SCOPE"] = "1"
+    try:
+        with pytest.raises(stores.WorkspaceScopeRequired):
+            stores.get_fabric_store()
+    finally:
+        os.environ.pop("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", None)

--- a/tests/test_workspace_store_migration.py
+++ b/tests/test_workspace_store_migration.py
@@ -1,0 +1,482 @@
+# tests/test_workspace_store_migration.py
+# Created: 2026-06-26 (ISO-4) — Tests for the one-time shared-store split migration.
+#
+# Verifies migrate_shared_stores_to_workspaces():
+#   - seeds a SHARED fabric.db + instinct.db with rows across two workspaces
+#     (ws-a, ws-b) plus NULL-workspace rows;
+#   - runs the migration and asserts per-workspace files exist on disk;
+#   - row counts match (sum across workspaces == shared total; no rows lost);
+#   - NULL-workspace rows land in system0 (the default system_workspace);
+#   - a query inside ws-a's fabric store returns only ws-a objects;
+#   - InstinctStore(<per-ws-file>).verify_audit_chain() is intact=True AND hashed>0
+#     for each workspace (re-chain worked);
+#   - shared source files were NOT destroyed (renamed to .migrated);
+#   - re-running the migration is a strict no-op (skipped=True; counts show 0 new rows);
+#   - SOURCE-CHAIN GATE (captain hard requirement): a clean source records an
+#     intact verdict in the marker; a TAMPERED source ABORTS with the source
+#     left untouched (no laundering); force=True overrides + records the override.
+#
+# Mirrors the style of tests/test_instinct_workspace_isolation.py.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pocketpaw.stores as stores
+from pocketpaw.fabric.store import FabricStore
+from pocketpaw.instinct.models import ActionTrigger
+from pocketpaw.instinct.store import InstinctStore
+from pocketpaw.migrations.split_workspace_stores import (
+    SourceChainTamperedError,
+    migrate_shared_stores_to_workspaces,
+)
+
+WS_A = "wsa"
+WS_B = "wsb"
+# "system0" — must start with [A-Za-z0-9] to pass the path-traversal allowlist;
+# "__system__" (leading underscore) is rejected by _safe_workspace_dir.
+WS_SYS = "system0"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="test", reason="migration test")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the store factory at tmp_path; reset caches + env between tests."""
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+async def _seed_shared_fabric(data_dir: Path) -> dict[str, Any]:
+    """Create the shared fabric.db and seed rows across ws-a, ws-b, and NULL workspace.
+
+    Returns the row counts so tests can assert total-preservation.
+    """
+    shared_path = data_dir / "fabric.db"
+    store = FabricStore(shared_path)
+
+    # Define a type (global / NULL workspace)
+    obj_type = await store.define_type(
+        "TestWidget",
+        properties=[],
+        workspace_id=None,
+    )
+
+    # ws-a objects
+    await store.create_object(obj_type.id, {"name": "a1"}, workspace_id=WS_A)
+    await store.create_object(obj_type.id, {"name": "a2"}, workspace_id=WS_A)
+    # ws-b objects
+    await store.create_object(obj_type.id, {"name": "b1"}, workspace_id=WS_B)
+    # NULL-workspace object (pre-tenancy)
+    await store.create_object(obj_type.id, {"name": "null1"}, workspace_id=None)
+
+    # A link between ws-a objects
+    result_a = await store.query(
+        __import__("pocketpaw.fabric.models", fromlist=["FabricQuery"]).FabricQuery(
+            type_name="TestWidget"
+        ),
+        workspace_id=WS_A,
+    )
+    if len(result_a.objects) >= 2:
+        await store.link(
+            result_a.objects[0].id,
+            result_a.objects[1].id,
+            "related",
+            workspace_id=WS_A,
+        )
+
+    return {
+        "objects": {"wsa": 2, "wsb": 1, "null": 1},
+        "type_id": obj_type.id,
+    }
+
+
+async def _seed_shared_instinct(data_dir: Path) -> dict[str, Any]:
+    """Create the shared instinct.db and seed actions + audit rows across ws-a, ws-b, NULL.
+
+    Returns metadata (action ids, audit row expectations).
+    """
+    shared_path = data_dir / "instinct.db"
+    store = InstinctStore(shared_path)
+    trigger = _make_trigger()
+
+    action_ids: dict[str, list[str]] = {WS_A: [], WS_B: [], WS_SYS: []}
+
+    # ws-a: 2 actions, approve them (2 audit rows each → 4 hashed rows)
+    for i in range(2):
+        act = await store.propose(
+            pocket_id="pocket-a",
+            title=f"A-action-{i}",
+            description="",
+            recommendation="",
+            trigger=trigger,
+            workspace_id=WS_A,
+        )
+        await store.approve(act.id, approver="user")
+        action_ids[WS_A].append(act.id)
+
+    # ws-b: 2 actions, approve them
+    for i in range(2):
+        act = await store.propose(
+            pocket_id="pocket-b",
+            title=f"B-action-{i}",
+            description="",
+            recommendation="",
+            trigger=trigger,
+            workspace_id=WS_B,
+        )
+        await store.approve(act.id, approver="user")
+        action_ids[WS_B].append(act.id)
+
+    # NULL-workspace: 1 action (pre-tenancy)
+    null_act = await store.propose(
+        pocket_id="pocket-sys",
+        title="Sys-action",
+        description="",
+        recommendation="",
+        trigger=trigger,
+        workspace_id=None,
+    )
+    action_ids[WS_SYS].append(null_act.id)
+
+    return {"action_ids": action_ids}
+
+
+# ---------------------------------------------------------------------------
+# Core migration test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_per_workspace_files(tmp_path: Path) -> None:
+    """After migration, per-workspace db files exist for every workspace found."""
+    await _seed_shared_fabric(tmp_path)
+    await _seed_shared_instinct(tmp_path)
+
+    result = await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    assert result["skipped"] is False
+
+    # Fabric per-workspace files
+    for ws in (WS_A, WS_B, WS_SYS):
+        assert (tmp_path / "workspaces" / ws / "fabric.db").exists(), f"expected fabric.db for {ws}"
+        assert (tmp_path / "workspaces" / ws / "instinct.db").exists(), (
+            f"expected instinct.db for {ws}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_migration_preserves_shared_files_as_migrated(tmp_path: Path) -> None:
+    """Source files must NOT be destroyed — they are renamed to .migrated."""
+    await _seed_shared_fabric(tmp_path)
+    await _seed_shared_instinct(tmp_path)
+
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    assert (tmp_path / "fabric.db.migrated").exists(), (
+        "shared fabric.db should be renamed not deleted"
+    )
+    assert (tmp_path / "instinct.db.migrated").exists(), (
+        "shared instinct.db should be renamed not deleted"
+    )
+    assert not (tmp_path / "fabric.db").exists(), "original fabric.db should be gone (renamed)"
+    assert not (tmp_path / "instinct.db").exists(), "original instinct.db should be gone (renamed)"
+
+
+@pytest.mark.asyncio
+async def test_fabric_null_rows_land_in_system_workspace(tmp_path: Path) -> None:
+    """NULL-workspace fabric objects must end up in the __system__ workspace."""
+    await _seed_shared_fabric(tmp_path)
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path, system_workspace=WS_SYS)
+
+    sys_store = FabricStore(tmp_path / "workspaces" / WS_SYS / "fabric.db")
+
+    from pocketpaw.fabric.models import FabricQuery
+
+    # Unscoped query in the __system__ file — should contain the null-workspace object
+    result = await sys_store.query(FabricQuery(type_name="TestWidget"))
+    names = {obj.properties.get("name") for obj in result.objects}
+    assert "null1" in names, f"null-workspace object 'null1' not found in __system__; got {names}"
+
+
+@pytest.mark.asyncio
+async def test_fabric_workspace_isolation_after_migration(tmp_path: Path) -> None:
+    """ws-a's per-workspace store must only contain ws-a objects (not ws-b's)."""
+    await _seed_shared_fabric(tmp_path)
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    from pocketpaw.fabric.models import FabricQuery
+
+    store_a = FabricStore(tmp_path / "workspaces" / WS_A / "fabric.db")
+    result = await store_a.query(FabricQuery(type_name="TestWidget"))
+    names = {obj.properties.get("name") for obj in result.objects}
+
+    assert "a1" in names, "ws-a object 'a1' missing"
+    assert "a2" in names, "ws-a object 'a2' missing"
+    assert "b1" not in names, "ws-b object 'b1' must not appear in ws-a's store"
+    assert "null1" not in names, "null-ws object must not appear in ws-a's store"
+
+
+@pytest.mark.asyncio
+async def test_fabric_row_count_preserved(tmp_path: Path) -> None:
+    """Total objects across all per-workspace files must equal the shared total."""
+    import aiosqlite
+
+    await _seed_shared_fabric(tmp_path)
+    shared_path = tmp_path / "fabric.db"
+
+    # Count source rows before migration renames it.
+    async with aiosqlite.connect(str(shared_path)) as db:
+        async with db.execute("SELECT COUNT(*) FROM fabric_objects") as cur:
+            row = await cur.fetchone()
+            shared_count = row[0] if row else 0
+
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    # Sum across per-workspace files.
+    total = 0
+    ws_root = tmp_path / "workspaces"
+    for ws_dir in ws_root.iterdir():
+        ws_db = ws_dir / "fabric.db"
+        if ws_db.exists():
+            async with aiosqlite.connect(str(ws_db)) as db:
+                async with db.execute("SELECT COUNT(*) FROM fabric_objects") as cur:
+                    row = await cur.fetchone()
+                    total += row[0] if row else 0
+
+    assert total == shared_count, (
+        f"Row count mismatch: shared had {shared_count} fabric_objects, "
+        f"per-workspace total = {total}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Instinct audit re-chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_instinct_audit_chain_intact_per_workspace_after_migration(
+    tmp_path: Path,
+) -> None:
+    """verify_audit_chain() must return intact=True AND hashed>0 for EACH workspace."""
+    await _seed_shared_instinct(tmp_path)
+
+    result = await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+    assert result["skipped"] is False
+
+    for ws_id in (WS_A, WS_B):
+        ws_file = tmp_path / "workspaces" / ws_id / "instinct.db"
+        assert ws_file.exists(), f"instinct.db for {ws_id} should exist"
+
+        ws_store = InstinctStore(ws_file)
+        verdict = await ws_store.verify_audit_chain()
+
+        assert verdict["intact"] is True, (
+            f"audit chain broken for workspace {ws_id}: {verdict['broken_at']}"
+        )
+        assert verdict["hashed"] > 0, (
+            f"workspace {ws_id} has no hashed audit rows — re-chain did not fire"
+        )
+        assert verdict["checked"] == verdict["hashed"], (
+            f"workspace {ws_id}: not all hashed rows verified (checked={verdict['checked']}, "
+            f"hashed={verdict['hashed']})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_instinct_actions_isolated_per_workspace_after_migration(
+    tmp_path: Path,
+) -> None:
+    """ws-a's per-workspace store must only contain ws-a actions."""
+    await _seed_shared_instinct(tmp_path)
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    store_a = InstinctStore(tmp_path / "workspaces" / WS_A / "instinct.db")
+    actions_a = await store_a.list_actions()
+    titles = {a.title for a in actions_a}
+
+    assert all(t.startswith("A-") for t in titles), f"ws-a store contains non-A actions: {titles}"
+    assert not any(t.startswith("B-") for t in titles), "ws-b actions must not appear in ws-a"
+
+
+@pytest.mark.asyncio
+async def test_instinct_null_actions_land_in_system_workspace(tmp_path: Path) -> None:
+    """NULL-workspace instinct actions must end up in __system__."""
+    await _seed_shared_instinct(tmp_path)
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    sys_store = InstinctStore(tmp_path / "workspaces" / WS_SYS / "instinct.db")
+    actions = await sys_store.list_actions()
+    titles = {a.title for a in actions}
+
+    assert "Sys-action" in titles, (
+        f"null-ws action 'Sys-action' not found in __system__; got {titles}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — second run must be a no-op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent_marker_file(tmp_path: Path) -> None:
+    """A second run detects the .workspace_split_done marker and skips entirely."""
+    await _seed_shared_fabric(tmp_path)
+    await _seed_shared_instinct(tmp_path)
+
+    first = await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+    assert first["skipped"] is False
+
+    second = await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+    assert second["skipped"] is True, "second run should be skipped (marker present)"
+    assert second["fabric"] == {}, "second run fabric summary must be empty"
+    assert second["instinct"] == {}, "second run instinct summary must be empty"
+
+
+@pytest.mark.asyncio
+async def test_migration_no_double_insert_on_second_run(tmp_path: Path) -> None:
+    """Even without the marker, rows are not duplicated on a second run."""
+
+    await _seed_shared_fabric(tmp_path)
+    await _seed_shared_instinct(tmp_path)
+
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    # Remove marker to simulate a partial-failure re-run (sources already renamed).
+    marker = tmp_path / ".workspace_split_done"
+    marker.unlink()
+
+    # Fabric and instinct .migrated still exist; sources are gone.
+    # Second run should skip both (no source files, no marker).
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+    # skipped=False because the marker was absent, but nothing to copy.
+    # Verify the audit chain is still intact for each workspace (no duplicates).
+    for ws in (WS_A, WS_B, WS_SYS):
+        ws_idb = tmp_path / "workspaces" / ws / "instinct.db"
+        if ws_idb.exists() and ws in (WS_A, WS_B):
+            ws_store = InstinctStore(ws_idb)
+            verdict = await ws_store.verify_audit_chain()
+            assert verdict["intact"] is True, (
+                f"chain broken after idempotent re-run for {ws}: {verdict['broken_at']}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Marker written after migration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_marker_file_created_after_migration(tmp_path: Path) -> None:
+    """A .workspace_split_done marker file must exist after a successful migration."""
+    await _seed_shared_fabric(tmp_path)
+    await _seed_shared_instinct(tmp_path)
+
+    await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    assert (tmp_path / ".workspace_split_done").exists()
+
+
+# ---------------------------------------------------------------------------
+# Source-chain integrity gate (captain hard requirement): re-chaining is only
+# sound over AUTHENTIC rows, so the shared instinct.db chain is verified intact
+# BEFORE re-chaining — abort on tamper unless force-overridden.
+# ---------------------------------------------------------------------------
+
+
+def _tamper_shared_instinct(data_dir: Path) -> None:
+    """Mutate a hashed row's content in the shared instinct.db, breaking the chain."""
+    import sqlite3
+
+    with sqlite3.connect(str(data_dir / "instinct.db")) as conn:
+        conn.execute(
+            "UPDATE instinct_audit SET description = 'TAMPERED' WHERE rowid = ("
+            "SELECT rowid FROM instinct_audit WHERE entry_hash IS NOT NULL "
+            "ORDER BY rowid LIMIT 1)"
+        )
+        conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_clean_source_records_intact_verdict_in_marker(tmp_path: Path) -> None:
+    """A clean source migrates AND the marker attests the source chain was intact."""
+    import json
+
+    await _seed_shared_instinct(tmp_path)
+
+    result = await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    assert result["skipped"] is False
+    assert result["source_chain"] is not None
+    assert result["source_chain"]["intact"] is True
+    # The marker is JSON recording the source-chain attestation.
+    marker_body = json.loads((tmp_path / ".workspace_split_done").read_text())
+    assert marker_body["source_chain_verified"]["intact"] is True
+    assert marker_body["forced"] is False
+    assert "migrated_at" in marker_body
+
+
+@pytest.mark.asyncio
+async def test_tampered_source_aborts_and_leaves_source_intact(tmp_path: Path) -> None:
+    """A broken source chain must ABORT the migration, untouched — no laundering."""
+    await _seed_shared_instinct(tmp_path)
+    _tamper_shared_instinct(tmp_path)
+
+    with pytest.raises(SourceChainTamperedError):
+        await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
+
+    # The source was NOT renamed/destroyed, NO per-workspace files were created,
+    # and NO marker was written — the abort is clean and reversible.
+    assert (tmp_path / "instinct.db").exists()
+    assert not (tmp_path / "instinct.db.migrated").exists()
+    assert not (tmp_path / "workspaces" / WS_A / "instinct.db").exists()
+    assert not (tmp_path / ".workspace_split_done").exists()
+
+
+@pytest.mark.asyncio
+async def test_force_overrides_tamper_gate_and_records_it(tmp_path: Path) -> None:
+    """force=True proceeds over a broken source and records the override in the marker."""
+    import json
+
+    await _seed_shared_instinct(tmp_path)
+    _tamper_shared_instinct(tmp_path)
+
+    result = await migrate_shared_stores_to_workspaces(data_dir=tmp_path, force=True)
+
+    assert result["skipped"] is False
+    assert result["source_chain"]["intact"] is False  # we knew it was broken
+    # Migration proceeded: per-workspace files exist and the source is renamed.
+    assert (tmp_path / "workspaces" / WS_A / "instinct.db").exists()
+    assert (tmp_path / "instinct.db.migrated").exists()
+    # The override is recorded in the marker (auditable).
+    marker_body = json.loads((tmp_path / ".workspace_split_done").read_text())
+    assert marker_body["forced"] is True
+    assert marker_body["source_chain_verified"]["intact"] is False
+    # Re-chained per-workspace files are themselves freshly VALID (the override's
+    # documented behavior — valid chains over possibly-tampered rows).
+    verdict = await InstinctStore(
+        str(tmp_path / "workspaces" / WS_A / "instinct.db")
+    ).verify_audit_chain()
+    assert verdict["intact"] is True

--- a/tests/test_workspace_store_migration.py
+++ b/tests/test_workspace_store_migration.py
@@ -205,7 +205,7 @@ async def test_migration_preserves_shared_files_as_migrated(tmp_path: Path) -> N
 
 @pytest.mark.asyncio
 async def test_fabric_null_rows_land_in_system_workspace(tmp_path: Path) -> None:
-    """NULL-workspace fabric objects must end up in the __system__ workspace."""
+    """NULL-workspace fabric objects must end up in the system0 workspace."""
     await _seed_shared_fabric(tmp_path)
     await migrate_shared_stores_to_workspaces(data_dir=tmp_path, system_workspace=WS_SYS)
 
@@ -213,10 +213,10 @@ async def test_fabric_null_rows_land_in_system_workspace(tmp_path: Path) -> None
 
     from pocketpaw.fabric.models import FabricQuery
 
-    # Unscoped query in the __system__ file — should contain the null-workspace object
+    # Unscoped query in the system0 file — should contain the null-workspace object
     result = await sys_store.query(FabricQuery(type_name="TestWidget"))
     names = {obj.properties.get("name") for obj in result.objects}
-    assert "null1" in names, f"null-workspace object 'null1' not found in __system__; got {names}"
+    assert "null1" in names, f"null-workspace object 'null1' not found in system0; got {names}"
 
 
 @pytest.mark.asyncio
@@ -322,7 +322,7 @@ async def test_instinct_actions_isolated_per_workspace_after_migration(
 
 @pytest.mark.asyncio
 async def test_instinct_null_actions_land_in_system_workspace(tmp_path: Path) -> None:
-    """NULL-workspace instinct actions must end up in __system__."""
+    """NULL-workspace instinct actions must end up in system0."""
     await _seed_shared_instinct(tmp_path)
     await migrate_shared_stores_to_workspaces(data_dir=tmp_path)
 
@@ -330,9 +330,7 @@ async def test_instinct_null_actions_land_in_system_workspace(tmp_path: Path) ->
     actions = await sys_store.list_actions()
     titles = {a.title for a in actions}
 
-    assert "Sys-action" in titles, (
-        f"null-ws action 'Sys-action' not found in __system__; got {titles}"
-    )
+    assert "Sys-action" in titles, f"null-ws action 'Sys-action' not found in system0; got {titles}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This is the backend half of the cloud paw-OS multi-tenant offering, assembled on one integration branch so it ships to dev as a single reviewed unit. It covers the five isolation and GA slices plus the one billing fix the live smoke surfaced.

## What's in here

- ISO-1: a workspace-keyed Fabric store factory. Each workspace's Fabric data lives in its own `~/.pocketpaw/workspaces/<id>/fabric.db`, and a cloud call with no workspace fails closed.
- ISO-2: the same physical split for Instinct, with a per-workspace audit hash-chain (its own genesis and verification per workspace).
- ISO-3: a ContextVar bridge so agent-tool, MCP, and connector writes that carry no explicit workspace_id still land in the caller's own file. The EE file-store provider is wired through the entry point.
- ISO-4: a one-time migration that splits any existing shared-store rows into per-workspace files, plus a lint guard that fails any direct store construction outside the factory.
- GA-1: a two-tenant isolation pen-test (zero cross-leak across Fabric, Instinct, Pockets, and KB; entitlement enforcement; fail-closed on every store path) and a live-acceptance runbook.
- Billing fix: Dodo's CustomerRequest needs `{email, name}`, not email alone. Sending email by itself returned a 422 and broke every live subscription and top-up. The sandbox smoke caught it; both call sites now send a name.

## Smoke (local, against the real Dodo sandbox)

Subscribe returned a real hosted-checkout URL. A signed `subscription.active` webhook provisioned the workspace (plan free to pro, monthly credits granted). Two tenants showed zero cross-leak. A free workspace was correctly denied an enterprise-only feature with a 403.

## Why the integration branch

The individual slice PRs (#1550, #1551, #1554, #1555, #1556) predate the billing fix, so merging them would ship the bug back. This branch is the complete, smoke-tested unit. It targets dev; please hold for merge until the live browser walk signs off.
