### PR TITLE
feat(notif): show sender name in group chat notification title

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/message_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/message_service.py
@@ -470,9 +470,9 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
         title = (
             f"New message from {sender_name}"
             if is_dm
-            else f"New message in #{group_name}"
+            else f"{sender_name} in #{group_name}"
             if group_name
-            else "New message"
+            else sender_name
         )
 
         notif_tasks = [


### PR DESCRIPTION
## Summary

Group chat notifications used to say just `"New message in #general"` — the sender's name was only shown in DMs. Now group notifications include who sent it, matching the DM format.

**Before:**
- DM: `New message from Amritesh`
- Group: `New message in #general`
- Group (no name): `New message`

**After:**
- DM: `New message from Amritesh` (unchanged)
- Group: `Amritesh in #general`
- Group (no name): `Amritesh`

## Changes

- `ee/pocketpaw_ee/cloud/chat/message_service.py` — swap title template for group chat notifications to prepend sender name