### PR TITLE
feat(instinct): finish deny-by-default — read_only marker + template deny-on-no-match

### DIFF
--- a/docs/concepts/pocket-write-actions.mdx
+++ b/docs/concepts/pocket-write-actions.mdx
@@ -75,7 +75,9 @@ A write binding lives inside `rippleSpec.actions` on the pocket. The minimum sha
 |-------|---------|
 | `method` | One of `POST` / `PUT` / `PATCH` / `DELETE`. Validated server-side; the client cannot override. |
 | `path` | Resolved path appended to the backend `base_url`. `:placeholder` segments are filled at call time. |
-| `requires_instinct` | When `true`, runs validation gates but parks the write for human approval via the Instinct surface. |
+| `requires_instinct` | Defaults to **`true`** (deny-by-default): runs validation gates but parks the write for human approval via the Instinct surface. Set `false` only with `instinct_exempt: true` to fire ungated. |
+| `instinct_exempt` | When `true` (paired with `requires_instinct: false`), the explicit, auditable opt-out of the gate. Rejected by the model validator alongside an `instinct_policy`. |
+| `read_only` | When `true`, marks a genuinely safe read (`GET` / `HEAD`) that proceeds ungated. Rejected on any mutating method or alongside an `instinct_policy`. See [Deny-by-default](#deny-by-default). |
 | `instinct_policy` | Optional reference to a named Instinct policy. Rejected by the model validator if set without `requires_instinct`. |
 | `outcome` | Optional outcome name emitted on success. Feeds RFC 07's DecisionProjection. |
 | `compensate` | Optional inverse-write spec (`{method, path, params, outcome?}`) — the action that undoes this one if a later step in a write sequence fails. Fired by the Saga runtime on rollback; ignored on a single `run_action` call. See [Saga Compensation](#saga-compensation-multi-step-rollback). |
@@ -97,6 +99,28 @@ Three things decide whether a write fires inline or routes to a human:
 3. **The Instinct policy** (optional) — when `instinct_policy` is set on the binding, the Instinct service can compose policy rules on top (allow-list of approvers, expiry, batch approval, etc.).
 
 The executor's contribution is the **fail-closed default**: a binding with `requires_instinct: true` and a misconfigured approval route still parks the write; it never silently falls through to direct execution.
+
+### Deny-by-default
+
+Governance is **deny-by-default at two layers**, so an agent-authored write is gated unless something explicitly clears it.
+
+**Binding layer.** `requires_instinct` defaults to **`true`**. A write binding routes through the Instinct approval gate unless it is explicitly exempted (`instinct_exempt: true`, paired with `requires_instinct: false`) or the call is an already-gated re-entry. An agent that authors a binding and never sets the field still gets a gated write — the moat claim ("every agent action routes through an audited approval gate") holds at author time.
+
+A genuinely safe **read** can be declared on the action surface with `read_only: true` (a `GET` / `HEAD` binding). A `read_only` action proceeds **ungated** — not because an author opted a write out, but because there is nothing to govern. A model validator rejects `read_only: true` on any mutating method or alongside an `instinct_policy`, so the marker can never relabel a write as safe.
+
+**Template layer (`instinct_template_default_deny`).** When a **template is bound** to a pocket and governs an action, the template's Instinct rules adjudicate the write. The remaining hole: a bound template that declares **no rule matching** an action used to fall through to the template gate's default `EXECUTE` and fire. The `instinct_template_default_deny` flag closes it.
+
+When the flag is **on**, a bound template with no matching rule for a **mutating** action (`POST` / `PUT` / `PATCH` / `DELETE` and not `read_only`) **parks the write for approval** (`instinct_pending`) instead of executing. **Reads** (`read_only` / `GET` / `HEAD`) always proceed ungated — the flip never gates a legitimate read. The scope is tight: only the *no-rule-match* default is flipped. A rule that matched and returned `EXECUTE`, a `notify_only` author floor, and a `BLOCK` rule are explicit policy decisions and are never overridden.
+
+The flag is **off by default** (`POCKETPAW_INSTINCT_TEMPLATE_DEFAULT_DENY`), so shipping it changes zero behavior. It is a **per-workspace opt-in**: the `instinct_template_default_deny` field on the workspace document overrides the global config default, exactly like `instinct_approval_level`. An unset workspace field falls back to the global default, and any read failure degrades safe to `false` — a DB hiccup can never silently start parking a tenant's writes.
+
+| Resolution order | Effect |
+|------------------|--------|
+| Workspace document field `instinct_template_default_deny` (when a non-null bool) | The per-workspace opt-in wins. |
+| Global config `instinct_template_default_deny` (`POCKETPAW_INSTINCT_TEMPLATE_DEFAULT_DENY`, default `false`) | Applies to workspaces that have not set their own field. |
+| Read failure / malformed id | Degrades safe to `false`. |
+
+> **Known nuance.** A `read_only` `GET` that skips the park still flows through the write-allowlist and the gate-8 write executor (the action surface, not `source_executor`). Routing `read_only` reads to `source_executor` is a deeper refactor and out of scope for the template default-deny flip; what the flag guarantees is only that it does **not** gate a read.
 
 ## Outcome Emission
 

--- a/ee/pocketpaw_ee/cloud/models/workspace.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace.py
@@ -1,5 +1,16 @@
 """Workspace document — one per deployment/org.
 
+2026-06-28 (AW-7 template gate deny-on-no-match): added
+``Workspace.instinct_template_default_deny`` — the PER-WORKSPACE override for
+the TEMPLATE-level deny-by-default. ``None`` (the default) means "use the
+global config default" (``Settings.instinct_template_default_deny``, itself
+False). When set True, a template BOUND to a pocket that declares no rule
+matching a MUTATING action parks the write for a human instead of firing;
+reads stay ungated. Resolved exactly like ``instinct_approval_level`` (per-
+workspace field → global default) via
+``resolve_workspace_template_default_deny``; the cloud router reads it and
+threads it through ``run_action`` → ``gate_action``.
+
 2026-06-19 (layered/learning gate, T6): added
 ``Workspace.instinct_approval_level`` — the PER-WORKSPACE override for the
 layered Instinct gate's triager activation level ("ASK" | "TRIAGE" |
@@ -109,6 +120,13 @@ class Workspace(TimestampedDocument):
     # workspace's writes; nothing else changes the default for an existing
     # tenant (design MF-9 — global config cannot silently upgrade tenants).
     instinct_approval_level: str | None = None
+    # AW-7 — per-workspace override for the TEMPLATE-level deny-by-default.
+    # None = use the global config default (Settings.
+    # instinct_template_default_deny, False). True parks a MUTATING action a
+    # bound template declares no rule for (instead of firing); reads stay
+    # ungated. Same MF-9 contract as instinct_approval_level above — a global
+    # env var never silently flips an existing tenant.
+    instinct_template_default_deny: bool | None = None
 
     class Settings:
         name = "workspaces"

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -1,4 +1,20 @@
 # action_executor.py — Server-side executor for pocket WRITE actions.
+# Updated: 2026-06-28 (AW-6 — read_only action marker) — `ActionBinding` gains
+#   a `read_only: bool = False` field that marks a genuinely SAFE, read-only
+#   action as gate-exempt BY DEFINITION. The `method` Literal is widened to
+#   accept GET / HEAD so a true read can be declared on this surface. A new
+#   `_read_only_is_safe` model_validator (mirrors `_exempt_is_consistent`)
+#   guards the widening BOTH ways so the write-only contract is preserved: a
+#   GET/HEAD binding WITHOUT `read_only=True` is still rejected (a bare read
+#   verb on the action surface stays a misconfiguration); and `read_only=True`
+#   is rejected on any mutating method (POST/PUT/PATCH/DELETE) or alongside an
+#   `instinct_policy` — a write can never be mislabeled safe. Gate 7 suppresses
+#   the Instinct park when `binding.read_only` is True, via its OWN path (NOT
+#   reusing `instinct_exempt`) so the audit trace stays truthful: a read
+#   proceeds ungated because there is nothing to govern, not because an author
+#   opted a write out. This is the marker AW-7 needs to flip the template
+#   default to deny without gating legitimate reads. No template-level gate or
+#   default is changed here.
 # Updated: 2026-06-11 (gap-housekeeping) — the
 #   `_outcome_value_pairs_with_unit` model_validator now also rejects a
 #   NEGATIVE `outcome_value`. The aggregation sums value by unit into a
@@ -370,7 +386,12 @@ class ActionBinding(BaseModel):
     model_config = {"extra": "ignore"}
 
     kind: Literal["write_binding"] = "write_binding"
-    method: Literal["POST", "PUT", "PATCH", "DELETE"]
+    # AW-6: GET / HEAD are accepted here ONLY so a genuinely read-only action
+    # can be declared on the write surface and marked `read_only=True` (the
+    # safe-by-definition exemption below). A mutating verb stays the common
+    # case; `_read_only_is_safe` rejects `read_only=True` on any mutating
+    # method, so the read-only flag can never label a write as safe.
+    method: Literal["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"]
     path: str
     params: dict = Field(default_factory=dict)
     confirm: bool = False
@@ -401,6 +422,14 @@ class ActionBinding(BaseModel):
     # W2a: explicit, auditable exemption. A binding the author deliberately
     # allows to fire WITHOUT the gate sets this True in the persisted spec.
     instinct_exempt: bool = False
+    # AW-6: SAFE-BY-DEFINITION read marker. A `read_only=True` binding is a
+    # genuine read (GET / HEAD, no `instinct_policy`) that proceeds UNGATED —
+    # not because the author opted a write out (`instinct_exempt`), but because
+    # there is nothing to govern. It rides its OWN gate-7 suppression path so
+    # the audit trace stays truthful (a read, not an exempted write).
+    # `_read_only_is_safe` rejects the flag on any mutating method or alongside
+    # an `instinct_policy`, so it can never silently un-gate a real write.
+    read_only: bool = False
     # --- Saga Compensate (RFC 05) ---------------------------------------
     # The inverse write that undoes this action on a mid-sequence rollback.
     # Declaration-only here; ``saga.py`` reads + fires it. ``None`` means
@@ -439,6 +468,52 @@ class ActionBinding(BaseModel):
             raise ValueError(
                 "instinct_exempt is true but instinct_policy is set — an "
                 "exempt binding has no gate for a policy to apply to"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _read_only_is_safe(self) -> ActionBinding:
+        """AW-6 — a non-write verb is ONLY admissible as a declared read.
+
+        This surface is write-first by contract: ``method`` historically was
+        a write-verb Literal so a compromised client could never coax a read
+        through the action executor (reads belong to ``source_executor``). AW-6
+        widens the Literal to admit ``GET`` / ``HEAD`` for ONE purpose: a
+        genuinely safe, read-only action that proceeds ungated. So the
+        non-write verbs are gated behind the ``read_only`` flag, both ways:
+
+        * A ``GET`` / ``HEAD`` binding WITHOUT ``read_only=True`` is rejected —
+          preserving the original write-only invariant (a bare read verb on
+          the action surface is still a misconfiguration / probe).
+        * A ``read_only=True`` binding on a mutating verb
+          (``POST`` / ``PUT`` / ``PATCH`` / ``DELETE``) is rejected — labelling
+          a write "safe" would un-gate a real state change.
+        * A ``read_only=True`` binding carrying an ``instinct_policy`` is
+          rejected — "proceeds ungated" and "gate this way" contradict.
+
+        Caught at parse time so neither the gate-7 suppression nor the
+        executor ever has to second-guess a mislabeled binding.
+        """
+        # A non-write verb is only legal when explicitly declared read_only.
+        if self.method in ("GET", "HEAD") and not self.read_only:
+            raise ValueError(
+                f"method is {self.method} but read_only is not set — a "
+                "non-write verb is only admissible on the action surface as an "
+                "explicit read_only action; writes use POST/PUT/PATCH/DELETE"
+            )
+        if not self.read_only:
+            return self
+        if self.method not in ("GET", "HEAD"):
+            raise ValueError(
+                f"read_only is true but method is {self.method} — a mutating "
+                "method (POST/PUT/PATCH/DELETE) must not be labeled read_only; "
+                "read_only is only valid for GET/HEAD"
+            )
+        if self.instinct_policy is not None:
+            raise ValueError(
+                "read_only is true but instinct_policy is set — a read_only "
+                "action proceeds ungated, so a gate policy has nothing to "
+                "apply to"
             )
         return self
 
@@ -1198,10 +1273,17 @@ async def run_action(
     # signals `instinct_pending`. The router hands `_park` to
     # `instinct_bridge.propose_pocket_write`, which builds the Instinct
     # Action. NO HTTP call is made here.
+    #   * `binding.read_only` (AW-6) — a genuine read (GET / HEAD, no policy;
+    #     enforced by `_read_only_is_safe`) is SAFE BY DEFINITION and proceeds
+    #     ungated. It rides its OWN suppression here rather than reusing
+    #     `instinct_exempt`, so the audit trace stays truthful: this is a read,
+    #     not an author-exempted write. This is what lets a later task (AW-7)
+    #     flip the template default to deny without gating legitimate reads.
     optimistic_gate_cleared = optimistic_execute
     if (
         binding.requires_instinct
         and not binding.instinct_exempt
+        and not binding.read_only
         and not from_instinct
         and not template_gate_cleared
         and not optimistic_gate_cleared

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -1,4 +1,16 @@
 # action_executor.py — Server-side executor for pocket WRITE actions.
+# Updated: 2026-06-28 (AW-7 — template gate deny-on-no-match) — `run_action`
+#   takes a new `template_default_deny: bool = False` and threads it into the
+#   gate-1.5 `gate_action` call ALONGSIDE an `is_mutating` flag the executor
+#   computes from the parsed binding (`method ∈ POST/PUT/PATCH/DELETE AND not
+#   read_only`). When the flag is ON and a bound template declares no rule
+#   matching a MUTATING action, the gate parks the write for a human instead of
+#   proceeding — finishing deny-by-default at the template layer. READS
+#   (read_only marker from AW-6, or GET/HEAD) are NOT mutating, so the flip
+#   never gates a legitimate read. AW-6 nuance carried forward: a read_only GET
+#   that skips the park still flows through the write-allowlist + gate-8
+#   executor; routing read_only to source_executor is a deeper refactor left
+#   out of scope here. Flag OFF (default) → byte-identical to the prior gate.
 # Updated: 2026-06-28 (AW-6 — read_only action marker) — `ActionBinding` gains
 #   a `read_only: bool = False` field that marks a genuinely SAFE, read-only
 #   action as gate-exempt BY DEFINITION. The `method` Literal is widened to
@@ -793,6 +805,7 @@ async def run_action(
     dry_run: bool = False,
     approval_level: Any = None,
     dry_run_mode: bool = False,
+    template_default_deny: bool = False,
 ) -> dict:
     """Run ONE pocket write action against its configured backend.
 
@@ -975,6 +988,23 @@ async def run_action(
             if approval_level is not None
             else _DEFAULT_APPROVAL_LEVEL,
             dry_run_mode=dry_run_mode,
+            # AW-7 — TEMPLATE-level deny-on-no-match. When the workspace/global
+            # flag is ON and this binding is a MUTATING write that the bound
+            # template declares no matching rule for, the gate parks it for a
+            # human instead of proceeding. `is_mutating` is computed from the
+            # parsed binding HERE (the executor owns the binding) so the gate
+            # never re-parses: a read_only marker (AW-6) or a GET/HEAD verb is
+            # NOT mutating and always proceeds ungated — the template flip never
+            # gates a legitimate read. NOTE (AW-6 nuance): a read_only GET that
+            # skips the park still flows through the write-allowlist + gate-8
+            # executor; routing read_only to source_executor is a deeper
+            # refactor left out of scope — what matters here is only that the
+            # default-deny flip does not gate it.
+            template_default_deny=template_default_deny,
+            is_mutating=(
+                binding.method in ("POST", "PUT", "PATCH", "DELETE")
+                and not binding.read_only
+            ),
         )
         if gate.next_step == "blocked":
             _audit_action_run(

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -1027,8 +1027,7 @@ async def run_action(
             # default-deny flip does not gate it.
             template_default_deny=template_default_deny,
             is_mutating=(
-                binding.method in ("POST", "PUT", "PATCH", "DELETE")
-                and not binding.read_only
+                binding.method in ("POST", "PUT", "PATCH", "DELETE") and not binding.read_only
             ),
         )
         if gate.next_step == "blocked":

--- a/ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
@@ -1,4 +1,17 @@
 # ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
+# Updated: 2026-07-02 (AW-7 follow-up — security) — CLOSE THE BULK
+#   DENY-BY-DEFAULT HOLE. AW-7 threaded ``instinct_template_default_deny``
+#   through the router + temporal dispatcher, but the bulk fan-out still fired
+#   an uncovered MUTATING no-rule-match action ungated (the planner bucketed it
+#   into ``executions`` and ``_fire_executions`` fires those un-re-gated).
+#   ``dispatch_bulk`` now resolves the per-workspace / global flag via
+#   ``pockets_service.resolve_workspace_template_default_deny`` (fail-safe OFF)
+#   and computes ``is_mutating`` from the pocket's parsed rippleSpec binding via
+#   the new ``_is_mutating_binding`` helper (fail-safe mutating=True), then
+#   threads BOTH into ``plan_bulk_execution`` so the planner routes a
+#   no-rule-match mutating EXECUTE into the BATCH APPROVAL bucket instead of
+#   firing — semantics identical to the router + temporal paths. Reads still
+#   fire; flag OFF (the default) keeps the plan byte-identical.
 # Created: 2026-05-28 (feat/wave-3b-action-pipeline) — EE-side library
 # wrapper around the OSS ``plan_bulk_execution`` planner. Implements the
 # RFC 03 v2 §"Bulk action execution model" invariant: a ``kind: bulk``
@@ -101,6 +114,28 @@ def _action_binding_for(
     actions = spec.actions if isinstance(spec.actions, dict) else {}
     raw_action = actions.get(action_name)
     return raw_action if isinstance(raw_action, dict) else None
+
+
+def _is_mutating_binding(raw_action: dict[str, Any] | None) -> bool:
+    """Compute ``is_mutating`` for the AW-7 bulk deny-on-no-match check.
+
+    Mirrors ``action_executor`` exactly — ``method in {POST,PUT,PATCH,DELETE}
+    and not read_only`` — reading the same rippleSpec ``ActionBinding`` dict the
+    executor parses (``method`` / ``read_only`` live on the binding, NOT the
+    template's ``ActionDef``, so the OSS planner cannot compute this itself).
+
+    Conservative on a missing / non-dict binding: returns ``True`` (treat as
+    mutating). With the flag ON that parks the batch for a human rather than
+    firing it ungated — fail CLOSED, matching the temporal sweep's
+    ``_resolve_is_mutating`` and ``gate_action``'s ``is_mutating=True`` default.
+    A read (``read_only`` marker from AW-6, or a GET/HEAD verb) returns ``False``
+    and is never re-bucketed.
+    """
+    if not isinstance(raw_action, dict):
+        return True
+    method = str(raw_action.get("method") or "POST").upper()
+    read_only = bool(raw_action.get("read_only", False))
+    return method in ("POST", "PUT", "PATCH", "DELETE") and not read_only
 
 
 # ---------------------------------------------------------------------------
@@ -229,6 +264,31 @@ async def dispatch_bulk(
         raise NotFound("pocket", pocket_id)
 
     # ── 2. plan the fan-out via the pure OSS planner ───────────────
+    # AW-7 follow-up (security) — close the BULK deny-by-default hole. The bulk
+    # path runs the gate ONCE per row via the planner, so the AW-7 template
+    # default-deny flip has to live in the planner too (the router + temporal
+    # paths get it through ``gate_action``). We resolve the per-workspace /
+    # global flag here (the EE layer owns the Beanie read) and compute
+    # ``is_mutating`` from the pocket's parsed rippleSpec binding — ``method`` /
+    # ``read_only`` live on the binding, not the template's ``ActionDef``, so
+    # the pure planner cannot compute it. Both are threaded in; with the flag ON
+    # and a mutating action the bound template declares no rule for, the planner
+    # buckets the row into the batch approval instead of ``executions`` (which
+    # ``_fire_executions`` fires un-re-gated). Reads never re-bucket; flag OFF
+    # (the default) keeps the plan byte-identical.
+    #
+    # Fail-safe split mirrors the temporal dispatcher: a flag-read failure falls
+    # back to OFF (dormant — never accidentally parks a whole workspace), while
+    # ``_is_mutating_binding`` treats an unreadable binding as mutating so it
+    # parks rather than fires ungated.
+    try:
+        template_default_deny = await pockets_service.resolve_workspace_template_default_deny(
+            workspace_id
+        )
+    except Exception:  # noqa: BLE001 — a flag read failure falls back to OFF (dormant)
+        template_default_deny = False
+    is_mutating = _is_mutating_binding(_action_binding_for(pocket.get("rippleSpec"), action_name))
+
     try:
         plan = plan_bulk_execution(
             template,
@@ -236,6 +296,8 @@ async def dispatch_bulk(
             selected_rows,
             resolver=resolver,
             now=now,
+            template_default_deny=template_default_deny,
+            is_mutating=is_mutating,
         )
     except BulkExecutionError as exc:
         # Unknown action OR non-bulk action — both are typed pre-flight

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
@@ -1,4 +1,24 @@
 # ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
+# Updated: 2026-06-28 (AW-7 — template gate deny-on-no-match) — `gate_action`
+# takes two new kwargs, `template_default_deny` (default False) and
+# `is_mutating` (default True), that close the TEMPLATE-level deny-by-default
+# hole. Before AW-7, a template BOUND to a pocket that declared NO rule
+# matching an action yielded `resolve_instinct`'s default EXECUTE verdict
+# (reason="auto", no matched_rules) → `next_step="proceed"` → the write fired.
+# Now, when `template_default_deny` is ON and the action `is_mutating`
+# (POST/PUT/PATCH/DELETE and NOT read_only — the executor computes this from
+# the parsed binding and passes it in), that no-rule-match EXECUTE is routed
+# to the human-pending path (`next_step="pending_approval"`) instead — the
+# same `_escalate_to_human` persistence the ESCALATE_APPROVAL verdict uses.
+# READS (read_only / GET / HEAD → `is_mutating=False`) still proceed ungated:
+# a read has nothing to govern. The flip is SCOPED to the no-rule-match
+# default ONLY — a rule that matched and said EXECUTE (or a `notify_only`
+# author floor → NOTIFY_AND_EXECUTE) is an explicit policy decision and is
+# NEVER overridden. When the flag is OFF (default) every path is byte-
+# identical to before. The per-workspace override and global config default
+# that feed `template_default_deny` are resolved in `pockets/service.py`
+# (`resolve_workspace_template_default_deny`) and threaded by the router,
+# mirroring `instinct_approval_level` exactly.
 # Updated: 2026-06-19 (feat/instinct-gate-integration, security-review FIX 3) —
 # `_find_existing_pending_id` now pushes the (action_name, row_id) match INTO
 # the approvals query (limit=1) instead of paging a default list and matching
@@ -294,6 +314,8 @@ async def gate_action(
     now: datetime | None = None,
     approval_level: ApprovalLevel | str | None = ApprovalLevel.ASK,
     dry_run_mode: bool = False,
+    template_default_deny: bool = False,
+    is_mutating: bool = True,
 ) -> InstinctGateResult:
     """Resolve the template-level Instinct verdict for one action+row.
 
@@ -330,6 +352,19 @@ async def gate_action(
     to DRY_RUN — but only AFTER the BLOCK and ASK floors, so a BLOCK row is
     still blocked and a dormant workspace still escalates to a human even
     when dry-run is globally on.
+
+    ``template_default_deny`` + ``is_mutating`` (AW-7) close the TEMPLATE-level
+    deny-by-default hole. When a bound template declares NO rule matching this
+    action, ``resolve_instinct`` returns its default EXECUTE verdict
+    (``reason="auto"``, no matched rules). If ``template_default_deny`` is True
+    AND ``is_mutating`` is True, that no-rule-match EXECUTE is routed to the
+    human-pending path instead of proceeding — finishing deny-by-default at the
+    template layer. READS (``is_mutating=False`` — the executor sets this for a
+    ``read_only`` / GET / HEAD binding) always proceed: a read has nothing to
+    govern. The flip is scoped to the no-rule-match default ONLY — a rule that
+    matched and returned EXECUTE, or a ``notify_only`` author floor
+    (NOTIFY_AND_EXECUTE), is an explicit policy decision and is never
+    overridden. Default OFF → byte-identical to the prior gate.
 
     Errors:
         ``InstinctResolutionError`` from the composer (unknown action
@@ -377,6 +412,44 @@ async def gate_action(
             park=park,
             level=level,
             dry_run_mode=dry_run_mode,
+        )
+
+    # AW-7 — TEMPLATE-level deny-on-no-match. The verdict is EXECUTE /
+    # NOTIFY_AND_EXECUTE (the BLOCK and ESCALATE_APPROVAL branches returned
+    # above). When the template declared NO rule that matched this action,
+    # `resolve_instinct` returns its default EXECUTE verdict — `reason="auto"`
+    # with no matched rules. That, plus `is_mutating`, is exactly the case
+    # deny-by-default must close: a write a bound template does not explicitly
+    # govern should park for a human, not fire silently.
+    #
+    # Scope is deliberately tight:
+    #   * verdict EXECUTE + reason "auto"  — the no-rule-match default ONLY. A
+    #     rule that matched and returned EXECUTE has a NON-"auto" reason; a
+    #     `notify_only` author floor returns NOTIFY_AND_EXECUTE. Both are
+    #     explicit policy decisions, never overridden here.
+    #   * is_mutating  — POST/PUT/PATCH/DELETE and NOT read_only (the executor
+    #     computes this from the parsed binding). A read (read_only / GET /
+    #     HEAD) has nothing to govern, so it always proceeds.
+    #   * template_default_deny  — the per-workspace/global opt-in. OFF (the
+    #     default) keeps every path byte-identical to the prior gate.
+    no_rule_matched = decision.verdict == "EXECUTE" and decision.reason == "auto"
+    if template_default_deny and is_mutating and no_rule_matched:
+        logger.info(
+            "instinct gate: template default-deny parks uncovered mutating "
+            "action=%s pocket=%s row=%s (no matching rule)",
+            action_name,
+            pocket_id,
+            row_id,
+        )
+        return await _escalate_to_human(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            action_name=action_name,
+            row_id=row_id,
+            row_context=row_context,
+            decision=decision,
+            park=park,
         )
 
     # EXECUTE / NOTIFY_AND_EXECUTE — proceed. Notify rules carry through.

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -1,5 +1,14 @@
 """Pockets domain — FastAPI router.
 
+Updated: 2026-06-28 (AW-7 — template gate deny-on-no-match) — ``run_pocket_action``
+resolves the workspace's TEMPLATE-level deny-by-default
+(``resolve_workspace_template_default_deny`` → per-workspace field → global
+config default → False) WHEN a template governs the action, and threads it into
+``run_action`` as ``template_default_deny``. When ON and the bound template
+declares no rule matching a MUTATING action, the executor's gate parks the write
+for a human instead of firing; reads stay ungated. Resolved only when a template
+governs the action (same condition as ``approval_level``), so a non-template
+write is byte-identical to before. OFF by default.
 Updated: 2026-06-20 (feat/workspace-jobs, pp#1459) — ``run_pocket_action`` now
 branches on ``raw_action["kind"] == "job"`` BEFORE the path-resolution +
 ``action_executor.run_action`` HTTP-write path. A job action enqueues a named
@@ -1241,11 +1250,19 @@ async def run_pocket_action(
     # never runs), so a non-template write is byte-identical to before.
     approval_level = "ASK"
     dry_run_mode = False
+    # AW-7 — TEMPLATE-level deny-on-no-match. Resolved alongside approval_level,
+    # under the same "only when a template governs this action" guard: a
+    # non-template write never runs the template gate, so its behavior is
+    # unchanged. Per-workspace field → global config default → False.
+    template_default_deny = False
     if template is not None:
         approval_level = await pockets_service.resolve_workspace_approval_level(workspace_id)
         from pocketpaw.config import get_settings
 
         dry_run_mode = bool(get_settings().instinct_dry_run_mode)
+        template_default_deny = await pockets_service.resolve_workspace_template_default_deny(
+            workspace_id
+        )
 
     # no-event: the write result is response-body delivery, not persisted.
     result = await action_executor.run_action(
@@ -1265,6 +1282,7 @@ async def run_pocket_action(
         template=template,
         approval_level=approval_level,
         dry_run_mode=dry_run_mode,
+        template_default_deny=template_default_deny,
     )
 
     # W2a — a template-level CEL rule BLOCKED this write (gate 1.5). It

--- a/ee/pocketpaw_ee/cloud/pockets/saga.py
+++ b/ee/pocketpaw_ee/cloud/pockets/saga.py
@@ -297,6 +297,19 @@ async def run_action_sequence(
             }
             break
 
+        # AW-7 note (SEC-3 deny-by-default consistency): the saga does NOT
+        # thread ``template=`` and runs with ``from_instinct=False``, so the
+        # template-level deny-on-no-match branch (which lives in
+        # ``gate_action`` and only runs when a template is present) is
+        # structurally UNREACHABLE here — no bulk/temporal-style plumbing is
+        # needed. Deny-by-default for an uncovered mutating forward write is
+        # still enforced one layer down: ``ActionBinding.requires_instinct``
+        # defaults True, so such a write PARKS at gate 7 (``instinct_pending``),
+        # ``_is_parked`` catches it, and the sequence rolls back. A binding that
+        # fires ungated is one the author explicitly set ``requires_instinct=
+        # False`` / ``instinct_exempt`` on — an auditable opt-out, not a
+        # no-rule-match fall-through — so it is consistent with the router and
+        # temporal paths, which also fire such a binding untemplated.
         result = await run_action(
             workspace_id=workspace_id,
             pocket_id=pocket_id,

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -4,6 +4,15 @@ Sole owner of writes to the ``Pocket`` Beanie document. Module-level
 ``async def`` API. The doc → domain mapping helpers (formerly in
 ``repositories.py``) live alongside the public API as private helpers.
 
+Updated: 2026-06-28 (AW-7 template gate deny-on-no-match) — added
+``resolve_workspace_template_default_deny`` — the effective TEMPLATE-level
+deny-by-default for a workspace (per-workspace ``instinct_template_default_deny``
+field → global config default → False). Mirrors
+``resolve_workspace_approval_level`` exactly: any read failure falls back to the
+global default (ultimately False), so a DB hiccup can never accidentally start
+parking writes. The cloud router reads it and threads it through ``run_action``
+→ ``gate_action``.
+
 Updated: 2026-06-20 (feat/workspace-jobs, pp#1459) — ``_check_domain_edit_access``
 now allows the synthetic ``system:workspace_job`` identity so a workspace job
 can merge its result back even on a private (non-workspace-visible) pocket.
@@ -1336,6 +1345,47 @@ async def resolve_workspace_approval_level(workspace_id: str) -> str:
         return global_default
     field = getattr(ws, "instinct_approval_level", None)
     if isinstance(field, str) and field:
+        return field
+    return global_default
+
+
+async def resolve_workspace_template_default_deny(workspace_id: str) -> bool:
+    """Return the effective TEMPLATE-level deny-by-default for a workspace (AW-7).
+
+    Resolution order (mirrors ``resolve_workspace_approval_level``):
+      1. The workspace document's ``instinct_template_default_deny`` field, when
+         set to a non-null bool — the PER-WORKSPACE opt-in.
+      2. Otherwise the GLOBAL config default
+         (``Settings.instinct_template_default_deny``, itself ``False``).
+
+    A global env var therefore changes the default only for workspaces that have
+    NOT set their own field; it can never silently flip a workspace that relies
+    on the default once that workspace pins its own value. Any read failure
+    falls back to the global default (and ultimately ``False``), so a DB hiccup
+    can never accidentally start parking a workspace's writes.
+
+    Returns a bare bool; ``gate_action`` reads it directly.
+    """
+    from pocketpaw.config import get_settings
+
+    try:
+        global_default = bool(get_settings().instinct_template_default_deny)
+    except Exception:  # noqa: BLE001 — config read failure → dormant (False)
+        global_default = False
+
+    if not workspace_id:
+        return global_default
+
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    try:
+        ws = await Workspace.get(PydanticObjectId(workspace_id))
+    except Exception:  # noqa: BLE001 — malformed id / read failure → global default
+        return global_default
+    if ws is None:
+        return global_default
+    field = getattr(ws, "instinct_template_default_deny", None)
+    if isinstance(field, bool):
         return field
     return global_default
 

--- a/ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
+++ b/ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
@@ -14,6 +14,22 @@
 # ``spec.actions[name]``. A corrupt spec yields the same ``action_not_found``
 # soft failure. Promote-on-read; no document migration.
 #
+# Updated: 2026-06-28 (AW-7 follow-up — security) — CLOSE THE TEMPORAL
+# DENY-BY-DEFAULT HOLE. AW-7 added the per-workspace
+# ``instinct_template_default_deny`` flag: when ON, a template-bound pocket
+# with NO matching rule for a MUTATING action PARKS it instead of firing. The
+# router path threads it, but this temporal-sweep path did NOT — so a
+# scheduled mutating action with no matching rule fired ungated even with the
+# flag ON, bypassing deny-by-default. ``_dispatch_one_edge`` now mirrors the
+# router (router.py ~L1257-1285): it resolves the flag via
+# ``pockets_service.resolve_workspace_template_default_deny(workspace_id)``,
+# computes ``is_mutating`` from the edge's action binding exactly as
+# ``action_executor`` does (method in {POST,PUT,PATCH,DELETE} and not
+# ``read_only``), and threads BOTH into the direct ``gate_action`` call AND
+# ``template_default_deny`` into the ``run_action`` re-gate (so the
+# double-gate the executor performs also honors deny-by-default). Flag OFF
+# (the default) keeps the temporal path byte-for-byte unchanged.
+#
 # Wave 3d scope (locked by the architect brief):
 #
 #   1. Load the prior sweep state via ``temporal_sweeps.service.load_last_seen``.
@@ -99,6 +115,45 @@ def _has_temporal_trigger(template: PocketTemplate) -> bool:
     return any(t.type == "temporal" for t in template.triggers)
 
 
+async def _resolve_is_mutating(workspace_id: str, pocket_id: str, action_name: str) -> bool:
+    """Compute ``is_mutating`` for the temporal-sweep gate, from the binding.
+
+    AW-7 follow-up (security): the direct ``gate_action`` call in
+    ``_dispatch_one_edge`` needs ``is_mutating`` so the template default-deny
+    flip parks a mutating write but never gates a read. We compute it the SAME
+    way ``action_executor`` does — ``method in {POST,PUT,PATCH,DELETE} and not
+    read_only`` — by reading the pocket's ``rippleSpec.actions[action_name]``
+    binding (the same source the executor parses).
+
+    Conservative on failure: a missing / corrupt / unreadable binding returns
+    ``True`` (treat as mutating). With the flag ON that parks the action for a
+    human rather than firing it ungated — fail CLOSED, never silently EXECUTE.
+    The action is fetched here ONLY to read the verb; the executor re-fetches
+    and re-parses the full binding when it actually runs the write.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    try:
+        ripple_spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
+        spec = RippleSpec.from_flat_dict(ripple_spec)
+        actions = spec.actions if spec is not None and isinstance(spec.actions, dict) else None
+        raw_action = actions.get(action_name) if isinstance(actions, dict) else None
+        if not isinstance(raw_action, dict):
+            return True
+        method = str(raw_action.get("method") or "POST").upper()
+        read_only = bool(raw_action.get("read_only", False))
+        return method in ("POST", "PUT", "PATCH", "DELETE") and not read_only
+    except Exception:  # noqa: BLE001 — fail closed: an unreadable binding is mutating
+        logger.warning(
+            "temporal sweep: pocket=%s could not resolve is_mutating for action=%s — "
+            "treating as mutating (fail closed)",
+            pocket_id,
+            action_name,
+            exc_info=True,
+        )
+        return True
+
+
 async def _dispatch_one_edge(
     *,
     edge: TemporalRisingEdge,
@@ -161,6 +216,30 @@ async def _dispatch_one_edge(
     actor = "system:temporal-sweeper"
     row_context = dict(edge.row)
 
+    # AW-7 follow-up (security) — resolve the workspace's TEMPLATE-level
+    # deny-by-default flag and the binding's mutating-ness BEFORE the gate, then
+    # thread both in. This mirrors the router path (router.py ~L1257-1285). When
+    # the flag is OFF (the default) ``template_default_deny`` is False and the
+    # gate behaves byte-for-byte as before — ``is_mutating`` is then irrelevant
+    # (the escalation condition is gated on the flag). The flag and the binding
+    # are resolved with their own try/except inside the helpers so a read
+    # failure can never raise into this loop.
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    try:
+        template_default_deny = await pockets_service.resolve_workspace_template_default_deny(
+            workspace_id
+        )
+    except Exception:  # noqa: BLE001 — a flag read failure falls back to OFF (dormant)
+        logger.warning(
+            "temporal sweep: pocket=%s could not resolve template_default_deny — "
+            "treating as OFF",
+            pocket_id,
+            exc_info=True,
+        )
+        template_default_deny = False
+    is_mutating = await _resolve_is_mutating(workspace_id, pocket_id, action_name)
+
     try:
         gate = await instinct_dispatch.gate_action(
             workspace_id=workspace_id,
@@ -170,6 +249,13 @@ async def _dispatch_one_edge(
             action_name=action_name,
             row_context=row_context,
             row_id=edge.row_id,
+            # AW-7 follow-up (security) — close the temporal deny-by-default
+            # hole. With the flag ON and a MUTATING action the bound template
+            # declares no matching rule for, the gate parks for a human
+            # (``pending_approval`` → counted under ``escalated`` below)
+            # instead of proceeding.
+            template_default_deny=template_default_deny,
+            is_mutating=is_mutating,
         )
     except Exception:  # noqa: BLE001 — gate raising into the loop is a bug; isolate
         logger.warning(
@@ -221,6 +307,13 @@ async def _dispatch_one_edge(
             action_name=action_name,
             row_context=row_context,
             row_id=edge.row_id,
+            # AW-7 follow-up (security) — thread the flag into the executor's
+            # re-gate too. The executor re-runs ``gate_action`` (so Wave 3c
+            # outcome emission fires) and computes ``is_mutating`` itself from
+            # the parsed binding; passing the flag makes that second gate honor
+            # deny-by-default as well. Without it the double-gate the review
+            # flagged would re-EXECUTE the very write the first gate parked.
+            template_default_deny=template_default_deny,
         )
     except Exception:  # noqa: BLE001 — executor raising into the loop is a bug; isolate
         logger.warning(
@@ -259,6 +352,7 @@ async def _invoke_executor(
     action_name: str,
     row_context: dict[str, Any],
     row_id: str,
+    template_default_deny: bool = False,
 ) -> dict:
     """Call ``action_executor.run_action`` for one rising-edge row.
 
@@ -337,6 +431,11 @@ async def _invoke_executor(
         template=template,
         row_context=row_context,
         row_id=row_id,
+        # AW-7 follow-up (security) — the executor's internal re-gate must also
+        # see the flag, or the double-gate re-EXECUTEs a write the first gate
+        # parked. The executor computes ``is_mutating`` itself from the parsed
+        # binding. Default False keeps the OFF path unchanged.
+        template_default_deny=template_default_deny,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
+++ b/ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
@@ -232,8 +232,7 @@ async def _dispatch_one_edge(
         )
     except Exception:  # noqa: BLE001 — a flag read failure falls back to OFF (dormant)
         logger.warning(
-            "temporal sweep: pocket=%s could not resolve template_default_deny — "
-            "treating as OFF",
+            "temporal sweep: pocket=%s could not resolve template_default_deny — treating as OFF",
             pocket_id,
             exc_info=True,
         )

--- a/src/pocketpaw/bundled_templates/bulk_executor.py
+++ b/src/pocketpaw/bundled_templates/bulk_executor.py
@@ -1,4 +1,18 @@
 # src/pocketpaw/bundled_templates/bulk_executor.py
+# Updated: 2026-07-02 (AW-7 follow-up — security) — CLOSE THE BULK
+#   DENY-BY-DEFAULT HOLE. AW-7 threaded the per-workspace
+#   ``instinct_template_default_deny`` flag through the router + temporal
+#   dispatcher, but the BULK fan-out still bucketed a no-rule-match EXECUTE
+#   (``reason="auto"``) straight into ``executions`` — and ``_fire_executions``
+#   fires those un-re-gated — so an uncovered MUTATING bulk action EXECUTED
+#   ungated with the flag ON. ``plan_bulk_execution`` now takes
+#   ``template_default_deny`` + ``is_mutating`` (the EE caller resolves the flag
+#   and computes ``is_mutating`` from the parsed binding, since ``method`` /
+#   ``read_only`` live on the rippleSpec binding, not the template ActionDef)
+#   and, when both are True, routes a no-rule-match default EXECUTE into the
+#   BATCH APPROVAL bucket instead — semantics identical to ``gate_action``'s
+#   AW-7 branch. Reads (``is_mutating=False``) still fire; flag OFF (default)
+#   keeps every path byte-identical.
 # Created: 2026-05-28 (feat/rfc-03-v2-bulk) — pure-library
 # implementation of the RFC 03 v2 bulk-action fan-out planner. Given a
 # template, a ``kind: bulk`` action name, and a list of selected rows,
@@ -85,6 +99,13 @@ Reason codes on :class:`BulkApprovalRequest`
   observable; the per-row decisions live on
   :attr:`BulkApprovalRequest.per_row_decisions` for fine-grained
   audit.
+* ``template_default_deny`` (AW-7) — every approval-needing row parked
+  purely because the TEMPLATE-level deny-on-no-match flip caught an
+  uncovered MUTATING action (verdict EXECUTE, reason "auto", no rule
+  matched). Only emitted when ``template_default_deny`` + ``is_mutating``
+  are both passed True by the EE caller; a deny-on-no-match row mixed
+  with a real rule escalation still consolidates to
+  ``mixed_approval_reasons``.
 
 Scope (locked by the PR brief)
 ------------------------------
@@ -221,8 +242,10 @@ class BulkApprovalRequest(BaseModel):
     payload that will be invoked on approval."""
 
     reason: str
-    """One of ``operator_overlay_escalated``, ``author_floor``, or
-    ``mixed_approval_reasons``. See module docstring."""
+    """One of ``operator_overlay_escalated``, ``author_floor``,
+    ``mixed_approval_reasons``, or ``template_default_deny`` (AW-7 — a
+    deny-on-no-match park of an uncovered mutating action). See module
+    docstring."""
 
     matched_rules: list[InstinctRule] = Field(default_factory=list)
     """Union (by identity) of every overlay approval rule that
@@ -305,6 +328,8 @@ def plan_bulk_execution(
     resolver: IdentifierResolver | None = None,
     row_id_field: str | None = None,
     now: datetime | None = None,
+    template_default_deny: bool = False,
+    is_mutating: bool = True,
 ) -> BulkPlan:
     """Plan the fan-out for a ``kind: bulk`` action against N rows.
 
@@ -344,6 +369,28 @@ def plan_bulk_execution(
         Optional wall-clock for the CEL ``within(...)`` function.
         Defaults to ``datetime.now(UTC)``. Tests should pass a fixed
         value for determinism.
+    template_default_deny:
+        AW-7 TEMPLATE-level deny-on-no-match. The EE runtime resolves
+        the per-workspace / global flag
+        (``resolve_workspace_template_default_deny``) and passes it in.
+        When True AND ``is_mutating`` is True, a per-row NO-RULE-MATCH
+        default EXECUTE (``verdict == "EXECUTE"`` and ``reason == "auto"``
+        — the composer's fall-through when the bound template declares no
+        matching rule) is routed to the batch APPROVAL bucket instead of
+        ``executions`` — the same deny-by-default the router
+        (``router.py`` ~L1257-1285) and the temporal sweep enforce
+        through ``gate_action``. Default False keeps every path
+        byte-identical to before.
+    is_mutating:
+        AW-7 mutating-vs-read signal, computed by the EE caller from the
+        pocket's parsed action binding exactly as ``action_executor``
+        does (``method in {POST,PUT,PATCH,DELETE} and not read_only``).
+        A read (``read_only`` marker / GET / HEAD → ``is_mutating=False``)
+        is never re-bucketed — a read has nothing to govern. The planner
+        cannot compute this itself: ``method`` / ``read_only`` live on the
+        rippleSpec ``ActionBinding`` (EE-parsed), not on the template's
+        ``ActionDef``. Default True (fail-safe: an unresolved binding
+        parks rather than fires) matches ``gate_action``'s default.
 
     Returns
     -------
@@ -404,6 +451,27 @@ def plan_bulk_execution(
         if decision.verdict == "ESCALATE_APPROVAL":
             # Consolidate later — collect now and emit one request
             # for the whole batch.
+            approval_rows.append((row_id, row, decision))
+            continue
+
+        # AW-7 — TEMPLATE-level deny-on-no-match, mirroring
+        # ``instinct_dispatch.gate_action`` exactly. When the workspace/global
+        # flag is ON and this action ``is_mutating`` (EE-computed from the
+        # parsed binding), a NO-RULE-MATCH default EXECUTE — ``verdict ==
+        # "EXECUTE"`` with ``reason == "auto"`` (the composer's fall-through
+        # when the bound template declares no matching rule) — is routed to the
+        # batch APPROVAL bucket instead of firing. This is the same escalation
+        # the router and temporal sweep enforce through ``gate_action``; here
+        # the planner buckets it so ``_fire_executions`` (which fires
+        # ``plan.executions`` un-re-gated) never touches the parked row. Scope
+        # is tight: only the ``reason == "auto"`` no-rule-match default flips —
+        # a rule that matched and returned EXECUTE (non-"auto" reason) or a
+        # ``notify_only`` author floor (NOTIFY_AND_EXECUTE) is an explicit
+        # policy decision, never overridden. Reads (``is_mutating=False``) and
+        # a flag that is OFF (the default) keep the bucketing byte-identical to
+        # before.
+        no_rule_matched = decision.verdict == "EXECUTE" and decision.reason == "auto"
+        if template_default_deny and is_mutating and no_rule_matched:
             approval_rows.append((row_id, row, decision))
             continue
 
@@ -524,9 +592,18 @@ def _consolidate_approval(
         consolidated_reason = "operator_overlay_escalated"
     elif reasons == {"author_floor"}:
         consolidated_reason = "author_floor"
+    elif reasons == {"auto"}:
+        # AW-7 — every row in this batch parked solely because of the
+        # TEMPLATE-level deny-on-no-match flip (verdict EXECUTE, reason
+        # "auto" — no rule matched). Label it truthfully rather than folding
+        # it into ``mixed_approval_reasons``: the approver sees this was a
+        # deny-by-default park of an uncovered mutating action, not a rule
+        # escalation. (The per-row decisions still carry reason "auto".)
+        consolidated_reason = "template_default_deny"
     else:
-        # Any other mix (e.g. {operator_overlay_escalated, author_floor})
-        # consolidates to a single typed string per the brief.
+        # Any other mix (e.g. {operator_overlay_escalated, author_floor}, or a
+        # deny-on-no-match "auto" row alongside a rule escalation) consolidates
+        # to a single typed string per the brief.
         consolidated_reason = "mixed_approval_reasons"
 
     return BulkApprovalRequest(

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,18 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-28 (AW-7 template gate deny-on-no-match): Added
+    ``instinct_template_default_deny`` (default False, env
+    POCKETPAW_INSTINCT_TEMPLATE_DEFAULT_DENY) — the host-wide default for the
+    TEMPLATE-level deny-by-default. When a template is BOUND to a pocket but
+    declares NO rule matching a MUTATING action, the template gate previously
+    returned EXECUTE (proceed). With this flag ON, that no-rule-match case
+    parks the write for human approval (PENDING_APPROVAL) instead; READS
+    (read_only / GET / HEAD actions) still proceed ungated. OFF by default so
+    day-one behavior is unchanged. A per-workspace override field
+    (``instinct_template_default_deny`` on the workspace document; null = use
+    this global default) is resolved exactly like
+    ``instinct_approval_level``.
   - 2026-06-26 (WU-F billing cutover): Added ``litellm_spend_mode``
     (Literal off|shadow|live, default 'off'; POCKETPAW_LITELLM_SPEND_MODE) — the
     three-position billing-cutover switch that supersedes the
@@ -1476,6 +1488,30 @@ class Settings(BaseSettings):
             "hard expiry. On expiry the registry fires an ALERT audit event and "
             "persists the expired handle (no heartbeat extension). Set via "
             "POCKETPAW_INSTINCT_OPTIMISTIC_TTL_SECONDS."
+        ),
+    )
+    # AW-7 — TEMPLATE-level deny-by-default. Binding-level deny-by-default
+    # (``ActionBinding.requires_instinct`` defaults True) is already live; this
+    # closes the remaining hole: a template BOUND to a pocket that declares NO
+    # rule matching a MUTATING action used to fall through to the template
+    # gate's EXECUTE default and fire. When this flag is ON the no-rule-match
+    # case parks the write for a human (PENDING_APPROVAL) instead. READS
+    # (read_only / GET / HEAD actions) still proceed ungated — a read has
+    # nothing to govern. DORMANT by default (False): shipping it changes zero
+    # behavior. A per-workspace override field of the same name on the
+    # workspace document (null = use this global default) is resolved exactly
+    # like ``instinct_approval_level`` via
+    # ``resolve_workspace_template_default_deny``.
+    instinct_template_default_deny: bool = Field(
+        default=False,
+        description=(
+            "When true, a template BOUND to a pocket that declares no rule "
+            "matching a MUTATING action (POST/PUT/PATCH/DELETE and not "
+            "read_only) parks the write for human approval instead of firing "
+            "(template-level deny-by-default). Reads (read_only / GET / HEAD) "
+            "still proceed ungated. Off by default (zero behavior change). "
+            "Per-workspace overrides live on the workspace document. Set via "
+            "POCKETPAW_INSTINCT_TEMPLATE_DEFAULT_DENY."
         ),
     )
 

--- a/tests/cloud/test_action_read_only_marker.py
+++ b/tests/cloud/test_action_read_only_marker.py
@@ -1,0 +1,167 @@
+# tests/cloud/test_action_read_only_marker.py
+# Created: 2026-06-28 (AW-6 — read_only action marker) — pins the
+# safe-by-definition read-only exemption added to the EE action_executor:
+#
+#   * VALIDATION: `read_only=True` is only valid for a genuine read —
+#     a GET/HEAD method with NO `instinct_policy`. A mutating verb
+#     (POST/PUT/PATCH/DELETE) marked read_only fails parse; a read_only
+#     binding carrying an `instinct_policy` fails parse. A plain
+#     `read_only=True` GET parses cleanly.
+#   * GATE 7: a `read_only=True` GET binding SKIPS the deny-by-default
+#     Instinct park (it proceeds ungated, falling through to the HTTP
+#     path) — so the executor never returns `instinct_pending` for it.
+#   * REGRESSION: a normal mutating binding (`read_only=False`, the
+#     default) still parks at gate 7 under deny-by-default, exactly as
+#     today — the marker changed nothing for real writes.
+#
+# Gate 7 sits AFTER the DNS pre-resolve guard (gate 6), so both gate-7
+# tests monkeypatch `_assert_host_external` to a no-op — otherwise the
+# bogus base_url is rejected at gate 6 before the park decision is ever
+# reached, and the test would pass vacuously. With gate 6 bypassed:
+#   * the mutating POST reaches gate 7 and PARKS (`instinct_pending`,
+#     no HTTP call) — the deny-by-default regression;
+#   * the read_only GET reaches gate 7, does NOT park, and falls into
+#     the gate-8 HTTP call (which fails against the bogus base_url) —
+#     proving the suppression actually let it past the gate, not that
+#     an earlier guard rejected it.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.pockets import action_executor
+from pocketpaw_ee.cloud.pockets.action_executor import ActionBinding
+from pydantic import ValidationError
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Validator — read_only is only valid for a genuine read (GET/HEAD, no policy)
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_get_binding_parses() -> None:
+    """A read_only GET with no policy is the canonical safe-read shape."""
+    binding = ActionBinding.model_validate(
+        {"kind": "write_binding", "method": "GET", "path": "/items", "read_only": True}
+    )
+    assert binding.read_only is True
+    assert binding.method == "GET"
+
+
+def test_read_only_head_binding_parses() -> None:
+    """HEAD is the other non-mutating method the marker allows."""
+    binding = ActionBinding.model_validate(
+        {"kind": "write_binding", "method": "HEAD", "path": "/items", "read_only": True}
+    )
+    assert binding.read_only is True
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_read_only_on_mutating_method_fails_validation(method: str) -> None:
+    """A mutating verb must NOT be labeled read_only — that would un-gate a
+    real write. Parse must reject it with a clear message."""
+    with pytest.raises(ValidationError) as exc:
+        ActionBinding.model_validate(
+            {
+                "kind": "write_binding",
+                "method": method,
+                "path": "/items",
+                "read_only": True,
+            }
+        )
+    assert "read_only" in str(exc.value)
+    assert "mutating" in str(exc.value) or "GET/HEAD" in str(exc.value)
+
+
+def test_read_only_with_instinct_policy_fails_validation() -> None:
+    """`read_only` says 'no gate'; `instinct_policy` says 'gate this way' —
+    the two contradict, so the binding must be rejected at parse time."""
+    with pytest.raises(ValidationError) as exc:
+        ActionBinding.model_validate(
+            {
+                "kind": "write_binding",
+                "method": "GET",
+                "path": "/items",
+                "read_only": True,
+                "instinct_policy": "approve_per_row",
+            }
+        )
+    assert "read_only" in str(exc.value)
+    assert "instinct_policy" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Gate 7 — read_only skips the park; a normal mutating write still parks
+# ---------------------------------------------------------------------------
+
+
+async def _noop_host_external(_hostname: str) -> None:
+    """Bypass gate 6 (DNS pre-resolve) so the test reaches gate 7."""
+    return None
+
+
+async def test_read_only_get_skips_gate_7_park(recording_bus, monkeypatch) -> None:
+    """A read_only GET proceeds UNGATED: gate 7's deny-by-default park does
+    NOT fire, so the executor never returns `instinct_pending`. With gate 6
+    bypassed it falls through to the gate-8 HTTP call, which fails against
+    the bogus base_url — proving the write got PAST gate 7, not that an
+    earlier guard rejected it."""
+    monkeypatch.setattr(action_executor, "_assert_host_external", _noop_host_external)
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="read_thing",
+        raw_action={
+            "kind": "write_binding",
+            "method": "GET",
+            "path": "/items",
+            "read_only": True,
+        },
+        path="/items",
+        params={},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "GET", "path_pattern": "/items*"}],
+    )
+
+    # The defining assertion: NO Instinct park for a safe read.
+    assert result.get("code") != "instinct_pending"
+    assert "_park" not in result
+    # It got past gate 7 into the HTTP call — which fails on the bogus host.
+    # The point is it REACHED the call (a park would have short-circuited).
+    assert result["ok"] is False
+    assert result["code"] == "request_failed"
+
+
+async def test_normal_mutating_binding_still_parks_at_gate_7(recording_bus, monkeypatch) -> None:
+    """Regression: a normal write (read_only defaults False) still parks at
+    gate 7 under deny-by-default — the marker changed nothing for real
+    writes. With gate 6 bypassed, the park sentinel returns BEFORE any HTTP
+    call (the bogus host is never contacted)."""
+    monkeypatch.setattr(action_executor, "_assert_host_external", _noop_host_external)
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="write_thing",
+        raw_action={"kind": "write_binding", "method": "POST", "path": "/items"},
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+    )
+
+    assert result["ok"] is True
+    assert result["code"] == "instinct_pending"
+    # The park blob carries the resolved write for a post-approval replay.
+    assert result["_park"]["method"] == "POST"
+    assert result["_park"]["path"] == "/items"

--- a/tests/cloud/test_bulk_dispatch.py
+++ b/tests/cloud/test_bulk_dispatch.py
@@ -1,4 +1,10 @@
 # tests/cloud/test_bulk_dispatch.py
+# Updated: 2026-07-02 (AW-7 follow-up — security) — added the AW-7
+#   TEMPLATE-level deny-on-no-match section pinning the EE wiring end-to-end:
+#   flag ON + an uncovered MUTATING (POST) bulk action PARKS into one batch
+#   approval (nothing fires); flag ON + a read_only GET binding still FIRES;
+#   flag OFF (default) is unchanged. The flag is toggled by monkeypatching
+#   ``resolve_workspace_template_default_deny`` (mirrors the temporal tests).
 # Created: 2026-05-28 (feat/wave-3b-action-pipeline) — pins the
 # Wave 3b bulk action dispatch pipeline. This is the EE-side library
 # wrapper around the OSS ``plan_bulk_execution`` planner.
@@ -432,3 +438,145 @@ async def test_service_emits_bulk_action_dispatched_once(stub_run_action, record
     assert payload["action_name"] == "mark_done"
     assert payload["total_rows"] == 2
     assert payload["workspace_id"] == "w1"
+
+
+# ---------------------------------------------------------------------------
+# AW-7 — TEMPLATE-level deny-on-no-match (bulk security hole fix)
+# ---------------------------------------------------------------------------
+#
+# Added: 2026-07-02 (AW-7 follow-up — security). The bulk fan-out ran the
+# gate ONCE per row via the planner and fired ``plan.executions`` un-re-gated,
+# so with the per-workspace ``instinct_template_default_deny`` flag ON an
+# uncovered MUTATING bulk action (no matching rule → EXECUTE/auto) executed
+# ungated while the router + temporal paths parked. ``dispatch_bulk`` now
+# resolves the flag and computes ``is_mutating`` from the pocket's parsed
+# binding, threading both into ``plan_bulk_execution``. These tests pin the
+# EE wiring end-to-end (flag toggled by monkeypatching the resolver, mirroring
+# the temporal-dispatcher tests):
+#   * flag ON + MUTATING (POST) + no rule  → PARKS (batch approval, never fires)
+#   * flag ON + a read_only GET binding    → FIRES (a read has nothing to govern)
+#   * flag OFF (default)                   → UNCHANGED (rows fire)
+
+
+def _stub_deny(monkeypatch, value: bool) -> None:
+    """Drive the AW-7 flag without touching a Workspace document."""
+
+    async def _deny(_ws: str) -> bool:
+        return value
+
+    monkeypatch.setattr(pockets_service, "resolve_workspace_template_default_deny", _deny)
+
+
+def _readonly_ripple_spec(action_name: str = "mark_done") -> dict[str, Any]:
+    """RippleSpec with a single SAFE read_only GET binding (AW-6)."""
+    return {
+        "actions": {
+            action_name: {
+                "kind": "write_binding",
+                "method": "GET",
+                "path": "/items",
+                "read_only": True,
+            }
+        }
+    }
+
+
+async def _make_pocket_with_spec(ripple_spec: dict[str, Any], *, workspace: str = "w1") -> str:
+    doc = _PocketDoc(
+        workspace=workspace,
+        name="test pocket",
+        owner="u1",
+        rippleSpec=ripple_spec,
+        visibility="workspace",
+        widgets=[],
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def test_aw7_flag_on_uncovered_mutating_bulk_parks(
+    stub_run_action, recording_bus, monkeypatch
+) -> None:
+    """THE BULK HOLE, CLOSED. Flag ON + a MUTATING (POST) bulk action + a
+    bound template with NO matching rule ⇒ every row PARKS into ONE batch
+    approval and NOTHING fires through run_action. Mirrors the router +
+    temporal deny-by-default tests."""
+    pocket_id = await _make_pocket()  # rippleSpec: POST /items (mutating)
+    await _make_backend(pocket_id=pocket_id)
+    template = _template(instinct_policy="auto")  # no rules → EXECUTE/auto per row
+    _stub_deny(monkeypatch, True)
+
+    rows = [{"id": "r1", "value": 1}, {"id": "r2", "value": 2}]
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=rows,
+        now=FROZEN_NOW,
+    )
+
+    # Nothing fired — every uncovered mutating row parked.
+    assert result.executions == []
+    assert result.blocked == []
+    assert len(stub_run_action) == 0
+    # ONE batch approval covers both rows.
+    assert result.batch_approval_id is not None
+    assert sorted(result.approval_row_ids) == ["r1", "r2"]
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1
+    assert approvals[0]["id"] == result.batch_approval_id
+    # Exactly one approval-created event.
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert len(created) == 1
+
+
+async def test_aw7_flag_on_read_only_bulk_still_fires(stub_run_action, monkeypatch) -> None:
+    """Flag ON but the binding is a SAFE read_only GET (is_mutating=False)
+    ⇒ every row still FIRES. A read has nothing to govern, so the
+    deny-by-default flip never gates it."""
+    pocket_id = await _make_pocket_with_spec(_readonly_ripple_spec())
+    await _make_backend(pocket_id=pocket_id)
+    template = _template(instinct_policy="auto")
+    _stub_deny(monkeypatch, True)
+
+    rows = [{"id": "r1", "value": 1}, {"id": "r2", "value": 2}]
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=rows,
+        now=FROZEN_NOW,
+    )
+
+    assert len(result.executions) == 2
+    assert result.batch_approval_id is None
+    assert result.approval_row_ids == []
+    assert len(stub_run_action) == 2
+
+
+async def test_aw7_flag_off_bulk_is_unchanged(stub_run_action, monkeypatch) -> None:
+    """Flag OFF (the default) ⇒ an uncovered mutating bulk action fires as
+    before AW-7. The zero-behavior-change day-one path."""
+    pocket_id = await _make_pocket()  # POST /items (mutating)
+    await _make_backend(pocket_id=pocket_id)
+    template = _template(instinct_policy="auto")
+    _stub_deny(monkeypatch, False)
+
+    rows = [{"id": "r1", "value": 1}, {"id": "r2", "value": 2}]
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=rows,
+        now=FROZEN_NOW,
+    )
+
+    assert len(result.executions) == 2
+    assert result.batch_approval_id is None
+    assert len(stub_run_action) == 2

--- a/tests/cloud/test_instinct_dispatch.py
+++ b/tests/cloud/test_instinct_dispatch.py
@@ -463,3 +463,292 @@ async def test_decide_cross_workspace_not_found() -> None:
 
     with pytest.raises(NotFound):
         await approvals_service.approve("wB", "u_approver", gate.approval_id, None)
+
+
+# ---------------------------------------------------------------------------
+# AW-7 — TEMPLATE-level deny-on-no-match. A bound template that declares no
+# rule matching a MUTATING action parks the write for a human when the
+# per-workspace / global flag is ON. Reads stay ungated; flag OFF is unchanged;
+# a per-workspace override beats the global default.
+# ---------------------------------------------------------------------------
+
+
+async def test_template_default_deny_parks_uncovered_mutating_action(recording_bus) -> None:
+    """Flag ON + a bound template with NO rule for a MUTATING action ⇒ park
+    (PENDING_APPROVAL), not proceed. This is the deny-by-default flip."""
+    # `auto` policy + no rules → resolve_instinct returns its default EXECUTE
+    # (reason="auto") — the no-rule-match case AW-7 must park.
+    template = _template(instinct_policy="auto")
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        row_id="row-1",
+        park={"action": "do_thing", "method": "POST", "path": "/items", "params": {}},
+        now=FROZEN_NOW,
+        template_default_deny=True,
+        is_mutating=True,
+    )
+
+    assert result.next_step == "pending_approval"
+    assert result.approval_id is not None
+    # The verdict is still EXECUTE/auto — we did not invent a rule, we parked a
+    # write the template did not govern.
+    assert result.decision.verdict == "EXECUTE"
+    assert result.decision.reason == "auto"
+
+    # One human-pending approval row was persisted.
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1
+    assert approvals[0]["id"] == result.approval_id
+    assert approvals[0]["status"] == "pending"
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert len(created) == 1
+
+
+async def test_template_default_deny_does_not_park_read(recording_bus) -> None:
+    """Flag ON but a READ (is_mutating=False) ⇒ proceed ungated. A read has
+    nothing to govern, so the deny-on-no-match flip must never gate it."""
+    template = _template(instinct_policy="auto")
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        now=FROZEN_NOW,
+        template_default_deny=True,
+        is_mutating=False,  # read_only / GET / HEAD
+    )
+
+    assert result.next_step == "proceed"
+    assert result.approval_id is None
+    # No approval row persisted for a read.
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert approvals == []
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert created == []
+
+
+async def test_template_default_deny_off_is_unchanged() -> None:
+    """Flag OFF (the default) ⇒ the no-rule-match EXECUTE still proceeds —
+    zero day-one behavior change."""
+    template = _template(instinct_policy="auto")
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        now=FROZEN_NOW,
+        template_default_deny=False,
+        is_mutating=True,
+    )
+
+    assert result.next_step == "proceed"
+    assert result.approval_id is None
+
+
+async def test_template_default_deny_does_not_override_matched_execute_rule(recording_bus) -> None:
+    """A rule that MATCHED and returned EXECUTE is an explicit policy decision —
+    deny-on-no-match must not override it. Only the no-rule-match `auto`
+    default parks. A notify rule that matches gives reason != "auto", so the
+    write still proceeds even with the flag ON."""
+    template = _template(
+        instinct_policy="notify_only",
+        rules=[{"when": "value > 0", "action": "notify"}],
+    )
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 5},
+        now=FROZEN_NOW,
+        template_default_deny=True,
+        is_mutating=True,
+    )
+
+    # notify_only author floor → NOTIFY_AND_EXECUTE (reason "notify_only"), NOT
+    # the no-rule-match "auto" default — so it proceeds, unparked.
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "NOTIFY_AND_EXECUTE"
+    assert result.approval_id is None
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert created == []
+
+
+async def test_template_default_deny_block_still_blocks() -> None:
+    """A BLOCK rule short-circuits before the deny-on-no-match flip — a blocked
+    write is still blocked, never silently turned into a park."""
+    template = _template(
+        instinct_policy="auto",
+        rules=[{"when": "value > 100", "action": "block"}],
+    )
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 999},
+        now=FROZEN_NOW,
+        template_default_deny=True,
+        is_mutating=True,
+    )
+
+    assert result.next_step == "blocked"
+    assert result.approval_id is None
+
+
+# --- executor-level integration (the gate is wired through run_action) ------
+
+
+async def test_executor_template_default_deny_parks_mutating_write(recording_bus) -> None:
+    """Flag ON threaded through `run_action` + a bound template with no rule
+    for a MUTATING (POST) action ⇒ `instinct_pending`, no HTTP call. The
+    executor computes is_mutating=True from the parsed binding."""
+    template = _template(instinct_policy="auto")
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="do_thing",
+        raw_action={"kind": "write_binding", "method": "POST", "path": "/items"},
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"value": 1},
+        row_id="r1",
+        template_default_deny=True,
+    )
+
+    assert result["ok"] is True
+    assert result["code"] == "instinct_pending"
+    assert result["approval_id"]
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1
+
+
+async def test_executor_template_default_deny_proceeds_for_read_only(recording_bus) -> None:
+    """Flag ON + a read_only GET binding ⇒ the executor computes
+    is_mutating=False, so the gate does NOT park; the write falls through to
+    the HTTP stack (the bogus base_url rejects later). No approval row, no
+    `instinct_pending`."""
+    template = _template(instinct_policy="auto")
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="do_thing",
+        raw_action={
+            "kind": "write_binding",
+            "method": "GET",
+            "path": "/items",
+            "read_only": True,
+        },
+        path="/items",
+        params={},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "GET", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"value": 1},
+        row_id="r1",
+        template_default_deny=True,
+    )
+
+    # NOT parked — a read is never gated by the template default-deny flip.
+    assert result.get("code") != "instinct_pending"
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert approvals == []
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert created == []
+
+
+async def test_executor_template_default_deny_off_proceeds(recording_bus) -> None:
+    """Flag OFF (default) threaded through `run_action` ⇒ the no-rule-match
+    mutating write is NOT parked — it falls into the existing HTTP gate stack
+    (bogus base_url rejects). Zero behavior change."""
+    template = _template(instinct_policy="auto")
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="do_thing",
+        raw_action={"kind": "write_binding", "method": "POST", "path": "/items"},
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"value": 1},
+        row_id="r1",
+        # template_default_deny defaults False
+    )
+
+    assert result.get("code") != "instinct_pending"
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert approvals == []
+
+
+# --- per-workspace override beats the global default ------------------------
+
+
+async def test_workspace_override_beats_global_template_default_deny(monkeypatch) -> None:
+    """The per-workspace `instinct_template_default_deny` field overrides the
+    global config default (resolve order mirrors approval_level)."""
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    # Global default OFF, workspace field ON → resolver returns True.
+    monkeypatch.setattr(
+        "pocketpaw.config.get_settings",
+        lambda: type("S", (), {"instinct_template_default_deny": False})(),
+    )
+    ws = Workspace(name="ws-on", slug="ws-on", owner="u1", instinct_template_default_deny=True)
+    await ws.insert()
+    resolved = await pockets_service.resolve_workspace_template_default_deny(str(ws.id))
+    assert resolved is True
+
+    # Global default ON, workspace field OFF → workspace wins (returns False).
+    monkeypatch.setattr(
+        "pocketpaw.config.get_settings",
+        lambda: type("S", (), {"instinct_template_default_deny": True})(),
+    )
+    ws_off = Workspace(
+        name="ws-off", slug="ws-off", owner="u1", instinct_template_default_deny=False
+    )
+    await ws_off.insert()
+    resolved_off = await pockets_service.resolve_workspace_template_default_deny(str(ws_off.id))
+    assert resolved_off is False
+
+    # Workspace field unset (None) → falls back to the global default (True).
+    ws_none = Workspace(name="ws-none", slug="ws-none", owner="u1")
+    await ws_none.insert()
+    resolved_none = await pockets_service.resolve_workspace_template_default_deny(str(ws_none.id))
+    assert resolved_none is True

--- a/tests/cloud/test_instinct_gate_config.py
+++ b/tests/cloud/test_instinct_gate_config.py
@@ -1,4 +1,9 @@
 # tests/cloud/test_instinct_gate_config.py
+# Updated: 2026-06-28 (AW-7 template gate deny-on-no-match) — pins the new
+# `instinct_template_default_deny` config field (default False, env
+# POCKETPAW_INSTINCT_TEMPLATE_DEFAULT_DENY) and its per-workspace resolution
+# (`resolve_workspace_template_default_deny` — workspace field → global default
+# → False, degrading safe on a bad id), mirroring the approval_level coverage.
 # Created: 2026-06-18 (feat/instinct-gate-foundation, T5) — config-default
 # tests for the layered/learning Instinct gate's four global settings
 # (2026-06-18 gate-layered-learning design).
@@ -59,6 +64,17 @@ def test_env_overrides_optimistic_ttl(monkeypatch) -> None:
     assert Settings().instinct_optimistic_ttl_seconds == 600
 
 
+def test_template_default_deny_defaults_off() -> None:
+    """AW-7 — the template deny-by-default ships DORMANT (False), so shipping
+    the flag changes zero behavior."""
+    assert Settings().instinct_template_default_deny is False
+
+
+def test_env_overrides_template_default_deny(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_INSTINCT_TEMPLATE_DEFAULT_DENY", "true")
+    assert Settings().instinct_template_default_deny is True
+
+
 # ---------------------------------------------------------------------------
 # T-25 / T6 — per-workspace override resolution.
 # ---------------------------------------------------------------------------
@@ -105,3 +121,48 @@ async def test_resolution_degrades_safe_on_bad_id() -> None:
 
     level = await pockets_service.resolve_workspace_approval_level("not-an-objectid")
     assert level == "ASK"
+
+
+# ---------------------------------------------------------------------------
+# AW-7 — per-workspace template-default-deny resolution (mirrors the
+# approval_level resolution above).
+# ---------------------------------------------------------------------------
+
+
+async def _make_workspace_deny(flag: bool | None) -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(name="W", slug=f"wd-{flag}", owner="u1")
+    if flag is not None:
+        ws.instinct_template_default_deny = flag
+    await ws.insert()
+    return str(ws.id)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_workspace_template_deny_field_overrides_global_default() -> None:
+    """A workspace that set the field True resolves True even though the global
+    default is False — the per-workspace opt-in."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    ws_id = await _make_workspace_deny(True)
+    assert await pockets_service.resolve_workspace_template_default_deny(ws_id) is True
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_workspace_template_deny_unset_falls_back_to_global_default() -> None:
+    """A workspace with no field set uses the global default (False)."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    ws_id = await _make_workspace_deny(None)
+    assert await pockets_service.resolve_workspace_template_default_deny(ws_id) is False
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_workspace_template_deny_degrades_safe_on_bad_id() -> None:
+    """A malformed / unknown workspace id resolves to the global default (False),
+    never silently parks — a read failure must never start gating writes."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    out = await pockets_service.resolve_workspace_template_default_deny("not-an-objectid")
+    assert out is False

--- a/tests/cloud/test_temporal_dispatcher.py
+++ b/tests/cloud/test_temporal_dispatcher.py
@@ -23,6 +23,17 @@
 #   * Eval failure: a bad CEL doesn't break the sweep — the failure
 #     is captured under ``errors`` and the sweep continues for the
 #     other rows.
+#
+# Updated: 2026-06-28 (AW-7 follow-up — security) — adds the TEMPLATE-level
+# deny-by-default coverage for the TEMPORAL path. AW-7's
+# ``instinct_template_default_deny`` flag was threaded through the router but
+# NOT this sweep path, so a scheduled MUTATING action with no matching rule
+# fired ungated even with the flag ON. New cases (using the REAL gate, only
+# the executor/creds/spec/flag-resolver stubbed) pin: flag ON + mutating + no
+# rule ⇒ PARK (escalated, executor never called, approval row persisted); flag
+# OFF ⇒ unchanged (fires); a read_only GET ⇒ never gated; and that the flag +
+# computed ``is_mutating`` actually REACH both gate points (the direct
+# ``gate_action`` and the ``run_action`` re-gate).
 
 from __future__ import annotations
 
@@ -539,3 +550,184 @@ async def test_template_none_is_no_op(monkeypatch) -> None:
     assert executor.calls == []
     persisted = await sweeps_service.load_last_seen("w1", "p1")
     assert persisted == {}
+
+
+# ---------------------------------------------------------------------------
+# AW-7 follow-up (security) — TEMPLATE-level deny-by-default on the TEMPORAL
+# sweep path. AW-7 added the per-workspace ``instinct_template_default_deny``
+# flag: ON ⇒ a template-bound pocket with NO matching rule for a MUTATING
+# action PARKS it instead of firing. The router threaded it; the temporal
+# sweep path did NOT, so a scheduled mutating action with no matching rule
+# fired ungated even with the flag ON — a hole in the exact feature meant to
+# close it. These tests pin that the temporal path now mirrors the router:
+# flag ON + mutating + no rule ⇒ PARK; flag OFF ⇒ unchanged; a READ is never
+# gated. They use the REAL ``gate_action`` (only the executor + creds + spec +
+# the flag resolver are stubbed) so the actual escalation logic fires
+# end-to-end — a stubbed gate would not prove the hole is closed.
+# ---------------------------------------------------------------------------
+
+
+def _patch_real_gate(
+    monkeypatch,
+    executor: _RecordingExecutor,
+    *,
+    default_deny: bool,
+    method: str = "POST",
+    read_only: bool = False,
+) -> None:
+    """Wire the dispatcher to the REAL gate but stub everything around it.
+
+    The executor is recorded (so we can assert it is/ isn't called), the creds
+    + spec are faked (no HTTP, no real pocket), and
+    ``resolve_workspace_template_default_deny`` returns ``default_deny`` so the
+    test drives the flag without touching a Workspace document. ``method`` /
+    ``read_only`` shape the single ``alert_overdue`` binding so the dispatcher's
+    ``is_mutating`` computation has real input.
+    """
+    from pocketpaw_ee.cloud.pockets import action_executor as real_executor
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    monkeypatch.setattr(real_executor, "run_action", executor.run_action)
+
+    async def _creds(_ws: str, _pid: str):
+        return (
+            "https://api.example.test",
+            "none",
+            None,
+            "",
+            [{"method": method, "path_pattern": "*"}],
+            None,
+        )
+
+    binding: dict[str, Any] = {
+        "kind": "write_binding",
+        "method": method,
+        "path": "/alerts",
+        "params": {},
+    }
+    if read_only:
+        binding["read_only"] = True
+
+    async def _spec(_ws: str, _pid: str):
+        return {"actions": {"alert_overdue": binding}}
+
+    async def _deny(_ws: str) -> bool:
+        return default_deny
+
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _creds)
+    monkeypatch.setattr(pockets_service, "get_pocket_ripple_spec", _spec)
+    monkeypatch.setattr(pockets_service, "resolve_workspace_template_default_deny", _deny)
+
+
+async def test_temporal_default_deny_parks_uncovered_mutating_action(
+    monkeypatch, recording_bus
+) -> None:
+    """THE HOLE, CLOSED. Flag ON + a temporal-triggered MUTATING action +
+    a bound template with NO matching rule ⇒ the action PARKS (escalated /
+    pending approval), it is NOT executed. Mirrors the router-path test
+    ``test_template_default_deny_parks_uncovered_mutating_action``."""
+    from pocketpaw_ee.cloud._core.realtime.events import InstinctApprovalCreated
+    from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    executor = _RecordingExecutor()
+    # POST (mutating), flag ON. `auto` policy + no rules ⇒ resolve_instinct
+    # returns its default EXECUTE/reason="auto" — the no-rule-match case.
+    _patch_real_gate(monkeypatch, executor, default_deny=True, method="POST")
+
+    template = _template_with_temporal(instinct_policy="auto")  # no instinct_rules
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 42}]
+    )
+
+    # The mutating action PARKED — counted under escalated, NOT fired, and the
+    # executor was NEVER called (no ungated write).
+    assert result.escalated == 1
+    assert result.edges_fired == 0
+    assert result.blocked == 0
+    assert executor.calls == []
+
+    # A real human-pending approval row was persisted by the gate.
+    approvals = await approvals_service.list_approvals("w1", "system:temporal-sweeper", {})
+    assert len(approvals) == 1
+    assert approvals[0]["action_name"] == "alert_overdue"
+    assert approvals[0]["status"] == "pending"
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert len(created) == 1
+
+
+async def test_temporal_default_deny_off_proceeds_unchanged(monkeypatch) -> None:
+    """Flag OFF (the default) ⇒ the temporal mutating action fires exactly as
+    before — the executor runs, the edge counts under ``fired``. Byte-for-byte
+    unchanged behavior on the dormant path."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    executor = _RecordingExecutor()
+    _patch_real_gate(monkeypatch, executor, default_deny=False, method="POST")
+
+    template = _template_with_temporal(instinct_policy="auto")
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 42}]
+    )
+
+    assert result.edges_fired == 1
+    assert result.escalated == 0
+    assert len(executor.calls) == 1
+    # The executor's re-gate also saw the flag OFF, so it did not park either.
+    assert executor.calls[0]["template_default_deny"] is False
+
+
+async def test_temporal_default_deny_does_not_gate_read_only(monkeypatch) -> None:
+    """Flag ON but the binding is a READ-ONLY GET ⇒ ``is_mutating`` is False, so
+    the deny-by-default flip never parks it — a read has nothing to govern. The
+    edge proceeds to the executor (counted under ``fired``)."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    executor = _RecordingExecutor()
+    _patch_real_gate(monkeypatch, executor, default_deny=True, method="GET", read_only=True)
+
+    template = _template_with_temporal(instinct_policy="auto")
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 42}]
+    )
+
+    # A read is never gated by the template default-deny flip.
+    assert result.edges_fired == 1
+    assert result.escalated == 0
+    assert len(executor.calls) == 1
+
+
+async def test_temporal_threads_flag_and_is_mutating_into_gate(monkeypatch) -> None:
+    """Defense against the security review's 'double-gate' note: the flag AND
+    the computed ``is_mutating`` must actually REACH the direct ``gate_action``
+    call, and the flag must reach the ``run_action`` re-gate. A recording gate
+    captures the kwargs so we prove the values arrive (not just that the call
+    happens)."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    gate = _RecordingGate(next_step="proceed")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    # Drive the flag ON via the resolver; the recorded gate proceeds regardless.
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    async def _deny(_ws: str) -> bool:
+        return True
+
+    monkeypatch.setattr(pockets_service, "resolve_workspace_template_default_deny", _deny)
+
+    template = _template_with_temporal(instinct_policy="auto")
+    await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 42}]
+    )
+
+    # FIRST gate point — the direct gate_action call got BOTH values.
+    assert len(gate.calls) == 1
+    assert gate.calls[0]["template_default_deny"] is True
+    # POST binding from `_patch_dispatch`'s spec ⇒ mutating.
+    assert gate.calls[0]["is_mutating"] is True
+
+    # SECOND gate point — run_action got the flag so its re-gate honors it too.
+    assert len(executor.calls) == 1
+    assert executor.calls[0]["template_default_deny"] is True

--- a/tests/unit/test_bulk_executor.py
+++ b/tests/unit/test_bulk_executor.py
@@ -1,4 +1,9 @@
 # tests/unit/test_bulk_executor.py
+# Updated: 2026-07-02 (AW-7 follow-up — security) — added the AW-7
+#   TEMPLATE-level deny-on-no-match section: flag ON + mutating + no-rule-match
+#   PARKS into the batch approval bucket; flag ON + read (is_mutating=False)
+#   still FIRES; flag OFF (default) is unchanged; a matched execute/notify rule
+#   is never re-bucketed by the flip.
 # Created: 2026-05-28 (feat/rfc-03-v2-bulk) — unit tests for the bulk
 # fan-out planner (``bulk_executor.plan_bulk_execution``). Pins the
 # RFC 03 v2 bulk-action execution model: per-row Instinct composition,
@@ -645,3 +650,131 @@ def test_bulk_approval_request_type_check() -> None:
     )
     plan = plan_bulk_execution(template, "bulk_op", [{"id": "r1", "score": 1}], now=FROZEN_NOW)
     assert isinstance(plan.approval_request, BulkApprovalRequest)
+
+
+# ---------------------------------------------------------------------------
+# AW-7 — TEMPLATE-level deny-on-no-match (bulk security hole fix)
+# ---------------------------------------------------------------------------
+#
+# Added: 2026-07-02 (AW-7 follow-up — security). AW-7 threaded the
+# per-workspace ``instinct_template_default_deny`` flag through the router +
+# temporal dispatcher, but the bulk fan-out still bucketed a no-rule-match
+# EXECUTE (reason "auto") into ``executions`` — which ``_fire_executions`` fires
+# un-re-gated — so an uncovered MUTATING bulk action executed ungated with the
+# flag ON. ``plan_bulk_execution`` now takes ``template_default_deny`` +
+# ``is_mutating`` (EE-computed) and, when both are True, routes a no-rule-match
+# default EXECUTE into the batch APPROVAL bucket instead. These tests pin:
+#   * flag ON + mutating + no-rule-match  → PARKS (approval bucket, not fired)
+#   * flag ON + read (is_mutating=False)  → FIRES (a read has nothing to govern)
+#   * flag OFF (default)                  → UNCHANGED (row fires)
+#   * scope: a MATCHED execute/notify rule is NEVER re-bucketed by the flip.
+
+
+def test_aw7_flag_on_mutating_no_rule_match_parks_into_approval() -> None:
+    """Flag ON + is_mutating + a clean row (no rule matches → verdict
+    EXECUTE, reason 'auto') → the row is routed to the batch APPROVAL
+    bucket, NOT ``executions``. This is the bulk deny-by-default fix."""
+    template = _minimal_template()  # auto policy, no rules
+    rows = [
+        {"id": "r1", "score": 1},
+        {"id": "r2", "score": 2},
+    ]
+    plan = plan_bulk_execution(
+        template,
+        "bulk_op",
+        rows,
+        now=FROZEN_NOW,
+        template_default_deny=True,
+        is_mutating=True,
+    )
+
+    # No row fires — every uncovered mutating row parked.
+    assert plan.executions == []
+    assert plan.blocked == []
+    # ONE consolidated batch approval covers both rows.
+    assert plan.approval_request is not None
+    assert plan.approval_request.row_ids == ["r1", "r2"]
+    # A pure deny-on-no-match batch gets its own truthful reason.
+    assert plan.approval_request.reason == "template_default_deny"
+    # The per-row decisions still carry the underlying EXECUTE/auto verdict.
+    for rid in ("r1", "r2"):
+        decision = plan.approval_request.per_row_decisions[rid]
+        assert decision.verdict == "EXECUTE"
+        assert decision.reason == "auto"
+
+
+def test_aw7_flag_on_read_only_still_fires() -> None:
+    """Flag ON but is_mutating=False (a read: read_only marker / GET /
+    HEAD) → the row still FIRES. A read has nothing to govern, so the
+    deny-by-default flip never gates it."""
+    template = _minimal_template()  # auto policy, no rules
+    rows = [{"id": "r1", "score": 1}]
+    plan = plan_bulk_execution(
+        template,
+        "bulk_op",
+        rows,
+        now=FROZEN_NOW,
+        template_default_deny=True,
+        is_mutating=False,
+    )
+
+    assert [r.row_id for r in plan.executions] == ["r1"]
+    assert all(r.verdict == "EXECUTE" for r in plan.executions)
+    assert plan.approval_request is None
+
+
+def test_aw7_flag_off_is_unchanged() -> None:
+    """Flag OFF (the default) → identical to before AW-7: an uncovered
+    mutating row fires. This is the day-one, zero-behavior-change path."""
+    template = _minimal_template()  # auto policy, no rules
+    rows = [{"id": "r1", "score": 1}, {"id": "r2", "score": 2}]
+
+    # Explicit OFF.
+    plan_off = plan_bulk_execution(
+        template,
+        "bulk_op",
+        rows,
+        now=FROZEN_NOW,
+        template_default_deny=False,
+        is_mutating=True,
+    )
+    assert [r.row_id for r in plan_off.executions] == ["r1", "r2"]
+    assert plan_off.approval_request is None
+
+    # Default (no kwargs) must match explicit OFF exactly.
+    plan_default = plan_bulk_execution(template, "bulk_op", rows, now=FROZEN_NOW)
+    assert [r.row_id for r in plan_default.executions] == ["r1", "r2"]
+    assert plan_default.approval_request is None
+
+
+def test_aw7_notify_only_author_floor_is_never_re_bucketed() -> None:
+    """Scope guard: the flip is the no-rule-match ('auto') default ONLY. An
+    action with a ``notify_only`` author floor returns NOTIFY_AND_EXECUTE
+    (reason 'notify_only', NOT 'auto') — an explicit policy decision — so it
+    keeps firing even with the flag ON + is_mutating; it is never overridden."""
+    template = _minimal_template(
+        actions=[
+            {
+                "name": "bulk_op",
+                "label": "Bulk op",
+                "kind": "bulk",
+                "instinct_policy": "notify_only",
+                "outcomes_emitted": ["thing_done"],
+            }
+        ],
+    )
+    rows = [{"id": "r1", "score": 1}]
+    plan = plan_bulk_execution(
+        template,
+        "bulk_op",
+        rows,
+        now=FROZEN_NOW,
+        template_default_deny=True,
+        is_mutating=True,
+    )
+
+    # The notify_only author floor → NOTIFY_AND_EXECUTE fires, not parked.
+    assert [r.row_id for r in plan.executions] == ["r1"]
+    assert plan.executions[0].verdict == "NOTIFY_AND_EXECUTE"
+    assert plan.executions[0].decision.reason == "notify_only"
+    assert plan.approval_request is None


### PR DESCRIPTION
## What

Binding-level Instinct routing already defaults to gated (`requires_instinct=True`). Two gaps remained: there was no way to mark a genuinely read-only action as gate-exempt, and a template-bound pocket fell through to EXECUTE when no rule matched an action. This closes both.

Two commits:
- **AW-6** — `read_only: bool` on `ActionBinding`, gate-7 suppression for read_only actions, and a bidirectional validator so a GET/HEAD binding is admissible only as an explicit `read_only` action. The action surface stays write-only otherwise, so a compromised client cannot smuggle a read verb in.
- **AW-7** — when a bound template has no matching rule for a mutating action, the gate now returns PENDING instead of EXECUTE, behind a per-workspace `instinct_template_default_deny` flag (global default plus a workspace-document override, mirroring how `approval_level` is plumbed). Reads still proceed. BLOCK, a matched EXECUTE rule, and notify-only are never overridden.

## Rollout

`instinct_template_default_deny` defaults **off**, so existing template-bound pockets are unchanged until a workspace opts in. The temporal sweeper is intentionally left unchanged (it inherits the off default; its rows are already planner-cleared).

## Tests

46 targeted tests pass; the broader instinct + executor sweep passes 246; `ruff` clean.

## Known nuance (carried forward, out of scope)

A `read_only` GET that skips the park still flows through the write-allowlist and the gate-8 write executor. AW-7 guarantees the template flip does not gate reads. Routing `read_only` actions to `source_executor` instead is a deeper refactor, noted in code and docs.

## Design

`docs/design/drafts/2026-06-24-aiam-whitespace-hardening{,-prd,-tasks}.md` — Slice 2 (AW-6, AW-7). This finishes deny-by-default end to end; the binding default shipped earlier in W2a.
