### PR TITLE
feat(cloud): per-workspace versioned file writes (file_versions)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -49,6 +49,12 @@ instead of firing an HTTP write, and the new
 GET /workspaces/{ws}/jobs/{job_id} status poll. Jobs run on the shared ARQ
 worker under the synthetic `system:workspace_job` identity and merge their
 results back into the pocket's `state` over the live update bridge.
+
+Updated: 2026-06-26 (ART-1) — documented the Files — Versioned Writes
+section: POST /files/write, PUT /files/{id}, and the two version-history
+reads (GET /files/{id}/versions[/{vid}]). The write path archives each
+prior blob as a FileVersionDoc and bumps a per-file content_version counter;
+every read is workspace-scoped.
 -->
 
 # Cloud REST API Reference
@@ -938,3 +944,67 @@ Response `200`:
 conversion, a pricing-rules engine, and disputes / clawback. This endpoint
 returns a raw sum of declared values — the queryable figure those layers
 will build on later (see `outcome-spec.md`).
+
+## Files — Versioned Writes
+
+The `file_versions` entity layers a versioned write path over the uploads
+storage adapter. A file's live (current) content lives in the
+StorageAdapter; each edit archives the prior blob as a `FileVersionDoc` row
+and bumps a per-file `content_version` counter on the `FileUpload` record.
+All four routes share the `/files` prefix with the listing router (`GET
+/files`, `/files/tree`, `/files/browse`) without collision, require a valid
+license, and are workspace-scoped — every read is filtered to the caller's
+workspace.
+
+### `POST /files/write`
+
+Create a file, or overwrite an existing one in place (versioned). Used for
+first-save and programmatic writes.
+
+Request body:
+
+```json
+{ "path": "<file id or path>", "content": "<full content>", "filename": "<optional display name>" }
+```
+
+Response `201`:
+
+```json
+{ "fileId": "<id>", "version": 1, "sizeBytes": 42 }
+```
+
+When a file already exists for `path`, the content is updated through the
+PUT path instead and `version` reflects the bumped counter.
+
+### `PUT /files/{file_id}`
+
+Replace a text file's content inline with optimistic concurrency. Body:
+
+```json
+{ "content": "<new text>", "expectedVersion": 3 }
+```
+
+`expectedVersion` (or the `If-Match: <version>` header, which takes
+precedence) guards against lost updates. Response `200`:
+
+```json
+{ "fileId": "<id>", "newVersion": 4, "sizeBytes": 57, "contentHash": "<sha256>" }
+```
+
+Returns `404` if the file is missing, `409` on a version conflict, and
+`422` if the file's mime type is not editable inline.
+
+### `GET /files/{file_id}/versions`
+
+List archived versions for a file (oldest first, content omitted). Returns
+only versions in the caller's workspace:
+
+```json
+[ { "id": "<oid>", "fileId": "<id>", "versionNumber": 2, "sizeBytes": 42,
+    "editorKind": "human", "editorId": "<user id>", "createdAt": "<iso>" } ]
+```
+
+### `GET /files/{file_id}/versions/{version_id}`
+
+Fetch a single archived version with its full content (for revert preview /
+diff). Workspace-scoped — a version id from another workspace returns `404`.

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -299,6 +299,7 @@ def mount_cloud(app: FastAPI) -> None:
             exc_info=True,
         )
 
+    from pocketpaw_ee.cloud.file_versions.router import router as file_versions_router
     from pocketpaw_ee.cloud.files.router import router as files_router
     from pocketpaw_ee.cloud.kb.knowledge_router import router as knowledge_router
 
@@ -335,6 +336,11 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(notifications_router, prefix="/api/v1")
     app.include_router(tasks_router, prefix="/api/v1")
     app.include_router(files_router, prefix="/api/v1")
+    # file_versions (ART-1) — versioned file-write storage spine. Shares the
+    # /files prefix with files_router (GET /files, /tree, /browse) but only
+    # adds POST /files/write, PUT /files/{id}, GET /files/{id}/versions[/{vid}]
+    # — no method+path collisions with the existing listing routes.
+    app.include_router(file_versions_router, prefix="/api/v1")
     app.include_router(mission_control_router, prefix="/api/v1")
     app.include_router(livekit_router, prefix="/api/v1")
     # Pocket outcomes — GET /api/v1/outcomes count surface (RFC 05 M2b.2).

--- a/ee/pocketpaw_ee/cloud/file_versions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/__init__.py
@@ -1,0 +1,5 @@
+# __init__.py — file_versions entity package.
+# Created: 2026-06-26 (ART-1) — versioned cloud file-write storage spine
+#   ported from dewani12's origin/feature/files. Holds the file-version
+#   core only (write/update/list/get); slides/spreadsheet/editor (Slice D)
+#   were intentionally excluded from the port.

--- a/ee/pocketpaw_ee/cloud/file_versions/domain.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/domain.py
@@ -1,0 +1,30 @@
+# domain.py — frozen FileVersion value object.
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files
+#   (ee/cloud/file_versions/domain.py) onto the current layout. No Beanie,
+#   no I/O — a pure value object carrying required tenancy (workspace_id).
+"""FileVersion domain value object."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+EditorKind = Literal["human", "agent"]
+
+
+@dataclass(frozen=True)
+class FileVersion:
+    id: str
+    file_id: str
+    workspace_id: str
+    version_number: int
+    content: str
+    content_hash: str
+    size_bytes: int
+    editor_kind: EditorKind
+    editor_id: str  # user_id or agent_id
+    created_at: datetime
+
+
+__all__ = ["EditorKind", "FileVersion"]

--- a/ee/pocketpaw_ee/cloud/file_versions/dto.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/dto.py
@@ -1,0 +1,82 @@
+# dto.py — request/response schemas for the file-version write API.
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files
+#   (ee/cloud/file_versions/dto.py). KEEPS the file-write/version core only:
+#   WriteFile{Request,Response}, UpdateFileContent{Request,Response}, and the
+#   version list/get DTOs. DROPPED the Slice-D editor transport DTOs
+#   (DiffResponse, AiEditRequest, AiEditResponse) — deferred, not ported.
+"""FileVersions DTOs — request/response schemas for the file-version API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class WriteFileRequest(BaseModel):
+    """Request body for POST /files/write — create or overwrite a file."""
+
+    path: str = Field(min_length=1)  # file id or path
+    content: str = Field(min_length=0)  # full file content
+    filename: str | None = None  # display name (defaults to path if omitted)
+
+
+class WriteFileResponse(BaseModel):
+    """Returned after POST /files/write."""
+
+    file_id: str = Field(alias="fileId")
+    version: int
+    size_bytes: int = Field(alias="sizeBytes")
+
+    model_config = {"populate_by_name": True}
+
+
+class UpdateFileContentRequest(BaseModel):
+    """Request body for PUT /files/{id}. Content is the full new text."""
+
+    content: str = Field(min_length=0)
+    # Expected version for If-Match. Omitted -> force-overwrite (escape hatch).
+    expected_version: int | None = Field(default=None, alias="expectedVersion")
+
+    model_config = {"populate_by_name": True}
+
+
+class UpdateFileContentResponse(BaseModel):
+    """Returned after a successful PUT /files/{id}."""
+
+    file_id: str = Field(alias="fileId")
+    new_version: int = Field(alias="newVersion")
+    size_bytes: int = Field(alias="sizeBytes")
+    content_hash: str = Field(alias="contentHash")
+
+    model_config = {"populate_by_name": True}
+
+
+class FileVersionListItem(BaseModel):
+    """One row in the version picker dropdown (content omitted)."""
+
+    id: str
+    file_id: str = Field(alias="fileId")
+    version_number: int = Field(alias="versionNumber")
+    size_bytes: int = Field(alias="sizeBytes")
+    editor_kind: str = Field(alias="editorKind")
+    editor_id: str = Field(alias="editorId")
+    created_at: datetime = Field(alias="createdAt")
+
+    model_config = {"populate_by_name": True}
+
+
+class FileVersionResponse(BaseModel):
+    """Full version payload including content (for revert / diff)."""
+
+    id: str
+    file_id: str = Field(alias="fileId")
+    version_number: int = Field(alias="versionNumber")
+    content: str
+    content_hash: str = Field(alias="contentHash")
+    size_bytes: int = Field(alias="sizeBytes")
+    editor_kind: str = Field(alias="editorKind")
+    editor_id: str = Field(alias="editorId")
+    created_at: datetime = Field(alias="createdAt")
+
+    model_config = {"populate_by_name": True}

--- a/ee/pocketpaw_ee/cloud/file_versions/dto.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/dto.py
@@ -4,6 +4,9 @@
 #   WriteFile{Request,Response}, UpdateFileContent{Request,Response}, and the
 #   version list/get DTOs. DROPPED the Slice-D editor transport DTOs
 #   (DiffResponse, AiEditRequest, AiEditResponse) — deferred, not ported.
+# Updated: 2026-06-26 (ART-1 quality fix loop, I2) — WriteFileRequest gained an
+#   optional `mime`; when omitted the service guesses from the filename
+#   extension instead of hardcoding application/json.
 """FileVersions DTOs — request/response schemas for the file-version API."""
 
 from __future__ import annotations
@@ -19,6 +22,9 @@ class WriteFileRequest(BaseModel):
     path: str = Field(min_length=1)  # file id or path
     content: str = Field(min_length=0)  # full file content
     filename: str | None = None  # display name (defaults to path if omitted)
+    # Explicit mime. When omitted the service guesses from the filename
+    # extension, defaulting to text/plain for extension-less paths.
+    mime: str | None = None
 
 
 class WriteFileResponse(BaseModel):

--- a/ee/pocketpaw_ee/cloud/file_versions/router.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/router.py
@@ -1,0 +1,88 @@
+# router.py — FastAPI router for the file-version write API.
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files
+#   (ee/cloud/file_versions/router.py). KEEPS the 4 core routes: POST
+#   /files/write, PUT /files/{id}, GET /files/{id}/versions,
+#   GET /files/{id}/versions/{vid}. DROPPED the Slice-D editor routes
+#   (revert, diff, ai-edit, editing/spreadsheet/slides-context). Thin
+#   pass-through: ``Depends(request_context)``, no Beanie, no HTTPException —
+#   the service raises CloudError subclasses and ``_core.http`` maps them to
+#   JSON. Coexists with the existing /files router (GET /files, /tree,
+#   /browse) — no method+path collisions.
+"""FileVersions router — file-version write + history API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import BadRequest
+from pocketpaw_ee.cloud.file_versions import service as _svc
+from pocketpaw_ee.cloud.file_versions.dto import (
+    FileVersionListItem,
+    FileVersionResponse,
+    UpdateFileContentRequest,
+    UpdateFileContentResponse,
+    WriteFileRequest,
+    WriteFileResponse,
+)
+from pocketpaw_ee.cloud.license import require_license
+
+router = APIRouter(
+    prefix="/files",
+    tags=["File Versions"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.post("/write", status_code=201, response_model=WriteFileResponse)
+async def write_file(
+    body: WriteFileRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WriteFileResponse:
+    """Create or overwrite a file. Returns the file id for subsequent versioned saves."""
+    return await _svc.write_file(ctx, body)
+
+
+@router.put("/{file_id}", response_model=UpdateFileContentResponse)
+async def update_file(
+    file_id: str,
+    body: UpdateFileContentRequest,
+    ctx: RequestContext = Depends(request_context),
+    if_match: str | None = Header(None, alias="If-Match"),
+) -> UpdateFileContentResponse:
+    """Replace a text file's content inline.
+
+    Body: ``{ content: "<new text>", expectedVersion?: <int> }``.
+    Header: ``If-Match: <current content_version>`` (optimistic concurrency)
+    takes precedence over ``expectedVersion`` when present.
+
+    Raises (mapped to JSON by ``_core.http``): 404 if the file is missing,
+    409 on a version conflict, 422 if the file type isn't editable.
+    """
+    # If-Match header (optimistic concurrency) wins over the body field.
+    if if_match is not None:
+        try:
+            body.expected_version = int(if_match.strip('"'))
+        except ValueError:
+            raise BadRequest("files.bad_version", "If-Match must be an integer.") from None
+
+    return await _svc.update_file_content(ctx, file_id, body)
+
+
+@router.get("/{file_id}/versions", response_model=list[FileVersionListItem])
+async def list_file_versions(
+    file_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> list[FileVersionListItem]:
+    """List all archived versions for a file (oldest first, no content)."""
+    return await _svc.list_versions(ctx, file_id)
+
+
+@router.get("/{file_id}/versions/{version_id}", response_model=FileVersionResponse)
+async def get_file_version(
+    file_id: str,
+    version_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> FileVersionResponse:
+    """Fetch a single version with full content (for revert preview / diff)."""
+    return await _svc.get_version(ctx, file_id, version_id)

--- a/ee/pocketpaw_ee/cloud/file_versions/service.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/service.py
@@ -10,7 +10,9 @@
 #     `${workspace}:${path}` (two workspaces can share a path); the bare path
 #     stays the client-facing id on FileVersionDoc, the DTOs, and the routes.
 #     write_file revives a soft-deleted tombstone in place instead of a blind
-#     insert (which would raise DuplicateKeyError on the tombstoned unique id).
+#     insert (which would raise DuplicateKeyError on the tombstoned unique id),
+#     and PURGES the dead file's FileVersionDoc rows on revive so the recreated
+#     file starts a fresh history (recreate = a new file at that path).
 #   I1 — a no-op (unchanged-content) update now returns the ACTUAL stored
 #     version, not a phantom +1.
 #   I2 — new files take a real mime (WriteFileRequest.mime, else guessed from
@@ -125,6 +127,10 @@ def _storage_id(workspace_id: str, path: str) -> str:
     neither collides on the unique key nor squats the other's path. The bare
     ``path`` stays the client-facing id everywhere else (FileVersionDoc,
     DTOs, routes); this value is only ever the FileUpload lookup/insert key.
+
+    Invariant: ``workspace_id`` is a colon-free 24-hex Mongo ObjectId, so the
+    first ``':'`` unambiguously splits ws from path — ``(ws, path) -> ws:path``
+    stays injective even when ``path`` itself contains a colon.
     """
     return f"{workspace_id}:{path}"
 
@@ -250,7 +256,13 @@ async def write_file(
     stored = await adapter.put(storage_key, _bytes_iter(content), mime)
 
     if doc is not None:
-        # Revive a soft-deleted tombstone in place — no second unique-key row.
+        # Revive a soft-deleted tombstone in place — a blind insert would
+        # collide on the still-unique stored id. Recreate semantics = a NEW
+        # file at this path = FRESH history, so purge the dead file's archived
+        # versions first (they outlive the FileUpload row — file_versions never
+        # deletes version rows otherwise — and would bleed stale content +
+        # duplicate version_number=1 labels into the revived file).
+        await FileVersionDoc.find({"file_id": path, "workspace_id": workspace_id}).delete()
         doc.deleted_at = None
         doc.filename = body.filename or path
         doc.mime = mime

--- a/ee/pocketpaw_ee/cloud/file_versions/service.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/service.py
@@ -1,14 +1,26 @@
 # service.py — FileVersions service: versioned cloud file-write storage spine.
-# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files
-#   (ee/cloud/file_versions/service.py). Migrated imports ee.cloud.* ->
-#   pocketpaw_ee.cloud.*. KEEPS the storage core: write_file,
-#   update_file_content, list_versions, get_version (+ helpers). DROPPED the
-#   Slice-D editor helpers (revert_to_version, diff_versions) — deferred.
-#   HARDENED _get_storage(): builds the adapter via the canonical
-#   uploads.factory.build_adapter() against the shared upload root, instead
-#   of reaching into the uploads router's private _SVC._adapter singleton.
-#   Sole Beanie importer for FileVersionDoc; every FileUpload / FileVersionDoc
-#   read is tenant-filtered (workspace).
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files,
+#   imports migrated ee.cloud.* -> pocketpaw_ee.cloud.*. Storage core only
+#   (write_file, update_file_content, list_versions, get_version); Slice-D
+#   helpers (revert/diff) dropped. Sole Beanie importer for FileVersionDoc;
+#   every FileUpload/FileVersionDoc read is workspace-filtered.
+# Updated: 2026-06-26 (ART-1 quality fix loop):
+#   C1 cross-tenant — FileUpload.file_id is GLOBALLY unique, so a client path
+#     collided across workspaces. The STORED FileUpload id is now namespaced
+#     `${workspace}:${path}` (two workspaces can share a path); the bare path
+#     stays the client-facing id on FileVersionDoc, the DTOs, and the routes.
+#     write_file revives a soft-deleted tombstone in place instead of a blind
+#     insert (which would raise DuplicateKeyError on the tombstoned unique id).
+#   I1 — a no-op (unchanged-content) update now returns the ACTUAL stored
+#     version, not a phantom +1.
+#   I2 — new files take a real mime (WriteFileRequest.mime, else guessed from
+#     the filename extension), no longer hardcoded application/json.
+#   I3 — a blob-read failure during archival aborts (CloudError) instead of
+#     silently archiving an empty "prior" version and destroying history.
+#   I4 — the archived FileVersionDoc is labelled with the version the content
+#     actually was (the pre-bump version), so version->content stays correct.
+#   M1 — read paths map FileVersionDoc -> FileVersion domain -> DTO.
+#   M2 — list/get reject an empty workspace (400), matching write/update.
 """FileVersions service — file-version write + history.
 
 Module-level ``async def`` functions. Sole owner of writes to the
@@ -20,12 +32,18 @@ Public API:
 - ``update_file_content(ctx, file_id, body)`` — PUT /files/{id}
 - ``list_versions(ctx, file_id)`` — version list (no content)
 - ``get_version(ctx, file_id, version_id)`` — full version with content
+
+The client-facing file id is the bare ``path`` throughout. The FileUpload
+row stores a workspace-namespaced id (``${workspace}:${path}``) because that
+collection's ``file_id`` index is globally unique; FileVersionDoc keeps the
+bare path (its reads are always workspace-filtered, so no global collision).
 """
 
 from __future__ import annotations
 
 import hashlib
 import logging
+import mimetypes
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
@@ -39,6 +57,7 @@ from pocketpaw_ee.cloud._core.context import RequestContext
 from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, NotFound
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import Event
+from pocketpaw_ee.cloud.file_versions.domain import FileVersion
 from pocketpaw_ee.cloud.file_versions.dto import (
     FileVersionListItem,
     FileVersionResponse,
@@ -70,8 +89,23 @@ EDITABLE_MIMES = frozenset(
     }
 )
 
-# Fallback mime for inline-edited content the dashboard renders as code.
+# Fallback mime when a filename has no usable extension. Editable (text/*),
+# so a no-extension write still round-trips through the inline editor.
 FALLBACK_EDIT_MIME = "text/plain"
+
+# Explicit extension->mime overrides for the editable types the stdlib
+# ``mimetypes`` registry doesn't reliably know across platforms (e.g. .md,
+# .yaml). Anything not here falls back to ``mimetypes.guess_type``.
+_EXT_MIME_OVERRIDES = {
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+    ".json": "application/json",
+    ".yaml": "application/x-yaml",
+    ".yml": "application/x-yaml",
+    ".ndjson": "application/x-ndjson",
+    ".csv": "text/csv",
+    ".txt": "text/plain",
+}
 
 # Canonical local-storage root — the same path the uploads router (_ROOT) and
 # ``EEUploadService.write_text_file`` build their adapter against, so the
@@ -83,12 +117,55 @@ def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+def _storage_id(workspace_id: str, path: str) -> str:
+    """Namespace a client path by workspace for the globally-unique
+    ``FileUpload.file_id`` index.
+
+    Two workspaces writing the same ``path`` map to distinct stored ids, so
+    neither collides on the unique key nor squats the other's path. The bare
+    ``path`` stays the client-facing id everywhere else (FileVersionDoc,
+    DTOs, routes); this value is only ever the FileUpload lookup/insert key.
+    """
+    return f"{workspace_id}:{path}"
+
+
+def _guess_mime(filename: str) -> str:
+    """Best-effort mime from a filename's extension.
+
+    Defaults to the inline-editable fallback (``text/plain``) when there's no
+    usable extension, so a path like ``"report"`` still produces an editable
+    file instead of an opaque blob.
+    """
+    ext = Path(filename).suffix.lower()
+    if ext in _EXT_MIME_OVERRIDES:
+        return _EXT_MIME_OVERRIDES[ext]
+    guessed, _ = mimetypes.guess_type(filename)
+    return guessed or FALLBACK_EDIT_MIME
+
+
 def _is_editable(mime: str | None) -> bool:
     if not mime:
         return False
     if mime.startswith("text/"):
         return True
     return mime in EDITABLE_MIMES
+
+
+def _to_domain(doc: FileVersionDoc) -> FileVersion:
+    """Map a FileVersionDoc (persistence) to the FileVersion value object the
+    read paths build their DTOs from (doc -> domain -> DTO)."""
+    return FileVersion(
+        id=str(doc.id),
+        file_id=doc.file_id,
+        workspace_id=doc.workspace_id,
+        version_number=doc.version_number,
+        content=doc.content,
+        content_hash=doc.content_hash,
+        size_bytes=doc.size_bytes,
+        editor_kind=doc.editor_kind,  # stored as str; FileVersion narrows to EditorKind
+        editor_id=doc.editor_id,
+        created_at=doc.created_at,
+    )
 
 
 async def _read_text(adapter: StorageAdapter, key: str) -> str:
@@ -136,64 +213,80 @@ async def write_file(
 ) -> WriteFileResponse:
     """Create or overwrite a file (POST /files/write).
 
-    If a FileUpload record already exists for the given path, content is
-    updated in place (versioned). Otherwise a new FileUpload record and
-    storage blob are created.
+    If a live FileUpload record already exists for the (workspace, path),
+    content is updated in place (versioned). A soft-deleted tombstone for the
+    same path is revived in place — a blind insert would collide on the
+    globally-unique stored id. Otherwise a new record + storage blob.
     """
     workspace_id = ctx.workspace_id
     if not workspace_id:
         raise CloudError(400, "files.missing_workspace", "Workspace is required.")
 
-    file_id = body.path
+    path = body.path  # bare, client-facing id
+    stored_id = _storage_id(workspace_id, path)
     content = body.content
-    mime = "application/json"  # Editor.js content is JSON
+    mime = body.mime or _guess_mime(body.filename or path)
 
     adapter = _get_storage()
 
-    doc = await FileUpload.find_one(
-        {"file_id": file_id, "workspace": workspace_id, "deleted_at": None}
-    )
+    # Find ANY existing row for (workspace, path), including a soft-deleted
+    # tombstone — it still holds the unique stored id, so a blind insert would
+    # raise DuplicateKeyError (500). Revive it instead.
+    doc = await FileUpload.find_one({"file_id": stored_id, "workspace": workspace_id})
 
-    if doc is not None:
+    if doc is not None and doc.deleted_at is None:
+        # Live file — versioned update in place (pass the bare path).
         update_body = UpdateFileContentRequest(content=content)
-        result = await update_file_content(ctx, file_id, update_body)
+        result = await update_file_content(ctx, path, update_body)
         return WriteFileResponse(
-            file_id=result.file_id,
+            file_id=path,
             version=result.new_version,
             size_bytes=result.size_bytes,
         )
 
-    # New file — create FileUpload record and storage blob.
-    storage_key = f"editor/{workspace_id}/{uuid.uuid4().hex}/{file_id}"
+    storage_key = (
+        doc.storage_key if doc is not None else f"editor/{workspace_id}/{uuid.uuid4().hex}"
+    )
     stored = await adapter.put(storage_key, _bytes_iter(content), mime)
 
-    doc = FileUpload(
-        file_id=file_id,
-        filename=body.filename or file_id,
-        workspace=workspace_id,
-        owner=ctx.user_id or "unknown",
-        mime=mime,
-        size=stored.size,
-        storage_key=storage_key,
-        content_version=1,
-    )
-    await doc.insert()
+    if doc is not None:
+        # Revive a soft-deleted tombstone in place — no second unique-key row.
+        doc.deleted_at = None
+        doc.filename = body.filename or path
+        doc.mime = mime
+        doc.size = stored.size
+        doc.storage_key = storage_key
+        doc.owner = ctx.user_id or doc.owner
+        doc.content_version = 1
+        await doc.save()
+    else:
+        doc = FileUpload(
+            file_id=stored_id,
+            filename=body.filename or path,
+            workspace=workspace_id,
+            owner=ctx.user_id or "unknown",
+            mime=mime,
+            size=stored.size,
+            storage_key=storage_key,
+            content_version=1,
+        )
+        await doc.insert()
 
     await emit(
         Event(
             type="file.created",
             data={
-                "file_id": file_id,
+                "file_id": path,
                 "workspace_id": workspace_id,
                 "size": stored.size,
             },
         )
     )
 
-    logger.info("file %s created via write (version 1)", file_id)
+    logger.info("file %s created via write (version 1)", path)
 
     return WriteFileResponse(
-        file_id=file_id,
+        file_id=path,
         version=1,
         size_bytes=stored.size,
     )
@@ -208,18 +301,21 @@ async def update_file_content(
 ) -> UpdateFileContentResponse:
     """Replace a text file's content with optimistic concurrency.
 
-    1. Fetch the ``FileUpload`` doc (tenant-filtered on workspace).
+    ``file_id`` is the bare client path. Steps:
+    1. Fetch the ``FileUpload`` doc by the workspace-namespaced stored id.
     2. Check the ``If-Match`` precondition against ``content_version``.
-    3. Archive the current blob as a ``FileVersionDoc``.
-    4. Upload the new content to StorageAdapter.
-    5. Update ``FileUpload`` metadata and bump the version counter.
+    3. Read + archive the current blob as a ``FileVersionDoc`` (labelled with
+       the version it actually was). A read failure aborts — never archive an
+       empty "prior" version.
+    4. Upload the new content and bump the version counter.
     """
     workspace_id = ctx.workspace_id
     if not workspace_id:
         raise CloudError(400, "files.missing_workspace", "Workspace is required.")
 
+    stored_id = _storage_id(workspace_id, file_id)
     doc = await FileUpload.find_one(
-        {"file_id": file_id, "workspace": workspace_id, "deleted_at": None}
+        {"file_id": stored_id, "workspace": workspace_id, "deleted_at": None}
     )
     if not doc:
         raise NotFound("file", file_id)
@@ -231,15 +327,15 @@ async def update_file_content(
             f"File type '{doc.mime}' cannot be edited inline.",
         )
 
+    current_version = doc.content_version
     expected = body.expected_version
-    if expected is not None and expected != doc.content_version:
+    if expected is not None and expected != current_version:
         raise ConflictError(
             "files.version_conflict",
-            f"Expected version {expected} but current is {doc.content_version}. "
+            f"Expected version {expected} but current is {current_version}. "
             "Someone else edited this file. Reload and try again.",
         )
 
-    new_version = doc.content_version + 1
     new_content = body.content
     new_hash = _sha256(new_content)
     new_size = len(new_content.encode("utf-8"))
@@ -247,61 +343,82 @@ async def update_file_content(
 
     adapter = _get_storage()
 
-    # --- archive current blob ---
+    # Read the current blob so it can be archived. A read failure must NOT be
+    # swallowed into an empty archive — that labels a fake-empty blob as the
+    # prior version and destroys real history. Abort the update instead.
     try:
         old_content = await _read_text(adapter, doc.storage_key)
-    except Exception:
-        old_content = ""
+    except Exception as exc:
+        logger.error(
+            "file %s: cannot read current blob %r to archive prior version: %s",
+            file_id,
+            doc.storage_key,
+            exc,
+        )
+        raise CloudError(
+            500,
+            "files.archive_read_failed",
+            "Could not read the file's current content to archive it; "
+            "aborting to protect version history.",
+        ) from exc
 
     old_hash = _sha256(old_content)
 
-    # Only archive if content actually changed.
-    if old_hash != new_hash:
-        version_doc = FileVersionDoc(
+    if old_hash == new_hash:
+        # No content change — nothing archived or bumped. Report the ACTUAL
+        # stored version so the caller's next If-Match doesn't 409 against it.
+        return UpdateFileContentResponse(
             file_id=file_id,
-            workspace_id=workspace_id,
-            version_number=new_version,
-            content=old_content,
-            content_hash=old_hash,
-            size_bytes=len(old_content.encode("utf-8")),
-            editor_kind=editor_kind,
-            editor_id=editor_id,
-            created_at=datetime.now(UTC),
-        )
-        await version_doc.insert()
-
-        # --- upload new blob ---
-        stored = await adapter.put(
-            doc.storage_key,
-            _bytes_iter(new_content),
-            doc.mime,
+            new_version=current_version,
+            size_bytes=new_size,
+            content_hash=new_hash,
         )
 
-        # --- update metadata ---
-        doc.size = stored.size
-        doc.content_version = new_version
-        await doc.save()
+    new_version = current_version + 1
 
-        await emit(
-            Event(
-                type="file.updated",
-                data={
-                    "file_id": file_id,
-                    "workspace_id": workspace_id,
-                    "version": new_version,
-                    "editor_kind": editor_kind,
-                    "editor_id": editor_id,
-                },
-            )
-        )
+    # Archive the OLD content under the version it actually was
+    # (``current_version``), so a future revert/diff maps version -> content
+    # correctly. FileVersionDoc keeps the bare path (reads are
+    # workspace-filtered, so the bare id is collision-safe here).
+    version_doc = FileVersionDoc(
+        file_id=file_id,
+        workspace_id=workspace_id,
+        version_number=current_version,
+        content=old_content,
+        content_hash=old_hash,
+        size_bytes=len(old_content.encode("utf-8")),
+        editor_kind=editor_kind,
+        editor_id=editor_id,
+        created_at=datetime.now(UTC),
+    )
+    await version_doc.insert()
 
-        logger.info(
-            "file %s updated to version %d by %s:%s",
-            file_id,
-            new_version,
-            editor_kind,
-            editor_id,
+    stored = await adapter.put(doc.storage_key, _bytes_iter(new_content), doc.mime)
+
+    doc.size = stored.size
+    doc.content_version = new_version
+    await doc.save()
+
+    await emit(
+        Event(
+            type="file.updated",
+            data={
+                "file_id": file_id,
+                "workspace_id": workspace_id,
+                "version": new_version,
+                "editor_kind": editor_kind,
+                "editor_id": editor_id,
+            },
         )
+    )
+
+    logger.info(
+        "file %s updated to version %d by %s:%s",
+        file_id,
+        new_version,
+        editor_kind,
+        editor_id,
+    )
 
     return UpdateFileContentResponse(
         file_id=file_id,
@@ -320,6 +437,9 @@ async def list_versions(
     Tenant-filtered: only versions in the caller's workspace are returned.
     """
     workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
     docs = (
         await FileVersionDoc.find({"file_id": file_id, "workspace_id": workspace_id})
         .sort("+version_number")
@@ -335,15 +455,15 @@ async def list_versions(
 
     return [
         FileVersionListItem(
-            id=str(doc.id),
-            file_id=doc.file_id,
-            version_number=doc.version_number,
-            size_bytes=doc.size_bytes,
-            editor_kind=doc.editor_kind,
-            editor_id=doc.editor_id,
-            created_at=doc.created_at,
+            id=fv.id,
+            file_id=fv.file_id,
+            version_number=fv.version_number,
+            size_bytes=fv.size_bytes,
+            editor_kind=fv.editor_kind,
+            editor_id=fv.editor_id,
+            created_at=fv.created_at,
         )
-        for doc in docs
+        for fv in map(_to_domain, docs)
     ]
 
 
@@ -358,6 +478,9 @@ async def get_version(
     never read another workspace's version blob.
     """
     workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
     try:
         oid = PydanticObjectId(version_id)
     except Exception:
@@ -369,14 +492,15 @@ async def get_version(
     if not doc:
         raise NotFound("version", version_id)
 
+    fv = _to_domain(doc)
     return FileVersionResponse(
-        id=str(doc.id),
-        file_id=doc.file_id,
-        version_number=doc.version_number,
-        content=doc.content,
-        content_hash=doc.content_hash,
-        size_bytes=doc.size_bytes,
-        editor_kind=doc.editor_kind,
-        editor_id=doc.editor_id,
-        created_at=doc.created_at,
+        id=fv.id,
+        file_id=fv.file_id,
+        version_number=fv.version_number,
+        content=fv.content,
+        content_hash=fv.content_hash,
+        size_bytes=fv.size_bytes,
+        editor_kind=fv.editor_kind,
+        editor_id=fv.editor_id,
+        created_at=fv.created_at,
     )

--- a/ee/pocketpaw_ee/cloud/file_versions/service.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/service.py
@@ -1,0 +1,382 @@
+# service.py — FileVersions service: versioned cloud file-write storage spine.
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files
+#   (ee/cloud/file_versions/service.py). Migrated imports ee.cloud.* ->
+#   pocketpaw_ee.cloud.*. KEEPS the storage core: write_file,
+#   update_file_content, list_versions, get_version (+ helpers). DROPPED the
+#   Slice-D editor helpers (revert_to_version, diff_versions) — deferred.
+#   HARDENED _get_storage(): builds the adapter via the canonical
+#   uploads.factory.build_adapter() against the shared upload root, instead
+#   of reaching into the uploads router's private _SVC._adapter singleton.
+#   Sole Beanie importer for FileVersionDoc; every FileUpload / FileVersionDoc
+#   read is tenant-filtered (workspace).
+"""FileVersions service — file-version write + history.
+
+Module-level ``async def`` functions. Sole owner of writes to the
+``FileVersionDoc`` Beanie document and the ``FileUpload.content_version``
+counter. Text-only — non-editable mime types are rejected early.
+
+Public API:
+- ``write_file(ctx, body)`` — POST /files/write (create or overwrite)
+- ``update_file_content(ctx, file_id, body)`` — PUT /files/{id}
+- ``list_versions(ctx, file_id)`` — version list (no content)
+- ``get_version(ctx, file_id, version_id)`` — full version with content
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+from beanie import PydanticObjectId
+
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.factory import build_adapter
+from pocketpaw_ee.cloud._core.context import RequestContext
+from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, NotFound
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import Event
+from pocketpaw_ee.cloud.file_versions.dto import (
+    FileVersionListItem,
+    FileVersionResponse,
+    UpdateFileContentRequest,
+    UpdateFileContentResponse,
+    WriteFileRequest,
+    WriteFileResponse,
+)
+from pocketpaw_ee.cloud.models.file_version import FileVersionDoc
+from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+logger = logging.getLogger(__name__)
+
+# Only these mime types are editable inline. Everything else gets a 422.
+EDITABLE_MIMES = frozenset(
+    {
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+        "text/html",
+        "text/css",
+        "text/javascript",
+        "text/xml",
+        "application/json",
+        "application/xml",
+        "application/javascript",
+        "application/x-yaml",
+        "application/x-ndjson",
+    }
+)
+
+# Fallback mime for inline-edited content the dashboard renders as code.
+FALLBACK_EDIT_MIME = "text/plain"
+
+# Canonical local-storage root — the same path the uploads router (_ROOT) and
+# ``EEUploadService.write_text_file`` build their adapter against, so the
+# version archive reads/writes the SAME blobs the uploads pipeline stored.
+_UPLOAD_ROOT = Path.home() / ".pocketpaw" / "uploads"
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _is_editable(mime: str | None) -> bool:
+    if not mime:
+        return False
+    if mime.startswith("text/"):
+        return True
+    return mime in EDITABLE_MIMES
+
+
+async def _read_text(adapter: StorageAdapter, key: str) -> str:
+    """Read all chunks from StorageAdapter and decode as UTF-8."""
+    chunks: list[bytes] = []
+    async for chunk in adapter.open(key):
+        chunks.append(chunk)
+    return b"".join(chunks).decode("utf-8")
+
+
+async def _bytes_iter(text: str) -> AsyncIterator[bytes]:
+    yield text.encode("utf-8")
+
+
+# Storage adapter singleton — injectable seam for tests / explicit wiring.
+_adapter: StorageAdapter | None = None
+
+
+def set_adapter(adapter: StorageAdapter) -> None:
+    """Inject a StorageAdapter (tests, or an explicit wiring seam)."""
+    global _adapter
+    _adapter = adapter
+
+
+def _get_storage() -> StorageAdapter:
+    """Return the process StorageAdapter.
+
+    Hardened replacement for dewani12's reach into
+    ``uploads.router._SVC._adapter`` (a private singleton inside another
+    entity's router module). Builds the adapter via the canonical
+    ``uploads.factory.build_adapter`` against the shared upload root — the
+    same construction the uploads router and ``write_text_file`` use — so
+    the env-driven local/S3 selection stays consistent across both paths.
+    """
+    global _adapter
+    if _adapter is None:
+        _UPLOAD_ROOT.mkdir(parents=True, exist_ok=True)
+        _adapter = build_adapter(_UPLOAD_ROOT)
+    return _adapter
+
+
+async def write_file(
+    ctx: RequestContext,
+    body: WriteFileRequest,
+) -> WriteFileResponse:
+    """Create or overwrite a file (POST /files/write).
+
+    If a FileUpload record already exists for the given path, content is
+    updated in place (versioned). Otherwise a new FileUpload record and
+    storage blob are created.
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
+    file_id = body.path
+    content = body.content
+    mime = "application/json"  # Editor.js content is JSON
+
+    adapter = _get_storage()
+
+    doc = await FileUpload.find_one(
+        {"file_id": file_id, "workspace": workspace_id, "deleted_at": None}
+    )
+
+    if doc is not None:
+        update_body = UpdateFileContentRequest(content=content)
+        result = await update_file_content(ctx, file_id, update_body)
+        return WriteFileResponse(
+            file_id=result.file_id,
+            version=result.new_version,
+            size_bytes=result.size_bytes,
+        )
+
+    # New file — create FileUpload record and storage blob.
+    storage_key = f"editor/{workspace_id}/{uuid.uuid4().hex}/{file_id}"
+    stored = await adapter.put(storage_key, _bytes_iter(content), mime)
+
+    doc = FileUpload(
+        file_id=file_id,
+        filename=body.filename or file_id,
+        workspace=workspace_id,
+        owner=ctx.user_id or "unknown",
+        mime=mime,
+        size=stored.size,
+        storage_key=storage_key,
+        content_version=1,
+    )
+    await doc.insert()
+
+    await emit(
+        Event(
+            type="file.created",
+            data={
+                "file_id": file_id,
+                "workspace_id": workspace_id,
+                "size": stored.size,
+            },
+        )
+    )
+
+    logger.info("file %s created via write (version 1)", file_id)
+
+    return WriteFileResponse(
+        file_id=file_id,
+        version=1,
+        size_bytes=stored.size,
+    )
+
+
+async def update_file_content(
+    ctx: RequestContext,
+    file_id: str,
+    body: UpdateFileContentRequest,
+    *,
+    editor_kind: str = "human",
+) -> UpdateFileContentResponse:
+    """Replace a text file's content with optimistic concurrency.
+
+    1. Fetch the ``FileUpload`` doc (tenant-filtered on workspace).
+    2. Check the ``If-Match`` precondition against ``content_version``.
+    3. Archive the current blob as a ``FileVersionDoc``.
+    4. Upload the new content to StorageAdapter.
+    5. Update ``FileUpload`` metadata and bump the version counter.
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
+    doc = await FileUpload.find_one(
+        {"file_id": file_id, "workspace": workspace_id, "deleted_at": None}
+    )
+    if not doc:
+        raise NotFound("file", file_id)
+
+    if not _is_editable(doc.mime):
+        raise CloudError(
+            422,
+            "files.not_editable",
+            f"File type '{doc.mime}' cannot be edited inline.",
+        )
+
+    expected = body.expected_version
+    if expected is not None and expected != doc.content_version:
+        raise ConflictError(
+            "files.version_conflict",
+            f"Expected version {expected} but current is {doc.content_version}. "
+            "Someone else edited this file. Reload and try again.",
+        )
+
+    new_version = doc.content_version + 1
+    new_content = body.content
+    new_hash = _sha256(new_content)
+    new_size = len(new_content.encode("utf-8"))
+    editor_id = ctx.user_id or "unknown"
+
+    adapter = _get_storage()
+
+    # --- archive current blob ---
+    try:
+        old_content = await _read_text(adapter, doc.storage_key)
+    except Exception:
+        old_content = ""
+
+    old_hash = _sha256(old_content)
+
+    # Only archive if content actually changed.
+    if old_hash != new_hash:
+        version_doc = FileVersionDoc(
+            file_id=file_id,
+            workspace_id=workspace_id,
+            version_number=new_version,
+            content=old_content,
+            content_hash=old_hash,
+            size_bytes=len(old_content.encode("utf-8")),
+            editor_kind=editor_kind,
+            editor_id=editor_id,
+            created_at=datetime.now(UTC),
+        )
+        await version_doc.insert()
+
+        # --- upload new blob ---
+        stored = await adapter.put(
+            doc.storage_key,
+            _bytes_iter(new_content),
+            doc.mime,
+        )
+
+        # --- update metadata ---
+        doc.size = stored.size
+        doc.content_version = new_version
+        await doc.save()
+
+        await emit(
+            Event(
+                type="file.updated",
+                data={
+                    "file_id": file_id,
+                    "workspace_id": workspace_id,
+                    "version": new_version,
+                    "editor_kind": editor_kind,
+                    "editor_id": editor_id,
+                },
+            )
+        )
+
+        logger.info(
+            "file %s updated to version %d by %s:%s",
+            file_id,
+            new_version,
+            editor_kind,
+            editor_id,
+        )
+
+    return UpdateFileContentResponse(
+        file_id=file_id,
+        new_version=new_version,
+        size_bytes=new_size,
+        content_hash=new_hash,
+    )
+
+
+async def list_versions(
+    ctx: RequestContext,
+    file_id: str,
+) -> list[FileVersionListItem]:
+    """List all archived versions for a file (oldest first), content omitted.
+
+    Tenant-filtered: only versions in the caller's workspace are returned.
+    """
+    workspace_id = ctx.workspace_id
+    docs = (
+        await FileVersionDoc.find({"file_id": file_id, "workspace_id": workspace_id})
+        .sort("+version_number")
+        .to_list()
+    )
+
+    logger.info(
+        "list_versions: file_id=%s workspace=%s found=%d",
+        file_id,
+        workspace_id,
+        len(docs),
+    )
+
+    return [
+        FileVersionListItem(
+            id=str(doc.id),
+            file_id=doc.file_id,
+            version_number=doc.version_number,
+            size_bytes=doc.size_bytes,
+            editor_kind=doc.editor_kind,
+            editor_id=doc.editor_id,
+            created_at=doc.created_at,
+        )
+        for doc in docs
+    ]
+
+
+async def get_version(
+    ctx: RequestContext,
+    file_id: str,
+    version_id: str,
+) -> FileVersionResponse:
+    """Fetch a single version with full content.
+
+    Tenant-filtered: the find includes ``workspace_id`` so a caller can
+    never read another workspace's version blob.
+    """
+    workspace_id = ctx.workspace_id
+    try:
+        oid = PydanticObjectId(version_id)
+    except Exception:
+        raise NotFound("version", version_id) from None
+
+    doc = await FileVersionDoc.find_one(
+        {"_id": oid, "file_id": file_id, "workspace_id": workspace_id}
+    )
+    if not doc:
+        raise NotFound("version", version_id)
+
+    return FileVersionResponse(
+        id=str(doc.id),
+        file_id=doc.file_id,
+        version_number=doc.version_number,
+        content=doc.content,
+        content_hash=doc.content_hash,
+        size_bytes=doc.size_bytes,
+        editor_kind=doc.editor_kind,
+        editor_id=doc.editor_id,
+        created_at=doc.created_at,
+    )

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -78,6 +78,7 @@ from pocketpaw_ee.cloud.models.fabric_ingest_state import (
     FabricIngestState,
 )
 from pocketpaw_ee.cloud.models.file import FileObj
+from pocketpaw_ee.cloud.models.file_version import FileVersionDoc
 from pocketpaw_ee.cloud.models.foresight_backtest import ForesightBacktest
 from pocketpaw_ee.cloud.models.foresight_prediction_record import (
     ForesightPredictionRecord,
@@ -221,6 +222,7 @@ __all__ = [
     "FileFolder",
     "FileObj",
     "FileUpload",
+    "FileVersionDoc",
     "ForesightBacktest",
     "ForesightPredictionRecord",
     "ForesightProjectedDecision",
@@ -292,6 +294,9 @@ def get_all_documents():
         FileObj,
         FileUpload,
         FileFolder,
+        # file_versions edit history (ART-1). Only ``file_versions.service``
+        # imports this class (import-linter "FileVersions" contract).
+        FileVersionDoc,
         Workspace,
         WorkspaceConnector,
         ComposioConnection,

--- a/ee/pocketpaw_ee/cloud/models/file_version.py
+++ b/ee/pocketpaw_ee/cloud/models/file_version.py
@@ -1,0 +1,39 @@
+# file_version.py — FileVersionDoc Beanie document for the file-version history trail.
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files
+#   (was ee/cloud/models/file_version.py) onto the post-cloud-restructure
+#   layout. Path migrated to ee/pocketpaw_ee/cloud/models/; registered in
+#   models.get_all_documents(). Only ``file_versions.service`` may import this
+#   class (import-linter "FileVersions" contract).
+"""FileVersion Beanie document — full-copy text blobs archived per edit.
+
+Stored in the ``file_versions`` collection. The live (current) file
+content lives in the StorageAdapter; this collection is the history trail.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+
+
+class FileVersionDoc(Document):
+    file_id: Indexed(str)  # type: ignore[valid-type]
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    version_number: int
+    content: str
+    content_hash: str
+    size_bytes: int
+    editor_kind: str  # "human" | "agent"
+    editor_id: str  # user_id or agent_id
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "file_versions"
+        indexes = [
+            # List versions for a file, oldest-first so the picker shows v1->vN.
+            [("file_id", 1), ("version_number", 1)],
+            # Workspace-scoped queries (tenant-filtered reads).
+            [("workspace_id", 1), ("file_id", 1)],
+        ]

--- a/ee/pocketpaw_ee/cloud/uploads/models.py
+++ b/ee/pocketpaw_ee/cloud/uploads/models.py
@@ -1,5 +1,10 @@
 """EE FileUpload document — Mongo metadata for blobs stored via StorageAdapter.
 
+2026-06-26 — ART-1. Added ``content_version`` (default 0) so the
+``file_versions`` service can run optimistic-concurrency edits and archive
+each prior blob as a ``FileVersionDoc``. Legacy rows read as 0; ``write_file``
+stamps new rows at 1. Beanie field-add is backward compatible (no migration).
+
 2026-05-03 — Stage 3.E "Files as Knowledge". Added ``pocket_id`` so the
 unified Files panel and the FileReady listener can route a single upload
 into a pocket-scoped KB instead of the workspace pool. ``None`` is the
@@ -43,6 +48,10 @@ class FileUpload(TimestampedDocument):
     # Storage layout is unchanged — partitioning is metadata-only.
     pocket_id: str | None = None
     deleted_at: datetime | None = None
+    # Optimistic-concurrency counter for the file_versions edit pipeline
+    # (ART-1). Each successful inline edit bumps this and archives the prior
+    # blob as a ``FileVersionDoc``. 0 on legacy rows; ``write_file`` stamps 1.
+    content_version: int = 0
 
     class Settings:
         name = "file_uploads"

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -380,6 +380,17 @@ source_modules = [
 forbidden_modules = ["pocketpaw_ee.cloud.models.notification"]
 
 [[tool.importlinter.contracts]]
+name = "FileVersions — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.file_versions.router",
+    "pocketpaw_ee.cloud.file_versions.dto",
+    "pocketpaw_ee.cloud.file_versions.domain",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.file_version"]
+
+[[tool.importlinter.contracts]]
 name = "FabricIngest — Beanie writes only from service.py"
 type = "forbidden"
 allow_indirect_imports = "true"

--- a/tests/cloud/file_versions/__init__.py
+++ b/tests/cloud/file_versions/__init__.py
@@ -1,0 +1,1 @@
+# __init__.py — test package for the file_versions entity (ART-1).

--- a/tests/cloud/file_versions/test_file_versions.py
+++ b/tests/cloud/file_versions/test_file_versions.py
@@ -5,7 +5,8 @@
 # Updated: 2026-06-26 (ART-1 quality fix loop) — added the LOGIC tests for the
 #   defects the unique-index-blind mongomock harness hid:
 #   C1 cross-tenant — two workspaces share a path -> distinct stored rows, no
-#      error, isolated content; same-workspace soft-delete then recreate works.
+#      error, isolated content; soft-delete then recreate revives with a FRESH
+#      history (the dead file's version rows are purged on revive).
 #   I1 — a no-op update returns the stored version (no phantom +1 / phantom 409).
 #   I2 — new-file mime comes from the filename / explicit mime, not hardcoded.
 #   I3 — a blob-read failure aborts and archives nothing (history preserved).
@@ -164,27 +165,41 @@ async def test_cross_tenant_same_path_no_collision(mongo_db, fake_storage):
 
 
 @pytest.mark.asyncio
-async def test_soft_delete_then_recreate_same_path(mongo_db, fake_storage):
-    """C1 — recreating a soft-deleted path succeeds (tombstone revived in place,
-    not a second unique-key row that would 500 on real Mongo)."""
+async def test_soft_delete_then_recreate_purges_history(mongo_db, fake_storage):
+    """C1 follow-up — soft-delete then recreate is a NEW file at that path with
+    FRESH history: the revive succeeds AND purges the dead file's version rows
+    so they don't bleed stale content / duplicate version_number=1 labels."""
     ctx = _ctx("w1")
     stored_id = service._storage_id("w1", "report")
 
-    await service.write_file(ctx, WriteFileRequest(path="report", content="first"))
+    # Build a 2-version history on the original file.
+    await service.write_file(ctx, WriteFileRequest(path="report", content="v1"))
+    await service.update_file_content(ctx, "report", UpdateFileContentRequest(content="v2"))
+    await service.update_file_content(ctx, "report", UpdateFileContentRequest(content="v3"))
+    versions = await service.list_versions(ctx, "report")
+    assert [v.version_number for v in versions] == [1, 2]
 
     # Simulate the uploads soft-delete (file_versions has no delete of its own).
     doc = await FileUpload.find_one({"file_id": stored_id, "workspace": "w1"})
     doc.deleted_at = datetime.now(UTC)
     await doc.save()
 
-    # Recreate the same path — must succeed.
-    res = await service.write_file(ctx, WriteFileRequest(path="report", content="second"))
+    # Recreate the same path — succeeds, and starts a CLEAN history.
+    res = await service.write_file(ctx, WriteFileRequest(path="report", content="fresh"))
     assert res.version == 1
+    assert await service.list_versions(ctx, "report") == []  # stale v1/v2 purged
 
-    # Exactly ONE row for the stored id (revived), and it's live again.
+    # Exactly ONE live row for the stored id (revived in place).
     rows = await FileUpload.find({"file_id": stored_id, "workspace": "w1"}).to_list()
     assert len(rows) == 1
     assert rows[0].deleted_at is None
+
+    # The next edit archives a clean version_number=1 (no duplicate label,
+    # no stale content) — proving the purge worked.
+    await service.update_file_content(ctx, "report", UpdateFileContentRequest(content="fresh2"))
+    versions2 = await service.list_versions(ctx, "report")
+    assert [v.version_number for v in versions2] == [1]
+    assert (await service.get_version(ctx, "report", versions2[0].id)).content == "fresh"
 
 
 @pytest.mark.asyncio

--- a/tests/cloud/file_versions/test_file_versions.py
+++ b/tests/cloud/file_versions/test_file_versions.py
@@ -1,11 +1,16 @@
 # test_file_versions.py — contract tests for the ported file_versions spine (ART-1).
-# Created: 2026-06-26 (ART-1). Locks two guarantees the storage core must hold:
-#   (a) write_file then PUT bumps the version and archives the prior blob;
-#   (b) two-workspace isolation — a workspace can never list or read another
-#       workspace's versions or content (tenant-filtered reads).
-# Plus an HTTP smoke test that exercises the 4 routes end-to-end through the
-# router (status codes + aliased wire shape) so the port's wiring is proven,
-# not just the service functions.
+# Created: 2026-06-26 (ART-1). Locks: (a) write->PUT version bump + archive,
+#   (b) two-workspace isolation on version list + content reads, (c) a 4-route
+#   HTTP smoke (status codes + aliased wire shape).
+# Updated: 2026-06-26 (ART-1 quality fix loop) — added the LOGIC tests for the
+#   defects the unique-index-blind mongomock harness hid:
+#   C1 cross-tenant — two workspaces share a path -> distinct stored rows, no
+#      error, isolated content; same-workspace soft-delete then recreate works.
+#   I1 — a no-op update returns the stored version (no phantom +1 / phantom 409).
+#   I2 — new-file mime comes from the filename / explicit mime, not hardcoded.
+#   I3 — a blob-read failure aborts and archives nothing (history preserved).
+#   I4 — the archived row is labelled with the version the content actually was.
+#   M2 — list/get reject an empty workspace.
 """Tests for the file_versions write + history storage spine."""
 
 from __future__ import annotations
@@ -16,12 +21,14 @@ from datetime import UTC, datetime
 import pytest
 import pytest_asyncio
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
-from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
 from pocketpaw_ee.cloud.file_versions import service
 from pocketpaw_ee.cloud.file_versions.dto import (
     UpdateFileContentRequest,
     WriteFileRequest,
 )
+from pocketpaw_ee.cloud.models.file_version import FileVersionDoc
+from pocketpaw_ee.cloud.uploads.models import FileUpload
 
 from pocketpaw.uploads.adapter import StoredObject
 
@@ -52,6 +59,17 @@ class _FakeAdapter:
         yield data
 
 
+class _ReadFailAdapter(_FakeAdapter):
+    """Adapter whose blob read always fails — exercises the I3 abort path."""
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        # The `yield` (never-taken branch) makes this an async generator; the
+        # read always raises so the service must abort the update.
+        if self._blobs.get(key) == b"__never__":
+            yield b""
+        raise OSError("simulated blob read failure")
+
+
 def _ctx(workspace_id: str, user_id: str = "u1") -> RequestContext:
     return RequestContext(
         user_id=user_id,
@@ -74,14 +92,12 @@ def fake_storage():
 
 @pytest.mark.asyncio
 async def test_write_then_update_bumps_version(mongo_db, fake_storage):
-    """write_file creates v1; a PUT with new content bumps to v2 and archives
-    the prior blob as exactly one FileVersionDoc."""
-    from pocketpaw_ee.cloud.uploads.models import FileUpload
-
+    """write_file creates v1; a PUT with new content bumps the live counter to
+    2 and archives the prior blob as one FileVersionDoc labelled v1."""
     ctx = _ctx("w1")
 
     res1 = await service.write_file(ctx, WriteFileRequest(path="doc1", content='{"v":1}'))
-    assert res1.file_id == "doc1"
+    assert res1.file_id == "doc1"  # client sees the bare path
     assert res1.version == 1
 
     res2 = await service.update_file_content(
@@ -89,18 +105,152 @@ async def test_write_then_update_bumps_version(mongo_db, fake_storage):
     )
     assert res2.new_version == 2
 
-    # The live FileUpload counter advanced to 2.
-    doc = await FileUpload.find_one({"file_id": "doc1", "workspace": "w1"})
+    # The live FileUpload counter advanced to 2 (stored id is workspace-namespaced).
+    doc = await FileUpload.find_one(
+        {"file_id": service._storage_id("w1", "doc1"), "workspace": "w1"}
+    )
     assert doc is not None
     assert doc.content_version == 2
 
-    # Exactly one archived version exists, holding the PRIOR (v1) content.
+    # One archived version, labelled with the version it actually was (1),
+    # holding the prior (v1) content.
     versions = await service.list_versions(ctx, "doc1")
     assert len(versions) == 1
-    assert versions[0].version_number == 2
+    assert versions[0].version_number == 1
 
     full = await service.get_version(ctx, "doc1", versions[0].id)
     assert full.content == '{"v":1}'
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_same_path_no_collision(mongo_db, fake_storage):
+    """C1 — two workspaces writing the SAME path produce distinct stored rows,
+    no error, and fully isolated content."""
+    ctx_a = _ctx("wA", "ua")
+    ctx_b = _ctx("wB", "ub")
+
+    ra = await service.write_file(ctx_a, WriteFileRequest(path="report", content='{"a":1}'))
+    # B writing the same path must NOT raise (no global unique-key collision).
+    rb = await service.write_file(ctx_b, WriteFileRequest(path="report", content='{"b":1}'))
+
+    # Client-facing id is the bare path for both.
+    assert ra.file_id == "report"
+    assert rb.file_id == "report"
+
+    # But the STORED FileUpload rows carry distinct workspace-namespaced ids.
+    doc_a = await FileUpload.find_one(
+        {"file_id": service._storage_id("wA", "report"), "workspace": "wA"}
+    )
+    doc_b = await FileUpload.find_one(
+        {"file_id": service._storage_id("wB", "report"), "workspace": "wB"}
+    )
+    assert doc_a is not None and doc_b is not None
+    assert doc_a.file_id != doc_b.file_id
+
+    # Each workspace edits + reads only its own content.
+    await service.update_file_content(ctx_a, "report", UpdateFileContentRequest(content='{"a":2}'))
+    await service.update_file_content(ctx_b, "report", UpdateFileContentRequest(content='{"b":2}'))
+
+    a_versions = await service.list_versions(ctx_a, "report")
+    b_versions = await service.list_versions(ctx_b, "report")
+    assert len(a_versions) == 1
+    assert len(b_versions) == 1
+    assert (await service.get_version(ctx_a, "report", a_versions[0].id)).content == '{"a":1}'
+    assert (await service.get_version(ctx_b, "report", b_versions[0].id)).content == '{"b":1}'
+
+    # A cannot read B's version row (tenant-filtered).
+    with pytest.raises(NotFound):
+        await service.get_version(ctx_a, "report", b_versions[0].id)
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_then_recreate_same_path(mongo_db, fake_storage):
+    """C1 — recreating a soft-deleted path succeeds (tombstone revived in place,
+    not a second unique-key row that would 500 on real Mongo)."""
+    ctx = _ctx("w1")
+    stored_id = service._storage_id("w1", "report")
+
+    await service.write_file(ctx, WriteFileRequest(path="report", content="first"))
+
+    # Simulate the uploads soft-delete (file_versions has no delete of its own).
+    doc = await FileUpload.find_one({"file_id": stored_id, "workspace": "w1"})
+    doc.deleted_at = datetime.now(UTC)
+    await doc.save()
+
+    # Recreate the same path — must succeed.
+    res = await service.write_file(ctx, WriteFileRequest(path="report", content="second"))
+    assert res.version == 1
+
+    # Exactly ONE row for the stored id (revived), and it's live again.
+    rows = await FileUpload.find({"file_id": stored_id, "workspace": "w1"}).to_list()
+    assert len(rows) == 1
+    assert rows[0].deleted_at is None
+
+
+@pytest.mark.asyncio
+async def test_noop_update_returns_stored_version(mongo_db, fake_storage):
+    """I1 — an unchanged-content update returns the actual stored version, not a
+    phantom +1, and doesn't poison the next If-Match."""
+    ctx = _ctx("w1")
+    await service.write_file(ctx, WriteFileRequest(path="doc", content="same"))
+
+    res = await service.update_file_content(ctx, "doc", UpdateFileContentRequest(content="same"))
+    assert res.new_version == 1  # stored version, not 2
+    assert await service.list_versions(ctx, "doc") == []  # nothing archived
+
+    # A subsequent If-Match=1 update applies cleanly (no phantom 409 against 2).
+    res2 = await service.update_file_content(
+        ctx, "doc", UpdateFileContentRequest(content="changed", expected_version=1)
+    )
+    assert res2.new_version == 2
+
+
+@pytest.mark.asyncio
+async def test_new_file_mime_from_filename(mongo_db, fake_storage):
+    """I2 — new-file mime comes from the filename extension or an explicit mime,
+    not a hardcoded application/json."""
+    ctx = _ctx("w1")
+
+    await service.write_file(ctx, WriteFileRequest(path="data", filename="data.csv", content="a,b"))
+    doc = await FileUpload.find_one(
+        {"file_id": service._storage_id("w1", "data"), "workspace": "w1"}
+    )
+    assert doc.mime == "text/csv"
+
+    # Explicit mime wins over the (here misleading) extension.
+    await service.write_file(
+        ctx, WriteFileRequest(path="page", filename="page.bin", content="x", mime="text/html")
+    )
+    doc2 = await FileUpload.find_one(
+        {"file_id": service._storage_id("w1", "page"), "workspace": "w1"}
+    )
+    assert doc2.mime == "text/html"
+
+    # Extension-less path falls back to an editable text/plain.
+    await service.write_file(ctx, WriteFileRequest(path="notes", content="hi"))
+    doc3 = await FileUpload.find_one(
+        {"file_id": service._storage_id("w1", "notes"), "workspace": "w1"}
+    )
+    assert doc3.mime == "text/plain"
+
+
+@pytest.mark.asyncio
+async def test_archive_read_failure_aborts_and_preserves_history(mongo_db, fake_storage):
+    """I3 — a blob-read failure aborts the update with a CloudError and archives
+    nothing, rather than writing an empty 'prior' version."""
+    ctx = _ctx("w1")
+    await service.write_file(ctx, WriteFileRequest(path="doc", content="orig"))
+
+    # Swap in an adapter whose blob read fails.
+    service.set_adapter(_ReadFailAdapter())
+
+    with pytest.raises(CloudError) as ei:
+        await service.update_file_content(ctx, "doc", UpdateFileContentRequest(content="new"))
+    assert ei.value.code == "files.archive_read_failed"
+
+    # No empty prior version was archived — history is intact.
+    archived = await FileVersionDoc.find({"file_id": "doc", "workspace_id": "w1"}).to_list()
+    assert archived == []
 
 
 @pytest.mark.asyncio
@@ -137,6 +287,16 @@ async def test_two_workspace_isolation(mongo_db, fake_storage):
         await service.update_file_content(
             ctx_b, "fileA", UpdateFileContentRequest(content='{"x":1}')
         )
+
+
+@pytest.mark.asyncio
+async def test_empty_workspace_rejected_on_reads(mongo_db, fake_storage):
+    """M2 — list/get reject an empty workspace (400), matching write/update."""
+    ctx_empty = _ctx("")
+    with pytest.raises(CloudError):
+        await service.list_versions(ctx_empty, "doc")
+    with pytest.raises(CloudError):
+        await service.get_version(ctx_empty, "doc", "000000000000000000000000")
 
 
 @pytest_asyncio.fixture
@@ -177,12 +337,12 @@ async def test_router_write_put_list_get_smoke(client):
     assert r.status_code == 200
     assert r.json()["newVersion"] == 2
 
-    # GET /files/{id}/versions -> the archived row (aliased versionNumber)
+    # GET /files/{id}/versions -> the archived row, labelled v1 (aliased)
     r = await client.get("/api/v1/files/d1/versions")
     assert r.status_code == 200
     versions = r.json()
     assert len(versions) == 1
-    assert versions[0]["versionNumber"] == 2
+    assert versions[0]["versionNumber"] == 1
 
     # GET /files/{id}/versions/{vid} -> the prior content blob
     vid = versions[0]["id"]

--- a/tests/cloud/file_versions/test_file_versions.py
+++ b/tests/cloud/file_versions/test_file_versions.py
@@ -1,0 +1,191 @@
+# test_file_versions.py — contract tests for the ported file_versions spine (ART-1).
+# Created: 2026-06-26 (ART-1). Locks two guarantees the storage core must hold:
+#   (a) write_file then PUT bumps the version and archives the prior blob;
+#   (b) two-workspace isolation — a workspace can never list or read another
+#       workspace's versions or content (tenant-filtered reads).
+# Plus an HTTP smoke test that exercises the 4 routes end-to-end through the
+# router (status codes + aliased wire shape) so the port's wiring is proven,
+# not just the service functions.
+"""Tests for the file_versions write + history storage spine."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.file_versions import service
+from pocketpaw_ee.cloud.file_versions.dto import (
+    UpdateFileContentRequest,
+    WriteFileRequest,
+)
+
+from pocketpaw.uploads.adapter import StoredObject
+
+
+class _FakeAdapter:
+    """In-memory StorageAdapter stand-in.
+
+    Implements only the two methods the file_versions service uses
+    (``put`` + ``open``) over a dict of blobs, so tests never touch the
+    real on-disk / S3 adapter.
+    """
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, bytes] = {}
+
+    async def put(self, key: str, stream: AsyncIterator[bytes], mime: str) -> StoredObject:
+        chunks: list[bytes] = []
+        async for chunk in stream:
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        self._blobs[key] = data
+        return StoredObject(key=key, size=len(data), mime=mime)
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        data = self._blobs.get(key)
+        if data is None:
+            raise FileNotFoundError(key)
+        yield data
+
+
+def _ctx(workspace_id: str, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def fake_storage():
+    """Inject an in-memory StorageAdapter for the duration of a test."""
+    adapter = _FakeAdapter()
+    prev = service._adapter
+    service.set_adapter(adapter)
+    yield adapter
+    service._adapter = prev
+
+
+@pytest.mark.asyncio
+async def test_write_then_update_bumps_version(mongo_db, fake_storage):
+    """write_file creates v1; a PUT with new content bumps to v2 and archives
+    the prior blob as exactly one FileVersionDoc."""
+    from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+    ctx = _ctx("w1")
+
+    res1 = await service.write_file(ctx, WriteFileRequest(path="doc1", content='{"v":1}'))
+    assert res1.file_id == "doc1"
+    assert res1.version == 1
+
+    res2 = await service.update_file_content(
+        ctx, "doc1", UpdateFileContentRequest(content='{"v":2}')
+    )
+    assert res2.new_version == 2
+
+    # The live FileUpload counter advanced to 2.
+    doc = await FileUpload.find_one({"file_id": "doc1", "workspace": "w1"})
+    assert doc is not None
+    assert doc.content_version == 2
+
+    # Exactly one archived version exists, holding the PRIOR (v1) content.
+    versions = await service.list_versions(ctx, "doc1")
+    assert len(versions) == 1
+    assert versions[0].version_number == 2
+
+    full = await service.get_version(ctx, "doc1", versions[0].id)
+    assert full.content == '{"v":1}'
+
+
+@pytest.mark.asyncio
+async def test_two_workspace_isolation(mongo_db, fake_storage):
+    """A workspace can never list or read another workspace's versions/content."""
+    ctx_a = _ctx("wA", "ua")
+    ctx_b = _ctx("wB", "ub")
+
+    # Each workspace creates its own file and edits it (archiving a version).
+    await service.write_file(ctx_a, WriteFileRequest(path="fileA", content='{"a":1}'))
+    await service.update_file_content(ctx_a, "fileA", UpdateFileContentRequest(content='{"a":2}'))
+    await service.write_file(ctx_b, WriteFileRequest(path="fileB", content='{"b":1}'))
+    await service.update_file_content(ctx_b, "fileB", UpdateFileContentRequest(content='{"b":2}'))
+
+    a_versions = await service.list_versions(ctx_a, "fileA")
+    b_versions = await service.list_versions(ctx_b, "fileB")
+    assert len(a_versions) == 1
+    assert len(b_versions) == 1
+
+    # Cross-workspace listing returns ZERO rows — no version leaks either way.
+    assert await service.list_versions(ctx_b, "fileA") == []
+    assert await service.list_versions(ctx_a, "fileB") == []
+
+    # Cross-workspace content read by a known version id is a tenant-filtered
+    # miss (NotFound) — the blob never crosses the workspace boundary.
+    with pytest.raises(NotFound):
+        await service.get_version(ctx_b, "fileA", a_versions[0].id)
+    with pytest.raises(NotFound):
+        await service.get_version(ctx_a, "fileB", b_versions[0].id)
+
+    # And editing the other workspace's file_id is a miss — the FileUpload is
+    # invisible across the boundary (tenant-filtered find).
+    with pytest.raises(NotFound):
+        await service.update_file_content(
+            ctx_b, "fileA", UpdateFileContentRequest(content='{"x":1}')
+        )
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db, fake_storage):
+    """A FastAPI app with just the file_versions router mounted, auth/license
+    bypassed, and request_context pinned to workspace ``w1``."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from pocketpaw_ee.cloud._core.context import request_context
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.file_versions.router import router
+    from pocketpaw_ee.cloud.license import require_license
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[request_context] = lambda: _ctx("w1")
+    app.dependency_overrides[require_license] = lambda: None
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_router_write_put_list_get_smoke(client):
+    """End-to-end through the 4 routes: status codes + aliased wire shape."""
+    # POST /files/write -> 201, aliased {fileId, version, sizeBytes}
+    r = await client.post("/api/v1/files/write", json={"path": "d1", "content": '{"v":1}'})
+    assert r.status_code == 201
+    body = r.json()
+    assert body["fileId"] == "d1"
+    assert body["version"] == 1
+    assert "sizeBytes" in body
+
+    # PUT /files/{id} -> 200, bumps version (aliased newVersion)
+    r = await client.put("/api/v1/files/d1", json={"content": '{"v":2}'})
+    assert r.status_code == 200
+    assert r.json()["newVersion"] == 2
+
+    # GET /files/{id}/versions -> the archived row (aliased versionNumber)
+    r = await client.get("/api/v1/files/d1/versions")
+    assert r.status_code == 200
+    versions = r.json()
+    assert len(versions) == 1
+    assert versions[0]["versionNumber"] == 2
+
+    # GET /files/{id}/versions/{vid} -> the prior content blob
+    vid = versions[0]["id"]
+    r = await client.get(f"/api/v1/files/d1/versions/{vid}")
+    assert r.status_code == 200
+    assert r.json()["content"] == '{"v":1}'


### PR DESCRIPTION
## What this adds

A `file_versions` cloud entity for versioned, per-workspace file writes. This is the storage foundation the cloud agent-artifact work builds on.

- `POST /files/write` — create or overwrite a file at a path; returns a file id and version
- `PUT /files/{id}` — inline save; archives the prior blob as a version and bumps the counter
- `GET /files/{id}/versions` and `/versions/{vid}` — version list and single-version fetch

Live content goes to the shared upload `StorageAdapter` (local or S3, env-selected) under a workspace-prefixed key. Version history lives in Mongo. Every read is workspace-filtered.

## Where it came from

This ports the storage core of dewani12's `feature/files` branch onto current dev. That branch had drifted 319 commits behind and predated the cloud restructure, so this is a path and import migration (`ee/cloud/*` → `ee/pocketpaw_ee/cloud/*`) conformed to the current 4-file shape, the tenant-filter rule, and the import-linter contracts. The editor tools and Editor.js UI from that branch are deliberately left out and tracked as a follow-up.

## Multi-tenant correctness

The stored `FileUpload` id is namespaced by workspace (`{workspace_id}:{path}`), so two tenants can each own a file at the same path without colliding on the collection's global unique index. Soft-deleting then recreating a path revives the row and starts a fresh version history.

Independent review caught the collision risk before this opened, plus a few version-handling edges (no-op writes returning a phantom version, hardcoded mime, silent content loss on an archive read failure, off-by-one version labels). Those fixes are in the second and third commits.

## Scope

Storage spine only. No agent-facing tool, no working-directory change, no editor surface. Those are the next tasks in this stack.

## Tests

`tests/cloud/file_versions/` — 9 tests: write plus version bump, two-workspace isolation (no cross-read on the version list or content), same-path-no-collision, soft-delete then recreate starts fresh history, no-op version handling, mime inference, and archive-read-failure abort. The tests assert the logic directly, because the mock Mongo harness does not enforce unique indexes (which is what hid the collision in the first pass).

import-linter: 26 contracts kept. ruff clean.

## Stack

This is the base of a stack. ART-2 (per-tenant agent working directory), ART-3 (jail lifecycle), and ART-4 (deliver tool) follow. Merge this base with `--rebase`, not squash.
