### PR TITLE
feat(cloud): drive supervised native-resume sessions through the executor (flag-gated)

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,28 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-30 (feat/session-supervisor SS-5) — ``_drive_agent_loop`` now drives
+  every supervised agent turn through the ``SessionSupervisor`` + the durable
+  ``(workspace, session, agent) -> cli_session_id`` mapping (SS-3
+  ``runtime_service``) + the per-tenant ``MongoSessionStore`` (SS-2), gated
+  behind ``POCKETPAW_SESSION_SUPERVISOR`` (default OFF). When ON: it resolves the
+  stable session identity (``workspace_id`` / ``scope_id`` as the per-conversation
+  key / ``target_agent_id``), recovers any prior native ``cli_session_id`` from
+  the durable mapping, calls ``supervisor.acquire(...)``, builds a
+  ``SessionHandle(cli_session_id=acq.cli_session_id, session_store=MongoSessionStore(ws))``
+  and threads it as ``session_handle=`` into ``pool.run`` so the agent RESUMES
+  its native CLI session (durable across restart, tenant-isolated) instead of
+  replaying Mongo history. The run is bracketed with
+  ``mark_run_start`` / ``mark_run_end`` (the latter in ``finally``); the turn-1
+  ``("session_id", {...})`` event the claude_sdk backend emits is consumed
+  internally (NOT yielded to the SSE transport) and persisted via
+  ``runtime_service.set_cli_session_id`` + ``supervisor.record_cli_session_id``;
+  a crash (pool.run raised, or a backend ``error`` event) flips the runtime to
+  COLD via ``mark_crashed``. v1 does NOT bind a live warm slot (WARM hot-process
+  reuse is a documented fast-follow) — every supervised turn resumes from the
+  store. When OFF, ``sup_acq`` stays ``None``, no supervisor/store/mapping call
+  fires, and ``pool.run`` is invoked WITHOUT a ``session_handle`` — byte-for-byte
+  the legacy path.
 - 2026-06-27 (fix/cloud-artifacts-reland) — ``execute_run`` now wraps the run
   lifecycle (the prewarm ``create_task`` + the main agent loop) in
   ``mark_cloud_chat_run`` so the per-tenant cwd jail's fail-closed
@@ -130,10 +152,18 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
 
+from pocketpaw.agents.backend import (  # type: ignore[import-untyped]
+    SessionHandle,
+)
 from pocketpaw.agents.pool import (  # type: ignore[import-untyped]
     get_agent_pool,
 )
+from pocketpaw.agents.session_supervisor import (  # type: ignore[import-untyped]
+    get_session_supervisor,
+)
 from pocketpaw_ee.cloud._core.realtime import xproc
+from pocketpaw_ee.cloud.agent_sessions import runtime_service
+from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore
 from pocketpaw_ee.cloud.chat.agent_service import (
     ScopeContext,
     ScopeKind,
@@ -219,6 +249,24 @@ def _looks_like_legacy_ripple_spec(candidate: Any) -> bool:
 
 def _stream_ttl() -> int:
     return int(os.environ.get("POCKETPAW_CLOUD_RUN_STREAM_TTL", "3600"))
+
+
+# Default-OFF flag (feat/session-supervisor SS-5). When truthy, the live executor
+# drives every supervised agent turn through the SessionSupervisor + the durable
+# native-id mapping (SS-3) + the per-tenant Mongo transcript store (SS-2) so the
+# agent RESUMES its native CLI session instead of replaying Mongo history into the
+# prompt. OFF (the default) leaves ``pool.run`` byte-for-byte the legacy path.
+_SUPERVISOR_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _session_supervisor_enabled() -> bool:
+    """Read the ``POCKETPAW_SESSION_SUPERVISOR`` flag (env, default OFF).
+
+    Mirrors the env-flag pattern the other ee runtime flags use (e.g. the
+    resumable-run executor / transport flags read ``POCKETPAW_*`` straight off
+    ``os.environ``). Truthy = any of ``1/true/yes/on`` (case-insensitive).
+    """
+    return os.environ.get("POCKETPAW_SESSION_SUPERVISOR", "").strip().lower() in _SUPERVISOR_TRUTHY
 
 
 async def _load_entity_profile_override(workspace_id: str, pocket_id: str) -> dict[str, Any] | None:
@@ -877,6 +925,24 @@ async def _drive_agent_loop(
     handled_pocket_ids: set[str] = set()
     next_event_task: asyncio.Task[Any] | None = None
     next_queue_task: asyncio.Task[tuple[str, dict[str, Any]]] | None = None
+    # Supervised native-resume bookkeeping (feat/session-supervisor SS-5).
+    # Pre-init OUTSIDE the ``try`` so the ``finally`` / ``except`` can always
+    # reference them even if setup raised mid-flight. ``sup_acq`` stays ``None``
+    # on the legacy (flag-OFF) path — every supervisor/store call below is then
+    # skipped, so the run is byte-for-byte unchanged.
+    #
+    # Session identity for the SS-3 durable mapping: ``ctx.scope_id`` is the
+    # stable PER-CONVERSATION key (``session:<id>`` / ``group:<id>`` / ``dm:<id>``)
+    # — present on every turn and stable across process restarts. We deliberately
+    # do NOT use ``ctx.session_id`` (the Mongo session-doc id), which
+    # ``resolve_scope_context`` leaves ``None`` on the worker path; ``scope_id`` is
+    # the key SS-3's ``(workspace, session, agent) -> cli_session_id`` map is keyed
+    # on, so resume resolves the same row turn after turn.
+    sup_acq: Any = None
+    sup_run_failed = False
+    sup_workspace_id = ctx.workspace_id
+    sup_session_id = ctx.scope_id
+    sup_agent_id = ctx.target_agent_id
     try:
         session_key = session_key_for(ctx)
         # Read the per-run tool policy from the PRE-RESOLVED, ENTITY-AWARE
@@ -933,6 +999,52 @@ async def _drive_agent_loop(
         # narrower signature safe.
         if surface_skills:
             run_kwargs["skill_names"] = surface_skills
+        # --- Supervised native-resume wiring (feat/session-supervisor SS-5) -----
+        # Flag-gated (default OFF). When ON, route this turn through the
+        # SessionSupervisor: recover any prior native ``cli_session_id`` from the
+        # durable SS-3 mapping, ``acquire`` the runtime (turn 1 owns capture; a
+        # later turn carries the resume id), and thread a ``SessionHandle`` that
+        # pairs that id with this tenant's ``MongoSessionStore`` so the agent
+        # resumes natively (durable, tenant-isolated) instead of replaying
+        # history. ``project_key`` is left ``None`` in v1: the durable mapping and
+        # the supervisor accept ``None`` (informational only), native resume needs
+        # only the ``cli_session_id``, and the SDK derives the store's own
+        # ``(workspace, project_key, session_id)`` key from its ``SessionKey`` at
+        # append/load time. Any failure degrades to the legacy path for THIS turn
+        # (no handle threaded) — a supervisor hiccup never breaks a run.
+        if (
+            _session_supervisor_enabled()
+            and sup_workspace_id
+            and sup_session_id
+            and sup_agent_id
+        ):
+            try:
+                prior_cli = await runtime_service.get_cli_session_id(
+                    sup_workspace_id, sup_session_id, sup_agent_id
+                )
+                supervisor = get_session_supervisor()
+                sup_acq = supervisor.acquire(
+                    sup_workspace_id,
+                    sup_session_id,
+                    sup_agent_id,
+                    cli_session_id=prior_cli,
+                    project_key=None,
+                )
+                run_kwargs["session_handle"] = SessionHandle(
+                    cli_session_id=sup_acq.cli_session_id,
+                    session_store=MongoSessionStore(sup_workspace_id),
+                )
+                supervisor.mark_run_start(sup_acq.runtime)
+            except Exception:
+                logger.warning(
+                    "session-supervisor acquire failed for ws=%s session=%s — "
+                    "falling back to the legacy (no native resume) path this turn",
+                    sup_workspace_id,
+                    sup_session_id,
+                    exc_info=True,
+                )
+                sup_acq = None
+                run_kwargs.pop("session_handle", None)
         agent_iter = pool.run(
             ctx.target_agent_id,
             user_content,
@@ -1031,6 +1143,40 @@ async def _drive_agent_loop(
                 meta = getattr(event, "metadata", None) or {}
                 usage_payload = dict(meta) if isinstance(meta, dict) else {}
                 yield ("token_usage", usage_payload)
+            elif etype == "session_id":
+                # Turn-1 native-id capture (feat/session-supervisor SS-5). The
+                # claude_sdk backend emits this ONCE per supervised session — and
+                # only when a ``session_handle`` was threaded (i.e. the flag is
+                # ON), so it never appears on the legacy path. Persist it durably
+                # (SS-3 mapping, for resume after a restart) AND onto the live
+                # supervisor runtime (so subsequent ``acquire`` calls this process
+                # resolve it). Consumed INTERNALLY — NOT yielded to the SSE
+                # transport: the client stream has no ``session_id`` frame, so
+                # keeping it internal leaves the wire identical to today. Best-
+                # effort: a persist failure must never break the in-flight turn.
+                if sup_acq is not None:
+                    sid_meta = getattr(event, "metadata", None) or {}
+                    native_id = sid_meta.get("session_id") if isinstance(sid_meta, dict) else None
+                    if native_id:
+                        try:
+                            await runtime_service.set_cli_session_id(
+                                sup_workspace_id,
+                                sup_session_id,
+                                sup_agent_id,
+                                native_id,
+                                project_key=None,
+                            )
+                            get_session_supervisor().record_cli_session_id(
+                                sup_acq.runtime, native_id, project_key=None
+                            )
+                        except Exception:
+                            logger.warning(
+                                "session-supervisor turn-1 capture persist failed "
+                                "for ws=%s session=%s",
+                                sup_workspace_id,
+                                sup_session_id,
+                                exc_info=True,
+                            )
             elif etype == "error":
                 # Surface backend-yielded errors instead of silently dropping
                 # them — a misconfigured backend (codex_cli without
@@ -1044,9 +1190,23 @@ async def _drive_agent_loop(
                     message[:200],
                 )
                 yield ("error", {"code": "agent.backend_error", "message": message})
+                # Supervised: a backend-yielded error is a run failure — flag it
+                # so ``finally`` demotes the runtime to COLD (keeping its
+                # cli_session_id so the next turn still resumes from the store).
+                sup_run_failed = True
                 break
         for ev in _drain_side_channel():
             yield ev
+    except Exception:
+        # A crash mid-stream (pool.run raised, a transport/store error, etc.) is a
+        # supervised-session failure: flag it so ``finally`` demotes the runtime to
+        # COLD via ``mark_crashed``. Re-raise so ``execute_run``'s existing error
+        # handling is unchanged. ``CancelledError`` / ``GeneratorExit`` are
+        # BaseExceptions and intentionally NOT caught here — a host cancel or an
+        # early consumer-close is a clean stop, not a crash (``mark_run_end`` still
+        # runs in ``finally``).
+        sup_run_failed = True
+        raise
     finally:
         pending = [t for t in (next_event_task, next_queue_task) if t is not None and not t.done()]
         for t in pending:
@@ -1061,6 +1221,20 @@ async def _drive_agent_loop(
             detach_agent_identity(identity_tokens)
         except Exception:
             pass
+        # Release the supervisor busy-counter — and, on a failed run, demote the
+        # runtime to COLD (``mark_crashed`` keeps the cli_session_id so the next
+        # turn still resumes from the store). Best-effort: bookkeeping must never
+        # break teardown. No-op on the legacy path (``sup_acq is None``).
+        if sup_acq is not None:
+            try:
+                _sup = get_session_supervisor()
+                if sup_run_failed:
+                    _sup.mark_crashed(sup_acq.runtime)
+                _sup.mark_run_end(sup_acq.runtime)
+            except Exception:
+                logger.debug(
+                    "session-supervisor run-end bookkeeping failed", exc_info=True
+                )
 
 
 async def _iter_agent_events(

--- a/tests/cloud/runs/test_run_core_session_supervisor.py
+++ b/tests/cloud/runs/test_run_core_session_supervisor.py
@@ -1,0 +1,304 @@
+# tests/cloud/runs/test_run_core_session_supervisor.py
+# Created 2026-06-30 (feat/session-supervisor SS-5). Pins the SS-5 wiring in
+# ``_drive_agent_loop``: behind the default-OFF ``POCKETPAW_SESSION_SUPERVISOR``
+# flag the executor drives every supervised turn through the SessionSupervisor +
+# the durable native-id mapping (SS-3) + the per-tenant Mongo transcript store
+# (SS-2), so the agent RESUMES its native CLI session instead of replaying
+# history. Hermetic: a capturing fake pool yields backend AgentEvents, the SS-3
+# ``runtime_service`` + the ``MongoSessionStore`` are faked (no live mongod), and
+# the supervisor is a thin recorder wrapping the REAL ``SessionSupervisor`` so we
+# assert the real acquire/bracket/capture/crash behavior plus the call sequence.
+#
+# Coverage:
+#   * Flag ON, turn 1 (no prior id): pool.run gets a SessionHandle carrying the
+#     store + a None cli_session_id; mark_run_start/mark_run_end bracket the run;
+#     the ("session_id", ...) event persists via set_cli_session_id +
+#     record_cli_session_id (and is NOT yielded to the stream).
+#   * Flag ON, turn 2 (prior id known): get_cli_session_id resolves it → the
+#     SessionHandle carries resume (cli_session_id set).
+#   * Flag OFF: pool.run is called WITHOUT a session_handle; zero
+#     supervisor/store/mapping calls — the legacy path is byte-for-byte unchanged.
+#   * Flag ON, backend error event: the run is flagged a crash → mark_crashed.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+
+from pocketpaw.agents.session_supervisor import SessionSupervisor
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------- #
+# Fakes / harness                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class _CapturePool:
+    """Fake AgentPool: captures ``run`` kwargs and yields the given events."""
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = events
+        self.run_kwargs: dict[str, Any] | None = None
+        self.run_called = False
+
+    async def get(self, _agent_id):
+        return SimpleNamespace(config={"backend": "claude_agent_sdk"}, agent_name="A")
+
+    def run(self, agent_id, content, session_key, **kwargs):
+        self.run_called = True
+        self.run_kwargs = kwargs
+
+        async def _gen():
+            for ev in self._events:
+                yield ev
+
+        return _gen()
+
+
+class _FakeRuntimeService:
+    """In-memory stand-in for the SS-3 durable ``runtime_service`` (no mongod)."""
+
+    def __init__(self, prior: str | None = None) -> None:
+        self._prior = prior
+        self.get_calls: list[tuple[str, str, str]] = []
+        self.set_calls: list[tuple[str, str, str, str, str | None]] = []
+
+    async def get_cli_session_id(self, ws, session, agent):
+        self.get_calls.append((ws, session, agent))
+        return self._prior
+
+    async def set_cli_session_id(self, ws, session, agent, cli_session_id, project_key=None):
+        self.set_calls.append((ws, session, agent, cli_session_id, project_key))
+
+
+class _FakeStore:
+    """Stand-in for ``MongoSessionStore`` — construction only, no I/O."""
+
+    def __init__(self, workspace_id: str) -> None:
+        self.workspace_id = workspace_id
+
+
+class _RecordingSupervisor:
+    """Thin recorder delegating to a REAL ``SessionSupervisor``.
+
+    Gives us the genuine acquire/bracket/capture/crash semantics (a real
+    ``Acquisition`` + ``SessionRuntime`` whose state we can assert) AND an ordered
+    log of which lifecycle hooks fired.
+    """
+
+    def __init__(self) -> None:
+        self.inner = SessionSupervisor()
+        self.calls: list[str] = []
+        self.acq: Any = None
+
+    def acquire(self, *a, **k):
+        self.calls.append("acquire")
+        self.acq = self.inner.acquire(*a, **k)
+        return self.acq
+
+    def mark_run_start(self, runtime):
+        self.calls.append("mark_run_start")
+        self.inner.mark_run_start(runtime)
+
+    def mark_run_end(self, runtime):
+        self.calls.append("mark_run_end")
+        self.inner.mark_run_end(runtime)
+
+    def record_cli_session_id(self, runtime, cli_session_id, project_key=None):
+        self.calls.append("record_cli_session_id")
+        self.inner.record_cli_session_id(runtime, cli_session_id, project_key=project_key)
+
+    def mark_crashed(self, runtime):
+        self.calls.append("mark_crashed")
+        self.inner.mark_crashed(runtime)
+
+
+def _scope_ctx() -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+
+
+async def _drive(
+    monkeypatch,
+    *,
+    events: list[Any],
+    flag_on: bool,
+    runtime_service: _FakeRuntimeService | None = None,
+    supervisor: _RecordingSupervisor | None = None,
+) -> tuple[_CapturePool, list[tuple[str, dict]]]:
+    """Run ``_drive_agent_loop`` hermetically; return (pool, produced events)."""
+    if flag_on:
+        monkeypatch.setenv("POCKETPAW_SESSION_SUPERVISOR", "true")
+    else:
+        monkeypatch.delenv("POCKETPAW_SESSION_SUPERVISOR", raising=False)
+
+    pool = _CapturePool(events)
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: pool)
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda *a, **k: "")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda *a, **k: None)
+
+    # SS-3 mapping + SS-2 store: faked so the path is hermetic (no live mongod).
+    rs = runtime_service or _FakeRuntimeService()
+    monkeypatch.setattr(run_core, "runtime_service", rs)
+    monkeypatch.setattr(run_core, "MongoSessionStore", _FakeStore)
+    sup = supervisor or _RecordingSupervisor()
+    monkeypatch.setattr(run_core, "get_session_supervisor", lambda: sup)
+
+    async def _never_cancelled():
+        return False
+
+    out: list[tuple[str, dict]] = []
+    gen = run_core._drive_agent_loop(
+        _scope_ctx(),
+        user_content="hi",
+        attachments_in=None,
+        mentions_in=None,
+        history=[],
+        is_cancelled=_never_cancelled,
+        emit_stream_start=False,
+    )
+    async for ev in gen:
+        out.append(ev)
+    return pool, out
+
+
+def _turn1_events() -> list[Any]:
+    return [
+        SimpleNamespace(type="message", content="hi there", metadata={}),
+        SimpleNamespace(
+            type="session_id",
+            content="",
+            metadata={"session_id": "native-abc", "backend": "claude_agent_sdk"},
+        ),
+        SimpleNamespace(type="done", content=""),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Flag ON — turn 1: capture + handle + bracket                                #
+# --------------------------------------------------------------------------- #
+
+
+async def test_flag_on_turn1_threads_handle_brackets_and_captures(monkeypatch):
+    rs = _FakeRuntimeService(prior=None)  # turn 1 → no prior native id
+    sup = _RecordingSupervisor()
+    pool, out = await _drive(
+        monkeypatch, events=_turn1_events(), flag_on=True, runtime_service=rs, supervisor=sup
+    )
+
+    # 1. pool.run received a SessionHandle carrying the store + a turn-1 None id.
+    assert pool.run_kwargs is not None
+    handle = pool.run_kwargs.get("session_handle")
+    assert handle is not None, "flag ON must thread a session_handle into pool.run"
+    assert handle.cli_session_id is None, "turn 1 has no native id yet → resume is None"
+    assert isinstance(handle.session_store, _FakeStore)
+    assert handle.session_store.workspace_id == "w1"
+
+    # 2. The prior id was looked up with the resolved identity (ws, scope_id, agent).
+    assert rs.get_calls == [("w1", "s1", "a1")]
+
+    # 3. The turn-1 ("session_id") event persisted the native id both durably and
+    #    onto the runtime — and was NOT surfaced to the SSE stream.
+    assert rs.set_calls == [("w1", "s1", "a1", "native-abc", None)]
+    assert sup.acq.runtime.cli_session_id == "native-abc"
+    assert "session_id" not in [name for name, _ in out]
+
+    # 4. The run was bracketed and balanced; no crash.
+    assert sup.calls == ["acquire", "mark_run_start", "record_cli_session_id", "mark_run_end"]
+    assert sup.acq.runtime.active_runs == 0
+
+
+# --------------------------------------------------------------------------- #
+# Flag ON — turn 2: resume from the prior native id                           #
+# --------------------------------------------------------------------------- #
+
+
+async def test_flag_on_turn2_resumes_with_prior_id(monkeypatch):
+    rs = _FakeRuntimeService(prior="native-xyz")  # turn 2 → prior id known
+    sup = _RecordingSupervisor()
+    events = [
+        SimpleNamespace(type="message", content="again", metadata={}),
+        SimpleNamespace(type="done", content=""),
+    ]
+    pool, _out = await _drive(
+        monkeypatch, events=events, flag_on=True, runtime_service=rs, supervisor=sup
+    )
+
+    handle = pool.run_kwargs.get("session_handle")
+    assert handle is not None
+    # The SessionHandle carries the resume id recovered from the durable mapping.
+    assert handle.cli_session_id == "native-xyz"
+    # acquire saw the recovered id.
+    assert sup.acq.cli_session_id == "native-xyz"
+    # No new capture this turn → no set_cli_session_id write, no record call.
+    assert rs.set_calls == []
+    assert sup.calls == ["acquire", "mark_run_start", "mark_run_end"]
+
+
+# --------------------------------------------------------------------------- #
+# Flag OFF — legacy path is byte-for-byte unchanged                           #
+# --------------------------------------------------------------------------- #
+
+
+async def test_flag_off_legacy_path_no_handle_no_supervisor(monkeypatch):
+    rs = _FakeRuntimeService(prior="native-should-not-be-read")
+    sup = _RecordingSupervisor()
+    pool, out = await _drive(
+        monkeypatch, events=_turn1_events(), flag_on=False, runtime_service=rs, supervisor=sup
+    )
+
+    # pool.run was called WITHOUT a session_handle.
+    assert pool.run_called
+    assert pool.run_kwargs is not None
+    assert "session_handle" not in pool.run_kwargs
+
+    # Zero supervisor / store / mapping interaction on the legacy path.
+    assert rs.get_calls == []
+    assert rs.set_calls == []
+    assert sup.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Flag ON — a backend error event flags the run as crashed                    #
+# --------------------------------------------------------------------------- #
+
+
+async def test_flag_on_backend_error_marks_crashed(monkeypatch):
+    rs = _FakeRuntimeService(prior="native-xyz")
+    sup = _RecordingSupervisor()
+    events = [
+        SimpleNamespace(type="message", content="partial", metadata={}),
+        SimpleNamespace(type="error", content="backend blew up", metadata={}),
+    ]
+    _pool, out = await _drive(
+        monkeypatch, events=events, flag_on=True, runtime_service=rs, supervisor=sup
+    )
+
+    # The error frame is surfaced to the stream...
+    assert any(name == "error" for name, _ in out)
+    # ...and the runtime is demoted (mark_crashed) then released (mark_run_end).
+    assert "mark_crashed" in sup.calls
+    assert sup.calls[-2:] == ["mark_crashed", "mark_run_end"]
+    # mark_crashed keeps the resume id for the next turn.
+    assert sup.acq.runtime.cli_session_id == "native-xyz"
+    assert sup.acq.runtime.active_runs == 0


### PR DESCRIPTION
Wires the supervisor, the durable id map, and the per-tenant store into the live chat executor, behind `POCKETPAW_SESSION_SUPERVISOR` (default off).

When on, each agent turn:
- recovers any prior native id for `(workspace, scope_id, agent)`,
- acquires the runtime (turn 1 owns capture, later turns carry the resume id),
- threads a `SessionHandle` pairing that id with this tenant's `MongoSessionStore`, so the agent resumes natively instead of replaying history,
- brackets the run with the busy-counter and persists the turn-1 id,
- demotes to COLD on failure so the next turn still resumes.

When off, `pool.run` is called with no handle and nothing else fires, so the path is unchanged. Any supervisor or store error during a turn falls back to the legacy path for that turn rather than breaking the run.

v1 doesn't bind a live warm slot; every supervised turn resumes from the store. Warm hot-process reuse is a follow-up.

Session identity uses `ctx.scope_id` (stable per conversation, present on the worker path) rather than the Mongo session-doc id, which is None there.

Tests: turn-1 capture, turn-2 resume, flag-off legacy path unchanged, backend-error demotes to COLD. The full chat-runs suite stays green (128).

Stacked on the SS-4 branch.
