### PR TITLE
fix(billing): source the usage chart from the credit ledger, not the LiteLLM proxy

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/dto.py
+++ b/ee/pocketpaw_ee/cloud/billing/dto.py
@@ -16,10 +16,14 @@
 #   now 422s at the DTO before the service is reached.
 # Updated 2026-06-29 (feat/billing-usage-endpoint): added the WORKSPACE USAGE
 #   response contract (``UsageModelStats`` / ``UsageBucket`` / ``WorkspaceUsageResponse``)
-#   for ``GET /billing/usage`` — daily usage by model over a date range, derived
-#   from the workspace's LiteLLM proxy usage. The backend stays DAILY (the frontend
-#   aggregates weekly/monthly + filters); spend is reported in CREDITS (the same
-#   denomination the rest of billing uses).
+#   for ``GET /billing/usage`` — daily usage by model over a date range. The backend
+#   stays DAILY (the frontend aggregates weekly/monthly + filters); spend is reported
+#   in CREDITS (the same denomination the rest of billing uses).
+# Updated 2026-06-29 (fix/billing-usage-ledger-source): the usage graph is now
+#   sourced from the workspace's CREDIT LEDGER (the wallet's own meter), not the
+#   LiteLLM proxy — the contract SHAPE is unchanged (the frontend is untouched), but
+#   ``UsageModelStats.tokens`` is 0 from this source (the ledger carries no per-entry
+#   token count). The credit + request figures are accurate.
 
 from __future__ import annotations
 
@@ -80,16 +84,19 @@ class WebhookAck(BaseModel):
 class UsageModelStats(BaseModel):
     """One model's usage within a single day.
 
-    ``credits`` is the day-and-model spend converted to integer credits (the same
-    USD->credits conversion the meter uses: ``round(cost_usd * markup / credit_usd)``,
-    1 credit == $0.01); ``tokens`` is total tokens (prompt + completion); ``requests``
-    is the count of API requests. A model whose rounded credit cost is 0 (sub-credit
-    spend) still appears — usage is real even when the rounded credit cost is 0.
+    ``credits`` is the day-and-model spend in integer credits straight off the
+    wallet's ledger (markup already applied at debit time, 1 credit == $0.01);
+    ``tokens`` is total tokens — currently 0 from the ledger source, which carries
+    no per-entry token count; ``requests`` is the count of charged ledger entries
+    for this model on this day. A model whose credit cost is 0 (sub-credit spend)
+    still appears — usage is real even when the credit cost rounds to 0.
     """
 
     credits: int = Field(..., description="Spend for this model on this day, in credits.")
-    tokens: int = Field(..., description="Total tokens (prompt + completion) for this model.")
-    requests: int = Field(..., description="API request count for this model on this day.")
+    tokens: int = Field(
+        ..., description="Total tokens for this model (0 from the ledger source — no token count)."
+    )
+    requests: int = Field(..., description="Charged request count for this model on this day.")
 
 
 class UsageBucket(BaseModel):
@@ -115,8 +122,8 @@ class WorkspaceUsageResponse(BaseModel):
     a stable legend / color map). ``buckets`` is one entry per day WITH usage, oldest
     first. ``total_credits`` is the grand total over every bucket. The shape is kept
     DAILY on purpose — the frontend aggregates to weekly / monthly and filters by
-    model client-side. A brand-new workspace with no usage (or no provisioned key)
-    yields empty ``models`` + ``buckets`` and ``total_credits`` 0 (HTTP 200).
+    model client-side. A workspace with no spend in the window yields empty
+    ``models`` + ``buckets`` and ``total_credits`` 0 (HTTP 200).
     """
 
     start_date: str

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -30,10 +30,16 @@
 #   session returns the buyer to the app's billing page after pay / cancel (the
 #   prior payment-link checkout had nowhere to send them).
 # Updated 2026-06-29 (feat/billing-usage-endpoint): added GET /billing/usage — the
-#   per-workspace USAGE graph (daily usage by model over a date range, derived from
-#   the workspace's LiteLLM proxy usage; spend reported in credits). Workspace-scoped
-#   via ``current_workspace_id`` (same auth as top-up / subscribe); logic lives in
-#   ``billing.usage``. A brand-new workspace with no usage returns an empty 200.
+#   per-workspace USAGE graph (daily usage by model over a date range; spend
+#   reported in credits). Workspace-scoped via ``current_workspace_id`` (same auth
+#   as top-up / subscribe); logic lives in ``billing.usage``. A brand-new workspace
+#   with no usage returns an empty 200.
+# Updated 2026-06-29 (fix/billing-usage-ledger-source): GET /billing/usage now
+#   sources the graph from the workspace's CREDIT LEDGER (the wallet's own meter,
+#   mode-agnostic) rather than the LiteLLM proxy, so the chart matches the wallet in
+#   every metering mode. The route surface is unchanged (same path, auth, and
+#   ``start_date`` / ``end_date`` query params) — only the docstring wording below
+#   is updated to reflect the source.
 
 from __future__ import annotations
 
@@ -87,7 +93,7 @@ async def list_billing_site_plans() -> SitePlanCatalogResponse:
 
 
 # ``YYYY-MM-DD`` — a light date-shape guard at the edge so a malformed param 422s
-# before the service / proxy is reached (the proxy also requires this format).
+# before the service is reached (the service re-validates + clamps the span).
 _DATE_PATTERN = r"^\d{4}-\d{2}-\d{2}$"
 
 
@@ -107,15 +113,16 @@ async def get_usage(
 ) -> WorkspaceUsageResponse:
     """Return the caller's workspace's daily usage, broken down by model.
 
-    Daily usage (spend in CREDITS, tokens, requests) per model over
-    ``[start_date, end_date]``, derived from the workspace's LiteLLM proxy usage and
-    scoped to that workspace. When both dates are omitted the window defaults to the
-    last 30 days. The response stays DAILY — the frontend aggregates to weekly /
-    monthly and filters by model client-side.
+    Daily usage (spend in CREDITS and request count per model) over
+    ``[start_date, end_date]``, sourced from the workspace's CREDIT LEDGER (the
+    wallet's own meter) and scoped to that workspace — so the chart matches the
+    wallet in every metering mode. When both dates are omitted the window defaults
+    to the last 30 days. The response stays DAILY — the frontend aggregates to
+    weekly / monthly and filters by model client-side. (``tokens`` is reported as 0:
+    the ledger does not carry a per-entry token count.)
 
-    A brand-new workspace with no provisioned key (or simply no usage in the window)
-    returns an empty contract (no models, no buckets, total 0) at HTTP 200 — not an
-    error.
+    A workspace with no spend in the window returns an empty contract (no models,
+    no buckets, total 0) at HTTP 200 — not an error.
     """
     return await usage_service.get_workspace_usage(
         workspace_id,

--- a/ee/pocketpaw_ee/cloud/billing/usage.py
+++ b/ee/pocketpaw_ee/cloud/billing/usage.py
@@ -3,48 +3,76 @@
 # Module-level ``async def`` API (NOT a class, per the EE cloud rule, mirroring the
 # rest of billing / credits / metering). One job: build the daily usage graph the
 # frontend renders — daily usage BROKEN DOWN BY MODEL over a date range — from the
-# workspace's LiteLLM proxy usage.
+# workspace's CREDIT LEDGER (the wallet's own meter).
 #
-# THE SEAM (read before changing the conversion — money-adjacent):
-#   * MAPPING: a workspace maps to its LiteLLM VIRTUAL KEY (NOT a user_id). The
-#     provisioning entity owns that mapping (one ``LiteLLMTenantKey`` row per
-#     workspace, the proxy key minted with metadata={workspace_id}); we resolve it
-#     through ``llm_provisioning.service.get_tenant_key`` rather than touching the
-#     doc (entity isolation — only that entity reads its key doc). The proxy's
-#     /user/daily/activity route accepts an ``api_key`` filter, so we scope usage to
-#     exactly that tenant's key. The admin client calls with the deployment MASTER
-#     key (the proxy treats it as admin view), so the api_key filter is honoured.
-#   * CONVERSION: spend USD -> integer credits via the SAME rate card the meter +
-#     spend-ingest use — ``SpendCredits.to_credits(cost_usd) =
-#     round(cost_usd * markup / credit_usd)`` (markup = billing_markup, default 2.5;
-#     credit_usd default 0.01). We deliberately reuse that conversion (via
-#     ``llm_provisioning.service.load_spend_credits``) rather than a flat
-#     ``round(usd * 100)`` so a dollar of usage SHOWN here equals a dollar of usage
-#     BILLED by the meter — the usage graph and the wallet never disagree. (A flat
-#     *100 would ignore the markup and under-report vs. what was charged.)
-#   * READ-ONLY: this is a pure read. It NEVER debits, NEVER touches the credit
-#     ledger or the spend high-water mark, NEVER calls the cutover/metering path.
-#     It only converts numbers for display.
+# THE SOURCE (read before changing — this is the whole point of the module):
+#   * The graph is sourced from the CREDIT LEDGER, not the LiteLLM proxy. The
+#     ledger is the UNIVERSAL meter: every finished run's compute cost is debited
+#     to it as a negative movement with the run's model on ``ref.model``. In the
+#     DEFAULT metering mode (POCKETPAW_LITELLM_SPEND_MODE=off) the meter
+#     (``metering/service.py:bill_run``) debits the ledger DIRECTLY under
+#     ``cause="compute_spend"`` and NOTHING flows through the proxy; after an
+#     off->live cutover the spend-ingest (``llm_provisioning:ingest_tenant_spend``)
+#     debits under ``cause="litellm_spend"``. Only ONE cause is ever active for a
+#     given run, so reading BOTH is safe (no double-count) and the chart matches
+#     the wallet IN EVERY MODE — by construction, since it is literally the
+#     wallet's own decomposition. (The prior version read the proxy's
+#     /user/daily/activity, which a Free/keyless workspace never populates — so a
+#     workspace deep in the negative showed "No usage to chart yet". This is the
+#     fix for that bug.)
+#   * NO CONVERSION HERE. Ledger credits are already markup-applied at debit time
+#     (the meter / spend-ingest convert USD->credits when they write the
+#     movement), so this read does NO ``to_credits`` and touches NO rate card — it
+#     just surfaces the integers the wallet already holds. That is what makes the
+#     graph and the wallet agree exactly.
+#   * ENTITY ISOLATION. Billing must NOT query ``CreditLedgerEntry`` directly — the
+#     credits entity owns reads of its own ledger doc. The (day, model) breakdown
+#     comes through ``credits.service.spend_by_model`` (a sibling of the existing
+#     ``sum_debits_by_cause``), the same boundary the cutover shadow-compare uses.
+#   * READ-ONLY: a pure read. It NEVER debits, NEVER touches the ledger or the
+#     balance, NEVER calls the cutover/metering path. It only reads + folds.
 #
-# EMPTY / NO-KEY CASE: a brand-new workspace with no provisioned key returns an
-# empty contract (no models, no buckets, total 0) at HTTP 200 — NOT an error, and
-# WITHOUT a proxy call (there is no key to scope). Same for a provisioned workspace
-# that simply had no usage in the window (the proxy returns no rows).
+# TOKENS=0 (a deliberate limitation): the ledger ``ref`` does not carry a token
+# count, so per-model ``tokens`` is reported as 0. The credit + request figures are
+# accurate; a follow-up can add ``total_tokens`` to the debit ``ref`` and surface
+# it here. Do NOT try to recover tokens from elsewhere — they aren't on the wallet.
+#
+# UNKNOWN MODEL: a real charged debit whose ``ref.model`` is absent is bucketed
+# under the model id ``"unknown"`` so its credits STILL count toward the day + the
+# grand total — the chart must reconcile with the wallet, and dropping unattributed
+# spend would make it under-report vs. what was charged.
+#
+# EMPTY CASE: a workspace with no spend in the window (a brand-new workspace, or a
+# provisioned one that simply had no usage) yields an empty contract — no models,
+# no buckets, total 0 — at HTTP 200, NOT an error. There is no proxy / key
+# dependency anymore: the empty case is simply "no ledger rows in the window".
 #
 # Rule 6 — validate at entry (a workspace id is required). Rule 7 — the read is
-# tenant-scoped (the key filter IS the tenant scope). Rule 10 — only CloudError
-# subclasses propagate to HTTP; a proxy read failure raises ``LiteLLMAdminError``
-# (a plain exception) which the route surfaces as a 502 via the cloud error path.
+# tenant-scoped (``spend_by_model`` filters on ``workspace``). The DTOs
+# (``WorkspaceUsageResponse`` / ``UsageBucket`` / ``UsageModelStats``) are
+# unchanged so the response contract stays byte-identical and the frontend is
+# untouched.
 #
 # Created 2026-06-29 (feat/billing-usage-endpoint): new module — the GET
 # /billing/usage transform (LiteLLM /user/daily/activity -> WorkspaceUsageResponse).
+# Changed 2026-06-29 (fix/billing-usage-ledger-source): RE-SOURCED the graph from
+# the credit ledger instead of the LiteLLM proxy daily-activity. The chart showed
+# "No usage to chart yet" for any workspace without a LiteLLM virtual key even
+# though the wallet held real ``compute_spend`` — the chart was wired to the one
+# meter (the proxy) that is empty in the default off-mode. Now reads the wallet's
+# own ledger via ``credits.service.spend_by_model`` (mode-agnostic across
+# compute_spend / litellm_spend), so the chart matches the wallet by construction.
+# Removed the proxy plumbing (get_tenant_key, the _DailyActivityClient Protocol,
+# the LiteLLMAdminClient import, the spend_card / rate-card conversion, the
+# record-folding helpers); kept the date-range validator + clamp and the response
+# contract intact. tokens=0 is now intentional (the ledger ref carries no token
+# count).
 
 from __future__ import annotations
 
 import logging
 import re
-from datetime import UTC, date, datetime, timedelta
-from typing import Any, Protocol
+from datetime import UTC, date, datetime, time, timedelta
 
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.billing.dto import (
@@ -52,8 +80,7 @@ from pocketpaw_ee.cloud.billing.dto import (
     UsageModelStats,
     WorkspaceUsageResponse,
 )
-from pocketpaw_ee.cloud.llm_provisioning import service as provisioning_service
-from pocketpaw_ee.cloud.llm_provisioning.domain import SpendCredits
+from pocketpaw_ee.cloud.credits import service as credits_service
 
 logger = logging.getLogger(__name__)
 
@@ -63,11 +90,9 @@ logger = logging.getLogger(__name__)
 _DEFAULT_WINDOW_DAYS = 30
 
 # A caller-supplied window must be YYYY-MM-DD and span at most a year. The format
-# check fails fast with a clean 400 rather than letting a malformed date reach the
-# proxy (a 502 on the error path); the span clamp bounds the per-request proxy
-# fan-out (the admin client walks pages, so an open-ended range like 2000..2099 is
-# dozens of serial calls). Both apply ONLY to an explicit range — the default
-# window is always sane.
+# check fails fast with a clean 400 rather than letting a malformed date through;
+# the span clamp bounds the per-request fan-out. Both apply ONLY to an explicit
+# range — the default window is always sane.
 _YMD = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _MAX_WINDOW_DAYS = 366
 
@@ -97,35 +122,6 @@ def _resolve_explicit_range(start_date: str, end_date: str) -> tuple[str, str]:
     return start.isoformat(), end.isoformat()
 
 
-class _DailyActivityClient(Protocol):
-    """The slice of LiteLLMAdminClient this module needs. A Protocol so tests can
-    inject a duck-typed fake (no HTTP) and we never construct an httpx client in a
-    unit test."""
-
-    async def user_daily_activity(
-        self, *, start_date: str, end_date: str, api_key: str, page_size: int = ...
-    ) -> list[dict[str, Any]]: ...
-
-
-def _num(value: Any) -> float:
-    """Coerce a proxy spend value to a float, tolerating None / strings (the proxy
-    occasionally serialises numbers as strings)."""
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def _int(value: Any) -> int:
-    """Coerce a token / request count to a non-negative int, tolerating None /
-    strings. A negative / unparseable value clamps to 0."""
-    try:
-        n = int(value)
-    except (TypeError, ValueError):
-        return 0
-    return n if n > 0 else 0
-
-
 def _default_range() -> tuple[str, str]:
     """The default (start_date, end_date) — the trailing 30 days inclusive of today,
     as ``YYYY-MM-DD`` strings in UTC."""
@@ -134,139 +130,82 @@ def _default_range() -> tuple[str, str]:
     return start.isoformat(), today.isoformat()
 
 
-def _record_date(record: dict[str, Any]) -> str | None:
-    """The ``YYYY-MM-DD`` date of a LiteLLM daily record. The proxy serialises the
-    ``date`` field as an ISO date string; we keep just the date portion. None when
-    a record carries no usable date (skipped rather than bucketed under ''
-    )."""
-    raw = record.get("date")
-    if raw is None:
-        return None
-    s = str(raw).strip()
-    if not s:
-        return None
-    # Tolerate a full ISO timestamp by keeping the date head (the proxy emits a bare
-    # date today, but a future shape change to a datetime must not mis-bucket).
-    return s.split("T", 1)[0]
-
-
-def _model_breakdown(record: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """The ``breakdown.models`` map of a daily record (model id -> {metrics, ...}),
-    or an empty dict when absent/malformed. Defensive across shapes so a partial
-    proxy row never crashes the transform."""
-    breakdown = record.get("breakdown")
-    if not isinstance(breakdown, dict):
-        return {}
-    models = breakdown.get("models")
-    if not isinstance(models, dict):
-        return {}
-    return {str(name): m for name, m in models.items() if isinstance(m, dict)}
-
-
 async def get_workspace_usage(
     workspace_id: str,
     *,
     start_date: str | None = None,
     end_date: str | None = None,
-    spend_card: SpendCredits | None = None,
-    daily_activity_client: _DailyActivityClient | None = None,
+    spend_reader=None,
 ) -> WorkspaceUsageResponse:
     """Build the per-workspace daily usage graph over ``[start_date, end_date]``.
 
-    Resolves the workspace's LiteLLM virtual key, reads its daily activity from the
-    proxy (scoped by that key), and folds each day's per-model breakdown into a
-    ``UsageBucket`` with a ``{credits, tokens, requests}`` block per model. Spend USD
-    is converted to credits with the SAME rate card the meter uses (so the graph and
-    the wallet agree). Returns a ``WorkspaceUsageResponse``.
+    Reads the workspace's spend straight from its CREDIT LEDGER (via
+    ``credits.service.spend_by_model``) and folds it into a ``UsageBucket`` per day
+    with a ``{credits, tokens, requests}`` block per model. Credits are the
+    integers the wallet already holds (markup applied at debit time — NO conversion
+    here), so the graph and the wallet agree by construction in every metering mode
+    (the ledger reads both ``compute_spend`` and ``litellm_spend``). Returns a
+    ``WorkspaceUsageResponse``.
 
-    ``start_date`` / ``end_date`` are ``YYYY-MM-DD``; when BOTH are omitted the window
-    defaults to the trailing 30 days. ``spend_card`` / ``daily_activity_client`` are
-    injectable for tests; production resolves the settings-derived rate card and a
-    master-key admin client.
+    ``start_date`` / ``end_date`` are ``YYYY-MM-DD``; when BOTH are omitted the
+    window defaults to the trailing 30 days. ``spend_reader`` is injectable for
+    pure-unit tests (defaults to ``credits.service.spend_by_model``).
 
-    A workspace with NO provisioned key (or no usage in the window) returns an empty
-    contract (no models, no buckets, total 0) — never an error, and the no-key case
-    makes NO proxy call.
+    ``tokens`` is reported as 0 per model — the ledger ``ref`` does not carry a
+    token count (the credit + request figures are accurate). A workspace with no
+    spend in the window returns an empty contract (no models, no buckets, total 0)
+    at HTTP 200 — never an error.
     """
     # Rule 6 — validate at entry.
     if not workspace_id:
         raise ValidationError("billing.invalid_workspace", "workspace_id is required")
 
     if start_date and end_date:
-        # Validate the format + clamp the span before either reaches the proxy.
+        # Validate the format + clamp the span.
         resolved_start, resolved_end = _resolve_explicit_range(start_date, end_date)
     else:
         # Any partial range (only one bound given) falls back to the full default
-        # window — the proxy requires BOTH bounds, so we never send a half range.
+        # window — we never source a half range.
         resolved_start, resolved_end = _default_range()
 
-    # MAPPING: workspace -> its LiteLLM virtual key, via the provisioning entity
-    # (entity isolation — we don't read the key doc directly). No key == a
-    # brand-new workspace with nothing provisioned yet.
-    key = await provisioning_service.get_tenant_key(workspace_id)
-    if not key:
-        # Empty contract, HTTP 200, NO proxy call — there is no key to scope.
-        return WorkspaceUsageResponse(
-            start_date=resolved_start,
-            end_date=resolved_end,
-            models=[],
-            buckets=[],
-            total_credits=0,
-        )
+    # Build the UTC datetime window the ledger read expects: ``since`` is the start
+    # day at 00:00 UTC (inclusive); ``until`` is the day AFTER end_date at 00:00 UTC
+    # (exclusive) so the whole of end_date is included by day. This matches
+    # ``spend_by_model``'s inclusive-since / exclusive-until ``createdAt`` filter.
+    start_day = date.fromisoformat(resolved_start)
+    end_day = date.fromisoformat(resolved_end)
+    since = datetime.combine(start_day, time.min, tzinfo=UTC)
+    until = datetime.combine(end_day + timedelta(days=1), time.min, tzinfo=UTC)
 
-    card = spend_card if spend_card is not None else provisioning_service.load_spend_credits()
-    client = daily_activity_client
-    if client is None:
-        # Lazy import — keep this module free of an import-time httpx dependency, and
-        # so a unit test that injects a fake never constructs a real client.
-        from pocketpaw_ee.catalog.admin_client import LiteLLMAdminClient
+    reader = spend_reader if spend_reader is not None else credits_service.spend_by_model
+    rows = await reader(workspace_id, since=since, until=until)
 
-        client = LiteLLMAdminClient()
-
-    records = await client.user_daily_activity(
-        start_date=resolved_start,
-        end_date=resolved_end,
-        api_key=key,
-    )
-
-    # Fold the daily records into per-day buckets keyed by date. A proxy is expected
-    # to return one record per date for a single-entity query, but we accumulate
-    # defensively so a duplicated date (or a future per-key split) sums correctly.
+    # Fold the (day, model) rows into per-day buckets. ``spend_by_model`` already
+    # aggregates one row per (day, model), so we assign directly; a duplicate
+    # (day, model) would still accumulate defensively.
     buckets: dict[str, dict[str, UsageModelStats]] = {}
     models_seen: set[str] = set()
+    for row in rows:
+        models_seen.add(row.model)
+        per_model = buckets.setdefault(row.day, {})
+        existing = per_model.get(row.model)
+        # ``tokens=0`` intentionally — the ledger ref carries no token count
+        # (see the module header). Credits + requests come straight off the ledger.
+        if existing is None:
+            per_model[row.model] = UsageModelStats(
+                credits=row.credits, tokens=0, requests=row.requests
+            )
+        else:
+            per_model[row.model] = UsageModelStats(
+                credits=existing.credits + row.credits,
+                tokens=0,
+                requests=existing.requests + row.requests,
+            )
 
-    for record in records:
-        day = _record_date(record)
-        if day is None:
-            continue
-        per_model = buckets.setdefault(day, {})
-        for model_id, model_block in _model_breakdown(record).items():
-            metrics = model_block.get("metrics")
-            if not isinstance(metrics, dict):
-                continue
-            credits = card.to_credits(_num(metrics.get("spend")))
-            tokens = _int(metrics.get("total_tokens"))
-            # The proxy splits requests into successful/failed + a combined
-            # api_requests; prefer api_requests (the total attempts), falling back to
-            # successful_requests for an older shape that lacked api_requests.
-            requests = _int(metrics.get("api_requests")) or _int(metrics.get("successful_requests"))
-            models_seen.add(model_id)
-            existing = per_model.get(model_id)
-            if existing is None:
-                per_model[model_id] = UsageModelStats(
-                    credits=credits, tokens=tokens, requests=requests
-                )
-            else:
-                # Accumulate a repeated (date, model) — keeps the transform correct
-                # if the proxy ever returns split rows for the same day+model.
-                per_model[model_id] = UsageModelStats(
-                    credits=existing.credits + credits,
-                    tokens=existing.tokens + tokens,
-                    requests=existing.requests + requests,
-                )
-
-    # Assemble the response: buckets oldest-first, each with its credit total; the
-    # grand total over every bucket; the sorted distinct model list (a stable legend).
+    # Assemble the response: buckets OLDEST-FIRST, each with its credit total; the
+    # grand total over every bucket; the sorted distinct model list (a stable
+    # legend). The "unknown" bucket (debits with no ``ref.model``) is kept so the
+    # total reconciles with the wallet.
     out_buckets: list[UsageBucket] = []
     total_credits = 0
     for day in sorted(buckets):

--- a/ee/pocketpaw_ee/cloud/credits/domain.py
+++ b/ee/pocketpaw_ee/cloud/credits/domain.py
@@ -17,6 +17,12 @@
 # capture emit) or a replay look genuine (a spurious emit). ``created`` is the
 # authoritative signal — set True only when the insert landed, False on
 # ``DuplicateKeyError``.
+# Changed 2026-06-29 (fix/billing-usage-ledger-source): added ``ModelSpendRow`` —
+# one (day, model) spend aggregate the credits service hands back from
+# ``spend_by_model`` so the billing usage graph can be sourced from the wallet's
+# own ledger (the universal meter, mode-agnostic across compute_spend /
+# litellm_spend) instead of the LiteLLM proxy. Framework-free like the other
+# domain shapes — billing consumes this, never the Beanie doc.
 
 from __future__ import annotations
 
@@ -39,6 +45,26 @@ class GrantResult:
 
     balance: int
     created: bool
+
+
+@dataclass(frozen=True)
+class ModelSpendRow:
+    """One (day, model) spend aggregate over a workspace's credit ledger.
+
+    The unit the credits service returns from ``spend_by_model`` so the billing
+    usage graph reads the wallet's own decomposition rather than the LiteLLM
+    proxy. ``day`` is ``YYYY-MM-DD`` (UTC, from the entry's ``createdAt`` date);
+    ``model`` is the charged model id (``ref.model``, or ``"unknown"`` when the
+    debit carried no model); ``credits`` is the POSITIVE credits debited for that
+    (day, model) over the window; ``requests`` is the number of ledger entries in
+    that group (a proxy for request count — the ledger ``ref`` does not carry a
+    token count, so tokens are not recoverable here).
+    """
+
+    day: str
+    model: str
+    credits: int
+    requests: int
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -112,6 +112,17 @@
 # tenant's window so the llm_provisioning entity never reads the credit ledger doc
 # directly (the credits service owns reads of its own ``CreditLedgerEntry``). It
 # performs NO writes — shadow mode debits nothing.
+# Changed 2026-06-29 (fix/billing-usage-ledger-source): added ``spend_by_model`` —
+# a read-only, tenant-filtered breakdown of spend credits by (UTC day, model)
+# over a ``createdAt`` window, summed across the spend causes
+# (``compute_spend`` + ``litellm_spend``, only ``applied`` entries). The billing
+# usage graph reads through it so the "Usage by model" chart is sourced from the
+# wallet's OWN ledger (the universal meter, mode-agnostic) instead of the LiteLLM
+# proxy — which is empty in the default off-mode where finished runs debit the
+# ledger directly and never route through the proxy. EE entity-isolation: billing
+# must not read ``CreditLedgerEntry`` itself, so this owns the read (sibling to
+# ``sum_debits_by_cause``). It performs NO writes and changes NOTHING that is
+# charged — a pure re-source of the display.
 
 from __future__ import annotations
 
@@ -126,7 +137,7 @@ from pymongo.errors import DuplicateKeyError
 from pocketpaw_ee.cloud._core.errors import InsufficientCredits, ValidationError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import CreditMovement
-from pocketpaw_ee.cloud.credits.domain import GrantResult, LedgerEntry
+from pocketpaw_ee.cloud.credits.domain import GrantResult, LedgerEntry, ModelSpendRow
 from pocketpaw_ee.cloud.models.credit import CreditBalance, CreditLedgerEntry
 
 logger = logging.getLogger(__name__)
@@ -471,6 +482,79 @@ async def sum_debits_by_cause(
     return total, len(entries)
 
 
+async def spend_by_model(
+    workspace: str,
+    *,
+    since: datetime,
+    until: datetime,
+    causes: tuple[str, ...] = ("compute_spend", "litellm_spend"),
+) -> list[ModelSpendRow]:
+    """Break a workspace's spend down by (UTC day, model) over a window.
+
+    Returns one ``ModelSpendRow`` per (day, model) that had spend in the window,
+    summed across ``causes``. This is the read the billing usage graph uses so the
+    "Usage by model" chart is sourced from the wallet's OWN ledger — the universal
+    meter — rather than the LiteLLM proxy. The two spend causes
+    (``compute_spend`` in the default off-mode, ``litellm_spend`` after a live
+    cutover) are mutually exclusive per run, so reading both is safe: a given run
+    is billed under exactly one cause and an off->live cutover leaves both in
+    history with no double-count.
+
+    The window is on ``createdAt``: ``since`` is inclusive (``>=``), ``until`` is
+    EXCLUSIVE (``<``) — identical to ``sum_debits_by_cause`` so adjacent windows
+    never double-count a boundary entry. Only ``applied is True`` entries are
+    counted (a committed-but-unapplied phantom never moved the wallet, so it must
+    not appear on the chart, the same rule ``reconcile`` enforces).
+
+    Per entry: ``day`` is ``createdAt.date()`` in UTC (``YYYY-MM-DD``); ``model``
+    is ``ref.model`` or ``"unknown"`` when the debit carried no model (real
+    charged spend with no model still counts toward the day so the chart
+    reconciles with the wallet); ``credits`` is the POSITIVE amount debited (a
+    stray positive delta is clamped out, like ``sum_debits_by_cause``). ``requests``
+    is the COUNT of entries in the (day, model) group — the ledger ``ref`` does not
+    carry a token count, so tokens are not recoverable here (a follow-up could add
+    ``total_tokens`` to the debit ``ref``).
+
+    EE entity-isolation: billing must not read ``CreditLedgerEntry`` directly, so
+    this owns the read (sibling to ``sum_debits_by_cause``). It performs NO writes.
+    """
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+
+    query: dict[str, Any] = {
+        "workspace": workspace,
+        "cause": {"$in": list(causes)},
+        "applied": True,
+        "createdAt": {"$gte": since, "$lt": until},
+    }
+    entries = await CreditLedgerEntry.find(query).to_list()
+
+    # In-Python aggregation over the fetched window (bounded — matches
+    # ``sum_debits_by_cause``). Group by (UTC day, model); sum positive-debited
+    # credits and count entries. A stray positive ``amount_delta`` under a spend
+    # cause (there should be none — spend is debit-only) is skipped so a bad row
+    # can't make a group read as a refund.
+    grouped: dict[tuple[str, str], list[int]] = {}  # (day, model) -> [credits, requests]
+    for e in entries:
+        delta = int(e.amount_delta)
+        if delta >= 0:
+            continue
+        created = getattr(e, "createdAt", None)
+        if created is None:
+            continue
+        day = created.date().isoformat()
+        ref = e.ref or {}
+        model = ref.get("model") or "unknown"
+        bucket = grouped.setdefault((day, model), [0, 0])
+        bucket[0] += -delta  # positive credits debited
+        bucket[1] += 1  # one more request in this group
+
+    return [
+        ModelSpendRow(day=day, model=model, credits=credits, requests=requests)
+        for (day, model), (credits, requests) in grouped.items()
+    ]
+
+
 async def history(
     workspace: str,
     *,
@@ -669,6 +753,7 @@ async def reconcile(workspace: str) -> int:
 
 __all__ = [
     "GrantResult",
+    "ModelSpendRow",
     "balance",
     "check_balance",
     "debit",
@@ -676,5 +761,6 @@ __all__ = [
     "history",
     "is_recorded",
     "reconcile",
+    "spend_by_model",
     "sum_debits_by_cause",
 ]

--- a/tests/cloud/billing/test_usage.py
+++ b/tests/cloud/billing/test_usage.py
@@ -1,34 +1,39 @@
 # tests/cloud/billing/test_usage.py — proves the per-workspace USAGE transform
-# (the billing usage-graph seam). The frontend renders a daily usage graph
-# broken down by model from a workspace's LiteLLM proxy usage; this module locks
-# the transform LiteLLM ``/user/daily/activity`` -> the WorkspaceUsage contract,
-# including the USD->credits conversion (money-adjacent — pinned, not ambient).
+# (the billing usage-graph seam). The frontend renders a daily usage graph broken
+# down by model; this module locks the transform CREDIT LEDGER -> the
+# WorkspaceUsage contract.
 #
 # Asserts:
-#   * the workspace -> LiteLLM virtual key mapping is resolved (via the provisioning
-#     service's get_tenant_key) and passed as the ``api_key`` filter to the proxy
-#     daily-activity read — usage is scoped to exactly that tenant's key.
-#   * each LiteLLM daily record's ``breakdown.models[<model>].metrics`` is folded
-#     into a daily bucket with a per-model {credits, tokens, requests} breakdown,
-#     the spend USD converted to credits via the SAME rate card the meter uses
-#     (round(cost_usd * markup / credit_usd) — a dollar shown == a dollar billed).
+#   * each charged ledger movement (``compute_spend`` / ``litellm_spend``, with the
+#     run's ``model`` on ``ref``) is folded into a daily bucket with a per-model
+#     {credits, tokens, requests} block; credits come STRAIGHT off the ledger
+#     (markup already applied at debit time — no conversion here), so the chart
+#     matches the wallet by construction.
 #   * ``models`` is the sorted distinct union across the range; ``total_credits``
 #     is the sum over every bucket; each bucket's ``total_credits`` sums its models.
+#   * ``tokens`` is 0 (the ledger ref carries no token count) and ``requests`` is
+#     the count of charged entries in the (day, model) group.
 #   * default date range = last 30 days when start/end omitted, and the resolved
 #     range is echoed onto the response.
-#   * a workspace with NO provisioned key -> empty buckets + empty models +
-#     total_credits 0 (HTTP 200, not an error) and NO proxy call.
-#   * pagination: when the proxy reports ``metadata.has_more`` the service walks
-#     every page and merges the daily records.
+#   * a workspace with no spend in the window -> empty buckets + empty models +
+#     total_credits 0 (HTTP 200, not an error).
+#   * the explicit-range validator + clamp (format / inverted / oversized-span)
+#     surface a clean ValidationError before the read.
 #
-# A FAKE daily-activity client (duck-typed, no HTTP) stands in for the proxy — the
-# admin client's own HTTP wiring (the new ``user_daily_activity`` method) is
-# covered separately in tests/cloud/catalog/test_admin_client.py. Uses the shared
-# ``mongo_db`` fixture (Beanie over ALL_DOCUMENTS) so get_tenant_key reads a real
-# persisted LiteLLMTenantKey row, the same DB-fixture pattern the provisioning /
-# credits tests use.
+# Uses the shared ``mongo_db`` fixture (Beanie over ALL_DOCUMENTS) so the read
+# path queries real persisted ``CreditLedgerEntry`` rows — the same DB-fixture
+# pattern the credits / provisioning tests use. ``createdAt`` is back-dated via the
+# raw collection because ``TimestampedDocument``'s @before_event(Insert) stamps
+# createdAt=now, so a past date can't be set through the constructor.
 #
 # Created 2026-06-29 (feat/billing-usage-endpoint): new test module.
+# Changed 2026-06-29 (fix/billing-usage-ledger-source): REWROTE the data-source
+# tests to seed the CREDIT LEDGER instead of a LiteLLM proxy fake — the graph is
+# now sourced from the wallet's own ledger, not the proxy /user/daily/activity
+# (the proxy was empty in the default off-mode, so the chart showed "No usage to
+# chart yet" despite real spend). Dropped the FakeDailyActivity / ensure_tenant_key
+# / proxy-transform machinery; kept the source-independent validator tests verbatim
+# and re-expressed the default-30-day-window test against the ledger.
 
 from __future__ import annotations
 
@@ -37,211 +42,150 @@ from datetime import UTC, date, datetime, timedelta
 import pytest
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.billing import usage
-from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
-from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
 
 WS = "ws_usage_test"
-
-# Pin the spend rate card so credits never depend on ambient POCKETPAW_* settings:
-# credits = round(cost_usd * 2.5 / 0.01) = round(cost_usd * 250). Identical to the
-# card the meter + spend-ingest use, so a dollar of usage shown matches a dollar
-# billed.
-SPEND = SpendCredits(markup=2.5, credit_usd=0.01)
-
-BUDGET = KeyBudget(max_budget_usd=25.0, budget_duration="30d", rpm_limit=60, tpm_limit=0, models=[])
+SONNET = "anthropic/claude-3-5-sonnet"
+GPT = "openai/gpt-4o"
 
 
-def _metrics(spend: float, prompt: int, completion: int, requests: int) -> dict:
-    """A LiteLLM ``SpendMetrics``-shaped dict (the per-model / per-day metric block)."""
-    return {
-        "spend": spend,
-        "prompt_tokens": prompt,
-        "completion_tokens": completion,
-        "total_tokens": prompt + completion,
-        "cache_read_input_tokens": 0,
-        "cache_creation_input_tokens": 0,
-        "successful_requests": requests,
-        "failed_requests": 0,
-        "api_requests": requests,
-    }
+async def _seed_spend(
+    ws: str,
+    *,
+    day: tuple[int, int, int],
+    model: str | None,
+    credits: int,
+    idem: str,
+    cause: str = "compute_spend",
+) -> None:
+    """Insert one APPLIED debit ledger entry stamped on a controlled date.
 
-
-def _day(date_str: str, models: dict[str, dict]) -> dict:
-    """A LiteLLM ``DailySpendData``-shaped record: a date + a breakdown.models map
-    (each model -> {"metrics": SpendMetrics}). The day-level ``metrics`` block is
-    present for shape-fidelity but the transform reads the per-model breakdown."""
-    day_metrics = _metrics(
-        sum(m["__spend"] for m in models.values()),
-        0,
-        0,
-        sum(m["__requests"] for m in models.values()),
-    )
-    breakdown_models = {
-        name: {"metrics": m["metrics"], "metadata": {}, "api_key_breakdown": {}}
-        for name, m in models.items()
-    }
-    return {"date": date_str, "metrics": day_metrics, "breakdown": {"models": breakdown_models}}
-
-
-def _model_entry(spend: float, prompt: int, completion: int, requests: int) -> dict:
-    """Helper bundling a model's metrics + its raw spend/requests (for the day total)."""
-    return {
-        "metrics": _metrics(spend, prompt, completion, requests),
-        "__spend": spend,
-        "__requests": requests,
-    }
-
-
-class FakeDailyActivity:
-    """In-memory stand-in for LiteLLMAdminClient.user_daily_activity (no HTTP).
-
-    ``pages`` is a list of response bodies (each a SpendAnalyticsPaginatedResponse-
-    shaped dict). The method returns the merged ``results`` across all pages and
-    records the kwargs it was called with so the test can assert the api_key filter
-    + date range round-tripped. ``calls`` counts invocations (0 proves the no-key
-    path makes no proxy call).
+    Mirrors what ``metering.service.bill_run`` writes: a negative ``amount_delta``
+    under ``cause`` with the run's ``model`` in ``ref``. Inserts first (the Insert
+    event forces createdAt=now), then back-dates ``createdAt`` via the raw
+    collection so the (day, model) bucketing can be asserted. ``model=None`` seeds a
+    debit with no ``ref.model`` (the "unknown" bucket).
     """
-
-    def __init__(self, *, pages: list[dict] | None = None) -> None:
-        self.calls = 0
-        self.last_kwargs: dict | None = None
-        self._pages = pages if pages is not None else [{"results": [], "metadata": {}}]
-
-    async def user_daily_activity(
-        self, *, start_date: str, end_date: str, api_key: str, page_size: int = 1000
-    ) -> list[dict]:
-        self.calls += 1
-        self.last_kwargs = {
-            "start_date": start_date,
-            "end_date": end_date,
-            "api_key": api_key,
-            "page_size": page_size,
-        }
-        merged: list[dict] = []
-        for body in self._pages:
-            merged.extend(body.get("results", []))
-        return merged
-
-
-# ---------------------------------------------------------------------------
-# The transform — LiteLLM daily activity -> the WorkspaceUsage contract.
-# ---------------------------------------------------------------------------
-
-
-async def test_usage_transforms_daily_activity_into_buckets_by_model(mongo_db):
-    # Provision the workspace so get_tenant_key resolves a real virtual key.
-    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=_FakeAdmin())
-
-    sonnet = "anthropic/claude-3-5-sonnet"
-    gpt = "openai/gpt-4o"
-    pages = [
-        {
-            "results": [
-                # Day 1: two models. sonnet $0.04 -> 10 credits; gpt $0.02 -> 5 credits.
-                _day(
-                    "2026-06-01",
-                    {
-                        sonnet: _model_entry(0.04, 1000, 200, 3),
-                        gpt: _model_entry(0.02, 500, 100, 2),
-                    },
-                ),
-                # Day 2: sonnet only. $0.10 -> 25 credits.
-                _day("2026-06-02", {sonnet: _model_entry(0.10, 4000, 800, 7)}),
-            ],
-            "metadata": {"has_more": False, "page": 1, "total_pages": 1},
-        }
-    ]
-    client = FakeDailyActivity(pages=pages)
-
-    result = await usage.get_workspace_usage(
-        WS,
-        start_date="2026-06-01",
-        end_date="2026-06-02",
-        spend_card=SPEND,
-        daily_activity_client=client,
+    ref = {"model": model} if model is not None else {}
+    entry = CreditLedgerEntry(
+        workspace=ws,
+        kind="spend",
+        amount_delta=-credits,
+        balance_after=0,
+        applied=True,
+        conditional=False,
+        cause=cause,
+        ref=ref,
+        idempotency_key=idem,
+    )
+    await entry.insert()
+    when = datetime(day[0], day[1], day[2], 12, 0, tzinfo=UTC)
+    await CreditLedgerEntry.get_pymongo_collection().update_one(
+        {"_id": entry.id}, {"$set": {"createdAt": when}}
     )
 
-    # The proxy read was scoped to the workspace's virtual key over the given range.
-    assert client.calls == 1
-    assert client.last_kwargs["api_key"] == "sk-ws-ws_usage_test"
-    assert client.last_kwargs["start_date"] == "2026-06-01"
-    assert client.last_kwargs["end_date"] == "2026-06-02"
+
+# ---------------------------------------------------------------------------
+# The transform — credit ledger -> the WorkspaceUsage contract.
+# ---------------------------------------------------------------------------
+
+
+async def test_usage_transforms_ledger_into_buckets_by_model(mongo_db):
+    # Day 1: two models. Day 2: sonnet only.
+    await _seed_spend(WS, day=(2026, 6, 1), model=SONNET, credits=10, idem="r1")
+    await _seed_spend(WS, day=(2026, 6, 1), model=GPT, credits=5, idem="r2")
+    await _seed_spend(WS, day=(2026, 6, 2), model=SONNET, credits=25, idem="r3")
+
+    result = await usage.get_workspace_usage(WS, start_date="2026-06-01", end_date="2026-06-02")
 
     # Echoed range.
     assert result.start_date == "2026-06-01"
     assert result.end_date == "2026-06-02"
 
     # Distinct model list, sorted (alphabetical: "anthropic/..." before "openai/...").
-    assert result.models == sorted([gpt, sonnet])
-    assert result.models == [sonnet, gpt]
+    assert result.models == sorted([GPT, SONNET])
+    assert result.models == [SONNET, GPT]
 
     # Two daily buckets.
     assert [b.date for b in result.buckets] == ["2026-06-01", "2026-06-02"]
 
     b1 = result.buckets[0]
-    assert b1.by_model[sonnet].credits == 10  # round(0.04 * 250)
-    assert b1.by_model[sonnet].tokens == 1200  # prompt + completion
-    assert b1.by_model[sonnet].requests == 3
-    assert b1.by_model[gpt].credits == 5  # round(0.02 * 250)
-    assert b1.by_model[gpt].tokens == 600
-    assert b1.by_model[gpt].requests == 2
+    assert b1.by_model[SONNET].credits == 10
+    assert b1.by_model[SONNET].tokens == 0  # ledger carries no token count
+    assert b1.by_model[SONNET].requests == 1
+    assert b1.by_model[GPT].credits == 5
+    assert b1.by_model[GPT].requests == 1
     assert b1.total_credits == 15  # 10 + 5
 
     b2 = result.buckets[1]
-    assert set(b2.by_model.keys()) == {sonnet}
-    assert b2.by_model[sonnet].credits == 25  # round(0.10 * 250)
-    assert b2.by_model[sonnet].tokens == 4800
+    assert set(b2.by_model.keys()) == {SONNET}
+    assert b2.by_model[SONNET].credits == 25
     assert b2.total_credits == 25
 
-    # Grand total over every bucket.
+    # Grand total over every bucket — matches the wallet's spend over the window.
     assert result.total_credits == 40  # 15 + 25
 
 
+async def test_usage_aggregates_repeated_day_model_requests(mongo_db):
+    # Two charged runs for the same (day, model) accumulate: credits sum and the
+    # request count is the number of entries.
+    await _seed_spend(WS, day=(2026, 6, 1), model=SONNET, credits=4, idem="r1")
+    await _seed_spend(WS, day=(2026, 6, 1), model=SONNET, credits=6, idem="r2")
+
+    result = await usage.get_workspace_usage(WS, start_date="2026-06-01", end_date="2026-06-01")
+
+    assert result.models == [SONNET]
+    b1 = result.buckets[0]
+    assert b1.by_model[SONNET].credits == 10  # 4 + 6
+    assert b1.by_model[SONNET].requests == 2  # two entries
+    assert result.total_credits == 10
+
+
 async def test_usage_defaults_to_last_30_days_when_range_omitted(mongo_db):
-    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=_FakeAdmin())
-    client = FakeDailyActivity(pages=[{"results": [], "metadata": {}}])
-
-    result = await usage.get_workspace_usage(WS, spend_card=SPEND, daily_activity_client=client)
-
     today = datetime.now(UTC).date()
     expected_start = (today - timedelta(days=29)).isoformat()  # inclusive 30-day window
     expected_end = today.isoformat()
 
-    assert result.start_date == expected_start
-    assert result.end_date == expected_end
-    assert client.last_kwargs["start_date"] == expected_start
-    assert client.last_kwargs["end_date"] == expected_end
-    # No usage -> empty, but a key exists so the proxy WAS queried.
-    assert result.buckets == []
-    assert result.models == []
-    assert result.total_credits == 0
-
-
-async def test_usage_unprovisioned_workspace_returns_empty_no_proxy_call(mongo_db):
-    # No LiteLLMTenantKey row for WS -> brand-new workspace, no usage yet.
-    assert await provisioning.get_tenant_key(WS) is None
-    client = FakeDailyActivity(pages=[{"results": [_day("2026-06-01", {})]}])
-
-    result = await usage.get_workspace_usage(
-        WS,
-        start_date="2026-06-01",
-        end_date="2026-06-30",
-        spend_card=SPEND,
-        daily_activity_client=client,
+    # Seed a spend INSIDE the default window (today) and one OUTSIDE it (40 days ago)
+    # so the default-window selection is actually exercised, not just the echo.
+    inside = today
+    outside = today - timedelta(days=40)
+    await _seed_spend(
+        WS, day=(inside.year, inside.month, inside.day), model=SONNET, credits=7, idem="in"
+    )
+    await _seed_spend(
+        WS, day=(outside.year, outside.month, outside.day), model=SONNET, credits=99, idem="out"
     )
 
-    # Empty contract, NOT an error — and the proxy is never called (no key to scope).
+    result = await usage.get_workspace_usage(WS)
+
+    assert result.start_date == expected_start
+    assert result.end_date == expected_end
+    # Only the in-window spend is charted; the 40-day-old row is excluded.
+    assert result.total_credits == 7
+    assert [b.date for b in result.buckets] == [inside.isoformat()]
+
+
+async def test_usage_empty_when_no_spend_in_window(mongo_db):
+    # No ledger rows for WS -> empty contract, HTTP 200 (not an error).
+    result = await usage.get_workspace_usage(WS, start_date="2026-06-01", end_date="2026-06-30")
+
     assert result.buckets == []
     assert result.models == []
     assert result.total_credits == 0
     assert result.start_date == "2026-06-01"
     assert result.end_date == "2026-06-30"
-    assert client.calls == 0
+
+
+async def test_usage_invalid_workspace_rejected(mongo_db):
+    with pytest.raises(ValidationError):
+        await usage.get_workspace_usage("", start_date="2026-06-01", end_date="2026-06-02")
 
 
 # --- HARDENING (fix/billing-usage-validate): the explicit-range validator + clamp.
 #     A caller-supplied range is format-checked, inverted-checked, and span-clamped
-#     before it reaches the proxy (a clean 400 instead of a 502, and a bounded fan-out). ---
+#     before it reaches the read (a clean 400, and a bounded window). These are
+#     source-independent — kept verbatim across the ledger re-source. ---
 
 
 def test_resolve_explicit_range_rejects_malformed_dates():
@@ -270,74 +214,3 @@ def test_resolve_explicit_range_passes_valid_window_through():
         "2026-06-01",
         "2026-06-30",
     )
-
-
-async def test_usage_walks_every_page_when_has_more(mongo_db):
-    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=_FakeAdmin())
-    sonnet = "anthropic/claude-3-5-sonnet"
-    # Two pages: the client merges both pages' results (pagination is the client's
-    # job; the service sees the merged list). Distinct dates across pages.
-    pages = [
-        {
-            "results": [_day("2026-06-01", {sonnet: _model_entry(0.04, 1000, 200, 1)})],
-            "metadata": {"has_more": True, "page": 1, "total_pages": 2},
-        },
-        {
-            "results": [_day("2026-06-02", {sonnet: _model_entry(0.02, 500, 100, 1)})],
-            "metadata": {"has_more": False, "page": 2, "total_pages": 2},
-        },
-    ]
-    client = FakeDailyActivity(pages=pages)
-
-    result = await usage.get_workspace_usage(
-        WS,
-        start_date="2026-06-01",
-        end_date="2026-06-02",
-        spend_card=SPEND,
-        daily_activity_client=client,
-    )
-
-    assert [b.date for b in result.buckets] == ["2026-06-01", "2026-06-02"]
-    assert result.total_credits == 15  # 10 + 5
-
-
-async def test_usage_sub_credit_spend_rounds_to_zero(mongo_db):
-    # A tiny spend below half a credit rounds to 0 credits (no phantom charge) but
-    # the model still appears with its tokens/requests — usage is real even if the
-    # rounded credit cost is 0.
-    await provisioning.ensure_tenant_key(WS, budget=BUDGET, admin_client=_FakeAdmin())
-    sonnet = "anthropic/claude-3-5-sonnet"
-    pages = [
-        {
-            "results": [_day("2026-06-01", {sonnet: _model_entry(0.0001, 5, 1, 1)})],
-            "metadata": {"has_more": False},
-        }
-    ]
-    client = FakeDailyActivity(pages=pages)
-
-    result = await usage.get_workspace_usage(
-        WS,
-        start_date="2026-06-01",
-        end_date="2026-06-01",
-        spend_card=SPEND,
-        daily_activity_client=client,
-    )
-
-    assert result.models == [sonnet]
-    b1 = result.buckets[0]
-    assert b1.by_model[sonnet].credits == 0  # round(0.0001 * 250) == 0
-    assert b1.by_model[sonnet].tokens == 6
-    assert b1.by_model[sonnet].requests == 1
-    assert b1.total_credits == 0
-    assert result.total_credits == 0
-
-
-# ---------------------------------------------------------------------------
-# Minimal fake admin client to provision a key (no HTTP) — mirrors the
-# provisioning test's FakeAdmin (only the generate_key surface is needed here).
-# ---------------------------------------------------------------------------
-
-
-class _FakeAdmin:
-    async def generate_key(self, **kwargs):
-        return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **kwargs}

--- a/tests/cloud/billing/test_usage_ledger_source.py
+++ b/tests/cloud/billing/test_usage_ledger_source.py
@@ -1,0 +1,148 @@
+# tests/cloud/billing/test_usage_ledger_source.py — REGRESSION for the
+# "No usage to chart yet" bug: the per-workspace usage graph must render spend
+# that exists in the CREDIT LEDGER even when the workspace has NO LiteLLM virtual
+# key. In the default metering mode (BC-3) a finished run's compute cost is
+# debited to the ledger as a ``compute_spend`` movement and NEVER routed through
+# the LiteLLM proxy — so a workspace can carry real spend (the dashboard's
+# "Recent activity" list is full) while the proxy's /user/daily/activity is empty.
+# The chart was sourced from the proxy, so it showed the empty state despite the
+# wallet being well into the negative. This test pins the corrected contract: the
+# graph is built from the wallet's own ledger, so the chart and the wallet agree.
+#
+# Seeds APPLIED debit entries directly (the read path is what's under test), one
+# per (day, model). ``createdAt`` is back-dated via the raw collection because
+# ``TimestampedDocument``'s @before_event(Insert) stamps createdAt=now, so a past
+# date can't be set through the constructor.
+#
+# Created 2026-06-29 (fix/billing-usage-ledger-source): RED anchor for
+# re-sourcing get_workspace_usage from the credit ledger instead of the LiteLLM
+# proxy daily-activity.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud.billing import usage
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+
+WS = "ws_usage_ledger_test"
+SONNET = "anthropic/claude-3-5-sonnet"
+GPT = "openai/gpt-4o"
+
+
+async def _seed_spend(
+    ws: str,
+    *,
+    day: tuple[int, int, int],
+    model: str,
+    credits: int,
+    idem: str,
+    cause: str = "compute_spend",
+) -> None:
+    """Insert one APPLIED debit ledger entry stamped on a controlled date.
+
+    Mirrors what ``metering.service.bill_run`` writes: a negative ``amount_delta``
+    under ``cause`` with the run's ``model`` in ``ref``. Inserts first (the Insert
+    event forces createdAt=now), then back-dates ``createdAt`` via the raw
+    collection so the (day, model) bucketing can be asserted.
+    """
+    entry = CreditLedgerEntry(
+        workspace=ws,
+        kind="spend",
+        amount_delta=-credits,
+        balance_after=0,
+        applied=True,
+        conditional=False,
+        cause=cause,
+        ref={"model": model},
+        idempotency_key=idem,
+    )
+    await entry.insert()
+    when = datetime(day[0], day[1], day[2], 12, 0, tzinfo=UTC)
+    await CreditLedgerEntry.get_pymongo_collection().update_one(
+        {"_id": entry.id}, {"$set": {"createdAt": when}}
+    )
+
+
+async def test_usage_renders_ledger_compute_spend_without_litellm_key(mongo_db):
+    """A workspace with compute_spend in the ledger but NO LiteLLM key renders its
+    spend on the chart (the bug returned an empty contract here)."""
+    # The exact bug scenario: real spend, no provisioned proxy key.
+    assert await provisioning.get_tenant_key(WS) is None
+
+    # Day 1: two models. Day 2: sonnet only.
+    await _seed_spend(WS, day=(2026, 6, 1), model=SONNET, credits=10, idem="run:r1")
+    await _seed_spend(WS, day=(2026, 6, 1), model=GPT, credits=5, idem="run:r2")
+    await _seed_spend(WS, day=(2026, 6, 2), model=SONNET, credits=25, idem="run:r3")
+
+    result = await usage.get_workspace_usage(WS, start_date="2026-06-01", end_date="2026-06-02")
+
+    # Pre-fix: no key -> the proxy source returns models=[], buckets=[] ("No usage
+    # to chart yet"). Post-fix: the ledger spend renders and matches the wallet.
+    assert result.models == [SONNET, GPT]  # sorted distinct union
+    assert [b.date for b in result.buckets] == ["2026-06-01", "2026-06-02"]
+
+    b1 = result.buckets[0]
+    assert b1.by_model[SONNET].credits == 10
+    assert b1.by_model[GPT].credits == 5
+    assert b1.total_credits == 15
+
+    b2 = result.buckets[1]
+    assert set(b2.by_model.keys()) == {SONNET}
+    assert b2.by_model[SONNET].credits == 25
+    assert b2.total_credits == 25
+
+    # The grand total equals the wallet's compute spend over the window.
+    assert result.total_credits == 40
+
+
+async def test_usage_includes_litellm_spend_cause_after_cutover(mongo_db):
+    """After an off->live cutover the ledger carries ``litellm_spend`` entries; the
+    graph reads both causes so it still matches the wallet (no double-count — a run
+    is billed under exactly one cause)."""
+    assert await provisioning.get_tenant_key(WS) is None
+
+    await _seed_spend(
+        WS, day=(2026, 6, 1), model=SONNET, credits=8, idem="run:bc3", cause="compute_spend"
+    )
+    await _seed_spend(
+        WS, day=(2026, 6, 2), model=SONNET, credits=12, idem="ingest:live", cause="litellm_spend"
+    )
+
+    result = await usage.get_workspace_usage(WS, start_date="2026-06-01", end_date="2026-06-02")
+
+    assert result.models == [SONNET]
+    assert result.total_credits == 20  # 8 (compute_spend) + 12 (litellm_spend)
+
+
+async def test_usage_excludes_non_spend_causes(mongo_db):
+    """A top_up / grant movement is NOT compute usage and must not appear on the
+    usage-by-model graph (only spend causes are charted)."""
+    assert await provisioning.get_tenant_key(WS) is None
+
+    await _seed_spend(
+        WS, day=(2026, 6, 1), model=SONNET, credits=10, idem="run:spend", cause="compute_spend"
+    )
+    # A positive grant under a non-spend cause (seeded as a movement on the ledger).
+    grant = CreditLedgerEntry(
+        workspace=WS,
+        kind="grant",
+        amount_delta=5000,
+        balance_after=0,
+        applied=True,
+        conditional=False,
+        cause="top_up",
+        ref={},
+        idempotency_key="topup:1",
+    )
+    await grant.insert()
+    await CreditLedgerEntry.get_pymongo_collection().update_one(
+        {"_id": grant.id}, {"$set": {"createdAt": datetime(2026, 6, 1, 12, 0, tzinfo=UTC)}}
+    )
+
+    result = await usage.get_workspace_usage(WS, start_date="2026-06-01", end_date="2026-06-01")
+
+    # Only the compute_spend movement is charted; the top_up is ignored.
+    assert result.models == [SONNET]
+    assert result.total_credits == 10

--- a/tests/cloud/credits/test_spend_by_model.py
+++ b/tests/cloud/credits/test_spend_by_model.py
@@ -1,0 +1,234 @@
+# tests/cloud/credits/test_spend_by_model.py — proves the BC-1 credits service's
+# ``spend_by_model`` read: the (UTC day, model) spend breakdown the billing usage
+# graph is sourced from. The wallet's own ledger is the universal meter, so this
+# read is what makes the "Usage by model" chart reconcile with the wallet.
+#
+# Covers:
+#   * the cause filter — only the spend causes (compute_spend / litellm_spend) feed
+#     it; a top_up / grant under another cause is excluded.
+#   * the ``applied is False`` exclusion — a committed-but-unapplied phantom never
+#     moved the wallet, so it must not appear on the chart.
+#   * the EXCLUSIVE ``until`` boundary — an entry stamped exactly at ``until`` is
+#     out; one at ``since`` is in (inclusive since / exclusive until, identical to
+#     ``sum_debits_by_cause`` so adjacent windows never double-count).
+#   * multi-day / multi-model aggregation and the per-group request count.
+#   * a debit with no ``ref.model`` -> the "unknown" bucket (its credits still count
+#     so the total reconciles with the wallet).
+#
+# Uses the shared ``mongo_db`` fixture (mongomock-motor + Beanie over ALL_DOCUMENTS).
+# ``createdAt`` is back-dated via the raw collection (the Insert event stamps
+# createdAt=now, so a controlled date can't be set through the constructor).
+#
+# Created 2026-06-29 (fix/billing-usage-ledger-source): new test module — unit
+# coverage for the ledger read that re-sources the billing usage graph.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.credits.domain import ModelSpendRow
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+
+WS = "ws_spend_by_model"
+SONNET = "anthropic/claude-3-5-sonnet"
+GPT = "openai/gpt-4o"
+
+
+async def _seed(
+    *,
+    when: datetime,
+    amount_delta: int,
+    model: str | None = SONNET,
+    cause: str = "compute_spend",
+    applied: bool = True,
+    idem: str,
+    ws: str = WS,
+) -> None:
+    """Insert one ledger entry stamped at ``when`` (back-dated via the raw
+    collection so the window boundaries can be asserted)."""
+    ref = {"model": model} if model is not None else {}
+    entry = CreditLedgerEntry(
+        workspace=ws,
+        kind="spend",
+        amount_delta=amount_delta,
+        balance_after=0,
+        applied=applied,
+        conditional=False,
+        cause=cause,
+        ref=ref,
+        idempotency_key=idem,
+    )
+    await entry.insert()
+    await CreditLedgerEntry.get_pymongo_collection().update_one(
+        {"_id": entry.id}, {"$set": {"createdAt": when}}
+    )
+
+
+def _by_key(rows: list[ModelSpendRow]) -> dict[tuple[str, str], ModelSpendRow]:
+    return {(r.day, r.model): r for r in rows}
+
+
+async def test_groups_by_day_and_model_with_request_counts(mongo_db):
+    # Day 1: two sonnet runs + one gpt run. Day 2: one sonnet run.
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC), amount_delta=-4, model=SONNET, idem="a"
+    )
+    await _seed(
+        when=datetime(2026, 6, 1, 18, 0, tzinfo=UTC), amount_delta=-6, model=SONNET, idem="b"
+    )
+    await _seed(when=datetime(2026, 6, 1, 12, 0, tzinfo=UTC), amount_delta=-5, model=GPT, idem="c")
+    await _seed(
+        when=datetime(2026, 6, 2, 8, 0, tzinfo=UTC), amount_delta=-25, model=SONNET, idem="d"
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 3, tzinfo=UTC),
+    )
+    by = _by_key(rows)
+
+    assert by[("2026-06-01", SONNET)].credits == 10  # 4 + 6
+    assert by[("2026-06-01", SONNET)].requests == 2  # two entries
+    assert by[("2026-06-01", GPT)].credits == 5
+    assert by[("2026-06-01", GPT)].requests == 1
+    assert by[("2026-06-02", SONNET)].credits == 25
+    assert by[("2026-06-02", SONNET)].requests == 1
+    # Exactly three groups.
+    assert len(rows) == 3
+
+
+async def test_reads_both_spend_causes(mongo_db):
+    # compute_spend (off-mode) + litellm_spend (post-cutover) both feed the chart.
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
+        amount_delta=-8,
+        model=SONNET,
+        cause="compute_spend",
+        idem="bc3",
+    )
+    await _seed(
+        when=datetime(2026, 6, 1, 10, 0, tzinfo=UTC),
+        amount_delta=-12,
+        model=SONNET,
+        cause="litellm_spend",
+        idem="live",
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+    by = _by_key(rows)
+
+    assert by[("2026-06-01", SONNET)].credits == 20  # 8 + 12
+    assert by[("2026-06-01", SONNET)].requests == 2
+
+
+async def test_excludes_non_spend_causes(mongo_db):
+    # A grant / top_up movement is not compute usage — it must not chart.
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
+        amount_delta=-10,
+        model=SONNET,
+        cause="compute_spend",
+        idem="spend",
+    )
+    # A positive grant under a non-spend cause.
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 30, tzinfo=UTC),
+        amount_delta=5000,
+        model=None,
+        cause="top_up",
+        idem="topup",
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+
+    assert len(rows) == 1
+    assert rows[0].model == SONNET
+    assert rows[0].credits == 10
+
+
+async def test_excludes_unapplied_phantom(mongo_db):
+    # A committed-but-unapplied entry never moved the wallet — exclude it.
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
+        amount_delta=-10,
+        model=SONNET,
+        applied=True,
+        idem="real",
+    )
+    await _seed(
+        when=datetime(2026, 6, 1, 10, 0, tzinfo=UTC),
+        amount_delta=-1000,
+        model=SONNET,
+        applied=False,  # phantom
+        idem="phantom",
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+
+    assert len(rows) == 1
+    assert rows[0].credits == 10  # the phantom -1000 is NOT counted
+
+
+async def test_until_is_exclusive_since_is_inclusive(mongo_db):
+    # An entry exactly at ``since`` is IN; one exactly at ``until`` is OUT.
+    since = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
+    until = datetime(2026, 6, 2, 0, 0, tzinfo=UTC)
+    await _seed(when=since, amount_delta=-3, model=SONNET, idem="at_since")
+    await _seed(when=until, amount_delta=-7, model=SONNET, idem="at_until")
+
+    rows = await credits.spend_by_model(WS, since=since, until=until)
+
+    assert len(rows) == 1
+    # Only the at-``since`` entry (2026-06-01) is in window; the at-``until`` one
+    # (2026-06-02 00:00) is excluded.
+    assert rows[0].day == "2026-06-01"
+    assert rows[0].credits == 3
+
+
+async def test_missing_ref_model_buckets_unknown(mongo_db):
+    # A charged debit with no ``ref.model`` still counts, under "unknown", so the
+    # total reconciles with the wallet.
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC), amount_delta=-15, model=None, idem="nm"
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+
+    assert len(rows) == 1
+    assert rows[0].model == "unknown"
+    assert rows[0].credits == 15
+
+
+async def test_is_tenant_scoped(mongo_db):
+    # Another workspace's spend must not leak into this workspace's chart.
+    await _seed(when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC), amount_delta=-10, idem="mine")
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC), amount_delta=-999, idem="theirs", ws="other_ws"
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+
+    assert len(rows) == 1
+    assert rows[0].credits == 10  # not 999


### PR DESCRIPTION
## What was wrong

The Settings > Billing "Usage by model" chart showed "No usage to chart yet" even while the wallet was spending. On the same page, "Recent activity" was full of `compute_spend` rows and the balance was negative.

The chart and the wallet read two different meters:

- The chart called `GET /billing/usage`, which read the LiteLLM proxy's `/user/daily/activity`.
- The wallet is filled by BC-3 metering, which reads each finished run's token usage and debits the credit ledger directly (`cause=compute_spend`). In the default mode (`POCKETPAW_LITELLM_SPEND_MODE=off`) nothing goes through the proxy.

So a Free or keyless workspace has no LiteLLM virtual key, the proxy read returns an empty 200 (`models: []`), and the chart draws its empty state, while every charge keeps landing in the ledger. The chart was wired to the one meter that is empty in the default mode.

## The fix

Read the chart from the credit ledger, which is the wallet's own meter, so the graph matches the wallet in every mode.

- New `credits.service.spend_by_model(workspace, since, until)` aggregates applied spend debits by day and `ref.model`. It reads both spend causes (`compute_spend` in off-mode, `litellm_spend` after a live cutover); only one is ever active per run, so there is no double-count, and a cutover history with both causes still reconciles. Credits come straight off the ledger (already markup-applied at debit time), so there is no second conversion. The read stays behind the credits service, the same entity boundary `sum_debits_by_cause` already uses.
- `get_workspace_usage` folds those rows into the same `WorkspaceUsageResponse`. The response shape is unchanged, so the chart component needs no edits.

Backend only, read only. No metering, debit, or wallet numbers change.

## One trade-off

Per-model `tokens` reports 0. The ledger `ref` carries the model, the credits, and a request count, but not token counts. The bars, the model legend, and the request counts are accurate. If we want the tooltip's token line populated, the follow-up is to add `total_tokens` to the debit `ref` at metering time.

## Tests

- Regression (`test_usage_ledger_source.py`): a workspace with `compute_spend` in the ledger and no LiteLLM key now renders its spend. This test fails on `dev` and passes here.
- Cutover: both `compute_spend` and `litellm_spend` are read with no double-count.
- Unit tests for `spend_by_model`: cause filter, applied-only, inclusive-since and exclusive-until window, missing-model bucket, tenant scoping.
- `tests/cloud/billing`, `tests/cloud/credits`, `tests/cloud/metering`: 106 passed locally; ruff clean.

## Verifying by hand

Open Settings > Billing > Usage on any workspace that has `compute_spend` in its ledger (the Recent activity list shows them). The bars should now match the spend in that list over the selected range, with no LiteLLM key required.
