### PR TITLE
fix(billing): return the buyer to the app after Dodo subscription checkout

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/domain.py
+++ b/ee/pocketpaw_ee/cloud/billing/domain.py
@@ -27,6 +27,11 @@
 #   subscription metadata's ``site_id`` (stamped at per-site subscribe time); a
 #   workspace-plan sub carries no ``site_id`` (""), so the webhook routes it to the
 #   workspace path. Defaults "" so a BC-7 workspace-plan delivery is unchanged.
+# Updated 2026-06-28 (fix/billing-checkout-sessions): documented that
+#   ``SubscriptionCheckout.subscription_id`` now carries the Dodo CHECKOUT SESSION
+#   id (the subscription is created at payment, not at checkout-create), with the
+#   real gateway subscription id arriving on the subscription.active webhook. Field
+#   shape is unchanged (no breaking change to the consumers / sites flow).
 
 from __future__ import annotations
 
@@ -72,9 +77,16 @@ class SubscriptionCheckout:
     """A created RECURRING-subscription hosted checkout, normalized across gateways.
 
     ``checkout_url`` is the hosted page the buyer is redirected to to confirm the
-    subscription. ``subscription_id`` is the gateway's own id for the created
-    subscription (Dodo's ``subscription_id``), kept so a later cancel / change can
-    address it and so the renewal webhook can be reconciled against it.
+    subscription. ``subscription_id`` is a gateway reference for the created
+    checkout kept for reconciliation / a later cancel or change.
+
+    NOTE (fix/billing-checkout-sessions): Dodo now opens a CHECKOUT SESSION, where
+    the subscription is created at PAYMENT time, not at checkout-create time — so
+    this field carries the SESSION id (``cks_…``) the create call returns, not the
+    final ``sub_…``. The authoritative gateway subscription id arrives later on the
+    verified ``subscription.active`` webhook body (``data.subscription_id``), which
+    is what the credit grant + the Subscription audit row key on; the session id
+    stamped here at checkout time is a pre-payment placeholder for that slot.
     """
 
     checkout_url: str

--- a/ee/pocketpaw_ee/cloud/billing/providers/base.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/base.py
@@ -95,14 +95,25 @@ class IPaymentsProvider(ABC):
         workspace_id: str,
         customer_email: str | None,
         metadata: dict,
+        return_url: str | None = None,
+        cancel_url: str | None = None,
     ) -> SubscriptionCheckout:
-        """Create a RECURRING subscription and return its hosted checkout.
+        """Create a RECURRING subscription checkout and return its hosted url.
 
         ``product_id`` is the gateway's recurring-product id for the tier
         (resolved by the service from config). The provider attaches ``metadata``
         — which MUST carry ``workspace_id`` AND ``plan_key`` so the renewal
         webhook can route the grant back to the right wallet at the right tier —
-        and returns the hosted ``checkout_url`` plus the gateway ``subscription_id``.
+        and returns the hosted ``checkout_url`` plus a gateway reference in
+        ``SubscriptionCheckout.subscription_id``.
+
+        ``return_url`` / ``cancel_url`` are where the buyer is sent back AFTER pay
+        / cancel — without them the buyer is stranded on the gateway. They are
+        OPTIONAL: a flow with no return base (e.g. server-side publish) passes
+        neither, and the provider omits them. When the gateway models the checkout
+        as a SESSION (the subscription is created at payment, not at create time),
+        ``SubscriptionCheckout.subscription_id`` carries the SESSION id; the real
+        gateway subscription id then arrives on the subscription.active webhook.
         """
         raise NotImplementedError
 

--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -348,9 +348,7 @@ class DodoProvider:
                 "billing.no_checkout_url",
                 "Dodo did not return a checkout session url for the subscription.",
             )
-        return SubscriptionCheckout(
-            checkout_url=str(checkout_url), subscription_id=str(session_id)
-        )
+        return SubscriptionCheckout(checkout_url=str(checkout_url), subscription_id=str(session_id))
 
     async def cancel_subscription(self, subscription_id: str) -> None:
         if not subscription_id:

--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -39,13 +39,22 @@
 #
 # SUBSCRIPTIONS (BC-7), again adapting the real SDK:
 #
-#   * ``create_subscription`` — calls ``client.subscriptions.create(...)`` with a
-#     single ``product_id`` (NOT a product_cart — the SDK's subscription create
-#     takes one recurring product id + a ``quantity``, unlike the one-time cart),
-#     ``payment_link=True`` for a HOSTED checkout, and ``metadata={"workspace_id",
-#     "plan_key"}`` so the renewal webhook can route the grant to the right wallet
-#     at the right tier. The hosted url is ``response.payment_link``; the gateway
-#     subscription ref is ``response.subscription_id``.
+#   * ``create_subscription`` — opens a CHECKOUT SESSION via
+#     ``client.checkout_sessions.create(...)``: a recurring ``product_cart`` line
+#     ([{product_id, quantity:1}]) creates the SUBSCRIPTION at payment time,
+#     ``return_url`` / ``cancel_url`` send the buyer back to the app afterward,
+#     ``customer`` carries the email, ``billing_address.country`` keeps the
+#     configurable billing country (IN+INR → UPI), and ``metadata={"workspace_id",
+#     "plan_key"}`` lets the renewal webhook route the grant. The response is a
+#     SESSION: the hosted url is ``response.checkout_url`` and ``response.session_id``
+#     is carried on ``SubscriptionCheckout.subscription_id`` (the real gateway
+#     subscription id is created at payment and arrives on the subscription.active
+#     webhook body, NOT from this create call).
+#
+#     WHY checkout sessions (the fix): the prior ``subscriptions.create(
+#     payment_link=True)`` call accepted NO return_url, so after paying on Dodo the
+#     buyer was stranded — the app never got them back. Checkout Sessions is the
+#     Dodo API that supports return_url + cancel_url.
 #
 #   * ``cancel_subscription`` — calls ``client.subscriptions.update(<id>,
 #     status="cancelled")`` (the SDK has no ``.cancel`` — cancellation is a status
@@ -79,6 +88,15 @@
 #   WORKSPACE-plan sub. A per-site subscribe stamps ``site_id`` on the metadata;
 #   the service routes a delivery with one to the site, without one to the
 #   workspace path. No new SDK call — site subs reuse ``create_subscription``.
+# Updated 2026-06-28 (fix/billing-checkout-sessions): ``create_subscription`` now
+#   opens a Dodo CHECKOUT SESSION (``checkout_sessions.create``) instead of
+#   ``subscriptions.create(payment_link=True)``. The old call accepted no
+#   return_url, stranding the buyer after payment; the session carries return_url +
+#   cancel_url (threaded in from the caller's Origin) so the buyer is returned to
+#   the app. The recurring product rides as a ``product_cart`` line and the
+#   subscription is created at payment; the response ``session_id`` is carried on
+#   ``SubscriptionCheckout.subscription_id``. The webhook grant is untouched (it
+#   reads the subscription_id + metadata off the event body, not this response).
 
 from __future__ import annotations
 
@@ -269,6 +287,8 @@ class DodoProvider:
         workspace_id: str,
         customer_email: str | None,
         metadata: dict,
+        return_url: str | None = None,
+        cancel_url: str | None = None,
     ) -> SubscriptionCheckout:
         if not plan_key:
             raise ValidationError("billing.invalid_plan", "plan_key is required")
@@ -288,29 +308,48 @@ class DodoProvider:
         meta["workspace_id"] = str(workspace_id)
         meta["plan_key"] = str(plan_key)
 
-        # The SDK's subscription create takes a SINGLE recurring product_id +
-        # quantity (NOT a product_cart like the one-time path). payment_link=True
-        # returns a HOSTED checkout url on ``response.payment_link``.
-        client = self._client()
-        response = await client.subscriptions.create(
-            billing={"country": self._billing_country},
-            customer=_customer_param(customer_email),
-            product_id=product_id,
-            quantity=1,
-            payment_link=True,
-            metadata=meta,
-        )
+        # CHECKOUT SESSIONS (the fix): ``subscriptions.create(payment_link=True)``
+        # accepts NO return_url, so the buyer was stranded after paying on Dodo.
+        # The Checkout Sessions API DOES carry return_url + cancel_url. A recurring
+        # product passed as a ``product_cart`` line creates the SUBSCRIPTION at
+        # payment time; the response is a SESSION (checkout_url + session_id), and
+        # the real subscription_id arrives later on the verified subscription.active
+        # webhook body — NOT from this create call.
+        #
+        # ``billing_address.country`` (was ``billing={"country": ...}`` on the old
+        # subscriptions API) preserves the configurable billing country so IN+INR
+        # products still surface UPI; the buyer can change it on the hosted page.
+        create_kwargs: dict[str, Any] = {
+            "product_cart": [{"product_id": product_id, "quantity": 1}],
+            "customer": _customer_param(customer_email),
+            "billing_address": {"country": self._billing_country},
+            "metadata": meta,
+        }
+        # Only attach return_url/cancel_url when the caller supplied a base — Dodo
+        # treats a missing return_url as "no redirect"; sending an empty string is
+        # worse than omitting it. The sites publish path passes neither.
+        if return_url:
+            create_kwargs["return_url"] = return_url
+        if cancel_url:
+            create_kwargs["cancel_url"] = cancel_url
 
-        checkout_url = getattr(response, "payment_link", None)
-        subscription_id = getattr(response, "subscription_id", "") or ""
+        client = self._client()
+        response = await client.checkout_sessions.create(**create_kwargs)
+
+        checkout_url = getattr(response, "checkout_url", None)
+        # The session id is repurposed onto SubscriptionCheckout.subscription_id —
+        # the create response has no subscription yet (it's created at payment). The
+        # authoritative gateway subscription_id comes in on the webhook body.
+        session_id = getattr(response, "session_id", "") or ""
         if not checkout_url:
-            # payment_link is only populated when payment_link=True succeeds.
+            # checkout_url is None only when payment_method_id was passed (we never
+            # do) or the create failed — treat a missing url as a hard error.
             raise ValidationError(
                 "billing.no_checkout_url",
-                "Dodo did not return a hosted payment link for the subscription.",
+                "Dodo did not return a checkout session url for the subscription.",
             )
         return SubscriptionCheckout(
-            checkout_url=str(checkout_url), subscription_id=str(subscription_id)
+            checkout_url=str(checkout_url), subscription_id=str(session_id)
         )
 
     async def cancel_subscription(self, subscription_id: str) -> None:

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -24,10 +24,15 @@
 #   catalog (each tier -> annual price + the Cloudflare features it resells). Like
 #   /billing/plans it is tenant-independent (no workspace scoping); the frontend
 #   (BC-11) reads it to render the publish tier picker.
+# Updated 2026-06-28 (fix/billing-checkout-sessions): POST /billing/subscribe now
+#   reads the buyer's Origin (fallback Referer) header via ``_request_origin`` and
+#   threads it to ``billing_service.subscribe(origin=...)`` so the Dodo checkout
+#   session returns the buyer to the app's billing page after pay / cancel (the
+#   prior payment-link checkout had nowhere to send them).
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from pocketpaw_ee.cloud.billing import plans as plan_catalog
 from pocketpaw_ee.cloud.billing import service as billing_service
@@ -94,9 +99,31 @@ async def create_topup(
     return CreateTopupResponse(checkout_url=result["checkout_url"])
 
 
+def _request_origin(request: Request) -> str:
+    """The buyer's app origin, for building the post-checkout return_url.
+
+    Prefer the ``Origin`` header (sent by the browser on the fetch); fall back to
+    deriving ``scheme://host`` from ``Referer`` when Origin is absent (some
+    same-origin navigations omit Origin). Empty string when neither is usable —
+    the service then falls back to the ``dodo_checkout_return_base`` config.
+    """
+    origin = (request.headers.get("origin") or "").strip()
+    if origin:
+        return origin
+    referer = (request.headers.get("referer") or "").strip()
+    if referer:
+        from urllib.parse import urlsplit
+
+        parts = urlsplit(referer)
+        if parts.scheme and parts.netloc:
+            return f"{parts.scheme}://{parts.netloc}"
+    return ""
+
+
 @router.post("/subscribe", response_model=CreateSubscriptionResponse)
 async def create_subscription(
     body: CreateSubscriptionRequest,
+    request: Request,
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> CreateSubscriptionResponse:
@@ -106,10 +133,15 @@ async def create_subscription(
     upgraded and credits are NOT granted here — both land when Dodo posts a
     verified ``subscription.active`` to the public webhook; each renewal then
     grants the tier's monthly allotment additively (unused credits roll over).
+
+    The buyer's ``Origin`` (fallback ``Referer``) header is threaded into the
+    checkout's return_url / cancel_url so Dodo returns them to the app's billing
+    page after pay / cancel — without it the buyer is stranded on the gateway.
     """
     result = await billing_service.subscribe(
         workspace_id=workspace_id,
         user_id=user_id,
         plan_key=body.plan_key,
+        origin=_request_origin(request),
     )
     return CreateSubscriptionResponse(checkout_url=result["checkout_url"])

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -67,6 +67,15 @@
 #   ``active`` does not re-deploy. ``renewed`` just refreshes the renewal date (the
 #   site is already live), ``cancelled`` marks the site cancelled WITHOUT undeploying
 #   it in v1.
+# Updated 2026-06-28 (fix/billing-checkout-sessions): ``subscribe`` now takes an
+#   ``origin`` (the buyer's app origin, read off the /subscribe route's Origin /
+#   Referer header) and threads it through ``_checkout_return_urls`` into the
+#   provider's ``return_url`` / ``cancel_url`` so Dodo returns the buyer to
+#   ``{origin}/settings/billing?checkout=success|cancel`` after pay/cancel (the
+#   prior payment-link checkout had nowhere to send the buyer). Falls back to the
+#   ``dodo_checkout_return_base`` config when no origin is present; omits the
+#   redirect entirely if both are absent. The webhook grant + idempotency are
+#   unchanged — they key on the event body's subscription_id + metadata + event_id.
 
 from __future__ import annotations
 
@@ -178,11 +187,36 @@ def _dodo_product_for_plan(plan_key: str) -> str | None:
     return tier.dodo_product_id if tier is not None else None
 
 
+def _checkout_return_urls(origin: str | None) -> tuple[str | None, str | None]:
+    """Build (return_url, cancel_url) for the subscription checkout, or (None, None).
+
+    After paying on Dodo the buyer must land back in the app. The base is the
+    buyer's ``origin`` (the route reads it from the Origin / Referer header); when
+    that is absent we fall back to the ``dodo_checkout_return_base`` config. If
+    BOTH are empty we return (None, None) and the provider omits return_url rather
+    than crash — a checkout with no redirect still works, the buyer just isn't
+    auto-returned.
+    """
+    base = (origin or "").strip()
+    if not base:
+        from pocketpaw.config import get_settings
+
+        base = (getattr(get_settings(), "dodo_checkout_return_base", "") or "").strip()
+    if not base:
+        return None, None
+    base = base.rstrip("/")
+    return (
+        f"{base}/settings/billing?checkout=success",
+        f"{base}/settings/billing?checkout=cancel",
+    )
+
+
 async def subscribe(
     workspace_id: str,
     user_id: str,
     plan_key: str,
     *,
+    origin: str | None = None,
     customer_email: str | None = None,
     provider: IPaymentsProvider | None = None,
 ) -> dict:
@@ -195,6 +229,12 @@ async def subscribe(
     right tier, and returns ``{"checkout_url": ...}``. Credits are NOT granted and
     the plan is NOT changed here — both land when Dodo posts a verified
     ``subscription.active`` to the public webhook.
+
+    ``origin`` is the buyer's app origin (the route reads it from the Origin /
+    Referer header). It builds the return_url / cancel_url Dodo sends the buyer
+    back to after pay / cancel, so the buyer is NOT stranded on the gateway. When
+    absent it falls back to the ``dodo_checkout_return_base`` config; if both are
+    empty the redirect is simply omitted.
     """
     # Rule 6 — validate at entry.
     if not workspace_id:
@@ -217,6 +257,7 @@ async def subscribe(
             "(POCKETPAW_DODO_PLAN_PRODUCTS).",
         )
 
+    return_url, cancel_url = _checkout_return_urls(origin)
     prov = provider or _default_provider()
     checkout = await prov.create_subscription(
         plan_key=plan_key,
@@ -224,6 +265,8 @@ async def subscribe(
         workspace_id=workspace_id,
         customer_email=customer_email,
         metadata={"workspace_id": workspace_id, "plan_key": plan_key, "user_id": user_id or ""},
+        return_url=return_url,
+        cancel_url=cancel_url,
     )
     return {"checkout_url": checkout.checkout_url}
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,12 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-28 (fix/billing-checkout-sessions): Added ``dodo_checkout_return_base``
+    (default "", env POCKETPAW_DODO_CHECKOUT_RETURN_BASE) — the fallback base URL a
+    Dodo subscription checkout session returns the buyer to after pay / cancel when
+    the /billing/subscribe request carries no Origin (or usable Referer) header.
+    Return urls become ``{base}/settings/billing?checkout=success|cancel``; empty
+    default omits the redirect when no origin is available.
   - 2026-06-26 (WU-F billing cutover): Added ``litellm_spend_mode``
     (Literal off|shadow|live, default 'off'; POCKETPAW_LITELLM_SPEND_MODE) — the
     three-position billing-cutover switch that supersedes the
@@ -1540,6 +1546,19 @@ class Settings(BaseSettings):
             "POCKETPAW_DODO_PLAN_PRODUCTS as a JSON object, e.g. "
             '{"team":"prod_team","business":"prod_biz"}. Default empty disables '
             "subscriptions (subscribe raises a clear ValidationError)."
+        ),
+    )
+    dodo_checkout_return_base: str = Field(
+        default="",
+        description=(
+            "Fallback base URL the Dodo subscription CHECKOUT SESSION returns the "
+            "buyer to after pay / cancel, used ONLY when the /billing/subscribe "
+            "request carries no Origin (and no usable Referer) header. The return "
+            "urls become ``{base}/settings/billing?checkout=success|cancel``. Set "
+            "via POCKETPAW_DODO_CHECKOUT_RETURN_BASE (e.g. https://app.example.com). "
+            "Default empty: when both this and the request Origin are absent the "
+            "redirect is omitted (the checkout still works, the buyer just isn't "
+            "auto-returned)."
         ),
     )
 

--- a/tests/cloud/billing/test_subscriptions.py
+++ b/tests/cloud/billing/test_subscriptions.py
@@ -34,6 +34,12 @@
 #   the unique (gateway, "") Subscription index. The fix SKIPS the audit upsert on
 #   a falsy subscription_id, so the second workspace never overwrites the first's
 #   row; the grant + plan change still apply for both.
+# Updated 2026-06-28 (fix/billing-checkout-sessions): added the checkout-sessions
+#   bug-fix tests — create_subscription must open a Dodo CHECKOUT SESSION with a
+#   non-empty return_url + cancel_url + a product_cart line + customer (so the buyer
+#   is returned to the app after paying), omit return_url when no base is available,
+#   and the service must thread an ``origin`` into the return_url. Rewired the
+#   existing criterion-1 mock from subscriptions.create to checkout_sessions.create.
 
 from __future__ import annotations
 
@@ -145,13 +151,15 @@ async def test_subscribe_creates_dodo_subscription_with_product_and_metadata(
 ):
     ws = await _make_workspace(plan="free")
 
-    # Mock the async DodoPayments client so no network call happens.
-    fake_response = MagicMock()
-    fake_response.payment_link = "https://checkout.dodopayments.test/sub/abc123"
-    fake_response.subscription_id = SUB_ID
+    # Mock the async DodoPayments client so no network call happens. The
+    # subscription checkout now goes through the CHECKOUT SESSIONS API (the fix),
+    # whose response carries ``session_id`` + ``checkout_url``.
+    fake_session = MagicMock()
+    fake_session.checkout_url = "https://checkout.dodopayments.test/sub/abc123"
+    fake_session.session_id = SESSION_ID
 
     fake_client = MagicMock()
-    fake_client.subscriptions.create = AsyncMock(return_value=fake_response)
+    fake_client.checkout_sessions.create = AsyncMock(return_value=fake_session)
 
     import pocketpaw_ee.cloud.billing.providers.dodo as dodo_mod
 
@@ -162,11 +170,11 @@ async def test_subscribe_creates_dodo_subscription_with_product_and_metadata(
     )
     assert result == {"checkout_url": "https://checkout.dodopayments.test/sub/abc123"}
 
-    # The Dodo client was called with the business recurring product id and the
-    # workspace_id + plan_key on metadata (so the renewal webhook can route back).
-    _, kwargs = fake_client.subscriptions.create.call_args
-    assert kwargs["product_id"] == "prod_pro_recurring"
-    assert kwargs["payment_link"] is True
+    # The Dodo client was called via checkout_sessions.create with the business
+    # recurring product as a product_cart line and the workspace_id + plan_key on
+    # metadata (so the renewal webhook can route the grant back).
+    _, kwargs = fake_client.checkout_sessions.create.call_args
+    assert kwargs["product_cart"] == [{"product_id": "prod_pro_recurring", "quantity": 1}]
     assert kwargs["metadata"]["workspace_id"] == ws
     assert kwargs["metadata"]["plan_key"] == "pro"
     # H1 — the new-customer object MUST carry a non-empty ``name`` alongside
@@ -178,6 +186,134 @@ async def test_subscribe_creates_dodo_subscription_with_product_and_metadata(
         "Dodo new-customer object is missing a non-empty 'name' — "
         f"{customer!r} would be rejected server-side"
     )
+
+
+# ---------------------------------------------------------------------------
+# Checkout-sessions bug fix (fix/billing-checkout-sessions) — after paying on
+# Dodo the buyer must be returned to the app. The OLD path called
+# ``subscriptions.create(payment_link=True)`` which accepts NO return_url, so the
+# buyer was stranded. The fix moves to the Checkout Sessions API
+# (``checkout_sessions.create``) which DOES carry return_url + cancel_url.
+#
+# These tests assert the provider now calls ``checkout_sessions.create`` (NOT
+# ``subscriptions.create``) with a non-empty ``return_url``, the recurring
+# product as a ``product_cart`` line ([{product_id, quantity:1}]), and a
+# ``customer`` object — and that the SESSION url + session_id come back on the
+# normalized ``SubscriptionCheckout``.
+# ---------------------------------------------------------------------------
+
+SESSION_ID = "cks_dodo_session_xyz789"
+SESSION_CHECKOUT_URL = "https://checkout.dodopayments.com/session/cks_dodo_session_xyz789"
+
+
+def _fake_session_client(monkeypatch) -> MagicMock:
+    """Patch ``AsyncDodoPayments`` with a client whose ``checkout_sessions.create``
+    returns a ``CheckoutSessionResponse``-shaped object (session_id + checkout_url).
+
+    ``subscriptions.create`` is ALSO stubbed and asserted NOT-called, so a
+    regression back to the stranded ``subscriptions.create(payment_link=True)``
+    path fails loudly here.
+    """
+    fake_session = MagicMock()
+    fake_session.session_id = SESSION_ID
+    fake_session.checkout_url = SESSION_CHECKOUT_URL
+
+    fake_client = MagicMock()
+    fake_client.checkout_sessions.create = AsyncMock(return_value=fake_session)
+    fake_client.subscriptions.create = AsyncMock(
+        side_effect=AssertionError("must use checkout_sessions.create, not subscriptions.create")
+    )
+
+    import pocketpaw_ee.cloud.billing.providers.dodo as dodo_mod
+
+    monkeypatch.setattr(dodo_mod, "AsyncDodoPayments", MagicMock(return_value=fake_client))
+    return fake_client
+
+
+async def test_create_subscription_uses_checkout_session_with_return_url(monkeypatch):
+    """The provider opens a CHECKOUT SESSION carrying return_url + cancel_url + a
+    product_cart line + customer — so the buyer is returned to the app after pay."""
+    fake_client = _fake_session_client(monkeypatch)
+
+    checkout = await _provider().create_subscription(
+        plan_key="pro",
+        product_id="prod_pro_recurring",
+        workspace_id="ws_checkout",
+        customer_email="buyer@example.com",
+        metadata={"workspace_id": "ws_checkout", "plan_key": "pro"},
+        return_url="https://app.pocketpaw.test/settings/billing?checkout=success",
+        cancel_url="https://app.pocketpaw.test/settings/billing?checkout=cancel",
+    )
+
+    # The Checkout Sessions API was used (NOT subscriptions.create).
+    fake_client.checkout_sessions.create.assert_awaited_once()
+    fake_client.subscriptions.create.assert_not_called()
+
+    _, kwargs = fake_client.checkout_sessions.create.call_args
+    # return_url is the whole point of the fix — it MUST be present and non-empty.
+    assert kwargs.get("return_url"), f"return_url missing/empty: {kwargs!r}"
+    assert kwargs["return_url"].startswith("https://app.pocketpaw.test/settings/billing")
+    assert kwargs.get("cancel_url"), f"cancel_url missing/empty: {kwargs!r}"
+    # The recurring product rides as a product_cart line (a session creates the
+    # subscription at payment when the product is recurring).
+    assert kwargs["product_cart"] == [{"product_id": "prod_pro_recurring", "quantity": 1}]
+    # Customer object carries email + a derived name (Dodo's NewCustomer needs both).
+    customer = kwargs["customer"]
+    assert customer.get("email") == "buyer@example.com"
+    assert customer.get("name"), customer
+    # workspace_id + plan_key still ride on metadata for the renewal webhook.
+    assert kwargs["metadata"]["workspace_id"] == "ws_checkout"
+    assert kwargs["metadata"]["plan_key"] == "pro"
+
+    # The normalized result carries the SESSION url + the session_id (repurposed
+    # onto SubscriptionCheckout.subscription_id — the real subscription_id arrives
+    # later on the subscription.active webhook body, not from this create call).
+    assert checkout.checkout_url == SESSION_CHECKOUT_URL
+    assert checkout.subscription_id == SESSION_ID
+
+
+async def test_create_subscription_omits_return_url_when_not_provided(monkeypatch):
+    """When no return base is available the call OMITS return_url (rather than
+    sending an empty string) — the sites publish path passes no origin."""
+    fake_client = _fake_session_client(monkeypatch)
+
+    await _provider().create_subscription(
+        plan_key="pro",
+        product_id="prod_pro_recurring",
+        workspace_id="ws_no_origin",
+        customer_email=None,
+        metadata={"workspace_id": "ws_no_origin", "plan_key": "pro"},
+        # no return_url / cancel_url
+    )
+
+    _, kwargs = fake_client.checkout_sessions.create.call_args
+    assert "return_url" not in kwargs
+    assert "cancel_url" not in kwargs
+    # Still a valid session create with the cart + customer.
+    assert kwargs["product_cart"] == [{"product_id": "prod_pro_recurring", "quantity": 1}]
+
+
+async def test_subscribe_threads_origin_into_return_url(mongo_db, monkeypatch, patch_plan_products):
+    """End-to-end at the service layer: an ``origin`` passed to ``subscribe`` is
+    woven into return_url/cancel_url on the checkout session (the route reads it
+    from the buyer's Origin header)."""
+    ws = await _make_workspace(plan="free")
+    fake_client = _fake_session_client(monkeypatch)
+
+    result = await billing.subscribe(
+        workspace_id=ws,
+        user_id="u1",
+        plan_key="pro",
+        origin="https://app.acme.com",
+        provider=_provider(),
+    )
+    # The /subscribe contract is preserved — the SESSION url is returned as
+    # checkout_url (the frontend reads checkout_url).
+    assert result == {"checkout_url": SESSION_CHECKOUT_URL}
+
+    _, kwargs = fake_client.checkout_sessions.create.call_args
+    assert kwargs["return_url"] == "https://app.acme.com/settings/billing?checkout=success"
+    assert kwargs["cancel_url"] == "https://app.acme.com/settings/billing?checkout=cancel"
 
 
 async def test_subscribe_rejects_unknown_plan(mongo_db, patch_plan_products):

--- a/tests/cloud/test_ga_two_tenant_pentest.py
+++ b/tests/cloud/test_ga_two_tenant_pentest.py
@@ -361,10 +361,10 @@ async def test_signed_webhook_provisions_plan_and_credits_isolated(
 
     # --- the signup->subscribe leg: subscribe opens a (mocked) Dodo checkout ---
     fake_resp = MagicMock()
-    fake_resp.payment_link = "https://checkout.dodopayments.test/sub/ga"
-    fake_resp.subscription_id = "sub_ga_a"
+    fake_resp.checkout_url = "https://checkout.dodopayments.test/sub/ga"
+    fake_resp.session_id = "cks_ga_a"
     fake_client = MagicMock()
-    fake_client.subscriptions.create = AsyncMock(return_value=fake_resp)
+    fake_client.checkout_sessions.create = AsyncMock(return_value=fake_resp)
     import pocketpaw_ee.cloud.billing.providers.dodo as dodo_mod
 
     monkeypatch.setattr(dodo_mod, "AsyncDodoPayments", MagicMock(return_value=fake_client))


### PR DESCRIPTION
## What this fixes

After a buyer paid for a plan on Dodo, they were stranded on Dodo's hosted checkout. The app never brought them back, because the checkout was created with no return_url. Root cause: `create_subscription` used `subscriptions.create(payment_link=True)`, which does not accept a return_url.

## The change

Switch to Dodo's Checkout Sessions API (`client.checkout_sessions.create`), which carries `return_url` and `cancel_url`. The return URL is built from the buyer's own origin (the Origin header on the /subscribe request, falling back to Referer, then a `dodo_checkout_return_base` config) and points at `/settings/billing?checkout=success` (and `?checkout=cancel`). So after paying, Dodo sends the buyer straight back into the app.

The recurring product rides as a `product_cart` line, which creates the subscription at payment time. The response is now a checkout session (checkout_url + session_id) instead of a bare payment link. The configurable billing country is preserved via `billing_address.country`, so UPI (IN + INR) still works.

## Safety (money code)

The webhook path is provably intact:
- `subscription.active` / `renewed` still grant credits and stamp the plan, keyed on the event body's `subscription_id` + metadata + `event_id`. The grant reads only the verified webhook event, never the create response, so the idempotent `(workspace, idempotency_key)` index is untouched.
- `SubscriptionCheckout.subscription_id` now carries the session id, but it is never persisted as the gateway subscription id. The authoritative subscription id arrives on the webhook (`data.subscription_id`), which is what every store and audit row keys on. Verified across the sites-billing consumers.

## Verification

Test-first (TDD): a failing test asserting the checkout uses `checkout_sessions.create` with a non-empty return_url, then the fix, then green. 52 billing tests and 352 site tests pass locally.

## Pairs with

The frontend PR (paw-enterprise) adds the overlay modal and the `/settings/billing?checkout=success` return handler. This PR is what makes Dodo redirect back.