### PR TITLE
feat(cloud): per-tenant agent working-directory jail with fail-closed gating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,17 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   env-configurable), marking queued/running `ChatRunDoc`s older than 10 minutes as
   `interrupted` so runs abandoned by a backend restart surface a retry affordance
   instead of leaving clients subscribed forever.
+- **Per-tenant agent cwd jail (cloud, ART-2)**: In multi-tenant cloud each
+  workspace's chat agent runs with `cwd = ~/.pocketpaw/workspaces/<workspace_id>/agent/<session_id>/`
+  (resolved per-run from the `attach_agent_identity` ContextVars in
+  `ee/pocketpaw_ee/cloud/agent_jail.py`) so one tenant's file ops never
+  co-mingle in the shared home dir. It **fails closed**: a cloud run that
+  reaches the backend with no resolvable `workspace_id` RAISES rather than
+  falling back to `~`. OSS / dedicated installs (no cloud DB initialized) keep
+  `settings.file_jail_path` unchanged. Override the jail root with
+  `POCKETPAW_WORKSPACE_JAIL_ROOT` (default `~/.pocketpaw/workspaces`) to anchor
+  it on a data volume. Lifecycle (quota / TTL-GC / disk-watermark eviction of
+  these dirs) is ART-3, not yet shipped.
 - **In-process bus subscribers**: `pocketpaw_ee.cloud._core.realtime.bus.InProcessBus` exposes `subscribe(event_type, handler)` for cloud-side listeners (e.g. the `FileReady` → KB indexer wired in `ee/pocketpaw_ee/cloud/uploads/listeners.py`). Register subscribers from `mount_cloud()` after `init_realtime()` runs. Handler exceptions are logged and swallowed per-handler so one bad listener can't block the rest of the dispatch.
 - **Memory backend (`POCKETPAW_MEMORY_BACKEND`)**: OSS self-hosted defaults to `"file"` (local JSON under `~/.pocketpaw/memory/`). The cloud forces `"mongodb"` via `register_default_backend()` (`ee/pocketpaw_ee/cloud/memory/bootstrap.py`) unless explicitly overridden. The cloud now **fails to boot** if the active store isn't `MongoMemoryStore` (`verify_cloud_memory_backend()` in `init_cloud_db`) — a deliberate guard so a misconfigured backend can never silently write chat history (files-surface chats included) to local disk. Don't set `POCKETPAW_MEMORY_BACKEND=file` on a cloud deployment.
 - **API key required**: The `claude_agent_sdk` backend requires an `ANTHROPIC_API_KEY` when using the Anthropic provider. OAuth tokens from Free/Pro/Max plans are not permitted for third-party use per [Anthropic's policy](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use). Ollama/local providers do not require an API key.

--- a/ee/pocketpaw_ee/cloud/agent_jail.py
+++ b/ee/pocketpaw_ee/cloud/agent_jail.py
@@ -20,20 +20,30 @@ client is set exactly when ``init_cloud_db`` ran (``CloudLifecycleHook`` on
 ``CLOUD_MONGODB_URI``), so it is the authoritative "this process is serving
 tenants" flag without inventing a new one.
 
+When the fail-closed fires (a cloud run that lost its workspace = a
+mis-tenanting signal), a high-severity cloud AuditEvent is emitted via the
+Layer-5 audit service before the raise — exactly the signal that audit exists
+to capture. The emit is best-effort and never blocks the raise.
+
 Scope (ART-2): cwd resolution + fail-closed + the cloud/OSS gate only. Quota,
 TTL garbage-collection and disk-watermark eviction of these dirs are ART-3.
 """
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 # A jail path segment is a single workspace / session id. Ids are Mongo
 # ObjectId hex in practice; restrict to a safe charset (no path separators)
-# so a malformed or hostile id can never escape its workspace subtree.
-_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9_.-]+$")
+# so a malformed or hostile id can never escape its workspace subtree. The
+# anchor is ``\Z`` (very end of string), NOT ``$`` — ``$`` also matches just
+# before a trailing newline, so ``"abc\n"`` would slip past a ``$`` guard.
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9_.-]+\Z")
 
 # Group/DM-bridge runs bind a workspace but no session; they share one
 # per-workspace dir under this name (still tenant-isolated, just not
@@ -51,6 +61,42 @@ def _safe_segment(value: str, *, label: str) -> str:
     if value in {".", ".."} or not _SAFE_SEGMENT.match(value):
         raise ValueError(f"unsafe {label} for agent jail path: {value!r}")
     return value
+
+
+def _emit_fail_closed_audit(actor_id: str | None, session_id: str | None) -> None:
+    """Best-effort high-severity audit alert for a fail-closed cloud run.
+
+    A cloud agent run reaching the backend with no resolvable workspace is a
+    mis-tenanting signal — exactly what Layer-5 audit exists to capture. Emit it
+    through the cloud audit service, fire-and-forget on the running loop (the
+    resolver is sync but runs inside the async agent loop). NEVER raises and
+    NEVER blocks the fail-closed raise that follows: a missing alert must not
+    turn a closed door into an open one. No running loop (e.g. a sync unit test)
+    → skip silently; the raise still happens.
+    """
+    try:
+        import asyncio
+
+        from pocketpaw_ee.cloud.audit import service as audit_service
+
+        async def _record() -> None:
+            # ``record`` itself never raises; the workspace is a sentinel
+            # because the whole alert IS "this run had no workspace".
+            await audit_service.record(
+                "__no_workspace__",
+                actor_id or "unknown",
+                "agent.cwd_jail.fail_closed",
+                target_type="agent_run",
+                target_id=session_id,
+                metadata={
+                    "severity": "high",
+                    "reason": "no resolvable workspace_id",
+                },
+            )
+
+        asyncio.get_running_loop().create_task(_record())
+    except Exception:  # noqa: BLE001 — telemetry must never break fail-closed
+        logger.debug("fail-closed audit alert could not be scheduled", exc_info=True)
 
 
 def workspace_jail_root() -> Path:
@@ -81,6 +127,7 @@ def resolve_agent_cwd() -> str | None:
     """
     from pocketpaw_ee.cloud.chat.agent_service import (
         current_session_mongo_id,
+        current_user_id,
         current_workspace_id,
     )
 
@@ -94,6 +141,8 @@ def resolve_agent_cwd() -> str | None:
         from pocketpaw_ee.cloud.shared.db import get_client
 
         if get_client() is not None:
+            # Mis-tenanting signal — alert before failing closed (best-effort).
+            _emit_fail_closed_audit(current_user_id(), current_session_mongo_id())
             raise RuntimeError(
                 "cloud agent run reached the backend with no resolvable "
                 "workspace_id; refusing to fall back to the shared home "

--- a/ee/pocketpaw_ee/cloud/agent_jail.py
+++ b/ee/pocketpaw_ee/cloud/agent_jail.py
@@ -1,0 +1,118 @@
+"""Per-tenant agent working-directory jail (cloud only).
+
+Created: 2026-06-26 (ART-2) — gives every multi-tenant cloud workspace its own
+agent working directory so a tenant's file operations never co-mingle in the
+shared home dir. Today the chat agent (``ClaudeSDKBackend``) runs with
+``cwd = settings.file_jail_path``, which defaults to ``Path.home()`` — in cloud
+every tenant's agent shares ``~`` and writes land on top of each other.
+
+``resolve_agent_cwd()`` reads the run's identity from the
+``attach_agent_identity`` ContextVars (``current_workspace_id`` /
+``current_session_mongo_id``) and returns a per-workspace, per-session jail dir.
+It FAILS CLOSED: a run that reaches the backend in multi-tenant cloud mode with
+no resolvable workspace RAISES rather than silently falling back to ``~`` — that
+silent fallback is the exact co-mingling bug this closes. OFF cloud (OSS /
+dedicated, where the cloud DB was never initialized) it returns ``None`` so the
+core agent keeps using ``settings.file_jail_path`` unchanged.
+
+The multi-tenant-cloud signal is ``get_client() is not None`` — the cloud DB
+client is set exactly when ``init_cloud_db`` ran (``CloudLifecycleHook`` on
+``CLOUD_MONGODB_URI``), so it is the authoritative "this process is serving
+tenants" flag without inventing a new one.
+
+Scope (ART-2): cwd resolution + fail-closed + the cloud/OSS gate only. Quota,
+TTL garbage-collection and disk-watermark eviction of these dirs are ART-3.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+# A jail path segment is a single workspace / session id. Ids are Mongo
+# ObjectId hex in practice; restrict to a safe charset (no path separators)
+# so a malformed or hostile id can never escape its workspace subtree.
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+# Group/DM-bridge runs bind a workspace but no session; they share one
+# per-workspace dir under this name (still tenant-isolated, just not
+# session-granular).
+_SESSIONLESS_DIRNAME = "_shared"
+
+
+def _safe_segment(value: str, *, label: str) -> str:
+    """Return *value* if it is a safe single path segment, else raise.
+
+    Guards the jail against path traversal: the charset excludes ``/`` so a
+    crafted id cannot climb out of its workspace dir, and the literal ``.`` /
+    ``..`` are rejected outright.
+    """
+    if value in {".", ".."} or not _SAFE_SEGMENT.match(value):
+        raise ValueError(f"unsafe {label} for agent jail path: {value!r}")
+    return value
+
+
+def workspace_jail_root() -> Path:
+    """Root under which every workspace's agent jail lives.
+
+    Defaults to ``~/.pocketpaw/workspaces``. Override with
+    ``POCKETPAW_WORKSPACE_JAIL_ROOT`` to anchor the jail on a data volume (and
+    so tests can redirect it off the real home dir).
+    """
+    override = os.environ.get("POCKETPAW_WORKSPACE_JAIL_ROOT", "").strip()
+    if override:
+        return Path(override)
+    return Path.home() / ".pocketpaw" / "workspaces"
+
+
+def resolve_agent_cwd() -> str | None:
+    """Resolve the per-session agent working directory for the active run.
+
+    Returns:
+        - ``<root>/<workspace_id>/agent/<session_id>/`` (created on demand) when
+          a workspace is bound to the active run.
+        - ``None`` when the process is not in multi-tenant cloud mode, so the
+          core agent falls back to ``settings.file_jail_path``.
+
+    Raises:
+        RuntimeError: cloud mode is active but no workspace is resolvable — the
+        fail-closed guard against tenant file co-mingling.
+    """
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        current_session_mongo_id,
+        current_workspace_id,
+    )
+
+    workspace_id = current_workspace_id()
+    if not workspace_id:
+        # No tenancy bound. Distinguish a multi-tenant cloud run that lost its
+        # workspace (a bug we must NOT paper over by writing into the shared
+        # home dir) from an OSS / dedicated run where identity is legitimately
+        # never bound. ``get_client()`` is non-None exactly when
+        # ``init_cloud_db`` ran — the authoritative multi-tenant-cloud signal.
+        from pocketpaw_ee.cloud.shared.db import get_client
+
+        if get_client() is not None:
+            raise RuntimeError(
+                "cloud agent run reached the backend with no resolvable "
+                "workspace_id; refusing to fall back to the shared home "
+                "directory (would co-mingle tenant files). A cloud run must "
+                "bind identity via attach_agent_identity before the agent runs."
+            )
+        return None
+
+    ws_segment = _safe_segment(workspace_id, label="workspace_id")
+    # ``session_mongo_id`` is set on the SSE chat path so a multi-turn chat
+    # reuses one dir; the group/DM bridge binds a workspace but no session, so
+    # those runs share a per-workspace ``_shared`` dir.
+    session_raw = current_session_mongo_id()
+    session_segment = (
+        _safe_segment(session_raw, label="session_mongo_id")
+        if session_raw
+        else _SESSIONLESS_DIRNAME
+    )
+
+    cwd = workspace_jail_root() / ws_segment / "agent" / session_segment
+    cwd.mkdir(parents=True, exist_ok=True)
+    return str(cwd)

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,15 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-26 (ART-2) — ``_prewarm_session`` now binds the run's identity
+  (``attach_agent_identity`` with the same ``session_mongo_id`` / ``pocket_id``
+  the stream path uses) around its ``pool.prewarm`` call, then detaches in a
+  ``finally``. The per-tenant cwd jail resolves the agent's working directory
+  from those ContextVars; since prewarm is fired in its own ``create_task``
+  context BEFORE the stream binds identity, without this the cloud cwd resolver
+  would fail closed during warm-up (swallowed) and every cloud session would
+  lose the turn-1 warm. Binding here makes prewarm warm the SAME per-session
+  jail turn 1 will use.
 - 2026-06-25 (fix/worker-trusts-spec-workspace) — ``execute_run`` now threads
   the authenticated ``spec.workspace_id`` into ``resolve_scope_context`` via the
   new ``expected_workspace_id`` kwarg, then raises a clean
@@ -739,16 +748,35 @@ async def _prewarm_session(ctx: ScopeContext) -> None:
             surface_skills = ctx.resolved_profile.skill_names or frozenset()
         surface_skills = surface_skills | _agent_skill_set(instance)
 
-        await pool.prewarm(
-            ctx.target_agent_id,
-            session_key_for(ctx),
-            instructions=behavior_instructions,
-            deny_mcp_tool_ids=surface_deny,
-            allow_sdk_tools=surface_allow,
-            allow_mcp_tool_ids=surface_allow_mcp,
-            system_message_override=surface_sys_override,
-            skill_names=surface_skills,
+        # Bind this run's tenancy for the warm-up so the prewarmed subprocess
+        # connects with the SAME per-tenant cwd jail the first turn will resolve
+        # (ART-2). _prewarm_session runs in its own create_task context, fired
+        # BEFORE the stream binds identity at the _drive_agent_loop seam, so
+        # without this the cloud cwd resolver would fail closed here (swallowed)
+        # and every cloud session would lose the turn-1 warm. Mirrors the
+        # run-path binding exactly (same session_mongo_id / pocket_id) so prewarm
+        # and turn 1 resolve one cwd; detached in finally so it can't leak into
+        # this task's later work.
+        session_mongo_id = ctx.scope_id if ctx.kind is ScopeKind.SESSION else None
+        identity_tokens = attach_agent_identity(
+            workspace_id=ctx.workspace_id,
+            user_id=ctx.user_id,
+            session_mongo_id=session_mongo_id,
+            pocket_id=ctx.pocket_id,
         )
+        try:
+            await pool.prewarm(
+                ctx.target_agent_id,
+                session_key_for(ctx),
+                instructions=behavior_instructions,
+                deny_mcp_tool_ids=surface_deny,
+                allow_sdk_tools=surface_allow,
+                allow_mcp_tool_ids=surface_allow_mcp,
+                system_message_override=surface_sys_override,
+                skill_names=surface_skills,
+            )
+        finally:
+            detach_agent_identity(identity_tokens)
     except Exception as exc:  # noqa: BLE001 — prewarm must NEVER break a run
         logger.debug("prewarm_session skipped (swallowed): %s", exc)
 

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -65,6 +65,14 @@ supplying the ``WorkspaceConnector``-backed ``CloudConnectorStateStore`` as the
 ConnectorRegistry's default durable state store, so cloud connector config
 rehydrates from the tenant DB after a process restart (no /connect needed).
 
+Updated: 2026-06-26 (ART-2) — ``CloudAgentExtension`` gained ``agent_cwd``: a
+per-tenant agent working-directory jail. It delegates to
+``pocketpaw_ee.cloud.agent_jail.resolve_agent_cwd``, which returns a
+per-workspace/session dir (``~/.pocketpaw/workspaces/<ws>/agent/<session>/``) so
+a cloud tenant's file ops never co-mingle in the shared home dir, and FAILS
+CLOSED when a cloud run has no resolvable workspace. OSS / dedicated installs
+return ``None`` and keep ``settings.file_jail_path``.
+
 Updated: 2026-06-11 (feat/fabric-instinct-mcp-providers) — added
 ``CloudFabricMcpProvider`` (entry ``fabric``; server ``pocketpaw_fabric``,
 tools ``fabric_query`` / ``fabric_stats``) and ``CloudInstinctMcpProvider``
@@ -915,8 +923,9 @@ class CloudAgentExtension:
     """`pocketpaw.agent_extensions` — EE additions to the core agent runtime.
 
     Contributes the cloud pocket-specialist function tool to MCP-capable
-    tool-list backends, and cloud workspace/user/session identity to agent
-    subprocess environments.
+    tool-list backends, cloud workspace/user/session identity to agent
+    subprocess environments, and (ART-2) a per-tenant agent working-directory
+    jail so each cloud workspace's file ops stay isolated from every other.
     """
 
     # Backends that receive ``PocketSpecialistTool`` as a native function
@@ -956,6 +965,18 @@ class CloudAgentExtension:
             if value:
                 env[var] = str(value)
         return env
+
+    def agent_cwd(self) -> str | None:
+        """`pocketpaw.agent_extensions` — per-session agent working directory.
+
+        In multi-tenant cloud each workspace gets its own agent cwd
+        (``~/.pocketpaw/workspaces/<ws>/agent/<session>/``) so tenant file ops
+        never co-mingle in the shared home dir; fails CLOSED when a cloud run
+        has no resolvable workspace. Returns ``None`` off-cloud so the core
+        agent keeps using ``settings.file_jail_path`` (ART-2)."""
+        from pocketpaw_ee.cloud.agent_jail import resolve_agent_cwd
+
+        return resolve_agent_cwd()
 
 
 class CloudConnectorStateStoreProvider:

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -9,8 +9,12 @@ Updated: 2026-06-26 (ART-2) — the agent's working directory is now resolved
   shared home dir. A provider that RAISES (a cloud run with no resolvable
   workspace) propagates — fail-closed, never a silent fallback to ``~``.
   ``_build_options`` carries the resolved cwd, so ``run`` and ``prewarm`` warm
-  the same per-session jail (the warm-client cache key already keys on
-  ``session_key``, so a session change rebuilds the subprocess with its own cwd).
+  the same per-session jail. ART-2 hardening: the resolved cwd is folded into
+  ``_client_cache_key`` so warm-client tenant isolation is STRUCTURAL (a changed
+  cwd forces a fresh subprocess), not merely an implicit session_key<->cwd
+  coupling; the now-inert ``set_working_directory`` setter was removed
+  (``_build_options`` no longer reads ``self._cwd``); and ``get_status`` reports
+  ``base_cwd`` (the OSS/default base) instead of a misleading ``cwd``.
 Updated: 2026-06-26 (integration/model-catalog-v2, MCG-11) — the ResultMessage
   token-usage path now runs ``pocketpaw.llm.caching.report_savings`` over the SDK
   usage to surface STRUCTURED prompt-cache telemetry (cache_read_tokens,
@@ -489,13 +493,14 @@ class ClaudeSDKBackend(BaseAgentBackend):
             logger.error(f"❌ Failed to initialize Claude Agent SDK: {e}")
             self._sdk_available = False
 
-    def set_working_directory(self, path: Path) -> None:
-        """Set the working directory for file operations."""
-        self._cwd = path
-        logger.info(f"📂 Working directory set to: {path}")
-
     def _resolve_cwd(self) -> Path:
         """Resolve the agent's working directory for THIS run.
+
+        NOTE: the per-tenant cwd jail + fail-closed live ONLY in this backend.
+        Other backends (codex_cli, deep_agents, …) receive workspace tenancy via
+        ``subprocess_env`` but NOT the cwd jail — a non-``claude_agent_sdk`` cloud
+        agent would run in ``file_jail_path``. Cloud chat defaults to this
+        backend; see ART-2's report for the residual non-claude gap.
 
         Defaults to ``settings.file_jail_path`` (the OSS / dedicated behavior,
         unchanged). When an EE ``pocketpaw.agent_extensions`` provider supplies
@@ -508,8 +513,8 @@ class ClaudeSDKBackend(BaseAgentBackend):
         point — we must never silently fall back to ``~`` and let one tenant's
         files land on another's. Resolved per-run (not cached on the instance)
         so a single warm backend serving multiple sessions reads each session's
-        own jail; the warm-client cache key already folds in ``session_key``, so
-        a session change rebuilds the subprocess with its correct cwd.
+        own jail; the warm-client cache key folds in the resolved cwd (ART-2), so
+        a changed cwd rebuilds the subprocess with its correct working directory.
         """
         from pocketpaw._registry import providers as _ext_providers
 
@@ -1022,8 +1027,8 @@ class ClaudeSDKBackend(BaseAgentBackend):
     def _client_cache_key(
         cls, options: Any, *, session_key: str | None = None, plugin_digest: str = ""
     ) -> str:
-        """Persistent-client cache key: session + model + tools + a digest of
-        the system prompt's stable behavioral prefix + the plugin-identity
+        """Persistent-client cache key: session + cwd + model + tools + a digest
+        of the system prompt's stable behavioral prefix + the plugin-identity
         digest.
 
         The prefix digest is what makes a mid-session backend config change
@@ -1036,11 +1041,19 @@ class ClaudeSDKBackend(BaseAgentBackend):
         re-spawning every turn. Empty ``plugin_digest`` (the default) leaves the
         key byte-for-byte identical to the pre-fix behavior for non-skill
         callers. Hashing keeps the key bounded regardless of prompt length.
+
+        ``cwd`` (ART-2) is folded in so warm-client tenant isolation is
+        STRUCTURAL, not an implicit consequence of the session_key<->cwd
+        coupling: if cwd derivation ever changes to depend on something not in
+        session_key, a stale warm subprocess can never be reused across two
+        different working directories (i.e. two tenants). The SDK fixes cwd at
+        connect() time, so a changed cwd MUST force a fresh subprocess.
         """
         prefix = cls._behavior_prefix(getattr(options, "system_prompt", None))
         prefix_digest = hashlib.sha256(prefix.encode("utf-8", "replace")).hexdigest()[:16]
         return (
             f"{session_key or ''}:"
+            f"{getattr(options, 'cwd', '')}:"
             f"{getattr(options, 'model', '')}:"
             f"{sorted(getattr(options, 'allowed_tools', []) or [])}:"
             f"{prefix_digest}:"
@@ -2355,7 +2368,11 @@ class ClaudeSDKBackend(BaseAgentBackend):
             "sdk_installed": self._sdk_available,
             "cli_installed": self._cli_available,
             "running": not self._stop_flag,
-            "cwd": str(self._cwd),
+            # Base (OSS/default) working dir only. The ACTUAL per-run cwd is
+            # resolved each turn by ``_resolve_cwd`` — in cloud it's a per-tenant
+            # jail, not this base — so labelling it ``base_cwd`` keeps status
+            # honest (and avoids resolving here, which would fail closed off-run).
+            "base_cwd": str(self._cwd),
             "features": ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebSearch", "WebFetch"]
             if ready
             else [],

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,16 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-06-26 (ART-2) — the agent's working directory is now resolved
+  PER-RUN via ``_resolve_cwd`` instead of being frozen to
+  ``settings.file_jail_path`` at ``__init__``. OSS / dedicated behavior is
+  unchanged (still ``file_jail_path``); when an EE ``pocketpaw.agent_extensions``
+  provider supplies ``agent_cwd`` (the cloud product), the run uses a
+  per-workspace/session jail so a tenant's file ops never co-mingle in the
+  shared home dir. A provider that RAISES (a cloud run with no resolvable
+  workspace) propagates — fail-closed, never a silent fallback to ``~``.
+  ``_build_options`` carries the resolved cwd, so ``run`` and ``prewarm`` warm
+  the same per-session jail (the warm-client cache key already keys on
+  ``session_key``, so a session change rebuilds the subprocess with its own cwd).
 Updated: 2026-06-26 (integration/model-catalog-v2, MCG-11) — the ResultMessage
   token-usage path now runs ``pocketpaw.llm.caching.report_savings`` over the SDK
   usage to surface STRUCTURED prompt-cache telemetry (cache_read_tokens,
@@ -482,6 +493,34 @@ class ClaudeSDKBackend(BaseAgentBackend):
         """Set the working directory for file operations."""
         self._cwd = path
         logger.info(f"📂 Working directory set to: {path}")
+
+    def _resolve_cwd(self) -> Path:
+        """Resolve the agent's working directory for THIS run.
+
+        Defaults to ``settings.file_jail_path`` (the OSS / dedicated behavior,
+        unchanged). When an EE ``pocketpaw.agent_extensions`` provider supplies
+        an ``agent_cwd`` (the cloud product), its result wins — a
+        per-workspace/session jail that keeps each tenant's file operations
+        isolated instead of co-mingling in the shared home dir.
+
+        A provider that RAISES (a multi-tenant cloud run with no resolvable
+        workspace) is propagated, NOT swallowed: that fail-closed is the whole
+        point — we must never silently fall back to ``~`` and let one tenant's
+        files land on another's. Resolved per-run (not cached on the instance)
+        so a single warm backend serving multiple sessions reads each session's
+        own jail; the warm-client cache key already folds in ``session_key``, so
+        a session change rebuilds the subprocess with its correct cwd.
+        """
+        from pocketpaw._registry import providers as _ext_providers
+
+        for ext in _ext_providers("pocketpaw.agent_extensions"):
+            resolver = getattr(ext, "agent_cwd", None)
+            if resolver is None:
+                continue
+            resolved = resolver()  # may raise (fail-closed) — let it propagate
+            if resolved:
+                return Path(resolved)
+        return self.settings.file_jail_path
 
     def _is_dangerous_command(self, command: str) -> str | None:
         """Check if a command matches dangerous patterns.
@@ -1195,6 +1234,14 @@ class ClaudeSDKBackend(BaseAgentBackend):
         skills_dir_adopted = False
         plugin_digest = ""
 
+        # Per-run working directory. OSS / dedicated → ``file_jail_path``; cloud
+        # → a per-workspace/session jail (or a fail-closed raise when a cloud run
+        # has no resolvable workspace). Resolved here so BOTH ``run`` and
+        # ``prewarm`` warm the SAME cwd for a session — the warm-client cache key
+        # already keys on ``session_key``, so a session change rebuilds the
+        # subprocess with its own jail.
+        resolved_cwd = self._resolve_cwd()
+
         # Resolve LLM provider early -- needed for routing + env.
         # Use per-backend provider setting (defaults to "anthropic").
         # An API key is REQUIRED for Anthropic provider -- OAuth tokens from
@@ -1443,7 +1490,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
             "allowed_tools": allowed_tools,
             "setting_sources": [],
             "hooks": hooks,
-            "cwd": str(self._cwd),
+            "cwd": str(resolved_cwd),
             "max_turns": self.settings.claude_sdk_max_turns or None,
         }
 
@@ -1569,7 +1616,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
             "set" if os.environ.get("ANTHROPIC_API_KEY") else "<unset>",
             list(sdk_env.keys()) if sdk_env else "none",
             _shutil.which("claude") or "<not found>",
-            self._cwd,
+            resolved_cwd,
         )
 
         # Wire in MCP servers (policy-filtered)

--- a/src/pocketpaw/extensions.py
+++ b/src/pocketpaw/extensions.py
@@ -183,6 +183,17 @@ class AgentExtension(Protocol):
         context is active (the common OSS / out-of-stream case)."""
         ...
 
+    def agent_cwd(self) -> str | None:
+        """Per-run working directory for the agent, or ``None`` to use
+        ``settings.file_jail_path``. The cloud product returns a
+        per-workspace/session jail so a tenant's file operations never
+        co-mingle in the shared home dir, and RAISES when a cloud run has
+        no resolvable workspace (fail-closed — never silently land in
+        ``~``). An OSS install registers no provider, so the core keeps
+        its ``file_jail_path`` default. Optional: a provider predating
+        this method simply isn't consulted (the core uses ``getattr``)."""
+        ...
+
 
 @runtime_checkable
 class PocketWriter(Protocol):

--- a/tests/cloud/agents/test_agent_jail.py
+++ b/tests/cloud/agents/test_agent_jail.py
@@ -7,11 +7,14 @@
 #   * cloud active + no workspace -> RAISES (fail-closed)
 #   * cloud NOT active + no workspace -> None (OSS / dedicated unchanged)
 #   * hostile / traversal ids are rejected before they touch the filesystem
+#   * a trailing-newline id is rejected (the \Z-vs-$ anchor hardening)
+#   * the fail-closed emits a high-severity cloud AuditEvent before it raises
 #   * CloudAgentExtension.agent_cwd delegates to the resolver
 """Per-tenant agent working-directory jail (ART-2)."""
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -156,6 +159,17 @@ def test_hostile_session_id_rejected(_jail_root):
         detach_agent_identity(tok)
 
 
+def test_trailing_newline_id_rejected(_jail_root):
+    # ``$`` matches just before a trailing newline; the ``\Z`` anchor must
+    # reject ``"ws1\n"`` so a newline can't slip past the traversal guard.
+    tok = _bind("ws1\n", session_mongo_id="sess1")
+    try:
+        with pytest.raises(ValueError, match="unsafe workspace_id"):
+            agent_jail.resolve_agent_cwd()
+    finally:
+        detach_agent_identity(tok)
+
+
 def test_extension_delegates(_jail_root):
     from pocketpaw_ee.extensions import CloudAgentExtension
 
@@ -165,3 +179,40 @@ def test_extension_delegates(_jail_root):
     finally:
         detach_agent_identity(tok)
     assert Path(cwd) == _jail_root / "ws1" / "agent" / "sessX"
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_emits_high_severity_audit(cloud_active, monkeypatch):
+    """The fail-closed (a cloud run that lost its workspace) emits a
+    high-severity cloud AuditEvent before it raises — best-effort, fire-and-
+    forget on the running loop."""
+    import pocketpaw_ee.cloud.audit.service as audit_service
+
+    calls: list[tuple] = []
+
+    async def fake_record(workspace_id, actor_id, action, **kwargs):
+        calls.append((workspace_id, actor_id, action, kwargs))
+
+    monkeypatch.setattr(audit_service, "record", fake_record)
+
+    from pocketpaw_ee.cloud.chat import agent_service as svc
+
+    # Bind a user + session but NO workspace (the mis-tenanting condition).
+    utok = svc._active_user_id.set("user-1")
+    stok = svc._active_session_mongo_id.set("sess-9")
+    try:
+        with pytest.raises(RuntimeError, match="no resolvable workspace"):
+            agent_jail.resolve_agent_cwd()
+        # The emit is scheduled on the loop; give it turns to run.
+        for _ in range(3):
+            await asyncio.sleep(0)
+    finally:
+        svc._active_user_id.reset(utok)
+        svc._active_session_mongo_id.reset(stok)
+
+    assert calls, "expected a fail-closed audit alert to be recorded"
+    workspace_id, actor_id, action, kwargs = calls[0]
+    assert action == "agent.cwd_jail.fail_closed"
+    assert actor_id == "user-1"
+    assert kwargs["target_id"] == "sess-9"
+    assert kwargs["metadata"]["severity"] == "high"

--- a/tests/cloud/agents/test_agent_jail.py
+++ b/tests/cloud/agents/test_agent_jail.py
@@ -1,0 +1,167 @@
+# tests/cloud/agents/test_agent_jail.py
+# Created 2026-06-26 (ART-2) — locks the per-tenant agent cwd jail contract:
+#   * two workspaces resolve to distinct, non-overlapping dirs (isolation)
+#   * workspace + session -> <root>/<ws>/agent/<session>/
+#   * workspace, no session -> <root>/<ws>/agent/_shared/ (group/DM bridge)
+#   * same identity reuses one dir across turns
+#   * cloud active + no workspace -> RAISES (fail-closed)
+#   * cloud NOT active + no workspace -> None (OSS / dedicated unchanged)
+#   * hostile / traversal ids are rejected before they touch the filesystem
+#   * CloudAgentExtension.agent_cwd delegates to the resolver
+"""Per-tenant agent working-directory jail (ART-2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud import agent_jail
+from pocketpaw_ee.cloud.chat.agent_service import (
+    attach_agent_identity,
+    detach_agent_identity,
+)
+
+
+@pytest.fixture(autouse=True)
+def _jail_root(tmp_path, monkeypatch):
+    """Anchor the jail under tmp_path so tests never touch the real home dir."""
+    root = tmp_path / "jail"
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_JAIL_ROOT", str(root))
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _clean_identity():
+    """Reset the identity ContextVars to None around each test.
+
+    Guarantees the no-workspace cases see a clean slate regardless of any
+    binding a prior test in the suite forgot to detach.
+    """
+    from pocketpaw_ee.cloud.chat import agent_service as svc
+
+    tokens = (
+        svc._active_workspace_id.set(None),
+        svc._active_user_id.set(None),
+        svc._active_session_mongo_id.set(None),
+        svc._active_pocket_id.set(None),
+    )
+    try:
+        yield
+    finally:
+        svc._active_workspace_id.reset(tokens[0])
+        svc._active_user_id.reset(tokens[1])
+        svc._active_session_mongo_id.reset(tokens[2])
+        svc._active_pocket_id.reset(tokens[3])
+
+
+@pytest.fixture
+def cloud_active(monkeypatch):
+    """Make get_client() report cloud mode active without a real Mongo client."""
+    monkeypatch.setattr("pocketpaw_ee.cloud.shared.db._client", object())
+
+
+@pytest.fixture
+def cloud_inactive(monkeypatch):
+    """Force get_client() to None (OSS / dedicated — no cloud DB)."""
+    monkeypatch.setattr("pocketpaw_ee.cloud.shared.db._client", None)
+
+
+def _bind(workspace_id: str, *, user_id: str = "u1", session_mongo_id: str | None = None):
+    return attach_agent_identity(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        session_mongo_id=session_mongo_id,
+    )
+
+
+def test_two_workspaces_isolated(_jail_root):
+    tok_a = _bind("wsAAA", session_mongo_id="sess1")
+    try:
+        cwd_a = Path(agent_jail.resolve_agent_cwd())
+    finally:
+        detach_agent_identity(tok_a)
+
+    tok_b = _bind("wsBBB", session_mongo_id="sess1")
+    try:
+        cwd_b = Path(agent_jail.resolve_agent_cwd())
+    finally:
+        detach_agent_identity(tok_b)
+
+    assert cwd_a != cwd_b
+    assert "wsAAA" in cwd_a.parts and "wsBBB" not in cwd_a.parts
+    assert "wsBBB" in cwd_b.parts and "wsAAA" not in cwd_b.parts
+    # Both under the jail root; neither nested inside the other (no co-mingling).
+    assert _jail_root in cwd_a.parents and _jail_root in cwd_b.parents
+    assert not str(cwd_a).startswith(str(cwd_b) + "/")
+    assert not str(cwd_b).startswith(str(cwd_a) + "/")
+    assert cwd_a.is_dir() and cwd_b.is_dir()
+
+
+def test_workspace_and_session_path(_jail_root):
+    tok = _bind("ws1", session_mongo_id="sessX")
+    try:
+        cwd = Path(agent_jail.resolve_agent_cwd())
+    finally:
+        detach_agent_identity(tok)
+    assert cwd == _jail_root / "ws1" / "agent" / "sessX"
+    assert cwd.is_dir()
+
+
+def test_workspace_without_session_uses_shared(_jail_root):
+    tok = _bind("ws1", session_mongo_id=None)
+    try:
+        cwd = Path(agent_jail.resolve_agent_cwd())
+    finally:
+        detach_agent_identity(tok)
+    assert cwd == _jail_root / "ws1" / "agent" / "_shared"
+    assert cwd.is_dir()
+
+
+def test_same_identity_reuses_dir(_jail_root):
+    tok = _bind("ws1", session_mongo_id="sessX")
+    try:
+        first = agent_jail.resolve_agent_cwd()
+        second = agent_jail.resolve_agent_cwd()
+    finally:
+        detach_agent_identity(tok)
+    assert first == second
+
+
+def test_fail_closed_when_cloud_active_and_no_workspace(cloud_active):
+    # No identity bound (contextvar default None) + cloud mode active.
+    with pytest.raises(RuntimeError, match="no resolvable workspace"):
+        agent_jail.resolve_agent_cwd()
+
+
+def test_returns_none_when_not_cloud(cloud_inactive):
+    # No identity bound + cloud DB never initialized → OSS / dedicated path.
+    assert agent_jail.resolve_agent_cwd() is None
+
+
+def test_hostile_workspace_id_rejected(_jail_root):
+    tok = _bind("../etc", session_mongo_id="sess1")
+    try:
+        with pytest.raises(ValueError, match="unsafe workspace_id"):
+            agent_jail.resolve_agent_cwd()
+    finally:
+        detach_agent_identity(tok)
+
+
+def test_hostile_session_id_rejected(_jail_root):
+    tok = _bind("ws1", session_mongo_id="../../root")
+    try:
+        with pytest.raises(ValueError, match="unsafe session_mongo_id"):
+            agent_jail.resolve_agent_cwd()
+    finally:
+        detach_agent_identity(tok)
+
+
+def test_extension_delegates(_jail_root):
+    from pocketpaw_ee.extensions import CloudAgentExtension
+
+    tok = _bind("ws1", session_mongo_id="sessX")
+    try:
+        cwd = CloudAgentExtension().agent_cwd()
+    finally:
+        detach_agent_identity(tok)
+    assert Path(cwd) == _jail_root / "ws1" / "agent" / "sessX"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -339,3 +339,75 @@ class TestClaudeSDKCliAuth:
 
         assert len(resolved_providers) > 0
         assert resolved_providers[0] == "anthropic"
+
+
+# =============================================================================
+# ART-2: per-run cwd resolution + fail-closed (agent_extensions seam)
+# =============================================================================
+
+
+class TestResolveCwd:
+    """``ClaudeSDKBackend._resolve_cwd`` — the OSS/cloud cwd gate.
+
+    OSS (no ``agent_extensions`` provider) must stay on ``file_jail_path``; an
+    EE provider's ``agent_cwd`` wins; a provider that RAISES (a cloud run with
+    no resolvable workspace) propagates — fail-closed, never a silent fallback.
+    """
+
+    def test_oss_defaults_to_file_jail_path(self, monkeypatch):
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: ())
+        settings = Settings()
+        backend = ClaudeSDKBackend(settings)
+        assert backend._resolve_cwd() == settings.file_jail_path
+
+    def test_extension_cwd_wins(self, monkeypatch, tmp_path):
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        jail = tmp_path / "jail" / "wsX"
+
+        class FakeExt:
+            def agent_cwd(self):
+                return str(jail)
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: (FakeExt(),))
+        backend = ClaudeSDKBackend(Settings())
+        assert backend._resolve_cwd() == jail
+
+    def test_extension_raise_propagates_fail_closed(self, monkeypatch):
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        class FailClosedExt:
+            def agent_cwd(self):
+                raise RuntimeError("no resolvable workspace_id")
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: (FailClosedExt(),))
+        backend = ClaudeSDKBackend(Settings())
+        with pytest.raises(RuntimeError, match="no resolvable workspace_id"):
+            backend._resolve_cwd()
+
+    def test_extension_returning_none_falls_back(self, monkeypatch):
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        class NoneExt:
+            def agent_cwd(self):
+                return None
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: (NoneExt(),))
+        settings = Settings()
+        backend = ClaudeSDKBackend(settings)
+        assert backend._resolve_cwd() == settings.file_jail_path
+
+    def test_provider_without_agent_cwd_ignored(self, monkeypatch):
+        # A provider predating agent_cwd must not break resolution.
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        class OldExt:
+            def subprocess_env(self):
+                return {}
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: (OldExt(),))
+        settings = Settings()
+        backend = ClaudeSDKBackend(settings)
+        assert backend._resolve_cwd() == settings.file_jail_path

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -7,8 +7,6 @@ Updated for multi-SDK architecture:
 - Removed: ExecutorProtocol, OrchestratorProtocol, pocketpaw_native, open_interpreter
 """
 
-from pathlib import Path
-
 import pytest
 
 from pocketpaw.config import Settings
@@ -154,14 +152,6 @@ class TestClaudeAgentSDK:
         assert sdk._stop_flag is False
         await sdk.stop()
         assert sdk._stop_flag is True
-
-    def test_sdk_set_working_directory(self):
-        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
-
-        sdk = ClaudeSDKBackend(Settings())
-        new_path = Path("/tmp")
-        sdk.set_working_directory(new_path)
-        assert sdk._cwd == new_path
 
     @pytest.mark.asyncio
     async def test_sdk_run_without_sdk_installed(self):
@@ -411,3 +401,68 @@ class TestResolveCwd:
         settings = Settings()
         backend = ClaudeSDKBackend(settings)
         assert backend._resolve_cwd() == settings.file_jail_path
+
+
+class TestCwdJailHardening:
+    """ART-2 hardening: run()-level fail-closed lock + cwd in the cache key."""
+
+    @pytest.mark.asyncio
+    async def test_run_fails_closed_no_home_fallback(self, monkeypatch):
+        """A cloud run whose cwd resolver RAISES must surface an error event and
+        NEVER execute the agent with a file_jail_path / home fallback cwd.
+
+        Locks the fail-closed at the run() seam, not just the _resolve_cwd unit:
+        guards against a future edit adding a generic cwd fallback in run()'s
+        except handler (the known cloud-fail-closed-slips-past-green-OSS-CI
+        pattern). Asserts the CLOUD branch — the resolver raises.
+        """
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        settings = Settings()
+        backend = ClaudeSDKBackend(settings)
+        backend._sdk_available = True
+        backend._cli_available = True
+
+        class FailClosedExt:
+            def agent_cwd(self):
+                raise RuntimeError("no resolvable workspace_id")
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: (FailClosedExt(),))
+
+        # Capture the cwd of every SDK-options construction — the only gateway
+        # to actually launching the agent. On the fail-closed path the resolver
+        # raises first, so options are never built at all.
+        built_cwds: list[str | None] = []
+
+        def spy_options(**kwargs):
+            built_cwds.append(kwargs.get("cwd"))
+            raise RuntimeError("options must not be built on the fail-closed path")
+
+        backend._ClaudeAgentOptions = spy_options
+
+        events = [e async for e in backend.run("hi", session_key="s1")]
+
+        # (1) the run surfaces an error event
+        assert any(e.type == "error" for e in events)
+        # (2) the agent NEVER executed with a home / file_jail_path fallback cwd
+        assert str(settings.file_jail_path) not in built_cwds
+        # in fact nothing was built — the raise precedes options construction
+        assert built_cwds == []
+
+    def test_cache_key_includes_cwd(self):
+        """Two different resolved cwds → different cache keys (no warm-client
+        reuse across tenants); identical inputs → identical key (reuse kept)."""
+        from types import SimpleNamespace
+
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        def opts(cwd):
+            return SimpleNamespace(
+                cwd=cwd, model="claude-x", allowed_tools=["Read"], system_prompt="p"
+            )
+
+        key_a = ClaudeSDKBackend._client_cache_key(opts("/jail/wsA/agent/s1"), session_key="s1")
+        key_b = ClaudeSDKBackend._client_cache_key(opts("/jail/wsB/agent/s1"), session_key="s1")
+        key_a2 = ClaudeSDKBackend._client_cache_key(opts("/jail/wsA/agent/s1"), session_key="s1")
+        assert key_a != key_b
+        assert key_a == key_a2

--- a/tests/test_fast_path.py
+++ b/tests/test_fast_path.py
@@ -287,6 +287,7 @@ async def test_persistent_client_reuse():
     options1 = MagicMock()
     options1.model = "claude-sonnet-4-5-20250929"
     options1.allowed_tools = ["Bash", "Read"]
+    options1.cwd = "/jail/ws"  # cwd is part of the cache key (ART-2)
 
     # First call — creates client
     client1 = await sdk._get_or_create_client(options1)
@@ -297,6 +298,7 @@ async def test_persistent_client_reuse():
     options2 = MagicMock()
     options2.model = "claude-sonnet-4-5-20250929"
     options2.allowed_tools = ["Bash", "Read"]
+    options2.cwd = "/jail/ws"  # same cwd → same key → warm reuse
 
     client2 = await sdk._get_or_create_client(options2)
     assert len(clients_created) == 1  # No new client created
@@ -333,6 +335,37 @@ async def test_persistent_client_reconnects_on_model_change():
     assert len(clients_created) == 2
     assert client2 is not client1
     assert client1.disconnected  # Old client was disconnected
+
+
+async def test_persistent_client_reconnects_on_cwd_change():
+    """Same session + model + tools but a DIFFERENT cwd (another tenant's jail)
+    must create a fresh client, never reuse the warm one (ART-2). Locks warm-
+    client tenant isolation as structural, not implicit in session_key."""
+    sdk = _make_sdk()
+
+    clients_created = []
+
+    def _client_factory(**kwargs):
+        c = _FakeSDKClient()
+        clients_created.append(c)
+        return c
+
+    sdk._ClaudeSDKClient = _client_factory
+
+    options1 = MagicMock()
+    options1.model = "claude-sonnet-4-5-20250929"
+    options1.allowed_tools = ["Bash"]
+    options1.cwd = "/jail/wsA/agent/s1"
+    client1 = await sdk._get_or_create_client(options1, session_key="s1")
+    assert len(clients_created) == 1
+
+    options2 = MagicMock()
+    options2.model = "claude-sonnet-4-5-20250929"
+    options2.allowed_tools = ["Bash"]
+    options2.cwd = "/jail/wsB/agent/s1"  # different tenant, same session_key
+    client2 = await sdk._get_or_create_client(options2, session_key="s1")
+    assert len(clients_created) == 2
+    assert client2 is not client1
 
 
 async def test_persistent_client_falls_back_to_query():


### PR DESCRIPTION
## What this adds

Per-tenant working-directory isolation for the cloud chat agent. The agent (a Claude Code subprocess) used to run with its cwd set to `settings.file_jail_path`, which defaults to the shared home dir. In multi-tenant cloud that means every tenant's agent writes into the same filesystem. This change jails each workspace's agent into `~/.pocketpaw/workspaces/<workspace_id>/agent/<session_id>/` and fails closed if it can't determine the workspace.

- Cloud run: cwd resolved per-run from the `attach_agent_identity` workspace ContextVar; directory created on demand.
- A cloud run that reaches the agent with no resolvable workspace **raises** instead of falling back to the home dir. Mis-tenanting fails loudly rather than co-mingling.
- OSS and single-tenant dedicated deployments are unchanged: no cloud DB, no resolver, cwd stays `file_jail_path`.
- The cloud-mode signal is `get_client()` truthiness, the existing convention (same gate as `cli.py`).

## Security

Reviewed for spec, quality, and as a dedicated tenant-isolation audit. The boundary holds:

- **Fail-closed is complete** on both the run and prewarm paths, and is locked by a run()-level test that proves the agent never builds SDK options (never spawns) when the workspace is unresolvable. This guards against a future generic cwd fallback silently slipping past green CI.
- **Path traversal:** workspace and session ids are validated against `^[A-Za-z0-9_.-]+\Z` with explicit `.`/`..` rejection before any mkdir. The ids are server-set authenticated values (24-hex ObjectIds), never request input.
- **Warm-client isolation is structural:** the resolved cwd is part of the agent subprocess cache key, so a warm client can never be reused across two tenants' directories.
- **Audit:** a high-severity audit event (`agent.cwd_jail.fail_closed`) fires when the fail-closed path triggers, as fire-and-forget that cannot block or swallow the raise.

## Scope

Working-directory isolation only. Quota / TTL GC / disk-watermark eviction is the next task (ART-3). The deliver-to-blob tool is ART-4.

The one scope-adjacent change is binding workspace identity in `_prewarm_session`: prewarm runs before the stream binds identity, so without it every cloud session would warm a wrong-cwd client and lose its turn-1 warm. It mirrors the run-path binding exactly.

## Known residual (tracked follow-up, not in this PR)

The jail lives in `ClaudeSDKBackend`. A cloud agent configured with a non-claude backend (`deep_agents`, `openai`, `codex`) would bypass the jail and run un-isolated. Reachability is low today: the cloud default is `claude_agent_sdk` and non-claude backends need keys the managed cloud doesn't provision. The fix is to either pin `claude_agent_sdk` for cloud chat agents or lift the jail into a shared backend base, tracked as a follow-up.

Minor: the fail-closed audit task is fire-and-forget and could be dropped under GC pressure (alert delivery only, never the raise) — a one-line follow-up to hold a task reference.

## Tests

`tests/cloud/agents/test_agent_jail.py` + `tests/test_agents.py` + `tests/test_fast_path.py`: two-workspace cwd isolation, per-session and sessionless `_shared` paths, fail-closed when cloud + no workspace, OSS default unchanged, hostile-id rejection (including trailing newline), run()-level fail-closed (no home fallback), and warm-client reconnect on cwd change. 200 in the focused sweep, 367 in the broad sweep. ruff clean.

One pre-existing unrelated red (`test_agent_bridge_emits.py`, a committed Windows path) is untouched by this change.

## Stack

Stacked on ART-1 (`feat/art1-file-versions-port`, PR #1565). Merge the base with `--rebase`, not squash.
