### PR TITLE
fix(chat): send WebSocket permission-errors to client instead of silent drop

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/router.py
+++ b/ee/pocketpaw_ee/cloud/chat/router.py
@@ -82,6 +82,7 @@ from pocketpaw_ee.cloud.shared.deps import (
     current_workspace_id,
     require_group_action,
 )
+from pocketpaw_ee.cloud.shared.errors import CloudError
 from pocketpaw_ee.cloud.shared.errors import Forbidden as CloudForbidden
 from pocketpaw_ee.cloud.workspace import service as workspace_service
 from pocketpaw_ee.guards.deps import check_workspace_action
@@ -768,36 +769,52 @@ async def _schedule_presence_offline(user_id: str) -> None:
 
 
 async def _handle_ws_message(websocket: WebSocket, user_id: str, msg: WsInbound) -> None:
-    """Dispatch validated WebSocket message to the appropriate handler."""
-    if msg.type == "message.send":
-        await _ws_message_send(user_id, msg)
-    elif msg.type == "message.edit":
-        await _ws_message_edit(user_id, msg)
-    elif msg.type == "message.delete":
-        await _ws_message_delete(user_id, msg)
-    elif msg.type == "message.react":
-        await _ws_message_react(user_id, msg)
-    elif msg.type == "typing.start":
-        await _ws_typing(user_id, msg, active=True)
-    elif msg.type == "typing.stop":
-        await _ws_typing(user_id, msg, active=False)
-    elif msg.type == "presence.update":
-        pass  # Will be wired in Task 19
-    elif msg.type == "read.ack":
-        await _ws_read_ack(user_id, msg)
-    elif msg.type == "thread.create":
-        await _ws_thread_create(user_id, msg)
-    elif msg.type == "thread.close":
-        await _ws_thread_close(user_id, msg)
-    elif msg.type == "thread.send":
-        await _ws_thread_send(user_id, msg)
-    elif msg.type == "room.join":
+    """Dispatch validated WebSocket message to the appropriate handler.
+
+    Catches ``CloudError`` (Forbidden, NotFound, etc.) from service calls and
+    sends an error response to the client so the user sees a toast rather than
+    the message being silently swallowed.
+    """
+    try:
+        if msg.type == "message.send":
+            await _ws_message_send(user_id, msg)
+        elif msg.type == "message.edit":
+            await _ws_message_edit(user_id, msg)
+        elif msg.type == "message.delete":
+            await _ws_message_delete(user_id, msg)
+        elif msg.type == "message.react":
+            await _ws_message_react(user_id, msg)
+        elif msg.type == "typing.start":
+            await _ws_typing(user_id, msg, active=True)
+        elif msg.type == "typing.stop":
+            await _ws_typing(user_id, msg, active=False)
+        elif msg.type == "presence.update":
+            pass  # Will be wired in Task 19
+        elif msg.type == "read.ack":
+            await _ws_read_ack(user_id, msg)
+        elif msg.type == "thread.create":
+            await _ws_thread_create(user_id, msg)
+        elif msg.type == "thread.close":
+            await _ws_thread_close(user_id, msg)
+        elif msg.type == "thread.send":
+            await _ws_thread_send(user_id, msg)
+        elif msg.type == "room.join":
+            if msg.group_id:
+                members = await group_service.list_member_ids(msg.group_id)
+                if user_id in members:
+                    manager.join_room(websocket, msg.group_id)
+        elif msg.type == "room.leave":
+            manager.leave_room(websocket)
+    except CloudError as e:
+        extra: dict[str, Any] = {}
         if msg.group_id:
-            members = await group_service.list_member_ids(msg.group_id)
-            if user_id in members:
-                manager.join_room(websocket, msg.group_id)
-    elif msg.type == "room.leave":
-        manager.leave_room(websocket)
+            extra["group_id"] = msg.group_id
+        await websocket.send_json(
+            WsOutbound(
+                type="error",
+                data={"code": e.code, "message": e.message, **extra},
+            ).model_dump(mode="json")
+        )
 
 
 async def _ws_message_send(user_id: str, msg: WsInbound) -> None:


### PR DESCRIPTION
## Description

When a user tries to send a message in a group they don't have permission for (e.g. `group.not_member`, `group.view_only`), the backend was raising `Forbidden` but only logging it server-side — the client got no feedback.

## Change

Catches `CloudError` in `_handle_ws_message` and sends a `WsOutbound(type='error', data={code, message, group_id})` back to the client WebSocket. The paired frontend PR in paw-enterprise subscribes to the `error` topic and shows a toast + removes the ghost optimistic message.

## Related

Paired frontend PR: https://github.com/qbtrix/paw-enterprise/pull/492