### PR TITLE
feat(connectors): route connector calls through the egress guard with a default-deny host allow-list

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,5 +1,9 @@
 <!--
   Connectors documentation.
+  Updated: 2026-07-02 (AW-3 egress default-close) — clarified the "Development
+  against localhost" section: the egress guard rejects internal/metadata IPs BY
+  DEFAULT; POCKETPAW_ALLOW_INTERNAL_URLS opens the escape ONLY when set to an
+  explicit truthy value; unset ⇒ reject (safe production posture).
   Updated: 2026-06-28 (AW-1/AW-2 connector egress guard) — added the "Egress
   allow-list (SSRF protection)" section: the POCKETPAW_CONNECTOR_EGRESS_GUARD
   flag (default-deny posture, off by default for safe rollout), the optional
@@ -304,16 +308,22 @@ supported (the resolved-IP internal check still applies to them).
 
 ### Development against localhost
 
+The egress guard **rejects internal/loopback/private/metadata IPs by default**.
+When `POCKETPAW_ALLOW_INTERNAL_URLS` is unset (or set to anything other than an
+explicit truthy value), a resolved internal IP is blocked — this is the safe
+production posture and needs no configuration.
+
 For local development against internal hosts (Ollama, a dev API on `127.0.0.1`),
-set the dev escape:
+set the dev escape **explicitly**:
 
 ```bash
 POCKETPAW_ALLOW_INTERNAL_URLS=true
 ```
 
-This permits resolved internal IPs **while the guard still enforces the
-allow-list** — so a localhost connector keeps working in development without
-disabling the guard entirely.
+Only an explicit `true` / `1` opens the escape. It permits resolved internal
+IPs **while the guard still enforces the allow-list** — so a localhost connector
+keeps working in development without disabling the guard entirely. This is a
+dev-only flag; leave it unset in production so internal IPs stay rejected.
 
 ### Guarantees
 

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,5 +1,13 @@
 <!--
   Connectors documentation.
+  Updated: 2026-06-28 (AW-1/AW-2 connector egress guard) — added the "Egress
+  allow-list (SSRF protection)" section: the POCKETPAW_CONNECTOR_EGRESS_GUARD
+  flag (default-deny posture, off by default for safe rollout), the optional
+  top-level `allowed_hosts:` YAML key + the per-workspace WorkspaceConnector
+  `allowed_hosts` field, how the effective allow-list is auto-seeded (declared
+  base-URL host + auth-endpoint host, templated hosts resolved at call time)
+  and how to add hosts, the dev escape POCKETPAW_ALLOW_INTERNAL_URLS, and the
+  fail-closed-on-config-error / cookie-jar-preserving guarantees.
   Updated: 2026-06-12 (connector-store-unification CS-6) — added the
   "Lifecycle: definitions, state, cache" section: the three layers a connector
   lives in (YAML definitions with two scan dirs + CWD precedence, the durable
@@ -155,6 +163,9 @@ sync:
     price: price
     created: created_at
 
+allowed_hosts:                    # OPTIONAL — extra egress allow-list hosts
+  - cdn.myservice.com             # added ON TOP of the auto-seeded hosts
+
 surface_profile:                  # OPTIONAL — connector→skill/tool auto-authoring
   skill: my_service               # a skill to load in rooms with this connector
   allow_tools: []                 # tool-id patterns to add to the SDK allowlist
@@ -163,6 +174,9 @@ surface_profile:                  # OPTIONAL — connector→skill/tool auto-aut
 
 The `surface_profile` block is optional. Connectors without it parse and behave
 exactly as before. See [Connector → Skill / Tool auto-authoring](#connector--skill--tool-auto-authoring) below.
+
+The `allowed_hosts` block is optional and only matters when the egress guard is
+on — see [Egress allow-list (SSRF protection)](#egress-allow-list-ssrf-protection) below.
 
 ## Auth Methods
 
@@ -227,6 +241,89 @@ Each action has a trust level that controls how much human oversight the agent n
 | `auto` | Agent executes without asking | Read-only operations (list, search) |
 | `confirm` | Agent asks user before executing | Write operations (create, update, delete) |
 | `restricted` | Requires admin approval | Destructive or financial operations |
+
+## Egress allow-list (SSRF protection)
+
+A connector executes HTTP with stored credentials attached. Without a guard,
+a connector whose URL is influenced by a template, a credential, or a call-time
+param could be steered at an internal address (cloud metadata endpoint, an
+internal service) — a classic SSRF. The egress guard closes that.
+
+### Turning it on
+
+The guard is a per-deployment switch, **off by default** for a safe rollout:
+
+```bash
+POCKETPAW_CONNECTOR_EGRESS_GUARD=true
+```
+
+When on, every connector request is checked before it leaves: the URL must be
+`https://`, carry no userinfo (`user:pass@host`) and no fragment, its host must
+be on the connector's **allow-list**, and the host is DNS-resolved and rejected
+if it lands on an internal/loopback/private/metadata IP. The vetted IP is then
+*pinned* for the connection, so the name can't be re-resolved to an internal
+address between the check and the connect (DNS-rebinding).
+
+### Default-deny — the allow-list is the gate
+
+With the guard on, a request to any host **not** on the allow-list is blocked
+with a clean error (`Blocked by egress guard: host '…' is not in the egress
+allow-list`). The allow-list is auto-seeded from the connector's own declared
+topology, so the common case needs **no configuration**:
+
+1. **Every action's base-URL host** — taken from each action's `url:`. A
+   templated host (`https://{REGION}.freshdesk.com/...`, `{CONFLUENCE_BASE_URL}`)
+   is resolved with the connector's credentials at call time, so the *real*
+   runtime host is allow-listed, never the template string. The `BASE_URL`
+   credential's host (the build-from-base path) is included too.
+2. **The auth-endpoint host** — `auth.auth_url` / `auth.token_url`. Some
+   connectors authenticate on a different host than the API; both are seeded so
+   the auth call and the API call each pass.
+
+### Adding hosts
+
+When a connector legitimately reaches a host outside its declared topology (a
+CDN, a regional mirror, a webhook host), add it explicitly. Additions are
+layered **on top** of the auto-seeded hosts — they never narrow the list.
+
+* **Per connector (all workspaces)** — the top-level `allowed_hosts:` key in the
+  connector YAML:
+
+  ```yaml
+  allowed_hosts:
+    - cdn.myservice.com
+    - eu.myservice.com
+  ```
+
+* **Per workspace** — the `allowed_hosts` field on the workspace's connector
+  binding (`WorkspaceConnector.allowed_hosts`). Use this to permit one extra
+  host for a single workspace without editing the shared YAML.
+
+Host matching is case-insensitive; IPv6-literal and IP-literal base URLs are
+supported (the resolved-IP internal check still applies to them).
+
+### Development against localhost
+
+For local development against internal hosts (Ollama, a dev API on `127.0.0.1`),
+set the dev escape:
+
+```bash
+POCKETPAW_ALLOW_INTERNAL_URLS=true
+```
+
+This permits resolved internal IPs **while the guard still enforces the
+allow-list** — so a localhost connector keeps working in development without
+disabling the guard entirely.
+
+### Guarantees
+
+* **Fail closed on config error.** If `POCKETPAW_CONNECTOR_EGRESS_GUARD` is set
+  but the settings load fails, the guard does **not** silently turn off — it logs
+  the error and fails closed (the request is routed through the guard), so a
+  malformed config can never silently re-open the SSRF bypass.
+* **Session/cookie auth keeps working.** The pinned HTTP client is cached per
+  resolved host, so a `Set-Cookie` from one call is replayed on the next —
+  cookie/session-auth connectors are unaffected by the guard.
 
 ## Connector → Skill / Tool auto-authoring
 

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -45,6 +45,11 @@
 #   ``execute()`` filters its doc read on ``enabled == True``, so a disabled
 #   row's credentials can never connect through the fallback: disable now
 #   revokes on every execute path, not just the durable seam.
+# Updated: 2026-06-28 (AW-2 connector multi-host egress allow-list) — the legacy
+#   one-shot fallback in ``execute()`` folds the row's ``allowed_hosts`` field
+#   into the config blob passed to ``adapter.connect`` so the per-workspace
+#   egress allow-list additions reach the adapter on that path too (the primary
+#   ensure_connected path folds them in ``state_provider.get``).
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -970,6 +975,11 @@ async def execute(
             _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
         )
         config = dict(doc.config) if doc else {}
+        # AW-2 — fold the per-workspace egress allow-list additions into the
+        # config blob so they reach connect() on this legacy fallback path too
+        # (the primary ensure_connected path folds them in state_provider.get).
+        if doc and getattr(doc, "allowed_hosts", None):
+            config["allowed_hosts"] = list(doc.allowed_hosts)
         pocket_key = body.pocket_id or workspace_id
         exec_adapter = adapter
         await exec_adapter.connect(pocket_key, config)

--- a/ee/pocketpaw_ee/cloud/connectors/state_provider.py
+++ b/ee/pocketpaw_ee/cloud/connectors/state_provider.py
@@ -7,6 +7,13 @@
 #   Discovered by core via the ``pocketpaw.connector_state_stores``
 #   entry-point (see ``CloudConnectorStateStoreProvider`` in
 #   ``pocketpaw_ee/extensions.py``); core never imports this module.
+# Updated: 2026-06-28 (AW-2 connector multi-host egress allow-list) — _get_cloud
+#   folds the row's ``allowed_hosts`` field into the returned config dict under
+#   the ``allowed_hosts`` key so the per-workspace egress allow-list additions
+#   reach the adapter's connect() through the existing config channel (the
+#   registry seam only carries the config dict, not the whole doc). _set_cloud
+#   strips the key back out before persisting so the dedicated field stays the
+#   single source of truth and the round-trip never duplicates it into config.
 #
 # Scope-key namespacing (the contract with ``connectors/service.py``):
 #   ``ws:<workspace_id>``     — the workspace's row for a connector name
@@ -110,7 +117,16 @@ class CloudConnectorStateStore:
             return None
         # An enabled row with empty config is still a valid binding (CLI/no-cred
         # connectors) — return the dict, never coerce {} to None.
-        return dict(doc.config)
+        config = dict(doc.config)
+        # AW-2 — fold the per-workspace egress allow-list additions into the
+        # config blob under ``allowed_hosts`` so they reach the adapter's
+        # connect() through the established config channel (the registry seam
+        # only carries the config dict). The adapter layers these on top of its
+        # YAML-declared hosts. ``_set_cloud`` strips the key back out before
+        # persisting so it never leaks into the stored config blob.
+        if getattr(doc, "allowed_hosts", None):
+            config["allowed_hosts"] = list(doc.allowed_hosts)
+        return config
 
     def set(self, name: str, scope_key: str, config: dict[str, Any]) -> Any:
         parsed = _parse_scope_key(scope_key)
@@ -136,7 +152,12 @@ class CloudConnectorStateStore:
                     ident,
                 )
                 return
-            doc.config = dict(config)
+            # AW-2 — ``allowed_hosts`` is a dedicated WorkspaceConnector field
+            # that _get_cloud folds into the config dict on read; strip it back
+            # out here so the round-trip never duplicates it into the stored
+            # config blob (the field stays the single source of truth).
+            persisted = {k: v for k, v in config.items() if k != "allowed_hosts"}
+            doc.config = persisted
             # no-event: registry-seam config mirror of a row the connectors
             # service owns; service-level writes emit their own events.
             await doc.save()

--- a/ee/pocketpaw_ee/cloud/models/connector.py
+++ b/ee/pocketpaw_ee/cloud/models/connector.py
@@ -5,6 +5,14 @@
 # granted at, and a free-form config blob the connector adapter reads on
 # execute. Token bytes themselves stay in src/pocketpaw/clients/
 # token_store.py for Phase 1 — only the *reference* + scope live here.
+# Updated: 2026-06-28 (AW-2 connector multi-host egress allow-list) — added
+#   ``allowed_hosts: list[str]``: per-workspace operator additions to the
+#   connector's egress allow-list, layered ON TOP of the auto-seeded hosts
+#   (the connector YAML's declared base-URL host + auth-endpoint host). Lets an
+#   operator permit an extra host (e.g. a regional API mirror) for one
+#   workspace without editing the shared YAML. Empty by default — no extra
+#   hosts. Read by the connector engine when the POCKETPAW_CONNECTOR_EGRESS_GUARD
+#   guard is on; never narrows the auto-seeded list.
 
 from __future__ import annotations
 
@@ -37,6 +45,12 @@ class WorkspaceConnector(TimestampedDocument):
     pocket_id: str | None = None  # set when scope == "pocket"
     user_id: str | None = None  # set when scope == "user"
     config: dict[str, Any] = Field(default_factory=dict)
+    # AW-2 — per-workspace egress allow-list additions, layered on top of the
+    # connector YAML's auto-seeded hosts (declared base-URL + auth-endpoint
+    # host). Lets an operator permit one extra host for this workspace without
+    # editing the shared YAML. Empty = no additions. Only consulted when the
+    # connector egress guard is enabled; never narrows the auto-seeded list.
+    allowed_hosts: list[str] = Field(default_factory=list)
     last_sync_at: datetime | None = None
     last_sync_status: str = "never"  # "never" | "ok" | "error"
     last_sync_error: str = ""

--- a/ee/pocketpaw_ee/cloud/pockets/_http_guard.py
+++ b/ee/pocketpaw_ee/cloud/pockets/_http_guard.py
@@ -5,6 +5,14 @@
 #   (`action_executor.py`) import for outbound-HTTP safety. Pure extraction —
 #   no behavior change from the alpha; the read-executor regression tests are
 #   the proof gate.
+# Updated: 2026-06-28 (AW-1 connector egress guard) — re-exports the OSS-side
+#   egress primitive so this module stays the ONE canonical guard entry point
+#   even though the reusable code now lives in OSS ``security.url_validators``
+#   (the OSS connector engine needs it and core may not import this EE module —
+#   the import boundary runs one way). ``assert_egress_allowed`` /
+#   ``PinnedTransport`` / ``EgressTarget`` / ``EgressError`` are surfaced here
+#   verbatim from that module; no behavior change for the existing executors,
+#   which keep importing ``_assert_host_external`` / ``_resolve_url`` as before.
 #
 # SSRF BOUNDARY. Every defense from the locked RFC 04 security review lives
 # here: strict path-traversal rejection, absolute-URL rejection, same-host
@@ -26,7 +34,13 @@ import urllib.parse
 
 import httpx
 
-from pocketpaw.security.url_validators import host_is_internal
+from pocketpaw.security.url_validators import (
+    EgressError,
+    EgressTarget,
+    PinnedTransport,
+    assert_egress_allowed,
+    host_is_internal,
+)
 
 # --- limits / policy --------------------------------------------------------
 _MAX_RESPONSE_BYTES = 524_288  # 512 KB (D11)
@@ -131,4 +145,10 @@ __all__ = [
     "_auth_headers",
     "_resolve_url",
     "_strip_query",
+    # AW-1 egress primitive — re-exported from OSS so this stays the canonical
+    # guard entry point (the OSS connector engine imports the originals).
+    "EgressError",
+    "EgressTarget",
+    "PinnedTransport",
+    "assert_egress_allowed",
 ]

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,15 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-28 (AW-1 connector egress guard): Added
+    ``connector_egress_guard`` (default False; env
+    POCKETPAW_CONNECTOR_EGRESS_GUARD) — the kill-switch for routing
+    DirectREST connector HTTP through the SSRF egress guard
+    (``assert_egress_allowed`` + the pinned-IP transport). OFF by default so
+    flipping it on per-deployment closes the connector SSRF bypass without
+    risking live connectors in the same change. The existing
+    ``POCKETPAW_ALLOW_INTERNAL_URLS`` flag stays the dev escape that permits
+    internal/loopback hosts when the guard is on.
   - 2026-06-26 (WU-F billing cutover): Added ``litellm_spend_mode``
     (Literal off|shadow|live, default 'off'; POCKETPAW_LITELLM_SPEND_MODE) — the
     three-position billing-cutover switch that supersedes the
@@ -990,6 +999,16 @@ class Settings(BaseSettings):
     a2a_trusted_agents: list[str] = Field(
         default_factory=list,
         description="Explicitly allowed A2A agent base URLs for task delegation (prevents SSRF)",
+    )
+    connector_egress_guard: bool = Field(
+        default=False,
+        description=(
+            "Route DirectREST connector HTTP through the SSRF egress guard "
+            "(host allow-list, DNS pre-resolve + internal-range reject, pinned-IP "
+            "transport). OFF by default — a safe-rollout kill-switch; flip on "
+            "per-deployment to close the connector SSRF bypass. "
+            "POCKETPAW_ALLOW_INTERNAL_URLS permits internal hosts when set."
+        ),
     )
     api_rate_limit_per_key: int = Field(
         default=60,

--- a/src/pocketpaw/connectors/yaml_engine.py
+++ b/src/pocketpaw/connectors/yaml_engine.py
@@ -21,18 +21,42 @@
 # Updated: 2026-06-28 (AW-1 connector egress guard) — execute() now routes its
 #   outbound HTTP through the SSRF egress guard when the
 #   POCKETPAW_CONNECTOR_EGRESS_GUARD flag is on. Before each request it calls
-#   ``assert_egress_allowed(url, {host})`` (https-only, no userinfo/fragment,
-#   host must equal the connector's declared base-URL host, DNS pre-resolve +
-#   internal-range reject) and dials the result through a per-request
-#   pinned-IP client (``PinnedTransport``, ``follow_redirects=False``) so the
-#   connection cannot be re-resolved to an internal address between check and
-#   connect (DNS-rebind TOCTOU). A rejection returns a clean ActionResult error.
-#   The flag defaults OFF (safe rollout) — with it off the pooled client path is
-#   byte-for-byte unchanged. The guard primitive lives in the OSS module
+#   ``assert_egress_allowed(url, allowed_hosts)`` (https-only, no
+#   userinfo/fragment, host must be on the allow-list, DNS pre-resolve +
+#   internal-range reject) and dials the result through a pinned-IP client
+#   (``PinnedTransport``, ``follow_redirects=False``) so the connection cannot
+#   be re-resolved to an internal address between check and connect (DNS-rebind
+#   TOCTOU). A rejection returns a clean ActionResult error. The flag defaults
+#   OFF (safe rollout) — with it off the pooled client path is byte-for-byte
+#   unchanged. The guard primitive lives in the OSS module
 #   ``security.url_validators`` (the OSS->EE import boundary forbids importing
-#   the EE ``_http_guard``); the EE guard re-exports it to stay canonical. For
-#   this task the allow-list is the single declared base-URL host —
-#   multi-host/auth-host support is a later task.
+#   the EE ``_http_guard``); the EE guard re-exports it to stay canonical.
+# Updated: 2026-06-28 (AW-2 multi-host allow-list + concern fixes) —
+#   * ConnectorDef grows ``allowed_hosts: list[str]`` parsed from a top-level
+#     ``allowed_hosts:`` YAML key (explicit operator additions).
+#   * The effective per-call allow-list is now built from THREE sources, not
+#     just the request host: every action's declared base-URL host (resolved
+#     through the SAME ``{template}`` substitution execute() applies, so
+#     ``{FRESHDESK_DOMAIN}.freshdesk.com`` and ``{CONFLUENCE_BASE_URL}`` resolve
+#     to the real runtime host), the auth-endpoint host (``auth.auth_url`` /
+#     ``auth.token_url`` — some connectors authenticate on a different host),
+#     and the explicit ``allowed_hosts``. Hosts are normalized (lowercase,
+#     IPv6 brackets stripped). The RESOLVED request host is checked against this
+#     set — never a template string — so a templated/dynamic base URL is vetted
+#     by its real host at call time. IP-literal and IPv6 base URLs flow through
+#     unchanged (urlsplit handles the brackets; the resolved-IP internal check
+#     still applies).
+#   * Concern fix 1 (fail-CLOSED on config error): ``_egress_guard_enabled``
+#     no longer swallows a settings-load error into "guard off". A settings
+#     failure now logs at error level and FAILS CLOSED (returns True → the
+#     guard runs) so a malformed settings load cannot silently re-open the
+#     SSRF bypass. The dev escape ``POCKETPAW_ALLOW_INTERNAL_URLS`` still lets
+#     localhost connectors through when the guard runs.
+#   * Concern fix 2 (preserve the cookie jar): pinned clients are now CACHED
+#     per resolved host (``_pinned_clients``) instead of built fresh per
+#     request, so the persistent cookie jar survives across calls — session /
+#     cookie-auth connectors keep working under the guard. The cache is closed
+#     alongside the pooled client in disconnect().
 
 from __future__ import annotations
 
@@ -91,6 +115,12 @@ class ConnectorDef:
     # Sense tier — the provider-agnostic capabilities this connector fills
     # (e.g. ["paw.email.v1"]). Empty when the YAML has no ``senses:`` key.
     senses: list[str] = field(default_factory=list)
+    # AW-2 — explicit egress allow-list additions from a top-level
+    # ``allowed_hosts:`` YAML key. These are ADDED on top of the auto-seeded
+    # hosts (declared base-URL host + auth-endpoint host); they never narrow
+    # the list. Empty when the YAML has no ``allowed_hosts:`` key. The effective
+    # per-call allow-list is computed in DirectRESTAdapter._effective_allowed_hosts.
+    allowed_hosts: list[str] = field(default_factory=list)
 
 
 def _parse_surface_profile(raw: Any) -> ConnectorSurfaceProfile | None:
@@ -135,6 +165,16 @@ def parse_connector_yaml(path: Path) -> ConnectorDef:
                 f"connector {name!r} declares invalid sense {sense_id!r}: {e}"
             ) from e
 
+    # AW-2 — explicit egress allow-list additions. Tolerate a missing key (the
+    # common case) and a non-list value (ignored) so connectors without the key
+    # parse byte-identically. Each entry is coerced to a stripped string.
+    raw_allowed = raw.get("allowed_hosts", [])
+    allowed_hosts = (
+        [str(h).strip() for h in raw_allowed if str(h).strip()]
+        if isinstance(raw_allowed, list)
+        else []
+    )
+
     return ConnectorDef(
         name=name,
         display_name=raw.get("display_name", raw.get("name", path.stem)),
@@ -145,6 +185,7 @@ def parse_connector_yaml(path: Path) -> ConnectorDef:
         sync=raw.get("sync", {}),
         surface_profile=_parse_surface_profile(raw.get("surface_profile")),
         senses=senses,
+        allowed_hosts=allowed_hosts,
     )
 
 
@@ -166,6 +207,17 @@ class DirectRESTAdapter:
         # in the client's cookie jar for the next request. ``Any`` avoids a
         # module-level httpx import (it stays inside execute()/_get_client).
         self._client: Any | None = None
+        # AW-2 concern fix 2 — per-resolved-host pinned clients. Building a
+        # fresh PinnedTransport client per request (AW-1) dropped the cookie
+        # jar, breaking session/cookie-auth connectors under the guard. Caching
+        # one pinned client per resolved host preserves that host's cookie jar
+        # across calls while keeping the IP pin (and DNS-rebind safety) intact.
+        # Closed alongside ``_client`` in disconnect().
+        self._pinned_clients: dict[str, Any] = {}
+        # AW-2 — per-workspace egress allow-list additions, populated by
+        # connect() from the config blob (WorkspaceConnector.allowed_hosts).
+        # Layered on top of the YAML-declared hosts in _effective_allowed_hosts.
+        self._ws_allowed_hosts: list[str] = []
 
     async def _get_client(self) -> Any:
         """Return the per-adapter httpx.AsyncClient, building it on first use."""
@@ -177,25 +229,135 @@ class DirectRESTAdapter:
 
     @staticmethod
     def _egress_guard_enabled() -> bool:
-        """True when POCKETPAW_CONNECTOR_EGRESS_GUARD is set (settings flag)."""
+        """Whether to route this request through the SSRF egress guard.
+
+        Returns the ``connector_egress_guard`` settings flag (default False).
+
+        AW-2 concern fix 1 — FAIL CLOSED, not open. AW-1 swallowed any
+        ``get_settings()`` error into ``False`` (guard off), so a malformed
+        settings load would silently re-open the SSRF bypass the guard exists to
+        close. Here a settings-load failure is logged at error level and FAILS
+        CLOSED (returns True → the guard runs). The cost of a false-closed is a
+        blocked connector call with a clear error; the cost of a false-open is a
+        silent SSRF hole, so closed is the safe default. The dev escape
+        ``POCKETPAW_ALLOW_INTERNAL_URLS`` still lets localhost through when the
+        guard runs, so local development is not broken by failing closed.
+        """
         try:
             from pocketpaw.config import get_settings
 
             return bool(get_settings().connector_egress_guard)
-        except Exception:  # noqa: BLE001 — never let a config-load issue break execute()
-            return False
+        except Exception:  # noqa: BLE001 — a config-load failure must not silently disable the guard
+            import logging
+
+            logging.getLogger(__name__).error(
+                "connector egress guard: settings load failed; FAILING CLOSED "
+                "(routing through the guard) so the SSRF bypass cannot silently re-open",
+                exc_info=True,
+            )
+            return True
+
+    def _substitute_host_template(self, value: str) -> str:
+        """Apply the SAME ``{placeholder}`` substitution execute() applies to a
+        declared URL, so a templated base URL resolves to its real runtime host.
+
+        Mirrors execute()'s loop: a ``{placeholder}`` is filled from a stored
+        credential first, then nothing else (params are per-call and not known
+        when seeding the static allow-list — the request host itself covers the
+        param-templated case at check time). An unresolved placeholder is left
+        as-is; its host is dropped by the caller (it can't be a real hostname).
+        """
+        import re
+
+        out = value
+        for placeholder in re.findall(r"\{(\w+)\}", out):
+            if placeholder in self._credentials:
+                out = out.replace(f"{{{placeholder}}}", self._credentials[placeholder])
+        return out
+
+    def _effective_allowed_hosts(self) -> set[str]:
+        """Build the connector's effective egress allow-list (AW-2).
+
+        Auto-seeded from THREE sources, normalized (lowercase, IPv6 brackets
+        stripped), with empty/unresolved entries dropped:
+
+        1. Every action's declared base-URL host, taken AFTER the same
+           ``{template}`` credential substitution execute() performs — so a
+           templated host (``{FRESHDESK_DOMAIN}.freshdesk.com``,
+           ``{CONFLUENCE_BASE_URL}``) contributes its real runtime host, never a
+           template string. The ``BASE_URL`` credential's host (the
+           build-from-base path) is included too.
+        2. The auth-endpoint host — ``auth.auth_url`` / ``auth.token_url`` — for
+           connectors that authenticate on a different host than the API.
+        3. Explicit operator additions — from ``allowed_hosts:`` in the YAML
+           (all workspaces) and the per-workspace ``WorkspaceConnector``
+           ``allowed_hosts`` (captured by connect()). These never narrow.
+
+        Used to check the RESOLVED request host at call time; a host outside
+        this set is rejected by ``assert_egress_allowed``.
+        """
+        from urllib.parse import urlsplit
+
+        def _host_of(url: str) -> str | None:
+            url = self._substitute_host_template(url).strip()
+            if not url or "{" in url:  # unresolved template — not a real host
+                return None
+            # A bare ``host/path`` (no scheme) lands the host in ``.path``;
+            # prepend a scheme so urlsplit populates ``.hostname``.
+            parts = urlsplit(url if "://" in url else f"https://{url}")
+            host = parts.hostname
+            return host.lower().strip("[]") if host else None
+
+        hosts: set[str] = set()
+
+        # 1. Declared action base-URL hosts + the BASE_URL credential host.
+        for act in self._def.actions:
+            url = act.get("url", "")
+            if url:
+                h = _host_of(str(url))
+                if h:
+                    hosts.add(h)
+        base_cred = self._credentials.get("BASE_URL", "")
+        if base_cred:
+            h = _host_of(base_cred)
+            if h:
+                hosts.add(h)
+
+        # 2. Auth-endpoint host (auth host may differ from the API host).
+        auth = self._def.auth or {}
+        for key in ("auth_url", "token_url", "authorization_url", "token_endpoint"):
+            endpoint = auth.get(key)
+            if endpoint:
+                h = _host_of(str(endpoint))
+                if h:
+                    hosts.add(h)
+
+        # 3. Explicit operator additions — from the connector YAML
+        # (``allowed_hosts:``) and from the per-workspace WorkspaceConnector row
+        # (folded into config by the cloud layer, captured in connect()).
+        for h_raw in (*self._def.allowed_hosts, *self._ws_allowed_hosts):
+            h = _host_of(str(h_raw))
+            if h:
+                hosts.add(h)
+
+        return hosts
 
     async def _egress_client(self, url: str) -> Any:
         """Validate ``url`` against the egress policy and return a pinned client.
 
-        Closes the connector SSRF bypass (AW-1): enforces https-only, no
-        userinfo/fragment, the host must equal the connector's own declared
-        base-URL host (the allow-list for this task is that single host), DNS
-        pre-resolve + internal-range reject, then dials the vetted/pinned IP via
-        a per-request ``PinnedTransport`` client with redirects disabled — so
-        the connection cannot be re-resolved to an internal address between the
-        check and the connect (DNS-rebind TOCTOU). The caller MUST close the
-        returned client (it is per-request, not the pooled adapter client).
+        Closes the connector SSRF bypass (AW-1) and adds the multi-host
+        allow-list (AW-2): enforces https-only, no userinfo/fragment, the
+        RESOLVED request host must be on the connector's effective allow-list
+        (declared base-URL host(s) + auth-endpoint host + explicit
+        ``allowed_hosts``), DNS pre-resolve + internal-range reject, then dials
+        the vetted/pinned IP via a ``PinnedTransport`` client with redirects
+        disabled — so the connection cannot be re-resolved to an internal
+        address between the check and the connect (DNS-rebind TOCTOU).
+
+        The pinned client is CACHED per resolved host (AW-2 concern fix 2) so
+        the cookie jar survives across calls — session/cookie-auth connectors
+        keep working under the guard. The cache is closed in disconnect(); the
+        caller MUST NOT close the returned client.
 
         Raises ``EgressError`` (a ``ValueError``) when the URL is disallowed.
         """
@@ -206,16 +368,33 @@ class DirectRESTAdapter:
             assert_egress_allowed,
         )
 
-        host = httpx.URL(url).host
-        # For this task the allow-list is exactly the connector's declared
-        # base-URL host. Multi-host / auth-host allow-lists are a later task.
-        target = await assert_egress_allowed(url, {host})
+        # Check the RESOLVED request host against the connector's effective
+        # allow-list. ``url`` already had its {templates} substituted by
+        # execute(), so this is a concrete host, never a template string.
+        allowed = self._effective_allowed_hosts()
+        target = await assert_egress_allowed(url, allowed)
+
+        # Cache one pinned client per resolved host so the cookie jar persists
+        # across calls (concern fix 2). Key on the host so the cookie jar is
+        # reused even if DNS later returns a different IP. ``assert_egress_allowed``
+        # above STILL re-resolves and re-checks the host on every call, so the
+        # security boundary (host on the allow-list + currently resolving to a
+        # non-internal IP) holds per request even though the cached transport
+        # keeps dialing the first call's pinned IP. That stale-pin is an
+        # availability edge (a host migrating IPs mid-session), not a security
+        # one — and re-pinning per call would discard the cookie jar, the exact
+        # regression this cache fixes. Rebuild only if the cached client closed.
+        cached = self._pinned_clients.get(target.host)
+        if cached is not None and not cached.is_closed:
+            return cached
         transport = PinnedTransport(target.pinned_ip)
-        return httpx.AsyncClient(
+        client = httpx.AsyncClient(
             timeout=30.0,
             follow_redirects=False,
             transport=transport,
         )
+        self._pinned_clients[target.host] = client
+        return client
 
     @property
     def name(self) -> str:
@@ -240,6 +419,18 @@ class DirectRESTAdapter:
                     message=f"Missing required credential: {key}",
                 )
 
+        # AW-2 — per-workspace egress allow-list additions. The cloud layer
+        # folds WorkspaceConnector.allowed_hosts into the config blob under
+        # ``allowed_hosts``; capture it so _effective_allowed_hosts() can layer
+        # these operator additions on top of the YAML-declared hosts. Tolerate a
+        # non-list value (ignored) so a malformed config can't break connect().
+        ws_allowed = config.get("allowed_hosts", [])
+        self._ws_allowed_hosts = (
+            [str(h).strip() for h in ws_allowed if str(h).strip()]
+            if isinstance(ws_allowed, list)
+            else []
+        )
+
         self._connected = True
         tables = []
         if self._def.sync.get("table"):
@@ -260,6 +451,12 @@ class DirectRESTAdapter:
         if self._client is not None:
             await self._client.aclose()
             self._client = None
+        # AW-2 — close every cached pinned client (one per resolved host) and
+        # drop their cookie jars too. They live across calls now, so disconnect
+        # is the single place they are torn down.
+        for client in self._pinned_clients.values():
+            await client.aclose()
+        self._pinned_clients.clear()
         return True
 
     async def actions(self) -> list[ActionSchema]:
@@ -361,11 +558,13 @@ class DirectRESTAdapter:
                 else:
                     body_data[key] = val
 
-        # AW-1 egress guard: when enabled, validate + pin the target and use a
-        # per-request client; when off, reuse the pooled adapter client exactly
-        # as before. ``guarded_client`` is closed in the finally block.
+        # AW-1/AW-2 egress guard: when enabled, validate the resolved request
+        # host against the connector's effective allow-list, pin the vetted IP,
+        # and use a per-resolved-host CACHED client (so the cookie jar persists
+        # across calls); when off, reuse the pooled adapter client exactly as
+        # before. The guarded client is cached on the adapter and closed in
+        # disconnect() — NOT per request — so it is not torn down here.
         guarded = self._egress_guard_enabled()
-        guarded_client = None
 
         try:
             import httpx
@@ -378,10 +577,9 @@ class DirectRESTAdapter:
 
             if guarded:
                 try:
-                    guarded_client = await self._egress_client(url)
+                    client = await self._egress_client(url)
                 except EgressError as e:
                     return ActionResult(success=False, error=f"Blocked by egress guard: {e}")
-                client = guarded_client
             else:
                 # Reuse the per-adapter client: pooled connections + persistent
                 # cookie jar across calls. Closed in disconnect().
@@ -445,11 +643,6 @@ class DirectRESTAdapter:
             return ActionResult(success=False, error=f"Request failed: {e}")
         except Exception as e:
             return ActionResult(success=False, error=str(e))
-        finally:
-            # The guarded client is per-request (pinned to this call's IP), so
-            # close it here. The pooled adapter client is left open for reuse.
-            if guarded_client is not None:
-                await guarded_client.aclose()
 
     def _build_auth_headers(self) -> dict[str, str]:
         """Build auth headers from stored credentials based on auth method."""

--- a/src/pocketpaw/connectors/yaml_engine.py
+++ b/src/pocketpaw/connectors/yaml_engine.py
@@ -18,6 +18,21 @@
 #   lazily-built httpx.AsyncClient per adapter instance (connection pooling +
 #   cookie jar) instead of opening a fresh client per call; disconnect() closes
 #   it. Existing auth methods, timeouts, and error mapping are unchanged.
+# Updated: 2026-06-28 (AW-1 connector egress guard) — execute() now routes its
+#   outbound HTTP through the SSRF egress guard when the
+#   POCKETPAW_CONNECTOR_EGRESS_GUARD flag is on. Before each request it calls
+#   ``assert_egress_allowed(url, {host})`` (https-only, no userinfo/fragment,
+#   host must equal the connector's declared base-URL host, DNS pre-resolve +
+#   internal-range reject) and dials the result through a per-request
+#   pinned-IP client (``PinnedTransport``, ``follow_redirects=False``) so the
+#   connection cannot be re-resolved to an internal address between check and
+#   connect (DNS-rebind TOCTOU). A rejection returns a clean ActionResult error.
+#   The flag defaults OFF (safe rollout) — with it off the pooled client path is
+#   byte-for-byte unchanged. The guard primitive lives in the OSS module
+#   ``security.url_validators`` (the OSS->EE import boundary forbids importing
+#   the EE ``_http_guard``); the EE guard re-exports it to stay canonical. For
+#   this task the allow-list is the single declared base-URL host —
+#   multi-host/auth-host support is a later task.
 
 from __future__ import annotations
 
@@ -159,6 +174,48 @@ class DirectRESTAdapter:
 
             self._client = httpx.AsyncClient(timeout=30.0)
         return self._client
+
+    @staticmethod
+    def _egress_guard_enabled() -> bool:
+        """True when POCKETPAW_CONNECTOR_EGRESS_GUARD is set (settings flag)."""
+        try:
+            from pocketpaw.config import get_settings
+
+            return bool(get_settings().connector_egress_guard)
+        except Exception:  # noqa: BLE001 — never let a config-load issue break execute()
+            return False
+
+    async def _egress_client(self, url: str) -> Any:
+        """Validate ``url`` against the egress policy and return a pinned client.
+
+        Closes the connector SSRF bypass (AW-1): enforces https-only, no
+        userinfo/fragment, the host must equal the connector's own declared
+        base-URL host (the allow-list for this task is that single host), DNS
+        pre-resolve + internal-range reject, then dials the vetted/pinned IP via
+        a per-request ``PinnedTransport`` client with redirects disabled — so
+        the connection cannot be re-resolved to an internal address between the
+        check and the connect (DNS-rebind TOCTOU). The caller MUST close the
+        returned client (it is per-request, not the pooled adapter client).
+
+        Raises ``EgressError`` (a ``ValueError``) when the URL is disallowed.
+        """
+        import httpx
+
+        from pocketpaw.security.url_validators import (
+            PinnedTransport,
+            assert_egress_allowed,
+        )
+
+        host = httpx.URL(url).host
+        # For this task the allow-list is exactly the connector's declared
+        # base-URL host. Multi-host / auth-host allow-lists are a later task.
+        target = await assert_egress_allowed(url, {host})
+        transport = PinnedTransport(target.pinned_ip)
+        return httpx.AsyncClient(
+            timeout=30.0,
+            follow_redirects=False,
+            transport=transport,
+        )
 
     @property
     def name(self) -> str:
@@ -304,16 +361,31 @@ class DirectRESTAdapter:
                 else:
                     body_data[key] = val
 
+        # AW-1 egress guard: when enabled, validate + pin the target and use a
+        # per-request client; when off, reuse the pooled adapter client exactly
+        # as before. ``guarded_client`` is closed in the finally block.
+        guarded = self._egress_guard_enabled()
+        guarded_client = None
+
         try:
             import httpx
+
+            from pocketpaw.security.url_validators import EgressError
 
             # Detect form-encoded APIs (Stripe, etc.) from URL or content_type hint
             content_type = act_def.get("content_type", "")
             use_form = content_type == "form" or "stripe.com" in url
 
-            # Reuse the per-adapter client: pooled connections + persistent
-            # cookie jar across calls. Closed in disconnect().
-            client = await self._get_client()
+            if guarded:
+                try:
+                    guarded_client = await self._egress_client(url)
+                except EgressError as e:
+                    return ActionResult(success=False, error=f"Blocked by egress guard: {e}")
+                client = guarded_client
+            else:
+                # Reuse the per-adapter client: pooled connections + persistent
+                # cookie jar across calls. Closed in disconnect().
+                client = await self._get_client()
             if method == "GET":
                 resp = await client.get(url, params=query_params, headers=headers)
             elif method == "POST":
@@ -373,6 +445,11 @@ class DirectRESTAdapter:
             return ActionResult(success=False, error=f"Request failed: {e}")
         except Exception as e:
             return ActionResult(success=False, error=str(e))
+        finally:
+            # The guarded client is per-request (pinned to this call's IP), so
+            # close it here. The pooled adapter client is left open for reuse.
+            if guarded_client is not None:
+                await guarded_client.aclose()
 
     def _build_auth_headers(self) -> dict[str, str]:
         """Build auth headers from stored credentials based on auth method."""

--- a/src/pocketpaw/security/url_validators.py
+++ b/src/pocketpaw/security/url_validators.py
@@ -20,9 +20,20 @@
 #   lookup between the check and the connect — closing the DNS-rebind TOCTOU.
 #   The EE ``_http_guard`` re-exports these so it stays the canonical entry
 #   point; the OSS connector engine imports them directly (the OSS->EE import
-#   boundary forbids importing ``pocketpaw_ee`` from core). When
-#   ``POCKETPAW_ALLOW_INTERNAL_URLS`` is set (dev escape) internal resolved
-#   IPs are permitted so localhost connectors keep working in development.
+#   boundary forbids importing ``pocketpaw_ee`` from core). The egress guard is
+#   DEFAULT-CLOSED on internal IPs: it uses ``_egress_allow_internal()`` (not
+#   the permissive ``_allow_internal()`` that legacy config-URL validation
+#   uses), which permits internal resolved IPs ONLY when
+#   ``POCKETPAW_ALLOW_INTERNAL_URLS`` is EXPLICITLY truthy — the dev escape for
+#   localhost connectors. Unset ⇒ reject, matching the EE ``_http_guard``.
+# Updated: 2026-07-02 (AW-3 egress default-close fix) — closed the default-OPEN
+#   SSRF hole: ``assert_egress_allowed`` previously called ``_allow_internal()``,
+#   which returns True when the env var is UNSET (its correct behaviour for
+#   permissive config-URL validation). With the connector guard ON but the env
+#   var unset (the realistic prod state) a resolved internal/metadata IP
+#   (169.254.169.254) slipped through and got pinned. The egress guard now uses
+#   ``_egress_allow_internal()`` which defaults to reject. ``_allow_internal()``
+#   is unchanged — ``validate_external_url`` stays permissive-by-design.
 # Updated: 2026-06-28 (AW-2 cookie-jar fix) — ``PinnedTransport`` now RESTORES
 #   the request's original (hostname) URL after the inner transport returns.
 #   ``httpx.AsyncClient`` runs ``cookies.extract_cookies(response)`` AFTER the
@@ -108,6 +119,27 @@ def _allow_internal() -> bool:
         val = _read_dotenv_flag()
     if val is None:
         return True
+    return val.strip().lower() in _TRUTHY
+
+
+def _egress_allow_internal() -> bool:
+    """Egress-guard variant of :func:`_allow_internal` — DEFAULTS TO REJECT.
+
+    The egress guard (:func:`assert_egress_allowed`) protects outbound
+    connector HTTP against SSRF, so its internal-IP block must be default-ON.
+    Unlike :func:`_allow_internal` (which is permissive-by-design for config
+    URLs and returns True when the flag is unset), this returns True ONLY when
+    ``POCKETPAW_ALLOW_INTERNAL_URLS`` is EXPLICITLY truthy ("true"/"1"/…) — the
+    dev escape that keeps localhost connectors working in development. Unset or
+    any non-truthy value ⇒ False (reject internal IPs), matching the EE
+    ``_http_guard._assert_host_external`` which rejects internal hosts
+    unconditionally.
+    """
+    val = os.getenv("POCKETPAW_ALLOW_INTERNAL_URLS")
+    if val is None:
+        val = _read_dotenv_flag()
+    if val is None:
+        return False
     return val.strip().lower() in _TRUTHY
 
 
@@ -268,8 +300,11 @@ async def assert_egress_allowed(url: str, allowed_hosts: set[str] | frozenset[st
       allow-list-confusion vectors (the real host can hide after the ``@``).
     * The hostname MUST be in ``allowed_hosts`` (compared case-insensitively).
     * DNS resolves the host and EVERY resolved IP is rejected if internal
-      (loopback / RFC1918 / link-local / metadata / reserved), unless the dev
-      escape ``POCKETPAW_ALLOW_INTERNAL_URLS`` permits internal hosts.
+      (loopback / RFC1918 / link-local / metadata / reserved) BY DEFAULT.
+      Internal IPs are permitted ONLY when ``POCKETPAW_ALLOW_INTERNAL_URLS`` is
+      EXPLICITLY truthy (the dev escape for localhost connectors); when the flag
+      is unset the guard rejects — default-closed, matching the EE
+      ``_http_guard`` which rejects internal hosts unconditionally.
 
     Returns an :class:`EgressTarget` carrying the single pinned IP. The caller
     MUST dial that IP via :class:`PinnedTransport` so the connection cannot be
@@ -303,7 +338,7 @@ async def assert_egress_allowed(url: str, allowed_hosts: set[str] | frozenset[st
     if not ips:
         raise EgressError(f"host '{host}' resolved to no addresses")
 
-    allow_internal = _allow_internal()
+    allow_internal = _egress_allow_internal()
     for ip in ips:
         if _ip_is_internal(ip) and not allow_internal:
             raise EgressError(f"host '{host}' resolves to an internal address")

--- a/src/pocketpaw/security/url_validators.py
+++ b/src/pocketpaw/security/url_validators.py
@@ -8,12 +8,31 @@
 # Updated: 2026-05-21 (PR #1177 security pass) — exposed a public
 #   ``host_is_internal`` alias and an ``__all__`` so callers no longer
 #   import the private ``_host_is_internal`` symbol.
+# Updated: 2026-06-28 (AW-1 connector egress guard) — added the OSS-side
+#   ``assert_egress_allowed(url, allowed_hosts)`` egress primitive and the
+#   pinned-IP ``PinnedTransport``. ``assert_egress_allowed`` enforces
+#   https-only, rejects userinfo (``@``) and fragments, requires the host to
+#   be in ``allowed_hosts``, DNS-resolves once, and rejects any resolved IP
+#   that is internal (reusing ``host_is_internal`` + the IP-class check the
+#   pocket guard already uses). It returns an ``EgressTarget`` carrying the
+#   resolved/pinned IP. ``PinnedTransport`` connects to that pinned IP while
+#   preserving the original Host header + TLS SNI, so there is no second DNS
+#   lookup between the check and the connect — closing the DNS-rebind TOCTOU.
+#   The EE ``_http_guard`` re-exports these so it stays the canonical entry
+#   point; the OSS connector engine imports them directly (the OSS->EE import
+#   boundary forbids importing ``pocketpaw_ee`` from core). When
+#   ``POCKETPAW_ALLOW_INTERNAL_URLS`` is set (dev escape) internal resolved
+#   IPs are permitted so localhost connectors keep working in development.
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import os
+import socket
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlsplit
 
 # Pre-load .env into os.environ at import time. Without this,
@@ -162,8 +181,203 @@ def validate_external_url_strict(value: str) -> str:
     return value
 
 
+# ---------------------------------------------------------------------------
+# Egress guard primitive (AW-1) — shared by the OSS connector engine and the
+# EE pocket HTTP guard (which re-exports it). Closes the connector SSRF bypass
+# by enforcing an allow-list + a DNS-rebind-safe pinned-IP transport.
+# ---------------------------------------------------------------------------
+
+
+class EgressError(ValueError):
+    """An egress-guard rejection. Subclasses ``ValueError`` so existing
+    ``except ValueError`` handlers around URL validation keep working."""
+
+
+@dataclass(frozen=True)
+class EgressTarget:
+    """The resolved, allow-listed target of an outbound request.
+
+    ``url`` is the original (validated) URL — unchanged, so the Host header
+    and TLS SNI stay correct. ``host`` is its hostname; ``port`` the resolved
+    port (scheme default applied). ``pinned_ip`` is the single IP the
+    connection MUST go to — :class:`PinnedTransport` dials it directly so no
+    second DNS lookup can race the check (the DNS-rebind TOCTOU).
+    """
+
+    url: str
+    host: str
+    port: int
+    pinned_ip: str
+
+
+def _ip_is_internal(ip: str) -> bool:
+    """True when ``ip`` (a literal) is loopback/private/link-local/reserved.
+
+    Layers the explicit ``host_is_internal`` block-list (RFC1918, CGNAT,
+    metadata link-local, …) with Python's ``ipaddress`` classification so
+    ranges the static list misses (e.g. multicast/reserved) are also caught.
+    """
+    if host_is_internal(ip):
+        return True
+    try:
+        addr = ipaddress.ip_address(ip.split("%", 1)[0])
+    except ValueError:
+        return False
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+def _resolve_ips(host: str) -> list[str]:
+    """Resolve ``host`` to its IP literals. Raises ``EgressError`` on failure."""
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise EgressError(f"host '{host}' could not be resolved") from exc
+    ips: list[str] = []
+    for info in infos:
+        ip = str(info[4][0]).split("%", 1)[0]  # strip a zone id (fe80::1%eth0)
+        if ip not in ips:
+            ips.append(ip)
+    return ips
+
+
+async def assert_egress_allowed(url: str, allowed_hosts: set[str] | frozenset[str]) -> EgressTarget:
+    """Validate an outbound URL against the egress policy and pin its IP.
+
+    Enforces, in order:
+
+    * ``https://`` only — plain http is rejected (an attacker who can force
+      http downgrades the channel and any allow-list bypass via redirect).
+    * No userinfo (``user:pass@host``) and no fragment — both are classic
+      allow-list-confusion vectors (the real host can hide after the ``@``).
+    * The hostname MUST be in ``allowed_hosts`` (compared case-insensitively).
+    * DNS resolves the host and EVERY resolved IP is rejected if internal
+      (loopback / RFC1918 / link-local / metadata / reserved), unless the dev
+      escape ``POCKETPAW_ALLOW_INTERNAL_URLS`` permits internal hosts.
+
+    Returns an :class:`EgressTarget` carrying the single pinned IP. The caller
+    MUST dial that IP via :class:`PinnedTransport` so the connection cannot be
+    re-resolved to a different (internal) address between this check and the
+    connect — that gap is the DNS-rebinding TOCTOU this guard exists to close.
+
+    Raises :class:`EgressError` (a ``ValueError``) on any policy violation.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise EgressError("URL must be a non-empty string")
+
+    parts = urlsplit(url)
+    if parts.scheme != "https":
+        raise EgressError(
+            f"URL scheme '{parts.scheme or '(none)'}' not allowed — egress is https-only"
+        )
+    if parts.username is not None or parts.password is not None or "@" in (parts.netloc or ""):
+        raise EgressError("URL must not contain userinfo (user:pass@host)")
+    if parts.fragment:
+        raise EgressError("URL must not contain a fragment")
+    host = parts.hostname
+    if not host:
+        raise EgressError(f"URL has no host: {url!r}")
+
+    normalized = {h.lower() for h in allowed_hosts}
+    if host.lower() not in normalized:
+        raise EgressError(f"host '{host}' is not in the egress allow-list")
+
+    # Resolve off the event loop; getaddrinfo blocks.
+    ips = await asyncio.to_thread(_resolve_ips, host)
+    if not ips:
+        raise EgressError(f"host '{host}' resolved to no addresses")
+
+    allow_internal = _allow_internal()
+    for ip in ips:
+        if _ip_is_internal(ip) and not allow_internal:
+            raise EgressError(f"host '{host}' resolves to an internal address")
+
+    port = parts.port or (443 if parts.scheme == "https" else 80)
+    # Pin the first resolved address. Every resolved IP already passed the
+    # internal-range check above, so whichever we pin is allow-listed.
+    return EgressTarget(url=url, host=host, port=port, pinned_ip=ips[0])
+
+
+_PINNED_TRANSPORT_CLS: type | None = None
+
+
+def _build_pinned_transport_cls() -> type:
+    """Build (once) the ``httpx.AsyncBaseTransport`` subclass for pinning.
+
+    Defined lazily so importing this module (which ``config.py`` imports at
+    startup) never requires httpx at import time — httpx is a hard dependency
+    but the class is only needed once an egress request is actually made.
+    httpx must subclass ``AsyncBaseTransport`` for ``AsyncClient(transport=...)``
+    to route requests through it.
+    """
+    global _PINNED_TRANSPORT_CLS
+    if _PINNED_TRANSPORT_CLS is not None:
+        return _PINNED_TRANSPORT_CLS
+
+    import httpx
+
+    class _PinnedTransport(httpx.AsyncBaseTransport):
+        """An httpx async transport that dials a pre-resolved (pinned) IP.
+
+        On each request it repoints ONLY the connection target to ``pinned_ip``
+        (by rewriting the request URL's host), while preserving the original
+        ``Host`` header and setting the ``sni_hostname`` extension to the real
+        hostname so TLS SNI + certificate validation run against the name, not
+        the IP. The bytes therefore go to the exact IP
+        :func:`assert_egress_allowed` already vetted — no second DNS lookup that
+        a rebinding attacker could race (the DNS-rebind TOCTOU).
+        """
+
+        def __init__(self, pinned_ip: str, *, verify: bool = True) -> None:
+            self._pinned_ip = pinned_ip
+            self._inner = httpx.AsyncHTTPTransport(verify=verify)
+
+        async def handle_async_request(self, request: Any) -> Any:
+            # httpx fixes the Host header at request-build time from the
+            # original URL host, so capture it before rewriting the URL.
+            original_host = request.url.host
+            # Repoint the connect target at the pinned IP (httpx brackets an
+            # IPv6 literal automatically). The Host header is left unchanged.
+            request.url = request.url.copy_with(host=self._pinned_ip)
+            request.headers["Host"] = original_host
+            # TLS handshake + cert validation use sni_hostname (read by
+            # httpcore), so the cert is verified against the real hostname,
+            # not the pinned IP.
+            request.extensions = dict(request.extensions or {})
+            request.extensions["sni_hostname"] = original_host
+            return await self._inner.handle_async_request(request)
+
+        async def aclose(self) -> None:
+            await self._inner.aclose()
+
+    _PINNED_TRANSPORT_CLS = _PinnedTransport
+    return _PinnedTransport
+
+
+def PinnedTransport(pinned_ip: str, *, verify: bool = True) -> Any:  # noqa: N802
+    """Return a pinned-IP ``httpx.AsyncBaseTransport`` for ``pinned_ip``.
+
+    A factory (spelled like a class for call-site readability) that defers the
+    httpx import + subclass construction until first use. Pass the result as
+    ``httpx.AsyncClient(transport=PinnedTransport(ip))`` so every request on
+    that client dials the vetted IP instead of re-resolving the hostname.
+    """
+    cls = _build_pinned_transport_cls()
+    return cls(pinned_ip, verify=verify)
+
+
 __all__ = [
     "host_is_internal",
     "validate_external_url",
     "validate_external_url_strict",
+    "EgressError",
+    "EgressTarget",
+    "assert_egress_allowed",
+    "PinnedTransport",
 ]

--- a/src/pocketpaw/security/url_validators.py
+++ b/src/pocketpaw/security/url_validators.py
@@ -23,6 +23,16 @@
 #   boundary forbids importing ``pocketpaw_ee`` from core). When
 #   ``POCKETPAW_ALLOW_INTERNAL_URLS`` is set (dev escape) internal resolved
 #   IPs are permitted so localhost connectors keep working in development.
+# Updated: 2026-06-28 (AW-2 cookie-jar fix) — ``PinnedTransport`` now RESTORES
+#   the request's original (hostname) URL after the inner transport returns.
+#   ``httpx.AsyncClient`` runs ``cookies.extract_cookies(response)`` AFTER the
+#   transport, keyed on ``response.request.url.host`` — the same request object
+#   the transport mutated in place. Leaving it pointed at the pinned IP stored
+#   every Set-Cookie against the IP, so the cookie jar never replayed on the
+#   next call (whose pre-transport URL is the hostname) — breaking
+#   session/cookie-auth under the guard. Restoring the hostname keeps cookie
+#   attribution on the real host. The connection still went to the pinned IP;
+#   only the post-hoc bookkeeping URL is reset.
 
 from __future__ import annotations
 
@@ -340,18 +350,32 @@ def _build_pinned_transport_cls() -> type:
 
         async def handle_async_request(self, request: Any) -> Any:
             # httpx fixes the Host header at request-build time from the
-            # original URL host, so capture it before rewriting the URL.
-            original_host = request.url.host
+            # original URL host, so capture the original URL before rewriting.
+            original_url = request.url
+            original_host = original_url.host
             # Repoint the connect target at the pinned IP (httpx brackets an
             # IPv6 literal automatically). The Host header is left unchanged.
-            request.url = request.url.copy_with(host=self._pinned_ip)
+            request.url = original_url.copy_with(host=self._pinned_ip)
             request.headers["Host"] = original_host
             # TLS handshake + cert validation use sni_hostname (read by
             # httpcore), so the cert is verified against the real hostname,
             # not the pinned IP.
             request.extensions = dict(request.extensions or {})
             request.extensions["sni_hostname"] = original_host
-            return await self._inner.handle_async_request(request)
+            try:
+                return await self._inner.handle_async_request(request)
+            finally:
+                # Restore the original (hostname) URL on the request object.
+                # ``AsyncClient`` runs ``cookies.extract_cookies(response)``
+                # AFTER the transport, keyed on ``response.request.url.host`` —
+                # which is THIS request object, mutated in place. If we leave it
+                # pointed at the pinned IP, every Set-Cookie is stored against
+                # the IP, so the cookie jar never replays on the next call (the
+                # next request's pre-transport URL is the hostname). Restoring
+                # the hostname here keeps cookie attribution on the real host,
+                # so session/cookie-auth survives the pin. The bytes already
+                # went to the pinned IP — this only fixes post-hoc bookkeeping.
+                request.url = original_url
 
         async def aclose(self) -> None:
             await self._inner.aclose()

--- a/tests/cloud/connectors/test_state_provider.py
+++ b/tests/cloud/connectors/test_state_provider.py
@@ -12,6 +12,12 @@
 #   test: a disabled row's credentials must never reach the legacy fallback's
 #   connect() (the fallback doc read now filters enabled == True), so disable
 #   revokes on the HTTP execute path too, not just the durable seam.
+# Updated: 2026-06-28 (AW-2 connector multi-host egress allow-list) — added
+#   TestCloudStoreAllowedHosts: _get_cloud folds the row's ``allowed_hosts``
+#   field into the returned config dict (so the per-workspace egress additions
+#   reach the adapter's connect() via the config channel), and _set_cloud
+#   strips the key back out before persisting (the dedicated field stays the
+#   single source of truth; the round-trip never duplicates it into config).
 
 from __future__ import annotations
 
@@ -40,6 +46,7 @@ async def _seed_doc(
     pocket_id: str | None = None,
     enabled: bool = True,
     config: dict | None = None,
+    allowed_hosts: list[str] | None = None,
 ) -> WorkspaceConnector:
     doc = WorkspaceConnector(
         workspace=workspace,
@@ -48,6 +55,7 @@ async def _seed_doc(
         scope=scope,
         pocket_id=pocket_id,
         config=config if config is not None else {"GITHUB_TOKEN": "ghp_test"},
+        allowed_hosts=allowed_hosts if allowed_hosts is not None else [],
     )
     await doc.insert()
     return doc
@@ -252,6 +260,55 @@ class TestCloudStoreOwnership:
     def test_list_returns_file_rows_only(self, cloud_store):
         cloud_store.set("testsvc", "default", {"k": "v"})
         assert cloud_store.list() == [("testsvc", "default")]
+
+
+class TestCloudStoreAllowedHosts:
+    """AW-2 — the per-workspace egress allow-list field rides the config channel
+    on read and is stripped back out on write."""
+
+    @pytest.mark.asyncio
+    async def test_get_folds_allowed_hosts_into_config(
+        self,
+        mongo_db,  # noqa: ARG002 — wires Beanie
+        cloud_store,
+    ):
+        await _seed_doc(
+            config={"GITHUB_TOKEN": "x"},
+            allowed_hosts=["mirror.example.com", "cdn.example.com"],
+        )
+        got = await cloud_store.get("github", "ws:ws-1")
+        # The dedicated field is folded into config so it reaches connect().
+        assert got == {
+            "GITHUB_TOKEN": "x",
+            "allowed_hosts": ["mirror.example.com", "cdn.example.com"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_omits_key_when_no_allowed_hosts(
+        self,
+        mongo_db,  # noqa: ARG002
+        cloud_store,
+    ):
+        # Empty allowed_hosts → no key added (config stays byte-identical).
+        await _seed_doc(config={"GITHUB_TOKEN": "x"}, allowed_hosts=[])
+        assert await cloud_store.get("github", "ws:ws-1") == {"GITHUB_TOKEN": "x"}
+
+    @pytest.mark.asyncio
+    async def test_set_strips_allowed_hosts_from_persisted_config(
+        self,
+        mongo_db,  # noqa: ARG002
+        cloud_store,
+    ):
+        # A round-trip (get folds in, set writes back) must NOT duplicate the
+        # key into the stored config blob — the field stays the source of truth.
+        doc = await _seed_doc(config={"GITHUB_TOKEN": "x"}, allowed_hosts=["mirror.example.com"])
+        folded = await cloud_store.get("github", "ws:ws-1")
+        assert "allowed_hosts" in folded  # present on read
+        await cloud_store.set("github", "ws:ws-1", folded)
+        refreshed = await WorkspaceConnector.get(doc.id)
+        # Stored config has the key stripped; the dedicated field is untouched.
+        assert refreshed.config == {"GITHUB_TOKEN": "x"}
+        assert refreshed.allowed_hosts == ["mirror.example.com"]
 
     @pytest.mark.asyncio
     async def test_get_degrades_softly_when_db_unavailable(self, cloud_store, monkeypatch):

--- a/tests/connectors/test_egress_guard.py
+++ b/tests/connectors/test_egress_guard.py
@@ -1,0 +1,255 @@
+# Tests for the AW-1 connector egress guard.
+# Added: 2026-06-28 (AW-1) — proves the SSRF egress primitive in
+#   ``pocketpaw.security.url_validators`` and its wiring into the DirectREST
+#   connector engine (``yaml_engine.DirectRESTAdapter``):
+#     * an allow-listed public host passes ``assert_egress_allowed`` and yields
+#       a pinned EgressTarget;
+#     * a non-allow-listed host, an http (non-https) URL, userinfo / fragment,
+#       and a loopback/internal-resolving host are all rejected;
+#     * ``PinnedTransport`` repoints the connect at the resolved IP while
+#       preserving the Host header + sni_hostname (no second DNS lookup);
+#     * a host that is allow-listed but RESOLVES to an internal IP is still
+#       blocked at the check (DNS-rebind defense);
+#     * an end-to-end connector smoke (mocked httpx transport) shows a
+#       non-allow-listed host blocked and an allowed host succeeding, gated by
+#       the POCKETPAW_CONNECTOR_EGRESS_GUARD flag.
+# DNS is mocked throughout (no network); ``POCKETPAW_ALLOW_INTERNAL_URLS`` is
+# pinned per-test so the dev escape never leaks across cases.
+
+from __future__ import annotations
+
+import socket
+
+import httpx
+import pytest
+
+from pocketpaw.security.url_validators import (
+    EgressError,
+    PinnedTransport,
+    assert_egress_allowed,
+)
+
+
+def _fake_getaddrinfo(mapping: dict[str, list[str]]):
+    """Build a ``socket.getaddrinfo`` stub returning the IPs in ``mapping``.
+
+    ``mapping`` is host -> list of IP strings. An unmapped host raises
+    ``socket.gaierror`` (matches a real resolution failure).
+    """
+
+    def _stub(host, *args, **kwargs):
+        ips = mapping.get(host)
+        if not ips:
+            raise socket.gaierror(f"name resolution disabled in test: {host}")
+        # getaddrinfo returns 5-tuples; only info[4][0] (the sockaddr host) is read.
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0)) for ip in ips]
+
+    return _stub
+
+
+@pytest.fixture(autouse=True)
+def _block_internal(monkeypatch):
+    """Default every test to the strict posture (internal hosts blocked)."""
+    monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+
+
+class TestAssertEgressAllowed:
+    async def test_allowed_host_passes(self, monkeypatch):
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"api.example.com": ["93.184.216.34"]})
+        )
+        target = await assert_egress_allowed(
+            "https://api.example.com/v1/orders", {"api.example.com"}
+        )
+        assert target.host == "api.example.com"
+        assert target.port == 443
+        assert target.pinned_ip == "93.184.216.34"
+        assert target.url == "https://api.example.com/v1/orders"
+
+    async def test_non_allowlisted_host_rejected(self, monkeypatch):
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"evil.com": ["93.184.216.34"]})
+        )
+        with pytest.raises(EgressError, match="allow-list"):
+            await assert_egress_allowed("https://evil.com/steal", {"api.example.com"})
+
+    async def test_http_scheme_rejected(self, monkeypatch):
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"api.example.com": ["93.184.216.34"]})
+        )
+        with pytest.raises(EgressError, match="https-only"):
+            await assert_egress_allowed("http://api.example.com/v1", {"api.example.com"})
+
+    async def test_userinfo_rejected(self):
+        # userinfo lets the real host hide after the '@'; reject before DNS.
+        with pytest.raises(EgressError, match="userinfo"):
+            await assert_egress_allowed("https://api.example.com@evil.com/", {"api.example.com"})
+
+    async def test_fragment_rejected(self):
+        with pytest.raises(EgressError, match="fragment"):
+            await assert_egress_allowed("https://api.example.com/v1#frag", {"api.example.com"})
+
+    async def test_loopback_host_rejected(self, monkeypatch):
+        # An allow-listed host name that resolves to loopback is still blocked.
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"localish.example.com": ["127.0.0.1"]})
+        )
+        with pytest.raises(EgressError, match="internal address"):
+            await assert_egress_allowed("https://localish.example.com/", {"localish.example.com"})
+
+    async def test_metadata_ip_rejected(self, monkeypatch):
+        # AWS metadata endpoint via a public-looking name — classic SSRF target.
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"metadata.example.com": ["169.254.169.254"]})
+        )
+        with pytest.raises(EgressError, match="internal address"):
+            await assert_egress_allowed(
+                "https://metadata.example.com/latest/meta-data", {"metadata.example.com"}
+            )
+
+    async def test_dns_rebind_after_allowlist_still_blocked(self, monkeypatch):
+        """The core TOCTOU case: the host IS allow-listed by name, but DNS now
+        returns an internal IP. ``assert_egress_allowed`` re-resolves at call
+        time and rejects, so the pin can never point at the internal address."""
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"rebind.example.com": ["10.0.0.7"]})
+        )
+        with pytest.raises(EgressError, match="internal address"):
+            await assert_egress_allowed("https://rebind.example.com/", {"rebind.example.com"})
+
+    async def test_internal_allowed_with_dev_escape(self, monkeypatch):
+        # POCKETPAW_ALLOW_INTERNAL_URLS=true is the documented dev escape.
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "true")
+        monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo({"dev.local": ["127.0.0.1"]}))
+        target = await assert_egress_allowed("https://dev.local/api", {"dev.local"})
+        assert target.pinned_ip == "127.0.0.1"
+
+
+class TestPinnedTransport:
+    async def test_connect_target_is_pinned_ip(self, monkeypatch):
+        """The transport must dial the pinned IP while keeping the Host header
+        and sni_hostname on the original hostname (so TLS verifies the cert and
+        no second DNS lookup happens)."""
+        captured: dict[str, object] = {}
+
+        async def _fake_inner(self, request):  # noqa: ANN001
+            captured["connect_host"] = request.url.host
+            captured["host_header"] = request.headers.get("Host")
+            captured["sni"] = request.extensions.get("sni_hostname")
+            return httpx.Response(200, request=request)
+
+        monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", _fake_inner)
+
+        transport = PinnedTransport("93.184.216.34")
+        request = httpx.Request("GET", "https://api.example.com/v1/orders")
+        resp = await transport.handle_async_request(request)
+        await transport.aclose()
+
+        assert resp.status_code == 200
+        # Connection went to the pinned IP, not a re-resolved hostname.
+        assert captured["connect_host"] == "93.184.216.34"
+        # Host header + TLS SNI preserved the original name.
+        assert captured["host_header"] == "api.example.com"
+        assert captured["sni"] == "api.example.com"
+
+
+class TestConnectorEgressSmoke:
+    """End-to-end-ish: drive ``DirectRESTAdapter.execute`` with the guard on,
+    using a mocked httpx transport so no real socket is opened."""
+
+    def _adapter(self, monkeypatch, *, base_url: str):
+        from pocketpaw.connectors.yaml_engine import ConnectorDef, DirectRESTAdapter
+
+        cdef = ConnectorDef(
+            name="demo",
+            display_name="Demo",
+            auth={"method": "none"},
+            actions=[{"name": "fetch", "method": "GET", "content_type": ""}],
+        )
+        adapter = DirectRESTAdapter(cdef)
+        adapter._connected = True
+        adapter._credentials = {"BASE_URL": base_url}
+        return adapter
+
+    def _force_guard(self, monkeypatch, enabled: bool) -> None:
+        """Force the egress-guard flag without a full ``Settings.load()``.
+
+        ``DirectRESTAdapter._egress_guard_enabled`` reads ``get_settings()``,
+        but reloading settings here would re-validate the developer's workspace
+        ``.env`` (which legitimately points several URL fields at localhost) and
+        fail. Patching the classmethod keeps this test about the guard wiring,
+        not the settings loader — the flag<->settings binding is covered by the
+        config test suite.
+        """
+        from pocketpaw.connectors.yaml_engine import DirectRESTAdapter
+
+        monkeypatch.setattr(
+            DirectRESTAdapter, "_egress_guard_enabled", staticmethod(lambda: enabled)
+        )
+
+    async def test_blocked_host_returns_egress_error(self, monkeypatch):
+        # Guard ON. The connector's declared base-URL host is the only
+        # allow-listed host; here that host resolves to an internal IP, so the
+        # check blocks it (DNS pre-resolve + internal-range reject).
+        self._force_guard(monkeypatch, True)
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"internal.example.com": ["10.1.2.3"]})
+        )
+
+        adapter = self._adapter(monkeypatch, base_url="https://internal.example.com")
+        result = await adapter.execute("fetch", {"path": "data"})
+        assert result.success is False
+        assert "egress guard" in result.error.lower()
+
+    async def test_allowed_host_succeeds_through_pinned_transport(self, monkeypatch):
+        # Guard ON, public host, mocked inner transport returns 200 JSON.
+        self._force_guard(monkeypatch, True)
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"api.example.com": ["93.184.216.34"]})
+        )
+
+        seen: dict[str, object] = {}
+
+        async def _fake_inner(self, request):  # noqa: ANN001
+            seen["connect_host"] = request.url.host
+            seen["host_header"] = request.headers.get("Host")
+            return httpx.Response(
+                200,
+                request=request,
+                headers={"content-type": "application/json"},
+                json={"ok": True, "data": [1, 2, 3]},
+            )
+
+        monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", _fake_inner)
+
+        adapter = self._adapter(monkeypatch, base_url="https://api.example.com")
+        result = await adapter.execute("fetch", {"path": "orders"})
+
+        assert result.success is True, result.error
+        assert result.data == {"ok": True, "data": [1, 2, 3]}
+        # Proof the bytes went to the pinned IP through the client transport,
+        # with the Host header preserved as the original hostname.
+        assert seen["connect_host"] == "93.184.216.34"
+        assert seen["host_header"] == "api.example.com"
+
+    async def test_guard_off_uses_pooled_client_unchanged(self, monkeypatch):
+        # Guard OFF (default): no allow-list, no pin — the legacy pooled path.
+        self._force_guard(monkeypatch, False)
+
+        async def _fake_inner(self, request):  # noqa: ANN001
+            # Pooled path leaves the URL host as the hostname (no pin).
+            return httpx.Response(
+                200,
+                request=request,
+                headers={"content-type": "application/json"},
+                json={"pooled": True},
+            )
+
+        monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", _fake_inner)
+
+        adapter = self._adapter(monkeypatch, base_url="https://api.example.com")
+        result = await adapter.execute("fetch", {"path": "orders"})
+        assert result.success is True, result.error
+        assert result.data == {"pooled": True}

--- a/tests/connectors/test_egress_guard.py
+++ b/tests/connectors/test_egress_guard.py
@@ -30,6 +30,13 @@
 #       error instead of silently disabling the guard (concern fix 1);
 #     * explicit ``allowed_hosts:`` (YAML) and per-workspace allowed_hosts (via
 #       connect() config) are layered on top of the auto-seeded hosts.
+# Updated: 2026-07-02 (AW-3 egress default-close) — added
+#   ``test_internal_rejected_when_flag_unset``: with POCKETPAW_ALLOW_INTERNAL_URLS
+#   UNSET (delenv, not just "false"), an allow-listed host resolving to a
+#   metadata IP is still rejected — proves the guard is default-closed. Also
+#   dropped the dead ``yaml_engine.get_settings`` no-op patch in
+#   ``TestEgressGuardFailsClosed`` (the method imports get_settings locally from
+#   pocketpaw.config, so only the config_mod patch is load-bearing).
 
 from __future__ import annotations
 
@@ -131,6 +138,23 @@ class TestAssertEgressAllowed:
         )
         with pytest.raises(EgressError, match="internal address"):
             await assert_egress_allowed("https://rebind.example.com/", {"rebind.example.com"})
+
+    async def test_internal_rejected_when_flag_unset(self, monkeypatch):
+        """AW-3 default-close: with POCKETPAW_ALLOW_INTERNAL_URLS UNSET (the
+        realistic prod state), an allow-listed host that resolves to a metadata
+        IP must STILL be rejected. Before the fix the egress guard reused the
+        permissive ``_allow_internal()`` (unset ⇒ True), so this pinned the
+        internal address — default-OPEN SSRF. The guard now defaults to reject."""
+        # The autouse fixture pins the flag to "false"; delete it entirely so we
+        # exercise the genuine unset path, not the explicit-false path.
+        monkeypatch.delenv("POCKETPAW_ALLOW_INTERNAL_URLS", raising=False)
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"metadata.example.com": ["169.254.169.254"]})
+        )
+        with pytest.raises(EgressError, match="internal address"):
+            await assert_egress_allowed(
+                "https://metadata.example.com/latest/meta-data", {"metadata.example.com"}
+            )
 
     async def test_internal_allowed_with_dev_escape(self, monkeypatch):
         # POCKETPAW_ALLOW_INTERNAL_URLS=true is the documented dev escape.
@@ -579,15 +603,14 @@ class TestEgressGuardFailsClosed:
     def test_fails_closed_on_settings_error(self, monkeypatch, caplog):
         import logging
 
-        from pocketpaw.connectors import yaml_engine
         from pocketpaw.connectors.yaml_engine import DirectRESTAdapter
 
         def _boom():
             raise RuntimeError("settings blew up")
 
-        # Patch get_settings at its source so the import inside the method hits
-        # the raising stub.
-        monkeypatch.setattr(yaml_engine, "get_settings", _boom, raising=False)
+        # ``_egress_guard_enabled`` imports get_settings locally from
+        # pocketpaw.config, so patch it there — that binding is what the method
+        # actually resolves.
         import pocketpaw.config as config_mod
 
         monkeypatch.setattr(config_mod, "get_settings", _boom)

--- a/tests/connectors/test_egress_guard.py
+++ b/tests/connectors/test_egress_guard.py
@@ -15,6 +15,21 @@
 #       the POCKETPAW_CONNECTOR_EGRESS_GUARD flag.
 # DNS is mocked throughout (no network); ``POCKETPAW_ALLOW_INTERNAL_URLS`` is
 # pinned per-test so the dev escape never leaks across cases.
+# Updated: 2026-06-28 (AW-2 multi-host allow-list + concern fixes) — added
+#   ``TestEffectiveAllowList`` and ``TestConnectorMultiHost`` proving:
+#     * a two-host connector (auth host on auth.auth_url ≠ the API host) calls
+#       BOTH hosts successfully under the guard — both are auto-seeded;
+#     * a templated base URL ({FOO}.api.example.com) resolves at call time and
+#       is checked by its RESOLVED host (not the template string);
+#     * a request to a host outside the connector's declared topology is
+#       blocked with a clean "egress guard" error even though it resolves to a
+#       public IP (the allow-list is now meaningful, not tautological);
+#     * a cookie/session-auth connector keeps its cookie jar across two calls
+#       under the guard (the pinned client is cached per host, concern fix 2);
+#     * ``_egress_guard_enabled`` FAILS CLOSED (returns True) on a settings-load
+#       error instead of silently disabling the guard (concern fix 1);
+#     * explicit ``allowed_hosts:`` (YAML) and per-workspace allowed_hosts (via
+#       connect() config) are layered on top of the auto-seeded hosts.
 
 from __future__ import annotations
 
@@ -253,3 +268,348 @@ class TestConnectorEgressSmoke:
         result = await adapter.execute("fetch", {"path": "orders"})
         assert result.success is True, result.error
         assert result.data == {"pooled": True}
+
+
+# ---------------------------------------------------------------------------
+# AW-2 — multi-host allow-list, edge cases, and the two AW-1 concern fixes.
+# ---------------------------------------------------------------------------
+
+
+def _force_guard(monkeypatch, enabled: bool) -> None:
+    """Force the egress-guard flag without a full ``Settings.load()``.
+
+    Same rationale as ``TestConnectorEgressSmoke._force_guard`` — patching the
+    classmethod keeps these tests about guard behavior, not the settings loader
+    (the workspace ``.env`` legitimately points URL fields at localhost).
+    """
+    from pocketpaw.connectors.yaml_engine import DirectRESTAdapter
+
+    monkeypatch.setattr(DirectRESTAdapter, "_egress_guard_enabled", staticmethod(lambda: enabled))
+
+
+class TestEffectiveAllowList:
+    """Unit-test the allow-list builder: auto-seed from declared base-URL host
+    + auth-endpoint host + explicit additions, with template resolution."""
+
+    def _adapter(self, **kw):
+        from pocketpaw.connectors.yaml_engine import ConnectorDef, DirectRESTAdapter
+
+        cdef = ConnectorDef(name="demo", display_name="Demo", **kw)
+        return DirectRESTAdapter(cdef)
+
+    def test_seeds_from_declared_action_hosts(self):
+        adapter = self._adapter(
+            actions=[
+                {"name": "a", "url": "https://api.example.com/v1/x"},
+                {"name": "b", "url": "https://api.example.com/v1/y"},
+            ]
+        )
+        assert adapter._effective_allowed_hosts() == {"api.example.com"}
+
+    def test_seeds_auth_endpoint_host_distinct_from_api(self):
+        # Two-host connector: API on api.example.com, auth on auth.example.com.
+        adapter = self._adapter(
+            auth={"method": "bearer", "auth_url": "https://auth.example.com/oauth/token"},
+            actions=[{"name": "a", "url": "https://api.example.com/v1/x"}],
+        )
+        assert adapter._effective_allowed_hosts() == {"api.example.com", "auth.example.com"}
+
+    def test_resolves_templated_host_from_credentials(self):
+        # A templated base URL resolves through the SAME substitution execute()
+        # applies — the allow-list carries the REAL host, not "{FOO}...".
+        adapter = self._adapter(
+            actions=[{"name": "a", "url": "https://{REGION}.freshdesk.com/api/v2/tickets"}]
+        )
+        adapter._credentials = {"REGION": "acme"}
+        assert adapter._effective_allowed_hosts() == {"acme.freshdesk.com"}
+
+    def test_unresolved_template_is_dropped_not_allowlisted(self):
+        # No credential to fill {REGION} → the template host is dropped, never
+        # added as a literal "{region}.freshdesk.com".
+        adapter = self._adapter(actions=[{"name": "a", "url": "https://{REGION}.freshdesk.com/x"}])
+        assert adapter._effective_allowed_hosts() == set()
+
+    def test_base_url_credential_host_is_seeded(self):
+        # The build-from-BASE_URL path host is allow-listed too.
+        adapter = self._adapter(actions=[{"name": "a"}])
+        adapter._credentials = {"BASE_URL": "https://gitlab.example.com"}
+        assert adapter._effective_allowed_hosts() == {"gitlab.example.com"}
+
+    def test_explicit_yaml_allowed_hosts_layered_on_top(self):
+        adapter = self._adapter(
+            actions=[{"name": "a", "url": "https://api.example.com/x"}],
+            allowed_hosts=["cdn.example.com", "Mirror.Example.COM"],
+        )
+        assert adapter._effective_allowed_hosts() == {
+            "api.example.com",
+            "cdn.example.com",
+            "mirror.example.com",  # normalized lowercase
+        }
+
+    def test_workspace_allowed_hosts_from_connect_config(self):
+        adapter = self._adapter(actions=[{"name": "a", "url": "https://api.example.com/x"}])
+        # Simulate what connect() captures from the WorkspaceConnector config.
+        adapter._ws_allowed_hosts = ["extra.example.com"]
+        assert adapter._effective_allowed_hosts() == {"api.example.com", "extra.example.com"}
+
+    def test_ipv6_literal_base_url_host_normalized(self):
+        # An IPv6-literal base URL keeps its host (brackets stripped) so a
+        # request to that literal is allow-listed; the resolved-IP internal
+        # check still applies at request time.
+        adapter = self._adapter(actions=[{"name": "a", "url": "https://[2606:2800:220:1::1]/x"}])
+        assert adapter._effective_allowed_hosts() == {"2606:2800:220:1::1"}
+
+
+class TestConnectorMultiHost:
+    """End-to-end-ish connector.execute() with the guard on and DNS mocked."""
+
+    def _adapter(self, monkeypatch, *, base_url="", actions=None, auth=None, **kw):
+        from pocketpaw.connectors.yaml_engine import ConnectorDef, DirectRESTAdapter
+
+        cdef = ConnectorDef(
+            name="demo",
+            display_name="Demo",
+            auth=auth or {"method": "none"},
+            actions=actions or [{"name": "fetch", "method": "GET"}],
+            **kw,
+        )
+        adapter = DirectRESTAdapter(cdef)
+        adapter._connected = True
+        if base_url:
+            adapter._credentials = {"BASE_URL": base_url}
+        return adapter
+
+    async def test_two_host_connector_both_hosts_succeed(self, monkeypatch):
+        # auth host ≠ API host; both are seeded so a call to EITHER works.
+        _force_guard(monkeypatch, True)
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            _fake_getaddrinfo(
+                {
+                    "api.example.com": ["93.184.216.34"],
+                    "auth.example.com": ["93.184.216.35"],
+                }
+            ),
+        )
+
+        async def _fake_inner(self, request):  # noqa: ANN001
+            return httpx.Response(
+                200,
+                request=request,
+                headers={"content-type": "application/json"},
+                json={"host": request.headers.get("Host")},
+            )
+
+        monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", _fake_inner)
+
+        adapter = self._adapter(
+            monkeypatch,
+            auth={"method": "none", "auth_url": "https://auth.example.com/oauth/token"},
+            actions=[
+                {"name": "api_call", "method": "GET", "url": "https://api.example.com/v1/orders"},
+                {
+                    "name": "auth_call",
+                    "method": "GET",
+                    "url": "https://auth.example.com/oauth/token",
+                },
+            ],
+        )
+
+        api = await adapter.execute("api_call", {})
+        assert api.success is True, api.error
+        assert api.data == {"host": "api.example.com"}
+
+        auth = await adapter.execute("auth_call", {})
+        assert auth.success is True, auth.error
+        assert auth.data == {"host": "auth.example.com"}
+
+    async def test_templated_host_resolved_and_allowed(self, monkeypatch):
+        # The connector's base URL is templated; it resolves to a concrete host
+        # that IS its own declared host, so the guard passes by RESOLVED host.
+        _force_guard(monkeypatch, True)
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"acme.freshdesk.com": ["93.184.216.34"]})
+        )
+
+        async def _fake_inner(self, request):  # noqa: ANN001
+            return httpx.Response(
+                200,
+                request=request,
+                headers={"content-type": "application/json"},
+                json={"ok": True},
+            )
+
+        monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", _fake_inner)
+
+        adapter = self._adapter(
+            monkeypatch,
+            actions=[
+                {
+                    "name": "tickets",
+                    "method": "GET",
+                    "url": "https://{REGION}.freshdesk.com/api/v2/tickets",
+                }
+            ],
+        )
+        adapter._credentials = {"REGION": "acme"}
+        result = await adapter.execute("tickets", {})
+        assert result.success is True, result.error
+
+    async def test_host_outside_declared_topology_blocked(self, monkeypatch):
+        # The connector declares api.example.com, but the action URL carries a
+        # PER-CALL {host} placeholder filled from params at call time (a classic
+        # SSRF vector: caller-controlled host). The substituted host is NOT in
+        # the connector's declared topology, so the allow-list rejects it BEFORE
+        # any connect — proof the list is meaningful, not the request host echoed
+        # back. evil.example.com resolves to a PUBLIC IP, so it is the allow-list
+        # (not the internal-IP check) that does the blocking.
+        _force_guard(monkeypatch, True)
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            _fake_getaddrinfo(
+                {"api.example.com": ["93.184.216.34"], "evil.example.com": ["93.184.216.99"]}
+            ),
+        )
+
+        adapter = self._adapter(
+            monkeypatch,
+            actions=[
+                # The declared host is api.example.com; {host} is a call-time
+                # param, never part of the static allow-list seed.
+                {"name": "fetch", "method": "GET", "url": "https://{host}/v1/x"},
+            ],
+        )
+        # Seed a credential so the connector's OWN declared host is allow-listed,
+        # then drive the request to a different, attacker-supplied host.
+        adapter._credentials = {"BASE_URL": "https://api.example.com"}
+        result = await adapter.execute("fetch", {"host": "evil.example.com"})
+        assert result.success is False
+        assert "egress guard" in result.error.lower()
+        assert "allow-list" in result.error.lower()
+
+    async def test_cookie_jar_persists_across_calls_under_guard(self, monkeypatch):
+        # Concern fix 2: the pinned client is cached per host, so a Set-Cookie
+        # from call 1 is sent back on call 2 (session/cookie-auth stays working).
+        _force_guard(monkeypatch, True)
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"api.example.com": ["93.184.216.34"]})
+        )
+
+        seen_cookies: list[str | None] = []
+
+        async def _fake_inner(self, request):  # noqa: ANN001
+            seen_cookies.append(request.headers.get("Cookie"))
+            # First response plants a session cookie; httpx stores it in the
+            # client's cookie jar and replays it on the next request.
+            return httpx.Response(
+                200,
+                request=request,
+                headers={
+                    "content-type": "application/json",
+                    "set-cookie": "sessionid=abc123; Path=/",
+                },
+                json={"ok": True},
+            )
+
+        monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", _fake_inner)
+
+        adapter = self._adapter(
+            monkeypatch,
+            actions=[{"name": "fetch", "method": "GET", "url": "https://api.example.com/v1/x"}],
+        )
+
+        r1 = await adapter.execute("fetch", {})
+        r2 = await adapter.execute("fetch", {})
+        assert r1.success is True and r2.success is True
+
+        # Call 1 sent no cookie; call 2 replayed the cookie the jar stored —
+        # only possible if the SAME (cached) pinned client served both calls.
+        assert seen_cookies[0] is None
+        assert seen_cookies[1] == "sessionid=abc123"
+        # And exactly one pinned client was cached for the host.
+        assert list(adapter._pinned_clients.keys()) == ["api.example.com"]
+        await adapter.disconnect("p")
+        # disconnect tears the cache down.
+        assert adapter._pinned_clients == {}
+
+    async def test_workspace_allowed_hosts_via_connect_config(self, monkeypatch):
+        # A host NOT in the YAML but added per-workspace (through connect config)
+        # is allow-listed — proves the WorkspaceConnector.allowed_hosts wiring.
+        _force_guard(monkeypatch, True)
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"mirror.example.com": ["93.184.216.34"]})
+        )
+
+        async def _fake_inner(self, request):  # noqa: ANN001
+            return httpx.Response(
+                200,
+                request=request,
+                headers={"content-type": "application/json"},
+                json={"ok": True},
+            )
+
+        monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", _fake_inner)
+
+        from pocketpaw.connectors.yaml_engine import ConnectorDef, DirectRESTAdapter
+
+        cdef = ConnectorDef(
+            name="demo",
+            display_name="Demo",
+            auth={"method": "none"},
+            actions=[{"name": "fetch", "method": "GET", "url": "https://mirror.example.com/x"}],
+        )
+        adapter = DirectRESTAdapter(cdef)
+        # connect() captures allowed_hosts from the config blob the cloud layer
+        # folds WorkspaceConnector.allowed_hosts into.
+        await adapter.connect("p", {"allowed_hosts": ["mirror.example.com"]})
+        result = await adapter.execute("fetch", {})
+        assert result.success is True, result.error
+
+
+class TestEgressGuardFailsClosed:
+    """Concern fix 1: a settings-load error must NOT silently disable the guard."""
+
+    def test_fails_closed_on_settings_error(self, monkeypatch, caplog):
+        import logging
+
+        from pocketpaw.connectors import yaml_engine
+        from pocketpaw.connectors.yaml_engine import DirectRESTAdapter
+
+        def _boom():
+            raise RuntimeError("settings blew up")
+
+        # Patch get_settings at its source so the import inside the method hits
+        # the raising stub.
+        monkeypatch.setattr(yaml_engine, "get_settings", _boom, raising=False)
+        import pocketpaw.config as config_mod
+
+        monkeypatch.setattr(config_mod, "get_settings", _boom)
+
+        with caplog.at_level(logging.ERROR):
+            enabled = DirectRESTAdapter._egress_guard_enabled()
+
+        # FAIL CLOSED — guard runs (True) rather than silently turning off.
+        assert enabled is True
+        assert any("FAILING CLOSED" in rec.message for rec in caplog.records)
+
+    def test_returns_flag_when_settings_ok(self, monkeypatch):
+        from types import SimpleNamespace
+
+        import pocketpaw.config as config_mod
+        from pocketpaw.connectors.yaml_engine import DirectRESTAdapter
+
+        monkeypatch.setattr(
+            config_mod, "get_settings", lambda: SimpleNamespace(connector_egress_guard=True)
+        )
+        assert DirectRESTAdapter._egress_guard_enabled() is True
+        monkeypatch.setattr(
+            config_mod, "get_settings", lambda: SimpleNamespace(connector_egress_guard=False)
+        )
+        assert DirectRESTAdapter._egress_guard_enabled() is False


### PR DESCRIPTION
## What

Connector HTTP calls went out as raw httpx requests with no SSRF guard, no host allow-list, and no DNS-rebinding protection, while carrying the connector's stored credentials. This routes them through the same `_http_guard` the pocket executors already use, behind a per-connector default-deny host allow-list.

Two commits:
- **AW-1** — the egress primitive (`assert_egress_allowed` + `PinnedTransport` in OSS `security/url_validators.py`, with EE `_http_guard` re-exporting it so there is still one canonical guard). Wired into `yaml_engine.execute()` behind `POCKETPAW_CONNECTOR_EGRESS_GUARD`.
- **AW-2** — `allowed_hosts` on the connector definition and the workspace connector, auto-seeded from the base host and the auth-endpoint host, with multi-host / IP-literal / IPv6 / templated-host handling. Fails closed on a settings error, and uses a pooled pinned client so cookie/session-auth connectors keep their jar.

## Security properties (each has a test)

- internal / loopback / metadata IPs and non-allow-listed hosts are rejected
- a host that resolves to an internal IP after passing the allow-list is still blocked at connect — the pinned IP closes the DNS-rebinding TOCTOU
- https-only; userinfo and fragments rejected; redirects stay off
- the guard fails closed (blocks), not open, when it is enabled and the settings load fails

## Rollout

`POCKETPAW_CONNECTOR_EGRESS_GUARD` defaults **off**, so behavior is unchanged until a deployment flips it on. Recommend flipping per-deployment after a short soak. Closing the live bypass needs that flip — flagging so it is a deliberate decision, not a silent default.

## Tests

49 targeted tests pass (egress guard + state provider); the connectors suite passes 186; `lint-imports` keeps the OSS→EE boundary; `ruff` clean. Two pre-existing failures in `test_ui_agent_invariant.py` were confirmed unrelated by stashing.

## Design

`docs/design/drafts/2026-06-24-aiam-whitespace-hardening{,-prd,-tasks}.md` — Slice 1 (AW-1, AW-2). Part of closing the gaps in Anthropic's Agent Identity Access Model.

Recommend a `/security-review` pass before merge.
