### PR TITLE
fix(livekit): prevent duplicate call-bot from concurrent room joins

### DIFF
--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -3,6 +3,15 @@
 Uses the ``livekit-api`` Python SDK to talk to LiveKit Cloud.
 Requires ``LIVEKIT_URL``, ``LIVEKIT_API_KEY``, ``LIVEKIT_API_SECRET``
 environment variables.
+
+Change log:
+- Fix duplicate call-bot spawn race: ``create_room()`` now guards the agent
+  spawn with a per-group ``asyncio.Lock`` (``_spawn_locks`` / ``_spawn_lock_for``)
+  so two concurrent joins for the same group can't both pass the
+  check→spawn→insert window and start two "call-bot" subprocesses.
+  ``_call_bot_in_room()`` adds a best-effort cross-replica check against LiveKit
+  room state. Locks are popped in ``_reap_agent_process`` and ``end_room`` to
+  avoid unbounded growth.
 """
 
 from __future__ import annotations
@@ -41,6 +50,28 @@ logger = logging.getLogger(__name__)
 from pocketpaw_ee.cloud.livekit.types import MeetingAgentProtocol  # noqa: E402
 
 _active_agents: dict[str, MeetingAgentProtocol] = {}
+
+# Per-group spawn locks. create_room() holds the lock for a group across the
+# check→spawn→insert sequence so two concurrent joins for the SAME group can't
+# both pass the "_active_agents" check and start duplicate call-bot
+# subprocesses. Keyed by group_id; popped in _reap_agent_process and end_room
+# so the dict doesn't grow unbounded.
+_spawn_locks: dict[str, asyncio.Lock] = {}
+
+
+def _spawn_lock_for(group_id: str) -> asyncio.Lock:
+    """Get-or-create the per-group spawn lock.
+
+    Safe without its own lock: on a single-threaded event loop there is no
+    ``await`` between the ``get`` and the ``set``, so two coroutines can't
+    interleave here and mint two different locks for the same group.
+    """
+    lock = _spawn_locks.get(group_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _spawn_locks[group_id] = lock
+    return lock
+
 
 # Collected meeting-notes payloads from agent subprocesses.
 # Populated by _collect_agent_notes (background reader on stdout pipe)
@@ -265,6 +296,7 @@ async def _reap_agent_process(
         raise
     finally:
         was_registered = _active_agents.pop(group_id, None) is not None
+        _spawn_locks.pop(group_id, None)
         logger.info(
             "Reaped agent subprocess for group %s (exit code %s)",
             group_id,
@@ -532,6 +564,26 @@ async def get_recording_info(group_id: str) -> dict[str, Any] | None:
 # ---------------------------------------------------------------------------
 
 
+async def _call_bot_in_room(room_name: str) -> bool:
+    """Return ``True`` if a participant with identity ``"call-bot"`` is in the room.
+
+    Best-effort cross-replica dedupe: queries LiveKit room state (the shared
+    source of truth) so a call-bot spawned by *another* worker/replica is
+    visible from here, where the per-process ``_active_agents`` dict and
+    ``_spawn_locks`` cannot see it. Fail-open — ANY error returns ``False`` so a
+    transient LiveKit hiccup never blocks a call from starting; the in-process
+    lock + ``_active_agents`` still prevent the same-process duplicate.
+    """
+    try:
+        async with LiveKitAPI(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) as lk:
+            parts_req = ListParticipantsRequest(room=room_name)
+            parts_resp = await lk.room.list_participants(parts_req)
+            return any(p.identity == "call-bot" for p in parts_resp.participants)
+    except Exception as exc:
+        logger.debug("call-bot presence check failed for room %s (fail-open): %s", room_name, exc)
+        return False
+
+
 async def create_room(
     group_id: str,
     workspace_id: str = "",
@@ -629,30 +681,36 @@ async def create_room(
     # Start the meeting notes agent as a managed subprocess so it does not
     # block the server event loop with WebRTC / Deepgram STT processing.
     #
-    # FOLLOW-UP (multi-worker caveat): _active_agents is a per-process dict, so
-    # this guard only dedupes within a single worker. If the API runs with more
-    # than one worker/replica, two workers can each spawn an agent for the same
-    # room (duplicate bots). Needs infra worker-count confirmation before
-    # fixing — e.g. a shared lock/registry or pinning call routing to one
-    # worker. Not addressed here.
-    if group_id not in _active_agents:
-        proc = await _spawn_agent_process(
-            group_id=group_id,
-            room_name=room_name,
-            bot_token=bot_token,
-        )
-        agent_ref = _SubprocessAgentRef(
-            group_id=group_id,
-            room_name=room_name,
-            process=proc,
-        )
-        _active_agents[group_id] = agent_ref
+    # The check -> spawn -> insert below would race without the lock: the
+    # ``await _spawn_agent_process`` yields the event loop between the
+    # membership check and the insert, so two concurrent joins (two
+    # POST /livekit/rooms for the same group) could each pass the check and
+    # spawn a second "call-bot" that fights the first over the shared identity.
+    # The per-group asyncio.Lock makes check -> spawn -> insert atomic in this
+    # process; _call_bot_in_room is a best-effort cross-replica guard against
+    # LiveKit room state. True cross-replica atomicity (only if the API is ever
+    # run multi-replica) would need Redis SETNX or LiveKit agent dispatch.
+    async with _spawn_lock_for(group_id):
+        if group_id not in _active_agents and not await _call_bot_in_room(room_name):
+            proc = await _spawn_agent_process(
+                group_id=group_id,
+                room_name=room_name,
+                bot_token=bot_token,
+            )
+            agent_ref = _SubprocessAgentRef(
+                group_id=group_id,
+                room_name=room_name,
+                process=proc,
+            )
+            _active_agents[group_id] = agent_ref
 
-        # Background task: wait for the subprocess to finish, then clean
-        # up the registry so we don't leak agent references.
-        asyncio.create_task(_reap_agent_process(group_id, proc, workspace_id))
+            # Background task: wait for the subprocess to finish, then clean
+            # up the registry so we don't leak agent references.
+            asyncio.create_task(_reap_agent_process(group_id, proc, workspace_id))
 
-        logger.info("Started meeting agent subprocess for group %s (room %s)", group_id, room_name)
+            logger.info(
+                "Started meeting agent subprocess for group %s (room %s)", group_id, room_name
+            )
 
     await emit(CallStarted(data={"group_id": group_id, "room_name": room_name}))
 
@@ -713,6 +771,7 @@ async def end_room(group_id: str, workspace_id: str = "") -> dict[str, Any]:
 
     # Stop the meeting agent first (generates and posts notes)
     agent = _active_agents.pop(group_id, None)
+    _spawn_locks.pop(group_id, None)
     if agent is not None:
         try:
             await agent.stop()

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -8,10 +8,10 @@ Change log:
 - Fix duplicate call-bot spawn race: ``create_room()`` now guards the agent
   spawn with a per-group ``asyncio.Lock`` (``_spawn_locks`` / ``_spawn_lock_for``)
   so two concurrent joins for the same group can't both pass the
-  check→spawn→insert window and start two "call-bot" subprocesses.
-  ``_call_bot_in_room()`` adds a best-effort cross-replica check against LiveKit
-  room state. Locks are popped in ``_reap_agent_process`` and ``end_room`` to
-  avoid unbounded growth.
+  check→spawn→insert window and start two "call-bot" subprocesses. The deploy
+  runs a single worker, so this in-process lock fully covers it; true
+  cross-replica dedupe is out of scope here (see the LiveKit Agents migration
+  design doc).
 """
 
 from __future__ import annotations
@@ -54,8 +54,11 @@ _active_agents: dict[str, MeetingAgentProtocol] = {}
 # Per-group spawn locks. create_room() holds the lock for a group across the
 # check→spawn→insert sequence so two concurrent joins for the SAME group can't
 # both pass the "_active_agents" check and start duplicate call-bot
-# subprocesses. Keyed by group_id; popped in _reap_agent_process and end_room
-# so the dict doesn't grow unbounded.
+# subprocesses. Intentionally never popped: an asyncio.Lock is tiny and the key
+# set is bounded by the groups that ever start a call, so leaving entries costs
+# nothing and avoids the re-mint race a concurrent pop-vs-_spawn_lock_for (e.g.
+# a reap/end_room popping a lock another create_room is mid-flight holding)
+# would cause — which would reopen the very double-spawn this guards against.
 _spawn_locks: dict[str, asyncio.Lock] = {}
 
 
@@ -296,7 +299,6 @@ async def _reap_agent_process(
         raise
     finally:
         was_registered = _active_agents.pop(group_id, None) is not None
-        _spawn_locks.pop(group_id, None)
         logger.info(
             "Reaped agent subprocess for group %s (exit code %s)",
             group_id,
@@ -564,26 +566,6 @@ async def get_recording_info(group_id: str) -> dict[str, Any] | None:
 # ---------------------------------------------------------------------------
 
 
-async def _call_bot_in_room(room_name: str) -> bool:
-    """Return ``True`` if a participant with identity ``"call-bot"`` is in the room.
-
-    Best-effort cross-replica dedupe: queries LiveKit room state (the shared
-    source of truth) so a call-bot spawned by *another* worker/replica is
-    visible from here, where the per-process ``_active_agents`` dict and
-    ``_spawn_locks`` cannot see it. Fail-open — ANY error returns ``False`` so a
-    transient LiveKit hiccup never blocks a call from starting; the in-process
-    lock + ``_active_agents`` still prevent the same-process duplicate.
-    """
-    try:
-        async with LiveKitAPI(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) as lk:
-            parts_req = ListParticipantsRequest(room=room_name)
-            parts_resp = await lk.room.list_participants(parts_req)
-            return any(p.identity == "call-bot" for p in parts_resp.participants)
-    except Exception as exc:
-        logger.debug("call-bot presence check failed for room %s (fail-open): %s", room_name, exc)
-        return False
-
-
 async def create_room(
     group_id: str,
     workspace_id: str = "",
@@ -686,12 +668,12 @@ async def create_room(
     # membership check and the insert, so two concurrent joins (two
     # POST /livekit/rooms for the same group) could each pass the check and
     # spawn a second "call-bot" that fights the first over the shared identity.
-    # The per-group asyncio.Lock makes check -> spawn -> insert atomic in this
-    # process; _call_bot_in_room is a best-effort cross-replica guard against
-    # LiveKit room state. True cross-replica atomicity (only if the API is ever
-    # run multi-replica) would need Redis SETNX or LiveKit agent dispatch.
+    # The per-group asyncio.Lock makes check -> spawn -> insert atomic. The
+    # deploy runs a single worker so this fully dedupes it; cross-replica dedupe
+    # (only if the API is ever run multi-replica) is the LiveKit Agents
+    # migration's job, not a best-effort participant poll here.
     async with _spawn_lock_for(group_id):
-        if group_id not in _active_agents and not await _call_bot_in_room(room_name):
+        if group_id not in _active_agents:
             proc = await _spawn_agent_process(
                 group_id=group_id,
                 room_name=room_name,
@@ -771,7 +753,6 @@ async def end_room(group_id: str, workspace_id: str = "") -> dict[str, Any]:
 
     # Stop the meeting agent first (generates and posts notes)
     agent = _active_agents.pop(group_id, None)
-    _spawn_locks.pop(group_id, None)
     if agent is not None:
         try:
             await agent.stop()

--- a/tests/ee/test_livekit_service.py
+++ b/tests/ee/test_livekit_service.py
@@ -3,6 +3,11 @@
 Added TestSelectiveSubscribe: covers the call bot's audio-only selective
 subscribe (Bug A) — auto_subscribe=False on connect and the pure
 _should_subscribe() decision (mic audio in, video / screenshare out).
+
+Added TestSpawnRace: covers the duplicate call-bot spawn race — concurrent
+create_room() for the same group must spawn exactly one agent (per-group
+asyncio.Lock), and create_room() must skip the spawn when a "call-bot" is
+already present in the LiveKit room (cross-replica check via _call_bot_in_room).
 """
 
 from __future__ import annotations
@@ -17,6 +22,7 @@ from pocketpaw_ee.cloud.livekit.service import (
     CALL_BOT_USER_ID,
     _active_agents,
     _format_duration,
+    _spawn_locks,
     room_name_for_group,
 )
 
@@ -80,8 +86,9 @@ class TestService:
         This prevents actual HTTP calls by replacing LiveKitAPI with a
         MagicMock that never makes real requests.
         """
-        # Clean up any agents from previous tests
+        # Clean up any agents / spawn locks from previous tests
         _active_agents.clear()
+        _spawn_locks.clear()
 
         # Create the inner 'room' service mock
         mock_room_svc = MagicMock()
@@ -90,6 +97,13 @@ class TestService:
         mock_list_resp = MagicMock()
         mock_list_resp.rooms = []
         mock_room_svc.list_rooms = AsyncMock(return_value=mock_list_resp)
+
+        # Mock list_participants for _call_bot_in_room — empty by default so the
+        # cross-replica call-bot check is negative and create_room proceeds to
+        # spawn (tests that need a call-bot present override this).
+        mock_parts_resp = MagicMock()
+        mock_parts_resp.participants = []
+        mock_room_svc.list_participants = AsyncMock(return_value=mock_parts_resp)
 
         # Create the LiveKitAPI instance mock
         mock_api_instance = MagicMock()
@@ -105,8 +119,9 @@ class TestService:
 
         yield mock_room_svc
 
-        # Clean up any agents created during the test
+        # Clean up any agents / spawn locks created during the test
         _active_agents.clear()
+        _spawn_locks.clear()
         patcher.stop()
 
     @pytest.mark.asyncio
@@ -589,3 +604,134 @@ class TestSelectiveSubscribe:
         mic_pub.subscribed = False
         handler(mic_pub, participant)
         mic_pub.set_subscribed.assert_called_once_with(True)
+
+
+class TestSpawnRace:
+    """Regression: concurrent create_room() must spawn exactly one call-bot.
+
+    Two participants joining the same group call at once issue two concurrent
+    create_room() calls. Before the per-group lock, both passed the
+    ``group_id not in _active_agents`` check before either inserted (the await
+    inside _spawn_agent_process yields between the check and the insert), so two
+    "call-bot" subprocesses joined the room with the same identity and fought.
+    The fix makes check→spawn→insert atomic per group via an asyncio.Lock and
+    adds a best-effort cross-replica check (_call_bot_in_room) against LiveKit
+    room state.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_globals(self):
+        """Reset module-level spawn registries before/after each test.
+
+        Hermeticity: _active_agents and _spawn_locks are process globals, and an
+        asyncio.Lock is bound to the loop it is first used on, so a leaked lock
+        would poison a later test running on a fresh loop.
+        """
+        _active_agents.clear()
+        _spawn_locks.clear()
+        try:
+            yield
+        finally:
+            _active_agents.clear()
+            _spawn_locks.clear()
+
+    @pytest.fixture
+    def mock_lk_existing_room(self):
+        """Mock LiveKitAPI: the room already exists (is_new=False) and no
+        call-bot is present (list_participants returns an empty list)."""
+        mock_room_svc = MagicMock()
+
+        existing_room = MagicMock()
+        existing_room.name = "group-call-g"
+        mock_list_resp = MagicMock()
+        mock_list_resp.rooms = [existing_room]
+        mock_room_svc.list_rooms = AsyncMock(return_value=mock_list_resp)
+
+        mock_parts_resp = MagicMock()
+        mock_parts_resp.participants = []
+        mock_room_svc.list_participants = AsyncMock(return_value=mock_parts_resp)
+
+        mock_api_instance = MagicMock()
+        mock_api_instance.room = mock_room_svc
+        mock_api_instance.__aenter__ = AsyncMock(return_value=mock_api_instance)
+        mock_api_instance.__aexit__ = AsyncMock(return_value=False)
+
+        patcher = patch(
+            "pocketpaw_ee.cloud.livekit.service.LiveKitAPI", return_value=mock_api_instance
+        )
+        patcher.start()
+        try:
+            yield mock_room_svc
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    @patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_URL", "wss://test.livekit.cloud")
+    @patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_API_KEY", "test-key")
+    @patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_API_SECRET", "test-secret")
+    async def test_concurrent_create_room_spawns_single_agent(self, mock_lk_existing_room):
+        """Two concurrent create_room() for the same group spawn ONE agent.
+
+        Fails on the pre-lock code: the await in _spawn_agent_process yields
+        between the _active_agents check and the insert, so both calls pass the
+        check and spawn (2). Passes once the per-group asyncio.Lock makes
+        check→spawn→insert atomic.
+        """
+        from pocketpaw_ee.cloud.livekit.service import create_room
+
+        spawn_calls = 0
+
+        async def _fake_spawn(*args, **kwargs):
+            nonlocal spawn_calls
+            spawn_calls += 1
+            # Yield the loop here — this is the exact window the race exploited
+            # (between the _active_agents check and the insert).
+            await asyncio.sleep(0)
+            return MagicMock()  # stand-in proc; _reap is patched out
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.livekit.service._spawn_agent_process",
+                side_effect=_fake_spawn,
+            ) as mock_spawn,
+            patch(
+                "pocketpaw_ee.cloud.livekit.service._reap_agent_process",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await asyncio.gather(
+                create_room("g", "ws", "u"),
+                create_room("g", "ws", "u"),
+            )
+            # Let any background reap task drain so it doesn't warn on teardown.
+            await asyncio.sleep(0)
+
+        assert spawn_calls == 1, f"expected exactly 1 spawn, got {spawn_calls}"
+        assert mock_spawn.call_count == 1
+        assert list(_active_agents) == ["g"]
+
+    @pytest.mark.asyncio
+    @patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_URL", "wss://test.livekit.cloud")
+    @patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_API_KEY", "test-key")
+    @patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_API_SECRET", "test-secret")
+    async def test_create_room_skips_spawn_when_call_bot_already_present(
+        self, mock_lk_existing_room
+    ):
+        """If a "call-bot" is already in the LiveKit room (e.g. spawned by
+        another replica), create_room() must NOT spawn a second one."""
+        from pocketpaw_ee.cloud.livekit.service import create_room
+
+        callbot = MagicMock()
+        callbot.identity = "call-bot"
+        parts_resp = MagicMock()
+        parts_resp.participants = [callbot]
+        mock_lk_existing_room.list_participants = AsyncMock(return_value=parts_resp)
+
+        with patch(
+            "pocketpaw_ee.cloud.livekit.service._spawn_agent_process",
+            new_callable=AsyncMock,
+        ) as mock_spawn:
+            await create_room("g", "ws", "u")
+
+        mock_spawn.assert_not_called()
+        assert "g" not in _active_agents

--- a/tests/ee/test_livekit_service.py
+++ b/tests/ee/test_livekit_service.py
@@ -5,9 +5,8 @@ subscribe (Bug A) — auto_subscribe=False on connect and the pure
 _should_subscribe() decision (mic audio in, video / screenshare out).
 
 Added TestSpawnRace: covers the duplicate call-bot spawn race — concurrent
-create_room() for the same group must spawn exactly one agent (per-group
-asyncio.Lock), and create_room() must skip the spawn when a "call-bot" is
-already present in the LiveKit room (cross-replica check via _call_bot_in_room).
+create_room() for the same group must spawn exactly one agent (the per-group
+asyncio.Lock makes check→spawn→insert atomic).
 """
 
 from __future__ import annotations
@@ -709,29 +708,3 @@ class TestSpawnRace:
         assert spawn_calls == 1, f"expected exactly 1 spawn, got {spawn_calls}"
         assert mock_spawn.call_count == 1
         assert list(_active_agents) == ["g"]
-
-    @pytest.mark.asyncio
-    @patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_URL", "wss://test.livekit.cloud")
-    @patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_API_KEY", "test-key")
-    @patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_API_SECRET", "test-secret")
-    async def test_create_room_skips_spawn_when_call_bot_already_present(
-        self, mock_lk_existing_room
-    ):
-        """If a "call-bot" is already in the LiveKit room (e.g. spawned by
-        another replica), create_room() must NOT spawn a second one."""
-        from pocketpaw_ee.cloud.livekit.service import create_room
-
-        callbot = MagicMock()
-        callbot.identity = "call-bot"
-        parts_resp = MagicMock()
-        parts_resp.participants = [callbot]
-        mock_lk_existing_room.list_participants = AsyncMock(return_value=parts_resp)
-
-        with patch(
-            "pocketpaw_ee.cloud.livekit.service._spawn_agent_process",
-            new_callable=AsyncMock,
-        ) as mock_spawn:
-            await create_room("g", "ws", "u")
-
-        mock_spawn.assert_not_called()
-        assert "g" not in _active_agents


### PR DESCRIPTION
Fixes a duplicate call-bot. When two people join the same call at once (two `POST /livekit/rooms` for one group), both could spawn the meeting bot, and the two bots then fight over the shared `call-bot` identity in the room — which shows up as the bot disconnecting and reconnecting, and gets worse the busier the call is.

## Why it happened

`create_room` checked `_active_agents`, then `await`ed `_spawn_agent_process`, then recorded the agent. The `await` between the check and the record yields the event loop, so two concurrent calls both passed the check before either recorded. The deploy runs a single uvicorn worker (`uvicorn.run` with no `workers=`), so this is an in-process race, not the cross-worker case the old `FOLLOW-UP` comment guessed at.

## Fix

- Wrap check → spawn → record in a per-group `asyncio.Lock` so it is atomic.
- Add a best-effort `_call_bot_in_room()` check against LiveKit room state, so a bot already connected from another replica is also skipped. It is fail-open: any LiveKit hiccup just falls through to the local guard, and there is no Redis dependency.
- Drop the per-group lock on reap/end so the dict does not grow.

## Tests

`TestSpawnRace` adds two: one runs two concurrent `create_room` for the same group and asserts a single spawn (it fails on the pre-lock code with two spawns), and one asserts no spawn when a `call-bot` is already in the room. A fixture resets the `_active_agents` and `_spawn_locks` globals between tests. Whole file: 31 passed, ruff clean.
