### PR TITLE
feat(cloud): durable map from chat session to native CLI session id

### DIFF
--- a/ee/pocketpaw_ee/cloud/agent_sessions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/agent_sessions/__init__.py
@@ -3,12 +3,21 @@
 # Holds the Mongo-backed ``SessionStore`` (feat/session-supervisor SS-2) that
 # durably mirrors Claude Agent SDK session transcripts per tenant, so an agent
 # conversation survives a backend restart by resuming from Mongo instead of the
-# subprocess's local disk.
+# subprocess's local disk, AND the durable
+# ``(workspace, session_id, agent_id) -> cli_session_id`` resume mapping
+# (SS-3, ``runtime_service``) so any turn — even a cold one after a restart —
+# can find the native session to resume.
 #
 # Created 2026-06-30 (feat/session-supervisor SS-2).
+# Updated 2026-06-30 (feat/session-supervisor SS-3): re-export the
+# ``runtime_service`` resume-mapping functions.
 
 from __future__ import annotations
 
+from pocketpaw_ee.cloud.agent_sessions.runtime_service import (
+    get_cli_session_id,
+    set_cli_session_id,
+)
 from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore
 
-__all__ = ["MongoSessionStore"]
+__all__ = ["MongoSessionStore", "get_cli_session_id", "set_cli_session_id"]

--- a/ee/pocketpaw_ee/cloud/agent_sessions/runtime_service.py
+++ b/ee/pocketpaw_ee/cloud/agent_sessions/runtime_service.py
@@ -1,0 +1,121 @@
+# ee/pocketpaw_ee/cloud/agent_sessions/runtime_service.py — the SOLE owner of
+# the durable ``(workspace, session_id, agent_id) -> cli_session_id`` mapping
+# (feat/session-supervisor SS-3).
+#
+# Module-level ``async def`` API (no class wrapper), mirroring
+# ``ee.cloud.sessions.service``. The executor (SS-5) calls:
+#   - ``set_cli_session_id`` on turn 1, when the OSS ``claude_sdk`` backend
+#     emits its ``session_id`` event, to durably record the native session id;
+#     and again on a later resume/backfill (it UPSERTs — one row per key).
+#   - ``get_cli_session_id`` on every later turn (including a COLD turn after a
+#     backend restart) to recover the native session and rebuild the
+#     ``SessionHandle`` so the agent resumes instead of starting fresh.
+#
+# Tenancy: EVERY read filters on ``workspace == workspace_id`` (the leading
+# component of the unique index), so a lookup scoped to tenant B can never
+# observe tenant A's mapping. Inputs are validated at entry; a foreign-tenant
+# or absent key resolves to ``None`` rather than raising.
+#
+# This module is the ONLY importer of ``AgentSessionRuntimeDoc`` (the ee
+# entity-isolation boundary). The mapping is internal-only (no HTTP surface),
+# so there is no DTO/router and no realtime event on write.
+#
+# no-event: this entity has no HTTP/realtime surface — it is an internal resume
+# index written by the executor on the agent turn hot path, never observed by a
+# client, so there is nothing to emit. (ee write-event convention.)
+#
+# Created 2026-06-30 (feat/session-supervisor SS-3): new entity service.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.models.agent_session_runtime import AgentSessionRuntimeDoc
+
+logger = logging.getLogger(__name__)
+
+
+def _require(name: str, value: str) -> str:
+    """Validate a required scope-key component at entry; raise on empty."""
+    if not value or not isinstance(value, str):
+        raise ValidationError(
+            "agent_session_runtime.invalid",
+            f"{name} must be a non-empty string",
+        )
+    return value
+
+
+async def _find_row(
+    workspace_id: str, session_id: str, agent_id: str
+) -> AgentSessionRuntimeDoc | None:
+    """Tenant-filtered lookup of the single row for this logical key.
+
+    The leading ``workspace`` filter is the tenancy boundary — a key from
+    another tenant simply does not match.
+    """
+    return await AgentSessionRuntimeDoc.find_one(
+        AgentSessionRuntimeDoc.workspace == workspace_id,
+        AgentSessionRuntimeDoc.session_id == session_id,
+        AgentSessionRuntimeDoc.agent_id == agent_id,
+    )
+
+
+async def set_cli_session_id(
+    workspace_id: str,
+    session_id: str,
+    agent_id: str,
+    cli_session_id: str,
+    project_key: str | None = None,
+) -> None:
+    """UPSERT the native ``cli_session_id`` for ``(ws, session, agent)``.
+
+    Inserts the row on turn 1 and updates it on a later resume/backfill — the
+    unique ``(workspace, session_id, agent_id)`` index guarantees a single row
+    per key, so this never produces a duplicate. ``project_key`` is recorded
+    when supplied (and left unchanged on update when omitted) so a cold resume
+    can rebuild the full ``SessionHandle``.
+    """
+    workspace_id = _require("workspace_id", workspace_id)
+    session_id = _require("session_id", session_id)
+    agent_id = _require("agent_id", agent_id)
+    cli_session_id = _require("cli_session_id", cli_session_id)
+
+    doc = await _find_row(workspace_id, session_id, agent_id)
+    if doc is None:
+        doc = AgentSessionRuntimeDoc(
+            workspace=workspace_id,
+            session_id=session_id,
+            agent_id=agent_id,
+            cli_session_id=cli_session_id,
+            project_key=project_key,
+        )
+    else:
+        doc.cli_session_id = cli_session_id
+        if project_key is not None:
+            doc.project_key = project_key
+    await doc.save()
+
+
+async def get_cli_session_id(
+    workspace_id: str,
+    session_id: str,
+    agent_id: str,
+) -> str | None:
+    """Return the native ``cli_session_id`` for ``(ws, session, agent)``.
+
+    Tenant-filtered: a foreign-tenant or never-written key resolves to ``None``
+    (the row either doesn't match the ``workspace`` filter or doesn't exist).
+    Also ``None`` when a row exists but its ``cli_session_id`` was never set.
+    """
+    workspace_id = _require("workspace_id", workspace_id)
+    session_id = _require("session_id", session_id)
+    agent_id = _require("agent_id", agent_id)
+
+    doc = await _find_row(workspace_id, session_id, agent_id)
+    if doc is None:
+        return None
+    return doc.cli_session_id
+
+
+__all__ = ["set_cli_session_id", "get_cli_session_id"]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,11 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-06-30 (feat/session-supervisor SS-3) — added
+``AgentSessionRuntimeDoc`` (the durable, tenant-scoped
+``(workspace, session_id, agent_id) -> cli_session_id`` mapping) to the
+imports, ``__all__``, and ``get_all_documents()`` so the
+``agent_session_runtimes`` collection is wired into ``init_beanie``. Only
+``ee.cloud.agent_sessions.runtime_service`` imports the doc class directly.
 Updated: 2026-06-30 (feat/session-supervisor SS-2) — added ``SessionTranscriptDoc``
 (the durable, tenant-scoped transcript rows backing the Mongo ``SessionStore``)
 to the imports, ``__all__``, and ``get_all_documents()`` so the
@@ -67,6 +73,7 @@ Updated: 2026-06-24 (integration/billing-credits, BC-7) — added ``Subscription
 from __future__ import annotations
 
 from pocketpaw_ee.cloud.models.agent import Agent, AgentConfig
+from pocketpaw_ee.cloud.models.agent_session_runtime import AgentSessionRuntimeDoc
 from pocketpaw_ee.cloud.models.api_key import APIKey
 from pocketpaw_ee.cloud.models.audit_event import AuditEvent
 from pocketpaw_ee.cloud.models.audit_webhook import AuditWebhook
@@ -265,6 +272,7 @@ __all__ = [
     "RequestLog",
     "Session",
     "SessionTranscriptDoc",
+    "AgentSessionRuntimeDoc",
     "Site",
     "SiteDomain",
     "SiteRateCounter",
@@ -303,6 +311,10 @@ def get_all_documents():
         # Agent-session transcript rows backing the Mongo SessionStore (SS-2).
         # Only ``ee.cloud.agent_sessions.store`` imports this doc directly.
         SessionTranscriptDoc,
+        # Durable (workspace, session_id, agent_id) -> cli_session_id mapping
+        # so any turn can resume the native session (SS-3). Only
+        # ``ee.cloud.agent_sessions.runtime_service`` imports this doc directly.
+        AgentSessionRuntimeDoc,
         Comment,
         Notification,
         FileObj,

--- a/ee/pocketpaw_ee/cloud/models/agent_session_runtime.py
+++ b/ee/pocketpaw_ee/cloud/models/agent_session_runtime.py
@@ -1,0 +1,71 @@
+# ee/pocketpaw_ee/cloud/models/agent_session_runtime.py — the durable,
+# tenant-scoped mapping from a chat-session scope to its native CLI session id
+# (feat/session-supervisor SS-3).
+#
+# One ``AgentSessionRuntimeDoc`` row records, for ONE
+# (workspace, session_id, agent_id) tuple, the native ``cli_session_id`` the
+# Claude Agent SDK minted for that conversation (plus the SDK ``project_key``
+# scope it lives under). The executor persists it on turn 1 (when the
+# ``claude_sdk`` backend emits the ``session_id`` event) and looks it up on
+# every later turn — even a COLD turn after a backend restart — so the agent
+# can resume the same native session instead of starting fresh. Without this
+# durable mapping the captured native id evaporates between turns and the user
+# gets "message with no agent reply".
+#
+# The UNIQUE compound index on ``(workspace, session_id, agent_id)`` keeps it
+# one row per logical key (so the service can upsert: insert on turn 1, update
+# on a later resume/backfill) and the leading ``workspace`` component is the
+# tenancy boundary — every read in the service filters on ``workspace`` so a
+# lookup scoped to tenant B can never observe tenant A's mapping even though
+# both live in the same collection.
+#
+# Created 2026-06-30 (feat/session-supervisor SS-3): new entity. Registered in
+# ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``agent_session_runtimes`` collection. Only
+# ``ee.cloud.agent_sessions.runtime_service`` imports this doc class
+# (entity-isolation boundary, mirroring the SS-2 transcript / sessions
+# entities).
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class AgentSessionRuntimeDoc(TimestampedDocument):
+    """Durable ``(workspace, session_id, agent_id) -> cli_session_id`` mapping.
+
+    ``session_id`` is the chat-session scope key (the conversation the user is
+    in), ``agent_id`` the agent answering it, and ``cli_session_id`` the native
+    Claude Agent SDK session id minted on turn 1 — ``None`` until the first
+    ``session_id`` event lands. ``project_key`` is the SDK scope the native
+    session lives under, carried so a resume can reconstruct the full
+    ``SessionHandle``. ``updatedAt`` (from :class:`TimestampedDocument`) records
+    the last backfill.
+    """
+
+    # Tenancy boundary. Indexed (non-unique) — many runtime rows per workspace.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The chat-session scope key (the conversation the turn belongs to).
+    session_id: str
+    # The agent answering this session.
+    agent_id: str
+    # The native Claude Agent SDK session id; None until turn 1's event lands.
+    cli_session_id: str | None = None
+    # The SDK ``project_key`` scope the native session lives under (default cwd).
+    project_key: str | None = None
+
+    class Settings:
+        name = "agent_session_runtimes"
+        indexes = [
+            # One row per logical key. The service upserts on this key; the
+            # leading ``workspace`` makes a guessed/leaked (session_id,
+            # agent_id) from another tenant impossible to collide with.
+            IndexModel(
+                [("workspace", 1), ("session_id", 1), ("agent_id", 1)],
+                unique=True,
+                name="uq_workspace_session_agent",
+            ),
+        ]

--- a/tests/cloud/test_agent_session_runtime_service.py
+++ b/tests/cloud/test_agent_session_runtime_service.py
@@ -1,0 +1,93 @@
+# tests/cloud/test_agent_session_runtime_service.py
+# Created: 2026-06-30 (feat/session-supervisor SS-3) — proves the durable
+# (workspace, session_id, agent_id) -> cli_session_id resume mapping over a real
+# Beanie query path (mongomock-motor — no live mongod). Covers the four
+# done-when cases: turn-1 persist + lookup, upsert/backfill (no duplicate row,
+# the unique index holds), tenancy isolation (a foreign workspace reads None),
+# and an absent key reading None. Uses the shared ``mongo_db`` fixture which
+# init_beanie's ALL_DOCUMENTS (now including AgentSessionRuntimeDoc).
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.agent_sessions import runtime_service
+from pocketpaw_ee.cloud.models.agent_session_runtime import AgentSessionRuntimeDoc
+
+WS = "ws-A"
+SESSION = "sess-1"
+AGENT = "agent-7"
+
+
+async def test_persist_then_lookup(mongo_db) -> None:  # noqa: ARG001 — forces Beanie init
+    """Turn-1 persist: set then get returns the native id (+ project_key kept)."""
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-abc", project_key="proj-1")
+    assert await runtime_service.get_cli_session_id(WS, SESSION, AGENT) == "cli-abc"
+
+    # project_key was persisted alongside the id.
+    row = await AgentSessionRuntimeDoc.find_one(
+        AgentSessionRuntimeDoc.workspace == WS,
+        AgentSessionRuntimeDoc.session_id == SESSION,
+        AgentSessionRuntimeDoc.agent_id == AGENT,
+    )
+    assert row is not None
+    assert row.project_key == "proj-1"
+
+
+async def test_upsert_backfill_updates_in_place(mongo_db) -> None:  # noqa: ARG001
+    """Calling set again for the same key UPDATES the id — no duplicate row."""
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-old")
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-new")
+
+    assert await runtime_service.get_cli_session_id(WS, SESSION, AGENT) == "cli-new"
+
+    # The unique (workspace, session_id, agent_id) index holds: exactly one row.
+    rows = await AgentSessionRuntimeDoc.find(
+        AgentSessionRuntimeDoc.workspace == WS,
+        AgentSessionRuntimeDoc.session_id == SESSION,
+        AgentSessionRuntimeDoc.agent_id == AGENT,
+    ).to_list()
+    assert len(rows) == 1
+
+
+async def test_upsert_preserves_project_key_when_omitted(mongo_db) -> None:  # noqa: ARG001
+    """A backfill that omits project_key leaves the prior one intact."""
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-1", project_key="proj-1")
+    # Resume only re-stamps the id; it has no project_key to pass.
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-2")
+
+    row = await AgentSessionRuntimeDoc.find_one(
+        AgentSessionRuntimeDoc.workspace == WS,
+        AgentSessionRuntimeDoc.session_id == SESSION,
+        AgentSessionRuntimeDoc.agent_id == AGENT,
+    )
+    assert row is not None
+    assert row.cli_session_id == "cli-2"
+    assert row.project_key == "proj-1"
+
+
+async def test_tenancy_isolation(mongo_db) -> None:  # noqa: ARG001
+    """A different workspace can't read tenant A's mapping."""
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-abc")
+
+    assert await runtime_service.get_cli_session_id("ws-B", SESSION, AGENT) is None
+    # A still sees its own row.
+    assert await runtime_service.get_cli_session_id(WS, SESSION, AGENT) == "cli-abc"
+
+
+async def test_absent_key_returns_none(mongo_db) -> None:  # noqa: ARG001
+    """An unknown (ws, session, agent) resolves to None, not an error."""
+    assert await runtime_service.get_cli_session_id(WS, "no-such-session", AGENT) is None
+    # A row for a different agent in the same session doesn't bleed across.
+    await runtime_service.set_cli_session_id(WS, SESSION, "agent-1", "cli-1")
+    assert await runtime_service.get_cli_session_id(WS, SESSION, "agent-2") is None
+
+
+async def test_empty_inputs_rejected(mongo_db) -> None:  # noqa: ARG001
+    """Inputs are validated at entry — empty scope-key components raise."""
+    with pytest.raises(ValidationError):
+        await runtime_service.set_cli_session_id("", SESSION, AGENT, "cli-1")
+    with pytest.raises(ValidationError):
+        await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "")
+    with pytest.raises(ValidationError):
+        await runtime_service.get_cli_session_id(WS, "", AGENT)


### PR DESCRIPTION
Records which native CLI session belongs to each `(workspace, session, agent)` so any later turn, including a cold one after a restart, can resume the right session instead of starting over.

- New `AgentSessionRuntimeDoc` (collection `agent_session_runtimes`) with a unique index leading on `workspace`.
- `runtime_service.set_cli_session_id` (upsert) and `get_cli_session_id` (tenant-filtered lookup). The service is the only importer of the doc; reads always filter by workspace.
- Internal index with no HTTP surface, so no DTO/router and no realtime event.

Tests: persist then look up, upsert/backfill keeps a single row, foreign-tenant and absent keys return None. 6 green.

Stacked on the SS-2 branch.
