### PR TITLE
fix(ci): ruff-format two files to clear the red dev Lint

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/media.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/media.py
@@ -754,9 +754,7 @@ async def _audio_transcribe_handler(args: dict) -> dict:
     if err is not None or text is None:
         return _error_response(err or "transcription returned no text")
 
-    return _success_response(
-        {"ok": True, "kind": "transcription", "model": model, "text": text}
-    )
+    return _success_response({"ok": True, "kind": "transcription", "model": model, "text": text})
 
 
 # ── Video (POST {proxy}/videos) ──────────────────────────────────────────────

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
@@ -131,9 +131,7 @@ async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
     # An unrecognised mode (mis-set env) — log loud and do nothing rather than
     # guess. ``effective_spend_mode`` only ever returns off|shadow|live, so this is
     # defensive against a hand-rolled caller passing a bad value.
-    logger.warning(
-        "run_cutover_sweep: unrecognised billing mode %r — sweeping nothing", resolved
-    )
+    logger.warning("run_cutover_sweep: unrecognised billing mode %r — sweeping nothing", resolved)
     return summary
 
 


### PR DESCRIPTION
Two files landed on dev mis-formatted, turning the Lint check red (dev CI has been failing since around 13:04 today): `ee/pocketpaw_ee/agent/mcp_servers/media.py` and `ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py`. This is a pure `ruff format` pass on those two, with no behavior change. It clears dev's Lint and unblocks the open PRs that inherit the failure through their test-merge commit.