### PR TITLE
feat(billing): cut over to LiteLLM as the single meter (shadow → live switch)

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -43,6 +43,13 @@ terminal runs the prior worker left unbilled are charged on restart. The
 metering sweep is idempotent (billed flag + ``run:{run_id}`` ledger key), so it
 is safe even when the boot stale-run sweep is disabled — it just bills the
 already-terminal backlog.
+
+Updated: 2026-06-26 (feat/litellm-billing-cutover, WU-F) — the boot sweep also
+runs the per-tenant LiteLLM billing-cutover sweep (``run_cutover_sweep``): a
+no-op in ``off`` mode, a read-only reconciliation compare in ``shadow``, and a
+proxy-spend debit in ``live`` (where ``sweep_unbilled_runs`` self-gates off so
+exactly one meter charges). Idempotent + its own try so a cutover-sweep failure
+can't abort worker startup.
 """
 
 from __future__ import annotations
@@ -130,13 +137,24 @@ async def _startup(ctx: dict[str, Any]) -> None:
     # BC-3 metering: bill any terminal runs the prior worker left unbilled (the
     # boot sweep above just turned this boot's orphans terminal, and earlier
     # finished runs may never have been billed). Own try so a metering failure
-    # can't abort worker startup.
+    # can't abort worker startup. Self-gated OFF in the WU-F ``live`` cutover mode.
     try:
         billed = await sweep_unbilled_runs()
         if billed:
             logger.info("worker boot: billed %d unbilled terminal runs", billed)
     except Exception:
         logger.exception("worker boot: compute-cost metering sweep failed")
+    # WU-F billing cutover: per-tenant LiteLLM spend sweep on boot too (no-op in
+    # ``off``; shadow-compare in ``shadow``; debit proxy spend in ``live``). Own try
+    # so a cutover-sweep failure can't abort worker startup.
+    try:
+        from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
+
+        summary = await run_cutover_sweep()
+        if summary.get("processed"):
+            logger.info("worker boot: cutover sweep processed %d tenants", summary["processed"])
+    except Exception:
+        logger.exception("worker boot: LiteLLM billing-cutover sweep failed")
 
 
 async def _shutdown(ctx: dict[str, Any]) -> None:

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -105,6 +105,13 @@
 # report an accurate newly-billed count and skip a redundant insert-then-rollback
 # on the duplicate path. It does NOT weaken the exactly-once guard (grant/debit
 # stay idempotent via the unique index); it only saves the wasted round-trip.
+# Changed 2026-06-26 (WU-F billing cutover): added ``sum_debits_by_cause`` — a
+# read-only, tenant-filtered sum of credits debited under one ``cause`` over a
+# ``createdAt`` window (only ``applied`` entries counted). The shadow-compare phase
+# of the LiteLLM cutover uses it to total the BC-3 ``compute_spend`` debits for a
+# tenant's window so the llm_provisioning entity never reads the credit ledger doc
+# directly (the credits service owns reads of its own ``CreditLedgerEntry``). It
+# performs NO writes — shadow mode debits nothing.
 
 from __future__ import annotations
 
@@ -414,6 +421,56 @@ async def is_recorded(workspace: str, idempotency_key: str) -> bool:
     return existing is not None
 
 
+async def sum_debits_by_cause(
+    workspace: str,
+    cause: str,
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+) -> tuple[int, int]:
+    """Sum the credits debited under ``cause`` for ``workspace`` over a window.
+
+    Returns ``(credits, entry_count)`` where ``credits`` is the POSITIVE total
+    debited (the absolute value of the summed negative ``amount_delta`` over the
+    matching APPLIED entries) and ``entry_count`` is how many entries fed it.
+
+    The window is on ``createdAt``: ``since`` is inclusive (``>=``), ``until`` is
+    EXCLUSIVE (``<``) so adjacent windows never double-count a boundary entry; a
+    ``None`` bound is open on that side. Only ``applied is True`` entries are
+    counted — a committed-but-unapplied phantom never moved the wallet, so it must
+    not inflate the sum (the same rule ``reconcile`` enforces).
+
+    WU-F's shadow compare uses this to total the BC-3 ``compute_spend`` debits over
+    a tenant's window WITHOUT the llm_provisioning entity reaching into the credit
+    ledger doc directly — the credits service owns the read of its own
+    ``CreditLedgerEntry`` (EE entity-isolation), so the cross-entity compare goes
+    through this tenant-filtered helper. It performs NO writes.
+    """
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+
+    query: dict[str, Any] = {
+        "workspace": workspace,
+        "cause": cause,
+        "applied": True,
+    }
+    created_filter: dict[str, Any] = {}
+    if since is not None:
+        created_filter["$gte"] = since
+    if until is not None:
+        created_filter["$lt"] = until
+    if created_filter:
+        query["createdAt"] = created_filter
+
+    entries = await CreditLedgerEntry.find(query).to_list()
+    # A debit's ``amount_delta`` is negative; sum and flip the sign to a positive
+    # "credits debited" figure. A stray positive delta under this cause (there
+    # should be none — compute_spend is debit-only) is clamped out so a bad row
+    # can't make the spend total read as a refund.
+    total = sum(-int(e.amount_delta) for e in entries if int(e.amount_delta) < 0)
+    return total, len(entries)
+
+
 async def history(
     workspace: str,
     *,
@@ -619,4 +676,5 @@ __all__ = [
     "history",
     "is_recorded",
     "reconcile",
+    "sum_debits_by_cause",
 ]

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
@@ -1,0 +1,140 @@
+# ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py — the durable
+# per-tenant LiteLLM billing-cutover sweep (WU-F).
+#
+# One system job that iterates every PROVISIONED tenant and runs the spend logic
+# for the current cutover mode (POCKETPAW_LITELLM_SPEND_MODE, honouring the legacy
+# INGEST bool via ``service.spend_mode()``):
+#
+#   * ``off``    — no-op. BC-3 per-run metering bills as today; nothing to sweep.
+#   * ``shadow`` — read-only compare. For each tenant, ``reconcile_tenant_spend``
+#                  reads proxy spend + the BC-3 ``compute_spend`` ledger over a
+#                  lookback window and records a reconciliation row. DEBITS NOTHING.
+#   * ``live``   — LiteLLM is the sole meter. For each tenant,
+#                  ``ingest_tenant_spend`` debits the proxy spend to the credit
+#                  ledger (the BC-3 sweep is gated OFF in ``metering.sweeper`` when
+#                  the mode is live, so exactly one meter charges).
+#
+# Runs on the SAME schedule as the BC-3 metering sweep — the in-process 5-minute
+# heartbeat (``ee.extensions._sweeper_loop``) and the Tier 2 worker boot
+# (``chat.runs.worker._startup``). Mirrors that sweep's shape: tenant-agnostic
+# iteration, every spend op workspace-scoped, idempotent + safe to run repeatedly.
+#
+# IDEMPOTENT BY CONSTRUCTION:
+#   * live   — ``ingest_tenant_spend`` is exactly-once per spend row (the
+#              ``litellm:{request_id}`` ledger key + the high-water mark), so a
+#              re-run bills nothing twice.
+#   * shadow — ``reconcile_tenant_spend`` writes an append-only audit row and moves
+#              no money, so a re-run only records another (consistent) compare. The
+#              window is a fixed lookback ending "now"; overlapping windows across
+#              ticks are harmless because shadow never debits.
+# A per-tenant failure (proxy blip, one bad key) is logged and skipped so one
+# tenant never wedges the whole sweep — the same isolation the BC-3 sweep uses.
+#
+# Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new entity.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning_service
+
+logger = logging.getLogger(__name__)
+
+# Shadow-compare lookback. Each shadow tick reconciles the trailing window ending
+# "now". Generous enough to overlap the sweep cadence (so no spend falls between
+# ticks) — overlap is safe because shadow debits nothing. Live mode ignores this
+# (its ingest is high-water-bounded, not window-bounded).
+_SHADOW_WINDOW = timedelta(hours=24)
+
+
+async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
+    """Run the LiteLLM billing-cutover spend logic for every provisioned tenant.
+
+    Resolves the cutover ``mode`` (defaulting to the deployment's
+    ``service.spend_mode()``) and dispatches per tenant:
+      * ``off``    — returns immediately, sweeps nothing.
+      * ``shadow`` — ``reconcile_tenant_spend`` per tenant (read-only compare).
+      * ``live``   — ``ingest_tenant_spend`` per tenant (debit proxy spend).
+
+    Returns a small summary dict ``{"tenants", "processed", "failed", "gaps",
+    "credits"}`` for the caller's log line (``gaps`` only meaningful in shadow,
+    ``credits`` only in live). Idempotent + safe to run repeatedly. A per-tenant
+    error is logged and skipped — never raised — so one tenant can't wedge the
+    sweep (it is retried next tick).
+    """
+    resolved = mode if mode is not None else provisioning_service.spend_mode()
+    summary = {"tenants": 0, "processed": 0, "failed": 0, "gaps": 0, "credits": 0}
+
+    if resolved == "off":
+        # Nothing to do — BC-3 bills as today.
+        return summary
+
+    workspaces = await provisioning_service.list_provisioned_workspaces()
+    summary["tenants"] = len(workspaces)
+    if not workspaces:
+        return summary
+
+    if resolved == "shadow":
+        until = datetime.now(UTC)
+        since = until - _SHADOW_WINDOW
+        for workspace in workspaces:
+            try:
+                rec = await provisioning_service.reconcile_tenant_spend(
+                    workspace, since=since, until=until
+                )
+                summary["processed"] += 1
+                if rec.coverage_gap:
+                    summary["gaps"] += 1
+            except Exception:
+                summary["failed"] += 1
+                logger.exception(
+                    "run_cutover_sweep[shadow]: reconcile failed for workspace=%s "
+                    "— will retry next tick",
+                    workspace,
+                )
+        logger.info(
+            "run_cutover_sweep[shadow]: reconciled %d/%d tenants over [%s,%s), "
+            "%d coverage gap(s), %d failed — NO debits",
+            summary["processed"],
+            summary["tenants"],
+            since.isoformat(),
+            until.isoformat(),
+            summary["gaps"],
+            summary["failed"],
+        )
+        return summary
+
+    if resolved == "live":
+        for workspace in workspaces:
+            try:
+                result = await provisioning_service.ingest_tenant_spend(workspace)
+                summary["processed"] += 1
+                summary["credits"] += result.credits_debited
+            except Exception:
+                summary["failed"] += 1
+                logger.exception(
+                    "run_cutover_sweep[live]: spend ingest failed for workspace=%s "
+                    "— will retry next tick",
+                    workspace,
+                )
+        logger.info(
+            "run_cutover_sweep[live]: ingested spend for %d/%d tenants -> %d credits, "
+            "%d failed (LiteLLM is the sole meter; BC-3 gated off)",
+            summary["processed"],
+            summary["tenants"],
+            summary["credits"],
+            summary["failed"],
+        )
+        return summary
+
+    # An unrecognised mode (mis-set env) — log loud and do nothing rather than
+    # guess. ``effective_spend_mode`` only ever returns off|shadow|live, so this is
+    # defensive against a hand-rolled caller passing a bad value.
+    logger.warning(
+        "run_cutover_sweep: unrecognised billing mode %r — sweeping nothing", resolved
+    )
+    return summary
+
+
+__all__ = ["run_cutover_sweep"]

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
@@ -15,12 +15,21 @@
 #                           proxy spend rows were read, how many credits were
 #                           debited, the USD total + cached-token savings, and the
 #                           resulting wallet balance.
+#   * ``SpendReconciliation`` — the outcome of one SHADOW compare for a tenant (WU-F):
+#                           the litellm-vs-BC-3 credits over a window, their delta,
+#                           and the coverage-gap verdict. Carries NO debit — shadow
+#                           only reads + compares. The Beanie persistence twin is
+#                           ``models.spend_reconciliation.SpendReconciliation``.
 #   * ``SpendCredits``    — the per-tenant spend rate card: USD-cost markup + the
 #                           per-credit USD denomination. Mirrors metering's
 #                           ``RateCard`` shape deliberately so proxy-spend and
 #                           per-run metering convert USD->credits identically.
 #
 # Created 2026-06-26 (integration/model-catalog-v2, MCG-8): new entity.
+# Updated 2026-06-26 (feat/litellm-billing-cutover, WU-F): added
+# ``SpendReconciliation`` — the value object returned by the shadow-mode compare
+# (``service.reconcile_tenant_spend``). Distinct from the Beanie doc of the same
+# concept; this is the framework-free shape the sweep logs + the doc is built from.
 
 from __future__ import annotations
 
@@ -105,3 +114,35 @@ class SpendIngestResult:
     cost_usd: float
     cached_tokens: int
     balance_after: int
+
+
+@dataclass(frozen=True)
+class SpendReconciliation:
+    """The outcome of one SHADOW compare for a tenant (WU-F billing cutover).
+
+    Shadow mode reads the tenant's LiteLLM proxy spend over a window, converts it
+    to credits (the SAME rate card BC-3 uses), sums the workspace's BC-3
+    ``compute_spend`` ledger debits over that window, and records the two side by
+    side. This object is the framework-free result; it carries NO debit — the whole
+    point of shadow is to compare WITHOUT touching the wallet.
+
+    ``litellm_credits`` is the proxy spend in credits; ``bc3_credits`` is the summed
+    BC-3 metered debits in credits. ``delta = litellm_credits - bc3_credits``
+    (positive ⇒ the proxy saw MORE than BC-3 billed — traffic likely bypassing
+    per-run metering, or a conversion mismatch; negative ⇒ BC-3 billed more than the
+    proxy attributed). ``coverage_gap`` is True when ``abs(delta) > threshold`` — a
+    discrepancy big enough to resolve BEFORE flipping to live. ``window_start`` /
+    ``window_end`` bound the compare (ISO ``startTime`` strings, half-open).
+    ``litellm_rows`` / ``bc3_entries`` are the input counts (provenance).
+    """
+
+    workspace_id: str
+    window_start: str | None
+    window_end: str | None
+    litellm_credits: int
+    bc3_credits: int
+    delta: int
+    coverage_gap: bool
+    threshold: int
+    litellm_rows: int
+    bc3_entries: int

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -52,8 +52,11 @@
 # billing cutover from per-run metering (BC-3) to LiteLLM as the single meter,
 # done through a safe shadow-compare phase.
 #   1. ``spend_mode`` / ``reconcile_gap_threshold`` — read the 3-position cutover
-#      switch (POCKETPAW_LITELLM_SPEND_MODE off|shadow|live, honouring the legacy
-#      INGEST bool). ``spend_ingest_enabled`` is now a back-compat shim over it.
+#      switch (POCKETPAW_LITELLM_SPEND_MODE off|shadow|live). The legacy INGEST bool
+#      is honoured ONLY as far as ``shadow`` — ``live`` requires an EXPLICIT mode, so
+#      deploying WU-F never auto-flips an old bool-setter into live billing (a
+#      one-time deprecation notice fires when the legacy bool is seen).
+#      ``spend_ingest_enabled`` is now a back-compat shim over it.
 #   2. ``reconcile_tenant_spend`` — the SHADOW compare. Reads proxy spend + the
 #      BC-3 ``compute_spend`` ledger debits over the same window and records a
 #      reconciliation row (litellm vs bc3 + delta + coverage_gap). It DEBITS
@@ -87,6 +90,12 @@ from pocketpaw_ee.cloud.models.spend_reconciliation import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Once-per-process guard for the legacy-spend-bool deprecation notice (WU-F). The
+# warning is emitted the first time the mode is resolved while the deprecated bool
+# is the only thing set, so an operator is told their old flag now means ``shadow``
+# (NOT ``live``) and that billing requires an explicit POCKETPAW_LITELLM_SPEND_MODE.
+_legacy_bool_warned = False
 
 # Business cause stamped on the ledger movement for proxy-attributed spend. KEPT
 # DISTINCT from BC-3 metering's ``compute_spend`` so a dashboard / audit can tell
@@ -157,15 +166,50 @@ def load_spend_credits() -> SpendCredits:
     )
 
 
+def warn_legacy_spend_bool_once() -> None:
+    """Emit a ONE-TIME deprecation notice when the legacy spend bool is the only
+    cutover signal set (WU-F money-safety guard).
+
+    Fires at most once per process, the first time the mode is resolved while
+    ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` AND the new
+    ``POCKETPAW_LITELLM_SPEND_MODE`` is left at its ``off`` default. Tells the
+    operator the legacy bool now resolves to ``shadow`` (reads + compares, debits
+    NOTHING) and that to actually bill from proxy spend they must EXPLICITLY set
+    ``POCKETPAW_LITELLM_SPEND_MODE=live``. This is why deploying WU-F can never
+    auto-flip an old bool-setter into live billing — the bool can only ever reach
+    the safe shadow mode, loudly, with this notice.
+    """
+    global _legacy_bool_warned
+    if _legacy_bool_warned:
+        return
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    if settings.litellm_spend_mode == "off" and settings.litellm_spend_ingest_enabled:
+        _legacy_bool_warned = True
+        logger.warning(
+            "DEPRECATION (WU-F): POCKETPAW_LITELLM_SPEND_INGEST_ENABLED is set but "
+            "POCKETPAW_LITELLM_SPEND_MODE is unset — the legacy bool now resolves to "
+            "'shadow' (read-only reconciliation, NO debits), NOT live billing. "
+            "LiteLLM will NOT charge and BC-3 per-run metering keeps billing. To make "
+            "LiteLLM the sole meter you must EXPLICITLY set "
+            "POCKETPAW_LITELLM_SPEND_MODE=live."
+        )
+
+
 def spend_mode() -> str:
     """The LiteLLM billing-cutover mode for this deployment: ``off`` | ``shadow`` |
     ``live`` (WU-F).
 
-    Delegates to ``Settings.effective_spend_mode()`` so the legacy
-    ``POCKETPAW_LITELLM_SPEND_INGEST`` bool is honoured (an existing True maps to
-    ``live`` while the new mode is left at its ``off`` default). Provisioning is
-    unaffected by the mode (always on); only the spend SWEEP behaviour changes.
+    Delegates to ``Settings.effective_spend_mode()``. The legacy
+    ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED`` bool is honoured ONLY as far as
+    ``shadow`` — it never resolves to ``live`` (that requires an explicit
+    ``POCKETPAW_LITELLM_SPEND_MODE=live``), so merely deploying WU-F can never flip
+    an old bool-setter into live billing. The first resolution that sees the legacy
+    bool emits a one-time deprecation notice. Provisioning is unaffected by the mode
+    (always on); only the spend SWEEP behaviour changes.
     """
+    warn_legacy_spend_bool_once()
     from pocketpaw.config import get_settings
 
     return get_settings().effective_spend_mode()
@@ -716,4 +760,5 @@ __all__ = [
     "reconcile_tenant_spend",
     "spend_ingest_enabled",
     "spend_mode",
+    "warn_legacy_spend_bool_once",
 ]

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -48,6 +48,22 @@
 # exception) which a system-job caller logs + retries, never a bare HTTPException.
 #
 # Created 2026-06-26 (integration/model-catalog-v2, MCG-8): new entity.
+# Updated 2026-06-26 (feat/litellm-billing-cutover, WU-F): three changes for the
+# billing cutover from per-run metering (BC-3) to LiteLLM as the single meter,
+# done through a safe shadow-compare phase.
+#   1. ``spend_mode`` / ``reconcile_gap_threshold`` — read the 3-position cutover
+#      switch (POCKETPAW_LITELLM_SPEND_MODE off|shadow|live, honouring the legacy
+#      INGEST bool). ``spend_ingest_enabled`` is now a back-compat shim over it.
+#   2. ``reconcile_tenant_spend`` — the SHADOW compare. Reads proxy spend + the
+#      BC-3 ``compute_spend`` ledger debits over the same window and records a
+#      reconciliation row (litellm vs bc3 + delta + coverage_gap). It DEBITS
+#      NOTHING and never advances the high-water mark — BC-3 keeps billing during
+#      shadow. The cross-entity ledger read goes through the credits service's
+#      tenant-filtered ``sum_debits_by_cause`` (entity-isolation preserved).
+#   3. ``ingest_tenant_spend`` high-water boundary fix — the same-second skip was
+#      ``<=`` (dropped a distinct boundary row on a later sweep → under-bill); it
+#      is now strict ``<`` with the ``litellm:{request_id}`` ledger dedup as the
+#      exactly-once guard at the boundary. See the inline note at the loop.
 
 from __future__ import annotations
 
@@ -63,8 +79,12 @@ from pocketpaw_ee.cloud.llm_provisioning.domain import (
     ProvisionResult,
     SpendCredits,
     SpendIngestResult,
+    SpendReconciliation,
 )
 from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+from pocketpaw_ee.cloud.models.spend_reconciliation import (
+    SpendReconciliation as SpendReconciliationDoc,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +93,14 @@ logger = logging.getLogger(__name__)
 # proxy-gateway spend apart from per-run metered spend (and so the two paths can
 # coexist without their idempotency namespaces colliding).
 _LITELLM_SPEND_CAUSE = "litellm_spend"
+
+# The BC-3 per-run metering cause (``metering.service._COMPUTE_SPEND_CAUSE``). The
+# shadow compare sums the credit ledger's ``compute_spend`` debits to put BC-3 next
+# to LiteLLM. Duplicated as a literal here ON PURPOSE — metering is a SIBLING entity,
+# and importing its private constant would couple two cloud entities at module load
+# (and the import-linter forbids the cross-entity reach). If BC-3's cause string ever
+# changes, this literal + the matching test must change with it.
+_BC3_COMPUTE_SPEND_CAUSE = "compute_spend"
 
 # The key-alias prefix the proxy stamps on a tenant's virtual key, for operator
 # legibility in the proxy admin UI + spend logs.
@@ -129,15 +157,41 @@ def load_spend_credits() -> SpendCredits:
     )
 
 
-def spend_ingest_enabled() -> bool:
-    """Whether the proxy-spend -> credits sweep is enabled for this deployment.
+def spend_mode() -> str:
+    """The LiteLLM billing-cutover mode for this deployment: ``off`` | ``shadow`` |
+    ``live`` (WU-F).
 
-    Default FALSE — see the DOUBLE-BILL BOUNDARY note in the module header.
-    Provisioning is unaffected by this flag (always on); only ingestion is gated.
+    Delegates to ``Settings.effective_spend_mode()`` so the legacy
+    ``POCKETPAW_LITELLM_SPEND_INGEST`` bool is honoured (an existing True maps to
+    ``live`` while the new mode is left at its ``off`` default). Provisioning is
+    unaffected by the mode (always on); only the spend SWEEP behaviour changes.
     """
     from pocketpaw.config import get_settings
 
-    return bool(get_settings().litellm_spend_ingest_enabled)
+    return get_settings().effective_spend_mode()
+
+
+def spend_ingest_enabled() -> bool:
+    """DEPRECATED back-compat shim — whether the spend sweep DEBITS (mode == live).
+
+    Superseded by ``spend_mode()`` (WU-F). Kept so any caller still asking the old
+    yes/no question gets the right answer: only ``live`` mode debits proxy spend.
+    ``shadow`` returns False here (it reads + compares but never debits), matching
+    the original contract that True meant "ingestion debits the ledger".
+    """
+    return spend_mode() == "live"
+
+
+def reconcile_gap_threshold() -> int:
+    """The shadow-compare coverage-gap threshold in credits (WU-F).
+
+    Reads ``POCKETPAW_LITELLM_RECONCILE_GAP_THRESHOLD_CREDITS`` (default 10). A
+    reconciliation row is flagged ``coverage_gap`` when ``abs(delta)`` exceeds this.
+    Clamped to >= 0 so a negative config can't make every window read as a gap.
+    """
+    from pocketpaw.config import get_settings
+
+    return max(0, int(get_settings().litellm_reconcile_gap_threshold_credits))
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +233,20 @@ async def get_tenant_key(workspace: str) -> str | None:
     _require_workspace(workspace)
     doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
     return doc.litellm_key if doc is not None else None
+
+
+async def list_provisioned_workspaces() -> list[str]:
+    """Every workspace that has a live LiteLLM virtual key.
+
+    The cutover sweep iterates these to run the per-mode spend logic. A SYSTEM-job
+    read across tenants (no per-tenant scope) — but it only returns workspace IDs
+    that have a real key; an unprovisioned workspace has nothing to sweep. Reading
+    ``LiteLLMTenantKey`` stays inside THIS entity (only this module touches that
+    doc), so the cutover sweeper goes through this helper rather than querying the
+    doc itself.
+    """
+    docs = await LiteLLMTenantKey.find(LiteLLMTenantKey.litellm_key != None).to_list()  # noqa: E711
+    return [d.workspace for d in docs if d.litellm_key]
 
 
 async def ensure_tenant_key(
@@ -368,8 +436,17 @@ async def ingest_tenant_spend(
     # Oldest first so the high-water mark advances monotonically.
     for row in sorted(rows, key=lambda r: _row_start_time(r) or ""):
         start_ts = _row_start_time(row)
-        # Skip rows at/older than the high-water mark — already ingested.
-        if high_water is not None and start_ts is not None and start_ts <= high_water:
+        # WU-F boundary fix — skip rows STRICTLY older than the high-water mark
+        # only. The previous ``start_ts <= high_water`` dropped a DISTINCT row that
+        # shared the mark's exact ``startTime`` second when it first appeared on a
+        # LATER sweep (proxy spend rows are not strictly ordered, and second-grained
+        # timestamps collide), silently UNDER-BILLING it. Now a same-second row at
+        # the boundary is RE-EXAMINED and de-duplicated by its own
+        # ``litellm:{request_id}`` ledger key below (the ``is_recorded`` skip + BC-1's
+        # unique index), so an already-ingested boundary row no-ops while a new
+        # boundary row bills exactly once. The mark stays an optimisation that bounds
+        # the read; the per-row request_id is the real exactly-once guard.
+        if high_water is not None and start_ts is not None and start_ts < high_water:
             continue
 
         rows_read += 1
@@ -462,11 +539,181 @@ async def ingest_tenant_spend(
     )
 
 
+# ---------------------------------------------------------------------------
+# Shadow compare — read proxy spend + BC-3 ledger side by side, debit NOTHING.
+# ---------------------------------------------------------------------------
+
+
+def _as_aware(dt: datetime | None) -> datetime | None:
+    """Normalise a datetime to tz-aware UTC (a naive value is assumed UTC), or
+    pass None through. Used so window comparisons never mix naive + aware."""
+    if dt is None:
+        return None
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    """Parse a LiteLLM ``startTime`` ISO string to a datetime, or None.
+
+    Tolerant of the proxy's shapes: a trailing ``Z`` is normalised to ``+00:00``;
+    a naive (no-offset) string parses as naive. Returns None on anything
+    unparseable so a malformed row is excluded from a window rather than crashing
+    the compare.
+    """
+    if not ts:
+        return None
+    try:
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    # LiteLLM /spend/logs ``startTime`` is frequently NAIVE (no offset). The window
+    # bounds the sweep passes are tz-AWARE (UTC), and Python refuses to compare a
+    # naive datetime to an aware one. Normalise a naive timestamp to UTC (the proxy
+    # records UTC) so the window test never crashes on a real proxy row.
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _in_window(row_dt: datetime | None, since: datetime | None, until: datetime | None) -> bool:
+    """Half-open window test ``[since, until)`` on a row's parsed timestamp.
+
+    A row with NO parseable timestamp is INCLUDED (we'd rather over-count an
+    undated row into the compare than silently drop spend from the shadow check —
+    the compare is a safety net, so it errs toward surfacing discrepancies). An
+    open bound (``None``) passes that side. ``since`` / ``until`` are normalised to
+    tz-aware UTC alongside the row timestamp so a caller passing naive bounds (or a
+    proxy emitting naive timestamps) can't trip a naive-vs-aware comparison.
+    """
+    if row_dt is None:
+        return True
+    since = _as_aware(since)
+    until = _as_aware(until)
+    row_dt = _as_aware(row_dt)
+    if since is not None and row_dt < since:
+        return False
+    return not (until is not None and row_dt >= until)
+
+
+async def reconcile_tenant_spend(
+    workspace: str,
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    spend_card: SpendCredits | None = None,
+    threshold: int | None = None,
+    admin_client: LiteLLMAdminClient | None = None,
+) -> SpendReconciliation:
+    """SHADOW compare for ``workspace`` over ``[since, until)`` — debit NOTHING.
+
+    The safe cutover step. Reads the tenant's LiteLLM proxy spend, converts it to
+    credits via the SAME rate card BC-3 uses, sums the workspace's BC-3
+    ``compute_spend`` ledger debits over the same window, and records the two side
+    by side as a ``SpendReconciliation`` doc (and a structured log line). The
+    ``delta`` (litellm - bc3) and the ``coverage_gap`` verdict (``abs(delta)`` over
+    ``threshold``) tell an operator whether the two meters agree before flipping to
+    ``live``.
+
+    CRITICAL — this performs ZERO debits. It NEVER calls ``credits.service.debit``
+    and NEVER advances the spend high-water mark. BC-3 keeps billing untouched
+    during shadow. The credit ledger is read (via the credits service's own
+    tenant-filtered ``sum_debits_by_cause``) but never written. A workspace with no
+    provisioned key still produces a record (litellm_credits=0) so the operator
+    sees every tenant in the compare, not a silent gap.
+
+    ``since`` / ``until`` bound the window (datetimes; ``until`` exclusive). The
+    LiteLLM rows are filtered on their parsed ``startTime``; the BC-3 debits on
+    ``createdAt`` — the same window on both sides. ``spend_card`` / ``threshold``
+    are injectable for tests; they default to the settings-derived values.
+    """
+    _require_workspace(workspace)
+
+    card = spend_card if spend_card is not None else load_spend_credits()
+    gap_threshold = threshold if threshold is not None else reconcile_gap_threshold()
+
+    # --- LiteLLM side: proxy spend over the window -> credits. ---------------
+    litellm_credits = 0
+    litellm_rows = 0
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+    if doc is not None and doc.litellm_key:
+        client = admin_client if admin_client is not None else LiteLLMAdminClient()
+        rows = await client.spend_logs(api_key=doc.litellm_key)
+        for row in rows:
+            row_dt = _parse_iso(_row_start_time(row))
+            if not _in_window(row_dt, since, until):
+                continue
+            litellm_rows += 1
+            litellm_credits += card.to_credits(_num(row.get("spend")))
+
+    # --- BC-3 side: the metered compute_spend debits over the SAME window. ---
+    # Read through the credits service (entity-isolation: it owns its ledger doc).
+    # This is a READ — no debit, no write.
+    bc3_credits, bc3_entries = await credits_service.sum_debits_by_cause(
+        workspace, _BC3_COMPUTE_SPEND_CAUSE, since=since, until=until
+    )
+
+    delta = litellm_credits - bc3_credits
+    coverage_gap = abs(delta) > gap_threshold
+
+    window_start = since.isoformat() if since is not None else None
+    window_end = until.isoformat() if until is not None else None
+
+    # Persist the reconciliation row (append-only audit — NOT a ledger; recording
+    # one moves no money). One row per tenant per window.
+    record = SpendReconciliationDoc(
+        workspace=workspace,
+        window_start=window_start,
+        window_end=window_end,
+        litellm_credits=litellm_credits,
+        bc3_credits=bc3_credits,
+        delta=delta,
+        coverage_gap=coverage_gap,
+        threshold=gap_threshold,
+        litellm_rows=litellm_rows,
+        bc3_entries=bc3_entries,
+    )
+    await record.insert()
+
+    log = logger.warning if coverage_gap else logger.info
+    log(
+        "llm_provisioning.reconcile_tenant_spend: workspace=%s window=[%s,%s) "
+        "litellm=%d bc3=%d delta=%d coverage_gap=%s (threshold=%d, litellm_rows=%d, "
+        "bc3_entries=%d) — SHADOW, no debit",
+        workspace,
+        window_start,
+        window_end,
+        litellm_credits,
+        bc3_credits,
+        delta,
+        coverage_gap,
+        gap_threshold,
+        litellm_rows,
+        bc3_entries,
+    )
+
+    return SpendReconciliation(
+        workspace_id=workspace,
+        window_start=window_start,
+        window_end=window_end,
+        litellm_credits=litellm_credits,
+        bc3_credits=bc3_credits,
+        delta=delta,
+        coverage_gap=coverage_gap,
+        threshold=gap_threshold,
+        litellm_rows=litellm_rows,
+        bc3_entries=bc3_entries,
+    )
+
+
 __all__ = [
     "ensure_tenant_key",
     "get_tenant_key",
     "ingest_tenant_spend",
+    "list_provisioned_workspaces",
     "load_key_budget",
     "load_spend_credits",
+    "reconcile_gap_threshold",
+    "reconcile_tenant_spend",
     "spend_ingest_enabled",
+    "spend_mode",
 ]

--- a/ee/pocketpaw_ee/cloud/metering/sweeper.py
+++ b/ee/pocketpaw_ee/cloud/metering/sweeper.py
@@ -20,7 +20,21 @@
 # racing it — bills each run once: the second debit collides on the key and is a
 # no-op, and the ``billed`` flag short-circuits the run out of later sweeps.
 #
+# THE BC-3 OFF-SWITCH (WU-F): this sweep is the ONLY place BC-3 actually charges —
+# ``bill_run`` is never called inline in the chat run lifecycle, only from here (the
+# ee/extensions heartbeat + the Tier 2 worker boot). When the billing cutover is in
+# ``live`` mode (POCKETPAW_LITELLM_SPEND_MODE=live) LiteLLM is the sole meter, so
+# this sweep MUST NOT run — otherwise the same usage is billed twice (once by the
+# proxy-spend sweep, once here). ``sweep_unbilled_runs`` therefore checks the mode
+# and no-ops in ``live``. In ``off`` and ``shadow`` it bills as today (shadow is a
+# read-only compare layered ON TOP of unchanged BC-3 billing). Runs that go unbilled
+# while ``live`` is in effect simply stay ``billed=False`` and are billed by LiteLLM
+# instead — they are NOT back-billed by BC-3 if the mode is later turned off, which
+# is the correct behaviour (the proxy already charged them).
+#
 # Created 2026-06-24 (integration/billing-credits, BC-3): new entity.
+# Updated 2026-06-26 (feat/litellm-billing-cutover, WU-F): gated OFF in ``live`` mode
+# — the single-meter guarantee. See "THE BC-3 OFF-SWITCH" above.
 
 from __future__ import annotations
 
@@ -46,6 +60,7 @@ async def sweep_unbilled_runs(
     *,
     batch_limit: int = _SWEEP_BATCH_LIMIT,
     rate_card: RateCard | None = None,
+    mode: str | None = None,
 ) -> int:
     """Bill every unbilled terminal chat run's compute cost, exactly once.
 
@@ -59,7 +74,28 @@ async def sweep_unbilled_runs(
     ``rate_card`` is resolved ONCE for the whole batch (a single settings read)
     and passed into each ``bill_run`` so a 200-run sweep doesn't re-read settings
     200 times. Tests inject a card here to pin the rate.
+
+    WU-F single-meter gate: when the billing-cutover ``mode`` is ``live`` LiteLLM
+    is the sole meter, so this BC-3 sweep MUST NOT charge — it returns 0 WITHOUT
+    touching any wallet or flipping any ``billed`` flag (the off-switch that keeps
+    exactly one meter charging; see the module header). ``off`` and ``shadow`` bill
+    as today. ``mode`` defaults to the resolved deployment mode
+    (``llm_provisioning.service.spend_mode()``, which honours the legacy bool);
+    tests pass it explicitly so they don't depend on ambient settings.
     """
+    if mode is None:
+        # Lazy import — avoids a metering<->llm_provisioning module-load cycle and
+        # mirrors the lazy settings reads elsewhere in the metering entity.
+        from pocketpaw_ee.cloud.llm_provisioning import service as provisioning_service
+
+        mode = provisioning_service.spend_mode()
+    if mode == "live":
+        logger.debug(
+            "sweep_unbilled_runs: billing mode is 'live' — LiteLLM is the sole "
+            "meter, BC-3 per-run metering is gated OFF (no debit, no flag write)"
+        )
+        return 0
+
     unbilled = (
         await ChatRunDoc.find(
             {"status": {"$in": _TERMINAL_STATES}},

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -116,6 +116,7 @@ from pocketpaw_ee.cloud.models.sense_preference import WorkspaceSensePreference
 from pocketpaw_ee.cloud.models.session import Session
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
+from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
 from pocketpaw_ee.cloud.models.subscription import Subscription
 from pocketpaw_ee.cloud.models.task import Task, TaskAssignee, TaskSource
 from pocketpaw_ee.cloud.models.task_attachment import TaskAttachment
@@ -254,6 +255,7 @@ __all__ = [
     "Site",
     "SiteDomain",
     "SiteRateCounter",
+    "SpendReconciliation",
     "Subscription",
     "WorkspaceSensePreference",
     "Task",
@@ -312,6 +314,9 @@ def get_all_documents():
         InstinctApproval,
         Message,
         ReadState,
+        # Shadow-compare reconciliation rows (WU-F). One per tenant per window
+        # during shadow mode. Only ``ee.cloud.llm_provisioning.service`` writes it.
+        SpendReconciliation,
         Task,
         TaskAttachment,
         TemporalSweepStateDoc,

--- a/ee/pocketpaw_ee/cloud/models/spend_reconciliation.py
+++ b/ee/pocketpaw_ee/cloud/models/spend_reconciliation.py
@@ -1,0 +1,78 @@
+# ee/pocketpaw_ee/cloud/models/spend_reconciliation.py — the per-tenant
+# shadow-compare reconciliation record (WU-F billing cutover).
+#
+# One Beanie document per tenant per shadow sweep window. The shadow mode of the
+# billing cutover (POCKETPAW_LITELLM_SPEND_MODE=shadow) reads a tenant's LiteLLM
+# proxy spend, converts it to credits, sums the BC-3 ``compute_spend`` ledger
+# debits over the SAME window, and records the two side by side plus their delta
+# and a ``coverage_gap`` flag. It is the audit trail that lets an operator confirm
+# the two meters AGREE before cutting over to LiteLLM as the single meter (live
+# mode). Writing this row performs ZERO debits — shadow only reads + compares.
+#
+#   * ``SpendReconciliation`` — ``{workspace, window_start, window_end,
+#     litellm_credits, bc3_credits, delta, coverage_gap, threshold}``. ``delta`` is
+#     ``litellm_credits - bc3_credits`` (positive ⇒ the proxy saw MORE spend than
+#     BC-3 billed — traffic likely bypassing per-run metering, or a conversion
+#     mismatch; negative ⇒ BC-3 billed more than the proxy attributed).
+#     ``coverage_gap`` is True when ``abs(delta)`` exceeds ``threshold`` credits.
+#
+# WHY a separate doc (not a field on LiteLLMTenantKey / the credit ledger): RFC 03
+# keeps domain-specific records in domain-owned docs, and this is an append-only
+# audit series (one row per window per tenant), not per-key state. Only
+# ``ee.cloud.llm_provisioning.service`` writes it — the same entity-isolation
+# boundary the credit / litellm-key docs use. It is NOT a ledger: it never moves
+# money, so it carries no idempotency key and no ``applied`` flag.
+#
+# Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new entity. Registered
+# in ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``spend_reconciliations`` collection.
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class SpendReconciliation(TimestampedDocument):
+    """One shadow-compare row: LiteLLM proxy spend vs BC-3 metering for a tenant
+    over a window.
+
+    Append-only audit, NOT a ledger — recording one performs no debit. The shadow
+    sweep writes one per provisioned tenant per window; an operator (or a future
+    dashboard) reads them to confirm the two meters agree before flipping to live.
+
+    ``litellm_credits`` is the proxy spend over ``[window_start, window_end)``
+    converted to integer credits via the SAME rate card BC-3 uses; ``bc3_credits``
+    is the sum of the workspace's ``compute_spend`` ledger debits whose timestamps
+    fall in that window. ``delta = litellm_credits - bc3_credits``. ``coverage_gap``
+    is True when ``abs(delta) > threshold`` — a likely proxy-bypass or conversion
+    mismatch that must be resolved before live cutover.
+    """
+
+    # The tenant this row reconciles. Indexed (NOT unique — many windows per
+    # workspace) so an operator query for one workspace's history is cheap.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The compare window, as ISO ``startTime`` strings (the same field shape the
+    # LiteLLM /spend/logs rows carry, so window math compares like-for-like).
+    # Half-open ``[window_start, window_end)``.
+    window_start: str | None = None
+    window_end: str | None = None
+    # The two meters, in integer credits.
+    litellm_credits: int = 0
+    bc3_credits: int = 0
+    # ``litellm_credits - bc3_credits``. Positive ⇒ proxy saw more than BC-3 billed.
+    delta: int = 0
+    # True when ``abs(delta)`` exceeds ``threshold`` — a coverage gap to resolve
+    # before cutting over.
+    coverage_gap: bool = False
+    # The credit threshold the gap was judged against (recorded for provenance so a
+    # later threshold change doesn't retro-reinterpret old rows).
+    threshold: int = 0
+    # How many proxy spend rows + ledger debits fed this compare (provenance for an
+    # operator triaging a flagged gap).
+    litellm_rows: int = 0
+    bc3_entries: int = 0
+
+    class Settings:
+        name = "spend_reconciliations"

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -61,6 +61,12 @@ general update() path on purpose (a non-ASK level enables auto-approval of
 agent writes), and emits a WARNING-severity append-only audit event with the
 old→new level. The write goes through this service per the import-linter
 Beanie-writes-only-from-service contract.
+2026-06-26 (feat/litellm-billing-cutover, WU-F): create() now also fires the
+per-tenant LiteLLM key provisioning trigger — a BEST-EFFORT, NON-BLOCKING
+ensure_tenant_key(workspace) call. A proxy outage / mint failure is logged and
+swallowed (workspace creation NEVER fails on a provisioning error); the call is
+idempotent, so the billing-cutover sweep and any later workspace touch back-fill
+a key that didn't mint here. Mirrors the best-effort seed_default_agent step.
 """
 
 from __future__ import annotations
@@ -342,6 +348,24 @@ async def create(ctx: RequestContext, body: CreateWorkspaceRequest) -> Workspace
         await agents_service.seed_default_agent(str(doc.id), ctx.user_id)
     except Exception as exc:
         logger.warning("Failed to seed default agent for workspace %s (non-fatal): %s", doc.id, exc)
+
+    # Provision the per-tenant LiteLLM virtual key (WU-F / MCG-8). BEST-EFFORT and
+    # NON-BLOCKING: if the proxy is unreachable or the mint fails, log + continue —
+    # workspace creation must NEVER fail on a provisioning error. ``ensure_tenant_key``
+    # is idempotent, so the cutover sweep (which iterates provisioned tenants) and a
+    # later workspace touch both back-fill a key that didn't get minted here. Lazy
+    # import keeps the workspace service free of an llm_provisioning dependency at
+    # module load.
+    try:
+        from pocketpaw_ee.cloud.llm_provisioning import service as llm_provisioning_service
+
+        await llm_provisioning_service.ensure_tenant_key(str(doc.id))
+    except Exception as exc:  # noqa: BLE001 — provisioning is best-effort, never fatal
+        logger.warning(
+            "Failed to provision LiteLLM tenant key for workspace %s (non-fatal): %s",
+            doc.id,
+            exc,
+        )
 
     await emit(
         WorkspaceMemberAdded(

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -91,6 +91,7 @@ _xproc_consumer_task: asyncio.Task[None] | None = None
 
 async def _sweeper_loop() -> None:
     from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
+    from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
     from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
     from pocketpaw_ee.sites.pending_sweeper import sweep_pending_sites
 
@@ -104,11 +105,20 @@ async def _sweeper_loop() -> None:
             _run_sweeper_logger.exception("sweep_stale_runs tick failed")
         # BC-3 metering: bill every newly-terminal run's compute cost on the same
         # heartbeat. Kept in its own try so a metering failure can't suppress the
-        # stale-run sweep (or vice versa) on the next tick.
+        # stale-run sweep (or vice versa) on the next tick. Self-gated OFF in the
+        # WU-F ``live`` cutover mode (LiteLLM is then the sole meter).
         try:
             await sweep_unbilled_runs()
         except Exception:
             _run_sweeper_logger.exception("sweep_unbilled_runs tick failed")
+        # WU-F billing cutover: per-tenant LiteLLM spend sweep. No-op in ``off``;
+        # a read-only reconciliation compare in ``shadow``; debits proxy spend in
+        # ``live``. Own try so a cutover-sweep failure can't suppress the other
+        # sweeps (or vice versa) on the next tick.
+        try:
+            await run_cutover_sweep()
+        except Exception:
+            _run_sweeper_logger.exception("run_cutover_sweep tick failed")
         # Charge-first (review fix C): surface PAID sites stuck pending past the
         # threshold (a lost/delayed subscription.active webhook). VISIBILITY ONLY —
         # logs at WARNING, never auto-deploys or auto-cancels. Its own try so a
@@ -123,11 +133,13 @@ async def start_run_sweeper() -> None:
     """Sweep once on boot, then tick every 5 minutes until shutdown.
 
     Boot runs the stale-run sweep (interrupt orphaned runs), the BC-3 compute-cost
-    metering sweep (bill any terminal runs left unbilled by the prior process), and
-    the charge-first pending-site reconciliation sweep (surface paid sites stuck
-    pending); the 5-minute loop then ticks all three.
+    metering sweep (bill any terminal runs left unbilled by the prior process), the
+    WU-F LiteLLM billing-cutover sweep (no-op / shadow-compare / live-ingest per the
+    cutover mode), and the charge-first pending-site reconciliation sweep (surface
+    paid sites stuck pending); the 5-minute loop then ticks all four.
     """
     from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
+    from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
     from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
     from pocketpaw_ee.sites.pending_sweeper import sweep_pending_sites
 
@@ -136,6 +148,8 @@ async def start_run_sweeper() -> None:
         await sweep_stale_runs()
     with suppress(Exception):
         await sweep_unbilled_runs()
+    with suppress(Exception):
+        await run_cutover_sweep()
     with suppress(Exception):
         await sweep_pending_sites()
     _sweeper_task = asyncio.create_task(_sweeper_loop())

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,16 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-26 (WU-F billing cutover): Added ``litellm_spend_mode``
+    (Literal off|shadow|live, default 'off'; POCKETPAW_LITELLM_SPEND_MODE) — the
+    three-position billing-cutover switch that supersedes the
+    ``litellm_spend_ingest_enabled`` bool. 'off' keeps BC-3 per-run metering as
+    today; 'shadow' runs a read-only per-tenant compare (litellm spend vs BC-3
+    ledger, ZERO debits) that records a reconciliation row; 'live' makes LiteLLM
+    the sole meter (proxy-spend sweep debits + BC-3 sweep gated off). The legacy
+    bool is kept for back-compat and resolved by ``effective_spend_mode()`` — an
+    existing ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` maps to 'live' only
+    while the new mode is left at 'off'.
   - 2026-06-26: Added the L2 cross-backend harness-failover settings (MCG-10) —
     ``backend_failover_enabled`` (default False; kill-switch — when False the
     new ``AgentRouter.run_with_failover`` behaves exactly like ``run`` and no
@@ -1596,14 +1606,49 @@ class Settings(BaseSettings):
     litellm_spend_ingest_enabled: bool = Field(
         default=False,
         description=(
-            "Whether the LiteLLM proxy-spend -> credits sweep (MCG-8) runs. Default "
-            "FALSE: the proxy's /spend/logs includes the text chat runs BC-3 "
-            "metering already bills per ChatRunDoc, so enabling this alongside "
-            "per-run metering would double-bill text chat. It is the future "
-            "single-source-of-truth path (bill all compute from proxy spend, retire "
-            "per-run metering) — flip it (with row-level dedup against BC-3) as a "
-            "deliberate migration. Provisioning the per-tenant key is unaffected by "
-            "this flag. Set via POCKETPAW_LITELLM_SPEND_INGEST."
+            "DEPRECATED back-compat flag for the MCG-8 spend sweep — superseded by "
+            "POCKETPAW_LITELLM_SPEND_MODE (WU-F). Left in place so an existing "
+            "deployment that set POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true keeps "
+            "billing from proxy spend: when the new mode is left at its 'off' default "
+            "and this bool is True, ``effective_spend_mode()`` resolves to 'live' "
+            "(the old bool meant 'ingest + single meter'). Prefer setting "
+            "POCKETPAW_LITELLM_SPEND_MODE explicitly; this flag is ignored once the "
+            "mode is set to any non-'off' value. Set via "
+            "POCKETPAW_LITELLM_SPEND_INGEST_ENABLED."
+        ),
+    )
+    litellm_spend_mode: Literal["off", "shadow", "live"] = Field(
+        default="off",
+        description=(
+            "The billing-cutover mode for LiteLLM proxy spend (WU-F). Replaces the "
+            "POCKETPAW_LITELLM_SPEND_INGEST bool with a three-position switch so the "
+            "cutover to LiteLLM as the single meter happens through a SAFE "
+            "shadow-compare phase:\n"
+            "  * 'off'    (default) — nothing changes; BC-3 per-run metering bills "
+            "as today, no proxy-spend sweep runs.\n"
+            "  * 'shadow' — the safe compare. A per-tenant sweep reads /spend/logs, "
+            "converts cost->credits, sums the BC-3 compute_spend ledger debits over "
+            "the same window, and records a reconciliation row (litellm vs bc3 + "
+            "delta + coverage_gap). It performs ZERO debits — BC-3 keeps billing — "
+            "so an operator can confirm the two meters agree BEFORE cutting over.\n"
+            "  * 'live'   — LiteLLM is the sole meter: the proxy-spend sweep debits "
+            "litellm_spend AND BC-3's per-run metering sweep is gated OFF, so "
+            "exactly one meter charges each unit of usage (no double-bill window).\n"
+            "Provisioning the per-tenant key is unaffected by this mode (always on). "
+            "Set via POCKETPAW_LITELLM_SPEND_MODE."
+        ),
+    )
+    litellm_reconcile_gap_threshold_credits: int = Field(
+        default=10,
+        description=(
+            "Shadow-compare coverage-gap threshold in CREDITS (WU-F). During "
+            "POCKETPAW_LITELLM_SPEND_MODE=shadow, a reconciliation row is flagged "
+            "``coverage_gap=true`` when |litellm_credits - bc3_credits| exceeds this "
+            "many credits — a discrepancy big enough to mean traffic is bypassing "
+            "the proxy OR the USD->credits conversion disagrees, which must be "
+            "resolved before flipping to 'live'. 1 credit == $0.01, so the default "
+            "10 ≈ $0.10 of tolerated per-tenant-per-window drift (rounding noise). "
+            "Set via POCKETPAW_LITELLM_RECONCILE_GAP_THRESHOLD_CREDITS."
         ),
     )
     site_pending_alert_hours: float = Field(
@@ -1904,6 +1949,25 @@ class Settings(BaseSettings):
             )
             self.kb_scopes = [self.kb_scope]
         return self
+
+    def effective_spend_mode(self) -> Literal["off", "shadow", "live"]:
+        """Resolve the LiteLLM billing-cutover mode, honouring the legacy bool.
+
+        WU-F replaced the ``litellm_spend_ingest_enabled`` bool with the
+        three-position ``litellm_spend_mode`` switch. To keep an existing
+        deployment that set ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` billing
+        from proxy spend, the bool is treated as a 'live'-intent fallback: when the
+        new mode is still at its 'off' default AND the old bool is True, the
+        effective mode is 'live' (the bool meant "ingest proxy spend as the
+        single meter"). Once the mode is set to ANY non-'off' value it wins
+        outright and the bool is ignored — so an explicit 'shadow' is never
+        silently upgraded to 'live' by a stale bool.
+        """
+        if self.litellm_spend_mode != "off":
+            return self.litellm_spend_mode
+        if self.litellm_spend_ingest_enabled:
+            return "live"
+        return "off"
 
     def save(self) -> None:
         """Save settings to config file.

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -9,8 +9,10 @@ Changes:
     ledger, ZERO debits) that records a reconciliation row; 'live' makes LiteLLM
     the sole meter (proxy-spend sweep debits + BC-3 sweep gated off). The legacy
     bool is kept for back-compat and resolved by ``effective_spend_mode()`` — an
-    existing ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` maps to 'live' only
-    while the new mode is left at 'off'.
+    existing ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` maps to 'shadow' (NOT
+    'live') while the new mode is left at 'off', so deploying WU-F can never
+    auto-flip an old bool-setter into live billing; 'live' requires an explicit
+    POCKETPAW_LITELLM_SPEND_MODE=live.
   - 2026-06-26: Added the L2 cross-backend harness-failover settings (MCG-10) —
     ``backend_failover_enabled`` (default False; kill-switch — when False the
     new ``AgentRouter.run_with_failover`` behaves exactly like ``run`` and no
@@ -1608,13 +1610,15 @@ class Settings(BaseSettings):
         description=(
             "DEPRECATED back-compat flag for the MCG-8 spend sweep — superseded by "
             "POCKETPAW_LITELLM_SPEND_MODE (WU-F). Left in place so an existing "
-            "deployment that set POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true keeps "
-            "billing from proxy spend: when the new mode is left at its 'off' default "
-            "and this bool is True, ``effective_spend_mode()`` resolves to 'live' "
-            "(the old bool meant 'ingest + single meter'). Prefer setting "
-            "POCKETPAW_LITELLM_SPEND_MODE explicitly; this flag is ignored once the "
-            "mode is set to any non-'off' value. Set via "
-            "POCKETPAW_LITELLM_SPEND_INGEST_ENABLED."
+            "deployment that set POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true is not "
+            "silently flipped into live billing by deploying WU-F: when the new mode "
+            "is left at its 'off' default and this bool is True, "
+            "``effective_spend_mode()`` resolves to 'shadow' (read-only "
+            "reconciliation, ZERO debits) — NOT 'live'. Making LiteLLM the sole meter "
+            "requires an EXPLICIT POCKETPAW_LITELLM_SPEND_MODE=live (a money-meter "
+            "flip must be a conscious operator choice). A one-time deprecation notice "
+            "is logged when this bool is seen. The flag is ignored once the mode is "
+            "set to any non-'off' value. Set via POCKETPAW_LITELLM_SPEND_INGEST_ENABLED."
         ),
     )
     litellm_spend_mode: Literal["off", "shadow", "live"] = Field(
@@ -1954,19 +1958,30 @@ class Settings(BaseSettings):
         """Resolve the LiteLLM billing-cutover mode, honouring the legacy bool.
 
         WU-F replaced the ``litellm_spend_ingest_enabled`` bool with the
-        three-position ``litellm_spend_mode`` switch. To keep an existing
-        deployment that set ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` billing
-        from proxy spend, the bool is treated as a 'live'-intent fallback: when the
-        new mode is still at its 'off' default AND the old bool is True, the
-        effective mode is 'live' (the bool meant "ingest proxy spend as the
-        single meter"). Once the mode is set to ANY non-'off' value it wins
-        outright and the bool is ignored — so an explicit 'shadow' is never
-        silently upgraded to 'live' by a stale bool.
+        three-position ``litellm_spend_mode`` switch. Resolution, in order:
+
+          1. An EXPLICIT ``POCKETPAW_LITELLM_SPEND_MODE`` (any non-'off' value)
+             wins outright — ``shadow`` and ``live`` are taken as set.
+          2. Mode unset / 'off' + the legacy bool True → ``shadow`` (NOT ``live``).
+          3. Mode unset / 'off' + the legacy bool False/unset → ``off``.
+
+        WHY the legacy bool maps to ``shadow`` and NEVER ``live`` (money safety):
+        WU-F adds the FIRST periodic ingestion caller (the cutover sweep on the
+        heartbeat + worker boot). Under WU-C the bool toggled an ingestion path
+        that had NO periodic caller, so a deployment could carry
+        ``POCKETPAW_LITELLM_SPEND_INGEST_ENABLED=true`` harmlessly. If WU-F resolved
+        that bool to ``live``, merely DEPLOYING WU-F would start LiteLLM debiting AND
+        gate BC-3 off — a billing-meter flip with no operator decision. So ``live``
+        requires an EXPLICIT ``POCKETPAW_LITELLM_SPEND_MODE=live`` and is never
+        inferred. The legacy bool resolves to ``shadow`` — it reads + compares but
+        debits nothing — so an old deployment gets the (safe) reconciliation signal
+        and the operator must consciously set the mode to ``live`` to bill. See
+        ``warn_legacy_spend_bool_once`` for the one-time startup notice.
         """
         if self.litellm_spend_mode != "off":
             return self.litellm_spend_mode
         if self.litellm_spend_ingest_enabled:
-            return "live"
+            return "shadow"
         return "off"
 
     def save(self) -> None:

--- a/tests/cloud/llm_provisioning/test_billing_cutover.py
+++ b/tests/cloud/llm_provisioning/test_billing_cutover.py
@@ -422,20 +422,88 @@ def test_mode_default_is_off(monkeypatch):
     assert _mode_for(monkeypatch, mode_env=None, ingest_env=None) == "off"
 
 
-def test_legacy_ingest_bool_maps_to_live(monkeypatch):
-    # Old deployments set only POCKETPAW_LITELLM_SPEND_INGEST=true.
-    assert _mode_for(monkeypatch, mode_env=None, ingest_env="true") == "live"
+def test_legacy_ingest_bool_maps_to_shadow_not_live(monkeypatch):
+    # MONEY SAFETY: an old deployment that set only the legacy bool must resolve to
+    # 'shadow' (read-only compare, ZERO debits) — NEVER 'live'. Deploying WU-F (which
+    # adds the first periodic ingestion caller) must not auto-start LiteLLM billing.
+    assert _mode_for(monkeypatch, mode_env=None, ingest_env="true") == "shadow"
+
+
+def test_live_is_never_inferred_from_legacy_bool(monkeypatch):
+    # 'live' requires an EXPLICIT POCKETPAW_LITELLM_SPEND_MODE=live. The legacy bool
+    # alone can only ever reach 'shadow' — there is no value of the bool that yields
+    # 'live'. This is the core anti-silent-flip guarantee.
+    assert _mode_for(monkeypatch, mode_env=None, ingest_env="true") == "shadow"
+    assert _mode_for(monkeypatch, mode_env="off", ingest_env="true") == "shadow"
+    # The ONLY path to live is the explicit mode.
+    assert _mode_for(monkeypatch, mode_env="live", ingest_env=None) == "live"
 
 
 def test_explicit_shadow_overrides_legacy_bool(monkeypatch):
-    # A new explicit 'shadow' is NOT silently upgraded to 'live' by a stale bool.
+    # A new explicit 'shadow' is taken as-is alongside a stale bool.
     assert _mode_for(monkeypatch, mode_env="shadow", ingest_env="true") == "shadow"
+
+
+def test_explicit_live_overrides_legacy_bool(monkeypatch):
+    # An explicit 'live' wins (the operator consciously chose to bill), bool or not.
+    assert _mode_for(monkeypatch, mode_env="live", ingest_env="true") == "live"
 
 
 def test_explicit_modes_resolve(monkeypatch):
     assert _mode_for(monkeypatch, mode_env="off", ingest_env=None) == "off"
     assert _mode_for(monkeypatch, mode_env="shadow", ingest_env=None) == "shadow"
     assert _mode_for(monkeypatch, mode_env="live", ingest_env=None) == "live"
+
+
+def test_legacy_bool_emits_one_time_deprecation_warning(monkeypatch, caplog):
+    # When the legacy bool is the only signal, the first mode resolution logs a
+    # one-time deprecation notice telling the operator it now means 'shadow' and
+    # that billing needs an explicit mode. Fires at most once per process.
+    import logging
+
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    from pocketpaw.config import get_settings
+
+    monkeypatch.setattr(svc, "_legacy_bool_warned", False)  # reset the once-guard
+    monkeypatch.delenv("POCKETPAW_LITELLM_SPEND_MODE", raising=False)
+    monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_INGEST_ENABLED", "true")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        with caplog.at_level(logging.WARNING, logger=svc.logger.name):
+            assert svc.spend_mode() == "shadow"
+            # Resolve again — the warning must NOT fire a second time.
+            assert svc.spend_mode() == "shadow"
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+    dep = [r for r in caplog.records if "DEPRECATION (WU-F)" in r.getMessage()]
+    assert len(dep) == 1, "the deprecation notice must fire exactly once"
+    msg = dep[0].getMessage()
+    assert "'shadow'" in msg
+    assert "POCKETPAW_LITELLM_SPEND_MODE=live" in msg
+
+
+def test_no_warning_when_mode_explicit(monkeypatch, caplog):
+    # With an explicit mode set, the legacy-bool notice never fires (the operator
+    # already made a conscious choice).
+    import logging
+
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    from pocketpaw.config import get_settings
+
+    monkeypatch.setattr(svc, "_legacy_bool_warned", False)
+    monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_MODE", "live")
+    monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_INGEST_ENABLED", "true")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        with caplog.at_level(logging.WARNING, logger=svc.logger.name):
+            assert svc.spend_mode() == "live"
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+    assert not [r for r in caplog.records if "DEPRECATION (WU-F)" in r.getMessage()]
 
 
 def test_spend_ingest_enabled_shim_true_only_in_live(monkeypatch):

--- a/tests/cloud/llm_provisioning/test_billing_cutover.py
+++ b/tests/cloud/llm_provisioning/test_billing_cutover.py
@@ -1,0 +1,503 @@
+# tests/cloud/llm_provisioning/test_billing_cutover.py — proves the WU-F billing
+# cutover from BC-3 per-run metering to LiteLLM as the SINGLE meter, via the safe
+# shadow-compare phase. This touches MONEY, so every mode is proven at the ledger:
+#
+# SHADOW (the safe compare — ZERO debits):
+#   * reconcile_tenant_spend records a reconciliation row with the right
+#     litellm/bc3/delta and the coverage_gap verdict, AND leaves the credit ledger
+#     COMPLETELY UNCHANGED (the critical invariant — shadow never debits).
+#   * a coverage-gap case (LiteLLM spend >> BC-3) flips coverage_gap=True.
+#   * the cutover sweep in shadow mode reconciles every provisioned tenant and
+#     still moves no money.
+#
+# LIVE (LiteLLM is the sole meter — exactly ONE meter charges):
+#   * the BC-3 metering sweep (sweep_unbilled_runs) is GATED OFF in live mode:
+#     it returns 0, debits nothing, and does NOT flip the run's billed flag.
+#   * the cutover sweep in live mode debits the proxy spend exactly once.
+#   * end-to-end: with the same usage present as a chat run AND a proxy spend row,
+#     live mode charges it once (LiteLLM), never twice.
+#
+# MODE TRANSITIONS + BACK-COMPAT:
+#   * effective_spend_mode resolves off/shadow/live and honours the legacy
+#     POCKETPAW_LITELLM_SPEND_INGEST bool (True -> live while mode is 'off').
+#
+# BOUNDARY FIX (WU-C high-water under-bill regression):
+#   * two DISTINCT spend rows sharing one startTime, arriving across two sweeps,
+#     are both billed EXACTLY once (the old start_ts <= high_water dropped the
+#     second one -> under-bill).
+#
+# Uses the shared ``mongo_db`` + autouse ``recording_bus`` fixtures from
+# tests/cloud/conftest.py. A FAKE admin client stands in for the proxy.
+#
+# Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.llm_provisioning import cutover_sweeper
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
+from pocketpaw_ee.cloud.metering.domain import RateCard
+from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
+from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
+
+WS = "ws_cutover_test"
+
+# Pin both rate cards so credits don't depend on ambient settings: round(usd*250).
+SPEND = SpendCredits(markup=2.5, credit_usd=0.01)
+RATE = RateCard(markup=2.5, credit_usd=0.01)
+
+
+class FakeAdmin:
+    """In-memory stand-in for LiteLLMAdminClient (no HTTP).
+
+    ``generate_key`` mints a deterministic key; ``spend_logs`` returns scripted
+    rows. ``raise_on_generate`` simulates a proxy-down provision failure.
+    """
+
+    def __init__(
+        self, *, spend_rows: list[dict] | None = None, raise_on_generate: bool = False
+    ) -> None:
+        self.generate_calls = 0
+        self._spend_rows = spend_rows or []
+        self._raise_on_generate = raise_on_generate
+
+    async def generate_key(self, **kwargs):
+        self.generate_calls += 1
+        if self._raise_on_generate:
+            from pocketpaw_ee.catalog.admin_client import LiteLLMAdminError
+
+            raise LiteLLMAdminError("proxy unreachable (simulated)")
+        return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **kwargs}
+
+    async def spend_logs(self, *, api_key: str):
+        return list(self._spend_rows)
+
+
+async def _make_run(
+    *, run_id: str, status: str = "completed", usage: dict | None = None, billed: bool = False
+) -> ChatRunDoc:
+    doc = ChatRunDoc(
+        run_id=run_id,
+        workspace=WS,
+        context_type="dm",
+        scope_id="scope-1",
+        session_key="sk-1",
+        user_id="u1",
+        agent_id="a1",
+        client_message_id=f"cmid-{run_id}",
+        user_message_id=f"umid-{run_id}",
+        status=status,  # type: ignore[arg-type]
+        usage=usage if usage is not None else {},
+        billed=billed,
+    )
+    await doc.insert()
+    return doc
+
+
+async def _ledger_snapshot(workspace: str) -> tuple[int, int]:
+    """(#ledger entries, balance) — the two things shadow must NOT change."""
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == workspace).to_list()
+    return len(entries), await credits.balance(workspace)
+
+
+# ===========================================================================
+# SHADOW — the safe compare. ZERO debits. Reconciliation record produced.
+# ===========================================================================
+
+
+async def test_shadow_records_reconciliation_and_never_debits(mongo_db):
+    # Seed a wallet and a BC-3 compute_spend debit (what BC-3 already billed).
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    # BC-3 billed 10 credits of compute for this workspace.
+    await credits.debit(
+        WS, 10, cause="compute_spend", idempotency_key="run:r1", allow_negative=True
+    )
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    # The proxy attributes 0.04 USD == 10 credits for the SAME window -> they agree.
+    admin = FakeAdmin(
+        spend_rows=[{"request_id": "req-1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"}]
+    )
+
+    before_entries, before_balance = await _ledger_snapshot(WS)
+
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+
+    # The compare: litellm 10 == bc3 10, delta 0, no gap.
+    assert rec.litellm_credits == 10
+    assert rec.bc3_credits == 10
+    assert rec.delta == 0
+    assert rec.coverage_gap is False
+    assert rec.litellm_rows == 1
+    assert rec.bc3_entries == 1
+
+    # CRITICAL — shadow performed ZERO debits: ledger entry count AND balance are
+    # byte-for-byte unchanged (no litellm_spend row was written).
+    after_entries, after_balance = await _ledger_snapshot(WS)
+    assert after_entries == before_entries
+    assert after_balance == before_balance
+    litellm_debits = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.cause == "litellm_spend",
+    ).to_list()
+    assert litellm_debits == []  # shadow NEVER writes a litellm_spend debit
+
+    # The reconciliation record was persisted (the audit trail).
+    records = await SpendReconciliation.find(SpendReconciliation.workspace == WS).to_list()
+    assert len(records) == 1
+    assert records[0].litellm_credits == 10
+    assert records[0].bc3_credits == 10
+    assert records[0].delta == 0
+    assert records[0].coverage_gap is False
+
+
+async def test_shadow_coverage_gap_when_litellm_exceeds_bc3(mongo_db):
+    # BC-3 billed only 2 credits, but the proxy saw 0.40 USD == 100 credits of
+    # spend -> a coverage gap (traffic bypassing per-run metering).
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await credits.debit(WS, 2, cause="compute_spend", idempotency_key="run:r1", allow_negative=True)
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    admin = FakeAdmin(
+        spend_rows=[{"request_id": "req-1", "spend": 0.40, "startTime": "2026-06-26T10:00:00"}]
+    )
+
+    before_entries, before_balance = await _ledger_snapshot(WS)
+
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, spend_card=SPEND, threshold=10, admin_client=admin
+    )
+
+    assert rec.litellm_credits == 100
+    assert rec.bc3_credits == 2
+    assert rec.delta == 98  # litellm - bc3
+    assert rec.coverage_gap is True  # |98| > 10
+
+    # Still ZERO debits — even a gap only RECORDS, never charges.
+    after_entries, after_balance = await _ledger_snapshot(WS)
+    assert after_entries == before_entries
+    assert after_balance == before_balance
+
+    records = await SpendReconciliation.find(SpendReconciliation.workspace == WS).to_list()
+    assert len(records) == 1
+    assert records[0].coverage_gap is True
+    assert records[0].delta == 98
+
+
+async def test_shadow_window_filters_bc3_and_litellm(mongo_db):
+    # A BC-3 debit and a proxy row INSIDE the window count; ones outside don't.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    # One in-window BC-3 debit (createdAt ~ now), recorded just before the sweep.
+    await credits.debit(WS, 5, cause="compute_spend", idempotency_key="run:in", allow_negative=True)
+
+    since = datetime(2000, 1, 1, tzinfo=UTC)  # wide-open past
+    until = datetime(2999, 1, 1, tzinfo=UTC)  # wide-open future
+    admin = FakeAdmin(
+        spend_rows=[
+            {"request_id": "req-in", "spend": 0.02, "startTime": "2026-06-26T10:00:00"},  # 5 cr
+        ]
+    )
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, since=since, until=until, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+    assert rec.litellm_credits == 5
+    assert rec.bc3_credits == 5
+    assert rec.delta == 0
+    assert rec.window_start == since.isoformat()
+    assert rec.window_end == until.isoformat()
+
+
+# ===========================================================================
+# LIVE — LiteLLM is the sole meter. Exactly ONE meter charges.
+# ===========================================================================
+
+
+async def test_live_gates_bc3_sweep_off(mongo_db):
+    # A terminal, unbilled run that BC-3 WOULD bill in off/shadow.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    run = await _make_run(run_id="run-live", usage={"total_cost_usd": 0.04, "model": "gpt-4o"})
+    before = await credits.balance(WS)
+
+    # In LIVE mode the BC-3 sweep MUST NOT charge.
+    billed = await sweep_unbilled_runs(rate_card=RATE, mode="live")
+
+    assert billed == 0  # gated off — nothing billed
+    assert await credits.balance(WS) == before  # NO debit
+    # And it did NOT flip the billed flag (so LiteLLM still owns this usage).
+    reloaded = await ChatRunDoc.find_one(ChatRunDoc.run_id == "run-live")
+    assert reloaded is not None
+    assert reloaded.billed is False
+    # No compute_spend ledger row was written.
+    bc3 = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.cause == "compute_spend",
+    ).to_list()
+    assert bc3 == []
+    _ = run  # silence unused
+
+
+async def test_off_and_shadow_modes_still_bill_bc3(mongo_db):
+    # Sanity: the gate is LIVE-only. In off + shadow, BC-3 bills as today.
+    for mode in ("off", "shadow"):
+        ws = f"{WS}_{mode}"
+        await credits.grant(ws, 1000, cause="top_up", idempotency_key=f"seed-{mode}")
+        doc = ChatRunDoc(
+            run_id=f"run-{mode}",
+            workspace=ws,
+            context_type="dm",
+            scope_id="s",
+            session_key="sk",
+            user_id="u1",
+            agent_id="a1",
+            client_message_id=f"cmid-{mode}",
+            user_message_id=f"umid-{mode}",
+            status="completed",  # type: ignore[arg-type]
+            usage={"total_cost_usd": 0.04, "model": "gpt-4o"},
+            billed=False,
+        )
+        await doc.insert()
+
+        billed = await sweep_unbilled_runs(rate_card=RATE, mode=mode)
+        assert billed == 1, f"BC-3 must bill in {mode} mode"
+        assert await credits.balance(ws) == 990, f"BC-3 debit must land in {mode} mode"
+
+
+async def test_live_cutover_sweep_debits_proxy_spend_once(mongo_db):
+    # In live mode the cutover sweep ingests proxy spend exactly once.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    rows = [{"request_id": "req-1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"}]
+
+    # Patch the admin client the service constructs (the sweep calls
+    # ingest_tenant_spend without an injected client), and pin the mode.
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    orig = svc.LiteLLMAdminClient
+    svc.LiteLLMAdminClient = lambda *a, **k: FakeAdmin(spend_rows=rows)  # type: ignore[assignment]
+    # Pin the rate card the same way so credits are deterministic.
+    orig_load = svc.load_spend_credits
+    svc.load_spend_credits = lambda: SPEND  # type: ignore[assignment]
+    try:
+        first = await cutover_sweeper.run_cutover_sweep(mode="live")
+        assert first["processed"] == 1
+        assert first["credits"] == 10
+        assert await credits.balance(WS) == 990  # 1000 - 10
+
+        # Re-run: the ledger key + high-water mark make it a no-op.
+        second = await cutover_sweeper.run_cutover_sweep(mode="live")
+        assert second["credits"] == 0
+        assert await credits.balance(WS) == 990  # never moved twice
+    finally:
+        svc.LiteLLMAdminClient = orig  # type: ignore[assignment]
+        svc.load_spend_credits = orig_load  # type: ignore[assignment]
+
+    # Exactly one litellm_spend ledger row.
+    entries = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "litellm:req-1",
+    ).to_list()
+    assert len(entries) == 1
+    assert entries[0].amount_delta == -10
+
+
+async def test_no_double_charge_same_usage_live(mongo_db):
+    # The single-meter guarantee end-to-end: the SAME unit of usage exists both as
+    # a terminal chat run (BC-3's input) AND as a proxy spend row (LiteLLM's input).
+    # In live mode it must be charged EXACTLY once, by LiteLLM only.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+    await _make_run(run_id="run-x", usage={"total_cost_usd": 0.04, "model": "gpt-4o"})
+
+    rows = [{"request_id": "req-x", "spend": 0.04, "startTime": "2026-06-26T10:00:00"}]
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    orig = svc.LiteLLMAdminClient
+    orig_load = svc.load_spend_credits
+    svc.LiteLLMAdminClient = lambda *a, **k: FakeAdmin(spend_rows=rows)  # type: ignore[assignment]
+    svc.load_spend_credits = lambda: SPEND  # type: ignore[assignment]
+    try:
+        # BC-3 sweep (gated off in live) + cutover sweep (live ingest).
+        bc3_billed = await sweep_unbilled_runs(rate_card=RATE, mode="live")
+        cut = await cutover_sweeper.run_cutover_sweep(mode="live")
+    finally:
+        svc.LiteLLMAdminClient = orig  # type: ignore[assignment]
+        svc.load_spend_credits = orig_load  # type: ignore[assignment]
+
+    assert bc3_billed == 0  # BC-3 charged nothing
+    assert cut["credits"] == 10  # LiteLLM charged the 10 credits
+
+    # Net: exactly 10 credits charged total (1000 -> 990), via litellm_spend only.
+    assert await credits.balance(WS) == 990
+    bc3_rows = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS, CreditLedgerEntry.cause == "compute_spend"
+    ).to_list()
+    litellm_rows = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS, CreditLedgerEntry.cause == "litellm_spend"
+    ).to_list()
+    assert bc3_rows == []  # BC-3 never charged this usage
+    assert len(litellm_rows) == 1  # LiteLLM charged it once
+
+
+# ===========================================================================
+# CUTOVER SWEEP — off no-ops; shadow reconciles every tenant, moves no money.
+# ===========================================================================
+
+
+async def test_cutover_sweep_off_is_noop(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+    before = await credits.balance(WS)
+
+    summary = await cutover_sweeper.run_cutover_sweep(mode="off")
+
+    assert summary["processed"] == 0
+    assert await credits.balance(WS) == before
+    assert await SpendReconciliation.find(SpendReconciliation.workspace == WS).to_list() == []
+
+
+async def test_cutover_sweep_shadow_reconciles_tenants_without_debit(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await credits.debit(
+        WS, 10, cause="compute_spend", idempotency_key="run:r1", allow_negative=True
+    )
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    rows = [{"request_id": "req-1", "spend": 0.04, "startTime": datetime.now(UTC).isoformat()}]
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    orig = svc.LiteLLMAdminClient
+    orig_load = svc.load_spend_credits
+    svc.LiteLLMAdminClient = lambda *a, **k: FakeAdmin(spend_rows=rows)  # type: ignore[assignment]
+    svc.load_spend_credits = lambda: SPEND  # type: ignore[assignment]
+    before_entries, before_balance = await _ledger_snapshot(WS)
+    try:
+        summary = await cutover_sweeper.run_cutover_sweep(mode="shadow")
+    finally:
+        svc.LiteLLMAdminClient = orig  # type: ignore[assignment]
+        svc.load_spend_credits = orig_load  # type: ignore[assignment]
+
+    assert summary["processed"] == 1
+    # ZERO debits even via the sweep path.
+    after_entries, after_balance = await _ledger_snapshot(WS)
+    assert after_entries == before_entries
+    assert after_balance == before_balance
+    # A reconciliation row was recorded for the tenant.
+    assert len(await SpendReconciliation.find(SpendReconciliation.workspace == WS).to_list()) == 1
+
+
+# ===========================================================================
+# MODE TRANSITIONS + BACK-COMPAT of the legacy POCKETPAW_LITELLM_SPEND_INGEST bool.
+# ===========================================================================
+
+
+def _mode_for(monkeypatch, *, mode_env: str | None, ingest_env: str | None) -> str:
+    from pocketpaw.config import get_settings
+
+    if mode_env is None:
+        monkeypatch.delenv("POCKETPAW_LITELLM_SPEND_MODE", raising=False)
+    else:
+        monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_MODE", mode_env)
+    if ingest_env is None:
+        monkeypatch.delenv("POCKETPAW_LITELLM_SPEND_INGEST_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_INGEST_ENABLED", ingest_env)
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        return provisioning.spend_mode()
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def test_mode_default_is_off(monkeypatch):
+    assert _mode_for(monkeypatch, mode_env=None, ingest_env=None) == "off"
+
+
+def test_legacy_ingest_bool_maps_to_live(monkeypatch):
+    # Old deployments set only POCKETPAW_LITELLM_SPEND_INGEST=true.
+    assert _mode_for(monkeypatch, mode_env=None, ingest_env="true") == "live"
+
+
+def test_explicit_shadow_overrides_legacy_bool(monkeypatch):
+    # A new explicit 'shadow' is NOT silently upgraded to 'live' by a stale bool.
+    assert _mode_for(monkeypatch, mode_env="shadow", ingest_env="true") == "shadow"
+
+
+def test_explicit_modes_resolve(monkeypatch):
+    assert _mode_for(monkeypatch, mode_env="off", ingest_env=None) == "off"
+    assert _mode_for(monkeypatch, mode_env="shadow", ingest_env=None) == "shadow"
+    assert _mode_for(monkeypatch, mode_env="live", ingest_env=None) == "live"
+
+
+def test_spend_ingest_enabled_shim_true_only_in_live(monkeypatch):
+    # The deprecated shim: True ONLY when the effective mode is live.
+    assert _mode_for(monkeypatch, mode_env="off", ingest_env=None) == "off"
+    from pocketpaw.config import get_settings
+
+    monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_MODE", "shadow")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        assert provisioning.spend_ingest_enabled() is False  # shadow does NOT debit
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+    monkeypatch.setenv("POCKETPAW_LITELLM_SPEND_MODE", "live")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    try:
+        assert provisioning.spend_ingest_enabled() is True
+    finally:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+# ===========================================================================
+# BOUNDARY FIX — two distinct same-startTime rows across two sweeps bill once each.
+# ===========================================================================
+
+
+async def test_high_water_boundary_same_second_rows_both_billed_once(mongo_db):
+    # The WU-C under-bill bug: with start_ts <= high_water, a DISTINCT row sharing
+    # the prior sweep's exact startTime second is dropped on the later sweep. With
+    # the strict-< fix + the litellm:{request_id} dedup, BOTH same-second rows bill
+    # exactly once across two sweeps.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    SAME_TS = "2026-06-26T10:00:00"
+
+    # Sweep 1 sees only req-1 at SAME_TS (0.04 USD -> 10 credits). Mark advances to
+    # SAME_TS.
+    admin = FakeAdmin(spend_rows=[{"request_id": "req-1", "spend": 0.04, "startTime": SAME_TS}])
+    first = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+    assert first.rows_billed == 1
+    assert first.credits_debited == 10
+    assert await credits.balance(WS) == 990
+
+    # Sweep 2: req-2 ALSO carries SAME_TS (a distinct row that arrived/settled at
+    # the same second) plus the already-billed req-1. The fix must bill req-2 (the
+    # old <= would have skipped it -> under-bill) while req-1 no-ops on its key.
+    admin._spend_rows = [
+        {"request_id": "req-1", "spend": 0.04, "startTime": SAME_TS},
+        {"request_id": "req-2", "spend": 0.06, "startTime": SAME_TS},  # -> 15 credits
+    ]
+    second = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    assert second.rows_billed == 1  # only req-2 is newly billed
+    assert second.credits_debited == 15
+    assert await credits.balance(WS) == 975  # 990 - 15
+
+    # Exactly one ledger row per request — neither double-billed.
+    for rid, delta in (("req-1", -10), ("req-2", -15)):
+        entries = await CreditLedgerEntry.find(
+            CreditLedgerEntry.workspace == WS,
+            CreditLedgerEntry.idempotency_key == f"litellm:{rid}",
+        ).to_list()
+        assert len(entries) == 1, f"{rid} must have exactly one ledger row"
+        assert entries[0].amount_delta == delta

--- a/tests/cloud/llm_provisioning/test_provisioning.py
+++ b/tests/cloud/llm_provisioning/test_provisioning.py
@@ -220,19 +220,28 @@ async def test_high_water_mark_skips_settled_rows(mongo_db):
     assert doc is not None
     assert doc.last_spend_ingest_ts == "2026-06-26T10:00:00"
 
-    # A re-sweep with the SAME (now-settled) row reads nothing new.
+    # A re-sweep with the SAME (now-settled) row bills NOTHING new. After the WU-F
+    # boundary fix the high-water skip is strict ``<`` (not ``<=``), so a row whose
+    # startTime EQUALS the mark is RE-EXAMINED (rows_read==1) and de-duplicated by
+    # its litellm:{request_id} ledger key — it must not re-bill. (The old ``<=``
+    # skipped it outright, rows_read==0, but that same skip silently DROPPED a
+    # distinct same-second row on a later sweep — the under-bill this fix closes;
+    # see test_high_water_boundary_same_second_rows_both_billed_once.)
+    before_balance = await credits.balance(WS)
     again = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
-    assert again.rows_read == 0
-    assert again.rows_billed == 0
+    assert again.rows_read == 1  # the boundary row is re-examined...
+    assert again.rows_billed == 0  # ...but never re-billed (deduped on its key)
+    assert await credits.balance(WS) == before_balance  # balance never moved twice
 
-    # A NEWER row gets ingested.
+    # A NEWER row gets ingested (the boundary row is re-examined + deduped, the
+    # newer row bills).
     admin._spend_rows = [
         {"request_id": "req-1", "spend": 0.04, "startTime": "2026-06-26T10:00:00"},
         {"request_id": "req-2", "spend": 0.08, "startTime": "2026-06-26T11:00:00"},
     ]
     newer = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
-    assert newer.rows_read == 1  # only the new row
-    assert newer.rows_billed == 1
+    assert newer.rows_read == 2  # the boundary row (re-examined) + the new row
+    assert newer.rows_billed == 1  # only the new row produces a debit
     assert newer.credits_debited == 20  # round(0.08 * 250)
     assert await credits.balance(WS) == 1000 - 10 - 20  # 970
 

--- a/tests/cloud/workspace/test_provisioning_trigger.py
+++ b/tests/cloud/workspace/test_provisioning_trigger.py
@@ -1,0 +1,117 @@
+# tests/cloud/workspace/test_provisioning_trigger.py — proves the WU-F workspace
+# provisioning trigger is BEST-EFFORT and NON-BLOCKING.
+#
+#   1. Happy path — creating a workspace fires ensure_tenant_key(workspace_id) so
+#      a per-tenant LiteLLM key is provisioned for the new workspace.
+#   2. Proxy-down — if ensure_tenant_key RAISES (proxy unreachable / mint failure),
+#      workspace creation STILL SUCCEEDS (the workspace + owner membership land);
+#      the provisioning error is swallowed + logged, never fatal.
+#
+# Uses the shared ``mongo_db`` + autouse ``recording_bus`` fixtures. The resolver
+# is mocked (the realtime resolver isn't initialised in unit tests).
+#
+# Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.workspace import service as workspace_service
+from pocketpaw_ee.cloud.workspace.dto import CreateWorkspaceRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(user_id: str) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=None,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_user(email: str = "owner@x.c") -> _UserDoc:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="Owner",
+        workspaces=[],
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture(autouse=True)
+def resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock = MagicMock()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.get_resolver", lambda: mock)
+    return mock
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def stub_proxy(monkeypatch):
+    """Stub the LiteLLM admin client so ensure_tenant_key never hits the network.
+
+    By default the mint succeeds with a deterministic key; a test that wants the
+    proxy-down path patches ensure_tenant_key to raise instead.
+    """
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    class _FakeAdmin:
+        async def generate_key(self, **kwargs):
+            return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **kwargs}
+
+    monkeypatch.setattr(svc, "LiteLLMAdminClient", lambda *a, **k: _FakeAdmin())
+    yield
+
+
+async def test_create_workspace_provisions_tenant_key() -> None:
+    owner = await _seed_user()
+
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="Acme", slug="acme")
+    )
+
+    # The provisioning trigger fired: a per-tenant key row exists for the new ws.
+    row = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == ws.id)
+    assert row is not None
+    assert row.litellm_key  # a key was minted
+    assert row.key_alias == f"ws-{ws.id}"
+
+
+async def test_create_workspace_survives_proxy_down(monkeypatch) -> None:
+    # Simulate the proxy being unreachable: ensure_tenant_key raises.
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    async def _boom(workspace, **kwargs):
+        raise RuntimeError("proxy unreachable (simulated)")
+
+    monkeypatch.setattr(svc, "ensure_tenant_key", _boom)
+
+    owner = await _seed_user()
+
+    # Creation MUST NOT raise even though provisioning blew up.
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="Acme", slug="acme")
+    )
+
+    # The workspace + owner membership landed (creation fully succeeded)...
+    assert ws.id
+    assert ws.name == "Acme"
+    reloaded = await _UserDoc.find_one(_UserDoc.email == "owner@x.c")
+    assert reloaded is not None
+    assert any(m.workspace == ws.id and m.role == "owner" for m in reloaded.workspaces)
+
+    # ...but no key row was provisioned (the failure was swallowed, not retried here).
+    row = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == ws.id)
+    assert row is None


### PR DESCRIPTION
Cuts billing over to LiteLLM as the single meter, via a safe shadow-compare phase. **Stacked on the model-catalog integration PR (#1559)** — review/merge that first.

## What's in it

A 3-mode switch, `POCKETPAW_LITELLM_SPEND_MODE`:
- **off** (default) — nothing changes; the existing meter (BC-3) bills as today.
- **shadow** — a periodic sweep reads LiteLLM's per-tenant spend, compares it to the BC-3 ledger for the same window, and records a reconciliation (`delta` + `coverage_gap` flag). **Charges nothing.** This is the parity check to run before trusting LiteLLM — a coverage gap means traffic is bypassing the proxy.
- **live** — LiteLLM ingestion debits credits; the BC-3 sweeper self-gates off. One meter.

Plus:
- **Auto-provisioning** — a per-tenant LiteLLM key + budget is minted on workspace creation (best-effort; a proxy outage never fails workspace creation).
- **The spend sweep** as an arq task (heartbeat + worker boot), per-tenant failure isolation.
- **Boundary fix** — the high-water-mark `<=`→`<` change so two distinct same-second spend rows each bill exactly once (no drop, no double).

## Money-safety (reviewed)

- **Shadow performs zero debits** — tested: the credit ledger is byte-identical after a shadow sweep.
- **Live charges exactly once** — `bill_run` has a single caller (the metering sweeper), which returns early in live mode; no usage can be billed by both meters (tested, incl. the same-usage-as-chat-run-and-proxy-row case).
- **No silent flip to live** — a money review caught that the legacy WU-C flag could have auto-started live billing on deploy. Fixed: the legacy flag now maps to **shadow**, and `live` requires an explicit `POCKETPAW_LITELLM_SPEND_MODE=live` (with a one-time deprecation warning). Billing behavior never changes without a deliberate setting.

## Going live (the order)

Fix the proxy's Anthropic key → confirm all billable traffic routes through the proxy → run **shadow** and confirm the per-tenant numbers match → set `mode=live`. The code for every step is in place behind the switch.

## Tests

66 passing across provisioning / metering / credits / workspace + config; `ruff` clean; EE→OSS import contract kept.
