### PR TITLE
feat(agents): soft-disable agents with revoke-everywhere enforcement

### DIFF
--- a/docs/concepts/agent-lifecycle.mdx
+++ b/docs/concepts/agent-lifecycle.mdx
@@ -1,0 +1,81 @@
+---
+title: "Agent Lifecycle: Disable, Enable, and Delete"
+description: "How a cloud agent moves through its lifecycle — disable to revoke it everywhere at once while keeping its soul and identity, re-enable to restore it, or delete to remove it permanently."
+section: Core Concepts
+ogType: article
+keywords: ["agent lifecycle", "disable agent", "revoke agent", "delete agent", "soft disable"]
+tags: ["agent", "security", "architecture"]
+---
+
+{/*
+  docs/concepts/agent-lifecycle.mdx
+  Created 2026-06-28 (feat/aiam-agent-revoke, AW-5) — documents the agent
+  disable/enable/delete lifecycle, the revoke-everywhere semantics via the
+  single AgentPool chokepoint, and the disable/enable endpoints. Pairs with the
+  AW-4 soft-disable implementation in ee/pocketpaw_ee/cloud/agents and
+  src/pocketpaw/agents/pool.py.
+*/}
+
+# Agent Lifecycle: Disable, Enable, and Delete
+
+A workspace agent has three lifecycle controls: **disable**, **enable**, and **delete**. Disable and delete look similar from a chat window — the agent stops answering — but they are not the same operation. Pick the wrong one and you either lose work you wanted to keep, or leave a "revoked" agent quietly answering on a path you forgot about.
+
+## Disable vs. delete
+
+| | **Disable** | **Delete** |
+|---|---|---|
+| Reversible | Yes — re-enable restores it | No — permanent |
+| Soul / identity | Preserved (memory, persona, DID kept on disk) | Removed |
+| Config & knowledge | Preserved | Removed |
+| Shows in the roster | Yes, marked `disabled: true` | Gone |
+| Answers in chat | No | No |
+| Use when | Pausing, suspending, or revoking an agent you may want back | Retiring an agent for good |
+
+**Disable is the safe default.** It is a soft, reversible suspend: the agent's `.soul` file, configuration, scope assignment, and knowledge base all stay intact. The only thing that changes is a single `disabled` flag on the agent document. Re-enabling flips it back and the agent resumes exactly where it left off — same memory, same persona, no re-onboarding.
+
+**Delete is permanent.** It removes the agent document. Use it only when you are certain the agent will not come back.
+
+If you are unsure, disable. You can always delete a disabled agent later; you cannot un-delete one.
+
+## Revoke everywhere — the AgentPool chokepoint
+
+The reason disable is trustworthy is that there is exactly one place an agent gets resolved before it can run: the **AgentPool** (`src/pocketpaw/agents/pool.py`). Every run path — the SSE chat endpoint, the group/DM bridge, channel dispatch — calls `AgentPool.get(agent_id)` to obtain a live agent instance before it can produce a reply. There is no second resolution path that bypasses it.
+
+That single chokepoint is what makes "revoke everywhere at once" a real guarantee rather than a best effort:
+
+- **`AgentPool.get()` checks the `disabled` flag first.** On both the cached-instance path and the cold-build path it raises `AgentDisabled` before any other work. The check runs ahead of the staleness check and is re-raised past the broad database-error guard, so it **fails closed** — a disabled agent is never resolvable, even if something else goes wrong during the build.
+- **Disable invalidates the cache immediately.** Flipping the flag also calls `AgentPool.invalidate(agent_id)`, which evicts any cached instance on the spot. There is no stale-instance window where a just-disabled agent keeps replying from a warm cache. The next `get()` rebuilds and raises `AgentDisabled`.
+- **In-flight runs finish.** A run that already resolved its instance before the flag flipped completes normally. Disable stops *new* resolutions; it does not kill a reply that is already streaming.
+- **Dispatch skips cleanly.** On the group/DM bridge, a disabled agent's `AgentDisabled` is caught and the agent is simply skipped — no error to the channel, no `500`. The other agents in the group still respond. On the SSE chat path the caller gets a clean `agent.unavailable` error instead of a stack trace.
+
+Because the flag is read at resolution time on the one shared path, disabling an agent revokes it across every channel and session at once — without having to hunt down individual caches or sessions.
+
+## Roster surfacing
+
+A disabled agent is **not** filtered out of the agent list. `list_agents` keeps it in the roster with `disabled: true` on the wire (the same flag rides `GET /agents` and `GET /agents/{id}`). This is deliberate: owners need to *see* a suspended agent in order to re-enable it. The client renders a disabled agent greyed out / inactive rather than letting it silently disappear — "where did my agent go?" is a worse experience than "your agent is paused."
+
+## Endpoints
+
+Both lifecycle toggles are `PATCH` routes under the agents router and carry the **same owner/admin guard as `DELETE`** (`require_agent_owner_or_admin`) — symmetric tenant-scope protection, so a non-owner or cross-workspace caller cannot revoke or restore an agent it does not own.
+
+| Method | Path | Effect |
+|---|---|---|
+| `PATCH` | `/agents/{id}/disable` | Soft-disable — revoke everywhere, keep the soul |
+| `PATCH` | `/agents/{id}/enable` | Restore a disabled agent |
+| `DELETE` | `/agents/{id}` | Permanently remove the agent |
+
+Both `PATCH` routes return the updated agent (with the new `disabled` value) and emit a realtime event — `AgentDisabled` or `AgentEnabled` — mirroring the `AgentDeleted` payload shape so connected clients update the roster live.
+
+## At a glance
+
+```text
+              disable                    enable
+   ACTIVE  ───────────▶  DISABLED  ───────────▶  ACTIVE
+   resolves              skipped /               resolves
+   in pool               AgentDisabled           in pool
+      │                  (soul kept)
+      │ delete                                  delete
+      ▼                                            ▼
+   GONE  ◀───────────────────────────────────────┘
+   (permanent — soul + config removed)
+```

--- a/docs/docs-config.json
+++ b/docs/docs-config.json
@@ -255,6 +255,11 @@
             "icon": "lucide:repeat"
           },
           {
+            "label": "Agent Lifecycle",
+            "href": "/concepts/agent-lifecycle",
+            "icon": "lucide:power"
+          },
+          {
             "label": "Health Engine",
             "href": "/concepts/health-engine",
             "icon": "lucide:activity"

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -37,6 +37,10 @@
 #   jobs primitive. Queued is emitted at dispatch; Updated on a terminal
 #   transition by the ARQ worker. Worker-side emits route over the xproc
 #   bridge to the web bus, the same path ``PocketUpdated`` uses.
+# Updated: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — added ``AgentDisabled``
+#   (type="agent.disabled") and ``AgentEnabled`` (type="agent.enabled") for the
+#   agent soft-disable / revoke-everywhere flow. Emitted by ``agents.service``
+#   on disable / enable, mirroring ``AgentDeleted``'s payload shape.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -383,6 +387,21 @@ class AgentUpdated(Event):
 @dataclass
 class AgentDeleted(Event):
     EVENT_TYPE: ClassVar[str] = "agent.deleted"
+
+
+@dataclass
+class AgentDisabled(Event):
+    # Soft-disable (AW-4): the agent is revoked everywhere at once — the run
+    # pool refuses to resolve it on any path until re-enabled. Mirrors
+    # AgentDeleted's payload shape so audit/analytics listeners can key off it.
+    EVENT_TYPE: ClassVar[str] = "agent.disabled"
+
+
+@dataclass
+class AgentEnabled(Event):
+    # Re-enable (AW-4): clears the soft-disable flag; the pool resolves the
+    # agent again on the next get() (the disable already invalidated the cache).
+    EVENT_TYPE: ClassVar[str] = "agent.enabled"
 
 
 @dataclass

--- a/ee/pocketpaw_ee/cloud/agents/domain.py
+++ b/ee/pocketpaw_ee/cloud/agents/domain.py
@@ -5,6 +5,10 @@ mirrors this domain ``AgentConfigSpec`` field-for-field; the repository
 converts. We keep the duplication for now because eliminating the
 Beanie sub-model would require touching every caller of
 ``Agent.config.<field>``.
+
+Updated: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — added ``Agent.disabled``
+mirroring the new top-level flag on the Beanie doc, so callers (and the wire
+dict) can read whether an agent has been soft-disabled / revoked.
 """
 
 from __future__ import annotations
@@ -48,6 +52,7 @@ class Agent:
     config: AgentConfigSpec
     created_at: datetime
     updated_at: datetime
+    disabled: bool = False  # soft-disable / revoke-everywhere (AW-4)
 
 
 __all__ = ["Agent", "AgentConfigSpec"]

--- a/ee/pocketpaw_ee/cloud/agents/dto.py
+++ b/ee/pocketpaw_ee/cloud/agents/dto.py
@@ -4,6 +4,9 @@ Replaces ``ee/cloud/agents/schemas.py``. The wire shape uses some
 unusual keys preserved from legacy: ``uname`` (the slug), ``createdOn``
 and ``lastUpdatedOn`` (with mixedCase). The mappers preserve these
 exactly.
+
+Updated: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — ``agent_to_dict`` now
+emits ``disabled`` so callers can see whether an agent has been soft-disabled.
 """
 
 from __future__ import annotations
@@ -140,6 +143,7 @@ def agent_to_dict(agent: Agent) -> dict[str, Any]:
         "visibility": agent.visibility,
         "config": _config_to_dict(agent.config),
         "owner": agent.owner,
+        "disabled": agent.disabled,
         "createdOn": iso_utc(agent.created_at),
         "lastUpdatedOn": iso_utc(agent.updated_at),
     }

--- a/ee/pocketpaw_ee/cloud/agents/router.py
+++ b/ee/pocketpaw_ee/cloud/agents/router.py
@@ -11,6 +11,13 @@ five knowledge mutation endpoints (POST text/url/urls/upload, DELETE) now
 require ``require_agent_owner_or_admin`` — same guard as PATCH/DELETE agent
 CRUD. Previously they had no RBAC guard beyond ``require_license``, so any
 workspace member could inject content into any agent's knowledge base.
+
+Updated 2026-06-28 (feat/aiam-agent-revoke, AW-4): added
+``PATCH /agents/{id}/disable`` and ``PATCH /agents/{id}/enable`` for the agent
+soft-disable / revoke-everywhere flow. Both carry the SAME owner/admin guard
+(``require_agent_owner_or_admin``) + ``current_user_id`` as DELETE — symmetric
+tenant-scope protection, so a cross-workspace / non-owner caller cannot revoke
+or restore an agent it doesn't own.
 """
 
 from __future__ import annotations
@@ -119,6 +126,35 @@ async def delete_agent(
     ctx = agents_service.legacy_ctx(user_id)
     await agents_service.delete(ctx, agent_id)
     return Response(status_code=204)
+
+
+@router.patch(
+    "/{agent_id}/disable",
+    dependencies=[Depends(require_agent_owner_or_admin)],
+)
+async def disable_agent(
+    agent_id: str,
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Soft-disable an agent — revoke it everywhere at once (AW-4).
+
+    Same owner/admin guard as DELETE: symmetric tenant-scope protection.
+    """
+    ctx = agents_service.legacy_ctx(user_id)
+    return agent_to_dict(await agents_service.disable(ctx, agent_id))
+
+
+@router.patch(
+    "/{agent_id}/enable",
+    dependencies=[Depends(require_agent_owner_or_admin)],
+)
+async def enable_agent(
+    agent_id: str,
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Re-enable a soft-disabled agent (AW-4)."""
+    ctx = agents_service.legacy_ctx(user_id)
+    return agent_to_dict(await agents_service.enable(ctx, agent_id))
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -20,6 +20,11 @@ Public API:
 - ``set_scopes(agent_id, scopes)``
 - ``discover(ctx, workspace_id, body)``
 - ``legacy_ctx(user_id, workspace_id)`` — helper for the router
+
+Updated 2026-07-02 (feat/aiam-agent-revoke, AW-4 follow-up): ``get_persona``
+now returns ``None`` for a soft-disabled agent (reusing the doc it already
+loads — no extra read), so ``agent_bridge``'s smart-relevance LLM probe never
+fires for an agent ``pool.get`` would refuse to run.
 """
 
 from __future__ import annotations
@@ -544,12 +549,20 @@ async def get_persona(agent_id: str) -> str | None:
     Resolves to ``soul_persona`` when set, falling back to ``system_prompt``
     and finally the agent's display name. Returns ``None`` if the agent
     doesn't exist (callers degrade silently).
+
+    A soft-disabled agent (AW-4) also returns ``None``: this is the only
+    caller's short-circuit, so the smart-relevance probe in ``agent_bridge``
+    never fires a live LLM call for an agent that ``pool.get`` would refuse to
+    run anyway. The check reuses the doc this function already loads — no extra
+    read — so a revoked agent does zero LLM work in group/DM dispatch.
     """
     try:
         doc = await _AgentDoc.get(PydanticObjectId(agent_id))
     except Exception:
         return None
     if doc is None:
+        return None
+    if getattr(doc, "disabled", False):
         return None
     return doc.config.soul_persona or doc.config.system_prompt or doc.name
 

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -12,6 +12,10 @@ Public API:
 - ``list_agents(workspace_id, query=None)``
 - ``update(ctx, agent_id, body)``
 - ``delete(ctx, agent_id)``
+- ``disable(ctx, agent_id)`` / ``enable(ctx, agent_id)`` — soft-disable / revoke
+  everywhere (AW-4): flips the doc's ``disabled`` flag, invalidates the run
+  pool's cached instance immediately, and emits ``AgentDisabled`` /
+  ``AgentEnabled``.
 - ``get_scopes(agent_id)``
 - ``set_scopes(agent_id, scopes)``
 - ``discover(ctx, workspace_id, body)``
@@ -33,6 +37,8 @@ from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     AgentCreated,
     AgentDeleted,
+    AgentDisabled,
+    AgentEnabled,
     AgentScopeUpdated,
     AgentUpdated,
 )
@@ -106,6 +112,7 @@ def _to_domain(doc: _AgentDoc) -> Agent:
         config=_config_to_domain(doc.config),
         created_at=getattr(doc, "createdAt", None),  # type: ignore[arg-type]
         updated_at=getattr(doc, "updatedAt", None),  # type: ignore[arg-type]
+        disabled=getattr(doc, "disabled", False),
     )
 
 
@@ -347,6 +354,59 @@ async def delete(ctx: RequestContext, agent_id: str) -> None:
             }
         )
     )
+
+
+async def _set_disabled(ctx: RequestContext, agent_id: str, disabled: bool) -> Agent:
+    """Flip the agent's soft-disable flag (AW-4) and revoke everywhere.
+
+    Owner-check mirrors ``delete()`` exactly. ``doc.save()`` bumps ``updatedAt``,
+    which the run pool's staleness check would eventually notice — but we do NOT
+    rely on that alone: we ALSO invalidate the pool's cached instance
+    immediately so a disabled agent is revoked the instant the flag flips, with
+    no stale-instance window. Emits ``AgentDisabled`` / ``AgentEnabled`` mirroring
+    ``AgentDeleted``'s payload shape.
+    """
+    try:
+        doc = await _AgentDoc.get(PydanticObjectId(agent_id))
+    except Exception:
+        doc = None
+    if doc is None:
+        raise NotFound("agent", agent_id)
+    if doc.owner != ctx.user_id:
+        raise Forbidden("agent.not_owner", "Only the agent owner can disable it")
+
+    doc.disabled = disabled
+    await doc.save()  # bumps updatedAt
+
+    # MUST-FIX: explicit immediate cache invalidation. The pool's staleness
+    # check is a fallback, not the primary revoke mechanism — drop the cached
+    # instance now so the very next get() rebuilds (and, while disabled, raises
+    # AgentDisabled). Lazy import keeps the EE service off a module-level
+    # dependency on the OSS pool singleton.
+    from pocketpaw.agents.pool import get_agent_pool
+
+    await get_agent_pool().invalidate(agent_id)
+
+    event_cls = AgentDisabled if disabled else AgentEnabled
+    await emit(
+        event_cls(
+            data={
+                "agent_id": agent_id,
+                "workspace_id": doc.workspace,
+            }
+        )
+    )
+    return _to_domain(doc)
+
+
+async def disable(ctx: RequestContext, agent_id: str) -> Agent:
+    """Soft-disable an agent — revoke it everywhere at once (AW-4)."""
+    return await _set_disabled(ctx, agent_id, True)
+
+
+async def enable(ctx: RequestContext, agent_id: str) -> Agent:
+    """Re-enable a soft-disabled agent (AW-4)."""
+    return await _set_disabled(ctx, agent_id, False)
 
 
 async def get_scopes(agent_id: str) -> list[str]:

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,11 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-28 (feat/aiam-agent-revoke, AW-4) — ``_drive_agent_loop`` catches
+  ``AgentDisabled`` from ``pool.get`` explicitly and yields a clean
+  ``agent.unavailable`` error instead of letting it fall through to the generic
+  ``agent.load_failed`` 500-style path. A soft-disabled agent surfaces a tidy
+  "currently unavailable" message to the chat client.
 - 2026-06-27 (fix/cloud-artifacts-reland) — ``execute_run`` now wraps the run
   lifecycle (the prewarm ``create_task`` + the main agent loop) in
   ``mark_cloud_chat_run`` so the per-tenant cwd jail's fail-closed
@@ -130,6 +135,7 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
 
+from pocketpaw.agents.errors import AgentDisabled  # type: ignore[import-untyped]
 from pocketpaw.agents.pool import (  # type: ignore[import-untyped]
     get_agent_pool,
 )
@@ -807,6 +813,19 @@ async def _drive_agent_loop(
     pool = get_agent_pool()
     try:
         instance = await pool.get(ctx.target_agent_id)
+    except AgentDisabled:
+        # Soft-disabled / revoked (AW-4): surface a CLEAN "agent unavailable"
+        # error to the chat client instead of an unhandled 500. The agent is
+        # not resolvable until an admin re-enables it.
+        logger.info("Agent %s is disabled; refusing run", ctx.target_agent_id)
+        yield (
+            "error",
+            {
+                "code": "agent.unavailable",
+                "message": "This agent is currently unavailable.",
+            },
+        )
+        return
     except Exception as e:
         logger.exception("Failed to load agent instance %s", ctx.target_agent_id)
         yield ("error", {"code": "agent.load_failed", "message": str(e)})

--- a/ee/pocketpaw_ee/cloud/models/agent.py
+++ b/ee/pocketpaw_ee/cloud/models/agent.py
@@ -8,6 +8,12 @@
 # its own skill set (direct refs + enabled plugins). These fold into the
 # per-run skill materialization (run_core) so they apply on EVERY run the
 # agent does, independent of the surface/entity profile.
+# Updated 2026-06-28 (feat/aiam-agent-revoke, AW-4): added top-level
+# ``disabled: bool = False``. When True the run pool (AgentPool.get) refuses to
+# resolve the agent on EVERY path at once — a soft-disable that revokes the
+# agent everywhere while letting in-flight runs finish. Top-level (not on
+# AgentConfig) so toggling it bumps the doc's ``updatedAt`` and the pool's
+# staleness check + explicit cache invalidation both see the change.
 
 """Agent configuration document."""
 
@@ -62,6 +68,9 @@ class Agent(TimestampedDocument):
     config: AgentConfig = Field(default_factory=AgentConfig)
     visibility: str = Field(default="private", pattern="^(private|workspace|public)$")
     owner: str  # User ID
+    # Soft-disable / revoke-everywhere (AW-4). True == the run pool refuses to
+    # resolve this agent on any NEW request; in-flight runs are unaffected.
+    disabled: bool = False
 
     class Settings:
         name = "agents"

--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -25,6 +25,11 @@ in-process MCP tools that resolve scope from ContextVars (fabric, instinct,
 decisions, connectors) work on the group/DM bridge path. The SSE chat path
 already did this in ``run_core``; the bridge path skipped it, so every
 scoped tool returned "requires workspace context".
+
+Updated 2026-06-28 (feat/aiam-agent-revoke, AW-4): ``_run_agent_response``
+catches ``AgentDisabled`` from ``pool.get`` explicitly and SKIPS the agent
+(returns None, no error to the channel) — a soft-disabled agent simply stops
+responding in groups/DMs until re-enabled.
 """
 
 from __future__ import annotations
@@ -412,6 +417,7 @@ async def _run_agent_response(
     ``meta``). They're formatted into ``user_message`` before ``pool.run`` so
     the agent sees filename/mime/size the same way it does on the DM path.
     """
+    from pocketpaw.agents.errors import AgentDisabled
     from pocketpaw.agents.pool import get_agent_pool
     from pocketpaw_ee.cloud.chat import message_service
     from pocketpaw_ee.cloud.chat.agent_service import (
@@ -431,6 +437,12 @@ async def _run_agent_response(
 
     try:
         instance = await pool.get(agent_id)
+    except AgentDisabled:
+        # Soft-disabled / revoked (AW-4): SKIP this agent in the group/DM
+        # dispatch — no error to the channel, no 500. A disabled agent simply
+        # does not respond until re-enabled.
+        logger.info("Skipping disabled agent %s in group %s", agent_id, group_id)
+        return None
     except Exception:
         logger.error("Failed to get agent instance %s", agent_id, exc_info=True)
         return None

--- a/src/pocketpaw/agents/errors.py
+++ b/src/pocketpaw/agents/errors.py
@@ -5,6 +5,12 @@ These carry no cloud/EE dependency. The cloud layer catches them broadly
 HTTP-mapped, so a plain exception hierarchy is sufficient. Before the OSS-EE
 split the pool raised ``pocketpaw_ee.cloud.shared.errors`` types directly;
 that cross-import is what this module replaces.
+
+Updated: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — added ``AgentDisabled``,
+raised by ``AgentPool.get`` when an admin has soft-disabled an agent (the
+``disabled`` flag on the cloud Agent doc). Distinct from ``AgentNotFound`` so
+dispatch sites can tell "no such agent" apart from "revoked, finish in-flight
+runs only" and surface a clean "agent unavailable" instead of a 500.
 """
 
 from __future__ import annotations
@@ -19,6 +25,20 @@ class AgentNotFound(AgentRuntimeError, LookupError):
 
     def __init__(self, agent_id: str) -> None:
         super().__init__(f"agent not found: {agent_id}")
+        self.agent_id = agent_id
+
+
+class AgentDisabled(AgentRuntimeError):
+    """The agent exists but has been soft-disabled (revoked) by an admin.
+
+    Raised by ``AgentPool.get`` so a NEW resolve fails closed everywhere at
+    once. In-flight runs are unaffected — only new resolutions are blocked.
+    Dispatch sites should skip (group/DM) or surface a clean "agent
+    unavailable" error (direct chat) rather than 500.
+    """
+
+    def __init__(self, agent_id: str) -> None:
+        super().__init__(f"agent disabled: {agent_id}")
         self.agent_id = agent_id
 
 

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -63,6 +63,16 @@ Updated: 2026-06-26 (feat/mcg-3-pool-route-model) — ``_build`` now routes the
   ``provider:model`` / ``provider/model`` formats verbatim. Legacy backend names
   are resolved through ``_LEGACY_BACKENDS`` before routing so old agent docs
   still map to the right field. Empty model stays a no-op (backend default).
+Updated: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — soft-disable enforcement.
+  ``get`` now raises ``AgentDisabled`` whenever the resolved agent doc carries
+  ``disabled=True``, on BOTH the cached-instance path (checked before the
+  staleness branch, re-raised past the broad DB-error guard so it fails closed)
+  and the cold-build path. A disabled agent is therefore unresolvable on every
+  run path at once — chat SSE, group/DM bridge, planner — while in-flight runs
+  keep their already-resolved instance. Added ``invalidate(agent_id)`` for the
+  service to drop a cached instance the instant the flag flips (immediate
+  revoke; the staleness check is only a fallback). ``invalidate`` does not tear
+  down the backend so a live run is not aborted mid-stream.
 """
 
 from __future__ import annotations
@@ -74,7 +84,11 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from pocketpaw.agents.errors import AgentBackendUnavailable, AgentNotFound
+from pocketpaw.agents.errors import (
+    AgentBackendUnavailable,
+    AgentDisabled,
+    AgentNotFound,
+)
 
 if TYPE_CHECKING:
     from pocketpaw.agents.backend import AgentBackend
@@ -165,6 +179,14 @@ class AgentPool:
                 agent_doc = (
                     await agent_model.get(PydanticObjectId(agent_id)) if agent_model else None
                 )
+                # Soft-disable / revoke-everywhere (AW-4): a disabled agent is
+                # unresolvable on every NEW request even if an instance is
+                # cached. Checked BEFORE the staleness branch so a cached
+                # instance is never handed back for a disabled agent; the
+                # ``disable()`` service call also evicts the cache explicitly,
+                # this is the defense-in-depth check for any path that didn't.
+                if agent_doc is not None and getattr(agent_doc, "disabled", False):
+                    raise AgentDisabled(agent_id)
                 if (
                     agent_doc
                     and agent_doc.updatedAt
@@ -186,6 +208,11 @@ class AgentPool:
                     await self._teardown(inst)
                     del self._instances[agent_id]
                     return await self._build(agent_doc)
+            except AgentDisabled:
+                # Must NOT be swallowed by the broad DB-error guard below — a
+                # disabled agent has to fail closed, not fall back to the
+                # cached instance.
+                raise
             except Exception:
                 pass  # Use cached instance on DB errors
             return inst
@@ -197,6 +224,10 @@ class AgentPool:
         agent_doc = await agent_model.get(PydanticObjectId(agent_id)) if agent_model else None
         if not agent_doc:
             raise AgentNotFound(agent_id)
+        # Soft-disable / revoke-everywhere (AW-4): the same fail-closed check on
+        # the cold-build path so a disabled agent can never be instantiated.
+        if getattr(agent_doc, "disabled", False):
+            raise AgentDisabled(agent_id)
 
         async with self._build_lock:
             # Double-check after acquiring lock
@@ -206,6 +237,20 @@ class AgentPool:
             if len(self._instances) >= self._max_instances:
                 await self._evict_oldest()
             return await self._build(agent_doc)
+
+    async def invalidate(self, agent_id: str) -> None:
+        """Drop any cached instance for ``agent_id`` so the next ``get`` rebuilds.
+
+        Used by the agents service on soft-disable / enable (AW-4) for IMMEDIATE
+        cache invalidation — the staleness check in ``get`` is a fallback, but a
+        disabled agent must be revoked the instant the flag flips, not on the
+        next config-bump-detecting request. Idempotent: a no-op if uncached.
+        Does NOT tear down the backend (no ``_teardown``) so an instance with an
+        in-flight run is not aborted mid-stream — the entry is simply removed
+        from the cache and the live ``run`` retains its own reference until it
+        completes; the NEXT ``get`` rebuilds (or raises ``AgentDisabled``).
+        """
+        self._instances.pop(agent_id, None)
 
     async def _assemble_system_prompt(
         self,

--- a/tests/cloud/agents/test_agent_disable.py
+++ b/tests/cloud/agents/test_agent_disable.py
@@ -1,0 +1,189 @@
+# tests/cloud/agents/test_agent_disable.py
+# Created: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — pins the EE service +
+# router layer of the agent soft-disable / revoke-everywhere flow:
+#   * disable()/enable() flip the doc's ``disabled`` flag and persist it.
+#   * disable()/enable() emit AgentDisabled / AgentEnabled (mirroring
+#     AgentDeleted), and invalidate the run-pool cache immediately (must-fix).
+#   * a non-owner caller is rejected with Forbidden (agent.not_owner) — the
+#     same owner-check as delete(), so the protection is symmetric.
+#   * the router's /disable + /enable routes carry the SAME owner/admin guard
+#     dependency as DELETE (symmetric tenant-scope protection — asymmetric
+#     protection = no protection).
+#   * the wire dict (agent_to_dict) surfaces the ``disabled`` flag.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud._core.realtime.events import AgentDisabled, AgentEnabled
+from pocketpaw_ee.cloud.agents import router as agents_router
+from pocketpaw_ee.cloud.agents import service as agents_service
+from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest, agent_to_dict
+from pocketpaw_ee.cloud.models.agent import Agent as _AgentDoc
+from pocketpaw_ee.cloud.shared.deps import require_agent_owner_or_admin
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(user_id: str = "u1", workspace_id: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _create_body(slug: str = "buddy", name: str = "Buddy") -> CreateAgentRequest:
+    # soul_enabled=False keeps create() off the eager-soul pool path.
+    return CreateAgentRequest(name=name, slug=slug, soul_enabled=False)
+
+
+# --- service: flag flips + persists ---------------------------------------
+
+
+async def test_disable_sets_flag_and_persists(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    assert agent.disabled is False
+
+    updated = await agents_service.disable(_ctx(), agent.id)
+    assert updated.disabled is True
+
+    # Re-read the doc from Mongo to confirm persistence (not just the return).
+    from beanie import PydanticObjectId
+
+    doc = await _AgentDoc.get(PydanticObjectId(agent.id))
+    assert doc.disabled is True
+
+
+async def test_enable_clears_flag(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    await agents_service.disable(_ctx(), agent.id)
+
+    restored = await agents_service.enable(_ctx(), agent.id)
+    assert restored.disabled is False
+
+    from beanie import PydanticObjectId
+
+    doc = await _AgentDoc.get(PydanticObjectId(agent.id))
+    assert doc.disabled is False
+
+
+# --- service: events emitted ----------------------------------------------
+
+
+async def test_disable_emits_agent_disabled(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    recording_bus.events.clear()
+
+    await agents_service.disable(_ctx(), agent.id)
+
+    evs = [e for e in recording_bus.events if isinstance(e, AgentDisabled)]
+    assert len(evs) == 1
+    ev = evs[0]
+    assert ev.type == "agent.disabled"
+    assert ev.data["agent_id"] == agent.id
+    assert ev.data["workspace_id"] == "w1"
+
+
+async def test_enable_emits_agent_enabled(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    await agents_service.disable(_ctx(), agent.id)
+    recording_bus.events.clear()
+
+    await agents_service.enable(_ctx(), agent.id)
+
+    evs = [e for e in recording_bus.events if isinstance(e, AgentEnabled)]
+    assert len(evs) == 1
+    assert evs[0].type == "agent.enabled"
+    assert evs[0].data["agent_id"] == agent.id
+
+
+# --- service: immediate cache invalidation (must-fix) ----------------------
+
+
+async def test_disable_invalidates_pool_cache(recording_bus, monkeypatch) -> None:
+    """disable() must call the run pool's invalidate() so the cached instance is
+    dropped the instant the flag flips — not left to the staleness fallback."""
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+
+    invalidated: list[str] = []
+
+    class _FakePool:
+        async def invalidate(self, agent_id: str) -> None:
+            invalidated.append(agent_id)
+
+    monkeypatch.setattr(
+        "pocketpaw.agents.pool.get_agent_pool",
+        lambda: _FakePool(),
+    )
+
+    await agents_service.disable(_ctx(), agent.id)
+    assert invalidated == [agent.id]
+
+
+# --- service: symmetric owner protection -----------------------------------
+
+
+async def test_disable_rejects_non_owner(recording_bus) -> None:
+    """A caller who is not the owner is rejected — same check as delete()."""
+    agent = await agents_service.create(_ctx(user_id="u1"), "w1", _create_body())
+
+    with pytest.raises(Forbidden):
+        await agents_service.disable(_ctx(user_id="someone-else"), agent.id)
+
+    # Flag must NOT have flipped.
+    from beanie import PydanticObjectId
+
+    doc = await _AgentDoc.get(PydanticObjectId(agent.id))
+    assert doc.disabled is False
+
+
+async def test_enable_rejects_non_owner(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(user_id="u1"), "w1", _create_body())
+    await agents_service.disable(_ctx(user_id="u1"), agent.id)
+
+    with pytest.raises(Forbidden):
+        await agents_service.enable(_ctx(user_id="cross-workspace-attacker"), agent.id)
+
+    from beanie import PydanticObjectId
+
+    doc = await _AgentDoc.get(PydanticObjectId(agent.id))
+    assert doc.disabled is True  # still disabled — attacker can't restore it
+
+
+# --- router: symmetric guard parity with DELETE ----------------------------
+
+
+def _route_dep_callables(path: str, method: str) -> set:
+    for route in agents_router.router.routes:
+        if getattr(route, "path", None) == path and method in getattr(route, "methods", set()):
+            return {d.call for d in route.dependant.dependencies}
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+def test_disable_enable_routes_carry_same_guard_as_delete() -> None:
+    """The /disable + /enable routes must depend on the SAME owner/admin guard
+    as DELETE — symmetric tenant-scope protection."""
+    delete_deps = _route_dep_callables("/agents/{agent_id}", "DELETE")
+    disable_deps = _route_dep_callables("/agents/{agent_id}/disable", "PATCH")
+    enable_deps = _route_dep_callables("/agents/{agent_id}/enable", "PATCH")
+
+    assert require_agent_owner_or_admin in delete_deps
+    assert require_agent_owner_or_admin in disable_deps
+    assert require_agent_owner_or_admin in enable_deps
+
+
+# --- wire format -----------------------------------------------------------
+
+
+async def test_agent_to_dict_surfaces_disabled(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    assert agent_to_dict(agent)["disabled"] is False
+
+    disabled = await agents_service.disable(_ctx(), agent.id)
+    assert agent_to_dict(disabled)["disabled"] is True

--- a/tests/cloud/agents/test_agent_disable.py
+++ b/tests/cloud/agents/test_agent_disable.py
@@ -10,6 +10,11 @@
 #     dependency as DELETE (symmetric tenant-scope protection — asymmetric
 #     protection = no protection).
 #   * the wire dict (agent_to_dict) surfaces the ``disabled`` flag.
+#
+# Updated: 2026-06-28 (feat/aiam-agent-revoke, AW-5) — roster surfacing:
+#   * list_agents() keeps a disabled agent IN the list (no hard filter) and the
+#     wire dict carries disabled=True, so the client can grey/inactive the row
+#     instead of the agent just silently vanishing.
 
 from __future__ import annotations
 
@@ -187,3 +192,29 @@ async def test_agent_to_dict_surfaces_disabled(recording_bus) -> None:
 
     disabled = await agents_service.disable(_ctx(), agent.id)
     assert agent_to_dict(disabled)["disabled"] is True
+
+
+# --- roster surfacing (AW-5) ----------------------------------------------
+
+
+async def test_list_agents_includes_disabled_with_flag(recording_bus) -> None:
+    """A disabled agent must STAY in list_agents() — surfaced with
+    ``disabled=True`` so the client can render it greyed/inactive, not hard
+    filtered out (owners need to see and re-enable it)."""
+    live = await agents_service.create(_ctx(), "w1", _create_body(slug="live", name="Live"))
+    dead = await agents_service.create(_ctx(), "w1", _create_body(slug="dead", name="Dead"))
+    await agents_service.disable(_ctx(), dead.id)
+
+    listed = await agents_service.list_agents("w1")
+    by_id = {a.id: a for a in listed}
+
+    # Both agents present — the disabled one is NOT filtered out.
+    assert live.id in by_id
+    assert dead.id in by_id
+    assert by_id[live.id].disabled is False
+    assert by_id[dead.id].disabled is True
+
+    # And the wire dicts the router returns carry the same flag.
+    wire = {d["_id"]: d for d in (agent_to_dict(a) for a in listed)}
+    assert wire[live.id]["disabled"] is False
+    assert wire[dead.id]["disabled"] is True

--- a/tests/cloud/agents/test_agent_disable.py
+++ b/tests/cloud/agents/test_agent_disable.py
@@ -15,6 +15,10 @@
 #   * list_agents() keeps a disabled agent IN the list (no hard filter) and the
 #     wire dict carries disabled=True, so the client can grey/inactive the row
 #     instead of the agent just silently vanishing.
+# Updated: 2026-07-02 (feat/aiam-agent-revoke, AW-4 follow-up) — get_persona()
+#   returns None for a disabled agent, so the smart-relevance LLM probe in
+#   agent_bridge never fires for an agent pool.get would refuse to run (a
+#   revoked agent does zero LLM work in group/DM dispatch).
 
 from __future__ import annotations
 
@@ -218,3 +222,21 @@ async def test_list_agents_includes_disabled_with_flag(recording_bus) -> None:
     wire = {d["_id"]: d for d in (agent_to_dict(a) for a in listed)}
     assert wire[live.id]["disabled"] is False
     assert wire[dead.id]["disabled"] is True
+
+
+# --- get_persona short-circuit (AW-4 follow-up) ----------------------------
+
+
+async def test_get_persona_returns_none_for_disabled_agent(recording_bus) -> None:
+    """A disabled agent's persona resolves to None so the smart-relevance LLM
+    probe in agent_bridge never runs for a revoked agent — the disabled guard
+    reuses the doc get_persona already loads, so there is no extra DB read and
+    no wasted LLM call."""
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    # Live agent has a resolvable persona (falls back to the display name).
+    assert await agents_service.get_persona(agent.id) is not None
+
+    await agents_service.disable(_ctx(), agent.id)
+    # Once disabled, the persona short-circuits to None → _smart_relevance_check
+    # returns False without ever building a backend or firing a model turn.
+    assert await agents_service.get_persona(agent.id) is None

--- a/tests/cloud/shared/test_agent_bridge_dispatch.py
+++ b/tests/cloud/shared/test_agent_bridge_dispatch.py
@@ -1,4 +1,9 @@
-"""Dispatch behavior tests for the cloud agent bridge."""
+"""Dispatch behavior tests for the cloud agent bridge.
+
+Updated 2026-06-28 (feat/aiam-agent-revoke, AW-5): added the disabled-agent
+skip test — when ``pool.get`` raises ``AgentDisabled``, ``_run_agent_response``
+returns ``None`` (skips the agent cleanly) instead of erroring to the channel.
+"""
 
 from __future__ import annotations
 
@@ -282,3 +287,105 @@ async def test_dispatch_agent_responses_skips_synthesis_when_only_one_agent_resp
     # No "Final response:" label was emitted because synthesis was skipped.
     final_labels = [call.kwargs.get("response_label") for call in run_mock.await_args_list]
     assert "Final response:" not in final_labels
+
+
+# --- disabled-agent skip (AW-4 behavior, AW-5 regression test) -------------
+
+
+@pytest.mark.asyncio
+async def test_run_agent_response_skips_disabled_agent() -> None:
+    """A soft-disabled agent is revoked at the AgentPool chokepoint: ``pool.get``
+    raises ``AgentDisabled``. The bridge must catch it and return ``None`` —
+    skip the agent with no error to the channel, no stream-start emit, no 500.
+
+    This is the auto-dispatch half of the revoke-everywhere guarantee: a
+    disabled agent simply stops responding in groups/DMs until re-enabled.
+    """
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    from pocketpaw.agents.errors import AgentDisabled
+
+    fake_pool = SimpleNamespace(get=AsyncMock(side_effect=AgentDisabled("agent-x")))
+    emit_mock = AsyncMock()
+
+    with (
+        patch(
+            "pocketpaw.agents.pool.get_agent_pool",
+            return_value=fake_pool,
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=emit_mock),
+    ):
+        result = await agent_bridge._run_agent_response(
+            agent_id="agent-x",
+            group_id="group-disabled",
+            workspace_id="ws-disabled",
+            user_message="hello?",
+            group_members=["user-1"],
+        )
+
+    # Skipped cleanly — no reply text, and nothing emitted to the channel
+    # (no AgentStreamStart for a revoked agent).
+    assert result is None
+    assert emit_mock.await_count == 0
+    fake_pool.get.assert_awaited_once_with("agent-x")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_disabled_agent_keeps_live_one() -> None:
+    """End-to-end at the dispatch layer: two auto-mode agents, one disabled.
+
+    The disabled agent's ``pool.get`` raises ``AgentDisabled`` (revoked at the
+    chokepoint), which ``_run_agent_response`` catches and turns into ``None``
+    (proven directly in ``test_run_agent_response_skips_disabled_agent``); the
+    live agent still responds. Here we model that contract — disabled -> ``None``
+    — and prove auto-dispatch does NOT 500 on a disabled member and does not
+    drop the healthy one.
+    """
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    group = SimpleNamespace(
+        members=["user-1"],
+        agents=[
+            SimpleNamespace(agent_id="agent-live", respond_mode="auto"),
+            SimpleNamespace(agent_id="agent-disabled", respond_mode="auto"),
+        ],
+    )
+
+    async def fake_run_agent_response(*, agent_id: str, **_kwargs):
+        # Mirror the real bridge contract: a disabled agent is a clean skip
+        # (returns None, the bridge having caught AgentDisabled internally); a
+        # live agent returns its reply text.
+        if agent_id == "agent-disabled":
+            return None
+        return "live reply"
+
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=group),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response",
+            new=AsyncMock(side_effect=fake_run_agent_response),
+        ) as run_mock,
+    ):
+        # Should not raise even though one member is disabled.
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "group-mixed",
+                "sender_id": "user-1",
+                "content": "anyone home?",
+                "mentions": [],
+                "workspace_id": "ws-mixed",
+            }
+        )
+
+    # Both were attempted (disabled isn't pre-filtered from the roster), but
+    # only the live one produced a reply and the disabled one was a clean skip.
+    dispatched = [call.kwargs["agent_id"] for call in run_mock.await_args_list]
+    assert "agent-live" in dispatched
+    assert "agent-disabled" in dispatched

--- a/tests/test_agent_pool_disable.py
+++ b/tests/test_agent_pool_disable.py
@@ -1,0 +1,230 @@
+# tests/test_agent_pool_disable.py
+# Created: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — pins the OSS run-pool
+# enforcement of the agent soft-disable / revoke-everywhere flow:
+#   * ``AgentPool.get`` raises ``AgentDisabled`` when the resolved agent doc has
+#     ``disabled=True`` — on BOTH the cold-build path and the cached-instance
+#     path (the must-fix: a cached instance is NOT handed back for a disabled
+#     agent, and the disabled check is not swallowed by the DB-error guard).
+#   * ``invalidate`` drops the cached instance so the NEXT ``get`` rebuilds /
+#     re-checks (immediate revoke, no stale-instance window).
+#   * re-enabling lets ``get`` return a working instance again.
+#   * ``invalidate`` does not tear down the backend, so an already-resolved
+#     in-flight instance keeps running (disable blocks NEW resolves only).
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from pocketpaw.agents.errors import AgentDisabled, AgentNotFound
+from pocketpaw.agents.pool import AgentInstance, AgentPool
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- Fakes -----------------------------------------------------------------
+
+
+class _FakeDoc:
+    """Stand-in for the cloud Agent Beanie doc the pool fetches."""
+
+    def __init__(self, *, disabled: bool = False, updated_at: datetime | None = None) -> None:
+        self.disabled = disabled
+        self.updatedAt = updated_at or datetime.now(UTC)
+
+
+class _FakeAgentModel:
+    """Stand-in for the resolved Agent document class; ``get`` returns the doc
+    registered for the id (or ``None`` for 'no such agent')."""
+
+    def __init__(self, docs: dict[str, _FakeDoc | None]) -> None:
+        self._docs = docs
+
+    async def get(self, oid):  # noqa: ANN001 — PydanticObjectId-ish, str() it
+        return self._docs.get(str(oid))
+
+
+# A valid-looking ObjectId hex so ``PydanticObjectId(agent_id)`` parses.
+AID = "0123456789abcdef01234567"
+
+
+def _patch_model(monkeypatch, docs: dict[str, _FakeDoc | None]) -> None:
+    monkeypatch.setattr(
+        "pocketpaw.agents.pool._resolve_agent_model",
+        lambda: _FakeAgentModel(docs),
+    )
+
+
+def _stub_instance(agent_id: str, *, updated_at: datetime | None = None) -> AgentInstance:
+    return AgentInstance(
+        agent_id=agent_id,
+        agent_name="Buddy",
+        config={},
+        backend=SimpleNamespace(),  # never run in these tests
+        soul_manager=None,
+        memory_namespace="ns",
+        created_from_updated_at=updated_at,
+    )
+
+
+def _patch_build(monkeypatch, pool: AgentPool) -> dict[str, int]:
+    """Make ``_build`` return a stub instance (no real backend) and count calls."""
+    calls = {"n": 0}
+
+    async def _fake_build(agent_doc):  # noqa: ANN001
+        calls["n"] += 1
+        inst = _stub_instance(AID, updated_at=getattr(agent_doc, "updatedAt", None))
+        pool._instances[AID] = inst
+        return inst
+
+    monkeypatch.setattr(pool, "_build", _fake_build)
+    return calls
+
+
+# --- Cold-build path -------------------------------------------------------
+
+
+async def test_get_raises_agent_disabled_on_cold_build(monkeypatch):
+    """A disabled agent with NO cached instance fails closed at the build path."""
+    _patch_model(monkeypatch, {AID: _FakeDoc(disabled=True)})
+    pool = AgentPool()
+    _patch_build(monkeypatch, pool)
+
+    with pytest.raises(AgentDisabled):
+        await pool.get(AID)
+
+
+async def test_get_raises_agent_not_found_when_missing(monkeypatch):
+    """Sanity: missing doc still raises AgentNotFound (not AgentDisabled)."""
+    _patch_model(monkeypatch, {AID: None})
+    pool = AgentPool()
+    _patch_build(monkeypatch, pool)
+
+    with pytest.raises(AgentNotFound):
+        await pool.get(AID)
+
+
+async def test_get_builds_when_enabled(monkeypatch):
+    """An enabled agent builds and returns a working instance."""
+    _patch_model(monkeypatch, {AID: _FakeDoc(disabled=False)})
+    pool = AgentPool()
+    calls = _patch_build(monkeypatch, pool)
+
+    inst = await pool.get(AID)
+    assert inst.agent_id == AID
+    assert calls["n"] == 1
+
+
+# --- Cached-instance path (the must-fix) -----------------------------------
+
+
+async def test_disable_invalidates_cache_then_get_raises(monkeypatch):
+    """MUST-FIX: an agent cached as an instance, then disabled + invalidated,
+    raises AgentDisabled on the NEXT get() — no stale instance reused."""
+    docs: dict[str, _FakeDoc | None] = {AID: _FakeDoc(disabled=False)}
+    _patch_model(monkeypatch, docs)
+    pool = AgentPool()
+    _patch_build(monkeypatch, pool)
+
+    # First get builds + caches.
+    inst = await pool.get(AID)
+    assert pool._instances.get(AID) is inst
+
+    # Admin disables: flip the doc + explicit cache invalidation (what the
+    # service's disable() does).
+    docs[AID] = _FakeDoc(disabled=True)
+    await pool.invalidate(AID)
+    assert AID not in pool._instances
+
+    # Next resolve fails closed.
+    with pytest.raises(AgentDisabled):
+        await pool.get(AID)
+
+
+async def test_cached_instance_not_reused_for_disabled_even_without_invalidate(monkeypatch):
+    """Defense in depth: even if invalidate were skipped, a cached instance is
+    NOT handed back once the doc reads disabled — the check runs before the
+    staleness branch and is re-raised past the broad DB-error guard."""
+    docs: dict[str, _FakeDoc | None] = {AID: _FakeDoc(disabled=False)}
+    _patch_model(monkeypatch, docs)
+    pool = AgentPool()
+    _patch_build(monkeypatch, pool)
+
+    inst = await pool.get(AID)
+    assert pool._instances.get(AID) is inst
+
+    # Flip disabled WITHOUT invalidating the cache.
+    docs[AID] = _FakeDoc(disabled=True)
+    with pytest.raises(AgentDisabled):
+        await pool.get(AID)
+
+
+async def test_enable_restores_working_instance(monkeypatch):
+    """After re-enable + invalidate, the next get() returns a working instance."""
+    docs: dict[str, _FakeDoc | None] = {AID: _FakeDoc(disabled=True)}
+    _patch_model(monkeypatch, docs)
+    pool = AgentPool()
+    _patch_build(monkeypatch, pool)
+
+    with pytest.raises(AgentDisabled):
+        await pool.get(AID)
+
+    # Re-enable + invalidate (what enable() does).
+    docs[AID] = _FakeDoc(disabled=False)
+    await pool.invalidate(AID)
+
+    inst = await pool.get(AID)
+    assert inst.agent_id == AID
+
+
+# --- In-flight runs are unaffected -----------------------------------------
+
+
+async def test_invalidate_does_not_teardown_running_instance(monkeypatch):
+    """``invalidate`` only drops the cache entry; an already-resolved instance
+    (e.g. with an in-flight run) keeps its backend — disable blocks NEW
+    resolves, it does not abort runs mid-stream."""
+    teardown_calls = {"n": 0}
+
+    docs: dict[str, _FakeDoc | None] = {AID: _FakeDoc(disabled=False)}
+    _patch_model(monkeypatch, docs)
+    pool = AgentPool()
+    _patch_build(monkeypatch, pool)
+
+    async def _spy_teardown(instance):  # noqa: ANN001
+        teardown_calls["n"] += 1
+
+    monkeypatch.setattr(pool, "_teardown", _spy_teardown)
+
+    inst = await pool.get(AID)
+    inst.active_runs = 1  # simulate an in-flight run holding this instance
+
+    # An admin disables mid-run: the in-flight caller still holds ``inst``.
+    docs[AID] = _FakeDoc(disabled=True)
+    await pool.invalidate(AID)
+
+    # invalidate must NOT have torn down the backend.
+    assert teardown_calls["n"] == 0
+    # The caller's own reference is intact and still usable for its run.
+    assert inst.active_runs == 1
+    assert inst.backend is not None
+
+
+async def test_staleness_rebuild_still_works_for_enabled(monkeypatch):
+    """Regression: the existing updatedAt-staleness rebuild path is unbroken for
+    an ENABLED agent (the new disabled check sits before it, no interference)."""
+    t0 = datetime.now(UTC)
+    docs: dict[str, _FakeDoc | None] = {AID: _FakeDoc(disabled=False, updated_at=t0)}
+    _patch_model(monkeypatch, docs)
+    pool = AgentPool()
+    calls = _patch_build(monkeypatch, pool)
+
+    await pool.get(AID)  # build #1
+    assert calls["n"] == 1
+
+    # Bump updatedAt → next get rebuilds.
+    docs[AID] = _FakeDoc(disabled=False, updated_at=t0 + timedelta(seconds=5))
+    await pool.get(AID)  # build #2
+    assert calls["n"] == 2


### PR DESCRIPTION
## What

An agent could only be hard-deleted. This adds a reversible `disabled` flag enforced at the single agent resolve chokepoint, so disabling an agent makes it unresolvable across chat, groups, DMs, pockets, and jobs at once, while runs already in flight finish.

Two commits:
- **AW-4** — `Agent.disabled` + an `AgentDisabled` exception + the check in `AgentPool.get()` (fail-closed on both the cached-instance path and the cold-build path) + `invalidate()` for immediate cache eviction + `service.disable()/enable()` with events and `PATCH /disable` + `/enable` endpoints carrying the same owner/admin guard as DELETE. Dispatch sites catch `AgentDisabled` and skip (group/DM) or return a clean error (chat), never a 500.
- **AW-5** — roster surfacing (a disabled agent stays listed with its flag rather than vanishing) plus an agent-lifecycle docs page.

## Why this design

A read-only spike confirmed `AgentPool.get()` is the only place an agent is materialized to run, so one check there covers every path. `disable()` invalidates the pool cache immediately, so there is no window where a warm instance keeps replying. The soul and identity are preserved, so `enable()` restores the same agent.

## Tests

25 targeted tests pass, including the must-fix (a cached-then-disabled agent raises on the next `get()`), the in-flight run finishing, and cross-owner/cross-workspace disable being rejected. `lint-imports` green on both boundaries; `ruff` clean.

## Follow-up

paw-enterprise needs a small change to render a `disabled: true` agent row as greyed. The flag is on every roster response now; the client just needs to read and style it.

## Design

`docs/design/drafts/2026-06-24-aiam-whitespace-hardening{,-prd,-tasks}.md` — Slice 3 (AW-4, AW-5). This is the AIAM "disable identity, revoke everywhere" control.

Recommend a `/security-review` pass before merge.
