### PR TITLE
test: make 10 tests hermetic so they pass in isolation

### DIFF
--- a/tests/test_api_serve.py
+++ b/tests/test_api_serve.py
@@ -1,4 +1,13 @@
-"""Tests for the ``pocketpaw serve`` API-only server."""
+"""Tests for the ``pocketpaw serve`` API-only server.
+
+Updated: 2026-06-27 (test hermeticity for pytest-xdist) — test_sessions_endpoint
+now satisfies the EE ``require_license`` dependency in-process via a per-test
+``app.dependency_overrides`` no-op (mirroring tests/cloud/conftest.py). In an
+isolated process no ``POCKETPAW_LICENSE_KEY`` is set, so the EE sessions router's
+license gate returned 403; the full serial suite only passed because an earlier
+test had cached a license. The override is a no-op when ee.cloud is absent, so
+the 200 (core router) / 401 (EE auth) assertion is unchanged.
+"""
 
 import socket
 from unittest.mock import MagicMock, patch
@@ -54,12 +63,34 @@ class TestAPIAppStructure:
         resp = client.get("/api/v1/backends")
         assert resp.status_code == 200
 
-    def test_sessions_endpoint(self, _mock, client):
-        resp = client.get("/api/v1/sessions")
+    def test_sessions_endpoint(self, _mock, api_app, client):
         # When ee.cloud is installed, the enterprise sessions router takes
-        # precedence and requires JWT auth (401).  The core sessions router
-        # returns 200 when ee is absent.
-        assert resp.status_code in (200, 401)
+        # precedence and gates on a license (403 with no key) then JWT auth
+        # (401).  Satisfy the license dependency in-process so the route
+        # reaches its auth check; without this the test depends on an earlier
+        # test having cached a license (non-hermetic under pytest-xdist).
+        try:
+            from pocketpaw_ee.cloud.license import require_license
+
+            async def _license_ok():
+                return None
+
+            api_app.dependency_overrides[require_license] = _license_ok
+        except ImportError:
+            # ee.cloud absent — core sessions router returns 200, no gate.
+            pass
+
+        try:
+            resp = client.get("/api/v1/sessions")
+            # ee present + licensed → 401 (JWT required); ee absent → 200.
+            assert resp.status_code in (200, 401)
+        finally:
+            try:
+                from pocketpaw_ee.cloud.license import require_license
+
+                api_app.dependency_overrides.pop(require_license, None)
+            except ImportError:
+                pass
 
     def test_skills_endpoint(self, _mock, client):
         resp = client.get("/api/v1/skills")

--- a/tests/test_google_adk_backend.py
+++ b/tests/test_google_adk_backend.py
@@ -1,4 +1,16 @@
-"""Tests for Google ADK backend — mocked (no real SDK needed)."""
+"""Tests for Google ADK backend — mocked SDK surface, real genai types.
+
+Updated: 2026-06-27 (test hermeticity for pytest-xdist) — back the mocked
+``google.genai`` module's ``types`` namespace with the REAL
+``google.genai.types`` module instead of a bare ``MagicMock``. The backend's
+run() path lazily imports ``google.adk`` (whose pydantic models annotate fields
+with ``genai.types.Content`` / ``.Part`` / etc.); a bare MagicMock ``types``
+made pydantic raise ``PydanticSchemaGenerationError`` on first cold import,
+so every TestGoogleADKRun test failed when run in isolation. Whenever the ADK
+run path executes, ``google.adk`` is importable, which guarantees its hard
+dependency ``google.genai`` is too — so the real types are always available
+here. The rest of ``google.genai`` stays mocked.
+"""
 
 import sys
 from types import SimpleNamespace
@@ -9,10 +21,18 @@ import pytest
 from pocketpaw.agents.backend import Capability
 from pocketpaw.config import Settings
 
-# --- Mock google.genai.types for all run() tests ---
-_mock_genai_types = MagicMock()
+# --- Mock the google.genai module surface, but back its ``types`` namespace
+# with the real google.genai.types so ADK's pydantic models can build schemas.
 _mock_genai = MagicMock()
-_mock_genai.types = _mock_genai_types
+try:
+    import google.genai.types as _real_genai_types
+
+    _mock_genai.types = _real_genai_types
+except ImportError:  # pragma: no cover — ADK/genai not installed in this env
+    _mock_genai.types = MagicMock()
+
+# Backwards-compatible alias retained for any external reference.
+_mock_genai_types = _mock_genai.types
 
 
 class TestGoogleADKInfo:

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -305,8 +305,37 @@ def _auth_headers():
     return {"Authorization": f"Bearer {_TEST_TOKEN}"}
 
 
+@pytest.fixture
+def _file_backed_memory_store(tmp_path):
+    """Point the global memory manager at a delete/title-capable FileMemoryStore.
+
+    The session REST routes resolve the store via ``get_memory_manager()._store``
+    and only support delete / rename / search when that store exposes
+    ``delete_session`` / ``update_session_title`` / ``_load_session_index``.
+    In an isolated process the default backend can be a non-file store (e.g.
+    the EE MongoMemoryStore), which lacks those methods, so the routes return
+    501 instead of the 404/200 the tests assert. Swap in a tmp-path
+    FileMemoryStore for the test's duration, then restore the original so we
+    never persist to or read from the real ``~/.pocketpaw``.
+    """
+    from pocketpaw.memory import FileMemoryStore, get_memory_manager
+
+    manager = get_memory_manager()
+    original_store = manager._store
+    manager._store = FileMemoryStore(base_path=tmp_path)
+    try:
+        yield manager._store
+    finally:
+        manager._store = original_store
+
+
 class TestSessionsRESTEndpoints:
     """Test dashboard REST endpoints for sessions."""
+
+    @pytest.fixture(autouse=True)
+    def _hermetic_store(self, _file_backed_memory_store):
+        """Ensure every REST endpoint test runs against the file-backed store."""
+        yield _file_backed_memory_store
 
     @pytest.fixture
     def client(self, _mock_auth):
@@ -371,6 +400,33 @@ class TestWebSocketSessionSwitching:
         ws_limiter._buckets.clear()
 
     @pytest.fixture
+    def _hermetic_home_store(self, tmp_path, monkeypatch):
+        """Redirect ``~`` and the global memory store under tmp_path.
+
+        ``dashboard_ws`` gates a resume on a file existing at the hardcoded
+        ``Path.home() / ".pocketpaw" / "memory" / "sessions"`` and then loads
+        history through ``get_memory_manager()._store``. Point both at the same
+        tmp-path location so the resume test stays fully isolated from the real
+        ``~/.pocketpaw`` while exercising the genuine resume-reads-persisted-
+        session path. Returns the swapped FileMemoryStore so the test can write
+        its session file under ``store.sessions_path``.
+        """
+        from pocketpaw.memory import FileMemoryStore, get_memory_manager
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+
+        store = FileMemoryStore(base_path=fake_home / ".pocketpaw" / "memory")
+        manager = get_memory_manager()
+        original_store = manager._store
+        manager._store = store
+        try:
+            yield store
+        finally:
+            manager._store = original_store
+
+    @pytest.fixture
     def client(self, _mock_auth):
         from fastapi.testclient import TestClient
 
@@ -407,10 +463,15 @@ class TestWebSocketSessionSwitching:
             assert data["type"] == "session_history"
             assert data["messages"] == []
 
-    def test_websocket_resume_session(self, client):
-        """Test resume_session query parameter."""
-        # Create a session file
-        sessions_dir = Path.home() / ".pocketpaw" / "memory" / "sessions"
+    def test_websocket_resume_session(self, client, _hermetic_home_store):
+        """Test resume_session query parameter.
+
+        Writes the persisted session under the swapped store's sessions path
+        (which lives under a tmp-path fake home), so the resume path is
+        exercised end-to-end without reading or writing the real ~/.pocketpaw.
+        """
+        store = _hermetic_home_store
+        sessions_dir = store.sessions_path
         sessions_dir.mkdir(parents=True, exist_ok=True)
         test_id = str(uuid.uuid4())
         safe_key = f"websocket_{test_id}"

--- a/tests/test_tool_bridge.py
+++ b/tests/test_tool_bridge.py
@@ -52,8 +52,16 @@ class TestInstantiateAllTools:
         """If a tool module fails to import, it's skipped without crashing."""
         from pocketpaw.agents.tool_bridge import _instantiate_all_tools
 
-        # Patch one module to raise ImportError
-        with patch("importlib.import_module") as mock_import:
+        # Patch one module to raise ImportError. Also pin the global soul
+        # manager to None: _instantiate_all_tools appends soul tools after the
+        # builtin loop via a direct import that the import_module mock does not
+        # block, so a soul left active by an earlier test on the same xdist
+        # worker would make `tools` non-empty. Pinning it keeps this test
+        # hermetic — it asserts only the builtin import-error path.
+        with (
+            patch("importlib.import_module") as mock_import,
+            patch("pocketpaw.soul.get_soul_manager", return_value=None),
+        ):
             mock_import.side_effect = ImportError("test failure")
             tools = _instantiate_all_tools()
             # Should return empty list (all tools failed to import)


### PR DESCRIPTION
## What this fixes

Ten tests passed in the full serial suite but failed when run in isolation. They depended on global state that an earlier test happened to set up, so on their own they did not prove what they claim. This makes them self-sufficient without weakening any assertion.

These surfaced while evaluating pytest-xdist. Turning on parallel test runs is deferred (the suite has more non-hermeticity to clean up first), but these fixes are worth landing on their own.

## The fixes

google_adk backend (5 tests): the mocked `google.genai.types` was a bare MagicMock, so ADK's pydantic models raised PydanticSchemaGenerationError on a cold import. The `types` namespace is now backed by the real `google.genai.types`, which is always importable when the ADK run path executes.

session REST and WebSocket endpoints (3 tests): swap the global memory manager's `_store` to a tmp-path FileMemoryStore for the test, then restore it. The WebSocket resume test also stops writing to the real `~/.pocketpaw` by pointing `Path.home()` at a tmp directory. It was creating session files in the developer's actual home directory.

api serve sessions endpoint (1 test): satisfy the EE `require_license` dependency in-process with `dependency_overrides` (the same pattern as tests/cloud/conftest), instead of relying on a license another test cached.

tool_bridge import-error test (1 test): pin the global soul manager to None so soul tools activated by an earlier test do not leak in and break the "all imports failed, so the list is empty" assertion.

## Verification

Each fixed test now passes alone in a fresh process. No assertions were weakened and all global state is restored.

## The standout

The `~/.pocketpaw` write: running the suite locally was creating real session files in the developer's home directory. That stops now.