### PR TITLE
Re-land: cloud agent artifacts → per-tenant blob (precise fail-closed gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,52 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   env-configurable), marking queued/running `ChatRunDoc`s older than 10 minutes as
   `interrupted` so runs abandoned by a backend restart surface a retry affordance
   instead of leaving clients subscribed forever.
+- **Per-tenant agent cwd jail (cloud, ART-2)**: In multi-tenant cloud each
+  workspace's chat agent runs with `cwd = ~/.pocketpaw/workspaces/<workspace_id>/agent/<session_id>/`
+  (resolved per-run from the `attach_agent_identity` ContextVars in
+  `ee/pocketpaw_ee/cloud/agent_jail.py`) so one tenant's file ops never
+  co-mingle in the shared home dir. It **fails closed**: a cloud run that
+  reaches the backend with no resolvable `workspace_id` RAISES rather than
+  falling back to `~`. OSS / dedicated installs (no cloud DB initialized) keep
+  `settings.file_jail_path` unchanged. Override the jail root with
+  `POCKETPAW_WORKSPACE_JAIL_ROOT` (default `~/.pocketpaw/workspaces`) to anchor
+  it on a data volume.
+- **Agent jail lifecycle (cloud, ART-3)**: bounds the ART-2 scratch jails so
+  disk scales with active concurrency, not user count (the jail is pure scratch;
+  durability lives in blob storage). Three knobs, all read from the environment
+  in `ee/pocketpaw_ee/cloud/agent_jail.py`:
+  `POCKETPAW_AGENT_JAIL_QUOTA_MB` (default `2048`) — per-workspace size cap
+  measured at RUN-START; an over-quota run is rejected cleanly (a terminal
+  `failed` run with an `agent.jail_over_quota` error frame, never an OOM/crash).
+  `0` disables it.
+  `POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS` (default `3600`) — idle grace after
+  which a jail with no active run is garbage-collected.
+  `POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT` (default `90`) — box disk-usage
+  high-water mark; over it, the GC evicts least-recently-used IDLE jails first
+  until back under. `0` disables watermark eviction.
+  `POCKETPAW_AGENT_JAIL_GC_ENABLED` (default `true`) — escape hatch to disable
+  the GC sweep entirely. The GC (`ee/pocketpaw_ee/cloud/agent_jail_gc.py`,
+  `sweep_agent_jails`) runs on cloud startup and the same 5-minute heartbeat as
+  the stale-run sweeper, and NEVER evicts a jail whose run is still queued or
+  running (resolved via `run_service.find_active_run_scopes`; a retried
+  interrupted run re-protects its jail by spawning a fresh queued run).
+- **Artifact delivery + storage boot guard (cloud, ART-4)**: the agent's jail is
+  pure scratch — durability lives in blob storage. The `deliver_artifact`
+  in-process MCP tool (`ee/pocketpaw_ee/agent/mcp_servers/deliver.py`, server
+  `pocketpaw_deliver`) lands a built file (or a zipped directory) from the jail
+  into the tenant's blob storage via `EEUploadService.upload` and returns a real
+  presigned download URL — so the agent shares a working link instead of a
+  container path or a `127.0.0.1` preview server. Path safety is jail-scoped
+  (rejects `..`, absolute paths out, symlinks out, another tenant's jail), and
+  `POCKETPAW_DELIVER_MAX_MB` (default `100`) caps artifact size. Because this
+  only works when uploads go to real object storage, `init_cloud_db` runs
+  `verify_cloud_storage_backend()` (`ee/pocketpaw_ee/cloud/uploads/bootstrap.py`,
+  mirroring the memory guard): in cloud, if `POCKETPAW_UPLOAD_ADAPTER` != `s3` it
+  **WARNs loudly** (a local-disk deploy that would silently no-op delivery is
+  visible in the boot logs), and `POCKETPAW_REQUIRE_S3_IN_CLOUD=1` escalates that
+  to a hard boot failure. The multi-tenant-cloud signal both the jail and this
+  guard read is `is_multi_tenant_cloud()` in `ee/pocketpaw_ee/cloud/shared/db.py`
+  (one name for the `get_client() is not None` check).
 - **In-process bus subscribers**: `pocketpaw_ee.cloud._core.realtime.bus.InProcessBus` exposes `subscribe(event_type, handler)` for cloud-side listeners (e.g. the `FileReady` → KB indexer wired in `ee/pocketpaw_ee/cloud/uploads/listeners.py`). Register subscribers from `mount_cloud()` after `init_realtime()` runs. Handler exceptions are logged and swallowed per-handler so one bad listener can't block the rest of the dispatch.
 - **Memory backend (`POCKETPAW_MEMORY_BACKEND`)**: OSS self-hosted defaults to `"file"` (local JSON under `~/.pocketpaw/memory/`). The cloud forces `"mongodb"` via `register_default_backend()` (`ee/pocketpaw_ee/cloud/memory/bootstrap.py`) unless explicitly overridden. The cloud now **fails to boot** if the active store isn't `MongoMemoryStore` (`verify_cloud_memory_backend()` in `init_cloud_db`) — a deliberate guard so a misconfigured backend can never silently write chat history (files-surface chats included) to local disk. Don't set `POCKETPAW_MEMORY_BACKEND=file` on a cloud deployment.
 - **API key required**: The `claude_agent_sdk` backend requires an `ANTHROPIC_API_KEY` when using the Anthropic provider. OAuth tokens from Free/Pro/Max plans are not permitted for third-party use per [Anthropic's policy](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use). Ollama/local providers do not require an API key.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -49,6 +49,16 @@ instead of firing an HTTP write, and the new
 GET /workspaces/{ws}/jobs/{job_id} status poll. Jobs run on the shared ARQ
 worker under the synthetic `system:workspace_job` identity and merge their
 results back into the pocket's `state` over the live update bridge.
+
+Updated: 2026-06-26 (ART-1) — documented the Files — Versioned Writes
+section: POST /files/write, PUT /files/{id}, and the two version-history
+reads (GET /files/{id}/versions[/{vid}]). The write path archives each
+prior blob as a FileVersionDoc and bumps a per-file content_version counter;
+every read is workspace-scoped.
+Updated: 2026-06-26 (ART-4) — documented the Agent Artifact Delivery
+(deliver_artifact) in-process MCP tool: routes a built file/dir through the
+workspace upload pipeline (file as-is, dir zipped) and returns a presigned
+download URL; jail-scoped path safety; POCKETPAW_DELIVER_MAX_MB cap.
 -->
 
 # Cloud REST API Reference
@@ -938,3 +948,114 @@ Response `200`:
 conversion, a pricing-rules engine, and disputes / clawback. This endpoint
 returns a raw sum of declared values — the queryable figure those layers
 will build on later (see `outcome-spec.md`).
+
+## Files — Versioned Writes
+
+The `file_versions` entity layers a versioned write path over the uploads
+storage adapter. A file's live (current) content lives in the
+StorageAdapter; each edit archives the prior blob as a `FileVersionDoc` row
+and bumps a per-file `content_version` counter on the `FileUpload` record.
+All four routes share the `/files` prefix with the listing router (`GET
+/files`, `/files/tree`, `/files/browse`) without collision, require a valid
+license, and are workspace-scoped — every read is filtered to the caller's
+workspace.
+
+### `POST /files/write`
+
+Create a file, or overwrite an existing one in place (versioned). Used for
+first-save and programmatic writes.
+
+Request body:
+
+```json
+{ "path": "<file id or path>", "content": "<full content>", "filename": "<optional display name>" }
+```
+
+Response `201`:
+
+```json
+{ "fileId": "<id>", "version": 1, "sizeBytes": 42 }
+```
+
+When a file already exists for `path`, the content is updated through the
+PUT path instead and `version` reflects the bumped counter.
+
+### `PUT /files/{file_id}`
+
+Replace a text file's content inline with optimistic concurrency. Body:
+
+```json
+{ "content": "<new text>", "expectedVersion": 3 }
+```
+
+`expectedVersion` (or the `If-Match: <version>` header, which takes
+precedence) guards against lost updates. Response `200`:
+
+```json
+{ "fileId": "<id>", "newVersion": 4, "sizeBytes": 57, "contentHash": "<sha256>" }
+```
+
+Returns `404` if the file is missing, `409` on a version conflict, and
+`422` if the file's mime type is not editable inline.
+
+### `GET /files/{file_id}/versions`
+
+List archived versions for a file (oldest first, content omitted). Returns
+only versions in the caller's workspace:
+
+```json
+[ { "id": "<oid>", "fileId": "<id>", "versionNumber": 2, "sizeBytes": 42,
+    "editorKind": "human", "editorId": "<user id>", "createdAt": "<iso>" } ]
+```
+
+### `GET /files/{file_id}/versions/{version_id}`
+
+Fetch a single archived version with its full content (for revert preview /
+diff). Workspace-scoped — a version id from another workspace returns `404`.
+
+## Agent Artifact Delivery (`deliver_artifact`)
+
+`deliver_artifact` is a cloud-only in-process MCP tool the chat agent calls to
+hand the user a **downloadable** result. The cloud agent works inside a
+per-tenant jail (ART-2) the user can't reach, so a file the agent "wrote to
+`./out.pdf`" — or a preview server it started on `127.0.0.1` — is invisible to
+them. This tool lands the artifact in the tenant's blob storage and returns a
+real, short-lived download URL.
+
+It is registered cloud-gated via the `pocketpaw.mcp_servers` entry point
+(`pocketpaw_deliver` → `mcp__pocketpaw_deliver__deliver_artifact`), ambient on
+the default chat surface (OSS never sees it). Source:
+`ee/pocketpaw_ee/agent/mcp_servers/deliver.py`.
+
+**Input:** `{ "path": "<file or directory inside the agent's workspace>" }`.
+
+**Routing:** a single file is uploaded as-is (mime guessed from the filename); a
+directory is zipped (`application/zip`) and the zip is uploaded. Both go through
+`EEUploadService.upload` — the same workspace-scoped pipeline as `POST /uploads`
+— so a delivered artifact emits `FileReady` (→ KB) and appears in the tenant's
+`GET /files` listing, and the returned URL is the storage adapter's presigned
+download (S3) or the authenticated `/api/v1/uploads/{id}` path (local adapter).
+
+**Result (JSON in the MCP text payload):**
+
+```json
+{ "ok": true, "filename": "report.pdf", "url": "<download URL>",
+  "file_id": "<id>", "size": 12345, "mime": "application/pdf",
+  "expires_in_seconds": 300 }
+```
+
+On failure the tool returns `is_error` with a plain reason (missing identity,
+path escapes the jail, file missing / over the size cap, or the upload failed) —
+the agent surfaces the reason rather than fabricating a link.
+
+**Security:** the path must resolve to inside the caller's own jail
+(`~/.pocketpaw/workspaces/<workspace_id>/...`); `..` traversal, absolute paths
+out, symlinks pointing out (including symlinks nested inside a delivered
+directory), and another tenant's jail are all rejected (reusing ART-2's
+path-segment guard). Size is capped by `POCKETPAW_DELIVER_MAX_MB` (default
+`100`). Because the upload relaxes the mime allowlist, a delivered artifact
+whose mime is not in `INLINE_MIMES` (HTML, SVG, JS, …) is served with
+`Content-Disposition: attachment` on the presigned download — it downloads, it
+does not render inline on the storage origin. Inline-safe types (images, pdf,
+plain text) still embed as before. The whole tool is gated on
+`is_multi_tenant_cloud()`.

--- a/docs/runbooks/2026-06-27-cloud-agent-artifacts-visual-smoke.md
+++ b/docs/runbooks/2026-06-27-cloud-agent-artifacts-visual-smoke.md
@@ -1,0 +1,141 @@
+<!-- Visual smoke-test runbook — cloud agent artifacts → per-tenant blob.
+     Created 2026-06-27. Covers ART-1..4 (file_versions spine, cwd jail,
+     jail lifecycle, deliver_artifact + boot guard). For the captain's
+     live smoke before merging integration/cloud-agent-artifacts → dev. -->
+
+# Cloud Agent Artifacts → Per-Tenant Blob — Visual Smoke Test
+
+What this proves end to end: when a cloud user asks the agent to build something
+downloadable, the artifact lands in **that tenant's** blob storage, comes back as
+a **real download link** in their Files, stays **isolated** from other tenants,
+and the agent's scratch filesystem is **bounded** so it can't fill the box.
+
+This replaces the old broken behavior (agent writes to the shared
+`/home/pocketpaw/...` and serves a preview from `127.0.0.1`, which the cloud user
+can't reach and which co-mingles across tenants).
+
+---
+
+## 0. Prerequisites
+
+```
+[ ] Cloud backend running (multi-tenant: CLOUD_MONGODB_URI set, init_cloud_db ran)
+[ ] S3 storage configured:  POCKETPAW_UPLOAD_ADAPTER=s3  +  S3_PRIVATE_BUCKET,
+    S3_REGION, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY  (S3_ENDPOINT for R2/MinIO)
+[ ] Two cloud workspaces with a logged-in user each (call them WS-A and WS-B)
+```
+
+**Boot-guard check (do this first):** start the backend and watch the logs.
+- On S3: no storage warning. Good.
+- On the default local adapter in cloud: you'll see
+  `WARNING ... cloud is not using the S3 upload adapter ...`. That's the guard
+  telling you artifacts would hit local disk. Set the S3 env, or set
+  `POCKETPAW_REQUIRE_S3_IN_CLOUD=1` to make a misconfigured deploy refuse to boot.
+
+---
+
+## 1. The headline test — downloadable landing page (WS-A)
+
+In WS-A chat:
+
+> build me a downloadable html/css/js landing page
+
+```
+EXPECT                                              FAILURE SIGNAL
+──────────────────────────────────────────────     ─────────────────────────────
+[ ] agent replies with a real download LINK         a /home/pocketpaw/... path,
+    (https… presigned S3 URL)                        or a 127.0.0.1:<port> link
+[ ] the file shows up in WS-A → Files                nothing appears in Files
+[ ] clicking the link DOWNLOADS the zip/file         the browser RENDERS it inline
+    (does not render in the browser)                  (that's the XSS guard failing)
+```
+
+The agent should narrate something like "I've saved it to your Files — download
+here: <link>". Under the hood it called the `deliver_artifact` tool, which zipped
+the project and uploaded it to `s3://…/<storage-key>` scoped to WS-A.
+
+---
+
+## 2. Per-tenant isolation (WS-A vs WS-B)
+
+```
+[ ] In WS-B → Files: WS-A's artifact is NOT listed
+[ ] WS-A's presigned link, opened while authenticated as WS-B's user, is denied
+    (404 / not found — not B silently downloading A's file)
+[ ] In WS-B, build a different artifact; confirm A and B each see only their own
+```
+
+This is the core multi-tenant property. Any cross-visibility here is a stop-ship.
+
+---
+
+## 3. Jail isolation on the box (optional, if you have shell access)
+
+While an agent run is active in WS-A, on the backend host:
+
+```
+[ ] WS-A's agent files are under  ~/.pocketpaw/workspaces/<WS-A-id>/agent/<session>/
+[ ] NOT in  /home/pocketpaw/  (the old shared dir)
+[ ] WS-B has its own  ~/.pocketpaw/workspaces/<WS-B-id>/agent/...  — separate tree
+```
+
+Note this sits alongside the ISO store isolation already on dev
+(`~/.pocketpaw/workspaces/<ws>/fabric.db`, `instinct.db`) — same per-workspace
+parent, the agent dir is the new sibling.
+
+---
+
+## 4. The "downloadable HTML can't XSS" check (the security fix)
+
+Ask WS-A:
+
+> save this as an index.html and give me the link:  <!doctype html><script>alert(document.domain)</script>
+
+```
+[ ] the returned presigned link DOWNLOADS index.html (Content-Disposition: attachment)
+[ ] it does NOT execute / show an alert when opened
+```
+
+If the html renders/executes from the storage origin, the attachment-disposition
+fix regressed — stop and flag it.
+
+---
+
+## 5. Boundedness (optional, advanced)
+
+```
+[ ] Set POCKETPAW_AGENT_JAIL_QUOTA_MB low (e.g. 5) and restart
+[ ] Ask the agent to create a large file / many files exceeding it
+[ ] The run is rejected cleanly with an "over quota" message — the worker keeps
+    running, the box does not fill or crash
+```
+
+The TTL/watermark garbage collection runs on the 5-minute sweep; idle jails get
+reclaimed automatically, and a jail backing an active run is never evicted.
+
+---
+
+## What "pass" looks like
+
+A cloud user gets a real, private, downloadable link for anything the agent
+builds; another tenant can't see or fetch it; the agent's scratch never touches
+the shared home dir and can't fill the box; and a delivered `.html` downloads
+instead of executing.
+
+## Known non-issues
+
+- `tests/cloud/uploads/` shows ~23 pre-existing red tests (auth-harness 401s in
+  the upload router / pocket-ACL / folders suites). They fail identically on
+  `dev` without this change and are unrelated — the deliver, jail, lifecycle, and
+  bootstrap suites are green.
+
+## Reference — env flags
+
+| Flag | Default | Effect |
+|---|---|---|
+| `POCKETPAW_UPLOAD_ADAPTER` | `local` | set `s3` for cloud blob storage |
+| `POCKETPAW_REQUIRE_S3_IN_CLOUD` | unset (warn) | set truthy → hard-fail boot if cloud + non-s3 |
+| `POCKETPAW_AGENT_JAIL_QUOTA_MB` | `2048` | per-workspace scratch cap |
+| `POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS` | `3600` | idle-jail reap grace |
+| `POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT` | `90` | disk % that triggers LRU eviction |
+| `POCKETPAW_AGENT_JAIL_GC_ENABLED` | `true` | master switch for the jail sweeper |

--- a/ee/pocketpaw_ee/agent/mcp_servers/__init__.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/__init__.py
@@ -17,6 +17,8 @@ Server surfaces (module → server name → tools):
 * ``belt.py`` → ``pocketpaw_belt`` → ``belt_propose_change`` (gated code change)
 * ``connectors.py`` → ``pocketpaw_connectors`` → connector listing + execution
 * ``decisions.py`` → ``pocketpaw_decisions`` → Decision-Graph queries
+* ``deliver.py`` → ``pocketpaw_deliver`` → ``deliver_artifact`` (land a built
+  file/dir in tenant blob storage, return a download URL)
 * ``external_actions.py`` → ``pocketpaw_external_actions`` →
   ``propose_external_action`` (gated connector call — the propose path for
   this backend)

--- a/ee/pocketpaw_ee/agent/mcp_servers/deliver.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/deliver.py
@@ -1,0 +1,438 @@
+# deliver.py — in-process MCP server exposing ``deliver_artifact`` to the cloud
+# chat agent (claude_agent_sdk). Created: 2026-06-26 (ART-4).
+#
+# This is the payoff of the cloud-artifacts stack: a cloud agent builds a file
+# (or a whole directory) inside its per-tenant jail (ART-2), then calls this tool
+# to LAND that artifact in the tenant's blob storage and get back a real,
+# short-lived download URL to hand the user — instead of printing a container
+# path or spinning a 127.0.0.1 preview server the user can never reach.
+#
+# Mirrors the sibling mcp_servers (sites.py / media.py): a single
+# ``create_sdk_mcp_server`` behind an SDK import-guard, ``SERVER_NAME`` /
+# ``*_TOOL_ID`` allowlist constants, and ContextVar-sourced identity (the same
+# ``current_workspace_id`` / ``current_user_id`` accessors in
+# ``ee.cloud.chat.agent_service`` the sites + tasks servers read). The tool id
+# namespaces as ``mcp__pocketpaw_deliver__deliver_artifact`` so the Claude Code
+# allowlist machinery matches it.
+#
+# Routing: a single file is uploaded directly (mime guessed from the filename); a
+# directory is zipped (``application/zip``) and the zip is uploaded. Both go
+# through ``EEUploadService.upload`` — the DOWNLOAD path that gives arbitrary
+# mime + a presigned URL + ``FileReady``→KB + visibility in the tenant's /files
+# (NOT file_versions.write_file, which is the editor-document path, Slice-D).
+#
+# Security: the path MUST resolve to inside the caller's own jail
+# (``workspace_jail_root()/<workspace_id>/...``). ``..``, absolute paths, and
+# symlinks pointing out are all rejected (resolve() then check it's under the
+# workspace root), reusing ART-2's path-segment guard so the agent can never
+# deliver ``/etc/passwd`` or another tenant's jail. Because the upload relaxes
+# the mime allowlist, a delivered non-inline type (HTML/SVG/JS) is served as a
+# DOWNLOAD, not inline — EEUploadService.presigned_get forces
+# ``Content-Disposition: attachment`` for anything outside INLINE_MIMES, so a
+# delivered .html can't render active content on the storage origin. The whole
+# server is gated on is_multi_tenant_cloud() (cloud-only, like the ART-4 boot
+# guard and ART-2 jail).
+"""Agent-side MCP surface for delivering a built artifact to tenant blob storage.
+
+Tool registered:
+
+  - ``deliver_artifact(path)`` — persist the file or directory at ``path``
+    (inside the caller's workspace jail) to the tenant's blob storage and return
+    ``{ok, filename, url, file_id, size, mime, expires_in_seconds}``. ``url`` is a
+    short-TTL download link the agent shows the user. ``is_error`` is set (with a
+    plain reason) when identity is missing, the path escapes the jail, the file
+    is missing / too large, or the upload fails — the agent then surfaces the
+    reason instead of fabricating a working link.
+
+Workspace / user identity comes from the per-stream ``ContextVar``s in
+``ee.cloud.chat.agent_service`` (same chokepoint the sites + tasks MCP servers
+use). Run outside an SSE chat stream, the tool returns a clear error rather than
+silently mis-tenanting the delivered file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import mimetypes
+import os
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_deliver"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form.
+DELIVER_ARTIFACT_TOOL_ID = f"mcp__{SERVER_NAME}__deliver_artifact"
+
+DELIVER_TOOL_IDS = (DELIVER_ARTIFACT_TOOL_ID,)
+
+# Default per-artifact size cap. Build artifacts (a zipped site, a generated
+# bundle) routinely exceed the 25 MiB browser-upload default, so the deliver
+# path carries its own, larger, configurable cap.
+_DEFAULT_DELIVER_MAX_MB = 100.0
+_TOOL_DESCRIPTION = (
+    "Deliver a built artifact to the user as a downloadable file. Pass `path` — "
+    "a file OR a directory inside your workspace. A single file is uploaded as-is; "
+    "a directory is zipped first. Returns {ok, filename, url, file_id, size, mime, "
+    "expires_in_seconds} — show the user the `url` (a short-lived download link) "
+    "and the filename. USE THIS whenever you produce something the user should be "
+    "able to download (a report, an export, a generated file, a built site bundle): "
+    "do NOT just print the path you wrote to, and do NOT start a local preview / web "
+    "server — the user cannot reach your container's filesystem or 127.0.0.1. "
+    "ok=false with an error means the path was missing, escaped your workspace, was "
+    "too large, or the upload failed; relay the error, do NOT report a fake link."
+)
+
+
+class _JailEscape(Exception):
+    """The requested path resolved outside the caller's workspace jail."""
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape Claude's SDK expects. The agent
+    reads ``text`` and surfaces the reason."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None]:
+    """Resolve the active workspace + user id from the per-stream ContextVars set
+    by the cloud chat agent runtime. Returns ``(workspace_id, user_id)``."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_user_id, current_workspace_id
+
+        return current_workspace_id(), current_user_id()
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
+def _deliver_max_bytes() -> int:
+    """Per-artifact size cap in bytes (``POCKETPAW_DELIVER_MAX_MB``, default 100)."""
+    raw = os.environ.get("POCKETPAW_DELIVER_MAX_MB", "").strip()
+    mb = _DEFAULT_DELIVER_MAX_MB
+    if raw:
+        try:
+            mb = float(raw)
+        except ValueError:
+            logger.warning("ignoring non-numeric POCKETPAW_DELIVER_MAX_MB=%r; using %s", raw, mb)
+    return int(mb * 1024 * 1024)
+
+
+def _too_large_message(size: int, cap: int) -> str:
+    return (
+        f"artifact is {size / 1024 / 1024:.1f} MB, over the "
+        f"{cap / 1024 / 1024:.0f} MB deliver limit. Reduce it (deliver a subset) "
+        "or raise POCKETPAW_DELIVER_MAX_MB."
+    )
+
+
+def _resolve_in_jail(path_arg: str, workspace_id: str) -> Path:
+    """Resolve ``path_arg`` and assert it lives inside the caller's workspace jail.
+
+    Relative paths resolve against the agent's session cwd (the jail dir ART-2
+    set as the agent's working directory); absolute paths are taken as-is. The
+    resolved path (symlinks followed) MUST be the workspace jail root
+    ``workspace_jail_root()/<workspace_id>`` or live under it — otherwise a
+    crafted ``..``, an absolute path, or a symlink pointing out would let the
+    agent read another tenant's jail or the host filesystem. Raises
+    :class:`_JailEscape` on any escape.
+    """
+    # ``_safe_segment`` is ART-2's path-segment guard (no separators, no ``.`` /
+    # ``..``); reuse it so the workspace root we build can't itself be a traversal.
+    from pocketpaw_ee.cloud.agent_jail import (
+        _safe_segment,
+        resolve_agent_cwd,
+        workspace_jail_root,
+    )
+
+    try:
+        ws_segment = _safe_segment(workspace_id, label="workspace_id")
+    except ValueError as exc:
+        raise _JailEscape("workspace identity is not a safe path segment") from exc
+
+    ws_root = (workspace_jail_root() / ws_segment).resolve()
+
+    # Relative paths are relative to the agent's cwd == its session jail (ART-2).
+    # resolve_agent_cwd() returns that exact dir; fall back to the workspace root
+    # if it can't be resolved (e.g. no session bound).
+    base: Path
+    try:
+        cwd = resolve_agent_cwd()
+        base = Path(cwd) if cwd else ws_root
+    except Exception:  # noqa: BLE001 — never let cwd resolution break delivery
+        base = ws_root
+
+    candidate = Path(path_arg)
+    if not candidate.is_absolute():
+        candidate = base / candidate
+    try:
+        resolved = candidate.resolve()
+    except OSError as exc:
+        raise _JailEscape(f"could not resolve path: {path_arg}") from exc
+
+    if resolved != ws_root and ws_root not in resolved.parents:
+        raise _JailEscape(
+            "path is outside your workspace — deliver_artifact only delivers "
+            "files inside your own workspace directory."
+        )
+    return resolved
+
+
+def _dir_size_skipping_symlinks(src: Path) -> int:
+    """Total size of the regular files under ``src``, never following symlinks.
+
+    Symlinks are skipped (not measured, not archived) so a link pointing out of
+    the jail can neither inflate the size nor smuggle its target into the zip."""
+    total = 0
+    for root, dirs, files in os.walk(src, followlinks=False):
+        dirs[:] = [d for d in dirs if not os.path.islink(os.path.join(root, d))]
+        for name in files:
+            fp = os.path.join(root, name)
+            if os.path.islink(fp):
+                continue
+            try:
+                total += os.path.getsize(fp)
+            except OSError:
+                continue
+    return total
+
+
+def _zip_dir_to_tempfile(src: Path) -> Path:
+    """Zip ``src`` into a temp file (OUTSIDE the jail) and return its path.
+
+    Walks without following symlinks and skips symlink entries entirely so a
+    link inside the directory can't drag its out-of-jail target into the archive.
+    The temp file lives in the system temp dir, not the jail, so it never
+    counts against the jail quota or re-enters a future delivery. Caller unlinks
+    it after the upload.
+    """
+    fd, tmp_name = tempfile.mkstemp(suffix=".zip", prefix="paw-deliver-")
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    parent = src.parent  # arcnames become ``<dirname>/...``
+    # The mkstemp file exists NOW, and the caller only binds it for cleanup
+    # AFTER this returns — so a failure mid-walk (a vanished file, a perms
+    # error, disk-full) would leak it. Clean it up here on any failure.
+    try:
+        with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, dirs, files in os.walk(src, followlinks=False):
+                dirs[:] = [d for d in dirs if not os.path.islink(os.path.join(root, d))]
+                for name in files:
+                    fp = os.path.join(root, name)
+                    if os.path.islink(fp):
+                        continue
+                    zf.write(fp, arcname=os.path.relpath(fp, parent))
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    return tmp_path
+
+
+async def _upload_and_sign(
+    upload_path: Path,
+    *,
+    filename: str,
+    mime: str,
+    workspace_id: str,
+    user_id: str,
+    deliver_max: int,
+) -> tuple[Any, str]:
+    """Upload ``upload_path`` through ``EEUploadService`` and return ``(rec, url)``.
+
+    Builds a delivery-scoped service per call (cheap, like ``write_text_file``):
+    the workspace-scoped ``StorageAdapter`` (local or S3 via
+    ``POCKETPAW_UPLOAD_ADAPTER``), a Mongo metadata store, and an
+    ``UploadSettings`` whose ``allowed_mimes`` includes the computed mime (+ zip)
+    so the OSS pipeline's mime gate never rejects a first-party artifact — while
+    its magic-byte sniff still upgrades recognized types (png/pdf/…) to their
+    canonical mime. ``url`` is the adapter's presigned URL when available (S3),
+    else the authenticated cloud download path.
+    """
+    from fastapi import UploadFile
+
+    from pocketpaw.uploads.config import DEFAULT_ALLOWED_MIMES, UploadSettings
+    from pocketpaw.uploads.factory import build_adapter
+    from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+    from pocketpaw_ee.cloud.uploads.service import EEUploadService
+
+    root = Path.home() / ".pocketpaw" / "uploads"
+    root.mkdir(parents=True, exist_ok=True)
+    adapter = build_adapter(root)
+    cfg = UploadSettings(
+        max_file_bytes=deliver_max,
+        allowed_mimes=frozenset({mime, "application/zip", *DEFAULT_ALLOWED_MIMES}),
+        local_root=root,
+    )
+    svc = EEUploadService(adapter=adapter, meta=MongoFileStore(), cfg=cfg)
+
+    with open(upload_path, "rb") as fh:
+        upload = UploadFile(
+            file=fh,
+            filename=filename,
+            headers={"content-type": mime},  # type: ignore[arg-type]
+        )
+        rec = await svc.upload(upload, owner_id=user_id, chat_id=None, workspace=workspace_id)
+
+    # Owner-scoped presign (the uploader is the requester, so the read gate
+    # passes). Fall back to the authenticated cloud download path when the
+    # adapter can't presign (local adapter).
+    _rec, url = await svc.presigned_get(rec.id, user_id, workspace_id, DEFAULT_TTL_SECONDS)
+    return rec, url or f"/api/v1/uploads/{rec.id}"
+
+
+async def _deliver_handler(args: dict) -> dict:
+    """MCP handler for ``deliver_artifact`` — resolve, jail-check, route, upload."""
+    from pocketpaw.uploads.errors import UploadError
+    from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS
+
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "deliver_artifact requires workspace and user context (call from a cloud chat session)."
+        )
+
+    path_arg = args.get("path")
+    if not isinstance(path_arg, str) or not path_arg.strip():
+        return _error_response(
+            "deliver_artifact requires a `path` — the file or directory inside "
+            "your workspace to deliver."
+        )
+    path_arg = path_arg.strip()
+
+    try:
+        resolved = _resolve_in_jail(path_arg, workspace_id)
+    except _JailEscape as exc:
+        return _error_response(str(exc))
+
+    if not resolved.exists():
+        return _error_response(f"no such file or directory: {path_arg}")
+
+    deliver_max = _deliver_max_bytes()
+    tmp_to_clean: Path | None = None
+    try:
+        if resolved.is_dir():
+            total = _dir_size_skipping_symlinks(resolved)
+            if total > deliver_max:
+                return _error_response(_too_large_message(total, deliver_max))
+            tmp_to_clean = _zip_dir_to_tempfile(resolved)
+            upload_path = tmp_to_clean
+            filename = f"{resolved.name}.zip"
+            mime = "application/zip"
+        else:
+            size = resolved.stat().st_size
+            if size > deliver_max:
+                return _error_response(_too_large_message(size, deliver_max))
+            upload_path = resolved
+            filename = resolved.name
+            mime = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+        rec, url = await _upload_and_sign(
+            upload_path,
+            filename=filename,
+            mime=mime,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            deliver_max=deliver_max,
+        )
+    except UploadError as exc:
+        # TooLarge / UnsupportedMime / EmptyFile / StorageFailure — relay cleanly.
+        return _error_response(f"could not deliver artifact: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("deliver_artifact failed", exc_info=True)
+        return _error_response(f"deliver failed: {exc}")
+    finally:
+        if tmp_to_clean is not None:
+            tmp_to_clean.unlink(missing_ok=True)
+
+    return _success_response(
+        {
+            "ok": True,
+            "filename": rec.filename,
+            "url": url,
+            "file_id": rec.id,
+            "size": rec.size,
+            "mime": rec.mime,
+            "expires_in_seconds": DEFAULT_TTL_SECONDS,
+        }
+    )
+
+
+def build_deliver_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for artifact delivery, or ``None`` if
+    delivery isn't available (not multi-tenant cloud, or the SDK is missing).
+
+    Matches the shape returned by ``build_sites_manager_server`` /
+    ``build_pocket_context_server`` (``(name, server)`` or ``None``) so the
+    backend's MCP registration loop in ``claude_sdk.py`` treats it identically.
+
+    Cloud-only gate: deliver lands artifacts in tenant blob storage and resolves
+    paths against the per-tenant jail, both of which only exist in multi-tenant
+    cloud. Gating on ``is_multi_tenant_cloud()`` makes the cloud-only intent
+    explicit — the same signal the ART-4 boot guard and the ART-2 jail read —
+    rather than relying solely on the tool's fail-closed-without-identity guard.
+    The per-run MCP build (``claude_sdk._get_mcp_servers``) happens after the
+    cloud DB is initialized, so this never hides the tool from a real cloud run.
+    """
+    from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
+
+    if not is_multi_tenant_cloud():
+        logger.debug("not multi-tenant cloud; pocketpaw_deliver MCP disabled")
+        return None
+
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_deliver MCP disabled")
+        return None
+
+    @tool(
+        "deliver_artifact",
+        _TOOL_DESCRIPTION,
+        {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "File or directory inside your workspace to deliver. A "
+                        "directory is zipped before upload."
+                    ),
+                },
+            },
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+    )
+    async def deliver_artifact(args):  # type: ignore[no-untyped-def]
+        return await _deliver_handler(args)
+
+    server = create_sdk_mcp_server(name=SERVER_NAME, version="1.0.0", tools=[deliver_artifact])
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "DELIVER_ARTIFACT_TOOL_ID",
+    "DELIVER_TOOL_IDS",
+    "SERVER_NAME",
+    "build_deliver_server",
+]

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -299,6 +299,7 @@ def mount_cloud(app: FastAPI) -> None:
             exc_info=True,
         )
 
+    from pocketpaw_ee.cloud.file_versions.router import router as file_versions_router
     from pocketpaw_ee.cloud.files.router import router as files_router
     from pocketpaw_ee.cloud.kb.knowledge_router import router as knowledge_router
 
@@ -335,6 +336,11 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(notifications_router, prefix="/api/v1")
     app.include_router(tasks_router, prefix="/api/v1")
     app.include_router(files_router, prefix="/api/v1")
+    # file_versions (ART-1) — versioned file-write storage spine. Shares the
+    # /files prefix with files_router (GET /files, /tree, /browse) but only
+    # adds POST /files/write, PUT /files/{id}, GET /files/{id}/versions[/{vid}]
+    # — no method+path collisions with the existing listing routes.
+    app.include_router(file_versions_router, prefix="/api/v1")
     app.include_router(mission_control_router, prefix="/api/v1")
     app.include_router(livekit_router, prefix="/api/v1")
     # Pocket outcomes — GET /api/v1/outcomes count surface (RFC 05 M2b.2).

--- a/ee/pocketpaw_ee/cloud/agent_jail.py
+++ b/ee/pocketpaw_ee/cloud/agent_jail.py
@@ -1,0 +1,400 @@
+"""Per-tenant agent working-directory jail (cloud only).
+
+Created: 2026-06-26 (ART-2) — gives every multi-tenant cloud workspace its own
+agent working directory so a tenant's file operations never co-mingle in the
+shared home dir. Today the chat agent (``ClaudeSDKBackend``) runs with
+``cwd = settings.file_jail_path``, which defaults to ``Path.home()`` — in cloud
+every tenant's agent shares ``~`` and writes land on top of each other.
+
+``resolve_agent_cwd()`` reads the run's identity from the
+``attach_agent_identity`` ContextVars (``current_workspace_id`` /
+``current_session_mongo_id``) and returns a per-workspace, per-session jail dir.
+It FAILS CLOSED: a run that reaches the backend in multi-tenant cloud mode with
+no resolvable workspace RAISES rather than silently falling back to ``~`` — that
+silent fallback is the exact co-mingling bug this closes. OFF cloud (OSS /
+dedicated, where the cloud DB was never initialized) it returns ``None`` so the
+core agent keeps using ``settings.file_jail_path`` unchanged.
+
+The multi-tenant-cloud signal is ``is_multi_tenant_cloud()`` (ART-4) — the cloud
+DB client is set exactly when ``init_cloud_db`` ran (``CloudLifecycleHook`` on
+``CLOUD_MONGODB_URI``), so it is the authoritative "this process is serving
+tenants" flag without inventing a new one. The signal now lives in one place
+(``pocketpaw_ee.cloud.shared.db``) so the jail and the cloud-storage boot guard
+read the same name.
+
+When the fail-closed fires (a cloud run that lost its workspace = a
+mis-tenanting signal), a high-severity cloud AuditEvent is emitted via the
+Layer-5 audit service before the raise — exactly the signal that audit exists
+to capture. The emit is best-effort and never blocks the raise.
+
+Scope (ART-2): cwd resolution + fail-closed + the cloud/OSS gate.
+
+ART-3 (2026-06-26) — jail lifecycle, so scratch disk scales with active
+concurrency, not user count. The jail is pure scratch (durability lives in blob
+storage, a later task), so an idle jail is always safe to evict. Three bounds,
+all cloud-only:
+
+  * **Per-workspace quota** (``POCKETPAW_AGENT_JAIL_QUOTA_MB``, default 2048).
+    ``check_workspace_jail_quota`` measures a workspace's total jail size at
+    RUN-START and returns a clean rejection message when over the cap — the
+    run is failed cleanly (``run_core`` turns it into a terminal ``failed``
+    event), never crashing the box. We measure at run-start rather than gating
+    each write because the agent writes through its native subprocess tools
+    (Write/Bash), so individual writes can't be cheaply intercepted; run-start
+    is the enforceable, testable granularity.
+  * **TTL garbage-collection + disk-watermark eviction** live in the sibling
+    ``agent_jail_gc`` module (``sweep_agent_jails``), registered on cloud
+    startup and the 5-minute heartbeat exactly like the stale-run sweeper. This
+    module owns the filesystem primitives the sweep composes (scan, enumerate,
+    evict, disk probe); the sweep owns the run-state coordination (it never
+    evicts a jail while its run is still queued or running — and a retried
+    interrupted run re-protects the jail by spawning a fresh queued run).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# A jail path segment is a single workspace / session id. Ids are Mongo
+# ObjectId hex in practice; restrict to a safe charset (no path separators)
+# so a malformed or hostile id can never escape its workspace subtree. The
+# anchor is ``\Z`` (very end of string), NOT ``$`` — ``$`` also matches just
+# before a trailing newline, so ``"abc\n"`` would slip past a ``$`` guard.
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9_.-]+\Z")
+
+# Group/DM-bridge runs bind a workspace but no session; they share one
+# per-workspace dir under this name (still tenant-isolated, just not
+# session-granular).
+_SESSIONLESS_DIRNAME = "_shared"
+
+
+def _safe_segment(value: str, *, label: str) -> str:
+    """Return *value* if it is a safe single path segment, else raise.
+
+    Guards the jail against path traversal: the charset excludes ``/`` so a
+    crafted id cannot climb out of its workspace dir, and the literal ``.`` /
+    ``..`` are rejected outright.
+    """
+    if value in {".", ".."} or not _SAFE_SEGMENT.match(value):
+        raise ValueError(f"unsafe {label} for agent jail path: {value!r}")
+    return value
+
+
+def _emit_fail_closed_audit(actor_id: str | None, session_id: str | None) -> None:
+    """Best-effort high-severity audit alert for a fail-closed cloud run.
+
+    A cloud agent run reaching the backend with no resolvable workspace is a
+    mis-tenanting signal — exactly what Layer-5 audit exists to capture. Emit it
+    through the cloud audit service, fire-and-forget on the running loop (the
+    resolver is sync but runs inside the async agent loop). NEVER raises and
+    NEVER blocks the fail-closed raise that follows: a missing alert must not
+    turn a closed door into an open one. No running loop (e.g. a sync unit test)
+    → skip silently; the raise still happens.
+    """
+    try:
+        import asyncio
+
+        from pocketpaw_ee.cloud.audit import service as audit_service
+
+        async def _record() -> None:
+            # ``record`` itself never raises; the workspace is a sentinel
+            # because the whole alert IS "this run had no workspace".
+            await audit_service.record(
+                "__no_workspace__",
+                actor_id or "unknown",
+                "agent.cwd_jail.fail_closed",
+                target_type="agent_run",
+                target_id=session_id,
+                metadata={
+                    "severity": "high",
+                    "reason": "no resolvable workspace_id",
+                },
+            )
+
+        asyncio.get_running_loop().create_task(_record())
+    except Exception:  # noqa: BLE001 — telemetry must never break fail-closed
+        logger.debug("fail-closed audit alert could not be scheduled", exc_info=True)
+
+
+def workspace_jail_root() -> Path:
+    """Root under which every workspace's agent jail lives.
+
+    Defaults to ``~/.pocketpaw/workspaces``. Override with
+    ``POCKETPAW_WORKSPACE_JAIL_ROOT`` to anchor the jail on a data volume (and
+    so tests can redirect it off the real home dir).
+    """
+    override = os.environ.get("POCKETPAW_WORKSPACE_JAIL_ROOT", "").strip()
+    if override:
+        return Path(override)
+    return Path.home() / ".pocketpaw" / "workspaces"
+
+
+def resolve_agent_cwd() -> str | None:
+    """Resolve the per-session agent working directory for the active run.
+
+    Returns:
+        - ``<root>/<workspace_id>/agent/<session_id>/`` (created on demand) when
+          a workspace is bound to the active run.
+        - ``None`` when the process is not in multi-tenant cloud mode, so the
+          core agent falls back to ``settings.file_jail_path``.
+
+    Raises:
+        RuntimeError: cloud mode is active but no workspace is resolvable — the
+        fail-closed guard against tenant file co-mingling.
+    """
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        current_session_mongo_id,
+        current_user_id,
+        current_workspace_id,
+    )
+
+    workspace_id = current_workspace_id()
+    if not workspace_id:
+        # No tenancy bound. Distinguish a multi-tenant cloud run that lost its
+        # workspace (a bug we must NOT paper over by writing into the shared
+        # home dir) from an OSS / dedicated run where identity is legitimately
+        # never bound. ``is_multi_tenant_cloud()`` is True exactly when
+        # ``init_cloud_db`` ran — the authoritative multi-tenant-cloud signal,
+        # named in one place (ART-4) so the boot guard reads the same check.
+        from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
+
+        if is_multi_tenant_cloud():
+            # Mis-tenanting signal — alert before failing closed (best-effort).
+            _emit_fail_closed_audit(current_user_id(), current_session_mongo_id())
+            raise RuntimeError(
+                "cloud agent run reached the backend with no resolvable "
+                "workspace_id; refusing to fall back to the shared home "
+                "directory (would co-mingle tenant files). A cloud run must "
+                "bind identity via attach_agent_identity before the agent runs."
+            )
+        return None
+
+    ws_segment = _safe_segment(workspace_id, label="workspace_id")
+    # ``session_mongo_id`` is set on the SSE chat path so a multi-turn chat
+    # reuses one dir; the group/DM bridge binds a workspace but no session, so
+    # those runs share a per-workspace ``_shared`` dir.
+    session_raw = current_session_mongo_id()
+    session_segment = (
+        _safe_segment(session_raw, label="session_mongo_id")
+        if session_raw
+        else _SESSIONLESS_DIRNAME
+    )
+
+    cwd = workspace_jail_root() / ws_segment / "agent" / session_segment
+    cwd.mkdir(parents=True, exist_ok=True)
+    return str(cwd)
+
+
+# --------------------------------------------------------------------------- #
+# ART-3 — jail lifecycle primitives (quota / TTL-GC / watermark).
+#
+# Settings are read straight from the environment, like ``workspace_jail_root``
+# above, so the jail module stays self-contained (no Settings import). Every
+# knob is cloud-only; off-cloud there is no jail to bound.
+# --------------------------------------------------------------------------- #
+
+_DEFAULT_QUOTA_MB = 2048.0
+_DEFAULT_TTL_GRACE_SECONDS = 3600.0
+_DEFAULT_DISK_WATERMARK_PCT = 90.0
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("ignoring non-numeric %s=%r; using default %s", name, raw, default)
+        return default
+
+
+def jail_quota_bytes() -> int:
+    """Per-workspace jail size cap in bytes (``POCKETPAW_AGENT_JAIL_QUOTA_MB``,
+    default 2048 MB). ``<= 0`` disables the quota."""
+    return int(_env_float("POCKETPAW_AGENT_JAIL_QUOTA_MB", _DEFAULT_QUOTA_MB) * 1024 * 1024)
+
+
+def jail_ttl_grace_seconds() -> float:
+    """Idle grace before a jail with no active run is GC'd, in seconds
+    (``POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS``, default 3600)."""
+    return _env_float("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", _DEFAULT_TTL_GRACE_SECONDS)
+
+
+def jail_disk_watermark_pct() -> float:
+    """Box disk-usage %% high-water mark that triggers LRU eviction
+    (``POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT``, default 90). ``<= 0`` disables
+    watermark eviction."""
+    return _env_float("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", _DEFAULT_DISK_WATERMARK_PCT)
+
+
+def jail_gc_enabled() -> bool:
+    """Whether the background jail GC sweep runs (default on). Set
+    ``POCKETPAW_AGENT_JAIL_GC_ENABLED=false`` to disable it as an escape hatch."""
+    return os.environ.get("POCKETPAW_AGENT_JAIL_GC_ENABLED", "true").strip().lower() not in {
+        "false",
+        "0",
+        "no",
+        "off",
+    }
+
+
+def scan_jail_dir(path: Path) -> tuple[int, float]:
+    """Return ``(size_bytes, last_activity_epoch)`` for one jail dir.
+
+    Walks the subtree ONCE (cheap ``os.scandir`` with the stat cached on the
+    DirEntry), summing file sizes and tracking the newest mtime. The newest
+    mtime over the WHOLE tree — not the top dir's own mtime — is the activity
+    signal: a directory's mtime does not advance when a file in a NESTED subdir
+    is written (``node_modules/x/y``), so the top mtime alone would read a busy
+    jail as idle and let the GC evict it mid-build. Vanishing / unreadable
+    entries (mid-build races, broken symlinks) are skipped; an empty dir reports
+    its own mtime. Symlinks are never followed, so a link can't inflate the size
+    or drag the scan outside the jail.
+    """
+    try:
+        latest = path.stat().st_mtime
+    except OSError:
+        return (0, 0.0)
+
+    size = 0
+    stack = [path]
+    while stack:
+        try:
+            entries = list(os.scandir(stack.pop()))
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                st = entry.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            latest = max(latest, st.st_mtime)
+            if entry.is_dir(follow_symlinks=False):
+                stack.append(Path(entry.path))
+            else:
+                size += st.st_size
+    return (size, latest)
+
+
+def workspace_jail_over_quota(workspace_id: str, limit_bytes: int) -> bool:
+    """``True`` as soon as a workspace's total jail size crosses ``limit_bytes``.
+
+    Short-circuits the moment the running sum passes the limit — it does NOT
+    finish the walk or compute the exact total. The run-start quota gate only
+    needs the boolean, and it runs on EVERY run's critical path: a workspace
+    whose jail holds a ``node_modules`` (tens of thousands of files) would
+    otherwise pay a full ``O(files)`` stat-walk before every run — exactly our
+    file-creating use case. With the early-exit the walk is bounded by roughly
+    ``limit_bytes`` worth of file entries even when a runaway jail is many times
+    over quota. (The off-critical-path GC sweep keeps the full ``scan_jail_dir``
+    walk; it needs the exact size + last-activity and runs on a 5-minute cadence.)
+    """
+    # Iterative DFS over the whole ``<root>/<ws>/agent`` subtree (all session
+    # dirs at once), summing file sizes and bailing the instant we cross.
+    total = 0
+    stack = [workspace_jail_root() / workspace_id / "agent"]
+    while stack:
+        try:
+            entries = list(os.scandir(stack.pop()))
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                st = entry.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                stack.append(Path(entry.path))
+            else:
+                total += st.st_size
+                if total > limit_bytes:
+                    return True
+    return False
+
+
+def check_workspace_jail_quota(workspace_id: str | None) -> str | None:
+    """Return a human-readable rejection message if a workspace's jail is over
+    quota, else ``None``.
+
+    Called at RUN-START by ``run_core`` to reject a run before it spins up the
+    agent, so it leans on ``workspace_jail_over_quota``'s early-exit rather than
+    a full size walk. A ``None`` / empty workspace (no jail) and a disabled quota
+    (``<= 0``) are always allowed.
+    """
+    if not workspace_id:
+        return None
+    quota = jail_quota_bytes()
+    if quota <= 0:
+        return None
+    if not workspace_jail_over_quota(workspace_id, quota):
+        return None
+    return (
+        f"agent workspace storage is full: the jail exceeds its "
+        f"{quota / 1024 / 1024:.0f} MB per-workspace limit. Deliver or remove "
+        f"build artifacts to free space, then retry."
+    )
+
+
+def iter_workspace_jail_dirs() -> Iterator[tuple[str, str, Path]]:
+    """Yield ``(workspace_id, session_segment, path)`` for every existing jail
+    dir ``<root>/<ws>/agent/<seg>``. Silent when the root doesn't exist yet."""
+    try:
+        ws_entries = list(os.scandir(workspace_jail_root()))
+    except OSError:
+        return
+    for ws in ws_entries:
+        if not ws.is_dir(follow_symlinks=False):
+            continue
+        try:
+            sess_entries = list(os.scandir(Path(ws.path) / "agent"))
+        except OSError:
+            continue
+        for sess in sess_entries:
+            if sess.is_dir(follow_symlinks=False):
+                yield (ws.name, sess.name, Path(sess.path))
+
+
+def disk_usage_pct() -> float:
+    """Percent (0–100) of the jail-root volume in use, or ``0.0`` if it can't be
+    probed (root missing, no psutil). 0.0 is the safe default — it reads as
+    "below any watermark" so a probe failure never triggers eviction."""
+    try:
+        import psutil
+
+        return float(psutil.disk_usage(str(workspace_jail_root())).percent)
+    except Exception:  # noqa: BLE001 — a probe failure must not break the sweep
+        logger.debug("jail disk-usage probe failed", exc_info=True)
+        return 0.0
+
+
+def evict_jail_dir(path: Path) -> bool:
+    """Delete a jail dir tree. Returns ``True`` on success (or if already gone).
+
+    Refuses any path that does not live UNDER the jail root — defense against a
+    bug handing this an arbitrary path. Refusing the root itself (a dir is not
+    its own parent) means a stray call can never wipe every tenant's jail.
+    """
+    root = workspace_jail_root().resolve()
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    if root not in resolved.parents:
+        logger.error("refusing to evict path outside the jail root: %s", path)
+        return False
+    try:
+        shutil.rmtree(resolved)
+        return True
+    except FileNotFoundError:
+        return True  # already gone — eviction is idempotent
+    except OSError:
+        logger.exception("failed to evict jail dir %s", path)
+        return False

--- a/ee/pocketpaw_ee/cloud/agent_jail.py
+++ b/ee/pocketpaw_ee/cloud/agent_jail.py
@@ -9,11 +9,16 @@ every tenant's agent shares ``~`` and writes land on top of each other.
 ``resolve_agent_cwd()`` reads the run's identity from the
 ``attach_agent_identity`` ContextVars (``current_workspace_id`` /
 ``current_session_mongo_id``) and returns a per-workspace, per-session jail dir.
-It FAILS CLOSED: a run that reaches the backend in multi-tenant cloud mode with
-no resolvable workspace RAISES rather than silently falling back to ``~`` — that
-silent fallback is the exact co-mingling bug this closes. OFF cloud (OSS /
-dedicated, where the cloud DB was never initialized) it returns ``None`` so the
-core agent keeps using ``settings.file_jail_path`` unchanged.
+It FAILS CLOSED, but ONLY for a cloud CHAT run: a run that reaches the backend on
+the cloud chat dispatch path (marked by ``current_cloud_chat_run()`` — set by
+``run_core.execute_run`` around the run lifecycle) with no resolvable workspace
+RAISES rather than silently falling back to ``~`` — that silent fallback is the
+exact co-mingling bug this closes. Every OTHER workspace-less run returns
+``None`` so the core agent keeps using ``settings.file_jail_path`` unchanged: an
+OSS / dedicated run (the cloud DB was never initialized), AND a non-chat run (the
+CLI, a background job, a direct backend test) that merely shares a
+cloud-connected process. ``is_multi_tenant_cloud()`` alone is a process-global,
+so without the per-run marker the gate would wrongly hard-fail all of those.
 
 The multi-tenant-cloud signal is ``is_multi_tenant_cloud()`` (ART-4) — the cloud
 DB client is set exactly when ``init_cloud_db`` ran (``CloudLifecycleHook`` on
@@ -49,6 +54,17 @@ all cloud-only:
     evict, disk probe); the sweep owns the run-state coordination (it never
     evicts a jail while its run is still queued or running — and a retried
     interrupted run re-protects the jail by spawning a fresh queued run).
+
+Changes: 2026-06-27 (fix/cloud-artifacts-reland) — ``resolve_agent_cwd``'s
+fail-closed is now ALSO gated on the per-run ``current_cloud_chat_run()`` marker,
+not ``is_multi_tenant_cloud()`` alone. The latter is a PROCESS-GLOBAL (True
+whenever the cloud Mongo client is connected), so the original gate hard-failed
+EVERY workspace-less run in a cloud-connected process — direct claude_sdk backend
+tests, the CLI, background jobs — and would have hard-failed legitimate
+non-tenant agent runs in a real cloud process. The marker (set by
+``run_core.execute_run`` around the run lifecycle) fires the fail-closed only for
+an actual cloud chat dispatch; otherwise the resolver returns ``None`` and the
+core falls back to ``settings.file_jail_path``.
 """
 
 from __future__ import annotations
@@ -150,6 +166,7 @@ def resolve_agent_cwd() -> str | None:
         fail-closed guard against tenant file co-mingling.
     """
     from pocketpaw_ee.cloud.chat.agent_service import (
+        current_cloud_chat_run,
         current_session_mongo_id,
         current_user_id,
         current_workspace_id,
@@ -157,15 +174,24 @@ def resolve_agent_cwd() -> str | None:
 
     workspace_id = current_workspace_id()
     if not workspace_id:
-        # No tenancy bound. Distinguish a multi-tenant cloud run that lost its
-        # workspace (a bug we must NOT paper over by writing into the shared
-        # home dir) from an OSS / dedicated run where identity is legitimately
-        # never bound. ``is_multi_tenant_cloud()`` is True exactly when
-        # ``init_cloud_db`` ran — the authoritative multi-tenant-cloud signal,
-        # named in one place (ART-4) so the boot guard reads the same check.
+        # No tenancy bound. Distinguish a multi-tenant cloud CHAT run that lost
+        # its workspace (a bug we must NOT paper over by writing into the shared
+        # home dir) from every OTHER workspace-less run: an OSS / dedicated run
+        # where identity is legitimately never bound, OR a non-chat run (the CLI,
+        # a background job, a direct backend test) that merely shares a
+        # cloud-connected process. ``is_multi_tenant_cloud()`` is a PROCESS-GLOBAL
+        # — True whenever ``init_cloud_db`` ran (the cloud Mongo client is set, so
+        # the box is serving tenants) — so it CANNOT tell a real chat dispatch
+        # from any other run in the same process. The per-run
+        # ``current_cloud_chat_run()`` marker (set by ``run_core.execute_run``
+        # around the run lifecycle, BEFORE identity is bound) carries that
+        # distinction. Fail closed ONLY for a cloud CHAT run; otherwise return
+        # ``None`` so the core falls back to ``settings.file_jail_path`` — the
+        # pre-ART-2 behavior — instead of hard-failing a legitimately un-tenanted
+        # run.
         from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
 
-        if is_multi_tenant_cloud():
+        if is_multi_tenant_cloud() and current_cloud_chat_run():
             # Mis-tenanting signal — alert before failing closed (best-effort).
             _emit_fail_closed_audit(current_user_id(), current_session_mongo_id())
             raise RuntimeError(

--- a/ee/pocketpaw_ee/cloud/agent_jail_gc.py
+++ b/ee/pocketpaw_ee/cloud/agent_jail_gc.py
@@ -1,0 +1,134 @@
+"""Agent-jail lifecycle GC (cloud only) — ART-3.
+
+Created 2026-06-26 (ART-3). Bounds the per-tenant agent scratch jails that
+``agent_jail`` hands out so one build-heavy run can't fill the shared box and
+break every tenant. The jail is pure scratch (durability lives in blob storage,
+a later task), so an idle jail is always safe to evict.
+
+``sweep_agent_jails`` is the periodic half of the lifecycle (the per-workspace
+quota is enforced inline at run-start in ``run_core``). One pass does two things,
+in order:
+
+  1. **TTL garbage-collection** — evict any jail whose run has ended and that has
+     sat idle past the grace (``POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS``).
+  2. **Disk-watermark eviction** — while the jail-root volume is over the
+     high-water mark (``POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT``), evict the
+     least-recently-used IDLE jails first until back under the mark.
+
+The one invariant that makes this safe: a jail backing a still-active run is
+NEVER evicted. "Active" = a non-terminal ``ChatRunDoc`` (status ``queued`` or
+``running`` — the only non-terminal states) whose scope names that jail dir —
+resolved once per pass via ``run_service.find_active_run_scopes`` and matched
+against each dir's ``(workspace, session_segment)``. An ``interrupted`` run that
+the user retries re-protects its jail by spawning a fresh ``queued`` run, so
+evicting an idle jail between runs never races a resume. Idleness is read from
+the jail's newest mtime (``agent_jail.scan_jail_dir``), which the DB active-set
+check backstops: even a freshly-created queued run whose dir hasn't been written
+yet (old mtime, empty dir) is protected, because its scope is in the active set.
+
+Registered on cloud startup and the 5-minute heartbeat in
+``extensions._sweeper_loop`` / ``start_run_sweeper``, in its own try, exactly
+like the stale-run sweeper it mirrors — a jail-GC failure can never suppress the
+other sweeps (or vice versa).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+from pocketpaw_ee.cloud import agent_jail
+
+logger = logging.getLogger(__name__)
+
+# Cap dirs scanned per tick so a backlog can't wedge the heartbeat (mirrors the
+# stale-run sweeper's batch cap). TTL eviction reaps idle dirs every pass, so the
+# steady-state count stays bounded by active concurrency and this cap is slack.
+_SWEEP_BATCH_LIMIT = 500
+
+# One snapshot row: workspace, session segment, path, size, last-activity epoch.
+_JailRow = tuple[str, str, Path, int, float]
+
+
+async def sweep_agent_jails() -> int:
+    """Run one TTL + watermark GC pass over the agent jails. Returns the number
+    of jail dirs evicted. Never raises for an expected condition; a jail backing
+    an active run is never evicted."""
+    if not agent_jail.jail_gc_enabled():
+        return 0
+
+    from pocketpaw_ee.cloud.chat.runs import service as run_service
+
+    active = await run_service.find_active_run_scopes()
+    # A jail dir is named after its run's scope: SESSION runs → ``<scope_id>``;
+    # the sessionless DM/group/pocket bridge → the per-workspace ``_shared`` dir.
+    active_sessions = {(ws, scope) for (ws, ctype, scope) in active if ctype == "session"}
+    active_shared_workspaces = {ws for (ws, ctype, _scope) in active if ctype != "session"}
+
+    def _is_active(workspace_id: str, segment: str) -> bool:
+        if segment == agent_jail._SESSIONLESS_DIRNAME:
+            return workspace_id in active_shared_workspaces
+        return (workspace_id, segment) in active_sessions
+
+    # Snapshot every jail once (size + last activity), bounded per tick.
+    rows: list[_JailRow] = []
+    for workspace_id, segment, path in agent_jail.iter_workspace_jail_dirs():
+        size, last_activity = agent_jail.scan_jail_dir(path)
+        rows.append((workspace_id, segment, path, size, last_activity))
+        if len(rows) >= _SWEEP_BATCH_LIMIT:
+            break
+
+    now = time.time()
+    grace = agent_jail.jail_ttl_grace_seconds()
+    evicted = 0
+    survivors: list[_JailRow] = []  # idle dirs that passed TTL → watermark pool
+
+    for row in rows:
+        workspace_id, segment, path, _size, last_activity = row
+        if _is_active(workspace_id, segment):
+            continue  # never evict a jail whose run is still queued or running
+        idle_for = now - last_activity
+        if idle_for > grace:
+            if agent_jail.evict_jail_dir(path):
+                evicted += 1
+                logger.info(
+                    "jail GC: TTL-evicted idle jail %s/%s (idle %.0fs)",
+                    workspace_id,
+                    segment,
+                    idle_for,
+                )
+        else:
+            survivors.append(row)
+
+    evicted += _evict_to_watermark(survivors)
+    if evicted:
+        logger.info("jail GC: evicted %d idle jail(s)", evicted)
+    return evicted
+
+
+def _evict_to_watermark(survivors: list[_JailRow]) -> int:
+    """Evict idle survivors LRU-first while the jail-root volume is over the
+    high-water mark. Only IDLE dirs reach here (active ones were skipped, TTL
+    ones already reaped), so this never touches a live run's jail. Returns the
+    count evicted."""
+    watermark = agent_jail.jail_disk_watermark_pct()
+    if watermark <= 0:
+        return 0
+    if agent_jail.disk_usage_pct() <= watermark:
+        return 0
+
+    evicted = 0
+    # LRU first: oldest last-activity (row[4]) at the front of the queue.
+    for workspace_id, segment, path, _size, _last in sorted(survivors, key=lambda r: r[4]):
+        if agent_jail.disk_usage_pct() <= watermark:
+            break
+        if agent_jail.evict_jail_dir(path):
+            evicted += 1
+            logger.warning(
+                "jail GC: watermark-evicted LRU idle jail %s/%s (disk over %.0f%%)",
+                workspace_id,
+                segment,
+                watermark,
+            )
+    return evicted

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -141,13 +141,27 @@ preserves today's doc-only behavior. Defense-in-depth: ``attach_agent_identity``
 now REJECTS an empty ``workspace_id`` / ``user_id`` (raises ``ValueError``)
 instead of binding ``""``, so any future caller that loses tenancy fails loudly
 at the seam, not deep inside an MCP tool.
+
+Changes: 2026-06-27 (fix/cloud-artifacts-reland) — added the per-run
+``_active_cloud_chat_run`` marker ContextVar (+ ``current_cloud_chat_run`` and
+the ``mark_cloud_chat_run`` context manager) beside the identity ContextVars.
+It distinguishes an actual cloud CHAT dispatch (the path that MUST bind
+workspace identity) from any other workspace-less run in a cloud-connected
+process. The agent cwd jail's fail-closed (``agent_jail.resolve_agent_cwd``) was
+gated on ``is_multi_tenant_cloud()`` alone — a PROCESS-GLOBAL, true whenever the
+cloud Mongo client is connected — so it hard-failed EVERY workspace-less run
+(direct backend tests, CLI, background jobs), not just a mis-tenanted chat run.
+``run_core.execute_run`` now wraps the run lifecycle in ``mark_cloud_chat_run``
+and the jail fails closed only when this marker is set; otherwise it falls back
+to ``settings.file_jail_path`` (pre-ART-2 behavior).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -209,6 +223,22 @@ _active_session_mongo_id: ContextVar[str | None] = ContextVar(
 # can resolve which room they're in without a request scope. ``None`` when the
 # chat isn't bound to a pocket (a plain DM / group thread).
 _active_pocket_id: ContextVar[str | None] = ContextVar("agent_pocket_id", default=None)
+
+# Marks the active async context as a live cloud CHAT run — the dispatch path
+# that is REQUIRED to bind workspace identity (``run_core.execute_run`` sets it
+# around the run lifecycle, BEFORE the prewarm ``create_task`` + the two
+# ``attach_agent_identity`` binds). The per-tenant cwd jail
+# (``agent_jail.resolve_agent_cwd``) fails CLOSED on a workspace-less run ONLY
+# when this marker is set: a workspace-less run in a cloud-connected process
+# that is NOT a chat dispatch (a direct backend test, the CLI, a background job)
+# is legitimately un-tenanted and must fall back to the shared file jail, not
+# hard-fail. ``is_multi_tenant_cloud()`` alone can't tell the two apart — it is a
+# PROCESS-GLOBAL, true whenever the cloud Mongo client is connected — so this
+# per-run marker carries the distinction. Default False; the context manager
+# resets it in a finally so it never leaks past one run. ``asyncio.create_task``
+# copies the context, so a marker set before the prewarm ``create_task``
+# propagates into the prewarm task too.
+_active_cloud_chat_run: ContextVar[bool] = ContextVar("agent_cloud_chat_run", default=False)
 
 
 def attach_agent_identity(
@@ -285,6 +315,36 @@ def current_session_mongo_id() -> str | None:
 
 def current_pocket_id() -> str | None:
     return _active_pocket_id.get()
+
+
+def current_cloud_chat_run() -> bool:
+    """True when the active context is a live cloud CHAT run dispatch.
+
+    Read by ``agent_jail.resolve_agent_cwd`` to decide whether a workspace-less
+    run in a cloud-connected process is a mis-tenanting bug (fail closed) or a
+    legitimately un-tenanted run that should fall back to the file jail.
+    """
+    return _active_cloud_chat_run.get()
+
+
+@contextmanager
+def mark_cloud_chat_run() -> Iterator[None]:
+    """Mark the active context as a live cloud CHAT run for the per-tenant cwd
+    jail's fail-closed (see ``_active_cloud_chat_run``).
+
+    Sets the marker True on enter and resets it to the prior value in a finally
+    so it never leaks past the run. ``run_core.execute_run`` wraps the run
+    lifecycle with this — set BEFORE the prewarm ``create_task`` (which copies
+    the context, carrying the marker into the prewarm task) and BEFORE
+    ``attach_agent_identity``, so a run that reaches the backend WITHOUT binding
+    identity (the real mis-tenanting bug) still trips the jail's fail-closed
+    instead of silently co-mingling tenant files in the shared home directory.
+    """
+    token = _active_cloud_chat_run.set(True)
+    try:
+        yield
+    finally:
+        _active_cloud_chat_run.reset(token)
 
 
 def push_sse_event(name: str, data: dict[str, Any]) -> None:

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -1182,6 +1182,11 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
 
     parts: list[str] = []
     parts.append(_RUNTIME_IDENTITY_RULE)
+    # Artifact-delivery rule (ART-4): the agent builds files in a per-tenant jail
+    # the user can't reach, so a downloadable result MUST go through
+    # deliver_artifact (which lands it in tenant blob storage and returns a real
+    # download URL) — not a printed container path and not a local preview server.
+    parts.append(_DELIVER_ARTIFACT_RULE)
     # Composio auth/search guidance is injected whenever Composio is
     # enabled. An enabled deployment ALWAYS surfaces at least the
     # discovery meta-tools — ``providers.py`` falls back to them when no
@@ -1313,6 +1318,35 @@ DOES NOT EXIST in this environment:
 - If you genuinely don't have a tool for what the user asked, say so
   plainly. Don't fabricate instructions for a different environment.
 </runtime-identity>"""
+
+
+# Artifact delivery (ART-4). The cloud agent's working directory is a per-tenant
+# jail on the server's filesystem — the user has no shell, no SSH, and cannot
+# reach 127.0.0.1 on the box. So a file the agent "wrote to ./out.pdf" or a
+# "preview running at http://localhost:8000" is invisible to them. The ONLY way
+# to hand the user a downloadable result is deliver_artifact, which uploads the
+# file/dir to the tenant's blob storage and returns a real, short-lived URL.
+_DELIVER_ARTIFACT_RULE = """\
+<artifact-delivery>
+You run in a sandboxed working directory the user cannot see or reach — they
+have no terminal on this machine and cannot open 127.0.0.1 / localhost here.
+
+When you produce something the user should be able to DOWNLOAD (a report, an
+export, a generated document, a built bundle, a zip):
+
+  1. Write it to a file (or a directory) in your working directory.
+  2. Call ``deliver_artifact`` with that path. A single file uploads as-is; a
+     directory is zipped automatically.
+  3. Share the ``url`` it returns — that is the user's real download link.
+
+Do NOT instead:
+  - print the path you wrote to (e.g. "I saved it to ./out.pdf") and stop — that
+    path lives in a container the user can't access;
+  - start a local preview / web server ("run `python -m http.server`", "open
+    http://localhost:8000") — nothing you bind on this box is reachable.
+
+If ``deliver_artifact`` returns an error, relay it; do not invent a link.
+</artifact-delivery>"""
 
 
 # Composio's direct-tools surface caps each toolkit at a fixed limit

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,15 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-26 (ART-2) — ``_prewarm_session`` now binds the run's identity
+  (``attach_agent_identity`` with the same ``session_mongo_id`` / ``pocket_id``
+  the stream path uses) around its ``pool.prewarm`` call, then detaches in a
+  ``finally``. The per-tenant cwd jail resolves the agent's working directory
+  from those ContextVars; since prewarm is fired in its own ``create_task``
+  context BEFORE the stream binds identity, without this the cloud cwd resolver
+  would fail closed during warm-up (swallowed) and every cloud session would
+  lose the turn-1 warm. Binding here makes prewarm warm the SAME per-session
+  jail turn 1 will use.
 - 2026-06-25 (fix/worker-trusts-spec-workspace) — ``execute_run`` now threads
   the authenticated ``spec.workspace_id`` into ``resolve_scope_context`` via the
   new ``expected_workspace_id`` kwarg, then raises a clean
@@ -739,16 +748,35 @@ async def _prewarm_session(ctx: ScopeContext) -> None:
             surface_skills = ctx.resolved_profile.skill_names or frozenset()
         surface_skills = surface_skills | _agent_skill_set(instance)
 
-        await pool.prewarm(
-            ctx.target_agent_id,
-            session_key_for(ctx),
-            instructions=behavior_instructions,
-            deny_mcp_tool_ids=surface_deny,
-            allow_sdk_tools=surface_allow,
-            allow_mcp_tool_ids=surface_allow_mcp,
-            system_message_override=surface_sys_override,
-            skill_names=surface_skills,
+        # Bind this run's tenancy for the warm-up so the prewarmed subprocess
+        # connects with the SAME per-tenant cwd jail the first turn will resolve
+        # (ART-2). _prewarm_session runs in its own create_task context, fired
+        # BEFORE the stream binds identity at the _drive_agent_loop seam, so
+        # without this the cloud cwd resolver would fail closed here (swallowed)
+        # and every cloud session would lose the turn-1 warm. Mirrors the
+        # run-path binding exactly (same session_mongo_id / pocket_id) so prewarm
+        # and turn 1 resolve one cwd; detached in finally so it can't leak into
+        # this task's later work.
+        session_mongo_id = ctx.scope_id if ctx.kind is ScopeKind.SESSION else None
+        identity_tokens = attach_agent_identity(
+            workspace_id=ctx.workspace_id,
+            user_id=ctx.user_id,
+            session_mongo_id=session_mongo_id,
+            pocket_id=ctx.pocket_id,
         )
+        try:
+            await pool.prewarm(
+                ctx.target_agent_id,
+                session_key_for(ctx),
+                instructions=behavior_instructions,
+                deny_mcp_tool_ids=surface_deny,
+                allow_sdk_tools=surface_allow,
+                allow_mcp_tool_ids=surface_allow_mcp,
+                system_message_override=surface_sys_override,
+                skill_names=surface_skills,
+            )
+        finally:
+            detach_agent_identity(identity_tokens)
     except Exception as exc:  # noqa: BLE001 — prewarm must NEVER break a run
         logger.debug("prewarm_session skipped (swallowed): %s", exc)
 
@@ -1055,6 +1083,41 @@ async def _handle_interrupted_cleanup(
         logger.debug("interrupted stream write failed", exc_info=True)
 
 
+async def _reject_if_over_jail_quota(spec: RunSpec, ctx: ScopeContext, transport: Any) -> bool:
+    """ART-3 per-workspace agent-jail quota, enforced at RUN-START.
+
+    The agent writes through its native subprocess tools (Write/Bash), so we
+    can't cheaply gate each individual write; instead we measure the workspace's
+    total jail size ONCE here — before spinning up the agent — and reject the run
+    CLEANLY when it's over quota. The rejection is a terminal ``failed`` run with
+    a clear message and an ``error`` stream frame, never an OOM/crash that takes
+    the worker (and every other tenant on the box) down. Returns ``True`` when
+    the run was rejected (the caller returns early), ``False`` to proceed. Off
+    cloud / under quota it is a no-op returning ``False``.
+    """
+    from pocketpaw_ee.cloud import agent_jail
+
+    quota_error = agent_jail.check_workspace_jail_quota(ctx.workspace_id)
+    if not quota_error:
+        return False
+    logger.warning("run %s rejected — agent jail over quota: %s", spec.run_id, quota_error)
+    try:
+        await transport.append_event(
+            spec.run_id, "error", {"code": "agent.jail_over_quota", "message": quota_error}
+        )
+    except Exception:
+        logger.debug("over-quota error frame append failed for %s", spec.run_id, exc_info=True)
+    try:
+        await run_service.mark_terminal(spec.run_id, status="failed", error=quota_error)
+    except Exception:
+        logger.exception("mark_terminal(failed) failed for over-quota run %s", spec.run_id)
+    try:
+        await transport.set_ttl(spec.run_id, _stream_ttl())
+    except Exception:
+        logger.debug("over-quota stream ttl set failed for %s", spec.run_id, exc_info=True)
+    return True
+
+
 async def execute_run(spec: RunSpec) -> None:
     """Run the agent for ``spec`` and write every event to the transport.
 
@@ -1133,6 +1196,12 @@ async def execute_run(spec: RunSpec) -> None:
     # instead of re-resolving. Never raises — a missing/foreign pocket degrades
     # to the surface base (today's behavior).
     ctx.resolved_profile = await _resolve_entity_profile(ctx)
+
+    # ART-3: reject a run whose workspace agent-jail is over quota BEFORE the
+    # prewarm + mark-running + agent spin-up, so a tenant that filled its scratch
+    # quota fails fast and cleanly instead of crashing the shared box mid-run.
+    if await _reject_if_over_jail_quota(spec, ctx, transport):
+        return
 
     # PREWARM (feat/claude-sdk-prewarm): kick off warming the agent's CLI
     # subprocess for this session NOW — concurrently with the remaining pre-turn

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,17 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-27 (fix/cloud-artifacts-reland) — ``execute_run`` now wraps the run
+  lifecycle (the prewarm ``create_task`` + the main agent loop) in
+  ``mark_cloud_chat_run`` so the per-tenant cwd jail's fail-closed
+  (``agent_jail.resolve_agent_cwd``) fires ONLY for an actual cloud chat
+  dispatch — not for any workspace-less run in a cloud-connected process. The
+  marker is set BEFORE the prewarm ``create_task`` (``asyncio.create_task``
+  copies the context, carrying it into the prewarm task) and BEFORE the two
+  ``attach_agent_identity`` binds, so a run that reaches the backend WITHOUT
+  binding identity still trips the guard. Fixes the dev-CI regression where the
+  jail hard-failed direct claude_sdk backend tests + a broad ee set once a cloud
+  test left ``is_multi_tenant_cloud()`` True in the process.
 - 2026-06-26 (ART-2) — ``_prewarm_session`` now binds the run's identity
   (``attach_agent_identity`` with the same ``session_mongo_id`` / ``pocket_id``
   the stream path uses) around its ``pool.prewarm`` call, then detaches in a
@@ -132,6 +143,7 @@ from pocketpaw_ee.cloud.chat.agent_service import (
     build_knowledge_context,
     detach_agent_identity,
     detach_sse_event_sink,
+    mark_cloud_chat_run,
     push_sse_event,
     session_key_for,
 )
@@ -1203,78 +1215,92 @@ async def execute_run(spec: RunSpec) -> None:
     if await _reject_if_over_jail_quota(spec, ctx, transport):
         return
 
-    # PREWARM (feat/claude-sdk-prewarm): kick off warming the agent's CLI
-    # subprocess for this session NOW — concurrently with the remaining pre-turn
-    # work below (mark-running, typing broadcast, and inside _drive_agent_loop:
-    # knowledge-context build, soul recall, SSE setup, prompt assembly). By the
-    # time pool.run reaches the first connect(), the subprocess is already live
-    # and turn 1 reuses it instead of paying the ~12s cold connect. Fire-and-
-    # forget: _prewarm_session swallows every error, so it can never delay or
-    # break this run; the task is intentionally not awaited.
-    asyncio.create_task(_prewarm_session(ctx))
+    # Mark this dispatch as a live cloud CHAT run for the per-tenant cwd jail's
+    # fail-closed (fix/cloud-artifacts-reland). ``agent_jail.resolve_agent_cwd``
+    # refuses to fall back to the shared home dir on a workspace-less run ONLY
+    # when this marker is set — so a workspace-less run in a cloud-connected
+    # process that ISN'T a chat dispatch (a direct backend test, the CLI, a
+    # background job) cleanly falls back instead of hard-failing. Set HERE, at
+    # the common dispatch ancestor and BEFORE the prewarm ``create_task`` and
+    # the two ``attach_agent_identity`` binds, so (a) the prewarm task inherits
+    # it (``asyncio.create_task`` copies the context) and (b) a run that reaches
+    # the backend WITHOUT binding identity — the real mis-tenanting bug — still
+    # trips the guard. Reset in the context manager's finally so it never leaks
+    # past this run. The post-loop persist below resolves no cwd, so it sits
+    # outside the marked region.
+    with mark_cloud_chat_run():
+        # PREWARM (feat/claude-sdk-prewarm): kick off warming the agent's CLI
+        # subprocess for this session NOW — concurrently with the remaining pre-turn
+        # work below (mark-running, typing broadcast, and inside _drive_agent_loop:
+        # knowledge-context build, soul recall, SSE setup, prompt assembly). By the
+        # time pool.run reaches the first connect(), the subprocess is already live
+        # and turn 1 reuses it instead of paying the ~12s cold connect. Fire-and-
+        # forget: _prewarm_session swallows every error, so it can never delay or
+        # break this run; the task is intentionally not awaited.
+        asyncio.create_task(_prewarm_session(ctx))
 
-    await _mark_running(spec.run_id)
-    await _broadcast_agent_typing(ctx, active=True)
+        await _mark_running(spec.run_id)
+        await _broadcast_agent_typing(ctx, active=True)
 
-    full_text = ""
-    cancelled = False
-    error: Exception | None = None
-    backend_error_message: str | None = None
-    # Per-run token metering (W3a). The backend yields a ``token_usage`` event
-    # carrying the real prompt / completion / cached token counts; ``_drive_agent_loop``
-    # surfaces it as a ``("token_usage", {...})`` tuple. Keep the LATEST one (a
-    # multi-turn agent loop can report usage more than once) so the final
-    # ``stream_end`` frame and the persisted run doc carry actual counts instead
-    # of the old hardcoded ``{}``.
-    usage: dict[str, Any] = {}
-    try:
-        async for event_name, event_data in _iter_agent_events(spec, ctx):
-            if await transport.is_cancelled(spec.run_id):
-                cancelled = True
-                break
-            if event_name == "chunk":
-                content = event_data.get("content", "")
-                if isinstance(content, str):
-                    full_text += content
-            elif event_name == "token_usage":
-                if isinstance(event_data, dict) and event_data:
-                    usage = event_data
-            await transport.append_event(spec.run_id, event_name, event_data)
-            if event_name == "error":
-                # ``_drive_agent_loop`` already broke out after yielding this.
-                # The frame is terminal for the client (TERMINAL_EVENTS); stop
-                # writing and route to the failed-mark path below so the doc
-                # doesn't get flipped to ``completed`` by the empty-text branch.
-                backend_error_message = str(event_data.get("message") or "")
-                break
-    except asyncio.CancelledError:
-        # The task itself was cancelled (worker shutdown, host signal). Run
-        # the interrupted-cleanup INSIDE the except clause so the bare
-        # ``raise`` below re-raises the original CancelledError instance —
-        # preserving the cancel-reason arq supplies via ``task.cancel(msg)``
-        # and the original traceback. The cleanup is shielded so a second
-        # cancel (SIGKILL grace window) can't abort mark_terminal mid-flight
-        # and strand the doc in ``running`` with no terminal stream frame.
-        logger.info("execute_run %s cancelled by host", spec.run_id)
+        full_text = ""
+        cancelled = False
+        error: Exception | None = None
+        backend_error_message: str | None = None
+        # Per-run token metering (W3a). The backend yields a ``token_usage`` event
+        # carrying the real prompt / completion / cached token counts; ``_drive_agent_loop``
+        # surfaces it as a ``("token_usage", {...})`` tuple. Keep the LATEST one (a
+        # multi-turn agent loop can report usage more than once) so the final
+        # ``stream_end`` frame and the persisted run doc carry actual counts instead
+        # of the old hardcoded ``{}``.
+        usage: dict[str, Any] = {}
         try:
-            await asyncio.shield(_handle_interrupted_cleanup(spec, ctx, full_text, transport))
+            async for event_name, event_data in _iter_agent_events(spec, ctx):
+                if await transport.is_cancelled(spec.run_id):
+                    cancelled = True
+                    break
+                if event_name == "chunk":
+                    content = event_data.get("content", "")
+                    if isinstance(content, str):
+                        full_text += content
+                elif event_name == "token_usage":
+                    if isinstance(event_data, dict) and event_data:
+                        usage = event_data
+                await transport.append_event(spec.run_id, event_name, event_data)
+                if event_name == "error":
+                    # ``_drive_agent_loop`` already broke out after yielding this.
+                    # The frame is terminal for the client (TERMINAL_EVENTS); stop
+                    # writing and route to the failed-mark path below so the doc
+                    # doesn't get flipped to ``completed`` by the empty-text branch.
+                    backend_error_message = str(event_data.get("message") or "")
+                    break
         except asyncio.CancelledError:
-            # The outer await is cancelled but the shielded inner task
-            # continues running to completion in the background. That's
-            # exactly what we want; just don't re-raise from this layer —
-            # let the original cancel propagate after the except clause.
-            pass
-        except Exception:
-            logger.exception("interrupted cleanup raised after shield for %s", spec.run_id)
-        raise
-    except Exception as exc:
-        error = exc
-        logger.exception("execute_run %s crashed", spec.run_id)
-        await transport.append_event(
-            spec.run_id,
-            "error",
-            {"code": "agent.run_failed", "message": str(exc)},
-        )
+            # The task itself was cancelled (worker shutdown, host signal). Run
+            # the interrupted-cleanup INSIDE the except clause so the bare
+            # ``raise`` below re-raises the original CancelledError instance —
+            # preserving the cancel-reason arq supplies via ``task.cancel(msg)``
+            # and the original traceback. The cleanup is shielded so a second
+            # cancel (SIGKILL grace window) can't abort mark_terminal mid-flight
+            # and strand the doc in ``running`` with no terminal stream frame.
+            logger.info("execute_run %s cancelled by host", spec.run_id)
+            try:
+                await asyncio.shield(_handle_interrupted_cleanup(spec, ctx, full_text, transport))
+            except asyncio.CancelledError:
+                # The outer await is cancelled but the shielded inner task
+                # continues running to completion in the background. That's
+                # exactly what we want; just don't re-raise from this layer —
+                # let the original cancel propagate after the except clause.
+                pass
+            except Exception:
+                logger.exception("interrupted cleanup raised after shield for %s", spec.run_id)
+            raise
+        except Exception as exc:
+            error = exc
+            logger.exception("execute_run %s crashed", spec.run_id)
+            await transport.append_event(
+                spec.run_id,
+                "error",
+                {"code": "agent.run_failed", "message": str(exc)},
+            )
 
     # Drop the typing indicator before persist so a slow Mongo write
     # doesn't leave it stuck on. Only reached on non-cancelled paths;

--- a/ee/pocketpaw_ee/cloud/chat/runs/service.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/service.py
@@ -167,3 +167,22 @@ async def find_stale_running(older_than: datetime) -> list[ChatRunDoc]:
         {"status": {"$in": ["queued", "running"]}},
         ChatRunDoc.createdAt < older_than,
     ).to_list()
+
+
+async def find_active_run_scopes() -> set[tuple[str, str, str]]:
+    """Every ``(workspace, context_type, scope_id)`` with a non-terminal
+    (``queued`` / ``running``) run.
+
+    The active-jail guard for the ART-3 jail GC: a per-session agent jail dir is
+    named after its run's scope (``session`` runs → ``<scope_id>``; ``dm`` /
+    ``group`` / ``pocket`` runs share the workspace ``_shared`` dir), so a jail
+    whose scope is in this set is in use and must never be evicted. Uses the
+    same ``active = queued | running`` definition as ``find_active_run_for_scope``
+    — an ``interrupted`` run that the user retries spawns a NEW queued/running
+    run for the same scope, which re-protects the jail, so a retry can't race a
+    GC pass into deleting a jail it's about to reuse.
+    """
+    docs = await ChatRunDoc.find(
+        {"status": {"$in": ["queued", "running"]}},
+    ).to_list()
+    return {(d.workspace, d.context_type, d.scope_id) for d in docs}

--- a/ee/pocketpaw_ee/cloud/file_versions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/__init__.py
@@ -1,0 +1,5 @@
+# __init__.py — file_versions entity package.
+# Created: 2026-06-26 (ART-1) — versioned cloud file-write storage spine
+#   ported from dewani12's origin/feature/files. Holds the file-version
+#   core only (write/update/list/get); slides/spreadsheet/editor (Slice D)
+#   were intentionally excluded from the port.

--- a/ee/pocketpaw_ee/cloud/file_versions/domain.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/domain.py
@@ -1,0 +1,30 @@
+# domain.py — frozen FileVersion value object.
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files
+#   (ee/cloud/file_versions/domain.py) onto the current layout. No Beanie,
+#   no I/O — a pure value object carrying required tenancy (workspace_id).
+"""FileVersion domain value object."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+EditorKind = Literal["human", "agent"]
+
+
+@dataclass(frozen=True)
+class FileVersion:
+    id: str
+    file_id: str
+    workspace_id: str
+    version_number: int
+    content: str
+    content_hash: str
+    size_bytes: int
+    editor_kind: EditorKind
+    editor_id: str  # user_id or agent_id
+    created_at: datetime
+
+
+__all__ = ["EditorKind", "FileVersion"]

--- a/ee/pocketpaw_ee/cloud/file_versions/dto.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/dto.py
@@ -1,0 +1,88 @@
+# dto.py — request/response schemas for the file-version write API.
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files
+#   (ee/cloud/file_versions/dto.py). KEEPS the file-write/version core only:
+#   WriteFile{Request,Response}, UpdateFileContent{Request,Response}, and the
+#   version list/get DTOs. DROPPED the Slice-D editor transport DTOs
+#   (DiffResponse, AiEditRequest, AiEditResponse) — deferred, not ported.
+# Updated: 2026-06-26 (ART-1 quality fix loop, I2) — WriteFileRequest gained an
+#   optional `mime`; when omitted the service guesses from the filename
+#   extension instead of hardcoding application/json.
+"""FileVersions DTOs — request/response schemas for the file-version API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class WriteFileRequest(BaseModel):
+    """Request body for POST /files/write — create or overwrite a file."""
+
+    path: str = Field(min_length=1)  # file id or path
+    content: str = Field(min_length=0)  # full file content
+    filename: str | None = None  # display name (defaults to path if omitted)
+    # Explicit mime. When omitted the service guesses from the filename
+    # extension, defaulting to text/plain for extension-less paths.
+    mime: str | None = None
+
+
+class WriteFileResponse(BaseModel):
+    """Returned after POST /files/write."""
+
+    file_id: str = Field(alias="fileId")
+    version: int
+    size_bytes: int = Field(alias="sizeBytes")
+
+    model_config = {"populate_by_name": True}
+
+
+class UpdateFileContentRequest(BaseModel):
+    """Request body for PUT /files/{id}. Content is the full new text."""
+
+    content: str = Field(min_length=0)
+    # Expected version for If-Match. Omitted -> force-overwrite (escape hatch).
+    expected_version: int | None = Field(default=None, alias="expectedVersion")
+
+    model_config = {"populate_by_name": True}
+
+
+class UpdateFileContentResponse(BaseModel):
+    """Returned after a successful PUT /files/{id}."""
+
+    file_id: str = Field(alias="fileId")
+    new_version: int = Field(alias="newVersion")
+    size_bytes: int = Field(alias="sizeBytes")
+    content_hash: str = Field(alias="contentHash")
+
+    model_config = {"populate_by_name": True}
+
+
+class FileVersionListItem(BaseModel):
+    """One row in the version picker dropdown (content omitted)."""
+
+    id: str
+    file_id: str = Field(alias="fileId")
+    version_number: int = Field(alias="versionNumber")
+    size_bytes: int = Field(alias="sizeBytes")
+    editor_kind: str = Field(alias="editorKind")
+    editor_id: str = Field(alias="editorId")
+    created_at: datetime = Field(alias="createdAt")
+
+    model_config = {"populate_by_name": True}
+
+
+class FileVersionResponse(BaseModel):
+    """Full version payload including content (for revert / diff)."""
+
+    id: str
+    file_id: str = Field(alias="fileId")
+    version_number: int = Field(alias="versionNumber")
+    content: str
+    content_hash: str = Field(alias="contentHash")
+    size_bytes: int = Field(alias="sizeBytes")
+    editor_kind: str = Field(alias="editorKind")
+    editor_id: str = Field(alias="editorId")
+    created_at: datetime = Field(alias="createdAt")
+
+    model_config = {"populate_by_name": True}

--- a/ee/pocketpaw_ee/cloud/file_versions/router.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/router.py
@@ -1,0 +1,88 @@
+# router.py — FastAPI router for the file-version write API.
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files
+#   (ee/cloud/file_versions/router.py). KEEPS the 4 core routes: POST
+#   /files/write, PUT /files/{id}, GET /files/{id}/versions,
+#   GET /files/{id}/versions/{vid}. DROPPED the Slice-D editor routes
+#   (revert, diff, ai-edit, editing/spreadsheet/slides-context). Thin
+#   pass-through: ``Depends(request_context)``, no Beanie, no HTTPException —
+#   the service raises CloudError subclasses and ``_core.http`` maps them to
+#   JSON. Coexists with the existing /files router (GET /files, /tree,
+#   /browse) — no method+path collisions.
+"""FileVersions router — file-version write + history API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import BadRequest
+from pocketpaw_ee.cloud.file_versions import service as _svc
+from pocketpaw_ee.cloud.file_versions.dto import (
+    FileVersionListItem,
+    FileVersionResponse,
+    UpdateFileContentRequest,
+    UpdateFileContentResponse,
+    WriteFileRequest,
+    WriteFileResponse,
+)
+from pocketpaw_ee.cloud.license import require_license
+
+router = APIRouter(
+    prefix="/files",
+    tags=["File Versions"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.post("/write", status_code=201, response_model=WriteFileResponse)
+async def write_file(
+    body: WriteFileRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WriteFileResponse:
+    """Create or overwrite a file. Returns the file id for subsequent versioned saves."""
+    return await _svc.write_file(ctx, body)
+
+
+@router.put("/{file_id}", response_model=UpdateFileContentResponse)
+async def update_file(
+    file_id: str,
+    body: UpdateFileContentRequest,
+    ctx: RequestContext = Depends(request_context),
+    if_match: str | None = Header(None, alias="If-Match"),
+) -> UpdateFileContentResponse:
+    """Replace a text file's content inline.
+
+    Body: ``{ content: "<new text>", expectedVersion?: <int> }``.
+    Header: ``If-Match: <current content_version>`` (optimistic concurrency)
+    takes precedence over ``expectedVersion`` when present.
+
+    Raises (mapped to JSON by ``_core.http``): 404 if the file is missing,
+    409 on a version conflict, 422 if the file type isn't editable.
+    """
+    # If-Match header (optimistic concurrency) wins over the body field.
+    if if_match is not None:
+        try:
+            body.expected_version = int(if_match.strip('"'))
+        except ValueError:
+            raise BadRequest("files.bad_version", "If-Match must be an integer.") from None
+
+    return await _svc.update_file_content(ctx, file_id, body)
+
+
+@router.get("/{file_id}/versions", response_model=list[FileVersionListItem])
+async def list_file_versions(
+    file_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> list[FileVersionListItem]:
+    """List all archived versions for a file (oldest first, no content)."""
+    return await _svc.list_versions(ctx, file_id)
+
+
+@router.get("/{file_id}/versions/{version_id}", response_model=FileVersionResponse)
+async def get_file_version(
+    file_id: str,
+    version_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> FileVersionResponse:
+    """Fetch a single version with full content (for revert preview / diff)."""
+    return await _svc.get_version(ctx, file_id, version_id)

--- a/ee/pocketpaw_ee/cloud/file_versions/service.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/service.py
@@ -1,0 +1,518 @@
+# service.py — FileVersions service: versioned cloud file-write storage spine.
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files,
+#   imports migrated ee.cloud.* -> pocketpaw_ee.cloud.*. Storage core only
+#   (write_file, update_file_content, list_versions, get_version); Slice-D
+#   helpers (revert/diff) dropped. Sole Beanie importer for FileVersionDoc;
+#   every FileUpload/FileVersionDoc read is workspace-filtered.
+# Updated: 2026-06-26 (ART-1 quality fix loop):
+#   C1 cross-tenant — FileUpload.file_id is GLOBALLY unique, so a client path
+#     collided across workspaces. The STORED FileUpload id is now namespaced
+#     `${workspace}:${path}` (two workspaces can share a path); the bare path
+#     stays the client-facing id on FileVersionDoc, the DTOs, and the routes.
+#     write_file revives a soft-deleted tombstone in place instead of a blind
+#     insert (which would raise DuplicateKeyError on the tombstoned unique id),
+#     and PURGES the dead file's FileVersionDoc rows on revive so the recreated
+#     file starts a fresh history (recreate = a new file at that path).
+#   I1 — a no-op (unchanged-content) update now returns the ACTUAL stored
+#     version, not a phantom +1.
+#   I2 — new files take a real mime (WriteFileRequest.mime, else guessed from
+#     the filename extension), no longer hardcoded application/json.
+#   I3 — a blob-read failure during archival aborts (CloudError) instead of
+#     silently archiving an empty "prior" version and destroying history.
+#   I4 — the archived FileVersionDoc is labelled with the version the content
+#     actually was (the pre-bump version), so version->content stays correct.
+#   M1 — read paths map FileVersionDoc -> FileVersion domain -> DTO.
+#   M2 — list/get reject an empty workspace (400), matching write/update.
+"""FileVersions service — file-version write + history.
+
+Module-level ``async def`` functions. Sole owner of writes to the
+``FileVersionDoc`` Beanie document and the ``FileUpload.content_version``
+counter. Text-only — non-editable mime types are rejected early.
+
+Public API:
+- ``write_file(ctx, body)`` — POST /files/write (create or overwrite)
+- ``update_file_content(ctx, file_id, body)`` — PUT /files/{id}
+- ``list_versions(ctx, file_id)`` — version list (no content)
+- ``get_version(ctx, file_id, version_id)`` — full version with content
+
+The client-facing file id is the bare ``path`` throughout. The FileUpload
+row stores a workspace-namespaced id (``${workspace}:${path}``) because that
+collection's ``file_id`` index is globally unique; FileVersionDoc keeps the
+bare path (its reads are always workspace-filtered, so no global collision).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import mimetypes
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+from beanie import PydanticObjectId
+
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.factory import build_adapter
+from pocketpaw_ee.cloud._core.context import RequestContext
+from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, NotFound
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import Event
+from pocketpaw_ee.cloud.file_versions.domain import FileVersion
+from pocketpaw_ee.cloud.file_versions.dto import (
+    FileVersionListItem,
+    FileVersionResponse,
+    UpdateFileContentRequest,
+    UpdateFileContentResponse,
+    WriteFileRequest,
+    WriteFileResponse,
+)
+from pocketpaw_ee.cloud.models.file_version import FileVersionDoc
+from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+logger = logging.getLogger(__name__)
+
+# Only these mime types are editable inline. Everything else gets a 422.
+EDITABLE_MIMES = frozenset(
+    {
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+        "text/html",
+        "text/css",
+        "text/javascript",
+        "text/xml",
+        "application/json",
+        "application/xml",
+        "application/javascript",
+        "application/x-yaml",
+        "application/x-ndjson",
+    }
+)
+
+# Fallback mime when a filename has no usable extension. Editable (text/*),
+# so a no-extension write still round-trips through the inline editor.
+FALLBACK_EDIT_MIME = "text/plain"
+
+# Explicit extension->mime overrides for the editable types the stdlib
+# ``mimetypes`` registry doesn't reliably know across platforms (e.g. .md,
+# .yaml). Anything not here falls back to ``mimetypes.guess_type``.
+_EXT_MIME_OVERRIDES = {
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+    ".json": "application/json",
+    ".yaml": "application/x-yaml",
+    ".yml": "application/x-yaml",
+    ".ndjson": "application/x-ndjson",
+    ".csv": "text/csv",
+    ".txt": "text/plain",
+}
+
+# Canonical local-storage root — the same path the uploads router (_ROOT) and
+# ``EEUploadService.write_text_file`` build their adapter against, so the
+# version archive reads/writes the SAME blobs the uploads pipeline stored.
+_UPLOAD_ROOT = Path.home() / ".pocketpaw" / "uploads"
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _storage_id(workspace_id: str, path: str) -> str:
+    """Namespace a client path by workspace for the globally-unique
+    ``FileUpload.file_id`` index.
+
+    Two workspaces writing the same ``path`` map to distinct stored ids, so
+    neither collides on the unique key nor squats the other's path. The bare
+    ``path`` stays the client-facing id everywhere else (FileVersionDoc,
+    DTOs, routes); this value is only ever the FileUpload lookup/insert key.
+
+    Invariant: ``workspace_id`` is a colon-free 24-hex Mongo ObjectId, so the
+    first ``':'`` unambiguously splits ws from path — ``(ws, path) -> ws:path``
+    stays injective even when ``path`` itself contains a colon.
+    """
+    return f"{workspace_id}:{path}"
+
+
+def _guess_mime(filename: str) -> str:
+    """Best-effort mime from a filename's extension.
+
+    Defaults to the inline-editable fallback (``text/plain``) when there's no
+    usable extension, so a path like ``"report"`` still produces an editable
+    file instead of an opaque blob.
+    """
+    ext = Path(filename).suffix.lower()
+    if ext in _EXT_MIME_OVERRIDES:
+        return _EXT_MIME_OVERRIDES[ext]
+    guessed, _ = mimetypes.guess_type(filename)
+    return guessed or FALLBACK_EDIT_MIME
+
+
+def _is_editable(mime: str | None) -> bool:
+    if not mime:
+        return False
+    if mime.startswith("text/"):
+        return True
+    return mime in EDITABLE_MIMES
+
+
+def _to_domain(doc: FileVersionDoc) -> FileVersion:
+    """Map a FileVersionDoc (persistence) to the FileVersion value object the
+    read paths build their DTOs from (doc -> domain -> DTO)."""
+    return FileVersion(
+        id=str(doc.id),
+        file_id=doc.file_id,
+        workspace_id=doc.workspace_id,
+        version_number=doc.version_number,
+        content=doc.content,
+        content_hash=doc.content_hash,
+        size_bytes=doc.size_bytes,
+        editor_kind=doc.editor_kind,  # stored as str; FileVersion narrows to EditorKind
+        editor_id=doc.editor_id,
+        created_at=doc.created_at,
+    )
+
+
+async def _read_text(adapter: StorageAdapter, key: str) -> str:
+    """Read all chunks from StorageAdapter and decode as UTF-8."""
+    chunks: list[bytes] = []
+    async for chunk in adapter.open(key):
+        chunks.append(chunk)
+    return b"".join(chunks).decode("utf-8")
+
+
+async def _bytes_iter(text: str) -> AsyncIterator[bytes]:
+    yield text.encode("utf-8")
+
+
+# Storage adapter singleton — injectable seam for tests / explicit wiring.
+_adapter: StorageAdapter | None = None
+
+
+def set_adapter(adapter: StorageAdapter) -> None:
+    """Inject a StorageAdapter (tests, or an explicit wiring seam)."""
+    global _adapter
+    _adapter = adapter
+
+
+def _get_storage() -> StorageAdapter:
+    """Return the process StorageAdapter.
+
+    Hardened replacement for dewani12's reach into
+    ``uploads.router._SVC._adapter`` (a private singleton inside another
+    entity's router module). Builds the adapter via the canonical
+    ``uploads.factory.build_adapter`` against the shared upload root — the
+    same construction the uploads router and ``write_text_file`` use — so
+    the env-driven local/S3 selection stays consistent across both paths.
+    """
+    global _adapter
+    if _adapter is None:
+        _UPLOAD_ROOT.mkdir(parents=True, exist_ok=True)
+        _adapter = build_adapter(_UPLOAD_ROOT)
+    return _adapter
+
+
+async def write_file(
+    ctx: RequestContext,
+    body: WriteFileRequest,
+) -> WriteFileResponse:
+    """Create or overwrite a file (POST /files/write).
+
+    If a live FileUpload record already exists for the (workspace, path),
+    content is updated in place (versioned). A soft-deleted tombstone for the
+    same path is revived in place — a blind insert would collide on the
+    globally-unique stored id. Otherwise a new record + storage blob.
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
+    path = body.path  # bare, client-facing id
+    stored_id = _storage_id(workspace_id, path)
+    content = body.content
+    mime = body.mime or _guess_mime(body.filename or path)
+
+    adapter = _get_storage()
+
+    # Find ANY existing row for (workspace, path), including a soft-deleted
+    # tombstone — it still holds the unique stored id, so a blind insert would
+    # raise DuplicateKeyError (500). Revive it instead.
+    doc = await FileUpload.find_one({"file_id": stored_id, "workspace": workspace_id})
+
+    if doc is not None and doc.deleted_at is None:
+        # Live file — versioned update in place (pass the bare path).
+        update_body = UpdateFileContentRequest(content=content)
+        result = await update_file_content(ctx, path, update_body)
+        return WriteFileResponse(
+            file_id=path,
+            version=result.new_version,
+            size_bytes=result.size_bytes,
+        )
+
+    storage_key = (
+        doc.storage_key if doc is not None else f"editor/{workspace_id}/{uuid.uuid4().hex}"
+    )
+    stored = await adapter.put(storage_key, _bytes_iter(content), mime)
+
+    if doc is not None:
+        # Revive a soft-deleted tombstone in place — a blind insert would
+        # collide on the still-unique stored id. Recreate semantics = a NEW
+        # file at this path = FRESH history, so purge the dead file's archived
+        # versions first (they outlive the FileUpload row — file_versions never
+        # deletes version rows otherwise — and would bleed stale content +
+        # duplicate version_number=1 labels into the revived file).
+        await FileVersionDoc.find({"file_id": path, "workspace_id": workspace_id}).delete()
+        doc.deleted_at = None
+        doc.filename = body.filename or path
+        doc.mime = mime
+        doc.size = stored.size
+        doc.storage_key = storage_key
+        doc.owner = ctx.user_id or doc.owner
+        doc.content_version = 1
+        await doc.save()
+    else:
+        doc = FileUpload(
+            file_id=stored_id,
+            filename=body.filename or path,
+            workspace=workspace_id,
+            owner=ctx.user_id or "unknown",
+            mime=mime,
+            size=stored.size,
+            storage_key=storage_key,
+            content_version=1,
+        )
+        await doc.insert()
+
+    await emit(
+        Event(
+            type="file.created",
+            data={
+                "file_id": path,
+                "workspace_id": workspace_id,
+                "size": stored.size,
+            },
+        )
+    )
+
+    logger.info("file %s created via write (version 1)", path)
+
+    return WriteFileResponse(
+        file_id=path,
+        version=1,
+        size_bytes=stored.size,
+    )
+
+
+async def update_file_content(
+    ctx: RequestContext,
+    file_id: str,
+    body: UpdateFileContentRequest,
+    *,
+    editor_kind: str = "human",
+) -> UpdateFileContentResponse:
+    """Replace a text file's content with optimistic concurrency.
+
+    ``file_id`` is the bare client path. Steps:
+    1. Fetch the ``FileUpload`` doc by the workspace-namespaced stored id.
+    2. Check the ``If-Match`` precondition against ``content_version``.
+    3. Read + archive the current blob as a ``FileVersionDoc`` (labelled with
+       the version it actually was). A read failure aborts — never archive an
+       empty "prior" version.
+    4. Upload the new content and bump the version counter.
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
+    stored_id = _storage_id(workspace_id, file_id)
+    doc = await FileUpload.find_one(
+        {"file_id": stored_id, "workspace": workspace_id, "deleted_at": None}
+    )
+    if not doc:
+        raise NotFound("file", file_id)
+
+    if not _is_editable(doc.mime):
+        raise CloudError(
+            422,
+            "files.not_editable",
+            f"File type '{doc.mime}' cannot be edited inline.",
+        )
+
+    current_version = doc.content_version
+    expected = body.expected_version
+    if expected is not None and expected != current_version:
+        raise ConflictError(
+            "files.version_conflict",
+            f"Expected version {expected} but current is {current_version}. "
+            "Someone else edited this file. Reload and try again.",
+        )
+
+    new_content = body.content
+    new_hash = _sha256(new_content)
+    new_size = len(new_content.encode("utf-8"))
+    editor_id = ctx.user_id or "unknown"
+
+    adapter = _get_storage()
+
+    # Read the current blob so it can be archived. A read failure must NOT be
+    # swallowed into an empty archive — that labels a fake-empty blob as the
+    # prior version and destroys real history. Abort the update instead.
+    try:
+        old_content = await _read_text(adapter, doc.storage_key)
+    except Exception as exc:
+        logger.error(
+            "file %s: cannot read current blob %r to archive prior version: %s",
+            file_id,
+            doc.storage_key,
+            exc,
+        )
+        raise CloudError(
+            500,
+            "files.archive_read_failed",
+            "Could not read the file's current content to archive it; "
+            "aborting to protect version history.",
+        ) from exc
+
+    old_hash = _sha256(old_content)
+
+    if old_hash == new_hash:
+        # No content change — nothing archived or bumped. Report the ACTUAL
+        # stored version so the caller's next If-Match doesn't 409 against it.
+        return UpdateFileContentResponse(
+            file_id=file_id,
+            new_version=current_version,
+            size_bytes=new_size,
+            content_hash=new_hash,
+        )
+
+    new_version = current_version + 1
+
+    # Archive the OLD content under the version it actually was
+    # (``current_version``), so a future revert/diff maps version -> content
+    # correctly. FileVersionDoc keeps the bare path (reads are
+    # workspace-filtered, so the bare id is collision-safe here).
+    version_doc = FileVersionDoc(
+        file_id=file_id,
+        workspace_id=workspace_id,
+        version_number=current_version,
+        content=old_content,
+        content_hash=old_hash,
+        size_bytes=len(old_content.encode("utf-8")),
+        editor_kind=editor_kind,
+        editor_id=editor_id,
+        created_at=datetime.now(UTC),
+    )
+    await version_doc.insert()
+
+    stored = await adapter.put(doc.storage_key, _bytes_iter(new_content), doc.mime)
+
+    doc.size = stored.size
+    doc.content_version = new_version
+    await doc.save()
+
+    await emit(
+        Event(
+            type="file.updated",
+            data={
+                "file_id": file_id,
+                "workspace_id": workspace_id,
+                "version": new_version,
+                "editor_kind": editor_kind,
+                "editor_id": editor_id,
+            },
+        )
+    )
+
+    logger.info(
+        "file %s updated to version %d by %s:%s",
+        file_id,
+        new_version,
+        editor_kind,
+        editor_id,
+    )
+
+    return UpdateFileContentResponse(
+        file_id=file_id,
+        new_version=new_version,
+        size_bytes=new_size,
+        content_hash=new_hash,
+    )
+
+
+async def list_versions(
+    ctx: RequestContext,
+    file_id: str,
+) -> list[FileVersionListItem]:
+    """List all archived versions for a file (oldest first), content omitted.
+
+    Tenant-filtered: only versions in the caller's workspace are returned.
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
+    docs = (
+        await FileVersionDoc.find({"file_id": file_id, "workspace_id": workspace_id})
+        .sort("+version_number")
+        .to_list()
+    )
+
+    logger.info(
+        "list_versions: file_id=%s workspace=%s found=%d",
+        file_id,
+        workspace_id,
+        len(docs),
+    )
+
+    return [
+        FileVersionListItem(
+            id=fv.id,
+            file_id=fv.file_id,
+            version_number=fv.version_number,
+            size_bytes=fv.size_bytes,
+            editor_kind=fv.editor_kind,
+            editor_id=fv.editor_id,
+            created_at=fv.created_at,
+        )
+        for fv in map(_to_domain, docs)
+    ]
+
+
+async def get_version(
+    ctx: RequestContext,
+    file_id: str,
+    version_id: str,
+) -> FileVersionResponse:
+    """Fetch a single version with full content.
+
+    Tenant-filtered: the find includes ``workspace_id`` so a caller can
+    never read another workspace's version blob.
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
+    try:
+        oid = PydanticObjectId(version_id)
+    except Exception:
+        raise NotFound("version", version_id) from None
+
+    doc = await FileVersionDoc.find_one(
+        {"_id": oid, "file_id": file_id, "workspace_id": workspace_id}
+    )
+    if not doc:
+        raise NotFound("version", version_id)
+
+    fv = _to_domain(doc)
+    return FileVersionResponse(
+        id=fv.id,
+        file_id=fv.file_id,
+        version_number=fv.version_number,
+        content=fv.content,
+        content_hash=fv.content_hash,
+        size_bytes=fv.size_bytes,
+        editor_kind=fv.editor_kind,
+        editor_id=fv.editor_id,
+        created_at=fv.created_at,
+    )

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -78,6 +78,7 @@ from pocketpaw_ee.cloud.models.fabric_ingest_state import (
     FabricIngestState,
 )
 from pocketpaw_ee.cloud.models.file import FileObj
+from pocketpaw_ee.cloud.models.file_version import FileVersionDoc
 from pocketpaw_ee.cloud.models.foresight_backtest import ForesightBacktest
 from pocketpaw_ee.cloud.models.foresight_prediction_record import (
     ForesightPredictionRecord,
@@ -221,6 +222,7 @@ __all__ = [
     "FileFolder",
     "FileObj",
     "FileUpload",
+    "FileVersionDoc",
     "ForesightBacktest",
     "ForesightPredictionRecord",
     "ForesightProjectedDecision",
@@ -292,6 +294,9 @@ def get_all_documents():
         FileObj,
         FileUpload,
         FileFolder,
+        # file_versions edit history (ART-1). Only ``file_versions.service``
+        # imports this class (import-linter "FileVersions" contract).
+        FileVersionDoc,
         Workspace,
         WorkspaceConnector,
         ComposioConnection,

--- a/ee/pocketpaw_ee/cloud/models/file_version.py
+++ b/ee/pocketpaw_ee/cloud/models/file_version.py
@@ -1,0 +1,39 @@
+# file_version.py — FileVersionDoc Beanie document for the file-version history trail.
+# Created: 2026-06-26 (ART-1) — ported from dewani12's origin/feature/files
+#   (was ee/cloud/models/file_version.py) onto the post-cloud-restructure
+#   layout. Path migrated to ee/pocketpaw_ee/cloud/models/; registered in
+#   models.get_all_documents(). Only ``file_versions.service`` may import this
+#   class (import-linter "FileVersions" contract).
+"""FileVersion Beanie document — full-copy text blobs archived per edit.
+
+Stored in the ``file_versions`` collection. The live (current) file
+content lives in the StorageAdapter; this collection is the history trail.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+
+
+class FileVersionDoc(Document):
+    file_id: Indexed(str)  # type: ignore[valid-type]
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    version_number: int
+    content: str
+    content_hash: str
+    size_bytes: int
+    editor_kind: str  # "human" | "agent"
+    editor_id: str  # user_id or agent_id
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "file_versions"
+        indexes = [
+            # List versions for a file, oldest-first so the picker shows v1->vN.
+            [("file_id", 1), ("version_number", 1)],
+            # Workspace-scoped queries (tenant-filtered reads).
+            [("workspace_id", 1), ("file_id", 1)],
+        ]

--- a/ee/pocketpaw_ee/cloud/shared/db.py
+++ b/ee/pocketpaw_ee/cloud/shared/db.py
@@ -1,5 +1,15 @@
 """MongoDB connection and Beanie ODM initialization.
 
+2026-06-26 (ART-4): added ``is_multi_tenant_cloud()`` — the single, named home
+for the established "this process is serving tenants" signal
+(``get_client() is not None``, set exactly when ``init_cloud_db`` ran). The
+agent cwd jail (ART-2) and the new cloud-storage boot guard both read it instead
+of re-spelling the ``get_client()`` truthiness check inline. ``init_cloud_db``
+also now calls ``verify_cloud_storage_backend()`` right after the memory guard so
+a cloud deploy missing the S3 upload adapter is loud (warn, or a hard boot
+failure under ``POCKETPAW_REQUIRE_S3_IN_CLOUD``) instead of silently writing
+"blob" artifacts to local disk.
+
 2026-06-07: added ``_drop_legacy_invite_token_index`` and called it after
 ``init_beanie``. The invite-token hashing rollout dropped ``unique=True``
 from ``Invite.token`` (uniqueness moved to ``token_hash``), but Beanie only
@@ -109,6 +119,16 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
     # chat history to disk; the cloud must keep everything in Mongo.
     verify_cloud_memory_backend()
 
+    # Loud guard on the upload/blob backend (ART-4). A cloud deploy that left
+    # POCKETPAW_UPLOAD_ADAPTER on its local default would write delivered agent
+    # artifacts to the box's disk instead of tenant blob storage — the whole
+    # deliver_artifact feature silently no-ops to local disk. WARN by default;
+    # POCKETPAW_REQUIRE_S3_IN_CLOUD escalates it to a hard boot failure. Runs
+    # AFTER _client is set so the is_multi_tenant_cloud() signal it reads is True.
+    from pocketpaw_ee.cloud.uploads.bootstrap import verify_cloud_storage_backend
+
+    verify_cloud_storage_backend()
+
 
 async def close_cloud_db() -> None:
     """Close the client."""
@@ -121,3 +141,20 @@ async def close_cloud_db() -> None:
 def get_client() -> AsyncMongoClient | None:
     """Return the current MongoDB client, or None if not initialized."""
     return _client
+
+
+def is_multi_tenant_cloud() -> bool:
+    """``True`` when this process is serving tenants (multi-tenant cloud mode).
+
+    The cloud DB client is set exactly when ``init_cloud_db`` ran
+    (``CloudLifecycleHook`` on ``CLOUD_MONGODB_URI``), so ``get_client() is not
+    None`` is the authoritative "this process is serving tenants" flag — there is
+    no separate cloud-mode env var to invent. OFF cloud (OSS / a process that
+    never initialized the cloud DB) it is ``False``.
+
+    Single home for the signal so callers (the ART-2 agent cwd jail, the ART-4
+    cloud-storage boot guard) read one name instead of re-spelling the
+    ``get_client()`` truthiness check — one place to change if the signal ever
+    moves.
+    """
+    return _client is not None

--- a/ee/pocketpaw_ee/cloud/uploads/bootstrap.py
+++ b/ee/pocketpaw_ee/cloud/uploads/bootstrap.py
@@ -1,0 +1,86 @@
+# bootstrap.py — cloud upload/blob-storage boot guard (ART-4, 2026-06-26).
+#
+# Mirrors ee/pocketpaw_ee/cloud/memory/bootstrap.py::verify_cloud_memory_backend.
+# The memory guard refuses to boot the cloud on a local memory backend (which
+# would write chat history to disk); this guard does the same for the upload
+# backend so a cloud deploy that left POCKETPAW_UPLOAD_ADAPTER on its local
+# default doesn't silently write delivered agent artifacts (deliver_artifact,
+# ART-4) to the box's filesystem instead of tenant blob storage.
+#
+# Warn-then-error: a misconfigured upload backend WARNs loudly by default (the
+# common "I forgot to set the adapter" case stays bootable for local/dedicated
+# trials), and POCKETPAW_REQUIRE_S3_IN_CLOUD escalates it to a hard boot failure
+# for deploys that must never fall back to local disk.
+"""ee upload/blob-storage backend boot guard.
+
+Called from ``init_cloud_db`` right after ``verify_cloud_memory_backend`` so a
+cloud deployment whose upload adapter is still the local default surfaces it at
+startup — as a loud warning by default, or a refused boot when
+``POCKETPAW_REQUIRE_S3_IN_CLOUD`` is set.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _require_s3_in_cloud() -> bool:
+    """Whether a non-s3 upload adapter should HARD-FAIL the cloud boot.
+
+    Default ``False`` (warn only) — set ``POCKETPAW_REQUIRE_S3_IN_CLOUD`` to a
+    truthy value on a deploy that must refuse to start without S3-backed blob
+    storage.
+    """
+    return os.environ.get("POCKETPAW_REQUIRE_S3_IN_CLOUD", "").strip().lower() in _TRUTHY
+
+
+def verify_cloud_storage_backend() -> None:
+    """Guard the cloud upload/blob backend at startup.
+
+    No-op OFF multi-tenant cloud (OSS / a process that never initialized the
+    cloud DB): there is no tenant blob storage to require, so local-disk uploads
+    are correct there.
+
+    In cloud, when ``POCKETPAW_UPLOAD_ADAPTER`` is not ``s3`` (the default is
+    ``local``), delivered artifacts and uploads land on the box's filesystem
+    rather than the tenant's object store — the ``deliver_artifact`` download
+    URL would point at a local path that disappears with the container and never
+    reaches the tenant's blob storage. That is almost always a misconfigured
+    deploy, so:
+
+    * WARN loudly by default (so the operator sees it in the boot logs but a
+      local/dedicated trial still comes up), and
+    * RAISE — refusing to boot — when ``POCKETPAW_REQUIRE_S3_IN_CLOUD`` is set,
+      for deploys that must never silently degrade to local disk.
+
+    Mirrors :func:`verify_cloud_memory_backend`, which refuses to boot the cloud
+    on a local memory backend for the same "don't silently write to disk"
+    reason.
+    """
+    if not is_multi_tenant_cloud():
+        return
+
+    adapter = os.environ.get("POCKETPAW_UPLOAD_ADAPTER", "local").strip().lower()
+    if adapter == "s3":
+        return
+
+    message = (
+        f"cloud startup: POCKETPAW_UPLOAD_ADAPTER={adapter!r}, expected 's3'. "
+        "In cloud, delivered artifacts and uploads must land in tenant blob "
+        "storage (S3 / S3-compatible); a local adapter writes them to the box's "
+        "filesystem, so deliver_artifact download URLs point at disk that "
+        "vanishes with the container. Set POCKETPAW_UPLOAD_ADAPTER=s3 (and the "
+        "S3_* settings). Set POCKETPAW_REQUIRE_S3_IN_CLOUD=1 to make this a hard "
+        "boot failure."
+    )
+
+    if _require_s3_in_cloud():
+        raise RuntimeError(message)
+    logger.warning(message)

--- a/ee/pocketpaw_ee/cloud/uploads/models.py
+++ b/ee/pocketpaw_ee/cloud/uploads/models.py
@@ -1,5 +1,10 @@
 """EE FileUpload document — Mongo metadata for blobs stored via StorageAdapter.
 
+2026-06-26 — ART-1. Added ``content_version`` (default 0) so the
+``file_versions`` service can run optimistic-concurrency edits and archive
+each prior blob as a ``FileVersionDoc``. Legacy rows read as 0; ``write_file``
+stamps new rows at 1. Beanie field-add is backward compatible (no migration).
+
 2026-05-03 — Stage 3.E "Files as Knowledge". Added ``pocket_id`` so the
 unified Files panel and the FileReady listener can route a single upload
 into a pocket-scoped KB instead of the workspace pool. ``None`` is the
@@ -43,6 +48,10 @@ class FileUpload(TimestampedDocument):
     # Storage layout is unchanged — partitioning is metadata-only.
     pocket_id: str | None = None
     deleted_at: datetime | None = None
+    # Optimistic-concurrency counter for the file_versions edit pipeline
+    # (ART-1). Each successful inline edit bumps this and archives the prior
+    # blob as a ``FileVersionDoc``. 0 on legacy rows; ``write_file`` stamps 1.
+    content_version: int = 0
 
     class Settings:
         name = "file_uploads"

--- a/ee/pocketpaw_ee/cloud/uploads/service.py
+++ b/ee/pocketpaw_ee/cloud/uploads/service.py
@@ -1,4 +1,12 @@
 # service.py — EEUploadService: workspace-scoped upload pipeline on top of OSS.
+# Updated: 2026-06-26 — ART-4 security follow-up. ``presigned_get`` now forwards
+#   a Content-Disposition to the storage adapter: ``attachment; filename="…"``
+#   for any mime NOT in ``INLINE_MIMES`` (mirroring the streaming download
+#   route's policy in uploads/router.py), ``None`` (adapter default → inline)
+#   for inline-safe types (images, pdf, plain text). This closes the gap where
+#   an S3 presigned GET served delivered HTML/SVG/JS INLINE on the storage
+#   origin — the deliver_artifact path relaxes the mime allowlist, so without
+#   this an agent-built .html could render active content from its download URL.
 # Updated: 2026-05-17 — pocketpaw#1118 P1. Added ``write_text_file()`` —
 #   a programmatic text-content write path for callers that have bytes
 #   in memory rather than an inbound HTTP ``UploadFile``. The cloud
@@ -28,7 +36,7 @@ from uuid import uuid4
 from fastapi import UploadFile
 
 from pocketpaw.uploads.adapter import StorageAdapter
-from pocketpaw.uploads.config import UploadSettings
+from pocketpaw.uploads.config import INLINE_MIMES, UploadSettings
 from pocketpaw.uploads.errors import NotFound
 from pocketpaw.uploads.factory import build_adapter
 from pocketpaw.uploads.file_store import FileRecord
@@ -41,6 +49,29 @@ from pocketpaw.uploads.service import (
 from pocketpaw_ee.cloud.realtime.emit import emit
 from pocketpaw_ee.cloud.realtime.events import FileDeleted, FileReady
 from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+
+def _safe_disposition_filename(filename: str) -> str:
+    """Strip characters that could break out of a ``Content-Disposition``
+    header value (quotes, backslashes, control chars). Returns ``"download"``
+    when nothing usable remains."""
+    cleaned = "".join(c for c in (filename or "") if c.isprintable() and c not in '"\\\r\n')
+    return cleaned or "download"
+
+
+def _download_disposition(mime: str, filename: str) -> str | None:
+    """``Content-Disposition`` to serve a presigned download with, or ``None``.
+
+    Mirrors the streaming download route (``uploads/router.py``): mimes in
+    ``INLINE_MIMES`` (images, pdf, plain text) may render inline, so we return
+    ``None`` and leave the adapter/object default untouched (byte-identical to
+    before). Everything else — including the HTML/SVG/JS the deliver_artifact
+    path can now store — is forced to ``attachment`` so a presigned GET
+    downloads it instead of rendering active content on the storage origin.
+    """
+    if mime in INLINE_MIMES:
+        return None
+    return f'attachment; filename="{_safe_disposition_filename(filename)}"'
 
 
 class _NullMeta:
@@ -222,7 +253,14 @@ class EEUploadService:
         if rec is None:
             raise NotFound()
         await self._assert_can_read(rec, requester_id, workspace)
-        url = await self._adapter.presigned_get(rec.storage_key, ttl_seconds)
+        # Force a download for anything that isn't inline-safe so a presigned
+        # GET can't render active content (HTML/SVG/JS) on the storage origin —
+        # the deliver_artifact path stores arbitrary mimes, so this is the gate
+        # that keeps a delivered .html from rendering from its download URL.
+        disposition = _download_disposition(rec.mime, rec.filename)
+        url = await self._adapter.presigned_get(
+            rec.storage_key, ttl_seconds, response_content_disposition=disposition
+        )
         return rec, url
 
     async def delete(

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -65,6 +65,14 @@ supplying the ``WorkspaceConnector``-backed ``CloudConnectorStateStore`` as the
 ConnectorRegistry's default durable state store, so cloud connector config
 rehydrates from the tenant DB after a process restart (no /connect needed).
 
+Updated: 2026-06-26 (ART-2) — ``CloudAgentExtension`` gained ``agent_cwd``: a
+per-tenant agent working-directory jail. It delegates to
+``pocketpaw_ee.cloud.agent_jail.resolve_agent_cwd``, which returns a
+per-workspace/session dir (``~/.pocketpaw/workspaces/<ws>/agent/<session>/``) so
+a cloud tenant's file ops never co-mingle in the shared home dir, and FAILS
+CLOSED when a cloud run has no resolvable workspace. OSS / dedicated installs
+return ``None`` and keep ``settings.file_jail_path``.
+
 Updated: 2026-06-11 (feat/fabric-instinct-mcp-providers) — added
 ``CloudFabricMcpProvider`` (entry ``fabric``; server ``pocketpaw_fabric``,
 tools ``fabric_query`` / ``fabric_stats``) and ``CloudInstinctMcpProvider``
@@ -101,6 +109,7 @@ _xproc_consumer_task: asyncio.Task[None] | None = None
 
 
 async def _sweeper_loop() -> None:
+    from pocketpaw_ee.cloud.agent_jail_gc import sweep_agent_jails
     from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
     from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
     from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
@@ -114,6 +123,14 @@ async def _sweeper_loop() -> None:
             raise
         except Exception:
             _run_sweeper_logger.exception("sweep_stale_runs tick failed")
+        # ART-3 jail lifecycle: TTL-GC idle agent jails + LRU-evict under the
+        # disk watermark, so scratch disk scales with active concurrency not user
+        # count. Own try so a jail-GC failure can't suppress the other sweeps (or
+        # vice versa); never evicts a jail backing a queued/running run.
+        try:
+            await sweep_agent_jails()
+        except Exception:
+            _run_sweeper_logger.exception("sweep_agent_jails tick failed")
         # BC-3 metering: bill every newly-terminal run's compute cost on the same
         # heartbeat. Kept in its own try so a metering failure can't suppress the
         # stale-run sweep (or vice versa) on the next tick. Self-gated OFF in the
@@ -146,9 +163,11 @@ async def start_run_sweeper() -> None:
     Boot runs the stale-run sweep (interrupt orphaned runs), the BC-3 compute-cost
     metering sweep (bill any terminal runs left unbilled by the prior process), the
     WU-F LiteLLM billing-cutover sweep (no-op / shadow-compare / live-ingest per the
-    cutover mode), and the charge-first pending-site reconciliation sweep (surface
-    paid sites stuck pending); the 5-minute loop then ticks all four.
+    cutover mode), the charge-first pending-site reconciliation sweep (surface paid
+    sites stuck pending), and the ART-3 agent-jail GC (reclaim scratch left by a
+    prior process's idle runs); the 5-minute loop then ticks all of them.
     """
+    from pocketpaw_ee.cloud.agent_jail_gc import sweep_agent_jails
     from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
     from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
     from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
@@ -163,6 +182,8 @@ async def start_run_sweeper() -> None:
         await run_cutover_sweep()
     with suppress(Exception):
         await sweep_pending_sites()
+    with suppress(Exception):
+        await sweep_agent_jails()
     _sweeper_task = asyncio.create_task(_sweeper_loop())
 
 
@@ -757,6 +778,34 @@ class CloudMediaMcpProvider:
         return list(MEDIA_TOOL_IDS)
 
 
+class CloudDeliverMcpProvider:
+    """`pocketpaw.mcp_servers` — the artifact-delivery in-process server
+    (``pocketpaw_deliver``). Hosts ``deliver_artifact`` only (ART-4).
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) so any cloud chat agent can deliver
+    a file it built — a report, an export, a zipped bundle — to the tenant's
+    blob storage and hand the user a real download URL, without an explicit
+    opt-in. Same regime the sites manager + media + pocket specialist use: the
+    cloud chat agent runs on the claude_agent_sdk backend, which only sees
+    in-process MCP servers, so the deliver path MUST be surfaced here.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from pocketpaw_ee.agent.mcp_servers.deliver import build_deliver_server
+
+            return build_deliver_server()
+        except ImportError:
+            # claude_agent_sdk not installed — the deliver server is
+            # unavailable, same as the other in-process servers.
+            return None
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.deliver import DELIVER_TOOL_IDS
+
+        return list(DELIVER_TOOL_IDS)
+
+
 class CloudLoomMcpProvider:
     """`pocketpaw.mcp_servers` — the loom codebase-orientation MCP server.
 
@@ -926,8 +975,9 @@ class CloudAgentExtension:
     """`pocketpaw.agent_extensions` — EE additions to the core agent runtime.
 
     Contributes the cloud pocket-specialist function tool to MCP-capable
-    tool-list backends, and cloud workspace/user/session identity to agent
-    subprocess environments.
+    tool-list backends, cloud workspace/user/session identity to agent
+    subprocess environments, and (ART-2) a per-tenant agent working-directory
+    jail so each cloud workspace's file ops stay isolated from every other.
     """
 
     # Backends that receive ``PocketSpecialistTool`` as a native function
@@ -967,6 +1017,18 @@ class CloudAgentExtension:
             if value:
                 env[var] = str(value)
         return env
+
+    def agent_cwd(self) -> str | None:
+        """`pocketpaw.agent_extensions` — per-session agent working directory.
+
+        In multi-tenant cloud each workspace gets its own agent cwd
+        (``~/.pocketpaw/workspaces/<ws>/agent/<session>/``) so tenant file ops
+        never co-mingle in the shared home dir; fails CLOSED when a cloud run
+        has no resolvable workspace. Returns ``None`` off-cloud so the core
+        agent keeps using ``settings.file_jail_path`` (ART-2)."""
+        from pocketpaw_ee.cloud.agent_jail import resolve_agent_cwd
+
+        return resolve_agent_cwd()
 
 
 class CloudConnectorStateStoreProvider:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -216,6 +216,7 @@ composio = "pocketpaw_ee.extensions:CloudComposioMcpProvider"
 meetings = "pocketpaw_ee.extensions:CloudMeetingsMcpProvider"
 sites = "pocketpaw_ee.extensions:CloudSitesMcpProvider"
 media = "pocketpaw_ee.extensions:CloudMediaMcpProvider"
+deliver = "pocketpaw_ee.extensions:CloudDeliverMcpProvider"
 loom = "pocketpaw_ee.extensions:CloudLoomMcpProvider"
 belt = "pocketpaw_ee.extensions:CloudBeltMcpProvider"
 external_actions = "pocketpaw_ee.extensions:CloudExternalActionsMcpProvider"
@@ -383,6 +384,17 @@ source_modules = [
     "pocketpaw_ee.cloud.notifications.domain",
 ]
 forbidden_modules = ["pocketpaw_ee.cloud.models.notification"]
+
+[[tool.importlinter.contracts]]
+name = "FileVersions — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.file_versions.router",
+    "pocketpaw_ee.cloud.file_versions.dto",
+    "pocketpaw_ee.cloud.file_versions.domain",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.file_version"]
 
 [[tool.importlinter.contracts]]
 name = "FabricIngest — Beanie writes only from service.py"

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,20 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-06-26 (ART-2) — the agent's working directory is now resolved
+  PER-RUN via ``_resolve_cwd`` instead of being frozen to
+  ``settings.file_jail_path`` at ``__init__``. OSS / dedicated behavior is
+  unchanged (still ``file_jail_path``); when an EE ``pocketpaw.agent_extensions``
+  provider supplies ``agent_cwd`` (the cloud product), the run uses a
+  per-workspace/session jail so a tenant's file ops never co-mingle in the
+  shared home dir. A provider that RAISES (a cloud run with no resolvable
+  workspace) propagates — fail-closed, never a silent fallback to ``~``.
+  ``_build_options`` carries the resolved cwd, so ``run`` and ``prewarm`` warm
+  the same per-session jail. ART-2 hardening: the resolved cwd is folded into
+  ``_client_cache_key`` so warm-client tenant isolation is STRUCTURAL (a changed
+  cwd forces a fresh subprocess), not merely an implicit session_key<->cwd
+  coupling; the now-inert ``set_working_directory`` setter was removed
+  (``_build_options`` no longer reads ``self._cwd``); and ``get_status`` reports
+  ``base_cwd`` (the OSS/default base) instead of a misleading ``cwd``.
 Updated: 2026-06-26 (integration/model-catalog-v2, MCG-11) — the ResultMessage
   token-usage path now runs ``pocketpaw.llm.caching.report_savings`` over the SDK
   usage to surface STRUCTURED prompt-cache telemetry (cache_read_tokens,
@@ -478,10 +493,39 @@ class ClaudeSDKBackend(BaseAgentBackend):
             logger.error(f"❌ Failed to initialize Claude Agent SDK: {e}")
             self._sdk_available = False
 
-    def set_working_directory(self, path: Path) -> None:
-        """Set the working directory for file operations."""
-        self._cwd = path
-        logger.info(f"📂 Working directory set to: {path}")
+    def _resolve_cwd(self) -> Path:
+        """Resolve the agent's working directory for THIS run.
+
+        NOTE: the per-tenant cwd jail + fail-closed live ONLY in this backend.
+        Other backends (codex_cli, deep_agents, …) receive workspace tenancy via
+        ``subprocess_env`` but NOT the cwd jail — a non-``claude_agent_sdk`` cloud
+        agent would run in ``file_jail_path``. Cloud chat defaults to this
+        backend; see ART-2's report for the residual non-claude gap.
+
+        Defaults to ``settings.file_jail_path`` (the OSS / dedicated behavior,
+        unchanged). When an EE ``pocketpaw.agent_extensions`` provider supplies
+        an ``agent_cwd`` (the cloud product), its result wins — a
+        per-workspace/session jail that keeps each tenant's file operations
+        isolated instead of co-mingling in the shared home dir.
+
+        A provider that RAISES (a multi-tenant cloud run with no resolvable
+        workspace) is propagated, NOT swallowed: that fail-closed is the whole
+        point — we must never silently fall back to ``~`` and let one tenant's
+        files land on another's. Resolved per-run (not cached on the instance)
+        so a single warm backend serving multiple sessions reads each session's
+        own jail; the warm-client cache key folds in the resolved cwd (ART-2), so
+        a changed cwd rebuilds the subprocess with its correct working directory.
+        """
+        from pocketpaw._registry import providers as _ext_providers
+
+        for ext in _ext_providers("pocketpaw.agent_extensions"):
+            resolver = getattr(ext, "agent_cwd", None)
+            if resolver is None:
+                continue
+            resolved = resolver()  # may raise (fail-closed) — let it propagate
+            if resolved:
+                return Path(resolved)
+        return self.settings.file_jail_path
 
     def _is_dangerous_command(self, command: str) -> str | None:
         """Check if a command matches dangerous patterns.
@@ -983,8 +1027,8 @@ class ClaudeSDKBackend(BaseAgentBackend):
     def _client_cache_key(
         cls, options: Any, *, session_key: str | None = None, plugin_digest: str = ""
     ) -> str:
-        """Persistent-client cache key: session + model + tools + a digest of
-        the system prompt's stable behavioral prefix + the plugin-identity
+        """Persistent-client cache key: session + cwd + model + tools + a digest
+        of the system prompt's stable behavioral prefix + the plugin-identity
         digest.
 
         The prefix digest is what makes a mid-session backend config change
@@ -997,11 +1041,19 @@ class ClaudeSDKBackend(BaseAgentBackend):
         re-spawning every turn. Empty ``plugin_digest`` (the default) leaves the
         key byte-for-byte identical to the pre-fix behavior for non-skill
         callers. Hashing keeps the key bounded regardless of prompt length.
+
+        ``cwd`` (ART-2) is folded in so warm-client tenant isolation is
+        STRUCTURAL, not an implicit consequence of the session_key<->cwd
+        coupling: if cwd derivation ever changes to depend on something not in
+        session_key, a stale warm subprocess can never be reused across two
+        different working directories (i.e. two tenants). The SDK fixes cwd at
+        connect() time, so a changed cwd MUST force a fresh subprocess.
         """
         prefix = cls._behavior_prefix(getattr(options, "system_prompt", None))
         prefix_digest = hashlib.sha256(prefix.encode("utf-8", "replace")).hexdigest()[:16]
         return (
             f"{session_key or ''}:"
+            f"{getattr(options, 'cwd', '')}:"
             f"{getattr(options, 'model', '')}:"
             f"{sorted(getattr(options, 'allowed_tools', []) or [])}:"
             f"{prefix_digest}:"
@@ -1194,6 +1246,14 @@ class ClaudeSDKBackend(BaseAgentBackend):
         run_skills_root: Path | None = None
         skills_dir_adopted = False
         plugin_digest = ""
+
+        # Per-run working directory. OSS / dedicated → ``file_jail_path``; cloud
+        # → a per-workspace/session jail (or a fail-closed raise when a cloud run
+        # has no resolvable workspace). Resolved here so BOTH ``run`` and
+        # ``prewarm`` warm the SAME cwd for a session — the warm-client cache key
+        # already keys on ``session_key``, so a session change rebuilds the
+        # subprocess with its own jail.
+        resolved_cwd = self._resolve_cwd()
 
         # Resolve LLM provider early -- needed for routing + env.
         # Use per-backend provider setting (defaults to "anthropic").
@@ -1443,7 +1503,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
             "allowed_tools": allowed_tools,
             "setting_sources": [],
             "hooks": hooks,
-            "cwd": str(self._cwd),
+            "cwd": str(resolved_cwd),
             "max_turns": self.settings.claude_sdk_max_turns or None,
         }
 
@@ -1569,7 +1629,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
             "set" if os.environ.get("ANTHROPIC_API_KEY") else "<unset>",
             list(sdk_env.keys()) if sdk_env else "none",
             _shutil.which("claude") or "<not found>",
-            self._cwd,
+            resolved_cwd,
         )
 
         # Wire in MCP servers (policy-filtered)
@@ -2308,7 +2368,11 @@ class ClaudeSDKBackend(BaseAgentBackend):
             "sdk_installed": self._sdk_available,
             "cli_installed": self._cli_available,
             "running": not self._stop_flag,
-            "cwd": str(self._cwd),
+            # Base (OSS/default) working dir only. The ACTUAL per-run cwd is
+            # resolved each turn by ``_resolve_cwd`` — in cloud it's a per-tenant
+            # jail, not this base — so labelling it ``base_cwd`` keeps status
+            # honest (and avoids resolving here, which would fail closed off-run).
+            "base_cwd": str(self._cwd),
             "features": ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebSearch", "WebFetch"]
             if ready
             else [],

--- a/src/pocketpaw/extensions.py
+++ b/src/pocketpaw/extensions.py
@@ -202,6 +202,17 @@ class AgentExtension(Protocol):
         context is active (the common OSS / out-of-stream case)."""
         ...
 
+    def agent_cwd(self) -> str | None:
+        """Per-run working directory for the agent, or ``None`` to use
+        ``settings.file_jail_path``. The cloud product returns a
+        per-workspace/session jail so a tenant's file operations never
+        co-mingle in the shared home dir, and RAISES when a cloud run has
+        no resolvable workspace (fail-closed — never silently land in
+        ``~``). An OSS install registers no provider, so the core keeps
+        its ``file_jail_path`` default. Optional: a provider predating
+        this method simply isn't consulted (the core uses ``getattr``)."""
+        ...
+
 
 @runtime_checkable
 class PocketWriter(Protocol):

--- a/src/pocketpaw/uploads/adapter.py
+++ b/src/pocketpaw/uploads/adapter.py
@@ -48,11 +48,23 @@ class StorageAdapter(Protocol):
         ``None`` — the caller should fall back to streaming via ``open``.
         """
 
-    async def presigned_get(self, key: str, ttl_seconds: int) -> str | None:
+    async def presigned_get(
+        self,
+        key: str,
+        ttl_seconds: int,
+        response_content_disposition: str | None = None,
+    ) -> str | None:
         """Return a time-limited public URL for reading ``key``.
 
         Adapters that natively support presigning (S3, GCS) return an
         absolute URL the browser can fetch without an Authorization header.
         Adapters that don't (local disk) return ``None``; the caller should
         fall back to its own signing scheme.
+
+        ``response_content_disposition`` (when set) is forwarded so the served
+        response carries that ``Content-Disposition`` — callers pass
+        ``attachment; filename="…"`` to force a download for content that must
+        not render inline on the storage origin (e.g. delivered HTML/SVG). The
+        local adapter ignores it (it never presigns); ``None`` preserves the
+        adapter/object default disposition.
         """

--- a/src/pocketpaw/uploads/local.py
+++ b/src/pocketpaw/uploads/local.py
@@ -81,7 +81,13 @@ class LocalStorageAdapter(StorageAdapter):
             return None
         return target if target.exists() else None
 
-    async def presigned_get(self, key: str, ttl_seconds: int) -> str | None:
+    async def presigned_get(
+        self,
+        key: str,
+        ttl_seconds: int,
+        response_content_disposition: str | None = None,
+    ) -> str | None:
         # Local disk can't mint a public URL. Callers fall back to the
-        # HMAC-signed ``/uploads/{id}?t=...`` proxy.
+        # HMAC-signed ``/uploads/{id}?t=...`` proxy, which sets its own
+        # Content-Disposition — so the disposition hint is unused here.
         return None

--- a/src/pocketpaw/uploads/s3.py
+++ b/src/pocketpaw/uploads/s3.py
@@ -134,12 +134,23 @@ class S3StorageAdapter(StorageAdapter):
     def local_path(self, key: str) -> Path | None:
         return None
 
-    async def presigned_get(self, key: str, ttl_seconds: int) -> str | None:
+    async def presigned_get(
+        self,
+        key: str,
+        ttl_seconds: int,
+        response_content_disposition: str | None = None,
+    ) -> str | None:
+        params: dict[str, str] = {"Bucket": self._bucket, "Key": key}
+        # Force the served Content-Disposition (e.g. ``attachment; filename=…``)
+        # so non-inline content delivered to blob storage downloads instead of
+        # rendering on the storage origin. Omitted ⇒ the object's own headers.
+        if response_content_disposition:
+            params["ResponseContentDisposition"] = response_content_disposition
         try:
             return await asyncio.to_thread(
                 self._client.generate_presigned_url,
                 "get_object",
-                Params={"Bucket": self._bucket, "Key": key},
+                Params=params,
                 ExpiresIn=int(ttl_seconds),
             )
         except Exception:

--- a/tests/cloud/agents/test_agent_jail.py
+++ b/tests/cloud/agents/test_agent_jail.py
@@ -4,12 +4,18 @@
 #   * workspace + session -> <root>/<ws>/agent/<session>/
 #   * workspace, no session -> <root>/<ws>/agent/_shared/ (group/DM bridge)
 #   * same identity reuses one dir across turns
-#   * cloud active + no workspace -> RAISES (fail-closed)
+#   * cloud active + cloud-chat-run marker + no workspace -> RAISES (fail-closed)
+#   * cloud active + NO marker + no workspace -> None (non-chat run falls back)
 #   * cloud NOT active + no workspace -> None (OSS / dedicated unchanged)
 #   * hostile / traversal ids are rejected before they touch the filesystem
 #   * a trailing-newline id is rejected (the \Z-vs-$ anchor hardening)
 #   * the fail-closed emits a high-severity cloud AuditEvent before it raises
 #   * CloudAgentExtension.agent_cwd delegates to the resolver
+# Updated 2026-06-27 (fix/cloud-artifacts-reland) — the fail-closed is now gated
+# on the per-run mark_cloud_chat_run() marker, not is_multi_tenant_cloud() alone
+# (a process-global). The fail-closed tests set the marker so a real cloud CHAT
+# run still raises; a new test locks the no-marker -> None fallback (a non-chat
+# run merely sharing a cloud-connected process must NOT hard-fail).
 """Per-tenant agent working-directory jail (ART-2)."""
 
 from __future__ import annotations
@@ -22,6 +28,7 @@ from pocketpaw_ee.cloud import agent_jail
 from pocketpaw_ee.cloud.chat.agent_service import (
     attach_agent_identity,
     detach_agent_identity,
+    mark_cloud_chat_run,
 )
 
 
@@ -131,9 +138,21 @@ def test_same_identity_reuses_dir(_jail_root):
 
 
 def test_fail_closed_when_cloud_active_and_no_workspace(cloud_active):
-    # No identity bound (contextvar default None) + cloud mode active.
-    with pytest.raises(RuntimeError, match="no resolvable workspace"):
+    # Cloud mode active + a live cloud CHAT run (marker set) + no identity bound
+    # (contextvar default None) → the mis-tenanting fail-closed fires. The marker
+    # is REQUIRED: without it the resolver falls back (see the next test), so a
+    # real chat run that lost its workspace must set it to keep the protection.
+    with pytest.raises(RuntimeError, match="no resolvable workspace"), mark_cloud_chat_run():
         agent_jail.resolve_agent_cwd()
+
+
+def test_returns_none_when_cloud_active_but_not_chat_run(cloud_active):
+    # Cloud mode active + no workspace BUT no cloud-chat-run marker — a direct
+    # backend test / CLI / background job merely sharing a cloud-connected
+    # process. The resolver MUST fall back to None, not hard-fail
+    # (fix/cloud-artifacts-reland): is_multi_tenant_cloud() is a process-global,
+    # so the fail-closed is gated on the per-run marker, which is absent here.
+    assert agent_jail.resolve_agent_cwd() is None
 
 
 def test_returns_none_when_not_cloud(cloud_inactive):
@@ -197,11 +216,12 @@ async def test_fail_closed_emits_high_severity_audit(cloud_active, monkeypatch):
 
     from pocketpaw_ee.cloud.chat import agent_service as svc
 
-    # Bind a user + session but NO workspace (the mis-tenanting condition).
+    # Bind a user + session but NO workspace (the mis-tenanting condition),
+    # under a live cloud CHAT run (marker set) so the fail-closed actually fires.
     utok = svc._active_user_id.set("user-1")
     stok = svc._active_session_mongo_id.set("sess-9")
     try:
-        with pytest.raises(RuntimeError, match="no resolvable workspace"):
+        with pytest.raises(RuntimeError, match="no resolvable workspace"), mark_cloud_chat_run():
             agent_jail.resolve_agent_cwd()
         # The emit is scheduled on the loop; give it turns to run.
         for _ in range(3):

--- a/tests/cloud/agents/test_agent_jail.py
+++ b/tests/cloud/agents/test_agent_jail.py
@@ -1,0 +1,218 @@
+# tests/cloud/agents/test_agent_jail.py
+# Created 2026-06-26 (ART-2) — locks the per-tenant agent cwd jail contract:
+#   * two workspaces resolve to distinct, non-overlapping dirs (isolation)
+#   * workspace + session -> <root>/<ws>/agent/<session>/
+#   * workspace, no session -> <root>/<ws>/agent/_shared/ (group/DM bridge)
+#   * same identity reuses one dir across turns
+#   * cloud active + no workspace -> RAISES (fail-closed)
+#   * cloud NOT active + no workspace -> None (OSS / dedicated unchanged)
+#   * hostile / traversal ids are rejected before they touch the filesystem
+#   * a trailing-newline id is rejected (the \Z-vs-$ anchor hardening)
+#   * the fail-closed emits a high-severity cloud AuditEvent before it raises
+#   * CloudAgentExtension.agent_cwd delegates to the resolver
+"""Per-tenant agent working-directory jail (ART-2)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud import agent_jail
+from pocketpaw_ee.cloud.chat.agent_service import (
+    attach_agent_identity,
+    detach_agent_identity,
+)
+
+
+@pytest.fixture(autouse=True)
+def _jail_root(tmp_path, monkeypatch):
+    """Anchor the jail under tmp_path so tests never touch the real home dir."""
+    root = tmp_path / "jail"
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_JAIL_ROOT", str(root))
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _clean_identity():
+    """Reset the identity ContextVars to None around each test.
+
+    Guarantees the no-workspace cases see a clean slate regardless of any
+    binding a prior test in the suite forgot to detach.
+    """
+    from pocketpaw_ee.cloud.chat import agent_service as svc
+
+    tokens = (
+        svc._active_workspace_id.set(None),
+        svc._active_user_id.set(None),
+        svc._active_session_mongo_id.set(None),
+        svc._active_pocket_id.set(None),
+    )
+    try:
+        yield
+    finally:
+        svc._active_workspace_id.reset(tokens[0])
+        svc._active_user_id.reset(tokens[1])
+        svc._active_session_mongo_id.reset(tokens[2])
+        svc._active_pocket_id.reset(tokens[3])
+
+
+@pytest.fixture
+def cloud_active(monkeypatch):
+    """Make get_client() report cloud mode active without a real Mongo client."""
+    monkeypatch.setattr("pocketpaw_ee.cloud.shared.db._client", object())
+
+
+@pytest.fixture
+def cloud_inactive(monkeypatch):
+    """Force get_client() to None (OSS / dedicated — no cloud DB)."""
+    monkeypatch.setattr("pocketpaw_ee.cloud.shared.db._client", None)
+
+
+def _bind(workspace_id: str, *, user_id: str = "u1", session_mongo_id: str | None = None):
+    return attach_agent_identity(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        session_mongo_id=session_mongo_id,
+    )
+
+
+def test_two_workspaces_isolated(_jail_root):
+    tok_a = _bind("wsAAA", session_mongo_id="sess1")
+    try:
+        cwd_a = Path(agent_jail.resolve_agent_cwd())
+    finally:
+        detach_agent_identity(tok_a)
+
+    tok_b = _bind("wsBBB", session_mongo_id="sess1")
+    try:
+        cwd_b = Path(agent_jail.resolve_agent_cwd())
+    finally:
+        detach_agent_identity(tok_b)
+
+    assert cwd_a != cwd_b
+    assert "wsAAA" in cwd_a.parts and "wsBBB" not in cwd_a.parts
+    assert "wsBBB" in cwd_b.parts and "wsAAA" not in cwd_b.parts
+    # Both under the jail root; neither nested inside the other (no co-mingling).
+    assert _jail_root in cwd_a.parents and _jail_root in cwd_b.parents
+    assert not str(cwd_a).startswith(str(cwd_b) + "/")
+    assert not str(cwd_b).startswith(str(cwd_a) + "/")
+    assert cwd_a.is_dir() and cwd_b.is_dir()
+
+
+def test_workspace_and_session_path(_jail_root):
+    tok = _bind("ws1", session_mongo_id="sessX")
+    try:
+        cwd = Path(agent_jail.resolve_agent_cwd())
+    finally:
+        detach_agent_identity(tok)
+    assert cwd == _jail_root / "ws1" / "agent" / "sessX"
+    assert cwd.is_dir()
+
+
+def test_workspace_without_session_uses_shared(_jail_root):
+    tok = _bind("ws1", session_mongo_id=None)
+    try:
+        cwd = Path(agent_jail.resolve_agent_cwd())
+    finally:
+        detach_agent_identity(tok)
+    assert cwd == _jail_root / "ws1" / "agent" / "_shared"
+    assert cwd.is_dir()
+
+
+def test_same_identity_reuses_dir(_jail_root):
+    tok = _bind("ws1", session_mongo_id="sessX")
+    try:
+        first = agent_jail.resolve_agent_cwd()
+        second = agent_jail.resolve_agent_cwd()
+    finally:
+        detach_agent_identity(tok)
+    assert first == second
+
+
+def test_fail_closed_when_cloud_active_and_no_workspace(cloud_active):
+    # No identity bound (contextvar default None) + cloud mode active.
+    with pytest.raises(RuntimeError, match="no resolvable workspace"):
+        agent_jail.resolve_agent_cwd()
+
+
+def test_returns_none_when_not_cloud(cloud_inactive):
+    # No identity bound + cloud DB never initialized → OSS / dedicated path.
+    assert agent_jail.resolve_agent_cwd() is None
+
+
+def test_hostile_workspace_id_rejected(_jail_root):
+    tok = _bind("../etc", session_mongo_id="sess1")
+    try:
+        with pytest.raises(ValueError, match="unsafe workspace_id"):
+            agent_jail.resolve_agent_cwd()
+    finally:
+        detach_agent_identity(tok)
+
+
+def test_hostile_session_id_rejected(_jail_root):
+    tok = _bind("ws1", session_mongo_id="../../root")
+    try:
+        with pytest.raises(ValueError, match="unsafe session_mongo_id"):
+            agent_jail.resolve_agent_cwd()
+    finally:
+        detach_agent_identity(tok)
+
+
+def test_trailing_newline_id_rejected(_jail_root):
+    # ``$`` matches just before a trailing newline; the ``\Z`` anchor must
+    # reject ``"ws1\n"`` so a newline can't slip past the traversal guard.
+    tok = _bind("ws1\n", session_mongo_id="sess1")
+    try:
+        with pytest.raises(ValueError, match="unsafe workspace_id"):
+            agent_jail.resolve_agent_cwd()
+    finally:
+        detach_agent_identity(tok)
+
+
+def test_extension_delegates(_jail_root):
+    from pocketpaw_ee.extensions import CloudAgentExtension
+
+    tok = _bind("ws1", session_mongo_id="sessX")
+    try:
+        cwd = CloudAgentExtension().agent_cwd()
+    finally:
+        detach_agent_identity(tok)
+    assert Path(cwd) == _jail_root / "ws1" / "agent" / "sessX"
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_emits_high_severity_audit(cloud_active, monkeypatch):
+    """The fail-closed (a cloud run that lost its workspace) emits a
+    high-severity cloud AuditEvent before it raises — best-effort, fire-and-
+    forget on the running loop."""
+    import pocketpaw_ee.cloud.audit.service as audit_service
+
+    calls: list[tuple] = []
+
+    async def fake_record(workspace_id, actor_id, action, **kwargs):
+        calls.append((workspace_id, actor_id, action, kwargs))
+
+    monkeypatch.setattr(audit_service, "record", fake_record)
+
+    from pocketpaw_ee.cloud.chat import agent_service as svc
+
+    # Bind a user + session but NO workspace (the mis-tenanting condition).
+    utok = svc._active_user_id.set("user-1")
+    stok = svc._active_session_mongo_id.set("sess-9")
+    try:
+        with pytest.raises(RuntimeError, match="no resolvable workspace"):
+            agent_jail.resolve_agent_cwd()
+        # The emit is scheduled on the loop; give it turns to run.
+        for _ in range(3):
+            await asyncio.sleep(0)
+    finally:
+        svc._active_user_id.reset(utok)
+        svc._active_session_mongo_id.reset(stok)
+
+    assert calls, "expected a fail-closed audit alert to be recorded"
+    workspace_id, actor_id, action, kwargs = calls[0]
+    assert action == "agent.cwd_jail.fail_closed"
+    assert actor_id == "user-1"
+    assert kwargs["target_id"] == "sess-9"
+    assert kwargs["metadata"]["severity"] == "high"

--- a/tests/cloud/agents/test_agent_jail_lifecycle.py
+++ b/tests/cloud/agents/test_agent_jail_lifecycle.py
@@ -1,0 +1,328 @@
+# tests/cloud/agents/test_agent_jail_lifecycle.py
+# Created 2026-06-26 (ART-3) — locks the agent-jail lifecycle contract:
+#   * per-workspace quota: over-limit -> clear rejection message; under-limit,
+#     disabled (0), and no-workspace -> None; sums across a workspace's sessions
+#   * scan_jail_dir: total size + NEWEST mtime over the tree (nested files count,
+#     so a build that only writes deep subdirs isn't misread as idle)
+#   * TTL GC: an idle jail past the grace is evicted; a fresh idle jail is kept
+#   * active-protection: a jail backing a queued/running run is NEVER evicted
+#     (both the per-session dir and the workspace _shared dir), and a TERMINAL
+#     run does not protect its idle jail
+#   * watermark: idle jails are evicted LRU-first, and only while over the mark
+"""Agent-jail lifecycle — quota / TTL-GC / watermark (ART-3)."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud import agent_jail, agent_jail_gc
+
+
+@pytest.fixture(autouse=True)
+def _jail_root(tmp_path, monkeypatch):
+    """Anchor the jail under tmp_path so tests never touch the real home dir."""
+    root = tmp_path / "jail"
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_JAIL_ROOT", str(root))
+    return root
+
+
+def _make_jail(
+    root: Path,
+    workspace_id: str,
+    segment: str,
+    *,
+    files: dict[str, int] | None = None,
+    mtime: float | None = None,
+) -> Path:
+    """Create ``<root>/<ws>/agent/<seg>/`` with ``files`` (``{relpath: bytes}``).
+
+    When ``mtime`` is given, stamp the whole subtree to it so ``scan_jail_dir``
+    reads a deterministic last-activity (utime never cascades, so order is moot).
+    """
+    jail = root / workspace_id / "agent" / segment
+    jail.mkdir(parents=True, exist_ok=True)
+    for rel, size in (files or {}).items():
+        target = jail / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x" * size)
+    if mtime is not None:
+        for path in jail.rglob("*"):
+            os.utime(path, (mtime, mtime))
+        os.utime(jail, (mtime, mtime))
+    return jail
+
+
+async def _insert_run(
+    *, workspace_id: str, context_type: str, scope_id: str, status: str, cmid: str
+):
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    doc = ChatRunDoc(
+        run_id=f"r-{cmid}",
+        workspace=workspace_id,
+        context_type=context_type,
+        scope_id=scope_id,
+        session_key="k",
+        user_id="u1",
+        agent_id="a1",
+        client_message_id=cmid,
+        user_message_id="m1",
+        status=status,  # type: ignore[arg-type]
+    )
+    await doc.insert()
+    return doc
+
+
+# --------------------------------------------------------------------------- #
+# Quota (run-start measurement)
+# --------------------------------------------------------------------------- #
+
+
+def test_quota_over_limit_returns_message(_jail_root, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "1")
+    _make_jail(_jail_root, "ws1", "s1", files={"big.bin": 2 * 1024 * 1024})
+    msg = agent_jail.check_workspace_jail_quota("ws1")
+    assert msg is not None
+    assert "full" in msg.lower() and "MB" in msg
+
+
+def test_quota_under_limit_returns_none(_jail_root, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "10")
+    _make_jail(_jail_root, "ws1", "s1", files={"small.bin": 1024})
+    assert agent_jail.check_workspace_jail_quota("ws1") is None
+
+
+def test_quota_none_workspace_allowed(_jail_root):
+    assert agent_jail.check_workspace_jail_quota(None) is None
+
+
+def test_quota_disabled_when_zero(_jail_root, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "0")
+    _make_jail(_jail_root, "ws1", "s1", files={"big.bin": 5 * 1024 * 1024})
+    assert agent_jail.check_workspace_jail_quota("ws1") is None
+
+
+def test_quota_sums_across_sessions(_jail_root, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "3")
+    _make_jail(_jail_root, "ws1", "s1", files={"a.bin": 2 * 1024 * 1024})
+    _make_jail(_jail_root, "ws1", "s2", files={"b.bin": 2 * 1024 * 1024})
+    # 4 MB across two session dirs > 3 MB cap — the cap is per-workspace, not per-session.
+    assert agent_jail.check_workspace_jail_quota("ws1") is not None
+
+
+def test_quota_over_limit_short_circuits(_jail_root, monkeypatch):
+    """The run-start check stops walking once the running sum passes the limit —
+    it does not stat the whole tree (the hot-path guarantee for big node_modules
+    jails). Two session dirs each already exceed the limit on their own, so
+    whichever the DFS reaches first crosses immediately; the other is never
+    scanned."""
+    limit = 1024
+    _make_jail(_jail_root, "ws1", "s1", files={"big1.bin": 4096})
+    _make_jail(_jail_root, "ws1", "s2", files={"big2.bin": 4096})
+
+    real_scandir = os.scandir
+    scanned: list[str] = []
+
+    def counting_scandir(path):
+        scanned.append(str(path))
+        return real_scandir(path)
+
+    monkeypatch.setattr(agent_jail.os, "scandir", counting_scandir)
+
+    assert agent_jail.workspace_jail_over_quota("ws1", limit) is True
+
+    agent_root = str(_jail_root / "ws1" / "agent")
+    session_scans = [p for p in scanned if p.startswith(agent_root) and p != agent_root]
+    # Exactly ONE session dir was walked before the early-exit fired; the second
+    # (and the rest of the tree) was skipped.
+    assert len(session_scans) == 1, f"expected short-circuit after 1 session dir, scanned {scanned}"
+
+
+# --------------------------------------------------------------------------- #
+# scan_jail_dir
+# --------------------------------------------------------------------------- #
+
+
+def test_scan_counts_nested_files_and_newest_mtime(_jail_root):
+    jail = _make_jail(
+        _jail_root,
+        "ws1",
+        "s1",
+        files={"top.txt": 100, "node_modules/pkg/index.js": 200},
+        mtime=time.time() - 10_000,
+    )
+    size, last_all_old = agent_jail.scan_jail_dir(jail)
+    assert size == 300
+
+    # Touch ONLY the deeply-nested file; the top dir's own mtime stays old.
+    nested = jail / "node_modules" / "pkg" / "index.js"
+    recent = time.time()
+    os.utime(nested, (recent, recent))
+
+    _size, last = agent_jail.scan_jail_dir(jail)
+    assert last >= recent - 1  # last-activity tracks the nested write
+    assert last > last_all_old
+    # The top dir's mtime alone would have read the busy jail as idle.
+    assert jail.stat().st_mtime <= recent - 9_000
+
+
+# --------------------------------------------------------------------------- #
+# TTL garbage-collection
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_ttl_evicts_idle_jail_past_grace(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "60")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "0")  # isolate TTL
+    jail = _make_jail(_jail_root, "ws1", "s_idle", files={"f": 10}, mtime=time.time() - 7200)
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 1
+    assert not jail.exists()
+
+
+@pytest.mark.asyncio
+async def test_ttl_keeps_fresh_idle_jail(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "3600")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "0")
+    jail = _make_jail(_jail_root, "ws1", "s_fresh", files={"f": 10}, mtime=time.time())
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 0
+    assert jail.is_dir()
+
+
+# --------------------------------------------------------------------------- #
+# Active-run protection (the safety invariant)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_active_session_jail_not_evicted(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "1")  # would TTL-evict if idle
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "0")
+    jail = _make_jail(_jail_root, "ws1", "sess-active", files={"f": 10}, mtime=time.time() - 7200)
+    # A running run whose scope_id == the jail dir name protects it.
+    await _insert_run(
+        workspace_id="ws1",
+        context_type="session",
+        scope_id="sess-active",
+        status="running",
+        cmid="c1",
+    )
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 0
+    assert jail.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_shared_jail_protected_by_bridge_run(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "1")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "0")
+    jail = _make_jail(
+        _jail_root,
+        "ws1",
+        agent_jail._SESSIONLESS_DIRNAME,
+        files={"f": 10},
+        mtime=time.time() - 7200,
+    )
+    # The sessionless DM/group/pocket bridge shares the per-workspace _shared dir;
+    # any non-session run in the workspace protects it.
+    await _insert_run(
+        workspace_id="ws1", context_type="dm", scope_id="dm-xyz", status="queued", cmid="c2"
+    )
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 0
+    assert jail.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_terminal_run_does_not_protect_jail(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "60")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "0")
+    jail = _make_jail(_jail_root, "ws1", "sess-done", files={"f": 10}, mtime=time.time() - 7200)
+    # A completed (terminal) run must NOT keep its idle jail alive.
+    await _insert_run(
+        workspace_id="ws1",
+        context_type="session",
+        scope_id="sess-done",
+        status="completed",
+        cmid="c3",
+    )
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 1
+    assert not jail.exists()
+
+
+# --------------------------------------------------------------------------- #
+# Disk-watermark eviction (LRU-first, only while over the mark)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_watermark_evicts_lru_idle_first(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    # Huge TTL so neither dir is TTL-evicted; both reach the watermark stage.
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "999999")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "90")
+    now = time.time()
+    older = _make_jail(_jail_root, "ws1", "s_old", files={"f": 10}, mtime=now - 5000)
+    newer = _make_jail(_jail_root, "ws1", "s_new", files={"f": 10}, mtime=now - 100)
+
+    evicted_paths: list[Path] = []
+    real_evict = agent_jail.evict_jail_dir
+
+    def fake_disk() -> float:
+        # Over the mark until one dir is reclaimed, then back under.
+        return 95.0 if not evicted_paths else 80.0
+
+    def spy_evict(path: Path) -> bool:
+        evicted_paths.append(Path(path))
+        return real_evict(path)
+
+    monkeypatch.setattr(agent_jail_gc.agent_jail, "disk_usage_pct", fake_disk)
+    monkeypatch.setattr(agent_jail_gc.agent_jail, "evict_jail_dir", spy_evict)
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 1
+    # Only the least-recently-used (oldest) jail was evicted; eviction stopped
+    # as soon as disk dropped under the mark.
+    assert older in evicted_paths and newer not in evicted_paths
+    assert not older.exists() and newer.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_watermark_noop_when_under_mark(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "999999")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_DISK_WATERMARK_PCT", "90")
+    jail = _make_jail(_jail_root, "ws1", "s1", files={"f": 10}, mtime=time.time() - 5000)
+    monkeypatch.setattr(agent_jail_gc.agent_jail, "disk_usage_pct", lambda: 50.0)
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 0
+    assert jail.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_gc_disabled_via_env(_jail_root, mongo_db, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_GC_ENABLED", "false")
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_TTL_GRACE_SECONDS", "1")
+    jail = _make_jail(_jail_root, "ws1", "s_idle", files={"f": 10}, mtime=time.time() - 7200)
+
+    n = await agent_jail_gc.sweep_agent_jails()
+
+    assert n == 0
+    assert jail.is_dir()

--- a/tests/cloud/agents/test_deliver_tool.py
+++ b/tests/cloud/agents/test_deliver_tool.py
@@ -1,0 +1,382 @@
+# test_deliver_tool.py — ART-4 deliver_artifact in-process MCP tool.
+#
+# Locks the deliver path's behavior end-to-end against the real EEUploadService +
+# a mongomock-backed Mongo store and a local StorageAdapter rooted in a tmp home:
+#   * single file  → workspace-scoped upload, presigned URL, guessed mime, shows
+#                    in the tenant's file list;
+#   * directory    → zipped (application/zip) and the zip round-trips;
+#   * two tenants  → each delivers, ZERO cross-read (Mongo scope + presign gate);
+#   * path safety  → ``..`` / absolute / symlink-out / cross-tenant all rejected;
+#   * guards       → missing identity, missing file, and the size cap.
+"""Tests for the deliver_artifact agent tool."""
+
+from __future__ import annotations
+
+import io
+import json
+import uuid
+import zipfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def beanie_db():
+    """Beanie initialized on a fresh mongomock client with the upload models, so
+    the MongoFileStore the deliver tool builds internally persists for real."""
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+
+    client = AsyncMongoMockClient()
+    db = client[f"test_deliver_{uuid.uuid4().hex[:8]}"]
+
+    original = db.list_collection_names
+
+    async def _safe(*_a, **_kw):
+        return await original()
+
+    db.list_collection_names = _safe  # type: ignore[method-assign]
+
+    from pocketpaw_ee.cloud.uploads.models import FileFolder, FileUpload
+
+    await init_beanie(database=db, document_models=[FileUpload, FileFolder])
+    yield db
+
+
+@pytest.fixture(autouse=True)
+def hermetic_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin Path.home() into tmp so BOTH the workspace jail root
+    (~/.pocketpaw/workspaces) and the upload adapter root (~/.pocketpaw/uploads)
+    stay off the real home dir. Force the local upload adapter."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.delenv("POCKETPAW_UPLOAD_ADAPTER", raising=False)
+    monkeypatch.delenv("POCKETPAW_WORKSPACE_JAIL_ROOT", raising=False)
+    monkeypatch.delenv("POCKETPAW_DELIVER_MAX_MB", raising=False)
+    return home
+
+
+def _bind(workspace_id: str, user_id: str, session: str):
+    from pocketpaw_ee.cloud.chat.agent_service import attach_agent_identity
+
+    return attach_agent_identity(
+        workspace_id=workspace_id, user_id=user_id, session_mongo_id=session
+    )
+
+
+def _detach(tokens) -> None:
+    from pocketpaw_ee.cloud.chat.agent_service import detach_agent_identity
+
+    detach_agent_identity(tokens)
+
+
+def _agent_cwd() -> Path:
+    """The jail dir the bound run's agent works in (where relative paths land)."""
+    from pocketpaw_ee.cloud.agent_jail import resolve_agent_cwd
+
+    cwd = resolve_agent_cwd()
+    assert cwd is not None
+    return Path(cwd)
+
+
+def _body(resp: dict) -> dict:
+    assert "is_error" not in resp, resp
+    return json.loads(resp["content"][0]["text"])
+
+
+async def _read_blob(storage_key: str) -> bytes:
+    """Read a stored blob back through the same local adapter the tool wrote it
+    with, so a directory delivery can be unzipped and asserted."""
+    from pocketpaw.uploads.factory import build_adapter
+
+    adapter = build_adapter(Path.home() / ".pocketpaw" / "uploads")
+    return b"".join([c async for c in adapter.open(storage_key)])
+
+
+async def test_deliver_single_file(beanie_db) -> None:
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    tokens = _bind("wsA", "uA", "sessA")
+    try:
+        (_agent_cwd() / "report.txt").write_text("hello report")
+        resp = await _deliver_handler({"path": "report.txt"})
+    finally:
+        _detach(tokens)
+
+    body = _body(resp)
+    assert body["ok"] is True
+    assert body["filename"] == "report.txt"
+    assert body["mime"] == "text/plain"
+    assert body["url"]
+    assert body["file_id"]
+    assert body["expires_in_seconds"] > 0
+
+    # Visible in the tenant's file list (workspace-scoped Mongo row).
+    rec = await MongoFileStore().get_scoped(body["file_id"], workspace="wsA")
+    assert rec is not None
+    assert rec.filename == "report.txt"
+    assert rec.mime == "text/plain"
+
+
+async def test_deliver_directory_zips_and_roundtrips(beanie_db) -> None:
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    tokens = _bind("wsA", "uA", "sessA")
+    try:
+        cwd = _agent_cwd()
+        bundle = cwd / "bundle"
+        (bundle / "sub").mkdir(parents=True)
+        (bundle / "index.html").write_text("<html>hi</html>")
+        (bundle / "sub" / "app.js").write_text("console.log(1)")
+        resp = await _deliver_handler({"path": "bundle"})
+    finally:
+        _detach(tokens)
+
+    body = _body(resp)
+    assert body["ok"] is True
+    assert body["filename"] == "bundle.zip"
+    assert body["mime"] == "application/zip"
+
+    rec = await MongoFileStore().get_scoped(body["file_id"], workspace="wsA")
+    assert rec is not None and rec.mime == "application/zip"
+
+    # The stored blob is a real zip carrying the directory tree.
+    data = await _read_blob(rec.storage_key)
+    names = set(zipfile.ZipFile(io.BytesIO(data)).namelist())
+    assert "bundle/index.html" in names
+    assert "bundle/sub/app.js" in names
+
+
+async def test_two_tenants_no_cross_read(beanie_db) -> None:
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+    from pocketpaw_ee.cloud.uploads.service import EEUploadService
+
+    from pocketpaw.uploads.config import UploadSettings
+    from pocketpaw.uploads.errors import NotFound
+    from pocketpaw.uploads.factory import build_adapter
+
+    ta = _bind("wsA", "uA", "sessA")
+    try:
+        (_agent_cwd() / "secretA.txt").write_text("alpha")
+        file_a = _body(await _deliver_handler({"path": "secretA.txt"}))["file_id"]
+    finally:
+        _detach(ta)
+
+    tb = _bind("wsB", "uB", "sessB")
+    try:
+        (_agent_cwd() / "secretB.txt").write_text("bravo")
+        file_b = _body(await _deliver_handler({"path": "secretB.txt"}))["file_id"]
+    finally:
+        _detach(tb)
+
+    store = MongoFileStore()
+    # Each file is invisible from the OTHER tenant's workspace scope.
+    assert await store.get_scoped(file_b, workspace="wsA") is None
+    assert await store.get_scoped(file_a, workspace="wsB") is None
+
+    # And the presign read-gate refuses a cross-tenant grant.
+    root = Path.home() / ".pocketpaw" / "uploads"
+    svc = EEUploadService(
+        adapter=build_adapter(root), meta=store, cfg=UploadSettings(local_root=root)
+    )
+    with pytest.raises(NotFound):
+        await svc.presigned_get(file_a, "uB", "wsB", 300)
+
+
+async def test_path_escapes_rejected(beanie_db) -> None:
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+    from pocketpaw_ee.cloud.agent_jail import workspace_jail_root
+
+    # A real secret OUTSIDE the jail, and a sibling tenant's jail file.
+    outside = Path.home() / "outside_secret.txt"
+    outside.write_text("TOPSECRET")
+    above_jail = workspace_jail_root() / "evil.txt"
+    above_jail.parent.mkdir(parents=True, exist_ok=True)
+    above_jail.write_text("nope")
+
+    tb = _bind("wsB", "uB", "sessB")
+    try:
+        victim = _agent_cwd() / "victimB.txt"
+        victim.write_text("tenant-B-data")
+    finally:
+        _detach(tb)
+
+    tokens = _bind("wsA", "uA", "sessA")
+    try:
+        cwd = _agent_cwd()
+        link = cwd / "escape_link"
+        link.symlink_to(outside)
+
+        responses = [
+            await _deliver_handler({"path": "../../../evil.txt"}),  # relative climb
+            await _deliver_handler({"path": str(outside)}),  # absolute outside
+            await _deliver_handler({"path": "/etc/passwd"}),  # host file
+            await _deliver_handler({"path": "escape_link"}),  # symlink out
+            await _deliver_handler({"path": str(victim)}),  # cross-tenant jail
+        ]
+    finally:
+        _detach(tokens)
+
+    for resp in responses:
+        assert resp.get("is_error") is True, resp
+
+
+async def test_missing_identity_errors(beanie_db) -> None:
+    """Called with no run identity bound (not a cloud chat stream)."""
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+
+    resp = await _deliver_handler({"path": "anything.txt"})
+    assert resp["is_error"] is True
+    assert "workspace and user context" in resp["content"][0]["text"]
+
+
+async def test_missing_file_errors(beanie_db) -> None:
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+
+    tokens = _bind("wsA", "uA", "sessA")
+    try:
+        resp = await _deliver_handler({"path": "does_not_exist.txt"})
+    finally:
+        _detach(tokens)
+    assert resp["is_error"] is True
+    assert "no such file" in resp["content"][0]["text"]
+
+
+async def test_oversize_rejected(beanie_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+
+    monkeypatch.setenv("POCKETPAW_DELIVER_MAX_MB", "0.00001")  # ~10 bytes
+    tokens = _bind("wsA", "uA", "sessA")
+    try:
+        (_agent_cwd() / "big.txt").write_text("x" * 1000)
+        resp = await _deliver_handler({"path": "big.txt"})
+    finally:
+        _detach(tokens)
+    assert resp["is_error"] is True
+    assert "deliver limit" in resp["content"][0]["text"]
+
+
+@pytest.mark.parametrize(
+    ("filename", "content", "expected_mime"),
+    [
+        ("evil.html", "<script>alert(1)</script>", "text/html"),
+        ("evil.svg", "<svg xmlns='http://www.w3.org/2000/svg'><script/></svg>", "image/svg+xml"),
+    ],
+)
+async def test_deliver_renderable_served_as_attachment(
+    beanie_db, monkeypatch: pytest.MonkeyPatch, filename, content, expected_mime
+) -> None:
+    """A delivered HTML/SVG artifact must download (attachment), never render
+    inline on the storage origin. A spy adapter records the Content-Disposition
+    the deliver path forwards to the (S3) presign."""
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+
+    import pocketpaw.uploads.factory as factory
+
+    recorded: dict[str, str | None] = {}
+    real_build = factory.build_adapter
+
+    class _SpyAdapter:
+        def __init__(self, inner):
+            self._inner = inner
+
+        async def put(self, key, stream, mime):
+            return await self._inner.put(key, stream, mime)
+
+        def open(self, key):
+            return self._inner.open(key)
+
+        async def delete(self, key):
+            return await self._inner.delete(key)
+
+        async def exists(self, key):
+            return await self._inner.exists(key)
+
+        def local_path(self, key):
+            return None
+
+        async def presigned_get(self, key, ttl_seconds, response_content_disposition=None):
+            recorded["disposition"] = response_content_disposition
+            return f"https://signed.example/{key}"
+
+    monkeypatch.setattr(factory, "build_adapter", lambda root: _SpyAdapter(real_build(root)))
+
+    tokens = _bind("wsA", "uA", "sessA")
+    try:
+        (_agent_cwd() / filename).write_text(content)
+        resp = await _deliver_handler({"path": filename})
+    finally:
+        _detach(tokens)
+
+    body = _body(resp)
+    assert body["mime"] == expected_mime
+    assert body["url"].startswith("https://signed.example/")
+    assert recorded["disposition"] is not None
+    assert recorded["disposition"].startswith("attachment;")
+
+
+async def test_symlink_inside_dir_not_archived(beanie_db) -> None:
+    """A symlink INSIDE a delivered directory that points out of the jail is
+    skipped — neither the link entry nor its target's bytes reach the zip."""
+    import io
+    import zipfile
+
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    tokens = _bind("wsA", "uA", "sessA")
+    try:
+        cwd = _agent_cwd()
+        secret = Path.home() / "secret_outside.txt"
+        secret.write_text("TOPSECRET-LEAK")
+        bundle = cwd / "bundle"
+        bundle.mkdir()
+        (bundle / "ok.txt").write_text("safe content")
+        (bundle / "link_to_secret").symlink_to(secret)
+        resp = await _deliver_handler({"path": "bundle"})
+    finally:
+        _detach(tokens)
+
+    body = _body(resp)
+    rec = await MongoFileStore().get_scoped(body["file_id"], workspace="wsA")
+    data = await _read_blob(rec.storage_key)
+    names = set(zipfile.ZipFile(io.BytesIO(data)).namelist())
+    assert "bundle/ok.txt" in names
+    assert "bundle/link_to_secret" not in names
+    assert b"TOPSECRET-LEAK" not in data
+
+
+async def test_deliver_excluded_from_restricted_surfaces() -> None:
+    """The deliver tool id must NOT leak onto restricted surfaces whose profiles
+    carry an explicit MCP allowlist (studio/sites/foresight/belt). Locks the
+    exclusion so a future allowlist edit can't silently expose deliver there."""
+    from pocketpaw_ee.agent.mcp_servers.deliver import DELIVER_ARTIFACT_TOOL_ID
+    from pocketpaw_ee.cloud.surface.surface_registry import _mcp_tool_ids
+
+    ids = _mcp_tool_ids()
+    assert ids.loaded, "surface MCP tool-ids failed to load — test would be vacuous"
+    for allow in (ids.studio_allow, ids.sites_allow, ids.foresight_allow, ids.belt_allow):
+        assert allow is not None
+        assert DELIVER_ARTIFACT_TOOL_ID not in allow
+
+
+async def test_build_deliver_server_gated_on_cloud(monkeypatch: pytest.MonkeyPatch) -> None:
+    """build_deliver_server is cloud-only — None off multi-tenant cloud, a real
+    server once the cloud DB signal is set."""
+    import pocketpaw_ee.cloud.shared.db as db
+    from pocketpaw_ee.agent.mcp_servers import deliver
+
+    monkeypatch.setattr(db, "_client", None)
+    assert deliver.build_deliver_server() is None
+
+    monkeypatch.setattr(db, "_client", object())  # fake "cloud DB initialized"
+    built = deliver.build_deliver_server()
+    assert built is not None
+    assert built[0] == "pocketpaw_deliver"

--- a/tests/cloud/file_versions/__init__.py
+++ b/tests/cloud/file_versions/__init__.py
@@ -1,0 +1,1 @@
+# __init__.py — test package for the file_versions entity (ART-1).

--- a/tests/cloud/file_versions/test_file_versions.py
+++ b/tests/cloud/file_versions/test_file_versions.py
@@ -1,0 +1,366 @@
+# test_file_versions.py — contract tests for the ported file_versions spine (ART-1).
+# Created: 2026-06-26 (ART-1). Locks: (a) write->PUT version bump + archive,
+#   (b) two-workspace isolation on version list + content reads, (c) a 4-route
+#   HTTP smoke (status codes + aliased wire shape).
+# Updated: 2026-06-26 (ART-1 quality fix loop) — added the LOGIC tests for the
+#   defects the unique-index-blind mongomock harness hid:
+#   C1 cross-tenant — two workspaces share a path -> distinct stored rows, no
+#      error, isolated content; soft-delete then recreate revives with a FRESH
+#      history (the dead file's version rows are purged on revive).
+#   I1 — a no-op update returns the stored version (no phantom +1 / phantom 409).
+#   I2 — new-file mime comes from the filename / explicit mime, not hardcoded.
+#   I3 — a blob-read failure aborts and archives nothing (history preserved).
+#   I4 — the archived row is labelled with the version the content actually was.
+#   M2 — list/get reject an empty workspace.
+"""Tests for the file_versions write + history storage spine."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
+from pocketpaw_ee.cloud.file_versions import service
+from pocketpaw_ee.cloud.file_versions.dto import (
+    UpdateFileContentRequest,
+    WriteFileRequest,
+)
+from pocketpaw_ee.cloud.models.file_version import FileVersionDoc
+from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+from pocketpaw.uploads.adapter import StoredObject
+
+
+class _FakeAdapter:
+    """In-memory StorageAdapter stand-in.
+
+    Implements only the two methods the file_versions service uses
+    (``put`` + ``open``) over a dict of blobs, so tests never touch the
+    real on-disk / S3 adapter.
+    """
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, bytes] = {}
+
+    async def put(self, key: str, stream: AsyncIterator[bytes], mime: str) -> StoredObject:
+        chunks: list[bytes] = []
+        async for chunk in stream:
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        self._blobs[key] = data
+        return StoredObject(key=key, size=len(data), mime=mime)
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        data = self._blobs.get(key)
+        if data is None:
+            raise FileNotFoundError(key)
+        yield data
+
+
+class _ReadFailAdapter(_FakeAdapter):
+    """Adapter whose blob read always fails — exercises the I3 abort path."""
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        # The `yield` (never-taken branch) makes this an async generator; the
+        # read always raises so the service must abort the update.
+        if self._blobs.get(key) == b"__never__":
+            yield b""
+        raise OSError("simulated blob read failure")
+
+
+def _ctx(workspace_id: str, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def fake_storage():
+    """Inject an in-memory StorageAdapter for the duration of a test."""
+    adapter = _FakeAdapter()
+    prev = service._adapter
+    service.set_adapter(adapter)
+    yield adapter
+    service._adapter = prev
+
+
+@pytest.mark.asyncio
+async def test_write_then_update_bumps_version(mongo_db, fake_storage):
+    """write_file creates v1; a PUT with new content bumps the live counter to
+    2 and archives the prior blob as one FileVersionDoc labelled v1."""
+    ctx = _ctx("w1")
+
+    res1 = await service.write_file(ctx, WriteFileRequest(path="doc1", content='{"v":1}'))
+    assert res1.file_id == "doc1"  # client sees the bare path
+    assert res1.version == 1
+
+    res2 = await service.update_file_content(
+        ctx, "doc1", UpdateFileContentRequest(content='{"v":2}')
+    )
+    assert res2.new_version == 2
+
+    # The live FileUpload counter advanced to 2 (stored id is workspace-namespaced).
+    doc = await FileUpload.find_one(
+        {"file_id": service._storage_id("w1", "doc1"), "workspace": "w1"}
+    )
+    assert doc is not None
+    assert doc.content_version == 2
+
+    # One archived version, labelled with the version it actually was (1),
+    # holding the prior (v1) content.
+    versions = await service.list_versions(ctx, "doc1")
+    assert len(versions) == 1
+    assert versions[0].version_number == 1
+
+    full = await service.get_version(ctx, "doc1", versions[0].id)
+    assert full.content == '{"v":1}'
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_same_path_no_collision(mongo_db, fake_storage):
+    """C1 — two workspaces writing the SAME path produce distinct stored rows,
+    no error, and fully isolated content."""
+    ctx_a = _ctx("wA", "ua")
+    ctx_b = _ctx("wB", "ub")
+
+    ra = await service.write_file(ctx_a, WriteFileRequest(path="report", content='{"a":1}'))
+    # B writing the same path must NOT raise (no global unique-key collision).
+    rb = await service.write_file(ctx_b, WriteFileRequest(path="report", content='{"b":1}'))
+
+    # Client-facing id is the bare path for both.
+    assert ra.file_id == "report"
+    assert rb.file_id == "report"
+
+    # But the STORED FileUpload rows carry distinct workspace-namespaced ids.
+    doc_a = await FileUpload.find_one(
+        {"file_id": service._storage_id("wA", "report"), "workspace": "wA"}
+    )
+    doc_b = await FileUpload.find_one(
+        {"file_id": service._storage_id("wB", "report"), "workspace": "wB"}
+    )
+    assert doc_a is not None and doc_b is not None
+    assert doc_a.file_id != doc_b.file_id
+
+    # Each workspace edits + reads only its own content.
+    await service.update_file_content(ctx_a, "report", UpdateFileContentRequest(content='{"a":2}'))
+    await service.update_file_content(ctx_b, "report", UpdateFileContentRequest(content='{"b":2}'))
+
+    a_versions = await service.list_versions(ctx_a, "report")
+    b_versions = await service.list_versions(ctx_b, "report")
+    assert len(a_versions) == 1
+    assert len(b_versions) == 1
+    assert (await service.get_version(ctx_a, "report", a_versions[0].id)).content == '{"a":1}'
+    assert (await service.get_version(ctx_b, "report", b_versions[0].id)).content == '{"b":1}'
+
+    # A cannot read B's version row (tenant-filtered).
+    with pytest.raises(NotFound):
+        await service.get_version(ctx_a, "report", b_versions[0].id)
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_then_recreate_purges_history(mongo_db, fake_storage):
+    """C1 follow-up — soft-delete then recreate is a NEW file at that path with
+    FRESH history: the revive succeeds AND purges the dead file's version rows
+    so they don't bleed stale content / duplicate version_number=1 labels."""
+    ctx = _ctx("w1")
+    stored_id = service._storage_id("w1", "report")
+
+    # Build a 2-version history on the original file.
+    await service.write_file(ctx, WriteFileRequest(path="report", content="v1"))
+    await service.update_file_content(ctx, "report", UpdateFileContentRequest(content="v2"))
+    await service.update_file_content(ctx, "report", UpdateFileContentRequest(content="v3"))
+    versions = await service.list_versions(ctx, "report")
+    assert [v.version_number for v in versions] == [1, 2]
+
+    # Simulate the uploads soft-delete (file_versions has no delete of its own).
+    doc = await FileUpload.find_one({"file_id": stored_id, "workspace": "w1"})
+    doc.deleted_at = datetime.now(UTC)
+    await doc.save()
+
+    # Recreate the same path — succeeds, and starts a CLEAN history.
+    res = await service.write_file(ctx, WriteFileRequest(path="report", content="fresh"))
+    assert res.version == 1
+    assert await service.list_versions(ctx, "report") == []  # stale v1/v2 purged
+
+    # Exactly ONE live row for the stored id (revived in place).
+    rows = await FileUpload.find({"file_id": stored_id, "workspace": "w1"}).to_list()
+    assert len(rows) == 1
+    assert rows[0].deleted_at is None
+
+    # The next edit archives a clean version_number=1 (no duplicate label,
+    # no stale content) — proving the purge worked.
+    await service.update_file_content(ctx, "report", UpdateFileContentRequest(content="fresh2"))
+    versions2 = await service.list_versions(ctx, "report")
+    assert [v.version_number for v in versions2] == [1]
+    assert (await service.get_version(ctx, "report", versions2[0].id)).content == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_noop_update_returns_stored_version(mongo_db, fake_storage):
+    """I1 — an unchanged-content update returns the actual stored version, not a
+    phantom +1, and doesn't poison the next If-Match."""
+    ctx = _ctx("w1")
+    await service.write_file(ctx, WriteFileRequest(path="doc", content="same"))
+
+    res = await service.update_file_content(ctx, "doc", UpdateFileContentRequest(content="same"))
+    assert res.new_version == 1  # stored version, not 2
+    assert await service.list_versions(ctx, "doc") == []  # nothing archived
+
+    # A subsequent If-Match=1 update applies cleanly (no phantom 409 against 2).
+    res2 = await service.update_file_content(
+        ctx, "doc", UpdateFileContentRequest(content="changed", expected_version=1)
+    )
+    assert res2.new_version == 2
+
+
+@pytest.mark.asyncio
+async def test_new_file_mime_from_filename(mongo_db, fake_storage):
+    """I2 — new-file mime comes from the filename extension or an explicit mime,
+    not a hardcoded application/json."""
+    ctx = _ctx("w1")
+
+    await service.write_file(ctx, WriteFileRequest(path="data", filename="data.csv", content="a,b"))
+    doc = await FileUpload.find_one(
+        {"file_id": service._storage_id("w1", "data"), "workspace": "w1"}
+    )
+    assert doc.mime == "text/csv"
+
+    # Explicit mime wins over the (here misleading) extension.
+    await service.write_file(
+        ctx, WriteFileRequest(path="page", filename="page.bin", content="x", mime="text/html")
+    )
+    doc2 = await FileUpload.find_one(
+        {"file_id": service._storage_id("w1", "page"), "workspace": "w1"}
+    )
+    assert doc2.mime == "text/html"
+
+    # Extension-less path falls back to an editable text/plain.
+    await service.write_file(ctx, WriteFileRequest(path="notes", content="hi"))
+    doc3 = await FileUpload.find_one(
+        {"file_id": service._storage_id("w1", "notes"), "workspace": "w1"}
+    )
+    assert doc3.mime == "text/plain"
+
+
+@pytest.mark.asyncio
+async def test_archive_read_failure_aborts_and_preserves_history(mongo_db, fake_storage):
+    """I3 — a blob-read failure aborts the update with a CloudError and archives
+    nothing, rather than writing an empty 'prior' version."""
+    ctx = _ctx("w1")
+    await service.write_file(ctx, WriteFileRequest(path="doc", content="orig"))
+
+    # Swap in an adapter whose blob read fails.
+    service.set_adapter(_ReadFailAdapter())
+
+    with pytest.raises(CloudError) as ei:
+        await service.update_file_content(ctx, "doc", UpdateFileContentRequest(content="new"))
+    assert ei.value.code == "files.archive_read_failed"
+
+    # No empty prior version was archived — history is intact.
+    archived = await FileVersionDoc.find({"file_id": "doc", "workspace_id": "w1"}).to_list()
+    assert archived == []
+
+
+@pytest.mark.asyncio
+async def test_two_workspace_isolation(mongo_db, fake_storage):
+    """A workspace can never list or read another workspace's versions/content."""
+    ctx_a = _ctx("wA", "ua")
+    ctx_b = _ctx("wB", "ub")
+
+    # Each workspace creates its own file and edits it (archiving a version).
+    await service.write_file(ctx_a, WriteFileRequest(path="fileA", content='{"a":1}'))
+    await service.update_file_content(ctx_a, "fileA", UpdateFileContentRequest(content='{"a":2}'))
+    await service.write_file(ctx_b, WriteFileRequest(path="fileB", content='{"b":1}'))
+    await service.update_file_content(ctx_b, "fileB", UpdateFileContentRequest(content='{"b":2}'))
+
+    a_versions = await service.list_versions(ctx_a, "fileA")
+    b_versions = await service.list_versions(ctx_b, "fileB")
+    assert len(a_versions) == 1
+    assert len(b_versions) == 1
+
+    # Cross-workspace listing returns ZERO rows — no version leaks either way.
+    assert await service.list_versions(ctx_b, "fileA") == []
+    assert await service.list_versions(ctx_a, "fileB") == []
+
+    # Cross-workspace content read by a known version id is a tenant-filtered
+    # miss (NotFound) — the blob never crosses the workspace boundary.
+    with pytest.raises(NotFound):
+        await service.get_version(ctx_b, "fileA", a_versions[0].id)
+    with pytest.raises(NotFound):
+        await service.get_version(ctx_a, "fileB", b_versions[0].id)
+
+    # And editing the other workspace's file_id is a miss — the FileUpload is
+    # invisible across the boundary (tenant-filtered find).
+    with pytest.raises(NotFound):
+        await service.update_file_content(
+            ctx_b, "fileA", UpdateFileContentRequest(content='{"x":1}')
+        )
+
+
+@pytest.mark.asyncio
+async def test_empty_workspace_rejected_on_reads(mongo_db, fake_storage):
+    """M2 — list/get reject an empty workspace (400), matching write/update."""
+    ctx_empty = _ctx("")
+    with pytest.raises(CloudError):
+        await service.list_versions(ctx_empty, "doc")
+    with pytest.raises(CloudError):
+        await service.get_version(ctx_empty, "doc", "000000000000000000000000")
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db, fake_storage):
+    """A FastAPI app with just the file_versions router mounted, auth/license
+    bypassed, and request_context pinned to workspace ``w1``."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from pocketpaw_ee.cloud._core.context import request_context
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.file_versions.router import router
+    from pocketpaw_ee.cloud.license import require_license
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[request_context] = lambda: _ctx("w1")
+    app.dependency_overrides[require_license] = lambda: None
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_router_write_put_list_get_smoke(client):
+    """End-to-end through the 4 routes: status codes + aliased wire shape."""
+    # POST /files/write -> 201, aliased {fileId, version, sizeBytes}
+    r = await client.post("/api/v1/files/write", json={"path": "d1", "content": '{"v":1}'})
+    assert r.status_code == 201
+    body = r.json()
+    assert body["fileId"] == "d1"
+    assert body["version"] == 1
+    assert "sizeBytes" in body
+
+    # PUT /files/{id} -> 200, bumps version (aliased newVersion)
+    r = await client.put("/api/v1/files/d1", json={"content": '{"v":2}'})
+    assert r.status_code == 200
+    assert r.json()["newVersion"] == 2
+
+    # GET /files/{id}/versions -> the archived row, labelled v1 (aliased)
+    r = await client.get("/api/v1/files/d1/versions")
+    assert r.status_code == 200
+    versions = r.json()
+    assert len(versions) == 1
+    assert versions[0]["versionNumber"] == 1
+
+    # GET /files/{id}/versions/{vid} -> the prior content blob
+    vid = versions[0]["id"]
+    r = await client.get(f"/api/v1/files/d1/versions/{vid}")
+    assert r.status_code == 200
+    assert r.json()["content"] == '{"v":1}'

--- a/tests/cloud/runs/test_run_core.py
+++ b/tests/cloud/runs/test_run_core.py
@@ -86,6 +86,54 @@ async def test_execute_run_writes_chunks_then_stream_end(monkeypatch):
     assert events[-1].data["cancelled"] is False
 
 
+async def test_execute_run_marks_cloud_chat_run_for_jail_fail_closed(monkeypatch):
+    """execute_run wraps the run lifecycle in ``mark_cloud_chat_run`` so the
+    per-tenant cwd jail's fail-closed (``agent_jail.resolve_agent_cwd``) can fire
+    for a real chat dispatch. Locks the wrap itself: the marker must be set
+    DURING the main agent loop AND inherited by the prewarm task
+    (``asyncio.create_task`` copies the context), and reset after the run so it
+    never leaks. Without this, the wrap could be silently removed and every other
+    test would still pass (they set the marker by hand)."""
+    from pocketpaw_ee.cloud.chat import agent_service as svc
+
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    seen: dict[str, bool] = {}
+
+    async def capturing_events(spec, ctx):
+        seen["loop"] = svc.current_cloud_chat_run()
+        yield ("chunk", {"content": "hi", "type": "text"})
+
+    async def capturing_prewarm(ctx):
+        # Fired via asyncio.create_task INSIDE the marked region — the copied
+        # context must carry the marker into this task.
+        seen["prewarm"] = svc.current_cloud_chat_run()
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", capturing_events)
+    monkeypatch.setattr(run_core, "_prewarm_session", capturing_prewarm)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _persist_stub)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+
+    # Outside any run the marker is its default (False).
+    assert svc.current_cloud_chat_run() is False
+
+    await run_core.execute_run(_spec())
+    # The prewarm task is fire-and-forget; give it turns to run if it hasn't.
+    for _ in range(5):
+        if "prewarm" in seen:
+            break
+        await asyncio.sleep(0)
+
+    assert seen.get("loop") is True, "marker must be set during the main agent loop"
+    assert seen.get("prewarm") is True, "prewarm task must inherit the marker via create_task"
+    # And it must NOT leak past the run.
+    assert svc.current_cloud_chat_run() is False
+
+
 async def test_execute_run_cancelled_does_not_persist(monkeypatch):
     redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
     transport = RedisStreamTransport(redis)

--- a/tests/cloud/runs/test_run_core_jail_quota.py
+++ b/tests/cloud/runs/test_run_core_jail_quota.py
@@ -1,0 +1,103 @@
+# tests/cloud/runs/test_run_core_jail_quota.py
+# Created 2026-06-26 (ART-3) — locks the run-start jail-quota gate in
+# run_core._reject_if_over_jail_quota:
+#   * over-quota -> the run is rejected CLEANLY (terminal `failed` doc + a
+#     terminal `error` stream frame), the call returns True, and it never raises
+#     (the worker survives — no OOM/abort)
+#   * under-quota -> returns False and touches nothing (the run proceeds)
+"""execute_run's ART-3 jail-quota gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeTransport:
+    """Records the terminal frames the gate writes, without a real Redis."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict]] = []
+        self.ttls: list[tuple[str, int]] = []
+
+    async def append_event(self, run_id: str, event: str, data: dict) -> None:
+        self.events.append((run_id, event, data))
+
+    async def set_ttl(self, run_id: str, ttl_seconds: int) -> None:
+        self.ttls.append((run_id, ttl_seconds))
+
+
+def _spec(run_id: str, workspace_id: str):
+    from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+
+    return RunSpec(
+        run_id=run_id,
+        workspace_id=workspace_id,
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id=f"c-{run_id}",
+        user_message_id="m1",
+        content="hi",
+        history=[],
+        intent=None,
+    )
+
+
+async def test_over_quota_rejects_cleanly(mongo_db, tmp_path, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_JAIL_ROOT", str(tmp_path / "jail"))
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "1")
+    # Build w1's jail at 2 MB — over the 1 MB cap.
+    jail = Path(tmp_path) / "jail" / "w1" / "agent" / "s1"
+    jail.mkdir(parents=True)
+    (jail / "big.bin").write_bytes(b"x" * (2 * 1024 * 1024))
+
+    from pocketpaw_ee.cloud.chat.runs import run_core
+    from pocketpaw_ee.cloud.chat.runs import service as run_service
+
+    spec = _spec("r1", "w1")
+    await run_service.create_run(spec)
+    transport = _FakeTransport()
+    ctx = SimpleNamespace(workspace_id="w1")
+
+    # Must NOT raise — a clean rejection, not a crash.
+    rejected = await run_core._reject_if_over_jail_quota(spec, ctx, transport)
+
+    assert rejected is True
+    doc = await run_service.get_run("r1")
+    assert doc.status == "failed"
+    assert "full" in (doc.error or "").lower()
+    # A terminal error frame went to the stream, with a TTL bound.
+    assert transport.events and transport.events[-1][1] == "error"
+    assert transport.events[-1][2]["code"] == "agent.jail_over_quota"
+    assert transport.ttls and transport.ttls[-1][0] == "r1"
+
+
+async def test_under_quota_proceeds_untouched(mongo_db, tmp_path, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_JAIL_ROOT", str(tmp_path / "jail"))
+    monkeypatch.setenv("POCKETPAW_AGENT_JAIL_QUOTA_MB", "10")
+    jail = Path(tmp_path) / "jail" / "w1" / "agent" / "s1"
+    jail.mkdir(parents=True)
+    (jail / "small.bin").write_bytes(b"x" * 1024)
+
+    from pocketpaw_ee.cloud.chat.runs import run_core
+    from pocketpaw_ee.cloud.chat.runs import service as run_service
+
+    spec = _spec("r2", "w1")
+    await run_service.create_run(spec)
+    transport = _FakeTransport()
+    ctx = SimpleNamespace(workspace_id="w1")
+
+    rejected = await run_core._reject_if_over_jail_quota(spec, ctx, transport)
+
+    assert rejected is False
+    doc = await run_service.get_run("r2")
+    assert doc.status == "queued"  # untouched
+    assert transport.events == [] and transport.ttls == []

--- a/tests/cloud/uploads/test_presigned_disposition.py
+++ b/tests/cloud/uploads/test_presigned_disposition.py
@@ -1,0 +1,103 @@
+# test_presigned_disposition.py — ART-4 security follow-up.
+#
+# Locks EEUploadService.presigned_get's Content-Disposition policy: non-inline
+# mimes (the HTML/SVG/JS the deliver_artifact path can now store) are served as
+# `attachment` so a presigned S3 GET downloads them instead of rendering active
+# content on the storage origin; inline-safe mimes (images, pdf, plain text)
+# keep the byte-identical None (adapter/object default → inline). A spy adapter
+# records the disposition the service forwards, so the policy is observable
+# without a real S3 bucket.
+"""Tests for the presigned-download Content-Disposition gate."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pocketpaw_ee.cloud.uploads.service import EEUploadService
+
+pytestmark = pytest.mark.asyncio
+
+
+class _SpyAdapter:
+    """Captures the response_content_disposition the service forwards and
+    returns a fake URL (so the policy is observable without S3)."""
+
+    def __init__(self) -> None:
+        self.dispositions: list[str | None] = []
+
+    async def presigned_get(self, key, ttl_seconds, response_content_disposition=None):
+        self.dispositions.append(response_content_disposition)
+        return f"https://signed.example/{key}"
+
+
+class _FakeMeta:
+    def __init__(self, rec) -> None:
+        self._rec = rec
+
+    async def get_scoped(self, file_id, workspace):
+        return self._rec
+
+
+async def _disposition_for(mime: str, filename: str = "file.bin") -> str | None:
+    rec = SimpleNamespace(
+        id="f1",
+        mime=mime,
+        filename=filename,
+        owner_id="u1",
+        storage_key="k1",
+        chat_id=None,
+    )
+    spy = _SpyAdapter()
+    svc = EEUploadService.__new__(EEUploadService)
+    svc._adapter = spy
+    svc._meta = _FakeMeta(rec)
+    svc._is_chat_member = None
+    svc._is_workspace_admin = None
+
+    got_rec, url = await svc.presigned_get("f1", "u1", "w1", 300)
+    assert url == "https://signed.example/k1"
+    assert got_rec is rec
+    return spy.dispositions[-1]
+
+
+@pytest.mark.parametrize(
+    "mime",
+    [
+        "text/html",
+        "image/svg+xml",
+        "text/javascript",
+        "application/zip",
+        "application/octet-stream",
+    ],
+)
+async def test_noninline_mimes_forced_attachment(mime: str) -> None:
+    disp = await _disposition_for(mime, filename="evil.bin")
+    assert disp is not None
+    assert disp.startswith("attachment;")
+
+
+@pytest.mark.parametrize(
+    "mime",
+    [
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "application/pdf",
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+    ],
+)
+async def test_inline_mimes_unchanged(mime: str) -> None:
+    # None ⇒ adapter/object default ⇒ inline, byte-identical to before the fix.
+    assert await _disposition_for(mime) is None
+
+
+async def test_disposition_filename_has_no_header_breakers() -> None:
+    disp = await _disposition_for("text/html", filename='a"b\r\n; drop.html')
+    assert disp is not None
+    assert "\r" not in disp and "\n" not in disp
+    # the quote that would close the filename token early is stripped
+    assert disp.count('"') == 2

--- a/tests/cloud/uploads/test_storage_bootstrap.py
+++ b/tests/cloud/uploads/test_storage_bootstrap.py
@@ -1,0 +1,70 @@
+# test_storage_bootstrap.py — ART-4 cloud upload/blob-storage boot guard.
+#
+# Locks verify_cloud_storage_backend()'s warn-then-error behavior: no-op off
+# cloud and on s3; WARN (no raise) when cloud + a non-s3 adapter; RAISE under
+# POCKETPAW_REQUIRE_S3_IN_CLOUD. is_multi_tenant_cloud() is monkeypatched so the
+# guard's cloud branch is exercised without standing up a real cloud DB.
+"""Tests for the cloud upload-backend boot guard."""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.uploads import bootstrap
+
+
+def _force_cloud(monkeypatch: pytest.MonkeyPatch, *, on: bool) -> None:
+    monkeypatch.setattr(bootstrap, "is_multi_tenant_cloud", lambda: on)
+
+
+def test_noop_off_cloud(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OFF cloud, local uploads are correct — the guard must not warn or raise."""
+    _force_cloud(monkeypatch, on=False)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+    monkeypatch.setenv("POCKETPAW_REQUIRE_S3_IN_CLOUD", "1")  # ignored off cloud
+    bootstrap.verify_cloud_storage_backend()  # no raise
+
+
+def test_noop_when_s3(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_cloud(monkeypatch, on=True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
+    bootstrap.verify_cloud_storage_backend()  # no raise
+
+
+def test_warns_when_cloud_and_local(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _force_cloud(monkeypatch, on=True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+    monkeypatch.delenv("POCKETPAW_REQUIRE_S3_IN_CLOUD", raising=False)
+    with caplog.at_level("WARNING"):
+        bootstrap.verify_cloud_storage_backend()  # warns, does NOT raise
+    assert "POCKETPAW_UPLOAD_ADAPTER" in caplog.text
+    assert "expected 's3'" in caplog.text
+
+
+def test_warns_when_adapter_unset(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unset adapter defaults to 'local' — same loud warning."""
+    _force_cloud(monkeypatch, on=True)
+    monkeypatch.delenv("POCKETPAW_UPLOAD_ADAPTER", raising=False)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_S3_IN_CLOUD", raising=False)
+    with caplog.at_level("WARNING"):
+        bootstrap.verify_cloud_storage_backend()
+    assert "POCKETPAW_UPLOAD_ADAPTER" in caplog.text
+
+
+def test_raises_under_require_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_cloud(monkeypatch, on=True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+    monkeypatch.setenv("POCKETPAW_REQUIRE_S3_IN_CLOUD", "1")
+    with pytest.raises(RuntimeError, match="POCKETPAW_UPLOAD_ADAPTER"):
+        bootstrap.verify_cloud_storage_backend()
+
+
+def test_require_flag_satisfied_by_s3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The hard-fail flag is moot when the adapter IS s3."""
+    _force_cloud(monkeypatch, on=True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
+    monkeypatch.setenv("POCKETPAW_REQUIRE_S3_IN_CLOUD", "true")
+    bootstrap.verify_cloud_storage_backend()  # no raise

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -415,6 +415,14 @@ class TestCwdJailHardening:
         guards against a future edit adding a generic cwd fallback in run()'s
         except handler (the known cloud-fail-closed-slips-past-green-OSS-CI
         pattern). Asserts the CLOUD branch — the resolver raises.
+
+        The OSS run() seam knows ONLY that the extension's ``agent_cwd`` raised;
+        it does not see the EE marker. In production (fix/cloud-artifacts-reland)
+        the EE resolver raises exactly when a cloud CHAT run — the
+        ``mark_cloud_chat_run`` dispatch — loses its workspace; the marker-gated
+        side of that contract is covered in tests/cloud/agents/test_agent_jail.py.
+        This mock stands in for that fail-closed without coupling the OSS test to
+        EE internals.
         """
         from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
 
@@ -424,6 +432,8 @@ class TestCwdJailHardening:
         backend._cli_available = True
 
         class FailClosedExt:
+            # Stands in for the EE resolver fail-closing on a marker-set cloud
+            # CHAT run that lost its workspace (the real mis-tenanting signal).
             def agent_cwd(self):
                 raise RuntimeError("no resolvable workspace_id")
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -7,8 +7,6 @@ Updated for multi-SDK architecture:
 - Removed: ExecutorProtocol, OrchestratorProtocol, pocketpaw_native, open_interpreter
 """
 
-from pathlib import Path
-
 import pytest
 
 from pocketpaw.config import Settings
@@ -154,14 +152,6 @@ class TestClaudeAgentSDK:
         assert sdk._stop_flag is False
         await sdk.stop()
         assert sdk._stop_flag is True
-
-    def test_sdk_set_working_directory(self):
-        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
-
-        sdk = ClaudeSDKBackend(Settings())
-        new_path = Path("/tmp")
-        sdk.set_working_directory(new_path)
-        assert sdk._cwd == new_path
 
     @pytest.mark.asyncio
     async def test_sdk_run_without_sdk_installed(self):
@@ -339,3 +329,140 @@ class TestClaudeSDKCliAuth:
 
         assert len(resolved_providers) > 0
         assert resolved_providers[0] == "anthropic"
+
+
+# =============================================================================
+# ART-2: per-run cwd resolution + fail-closed (agent_extensions seam)
+# =============================================================================
+
+
+class TestResolveCwd:
+    """``ClaudeSDKBackend._resolve_cwd`` — the OSS/cloud cwd gate.
+
+    OSS (no ``agent_extensions`` provider) must stay on ``file_jail_path``; an
+    EE provider's ``agent_cwd`` wins; a provider that RAISES (a cloud run with
+    no resolvable workspace) propagates — fail-closed, never a silent fallback.
+    """
+
+    def test_oss_defaults_to_file_jail_path(self, monkeypatch):
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: ())
+        settings = Settings()
+        backend = ClaudeSDKBackend(settings)
+        assert backend._resolve_cwd() == settings.file_jail_path
+
+    def test_extension_cwd_wins(self, monkeypatch, tmp_path):
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        jail = tmp_path / "jail" / "wsX"
+
+        class FakeExt:
+            def agent_cwd(self):
+                return str(jail)
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: (FakeExt(),))
+        backend = ClaudeSDKBackend(Settings())
+        assert backend._resolve_cwd() == jail
+
+    def test_extension_raise_propagates_fail_closed(self, monkeypatch):
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        class FailClosedExt:
+            def agent_cwd(self):
+                raise RuntimeError("no resolvable workspace_id")
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: (FailClosedExt(),))
+        backend = ClaudeSDKBackend(Settings())
+        with pytest.raises(RuntimeError, match="no resolvable workspace_id"):
+            backend._resolve_cwd()
+
+    def test_extension_returning_none_falls_back(self, monkeypatch):
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        class NoneExt:
+            def agent_cwd(self):
+                return None
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: (NoneExt(),))
+        settings = Settings()
+        backend = ClaudeSDKBackend(settings)
+        assert backend._resolve_cwd() == settings.file_jail_path
+
+    def test_provider_without_agent_cwd_ignored(self, monkeypatch):
+        # A provider predating agent_cwd must not break resolution.
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        class OldExt:
+            def subprocess_env(self):
+                return {}
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: (OldExt(),))
+        settings = Settings()
+        backend = ClaudeSDKBackend(settings)
+        assert backend._resolve_cwd() == settings.file_jail_path
+
+
+class TestCwdJailHardening:
+    """ART-2 hardening: run()-level fail-closed lock + cwd in the cache key."""
+
+    @pytest.mark.asyncio
+    async def test_run_fails_closed_no_home_fallback(self, monkeypatch):
+        """A cloud run whose cwd resolver RAISES must surface an error event and
+        NEVER execute the agent with a file_jail_path / home fallback cwd.
+
+        Locks the fail-closed at the run() seam, not just the _resolve_cwd unit:
+        guards against a future edit adding a generic cwd fallback in run()'s
+        except handler (the known cloud-fail-closed-slips-past-green-OSS-CI
+        pattern). Asserts the CLOUD branch — the resolver raises.
+        """
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        settings = Settings()
+        backend = ClaudeSDKBackend(settings)
+        backend._sdk_available = True
+        backend._cli_available = True
+
+        class FailClosedExt:
+            def agent_cwd(self):
+                raise RuntimeError("no resolvable workspace_id")
+
+        monkeypatch.setattr("pocketpaw._registry.providers", lambda group: (FailClosedExt(),))
+
+        # Capture the cwd of every SDK-options construction — the only gateway
+        # to actually launching the agent. On the fail-closed path the resolver
+        # raises first, so options are never built at all.
+        built_cwds: list[str | None] = []
+
+        def spy_options(**kwargs):
+            built_cwds.append(kwargs.get("cwd"))
+            raise RuntimeError("options must not be built on the fail-closed path")
+
+        backend._ClaudeAgentOptions = spy_options
+
+        events = [e async for e in backend.run("hi", session_key="s1")]
+
+        # (1) the run surfaces an error event
+        assert any(e.type == "error" for e in events)
+        # (2) the agent NEVER executed with a home / file_jail_path fallback cwd
+        assert str(settings.file_jail_path) not in built_cwds
+        # in fact nothing was built — the raise precedes options construction
+        assert built_cwds == []
+
+    def test_cache_key_includes_cwd(self):
+        """Two different resolved cwds → different cache keys (no warm-client
+        reuse across tenants); identical inputs → identical key (reuse kept)."""
+        from types import SimpleNamespace
+
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        def opts(cwd):
+            return SimpleNamespace(
+                cwd=cwd, model="claude-x", allowed_tools=["Read"], system_prompt="p"
+            )
+
+        key_a = ClaudeSDKBackend._client_cache_key(opts("/jail/wsA/agent/s1"), session_key="s1")
+        key_b = ClaudeSDKBackend._client_cache_key(opts("/jail/wsB/agent/s1"), session_key="s1")
+        key_a2 = ClaudeSDKBackend._client_cache_key(opts("/jail/wsA/agent/s1"), session_key="s1")
+        assert key_a != key_b
+        assert key_a == key_a2

--- a/tests/test_fast_path.py
+++ b/tests/test_fast_path.py
@@ -287,6 +287,7 @@ async def test_persistent_client_reuse():
     options1 = MagicMock()
     options1.model = "claude-sonnet-4-5-20250929"
     options1.allowed_tools = ["Bash", "Read"]
+    options1.cwd = "/jail/ws"  # cwd is part of the cache key (ART-2)
 
     # First call — creates client
     client1 = await sdk._get_or_create_client(options1)
@@ -297,6 +298,7 @@ async def test_persistent_client_reuse():
     options2 = MagicMock()
     options2.model = "claude-sonnet-4-5-20250929"
     options2.allowed_tools = ["Bash", "Read"]
+    options2.cwd = "/jail/ws"  # same cwd → same key → warm reuse
 
     client2 = await sdk._get_or_create_client(options2)
     assert len(clients_created) == 1  # No new client created
@@ -333,6 +335,37 @@ async def test_persistent_client_reconnects_on_model_change():
     assert len(clients_created) == 2
     assert client2 is not client1
     assert client1.disconnected  # Old client was disconnected
+
+
+async def test_persistent_client_reconnects_on_cwd_change():
+    """Same session + model + tools but a DIFFERENT cwd (another tenant's jail)
+    must create a fresh client, never reuse the warm one (ART-2). Locks warm-
+    client tenant isolation as structural, not implicit in session_key."""
+    sdk = _make_sdk()
+
+    clients_created = []
+
+    def _client_factory(**kwargs):
+        c = _FakeSDKClient()
+        clients_created.append(c)
+        return c
+
+    sdk._ClaudeSDKClient = _client_factory
+
+    options1 = MagicMock()
+    options1.model = "claude-sonnet-4-5-20250929"
+    options1.allowed_tools = ["Bash"]
+    options1.cwd = "/jail/wsA/agent/s1"
+    client1 = await sdk._get_or_create_client(options1, session_key="s1")
+    assert len(clients_created) == 1
+
+    options2 = MagicMock()
+    options2.model = "claude-sonnet-4-5-20250929"
+    options2.allowed_tools = ["Bash"]
+    options2.cwd = "/jail/wsB/agent/s1"  # different tenant, same session_key
+    client2 = await sdk._get_or_create_client(options2, session_key="s1")
+    assert len(clients_created) == 2
+    assert client2 is not client1
 
 
 async def test_persistent_client_falls_back_to_query():

--- a/tests/uploads/test_s3_adapter.py
+++ b/tests/uploads/test_s3_adapter.py
@@ -126,6 +126,28 @@ async def test_presigned_get_returns_url():
     )
 
 
+async def test_presigned_get_forwards_content_disposition():
+    """A disposition is forwarded as ResponseContentDisposition so non-inline
+    content (delivered HTML/SVG) downloads instead of rendering on the origin."""
+    client = MagicMock()
+    client.generate_presigned_url.return_value = "https://s3.example.com/signed"
+    adapter = _make_adapter(client)
+
+    await adapter.presigned_get(
+        "k", 300, response_content_disposition='attachment; filename="evil.html"'
+    )
+
+    client.generate_presigned_url.assert_called_once_with(
+        "get_object",
+        Params={
+            "Bucket": "test-bucket",
+            "Key": "k",
+            "ResponseContentDisposition": 'attachment; filename="evil.html"',
+        },
+        ExpiresIn=300,
+    )
+
+
 async def test_presigned_get_swallows_errors():
     client = MagicMock()
     client.generate_presigned_url.side_effect = RuntimeError("boom")


### PR DESCRIPTION
Re-lands the cloud agent-artifacts feature (reverted from dev as #1573 due to a CI regression), with the regression fixed.

**The #1570 regression:** the per-tenant cwd fail-closed (`resolve_agent_cwd`) gated on `is_multi_tenant_cloud()` — a process-global, true whenever the cloud Mongo client is connected. So every workspace-less agent run in a cloud-connected process hard-failed; in the full test suite a leaked `_client` global broke claude-sdk prewarm/warm-client + a broad set of ee tests, and the same gate would hard-fail legitimate non-tenant agent runs in a real cloud process.

**The fix:** a positive per-run marker `current_cloud_chat_run` (set by `run_core.execute_run`, the sole cloud chat-run dispatch ancestor, before identity binding so a run that fails to bind still trips the guard). Fail-closed now fires only when `not workspace_id AND is_multi_tenant_cloud() AND current_cloud_chat_run()` — i.e. only for an actual cloud chat run. Non-chat runs (CLI/background/tests) fall back to `file_jail_path` (pre-ART-2 behavior). Proven reproduce-then-fix: a durable `_client` leak + prewarm tests reproduces the red with the fix stashed out, green with it in.

Everything else is #1570 unchanged (full feature + reviews + the captain's 6/6 live smoke). The only addition is the gate fix (1 commit, 6 files: marker + execute_run wrap + tightened gate + tests).

**Gate:** merge only on a FULL green CI matrix — the #1570 miss was trusting targeted tests over the full suite.