### PR TITLE
feat(billing): configurable Dodo checkout billing country (unblocks UPI)

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -28,6 +28,9 @@
 #     for an arbitrary credit amount is therefore modeled as a pay-what-you-want
 #     line on a configured credits product (``dodo_credit_product_id``), with the
 #     amount carried on the cart item.
+#   * The ``billing`` country defaults to ``US`` but is configurable via
+#     ``dodo_billing_country`` (POCKETPAW_DODO_BILLING_COUNTRY) — set ``IN`` with
+#     INR products to surface UPI; the buyer can still change it on the hosted page.
 #   * The hosted url comes back as ``response.payment_link`` (only populated when
 #     ``payment_link=True``); ``response.payment_id`` is the gateway ref.
 #   * The webhook body is ``{business_id, data: Payment, timestamp, type}``; the
@@ -134,6 +137,7 @@ class DodoProvider:
         webhook_secret: str | None,
         credit_product_id: str | None,
         plan_products: dict[str, str] | None = None,
+        billing_country: str = _DEFAULT_BILLING_COUNTRY,
     ) -> None:
         # Stored, not validated here — a deployment may construct the provider
         # with billing disabled. Each call validates the inputs IT needs, so a
@@ -147,6 +151,9 @@ class DodoProvider:
         # delivery's metadata lacks plan_key; the forward direction (picking a
         # product for a tier) is the service's job, passed in to create_subscription.
         self._plan_products = dict(plan_products or {})
+        # ISO-3166 alpha-2 country prefilled on the hosted checkout's billing
+        # address — drives which payment methods Dodo surfaces (e.g. IN -> UPI).
+        self._billing_country = billing_country or _DEFAULT_BILLING_COUNTRY
 
     @classmethod
     def from_settings(cls, settings: Any) -> DodoProvider:
@@ -158,6 +165,7 @@ class DodoProvider:
             webhook_secret=getattr(settings, "dodo_webhook_secret", None),
             credit_product_id=getattr(settings, "dodo_credit_product_id", None),
             plan_products=plan_products if isinstance(plan_products, dict) else None,
+            billing_country=getattr(settings, "dodo_billing_country", _DEFAULT_BILLING_COUNTRY),
         )
 
     def _plan_key_for_product(self, product_id: str) -> str:
@@ -226,7 +234,7 @@ class DodoProvider:
 
         client = self._client()
         response = await client.payments.create(
-            billing={"country": _DEFAULT_BILLING_COUNTRY},
+            billing={"country": self._billing_country},
             customer=_customer_param(customer_email),
             product_cart=[
                 {
@@ -285,7 +293,7 @@ class DodoProvider:
         # returns a HOSTED checkout url on ``response.payment_link``.
         client = self._client()
         response = await client.subscriptions.create(
-            billing={"country": _DEFAULT_BILLING_COUNTRY},
+            billing={"country": self._billing_country},
             customer=_customer_param(customer_email),
             product_id=product_id,
             quantity=1,

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1501,6 +1501,16 @@ class Settings(BaseSettings):
             "POCKETPAW_DODO_ENVIRONMENT."
         ),
     )
+    dodo_billing_country: str = Field(
+        default="US",
+        description=(
+            "Default ISO-3166 alpha-2 country prefilled on the Dodo hosted "
+            "checkout's billing address. Drives which payment methods Dodo "
+            "surfaces — e.g. 'IN' (with INR products) is required for UPI to "
+            "appear; 'US' shows cards. The buyer can still change it on the "
+            "hosted page. Set via POCKETPAW_DODO_BILLING_COUNTRY."
+        ),
+    )
     dodo_webhook_secret: str | None = Field(
         default=None,
         description=(


### PR DESCRIPTION
The hosted-checkout billing country was hardcoded to `US`. India-only payment methods like UPI only surface when the checkout country is `IN` and the products are INR-priced, so the hardcode silently blocked UPI for Indian buyers.

This makes it a config field, `POCKETPAW_DODO_BILLING_COUNTRY`, defaulting to `US` so existing deployments don't change. Set it to `IN` on the India cloud and Dodo offers UPI at checkout (with INR products). Threaded through `DodoProvider.from_settings` and both the subscription and top-up checkout calls; the old constant stays as the fallback default, so behavior is identical until the env is set.