### PR TITLE
ci: cut PR test time (dedupe suite, trim matrix, deflake limiter test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@
 # image-build time). Lives in this workflow (not workflow_run) because the
 # repo's default branch is main — workflow_run triggers only fire from the
 # default branch's file, and main lags dev.
+# Updated: 2026-06-27 — CI speed: the `test` job now runs the full 3.11/3.12/
+# 3.13 matrix only on push to dev/main; PRs test 3.12 alone (the prod version,
+# per the Dockerfile), so version-specific breaks are still caught at the merge
+# gate. The duplicate full-suite run in tests.yaml was removed in the same pass.
 name: CI
 
 on:
@@ -159,7 +163,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        # PRs test only the prod version (3.12, per the Dockerfile) for speed;
+        # the full 3.11/3.12/3.13 matrix runs on push to dev/main so version-
+        # specific breaks are still caught at the merge gate.
+        python-version: ${{ (github.event_name == 'push') && fromJSON('["3.11", "3.12", "3.13"]') || fromJSON('["3.12"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,11 +6,13 @@
 # Updated: 2026-05-25 — Triggers added for feat/*-integration branches so
 # sub-PRs in a multi-PR RFC rollout get full CI coverage during integration.
 # Stale `ee` branch reference dropped (the ee branch was deprecated 2026-05-21).
-# Updated: 2026-06-26 — Added the `pytest-flag-mode` job (FU-4): the OSS pytest
-# lane above runs WITHOUT POCKETPAW_REQUIRE_WORKSPACE_SCOPE, so cloud fail-closed
-# (per-workspace physical isolation) regressions pass green. The new job re-runs
-# the isolation subset WITH the flag set so the whole bug class the C1 fix closed
-# stays caught. Both jobs are required.
+# Updated: 2026-06-26 — Added the `pytest-flag-mode` job (FU-4): re-runs the
+# isolation subset WITH POCKETPAW_REQUIRE_WORKSPACE_SCOPE=1 so cloud fail-closed
+# (per-workspace physical isolation) regressions are caught (the full suite runs
+# WITHOUT the flag, over in ci.yml). Required.
+# Updated: 2026-06-27 — Removed the duplicate `pytest` job: it re-ran the full
+# suite already covered by ci.yml's `test` matrix (which includes 3.12). This
+# file is now the flag-mode lane only.
 name: Tests
 
 on:
@@ -24,50 +26,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pytest:
-    name: pytest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-
-      - name: Set Python version
-        run: uv python install 3.12
-
-      - name: Install dependencies
-        # --all-extras pulls every optional core extra (soul, vector, etc.).
-        # The enterprise layer is the separate `pocketpaw-ee` package since the
-        # OSS-EE split (Phase 4) — install it editable so tests/ee can import
-        # pocketpaw_ee (beanie / motor / fastapi-users ship as its deps).
-        # Cold-start installs are heavier (~60 s on cache miss because chromadb
-        # pulls onnxruntime, plus a few smaller wheels) but uv's cache keeps
-        # subsequent runs fast.
-        run: uv sync --dev --all-extras --group ee
-
-      - name: Run pytest
-        # No -x: this is a PR gate, surface ALL failures, not just the first.
-        # --deselect entries are pre-existing failures the gate caught on first
-        # run (#1066). Tracked separately so the gate stays green for new
-        # changes and goes red when someone introduces a new regression:
-        #   - #1079: tests/test_concurrency.py — list-membership flakes
-        #   - #1080: tests/test_context_budget.py::TestKbContext::test_successful_kb_fetch
-        # Remove the corresponding --deselect once each issue lands its fix.
-        run: |
-          uv run pytest tests/ \
-            --ignore=tests/e2e \
-            --ignore=tests/test_frontend_syntax.py \
-            --deselect tests/test_concurrency.py::test_session_lock_serialises_same_session \
-            --deselect tests/test_concurrency.py::test_cross_session_runs_in_parallel \
-            --deselect tests/test_concurrency.py::test_global_semaphore_caps_concurrency \
-            --deselect tests/test_context_budget.py::TestKbContext::test_successful_kb_fetch \
-            -q --tb=short
-        env:
-          POCKETPAW_LLM_PROVIDER: "ollama"
-          POCKETPAW_OLLAMA_HOST: "http://localhost:11434"
-
   pytest-flag-mode:
     # FU-4 — the cloud paw-OS deployment runs EVERY store path with
     # POCKETPAW_REQUIRE_WORKSPACE_SCOPE=1 (fail-closed per-workspace physical

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -753,7 +753,14 @@ class TestFullAccessApiLimiterExemption:
         from pocketpaw.dashboard_auth import _auth_dispatch
         from pocketpaw.security.rate_limiter import RateLimiter
 
-        fresh = RateLimiter(rate=10.0, capacity=30)
+        # rate=0: a no-refill bucket. The cap (capacity 30) is what this test
+        # guards — an unauthenticated flood must still get a 429. With the real
+        # rate=10/s refill, a loaded CI runner spent enough time per await that
+        # the bucket refilled mid-flood and never fully drained, so the 429
+        # never fired → intermittent false green (the recurring CI flake). Zero
+        # refill makes "40 requests > capacity 30 → 429" deterministic without
+        # weakening what the test guards.
+        fresh = RateLimiter(rate=0.0, capacity=30)
         saw_429 = False
         with (
             patch("pocketpaw.dashboard_auth.api_limiter", fresh),


### PR DESCRIPTION
## What this does

PR CI ran the full test suite about five times: `test-oss`, the 3.11/3.12/3.13 matrix, and a `pytest` job in tests.yaml that re-ran what the matrix already covers. This trims the redundancy without losing coverage.

## Changes

- Drop the duplicate `pytest` job from tests.yaml. It ran the exact same command as ci.yml's `test` matrix, which already includes 3.12, so it was pure duplication. The flag-mode lane (the unique one) stays.
- PR matrix down to one version. The full 3.11/3.12/3.13 matrix now runs only on push to dev/main. PRs test 3.12, which is what the Dockerfile ships, so a version-specific break still gets caught when the branch merges to dev.
- Deflake `test_unauthenticated_flood_still_limited`. The token bucket refilled mid-flood on loaded runners (rate 10/s), so the 40-request flood never drained the 30-token bucket and the 429 never fired. This one tripped on #1560, dev, and #1571. A no-refill bucket (rate 0) makes the capacity cap deterministic and keeps the security check intact.

## Effect

The jobs run in parallel, so the single slowest job still gates time-to-green (about 5 minutes for one matrix run). What this actually buys:

- CI compute drops roughly threefold, about five full-suite runs down to two (test-oss, one matrix job, the flag-mode lane). Fewer runner-minutes, and less queue pressure when the pool is busy.
- The deflake removes the re-run tax. A tripped flake used to cost a full extra run, around 5 minutes, every time it hit.

Cutting the single 5-minute job itself needs pytest-xdist (see follow-up). This PR's own checks show the new shape: one Test (Python 3.12), no standalone pytest.

## Verification

Ran the deflaked class three times locally, all green: `tests/test_dashboard_security.py::TestFullAccessApiLimiterExemption` (3 passed each run). YAML for both workflows parses and the matrix expression resolves. The PR's own CI is green with the trimmed shape.

## Follow-up (separate)

pytest-xdist (`-n auto`) for in-job parallelism is the real wall-clock lever, roughly two to three times faster per job, but it needs a parallel-safety pass first since the suite has known global-state coupling (the prewarm `_client` incident). Not in this PR.