### PR TITLE
feat(agents): native session resume wiring for the Claude SDK backend

### DIFF
--- a/src/pocketpaw/agents/backend.py
+++ b/src/pocketpaw/agents/backend.py
@@ -22,6 +22,15 @@ per-entity skill subset the Claude SDK backend materializes into a per-run local
 plugin). The ``system_message_override`` field is applied UPSTREAM in
 ``AgentPool.run`` (it swaps the base system prompt before assembly), so it never
 reaches a backend as a kwarg — it rides the existing ``system_prompt`` channel.
+
+Updated: 2026-06-30 (feat/session-supervisor SS-1) — adds the ``SessionHandle``
+dataclass: native-resume identity for a single agent session. It rides the SAME
+withhold-when-empty contract as the kwargs above — ``AgentPool.run`` forwards a
+``session_handle`` to ``backend.run`` ONLY when it is non-None, so the backends
+that keep the narrower signature are unaffected, and only the Claude SDK backend
+acts on it today (passing its ``cli_session_id`` as ``ClaudeAgentOptions.resume``
+so a fresh-process turn resumes the on-disk conversation natively instead of
+replaying Mongo history into the prompt). ``None`` is the unchanged legacy path.
 """
 
 from __future__ import annotations
@@ -68,6 +77,34 @@ class BackendInfo:
     supported_providers: list[str] = field(default_factory=list)
     install_hint: dict[str, str] = field(default_factory=dict)
     beta: bool = False
+
+
+@dataclass
+class SessionHandle:
+    """SS-1 — native-resume identity for a single agent session.
+
+    Carries the bookkeeping that lets ONE agent hold a conversation across
+    turns via the Claude Agent SDK's NATIVE ``resume`` instead of replaying
+    Mongo history into the prompt:
+
+    * ``cli_session_id`` — the SDK session id captured on turn 1 (extracted
+      from the init/system message the SDK emits at the start of a run). When
+      set, the Claude SDK backend passes it as ``ClaudeAgentOptions.resume`` so
+      a fresh-process turn resumes the on-disk conversation natively. ``None``
+      (turn 1, or any non-supervised run) is the LEGACY path — behavior is
+      unchanged from today.
+    * ``session_store`` — carried through OPAQUELY for SS-2 (a custom SDK
+      ``SessionStore``). SS-1 does NOT implement or consume it; it is an inert
+      pass-through field only.
+
+    Like ``deny_mcp_tool_ids`` / ``allow_sdk_tools`` / ``skill_names``, the
+    handle rides the withhold-when-empty contract: ``AgentPool.run`` forwards it
+    to ``backend.run`` ONLY when it is non-None, so backends that keep the
+    narrower signature are unaffected. Only the Claude SDK backend acts on it.
+    """
+
+    cli_session_id: str | None = None
+    session_store: Any | None = None
 
 
 @runtime_checkable

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,21 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-06-30 (feat/session-supervisor SS-1) — ``run`` accepts an optional
+  ``session_handle: SessionHandle | None``. When it carries a non-None
+  ``cli_session_id``, ``_build_options`` sets ``ClaudeAgentOptions.resume`` so the
+  CLI subprocess RESUMES that on-disk session natively (no Mongo-history replay),
+  and ``run`` routes the turn down the FRESH stateless ``query()`` launch path
+  rather than the warm persistent client (the warm client applies its options
+  only at first ``connect()`` and its cache key omits ``resume``, so a reused warm
+  client would silently ignore a fresh ``resume`` — the documented hazard). The
+  freshly-rebuilt per-turn ``system_prompt`` still rides ``--system-prompt`` on
+  every turn, so a resumed session honors a new system prompt. Turn-1 capture: the
+  SDK's init/system message carries a ``session_id`` in its ``data``; when a
+  ``session_handle`` is present, ``run`` extracts it and surfaces it once as a
+  ``session_id`` ``AgentEvent`` (mirroring the ``token_usage`` event) so the
+  controller can persist it for a later resume (SS-3). ``cli_session_id is None``
+  / no handle = the unchanged legacy warm-client path. ``session_handle`` is
+  forwarded by ``AgentPool.run`` only when non-None (withhold-when-empty idiom).
 Updated: 2026-06-26 (ART-2) — the agent's working directory is now resolved
   PER-RUN via ``_resolve_cwd`` instead of being frozen to
   ``settings.file_jail_path`` at ``__init__``. OSS / dedicated behavior is
@@ -185,7 +201,12 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any, NamedTuple
 
-from pocketpaw.agents.backend import BackendInfo, BaseAgentBackend, Capability
+from pocketpaw.agents.backend import (
+    BackendInfo,
+    BaseAgentBackend,
+    Capability,
+    SessionHandle,
+)
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.config import Settings
 from pocketpaw.security.rails import is_substring_blocked
@@ -1217,6 +1238,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         allow_mcp_tool_ids: frozenset[str] | None,
         skill_names: frozenset[str],
         stderr_sink: list[str],
+        session_handle: SessionHandle | None = None,
     ) -> _BuiltOptions:
         """Assemble the ``ClaudeAgentOptions`` a turn (or a prewarm) will run on.
 
@@ -1325,15 +1347,25 @@ class ClaudeSDKBackend(BaseAgentBackend):
         except Exception:
             pass  # Don't break agent if connector registry fails
 
+        # Native-resume session id (feat/session-supervisor SS-1). When set, the
+        # CLI subprocess will be launched with ``resume=<id>`` and reloads that
+        # session's transcript NATIVELY, so injecting Mongo ``history`` into the
+        # prompt below would DUPLICATE the conversation. The whole point of the
+        # slice is native continuity INSTEAD of history replay, so a resume turn
+        # skips the injection. ``None`` (legacy / no handle) keeps every existing
+        # cold-start run injecting history exactly as before.
+        resume_session_id = session_handle.cli_session_id if session_handle is not None else None
+
         # Inject prior turns into the system prompt at connect time. The
         # persistent ClaudeSDKClient accumulates new turns natively after
         # connect, but a fresh subprocess (after eviction, restart, or
         # session switch) has empty native history — without this, those
         # cold-start runs lose all conversation context. Reused clients
         # keep the prompt set at first connect and ignore later option
-        # changes, so there's no duplication on the warm path.
+        # changes, so there's no duplication on the warm path. Skipped on a
+        # native-resume turn (the resumed session already carries its history).
         final_prompt = identity
-        if history:
+        if history and not resume_session_id:
             lines = ["# Recent Conversation"]
             for msg in history:
                 role = msg.get("role", "user").capitalize()
@@ -1671,6 +1703,17 @@ class ClaudeSDKBackend(BaseAgentBackend):
 
         options_kwargs["stderr"] = _on_stderr
 
+        # Native-resume (feat/session-supervisor SS-1). When the caller threads a
+        # ``session_handle`` carrying a ``cli_session_id``, set the SDK's
+        # ``resume`` field so the freshly-launched CLI subprocess loads that
+        # session's transcript natively (the ``ClaudeAgentOptions.resume: str |
+        # None`` field). ``run`` routes a resume-bearing turn down the stateless
+        # ``query()`` path precisely so this fresh-launch option is honored (the
+        # warm client applies options only at first ``connect()``). Absent /
+        # ``None`` leaves ``resume`` unset — the unchanged legacy path.
+        if resume_session_id:
+            options_kwargs["resume"] = resume_session_id
+
         # Create options (after all kwargs are set, including model)
         options = self._ClaudeAgentOptions(**options_kwargs)
 
@@ -1796,10 +1839,26 @@ class ClaudeSDKBackend(BaseAgentBackend):
         allow_sdk_tools: frozenset[str] = frozenset(),
         allow_mcp_tool_ids: frozenset[str] | None = None,
         skill_names: frozenset[str] = frozenset(),
+        session_handle: SessionHandle | None = None,
     ) -> AsyncIterator[AgentEvent]:
         """Process a message through Claude Agent SDK with streaming.
 
         Yields AgentEvent objects as the agent responds.
+
+        ``session_handle`` (feat/session-supervisor SS-1) carries native-resume
+        identity. When it holds a non-None ``cli_session_id``, the SDK options
+        get ``resume=<cli_session_id>`` (so the CLI subprocess resumes that
+        on-disk session natively instead of replaying Mongo history) and THIS
+        run is routed down the FRESH stateless ``query()`` launch path — never
+        the warm persistent client, whose options freeze at first ``connect()``
+        and whose cache key omits ``resume`` (so a reused warm client would
+        silently ignore a fresh ``resume``). The per-turn ``system_prompt`` is
+        still passed on every turn, so a resumed session honors a rebuilt
+        prompt. When a handle is present, the SDK's turn-1 init/system message
+        ``session_id`` is extracted and surfaced once as a ``session_id``
+        AgentEvent (for the controller to persist — SS-3). ``cli_session_id is
+        None`` / no handle = the UNCHANGED legacy warm-client path. The
+        ``session_store`` field is opaque here (SS-2 owns it).
 
         ``deny_mcp_tool_ids`` is a per-surface MCP-tool deny set threaded down
         from the chat loop (resolved from the request's ``SurfaceProfile``).
@@ -1930,6 +1989,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 allow_sdk_tools=allow_sdk_tools,
                 allow_mcp_tool_ids=allow_mcp_tool_ids,
                 skill_names=skill_names,
+                session_handle=session_handle,
                 stderr_sink=_stderr_lines,
             )
             options = _built.options
@@ -1951,16 +2011,27 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 session_key,
             )
             _persistent_client = None
+            # Native-resume runs (feat/session-supervisor SS-1) MUST take the
+            # fresh stateless ``query()`` launch path, never the warm persistent
+            # client: the warm client applies its options (incl. ``resume``) only
+            # at first ``connect()``, and ``_client_cache_key`` does NOT fold in
+            # ``resume`` — so a reused warm client would silently ignore the fresh
+            # ``resume`` and continue its OWN in-memory conversation instead of
+            # the requested on-disk session. The stateless ``query()`` spawns a
+            # fresh subprocess per call that honors ``options.resume`` directly.
+            _resume_active = (
+                session_handle is not None and session_handle.cli_session_id is not None
+            )
             # fix/claude-sdk-warm-client-skills: the warm-client bypass for skill
             # runs is REMOVED. ``_client_cache_key`` now folds in
             # ``plugin_digest`` (the skill-identity hash), so a warm client can
             # distinguish a skill run from a non-skill one — a same-skill turn
             # reuses the subprocess and a changed skill set rebuilds it. The
             # materialized plugin dir was cached + adopted above so the warm
-            # subprocess keeps a valid path across turns. The only fallback to
-            # the stateless path now is the original concurrency guard: a sibling
-            # run already holds the lease (_client_in_use).
-            if not self._client_in_use:
+            # subprocess keeps a valid path across turns. Fallbacks to the
+            # stateless path: the original concurrency guard (a sibling run holds
+            # the lease, ``_client_in_use``) OR a native-resume turn.
+            if not self._client_in_use and not _resume_active:
                 try:
                     self._client_in_use = True
                     acquired_lease = True
@@ -2019,6 +2090,10 @@ class ClaudeSDKBackend(BaseAgentBackend):
             _announced_tools: set[str] = set()
             _event_count = 0
             _saw_result = False  # Track if ResultMessage was consumed
+            # feat/session-supervisor SS-1: emit the native session id at most
+            # once per run (from the SDK's turn-1 init/system message). Gated on
+            # an opted-in ``session_handle`` so the legacy stream is byte-identical.
+            _session_id_emitted = False
 
             # Stream responses — release the persistent client guard when done
             try:
@@ -2063,9 +2138,30 @@ class ClaudeSDKBackend(BaseAgentBackend):
                                 yield AgentEvent(type="thinking_done", content="")
                         continue
 
-                    # ========== SystemMessage - metadata, skip ==========
+                    # ========== SystemMessage - metadata ==========
                     if self._SystemMessage and isinstance(event, self._SystemMessage):
                         subtype = getattr(event, "subtype", "")
+                        # feat/session-supervisor SS-1: the SDK's init/system
+                        # message carries the native ``session_id`` in its
+                        # ``data`` dict. When the caller opted into a
+                        # ``session_handle``, capture it on turn 1 and surface it
+                        # ONCE as a ``session_id`` AgentEvent (mirroring the
+                        # ``token_usage`` metadata event) so the controller can
+                        # persist it for a later ``resume`` turn (SS-3). Gated on
+                        # the handle so the legacy stream stays byte-identical.
+                        if session_handle is not None and not _session_id_emitted:
+                            _data = getattr(event, "data", None)
+                            _sid = _data.get("session_id") if isinstance(_data, dict) else None
+                            if _sid:
+                                _session_id_emitted = True
+                                yield AgentEvent(
+                                    type="session_id",
+                                    content="",
+                                    metadata={
+                                        "session_id": _sid,
+                                        "backend": "claude_agent_sdk",
+                                    },
+                                )
                         logger.debug(f"SystemMessage: {subtype}")
                         continue
 
@@ -2294,6 +2390,10 @@ class ClaudeSDKBackend(BaseAgentBackend):
                         system_prompt=system_prompt,
                         history=history,
                         session_key=session_key,
+                        # Preserve native-resume identity across the crash retry
+                        # (feat/session-supervisor SS-1) so a resumed turn does
+                        # not silently restart a fresh session after a Bun crash.
+                        session_handle=session_handle,
                     ):
                         yield retry_event
                 finally:

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -77,7 +77,7 @@ from typing import TYPE_CHECKING, Any
 from pocketpaw.agents.errors import AgentBackendUnavailable, AgentNotFound
 
 if TYPE_CHECKING:
-    from pocketpaw.agents.backend import AgentBackend
+    from pocketpaw.agents.backend import AgentBackend, SessionHandle
     from pocketpaw.soul import SoulManager
 
 logger = logging.getLogger(__name__)
@@ -403,6 +403,7 @@ class AgentPool:
         allow_mcp_tool_ids: frozenset[str] | None = None,
         system_message_override: str | None = None,
         skill_names: frozenset[str] = frozenset(),
+        session_handle: SessionHandle | None = None,
     ) -> AsyncIterator[Any]:
         """Run an agent on a message. Yields AgentEvent stream.
 
@@ -518,6 +519,15 @@ class AgentPool:
             # non-empty. Empty = legacy all-skills advertise behavior.
             if skill_names:
                 run_kwargs["skill_names"] = skill_names
+            # Native-resume handle (feat/session-supervisor SS-1). Same
+            # withhold-when-empty rule as the kwargs above: only the Claude SDK
+            # backend accepts ``session_handle`` (it passes a non-None
+            # ``cli_session_id`` as ``ClaudeAgentOptions.resume`` and routes the
+            # turn down the fresh-launch path); the other backends keep the
+            # narrower signature, so the handle is forwarded ONLY when non-None.
+            # None = legacy warm-client path, unchanged for every existing run.
+            if session_handle is not None:
+                run_kwargs["session_handle"] = session_handle
             async for event in instance.backend.run(message, **run_kwargs):
                 instance.last_active = datetime.now(UTC)
                 yield event

--- a/src/pocketpaw/agents/protocol.py
+++ b/src/pocketpaw/agents/protocol.py
@@ -16,6 +16,9 @@ class AgentEvent:
         - "thinking": Extended thinking content (Activity panel only)
         - "thinking_done": Thinking phase completed
         - "token_usage": Token usage metadata
+        - "session_id": Native SDK session id captured on turn 1 (SS-1) —
+          metadata carries ``session_id`` so the controller can persist it for a
+          later native ``resume``. Only emitted when a ``SessionHandle`` is threaded.
         - "error": Error message
         - "done": Agent finished processing
     """

--- a/tests/test_claude_sdk_session_handle.py
+++ b/tests/test_claude_sdk_session_handle.py
@@ -1,0 +1,345 @@
+# tests/test_claude_sdk_session_handle.py
+# Created: 2026-06-30 (feat/session-supervisor SS-1) — pins the wiring contract
+# for native SDK ``resume`` on the OSS Claude SDK backend. The de-risk slice lets
+# ONE agent hold a conversation across turns via the Claude Agent SDK's NATIVE
+# ``resume`` (a fresh-process launch that reloads the on-disk session) instead of
+# replaying Mongo history into the prompt, while a freshly-rebuilt system prompt
+# is honored on every turn.
+#
+# Live ``claude`` model calls are BLOCKED in CI, so these tests SPY on the
+# boundary (the constructed ``ClaudeAgentOptions`` + the faked SDK message stream)
+# rather than making a real call. They assert four things:
+#   1. ``run(session_handle=SessionHandle(cli_session_id="..."))`` constructs
+#      options carrying ``resume="..."`` AND routes down the FRESH stateless
+#      ``query()`` launch path (never the warm persistent client, which would
+#      silently ignore a fresh ``resume``).
+#   2. The per-turn ``system_prompt`` is reflected on the resume path — a second
+#      call with a different system prompt builds options carrying THAT prompt
+#      (per-turn injection survives the resume seam, not a frozen turn-1 prompt).
+#   3. The turn-1 native ``session_id`` is extracted from the SDK init/system
+#      message and surfaced once as a ``session_id`` AgentEvent.
+#   4. The legacy path (no handle / cli_session_id=None) is UNCHANGED: no
+#      ``resume`` is set and no ``session_id`` event is emitted.
+#
+# The spy targets ONLY the construction/stream boundary (the seam under test is
+# claude_sdk's own resume-routing + capture logic, which is exercised for real).
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+from pocketpaw.agents.backend import SessionHandle
+from pocketpaw.agents.claude_sdk import ClaudeAgentSDK, ClaudeSDKBackend
+from pocketpaw.agents.model_router import ModelSelection, TaskComplexity
+
+_LLM_CLIENT = "pocketpaw.llm.client.resolve_llm_client"
+_MODEL_ROUTER = "pocketpaw.agents.model_router.ModelRouter"
+
+
+# ===========================================================================
+# Fakes — a capturing options factory + a faked SDK message stream, so a full
+# run() completes WITHOUT a live model call and the constructed options + the
+# emitted events are observable.
+# ===========================================================================
+
+
+def _make_settings(**overrides):
+    defaults = {
+        "agent_backend": "claude_agent_sdk",
+        "tool_profile": "full",
+        "tools_allow": [],
+        "tools_deny": [],
+        "smart_routing_enabled": False,
+        "claude_sdk_provider": "anthropic",
+        "claude_sdk_model": None,
+        "claude_sdk_max_turns": None,
+        "sdk_load_bundled_skills": False,
+        "anthropic_api_key": "sk-test-key",
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class _Options:
+    """Real options stand-in so ``_client_cache_key`` / dispatch can read
+    ``system_prompt`` / ``model`` / ``allowed_tools`` / ``plugins`` / ``resume``."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.model = kwargs.get("model", "")
+        self.allowed_tools = kwargs.get("allowed_tools", [])
+        self.system_prompt = kwargs.get("system_prompt", "")
+        self.plugins = kwargs.get("plugins", [])
+        # Mirror the real ClaudeAgentOptions default so a legacy run reads None.
+        self.resume = kwargs.get("resume", None)
+
+
+def _capturing_options(sink: list[_Options]):
+    """Factory that records every constructed options object into ``sink``."""
+
+    def _factory(**kwargs):
+        opt = _Options(**kwargs)
+        sink.append(opt)
+        return opt
+
+    return _factory
+
+
+class _FakeSystemMessage:
+    """Stand-in for the SDK's init/system message (carries ``data.session_id``)."""
+
+    def __init__(self, subtype: str, data: dict):
+        self.subtype = subtype
+        self.data = data
+
+
+class _FakeResultMsg:
+    def __init__(self):
+        self.is_error = False
+        self.result = "ok"
+        self.total_cost_usd = None
+        self.usage = {}
+
+
+class _FakeClient:
+    """Warm persistent client. Its ``receive_messages()`` yields the init/system
+    message (carrying ``session_id``) then a ResultMessage — the warm path the
+    legacy + turn-1-capture runs take."""
+
+    def __init__(self, options=None, *, init_session_id="sess-warm-init", **_kw):
+        self.options = options
+        self._init_session_id = init_session_id
+        self.queries: list[str] = []
+
+    async def connect(self, prompt=None):
+        pass
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def receive_messages(self):
+        yield _FakeSystemMessage(subtype="init", data={"session_id": self._init_session_id})
+        yield _FakeResultMsg()
+
+    async def disconnect(self):
+        pass
+
+    async def interrupt(self):
+        pass
+
+
+def _wire_fakes(sdk, options_sink: list[_Options], stateless_options: list[_Options]):
+    """Wire the SDK symbol table to the fakes. ``options_sink`` records EVERY
+    constructed options; ``stateless_options`` records the options handed to the
+    stateless ``query()`` launch path (proving a resume run took it)."""
+    sdk._ClaudeAgentOptions = _capturing_options(options_sink)
+    sdk._ResultMessage = _FakeResultMsg
+    sdk._SystemMessage = _FakeSystemMessage
+    sdk._ClaudeSDKClient = lambda **kwargs: _FakeClient(**kwargs)
+    sdk._HookMatcher = MagicMock()
+    sdk._StreamEvent = None
+    sdk._AssistantMessage = None
+    sdk._UserMessage = None
+    sdk._ToolResultBlock = None
+
+    async def _fake_query(prompt, options, init_session_id="sess-stateless-init"):
+        # The stateless fresh-launch path — record the options it was handed and
+        # emit the init/system message + result the SDK would.
+        stateless_options.append(options)
+        yield _FakeSystemMessage(subtype="init", data={"session_id": init_session_id})
+        yield _FakeResultMsg()
+
+    sdk._query = _fake_query
+
+
+def _make_sdk(options_sink, stateless_options, settings=None):
+    s = settings or _make_settings()
+    with patch.object(ClaudeSDKBackend, "_initialize"):
+        sdk = ClaudeAgentSDK(s)
+    sdk._sdk_available = True
+    sdk._cli_available = True
+    _wire_fakes(sdk, options_sink, stateless_options)
+    return sdk
+
+
+def _patched(fn):
+    """Run ``fn()`` under the standard LLM / router / MCP patches run() needs."""
+
+    async def _inner():
+        selection = ModelSelection(
+            complexity=TaskComplexity.MODERATE,
+            model="claude-sonnet-4-5-20250929",
+            reason="test",
+        )
+        with patch(_LLM_CLIENT) as mock_resolve:
+            mock_llm = MagicMock()
+            mock_llm.is_ollama = False
+            mock_llm.is_openai_compatible = False
+            mock_llm.is_gemini = False
+            mock_llm.is_litellm = False
+            mock_llm.is_openrouter = False
+            mock_llm.to_sdk_env.return_value = {"ANTHROPIC_API_KEY": "sk-test"}
+            mock_resolve.return_value = mock_llm
+            with patch(_MODEL_ROUTER) as MockRouter:
+                MockRouter.return_value.classify.return_value = selection
+                with patch.object(ClaudeSDKBackend, "_get_mcp_servers", return_value={}):
+                    return await fn()
+
+    return _inner
+
+
+async def _drive_run(sdk, message, *, system_prompt="identity", session_handle=None):
+    async def _go():
+        events = []
+        async for ev in sdk.run(
+            message,
+            system_prompt=system_prompt,
+            session_key="s1",
+            session_handle=session_handle,
+        ):
+            events.append(ev)
+        return events
+
+    return await _patched(_go)()
+
+
+# ===========================================================================
+# 0. Signature contract
+# ===========================================================================
+
+
+def test_run_accepts_session_handle_kwarg() -> None:
+    """``ClaudeSDKBackend.run`` accepts a keyword-only ``session_handle``
+    defaulting to ``None`` (the legacy / non-supervised path)."""
+    params = inspect.signature(ClaudeSDKBackend.run).parameters
+    assert "session_handle" in params, "run must accept a session_handle kwarg"
+    assert params["session_handle"].default is None, (
+        "session_handle must default to None so non-supervised runs are unaffected"
+    )
+
+
+def test_session_handle_carries_store_opaquely() -> None:
+    """SS-1 carries ``session_store`` as an inert pass-through field (SS-2 owns
+    it); the dataclass exposes both fields with None defaults."""
+    sentinel = object()
+    sh = SessionHandle(cli_session_id="abc", session_store=sentinel)
+    assert sh.cli_session_id == "abc"
+    assert sh.session_store is sentinel
+    assert SessionHandle().cli_session_id is None
+    assert SessionHandle().session_store is None
+
+
+# ===========================================================================
+# 1. Resume wiring — options carry resume + the fresh-launch path is taken
+# ===========================================================================
+
+
+async def test_resume_sets_options_resume_and_uses_fresh_launch_path() -> None:
+    """A run with ``SessionHandle(cli_session_id=...)`` constructs options
+    carrying ``resume=<id>`` AND dispatches down the stateless ``query()``
+    fresh-launch path (never the warm client, which would ignore the resume)."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    sdk = _make_sdk(options_sink, stateless_options)
+
+    handle = SessionHandle(cli_session_id="sess-xyz")
+    events = await _drive_run(
+        sdk, "turn two", system_prompt="IDENTITY-ALPHA", session_handle=handle
+    )
+
+    assert any(e.type == "done" for e in events)
+    assert options_sink, "options must have been constructed"
+    opt = options_sink[-1]
+    assert getattr(opt, "resume", None) == "sess-xyz", (
+        "the constructed ClaudeAgentOptions must carry resume=<cli_session_id> so "
+        "the CLI subprocess resumes that on-disk session natively"
+    )
+    # The SAME options object must reach the stateless launch path — proving the
+    # warm persistent client (which freezes options at connect()) was bypassed.
+    assert stateless_options and stateless_options[-1] is opt, (
+        "a resume-bearing run must take the fresh stateless query() launch path"
+    )
+
+
+# ===========================================================================
+# 2. Per-turn system prompt survives the resume seam
+# ===========================================================================
+
+
+async def test_per_turn_system_prompt_reflected_on_resume_path() -> None:
+    """Resume must NOT freeze a turn-1 prompt: a second resume turn with a
+    different system prompt builds options carrying THAT prompt, proving the
+    freshly-rebuilt per-turn system prompt is honored every turn."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    sdk = _make_sdk(options_sink, stateless_options)
+    handle = SessionHandle(cli_session_id="sess-1")
+
+    await _drive_run(sdk, "turn A", system_prompt="IDENTITY-ALPHA", session_handle=handle)
+    first = options_sink[-1]
+    assert "IDENTITY-ALPHA" in first.system_prompt
+
+    await _drive_run(sdk, "turn B", system_prompt="IDENTITY-BRAVO", session_handle=handle)
+    second = options_sink[-1]
+    assert "IDENTITY-BRAVO" in second.system_prompt, (
+        "the second turn's options must reflect the NEW per-turn system prompt"
+    )
+    assert "IDENTITY-ALPHA" not in second.system_prompt, (
+        "the per-turn prompt is rebuilt each turn — turn-1's prompt must not leak "
+        "into turn-2's options (resume does not freeze the system prompt)"
+    )
+
+
+# ===========================================================================
+# 3. Turn-1 native session-id capture surfaces on the event stream
+# ===========================================================================
+
+
+async def test_turn_one_session_id_is_captured_and_surfaced() -> None:
+    """Turn 1 (handle present, cli_session_id=None) extracts the native
+    ``session_id`` from the SDK init/system message and surfaces it once as a
+    ``session_id`` AgentEvent so the controller can persist it (SS-3)."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    sdk = _make_sdk(options_sink, stateless_options)
+
+    # Turn 1: no id yet → legacy warm path, but the handle opts into capture.
+    handle = SessionHandle(cli_session_id=None)
+    events = await _drive_run(sdk, "turn one", session_handle=handle)
+
+    sid_events = [e for e in events if e.type == "session_id"]
+    assert len(sid_events) == 1, "exactly one session_id event must be surfaced on turn 1"
+    assert sid_events[0].metadata.get("session_id") == "sess-warm-init", (
+        "the surfaced id must be the one carried in the init/system message data"
+    )
+    # Turn 1 has no cli_session_id, so no resume is set (capture-only).
+    assert getattr(options_sink[-1], "resume", None) is None
+
+
+# ===========================================================================
+# 4. Legacy path unchanged — no resume, no session_id event
+# ===========================================================================
+
+
+async def test_legacy_path_no_handle_is_unchanged() -> None:
+    """With NO session_handle, behavior is byte-identical to today: options carry
+    no ``resume`` and the stream emits no ``session_id`` event."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    sdk = _make_sdk(options_sink, stateless_options)
+
+    events = await _drive_run(sdk, "ordinary turn", session_handle=None)
+
+    assert any(e.type == "done" for e in events)
+    assert getattr(options_sink[-1], "resume", None) is None, (
+        "a no-handle run must not set resume on the options"
+    )
+    assert not any(e.type == "session_id" for e in events), (
+        "a no-handle run must not surface a session_id event (legacy stream is byte-identical)"
+    )
+    # And it must take the warm path, not the stateless fresh-launch path.
+    assert not stateless_options, "a legacy run must not take the stateless resume path"


### PR DESCRIPTION
Adds the plumbing for an agent to continue a conversation by resuming its native CLI session instead of replaying chat history into the prompt each turn.

- `SessionHandle` (cli_session_id + an opaque session_store), threaded through `AgentPool.run` only when set, matching the existing deny/allow/skills idiom.
- In the Claude SDK backend, a handle carrying a `cli_session_id` sets `ClaudeAgentOptions.resume` and routes that turn down the fresh `query()` launch path. The warm persistent client can't take a fresh resume (its cache key omits it), so a resume turn deliberately bypasses it.
- History injection is skipped on a resume turn (the native session already carries it); the per-turn system prompt is still rebuilt and applied, so resumed turns honor fresh instructions and KB.
- The native session id is captured from the turn-1 init message and surfaced as a `session_id` event for the executor to persist.

Without a handle, behavior is unchanged.

Tests: resume sets `resume` and uses the fresh path, per-turn system prompt is honored on resume, turn-1 id is captured, legacy path unchanged. 6 new plus regression, green.

First of 6 stacked PRs (base: dev). Live two-turn continuity is confirmed by hand separately, since nested `claude` calls can't run in the build sandbox.

Out of scope here: the durable store, the supervisor, and the executor wiring (later PRs in the stack).
