### PR TITLE
fix(cloud): deliver returns the stable Files link, not an expiring presign

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/deliver.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/deliver.py
@@ -3,9 +3,15 @@
 #
 # This is the payoff of the cloud-artifacts stack: a cloud agent builds a file
 # (or a whole directory) inside its per-tenant jail (ART-2), then calls this tool
-# to LAND that artifact in the tenant's blob storage and get back a real,
-# short-lived download URL to hand the user — instead of printing a container
-# path or spinning a 127.0.0.1 preview server the user can never reach.
+# to LAND that artifact in the tenant's blob storage and hand the user back a
+# STABLE link to that file in their Files — instead of printing a container path
+# or spinning a 127.0.0.1 preview server the user can never reach.
+#
+# 2026-06-29: deliver returns the Files module's own stable download link
+# (``/api/v1/uploads/{file_id}``) rather than minting its own short-lived presign.
+# The delivered file is already a first-class /files row, so its permanent,
+# auth-gated link never expires — and since deliver no longer hands back a raw
+# storage presign, it sidesteps the inline-render concern entirely.
 #
 # Mirrors the sibling mcp_servers (sites.py / media.py): a single
 # ``create_sdk_mcp_server`` behind an SDK import-guard, ``SERVER_NAME`` /
@@ -18,8 +24,11 @@
 # Routing: a single file is uploaded directly (mime guessed from the filename); a
 # directory is zipped (``application/zip``) and the zip is uploaded. Both go
 # through ``EEUploadService.upload`` — the DOWNLOAD path that gives arbitrary
-# mime + a presigned URL + ``FileReady``→KB + visibility in the tenant's /files
-# (NOT file_versions.write_file, which is the editor-document path, Slice-D).
+# mime + ``FileReady``→KB + visibility in the tenant's /files (NOT
+# file_versions.write_file, which is the editor-document path, Slice-D). deliver
+# then hands back the Files module's OWN stable link to that row,
+# ``GET /api/v1/uploads/{file_id}`` (auth-gated, never expires) — not a
+# self-minted, expiring presign.
 #
 # Security: the path MUST resolve to inside the caller's own jail
 # (``workspace_jail_root()/<workspace_id>/...``). ``..``, absolute paths, and
@@ -27,9 +36,10 @@
 # workspace root), reusing ART-2's path-segment guard so the agent can never
 # deliver ``/etc/passwd`` or another tenant's jail. Because the upload relaxes
 # the mime allowlist, a delivered non-inline type (HTML/SVG/JS) is served as a
-# DOWNLOAD, not inline — EEUploadService.presigned_get forces
+# DOWNLOAD, not inline — the stable ``GET /api/v1/uploads/{file_id}`` route forces
 # ``Content-Disposition: attachment`` for anything outside INLINE_MIMES, so a
-# delivered .html can't render active content on the storage origin. The whole
+# delivered .html can't render active content. Returning that app route instead
+# of a raw storage presign sidesteps the inline-render concern entirely. The whole
 # server is gated on is_multi_tenant_cloud() (cloud-only, like the ART-4 boot
 # guard and ART-2 jail).
 """Agent-side MCP surface for delivering a built artifact to tenant blob storage.
@@ -38,11 +48,12 @@ Tool registered:
 
   - ``deliver_artifact(path)`` — persist the file or directory at ``path``
     (inside the caller's workspace jail) to the tenant's blob storage and return
-    ``{ok, filename, url, file_id, size, mime, expires_in_seconds}``. ``url`` is a
-    short-TTL download link the agent shows the user. ``is_error`` is set (with a
-    plain reason) when identity is missing, the path escapes the jail, the file
-    is missing / too large, or the upload fails — the agent then surfaces the
-    reason instead of fabricating a working link.
+    ``{ok, filename, url, file_id, size, mime}``. ``url`` is the stable link to
+    the file in the user's Files (``/api/v1/uploads/{file_id}`` — never expires;
+    the file also appears in the Files panel) that the agent shows the user.
+    ``is_error`` is set (with a plain reason) when identity is missing, the path
+    escapes the jail, the file is missing / too large, or the upload fails — the
+    agent then surfaces the reason instead of fabricating a working link.
 
 Workspace / user identity comes from the per-stream ``ContextVar``s in
 ``ee.cloud.chat.agent_service`` (same chokepoint the sites + tasks MCP servers
@@ -77,9 +88,10 @@ _DEFAULT_DELIVER_MAX_MB = 100.0
 _TOOL_DESCRIPTION = (
     "Deliver a built artifact to the user as a downloadable file. Pass `path` — "
     "a file OR a directory inside your workspace. A single file is uploaded as-is; "
-    "a directory is zipped first. Returns {ok, filename, url, file_id, size, mime, "
-    "expires_in_seconds} — show the user the `url` (a short-lived download link) "
-    "and the filename. USE THIS whenever you produce something the user should be "
+    "a directory is zipped first. Returns {ok, filename, url, file_id, size, mime} "
+    "— show the user the `url` (a stable link to the file in their Files; it never "
+    "expires and the file also appears in their Files panel) and the filename. "
+    "USE THIS whenever you produce something the user should be "
     "able to download (a report, an export, a generated file, a built site bundle): "
     "do NOT just print the path you wrote to, and do NOT start a local preview / web "
     "server — the user cannot reach your container's filesystem or 127.0.0.1. "
@@ -246,7 +258,7 @@ def _zip_dir_to_tempfile(src: Path) -> Path:
     return tmp_path
 
 
-async def _upload_and_sign(
+async def _upload_artifact(
     upload_path: Path,
     *,
     filename: str,
@@ -263,14 +275,19 @@ async def _upload_and_sign(
     ``UploadSettings`` whose ``allowed_mimes`` includes the computed mime (+ zip)
     so the OSS pipeline's mime gate never rejects a first-party artifact — while
     its magic-byte sniff still upgrades recognized types (png/pdf/…) to their
-    canonical mime. ``url`` is the adapter's presigned URL when available (S3),
-    else the authenticated cloud download path.
+    canonical mime.
+
+    ``url`` is the Files module's own STABLE download link to the new row,
+    ``/api/v1/uploads/{rec.id}`` — auth-gated, never expires, and already
+    attachment-safe for non-inline mimes. We deliberately do NOT mint a
+    short-lived presign here: the delivered file is a first-class /files entry, so
+    we hand back its permanent link instead. (On-demand presigning still lives on
+    the /grant + /download-url routes for external / unauthenticated sharing.)
     """
     from fastapi import UploadFile
 
     from pocketpaw.uploads.config import DEFAULT_ALLOWED_MIMES, UploadSettings
     from pocketpaw.uploads.factory import build_adapter
-    from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS
     from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
     from pocketpaw_ee.cloud.uploads.service import EEUploadService
 
@@ -292,17 +309,14 @@ async def _upload_and_sign(
         )
         rec = await svc.upload(upload, owner_id=user_id, chat_id=None, workspace=workspace_id)
 
-    # Owner-scoped presign (the uploader is the requester, so the read gate
-    # passes). Fall back to the authenticated cloud download path when the
-    # adapter can't presign (local adapter).
-    _rec, url = await svc.presigned_get(rec.id, user_id, workspace_id, DEFAULT_TTL_SECONDS)
-    return rec, url or f"/api/v1/uploads/{rec.id}"
+    # The file is now a first-class /files row; hand back its stable, auth-gated
+    # download link instead of a self-minted presign that would expire.
+    return rec, f"/api/v1/uploads/{rec.id}"
 
 
 async def _deliver_handler(args: dict) -> dict:
     """MCP handler for ``deliver_artifact`` — resolve, jail-check, route, upload."""
     from pocketpaw.uploads.errors import UploadError
-    from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS
 
     workspace_id, user_id = _identity()
     if not workspace_id or not user_id:
@@ -345,7 +359,7 @@ async def _deliver_handler(args: dict) -> dict:
             filename = resolved.name
             mime = mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
-        rec, url = await _upload_and_sign(
+        rec, url = await _upload_artifact(
             upload_path,
             filename=filename,
             mime=mime,
@@ -371,7 +385,6 @@ async def _deliver_handler(args: dict) -> dict:
             "file_id": rec.id,
             "size": rec.size,
             "mime": rec.mime,
-            "expires_in_seconds": DEFAULT_TTL_SECONDS,
         }
     )
 

--- a/tests/cloud/agents/test_deliver_tool.py
+++ b/tests/cloud/agents/test_deliver_tool.py
@@ -1,11 +1,20 @@
 # test_deliver_tool.py — ART-4 deliver_artifact in-process MCP tool.
 #
+# 2026-06-29: deliver now returns the Files module's STABLE download link
+# (``/api/v1/uploads/{file_id}``) instead of a self-minted, expiring presign — the
+# delivered file is already a first-class /files row. Assertions updated to expect
+# the stable url and no ``expires_in_seconds``; the upload + scoping behavior is
+# unchanged.
+#
 # Locks the deliver path's behavior end-to-end against the real EEUploadService +
 # a mongomock-backed Mongo store and a local StorageAdapter rooted in a tmp home:
-#   * single file  → workspace-scoped upload, presigned URL, guessed mime, shows
-#                    in the tenant's file list;
+#   * single file  → workspace-scoped upload, stable /files link, guessed mime,
+#                    shows in the tenant's file list;
 #   * directory    → zipped (application/zip) and the zip round-trips;
 #   * two tenants  → each delivers, ZERO cross-read (Mongo scope + presign gate);
+#   * renderable   → HTML/SVG comes back as the stable link with an attachment-only
+#                    mime (outside INLINE_MIMES), so the download route never
+#                    renders it inline;
 #   * path safety  → ``..`` / absolute / symlink-out / cross-tenant all rejected;
 #   * guards       → missing identity, missing file, and the size cap.
 """Tests for the deliver_artifact agent tool."""
@@ -112,9 +121,10 @@ async def test_deliver_single_file(beanie_db) -> None:
     assert body["ok"] is True
     assert body["filename"] == "report.txt"
     assert body["mime"] == "text/plain"
-    assert body["url"]
     assert body["file_id"]
-    assert body["expires_in_seconds"] > 0
+    # Stable Files-module link, not a self-minted expiring presign.
+    assert body["url"] == f"/api/v1/uploads/{body['file_id']}"
+    assert "expires_in_seconds" not in body
 
     # Visible in the tenant's file list (workspace-scoped Mongo row).
     rec = await MongoFileStore().get_scoped(body["file_id"], workspace="wsA")
@@ -270,43 +280,21 @@ async def test_oversize_rejected(beanie_db, monkeypatch: pytest.MonkeyPatch) -> 
         ("evil.svg", "<svg xmlns='http://www.w3.org/2000/svg'><script/></svg>", "image/svg+xml"),
     ],
 )
-async def test_deliver_renderable_served_as_attachment(
-    beanie_db, monkeypatch: pytest.MonkeyPatch, filename, content, expected_mime
+async def test_deliver_renderable_returns_stable_attachment_link(
+    beanie_db, filename, content, expected_mime
 ) -> None:
-    """A delivered HTML/SVG artifact must download (attachment), never render
-    inline on the storage origin. A spy adapter records the Content-Disposition
-    the deliver path forwards to the (S3) presign."""
+    """A delivered HTML/SVG artifact comes back as the stable Files link, and its
+    mime is one the download route serves as an attachment (outside INLINE_MIMES)
+    — so it downloads, never renders inline on the app origin.
+
+    deliver no longer mints a presign, so it can't render active content on a raw
+    storage origin at all; the attachment policy is now the download route's job
+    (router forces ``attachment`` for non-INLINE mimes). This locks that the
+    renderable types deliver produces are exactly the ones that route downloads.
+    """
     from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
 
-    import pocketpaw.uploads.factory as factory
-
-    recorded: dict[str, str | None] = {}
-    real_build = factory.build_adapter
-
-    class _SpyAdapter:
-        def __init__(self, inner):
-            self._inner = inner
-
-        async def put(self, key, stream, mime):
-            return await self._inner.put(key, stream, mime)
-
-        def open(self, key):
-            return self._inner.open(key)
-
-        async def delete(self, key):
-            return await self._inner.delete(key)
-
-        async def exists(self, key):
-            return await self._inner.exists(key)
-
-        def local_path(self, key):
-            return None
-
-        async def presigned_get(self, key, ttl_seconds, response_content_disposition=None):
-            recorded["disposition"] = response_content_disposition
-            return f"https://signed.example/{key}"
-
-    monkeypatch.setattr(factory, "build_adapter", lambda root: _SpyAdapter(real_build(root)))
+    from pocketpaw.uploads.config import INLINE_MIMES
 
     tokens = _bind("wsA", "uA", "sessA")
     try:
@@ -317,9 +305,10 @@ async def test_deliver_renderable_served_as_attachment(
 
     body = _body(resp)
     assert body["mime"] == expected_mime
-    assert body["url"].startswith("https://signed.example/")
-    assert recorded["disposition"] is not None
-    assert recorded["disposition"].startswith("attachment;")
+    assert body["url"] == f"/api/v1/uploads/{body['file_id']}"
+    assert "expires_in_seconds" not in body
+    # Outside INLINE_MIMES → the stable download route serves it as an attachment.
+    assert expected_mime not in INLINE_MIMES
 
 
 async def test_symlink_inside_dir_not_archived(beanie_db) -> None:


### PR DESCRIPTION
`deliver_artifact` was minting its own short-lived presigned S3 URL (with a TTL / `expires_in_seconds`). But the delivered file is already a first-class `/files` entry, and the Files module already has a stable, auth-gated download: `GET /api/v1/uploads/{file_id}` (permanent, no expiry, already forces `Content-Disposition: attachment` for non-inline mimes).

**Change:** deliver returns that stable `/files` link + `file_id`, and drops the TTL presign + `expires_in_seconds`. The upload and per-tenant/user scoping are unchanged — the file still lands in `/files` exactly as before; only the returned link changes.

**Why:** reuses the Files module we already have (the captain's point), the link never expires, and since deliver no longer returns a raw S3 presign it sidesteps the inline-render concern entirely (the app download route is attachment-safe). Net: deliver gets simpler.

`presigned_get` / `uploads/router.py` are untouched — the on-demand presign still serves `/grant` + `/download-url` for external/unauthenticated sharing.

Tests updated (stable url asserted, `expires_in_seconds` gone; isolation/zip/path-escape intact). The ~23 pre-existing `tests/cloud/uploads/` auth-harness 401 reds are unrelated (confirmed identical on clean origin/dev). Merging on full green CI.