### PR TITLE
feat(sites): thread builder_origin into the dev-preview path so the dev source carries the edit-bridge

### DIFF
--- a/ee/pocketpaw_ee/sites/dev_server.py
+++ b/ee/pocketpaw_ee/sites/dev_server.py
@@ -3,6 +3,24 @@
 #
 # Created: 2026-06-18 (feat/sites-devserver, Phase 2 / P2a).
 #
+# Updated 2026-06-26 (feat/sites-dev-bridge-source, S1 — dev source carries the
+# edit-bridge): ``ensure_dev_server`` (method + module convenience) and
+# ``_default_materialize`` gained an optional ``builder_origin`` that is threaded
+# into ``GeneratorClient.build(builder_origin=..., static_build=False)``. The
+# generator (paw-sites SE-1) gates the section anchors + postMessage edit-bridge on
+# ``siteConfig.builderOrigin``, so passing the origin makes the dev-server-
+# materialized SOURCE carry the bridge — the hover-edit overlay then works against
+# the dev server, not only the static ``/editable`` build. Before this the dev path
+# called ``build()`` with NO ``builder_origin``, so the dev source had no anchors /
+# no bridge and flipping ``BRIDGE_IN_DEV`` regressed the overlay (the 2026-06-19
+# back-out). The origin is sourced upstream the SAME way ``/editable`` sources it
+# (router request ``Origin`` → service ``PAW_SITES_BUILDER_ORIGIN`` fallback); a
+# None/empty origin still materializes a NON-bridged source (the generator's gate
+# holds). ``static_build`` stays ``False`` — the bridge is in the SOURCE the scaffold
+# step injects, not in the (skipped) prod static output, so the dev path's speed win
+# is untouched. This supersedes the EDIT-BRIDGE NOTE below: the active generator now
+# carries the SE-1/SE-2b injection; this change just threads the origin to it.
+#
 # Updated 2026-06-19 (fix/sites-preview-fresh-build, P0a): the P0a fix makes
 # generator.build()'s ``bun run build`` static-output step ALWAYS run by default
 # (so the served preview/publish is fresh + anchored — the #1 bug). The dev server
@@ -154,14 +172,24 @@ def _default_free_port() -> int:
         s.close()
 
 
-async def _default_materialize(*, workspace_id: str, user_id: str, pocket_id: str) -> str:
+async def _default_materialize(
+    *, workspace_id: str, user_id: str, pocket_id: str, builder_origin: str | None = None
+) -> str:
     """Default source-materialize: run the generator into the PERSISTENT per-pocket
     dir (PERF-3 — node_modules already cached there) and return the SvelteKit
     project dir `vite dev` runs in. We reuse the same build path the preview/edit
     flow uses with ``smoke=False`` (the workerd render is a publish-only gate,
     PERF-4) — generate + cached install is all the dev server needs before it can
     serve + HMR. Reads the pocket's draft content via the sites service the same way
-    a preview build does. Replaced in tests by an injected fake."""
+    a preview build does. Replaced in tests by an injected fake.
+
+    ``builder_origin`` (S1) is threaded into the GENERATE step so the materialized
+    SOURCE carries SE-1's gated section anchors + postMessage edit-bridge — the same
+    injection the static ``/editable`` build gets. It rides
+    ``siteConfig.builderOrigin`` and the generator gates the injection on it, so when
+    it is None/empty the dev source is materialized WITHOUT the bridge (the gate
+    holds, matching the publish path's non-editable behaviour). Only the
+    generate/scaffold step needs it — ``static_build`` stays ``False``."""
     from pocketpaw_ee.cloud.pockets import service as pockets_service
     from pocketpaw_ee.sites.generator_client import GeneratorClient
 
@@ -183,6 +211,12 @@ async def _default_materialize(*, workspace_id: str, user_id: str, pocket_id: st
         capture_signed_key="dev-preview",
         engine=engine,
         source=source,
+        # S1: the EDITABLE builder origin. Threaded into the generate/scaffold step so
+        # the dev-served SOURCE carries the gated edit-bridge (mirrors the /editable
+        # build). Gated by the generator: None/empty → no bridge injected, so the dev
+        # source stays non-editable when no origin is supplied. Sourced upstream the
+        # same way /editable sources it (request Origin → PAW_SITES_BUILDER_ORIGIN).
+        builder_origin=builder_origin,
         # PERF-3: build into the stable per-pocket working dir (cached node_modules).
         pocket_id=f"dev-{pocket_id}",
         # PERF-4: the dev server never needs the workerd smoke render.
@@ -193,6 +227,8 @@ async def _default_materialize(*, workspace_id: str, user_id: str, pocket_id: st
         # dev`). Forcing the static build here would add a wasted full prod build
         # before every dev-server start. (The static build is REQUIRED only on the
         # served preview/publish path — that is where the #1 stale-build bug lived.)
+        # S1: ONLY the generate step needs builder_origin for the source injection —
+        # static_build stays False (the bridge is in the SOURCE, not the prod output).
         static_build=False,
     )
     return build.project_dir
@@ -234,10 +270,23 @@ class DevServerManager:
 
     # --- public API --------------------------------------------------------
 
-    async def ensure_dev_server(self, *, workspace_id: str, user_id: str, pocket_id: str) -> str:
+    async def ensure_dev_server(
+        self,
+        *,
+        workspace_id: str,
+        user_id: str,
+        pocket_id: str,
+        builder_origin: str | None = None,
+    ) -> str:
         """Return the dev URL for the pocket's live `vite dev` server, starting it
         if needed. A second call for a running pocket touches it (LRU bump) and
-        returns the same URL without respawning."""
+        returns the same URL without respawning.
+
+        ``builder_origin`` (S1) is forwarded to ``_materialize`` so the dev-served
+        SOURCE carries SE-1's gated edit-bridge — the hover-edit overlay then works
+        against the dev server. It only matters on the spawn path (a reused running
+        server already materialized its source); a None/empty origin materializes a
+        non-bridged source (the generator's gate holds)."""
         lock = self._lock_for(pocket_id)
         async with lock:
             existing = self._servers.get(pocket_id)
@@ -254,7 +303,10 @@ class DevServerManager:
             await self._enforce_cap()
 
             project_dir = await self._materialize(
-                workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id
+                workspace_id=workspace_id,
+                user_id=user_id,
+                pocket_id=pocket_id,
+                builder_origin=builder_origin,
             )
             port = self._free_port()
             cmd = _dev_cmd_argv(port, self.host)
@@ -415,10 +467,18 @@ def get_manager() -> DevServerManager:
     return _MANAGER
 
 
-async def ensure_dev_server(*, workspace_id: str, user_id: str, pocket_id: str) -> str:
-    """Module-level convenience over the singleton — the endpoint calls this."""
+async def ensure_dev_server(
+    *, workspace_id: str, user_id: str, pocket_id: str, builder_origin: str | None = None
+) -> str:
+    """Module-level convenience over the singleton — the endpoint calls this.
+
+    ``builder_origin`` (S1) is forwarded so the dev-served source carries the gated
+    edit-bridge (see ``DevServerManager.ensure_dev_server``)."""
     return await get_manager().ensure_dev_server(
-        workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        builder_origin=builder_origin,
     )
 
 

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -78,6 +78,17 @@
 # `vite dev` per pocket, HMR in ~ms vs a per-edit rebuild). Carries fabric.write (it
 # spawns a process / mutates server state); a missing pocket is a 404 (the pockets
 # service raises NotFound during materialize). Publish/editable are unchanged.
+# Updated 2026-06-26 (feat/sites-dev-bridge-source, S1 — dev source carries the
+# edit-bridge): dev_preview_by_pocket now resolves a ``builder_origin`` (the
+# request ``Origin`` header, with the PAW_SITES_BUILDER_ORIGIN env fallback applied
+# in the service) and threads it to dev_preview_pocket → ensure_dev_server →
+# _default_materialize → GeneratorClient.build(builder_origin=..., static_build=
+# False). This makes the dev-server-materialized SOURCE carry SE-1's section anchors
+# + gated edit-bridge (mirroring /editable's origin precedence), so the hover-edit
+# overlay works against the dev server — without it the dev path materialized
+# anchorless source and flipping BRIDGE_IN_DEV regressed the overlay. static_build
+# stays False (no prod build on the dev path — only the generate/scaffold step needs
+# builder_origin for the source injection).
 # Updated 2026-06-19 (P2b-backend — revert endpoint): added POST
 # /sites/by-pocket/{pocket_id}/versions/{version_no}/revert — revert a pocket's site
 # to a prior version by ordinal. Delegates to sites_service.revert_pocket_version,
@@ -221,6 +232,7 @@ async def preview_by_pocket(
 @router.post("/sites/by-pocket/{pocket_id}/dev-preview", response_model=DevPreviewResponse)
 async def dev_preview_by_pocket(
     pocket_id: str,
+    request: Request,
     ctx: RequestContext = Depends(request_context),
     _: object = Depends(require_action_any_workspace("fabric.write")),
 ) -> DevPreviewResponse:
@@ -233,11 +245,24 @@ async def dev_preview_by_pocket(
     (PERF-3 persistent dir, cached node_modules) and started on an ephemeral port.
     Publish / make_site_editable are unchanged — this is the editing preview only.
 
+    The materialized dev source carries the gated edit-bridge so the hover-edit
+    overlay works against the dev server. The builder origin is resolved the SAME
+    way as ``/editable``: the request's ``Origin`` header (the dashboard the call
+    came from), with the service falling back to the configured
+    ``PAW_SITES_BUILDER_ORIGIN`` when the header is absent, so the dev-served source
+    is anchored + bridged exactly like the static editable build.
+
     Carries fabric.write (it spawns a process / mutates server state), matching the
     other by-pocket write actions. A missing / access-denied pocket surfaces as a
     404 (the pockets service raises NotFound itself during materialize)."""
+    # Mirror /editable's origin resolution: the request Origin header here; the
+    # service applies the PAW_SITES_BUILDER_ORIGIN env fallback when it is blank.
+    builder_origin = request.headers.get("origin") or ""
     return await sites_service.dev_preview_pocket(
-        workspace_id=ctx.workspace_id, user_id=ctx.user_id, pocket_id=pocket_id
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user_id,
+        pocket_id=pocket_id,
+        builder_origin=builder_origin,
     )
 
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,19 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-26 (feat/sites-dev-bridge-source, S1 — dev source carries the
+# edit-bridge): ``dev_preview_pocket`` gained an optional ``builder_origin`` and
+# threads it to ``get_manager().ensure_dev_server(builder_origin=...)`` so the
+# dev-server-materialized SOURCE carries SE-1's section anchors + gated edit-bridge
+# (the hover-edit overlay then works against the dev server, not only the static
+# /editable build). The origin is resolved the SAME way ``make_site_editable``
+# resolves it — the passed origin (the router's request ``Origin`` header) when
+# present, else the ``_builder_origin()`` env fallback (PAW_SITES_BUILDER_ORIGIN) —
+# so no new sourcing mechanism is invented. The dev path keeps ``static_build=False``
+# (no prod build); only the generate/scaffold step needs the origin for the gated
+# source injection, and an empty/unset origin still yields a non-bridged source (the
+# generator's gate holds).
+#
 # Updated 2026-06-25 (feat/sites-workers-deploy-mode — workers.dev deploy mode):
 # ``_deploy_site_doc`` now picks one of THREE deploy targets via a new
 # ``_deploy_mode()`` helper reading PAW_CF_DEPLOY_MODE (``local`` | ``workers`` |
@@ -2425,6 +2438,7 @@ async def dev_preview_pocket(
     workspace_id: str,
     user_id: str,
     pocket_id: str,
+    builder_origin: str | None = None,
 ) -> DevPreviewResponse:
     """Ensure a live Vite dev-server is running for the pocket and return its URL
     (Phase 2 / P2a — the EDITING preview).
@@ -2437,6 +2451,17 @@ async def dev_preview_pocket(
     workerd smoke render is NOT run for the dev server (it is a publish-only gate,
     PERF-4); publish() is unchanged and still does the full prod build + smoke.
 
+    ``builder_origin`` (S1) makes the dev-materialized SOURCE carry SE-1's gated
+    section anchors + postMessage edit-bridge so the hover-edit overlay works against
+    the dev server. It is resolved the SAME way ``make_site_editable`` resolves it —
+    the passed origin (the request ``Origin`` header at the router) when present, else
+    the configured ``PAW_SITES_BUILDER_ORIGIN`` (``_builder_origin()``) — so the dev
+    source is anchored + bridged exactly like the static editable build. It is threaded
+    to the manager → ``_default_materialize`` → ``GeneratorClient.build`` and rides
+    ``siteConfig.builderOrigin``; the generator gates the injection on it, so an
+    empty origin still produces a non-bridged source (the gate holds). The dev path
+    keeps ``static_build=False`` — only the generate/scaffold step needs the origin.
+
     ``user_id`` is threaded through so the manager reads the pocket via the pockets
     service under the caller's scope (it raises NotFound / Forbidden itself, mapped
     by the router to 404 / 403). ``workspace_id`` keeps the surface uniform and
@@ -2444,8 +2469,15 @@ async def dev_preview_pocket(
     """
     from pocketpaw_ee.sites.dev_server import get_manager
 
+    # Mirror make_site_editable's origin resolution: the passed origin (request
+    # Origin header) when present, else the PAW_SITES_BUILDER_ORIGIN env fallback.
+    origin = (builder_origin or "").strip() or _builder_origin()
+
     url = await get_manager().ensure_dev_server(
-        workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        builder_origin=origin,
     )
     return DevPreviewResponse(pocket_id=pocket_id, url=url)
 

--- a/tests/ee/sites/test_dev_bridge_source.py
+++ b/tests/ee/sites/test_dev_bridge_source.py
@@ -1,0 +1,351 @@
+# tests/ee/sites/test_dev_bridge_source.py
+# Created: 2026-06-26 (feat/sites-dev-bridge-source, S1 — the CRUX slice): prove the
+# DEV-server-materialized SOURCE carries the gated edit-bridge so flipping
+# BRIDGE_IN_DEV later won't regress the hover-edit overlay.
+#
+# THE GAP this covers: the dev-server HMR path (dev_server._default_materialize)
+# calls GeneratorClient().build(static_build=False) to SKIP the prod `bun run build`
+# (the speed win) and serve from SOURCE via `vite dev`. But it did NOT thread a
+# ``builder_origin`` into the build, so the dev-served source had NO data-paw-section
+# anchors and NO edit-bridge — flipping BRIDGE_IN_DEV without this is exactly the
+# 2026-06-19 overlay regression that got backed out. The static /editable path DOES
+# pass builder_origin (request Origin → PAW_SITES_BUILDER_ORIGIN fallback); S1
+# mirrors that on the dev path: dev-preview endpoint → dev_preview_pocket →
+# ensure_dev_server → _default_materialize → build(builder_origin=..., static_build=
+# False). Only the generate/scaffold step needs the origin; the prod build still
+# never runs on the dev path.
+#
+# TWO proofs, both driving the REAL _default_materialize → REAL GeneratorClient.build
+# (the actual S1 arg-threading), differing only in the generator behind it:
+#
+#   1. test_dev_materialized_source_carries_bridge / _absent_without_origin
+#      (REAL GENERATED SOURCE) — points PAW_SITES_GEN_CMD at the local paw-sites
+#      generator that has the SE-1 gated injection (PR #14) and asserts the
+#      materialized SOURCE FILES on disk: the composed section component's root has
+#      data-paw-section="..." AND app.html (source) carries the gated edit-bridge IIFE
+#      (id="paw-edit-bridge", the paw_edit flag, the origin). With no builder_origin
+#      the gate holds — neither anchors nor bridge. SKIPPED when no such generator is
+#      found (it needs node + the #14 build), so CI stays green without the toolchain.
+#
+#   2. test_dev_path_threads_builder_origin_into_build / _omits_when_unset
+#      (ARG-THREADING, always runs) — drives _default_materialize through a real
+#      GeneratorClient whose _runner is a FAKE that (a) RECORDS the siteConfig it is
+#      called with (so we assert build() received builder_origin on the dev path) and
+#      (b) writes anchored+bridged SOURCE to disk ONLY when siteConfig.builderOrigin
+#      is set (mirroring the real generator's gate), so we still assert the
+#      materialized source carries the bridge — without needing node/bun in CI. Also
+#      pins static_build stays False (the dev speed win is preserved).
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+# A minimal svelte pocket whose +page.svelte composes one section component (Hero),
+# so the generator's stampSectionAnchors has a top-level section to anchor.
+_HERO = '<section class="hero"><h1>Bright Smile</h1></section>\n'
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte';</script>\n<Hero/>\n"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css';</script>\n<slot/>\n",
+    "src/routes/+page.ts": "export const prerender = true;\n",
+    "src/app.css": ":root{--brand:#0A84FF}\n",
+    "src/lib/components/Hero.svelte": _HERO,
+}
+
+_BUILDER_ORIGIN = "http://localhost:8888"
+
+
+def _pocket_wire() -> dict:
+    """The pocket dict ``_default_materialize`` reads (engine/source/name/theme)."""
+    return {
+        "name": "Bright Smile",
+        "engine": "svelte",
+        "source": dict(_SVELTE_SOURCE),
+        "rippleSpec": {"theme": {"primary": "#0A84FF"}},
+    }
+
+
+# --------------------------------------------------------------------------------
+# Proof 1 — REAL GENERATED SOURCE (skipped when the #14 generator isn't available).
+# --------------------------------------------------------------------------------
+
+
+def _real_gen_cmd() -> list[str] | None:
+    """Locate a paw-sites generator that has the SE-1 gated edit-bridge injection
+    (PR #14). Prefer an explicit PAW_SITES_GEN_CMD; else probe the known local
+    checkouts' built ``dist/cli.js``. Returns the argv to run, or None if none has
+    the #14 injection (then the real-source proof skips and proof 2 still runs)."""
+    explicit = os.environ.get("PAW_SITES_DEV_BRIDGE_GEN_CMD") or os.environ.get("PAW_SITES_GEN_CMD")
+    if explicit:
+        import shlex
+
+        argv = shlex.split(explicit)
+        if argv and (shutil.which(argv[0]) or Path(argv[0]).exists()):
+            return argv
+
+    node = shutil.which("node")
+    if not node:
+        return None
+    # Known local checkouts that build the generator. The SE-1 injection (PR #14)
+    # lives in edit-bridge.{ts,js}; only a dist that carries the gated injection
+    # produces the bridged source, so we require the marker token in the build.
+    candidates = [
+        Path.home() / "Documents/paw-worktrees/intg-paw-sites/dist/cli.js",
+        Path.home() / "Documents/paw-workspace/paw-sites/dist/cli.js",
+    ]
+    for cli in candidates:
+        if not cli.is_file():
+            continue
+        dist = cli.parent
+        injects = any(
+            (dist / name).is_file()
+            and "data-paw-section" in (dist / name).read_text(errors="ignore")
+            and "builderOrigin" in (dist / name).read_text(errors="ignore")
+            for name in ("index.js", "svelte-scaffold.js", "edit-bridge.js")
+        )
+        if injects:
+            return [node, str(cli)]
+    return None
+
+
+_REAL_GEN = _real_gen_cmd()
+_skip_no_gen = pytest.mark.skipif(
+    _REAL_GEN is None,
+    reason="no paw-sites generator with the SE-1 (#14) gated edit-bridge injection found",
+)
+
+
+async def _materialize_real(*, builder_origin: str | None, tmp_path: Path, monkeypatch) -> Path:
+    """Run the REAL dev-path materialize against the real generator and return the
+    materialized project dir. Threads through the actual S1 code path:
+    _default_materialize → GeneratorClient().build(builder_origin=..., static_build=
+    False). bun install / static build never run (static_build=False), so this needs
+    only ``node`` + the generator — no bun/workerd."""
+    from pocketpaw_ee.sites import dev_server
+
+    monkeypatch.setenv("PAW_SITES_GEN_CMD", " ".join(_REAL_GEN))  # type: ignore[arg-type]
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path / "builds"))
+
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=_pocket_wire()),
+    ):
+        project_dir = await dev_server._default_materialize(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            builder_origin=builder_origin,
+        )
+    return Path(project_dir)
+
+
+@_skip_no_gen
+async def test_dev_materialized_source_carries_bridge(tmp_path, monkeypatch):
+    """S1 CRUX (real source): the dev-materialized SOURCE — with a builder_origin —
+    carries the bridge. The composed section component's root has data-paw-section,
+    and app.html (SOURCE, not build output) contains the gated edit-bridge IIFE. This
+    is exactly what the hover-edit overlay needs once BRIDGE_IN_DEV is flipped."""
+    project_dir = await _materialize_real(
+        builder_origin=_BUILDER_ORIGIN, tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
+
+    hero = project_dir / "src/lib/components/Hero.svelte"
+    assert hero.is_file(), f"no Hero component at {hero}"
+    hero_src = hero.read_text()
+    assert "data-paw-section" in hero_src, (
+        "the composed section component's SOURCE root has no data-paw-section anchor "
+        "— the hover-edit overlay can't bind a section"
+    )
+
+    app_html = project_dir / "src/app.html"
+    assert app_html.is_file(), f"no app.html source at {app_html}"
+    bridge_src = app_html.read_text()
+    assert 'id="paw-edit-bridge"' in bridge_src, (
+        "app.html SOURCE has no gated edit-bridge IIFE — the dev-served page can't "
+        "postMessage section rects"
+    )
+    # The IIFE references the paw_edit gate flag and the builder origin.
+    assert "paw_edit" in bridge_src
+    assert _BUILDER_ORIGIN in bridge_src
+
+
+@_skip_no_gen
+async def test_dev_materialized_source_no_bridge_without_origin(tmp_path, monkeypatch):
+    """The gate holds (real source): with NO builder_origin the dev-materialized
+    SOURCE carries neither anchors nor bridge — the generator injects only when the
+    origin is set, so the dev source stays non-editable (matches the publish path's
+    non-editable behaviour)."""
+    project_dir = await _materialize_real(
+        builder_origin=None, tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
+
+    hero_src = (project_dir / "src/lib/components/Hero.svelte").read_text()
+    assert "data-paw-section" not in hero_src, "anchor leaked with no builder_origin"
+
+    app_html = project_dir / "src/app.html"
+    if app_html.is_file():
+        assert 'id="paw-edit-bridge"' not in app_html.read_text(), (
+            "edit-bridge leaked into app.html with no builder_origin — the gate broke"
+        )
+
+
+# --------------------------------------------------------------------------------
+# Proof 2 — ARG-THREADING via a fake runner (always runs in CI; no node/bun needed).
+# --------------------------------------------------------------------------------
+
+# The exact source-injection tokens the real SE-1 generator emits (mirrored so the
+# fake's gated output matches what the overlay looks for).
+_FAKE_ANCHORED_HERO = (
+    '<section data-paw-section="Hero" class="hero"><h1>Bright Smile</h1></section>\n'
+)
+
+
+def _fake_bridge_app_html(origin: str) -> str:
+    return (
+        "<!doctype html><html><head>%sveltekit.head%</head>"
+        "<body><div>%sveltekit.body%</div>"
+        f'<script id="paw-edit-bridge">(function(){{'
+        f"var p=new URLSearchParams(location.search);"
+        f"if(p.get('paw_edit')!=='1')return;"
+        f"window.parent.postMessage({{}}, {json.dumps(origin)});"
+        f"}})();</script></body></html>"
+    )
+
+
+class _GatedFakeRunner:
+    """A fake GeneratorClient runner that mirrors the real generator's CONTRACT for
+    this test: it RECORDS the siteConfig it was called with (so we assert build()
+    forwarded builder_origin on the dev path), and it materializes svelte SOURCE to
+    disk, injecting the data-paw-section anchor + the gated edit-bridge into app.html
+    ONLY when ``siteConfig.builderOrigin`` is present — exactly the SE-1 gate. No
+    install/build_static here: the dev path passes static_build=False, so those never
+    run (which this test also pins)."""
+
+    def __init__(self) -> None:
+        self.generate_site_config: dict | None = None
+        self.install_called = False
+        self.build_static_called = False
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        site_config = input_json.get("siteConfig", {})
+        self.generate_site_config = site_config
+        origin = site_config.get("builderOrigin")
+        src = input_json.get("source", {})
+
+        proj = Path(out_dir)
+        proj.mkdir(parents=True, exist_ok=True)
+        # Write the svelte source map to disk (what materializeSource does).
+        for rel, contents in src.items():
+            p = proj / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(contents)
+        # The generator always materializes app.html; the gated injection only fires
+        # when builderOrigin is set.
+        app_html = proj / "src/app.html"
+        app_html.parent.mkdir(parents=True, exist_ok=True)
+        if origin:
+            # Stamp the composed section root (mirrors stampSectionAnchors).
+            (proj / "src/lib/components/Hero.svelte").write_text(_FAKE_ANCHORED_HERO)
+            app_html.write_text(_fake_bridge_app_html(origin))
+        else:
+            app_html.write_text("<!doctype html><html><head></head><body></body></html>")
+        return {"projectDir": str(proj), "engine": "svelte"}
+
+    def install_inputs_hash(self, project_dir: str) -> str:
+        return "h1"
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        self.install_called = True
+        return True, "ok"
+
+    async def build_static(self, project_dir: str, *, gate: bool) -> tuple[bool, str]:
+        # The dev path must NEVER call this (static_build=False).
+        self.build_static_called = True
+        return True, "ok"
+
+
+async def _materialize_with_fake_runner(
+    *, builder_origin: str | None, tmp_path: Path, monkeypatch
+) -> tuple[Path, _GatedFakeRunner]:
+    """Drive the REAL _default_materialize, but with the GeneratorClient constructed
+    with a fake runner, so the actual S1 arg-threading (materialize → build) runs
+    end-to-end without node/bun. We inject the fake runner by patching the
+    GeneratorClient the materialize constructs."""
+    from pocketpaw_ee.sites import dev_server, generator_client
+
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path / "builds"))
+    runner = _GatedFakeRunner()
+
+    real_client_cls = generator_client.GeneratorClient
+
+    def _client_factory(*_args, **_kwargs) -> generator_client.GeneratorClient:
+        # _default_materialize calls ``GeneratorClient()`` (no runner) — return one
+        # backed by our gated fake so the real build() arg-threading runs without bun.
+        return real_client_cls(_runner=runner)
+
+    # _default_materialize imports GeneratorClient from generator_client at call time
+    # (``from ... import GeneratorClient``), so patch it on the source module.
+    with (
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=_pocket_wire()),
+        ),
+        patch.object(generator_client, "GeneratorClient", _client_factory),
+    ):
+        project_dir = await dev_server._default_materialize(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            builder_origin=builder_origin,
+        )
+    return Path(project_dir), runner
+
+
+async def test_dev_path_threads_builder_origin_into_build(tmp_path, monkeypatch):
+    """S1 arg-threading: the dev path forwards builder_origin all the way into the
+    generate step (build() puts it on siteConfig.builderOrigin), and keeps
+    static_build=False (no prod build — the dev speed win). The materialized SOURCE
+    then carries the bridge."""
+    project_dir, runner = await _materialize_with_fake_runner(
+        builder_origin=_BUILDER_ORIGIN, tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
+
+    # build() received the origin and put it on the generator input's siteConfig.
+    assert runner.generate_site_config is not None
+    assert runner.generate_site_config.get("builderOrigin") == _BUILDER_ORIGIN
+    # The dev path NEVER runs the prod static build (the whole point — vite dev only).
+    assert runner.build_static_called is False, "the dev path must not run `bun run build`"
+
+    # And the materialized SOURCE carries the bridge (anchors + gated IIFE).
+    hero_src = (project_dir / "src/lib/components/Hero.svelte").read_text()
+    assert "data-paw-section" in hero_src
+    bridge_src = (project_dir / "src/app.html").read_text()
+    assert 'id="paw-edit-bridge"' in bridge_src
+    assert "paw_edit" in bridge_src
+    assert _BUILDER_ORIGIN in bridge_src
+
+
+async def test_dev_path_omits_origin_when_unset(tmp_path, monkeypatch):
+    """The gate holds end-to-end: with no builder_origin the generator input carries
+    no builderOrigin and the materialized SOURCE has neither anchors nor bridge."""
+    project_dir, runner = await _materialize_with_fake_runner(
+        builder_origin=None, tmp_path=tmp_path, monkeypatch=monkeypatch
+    )
+
+    assert runner.generate_site_config is not None
+    # build() omits builderOrigin from siteConfig when the origin is None/empty.
+    assert "builderOrigin" not in runner.generate_site_config
+    assert runner.build_static_called is False
+
+    hero_src = (project_dir / "src/lib/components/Hero.svelte").read_text()
+    assert "data-paw-section" not in hero_src
+    bridge_src = (project_dir / "src/app.html").read_text()
+    assert 'id="paw-edit-bridge"' not in bridge_src

--- a/tests/ee/sites/test_dev_server.py
+++ b/tests/ee/sites/test_dev_server.py
@@ -2,6 +2,13 @@
 # Created: 2026-06-18 (feat/sites-devserver, Phase 2 / P2a) — unit tests for the
 # live Vite dev-server preview manager (ee/pocketpaw_ee/sites/dev_server.py).
 #
+# Updated 2026-06-26 (feat/sites-dev-bridge-source, S1 — dev source carries the
+# edit-bridge): the fake ``_materialize`` seams now accept the new ``builder_origin``
+# kwarg ``ensure_dev_server`` threads through, and ``test_ensure_threads_builder_
+# origin_to_materialize`` pins that the origin reaches the materialize seam (the
+# manager-level half of the dev-path threading — the source-level proof that the
+# materialized files carry the bridge lives in test_dev_bridge_source.py).
+#
 # The manager spawns a long-lived `vite dev` per pocket so edits hot-reload in ~ms
 # instead of rebuilding the whole site per edit. These tests exercise the FULL
 # lifecycle WITHOUT a real vite/bun: the spawner, the free-port allocator, and the
@@ -54,11 +61,15 @@ def _make_manager(
     def _free_port() -> int:
         return next(probe["ports"])
 
-    async def _materialize(*, workspace_id: str, user_id: str, pocket_id: str) -> str:
+    async def _materialize(
+        *, workspace_id: str, user_id: str, pocket_id: str, builder_origin: str | None = None
+    ) -> str:
         # The real seam runs GeneratorClient.build(preview) and returns the
-        # persistent per-pocket project dir; the fake just records the call and
-        # returns a deterministic path so the spawn cwd is observable.
+        # persistent per-pocket project dir; the fake just records the call (incl.
+        # the S1 builder_origin) and returns a deterministic path so the spawn cwd
+        # is observable.
         probe["materialized"].append(pocket_id)
+        probe.setdefault("builder_origins", []).append(builder_origin)
         return f"/tmp/site-builds/{pocket_id}"
 
     async def _spawn(cmd: list[str], cwd: str, port: int) -> _FakeProc:
@@ -93,6 +104,37 @@ async def test_ensure_starts_once_and_reuses_on_second_call():
     # Exactly ONE spawn + ONE materialize across both calls.
     assert len(probe["spawned"]) == 1
     assert probe["materialized"] == ["pk1"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_threads_builder_origin_to_materialize():
+    """S1: ensure_dev_server forwards ``builder_origin`` to the materialize seam, so
+    the dev-server-materialized SOURCE can carry SE-1's gated edit-bridge. Before S1
+    the dev path materialized with no origin, so the dev source had no anchors / no
+    bridge (flipping BRIDGE_IN_DEV regressed the overlay)."""
+    mgr, probe = _make_manager()
+
+    await mgr.ensure_dev_server(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        builder_origin="https://app.paw.example",
+    )
+
+    # The origin reached materialize verbatim (it then rides build()'s builder_origin).
+    assert probe["builder_origins"] == ["https://app.paw.example"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_without_builder_origin_passes_none():
+    """The gate still holds: with no ``builder_origin``, materialize is called with
+    None, so the generator injects no bridge and the dev source stays non-editable
+    (matches the publish path's non-editable behaviour)."""
+    mgr, probe = _make_manager()
+
+    await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk1")
+
+    assert probe["builder_origins"] == [None]
 
 
 @pytest.mark.asyncio
@@ -181,7 +223,9 @@ async def test_concurrent_ensure_spawns_only_once():
     def _free_port() -> int:
         return next(probe["ports"])
 
-    async def _materialize(*, workspace_id: str, user_id: str, pocket_id: str) -> str:
+    async def _materialize(
+        *, workspace_id: str, user_id: str, pocket_id: str, builder_origin: str | None = None
+    ) -> str:
         await asyncio.sleep(0.02)  # force interleave
         return f"/tmp/site-builds/{pocket_id}"
 

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -267,11 +267,18 @@ async def test_dev_preview_by_pocket_returns_url(beanie_test_db, monkeypatch):
     Vite dev-server URL for the editing preview (P2a). The route delegates to
     sites_service.dev_preview_pocket → the DevServerManager singleton; we inject a
     manager built with fake spawn/port/materialize seams so no real vite is spawned,
-    exercising the real service→manager→endpoint path end to end."""
+    exercising the real service→manager→endpoint path end to end.
+
+    S1: the fake materialize also records the ``builder_origin`` the manager forwards
+    so we assert the endpoint resolves the request ``Origin`` header (the dev source
+    then carries the gated edit-bridge), mirroring the /editable origin precedence."""
     import pocketpaw_ee.sites.dev_server as dev_server_mod
     from pocketpaw_ee.sites.dev_server import DevServerManager
 
-    async def _fake_materialize(*, workspace_id, user_id, pocket_id):
+    seen: dict = {}
+
+    async def _fake_materialize(*, workspace_id, user_id, pocket_id, builder_origin=None):
+        seen["builder_origin"] = builder_origin
         return f"/tmp/site-builds/{pocket_id}"
 
     async def _fake_spawn(cmd, cwd, port):
@@ -296,12 +303,61 @@ async def test_dev_preview_by_pocket_returns_url(beanie_test_db, monkeypatch):
 
     app = _build_app("ws_owner", monkeypatch)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
-        resp = await c.post("/api/v1/sites/by-pocket/pk1/dev-preview")
+        resp = await c.post(
+            "/api/v1/sites/by-pocket/pk1/dev-preview",
+            headers={"origin": "https://dash.paw.example"},
+        )
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body == {"pocket_id": "pk1", "url": "http://127.0.0.1:41234/"}
     # The endpoint actually started a server in the singleton.
     assert mgr.live_pocket_ids() == ["pk1"]
+    # S1: the request Origin header was sourced + threaded to materialize (same
+    # precedence /editable uses), so the dev source carries the edit-bridge.
+    assert seen["builder_origin"] == "https://dash.paw.example"
+    await mgr.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_dev_preview_by_pocket_defaults_origin_from_config(beanie_test_db, monkeypatch):
+    """S1: with NO request Origin header, the dev-preview endpoint falls back to the
+    configured PAW_SITES_BUILDER_ORIGIN (the same env fallback /editable uses), so the
+    dev source is still bridged when the call carries no Origin."""
+    import pocketpaw_ee.sites.dev_server as dev_server_mod
+    from pocketpaw_ee.sites.dev_server import DevServerManager
+
+    monkeypatch.setenv("PAW_SITES_BUILDER_ORIGIN", "https://configured.paw.example")
+    seen: dict = {}
+
+    async def _fake_materialize(*, workspace_id, user_id, pocket_id, builder_origin=None):
+        seen["builder_origin"] = builder_origin
+        return f"/tmp/site-builds/{pocket_id}"
+
+    async def _fake_spawn(cmd, cwd, port):
+        class _P:
+            returncode = None
+
+            def terminate(self):
+                pass
+
+            def kill(self):
+                pass
+
+            async def wait(self):
+                return 0
+
+        return _P()
+
+    mgr = DevServerManager(
+        _spawn=_fake_spawn, _free_port=lambda: 41235, _materialize=_fake_materialize
+    )
+    monkeypatch.setattr(dev_server_mod, "_MANAGER", mgr)
+
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/by-pocket/pk1/dev-preview")
+    assert resp.status_code == 200, resp.text
+    assert seen["builder_origin"] == "https://configured.paw.example"
     await mgr.stop_all()
 
 


### PR DESCRIPTION
## What this does (S1 of the editable-preview dev-HMR fix)

The dev-server HMR preview path (`dev_server.py` → `vite dev` per pocket, `static_build=False`, instant HMR) materialized its source **without** `builder_origin` — so the generator's gated edit-bridge injection (the `data-paw-section` anchors + the postMessage IIFE, which fire only when `builderOrigin` is set) never ran. The dev-served source had no anchors/bridge, which is why `BRIDGE_IN_DEV` is held `false` (flipping it without this is the 2026-06-19 overlay regression).

This threads `builder_origin` through the dev-preview path, **mirroring the `/editable` path exactly** (request `Origin` header → `PAW_SITES_BUILDER_ORIGIN` env fallback): `router.dev_preview_by_pocket` → `service.dev_preview_pocket` → `ensure_dev_server` → `_default_materialize` → `GeneratorClient.build(builder_origin=…, static_build=False)`. `static_build` stays `False` — only the generate/scaffold step gets the origin, so there's still no per-edit prod build.

## Tests

`tests/ee/sites/test_dev_bridge_source.py` — real-generated-source proof (the materialized `Hero.svelte` root carries `data-paw-section`, `app.html` source carries the gated IIFE; both absent when origin unset) + CI-safe arg-threading proof (build receives `builder_origin`, `static_build` stays False). Endpoint origin-sourcing + seam tests too. Targeted run: 17 passed; full sites suite 286 passed, 1 skipped.

## Sequence note

This is S1 of Option A in `docs/design/drafts/2026-06-26-editable-preview-speedup.md`. It must land + deploy together with the generator re-vendor (S2) **before** the FE flips `BRIDGE_IN_DEV=true` (S3), or the dev overlay won't arm.
