### PR TITLE
feat(cloud): bound the per-tenant agent jail — quota, TTL GC, watermark eviction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,8 +247,9 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   `POCKETPAW_AGENT_JAIL_GC_ENABLED` (default `true`) — escape hatch to disable
   the GC sweep entirely. The GC (`ee/pocketpaw_ee/cloud/agent_jail_gc.py`,
   `sweep_agent_jails`) runs on cloud startup and the same 5-minute heartbeat as
-  the stale-run sweeper, and NEVER evicts a jail whose run is still
-  queued/running/resumable (resolved via `run_service.find_active_run_scopes`).
+  the stale-run sweeper, and NEVER evicts a jail whose run is still queued or
+  running (resolved via `run_service.find_active_run_scopes`; a retried
+  interrupted run re-protects its jail by spawning a fresh queued run).
 - **In-process bus subscribers**: `pocketpaw_ee.cloud._core.realtime.bus.InProcessBus` exposes `subscribe(event_type, handler)` for cloud-side listeners (e.g. the `FileReady` → KB indexer wired in `ee/pocketpaw_ee/cloud/uploads/listeners.py`). Register subscribers from `mount_cloud()` after `init_realtime()` runs. Handler exceptions are logged and swallowed per-handler so one bad listener can't block the rest of the dispatch.
 - **Memory backend (`POCKETPAW_MEMORY_BACKEND`)**: OSS self-hosted defaults to `"file"` (local JSON under `~/.pocketpaw/memory/`). The cloud forces `"mongodb"` via `register_default_backend()` (`ee/pocketpaw_ee/cloud/memory/bootstrap.py`) unless explicitly overridden. The cloud now **fails to boot** if the active store isn't `MongoMemoryStore` (`verify_cloud_memory_backend()` in `init_cloud_db`) — a deliberate guard so a misconfigured backend can never silently write chat history (files-surface chats included) to local disk. Don't set `POCKETPAW_MEMORY_BACKEND=file` on a cloud deployment.
 - **API key required**: The `claude_agent_sdk` backend requires an `ANTHROPIC_API_KEY` when using the Anthropic provider. OAuth tokens from Free/Pro/Max plans are not permitted for third-party use per [Anthropic's policy](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use). Ollama/local providers do not require an API key.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,25 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   falling back to `~`. OSS / dedicated installs (no cloud DB initialized) keep
   `settings.file_jail_path` unchanged. Override the jail root with
   `POCKETPAW_WORKSPACE_JAIL_ROOT` (default `~/.pocketpaw/workspaces`) to anchor
-  it on a data volume. Lifecycle (quota / TTL-GC / disk-watermark eviction of
-  these dirs) is ART-3, not yet shipped.
+  it on a data volume.
+- **Agent jail lifecycle (cloud, ART-3)**: bounds the ART-2 scratch jails so
+  disk scales with active concurrency, not user count (the jail is pure scratch;
+  durability lives in blob storage). Three knobs, all read from the environment
+  in `ee/pocketpaw_ee/cloud/agent_jail.py`:
+  `POCKETPAW_AGENT_JAIL_QUOTA_MB` (default `2048`) — per-workspace size cap
+  measured at RUN-START; an over-quota run is rejected cleanly (a terminal
+  `failed` run with an `agent.jail_over_quota` error frame, never an OOM/crash).
+  `0` disables it.
+  `POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS` (default `3600`) — idle grace after
+  which a jail with no active run is garbage-collected.
+  `POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT` (default `90`) — box disk-usage
+  high-water mark; over it, the GC evicts least-recently-used IDLE jails first
+  until back under. `0` disables watermark eviction.
+  `POCKETPAW_AGENT_JAIL_GC_ENABLED` (default `true`) — escape hatch to disable
+  the GC sweep entirely. The GC (`ee/pocketpaw_ee/cloud/agent_jail_gc.py`,
+  `sweep_agent_jails`) runs on cloud startup and the same 5-minute heartbeat as
+  the stale-run sweeper, and NEVER evicts a jail whose run is still
+  queued/running/resumable (resolved via `run_service.find_active_run_scopes`).
 - **In-process bus subscribers**: `pocketpaw_ee.cloud._core.realtime.bus.InProcessBus` exposes `subscribe(event_type, handler)` for cloud-side listeners (e.g. the `FileReady` → KB indexer wired in `ee/pocketpaw_ee/cloud/uploads/listeners.py`). Register subscribers from `mount_cloud()` after `init_realtime()` runs. Handler exceptions are logged and swallowed per-handler so one bad listener can't block the rest of the dispatch.
 - **Memory backend (`POCKETPAW_MEMORY_BACKEND`)**: OSS self-hosted defaults to `"file"` (local JSON under `~/.pocketpaw/memory/`). The cloud forces `"mongodb"` via `register_default_backend()` (`ee/pocketpaw_ee/cloud/memory/bootstrap.py`) unless explicitly overridden. The cloud now **fails to boot** if the active store isn't `MongoMemoryStore` (`verify_cloud_memory_backend()` in `init_cloud_db`) — a deliberate guard so a misconfigured backend can never silently write chat history (files-surface chats included) to local disk. Don't set `POCKETPAW_MEMORY_BACKEND=file` on a cloud deployment.
 - **API key required**: The `claude_agent_sdk` backend requires an `ANTHROPIC_API_KEY` when using the Anthropic provider. OAuth tokens from Free/Pro/Max plans are not permitted for third-party use per [Anthropic's policy](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use). Ollama/local providers do not require an API key.

--- a/ee/pocketpaw_ee/cloud/agent_jail.py
+++ b/ee/pocketpaw_ee/cloud/agent_jail.py
@@ -25,8 +25,27 @@ mis-tenanting signal), a high-severity cloud AuditEvent is emitted via the
 Layer-5 audit service before the raise — exactly the signal that audit exists
 to capture. The emit is best-effort and never blocks the raise.
 
-Scope (ART-2): cwd resolution + fail-closed + the cloud/OSS gate only. Quota,
-TTL garbage-collection and disk-watermark eviction of these dirs are ART-3.
+Scope (ART-2): cwd resolution + fail-closed + the cloud/OSS gate.
+
+ART-3 (2026-06-26) — jail lifecycle, so scratch disk scales with active
+concurrency, not user count. The jail is pure scratch (durability lives in blob
+storage, a later task), so an idle jail is always safe to evict. Three bounds,
+all cloud-only:
+
+  * **Per-workspace quota** (``POCKETPAW_AGENT_JAIL_QUOTA_MB``, default 2048).
+    ``check_workspace_jail_quota`` measures a workspace's total jail size at
+    RUN-START and returns a clean rejection message when over the cap — the
+    run is failed cleanly (``run_core`` turns it into a terminal ``failed``
+    event), never crashing the box. We measure at run-start rather than gating
+    each write because the agent writes through its native subprocess tools
+    (Write/Bash), so individual writes can't be cheaply intercepted; run-start
+    is the enforceable, testable granularity.
+  * **TTL garbage-collection + disk-watermark eviction** live in the sibling
+    ``agent_jail_gc`` module (``sweep_agent_jails``), registered on cloud
+    startup and the 5-minute heartbeat exactly like the stale-run sweeper. This
+    module owns the filesystem primitives the sweep composes (scan, enumerate,
+    evict, disk probe); the sweep owns the run-state coordination (it never
+    evicts a jail whose run is still queued/running/resumable).
 """
 
 from __future__ import annotations
@@ -34,6 +53,8 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shutil
+from collections.abc import Iterator
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -165,3 +186,189 @@ def resolve_agent_cwd() -> str | None:
     cwd = workspace_jail_root() / ws_segment / "agent" / session_segment
     cwd.mkdir(parents=True, exist_ok=True)
     return str(cwd)
+
+
+# --------------------------------------------------------------------------- #
+# ART-3 — jail lifecycle primitives (quota / TTL-GC / watermark).
+#
+# Settings are read straight from the environment, like ``workspace_jail_root``
+# above, so the jail module stays self-contained (no Settings import). Every
+# knob is cloud-only; off-cloud there is no jail to bound.
+# --------------------------------------------------------------------------- #
+
+_DEFAULT_QUOTA_MB = 2048.0
+_DEFAULT_TTL_GRACE_SECONDS = 3600.0
+_DEFAULT_DISK_WATERMARK_PCT = 90.0
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("ignoring non-numeric %s=%r; using default %s", name, raw, default)
+        return default
+
+
+def jail_quota_bytes() -> int:
+    """Per-workspace jail size cap in bytes (``POCKETPAW_AGENT_JAIL_QUOTA_MB``,
+    default 2048 MB). ``<= 0`` disables the quota."""
+    return int(_env_float("POCKETPAW_AGENT_JAIL_QUOTA_MB", _DEFAULT_QUOTA_MB) * 1024 * 1024)
+
+
+def jail_ttl_grace_seconds() -> float:
+    """Idle grace before a jail with no active run is GC'd, in seconds
+    (``POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS``, default 3600)."""
+    return _env_float("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", _DEFAULT_TTL_GRACE_SECONDS)
+
+
+def jail_disk_watermark_pct() -> float:
+    """Box disk-usage %% high-water mark that triggers LRU eviction
+    (``POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT``, default 90). ``<= 0`` disables
+    watermark eviction."""
+    return _env_float("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", _DEFAULT_DISK_WATERMARK_PCT)
+
+
+def jail_gc_enabled() -> bool:
+    """Whether the background jail GC sweep runs (default on). Set
+    ``POCKETPAW_AGENT_JAIL_GC_ENABLED=false`` to disable it as an escape hatch."""
+    return os.environ.get("POCKETPAW_AGENT_JAIL_GC_ENABLED", "true").strip().lower() not in {
+        "false",
+        "0",
+        "no",
+        "off",
+    }
+
+
+def scan_jail_dir(path: Path) -> tuple[int, float]:
+    """Return ``(size_bytes, last_activity_epoch)`` for one jail dir.
+
+    Walks the subtree ONCE (cheap ``os.scandir`` with the stat cached on the
+    DirEntry), summing file sizes and tracking the newest mtime. The newest
+    mtime over the WHOLE tree — not the top dir's own mtime — is the activity
+    signal: a directory's mtime does not advance when a file in a NESTED subdir
+    is written (``node_modules/x/y``), so the top mtime alone would read a busy
+    jail as idle and let the GC evict it mid-build. Vanishing / unreadable
+    entries (mid-build races, broken symlinks) are skipped; an empty dir reports
+    its own mtime. Symlinks are never followed, so a link can't inflate the size
+    or drag the scan outside the jail.
+    """
+    try:
+        latest = path.stat().st_mtime
+    except OSError:
+        return (0, 0.0)
+
+    size = 0
+    stack = [path]
+    while stack:
+        try:
+            entries = list(os.scandir(stack.pop()))
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                st = entry.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            latest = max(latest, st.st_mtime)
+            if entry.is_dir(follow_symlinks=False):
+                stack.append(Path(entry.path))
+            else:
+                size += st.st_size
+    return (size, latest)
+
+
+def workspace_jail_used_bytes(workspace_id: str) -> int:
+    """Total bytes used across every session jail of one workspace."""
+    agent_root = workspace_jail_root() / workspace_id / "agent"
+    try:
+        entries = list(os.scandir(agent_root))
+    except OSError:
+        return 0
+    total = 0
+    for entry in entries:
+        if entry.is_dir(follow_symlinks=False):
+            total += scan_jail_dir(Path(entry.path))[0]
+    return total
+
+
+def check_workspace_jail_quota(workspace_id: str | None) -> str | None:
+    """Return a human-readable rejection message if a workspace's jail is over
+    quota, else ``None``.
+
+    Called at RUN-START by ``run_core`` to reject a run before it spins up the
+    agent. A ``None`` / empty workspace (no jail) and a disabled quota
+    (``<= 0``) are always allowed.
+    """
+    if not workspace_id:
+        return None
+    quota = jail_quota_bytes()
+    if quota <= 0:
+        return None
+    used = workspace_jail_used_bytes(workspace_id)
+    if used <= quota:
+        return None
+    return (
+        f"agent workspace storage is full: {used / 1024 / 1024:.0f} MB used "
+        f"exceeds the {quota / 1024 / 1024:.0f} MB per-workspace limit. Deliver "
+        f"or remove build artifacts to free space, then retry."
+    )
+
+
+def iter_workspace_jail_dirs() -> Iterator[tuple[str, str, Path]]:
+    """Yield ``(workspace_id, session_segment, path)`` for every existing jail
+    dir ``<root>/<ws>/agent/<seg>``. Silent when the root doesn't exist yet."""
+    try:
+        ws_entries = list(os.scandir(workspace_jail_root()))
+    except OSError:
+        return
+    for ws in ws_entries:
+        if not ws.is_dir(follow_symlinks=False):
+            continue
+        try:
+            sess_entries = list(os.scandir(Path(ws.path) / "agent"))
+        except OSError:
+            continue
+        for sess in sess_entries:
+            if sess.is_dir(follow_symlinks=False):
+                yield (ws.name, sess.name, Path(sess.path))
+
+
+def disk_usage_pct() -> float:
+    """Percent (0–100) of the jail-root volume in use, or ``0.0`` if it can't be
+    probed (root missing, no psutil). 0.0 is the safe default — it reads as
+    "below any watermark" so a probe failure never triggers eviction."""
+    try:
+        import psutil
+
+        return float(psutil.disk_usage(str(workspace_jail_root())).percent)
+    except Exception:  # noqa: BLE001 — a probe failure must not break the sweep
+        logger.debug("jail disk-usage probe failed", exc_info=True)
+        return 0.0
+
+
+def evict_jail_dir(path: Path) -> bool:
+    """Delete a jail dir tree. Returns ``True`` on success (or if already gone).
+
+    Refuses any path that does not live UNDER the jail root — defense against a
+    bug handing this an arbitrary path. Refusing the root itself (a dir is not
+    its own parent) means a stray call can never wipe every tenant's jail.
+    """
+    root = workspace_jail_root().resolve()
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    if root not in resolved.parents:
+        logger.error("refusing to evict path outside the jail root: %s", path)
+        return False
+    try:
+        shutil.rmtree(resolved)
+        return True
+    except FileNotFoundError:
+        return True  # already gone — eviction is idempotent
+    except OSError:
+        logger.exception("failed to evict jail dir %s", path)
+        return False

--- a/ee/pocketpaw_ee/cloud/agent_jail.py
+++ b/ee/pocketpaw_ee/cloud/agent_jail.py
@@ -45,7 +45,8 @@ all cloud-only:
     startup and the 5-minute heartbeat exactly like the stale-run sweeper. This
     module owns the filesystem primitives the sweep composes (scan, enumerate,
     evict, disk probe); the sweep owns the run-state coordination (it never
-    evicts a jail whose run is still queued/running/resumable).
+    evicts a jail while its run is still queued or running — and a retried
+    interrupted run re-protects the jail by spawning a fresh queued run).
 """
 
 from __future__ import annotations
@@ -280,18 +281,40 @@ def scan_jail_dir(path: Path) -> tuple[int, float]:
     return (size, latest)
 
 
-def workspace_jail_used_bytes(workspace_id: str) -> int:
-    """Total bytes used across every session jail of one workspace."""
-    agent_root = workspace_jail_root() / workspace_id / "agent"
-    try:
-        entries = list(os.scandir(agent_root))
-    except OSError:
-        return 0
+def workspace_jail_over_quota(workspace_id: str, limit_bytes: int) -> bool:
+    """``True`` as soon as a workspace's total jail size crosses ``limit_bytes``.
+
+    Short-circuits the moment the running sum passes the limit — it does NOT
+    finish the walk or compute the exact total. The run-start quota gate only
+    needs the boolean, and it runs on EVERY run's critical path: a workspace
+    whose jail holds a ``node_modules`` (tens of thousands of files) would
+    otherwise pay a full ``O(files)`` stat-walk before every run — exactly our
+    file-creating use case. With the early-exit the walk is bounded by roughly
+    ``limit_bytes`` worth of file entries even when a runaway jail is many times
+    over quota. (The off-critical-path GC sweep keeps the full ``scan_jail_dir``
+    walk; it needs the exact size + last-activity and runs on a 5-minute cadence.)
+    """
+    # Iterative DFS over the whole ``<root>/<ws>/agent`` subtree (all session
+    # dirs at once), summing file sizes and bailing the instant we cross.
     total = 0
-    for entry in entries:
-        if entry.is_dir(follow_symlinks=False):
-            total += scan_jail_dir(Path(entry.path))[0]
-    return total
+    stack = [workspace_jail_root() / workspace_id / "agent"]
+    while stack:
+        try:
+            entries = list(os.scandir(stack.pop()))
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                st = entry.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                stack.append(Path(entry.path))
+            else:
+                total += st.st_size
+                if total > limit_bytes:
+                    return True
+    return False
 
 
 def check_workspace_jail_quota(workspace_id: str | None) -> str | None:
@@ -299,7 +322,8 @@ def check_workspace_jail_quota(workspace_id: str | None) -> str | None:
     quota, else ``None``.
 
     Called at RUN-START by ``run_core`` to reject a run before it spins up the
-    agent. A ``None`` / empty workspace (no jail) and a disabled quota
+    agent, so it leans on ``workspace_jail_over_quota``'s early-exit rather than
+    a full size walk. A ``None`` / empty workspace (no jail) and a disabled quota
     (``<= 0``) are always allowed.
     """
     if not workspace_id:
@@ -307,13 +331,12 @@ def check_workspace_jail_quota(workspace_id: str | None) -> str | None:
     quota = jail_quota_bytes()
     if quota <= 0:
         return None
-    used = workspace_jail_used_bytes(workspace_id)
-    if used <= quota:
+    if not workspace_jail_over_quota(workspace_id, quota):
         return None
     return (
-        f"agent workspace storage is full: {used / 1024 / 1024:.0f} MB used "
-        f"exceeds the {quota / 1024 / 1024:.0f} MB per-workspace limit. Deliver "
-        f"or remove build artifacts to free space, then retry."
+        f"agent workspace storage is full: the jail exceeds its "
+        f"{quota / 1024 / 1024:.0f} MB per-workspace limit. Deliver or remove "
+        f"build artifacts to free space, then retry."
     )
 
 

--- a/ee/pocketpaw_ee/cloud/agent_jail_gc.py
+++ b/ee/pocketpaw_ee/cloud/agent_jail_gc.py
@@ -1,0 +1,132 @@
+"""Agent-jail lifecycle GC (cloud only) — ART-3.
+
+Created 2026-06-26 (ART-3). Bounds the per-tenant agent scratch jails that
+``agent_jail`` hands out so one build-heavy run can't fill the shared box and
+break every tenant. The jail is pure scratch (durability lives in blob storage,
+a later task), so an idle jail is always safe to evict.
+
+``sweep_agent_jails`` is the periodic half of the lifecycle (the per-workspace
+quota is enforced inline at run-start in ``run_core``). One pass does two things,
+in order:
+
+  1. **TTL garbage-collection** — evict any jail whose run has ended and that has
+     sat idle past the grace (``POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS``).
+  2. **Disk-watermark eviction** — while the jail-root volume is over the
+     high-water mark (``POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT``), evict the
+     least-recently-used IDLE jails first until back under the mark.
+
+The one invariant that makes this safe: a jail backing a still-active run is
+NEVER evicted. "Active" = a non-terminal (``queued`` / ``running`` / resumable)
+``ChatRunDoc`` whose scope names that jail dir — resolved once per pass via
+``run_service.find_active_run_scopes`` and matched against each dir's
+``(workspace, session_segment)``. Idleness is read from the jail's newest mtime
+(``agent_jail.scan_jail_dir``), which the DB active-set check backstops: even a
+freshly-created queued run whose dir hasn't been written yet (old mtime, empty
+dir) is protected, because its scope is in the active set.
+
+Registered on cloud startup and the 5-minute heartbeat in
+``extensions._sweeper_loop`` / ``start_run_sweeper``, in its own try, exactly
+like the stale-run sweeper it mirrors — a jail-GC failure can never suppress the
+other sweeps (or vice versa).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+from pocketpaw_ee.cloud import agent_jail
+
+logger = logging.getLogger(__name__)
+
+# Cap dirs scanned per tick so a backlog can't wedge the heartbeat (mirrors the
+# stale-run sweeper's batch cap). TTL eviction reaps idle dirs every pass, so the
+# steady-state count stays bounded by active concurrency and this cap is slack.
+_SWEEP_BATCH_LIMIT = 500
+
+# One snapshot row: workspace, session segment, path, size, last-activity epoch.
+_JailRow = tuple[str, str, Path, int, float]
+
+
+async def sweep_agent_jails() -> int:
+    """Run one TTL + watermark GC pass over the agent jails. Returns the number
+    of jail dirs evicted. Never raises for an expected condition; a jail backing
+    an active run is never evicted."""
+    if not agent_jail.jail_gc_enabled():
+        return 0
+
+    from pocketpaw_ee.cloud.chat.runs import service as run_service
+
+    active = await run_service.find_active_run_scopes()
+    # A jail dir is named after its run's scope: SESSION runs → ``<scope_id>``;
+    # the sessionless DM/group/pocket bridge → the per-workspace ``_shared`` dir.
+    active_sessions = {(ws, scope) for (ws, ctype, scope) in active if ctype == "session"}
+    active_shared_workspaces = {ws for (ws, ctype, _scope) in active if ctype != "session"}
+
+    def _is_active(workspace_id: str, segment: str) -> bool:
+        if segment == agent_jail._SESSIONLESS_DIRNAME:
+            return workspace_id in active_shared_workspaces
+        return (workspace_id, segment) in active_sessions
+
+    # Snapshot every jail once (size + last activity), bounded per tick.
+    rows: list[_JailRow] = []
+    for workspace_id, segment, path in agent_jail.iter_workspace_jail_dirs():
+        size, last_activity = agent_jail.scan_jail_dir(path)
+        rows.append((workspace_id, segment, path, size, last_activity))
+        if len(rows) >= _SWEEP_BATCH_LIMIT:
+            break
+
+    now = time.time()
+    grace = agent_jail.jail_ttl_grace_seconds()
+    evicted = 0
+    survivors: list[_JailRow] = []  # idle dirs that passed TTL → watermark pool
+
+    for row in rows:
+        workspace_id, segment, path, _size, last_activity = row
+        if _is_active(workspace_id, segment):
+            continue  # never evict a jail with a queued/running/resumable run
+        idle_for = now - last_activity
+        if idle_for > grace:
+            if agent_jail.evict_jail_dir(path):
+                evicted += 1
+                logger.info(
+                    "jail GC: TTL-evicted idle jail %s/%s (idle %.0fs)",
+                    workspace_id,
+                    segment,
+                    idle_for,
+                )
+        else:
+            survivors.append(row)
+
+    evicted += _evict_to_watermark(survivors)
+    if evicted:
+        logger.info("jail GC: evicted %d idle jail(s)", evicted)
+    return evicted
+
+
+def _evict_to_watermark(survivors: list[_JailRow]) -> int:
+    """Evict idle survivors LRU-first while the jail-root volume is over the
+    high-water mark. Only IDLE dirs reach here (active ones were skipped, TTL
+    ones already reaped), so this never touches a live run's jail. Returns the
+    count evicted."""
+    watermark = agent_jail.jail_disk_watermark_pct()
+    if watermark <= 0:
+        return 0
+    if agent_jail.disk_usage_pct() <= watermark:
+        return 0
+
+    evicted = 0
+    # LRU first: oldest last-activity (row[4]) at the front of the queue.
+    for workspace_id, segment, path, _size, _last in sorted(survivors, key=lambda r: r[4]):
+        if agent_jail.disk_usage_pct() <= watermark:
+            break
+        if agent_jail.evict_jail_dir(path):
+            evicted += 1
+            logger.warning(
+                "jail GC: watermark-evicted LRU idle jail %s/%s (disk over %.0f%%)",
+                workspace_id,
+                segment,
+                watermark,
+            )
+    return evicted

--- a/ee/pocketpaw_ee/cloud/agent_jail_gc.py
+++ b/ee/pocketpaw_ee/cloud/agent_jail_gc.py
@@ -16,13 +16,15 @@ in order:
      least-recently-used IDLE jails first until back under the mark.
 
 The one invariant that makes this safe: a jail backing a still-active run is
-NEVER evicted. "Active" = a non-terminal (``queued`` / ``running`` / resumable)
-``ChatRunDoc`` whose scope names that jail dir — resolved once per pass via
-``run_service.find_active_run_scopes`` and matched against each dir's
-``(workspace, session_segment)``. Idleness is read from the jail's newest mtime
-(``agent_jail.scan_jail_dir``), which the DB active-set check backstops: even a
-freshly-created queued run whose dir hasn't been written yet (old mtime, empty
-dir) is protected, because its scope is in the active set.
+NEVER evicted. "Active" = a non-terminal ``ChatRunDoc`` (status ``queued`` or
+``running`` — the only non-terminal states) whose scope names that jail dir —
+resolved once per pass via ``run_service.find_active_run_scopes`` and matched
+against each dir's ``(workspace, session_segment)``. An ``interrupted`` run that
+the user retries re-protects its jail by spawning a fresh ``queued`` run, so
+evicting an idle jail between runs never races a resume. Idleness is read from
+the jail's newest mtime (``agent_jail.scan_jail_dir``), which the DB active-set
+check backstops: even a freshly-created queued run whose dir hasn't been written
+yet (old mtime, empty dir) is protected, because its scope is in the active set.
 
 Registered on cloud startup and the 5-minute heartbeat in
 ``extensions._sweeper_loop`` / ``start_run_sweeper``, in its own try, exactly
@@ -85,7 +87,7 @@ async def sweep_agent_jails() -> int:
     for row in rows:
         workspace_id, segment, path, _size, last_activity = row
         if _is_active(workspace_id, segment):
-            continue  # never evict a jail with a queued/running/resumable run
+            continue  # never evict a jail whose run is still queued or running
         idle_for = now - last_activity
         if idle_for > grace:
             if agent_jail.evict_jail_dir(path):

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1083,6 +1083,41 @@ async def _handle_interrupted_cleanup(
         logger.debug("interrupted stream write failed", exc_info=True)
 
 
+async def _reject_if_over_jail_quota(spec: RunSpec, ctx: ScopeContext, transport: Any) -> bool:
+    """ART-3 per-workspace agent-jail quota, enforced at RUN-START.
+
+    The agent writes through its native subprocess tools (Write/Bash), so we
+    can't cheaply gate each individual write; instead we measure the workspace's
+    total jail size ONCE here — before spinning up the agent — and reject the run
+    CLEANLY when it's over quota. The rejection is a terminal ``failed`` run with
+    a clear message and an ``error`` stream frame, never an OOM/crash that takes
+    the worker (and every other tenant on the box) down. Returns ``True`` when
+    the run was rejected (the caller returns early), ``False`` to proceed. Off
+    cloud / under quota it is a no-op returning ``False``.
+    """
+    from pocketpaw_ee.cloud import agent_jail
+
+    quota_error = agent_jail.check_workspace_jail_quota(ctx.workspace_id)
+    if not quota_error:
+        return False
+    logger.warning("run %s rejected — agent jail over quota: %s", spec.run_id, quota_error)
+    try:
+        await transport.append_event(
+            spec.run_id, "error", {"code": "agent.jail_over_quota", "message": quota_error}
+        )
+    except Exception:
+        logger.debug("over-quota error frame append failed for %s", spec.run_id, exc_info=True)
+    try:
+        await run_service.mark_terminal(spec.run_id, status="failed", error=quota_error)
+    except Exception:
+        logger.exception("mark_terminal(failed) failed for over-quota run %s", spec.run_id)
+    try:
+        await transport.set_ttl(spec.run_id, _stream_ttl())
+    except Exception:
+        logger.debug("over-quota stream ttl set failed for %s", spec.run_id, exc_info=True)
+    return True
+
+
 async def execute_run(spec: RunSpec) -> None:
     """Run the agent for ``spec`` and write every event to the transport.
 
@@ -1161,6 +1196,12 @@ async def execute_run(spec: RunSpec) -> None:
     # instead of re-resolving. Never raises — a missing/foreign pocket degrades
     # to the surface base (today's behavior).
     ctx.resolved_profile = await _resolve_entity_profile(ctx)
+
+    # ART-3: reject a run whose workspace agent-jail is over quota BEFORE the
+    # prewarm + mark-running + agent spin-up, so a tenant that filled its scratch
+    # quota fails fast and cleanly instead of crashing the shared box mid-run.
+    if await _reject_if_over_jail_quota(spec, ctx, transport):
+        return
 
     # PREWARM (feat/claude-sdk-prewarm): kick off warming the agent's CLI
     # subprocess for this session NOW — concurrently with the remaining pre-turn

--- a/ee/pocketpaw_ee/cloud/chat/runs/service.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/service.py
@@ -167,3 +167,22 @@ async def find_stale_running(older_than: datetime) -> list[ChatRunDoc]:
         {"status": {"$in": ["queued", "running"]}},
         ChatRunDoc.createdAt < older_than,
     ).to_list()
+
+
+async def find_active_run_scopes() -> set[tuple[str, str, str]]:
+    """Every ``(workspace, context_type, scope_id)`` with a non-terminal
+    (``queued`` / ``running``) run.
+
+    The active-jail guard for the ART-3 jail GC: a per-session agent jail dir is
+    named after its run's scope (``session`` runs → ``<scope_id>``; ``dm`` /
+    ``group`` / ``pocket`` runs share the workspace ``_shared`` dir), so a jail
+    whose scope is in this set is in use and must never be evicted. Uses the
+    same ``active = queued | running`` definition as ``find_active_run_for_scope``
+    — an ``interrupted`` run that the user retries spawns a NEW queued/running
+    run for the same scope, which re-protects the jail, so a retry can't race a
+    GC pass into deleting a jail it's about to reuse.
+    """
+    docs = await ChatRunDoc.find(
+        {"status": {"$in": ["queued", "running"]}},
+    ).to_list()
+    return {(d.workspace, d.context_type, d.scope_id) for d in docs}

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -98,6 +98,7 @@ _xproc_consumer_task: asyncio.Task[None] | None = None
 
 
 async def _sweeper_loop() -> None:
+    from pocketpaw_ee.cloud.agent_jail_gc import sweep_agent_jails
     from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
     from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
     from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
@@ -111,6 +112,14 @@ async def _sweeper_loop() -> None:
             raise
         except Exception:
             _run_sweeper_logger.exception("sweep_stale_runs tick failed")
+        # ART-3 jail lifecycle: TTL-GC idle agent jails + LRU-evict under the
+        # disk watermark, so scratch disk scales with active concurrency not user
+        # count. Own try so a jail-GC failure can't suppress the other sweeps (or
+        # vice versa); never evicts a jail backing a queued/running run.
+        try:
+            await sweep_agent_jails()
+        except Exception:
+            _run_sweeper_logger.exception("sweep_agent_jails tick failed")
         # BC-3 metering: bill every newly-terminal run's compute cost on the same
         # heartbeat. Kept in its own try so a metering failure can't suppress the
         # stale-run sweep (or vice versa) on the next tick. Self-gated OFF in the
@@ -143,9 +152,11 @@ async def start_run_sweeper() -> None:
     Boot runs the stale-run sweep (interrupt orphaned runs), the BC-3 compute-cost
     metering sweep (bill any terminal runs left unbilled by the prior process), the
     WU-F LiteLLM billing-cutover sweep (no-op / shadow-compare / live-ingest per the
-    cutover mode), and the charge-first pending-site reconciliation sweep (surface
-    paid sites stuck pending); the 5-minute loop then ticks all four.
+    cutover mode), the charge-first pending-site reconciliation sweep (surface paid
+    sites stuck pending), and the ART-3 agent-jail GC (reclaim scratch left by a
+    prior process's idle runs); the 5-minute loop then ticks all of them.
     """
+    from pocketpaw_ee.cloud.agent_jail_gc import sweep_agent_jails
     from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
     from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
     from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
@@ -160,6 +171,8 @@ async def start_run_sweeper() -> None:
         await run_cutover_sweep()
     with suppress(Exception):
         await sweep_pending_sites()
+    with suppress(Exception):
+        await sweep_agent_jails()
     _sweeper_task = asyncio.create_task(_sweeper_loop())
 
 

--- a/tests/cloud/agents/test_agent_jail_lifecycle.py
+++ b/tests/cloud/agents/test_agent_jail_lifecycle.py
@@ -113,6 +113,34 @@ def test_quota_sums_across_sessions(_jail_root, monkeypatch):
     assert agent_jail.check_workspace_jail_quota("ws1") is not None
 
 
+def test_quota_over_limit_short_circuits(_jail_root, monkeypatch):
+    """The run-start check stops walking once the running sum passes the limit —
+    it does not stat the whole tree (the hot-path guarantee for big node_modules
+    jails). Two session dirs each already exceed the limit on their own, so
+    whichever the DFS reaches first crosses immediately; the other is never
+    scanned."""
+    limit = 1024
+    _make_jail(_jail_root, "ws1", "s1", files={"big1.bin": 4096})
+    _make_jail(_jail_root, "ws1", "s2", files={"big2.bin": 4096})
+
+    real_scandir = os.scandir
+    scanned: list[str] = []
+
+    def counting_scandir(path):
+        scanned.append(str(path))
+        return real_scandir(path)
+
+    monkeypatch.setattr(agent_jail.os, "scandir", counting_scandir)
+
+    assert agent_jail.workspace_jail_over_quota("ws1", limit) is True
+
+    agent_root = str(_jail_root / "ws1" / "agent")
+    session_scans = [p for p in scanned if p.startswith(agent_root) and p != agent_root]
+    # Exactly ONE session dir was walked before the early-exit fired; the second
+    # (and the rest of the tree) was skipped.
+    assert len(session_scans) == 1, f"expected short-circuit after 1 session dir, scanned {scanned}"
+
+
 # --------------------------------------------------------------------------- #
 # scan_jail_dir
 # --------------------------------------------------------------------------- #

--- a/tests/cloud/agents/test_agent_jail_lifecycle.py
+++ b/tests/cloud/agents/test_agent_jail_lifecycle.py
@@ -1,0 +1,300 @@
+# tests/cloud/agents/test_agent_jail_lifecycle.py
+# Created 2026-06-26 (ART-3) — locks the agent-jail lifecycle contract:
+#   * per-workspace quota: over-limit -> clear rejection message; under-limit,
+#     disabled (0), and no-workspace -> None; sums across a workspace's sessions
+#   * scan_jail_dir: total size + NEWEST mtime over the tree (nested files count,
+#     so a build that only writes deep subdirs isn't misread as idle)
+#   * TTL GC: an idle jail past the grace is evicted; a fresh idle jail is kept
+#   * active-protection: a jail backing a queued/running run is NEVER evicted
+#     (both the per-session dir and the workspace _shared dir), and a TERMINAL
+#     run does not protect its idle jail
+#   * watermark: idle jails are evicted LRU-first, and only while over the mark
+"""Agent-jail lifecycle — quota / TTL-GC / watermark (ART-3)."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud import agent_jail, agent_jail_gc
+
+
+@pytest.fixture(autouse=True)
+def _jail_root(tmp_path, monkeypatch):
+    """Anchor the jail under tmp_path so tests never touch the real home dir."""
+    root = tmp_path / "jail"
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_JAIL_ROOT", str(root))
+    return root
+
+
+def _make_jail(
+    root: Path,
+    workspace_id: str,
+    segment: str,
+    *,
+    files: dict[str, int] | None = None,
+    mtime: float | None = None,
+) -> Path:
+    """Create ``<root>/<ws>/agent/<seg>/`` with ``files`` (``{relpath: bytes}``).
+
+    When ``mtime`` is given, stamp the whole subtree to it so ``scan_jail_dir``
+    reads a deterministic last-activity (utime never cascades, so order is moot).
+    """
+    jail = root / workspace_id / "agent" / segment
+    jail.mkdir(parents=True, exist_ok=True)
+    for rel, size in (files or {}).items():
+        target = jail / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x" * size)
+    if mtime is not None:
+        for path in jail.rglob("*"):
+            os.utime(path, (mtime, mtime))
+        os.utime(jail, (mtime, mtime))
+    return jail
+
+
+async def _insert_run(
+    *, workspace_id: str, context_type: str, scope_id: str, status: str, cmid: str
+):
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    doc = ChatRunDoc(
+        run_id=f"r-{cmid}",
+        workspace=workspace_id,
+        context_type=context_type,
+        scope_id=scope_id,
+        session_key="k",
+        user_id="u1",
+        agent_id="a1",
+        client_message_id=cmid,
+        user_message_id="m1",
+        status=status,  # type: ignore[arg-type]
+    )
+    await doc.insert()
+    return doc
+
+
+# --------------------------------------------------------------------------- #
+# Quota (run-start measurement)
+# --------------------------------------------------------------------------- #
+
+
+def test_quota_over_limit_returns_message(_jail_root, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "1")
+    _make_jail(_jail_root, "ws1", "s1", files={"big.bin": 2 * 1024 * 1024})
+    msg = agent_jail.check_workspace_jail_quota("ws1")
+    assert msg is not None
+    assert "full" in msg.lower() and "MB" in msg
+
+
+def test_quota_under_limit_returns_none(_jail_root, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "10")
+    _make_jail(_jail_root, "ws1", "s1", files={"small.bin": 1024})
+    assert agent_jail.check_workspace_jail_quota("ws1") is None
+
+
+def test_quota_none_workspace_allowed(_jail_root):
+    assert agent_jail.check_workspace_jail_quota(None) is None
+
+
+def test_quota_disabled_when_zero(_jail_root, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "0")
+    _make_jail(_jail_root, "ws1", "s1", files={"big.bin": 5 * 1024 * 1024})
+    assert agent_jail.check_workspace_jail_quota("ws1") is None
+
+
+def test_quota_sums_across_sessions(_jail_root, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "3")
+    _make_jail(_jail_root, "ws1", "s1", files={"a.bin": 2 * 1024 * 1024})
+    _make_jail(_jail_root, "ws1", "s2", files={"b.bin": 2 * 1024 * 1024})
+    # 4 MB across two session dirs > 3 MB cap — the cap is per-workspace, not per-session.
+    assert agent_jail.check_workspace_jail_quota("ws1") is not None
+
+
+# --------------------------------------------------------------------------- #
+# scan_jail_dir
+# --------------------------------------------------------------------------- #
+
+
+def test_scan_counts_nested_files_and_newest_mtime(_jail_root):
+    jail = _make_jail(
+        _jail_root,
+        "ws1",
+        "s1",
+        files={"top.txt": 100, "node_modules/pkg/index.js": 200},
+        mtime=time.time() - 10_000,
+    )
+    size, last_all_old = agent_jail.scan_jail_dir(jail)
+    assert size == 300
+
+    # Touch ONLY the deeply-nested file; the top dir's own mtime stays old.
+    nested = jail / "node_modules" / "pkg" / "index.js"
+    recent = time.time()
+    os.utime(nested, (recent, recent))
+
+    _size, last = agent_jail.scan_jail_dir(jail)
+    assert last >= recent - 1  # last-activity tracks the nested write
+    assert last > last_all_old
+    # The top dir's mtime alone would have read the busy jail as idle.
+    assert jail.stat().st_mtime <= recent - 9_000
+
+
+# --------------------------------------------------------------------------- #
+# TTL garbage-collection
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_ttl_evicts_idle_jail_past_grace(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "60")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "0")  # isolate TTL
+    jail = _make_jail(_jail_root, "ws1", "s_idle", files={"f": 10}, mtime=time.time() - 7200)
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 1
+    assert not jail.exists()
+
+
+@pytest.mark.asyncio
+async def test_ttl_keeps_fresh_idle_jail(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "3600")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "0")
+    jail = _make_jail(_jail_root, "ws1", "s_fresh", files={"f": 10}, mtime=time.time())
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 0
+    assert jail.is_dir()
+
+
+# --------------------------------------------------------------------------- #
+# Active-run protection (the safety invariant)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_active_session_jail_not_evicted(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "1")  # would TTL-evict if idle
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "0")
+    jail = _make_jail(_jail_root, "ws1", "sess-active", files={"f": 10}, mtime=time.time() - 7200)
+    # A running run whose scope_id == the jail dir name protects it.
+    await _insert_run(
+        workspace_id="ws1",
+        context_type="session",
+        scope_id="sess-active",
+        status="running",
+        cmid="c1",
+    )
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 0
+    assert jail.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_shared_jail_protected_by_bridge_run(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "1")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "0")
+    jail = _make_jail(
+        _jail_root,
+        "ws1",
+        agent_jail._SESSIONLESS_DIRNAME,
+        files={"f": 10},
+        mtime=time.time() - 7200,
+    )
+    # The sessionless DM/group/pocket bridge shares the per-workspace _shared dir;
+    # any non-session run in the workspace protects it.
+    await _insert_run(
+        workspace_id="ws1", context_type="dm", scope_id="dm-xyz", status="queued", cmid="c2"
+    )
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 0
+    assert jail.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_terminal_run_does_not_protect_jail(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "60")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "0")
+    jail = _make_jail(_jail_root, "ws1", "sess-done", files={"f": 10}, mtime=time.time() - 7200)
+    # A completed (terminal) run must NOT keep its idle jail alive.
+    await _insert_run(
+        workspace_id="ws1",
+        context_type="session",
+        scope_id="sess-done",
+        status="completed",
+        cmid="c3",
+    )
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 1
+    assert not jail.exists()
+
+
+# --------------------------------------------------------------------------- #
+# Disk-watermark eviction (LRU-first, only while over the mark)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_watermark_evicts_lru_idle_first(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    # Huge TTL so neither dir is TTL-evicted; both reach the watermark stage.
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "999999")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "90")
+    now = time.time()
+    older = _make_jail(_jail_root, "ws1", "s_old", files={"f": 10}, mtime=now - 5000)
+    newer = _make_jail(_jail_root, "ws1", "s_new", files={"f": 10}, mtime=now - 100)
+
+    evicted_paths: list[Path] = []
+    real_evict = agent_jail.evict_jail_dir
+
+    def fake_disk() -> float:
+        # Over the mark until one dir is reclaimed, then back under.
+        return 95.0 if not evicted_paths else 80.0
+
+    def spy_evict(path: Path) -> bool:
+        evicted_paths.append(Path(path))
+        return real_evict(path)
+
+    monkeypatch.setattr(agent_jail_gc.agent_jail, "disk_usage_pct", fake_disk)
+    monkeypatch.setattr(agent_jail_gc.agent_jail, "evict_jail_dir", spy_evict)
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 1
+    # Only the least-recently-used (oldest) jail was evicted; eviction stopped
+    # as soon as disk dropped under the mark.
+    assert older in evicted_paths and newer not in evicted_paths
+    assert not older.exists() and newer.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_watermark_noop_when_under_mark(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "999999")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "90")
+    jail = _make_jail(_jail_root, "ws1", "s1", files={"f": 10}, mtime=time.time() - 5000)
+    monkeypatch.setattr(agent_jail_gc.agent_jail, "disk_usage_pct", lambda: 50.0)
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 0
+    assert jail.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_gc_disabled_via_env(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_GC_ENABLED", "false")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "1")
+    jail = _make_jail(_jail_root, "ws1", "s_idle", files={"f": 10}, mtime=time.time() - 7200)
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 0
+    assert jail.is_dir()

--- a/tests/cloud/runs/test_run_core_jail_quota.py
+++ b/tests/cloud/runs/test_run_core_jail_quota.py
@@ -1,0 +1,103 @@
+# tests/cloud/runs/test_run_core_jail_quota.py
+# Created 2026-06-26 (ART-3) — locks the run-start jail-quota gate in
+# run_core._reject_if_over_jail_quota:
+#   * over-quota -> the run is rejected CLEANLY (terminal `failed` doc + a
+#     terminal `error` stream frame), the call returns True, and it never raises
+#     (the worker survives — no OOM/abort)
+#   * under-quota -> returns False and touches nothing (the run proceeds)
+"""execute_run's ART-3 jail-quota gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeTransport:
+    """Records the terminal frames the gate writes, without a real Redis."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict]] = []
+        self.ttls: list[tuple[str, int]] = []
+
+    async def append_event(self, run_id: str, event: str, data: dict) -> None:
+        self.events.append((run_id, event, data))
+
+    async def set_ttl(self, run_id: str, ttl_seconds: int) -> None:
+        self.ttls.append((run_id, ttl_seconds))
+
+
+def _spec(run_id: str, workspace_id: str):
+    from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+
+    return RunSpec(
+        run_id=run_id,
+        workspace_id=workspace_id,
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id=f"c-{run_id}",
+        user_message_id="m1",
+        content="hi",
+        history=[],
+        intent=None,
+    )
+
+
+async def test_over_quota_rejects_cleanly(mongo_db, tmp_path, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_JAIL_ROOT", str(tmp_path / "jail"))
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "1")
+    # Build w1's jail at 2 MB — over the 1 MB cap.
+    jail = Path(tmp_path) / "jail" / "w1" / "agent" / "s1"
+    jail.mkdir(parents=True)
+    (jail / "big.bin").write_bytes(b"x" * (2 * 1024 * 1024))
+
+    from pocketpaw_ee.cloud.chat.runs import run_core
+    from pocketpaw_ee.cloud.chat.runs import service as run_service
+
+    spec = _spec("r1", "w1")
+    await run_service.create_run(spec)
+    transport = _FakeTransport()
+    ctx = SimpleNamespace(workspace_id="w1")
+
+    # Must NOT raise — a clean rejection, not a crash.
+    rejected = await run_core._reject_if_over_jail_quota(spec, ctx, transport)
+
+    assert rejected is True
+    doc = await run_service.get_run("r1")
+    assert doc.status == "failed"
+    assert "full" in (doc.error or "").lower()
+    # A terminal error frame went to the stream, with a TTL bound.
+    assert transport.events and transport.events[-1][1] == "error"
+    assert transport.events[-1][2]["code"] == "agent.jail_over_quota"
+    assert transport.ttls and transport.ttls[-1][0] == "r1"
+
+
+async def test_under_quota_proceeds_untouched(mongo_db, tmp_path, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_JAIL_ROOT", str(tmp_path / "jail"))
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "10")
+    jail = Path(tmp_path) / "jail" / "w1" / "agent" / "s1"
+    jail.mkdir(parents=True)
+    (jail / "small.bin").write_bytes(b"x" * 1024)
+
+    from pocketpaw_ee.cloud.chat.runs import run_core
+    from pocketpaw_ee.cloud.chat.runs import service as run_service
+
+    spec = _spec("r2", "w1")
+    await run_service.create_run(spec)
+    transport = _FakeTransport()
+    ctx = SimpleNamespace(workspace_id="w1")
+
+    rejected = await run_core._reject_if_over_jail_quota(spec, ctx, transport)
+
+    assert rejected is False
+    doc = await run_service.get_run("r2")
+    assert doc.status == "queued"  # untouched
+    assert transport.events == [] and transport.ttls == []


### PR DESCRIPTION
## What this adds

A lifecycle for the per-tenant agent scratch jail introduced in ART-2, so the jail can't fill the box. This is the answer to "what happens at 1000 users": disk scales with *active concurrency*, not total user count, because the jail is pure scratch (durability lives in blob storage) and gets reclaimed aggressively.

Three mechanisms, all cloud-only:

- **Per-workspace quota** checked at run-start. Over quota → the run is rejected cleanly (a terminal `failed` run plus an `agent.jail_over_quota` error frame), the worker survives, no crash. The check early-exits as soon as the jail crosses the limit, so it doesn't stat a huge tree on every run's critical path.
- **TTL garbage collection.** A background sweeper (registered at cloud boot and on the existing 5-minute heartbeat, mirroring the resumable-run sweeper, each isolated so a GC failure can't suppress the other sweeps) deletes idle jails after a grace period.
- **Disk-watermark eviction.** When box disk crosses a high-water mark, the least-recently-used idle jails are evicted first until back under the mark.

## The safety invariant

A jail backing a live run is **never** evicted. This holds via two complementary signals, and a jail is reclaimed only when both agree it's safe:

- the DB active-set (`find_active_run_scopes` — every queued or running run), which protects a freshly-queued run whose jail is still empty;
- the newest mtime across the whole jail subtree, which protects a long in-progress write (a deep `node_modules` write that doesn't bump the top-dir mtime) even if the run were wrongly excluded from the DB set.

Eviction is path-guarded (refuses any path not strictly under the jail root) and idempotent, so concurrent web replicas only double the IO, never corrupt. Reviewed as spec + quality with the eviction-safety property traced explicitly, including the queued-after-snapshot race (benign).

## New env vars (cloud-only)

`POCKETPAW_AGENT_JAIL_QUOTA_MB` (2048), `POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS` (3600), `POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT` (90), `POCKETPAW_AGENT_JAIL_GC_ENABLED` (true).

## Known limits (by design)

- The sweep is per-process, not distributed-locked — safe because eviction is idempotent and the topology is single-box per tenant.
- If every jail on the box is backed by an active run and disk is over the watermark, the GC correctly evicts nothing (it won't kill a live run to free disk); the per-workspace quota is the backstop. Box sizing should budget roughly `quota × max-concurrent-workspaces`.

## Scope

Lifecycle only. ART-2's cwd resolution and fail-closed logic are untouched. The deliver-to-blob tool is the next task (ART-4).

## Tests

`tests/cloud/agents/test_agent_jail_lifecycle.py` + `tests/cloud/runs/test_run_core_jail_quota.py`: over-quota clean reject (run survives), the quota walk short-circuits, idle jail swept after grace, watermark evicts LRU-idle first, and an active run's jail (session and the sessionless `_shared` dir) is protected while a terminal run's is not. 38 in the agents sweep, 119 in the runs sweep, ruff clean.

## Stack

Stacked on ART-2 (`feat/art2-cwd-jail`, PR #1566). Merge the base with `--rebase`, not squash.
