### PR TITLE
feat(billing): per-workspace usage endpoint (daily by model, from LiteLLM)

### DIFF
--- a/ee/pocketpaw_ee/catalog/admin_client.py
+++ b/ee/pocketpaw_ee/catalog/admin_client.py
@@ -234,9 +234,7 @@ class LiteLLMAdminClient:
                 "page_size": page_size,
             }
             async with self._client() as client:
-                resp = await client.get(
-                    f"{self._base_url}/user/daily/activity", params=params
-                )
+                resp = await client.get(f"{self._base_url}/user/daily/activity", params=params)
             body = self._json_or_raise(resp, "/user/daily/activity")
             rows = body.get("results")
             if isinstance(rows, list):

--- a/ee/pocketpaw_ee/catalog/admin_client.py
+++ b/ee/pocketpaw_ee/catalog/admin_client.py
@@ -17,6 +17,15 @@
 #                              incl. cached tokens). MUST pass ``api_key`` — an
 #                              unfiltered /spend/logs scans the whole proxy and
 #                              times out (noted in the MCG-8 task brief).
+#   * GET  /user/daily/activity?start_date=&end_date=&api_key=<key> — DAILY usage
+#                              for one virtual key, broken down BY MODEL (spend +
+#                              token counts + request counts). Paginated; this
+#                              client walks every page (follows ``metadata.has_more``)
+#                              and returns the merged ``results`` list. Scoped by the
+#                              ``api_key`` filter, called with the master key (which
+#                              the proxy treats as admin view), so it returns exactly
+#                              that tenant's daily activity. Powers the billing usage
+#                              graph (the WorkspaceUsage transform in cloud.billing.usage).
 #   * POST /key/delete       — revoke keys (used by the live-check teardown so a
 #                              throwaway probe key never lingers on the proxy).
 #
@@ -26,6 +35,9 @@
 # rather than silently minting nothing / billing nothing.
 #
 # Created 2026-06-26 (integration/model-catalog-v2, MCG-8): the proxy admin client.
+# Updated 2026-06-29 (feat/billing-usage-endpoint): added ``user_daily_activity`` —
+#   the per-key DAILY usage read (GET /user/daily/activity) that backs the billing
+#   usage graph. Walks pagination internally and returns the merged daily records.
 
 from __future__ import annotations
 
@@ -171,6 +183,76 @@ class LiteLLMAdminClient:
         data = body.get("data")
         rows = data if isinstance(data, list) else []
         return [r for r in rows if isinstance(r, dict)]
+
+    async def user_daily_activity(
+        self,
+        *,
+        start_date: str,
+        end_date: str,
+        api_key: str,
+        page_size: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """GET /user/daily/activity — DAILY usage for ONE virtual key, by model.
+
+        Returns the merged list of daily-activity records (LiteLLM ``DailySpendData``
+        shape: each has a ``date``, a day-level ``metrics`` block, and a
+        ``breakdown.models`` map keyed by model name, each value carrying
+        ``metrics`` with ``spend`` (USD) + token + request counts). The caller
+        (cloud.billing.usage) folds the per-model breakdown into the usage graph
+        and converts spend USD -> credits.
+
+        ``start_date`` / ``end_date`` are ``YYYY-MM-DD`` (the proxy 400s if either is
+        missing). ``api_key`` REQUIRED — it filters the analytics to a single
+        tenant's virtual key (the proxy supports a key filter on this route); calling
+        with the master key gives the admin view so the filter is honoured. An empty
+        ``api_key`` raises rather than returning every tenant's usage.
+
+        PAGINATION: the route is paginated (default page_size 50, max 1000). This
+        walks every page — following the response ``metadata.has_more`` flag,
+        advancing ``page`` — and merges ``results`` so the caller gets the whole
+        window. A defensive page ceiling stops a malformed proxy that never clears
+        ``has_more`` from looping forever.
+        """
+        if not api_key:
+            raise LiteLLMAdminError(
+                "user_daily_activity requires api_key (an unscoped read returns every "
+                "tenant's usage)"
+            )
+
+        results: list[dict[str, Any]] = []
+        page = 1
+        # Defensive ceiling: 1000 rows/page over a year is ~ a handful of pages; 200
+        # pages (up to 200k daily rows) is far beyond any real window and bounds a
+        # proxy bug that never clears has_more.
+        max_pages = 200
+        while page <= max_pages:
+            params: dict[str, Any] = {
+                "start_date": start_date,
+                "end_date": end_date,
+                "api_key": api_key,
+                "page": page,
+                "page_size": page_size,
+            }
+            async with self._client() as client:
+                resp = await client.get(
+                    f"{self._base_url}/user/daily/activity", params=params
+                )
+            body = self._json_or_raise(resp, "/user/daily/activity")
+            rows = body.get("results")
+            if isinstance(rows, list):
+                results.extend(r for r in rows if isinstance(r, dict))
+            metadata = body.get("metadata")
+            has_more = bool(metadata.get("has_more")) if isinstance(metadata, dict) else False
+            if not has_more:
+                break
+            page += 1
+        else:
+            logger.warning(
+                "LiteLLM /user/daily/activity never cleared has_more after %d pages — "
+                "stopping (usage may be truncated)",
+                max_pages,
+            )
+        return results
 
     async def delete_keys(self, keys: list[str]) -> dict[str, Any]:
         """POST /key/delete — revoke the given virtual keys. Used by the live-check

--- a/ee/pocketpaw_ee/cloud/billing/dto.py
+++ b/ee/pocketpaw_ee/cloud/billing/dto.py
@@ -14,6 +14,12 @@
 #   carries an upper bound (``le=1_000_000`` == $10,000). Without a ceiling a
 #   typo'd / hostile amount could open a checkout for an absurd sum; over-ceiling
 #   now 422s at the DTO before the service is reached.
+# Updated 2026-06-29 (feat/billing-usage-endpoint): added the WORKSPACE USAGE
+#   response contract (``UsageModelStats`` / ``UsageBucket`` / ``WorkspaceUsageResponse``)
+#   for ``GET /billing/usage`` — daily usage by model over a date range, derived
+#   from the workspace's LiteLLM proxy usage. The backend stays DAILY (the frontend
+#   aggregates weekly/monthly + filters); spend is reported in CREDITS (the same
+#   denomination the rest of billing uses).
 
 from __future__ import annotations
 
@@ -64,3 +70,57 @@ class WebhookAck(BaseModel):
 
     ok: bool = True
     granted: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Workspace usage graph (GET /billing/usage)
+# ---------------------------------------------------------------------------
+
+
+class UsageModelStats(BaseModel):
+    """One model's usage within a single day.
+
+    ``credits`` is the day-and-model spend converted to integer credits (the same
+    USD->credits conversion the meter uses: ``round(cost_usd * markup / credit_usd)``,
+    1 credit == $0.01); ``tokens`` is total tokens (prompt + completion); ``requests``
+    is the count of API requests. A model whose rounded credit cost is 0 (sub-credit
+    spend) still appears — usage is real even when the rounded credit cost is 0.
+    """
+
+    credits: int = Field(..., description="Spend for this model on this day, in credits.")
+    tokens: int = Field(..., description="Total tokens (prompt + completion) for this model.")
+    requests: int = Field(..., description="API request count for this model on this day.")
+
+
+class UsageBucket(BaseModel):
+    """One day's usage: the per-model breakdown plus the day's credit total.
+
+    ``date`` is ``YYYY-MM-DD``. ``by_model`` maps a model id to its stats for that
+    day; ``total_credits`` is the sum of the bucket's per-model credits.
+    """
+
+    date: str = Field(..., description="The bucket day, YYYY-MM-DD.")
+    by_model: dict[str, UsageModelStats] = Field(
+        default_factory=dict, description="Model id -> usage stats for this day."
+    )
+    total_credits: int = Field(..., description="Sum of this day's per-model credits.")
+
+
+class WorkspaceUsageResponse(BaseModel):
+    """Per-workspace daily usage over a date range, broken down by model.
+
+    ``start_date`` / ``end_date`` echo the resolved window (``YYYY-MM-DD``; defaults
+    to the last 30 days when the request omits them). ``models`` is the sorted
+    distinct set of model ids seen across the whole range (so the frontend can build
+    a stable legend / color map). ``buckets`` is one entry per day WITH usage, oldest
+    first. ``total_credits`` is the grand total over every bucket. The shape is kept
+    DAILY on purpose — the frontend aggregates to weekly / monthly and filters by
+    model client-side. A brand-new workspace with no usage (or no provisioned key)
+    yields empty ``models`` + ``buckets`` and ``total_credits`` 0 (HTTP 200).
+    """
+
+    start_date: str
+    end_date: str
+    models: list[str] = Field(default_factory=list)
+    buckets: list[UsageBucket] = Field(default_factory=list)
+    total_credits: int = 0

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -29,19 +29,26 @@
 #   threads it to ``billing_service.subscribe(origin=...)`` so the Dodo checkout
 #   session returns the buyer to the app's billing page after pay / cancel (the
 #   prior payment-link checkout had nowhere to send them).
+# Updated 2026-06-29 (feat/billing-usage-endpoint): added GET /billing/usage — the
+#   per-workspace USAGE graph (daily usage by model over a date range, derived from
+#   the workspace's LiteLLM proxy usage; spend reported in credits). Workspace-scoped
+#   via ``current_workspace_id`` (same auth as top-up / subscribe); logic lives in
+#   ``billing.usage``. A brand-new workspace with no usage returns an empty 200.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Query, Request
 
 from pocketpaw_ee.cloud.billing import plans as plan_catalog
 from pocketpaw_ee.cloud.billing import service as billing_service
 from pocketpaw_ee.cloud.billing import site_plans as site_plan_catalog
+from pocketpaw_ee.cloud.billing import usage as usage_service
 from pocketpaw_ee.cloud.billing.dto import (
     CreateSubscriptionRequest,
     CreateSubscriptionResponse,
     CreateTopupRequest,
     CreateTopupResponse,
+    WorkspaceUsageResponse,
 )
 from pocketpaw_ee.cloud.entitlements.dto import (
     PlanCatalogResponse,
@@ -76,6 +83,44 @@ async def list_billing_site_plans() -> SitePlanCatalogResponse:
     """
     return SitePlanCatalogResponse(
         site_plans=[site_plan_tier_to_dto(t) for t in site_plan_catalog.list_site_plans()]
+    )
+
+
+# ``YYYY-MM-DD`` — a light date-shape guard at the edge so a malformed param 422s
+# before the service / proxy is reached (the proxy also requires this format).
+_DATE_PATTERN = r"^\d{4}-\d{2}-\d{2}$"
+
+
+@router.get("/usage", response_model=WorkspaceUsageResponse)
+async def get_usage(
+    workspace_id: str = Depends(current_workspace_id),
+    start_date: str | None = Query(
+        default=None,
+        pattern=_DATE_PATTERN,
+        description="Start of the window, YYYY-MM-DD. Defaults to 30 days ago when omitted.",
+    ),
+    end_date: str | None = Query(
+        default=None,
+        pattern=_DATE_PATTERN,
+        description="End of the window, YYYY-MM-DD. Defaults to today when omitted.",
+    ),
+) -> WorkspaceUsageResponse:
+    """Return the caller's workspace's daily usage, broken down by model.
+
+    Daily usage (spend in CREDITS, tokens, requests) per model over
+    ``[start_date, end_date]``, derived from the workspace's LiteLLM proxy usage and
+    scoped to that workspace. When both dates are omitted the window defaults to the
+    last 30 days. The response stays DAILY — the frontend aggregates to weekly /
+    monthly and filters by model client-side.
+
+    A brand-new workspace with no provisioned key (or simply no usage in the window)
+    returns an empty contract (no models, no buckets, total 0) at HTTP 200 — not an
+    error.
+    """
+    return await usage_service.get_workspace_usage(
+        workspace_id,
+        start_date=start_date,
+        end_date=end_date,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/billing/usage.py
+++ b/ee/pocketpaw_ee/cloud/billing/usage.py
@@ -213,9 +213,7 @@ async def get_workspace_usage(
             # The proxy splits requests into successful/failed + a combined
             # api_requests; prefer api_requests (the total attempts), falling back to
             # successful_requests for an older shape that lacked api_requests.
-            requests = _int(metrics.get("api_requests")) or _int(
-                metrics.get("successful_requests")
-            )
+            requests = _int(metrics.get("api_requests")) or _int(metrics.get("successful_requests"))
             models_seen.add(model_id)
             existing = per_model.get(model_id)
             if existing is None:
@@ -239,9 +237,7 @@ async def get_workspace_usage(
         per_model = buckets[day]
         day_credits = sum(stats.credits for stats in per_model.values())
         total_credits += day_credits
-        out_buckets.append(
-            UsageBucket(date=day, by_model=per_model, total_credits=day_credits)
-        )
+        out_buckets.append(UsageBucket(date=day, by_model=per_model, total_credits=day_credits))
 
     return WorkspaceUsageResponse(
         start_date=resolved_start,

--- a/ee/pocketpaw_ee/cloud/billing/usage.py
+++ b/ee/pocketpaw_ee/cloud/billing/usage.py
@@ -1,0 +1,255 @@
+# ee/pocketpaw_ee/cloud/billing/usage.py — the per-workspace USAGE-graph read.
+#
+# Module-level ``async def`` API (NOT a class, per the EE cloud rule, mirroring the
+# rest of billing / credits / metering). One job: build the daily usage graph the
+# frontend renders — daily usage BROKEN DOWN BY MODEL over a date range — from the
+# workspace's LiteLLM proxy usage.
+#
+# THE SEAM (read before changing the conversion — money-adjacent):
+#   * MAPPING: a workspace maps to its LiteLLM VIRTUAL KEY (NOT a user_id). The
+#     provisioning entity owns that mapping (one ``LiteLLMTenantKey`` row per
+#     workspace, the proxy key minted with metadata={workspace_id}); we resolve it
+#     through ``llm_provisioning.service.get_tenant_key`` rather than touching the
+#     doc (entity isolation — only that entity reads its key doc). The proxy's
+#     /user/daily/activity route accepts an ``api_key`` filter, so we scope usage to
+#     exactly that tenant's key. The admin client calls with the deployment MASTER
+#     key (the proxy treats it as admin view), so the api_key filter is honoured.
+#   * CONVERSION: spend USD -> integer credits via the SAME rate card the meter +
+#     spend-ingest use — ``SpendCredits.to_credits(cost_usd) =
+#     round(cost_usd * markup / credit_usd)`` (markup = billing_markup, default 2.5;
+#     credit_usd default 0.01). We deliberately reuse that conversion (via
+#     ``llm_provisioning.service.load_spend_credits``) rather than a flat
+#     ``round(usd * 100)`` so a dollar of usage SHOWN here equals a dollar of usage
+#     BILLED by the meter — the usage graph and the wallet never disagree. (A flat
+#     *100 would ignore the markup and under-report vs. what was charged.)
+#   * READ-ONLY: this is a pure read. It NEVER debits, NEVER touches the credit
+#     ledger or the spend high-water mark, NEVER calls the cutover/metering path.
+#     It only converts numbers for display.
+#
+# EMPTY / NO-KEY CASE: a brand-new workspace with no provisioned key returns an
+# empty contract (no models, no buckets, total 0) at HTTP 200 — NOT an error, and
+# WITHOUT a proxy call (there is no key to scope). Same for a provisioned workspace
+# that simply had no usage in the window (the proxy returns no rows).
+#
+# Rule 6 — validate at entry (a workspace id is required). Rule 7 — the read is
+# tenant-scoped (the key filter IS the tenant scope). Rule 10 — only CloudError
+# subclasses propagate to HTTP; a proxy read failure raises ``LiteLLMAdminError``
+# (a plain exception) which the route surfaces as a 502 via the cloud error path.
+#
+# Created 2026-06-29 (feat/billing-usage-endpoint): new module — the GET
+# /billing/usage transform (LiteLLM /user/daily/activity -> WorkspaceUsageResponse).
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.billing.dto import (
+    UsageBucket,
+    UsageModelStats,
+    WorkspaceUsageResponse,
+)
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning_service
+from pocketpaw_ee.cloud.llm_provisioning.domain import SpendCredits
+
+logger = logging.getLogger(__name__)
+
+# Default window when the caller omits start/end: the trailing 30 days INCLUSIVE of
+# today (today minus 29 days .. today). Inclusive so a 30-day request shows 30 day
+# columns, not 31.
+_DEFAULT_WINDOW_DAYS = 30
+
+
+class _DailyActivityClient(Protocol):
+    """The slice of LiteLLMAdminClient this module needs. A Protocol so tests can
+    inject a duck-typed fake (no HTTP) and we never construct an httpx client in a
+    unit test."""
+
+    async def user_daily_activity(
+        self, *, start_date: str, end_date: str, api_key: str, page_size: int = ...
+    ) -> list[dict[str, Any]]: ...
+
+
+def _num(value: Any) -> float:
+    """Coerce a proxy spend value to a float, tolerating None / strings (the proxy
+    occasionally serialises numbers as strings)."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _int(value: Any) -> int:
+    """Coerce a token / request count to a non-negative int, tolerating None /
+    strings. A negative / unparseable value clamps to 0."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+def _default_range() -> tuple[str, str]:
+    """The default (start_date, end_date) — the trailing 30 days inclusive of today,
+    as ``YYYY-MM-DD`` strings in UTC."""
+    today = datetime.now(UTC).date()
+    start = today - timedelta(days=_DEFAULT_WINDOW_DAYS - 1)
+    return start.isoformat(), today.isoformat()
+
+
+def _record_date(record: dict[str, Any]) -> str | None:
+    """The ``YYYY-MM-DD`` date of a LiteLLM daily record. The proxy serialises the
+    ``date`` field as an ISO date string; we keep just the date portion. None when
+    a record carries no usable date (skipped rather than bucketed under ''
+    )."""
+    raw = record.get("date")
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    if not s:
+        return None
+    # Tolerate a full ISO timestamp by keeping the date head (the proxy emits a bare
+    # date today, but a future shape change to a datetime must not mis-bucket).
+    return s.split("T", 1)[0]
+
+
+def _model_breakdown(record: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """The ``breakdown.models`` map of a daily record (model id -> {metrics, ...}),
+    or an empty dict when absent/malformed. Defensive across shapes so a partial
+    proxy row never crashes the transform."""
+    breakdown = record.get("breakdown")
+    if not isinstance(breakdown, dict):
+        return {}
+    models = breakdown.get("models")
+    if not isinstance(models, dict):
+        return {}
+    return {str(name): m for name, m in models.items() if isinstance(m, dict)}
+
+
+async def get_workspace_usage(
+    workspace_id: str,
+    *,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    spend_card: SpendCredits | None = None,
+    daily_activity_client: _DailyActivityClient | None = None,
+) -> WorkspaceUsageResponse:
+    """Build the per-workspace daily usage graph over ``[start_date, end_date]``.
+
+    Resolves the workspace's LiteLLM virtual key, reads its daily activity from the
+    proxy (scoped by that key), and folds each day's per-model breakdown into a
+    ``UsageBucket`` with a ``{credits, tokens, requests}`` block per model. Spend USD
+    is converted to credits with the SAME rate card the meter uses (so the graph and
+    the wallet agree). Returns a ``WorkspaceUsageResponse``.
+
+    ``start_date`` / ``end_date`` are ``YYYY-MM-DD``; when BOTH are omitted the window
+    defaults to the trailing 30 days. ``spend_card`` / ``daily_activity_client`` are
+    injectable for tests; production resolves the settings-derived rate card and a
+    master-key admin client.
+
+    A workspace with NO provisioned key (or no usage in the window) returns an empty
+    contract (no models, no buckets, total 0) — never an error, and the no-key case
+    makes NO proxy call.
+    """
+    # Rule 6 — validate at entry.
+    if not workspace_id:
+        raise ValidationError("billing.invalid_workspace", "workspace_id is required")
+
+    if start_date and end_date:
+        resolved_start, resolved_end = start_date, end_date
+    else:
+        # Any partial range (only one bound given) falls back to the full default
+        # window — the proxy requires BOTH bounds, so we never send a half range.
+        resolved_start, resolved_end = _default_range()
+
+    # MAPPING: workspace -> its LiteLLM virtual key, via the provisioning entity
+    # (entity isolation — we don't read the key doc directly). No key == a
+    # brand-new workspace with nothing provisioned yet.
+    key = await provisioning_service.get_tenant_key(workspace_id)
+    if not key:
+        # Empty contract, HTTP 200, NO proxy call — there is no key to scope.
+        return WorkspaceUsageResponse(
+            start_date=resolved_start,
+            end_date=resolved_end,
+            models=[],
+            buckets=[],
+            total_credits=0,
+        )
+
+    card = spend_card if spend_card is not None else provisioning_service.load_spend_credits()
+    client = daily_activity_client
+    if client is None:
+        # Lazy import — keep this module free of an import-time httpx dependency, and
+        # so a unit test that injects a fake never constructs a real client.
+        from pocketpaw_ee.catalog.admin_client import LiteLLMAdminClient
+
+        client = LiteLLMAdminClient()
+
+    records = await client.user_daily_activity(
+        start_date=resolved_start,
+        end_date=resolved_end,
+        api_key=key,
+    )
+
+    # Fold the daily records into per-day buckets keyed by date. A proxy is expected
+    # to return one record per date for a single-entity query, but we accumulate
+    # defensively so a duplicated date (or a future per-key split) sums correctly.
+    buckets: dict[str, dict[str, UsageModelStats]] = {}
+    models_seen: set[str] = set()
+
+    for record in records:
+        day = _record_date(record)
+        if day is None:
+            continue
+        per_model = buckets.setdefault(day, {})
+        for model_id, model_block in _model_breakdown(record).items():
+            metrics = model_block.get("metrics")
+            if not isinstance(metrics, dict):
+                continue
+            credits = card.to_credits(_num(metrics.get("spend")))
+            tokens = _int(metrics.get("total_tokens"))
+            # The proxy splits requests into successful/failed + a combined
+            # api_requests; prefer api_requests (the total attempts), falling back to
+            # successful_requests for an older shape that lacked api_requests.
+            requests = _int(metrics.get("api_requests")) or _int(
+                metrics.get("successful_requests")
+            )
+            models_seen.add(model_id)
+            existing = per_model.get(model_id)
+            if existing is None:
+                per_model[model_id] = UsageModelStats(
+                    credits=credits, tokens=tokens, requests=requests
+                )
+            else:
+                # Accumulate a repeated (date, model) — keeps the transform correct
+                # if the proxy ever returns split rows for the same day+model.
+                per_model[model_id] = UsageModelStats(
+                    credits=existing.credits + credits,
+                    tokens=existing.tokens + tokens,
+                    requests=existing.requests + requests,
+                )
+
+    # Assemble the response: buckets oldest-first, each with its credit total; the
+    # grand total over every bucket; the sorted distinct model list (a stable legend).
+    out_buckets: list[UsageBucket] = []
+    total_credits = 0
+    for day in sorted(buckets):
+        per_model = buckets[day]
+        day_credits = sum(stats.credits for stats in per_model.values())
+        total_credits += day_credits
+        out_buckets.append(
+            UsageBucket(date=day, by_model=per_model, total_credits=day_credits)
+        )
+
+    return WorkspaceUsageResponse(
+        start_date=resolved_start,
+        end_date=resolved_end,
+        models=sorted(models_seen),
+        buckets=out_buckets,
+        total_credits=total_credits,
+    )
+
+
+__all__ = ["get_workspace_usage"]

--- a/tests/cloud/billing/test_usage.py
+++ b/tests/cloud/billing/test_usage.py
@@ -1,0 +1,308 @@
+# tests/cloud/billing/test_usage.py — proves the per-workspace USAGE transform
+# (the billing usage-graph seam). The frontend renders a daily usage graph
+# broken down by model from a workspace's LiteLLM proxy usage; this module locks
+# the transform LiteLLM ``/user/daily/activity`` -> the WorkspaceUsage contract,
+# including the USD->credits conversion (money-adjacent — pinned, not ambient).
+#
+# Asserts:
+#   * the workspace -> LiteLLM virtual key mapping is resolved (via the provisioning
+#     service's get_tenant_key) and passed as the ``api_key`` filter to the proxy
+#     daily-activity read — usage is scoped to exactly that tenant's key.
+#   * each LiteLLM daily record's ``breakdown.models[<model>].metrics`` is folded
+#     into a daily bucket with a per-model {credits, tokens, requests} breakdown,
+#     the spend USD converted to credits via the SAME rate card the meter uses
+#     (round(cost_usd * markup / credit_usd) — a dollar shown == a dollar billed).
+#   * ``models`` is the sorted distinct union across the range; ``total_credits``
+#     is the sum over every bucket; each bucket's ``total_credits`` sums its models.
+#   * default date range = last 30 days when start/end omitted, and the resolved
+#     range is echoed onto the response.
+#   * a workspace with NO provisioned key -> empty buckets + empty models +
+#     total_credits 0 (HTTP 200, not an error) and NO proxy call.
+#   * pagination: when the proxy reports ``metadata.has_more`` the service walks
+#     every page and merges the daily records.
+#
+# A FAKE daily-activity client (duck-typed, no HTTP) stands in for the proxy — the
+# admin client's own HTTP wiring (the new ``user_daily_activity`` method) is
+# covered separately in tests/cloud/catalog/test_admin_client.py. Uses the shared
+# ``mongo_db`` fixture (Beanie over ALL_DOCUMENTS) so get_tenant_key reads a real
+# persisted LiteLLMTenantKey row, the same DB-fixture pattern the provisioning /
+# credits tests use.
+#
+# Created 2026-06-29 (feat/billing-usage-endpoint): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from pocketpaw_ee.cloud.billing import usage
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
+
+WS = "ws_usage_test"
+
+# Pin the spend rate card so credits never depend on ambient POCKETPAW_* settings:
+# credits = round(cost_usd * 2.5 / 0.01) = round(cost_usd * 250). Identical to the
+# card the meter + spend-ingest use, so a dollar of usage shown matches a dollar
+# billed.
+SPEND = SpendCredits(markup=2.5, credit_usd=0.01)
+
+BUDGET = KeyBudget(max_budget_usd=25.0, budget_duration="30d", rpm_limit=60, tpm_limit=0, models=[])
+
+
+def _metrics(spend: float, prompt: int, completion: int, requests: int) -> dict:
+    """A LiteLLM ``SpendMetrics``-shaped dict (the per-model / per-day metric block)."""
+    return {
+        "spend": spend,
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": prompt + completion,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "successful_requests": requests,
+        "failed_requests": 0,
+        "api_requests": requests,
+    }
+
+
+def _day(date_str: str, models: dict[str, dict]) -> dict:
+    """A LiteLLM ``DailySpendData``-shaped record: a date + a breakdown.models map
+    (each model -> {"metrics": SpendMetrics}). The day-level ``metrics`` block is
+    present for shape-fidelity but the transform reads the per-model breakdown."""
+    day_metrics = _metrics(
+        sum(m["__spend"] for m in models.values()),
+        0,
+        0,
+        sum(m["__requests"] for m in models.values()),
+    )
+    breakdown_models = {
+        name: {"metrics": m["metrics"], "metadata": {}, "api_key_breakdown": {}}
+        for name, m in models.items()
+    }
+    return {"date": date_str, "metrics": day_metrics, "breakdown": {"models": breakdown_models}}
+
+
+def _model_entry(spend: float, prompt: int, completion: int, requests: int) -> dict:
+    """Helper bundling a model's metrics + its raw spend/requests (for the day total)."""
+    return {
+        "metrics": _metrics(spend, prompt, completion, requests),
+        "__spend": spend,
+        "__requests": requests,
+    }
+
+
+class FakeDailyActivity:
+    """In-memory stand-in for LiteLLMAdminClient.user_daily_activity (no HTTP).
+
+    ``pages`` is a list of response bodies (each a SpendAnalyticsPaginatedResponse-
+    shaped dict). The method returns the merged ``results`` across all pages and
+    records the kwargs it was called with so the test can assert the api_key filter
+    + date range round-tripped. ``calls`` counts invocations (0 proves the no-key
+    path makes no proxy call).
+    """
+
+    def __init__(self, *, pages: list[dict] | None = None) -> None:
+        self.calls = 0
+        self.last_kwargs: dict | None = None
+        self._pages = pages if pages is not None else [{"results": [], "metadata": {}}]
+
+    async def user_daily_activity(
+        self, *, start_date: str, end_date: str, api_key: str, page_size: int = 1000
+    ) -> list[dict]:
+        self.calls += 1
+        self.last_kwargs = {
+            "start_date": start_date,
+            "end_date": end_date,
+            "api_key": api_key,
+            "page_size": page_size,
+        }
+        merged: list[dict] = []
+        for body in self._pages:
+            merged.extend(body.get("results", []))
+        return merged
+
+
+# ---------------------------------------------------------------------------
+# The transform — LiteLLM daily activity -> the WorkspaceUsage contract.
+# ---------------------------------------------------------------------------
+
+
+async def test_usage_transforms_daily_activity_into_buckets_by_model(mongo_db):
+    # Provision the workspace so get_tenant_key resolves a real virtual key.
+    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=_FakeAdmin())
+
+    sonnet = "anthropic/claude-3-5-sonnet"
+    gpt = "openai/gpt-4o"
+    pages = [
+        {
+            "results": [
+                # Day 1: two models. sonnet $0.04 -> 10 credits; gpt $0.02 -> 5 credits.
+                _day(
+                    "2026-06-01",
+                    {
+                        sonnet: _model_entry(0.04, 1000, 200, 3),
+                        gpt: _model_entry(0.02, 500, 100, 2),
+                    },
+                ),
+                # Day 2: sonnet only. $0.10 -> 25 credits.
+                _day("2026-06-02", {sonnet: _model_entry(0.10, 4000, 800, 7)}),
+            ],
+            "metadata": {"has_more": False, "page": 1, "total_pages": 1},
+        }
+    ]
+    client = FakeDailyActivity(pages=pages)
+
+    result = await usage.get_workspace_usage(
+        WS,
+        start_date="2026-06-01",
+        end_date="2026-06-02",
+        spend_card=SPEND,
+        daily_activity_client=client,
+    )
+
+    # The proxy read was scoped to the workspace's virtual key over the given range.
+    assert client.calls == 1
+    assert client.last_kwargs["api_key"] == "sk-ws-ws_usage_test"
+    assert client.last_kwargs["start_date"] == "2026-06-01"
+    assert client.last_kwargs["end_date"] == "2026-06-02"
+
+    # Echoed range.
+    assert result.start_date == "2026-06-01"
+    assert result.end_date == "2026-06-02"
+
+    # Distinct model list, sorted (alphabetical: "anthropic/..." before "openai/...").
+    assert result.models == sorted([gpt, sonnet])
+    assert result.models == [sonnet, gpt]
+
+    # Two daily buckets.
+    assert [b.date for b in result.buckets] == ["2026-06-01", "2026-06-02"]
+
+    b1 = result.buckets[0]
+    assert b1.by_model[sonnet].credits == 10  # round(0.04 * 250)
+    assert b1.by_model[sonnet].tokens == 1200  # prompt + completion
+    assert b1.by_model[sonnet].requests == 3
+    assert b1.by_model[gpt].credits == 5  # round(0.02 * 250)
+    assert b1.by_model[gpt].tokens == 600
+    assert b1.by_model[gpt].requests == 2
+    assert b1.total_credits == 15  # 10 + 5
+
+    b2 = result.buckets[1]
+    assert set(b2.by_model.keys()) == {sonnet}
+    assert b2.by_model[sonnet].credits == 25  # round(0.10 * 250)
+    assert b2.by_model[sonnet].tokens == 4800
+    assert b2.total_credits == 25
+
+    # Grand total over every bucket.
+    assert result.total_credits == 40  # 15 + 25
+
+
+async def test_usage_defaults_to_last_30_days_when_range_omitted(mongo_db):
+    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=_FakeAdmin())
+    client = FakeDailyActivity(pages=[{"results": [], "metadata": {}}])
+
+    result = await usage.get_workspace_usage(WS, spend_card=SPEND, daily_activity_client=client)
+
+    today = datetime.now(UTC).date()
+    expected_start = (today - timedelta(days=29)).isoformat()  # inclusive 30-day window
+    expected_end = today.isoformat()
+
+    assert result.start_date == expected_start
+    assert result.end_date == expected_end
+    assert client.last_kwargs["start_date"] == expected_start
+    assert client.last_kwargs["end_date"] == expected_end
+    # No usage -> empty, but a key exists so the proxy WAS queried.
+    assert result.buckets == []
+    assert result.models == []
+    assert result.total_credits == 0
+
+
+async def test_usage_unprovisioned_workspace_returns_empty_no_proxy_call(mongo_db):
+    # No LiteLLMTenantKey row for WS -> brand-new workspace, no usage yet.
+    assert await provisioning.get_tenant_key(WS) is None
+    client = FakeDailyActivity(pages=[{"results": [_day("2026-06-01", {})]}])
+
+    result = await usage.get_workspace_usage(
+        WS,
+        start_date="2026-06-01",
+        end_date="2026-06-30",
+        spend_card=SPEND,
+        daily_activity_client=client,
+    )
+
+    # Empty contract, NOT an error — and the proxy is never called (no key to scope).
+    assert result.buckets == []
+    assert result.models == []
+    assert result.total_credits == 0
+    assert result.start_date == "2026-06-01"
+    assert result.end_date == "2026-06-30"
+    assert client.calls == 0
+
+
+async def test_usage_walks_every_page_when_has_more(mongo_db):
+    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=_FakeAdmin())
+    sonnet = "anthropic/claude-3-5-sonnet"
+    # Two pages: the client merges both pages' results (pagination is the client's
+    # job; the service sees the merged list). Distinct dates across pages.
+    pages = [
+        {
+            "results": [_day("2026-06-01", {sonnet: _model_entry(0.04, 1000, 200, 1)})],
+            "metadata": {"has_more": True, "page": 1, "total_pages": 2},
+        },
+        {
+            "results": [_day("2026-06-02", {sonnet: _model_entry(0.02, 500, 100, 1)})],
+            "metadata": {"has_more": False, "page": 2, "total_pages": 2},
+        },
+    ]
+    client = FakeDailyActivity(pages=pages)
+
+    result = await usage.get_workspace_usage(
+        WS,
+        start_date="2026-06-01",
+        end_date="2026-06-02",
+        spend_card=SPEND,
+        daily_activity_client=client,
+    )
+
+    assert [b.date for b in result.buckets] == ["2026-06-01", "2026-06-02"]
+    assert result.total_credits == 15  # 10 + 5
+
+
+async def test_usage_sub_credit_spend_rounds_to_zero(mongo_db):
+    # A tiny spend below half a credit rounds to 0 credits (no phantom charge) but
+    # the model still appears with its tokens/requests — usage is real even if the
+    # rounded credit cost is 0.
+    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=_FakeAdmin())
+    sonnet = "anthropic/claude-3-5-sonnet"
+    pages = [
+        {
+            "results": [_day("2026-06-01", {sonnet: _model_entry(0.0001, 5, 1, 1)})],
+            "metadata": {"has_more": False},
+        }
+    ]
+    client = FakeDailyActivity(pages=pages)
+
+    result = await usage.get_workspace_usage(
+        WS,
+        start_date="2026-06-01",
+        end_date="2026-06-01",
+        spend_card=SPEND,
+        daily_activity_client=client,
+    )
+
+    assert result.models == [sonnet]
+    b1 = result.buckets[0]
+    assert b1.by_model[sonnet].credits == 0  # round(0.0001 * 250) == 0
+    assert b1.by_model[sonnet].tokens == 6
+    assert b1.by_model[sonnet].requests == 1
+    assert b1.total_credits == 0
+    assert result.total_credits == 0
+
+
+# ---------------------------------------------------------------------------
+# Minimal fake admin client to provision a key (no HTTP) — mirrors the
+# provisioning test's FakeAdmin (only the generate_key surface is needed here).
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdmin:
+    async def generate_key(self, **kwargs):
+        return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **kwargs}

--- a/tests/cloud/catalog/test_admin_client.py
+++ b/tests/cloud/catalog/test_admin_client.py
@@ -6,11 +6,16 @@
 #   * key_info GETs /key/info?key=.
 #   * spend_logs GETs /spend/logs?api_key= (the required filter) and unwraps both
 #     a bare-list and a {"data": [...]} response; an empty api_key raises.
+#   * user_daily_activity GETs /user/daily/activity?start_date=&end_date=&api_key=
+#     (the per-key DAILY usage read backing the billing usage graph), walks every
+#     page (following metadata.has_more) merging results, and raises on empty api_key.
 #   * delete_keys POSTs /key/delete with the keys list.
 #   * the master key rides as a Bearer header.
 #   * a non-2xx surfaces LiteLLMAdminError with the proxy's error message.
 #
 # Created 2026-06-26 (integration/model-catalog-v2, MCG-8).
+# Updated 2026-06-29 (feat/billing-usage-endpoint): added user_daily_activity tests
+#   (scoping params, pagination merge, empty-key raise, master-key bearer).
 
 from __future__ import annotations
 
@@ -123,6 +128,83 @@ async def test_spend_logs_unwraps_data_envelope():
     client = _client(handler)
     out = await client.spend_logs(api_key="sk-tenant-abc")
     assert out == rows
+
+
+async def test_user_daily_activity_scopes_by_key_and_dates():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("Authorization")
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "date": "2026-06-01",
+                        "metrics": {"spend": 0.04},
+                        "breakdown": {"models": {"anthropic/claude-3-5-sonnet": {"metrics": {}}}},
+                    }
+                ],
+                "metadata": {"has_more": False, "page": 1, "total_pages": 1},
+            },
+        )
+
+    client = _client(handler, api_key="sk-master")
+    rows = await client.user_daily_activity(
+        start_date="2026-06-01", end_date="2026-06-30", api_key="sk-tenant-abc"
+    )
+
+    # One page -> the single daily record, scoped to the tenant key over the range.
+    assert len(rows) == 1
+    assert rows[0]["date"] == "2026-06-01"
+    assert "/user/daily/activity" in captured["url"]
+    assert "start_date=2026-06-01" in captured["url"]
+    assert "end_date=2026-06-30" in captured["url"]
+    assert "api_key=sk-tenant-abc" in captured["url"]
+    # The MASTER key Bearers the privileged read (so the proxy grants admin view and
+    # honours the api_key filter).
+    assert captured["auth"] == "Bearer sk-master"
+
+
+async def test_user_daily_activity_requires_api_key():
+    client = _client(lambda r: httpx.Response(200, json={"results": []}))
+    with pytest.raises(LiteLLMAdminError):
+        await client.user_daily_activity(start_date="2026-06-01", end_date="2026-06-30", api_key="")
+
+
+async def test_user_daily_activity_walks_pages_until_has_more_false():
+    seen_pages: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        # The page param drives which body we return; record it to prove the walk.
+        if "page=1" in url:
+            seen_pages.append("1")
+            return httpx.Response(
+                200,
+                json={
+                    "results": [{"date": "2026-06-01", "breakdown": {"models": {}}}],
+                    "metadata": {"has_more": True, "page": 1, "total_pages": 2},
+                },
+            )
+        seen_pages.append("2")
+        return httpx.Response(
+            200,
+            json={
+                "results": [{"date": "2026-06-02", "breakdown": {"models": {}}}],
+                "metadata": {"has_more": False, "page": 2, "total_pages": 2},
+            },
+        )
+
+    client = _client(handler, api_key="sk-master")
+    rows = await client.user_daily_activity(
+        start_date="2026-06-01", end_date="2026-06-02", api_key="sk-tenant-abc"
+    )
+
+    # Both pages were fetched and their results merged.
+    assert seen_pages == ["1", "2"]
+    assert [r["date"] for r in rows] == ["2026-06-01", "2026-06-02"]
 
 
 async def test_delete_keys_posts_keys_list():


### PR DESCRIPTION
## What this does

Adds `GET /api/v1/billing/usage?start_date=&end_date=` so the frontend can render a real usage graph: daily usage broken down by model, for the caller's workspace.

It pulls from the workspace's LiteLLM usage via the proxy's `/user/daily/activity`, scoped by the workspace's virtual key (the unique LiteLLMTenantKey row), and transforms it into daily buckets with a per-model breakdown.

## The contract

```
{ start_date, end_date,
  models: [...],                                                    // distinct models, sorted (the legend)
  buckets: [ {date, by_model: {model: {credits, tokens, requests}}, total_credits} ],   // daily, oldest-first
  total_credits }
```
An empty workspace (no key or no usage yet) returns empty buckets with HTTP 200, not an error.

## Money correctness

USD spend converts to credits via the canonical `SpendCredits.to_credits` (the same markup-aware conversion the meter uses to bill), not a flat times-100, so the usage graph agrees with the wallet. A flat times-100 would have under-reported versus what was actually charged.

## Verification

Test-first: 16 new tests (the transform plus the admin-client wiring) and the full billing, catalog, and provisioning suite (136) green. Ruff and mypy clean.

## Pairs with

The frontend usage chart (paw-enterprise) consumes this endpoint.