### PR TITLE
feat(agents): tenancy-keyed SessionStore for durable native resume

### DIFF
--- a/ee/pocketpaw_ee/cloud/agent_sessions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/agent_sessions/__init__.py
@@ -1,0 +1,14 @@
+# ee/pocketpaw_ee/cloud/agent_sessions/__init__.py — the agent-session entity.
+#
+# Holds the Mongo-backed ``SessionStore`` (feat/session-supervisor SS-2) that
+# durably mirrors Claude Agent SDK session transcripts per tenant, so an agent
+# conversation survives a backend restart by resuming from Mongo instead of the
+# subprocess's local disk.
+#
+# Created 2026-06-30 (feat/session-supervisor SS-2).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore
+
+__all__ = ["MongoSessionStore"]

--- a/ee/pocketpaw_ee/cloud/agent_sessions/store.py
+++ b/ee/pocketpaw_ee/cloud/agent_sessions/store.py
@@ -1,0 +1,160 @@
+# ee/pocketpaw_ee/cloud/agent_sessions/store.py — the Mongo-backed, tenancy-keyed
+# ``SessionStore`` (feat/session-supervisor SS-2).
+#
+# The real, durable counterpart to the OSS reference
+# ``pocketpaw.agents.session_store.InMemorySessionStore``. It satisfies the
+# Claude Agent SDK's ``SessionStore`` protocol by DUCK TYPING (the SDK never
+# uses ``isinstance``) and persists every transcript line as a
+# ``SessionTranscriptDoc`` row in the ``session_transcripts`` collection.
+#
+# The store is bound to a ``workspace_id`` at construction; EVERY query filters
+# on ``workspace == self._workspace_id``, so a store bound to tenant B can never
+# read tenant A's rows even though both live in the same collection — the core
+# isolation property (SS-7 tests it). It mirrors the in-memory ref impl's
+# semantics 1:1 (subpath ``""`` == main transcript, uuid-keyed idempotency on
+# ``append``, main-transcript ``delete`` cascades to subkeys).
+#
+# EE→OSS boundary: this concrete class lives in ee and is constructed by the
+# cloud controller (SS-5). It reaches the OSS ``claude_sdk`` backend ONLY as an
+# opaque object on ``SessionHandle.session_store`` — ``src/pocketpaw`` never
+# imports it.
+#
+# Created 2026-06-30 (feat/session-supervisor SS-2): new entity. Only this module
+# imports ``SessionTranscriptDoc``.
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pocketpaw_ee.cloud.models.session_transcript import SessionTranscriptDoc
+
+if TYPE_CHECKING:
+    from claude_agent_sdk.types import (
+        SessionKey,
+        SessionListSubkeysKey,
+        SessionStoreEntry,
+        SessionStoreListEntry,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+def _to_ms(dt: Any) -> int:
+    """Epoch-milliseconds for a datetime; 0 when absent.
+
+    Mongo strips tzinfo on persistence, so a naive datetime is treated as UTC.
+    """
+    if dt is None:
+        return 0
+    return int(dt.timestamp() * 1000)
+
+
+class MongoSessionStore:
+    """Tenancy-keyed ``SessionStore`` persisted in the ``session_transcripts``
+    collection. Construct one per ``workspace_id``."""
+
+    def __init__(self, workspace_id: str):
+        if not workspace_id:
+            raise ValueError("MongoSessionStore requires a non-empty workspace_id")
+        self._workspace_id = workspace_id
+
+    @staticmethod
+    def _subpath_of(key: SessionKey) -> str:
+        """Read the optional ``subpath`` (``""`` == main transcript)."""
+        return key.get("subpath") or ""
+
+    async def _find_row(
+        self, project_key: str, session_id: str, subpath: str
+    ) -> SessionTranscriptDoc | None:
+        return await SessionTranscriptDoc.find_one(
+            SessionTranscriptDoc.workspace == self._workspace_id,
+            SessionTranscriptDoc.project_key == project_key,
+            SessionTranscriptDoc.session_id == session_id,
+            SessionTranscriptDoc.subpath == subpath,
+        )
+
+    # -- SessionStore protocol ---------------------------------------------
+
+    async def append(self, key: SessionKey, entries: list[SessionStoreEntry]) -> None:
+        """Mirror a batch of transcript entries for ``key``.
+
+        Find-or-create the row, then extend its ``entries`` array, deduping any
+        entry that carries a ``uuid`` already present (the protocol's
+        idempotency contract). Read-modify-write — see the concurrency note in
+        the module/PR; v1 keeps it simple and correct for the de-risk slice.
+        """
+        subpath = self._subpath_of(key)
+        doc = await self._find_row(key["project_key"], key["session_id"], subpath)
+        if doc is None:
+            doc = SessionTranscriptDoc(
+                workspace=self._workspace_id,
+                project_key=key["project_key"],
+                session_id=key["session_id"],
+                subpath=subpath,
+                entries=[],
+            )
+        seen = {e.get("uuid") for e in doc.entries if isinstance(e, dict) and e.get("uuid")}
+        for entry in entries:
+            uuid = entry.get("uuid")
+            if uuid is not None:
+                if uuid in seen:
+                    continue
+                seen.add(uuid)
+            doc.entries.append(dict(entry))
+        await doc.save()
+
+    async def load(self, key: SessionKey) -> list[SessionStoreEntry] | None:
+        """Return the full transcript for ``key``, or ``None`` if never written.
+
+        A store bound to a different workspace returns ``None`` — the
+        ``workspace`` filter excludes the other tenant's row.
+        """
+        doc = await self._find_row(
+            key["project_key"], key["session_id"], self._subpath_of(key)
+        )
+        if doc is None:
+            return None
+        return list(doc.entries)  # type: ignore[return-value]
+
+    async def list_sessions(self, project_key: str) -> list[SessionStoreListEntry]:
+        """List MAIN-transcript sessions for ``project_key`` in this workspace."""
+        docs = await SessionTranscriptDoc.find(
+            SessionTranscriptDoc.workspace == self._workspace_id,
+            SessionTranscriptDoc.project_key == project_key,
+            SessionTranscriptDoc.subpath == "",
+        ).to_list()
+        return [
+            {"session_id": d.session_id, "mtime": _to_ms(getattr(d, "updatedAt", None))}
+            for d in docs
+        ]
+
+    async def list_subkeys(self, key: SessionListSubkeysKey) -> list[str]:
+        """List the subpaths (e.g. subagent transcripts) under a session."""
+        docs = await SessionTranscriptDoc.find(
+            SessionTranscriptDoc.workspace == self._workspace_id,
+            SessionTranscriptDoc.project_key == key["project_key"],
+            SessionTranscriptDoc.session_id == key["session_id"],
+        ).to_list()
+        return [d.subpath for d in docs if d.subpath]
+
+    async def delete(self, key: SessionKey) -> None:
+        """Delete a session entry.
+
+        Deleting a main transcript (no ``subpath``) cascades to every subkey
+        under that session; a keyed ``subpath`` deletes only that one entry.
+        """
+        subpath = self._subpath_of(key)
+        if subpath:
+            doc = await self._find_row(key["project_key"], key["session_id"], subpath)
+            if doc is not None:
+                await doc.delete()
+            return
+        # Main transcript: cascade-delete the main row + all subkeys.
+        docs = await SessionTranscriptDoc.find(
+            SessionTranscriptDoc.workspace == self._workspace_id,
+            SessionTranscriptDoc.project_key == key["project_key"],
+            SessionTranscriptDoc.session_id == key["session_id"],
+        ).to_list()
+        for doc in docs:
+            await doc.delete()

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,10 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-06-30 (feat/session-supervisor SS-2) — added ``SessionTranscriptDoc``
+(the durable, tenant-scoped transcript rows backing the Mongo ``SessionStore``)
+to the imports, ``__all__``, and ``get_all_documents()`` so the
+``session_transcripts`` collection is wired into ``init_beanie``. Only
+``ee.cloud.agent_sessions.store`` imports the doc class directly.
 Updated: 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.2) — added the
 ``Lead`` and ``Site`` tenant-scoped Paw Sites documents (plus their
 ``LeadSource`` / ``SiteDomain`` subdocs) to the imports, ``__all__``, and the
@@ -117,6 +122,7 @@ from pocketpaw_ee.cloud.models.read_state import ReadState
 from pocketpaw_ee.cloud.models.request_log import RequestLog
 from pocketpaw_ee.cloud.models.sense_preference import WorkspaceSensePreference
 from pocketpaw_ee.cloud.models.session import Session
+from pocketpaw_ee.cloud.models.session_transcript import SessionTranscriptDoc
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
 from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
@@ -258,6 +264,7 @@ __all__ = [
     "DeepWorkLog",
     "RequestLog",
     "Session",
+    "SessionTranscriptDoc",
     "Site",
     "SiteDomain",
     "SiteRateCounter",
@@ -293,6 +300,9 @@ def get_all_documents():
         Pocket,
         PocketBackendCredential,
         Session,
+        # Agent-session transcript rows backing the Mongo SessionStore (SS-2).
+        # Only ``ee.cloud.agent_sessions.store`` imports this doc directly.
+        SessionTranscriptDoc,
         Comment,
         Notification,
         FileObj,

--- a/ee/pocketpaw_ee/cloud/models/session_transcript.py
+++ b/ee/pocketpaw_ee/cloud/models/session_transcript.py
@@ -1,0 +1,67 @@
+# ee/pocketpaw_ee/cloud/models/session_transcript.py — the durable, tenant-scoped
+# transcript rows that back the Mongo ``SessionStore`` (feat/session-supervisor
+# SS-2).
+#
+# One ``SessionTranscriptDoc`` row holds the full JSONL transcript for ONE
+# (workspace, project_key, session_id, subpath) tuple. The Claude Agent SDK's
+# ``SessionStore`` protocol mirrors transcript lines here via ``append`` and
+# reconstructs a conversation on resume via ``load`` — so an agent session
+# survives a backend restart by reading from Mongo instead of the subprocess's
+# local disk.
+#
+# ``subpath`` is ``""`` for the main transcript and a non-empty path (e.g.
+# ``"subagents/agent-{id}"``) for a subagent transcript. The UNIQUE compound
+# index on ``(workspace, project_key, session_id, subpath)`` keeps it one row
+# per logical key (so ``append`` can find-and-extend) and the leading
+# ``workspace`` component is the tenancy boundary — every read in the adapter
+# filters on ``workspace`` so a store bound to tenant B can never observe tenant
+# A's rows.
+#
+# Created 2026-06-30 (feat/session-supervisor SS-2): new entity. Registered in
+# ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``session_transcripts`` collection. Only
+# ``ee.cloud.agent_sessions.store`` imports this doc class (entity-isolation
+# boundary, mirroring the credit / sessions entities).
+
+from __future__ import annotations
+
+from typing import Any
+
+from beanie import Indexed
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class SessionTranscriptDoc(TimestampedDocument):
+    """One agent-session transcript (or subagent transcript) for a tenant.
+
+    Mirrors the SDK ``SessionStore`` key shape. ``entries`` is the ordered list
+    of opaque JSONL transcript lines (pass-through blobs — the adapter never
+    interprets them). ``updatedAt`` (from :class:`TimestampedDocument`) is the
+    ``mtime`` source the adapter surfaces in ``list_sessions``.
+    """
+
+    # Tenancy boundary. Indexed (non-unique) — many sessions per workspace.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The SDK ``project_key`` — caller-defined scope (default: sanitized cwd).
+    project_key: str
+    # The SDK session id.
+    session_id: str
+    # "" for the main transcript; a non-empty subpath for a subagent transcript.
+    subpath: str = ""
+    # Ordered opaque transcript lines. Each is one JSONL entry as a plain dict.
+    entries: list[dict[str, Any]] = []  # noqa: RUF012 — Beanie field default, not a shared mutable
+
+    class Settings:
+        name = "session_transcripts"
+        indexes = [
+            # One row per logical key. ``append`` upserts on this key; the
+            # leading ``workspace`` makes a guessed/leaked (project_key,
+            # session_id) from another tenant impossible to collide with.
+            IndexModel(
+                [("workspace", 1), ("project_key", 1), ("session_id", 1), ("subpath", 1)],
+                unique=True,
+                name="uq_workspace_project_session_subpath",
+            ),
+        ]

--- a/src/pocketpaw/agents/backend.py
+++ b/src/pocketpaw/agents/backend.py
@@ -23,6 +23,13 @@ plugin). The ``system_message_override`` field is applied UPSTREAM in
 ``AgentPool.run`` (it swaps the base system prompt before assembly), so it never
 reaches a backend as a kwarg — it rides the existing ``system_prompt`` channel.
 
+Updated: 2026-06-30 (feat/session-supervisor SS-2) — the ``SessionHandle.session_store``
+field is now real: a tenancy-keyed custom SDK ``SessionStore``. The Claude SDK
+backend forwards it OPAQUELY to ``ClaudeAgentOptions.session_store`` so a resume
+turn reconstructs the conversation from OUR durable store (not local disk),
+namespaced by ``(workspace_id, project_key, session_id)`` so one tenant can never
+read another's session. SS-1's ``cli_session_id`` resume wiring is unchanged.
+
 Updated: 2026-06-30 (feat/session-supervisor SS-1) — adds the ``SessionHandle``
 dataclass: native-resume identity for a single agent session. It rides the SAME
 withhold-when-empty contract as the kwargs above — ``AgentPool.run`` forwards a
@@ -93,9 +100,14 @@ class SessionHandle:
       a fresh-process turn resumes the on-disk conversation natively. ``None``
       (turn 1, or any non-supervised run) is the LEGACY path — behavior is
       unchanged from today.
-    * ``session_store`` — carried through OPAQUELY for SS-2 (a custom SDK
-      ``SessionStore``). SS-1 does NOT implement or consume it; it is an inert
-      pass-through field only.
+    * ``session_store`` — a custom SDK ``SessionStore`` (SS-2). The Claude SDK
+      backend forwards it OPAQUELY to ``ClaudeAgentOptions.session_store`` when
+      non-None, so a resume turn materializes the conversation from OUR store
+      (tenancy-keyed by ``(workspace_id, project_key, session_id)`` — see
+      ``pocketpaw.agents.session_store.InMemorySessionStore`` and the ee
+      Mongo-backed ``MongoSessionStore``) instead of local disk. It rides
+      through opaquely so OSS never imports the concrete (possibly ee) store
+      class. ``None`` is the unchanged legacy path.
 
     Like ``deny_mcp_tool_ids`` / ``allow_sdk_tools`` / ``skill_names``, the
     handle rides the withhold-when-empty contract: ``AgentPool.run`` forwards it

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,14 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-06-30 (feat/session-supervisor SS-2) — ``_build_options`` now also
+  forwards ``session_handle.session_store`` to the SDK as
+  ``ClaudeAgentOptions.session_store`` when it is non-None. On a resume turn the
+  SDK materializes the conversation from THAT store (a tenancy-keyed custom
+  ``SessionStore``) instead of local disk, and mirrors new transcript lines back
+  via the store's ``append``. The store flows through OPAQUELY — OSS never
+  imports the concrete (possibly ee Mongo-backed) class, so the EE→OSS boundary
+  stays clean. ``None`` leaves ``session_store`` unset (unchanged SS-1 / legacy
+  behavior). Small additive change; the SS-1 resume wiring is untouched.
 Updated: 2026-06-30 (feat/session-supervisor SS-1) — ``run`` accepts an optional
   ``session_handle: SessionHandle | None``. When it carries a non-None
   ``cli_session_id``, ``_build_options`` sets ``ClaudeAgentOptions.resume`` so the
@@ -1713,6 +1722,20 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # ``None`` leaves ``resume`` unset — the unchanged legacy path.
         if resume_session_id:
             options_kwargs["resume"] = resume_session_id
+
+        # Tenancy-keyed session store (feat/session-supervisor SS-2). When the
+        # caller threads a ``session_handle`` carrying a ``session_store``, hand
+        # it to the SDK opaquely (the ``ClaudeAgentOptions.session_store: SessionStore
+        # | None`` field). On a resume turn the SDK materializes the conversation
+        # from THIS store — tenancy-keyed by ``(workspace_id, project_key,
+        # session_id)`` — instead of local disk, and mirrors new transcript
+        # lines back via ``append``. The object satisfies the SDK's ``SessionStore``
+        # protocol by duck typing; OSS never imports the concrete (possibly ee)
+        # class, so it flows through as-is and the EE→OSS boundary stays clean.
+        # Absent / ``None`` leaves ``session_store`` unset — the unchanged SS-1
+        # (and legacy) behavior.
+        if session_handle is not None and session_handle.session_store is not None:
+            options_kwargs["session_store"] = session_handle.session_store
 
         # Create options (after all kwargs are set, including model)
         options = self._ClaudeAgentOptions(**options_kwargs)

--- a/src/pocketpaw/agents/session_store.py
+++ b/src/pocketpaw/agents/session_store.py
@@ -1,0 +1,169 @@
+"""Tenancy-keyed in-memory SessionStore — OSS reference impl (SS-2).
+
+Created: 2026-06-30 (feat/session-supervisor SS-2). Implements the Claude Agent
+SDK's ``SessionStore`` protocol (``claude_agent_sdk.types.SessionStore``) so a
+backend can resume an agent conversation from OUR durable store instead of the
+subprocess's local disk. The SDK calls ``load`` once (in the parent, before
+spawn) and materializes the returned transcript entries into a temp dir the
+fresh subprocess resumes from; it calls ``append`` after each local write to
+mirror new transcript lines back.
+
+This module is the OSS, dev-grade reference: durability lives in an in-memory
+backing dict that callers can SHARE across instances (the analog of a Mongo
+collection two processes both read). The real durable impl is the Mongo-backed
+``MongoSessionStore`` in the ee layer (``pocketpaw_ee.cloud.agent_sessions``);
+it mirrors these exact semantics. The store flows to ``claude_sdk`` OPAQUELY via
+``SessionHandle.session_store`` so OSS never imports the ee class — the
+EE→OSS boundary stays clean.
+
+Tenancy keying
+--------------
+The store is bound to a ``workspace_id`` at construction. Every storage key is
+the 4-tuple ``(workspace_id, project_key, session_id, subpath)`` (``subpath``
+defaults to ``""`` for a main transcript). A store bound to workspace B builds
+keys with ``workspace_id == "B"``, so it can NEVER observe a row written by a
+store bound to workspace A even over the same backing dict — that is the core
+isolation property (SS-7 tests it hard). Reads return ``None`` / ``[]`` for a
+foreign tenant's session exactly as for one that was never written.
+
+The store satisfies the protocol by DUCK TYPING — the SDK never uses
+``isinstance`` (see the protocol docstring), so this class need not subclass
+``SessionStore``.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from claude_agent_sdk.types import (
+        SessionKey,
+        SessionListSubkeysKey,
+        SessionStoreEntry,
+        SessionStoreListEntry,
+    )
+
+# A backing record: the ordered transcript entries plus the set of uuids already
+# seen (idempotency), plus the last-write time in epoch ms (the mtime source).
+_StorageKey = tuple[str, str, str, str]  # (workspace_id, project_key, session_id, subpath)
+
+
+def _now_ms() -> int:
+    """Current wall-clock time in Unix epoch milliseconds (the ``mtime`` clock)."""
+    return int(time.time() * 1000)
+
+
+class InMemorySessionStore:
+    """Conformant, tenancy-keyed ``SessionStore`` backed by an in-memory dict.
+
+    Construct one per ``workspace_id``. Pass a shared ``backing`` dict to model
+    durability across a "restart" (a fresh instance over the same backing dict
+    still sees prior writes — durability lives in the store, not the process).
+    Omit it for a private, throwaway store.
+    """
+
+    def __init__(
+        self, workspace_id: str, *, backing: dict[_StorageKey, dict[str, Any]] | None = None
+    ):
+        if not workspace_id:
+            raise ValueError("InMemorySessionStore requires a non-empty workspace_id")
+        self._workspace_id = workspace_id
+        # Shared-able backing: maps the 4-tuple key -> {"entries", "uuids", "mtime"}.
+        self._backing: dict[_StorageKey, dict[str, Any]] = backing if backing is not None else {}
+
+    # -- key helpers --------------------------------------------------------
+
+    def _key(self, project_key: str, session_id: str, subpath: str = "") -> _StorageKey:
+        """Namespace a (project_key, session_id, subpath) by the bound workspace."""
+        return (self._workspace_id, project_key, session_id, subpath)
+
+    @staticmethod
+    def _subpath_of(key: SessionKey) -> str:
+        """Read the optional ``subpath`` (``""`` == main transcript)."""
+        return key.get("subpath") or ""
+
+    # -- SessionStore protocol ---------------------------------------------
+
+    async def append(self, key: SessionKey, entries: list[SessionStoreEntry]) -> None:
+        """Mirror a batch of transcript entries for ``key``.
+
+        Entries carrying a stable ``uuid`` are treated as idempotency keys
+        (duplicates ignored); entries without one are always appended. Matches
+        the protocol's upsert/ignore-duplicate contract.
+        """
+        sk = self._key(key["project_key"], key["session_id"], self._subpath_of(key))
+        record = self._backing.get(sk)
+        if record is None:
+            record = {"entries": [], "uuids": set(), "mtime": 0}
+            self._backing[sk] = record
+        seen: set[str] = record["uuids"]
+        for entry in entries:
+            uuid = entry.get("uuid")
+            if uuid is not None:
+                if uuid in seen:
+                    continue
+                seen.add(uuid)
+            record["entries"].append(entry)
+        record["mtime"] = _now_ms()
+
+    async def load(self, key: SessionKey) -> list[SessionStoreEntry] | None:
+        """Return the full transcript for ``key``, or ``None`` if never written.
+
+        A store bound to a different workspace returns ``None`` — the namespaced
+        key simply doesn't exist for that tenant.
+        """
+        sk = self._key(key["project_key"], key["session_id"], self._subpath_of(key))
+        record = self._backing.get(sk)
+        if record is None:
+            return None
+        # Return a shallow copy so a caller mutating the list can't corrupt the
+        # backing store; entries themselves are opaque pass-through blobs.
+        return list(record["entries"])
+
+    async def list_sessions(self, project_key: str) -> list[SessionStoreListEntry]:
+        """List MAIN-transcript sessions for ``project_key`` in this workspace.
+
+        Only main transcripts (no ``subpath``) are returned; subagent transcripts
+        are discovered via :meth:`list_subkeys`. Order is unspecified — the SDK
+        sorts by ``mtime`` descending.
+        """
+        out: list[SessionStoreListEntry] = []
+        for (ws, pk, sid, sub), record in self._backing.items():
+            if ws != self._workspace_id or pk != project_key or sub != "":
+                continue
+            out.append({"session_id": sid, "mtime": record["mtime"]})
+        return out
+
+    async def list_subkeys(self, key: SessionListSubkeysKey) -> list[str]:
+        """List the subpaths (e.g. subagent transcripts) under a session."""
+        target_pk = key["project_key"]
+        target_sid = key["session_id"]
+        out: list[str] = []
+        for (ws, pk, sid, sub), _record in self._backing.items():
+            if ws != self._workspace_id or pk != target_pk or sid != target_sid:
+                continue
+            if sub:
+                out.append(sub)
+        return out
+
+    async def delete(self, key: SessionKey) -> None:
+        """Delete a session entry.
+
+        Deleting a main transcript (no ``subpath``) cascades to every subkey
+        under that session; a keyed ``subpath`` deletes only that one entry.
+        """
+        pk = key["project_key"]
+        sid = key["session_id"]
+        sub = self._subpath_of(key)
+        if sub:
+            self._backing.pop(self._key(pk, sid, sub), None)
+            return
+        # Main transcript: cascade-delete the main row + all subkeys.
+        doomed = [
+            stored_key
+            for stored_key in self._backing
+            if stored_key[0] == self._workspace_id and stored_key[1] == pk and stored_key[2] == sid
+        ]
+        for stored_key in doomed:
+            self._backing.pop(stored_key, None)

--- a/tests/cloud/test_session_transcript_store.py
+++ b/tests/cloud/test_session_transcript_store.py
@@ -1,0 +1,99 @@
+# tests/cloud/test_session_transcript_store.py
+# Created: 2026-06-30 (feat/session-supervisor SS-2) — proves the Mongo-backed
+# MongoSessionStore mirrors the OSS in-memory reference impl's semantics on a
+# real Beanie query path (mongomock-motor — no live mongod). Same three core
+# assertions as the OSS store: round-trip + list_sessions/list_subkeys,
+# durability across a "restart" (a fresh adapter instance over the same DB),
+# and tenancy isolation (a store bound to workspace B can't read workspace A's
+# session). Uses the shared ``mongo_db`` fixture which init_beanie's
+# ALL_DOCUMENTS (now including SessionTranscriptDoc).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore
+
+
+def _key(project_key="proj", session_id="sess-1", subpath=None):
+    k = {"project_key": project_key, "session_id": session_id}
+    if subpath is not None:
+        k["subpath"] = subpath
+    return k
+
+
+async def test_round_trip_and_listings(mongo_db) -> None:  # noqa: ARG001 — forces Beanie init
+    store = MongoSessionStore("ws-A")
+    e1 = {"type": "user", "uuid": "u1", "timestamp": "t1"}
+    e2 = {"type": "assistant", "uuid": "u2", "timestamp": "t2"}
+
+    await store.append(_key(), [e1])
+    await store.append(_key(), [e2])
+    assert await store.load(_key()) == [e1, e2]
+
+    sessions = await store.list_sessions("proj")
+    assert [s["session_id"] for s in sessions] == ["sess-1"]
+    assert isinstance(sessions[0]["mtime"], int)
+
+    sub = {"type": "user", "uuid": "s1"}
+    await store.append(_key(subpath="subagents/agent-7"), [sub])
+    assert await store.load(_key(subpath="subagents/agent-7")) == [sub]
+    assert await store.list_subkeys(_key()) == ["subagents/agent-7"]
+    # The subagent row must not surface as a second main session.
+    assert [s["session_id"] for s in await store.list_sessions("proj")] == ["sess-1"]
+
+
+async def test_append_dedups_by_uuid(mongo_db) -> None:  # noqa: ARG001
+    store = MongoSessionStore("ws-A")
+    e = {"type": "user", "uuid": "dup"}
+    await store.append(_key(), [e])
+    await store.append(_key(), [e])
+    no_uuid = {"type": "summary"}
+    await store.append(_key(), [no_uuid])
+    await store.append(_key(), [no_uuid])
+    assert await store.load(_key()) == [e, no_uuid, no_uuid]
+
+
+async def test_durability_across_fresh_instance(mongo_db) -> None:  # noqa: ARG001
+    """A FRESH adapter instance over the SAME DB still loads prior writes —
+    durability lives in Mongo, not the process (the real restart scenario)."""
+    entries = [{"type": "user", "uuid": "u1"}, {"type": "assistant", "uuid": "u2"}]
+    await MongoSessionStore("ws-A").append(_key(), entries)
+    # New instance, same backing collection.
+    assert await MongoSessionStore("ws-A").load(_key()) == entries
+
+
+async def test_tenancy_isolation(mongo_db) -> None:  # noqa: ARG001
+    """A store bound to workspace B can't read a session written under
+    workspace A, even sharing the same collection."""
+    await MongoSessionStore("ws-A").append(_key(), [{"type": "user", "uuid": "u1"}])
+    await MongoSessionStore("ws-A").append(
+        _key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}]
+    )
+
+    store_b = MongoSessionStore("ws-B")
+    assert await store_b.load(_key()) is None
+    assert await store_b.list_sessions("proj") == []
+    assert await store_b.list_subkeys(_key()) == []
+
+    # A still sees its own row.
+    assert await MongoSessionStore("ws-A").load(_key()) == [{"type": "user", "uuid": "u1"}]
+
+
+async def test_delete_main_cascades(mongo_db) -> None:  # noqa: ARG001
+    store = MongoSessionStore("ws-A")
+    await store.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+
+    await store.delete(_key())
+    assert await store.load(_key()) is None
+    assert await store.load(_key(subpath="subagents/agent-1")) is None
+    assert await store.list_subkeys(_key()) == []
+
+
+async def test_delete_targeted_subpath(mongo_db) -> None:  # noqa: ARG001
+    store = MongoSessionStore("ws-A")
+    await store.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+
+    await store.delete(_key(subpath="subagents/agent-1"))
+    assert await store.load(_key()) == [{"type": "user", "uuid": "u1"}]
+    assert await store.list_subkeys(_key()) == []

--- a/tests/test_agent_session_store.py
+++ b/tests/test_agent_session_store.py
@@ -1,0 +1,191 @@
+# tests/test_agent_session_store.py
+# Created: 2026-06-30 (feat/session-supervisor SS-2) — pins the contract for the
+# tenancy-keyed SessionStore and its claude_sdk wiring. Two concerns:
+#
+#   1. The OSS reference ``InMemorySessionStore`` satisfies the SDK's
+#      ``SessionStore`` protocol and is correctly tenancy-keyed:
+#        * round-trip — append -> load returns the entries; list_sessions
+#          includes the session; list_subkeys finds a subagent subpath.
+#        * durability across a "restart" — a FRESH store instance over the SAME
+#          backing dict still loads prior writes (durability lives in the store,
+#          not the process).
+#        * tenancy isolation — a store bound to workspace B can NEVER read a
+#          session written by a store bound to workspace A (the core property
+#          SS-7 will test hard).
+#        * idempotency + cascade-delete edge cases.
+#
+#   2. The claude_sdk wiring SPY (no live model call — blocked in this env):
+#      when ``run()`` gets a ``SessionHandle(session_store=<obj>)``, the
+#      constructed ``ClaudeAgentOptions`` carries that exact ``session_store``;
+#      a handle without a store leaves it unset (SS-1 / legacy behavior).
+#
+# The spy reuses the proven SS-1 run()-driving harness
+# (``tests.test_claude_sdk_session_handle``) so a full ``run`` completes WITHOUT
+# a live call and the constructed options are observable.
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.agents.backend import SessionHandle
+from pocketpaw.agents.session_store import InMemorySessionStore
+
+# Reuse the SS-1 harness (capturing options factory + faked SDK stream).
+from tests.test_claude_sdk_session_handle import _drive_run, _make_sdk
+
+# ===========================================================================
+# OSS reference store — protocol conformance + tenancy keying
+# ===========================================================================
+
+
+def _key(project_key="proj", session_id="sess-1", subpath=None):
+    k = {"project_key": project_key, "session_id": session_id}
+    if subpath is not None:
+        k["subpath"] = subpath
+    return k
+
+
+async def test_round_trip_append_load_list_sessions_and_subkeys() -> None:
+    """append -> load round-trips; list_sessions includes the session; a
+    subagent subpath is discoverable via list_subkeys and excluded from
+    list_sessions."""
+    store = InMemorySessionStore("ws-A")
+    e1 = {"type": "user", "uuid": "u1", "timestamp": "t1"}
+    e2 = {"type": "assistant", "uuid": "u2", "timestamp": "t2"}
+
+    await store.append(_key(), [e1])
+    await store.append(_key(), [e2])
+
+    assert await store.load(_key()) == [e1, e2]
+
+    sessions = await store.list_sessions("proj")
+    assert [s["session_id"] for s in sessions] == ["sess-1"]
+    assert isinstance(sessions[0]["mtime"], int)
+
+    # A subagent transcript rides a subpath; it's a separate row.
+    sub = {"type": "user", "uuid": "s1"}
+    await store.append(_key(subpath="subagents/agent-7"), [sub])
+    assert await store.load(_key(subpath="subagents/agent-7")) == [sub]
+    assert await store.list_subkeys(_key()) == ["subagents/agent-7"]
+
+    # list_sessions returns only MAIN transcripts — the subpath row must not
+    # leak in as a second "session".
+    sessions2 = await store.list_sessions("proj")
+    assert [s["session_id"] for s in sessions2] == ["sess-1"]
+
+
+async def test_load_returns_none_for_never_written_key() -> None:
+    store = InMemorySessionStore("ws-A")
+    assert await store.load(_key(session_id="nope")) is None
+
+
+async def test_append_dedups_by_uuid() -> None:
+    """An entry carrying a ``uuid`` already present is ignored (the protocol's
+    idempotency contract); a uuid-less entry is always appended."""
+    store = InMemorySessionStore("ws-A")
+    e = {"type": "user", "uuid": "dup"}
+    await store.append(_key(), [e])
+    await store.append(_key(), [e])  # same uuid → ignored
+    no_uuid = {"type": "summary"}
+    await store.append(_key(), [no_uuid])
+    await store.append(_key(), [no_uuid])  # no uuid → appended twice
+    loaded = await store.load(_key())
+    assert loaded == [e, no_uuid, no_uuid]
+
+
+async def test_durability_across_restart_via_shared_backing() -> None:
+    """A FRESH store instance over the SAME backing dict still loads prior
+    writes — proving durability lives in the backing store, not the instance
+    (the in-memory analog of resuming from Mongo after a backend restart)."""
+    shared: dict = {}
+    store1 = InMemorySessionStore("ws-A", backing=shared)
+    entries = [{"type": "user", "uuid": "u1"}, {"type": "assistant", "uuid": "u2"}]
+    await store1.append(_key(), entries)
+
+    # Simulate the restart: a brand-new instance, same backing store.
+    store2 = InMemorySessionStore("ws-A", backing=shared)
+    assert await store2.load(_key()) == entries
+
+
+async def test_tenancy_isolation_other_workspace_sees_nothing() -> None:
+    """A store bound to workspace B can NEVER observe a session written under
+    workspace A — even over the same physical backing store. Core property."""
+    shared: dict = {}
+    store_a = InMemorySessionStore("ws-A", backing=shared)
+    await store_a.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store_a.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+
+    store_b = InMemorySessionStore("ws-B", backing=shared)
+    assert await store_b.load(_key()) is None
+    assert await store_b.list_sessions("proj") == []
+    assert await store_b.list_subkeys(_key()) == []
+
+    # And A still sees its own data (the namespace didn't clobber it).
+    assert await store_a.load(_key()) == [{"type": "user", "uuid": "u1"}]
+
+
+async def test_delete_main_cascades_to_subkeys() -> None:
+    store = InMemorySessionStore("ws-A")
+    await store.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+
+    # Deleting the main transcript (no subpath) cascades to subagent rows.
+    await store.delete(_key())
+    assert await store.load(_key()) is None
+    assert await store.load(_key(subpath="subagents/agent-1")) is None
+    assert await store.list_subkeys(_key()) == []
+
+
+async def test_delete_targeted_subpath_only() -> None:
+    store = InMemorySessionStore("ws-A")
+    await store.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+
+    await store.delete(_key(subpath="subagents/agent-1"))
+    # Only the subagent row went; the main transcript survives.
+    assert await store.load(_key()) == [{"type": "user", "uuid": "u1"}]
+    assert await store.list_subkeys(_key()) == []
+
+
+def test_workspace_id_is_required() -> None:
+    with pytest.raises(ValueError):
+        InMemorySessionStore("")
+
+
+# ===========================================================================
+# claude_sdk wiring spy — options carry the session_store opaquely
+# ===========================================================================
+
+
+async def test_session_store_is_threaded_into_constructed_options() -> None:
+    """A run with ``SessionHandle(session_store=<obj>)`` builds
+    ``ClaudeAgentOptions`` carrying that exact object — proving claude_sdk
+    forwards the store opaquely so the SDK can materialize a resume from it."""
+    options_sink: list = []
+    stateless_options: list = []
+    sdk = _make_sdk(options_sink, stateless_options)
+
+    sentinel = object()
+    handle = SessionHandle(cli_session_id=None, session_store=sentinel)
+    events = await _drive_run(sdk, "turn", session_handle=handle)
+
+    assert any(e.type == "done" for e in events)
+    assert options_sink, "options must have been constructed"
+    assert getattr(options_sink[-1], "session_store", None) is sentinel, (
+        "the constructed ClaudeAgentOptions must carry the handle's session_store "
+        "so the SDK materializes a resume from OUR store, not local disk"
+    )
+
+
+async def test_no_store_leaves_session_store_unset() -> None:
+    """A handle WITHOUT a store (or no handle) leaves ``session_store`` unset on
+    the options — the unchanged SS-1 / legacy path."""
+    options_sink: list = []
+    stateless_options: list = []
+    sdk = _make_sdk(options_sink, stateless_options)
+
+    await _drive_run(sdk, "turn", session_handle=SessionHandle(session_store=None))
+    assert getattr(options_sink[-1], "session_store", None) is None
+
+    await _drive_run(sdk, "turn2", session_handle=None)
+    assert getattr(options_sink[-1], "session_store", None) is None


### PR DESCRIPTION
Backs native resume with our own store, so a session survives a backend restart and two tenants on one box can't read each other's transcripts.

- `InMemorySessionStore` (OSS reference) and `MongoSessionStore` (ee, durable) both implement the SDK's `SessionStore` protocol. Every key is `(workspace_id, project_key, session_id, subpath)` and the store is bound to a workspace at construction, so a store for tenant B never sees tenant A's rows.
- The Claude SDK backend passes the store through to `ClaudeAgentOptions.session_store` when present. On a resume turn the SDK materializes the transcript from the store into a throwaway temp dir, then mirrors new turns back via `append`.
- The store reaches the OSS backend opaquely, so `src/pocketpaw` never imports `pocketpaw_ee`.

Known limitation: the Mongo `append` is read-modify-write, not an atomic `$push`. Fine at current volume, flagged for concurrency hardening.

Tests: store round-trip, durability across a simulated restart, tenant isolation, and the backend passing the store into options. 22 green (OSS plus mongomock).

Stacked on the SS-1 branch.
