### PR TITLE
feat(agents): SessionSupervisor with warm tiers, per-tenant quota, turn-1 capture routing

### DIFF
--- a/src/pocketpaw/agents/session_supervisor.py
+++ b/src/pocketpaw/agents/session_supervisor.py
@@ -1,0 +1,437 @@
+"""Session Supervisor — agent-session lifecycle across COLD/WARM tiers (SS-4).
+
+Created 2026-06-30 (feat/session-supervisor SS-4): the policy / lifecycle engine
+that owns one ``SessionRuntime`` per ``(workspace_id, session_id)`` and decides,
+for each turn, whether to reuse a live warm slot (WARM) or take a fresh launch
+(COLD/turn-1). It enforces a per-tenant warm quota, reaps idle warm sessions,
+and NEVER touches a busy one — the same busy-guard + LRU idioms proven in
+``pocketpaw.agents.pool`` (an instance with ``active_runs > 0`` is never evicted).
+
+What this engine does NOT do: it does not spawn the OS subprocess. The executor
+(SS-5) supplies the live warm "slot" plus a ``teardown`` callback via
+``bind_warm_slot``; the supervisor owns COLD-vs-WARM routing, quota/reaping, and
+— critically — turn-1 capture ownership: turn 1 of a supervised session ALWAYS
+routes to its own fresh launch so the native ``cli_session_id`` the SDK captures
+binds to THIS session, never a foreign warm client (the turn-1 capture concern
+carried from SS-1). That keeps SS-4 fully unit-testable with fakes (a fake clock
+injected via ``now=`` and fake ``teardown`` recorders) — no live model or real
+subprocess required.
+
+Tier model: COLD (no live slot — next acquire is a fresh launch, resuming from
+the store via ``cli_session_id`` when one exists), WARM (a live slot bound, reused
+within TTL), LIVE (a declared enum value reserved for a future always-on tier —
+no behavior in v1).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SessionTier(Enum):
+    """Lifecycle tier of a supervised agent session.
+
+    * ``COLD`` — no live warm slot. The next ``acquire`` is a FRESH launch; if a
+      ``cli_session_id`` is known it resumes from the store, otherwise it is
+      turn 1.
+    * ``WARM`` — a live slot (process/client) is bound and reusable within TTL.
+    * ``LIVE`` — RESERVED for a future always-on tier (e.g. a pinned, never-reaped
+      session). Declared so callers can switch on it, but it carries NO behavior
+      in v1 — nothing in this module ever puts a runtime into ``LIVE``.
+    """
+
+    COLD = "cold"
+    WARM = "warm"
+    LIVE = "live"
+
+
+@dataclass
+class SessionRuntime:
+    """Per-``(workspace_id, session_id)`` descriptor the supervisor owns.
+
+    Holds the session's identity, its current tier, the busy-counter, and the
+    opaque warm slot + how to tear it down. The supervisor never interprets
+    ``warm_slot`` — it is whatever the executor (SS-5) hands it (a process
+    handle, a warm client, etc.); the supervisor only tracks its lifecycle.
+    """
+
+    workspace_id: str
+    session_id: str
+    agent_id: str
+    cli_session_id: str | None = None
+    project_key: str | None = None
+    tier: SessionTier = SessionTier.COLD
+    last_active: float = 0.0
+    # In-flight ``run`` count. The reaper and the quota evictor NEVER touch a
+    # runtime with ``active_runs > 0`` — tearing down a busy slot would abort
+    # its live turn. ``last_active`` only ranks idle eviction candidates; this
+    # counter is the authoritative "busy" signal (mirrors pool.AgentInstance).
+    active_runs: int = 0
+    # Opaque live warm slot supplied by the executor (SS-5) — never interpreted
+    # here. Present only while ``tier is WARM``.
+    warm_slot: Any | None = None
+    # How to release ``warm_slot``. Called best-effort on reap / quota-evict /
+    # crash / stop. May be sync or return an awaitable.
+    teardown: Callable[[], Any] | None = field(default=None, repr=False)
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """The supervisor key — tenancy boundary first."""
+        return (self.workspace_id, self.session_id)
+
+
+@dataclass(frozen=True)
+class Acquisition:
+    """The routing decision ``acquire`` returns for one turn.
+
+    * ``warm_reuse`` — True when a live, unexpired warm slot exists and is being
+      reused (the fast 2nd+ turn). False means a FRESH launch is required.
+    * ``owns_capture`` — True on turn 1 (no ``cli_session_id`` known yet): this
+      runtime OWNS the native-id capture, so the executor must route to its own
+      fresh process and the id the SDK emits binds to THIS session.
+    * ``cli_session_id`` — the resolved native session id (or ``None`` on turn 1)
+      for the ``SessionHandle`` the executor builds.
+    """
+
+    runtime: SessionRuntime
+    warm_reuse: bool
+    owns_capture: bool
+    cli_session_id: str | None
+
+    @property
+    def fresh(self) -> bool:
+        """True when this turn needs a fresh launch (the inverse of warm reuse)."""
+        return not self.warm_reuse
+
+    @property
+    def slot(self) -> Any | None:
+        """Convenience: the warm slot to reuse (only meaningful when ``warm_reuse``)."""
+        return self.runtime.warm_slot
+
+
+class SessionSupervisor:
+    """Owns agent-session lifecycle keyed by ``(workspace_id, session_id)``.
+
+    A pure policy/lifecycle engine over ``SessionRuntime`` descriptors — it does
+    not spawn subprocesses. The executor (SS-5) drives it: ``acquire`` per turn
+    to learn COLD-vs-WARM + capture ownership, ``bind_warm_slot`` to register the
+    live slot it launched, ``mark_run_start`` / ``mark_run_end`` around the turn,
+    ``record_cli_session_id`` after turn-1 capture, and ``mark_crashed`` on
+    failure. A background reaper (``start`` / ``stop``) releases idle warm slots
+    past ``warm_ttl``.
+    """
+
+    def __init__(
+        self,
+        *,
+        warm_ttl: float = 120,
+        max_warm_per_tenant: int = 8,
+        max_warm_global: int = 64,
+        now: Callable[[], float] | None = None,
+    ) -> None:
+        self._warm_ttl = warm_ttl
+        self._max_warm_per_tenant = max_warm_per_tenant
+        self._max_warm_global = max_warm_global
+        # Injected clock — tests pass a fake closure so reap/TTL is deterministic.
+        self._now: Callable[[], float] = now or time.monotonic
+        self._runtimes: dict[tuple[str, str], SessionRuntime] = {}
+        self._reaper_task: asyncio.Task | None = None
+        # The reaper wakes at least as often as it would need to honor the TTL,
+        # capped so a long TTL doesn't leave slots resident much past expiry.
+        self._reap_interval: float = max(1.0, min(30.0, float(warm_ttl)))
+
+    # -- lifecycle (background reaper) --------------------------------------
+
+    async def start(self) -> None:
+        """Start the idle-warm-slot reaper background task."""
+        if self._reaper_task is None:
+            self._reaper_task = asyncio.create_task(self._reaper_loop())
+            logger.info(
+                "SessionSupervisor started (warm_ttl=%ss, per_tenant=%d, global=%d)",
+                self._warm_ttl,
+                self._max_warm_per_tenant,
+                self._max_warm_global,
+            )
+
+    async def stop(self) -> None:
+        """Cancel the reaper and tear down every live warm slot."""
+        if self._reaper_task:
+            self._reaper_task.cancel()
+            try:
+                await self._reaper_task
+            except asyncio.CancelledError:
+                pass
+            self._reaper_task = None
+        for runtime in list(self._runtimes.values()):
+            await self._run_teardown_async(self._drop_slot(runtime))
+
+    async def _reaper_loop(self) -> None:
+        """Periodically reap idle warm slots past ``warm_ttl`` (mirrors _gc_loop)."""
+        while True:
+            await asyncio.sleep(self._reap_interval)
+            try:
+                self.reap_once()
+            except Exception:
+                logger.warning("SessionSupervisor reaper pass failed", exc_info=True)
+
+    # -- acquire / routing ---------------------------------------------------
+
+    def acquire(
+        self,
+        workspace_id: str,
+        session_id: str,
+        agent_id: str,
+        *,
+        cli_session_id: str | None = None,
+        project_key: str | None = None,
+    ) -> Acquisition:
+        """Get-or-create the runtime for ``(workspace_id, session_id)`` and decide
+        whether this turn is a WARM reuse or a FRESH launch.
+
+        ``cli_session_id`` is what the caller recovered from the durable store
+        (SS-3) for this key, or ``None`` on turn 1 / before any capture. When
+        supplied it reconciles onto the in-memory runtime (the store is
+        authoritative for resume); the resolved id is surfaced on the returned
+        ``Acquisition`` for the ``SessionHandle`` the executor builds.
+
+        FRESH (``warm_reuse=False``) when any of: no runtime yet, the runtime is
+        COLD, its warm slot has expired past ``warm_ttl``, OR no ``cli_session_id``
+        is known (turn 1 — and then ``owns_capture=True`` so the native id binds
+        to THIS session rather than a foreign warm client). Otherwise WARM reuse.
+        """
+        key = (workspace_id, session_id)
+        runtime = self._runtimes.get(key)
+        if runtime is None:
+            runtime = SessionRuntime(
+                workspace_id=workspace_id,
+                session_id=session_id,
+                agent_id=agent_id,
+                cli_session_id=cli_session_id,
+                project_key=project_key,
+                tier=SessionTier.COLD,
+                last_active=self._now(),
+            )
+            self._runtimes[key] = runtime
+        else:
+            # Reconcile the durable id/key onto the live runtime.
+            if cli_session_id is not None:
+                runtime.cli_session_id = cli_session_id
+            if project_key is not None:
+                runtime.project_key = project_key
+            runtime.agent_id = agent_id
+
+        resolved_cli = runtime.cli_session_id
+
+        # Evaluate warm liveness against the PRIOR last_active (before this turn
+        # refreshes it) so an idle-expired slot is correctly seen as stale.
+        warm_alive = (
+            runtime.tier is SessionTier.WARM
+            and runtime.warm_slot is not None
+            and (self._now() - runtime.last_active) <= self._warm_ttl
+        )
+        runtime.last_active = self._now()
+
+        # Turn 1 (no native id yet) ALWAYS takes its own fresh process so the
+        # captured id binds to THIS session — never reuse a warm slot here even
+        # if one somehow exists.
+        owns_capture = resolved_cli is None
+        warm_reuse = warm_alive and not owns_capture
+        return Acquisition(
+            runtime=runtime,
+            warm_reuse=warm_reuse,
+            owns_capture=owns_capture,
+            cli_session_id=resolved_cli,
+        )
+
+    # -- executor hand-offs --------------------------------------------------
+
+    def bind_warm_slot(
+        self, runtime: SessionRuntime, slot: Any, teardown: Callable[[], Any] | None
+    ) -> None:
+        """Register the live warm slot the executor launched; move runtime → WARM.
+
+        Tears down any stale slot already bound, refreshes ``last_active``, then
+        enforces the per-tenant and global warm quotas (LRU-evicting the oldest
+        IDLE warm runtime in scope when over the cap — never a busy one).
+        """
+        if runtime.warm_slot is not None and runtime.warm_slot is not slot:
+            self._run_teardown(self._drop_slot(runtime))
+        runtime.warm_slot = slot
+        runtime.teardown = teardown
+        runtime.tier = SessionTier.WARM
+        runtime.last_active = self._now()
+        self._enforce_quota(runtime)
+
+    def mark_run_start(self, runtime: SessionRuntime) -> None:
+        """Mark a turn as in-flight (busy-guard) and refresh activity."""
+        runtime.active_runs += 1
+        runtime.last_active = self._now()
+
+    def mark_run_end(self, runtime: SessionRuntime) -> None:
+        """Mark a turn finished; refresh activity for idle ranking."""
+        runtime.active_runs = max(0, runtime.active_runs - 1)
+        runtime.last_active = self._now()
+
+    def record_cli_session_id(
+        self, runtime: SessionRuntime, cli_session_id: str, project_key: str | None = None
+    ) -> None:
+        """Record the native session id captured on turn 1 onto the runtime.
+
+        SS-5 ALSO persists it durably via the SS-3 service; this just keeps the
+        in-memory runtime current so subsequent ``acquire`` calls resolve it.
+        """
+        runtime.cli_session_id = cli_session_id
+        if project_key is not None:
+            runtime.project_key = project_key
+
+    def mark_crashed(self, runtime: SessionRuntime) -> None:
+        """Demote a runtime to COLD after a slot failure; drop + tear down the slot.
+
+        Keeps ``cli_session_id`` so the next ``acquire`` is FRESH but carries the
+        prior id (the resume-from-store path).
+        """
+        self._run_teardown(self._drop_slot(runtime))
+
+    # -- quota + reaping internals ------------------------------------------
+
+    def _warm_runtimes(self, *, workspace_id: str | None = None) -> list[SessionRuntime]:
+        """All runtimes holding a live warm slot, optionally scoped to a tenant."""
+        return [
+            r
+            for r in self._runtimes.values()
+            if r.tier is SessionTier.WARM
+            and r.warm_slot is not None
+            and (workspace_id is None or r.workspace_id == workspace_id)
+        ]
+
+    def _enforce_quota(self, protect: SessionRuntime) -> None:
+        """Enforce per-tenant then global warm quotas, sparing ``protect``."""
+        self._enforce_scope(
+            limit=self._max_warm_per_tenant,
+            protect=protect,
+            workspace_id=protect.workspace_id,
+            label="per-tenant",
+        )
+        self._enforce_scope(
+            limit=self._max_warm_global,
+            protect=protect,
+            workspace_id=None,
+            label="global",
+        )
+
+    def _enforce_scope(
+        self,
+        *,
+        limit: int,
+        protect: SessionRuntime,
+        workspace_id: str | None,
+        label: str,
+    ) -> None:
+        """LRU-evict the oldest IDLE warm runtime in scope until at/under ``limit``.
+
+        Never evicts ``protect`` (the just-bound runtime) or any busy runtime
+        (``active_runs > 0``). If the cap is exceeded but every candidate is busy,
+        we accept being over quota this cycle (mirrors pool._evict_oldest).
+        """
+        while len(self._warm_runtimes(workspace_id=workspace_id)) > limit:
+            idle = [
+                r
+                for r in self._warm_runtimes(workspace_id=workspace_id)
+                if r.active_runs == 0 and r is not protect
+            ]
+            if not idle:
+                logger.warning(
+                    "SessionSupervisor %s warm quota exceeded but every candidate "
+                    "is busy — skipping eviction this cycle",
+                    label,
+                )
+                return
+            victim = min(idle, key=lambda r: r.last_active)
+            self._run_teardown(self._drop_slot(victim))
+            logger.info(
+                "SessionSupervisor evicted idle warm session %s (%s quota)",
+                victim.key,
+                label,
+            )
+
+    def reap_once(self) -> int:
+        """Run one reaper pass: tear down idle warm slots past ``warm_ttl``.
+
+        Skips any runtime with ``active_runs > 0`` (busy-guard) regardless of how
+        stale ``last_active`` looks. Returns the number of slots reaped. Exposed
+        (not ``_``-private) so tests can drive a deterministic pass with the fake
+        clock instead of waiting on the background loop.
+        """
+        now = self._now()
+        reaped = 0
+        for runtime in list(self._runtimes.values()):
+            if (
+                runtime.tier is SessionTier.WARM
+                and runtime.warm_slot is not None
+                and runtime.active_runs == 0
+                and (now - runtime.last_active) > self._warm_ttl
+            ):
+                self._run_teardown(self._drop_slot(runtime))
+                reaped += 1
+        return reaped
+
+    def _drop_slot(self, runtime: SessionRuntime) -> Callable[[], Any] | None:
+        """Null the slot fields, demote to COLD, and return the old teardown."""
+        teardown = runtime.teardown
+        runtime.warm_slot = None
+        runtime.teardown = None
+        runtime.tier = SessionTier.COLD
+        return teardown
+
+    def _run_teardown(self, teardown: Callable[[], Any] | None) -> None:
+        """Best-effort sync teardown; schedules an awaitable result on the loop.
+
+        Sync teardowns (the common case, and what tests use) run inline. If a
+        teardown returns a coroutine/awaitable and a loop is running, it is
+        scheduled; with no running loop it is closed so it never warns. Never
+        raises.
+        """
+        if teardown is None:
+            return
+        try:
+            result = teardown()
+        except Exception:
+            logger.warning("SessionSupervisor warm-slot teardown raised", exc_info=True)
+            return
+        if inspect.isawaitable(result):
+            try:
+                asyncio.get_running_loop().create_task(result)
+            except RuntimeError:
+                result.close()
+
+    async def _run_teardown_async(self, teardown: Callable[[], Any] | None) -> None:
+        """Await an async teardown to completion (used by ``stop``). Never raises."""
+        if teardown is None:
+            return
+        try:
+            result = teardown()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.warning("SessionSupervisor warm-slot teardown raised", exc_info=True)
+
+
+# Module-level singleton (mirrors pool.get_agent_pool).
+_supervisor: SessionSupervisor | None = None
+
+
+def get_session_supervisor() -> SessionSupervisor:
+    """Get or create the global session supervisor."""
+    global _supervisor
+    if _supervisor is None:
+        _supervisor = SessionSupervisor()
+    return _supervisor

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -1,0 +1,330 @@
+# tests/test_session_supervisor.py
+# Created: 2026-06-30 (feat/session-supervisor SS-4) — pins the SessionSupervisor
+# policy/lifecycle engine WITHOUT a live model or real subprocess. A fake clock
+# (injected via now=) makes TTL/reaping deterministic, and fake teardown
+# recorders prove the supervisor releases slots at exactly the right moments.
+#
+# Coverage (the SS-4 done-when matrix):
+#   * WARM reuse — re-acquire within TTL reuses the bound slot, no teardown.
+#   * Idle reap — past warm_ttl, one reaper pass tears the idle slot down → COLD.
+#   * Busy guard — a slot with active_runs>0 is never reaped, even when stale;
+#     once the run ends and TTL passes it is.
+#   * Per-tenant quota — a 3rd warm session for tenant A LRU-evicts A's oldest
+#     IDLE warm; tenant B is untouched (quota is per-tenant).
+#   * Turn-1 routing — acquire(cli_session_id=None) is FRESH + owns_capture; a
+#     later acquire with a recorded id within TTL is WARM reuse.
+#   * Crash → COLD — mark_crashed drops the slot but keeps cli_session_id, so the
+#     next acquire is FRESH and resumes from the stored id.
+
+from __future__ import annotations
+
+from pocketpaw.agents.session_supervisor import (
+    Acquisition,
+    SessionSupervisor,
+    SessionTier,
+    get_session_supervisor,
+)
+
+
+class FakeClock:
+    """Deterministic monotonic clock — advance it explicitly in the test."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class Teardown:
+    """Fake teardown callback that records how many times it was called."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> None:
+        self.calls += 1
+
+
+# ===========================================================================
+# WARM reuse
+# ===========================================================================
+
+
+def test_warm_reuse_within_ttl() -> None:
+    """A bound warm slot is reused on the next acquire within TTL — no teardown."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    # Turn 1: fresh launch, owns capture.
+    acq1 = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    assert acq1.fresh and acq1.owns_capture
+
+    # Executor captures the native id and binds the warm slot it launched.
+    sup.record_cli_session_id(acq1.runtime, "cli-123")
+    td = Teardown()
+    sup.bind_warm_slot(acq1.runtime, slot="warm-client", teardown=td)
+    assert acq1.runtime.tier is SessionTier.WARM
+
+    # Turn 2 within TTL → WARM reuse, slot reused, teardown NOT called.
+    clock.advance(30)
+    acq2 = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-123")
+    assert acq2.warm_reuse is True
+    assert acq2.owns_capture is False
+    assert acq2.slot == "warm-client"
+    assert acq2.cli_session_id == "cli-123"
+    assert td.calls == 0
+
+
+# ===========================================================================
+# Idle reap
+# ===========================================================================
+
+
+def test_idle_warm_slot_reaped_past_ttl() -> None:
+    """Past warm_ttl with no activity, one reaper pass tears the slot down → COLD."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    td = Teardown()
+    sup.bind_warm_slot(acq.runtime, slot="slot", teardown=td)
+
+    # Not yet expired — no reap.
+    clock.advance(100)
+    assert sup.reap_once() == 0
+    assert td.calls == 0
+    assert acq.runtime.tier is SessionTier.WARM
+
+    # Past TTL — reaped.
+    clock.advance(50)  # 150 > 120
+    assert sup.reap_once() == 1
+    assert td.calls == 1
+    assert acq.runtime.tier is SessionTier.COLD
+    assert acq.runtime.warm_slot is None
+
+
+# ===========================================================================
+# Busy guard
+# ===========================================================================
+
+
+def test_busy_runtime_never_reaped() -> None:
+    """A busy slot (active_runs>0) is never reaped even when stale; idle+TTL is."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    td = Teardown()
+    sup.bind_warm_slot(acq.runtime, slot="slot", teardown=td)
+
+    # Run in flight — advance well past TTL, reaper must skip it.
+    sup.mark_run_start(acq.runtime)
+    clock.advance(500)
+    assert sup.reap_once() == 0
+    assert td.calls == 0
+    assert acq.runtime.tier is SessionTier.WARM
+
+    # Run ends; one more TTL window passes → now reapable.
+    sup.mark_run_end(acq.runtime)
+    assert acq.runtime.active_runs == 0
+    clock.advance(121)
+    assert sup.reap_once() == 1
+    assert td.calls == 1
+    assert acq.runtime.tier is SessionTier.COLD
+
+
+# ===========================================================================
+# Per-tenant quota
+# ===========================================================================
+
+
+def test_per_tenant_quota_lru_evicts_oldest_idle_in_tenant() -> None:
+    """A 3rd warm session for tenant A LRU-evicts A's oldest IDLE warm; tenant B
+    is untouched (quota is per-tenant)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=10_000, max_warm_per_tenant=2, now=clock)
+
+    # Tenant B has a warm session — it must survive A hitting its cap.
+    b = sup.acquire("ws-b", "sess-b1", "agent", cli_session_id="cli-b1")
+    td_b = Teardown()
+    sup.bind_warm_slot(b.runtime, slot="b1", teardown=td_b)
+
+    # Tenant A: two warm sessions (a1 older than a2).
+    clock.advance(1)
+    a1 = sup.acquire("ws-a", "sess-a1", "agent", cli_session_id="cli-a1")
+    td_a1 = Teardown()
+    sup.bind_warm_slot(a1.runtime, slot="a1", teardown=td_a1)
+
+    clock.advance(1)
+    a2 = sup.acquire("ws-a", "sess-a2", "agent", cli_session_id="cli-a2")
+    td_a2 = Teardown()
+    sup.bind_warm_slot(a2.runtime, slot="a2", teardown=td_a2)
+
+    # A 3rd warm session for A → over the per-tenant cap of 2 → evict A's oldest
+    # IDLE warm (a1), tearing it down. a2 and the new one stay; B is untouched.
+    clock.advance(1)
+    a3 = sup.acquire("ws-a", "sess-a3", "agent", cli_session_id="cli-a3")
+    td_a3 = Teardown()
+    sup.bind_warm_slot(a3.runtime, slot="a3", teardown=td_a3)
+
+    assert td_a1.calls == 1  # oldest idle in tenant A evicted
+    assert a1.runtime.tier is SessionTier.COLD
+    assert td_a2.calls == 0 and a2.runtime.tier is SessionTier.WARM
+    assert td_a3.calls == 0 and a3.runtime.tier is SessionTier.WARM
+    assert td_b.calls == 0 and b.runtime.tier is SessionTier.WARM  # per-tenant
+
+
+def test_per_tenant_quota_skips_busy_candidate() -> None:
+    """When the only over-cap candidate is busy, it is NOT evicted (busy-guard)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=10_000, max_warm_per_tenant=1, now=clock)
+
+    a1 = sup.acquire("ws-a", "sess-a1", "agent", cli_session_id="cli-a1")
+    td_a1 = Teardown()
+    sup.bind_warm_slot(a1.runtime, slot="a1", teardown=td_a1)
+    sup.mark_run_start(a1.runtime)  # busy — cannot be evicted
+
+    clock.advance(1)
+    a2 = sup.acquire("ws-a", "sess-a2", "agent", cli_session_id="cli-a2")
+    td_a2 = Teardown()
+    sup.bind_warm_slot(a2.runtime, slot="a2", teardown=td_a2)
+
+    # Over cap (2 > 1) but the only idle candidate is a2 itself (protected as the
+    # just-bound runtime); a1 is busy → nothing evicted this cycle.
+    assert td_a1.calls == 0 and a1.runtime.tier is SessionTier.WARM
+    assert td_a2.calls == 0 and a2.runtime.tier is SessionTier.WARM
+
+
+# ===========================================================================
+# Turn-1 routing / capture ownership
+# ===========================================================================
+
+
+def test_turn_one_routes_fresh_and_owns_capture() -> None:
+    """Turn 1 (cli_session_id=None) is a FRESH launch that OWNS capture; a later
+    acquire with the recorded id within TTL is WARM reuse."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq1 = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    assert isinstance(acq1, Acquisition)
+    assert acq1.warm_reuse is False
+    assert acq1.fresh is True
+    assert acq1.owns_capture is True
+    assert acq1.cli_session_id is None
+
+    # Executor captures the native id, records it, binds the slot it launched.
+    sup.record_cli_session_id(acq1.runtime, "cli-xyz")
+    sup.bind_warm_slot(acq1.runtime, slot="proc", teardown=Teardown())
+
+    # Next turn within TTL — recorded id resolves, warm slot reused.
+    clock.advance(10)
+    acq2 = sup.acquire("ws-a", "sess-1", "agent-x")  # caller passes no id
+    assert acq2.warm_reuse is True
+    assert acq2.owns_capture is False
+    assert acq2.cli_session_id == "cli-xyz"
+
+
+def test_turn_one_never_reuses_foreign_warm_slot() -> None:
+    """Even if a warm slot somehow exists, a turn with no known id stays FRESH so
+    capture binds to THIS session (the SS-1 turn-1 concern)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    sup.bind_warm_slot(acq.runtime, slot="proc", teardown=Teardown())
+    # Force the in-memory id back to unknown to simulate a not-yet-captured turn.
+    acq.runtime.cli_session_id = None
+
+    again = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    assert again.warm_reuse is False
+    assert again.owns_capture is True
+
+
+def test_expired_warm_slot_routes_fresh() -> None:
+    """A warm slot idle past TTL routes FRESH on the next acquire (resume path)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    sup.bind_warm_slot(acq.runtime, slot="proc", teardown=Teardown())
+
+    clock.advance(200)  # past TTL — slot stale, reaper hasn't run yet
+    nxt = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    assert nxt.warm_reuse is False  # stale slot not reused
+    assert nxt.owns_capture is False  # id known → resume, not turn 1
+    assert nxt.cli_session_id == "cli-1"
+
+
+# ===========================================================================
+# Crash → COLD
+# ===========================================================================
+
+
+def test_crash_drops_slot_keeps_id_next_acquire_fresh() -> None:
+    """mark_crashed → COLD + slot dropped; next acquire is FRESH and carries the
+    prior cli_session_id (resume-from-store path)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    sup.record_cli_session_id(acq.runtime, "cli-survives")
+    td = Teardown()
+    sup.bind_warm_slot(acq.runtime, slot="proc", teardown=td)
+
+    sup.mark_crashed(acq.runtime)
+    assert td.calls == 1  # best-effort teardown of the dead slot
+    assert acq.runtime.tier is SessionTier.COLD
+    assert acq.runtime.warm_slot is None
+    assert acq.runtime.cli_session_id == "cli-survives"  # kept for resume
+
+    nxt = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-survives")
+    assert nxt.warm_reuse is False  # FRESH launch
+    assert nxt.owns_capture is False  # id known → resume from store
+    assert nxt.cli_session_id == "cli-survives"
+
+
+# ===========================================================================
+# Identity helpers + singleton
+# ===========================================================================
+
+
+def test_runtime_key_is_tenancy_first() -> None:
+    """SessionRuntime.key is (workspace_id, session_id) — tenancy boundary first."""
+    sup = SessionSupervisor()
+    acq = sup.acquire("ws-a", "sess-1", "agent-x")
+    assert acq.runtime.key == ("ws-a", "sess-1")
+
+
+def test_get_session_supervisor_singleton() -> None:
+    """get_session_supervisor returns a stable process-global instance."""
+    assert get_session_supervisor() is get_session_supervisor()
+
+
+# ===========================================================================
+# Background reaper lifecycle (async)
+# ===========================================================================
+
+
+async def test_start_stop_tears_down_all_slots() -> None:
+    """stop() cancels the reaper and tears down every live warm slot."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+    await sup.start()
+
+    a = sup.acquire("ws-a", "sess-1", "agent", cli_session_id="cli-a")
+    td_a = Teardown()
+    sup.bind_warm_slot(a.runtime, slot="a", teardown=td_a)
+
+    b = sup.acquire("ws-b", "sess-2", "agent", cli_session_id="cli-b")
+    td_b = Teardown()
+    sup.bind_warm_slot(b.runtime, slot="b", teardown=td_b)
+
+    await sup.stop()
+    assert td_a.calls == 1 and td_b.calls == 1
+    assert a.runtime.tier is SessionTier.COLD
+    assert b.runtime.tier is SessionTier.COLD


### PR DESCRIPTION
The lifecycle engine that owns one runtime per `(workspace, session)` and decides, per turn, whether to reuse a warm process or take a fresh launch.

- COLD and WARM tiers (LIVE reserved). A second turn within the TTL can reuse a warm slot; idle slots are reaped; a busy runtime (active_runs > 0) is never reaped or evicted, the same guard the agent pool uses.
- Per-tenant warm quota plus a global cap, evicting the oldest idle warm session in scope. One tenant hitting its cap never evicts another tenant's sessions.
- Turn 1 of a session, before any native id is known, always routes to its own fresh launch, so the id the SDK captures binds to that session rather than a shared warm client. This closes the turn-1 capture gap noted in the SS-1 PR.
- Crash, reap, and evict all demote to COLD while keeping the cli_session_id, so the next turn resumes from the store.

The supervisor doesn't spawn processes. The executor supplies the warm slot and a teardown callback, which keeps this a pure policy engine, tested with a fake clock and fake teardowns.

Known limitation: COLD runtimes stay resident in memory; a COLD-TTL prune is the follow-up for long SaaS uptime.

Tests: warm reuse, idle reap, busy-guard, per-tenant quota including a busy-skip case, turn-1 routing with foreign-slot and expired-slot edges, crash to COLD. 12 green.

Stacked on the SS-3 branch.
