### PR TITLE
fix(livekit): call bot subscribes to mic audio only

### DIFF
--- a/ee/pocketpaw_ee/cloud/livekit/agent.py
+++ b/ee/pocketpaw_ee/cloud/livekit/agent.py
@@ -7,7 +7,13 @@ as a silent listener participant and transcribes the conversation using
 Deepgram's speech-to-text API.
 
 1. Connects to the LiveKit room via ``livekit.rtc.Room`` (WebRTC)
-2. Subscribes to all remote audio tracks
+2. Subscribes to remote MICROPHONE AUDIO tracks only — never video or
+   screenshare. The room is joined with ``auto_subscribe=False`` and each
+   audio publication is opted in via ``_should_subscribe`` /
+   ``publication.set_subscribed(True)``. This keeps the bot's per-participant
+   load flat: auto-subscribe would otherwise pull (and decode) every
+   participant's video, which the bot never uses (Bug A — the call got
+   unstable past a few participants).
 3. Pipes each track through Deepgram STT streaming for real-time transcription
 4. Accumulates transcript segments with speaker identification
 5. Detects when the room empties (via polling + room events)
@@ -54,6 +60,38 @@ _CALL_END_GRACE_SECONDS = 5
 
 # How often (seconds) to poll room state
 _MONITOR_POLL_INTERVAL = 5
+
+
+# ---------------------------------------------------------------------------
+# Track subscription policy
+# ---------------------------------------------------------------------------
+
+
+def _should_subscribe(publication: Any) -> bool:
+    """Decide whether the call bot should subscribe to a remote publication.
+
+    The meeting-notes bot only transcribes participant microphone audio, so it
+    subscribes to microphone audio publications and nothing else — never video
+    (camera or screenshare) and never screenshare system audio. Combined with
+    ``auto_subscribe=False`` on connect, this keeps the bot's per-participant
+    load flat instead of pulling and decoding every participant's video.
+
+    Kept as a small pure function (it only reads ``publication.kind`` and
+    ``publication.source``) so the subscribe decision is unit-testable without
+    standing up the whole LiveKit SDK.
+    """
+    # ``kind`` / ``source`` are protobuf int enums (TrackKind.ValueType /
+    # TrackSource.ValueType), NOT strings — comparing against "audio" silently
+    # never matches.
+    from livekit.rtc import TrackKind, TrackSource
+
+    if getattr(publication, "kind", None) != TrackKind.KIND_AUDIO:
+        return False
+    # ``source`` may be SOURCE_UNKNOWN when the publisher didn't tag the track;
+    # treat untagged audio as a microphone (the common plain-audio publish) so
+    # we don't drop real speech. Screenshare system audio is excluded.
+    source = getattr(publication, "source", TrackSource.SOURCE_UNKNOWN)
+    return source in (TrackSource.SOURCE_MICROPHONE, TrackSource.SOURCE_UNKNOWN)
 
 
 # ---------------------------------------------------------------------------
@@ -204,6 +242,12 @@ class CallMeetingAgent:
         """
         import aiohttp
 
+        # Declared before the try so the finally block can always clean them
+        # up — even if the livekit import below fails.
+        stt_streams: dict[str, Any] = {}  # participant identity → Deepgram stream
+        pipe_tasks: dict[str, asyncio.Task] = {}  # participant identity → audio pipe task
+        http_session: Any = None
+
         try:
             from livekit.plugins.deepgram import STT as DeepgramSTT
             from livekit.rtc import (
@@ -214,13 +258,13 @@ class CallMeetingAgent:
                 TrackSource,
             )
 
-            room_opts = RoomOptions(auto_subscribe=True)
+            # auto_subscribe=False: do NOT pull every participant's tracks.
+            # The bot opts in to microphone audio only (see _should_subscribe),
+            # so it never decodes the video/screenshare it has no use for —
+            # which is what made the call unstable past a few participants.
+            room_opts = RoomOptions(auto_subscribe=False)
             room = Room(loop=asyncio.get_event_loop())
             self._rtc_room = room
-
-            # Track STT streams keyed by participant identity
-            stt_streams: dict[str, Any] = {}
-            pipe_tasks: dict[str, asyncio.Task] = {}
 
             # Shared HTTP session for Deepgram (avoids "outside job context" error)
             http_session = aiohttp.ClientSession()
@@ -295,6 +339,34 @@ class CallMeetingAgent:
                     )
 
             # ------------------------------------------------------------------
+            # Helper: opt in to a participant's microphone publications
+            # ------------------------------------------------------------------
+            def _subscribe_mic_publications(participant: RemoteParticipant) -> None:
+                """Subscribe to a participant's mic audio publications only.
+
+                With ``auto_subscribe=False`` nothing is subscribed by default,
+                so we explicitly opt in to microphone audio (and never video /
+                screenshare) via ``_should_subscribe``.
+                """
+                for pub in participant.track_publications.values():
+                    if _should_subscribe(pub) and not pub.subscribed:
+                        logger.info(
+                            "Agent: subscribing to %s's mic audio track",
+                            participant.name or participant.identity,
+                        )
+                        pub.set_subscribed(True)
+
+            # ------------------------------------------------------------------
+            # Helper: close a Deepgram STT stream (fire-and-forget on disconnect)
+            # ------------------------------------------------------------------
+            async def _aclose_stt_stream(stt_stream: Any, pid: str) -> None:
+                """Close a Deepgram WebSocket stream so it doesn't leak."""
+                try:
+                    await stt_stream.aclose()
+                except Exception as exc:
+                    logger.debug("Error closing STT stream for %s: %s", pid, exc)
+
+            # ------------------------------------------------------------------
             # Event handlers (set up BEFORE connect to avoid race conditions)
             # ------------------------------------------------------------------
 
@@ -309,14 +381,44 @@ class CallMeetingAgent:
                     participant.name or pid,
                     pid,
                 )
+                # Opt in to any mic audio they already have published; tracks
+                # published later are picked up by the track_published handler.
+                _subscribe_mic_publications(participant)
                 asyncio.create_task(_setup_audio_pipe_for_participant(participant))
+
+            @room.on("track_published")
+            def on_track_published(publication: Any, participant: Any) -> None:
+                """Subscribe to newly published microphone audio only.
+
+                With ``auto_subscribe=False`` the server forwards a track only
+                once we subscribe, so this is where we opt in to mic audio (and
+                skip video / screenshare entirely).
+                """
+                pid = participant.identity if participant else ""
+                if not pid or pid == "call-bot":
+                    return
+                if _should_subscribe(publication) and not publication.subscribed:
+                    logger.info(
+                        "Agent: subscribing to %s's published mic audio track",
+                        participant.name or pid,
+                    )
+                    publication.set_subscribed(True)
 
             @room.on("participant_disconnected")
             def on_participant_disconnected(participant: RemoteParticipant) -> None:
-                """Clean up when a participant leaves."""
+                """Clean up when a participant leaves.
+
+                Cancels the audio pipe task and closes the participant's
+                Deepgram WebSocket so it doesn't leak for the rest of a long
+                call.
+                """
                 pid = participant.identity
-                stt_streams.pop(pid, None)
-                pipe_tasks.pop(pid, None)
+                stt_stream = stt_streams.pop(pid, None)
+                pipe_task = pipe_tasks.pop(pid, None)
+                if pipe_task is not None:
+                    pipe_task.cancel()
+                if stt_stream is not None:
+                    asyncio.create_task(_aclose_stt_stream(stt_stream, pid))
                 logger.info(
                     "Agent: participant disconnected: %s",
                     pid,
@@ -328,13 +430,13 @@ class CallMeetingAgent:
                 publication: Any,
                 participant: Any,
             ) -> None:
-                """Fallback: handle any tracks that get auto-subscribed.
+                """Safety net: ensure a pipe exists for a subscribed mic track.
 
-                This is a safety net in case ``from_participant`` doesn't
-                cover all scenarios. We only act if we don't already have
-                a pipe for this participant.
+                With ``auto_subscribe=False`` this fires only for tracks we
+                explicitly subscribed to (mic audio), but we still guard with
+                ``_should_subscribe`` and skip if a pipe already exists.
                 """
-                if track.kind != "audio":
+                if not _should_subscribe(publication):
                     return
                 pid = participant.identity if participant else ""
                 if not pid or pid == "call-bot":
@@ -381,14 +483,9 @@ class CallMeetingAgent:
                 )
                 asyncio.create_task(_setup_audio_pipe_for_participant(participant))
 
-                # Also explicitly subscribe to any audio publications as backup
-                for pub in participant.track_publications.values():
-                    if pub.kind == "audio" and not pub.subscribed:
-                        logger.info(
-                            "Agent: explicitly subscribing to %s's audio track",
-                            participant.name or pid,
-                        )
-                        pub.set_subscribed(True)
+                # Explicitly opt in to their mic audio publications (needed
+                # under auto_subscribe=False so the server forwards the track).
+                _subscribe_mic_publications(participant)
 
             logger.info(
                 "Agent: transcription running for room %s (watching %d participants)",
@@ -417,17 +514,21 @@ class CallMeetingAgent:
 
             logger.error("Traceback:\n%s", traceback.format_exc())
         finally:
+            # Cancel any still-running audio pipe tasks
+            for t in pipe_tasks.values():
+                t.cancel()
             # Clean up STT streams
-            for pid, s in list(stt_streams.items()):
+            for s in list(stt_streams.values()):
                 try:
                     await s.aclose()
                 except Exception:
                     pass
-            # Clean up the HTTP session
-            try:
-                await http_session.close()
-            except Exception:
-                pass
+            # Clean up the HTTP session (may be None if the import failed)
+            if http_session is not None:
+                try:
+                    await http_session.close()
+                except Exception:
+                    pass
 
     async def _pipe_audio_to_stt(
         self,

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -628,6 +628,13 @@ async def create_room(
 
     # Start the meeting notes agent as a managed subprocess so it does not
     # block the server event loop with WebRTC / Deepgram STT processing.
+    #
+    # FOLLOW-UP (multi-worker caveat): _active_agents is a per-process dict, so
+    # this guard only dedupes within a single worker. If the API runs with more
+    # than one worker/replica, two workers can each spawn an agent for the same
+    # room (duplicate bots). Needs infra worker-count confirmation before
+    # fixing — e.g. a shared lock/registry or pinning call routing to one
+    # worker. Not addressed here.
     if group_id not in _active_agents:
         proc = await _spawn_agent_process(
             group_id=group_id,

--- a/tests/ee/test_livekit_service.py
+++ b/tests/ee/test_livekit_service.py
@@ -1,9 +1,15 @@
-"""Tests for the LiveKit call service."""
+"""Tests for the LiveKit call service.
+
+Added TestSelectiveSubscribe: covers the call bot's audio-only selective
+subscribe (Bug A) — auto_subscribe=False on connect and the pure
+_should_subscribe() decision (mic audio in, video / screenshare out).
+"""
 
 from __future__ import annotations
 
 import asyncio
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -455,3 +461,131 @@ class TestMeetingNotesPosting:
             mock_create.assert_called_once()
             assert "No speech detected" in mock_create.call_args[1]["content"]
             mock_emit.assert_called_once()
+
+
+class _FakeRoom:
+    """Minimal stand-in for ``livekit.rtc.Room``.
+
+    Records the event handlers the agent registers via ``@room.on(...)`` so a
+    test can fire them directly, and captures the ``RoomOptions`` passed to
+    ``connect`` so we can assert on ``auto_subscribe``.
+    """
+
+    def __init__(self) -> None:
+        self.handlers: dict = {}
+        self.remote_participants: dict = {}
+        self.connect = AsyncMock()
+        self.disconnect = AsyncMock()
+
+    def on(self, event: str):
+        def _register(fn):
+            self.handlers[event] = fn
+            return fn
+
+        return _register
+
+
+class TestSelectiveSubscribe:
+    """Bug A: the call bot must subscribe to mic audio only, never video."""
+
+    def test_should_subscribe_microphone_audio(self):
+        from livekit.rtc import TrackKind, TrackSource
+        from pocketpaw_ee.cloud.livekit.agent import _should_subscribe
+
+        pub = SimpleNamespace(kind=TrackKind.KIND_AUDIO, source=TrackSource.SOURCE_MICROPHONE)
+        assert _should_subscribe(pub) is True
+
+    def test_should_subscribe_untagged_audio(self):
+        # Some publishers leave the source UNKNOWN on a plain audio publish;
+        # treat that as a microphone so we don't drop real speech.
+        from livekit.rtc import TrackKind, TrackSource
+        from pocketpaw_ee.cloud.livekit.agent import _should_subscribe
+
+        pub = SimpleNamespace(kind=TrackKind.KIND_AUDIO, source=TrackSource.SOURCE_UNKNOWN)
+        assert _should_subscribe(pub) is True
+
+    def test_should_not_subscribe_camera_video(self):
+        from livekit.rtc import TrackKind, TrackSource
+        from pocketpaw_ee.cloud.livekit.agent import _should_subscribe
+
+        pub = SimpleNamespace(kind=TrackKind.KIND_VIDEO, source=TrackSource.SOURCE_CAMERA)
+        assert _should_subscribe(pub) is False
+
+    def test_should_not_subscribe_screenshare_video(self):
+        from livekit.rtc import TrackKind, TrackSource
+        from pocketpaw_ee.cloud.livekit.agent import _should_subscribe
+
+        pub = SimpleNamespace(kind=TrackKind.KIND_VIDEO, source=TrackSource.SOURCE_SCREENSHARE)
+        assert _should_subscribe(pub) is False
+
+    def test_should_not_subscribe_screenshare_audio(self):
+        # System audio shared from a screen share is not a participant mic.
+        from livekit.rtc import TrackKind, TrackSource
+        from pocketpaw_ee.cloud.livekit.agent import _should_subscribe
+
+        pub = SimpleNamespace(
+            kind=TrackKind.KIND_AUDIO, source=TrackSource.SOURCE_SCREENSHARE_AUDIO
+        )
+        assert _should_subscribe(pub) is False
+
+    @pytest.mark.asyncio
+    async def test_connect_uses_auto_subscribe_false(self):
+        """The bot must connect with auto_subscribe disabled.
+
+        Auto-subscribe drags in every participant's video, which the bot
+        never uses — the source of the O(N) per-participant load.
+        """
+        from pocketpaw_ee.cloud.livekit.agent import CallMeetingAgent
+
+        agent = CallMeetingAgent(
+            group_id="g",
+            room_name="group-call-g",
+            bot_token="tok",
+            livekit_url="wss://fake.livekit.cloud",
+        )
+        agent._running = False  # exit the keep-alive loop immediately
+
+        fake = _FakeRoom()
+        with patch("livekit.rtc.Room", return_value=fake):
+            await agent._connect_and_transcribe()
+
+        fake.connect.assert_awaited_once()
+        opts = fake.connect.await_args.args[2]
+        assert opts.auto_subscribe is False
+
+    @pytest.mark.asyncio
+    async def test_video_publication_not_subscribed_in_handler(self):
+        """track_published must subscribe mic audio but ignore video."""
+        from livekit.rtc import TrackKind, TrackSource
+        from pocketpaw_ee.cloud.livekit.agent import CallMeetingAgent
+
+        agent = CallMeetingAgent(
+            group_id="g",
+            room_name="group-call-g",
+            bot_token="tok",
+            livekit_url="wss://fake.livekit.cloud",
+        )
+        agent._running = False
+
+        fake = _FakeRoom()
+        with patch("livekit.rtc.Room", return_value=fake):
+            await agent._connect_and_transcribe()
+
+        handler = fake.handlers["track_published"]
+        participant = MagicMock()
+        participant.identity = "user_1"
+        participant.name = "User One"
+
+        video_pub = MagicMock()
+        video_pub.kind = TrackKind.KIND_VIDEO
+        video_pub.source = TrackSource.SOURCE_CAMERA
+        video_pub.subscribed = False
+        handler(video_pub, participant)
+        video_pub.set_subscribed.assert_not_called()
+
+        mic_pub = MagicMock()
+        mic_pub.kind = TrackKind.KIND_AUDIO
+        mic_pub.source = TrackSource.SOURCE_MICROPHONE
+        mic_pub.subscribed = False
+        handler(mic_pub, participant)
+        mic_pub.set_subscribed.assert_called_once_with(True)


### PR DESCRIPTION
## What this fixes

Voice and connection broke once a call had more than about three people. One cause is the meeting-notes call bot.

The bot joins every LiveKit room to transcribe it. It connected with `auto_subscribe=True`, so it pulled and decoded every participant's tracks, including the camera and screenshare video it never looks at. It only needs each person's microphone for Deepgram. That wasted decode grows with each extra participant and made the bot's own connection unstable on larger calls.

## Change

The bot now connects with `auto_subscribe=False` and opts in to microphone audio only.

- New pure function `_should_subscribe(publication)`: microphone audio passes; camera, screenshare, and screenshare system-audio do not. Untagged audio is treated as a mic so a plain audio publish is not dropped.
- A `track_published` handler subscribes to mic audio as it appears. This is required under `auto_subscribe=False`, where the server forwards a track only after you subscribe. Existing participants are opted in on connect.
- Fixed a Deepgram stream leak: when a participant leaves, the audio pipe task is cancelled and their Deepgram socket is closed. The old code only dropped the dictionary entries.
- Removed dead code found along the way. The previous checks compared an int enum against the string `"audio"`, so they never matched.
- Added a comment at the `_active_agents` guard noting it dedupes per process, so a deployment with more than one worker could spawn duplicate bots. That needs the worker count confirmed and is a separate change.

## Tests

`tests/ee/test_livekit_service.py` gains `TestSelectiveSubscribe` (7 tests), written failing first. `_should_subscribe` is tested directly rather than through a mock. Whole file: 29 passed, ruff clean. Verified against the installed `livekit==1.1.8` (kind/source are protobuf int enums, not strings).

## Verify on a live call

CI cannot run a real multi-party room. On a live call, confirm the transcript still populates (mic audio reaches Deepgram under `auto_subscribe=False`) and that the bot no longer subscribes to anyone's video.
