### PR TITLE
fix(billing): validate + clamp the usage endpoint's date range

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/usage.py
+++ b/ee/pocketpaw_ee/cloud/billing/usage.py
@@ -42,7 +42,8 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime, timedelta
+import re
+from datetime import UTC, date, datetime, timedelta
 from typing import Any, Protocol
 
 from pocketpaw_ee.cloud._core.errors import ValidationError
@@ -60,6 +61,40 @@ logger = logging.getLogger(__name__)
 # today (today minus 29 days .. today). Inclusive so a 30-day request shows 30 day
 # columns, not 31.
 _DEFAULT_WINDOW_DAYS = 30
+
+# A caller-supplied window must be YYYY-MM-DD and span at most a year. The format
+# check fails fast with a clean 400 rather than letting a malformed date reach the
+# proxy (a 502 on the error path); the span clamp bounds the per-request proxy
+# fan-out (the admin client walks pages, so an open-ended range like 2000..2099 is
+# dozens of serial calls). Both apply ONLY to an explicit range — the default
+# window is always sane.
+_YMD = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_MAX_WINDOW_DAYS = 366
+
+
+def _resolve_explicit_range(start_date: str, end_date: str) -> tuple[str, str]:
+    """Validate a caller-supplied ``[start_date, end_date]`` and clamp its span.
+
+    Both bounds must be ``YYYY-MM-DD`` calendar dates with start on or before end;
+    a malformed or inverted range raises ``ValidationError`` (a clean 400). A span
+    over ``_MAX_WINDOW_DAYS`` is clamped to the most recent that many days ending at
+    ``end_date`` (the response stamps the resolved window, so the axis reflects it).
+    """
+    for label, value in (("start_date", start_date), ("end_date", end_date)):
+        if not _YMD.match(value):
+            raise ValidationError("billing.invalid_date", f"{label} must be YYYY-MM-DD")
+    try:
+        start = date.fromisoformat(start_date)
+        end = date.fromisoformat(end_date)
+    except ValueError as exc:
+        raise ValidationError(
+            "billing.invalid_date", "start_date / end_date must be a valid calendar date"
+        ) from exc
+    if start > end:
+        raise ValidationError("billing.invalid_range", "start_date must be on or before end_date")
+    if (end - start).days > _MAX_WINDOW_DAYS - 1:
+        start = end - timedelta(days=_MAX_WINDOW_DAYS - 1)
+    return start.isoformat(), end.isoformat()
 
 
 class _DailyActivityClient(Protocol):
@@ -158,7 +193,8 @@ async def get_workspace_usage(
         raise ValidationError("billing.invalid_workspace", "workspace_id is required")
 
     if start_date and end_date:
-        resolved_start, resolved_end = start_date, end_date
+        # Validate the format + clamp the span before either reaches the proxy.
+        resolved_start, resolved_end = _resolve_explicit_range(start_date, end_date)
     else:
         # Any partial range (only one bound given) falls back to the full default
         # window — the proxy requires BOTH bounds, so we never send a half range.

--- a/tests/cloud/billing/test_usage.py
+++ b/tests/cloud/billing/test_usage.py
@@ -32,8 +32,10 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.billing import usage
 from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
 from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
@@ -235,6 +237,39 @@ async def test_usage_unprovisioned_workspace_returns_empty_no_proxy_call(mongo_d
     assert result.start_date == "2026-06-01"
     assert result.end_date == "2026-06-30"
     assert client.calls == 0
+
+
+# --- HARDENING (fix/billing-usage-validate): the explicit-range validator + clamp.
+#     A caller-supplied range is format-checked, inverted-checked, and span-clamped
+#     before it reaches the proxy (a clean 400 instead of a 502, and a bounded fan-out). ---
+
+
+def test_resolve_explicit_range_rejects_malformed_dates():
+    # A non-YYYY-MM-DD string fails the format gate; a well-formed but impossible
+    # calendar date (month 13) fails fromisoformat. Both surface ValidationError.
+    with pytest.raises(ValidationError):
+        usage._resolve_explicit_range("garbage", "2026-06-30")
+    with pytest.raises(ValidationError):
+        usage._resolve_explicit_range("2026-13-01", "2026-06-30")
+
+
+def test_resolve_explicit_range_rejects_inverted():
+    with pytest.raises(ValidationError):
+        usage._resolve_explicit_range("2026-06-30", "2026-06-01")
+
+
+def test_resolve_explicit_range_clamps_oversized_span():
+    # A multi-year span clamps to the most recent _MAX_WINDOW_DAYS ending at end_date.
+    start, end = usage._resolve_explicit_range("2023-01-01", "2026-06-30")
+    assert end == "2026-06-30"
+    assert start == (date(2026, 6, 30) - timedelta(days=usage._MAX_WINDOW_DAYS - 1)).isoformat()
+
+
+def test_resolve_explicit_range_passes_valid_window_through():
+    assert usage._resolve_explicit_range("2026-06-01", "2026-06-30") == (
+        "2026-06-01",
+        "2026-06-30",
+    )
 
 
 async def test_usage_walks_every_page_when_has_more(mongo_db):


### PR DESCRIPTION
Follow-up to the usage endpoint review (#1582), addressing two of the three hardening notes.

## What this does

The `/billing/usage` date range was passed straight to the LiteLLM proxy with no checks. This adds `_resolve_explicit_range`, applied only to an explicit caller range (the default window is always sane):

- **Format**: both bounds must be `YYYY-MM-DD` calendar dates. A malformed date now raises `ValidationError` (a clean 400) instead of reaching the proxy and surfacing as a 502.
- **Order**: start must be on or before end, else a 400.
- **Span**: a range over a year is clamped to the most recent 366 days ending at `end_date`. This bounds the per-request proxy fan-out (the admin client walks pages, so an open-ended range was dozens of serial calls). The response stamps the resolved window, so the chart axis reflects the clamp.

## The third note (deferred by design)

The tenant-isolation dependency on the proxy honoring the `api_key` filter is already guarded by the empty-key check (an unscoped read raises) and documented in `usage.py`; it isn't independently assertable from the daily-activity response, so it stays a documented, version-pinned dependency rather than a code change.

## Verification

Four unit tests: format reject, inverted reject, oversized clamp, valid passthrough. The usage suite is green (9 tests); ruff clean.