### PR TITLE
feat: CLI agent session supervisor v1 — native resume, durable + tenant-isolated (flag-gated)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,17 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   env-configurable), marking queued/running `ChatRunDoc`s older than 10 minutes as
   `interrupted` so runs abandoned by a backend restart surface a retry affordance
   instead of leaving clients subscribed forever.
+- **Session supervisor config**: `POCKETPAW_SESSION_SUPERVISOR` (default OFF). When
+  truthy (`1`/`true`/`yes`/`on`), the cloud chat executor drives every agent turn
+  through the `SessionSupervisor` + the durable `(workspace, session, agent) ->
+  cli_session_id` map (`ee/.../agent_sessions/runtime_service.py`) + the per-tenant
+  `MongoSessionStore`, so the agent RESUMES its native CLI session (durable across
+  restart, tenant-isolated) instead of replaying Mongo history into the prompt. OFF
+  leaves `pool.run` byte-for-byte the legacy path, and any supervisor/store error
+  during a turn falls back to legacy for that turn. v1 resumes cold from the store
+  each turn (no warm hot-process reuse yet). Design:
+  `docs/concepts/agent-session-management.mdx`; smoke:
+  `docs/handoff/2026-06-30-session-supervisor-smoke.md`.
 - **Per-tenant agent cwd jail (cloud, ART-2)**: In multi-tenant cloud each
   workspace's chat agent runs with `cwd = ~/.pocketpaw/workspaces/<workspace_id>/agent/<session_id>/`
   (resolved per-run from the `attach_agent_identity` ContextVars in

--- a/docs/backends/claude-sdk.mdx
+++ b/docs/backends/claude-sdk.mdx
@@ -205,6 +205,21 @@ AgentEvent(type="done", content="")
 
 All backends use the same `AgentEvent` format, defined in `agents/backend.py`.
 
+## Native session resume
+
+This backend can continue a conversation by resuming the SDK's **native session**
+instead of replaying chat history into the prompt each turn. When `run()` receives
+a `SessionHandle` carrying a `cli_session_id`, it sets `ClaudeAgentOptions.resume`
+and launches a fresh subprocess that reloads that session's transcript; the
+per-turn system prompt is still applied, so a resumed turn honors fresh
+instructions and KB context. A `session_store` on the handle points the SDK at a
+custom `SessionStore` (durable, tenancy-keyed) so resume reads from there rather
+than local disk.
+
+This path is owned by the session supervisor and gated behind
+`POCKETPAW_SESSION_SUPERVISOR` (off by default). See
+[Agent Session Management](/concepts/agent-session-management) for the full design.
+
 ## Related
 
 <CardGroup>

--- a/docs/concepts/agent-session-management.mdx
+++ b/docs/concepts/agent-session-management.mdx
@@ -1,0 +1,165 @@
+---
+title: "Agent Session Management: Native Resume and the Session Supervisor"
+description: "How PocketPaw keeps a per-user CLI agent session alive across turns — durable native resume backed by a tenancy-keyed SessionStore, a runtime mapping, and a per-session lifecycle supervisor."
+section: Concepts
+ogType: article
+keywords: ["agent session", "native resume", "session supervisor", "session store", "multi-tenant", "claude agent sdk"]
+tags: ["concepts", "agents", "architecture"]
+---
+
+# Agent Session Management: Native Resume and the Session Supervisor
+
+When a user chats with a CLI agent (the Claude Agent SDK backend, Codex, and the
+others), that conversation has to be **maintained across turns** — and, in the
+multi-tenant cloud, isolated per tenant and bounded in resource use. This page
+describes how that works.
+
+<Callout type="note">
+  This is the agent **execution** layer (`src/pocketpaw/agents/` plus the cloud
+  executor). Don't confuse it with the chat **`Session`** Mongo document (the
+  conversation thread the sidebar lists) or the **`AuthSession`** (a login/JWT
+  row). Those are separate. This page is about the *agent process / native CLI
+  session* underneath a chat turn.
+</Callout>
+
+## Three things called "session"
+
+| Term | What it is | Where |
+|------|------------|-------|
+| `AuthSession` | One row per minted JWT (login/device) | `ee/.../models/auth_session.py` |
+| chat `Session` | The conversation thread the user sees | `ee/.../models/session.py` |
+| **native CLI session** | The agent CLI's own on-disk conversation state (`~/.claude/projects/*.jsonl`), resumable via `resume` | the CLI / Claude Agent SDK |
+
+This page is about binding a chat `Session` to a durable **native CLI session**
+so the agent continues where it left off.
+
+## Why native resume, not a kept-alive process
+
+The substrate is the **Claude Agent SDK's native session resume**, not a
+persistent process held open per user (and not a terminal multiplexer like
+tmux/cmux):
+
+- The CLI already persists each session to disk and reloads exact context on
+  `resume` — more faithful than replaying chat history into the prompt, and more
+  durable than a process (a held process dies on restart; the session file does
+  not).
+- We already stream structured events (`stream-json` → `ChatRunDoc` → Redis
+  Stream → SSE). Driving the agent through a terminal would mean screen-scraping
+  instead.
+- One live process per active session per tenant does not scale on a shared
+  multi-tenant box. Cold sessions cost zero process under resume.
+
+A live, attachable process (for "watch and steer the terminal") is a **deferred
+LIVE tier**, exposed through `cmux` on a supervisor-owned PTY — not the default
+substrate.
+
+## The pieces
+
+```
+chat turn ──▶ SessionSupervisor.acquire(ws, session, agent)
+                 │  resolves prior native id from the runtime map (SS-3)
+                 ▼
+            SessionHandle{ cli_session_id, session_store }
+                 │  threaded into AgentBackend.run()
+                 ▼
+            Claude SDK backend
+                 ├─ resume=cli_session_id  → fresh launch reloads the session
+                 └─ session_store          → SDK materializes the transcript
+                                              from OUR store into an ephemeral
+                                              temp dir, mirrors new turns back
+```
+
+### SessionHandle (`agents/backend.py`)
+A small value (`cli_session_id`, `session_store`) threaded through
+`AgentPool.run` → `AgentBackend.run` **only when set** — the same
+withhold-when-empty contract used for tool deny/allow/skill kwargs, so the other
+backends keep their narrower signature. When it carries a `cli_session_id`, the
+Claude SDK backend sets `ClaudeAgentOptions.resume` and routes that turn down the
+fresh `query()` launch path (the warm persistent client's cache key omits
+`resume`, so it can't honor a fresh one). The per-turn system prompt is still
+rebuilt and applied, so a resumed turn honors fresh instructions and KB context.
+
+### SessionStore (`agents/session_store.py`, `ee/.../agent_sessions/store.py`)
+Implements the SDK's `SessionStore` protocol so resume reads from **our** store
+instead of local disk. Every key is `(workspace_id, project_key, session_id,
+subpath)` and a store is **bound to a workspace** at construction, so a store for
+tenant B can never read tenant A's transcripts. The OSS `InMemorySessionStore` is
+the reference impl; `MongoSessionStore` is the durable one (every query filters
+`workspace == workspace_id`). The store reaches the OSS backend opaquely, so the
+OSS core never imports `pocketpaw_ee`.
+
+### Runtime mapping (`ee/.../agent_sessions/runtime_service.py`)
+`AgentSessionRuntimeDoc` is the durable map
+`(workspace, session, agent) → cli_session_id`, with a unique index leading on
+`workspace`. The native id is captured on turn 1 (from the SDK's init message)
+and looked up on every later turn, so even a cold turn after a restart resumes
+the right session.
+
+### SessionSupervisor (`agents/session_supervisor.py`)
+Owns one `SessionRuntime` per `(workspace, session)` across **COLD / WARM** tiers
+(LIVE reserved). It:
+
+- decides per turn whether to reuse a warm slot or take a fresh launch;
+- forces **turn 1** of a session to its own fresh launch, so the captured native
+  id binds to that session and not a shared warm client;
+- enforces a **per-tenant warm quota** plus a global cap (the guardrail that
+  keeps one tenant from exhausting a shared box), LRU-evicting the oldest *idle*
+  warm session in scope;
+- never reaps or evicts a **busy** runtime (`active_runs > 0`), the same guard
+  the agent pool uses;
+- demotes to COLD on reap / evict / crash while keeping the `cli_session_id`, so
+  the next turn resumes from the store.
+
+It does not spawn processes itself — the executor supplies the warm slot and a
+teardown callback.
+
+## Executor wiring and the flag
+
+`ee/.../chat/runs/run_core.py` drives every supervised turn through the
+supervisor, behind **`POCKETPAW_SESSION_SUPERVISOR`** (default **off**). When off,
+the executor calls `pool.run` with no handle and the path is byte-for-byte the
+legacy one. When on, it resolves the prior native id, acquires the runtime,
+threads the `SessionHandle`, brackets the run with the busy-counter, persists the
+turn-1 id, and demotes to COLD on failure. Any supervisor or store error during a
+turn falls back to the legacy path for that turn rather than breaking the run.
+
+## Multi-tenant isolation and security
+
+On the multi-tenant SaaS track the isolation rests on the SessionStore and the
+SDK's own materialize path:
+
+- session bytes live in our tenancy-filtered store, not as persistent shared
+  files; on resume the SDK writes them to an **ephemeral** `mkdtemp` config dir
+  and removes it after the run;
+- `resume` ids are UUID-validated and subagent subpaths are checked, so a store
+  key can't traverse out of its session;
+- materialized files are written `0600`, and the OAuth **`refreshToken` is
+  redacted** before the subprocess sees it, so a per-tenant subprocess can't burn
+  the parent / account-pool token.
+
+An adversarial isolation suite covers shared-backing collisions, guessed/leaked
+native ids, and quota cross-starvation (see
+`tests/test_multitenant_session_isolation.py` and the cloud counterpart).
+
+## Status and deferred work
+
+**v1 (this design):** native resume substrate, durable tenancy-keyed store, the
+runtime mapping, the supervisor (COLD/WARM + per-tenant quota), and the
+flag-gated executor wiring. Every supervised turn resumes from the store.
+
+**Deferred / follow-up:**
+
+- **WARM hot-process reuse** — keeping a per-session client live to skip
+  re-materialization (v1 resumes cold each turn).
+- **LIVE / attach tier** — an attachable long-running process surfaced through
+  `cmux` for watch-and-steer.
+- Atomic store `append`/upsert (the v1 path is read-modify-write).
+- A COLD-runtime memory prune for very long SaaS uptime.
+- Codex native resume parity.
+
+## Related
+
+- [Claude Agent SDK backend](/backends/claude-sdk)
+- [Memory System](/concepts/memory-system)
+- [Agent Loop](/concepts/agent-loop)
+- [OSS / EE split](/concepts/oss-ee-split)

--- a/docs/handoff/2026-06-30-session-supervisor-smoke.md
+++ b/docs/handoff/2026-06-30-session-supervisor-smoke.md
@@ -1,0 +1,103 @@
+<!-- Smoke-test guide — CLI Agent Session Supervisor v1. Created 2026-06-30.
+     Branch: integration/session-supervisor (= origin/dev + the 6 stacked commits).
+     Run this before shipping the integration branch to dev. -->
+
+# Session Supervisor v1 — Smoke Test Guide
+
+Branch under test: **`integration/session-supervisor`** (origin/dev + SS-1..SS-5 + SS-7).
+The feature is gated behind **`POCKETPAW_SESSION_SUPERVISOR`** (default off), so the
+default path is unchanged; you opt in to test it.
+
+## 0. Test-level integration (already green, re-run to confirm)
+
+```bash
+git fetch origin && git checkout integration/session-supervisor
+cd pocketPaw && uv sync --dev --group ee   # if the worktree venv isn't reused
+uv run pytest \
+  tests/test_session_supervisor.py tests/test_claude_sdk_session_handle.py \
+  tests/test_agent_session_store.py tests/test_multitenant_session_isolation.py \
+  tests/cloud/test_session_transcript_store.py tests/cloud/test_agent_session_runtime_service.py \
+  tests/cloud/test_multitenant_session_isolation.py tests/cloud/runs/ -q -o addopts=""
+# expect: 180 passed
+```
+
+## 1. SS-1 live-confirm — native resume actually works (the one check tests can't make)
+
+The automated tests spy on the wiring; this proves the CLI genuinely resumes and
+honors a fresh system prompt. **PASS** = the second reply contains `BANANA`
+(continuity) **and** ends with `[BETA]` (fresh system prompt honored on resume).
+
+```bash
+D=$(mktemp -d); cd "$D"
+S=$(claude -p "Secret word is BANANA. Reply 'ok'." --output-format json | jq -r .session_id)
+claude -p "What is the secret word?" --resume "$S" \
+  --append-system-prompt "End every message with the marker [BETA]." \
+  --output-format json | jq -r .result
+```
+
+If this fails, stop — the substrate assumption is wrong and SS-1 needs a rethink
+before any of this ships.
+
+## 2. Live stack — supervised resume end to end (flag ON)
+
+Boot the backend with the flag on (full local boot recipe is unchanged; only the
+env var is new):
+
+```bash
+cd pocketPaw
+POCKETPAW_SESSION_SUPERVISOR=true uv run pocketpaw serve --port 8888
+# frontend: cd paw-enterprise && VITE_API_URL=http://localhost:8888 ... bun run dev
+```
+
+**Resume continuity (the headline):**
+1. Open a chat, send turn 1: *"My favorite color is teal. Just acknowledge."*
+2. Send turn 2: *"What's my favorite color?"* → the agent answers **teal**.
+3. Confirm it came from native resume, not history replay — check the runtime map
+   got a native id for this session:
+   ```bash
+   mongosh paw-enterprise --quiet --eval \
+     'db.agent_session_runtimes.find({}, {workspace:1, session_id:1, agent_id:1, cli_session_id:1}).sort({_id:-1}).limit(3)'
+   ```
+   Expect a row with a non-null `cli_session_id` for your workspace/session/agent.
+   And the transcript store has the session:
+   ```bash
+   mongosh paw-enterprise --quiet --eval \
+     'db.session_transcripts.countDocuments({})'   # > 0
+   ```
+
+**Durability across restart (the reason native resume beats a kept-alive process):**
+4. Stop the backend (Ctrl-C), start it again with the flag on.
+5. In the same chat, send turn 3: *"What was my favorite color again?"* → still
+   **teal**. The warm process is gone, but the session resumed from the store.
+
+## 3. Flag OFF — legacy path unchanged
+
+6. Restart the backend WITHOUT the flag (`uv run pocketpaw serve --port 8888`).
+7. Chat normally — everything behaves as it does today. No `agent_session_runtimes`
+   rows are written for new chats; no behavior change. (This is the safety net:
+   merging the branch changes nothing until you flip the flag.)
+
+## 4. Multi-tenant isolation (covered by tests; spot-check optional)
+
+The adversarial gate (`tests/.../test_multitenant_session_isolation.py`, 12 tests,
+0 leaks) covers cross-tenant store reads, the runtime-map, quota cross-starvation,
+and a leaked/guessed native id. If you want a live spot-check, run two workspaces
+and confirm `db.agent_session_runtimes` keeps separate rows per `workspace` for the
+same logical session/agent.
+
+## What to watch / known v1 limits
+
+- Every supervised turn resumes **cold** from the store (no warm hot-process reuse
+  yet) — correct and durable, but you'll pay materialization each turn. WARM reuse
+  is a follow-up.
+- COLD `SessionRuntime`s stay resident in memory — fine for a smoke test, needs a
+  prune for long SaaS uptime.
+- Mongo `append`/upsert is read-modify-write — fine at low concurrency.
+- Codex native resume is not wired yet (claude_sdk only).
+
+## Ship-to-dev
+
+Once §1–§3 pass, the branch is ready to ship to dev. Stacked-PR note: the 6 slice
+PRs (#1590–#1595) are the per-slice review; this integration branch is the rollup.
+Ship either by merging the integration branch to dev (squash) or by merging the
+stack bottom-up with `--rebase`.

--- a/docs/handoff/2026-06-30-session-supervisor-smoke.md
+++ b/docs/handoff/2026-06-30-session-supervisor-smoke.md
@@ -8,6 +8,11 @@ Branch under test: **`integration/session-supervisor`** (origin/dev + SS-1..SS-5
 The feature is gated behind **`POCKETPAW_SESSION_SUPERVISOR`** (default off), so the
 default path is unchanged; you opt in to test it.
 
+> **Verified live 2026-06-30** — §1–§3 passed, no bugs: a real two-turn cloud chat
+> captured the native `cli_session_id` into Mongo, a backend restart wiped the warm
+> process, and turn 3 still answered "Teal" (resumed from the store). Flag-off wrote
+> zero `agent_session_runtimes` rows. v1's cold-resume-each-turn limit held as documented.
+
 ## 0. Test-level integration (already green, re-run to confirm)
 
 ```bash
@@ -41,11 +46,18 @@ before any of this ships.
 ## 2. Live stack — supervised resume end to end (flag ON)
 
 Boot the backend with the flag on (full local boot recipe is unchanged; only the
-env var is new):
+env var is new).
+
+**Prerequisites on a cold box** (a ready dev stack already has these): cloud
+features return **401 without a license** — set `POCKETPAW_LICENSE_KEY` — and you
+need a provisioned **workspace + a `pocketpaw`-slug agent + a chat scope**
+(group / session / pocket) to post turns to. A fresh `serve` seeds an admin and a
+workspace; confirm an agent and a group exist (or create one) before §2.
 
 ```bash
 cd pocketPaw
-POCKETPAW_SESSION_SUPERVISOR=true uv run pocketpaw serve --port 8888
+POCKETPAW_SESSION_SUPERVISOR=true POCKETPAW_LICENSE_KEY=<your-key> \
+  uv run pocketpaw serve --port 8888
 # frontend: cd paw-enterprise && VITE_API_URL=http://localhost:8888 ... bun run dev
 ```
 

--- a/ee/pocketpaw_ee/cloud/agent_sessions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/agent_sessions/__init__.py
@@ -1,0 +1,14 @@
+# ee/pocketpaw_ee/cloud/agent_sessions/__init__.py — the agent-session entity.
+#
+# Holds the Mongo-backed ``SessionStore`` (feat/session-supervisor SS-2) that
+# durably mirrors Claude Agent SDK session transcripts per tenant, so an agent
+# conversation survives a backend restart by resuming from Mongo instead of the
+# subprocess's local disk.
+#
+# Created 2026-06-30 (feat/session-supervisor SS-2).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore
+
+__all__ = ["MongoSessionStore"]

--- a/ee/pocketpaw_ee/cloud/agent_sessions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/agent_sessions/__init__.py
@@ -3,12 +3,21 @@
 # Holds the Mongo-backed ``SessionStore`` (feat/session-supervisor SS-2) that
 # durably mirrors Claude Agent SDK session transcripts per tenant, so an agent
 # conversation survives a backend restart by resuming from Mongo instead of the
-# subprocess's local disk.
+# subprocess's local disk, AND the durable
+# ``(workspace, session_id, agent_id) -> cli_session_id`` resume mapping
+# (SS-3, ``runtime_service``) so any turn — even a cold one after a restart —
+# can find the native session to resume.
 #
 # Created 2026-06-30 (feat/session-supervisor SS-2).
+# Updated 2026-06-30 (feat/session-supervisor SS-3): re-export the
+# ``runtime_service`` resume-mapping functions.
 
 from __future__ import annotations
 
+from pocketpaw_ee.cloud.agent_sessions.runtime_service import (
+    get_cli_session_id,
+    set_cli_session_id,
+)
 from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore
 
-__all__ = ["MongoSessionStore"]
+__all__ = ["MongoSessionStore", "get_cli_session_id", "set_cli_session_id"]

--- a/ee/pocketpaw_ee/cloud/agent_sessions/runtime_service.py
+++ b/ee/pocketpaw_ee/cloud/agent_sessions/runtime_service.py
@@ -1,0 +1,121 @@
+# ee/pocketpaw_ee/cloud/agent_sessions/runtime_service.py — the SOLE owner of
+# the durable ``(workspace, session_id, agent_id) -> cli_session_id`` mapping
+# (feat/session-supervisor SS-3).
+#
+# Module-level ``async def`` API (no class wrapper), mirroring
+# ``ee.cloud.sessions.service``. The executor (SS-5) calls:
+#   - ``set_cli_session_id`` on turn 1, when the OSS ``claude_sdk`` backend
+#     emits its ``session_id`` event, to durably record the native session id;
+#     and again on a later resume/backfill (it UPSERTs — one row per key).
+#   - ``get_cli_session_id`` on every later turn (including a COLD turn after a
+#     backend restart) to recover the native session and rebuild the
+#     ``SessionHandle`` so the agent resumes instead of starting fresh.
+#
+# Tenancy: EVERY read filters on ``workspace == workspace_id`` (the leading
+# component of the unique index), so a lookup scoped to tenant B can never
+# observe tenant A's mapping. Inputs are validated at entry; a foreign-tenant
+# or absent key resolves to ``None`` rather than raising.
+#
+# This module is the ONLY importer of ``AgentSessionRuntimeDoc`` (the ee
+# entity-isolation boundary). The mapping is internal-only (no HTTP surface),
+# so there is no DTO/router and no realtime event on write.
+#
+# no-event: this entity has no HTTP/realtime surface — it is an internal resume
+# index written by the executor on the agent turn hot path, never observed by a
+# client, so there is nothing to emit. (ee write-event convention.)
+#
+# Created 2026-06-30 (feat/session-supervisor SS-3): new entity service.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.models.agent_session_runtime import AgentSessionRuntimeDoc
+
+logger = logging.getLogger(__name__)
+
+
+def _require(name: str, value: str) -> str:
+    """Validate a required scope-key component at entry; raise on empty."""
+    if not value or not isinstance(value, str):
+        raise ValidationError(
+            "agent_session_runtime.invalid",
+            f"{name} must be a non-empty string",
+        )
+    return value
+
+
+async def _find_row(
+    workspace_id: str, session_id: str, agent_id: str
+) -> AgentSessionRuntimeDoc | None:
+    """Tenant-filtered lookup of the single row for this logical key.
+
+    The leading ``workspace`` filter is the tenancy boundary — a key from
+    another tenant simply does not match.
+    """
+    return await AgentSessionRuntimeDoc.find_one(
+        AgentSessionRuntimeDoc.workspace == workspace_id,
+        AgentSessionRuntimeDoc.session_id == session_id,
+        AgentSessionRuntimeDoc.agent_id == agent_id,
+    )
+
+
+async def set_cli_session_id(
+    workspace_id: str,
+    session_id: str,
+    agent_id: str,
+    cli_session_id: str,
+    project_key: str | None = None,
+) -> None:
+    """UPSERT the native ``cli_session_id`` for ``(ws, session, agent)``.
+
+    Inserts the row on turn 1 and updates it on a later resume/backfill — the
+    unique ``(workspace, session_id, agent_id)`` index guarantees a single row
+    per key, so this never produces a duplicate. ``project_key`` is recorded
+    when supplied (and left unchanged on update when omitted) so a cold resume
+    can rebuild the full ``SessionHandle``.
+    """
+    workspace_id = _require("workspace_id", workspace_id)
+    session_id = _require("session_id", session_id)
+    agent_id = _require("agent_id", agent_id)
+    cli_session_id = _require("cli_session_id", cli_session_id)
+
+    doc = await _find_row(workspace_id, session_id, agent_id)
+    if doc is None:
+        doc = AgentSessionRuntimeDoc(
+            workspace=workspace_id,
+            session_id=session_id,
+            agent_id=agent_id,
+            cli_session_id=cli_session_id,
+            project_key=project_key,
+        )
+    else:
+        doc.cli_session_id = cli_session_id
+        if project_key is not None:
+            doc.project_key = project_key
+    await doc.save()
+
+
+async def get_cli_session_id(
+    workspace_id: str,
+    session_id: str,
+    agent_id: str,
+) -> str | None:
+    """Return the native ``cli_session_id`` for ``(ws, session, agent)``.
+
+    Tenant-filtered: a foreign-tenant or never-written key resolves to ``None``
+    (the row either doesn't match the ``workspace`` filter or doesn't exist).
+    Also ``None`` when a row exists but its ``cli_session_id`` was never set.
+    """
+    workspace_id = _require("workspace_id", workspace_id)
+    session_id = _require("session_id", session_id)
+    agent_id = _require("agent_id", agent_id)
+
+    doc = await _find_row(workspace_id, session_id, agent_id)
+    if doc is None:
+        return None
+    return doc.cli_session_id
+
+
+__all__ = ["set_cli_session_id", "get_cli_session_id"]

--- a/ee/pocketpaw_ee/cloud/agent_sessions/store.py
+++ b/ee/pocketpaw_ee/cloud/agent_sessions/store.py
@@ -1,0 +1,160 @@
+# ee/pocketpaw_ee/cloud/agent_sessions/store.py — the Mongo-backed, tenancy-keyed
+# ``SessionStore`` (feat/session-supervisor SS-2).
+#
+# The real, durable counterpart to the OSS reference
+# ``pocketpaw.agents.session_store.InMemorySessionStore``. It satisfies the
+# Claude Agent SDK's ``SessionStore`` protocol by DUCK TYPING (the SDK never
+# uses ``isinstance``) and persists every transcript line as a
+# ``SessionTranscriptDoc`` row in the ``session_transcripts`` collection.
+#
+# The store is bound to a ``workspace_id`` at construction; EVERY query filters
+# on ``workspace == self._workspace_id``, so a store bound to tenant B can never
+# read tenant A's rows even though both live in the same collection — the core
+# isolation property (SS-7 tests it). It mirrors the in-memory ref impl's
+# semantics 1:1 (subpath ``""`` == main transcript, uuid-keyed idempotency on
+# ``append``, main-transcript ``delete`` cascades to subkeys).
+#
+# EE→OSS boundary: this concrete class lives in ee and is constructed by the
+# cloud controller (SS-5). It reaches the OSS ``claude_sdk`` backend ONLY as an
+# opaque object on ``SessionHandle.session_store`` — ``src/pocketpaw`` never
+# imports it.
+#
+# Created 2026-06-30 (feat/session-supervisor SS-2): new entity. Only this module
+# imports ``SessionTranscriptDoc``.
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pocketpaw_ee.cloud.models.session_transcript import SessionTranscriptDoc
+
+if TYPE_CHECKING:
+    from claude_agent_sdk.types import (
+        SessionKey,
+        SessionListSubkeysKey,
+        SessionStoreEntry,
+        SessionStoreListEntry,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+def _to_ms(dt: Any) -> int:
+    """Epoch-milliseconds for a datetime; 0 when absent.
+
+    Mongo strips tzinfo on persistence, so a naive datetime is treated as UTC.
+    """
+    if dt is None:
+        return 0
+    return int(dt.timestamp() * 1000)
+
+
+class MongoSessionStore:
+    """Tenancy-keyed ``SessionStore`` persisted in the ``session_transcripts``
+    collection. Construct one per ``workspace_id``."""
+
+    def __init__(self, workspace_id: str):
+        if not workspace_id:
+            raise ValueError("MongoSessionStore requires a non-empty workspace_id")
+        self._workspace_id = workspace_id
+
+    @staticmethod
+    def _subpath_of(key: SessionKey) -> str:
+        """Read the optional ``subpath`` (``""`` == main transcript)."""
+        return key.get("subpath") or ""
+
+    async def _find_row(
+        self, project_key: str, session_id: str, subpath: str
+    ) -> SessionTranscriptDoc | None:
+        return await SessionTranscriptDoc.find_one(
+            SessionTranscriptDoc.workspace == self._workspace_id,
+            SessionTranscriptDoc.project_key == project_key,
+            SessionTranscriptDoc.session_id == session_id,
+            SessionTranscriptDoc.subpath == subpath,
+        )
+
+    # -- SessionStore protocol ---------------------------------------------
+
+    async def append(self, key: SessionKey, entries: list[SessionStoreEntry]) -> None:
+        """Mirror a batch of transcript entries for ``key``.
+
+        Find-or-create the row, then extend its ``entries`` array, deduping any
+        entry that carries a ``uuid`` already present (the protocol's
+        idempotency contract). Read-modify-write — see the concurrency note in
+        the module/PR; v1 keeps it simple and correct for the de-risk slice.
+        """
+        subpath = self._subpath_of(key)
+        doc = await self._find_row(key["project_key"], key["session_id"], subpath)
+        if doc is None:
+            doc = SessionTranscriptDoc(
+                workspace=self._workspace_id,
+                project_key=key["project_key"],
+                session_id=key["session_id"],
+                subpath=subpath,
+                entries=[],
+            )
+        seen = {e.get("uuid") for e in doc.entries if isinstance(e, dict) and e.get("uuid")}
+        for entry in entries:
+            uuid = entry.get("uuid")
+            if uuid is not None:
+                if uuid in seen:
+                    continue
+                seen.add(uuid)
+            doc.entries.append(dict(entry))
+        await doc.save()
+
+    async def load(self, key: SessionKey) -> list[SessionStoreEntry] | None:
+        """Return the full transcript for ``key``, or ``None`` if never written.
+
+        A store bound to a different workspace returns ``None`` — the
+        ``workspace`` filter excludes the other tenant's row.
+        """
+        doc = await self._find_row(
+            key["project_key"], key["session_id"], self._subpath_of(key)
+        )
+        if doc is None:
+            return None
+        return list(doc.entries)  # type: ignore[return-value]
+
+    async def list_sessions(self, project_key: str) -> list[SessionStoreListEntry]:
+        """List MAIN-transcript sessions for ``project_key`` in this workspace."""
+        docs = await SessionTranscriptDoc.find(
+            SessionTranscriptDoc.workspace == self._workspace_id,
+            SessionTranscriptDoc.project_key == project_key,
+            SessionTranscriptDoc.subpath == "",
+        ).to_list()
+        return [
+            {"session_id": d.session_id, "mtime": _to_ms(getattr(d, "updatedAt", None))}
+            for d in docs
+        ]
+
+    async def list_subkeys(self, key: SessionListSubkeysKey) -> list[str]:
+        """List the subpaths (e.g. subagent transcripts) under a session."""
+        docs = await SessionTranscriptDoc.find(
+            SessionTranscriptDoc.workspace == self._workspace_id,
+            SessionTranscriptDoc.project_key == key["project_key"],
+            SessionTranscriptDoc.session_id == key["session_id"],
+        ).to_list()
+        return [d.subpath for d in docs if d.subpath]
+
+    async def delete(self, key: SessionKey) -> None:
+        """Delete a session entry.
+
+        Deleting a main transcript (no ``subpath``) cascades to every subkey
+        under that session; a keyed ``subpath`` deletes only that one entry.
+        """
+        subpath = self._subpath_of(key)
+        if subpath:
+            doc = await self._find_row(key["project_key"], key["session_id"], subpath)
+            if doc is not None:
+                await doc.delete()
+            return
+        # Main transcript: cascade-delete the main row + all subkeys.
+        docs = await SessionTranscriptDoc.find(
+            SessionTranscriptDoc.workspace == self._workspace_id,
+            SessionTranscriptDoc.project_key == key["project_key"],
+            SessionTranscriptDoc.session_id == key["session_id"],
+        ).to_list()
+        for doc in docs:
+            await doc.delete()

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,28 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-30 (feat/session-supervisor SS-5) — ``_drive_agent_loop`` now drives
+  every supervised agent turn through the ``SessionSupervisor`` + the durable
+  ``(workspace, session, agent) -> cli_session_id`` mapping (SS-3
+  ``runtime_service``) + the per-tenant ``MongoSessionStore`` (SS-2), gated
+  behind ``POCKETPAW_SESSION_SUPERVISOR`` (default OFF). When ON: it resolves the
+  stable session identity (``workspace_id`` / ``scope_id`` as the per-conversation
+  key / ``target_agent_id``), recovers any prior native ``cli_session_id`` from
+  the durable mapping, calls ``supervisor.acquire(...)``, builds a
+  ``SessionHandle(cli_session_id=acq.cli_session_id, session_store=MongoSessionStore(ws))``
+  and threads it as ``session_handle=`` into ``pool.run`` so the agent RESUMES
+  its native CLI session (durable across restart, tenant-isolated) instead of
+  replaying Mongo history. The run is bracketed with
+  ``mark_run_start`` / ``mark_run_end`` (the latter in ``finally``); the turn-1
+  ``("session_id", {...})`` event the claude_sdk backend emits is consumed
+  internally (NOT yielded to the SSE transport) and persisted via
+  ``runtime_service.set_cli_session_id`` + ``supervisor.record_cli_session_id``;
+  a crash (pool.run raised, or a backend ``error`` event) flips the runtime to
+  COLD via ``mark_crashed``. v1 does NOT bind a live warm slot (WARM hot-process
+  reuse is a documented fast-follow) — every supervised turn resumes from the
+  store. When OFF, ``sup_acq`` stays ``None``, no supervisor/store/mapping call
+  fires, and ``pool.run`` is invoked WITHOUT a ``session_handle`` — byte-for-byte
+  the legacy path.
 - 2026-06-27 (fix/cloud-artifacts-reland) — ``execute_run`` now wraps the run
   lifecycle (the prewarm ``create_task`` + the main agent loop) in
   ``mark_cloud_chat_run`` so the per-tenant cwd jail's fail-closed
@@ -130,10 +152,18 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
 
+from pocketpaw.agents.backend import (  # type: ignore[import-untyped]
+    SessionHandle,
+)
 from pocketpaw.agents.pool import (  # type: ignore[import-untyped]
     get_agent_pool,
 )
+from pocketpaw.agents.session_supervisor import (  # type: ignore[import-untyped]
+    get_session_supervisor,
+)
 from pocketpaw_ee.cloud._core.realtime import xproc
+from pocketpaw_ee.cloud.agent_sessions import runtime_service
+from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore
 from pocketpaw_ee.cloud.chat.agent_service import (
     ScopeContext,
     ScopeKind,
@@ -219,6 +249,24 @@ def _looks_like_legacy_ripple_spec(candidate: Any) -> bool:
 
 def _stream_ttl() -> int:
     return int(os.environ.get("POCKETPAW_CLOUD_RUN_STREAM_TTL", "3600"))
+
+
+# Default-OFF flag (feat/session-supervisor SS-5). When truthy, the live executor
+# drives every supervised agent turn through the SessionSupervisor + the durable
+# native-id mapping (SS-3) + the per-tenant Mongo transcript store (SS-2) so the
+# agent RESUMES its native CLI session instead of replaying Mongo history into the
+# prompt. OFF (the default) leaves ``pool.run`` byte-for-byte the legacy path.
+_SUPERVISOR_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _session_supervisor_enabled() -> bool:
+    """Read the ``POCKETPAW_SESSION_SUPERVISOR`` flag (env, default OFF).
+
+    Mirrors the env-flag pattern the other ee runtime flags use (e.g. the
+    resumable-run executor / transport flags read ``POCKETPAW_*`` straight off
+    ``os.environ``). Truthy = any of ``1/true/yes/on`` (case-insensitive).
+    """
+    return os.environ.get("POCKETPAW_SESSION_SUPERVISOR", "").strip().lower() in _SUPERVISOR_TRUTHY
 
 
 async def _load_entity_profile_override(workspace_id: str, pocket_id: str) -> dict[str, Any] | None:
@@ -877,6 +925,24 @@ async def _drive_agent_loop(
     handled_pocket_ids: set[str] = set()
     next_event_task: asyncio.Task[Any] | None = None
     next_queue_task: asyncio.Task[tuple[str, dict[str, Any]]] | None = None
+    # Supervised native-resume bookkeeping (feat/session-supervisor SS-5).
+    # Pre-init OUTSIDE the ``try`` so the ``finally`` / ``except`` can always
+    # reference them even if setup raised mid-flight. ``sup_acq`` stays ``None``
+    # on the legacy (flag-OFF) path — every supervisor/store call below is then
+    # skipped, so the run is byte-for-byte unchanged.
+    #
+    # Session identity for the SS-3 durable mapping: ``ctx.scope_id`` is the
+    # stable PER-CONVERSATION key (``session:<id>`` / ``group:<id>`` / ``dm:<id>``)
+    # — present on every turn and stable across process restarts. We deliberately
+    # do NOT use ``ctx.session_id`` (the Mongo session-doc id), which
+    # ``resolve_scope_context`` leaves ``None`` on the worker path; ``scope_id`` is
+    # the key SS-3's ``(workspace, session, agent) -> cli_session_id`` map is keyed
+    # on, so resume resolves the same row turn after turn.
+    sup_acq: Any = None
+    sup_run_failed = False
+    sup_workspace_id = ctx.workspace_id
+    sup_session_id = ctx.scope_id
+    sup_agent_id = ctx.target_agent_id
     try:
         session_key = session_key_for(ctx)
         # Read the per-run tool policy from the PRE-RESOLVED, ENTITY-AWARE
@@ -933,6 +999,52 @@ async def _drive_agent_loop(
         # narrower signature safe.
         if surface_skills:
             run_kwargs["skill_names"] = surface_skills
+        # --- Supervised native-resume wiring (feat/session-supervisor SS-5) -----
+        # Flag-gated (default OFF). When ON, route this turn through the
+        # SessionSupervisor: recover any prior native ``cli_session_id`` from the
+        # durable SS-3 mapping, ``acquire`` the runtime (turn 1 owns capture; a
+        # later turn carries the resume id), and thread a ``SessionHandle`` that
+        # pairs that id with this tenant's ``MongoSessionStore`` so the agent
+        # resumes natively (durable, tenant-isolated) instead of replaying
+        # history. ``project_key`` is left ``None`` in v1: the durable mapping and
+        # the supervisor accept ``None`` (informational only), native resume needs
+        # only the ``cli_session_id``, and the SDK derives the store's own
+        # ``(workspace, project_key, session_id)`` key from its ``SessionKey`` at
+        # append/load time. Any failure degrades to the legacy path for THIS turn
+        # (no handle threaded) — a supervisor hiccup never breaks a run.
+        if (
+            _session_supervisor_enabled()
+            and sup_workspace_id
+            and sup_session_id
+            and sup_agent_id
+        ):
+            try:
+                prior_cli = await runtime_service.get_cli_session_id(
+                    sup_workspace_id, sup_session_id, sup_agent_id
+                )
+                supervisor = get_session_supervisor()
+                sup_acq = supervisor.acquire(
+                    sup_workspace_id,
+                    sup_session_id,
+                    sup_agent_id,
+                    cli_session_id=prior_cli,
+                    project_key=None,
+                )
+                run_kwargs["session_handle"] = SessionHandle(
+                    cli_session_id=sup_acq.cli_session_id,
+                    session_store=MongoSessionStore(sup_workspace_id),
+                )
+                supervisor.mark_run_start(sup_acq.runtime)
+            except Exception:
+                logger.warning(
+                    "session-supervisor acquire failed for ws=%s session=%s — "
+                    "falling back to the legacy (no native resume) path this turn",
+                    sup_workspace_id,
+                    sup_session_id,
+                    exc_info=True,
+                )
+                sup_acq = None
+                run_kwargs.pop("session_handle", None)
         agent_iter = pool.run(
             ctx.target_agent_id,
             user_content,
@@ -1031,6 +1143,40 @@ async def _drive_agent_loop(
                 meta = getattr(event, "metadata", None) or {}
                 usage_payload = dict(meta) if isinstance(meta, dict) else {}
                 yield ("token_usage", usage_payload)
+            elif etype == "session_id":
+                # Turn-1 native-id capture (feat/session-supervisor SS-5). The
+                # claude_sdk backend emits this ONCE per supervised session — and
+                # only when a ``session_handle`` was threaded (i.e. the flag is
+                # ON), so it never appears on the legacy path. Persist it durably
+                # (SS-3 mapping, for resume after a restart) AND onto the live
+                # supervisor runtime (so subsequent ``acquire`` calls this process
+                # resolve it). Consumed INTERNALLY — NOT yielded to the SSE
+                # transport: the client stream has no ``session_id`` frame, so
+                # keeping it internal leaves the wire identical to today. Best-
+                # effort: a persist failure must never break the in-flight turn.
+                if sup_acq is not None:
+                    sid_meta = getattr(event, "metadata", None) or {}
+                    native_id = sid_meta.get("session_id") if isinstance(sid_meta, dict) else None
+                    if native_id:
+                        try:
+                            await runtime_service.set_cli_session_id(
+                                sup_workspace_id,
+                                sup_session_id,
+                                sup_agent_id,
+                                native_id,
+                                project_key=None,
+                            )
+                            get_session_supervisor().record_cli_session_id(
+                                sup_acq.runtime, native_id, project_key=None
+                            )
+                        except Exception:
+                            logger.warning(
+                                "session-supervisor turn-1 capture persist failed "
+                                "for ws=%s session=%s",
+                                sup_workspace_id,
+                                sup_session_id,
+                                exc_info=True,
+                            )
             elif etype == "error":
                 # Surface backend-yielded errors instead of silently dropping
                 # them — a misconfigured backend (codex_cli without
@@ -1044,9 +1190,23 @@ async def _drive_agent_loop(
                     message[:200],
                 )
                 yield ("error", {"code": "agent.backend_error", "message": message})
+                # Supervised: a backend-yielded error is a run failure — flag it
+                # so ``finally`` demotes the runtime to COLD (keeping its
+                # cli_session_id so the next turn still resumes from the store).
+                sup_run_failed = True
                 break
         for ev in _drain_side_channel():
             yield ev
+    except Exception:
+        # A crash mid-stream (pool.run raised, a transport/store error, etc.) is a
+        # supervised-session failure: flag it so ``finally`` demotes the runtime to
+        # COLD via ``mark_crashed``. Re-raise so ``execute_run``'s existing error
+        # handling is unchanged. ``CancelledError`` / ``GeneratorExit`` are
+        # BaseExceptions and intentionally NOT caught here — a host cancel or an
+        # early consumer-close is a clean stop, not a crash (``mark_run_end`` still
+        # runs in ``finally``).
+        sup_run_failed = True
+        raise
     finally:
         pending = [t for t in (next_event_task, next_queue_task) if t is not None and not t.done()]
         for t in pending:
@@ -1061,6 +1221,20 @@ async def _drive_agent_loop(
             detach_agent_identity(identity_tokens)
         except Exception:
             pass
+        # Release the supervisor busy-counter — and, on a failed run, demote the
+        # runtime to COLD (``mark_crashed`` keeps the cli_session_id so the next
+        # turn still resumes from the store). Best-effort: bookkeeping must never
+        # break teardown. No-op on the legacy path (``sup_acq is None``).
+        if sup_acq is not None:
+            try:
+                _sup = get_session_supervisor()
+                if sup_run_failed:
+                    _sup.mark_crashed(sup_acq.runtime)
+                _sup.mark_run_end(sup_acq.runtime)
+            except Exception:
+                logger.debug(
+                    "session-supervisor run-end bookkeeping failed", exc_info=True
+                )
 
 
 async def _iter_agent_events(

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,10 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-06-30 (feat/session-supervisor SS-2) — added ``SessionTranscriptDoc``
+(the durable, tenant-scoped transcript rows backing the Mongo ``SessionStore``)
+to the imports, ``__all__``, and ``get_all_documents()`` so the
+``session_transcripts`` collection is wired into ``init_beanie``. Only
+``ee.cloud.agent_sessions.store`` imports the doc class directly.
 Updated: 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.2) — added the
 ``Lead`` and ``Site`` tenant-scoped Paw Sites documents (plus their
 ``LeadSource`` / ``SiteDomain`` subdocs) to the imports, ``__all__``, and the
@@ -117,6 +122,7 @@ from pocketpaw_ee.cloud.models.read_state import ReadState
 from pocketpaw_ee.cloud.models.request_log import RequestLog
 from pocketpaw_ee.cloud.models.sense_preference import WorkspaceSensePreference
 from pocketpaw_ee.cloud.models.session import Session
+from pocketpaw_ee.cloud.models.session_transcript import SessionTranscriptDoc
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
 from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
@@ -258,6 +264,7 @@ __all__ = [
     "DeepWorkLog",
     "RequestLog",
     "Session",
+    "SessionTranscriptDoc",
     "Site",
     "SiteDomain",
     "SiteRateCounter",
@@ -293,6 +300,9 @@ def get_all_documents():
         Pocket,
         PocketBackendCredential,
         Session,
+        # Agent-session transcript rows backing the Mongo SessionStore (SS-2).
+        # Only ``ee.cloud.agent_sessions.store`` imports this doc directly.
+        SessionTranscriptDoc,
         Comment,
         Notification,
         FileObj,

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,11 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-06-30 (feat/session-supervisor SS-3) — added
+``AgentSessionRuntimeDoc`` (the durable, tenant-scoped
+``(workspace, session_id, agent_id) -> cli_session_id`` mapping) to the
+imports, ``__all__``, and ``get_all_documents()`` so the
+``agent_session_runtimes`` collection is wired into ``init_beanie``. Only
+``ee.cloud.agent_sessions.runtime_service`` imports the doc class directly.
 Updated: 2026-06-30 (feat/session-supervisor SS-2) — added ``SessionTranscriptDoc``
 (the durable, tenant-scoped transcript rows backing the Mongo ``SessionStore``)
 to the imports, ``__all__``, and ``get_all_documents()`` so the
@@ -67,6 +73,7 @@ Updated: 2026-06-24 (integration/billing-credits, BC-7) — added ``Subscription
 from __future__ import annotations
 
 from pocketpaw_ee.cloud.models.agent import Agent, AgentConfig
+from pocketpaw_ee.cloud.models.agent_session_runtime import AgentSessionRuntimeDoc
 from pocketpaw_ee.cloud.models.api_key import APIKey
 from pocketpaw_ee.cloud.models.audit_event import AuditEvent
 from pocketpaw_ee.cloud.models.audit_webhook import AuditWebhook
@@ -265,6 +272,7 @@ __all__ = [
     "RequestLog",
     "Session",
     "SessionTranscriptDoc",
+    "AgentSessionRuntimeDoc",
     "Site",
     "SiteDomain",
     "SiteRateCounter",
@@ -303,6 +311,10 @@ def get_all_documents():
         # Agent-session transcript rows backing the Mongo SessionStore (SS-2).
         # Only ``ee.cloud.agent_sessions.store`` imports this doc directly.
         SessionTranscriptDoc,
+        # Durable (workspace, session_id, agent_id) -> cli_session_id mapping
+        # so any turn can resume the native session (SS-3). Only
+        # ``ee.cloud.agent_sessions.runtime_service`` imports this doc directly.
+        AgentSessionRuntimeDoc,
         Comment,
         Notification,
         FileObj,

--- a/ee/pocketpaw_ee/cloud/models/agent_session_runtime.py
+++ b/ee/pocketpaw_ee/cloud/models/agent_session_runtime.py
@@ -1,0 +1,71 @@
+# ee/pocketpaw_ee/cloud/models/agent_session_runtime.py — the durable,
+# tenant-scoped mapping from a chat-session scope to its native CLI session id
+# (feat/session-supervisor SS-3).
+#
+# One ``AgentSessionRuntimeDoc`` row records, for ONE
+# (workspace, session_id, agent_id) tuple, the native ``cli_session_id`` the
+# Claude Agent SDK minted for that conversation (plus the SDK ``project_key``
+# scope it lives under). The executor persists it on turn 1 (when the
+# ``claude_sdk`` backend emits the ``session_id`` event) and looks it up on
+# every later turn — even a COLD turn after a backend restart — so the agent
+# can resume the same native session instead of starting fresh. Without this
+# durable mapping the captured native id evaporates between turns and the user
+# gets "message with no agent reply".
+#
+# The UNIQUE compound index on ``(workspace, session_id, agent_id)`` keeps it
+# one row per logical key (so the service can upsert: insert on turn 1, update
+# on a later resume/backfill) and the leading ``workspace`` component is the
+# tenancy boundary — every read in the service filters on ``workspace`` so a
+# lookup scoped to tenant B can never observe tenant A's mapping even though
+# both live in the same collection.
+#
+# Created 2026-06-30 (feat/session-supervisor SS-3): new entity. Registered in
+# ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``agent_session_runtimes`` collection. Only
+# ``ee.cloud.agent_sessions.runtime_service`` imports this doc class
+# (entity-isolation boundary, mirroring the SS-2 transcript / sessions
+# entities).
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class AgentSessionRuntimeDoc(TimestampedDocument):
+    """Durable ``(workspace, session_id, agent_id) -> cli_session_id`` mapping.
+
+    ``session_id`` is the chat-session scope key (the conversation the user is
+    in), ``agent_id`` the agent answering it, and ``cli_session_id`` the native
+    Claude Agent SDK session id minted on turn 1 — ``None`` until the first
+    ``session_id`` event lands. ``project_key`` is the SDK scope the native
+    session lives under, carried so a resume can reconstruct the full
+    ``SessionHandle``. ``updatedAt`` (from :class:`TimestampedDocument`) records
+    the last backfill.
+    """
+
+    # Tenancy boundary. Indexed (non-unique) — many runtime rows per workspace.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The chat-session scope key (the conversation the turn belongs to).
+    session_id: str
+    # The agent answering this session.
+    agent_id: str
+    # The native Claude Agent SDK session id; None until turn 1's event lands.
+    cli_session_id: str | None = None
+    # The SDK ``project_key`` scope the native session lives under (default cwd).
+    project_key: str | None = None
+
+    class Settings:
+        name = "agent_session_runtimes"
+        indexes = [
+            # One row per logical key. The service upserts on this key; the
+            # leading ``workspace`` makes a guessed/leaked (session_id,
+            # agent_id) from another tenant impossible to collide with.
+            IndexModel(
+                [("workspace", 1), ("session_id", 1), ("agent_id", 1)],
+                unique=True,
+                name="uq_workspace_session_agent",
+            ),
+        ]

--- a/ee/pocketpaw_ee/cloud/models/session_transcript.py
+++ b/ee/pocketpaw_ee/cloud/models/session_transcript.py
@@ -1,0 +1,67 @@
+# ee/pocketpaw_ee/cloud/models/session_transcript.py — the durable, tenant-scoped
+# transcript rows that back the Mongo ``SessionStore`` (feat/session-supervisor
+# SS-2).
+#
+# One ``SessionTranscriptDoc`` row holds the full JSONL transcript for ONE
+# (workspace, project_key, session_id, subpath) tuple. The Claude Agent SDK's
+# ``SessionStore`` protocol mirrors transcript lines here via ``append`` and
+# reconstructs a conversation on resume via ``load`` — so an agent session
+# survives a backend restart by reading from Mongo instead of the subprocess's
+# local disk.
+#
+# ``subpath`` is ``""`` for the main transcript and a non-empty path (e.g.
+# ``"subagents/agent-{id}"``) for a subagent transcript. The UNIQUE compound
+# index on ``(workspace, project_key, session_id, subpath)`` keeps it one row
+# per logical key (so ``append`` can find-and-extend) and the leading
+# ``workspace`` component is the tenancy boundary — every read in the adapter
+# filters on ``workspace`` so a store bound to tenant B can never observe tenant
+# A's rows.
+#
+# Created 2026-06-30 (feat/session-supervisor SS-2): new entity. Registered in
+# ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``session_transcripts`` collection. Only
+# ``ee.cloud.agent_sessions.store`` imports this doc class (entity-isolation
+# boundary, mirroring the credit / sessions entities).
+
+from __future__ import annotations
+
+from typing import Any
+
+from beanie import Indexed
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class SessionTranscriptDoc(TimestampedDocument):
+    """One agent-session transcript (or subagent transcript) for a tenant.
+
+    Mirrors the SDK ``SessionStore`` key shape. ``entries`` is the ordered list
+    of opaque JSONL transcript lines (pass-through blobs — the adapter never
+    interprets them). ``updatedAt`` (from :class:`TimestampedDocument`) is the
+    ``mtime`` source the adapter surfaces in ``list_sessions``.
+    """
+
+    # Tenancy boundary. Indexed (non-unique) — many sessions per workspace.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The SDK ``project_key`` — caller-defined scope (default: sanitized cwd).
+    project_key: str
+    # The SDK session id.
+    session_id: str
+    # "" for the main transcript; a non-empty subpath for a subagent transcript.
+    subpath: str = ""
+    # Ordered opaque transcript lines. Each is one JSONL entry as a plain dict.
+    entries: list[dict[str, Any]] = []  # noqa: RUF012 — Beanie field default, not a shared mutable
+
+    class Settings:
+        name = "session_transcripts"
+        indexes = [
+            # One row per logical key. ``append`` upserts on this key; the
+            # leading ``workspace`` makes a guessed/leaked (project_key,
+            # session_id) from another tenant impossible to collide with.
+            IndexModel(
+                [("workspace", 1), ("project_key", 1), ("session_id", 1), ("subpath", 1)],
+                unique=True,
+                name="uq_workspace_project_session_subpath",
+            ),
+        ]

--- a/src/pocketpaw/agents/backend.py
+++ b/src/pocketpaw/agents/backend.py
@@ -23,6 +23,13 @@ plugin). The ``system_message_override`` field is applied UPSTREAM in
 ``AgentPool.run`` (it swaps the base system prompt before assembly), so it never
 reaches a backend as a kwarg — it rides the existing ``system_prompt`` channel.
 
+Updated: 2026-06-30 (feat/session-supervisor SS-2) — the ``SessionHandle.session_store``
+field is now real: a tenancy-keyed custom SDK ``SessionStore``. The Claude SDK
+backend forwards it OPAQUELY to ``ClaudeAgentOptions.session_store`` so a resume
+turn reconstructs the conversation from OUR durable store (not local disk),
+namespaced by ``(workspace_id, project_key, session_id)`` so one tenant can never
+read another's session. SS-1's ``cli_session_id`` resume wiring is unchanged.
+
 Updated: 2026-06-30 (feat/session-supervisor SS-1) — adds the ``SessionHandle``
 dataclass: native-resume identity for a single agent session. It rides the SAME
 withhold-when-empty contract as the kwargs above — ``AgentPool.run`` forwards a
@@ -93,9 +100,14 @@ class SessionHandle:
       a fresh-process turn resumes the on-disk conversation natively. ``None``
       (turn 1, or any non-supervised run) is the LEGACY path — behavior is
       unchanged from today.
-    * ``session_store`` — carried through OPAQUELY for SS-2 (a custom SDK
-      ``SessionStore``). SS-1 does NOT implement or consume it; it is an inert
-      pass-through field only.
+    * ``session_store`` — a custom SDK ``SessionStore`` (SS-2). The Claude SDK
+      backend forwards it OPAQUELY to ``ClaudeAgentOptions.session_store`` when
+      non-None, so a resume turn materializes the conversation from OUR store
+      (tenancy-keyed by ``(workspace_id, project_key, session_id)`` — see
+      ``pocketpaw.agents.session_store.InMemorySessionStore`` and the ee
+      Mongo-backed ``MongoSessionStore``) instead of local disk. It rides
+      through opaquely so OSS never imports the concrete (possibly ee) store
+      class. ``None`` is the unchanged legacy path.
 
     Like ``deny_mcp_tool_ids`` / ``allow_sdk_tools`` / ``skill_names``, the
     handle rides the withhold-when-empty contract: ``AgentPool.run`` forwards it

--- a/src/pocketpaw/agents/backend.py
+++ b/src/pocketpaw/agents/backend.py
@@ -22,6 +22,15 @@ per-entity skill subset the Claude SDK backend materializes into a per-run local
 plugin). The ``system_message_override`` field is applied UPSTREAM in
 ``AgentPool.run`` (it swaps the base system prompt before assembly), so it never
 reaches a backend as a kwarg — it rides the existing ``system_prompt`` channel.
+
+Updated: 2026-06-30 (feat/session-supervisor SS-1) — adds the ``SessionHandle``
+dataclass: native-resume identity for a single agent session. It rides the SAME
+withhold-when-empty contract as the kwargs above — ``AgentPool.run`` forwards a
+``session_handle`` to ``backend.run`` ONLY when it is non-None, so the backends
+that keep the narrower signature are unaffected, and only the Claude SDK backend
+acts on it today (passing its ``cli_session_id`` as ``ClaudeAgentOptions.resume``
+so a fresh-process turn resumes the on-disk conversation natively instead of
+replaying Mongo history into the prompt). ``None`` is the unchanged legacy path.
 """
 
 from __future__ import annotations
@@ -68,6 +77,34 @@ class BackendInfo:
     supported_providers: list[str] = field(default_factory=list)
     install_hint: dict[str, str] = field(default_factory=dict)
     beta: bool = False
+
+
+@dataclass
+class SessionHandle:
+    """SS-1 — native-resume identity for a single agent session.
+
+    Carries the bookkeeping that lets ONE agent hold a conversation across
+    turns via the Claude Agent SDK's NATIVE ``resume`` instead of replaying
+    Mongo history into the prompt:
+
+    * ``cli_session_id`` — the SDK session id captured on turn 1 (extracted
+      from the init/system message the SDK emits at the start of a run). When
+      set, the Claude SDK backend passes it as ``ClaudeAgentOptions.resume`` so
+      a fresh-process turn resumes the on-disk conversation natively. ``None``
+      (turn 1, or any non-supervised run) is the LEGACY path — behavior is
+      unchanged from today.
+    * ``session_store`` — carried through OPAQUELY for SS-2 (a custom SDK
+      ``SessionStore``). SS-1 does NOT implement or consume it; it is an inert
+      pass-through field only.
+
+    Like ``deny_mcp_tool_ids`` / ``allow_sdk_tools`` / ``skill_names``, the
+    handle rides the withhold-when-empty contract: ``AgentPool.run`` forwards it
+    to ``backend.run`` ONLY when it is non-None, so backends that keep the
+    narrower signature are unaffected. Only the Claude SDK backend acts on it.
+    """
+
+    cli_session_id: str | None = None
+    session_store: Any | None = None
 
 
 @runtime_checkable

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,14 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-06-30 (feat/session-supervisor SS-2) — ``_build_options`` now also
+  forwards ``session_handle.session_store`` to the SDK as
+  ``ClaudeAgentOptions.session_store`` when it is non-None. On a resume turn the
+  SDK materializes the conversation from THAT store (a tenancy-keyed custom
+  ``SessionStore``) instead of local disk, and mirrors new transcript lines back
+  via the store's ``append``. The store flows through OPAQUELY — OSS never
+  imports the concrete (possibly ee Mongo-backed) class, so the EE→OSS boundary
+  stays clean. ``None`` leaves ``session_store`` unset (unchanged SS-1 / legacy
+  behavior). Small additive change; the SS-1 resume wiring is untouched.
 Updated: 2026-06-30 (feat/session-supervisor SS-1) — ``run`` accepts an optional
   ``session_handle: SessionHandle | None``. When it carries a non-None
   ``cli_session_id``, ``_build_options`` sets ``ClaudeAgentOptions.resume`` so the
@@ -1713,6 +1722,20 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # ``None`` leaves ``resume`` unset — the unchanged legacy path.
         if resume_session_id:
             options_kwargs["resume"] = resume_session_id
+
+        # Tenancy-keyed session store (feat/session-supervisor SS-2). When the
+        # caller threads a ``session_handle`` carrying a ``session_store``, hand
+        # it to the SDK opaquely (the ``ClaudeAgentOptions.session_store: SessionStore
+        # | None`` field). On a resume turn the SDK materializes the conversation
+        # from THIS store — tenancy-keyed by ``(workspace_id, project_key,
+        # session_id)`` — instead of local disk, and mirrors new transcript
+        # lines back via ``append``. The object satisfies the SDK's ``SessionStore``
+        # protocol by duck typing; OSS never imports the concrete (possibly ee)
+        # class, so it flows through as-is and the EE→OSS boundary stays clean.
+        # Absent / ``None`` leaves ``session_store`` unset — the unchanged SS-1
+        # (and legacy) behavior.
+        if session_handle is not None and session_handle.session_store is not None:
+            options_kwargs["session_store"] = session_handle.session_store
 
         # Create options (after all kwargs are set, including model)
         options = self._ClaudeAgentOptions(**options_kwargs)

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,21 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-06-30 (feat/session-supervisor SS-1) — ``run`` accepts an optional
+  ``session_handle: SessionHandle | None``. When it carries a non-None
+  ``cli_session_id``, ``_build_options`` sets ``ClaudeAgentOptions.resume`` so the
+  CLI subprocess RESUMES that on-disk session natively (no Mongo-history replay),
+  and ``run`` routes the turn down the FRESH stateless ``query()`` launch path
+  rather than the warm persistent client (the warm client applies its options
+  only at first ``connect()`` and its cache key omits ``resume``, so a reused warm
+  client would silently ignore a fresh ``resume`` — the documented hazard). The
+  freshly-rebuilt per-turn ``system_prompt`` still rides ``--system-prompt`` on
+  every turn, so a resumed session honors a new system prompt. Turn-1 capture: the
+  SDK's init/system message carries a ``session_id`` in its ``data``; when a
+  ``session_handle`` is present, ``run`` extracts it and surfaces it once as a
+  ``session_id`` ``AgentEvent`` (mirroring the ``token_usage`` event) so the
+  controller can persist it for a later resume (SS-3). ``cli_session_id is None``
+  / no handle = the unchanged legacy warm-client path. ``session_handle`` is
+  forwarded by ``AgentPool.run`` only when non-None (withhold-when-empty idiom).
 Updated: 2026-06-26 (ART-2) — the agent's working directory is now resolved
   PER-RUN via ``_resolve_cwd`` instead of being frozen to
   ``settings.file_jail_path`` at ``__init__``. OSS / dedicated behavior is
@@ -185,7 +201,12 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any, NamedTuple
 
-from pocketpaw.agents.backend import BackendInfo, BaseAgentBackend, Capability
+from pocketpaw.agents.backend import (
+    BackendInfo,
+    BaseAgentBackend,
+    Capability,
+    SessionHandle,
+)
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.config import Settings
 from pocketpaw.security.rails import is_substring_blocked
@@ -1217,6 +1238,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         allow_mcp_tool_ids: frozenset[str] | None,
         skill_names: frozenset[str],
         stderr_sink: list[str],
+        session_handle: SessionHandle | None = None,
     ) -> _BuiltOptions:
         """Assemble the ``ClaudeAgentOptions`` a turn (or a prewarm) will run on.
 
@@ -1325,15 +1347,25 @@ class ClaudeSDKBackend(BaseAgentBackend):
         except Exception:
             pass  # Don't break agent if connector registry fails
 
+        # Native-resume session id (feat/session-supervisor SS-1). When set, the
+        # CLI subprocess will be launched with ``resume=<id>`` and reloads that
+        # session's transcript NATIVELY, so injecting Mongo ``history`` into the
+        # prompt below would DUPLICATE the conversation. The whole point of the
+        # slice is native continuity INSTEAD of history replay, so a resume turn
+        # skips the injection. ``None`` (legacy / no handle) keeps every existing
+        # cold-start run injecting history exactly as before.
+        resume_session_id = session_handle.cli_session_id if session_handle is not None else None
+
         # Inject prior turns into the system prompt at connect time. The
         # persistent ClaudeSDKClient accumulates new turns natively after
         # connect, but a fresh subprocess (after eviction, restart, or
         # session switch) has empty native history — without this, those
         # cold-start runs lose all conversation context. Reused clients
         # keep the prompt set at first connect and ignore later option
-        # changes, so there's no duplication on the warm path.
+        # changes, so there's no duplication on the warm path. Skipped on a
+        # native-resume turn (the resumed session already carries its history).
         final_prompt = identity
-        if history:
+        if history and not resume_session_id:
             lines = ["# Recent Conversation"]
             for msg in history:
                 role = msg.get("role", "user").capitalize()
@@ -1671,6 +1703,17 @@ class ClaudeSDKBackend(BaseAgentBackend):
 
         options_kwargs["stderr"] = _on_stderr
 
+        # Native-resume (feat/session-supervisor SS-1). When the caller threads a
+        # ``session_handle`` carrying a ``cli_session_id``, set the SDK's
+        # ``resume`` field so the freshly-launched CLI subprocess loads that
+        # session's transcript natively (the ``ClaudeAgentOptions.resume: str |
+        # None`` field). ``run`` routes a resume-bearing turn down the stateless
+        # ``query()`` path precisely so this fresh-launch option is honored (the
+        # warm client applies options only at first ``connect()``). Absent /
+        # ``None`` leaves ``resume`` unset — the unchanged legacy path.
+        if resume_session_id:
+            options_kwargs["resume"] = resume_session_id
+
         # Create options (after all kwargs are set, including model)
         options = self._ClaudeAgentOptions(**options_kwargs)
 
@@ -1796,10 +1839,26 @@ class ClaudeSDKBackend(BaseAgentBackend):
         allow_sdk_tools: frozenset[str] = frozenset(),
         allow_mcp_tool_ids: frozenset[str] | None = None,
         skill_names: frozenset[str] = frozenset(),
+        session_handle: SessionHandle | None = None,
     ) -> AsyncIterator[AgentEvent]:
         """Process a message through Claude Agent SDK with streaming.
 
         Yields AgentEvent objects as the agent responds.
+
+        ``session_handle`` (feat/session-supervisor SS-1) carries native-resume
+        identity. When it holds a non-None ``cli_session_id``, the SDK options
+        get ``resume=<cli_session_id>`` (so the CLI subprocess resumes that
+        on-disk session natively instead of replaying Mongo history) and THIS
+        run is routed down the FRESH stateless ``query()`` launch path — never
+        the warm persistent client, whose options freeze at first ``connect()``
+        and whose cache key omits ``resume`` (so a reused warm client would
+        silently ignore a fresh ``resume``). The per-turn ``system_prompt`` is
+        still passed on every turn, so a resumed session honors a rebuilt
+        prompt. When a handle is present, the SDK's turn-1 init/system message
+        ``session_id`` is extracted and surfaced once as a ``session_id``
+        AgentEvent (for the controller to persist — SS-3). ``cli_session_id is
+        None`` / no handle = the UNCHANGED legacy warm-client path. The
+        ``session_store`` field is opaque here (SS-2 owns it).
 
         ``deny_mcp_tool_ids`` is a per-surface MCP-tool deny set threaded down
         from the chat loop (resolved from the request's ``SurfaceProfile``).
@@ -1930,6 +1989,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 allow_sdk_tools=allow_sdk_tools,
                 allow_mcp_tool_ids=allow_mcp_tool_ids,
                 skill_names=skill_names,
+                session_handle=session_handle,
                 stderr_sink=_stderr_lines,
             )
             options = _built.options
@@ -1951,16 +2011,27 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 session_key,
             )
             _persistent_client = None
+            # Native-resume runs (feat/session-supervisor SS-1) MUST take the
+            # fresh stateless ``query()`` launch path, never the warm persistent
+            # client: the warm client applies its options (incl. ``resume``) only
+            # at first ``connect()``, and ``_client_cache_key`` does NOT fold in
+            # ``resume`` — so a reused warm client would silently ignore the fresh
+            # ``resume`` and continue its OWN in-memory conversation instead of
+            # the requested on-disk session. The stateless ``query()`` spawns a
+            # fresh subprocess per call that honors ``options.resume`` directly.
+            _resume_active = (
+                session_handle is not None and session_handle.cli_session_id is not None
+            )
             # fix/claude-sdk-warm-client-skills: the warm-client bypass for skill
             # runs is REMOVED. ``_client_cache_key`` now folds in
             # ``plugin_digest`` (the skill-identity hash), so a warm client can
             # distinguish a skill run from a non-skill one — a same-skill turn
             # reuses the subprocess and a changed skill set rebuilds it. The
             # materialized plugin dir was cached + adopted above so the warm
-            # subprocess keeps a valid path across turns. The only fallback to
-            # the stateless path now is the original concurrency guard: a sibling
-            # run already holds the lease (_client_in_use).
-            if not self._client_in_use:
+            # subprocess keeps a valid path across turns. Fallbacks to the
+            # stateless path: the original concurrency guard (a sibling run holds
+            # the lease, ``_client_in_use``) OR a native-resume turn.
+            if not self._client_in_use and not _resume_active:
                 try:
                     self._client_in_use = True
                     acquired_lease = True
@@ -2019,6 +2090,10 @@ class ClaudeSDKBackend(BaseAgentBackend):
             _announced_tools: set[str] = set()
             _event_count = 0
             _saw_result = False  # Track if ResultMessage was consumed
+            # feat/session-supervisor SS-1: emit the native session id at most
+            # once per run (from the SDK's turn-1 init/system message). Gated on
+            # an opted-in ``session_handle`` so the legacy stream is byte-identical.
+            _session_id_emitted = False
 
             # Stream responses — release the persistent client guard when done
             try:
@@ -2063,9 +2138,30 @@ class ClaudeSDKBackend(BaseAgentBackend):
                                 yield AgentEvent(type="thinking_done", content="")
                         continue
 
-                    # ========== SystemMessage - metadata, skip ==========
+                    # ========== SystemMessage - metadata ==========
                     if self._SystemMessage and isinstance(event, self._SystemMessage):
                         subtype = getattr(event, "subtype", "")
+                        # feat/session-supervisor SS-1: the SDK's init/system
+                        # message carries the native ``session_id`` in its
+                        # ``data`` dict. When the caller opted into a
+                        # ``session_handle``, capture it on turn 1 and surface it
+                        # ONCE as a ``session_id`` AgentEvent (mirroring the
+                        # ``token_usage`` metadata event) so the controller can
+                        # persist it for a later ``resume`` turn (SS-3). Gated on
+                        # the handle so the legacy stream stays byte-identical.
+                        if session_handle is not None and not _session_id_emitted:
+                            _data = getattr(event, "data", None)
+                            _sid = _data.get("session_id") if isinstance(_data, dict) else None
+                            if _sid:
+                                _session_id_emitted = True
+                                yield AgentEvent(
+                                    type="session_id",
+                                    content="",
+                                    metadata={
+                                        "session_id": _sid,
+                                        "backend": "claude_agent_sdk",
+                                    },
+                                )
                         logger.debug(f"SystemMessage: {subtype}")
                         continue
 
@@ -2294,6 +2390,10 @@ class ClaudeSDKBackend(BaseAgentBackend):
                         system_prompt=system_prompt,
                         history=history,
                         session_key=session_key,
+                        # Preserve native-resume identity across the crash retry
+                        # (feat/session-supervisor SS-1) so a resumed turn does
+                        # not silently restart a fresh session after a Bun crash.
+                        session_handle=session_handle,
                     ):
                         yield retry_event
                 finally:

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -77,7 +77,7 @@ from typing import TYPE_CHECKING, Any
 from pocketpaw.agents.errors import AgentBackendUnavailable, AgentNotFound
 
 if TYPE_CHECKING:
-    from pocketpaw.agents.backend import AgentBackend
+    from pocketpaw.agents.backend import AgentBackend, SessionHandle
     from pocketpaw.soul import SoulManager
 
 logger = logging.getLogger(__name__)
@@ -403,6 +403,7 @@ class AgentPool:
         allow_mcp_tool_ids: frozenset[str] | None = None,
         system_message_override: str | None = None,
         skill_names: frozenset[str] = frozenset(),
+        session_handle: SessionHandle | None = None,
     ) -> AsyncIterator[Any]:
         """Run an agent on a message. Yields AgentEvent stream.
 
@@ -518,6 +519,15 @@ class AgentPool:
             # non-empty. Empty = legacy all-skills advertise behavior.
             if skill_names:
                 run_kwargs["skill_names"] = skill_names
+            # Native-resume handle (feat/session-supervisor SS-1). Same
+            # withhold-when-empty rule as the kwargs above: only the Claude SDK
+            # backend accepts ``session_handle`` (it passes a non-None
+            # ``cli_session_id`` as ``ClaudeAgentOptions.resume`` and routes the
+            # turn down the fresh-launch path); the other backends keep the
+            # narrower signature, so the handle is forwarded ONLY when non-None.
+            # None = legacy warm-client path, unchanged for every existing run.
+            if session_handle is not None:
+                run_kwargs["session_handle"] = session_handle
             async for event in instance.backend.run(message, **run_kwargs):
                 instance.last_active = datetime.now(UTC)
                 yield event

--- a/src/pocketpaw/agents/protocol.py
+++ b/src/pocketpaw/agents/protocol.py
@@ -16,6 +16,9 @@ class AgentEvent:
         - "thinking": Extended thinking content (Activity panel only)
         - "thinking_done": Thinking phase completed
         - "token_usage": Token usage metadata
+        - "session_id": Native SDK session id captured on turn 1 (SS-1) —
+          metadata carries ``session_id`` so the controller can persist it for a
+          later native ``resume``. Only emitted when a ``SessionHandle`` is threaded.
         - "error": Error message
         - "done": Agent finished processing
     """

--- a/src/pocketpaw/agents/session_store.py
+++ b/src/pocketpaw/agents/session_store.py
@@ -1,0 +1,169 @@
+"""Tenancy-keyed in-memory SessionStore — OSS reference impl (SS-2).
+
+Created: 2026-06-30 (feat/session-supervisor SS-2). Implements the Claude Agent
+SDK's ``SessionStore`` protocol (``claude_agent_sdk.types.SessionStore``) so a
+backend can resume an agent conversation from OUR durable store instead of the
+subprocess's local disk. The SDK calls ``load`` once (in the parent, before
+spawn) and materializes the returned transcript entries into a temp dir the
+fresh subprocess resumes from; it calls ``append`` after each local write to
+mirror new transcript lines back.
+
+This module is the OSS, dev-grade reference: durability lives in an in-memory
+backing dict that callers can SHARE across instances (the analog of a Mongo
+collection two processes both read). The real durable impl is the Mongo-backed
+``MongoSessionStore`` in the ee layer (``pocketpaw_ee.cloud.agent_sessions``);
+it mirrors these exact semantics. The store flows to ``claude_sdk`` OPAQUELY via
+``SessionHandle.session_store`` so OSS never imports the ee class — the
+EE→OSS boundary stays clean.
+
+Tenancy keying
+--------------
+The store is bound to a ``workspace_id`` at construction. Every storage key is
+the 4-tuple ``(workspace_id, project_key, session_id, subpath)`` (``subpath``
+defaults to ``""`` for a main transcript). A store bound to workspace B builds
+keys with ``workspace_id == "B"``, so it can NEVER observe a row written by a
+store bound to workspace A even over the same backing dict — that is the core
+isolation property (SS-7 tests it hard). Reads return ``None`` / ``[]`` for a
+foreign tenant's session exactly as for one that was never written.
+
+The store satisfies the protocol by DUCK TYPING — the SDK never uses
+``isinstance`` (see the protocol docstring), so this class need not subclass
+``SessionStore``.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from claude_agent_sdk.types import (
+        SessionKey,
+        SessionListSubkeysKey,
+        SessionStoreEntry,
+        SessionStoreListEntry,
+    )
+
+# A backing record: the ordered transcript entries plus the set of uuids already
+# seen (idempotency), plus the last-write time in epoch ms (the mtime source).
+_StorageKey = tuple[str, str, str, str]  # (workspace_id, project_key, session_id, subpath)
+
+
+def _now_ms() -> int:
+    """Current wall-clock time in Unix epoch milliseconds (the ``mtime`` clock)."""
+    return int(time.time() * 1000)
+
+
+class InMemorySessionStore:
+    """Conformant, tenancy-keyed ``SessionStore`` backed by an in-memory dict.
+
+    Construct one per ``workspace_id``. Pass a shared ``backing`` dict to model
+    durability across a "restart" (a fresh instance over the same backing dict
+    still sees prior writes — durability lives in the store, not the process).
+    Omit it for a private, throwaway store.
+    """
+
+    def __init__(
+        self, workspace_id: str, *, backing: dict[_StorageKey, dict[str, Any]] | None = None
+    ):
+        if not workspace_id:
+            raise ValueError("InMemorySessionStore requires a non-empty workspace_id")
+        self._workspace_id = workspace_id
+        # Shared-able backing: maps the 4-tuple key -> {"entries", "uuids", "mtime"}.
+        self._backing: dict[_StorageKey, dict[str, Any]] = backing if backing is not None else {}
+
+    # -- key helpers --------------------------------------------------------
+
+    def _key(self, project_key: str, session_id: str, subpath: str = "") -> _StorageKey:
+        """Namespace a (project_key, session_id, subpath) by the bound workspace."""
+        return (self._workspace_id, project_key, session_id, subpath)
+
+    @staticmethod
+    def _subpath_of(key: SessionKey) -> str:
+        """Read the optional ``subpath`` (``""`` == main transcript)."""
+        return key.get("subpath") or ""
+
+    # -- SessionStore protocol ---------------------------------------------
+
+    async def append(self, key: SessionKey, entries: list[SessionStoreEntry]) -> None:
+        """Mirror a batch of transcript entries for ``key``.
+
+        Entries carrying a stable ``uuid`` are treated as idempotency keys
+        (duplicates ignored); entries without one are always appended. Matches
+        the protocol's upsert/ignore-duplicate contract.
+        """
+        sk = self._key(key["project_key"], key["session_id"], self._subpath_of(key))
+        record = self._backing.get(sk)
+        if record is None:
+            record = {"entries": [], "uuids": set(), "mtime": 0}
+            self._backing[sk] = record
+        seen: set[str] = record["uuids"]
+        for entry in entries:
+            uuid = entry.get("uuid")
+            if uuid is not None:
+                if uuid in seen:
+                    continue
+                seen.add(uuid)
+            record["entries"].append(entry)
+        record["mtime"] = _now_ms()
+
+    async def load(self, key: SessionKey) -> list[SessionStoreEntry] | None:
+        """Return the full transcript for ``key``, or ``None`` if never written.
+
+        A store bound to a different workspace returns ``None`` — the namespaced
+        key simply doesn't exist for that tenant.
+        """
+        sk = self._key(key["project_key"], key["session_id"], self._subpath_of(key))
+        record = self._backing.get(sk)
+        if record is None:
+            return None
+        # Return a shallow copy so a caller mutating the list can't corrupt the
+        # backing store; entries themselves are opaque pass-through blobs.
+        return list(record["entries"])
+
+    async def list_sessions(self, project_key: str) -> list[SessionStoreListEntry]:
+        """List MAIN-transcript sessions for ``project_key`` in this workspace.
+
+        Only main transcripts (no ``subpath``) are returned; subagent transcripts
+        are discovered via :meth:`list_subkeys`. Order is unspecified — the SDK
+        sorts by ``mtime`` descending.
+        """
+        out: list[SessionStoreListEntry] = []
+        for (ws, pk, sid, sub), record in self._backing.items():
+            if ws != self._workspace_id or pk != project_key or sub != "":
+                continue
+            out.append({"session_id": sid, "mtime": record["mtime"]})
+        return out
+
+    async def list_subkeys(self, key: SessionListSubkeysKey) -> list[str]:
+        """List the subpaths (e.g. subagent transcripts) under a session."""
+        target_pk = key["project_key"]
+        target_sid = key["session_id"]
+        out: list[str] = []
+        for (ws, pk, sid, sub), _record in self._backing.items():
+            if ws != self._workspace_id or pk != target_pk or sid != target_sid:
+                continue
+            if sub:
+                out.append(sub)
+        return out
+
+    async def delete(self, key: SessionKey) -> None:
+        """Delete a session entry.
+
+        Deleting a main transcript (no ``subpath``) cascades to every subkey
+        under that session; a keyed ``subpath`` deletes only that one entry.
+        """
+        pk = key["project_key"]
+        sid = key["session_id"]
+        sub = self._subpath_of(key)
+        if sub:
+            self._backing.pop(self._key(pk, sid, sub), None)
+            return
+        # Main transcript: cascade-delete the main row + all subkeys.
+        doomed = [
+            stored_key
+            for stored_key in self._backing
+            if stored_key[0] == self._workspace_id and stored_key[1] == pk and stored_key[2] == sid
+        ]
+        for stored_key in doomed:
+            self._backing.pop(stored_key, None)

--- a/src/pocketpaw/agents/session_supervisor.py
+++ b/src/pocketpaw/agents/session_supervisor.py
@@ -1,0 +1,437 @@
+"""Session Supervisor — agent-session lifecycle across COLD/WARM tiers (SS-4).
+
+Created 2026-06-30 (feat/session-supervisor SS-4): the policy / lifecycle engine
+that owns one ``SessionRuntime`` per ``(workspace_id, session_id)`` and decides,
+for each turn, whether to reuse a live warm slot (WARM) or take a fresh launch
+(COLD/turn-1). It enforces a per-tenant warm quota, reaps idle warm sessions,
+and NEVER touches a busy one — the same busy-guard + LRU idioms proven in
+``pocketpaw.agents.pool`` (an instance with ``active_runs > 0`` is never evicted).
+
+What this engine does NOT do: it does not spawn the OS subprocess. The executor
+(SS-5) supplies the live warm "slot" plus a ``teardown`` callback via
+``bind_warm_slot``; the supervisor owns COLD-vs-WARM routing, quota/reaping, and
+— critically — turn-1 capture ownership: turn 1 of a supervised session ALWAYS
+routes to its own fresh launch so the native ``cli_session_id`` the SDK captures
+binds to THIS session, never a foreign warm client (the turn-1 capture concern
+carried from SS-1). That keeps SS-4 fully unit-testable with fakes (a fake clock
+injected via ``now=`` and fake ``teardown`` recorders) — no live model or real
+subprocess required.
+
+Tier model: COLD (no live slot — next acquire is a fresh launch, resuming from
+the store via ``cli_session_id`` when one exists), WARM (a live slot bound, reused
+within TTL), LIVE (a declared enum value reserved for a future always-on tier —
+no behavior in v1).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SessionTier(Enum):
+    """Lifecycle tier of a supervised agent session.
+
+    * ``COLD`` — no live warm slot. The next ``acquire`` is a FRESH launch; if a
+      ``cli_session_id`` is known it resumes from the store, otherwise it is
+      turn 1.
+    * ``WARM`` — a live slot (process/client) is bound and reusable within TTL.
+    * ``LIVE`` — RESERVED for a future always-on tier (e.g. a pinned, never-reaped
+      session). Declared so callers can switch on it, but it carries NO behavior
+      in v1 — nothing in this module ever puts a runtime into ``LIVE``.
+    """
+
+    COLD = "cold"
+    WARM = "warm"
+    LIVE = "live"
+
+
+@dataclass
+class SessionRuntime:
+    """Per-``(workspace_id, session_id)`` descriptor the supervisor owns.
+
+    Holds the session's identity, its current tier, the busy-counter, and the
+    opaque warm slot + how to tear it down. The supervisor never interprets
+    ``warm_slot`` — it is whatever the executor (SS-5) hands it (a process
+    handle, a warm client, etc.); the supervisor only tracks its lifecycle.
+    """
+
+    workspace_id: str
+    session_id: str
+    agent_id: str
+    cli_session_id: str | None = None
+    project_key: str | None = None
+    tier: SessionTier = SessionTier.COLD
+    last_active: float = 0.0
+    # In-flight ``run`` count. The reaper and the quota evictor NEVER touch a
+    # runtime with ``active_runs > 0`` — tearing down a busy slot would abort
+    # its live turn. ``last_active`` only ranks idle eviction candidates; this
+    # counter is the authoritative "busy" signal (mirrors pool.AgentInstance).
+    active_runs: int = 0
+    # Opaque live warm slot supplied by the executor (SS-5) — never interpreted
+    # here. Present only while ``tier is WARM``.
+    warm_slot: Any | None = None
+    # How to release ``warm_slot``. Called best-effort on reap / quota-evict /
+    # crash / stop. May be sync or return an awaitable.
+    teardown: Callable[[], Any] | None = field(default=None, repr=False)
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """The supervisor key — tenancy boundary first."""
+        return (self.workspace_id, self.session_id)
+
+
+@dataclass(frozen=True)
+class Acquisition:
+    """The routing decision ``acquire`` returns for one turn.
+
+    * ``warm_reuse`` — True when a live, unexpired warm slot exists and is being
+      reused (the fast 2nd+ turn). False means a FRESH launch is required.
+    * ``owns_capture`` — True on turn 1 (no ``cli_session_id`` known yet): this
+      runtime OWNS the native-id capture, so the executor must route to its own
+      fresh process and the id the SDK emits binds to THIS session.
+    * ``cli_session_id`` — the resolved native session id (or ``None`` on turn 1)
+      for the ``SessionHandle`` the executor builds.
+    """
+
+    runtime: SessionRuntime
+    warm_reuse: bool
+    owns_capture: bool
+    cli_session_id: str | None
+
+    @property
+    def fresh(self) -> bool:
+        """True when this turn needs a fresh launch (the inverse of warm reuse)."""
+        return not self.warm_reuse
+
+    @property
+    def slot(self) -> Any | None:
+        """Convenience: the warm slot to reuse (only meaningful when ``warm_reuse``)."""
+        return self.runtime.warm_slot
+
+
+class SessionSupervisor:
+    """Owns agent-session lifecycle keyed by ``(workspace_id, session_id)``.
+
+    A pure policy/lifecycle engine over ``SessionRuntime`` descriptors — it does
+    not spawn subprocesses. The executor (SS-5) drives it: ``acquire`` per turn
+    to learn COLD-vs-WARM + capture ownership, ``bind_warm_slot`` to register the
+    live slot it launched, ``mark_run_start`` / ``mark_run_end`` around the turn,
+    ``record_cli_session_id`` after turn-1 capture, and ``mark_crashed`` on
+    failure. A background reaper (``start`` / ``stop``) releases idle warm slots
+    past ``warm_ttl``.
+    """
+
+    def __init__(
+        self,
+        *,
+        warm_ttl: float = 120,
+        max_warm_per_tenant: int = 8,
+        max_warm_global: int = 64,
+        now: Callable[[], float] | None = None,
+    ) -> None:
+        self._warm_ttl = warm_ttl
+        self._max_warm_per_tenant = max_warm_per_tenant
+        self._max_warm_global = max_warm_global
+        # Injected clock — tests pass a fake closure so reap/TTL is deterministic.
+        self._now: Callable[[], float] = now or time.monotonic
+        self._runtimes: dict[tuple[str, str], SessionRuntime] = {}
+        self._reaper_task: asyncio.Task | None = None
+        # The reaper wakes at least as often as it would need to honor the TTL,
+        # capped so a long TTL doesn't leave slots resident much past expiry.
+        self._reap_interval: float = max(1.0, min(30.0, float(warm_ttl)))
+
+    # -- lifecycle (background reaper) --------------------------------------
+
+    async def start(self) -> None:
+        """Start the idle-warm-slot reaper background task."""
+        if self._reaper_task is None:
+            self._reaper_task = asyncio.create_task(self._reaper_loop())
+            logger.info(
+                "SessionSupervisor started (warm_ttl=%ss, per_tenant=%d, global=%d)",
+                self._warm_ttl,
+                self._max_warm_per_tenant,
+                self._max_warm_global,
+            )
+
+    async def stop(self) -> None:
+        """Cancel the reaper and tear down every live warm slot."""
+        if self._reaper_task:
+            self._reaper_task.cancel()
+            try:
+                await self._reaper_task
+            except asyncio.CancelledError:
+                pass
+            self._reaper_task = None
+        for runtime in list(self._runtimes.values()):
+            await self._run_teardown_async(self._drop_slot(runtime))
+
+    async def _reaper_loop(self) -> None:
+        """Periodically reap idle warm slots past ``warm_ttl`` (mirrors _gc_loop)."""
+        while True:
+            await asyncio.sleep(self._reap_interval)
+            try:
+                self.reap_once()
+            except Exception:
+                logger.warning("SessionSupervisor reaper pass failed", exc_info=True)
+
+    # -- acquire / routing ---------------------------------------------------
+
+    def acquire(
+        self,
+        workspace_id: str,
+        session_id: str,
+        agent_id: str,
+        *,
+        cli_session_id: str | None = None,
+        project_key: str | None = None,
+    ) -> Acquisition:
+        """Get-or-create the runtime for ``(workspace_id, session_id)`` and decide
+        whether this turn is a WARM reuse or a FRESH launch.
+
+        ``cli_session_id`` is what the caller recovered from the durable store
+        (SS-3) for this key, or ``None`` on turn 1 / before any capture. When
+        supplied it reconciles onto the in-memory runtime (the store is
+        authoritative for resume); the resolved id is surfaced on the returned
+        ``Acquisition`` for the ``SessionHandle`` the executor builds.
+
+        FRESH (``warm_reuse=False``) when any of: no runtime yet, the runtime is
+        COLD, its warm slot has expired past ``warm_ttl``, OR no ``cli_session_id``
+        is known (turn 1 — and then ``owns_capture=True`` so the native id binds
+        to THIS session rather than a foreign warm client). Otherwise WARM reuse.
+        """
+        key = (workspace_id, session_id)
+        runtime = self._runtimes.get(key)
+        if runtime is None:
+            runtime = SessionRuntime(
+                workspace_id=workspace_id,
+                session_id=session_id,
+                agent_id=agent_id,
+                cli_session_id=cli_session_id,
+                project_key=project_key,
+                tier=SessionTier.COLD,
+                last_active=self._now(),
+            )
+            self._runtimes[key] = runtime
+        else:
+            # Reconcile the durable id/key onto the live runtime.
+            if cli_session_id is not None:
+                runtime.cli_session_id = cli_session_id
+            if project_key is not None:
+                runtime.project_key = project_key
+            runtime.agent_id = agent_id
+
+        resolved_cli = runtime.cli_session_id
+
+        # Evaluate warm liveness against the PRIOR last_active (before this turn
+        # refreshes it) so an idle-expired slot is correctly seen as stale.
+        warm_alive = (
+            runtime.tier is SessionTier.WARM
+            and runtime.warm_slot is not None
+            and (self._now() - runtime.last_active) <= self._warm_ttl
+        )
+        runtime.last_active = self._now()
+
+        # Turn 1 (no native id yet) ALWAYS takes its own fresh process so the
+        # captured id binds to THIS session — never reuse a warm slot here even
+        # if one somehow exists.
+        owns_capture = resolved_cli is None
+        warm_reuse = warm_alive and not owns_capture
+        return Acquisition(
+            runtime=runtime,
+            warm_reuse=warm_reuse,
+            owns_capture=owns_capture,
+            cli_session_id=resolved_cli,
+        )
+
+    # -- executor hand-offs --------------------------------------------------
+
+    def bind_warm_slot(
+        self, runtime: SessionRuntime, slot: Any, teardown: Callable[[], Any] | None
+    ) -> None:
+        """Register the live warm slot the executor launched; move runtime → WARM.
+
+        Tears down any stale slot already bound, refreshes ``last_active``, then
+        enforces the per-tenant and global warm quotas (LRU-evicting the oldest
+        IDLE warm runtime in scope when over the cap — never a busy one).
+        """
+        if runtime.warm_slot is not None and runtime.warm_slot is not slot:
+            self._run_teardown(self._drop_slot(runtime))
+        runtime.warm_slot = slot
+        runtime.teardown = teardown
+        runtime.tier = SessionTier.WARM
+        runtime.last_active = self._now()
+        self._enforce_quota(runtime)
+
+    def mark_run_start(self, runtime: SessionRuntime) -> None:
+        """Mark a turn as in-flight (busy-guard) and refresh activity."""
+        runtime.active_runs += 1
+        runtime.last_active = self._now()
+
+    def mark_run_end(self, runtime: SessionRuntime) -> None:
+        """Mark a turn finished; refresh activity for idle ranking."""
+        runtime.active_runs = max(0, runtime.active_runs - 1)
+        runtime.last_active = self._now()
+
+    def record_cli_session_id(
+        self, runtime: SessionRuntime, cli_session_id: str, project_key: str | None = None
+    ) -> None:
+        """Record the native session id captured on turn 1 onto the runtime.
+
+        SS-5 ALSO persists it durably via the SS-3 service; this just keeps the
+        in-memory runtime current so subsequent ``acquire`` calls resolve it.
+        """
+        runtime.cli_session_id = cli_session_id
+        if project_key is not None:
+            runtime.project_key = project_key
+
+    def mark_crashed(self, runtime: SessionRuntime) -> None:
+        """Demote a runtime to COLD after a slot failure; drop + tear down the slot.
+
+        Keeps ``cli_session_id`` so the next ``acquire`` is FRESH but carries the
+        prior id (the resume-from-store path).
+        """
+        self._run_teardown(self._drop_slot(runtime))
+
+    # -- quota + reaping internals ------------------------------------------
+
+    def _warm_runtimes(self, *, workspace_id: str | None = None) -> list[SessionRuntime]:
+        """All runtimes holding a live warm slot, optionally scoped to a tenant."""
+        return [
+            r
+            for r in self._runtimes.values()
+            if r.tier is SessionTier.WARM
+            and r.warm_slot is not None
+            and (workspace_id is None or r.workspace_id == workspace_id)
+        ]
+
+    def _enforce_quota(self, protect: SessionRuntime) -> None:
+        """Enforce per-tenant then global warm quotas, sparing ``protect``."""
+        self._enforce_scope(
+            limit=self._max_warm_per_tenant,
+            protect=protect,
+            workspace_id=protect.workspace_id,
+            label="per-tenant",
+        )
+        self._enforce_scope(
+            limit=self._max_warm_global,
+            protect=protect,
+            workspace_id=None,
+            label="global",
+        )
+
+    def _enforce_scope(
+        self,
+        *,
+        limit: int,
+        protect: SessionRuntime,
+        workspace_id: str | None,
+        label: str,
+    ) -> None:
+        """LRU-evict the oldest IDLE warm runtime in scope until at/under ``limit``.
+
+        Never evicts ``protect`` (the just-bound runtime) or any busy runtime
+        (``active_runs > 0``). If the cap is exceeded but every candidate is busy,
+        we accept being over quota this cycle (mirrors pool._evict_oldest).
+        """
+        while len(self._warm_runtimes(workspace_id=workspace_id)) > limit:
+            idle = [
+                r
+                for r in self._warm_runtimes(workspace_id=workspace_id)
+                if r.active_runs == 0 and r is not protect
+            ]
+            if not idle:
+                logger.warning(
+                    "SessionSupervisor %s warm quota exceeded but every candidate "
+                    "is busy — skipping eviction this cycle",
+                    label,
+                )
+                return
+            victim = min(idle, key=lambda r: r.last_active)
+            self._run_teardown(self._drop_slot(victim))
+            logger.info(
+                "SessionSupervisor evicted idle warm session %s (%s quota)",
+                victim.key,
+                label,
+            )
+
+    def reap_once(self) -> int:
+        """Run one reaper pass: tear down idle warm slots past ``warm_ttl``.
+
+        Skips any runtime with ``active_runs > 0`` (busy-guard) regardless of how
+        stale ``last_active`` looks. Returns the number of slots reaped. Exposed
+        (not ``_``-private) so tests can drive a deterministic pass with the fake
+        clock instead of waiting on the background loop.
+        """
+        now = self._now()
+        reaped = 0
+        for runtime in list(self._runtimes.values()):
+            if (
+                runtime.tier is SessionTier.WARM
+                and runtime.warm_slot is not None
+                and runtime.active_runs == 0
+                and (now - runtime.last_active) > self._warm_ttl
+            ):
+                self._run_teardown(self._drop_slot(runtime))
+                reaped += 1
+        return reaped
+
+    def _drop_slot(self, runtime: SessionRuntime) -> Callable[[], Any] | None:
+        """Null the slot fields, demote to COLD, and return the old teardown."""
+        teardown = runtime.teardown
+        runtime.warm_slot = None
+        runtime.teardown = None
+        runtime.tier = SessionTier.COLD
+        return teardown
+
+    def _run_teardown(self, teardown: Callable[[], Any] | None) -> None:
+        """Best-effort sync teardown; schedules an awaitable result on the loop.
+
+        Sync teardowns (the common case, and what tests use) run inline. If a
+        teardown returns a coroutine/awaitable and a loop is running, it is
+        scheduled; with no running loop it is closed so it never warns. Never
+        raises.
+        """
+        if teardown is None:
+            return
+        try:
+            result = teardown()
+        except Exception:
+            logger.warning("SessionSupervisor warm-slot teardown raised", exc_info=True)
+            return
+        if inspect.isawaitable(result):
+            try:
+                asyncio.get_running_loop().create_task(result)
+            except RuntimeError:
+                result.close()
+
+    async def _run_teardown_async(self, teardown: Callable[[], Any] | None) -> None:
+        """Await an async teardown to completion (used by ``stop``). Never raises."""
+        if teardown is None:
+            return
+        try:
+            result = teardown()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.warning("SessionSupervisor warm-slot teardown raised", exc_info=True)
+
+
+# Module-level singleton (mirrors pool.get_agent_pool).
+_supervisor: SessionSupervisor | None = None
+
+
+def get_session_supervisor() -> SessionSupervisor:
+    """Get or create the global session supervisor."""
+    global _supervisor
+    if _supervisor is None:
+        _supervisor = SessionSupervisor()
+    return _supervisor

--- a/tests/cloud/runs/test_run_core_session_supervisor.py
+++ b/tests/cloud/runs/test_run_core_session_supervisor.py
@@ -1,0 +1,304 @@
+# tests/cloud/runs/test_run_core_session_supervisor.py
+# Created 2026-06-30 (feat/session-supervisor SS-5). Pins the SS-5 wiring in
+# ``_drive_agent_loop``: behind the default-OFF ``POCKETPAW_SESSION_SUPERVISOR``
+# flag the executor drives every supervised turn through the SessionSupervisor +
+# the durable native-id mapping (SS-3) + the per-tenant Mongo transcript store
+# (SS-2), so the agent RESUMES its native CLI session instead of replaying
+# history. Hermetic: a capturing fake pool yields backend AgentEvents, the SS-3
+# ``runtime_service`` + the ``MongoSessionStore`` are faked (no live mongod), and
+# the supervisor is a thin recorder wrapping the REAL ``SessionSupervisor`` so we
+# assert the real acquire/bracket/capture/crash behavior plus the call sequence.
+#
+# Coverage:
+#   * Flag ON, turn 1 (no prior id): pool.run gets a SessionHandle carrying the
+#     store + a None cli_session_id; mark_run_start/mark_run_end bracket the run;
+#     the ("session_id", ...) event persists via set_cli_session_id +
+#     record_cli_session_id (and is NOT yielded to the stream).
+#   * Flag ON, turn 2 (prior id known): get_cli_session_id resolves it → the
+#     SessionHandle carries resume (cli_session_id set).
+#   * Flag OFF: pool.run is called WITHOUT a session_handle; zero
+#     supervisor/store/mapping calls — the legacy path is byte-for-byte unchanged.
+#   * Flag ON, backend error event: the run is flagged a crash → mark_crashed.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+
+from pocketpaw.agents.session_supervisor import SessionSupervisor
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------- #
+# Fakes / harness                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class _CapturePool:
+    """Fake AgentPool: captures ``run`` kwargs and yields the given events."""
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = events
+        self.run_kwargs: dict[str, Any] | None = None
+        self.run_called = False
+
+    async def get(self, _agent_id):
+        return SimpleNamespace(config={"backend": "claude_agent_sdk"}, agent_name="A")
+
+    def run(self, agent_id, content, session_key, **kwargs):
+        self.run_called = True
+        self.run_kwargs = kwargs
+
+        async def _gen():
+            for ev in self._events:
+                yield ev
+
+        return _gen()
+
+
+class _FakeRuntimeService:
+    """In-memory stand-in for the SS-3 durable ``runtime_service`` (no mongod)."""
+
+    def __init__(self, prior: str | None = None) -> None:
+        self._prior = prior
+        self.get_calls: list[tuple[str, str, str]] = []
+        self.set_calls: list[tuple[str, str, str, str, str | None]] = []
+
+    async def get_cli_session_id(self, ws, session, agent):
+        self.get_calls.append((ws, session, agent))
+        return self._prior
+
+    async def set_cli_session_id(self, ws, session, agent, cli_session_id, project_key=None):
+        self.set_calls.append((ws, session, agent, cli_session_id, project_key))
+
+
+class _FakeStore:
+    """Stand-in for ``MongoSessionStore`` — construction only, no I/O."""
+
+    def __init__(self, workspace_id: str) -> None:
+        self.workspace_id = workspace_id
+
+
+class _RecordingSupervisor:
+    """Thin recorder delegating to a REAL ``SessionSupervisor``.
+
+    Gives us the genuine acquire/bracket/capture/crash semantics (a real
+    ``Acquisition`` + ``SessionRuntime`` whose state we can assert) AND an ordered
+    log of which lifecycle hooks fired.
+    """
+
+    def __init__(self) -> None:
+        self.inner = SessionSupervisor()
+        self.calls: list[str] = []
+        self.acq: Any = None
+
+    def acquire(self, *a, **k):
+        self.calls.append("acquire")
+        self.acq = self.inner.acquire(*a, **k)
+        return self.acq
+
+    def mark_run_start(self, runtime):
+        self.calls.append("mark_run_start")
+        self.inner.mark_run_start(runtime)
+
+    def mark_run_end(self, runtime):
+        self.calls.append("mark_run_end")
+        self.inner.mark_run_end(runtime)
+
+    def record_cli_session_id(self, runtime, cli_session_id, project_key=None):
+        self.calls.append("record_cli_session_id")
+        self.inner.record_cli_session_id(runtime, cli_session_id, project_key=project_key)
+
+    def mark_crashed(self, runtime):
+        self.calls.append("mark_crashed")
+        self.inner.mark_crashed(runtime)
+
+
+def _scope_ctx() -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+
+
+async def _drive(
+    monkeypatch,
+    *,
+    events: list[Any],
+    flag_on: bool,
+    runtime_service: _FakeRuntimeService | None = None,
+    supervisor: _RecordingSupervisor | None = None,
+) -> tuple[_CapturePool, list[tuple[str, dict]]]:
+    """Run ``_drive_agent_loop`` hermetically; return (pool, produced events)."""
+    if flag_on:
+        monkeypatch.setenv("POCKETPAW_SESSION_SUPERVISOR", "true")
+    else:
+        monkeypatch.delenv("POCKETPAW_SESSION_SUPERVISOR", raising=False)
+
+    pool = _CapturePool(events)
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: pool)
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda *a, **k: "")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda *a, **k: None)
+
+    # SS-3 mapping + SS-2 store: faked so the path is hermetic (no live mongod).
+    rs = runtime_service or _FakeRuntimeService()
+    monkeypatch.setattr(run_core, "runtime_service", rs)
+    monkeypatch.setattr(run_core, "MongoSessionStore", _FakeStore)
+    sup = supervisor or _RecordingSupervisor()
+    monkeypatch.setattr(run_core, "get_session_supervisor", lambda: sup)
+
+    async def _never_cancelled():
+        return False
+
+    out: list[tuple[str, dict]] = []
+    gen = run_core._drive_agent_loop(
+        _scope_ctx(),
+        user_content="hi",
+        attachments_in=None,
+        mentions_in=None,
+        history=[],
+        is_cancelled=_never_cancelled,
+        emit_stream_start=False,
+    )
+    async for ev in gen:
+        out.append(ev)
+    return pool, out
+
+
+def _turn1_events() -> list[Any]:
+    return [
+        SimpleNamespace(type="message", content="hi there", metadata={}),
+        SimpleNamespace(
+            type="session_id",
+            content="",
+            metadata={"session_id": "native-abc", "backend": "claude_agent_sdk"},
+        ),
+        SimpleNamespace(type="done", content=""),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Flag ON — turn 1: capture + handle + bracket                                #
+# --------------------------------------------------------------------------- #
+
+
+async def test_flag_on_turn1_threads_handle_brackets_and_captures(monkeypatch):
+    rs = _FakeRuntimeService(prior=None)  # turn 1 → no prior native id
+    sup = _RecordingSupervisor()
+    pool, out = await _drive(
+        monkeypatch, events=_turn1_events(), flag_on=True, runtime_service=rs, supervisor=sup
+    )
+
+    # 1. pool.run received a SessionHandle carrying the store + a turn-1 None id.
+    assert pool.run_kwargs is not None
+    handle = pool.run_kwargs.get("session_handle")
+    assert handle is not None, "flag ON must thread a session_handle into pool.run"
+    assert handle.cli_session_id is None, "turn 1 has no native id yet → resume is None"
+    assert isinstance(handle.session_store, _FakeStore)
+    assert handle.session_store.workspace_id == "w1"
+
+    # 2. The prior id was looked up with the resolved identity (ws, scope_id, agent).
+    assert rs.get_calls == [("w1", "s1", "a1")]
+
+    # 3. The turn-1 ("session_id") event persisted the native id both durably and
+    #    onto the runtime — and was NOT surfaced to the SSE stream.
+    assert rs.set_calls == [("w1", "s1", "a1", "native-abc", None)]
+    assert sup.acq.runtime.cli_session_id == "native-abc"
+    assert "session_id" not in [name for name, _ in out]
+
+    # 4. The run was bracketed and balanced; no crash.
+    assert sup.calls == ["acquire", "mark_run_start", "record_cli_session_id", "mark_run_end"]
+    assert sup.acq.runtime.active_runs == 0
+
+
+# --------------------------------------------------------------------------- #
+# Flag ON — turn 2: resume from the prior native id                           #
+# --------------------------------------------------------------------------- #
+
+
+async def test_flag_on_turn2_resumes_with_prior_id(monkeypatch):
+    rs = _FakeRuntimeService(prior="native-xyz")  # turn 2 → prior id known
+    sup = _RecordingSupervisor()
+    events = [
+        SimpleNamespace(type="message", content="again", metadata={}),
+        SimpleNamespace(type="done", content=""),
+    ]
+    pool, _out = await _drive(
+        monkeypatch, events=events, flag_on=True, runtime_service=rs, supervisor=sup
+    )
+
+    handle = pool.run_kwargs.get("session_handle")
+    assert handle is not None
+    # The SessionHandle carries the resume id recovered from the durable mapping.
+    assert handle.cli_session_id == "native-xyz"
+    # acquire saw the recovered id.
+    assert sup.acq.cli_session_id == "native-xyz"
+    # No new capture this turn → no set_cli_session_id write, no record call.
+    assert rs.set_calls == []
+    assert sup.calls == ["acquire", "mark_run_start", "mark_run_end"]
+
+
+# --------------------------------------------------------------------------- #
+# Flag OFF — legacy path is byte-for-byte unchanged                           #
+# --------------------------------------------------------------------------- #
+
+
+async def test_flag_off_legacy_path_no_handle_no_supervisor(monkeypatch):
+    rs = _FakeRuntimeService(prior="native-should-not-be-read")
+    sup = _RecordingSupervisor()
+    pool, out = await _drive(
+        monkeypatch, events=_turn1_events(), flag_on=False, runtime_service=rs, supervisor=sup
+    )
+
+    # pool.run was called WITHOUT a session_handle.
+    assert pool.run_called
+    assert pool.run_kwargs is not None
+    assert "session_handle" not in pool.run_kwargs
+
+    # Zero supervisor / store / mapping interaction on the legacy path.
+    assert rs.get_calls == []
+    assert rs.set_calls == []
+    assert sup.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Flag ON — a backend error event flags the run as crashed                    #
+# --------------------------------------------------------------------------- #
+
+
+async def test_flag_on_backend_error_marks_crashed(monkeypatch):
+    rs = _FakeRuntimeService(prior="native-xyz")
+    sup = _RecordingSupervisor()
+    events = [
+        SimpleNamespace(type="message", content="partial", metadata={}),
+        SimpleNamespace(type="error", content="backend blew up", metadata={}),
+    ]
+    _pool, out = await _drive(
+        monkeypatch, events=events, flag_on=True, runtime_service=rs, supervisor=sup
+    )
+
+    # The error frame is surfaced to the stream...
+    assert any(name == "error" for name, _ in out)
+    # ...and the runtime is demoted (mark_crashed) then released (mark_run_end).
+    assert "mark_crashed" in sup.calls
+    assert sup.calls[-2:] == ["mark_crashed", "mark_run_end"]
+    # mark_crashed keeps the resume id for the next turn.
+    assert sup.acq.runtime.cli_session_id == "native-xyz"
+    assert sup.acq.runtime.active_runs == 0

--- a/tests/cloud/test_agent_session_runtime_service.py
+++ b/tests/cloud/test_agent_session_runtime_service.py
@@ -1,0 +1,93 @@
+# tests/cloud/test_agent_session_runtime_service.py
+# Created: 2026-06-30 (feat/session-supervisor SS-3) — proves the durable
+# (workspace, session_id, agent_id) -> cli_session_id resume mapping over a real
+# Beanie query path (mongomock-motor — no live mongod). Covers the four
+# done-when cases: turn-1 persist + lookup, upsert/backfill (no duplicate row,
+# the unique index holds), tenancy isolation (a foreign workspace reads None),
+# and an absent key reading None. Uses the shared ``mongo_db`` fixture which
+# init_beanie's ALL_DOCUMENTS (now including AgentSessionRuntimeDoc).
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.agent_sessions import runtime_service
+from pocketpaw_ee.cloud.models.agent_session_runtime import AgentSessionRuntimeDoc
+
+WS = "ws-A"
+SESSION = "sess-1"
+AGENT = "agent-7"
+
+
+async def test_persist_then_lookup(mongo_db) -> None:  # noqa: ARG001 — forces Beanie init
+    """Turn-1 persist: set then get returns the native id (+ project_key kept)."""
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-abc", project_key="proj-1")
+    assert await runtime_service.get_cli_session_id(WS, SESSION, AGENT) == "cli-abc"
+
+    # project_key was persisted alongside the id.
+    row = await AgentSessionRuntimeDoc.find_one(
+        AgentSessionRuntimeDoc.workspace == WS,
+        AgentSessionRuntimeDoc.session_id == SESSION,
+        AgentSessionRuntimeDoc.agent_id == AGENT,
+    )
+    assert row is not None
+    assert row.project_key == "proj-1"
+
+
+async def test_upsert_backfill_updates_in_place(mongo_db) -> None:  # noqa: ARG001
+    """Calling set again for the same key UPDATES the id — no duplicate row."""
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-old")
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-new")
+
+    assert await runtime_service.get_cli_session_id(WS, SESSION, AGENT) == "cli-new"
+
+    # The unique (workspace, session_id, agent_id) index holds: exactly one row.
+    rows = await AgentSessionRuntimeDoc.find(
+        AgentSessionRuntimeDoc.workspace == WS,
+        AgentSessionRuntimeDoc.session_id == SESSION,
+        AgentSessionRuntimeDoc.agent_id == AGENT,
+    ).to_list()
+    assert len(rows) == 1
+
+
+async def test_upsert_preserves_project_key_when_omitted(mongo_db) -> None:  # noqa: ARG001
+    """A backfill that omits project_key leaves the prior one intact."""
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-1", project_key="proj-1")
+    # Resume only re-stamps the id; it has no project_key to pass.
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-2")
+
+    row = await AgentSessionRuntimeDoc.find_one(
+        AgentSessionRuntimeDoc.workspace == WS,
+        AgentSessionRuntimeDoc.session_id == SESSION,
+        AgentSessionRuntimeDoc.agent_id == AGENT,
+    )
+    assert row is not None
+    assert row.cli_session_id == "cli-2"
+    assert row.project_key == "proj-1"
+
+
+async def test_tenancy_isolation(mongo_db) -> None:  # noqa: ARG001
+    """A different workspace can't read tenant A's mapping."""
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-abc")
+
+    assert await runtime_service.get_cli_session_id("ws-B", SESSION, AGENT) is None
+    # A still sees its own row.
+    assert await runtime_service.get_cli_session_id(WS, SESSION, AGENT) == "cli-abc"
+
+
+async def test_absent_key_returns_none(mongo_db) -> None:  # noqa: ARG001
+    """An unknown (ws, session, agent) resolves to None, not an error."""
+    assert await runtime_service.get_cli_session_id(WS, "no-such-session", AGENT) is None
+    # A row for a different agent in the same session doesn't bleed across.
+    await runtime_service.set_cli_session_id(WS, SESSION, "agent-1", "cli-1")
+    assert await runtime_service.get_cli_session_id(WS, SESSION, "agent-2") is None
+
+
+async def test_empty_inputs_rejected(mongo_db) -> None:  # noqa: ARG001
+    """Inputs are validated at entry — empty scope-key components raise."""
+    with pytest.raises(ValidationError):
+        await runtime_service.set_cli_session_id("", SESSION, AGENT, "cli-1")
+    with pytest.raises(ValidationError):
+        await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "")
+    with pytest.raises(ValidationError):
+        await runtime_service.get_cli_session_id(WS, "", AGENT)

--- a/tests/cloud/test_multitenant_session_isolation.py
+++ b/tests/cloud/test_multitenant_session_isolation.py
@@ -1,0 +1,110 @@
+# tests/cloud/test_multitenant_session_isolation.py
+# Created 2026-06-30 (feat/session-supervisor SS-7) — the durable (Mongo) half of
+# the consolidated, ADVERSARIAL multi-tenant session-isolation GATE. The OSS half
+# (shared-backing store, supervisor quota, SDK resume guards) lives in
+# tests/test_multitenant_session_isolation.py; this file proves the same isolation
+# holds on the REAL Beanie query path (mongomock-motor — no live mongod), where
+# every tenant's rows physically share ONE collection.
+#
+# Covers two SS-7 concerns that need persistence:
+#   1. MongoSessionStore isolation over one collection — a workspace-B store can
+#      neither load, list, nor delete a workspace-A session that collides on the
+#      same (project_key, session_id); a both-write collision keeps two scoped rows.
+#   2. Durable (workspace, session_id, agent_id) -> cli_session_id mapping
+#      isolation — a B lookup for an (id, agent) only A wrote is None, and a B
+#      write for the SAME (session, agent) creates a SEPARATE row (the unique index
+#      leads on ``workspace``) instead of overwriting A's mapping.
+#
+# These are the ADVERSARIAL cross-tenant scenarios; the per-slice happy-path
+# tenancy tests (SS-2 / SS-3) live in test_session_transcript_store.py and
+# test_agent_session_runtime_service.py and are not duplicated here.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.agent_sessions import runtime_service
+from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore
+from pocketpaw_ee.cloud.models.agent_session_runtime import AgentSessionRuntimeDoc
+
+
+def _key(project_key="proj", session_id="sess-1", subpath=None):
+    k = {"project_key": project_key, "session_id": session_id}
+    if subpath is not None:
+        k["subpath"] = subpath
+    return k
+
+
+# ===========================================================================
+# 1. MongoSessionStore isolation over one collection
+# ===========================================================================
+
+
+async def test_mongo_store_tenant_b_cannot_observe_or_delete_tenant_a(mongo_db) -> None:  # noqa: ARG001
+    """One collection, two tenants colliding on the SAME (project_key, session_id).
+    A wrote it; B never did. B's load is None, B's listings exclude A, a guessed-id
+    load is None, and B deleting "its" key leaves A's row intact — the workspace
+    filter on every query is the only thing between the tenants and it holds."""
+    store_a = MongoSessionStore("ws-A")
+    await store_a.append(_key(), [{"type": "user", "uuid": "a1"}])
+    await store_a.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "as1"}])
+
+    store_b = MongoSessionStore("ws-B")
+    assert await store_b.load(_key()) is None
+    assert await store_b.list_sessions("proj") == []
+    assert await store_b.list_subkeys(_key()) == []
+    # "Guessed id" attack: a session_id that exists ONLY under A.
+    assert await store_b.load(_key(session_id="sess-1")) is None
+
+    # B deleting that key must not cascade into A's rows.
+    await store_b.delete(_key())
+    assert await store_a.load(_key()) == [{"type": "user", "uuid": "a1"}]
+    assert await store_a.list_subkeys(_key()) == ["subagents/agent-1"]
+
+
+async def test_mongo_store_same_key_two_tenants_coexist_and_delete_is_scoped(mongo_db) -> None:  # noqa: ARG001
+    """Both tenants write the SAME (project_key, session_id) into one collection.
+    Two ``workspace``-scoped rows coexist; each loads ITS OWN content, and B's
+    delete removes only B's row while A's survives."""
+    store_a = MongoSessionStore("ws-A")
+    store_b = MongoSessionStore("ws-B")
+    await store_a.append(_key(), [{"type": "user", "uuid": "a-row"}])
+    await store_b.append(_key(), [{"type": "user", "uuid": "b-row"}])
+
+    # Each tenant sees only its own write — B's append did not clobber A's row.
+    assert await store_a.load(_key()) == [{"type": "user", "uuid": "a-row"}]
+    assert await store_b.load(_key()) == [{"type": "user", "uuid": "b-row"}]
+
+    await store_b.delete(_key())
+    assert await store_b.load(_key()) is None
+    assert await store_a.load(_key()) == [{"type": "user", "uuid": "a-row"}]
+
+
+# ===========================================================================
+# 2. Durable (workspace, session, agent) -> cli_session_id mapping isolation
+# ===========================================================================
+
+
+async def test_runtime_mapping_b_write_creates_separate_row_not_an_overwrite(mongo_db) -> None:  # noqa: ARG001
+    """The unique index leads on ``workspace``, so a B write for the SAME
+    (session_id, agent_id) A already mapped creates a SEPARATE row instead of
+    upserting A's. A leaked/guessed (session, agent) from another tenant can never
+    collide with — or overwrite — A's native cli_session_id."""
+    await runtime_service.set_cli_session_id("ws-A", "sess", "agent", "cli-A")
+
+    # B has no mapping for the same (session, agent) A wrote.
+    assert await runtime_service.get_cli_session_id("ws-B", "sess", "agent") is None
+
+    # B writes the SAME (session, agent) → a new row keyed on ws-B, NOT an
+    # overwrite of A's row.
+    await runtime_service.set_cli_session_id("ws-B", "sess", "agent", "cli-B")
+    assert await runtime_service.get_cli_session_id("ws-A", "sess", "agent") == "cli-A"
+    assert await runtime_service.get_cli_session_id("ws-B", "sess", "agent") == "cli-B"
+
+    # Exactly two rows exist for this (session, agent) — one per workspace —
+    # proving the workspace-led unique index kept them apart.
+    rows = await AgentSessionRuntimeDoc.find(
+        AgentSessionRuntimeDoc.session_id == "sess",
+        AgentSessionRuntimeDoc.agent_id == "agent",
+    ).to_list()
+    assert len(rows) == 2
+    assert {r.workspace for r in rows} == {"ws-A", "ws-B"}
+    assert {r.cli_session_id for r in rows} == {"cli-A", "cli-B"}

--- a/tests/cloud/test_session_transcript_store.py
+++ b/tests/cloud/test_session_transcript_store.py
@@ -1,0 +1,99 @@
+# tests/cloud/test_session_transcript_store.py
+# Created: 2026-06-30 (feat/session-supervisor SS-2) — proves the Mongo-backed
+# MongoSessionStore mirrors the OSS in-memory reference impl's semantics on a
+# real Beanie query path (mongomock-motor — no live mongod). Same three core
+# assertions as the OSS store: round-trip + list_sessions/list_subkeys,
+# durability across a "restart" (a fresh adapter instance over the same DB),
+# and tenancy isolation (a store bound to workspace B can't read workspace A's
+# session). Uses the shared ``mongo_db`` fixture which init_beanie's
+# ALL_DOCUMENTS (now including SessionTranscriptDoc).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore
+
+
+def _key(project_key="proj", session_id="sess-1", subpath=None):
+    k = {"project_key": project_key, "session_id": session_id}
+    if subpath is not None:
+        k["subpath"] = subpath
+    return k
+
+
+async def test_round_trip_and_listings(mongo_db) -> None:  # noqa: ARG001 — forces Beanie init
+    store = MongoSessionStore("ws-A")
+    e1 = {"type": "user", "uuid": "u1", "timestamp": "t1"}
+    e2 = {"type": "assistant", "uuid": "u2", "timestamp": "t2"}
+
+    await store.append(_key(), [e1])
+    await store.append(_key(), [e2])
+    assert await store.load(_key()) == [e1, e2]
+
+    sessions = await store.list_sessions("proj")
+    assert [s["session_id"] for s in sessions] == ["sess-1"]
+    assert isinstance(sessions[0]["mtime"], int)
+
+    sub = {"type": "user", "uuid": "s1"}
+    await store.append(_key(subpath="subagents/agent-7"), [sub])
+    assert await store.load(_key(subpath="subagents/agent-7")) == [sub]
+    assert await store.list_subkeys(_key()) == ["subagents/agent-7"]
+    # The subagent row must not surface as a second main session.
+    assert [s["session_id"] for s in await store.list_sessions("proj")] == ["sess-1"]
+
+
+async def test_append_dedups_by_uuid(mongo_db) -> None:  # noqa: ARG001
+    store = MongoSessionStore("ws-A")
+    e = {"type": "user", "uuid": "dup"}
+    await store.append(_key(), [e])
+    await store.append(_key(), [e])
+    no_uuid = {"type": "summary"}
+    await store.append(_key(), [no_uuid])
+    await store.append(_key(), [no_uuid])
+    assert await store.load(_key()) == [e, no_uuid, no_uuid]
+
+
+async def test_durability_across_fresh_instance(mongo_db) -> None:  # noqa: ARG001
+    """A FRESH adapter instance over the SAME DB still loads prior writes —
+    durability lives in Mongo, not the process (the real restart scenario)."""
+    entries = [{"type": "user", "uuid": "u1"}, {"type": "assistant", "uuid": "u2"}]
+    await MongoSessionStore("ws-A").append(_key(), entries)
+    # New instance, same backing collection.
+    assert await MongoSessionStore("ws-A").load(_key()) == entries
+
+
+async def test_tenancy_isolation(mongo_db) -> None:  # noqa: ARG001
+    """A store bound to workspace B can't read a session written under
+    workspace A, even sharing the same collection."""
+    await MongoSessionStore("ws-A").append(_key(), [{"type": "user", "uuid": "u1"}])
+    await MongoSessionStore("ws-A").append(
+        _key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}]
+    )
+
+    store_b = MongoSessionStore("ws-B")
+    assert await store_b.load(_key()) is None
+    assert await store_b.list_sessions("proj") == []
+    assert await store_b.list_subkeys(_key()) == []
+
+    # A still sees its own row.
+    assert await MongoSessionStore("ws-A").load(_key()) == [{"type": "user", "uuid": "u1"}]
+
+
+async def test_delete_main_cascades(mongo_db) -> None:  # noqa: ARG001
+    store = MongoSessionStore("ws-A")
+    await store.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+
+    await store.delete(_key())
+    assert await store.load(_key()) is None
+    assert await store.load(_key(subpath="subagents/agent-1")) is None
+    assert await store.list_subkeys(_key()) == []
+
+
+async def test_delete_targeted_subpath(mongo_db) -> None:  # noqa: ARG001
+    store = MongoSessionStore("ws-A")
+    await store.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+
+    await store.delete(_key(subpath="subagents/agent-1"))
+    assert await store.load(_key()) == [{"type": "user", "uuid": "u1"}]
+    assert await store.list_subkeys(_key()) == []

--- a/tests/test_agent_session_store.py
+++ b/tests/test_agent_session_store.py
@@ -1,0 +1,191 @@
+# tests/test_agent_session_store.py
+# Created: 2026-06-30 (feat/session-supervisor SS-2) — pins the contract for the
+# tenancy-keyed SessionStore and its claude_sdk wiring. Two concerns:
+#
+#   1. The OSS reference ``InMemorySessionStore`` satisfies the SDK's
+#      ``SessionStore`` protocol and is correctly tenancy-keyed:
+#        * round-trip — append -> load returns the entries; list_sessions
+#          includes the session; list_subkeys finds a subagent subpath.
+#        * durability across a "restart" — a FRESH store instance over the SAME
+#          backing dict still loads prior writes (durability lives in the store,
+#          not the process).
+#        * tenancy isolation — a store bound to workspace B can NEVER read a
+#          session written by a store bound to workspace A (the core property
+#          SS-7 will test hard).
+#        * idempotency + cascade-delete edge cases.
+#
+#   2. The claude_sdk wiring SPY (no live model call — blocked in this env):
+#      when ``run()`` gets a ``SessionHandle(session_store=<obj>)``, the
+#      constructed ``ClaudeAgentOptions`` carries that exact ``session_store``;
+#      a handle without a store leaves it unset (SS-1 / legacy behavior).
+#
+# The spy reuses the proven SS-1 run()-driving harness
+# (``tests.test_claude_sdk_session_handle``) so a full ``run`` completes WITHOUT
+# a live call and the constructed options are observable.
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.agents.backend import SessionHandle
+from pocketpaw.agents.session_store import InMemorySessionStore
+
+# Reuse the SS-1 harness (capturing options factory + faked SDK stream).
+from tests.test_claude_sdk_session_handle import _drive_run, _make_sdk
+
+# ===========================================================================
+# OSS reference store — protocol conformance + tenancy keying
+# ===========================================================================
+
+
+def _key(project_key="proj", session_id="sess-1", subpath=None):
+    k = {"project_key": project_key, "session_id": session_id}
+    if subpath is not None:
+        k["subpath"] = subpath
+    return k
+
+
+async def test_round_trip_append_load_list_sessions_and_subkeys() -> None:
+    """append -> load round-trips; list_sessions includes the session; a
+    subagent subpath is discoverable via list_subkeys and excluded from
+    list_sessions."""
+    store = InMemorySessionStore("ws-A")
+    e1 = {"type": "user", "uuid": "u1", "timestamp": "t1"}
+    e2 = {"type": "assistant", "uuid": "u2", "timestamp": "t2"}
+
+    await store.append(_key(), [e1])
+    await store.append(_key(), [e2])
+
+    assert await store.load(_key()) == [e1, e2]
+
+    sessions = await store.list_sessions("proj")
+    assert [s["session_id"] for s in sessions] == ["sess-1"]
+    assert isinstance(sessions[0]["mtime"], int)
+
+    # A subagent transcript rides a subpath; it's a separate row.
+    sub = {"type": "user", "uuid": "s1"}
+    await store.append(_key(subpath="subagents/agent-7"), [sub])
+    assert await store.load(_key(subpath="subagents/agent-7")) == [sub]
+    assert await store.list_subkeys(_key()) == ["subagents/agent-7"]
+
+    # list_sessions returns only MAIN transcripts — the subpath row must not
+    # leak in as a second "session".
+    sessions2 = await store.list_sessions("proj")
+    assert [s["session_id"] for s in sessions2] == ["sess-1"]
+
+
+async def test_load_returns_none_for_never_written_key() -> None:
+    store = InMemorySessionStore("ws-A")
+    assert await store.load(_key(session_id="nope")) is None
+
+
+async def test_append_dedups_by_uuid() -> None:
+    """An entry carrying a ``uuid`` already present is ignored (the protocol's
+    idempotency contract); a uuid-less entry is always appended."""
+    store = InMemorySessionStore("ws-A")
+    e = {"type": "user", "uuid": "dup"}
+    await store.append(_key(), [e])
+    await store.append(_key(), [e])  # same uuid → ignored
+    no_uuid = {"type": "summary"}
+    await store.append(_key(), [no_uuid])
+    await store.append(_key(), [no_uuid])  # no uuid → appended twice
+    loaded = await store.load(_key())
+    assert loaded == [e, no_uuid, no_uuid]
+
+
+async def test_durability_across_restart_via_shared_backing() -> None:
+    """A FRESH store instance over the SAME backing dict still loads prior
+    writes — proving durability lives in the backing store, not the instance
+    (the in-memory analog of resuming from Mongo after a backend restart)."""
+    shared: dict = {}
+    store1 = InMemorySessionStore("ws-A", backing=shared)
+    entries = [{"type": "user", "uuid": "u1"}, {"type": "assistant", "uuid": "u2"}]
+    await store1.append(_key(), entries)
+
+    # Simulate the restart: a brand-new instance, same backing store.
+    store2 = InMemorySessionStore("ws-A", backing=shared)
+    assert await store2.load(_key()) == entries
+
+
+async def test_tenancy_isolation_other_workspace_sees_nothing() -> None:
+    """A store bound to workspace B can NEVER observe a session written under
+    workspace A — even over the same physical backing store. Core property."""
+    shared: dict = {}
+    store_a = InMemorySessionStore("ws-A", backing=shared)
+    await store_a.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store_a.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+
+    store_b = InMemorySessionStore("ws-B", backing=shared)
+    assert await store_b.load(_key()) is None
+    assert await store_b.list_sessions("proj") == []
+    assert await store_b.list_subkeys(_key()) == []
+
+    # And A still sees its own data (the namespace didn't clobber it).
+    assert await store_a.load(_key()) == [{"type": "user", "uuid": "u1"}]
+
+
+async def test_delete_main_cascades_to_subkeys() -> None:
+    store = InMemorySessionStore("ws-A")
+    await store.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+
+    # Deleting the main transcript (no subpath) cascades to subagent rows.
+    await store.delete(_key())
+    assert await store.load(_key()) is None
+    assert await store.load(_key(subpath="subagents/agent-1")) is None
+    assert await store.list_subkeys(_key()) == []
+
+
+async def test_delete_targeted_subpath_only() -> None:
+    store = InMemorySessionStore("ws-A")
+    await store.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+
+    await store.delete(_key(subpath="subagents/agent-1"))
+    # Only the subagent row went; the main transcript survives.
+    assert await store.load(_key()) == [{"type": "user", "uuid": "u1"}]
+    assert await store.list_subkeys(_key()) == []
+
+
+def test_workspace_id_is_required() -> None:
+    with pytest.raises(ValueError):
+        InMemorySessionStore("")
+
+
+# ===========================================================================
+# claude_sdk wiring spy — options carry the session_store opaquely
+# ===========================================================================
+
+
+async def test_session_store_is_threaded_into_constructed_options() -> None:
+    """A run with ``SessionHandle(session_store=<obj>)`` builds
+    ``ClaudeAgentOptions`` carrying that exact object — proving claude_sdk
+    forwards the store opaquely so the SDK can materialize a resume from it."""
+    options_sink: list = []
+    stateless_options: list = []
+    sdk = _make_sdk(options_sink, stateless_options)
+
+    sentinel = object()
+    handle = SessionHandle(cli_session_id=None, session_store=sentinel)
+    events = await _drive_run(sdk, "turn", session_handle=handle)
+
+    assert any(e.type == "done" for e in events)
+    assert options_sink, "options must have been constructed"
+    assert getattr(options_sink[-1], "session_store", None) is sentinel, (
+        "the constructed ClaudeAgentOptions must carry the handle's session_store "
+        "so the SDK materializes a resume from OUR store, not local disk"
+    )
+
+
+async def test_no_store_leaves_session_store_unset() -> None:
+    """A handle WITHOUT a store (or no handle) leaves ``session_store`` unset on
+    the options — the unchanged SS-1 / legacy path."""
+    options_sink: list = []
+    stateless_options: list = []
+    sdk = _make_sdk(options_sink, stateless_options)
+
+    await _drive_run(sdk, "turn", session_handle=SessionHandle(session_store=None))
+    assert getattr(options_sink[-1], "session_store", None) is None
+
+    await _drive_run(sdk, "turn2", session_handle=None)
+    assert getattr(options_sink[-1], "session_store", None) is None

--- a/tests/test_claude_sdk_session_handle.py
+++ b/tests/test_claude_sdk_session_handle.py
@@ -1,0 +1,345 @@
+# tests/test_claude_sdk_session_handle.py
+# Created: 2026-06-30 (feat/session-supervisor SS-1) — pins the wiring contract
+# for native SDK ``resume`` on the OSS Claude SDK backend. The de-risk slice lets
+# ONE agent hold a conversation across turns via the Claude Agent SDK's NATIVE
+# ``resume`` (a fresh-process launch that reloads the on-disk session) instead of
+# replaying Mongo history into the prompt, while a freshly-rebuilt system prompt
+# is honored on every turn.
+#
+# Live ``claude`` model calls are BLOCKED in CI, so these tests SPY on the
+# boundary (the constructed ``ClaudeAgentOptions`` + the faked SDK message stream)
+# rather than making a real call. They assert four things:
+#   1. ``run(session_handle=SessionHandle(cli_session_id="..."))`` constructs
+#      options carrying ``resume="..."`` AND routes down the FRESH stateless
+#      ``query()`` launch path (never the warm persistent client, which would
+#      silently ignore a fresh ``resume``).
+#   2. The per-turn ``system_prompt`` is reflected on the resume path — a second
+#      call with a different system prompt builds options carrying THAT prompt
+#      (per-turn injection survives the resume seam, not a frozen turn-1 prompt).
+#   3. The turn-1 native ``session_id`` is extracted from the SDK init/system
+#      message and surfaced once as a ``session_id`` AgentEvent.
+#   4. The legacy path (no handle / cli_session_id=None) is UNCHANGED: no
+#      ``resume`` is set and no ``session_id`` event is emitted.
+#
+# The spy targets ONLY the construction/stream boundary (the seam under test is
+# claude_sdk's own resume-routing + capture logic, which is exercised for real).
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+from pocketpaw.agents.backend import SessionHandle
+from pocketpaw.agents.claude_sdk import ClaudeAgentSDK, ClaudeSDKBackend
+from pocketpaw.agents.model_router import ModelSelection, TaskComplexity
+
+_LLM_CLIENT = "pocketpaw.llm.client.resolve_llm_client"
+_MODEL_ROUTER = "pocketpaw.agents.model_router.ModelRouter"
+
+
+# ===========================================================================
+# Fakes — a capturing options factory + a faked SDK message stream, so a full
+# run() completes WITHOUT a live model call and the constructed options + the
+# emitted events are observable.
+# ===========================================================================
+
+
+def _make_settings(**overrides):
+    defaults = {
+        "agent_backend": "claude_agent_sdk",
+        "tool_profile": "full",
+        "tools_allow": [],
+        "tools_deny": [],
+        "smart_routing_enabled": False,
+        "claude_sdk_provider": "anthropic",
+        "claude_sdk_model": None,
+        "claude_sdk_max_turns": None,
+        "sdk_load_bundled_skills": False,
+        "anthropic_api_key": "sk-test-key",
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class _Options:
+    """Real options stand-in so ``_client_cache_key`` / dispatch can read
+    ``system_prompt`` / ``model`` / ``allowed_tools`` / ``plugins`` / ``resume``."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.model = kwargs.get("model", "")
+        self.allowed_tools = kwargs.get("allowed_tools", [])
+        self.system_prompt = kwargs.get("system_prompt", "")
+        self.plugins = kwargs.get("plugins", [])
+        # Mirror the real ClaudeAgentOptions default so a legacy run reads None.
+        self.resume = kwargs.get("resume", None)
+
+
+def _capturing_options(sink: list[_Options]):
+    """Factory that records every constructed options object into ``sink``."""
+
+    def _factory(**kwargs):
+        opt = _Options(**kwargs)
+        sink.append(opt)
+        return opt
+
+    return _factory
+
+
+class _FakeSystemMessage:
+    """Stand-in for the SDK's init/system message (carries ``data.session_id``)."""
+
+    def __init__(self, subtype: str, data: dict):
+        self.subtype = subtype
+        self.data = data
+
+
+class _FakeResultMsg:
+    def __init__(self):
+        self.is_error = False
+        self.result = "ok"
+        self.total_cost_usd = None
+        self.usage = {}
+
+
+class _FakeClient:
+    """Warm persistent client. Its ``receive_messages()`` yields the init/system
+    message (carrying ``session_id``) then a ResultMessage — the warm path the
+    legacy + turn-1-capture runs take."""
+
+    def __init__(self, options=None, *, init_session_id="sess-warm-init", **_kw):
+        self.options = options
+        self._init_session_id = init_session_id
+        self.queries: list[str] = []
+
+    async def connect(self, prompt=None):
+        pass
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def receive_messages(self):
+        yield _FakeSystemMessage(subtype="init", data={"session_id": self._init_session_id})
+        yield _FakeResultMsg()
+
+    async def disconnect(self):
+        pass
+
+    async def interrupt(self):
+        pass
+
+
+def _wire_fakes(sdk, options_sink: list[_Options], stateless_options: list[_Options]):
+    """Wire the SDK symbol table to the fakes. ``options_sink`` records EVERY
+    constructed options; ``stateless_options`` records the options handed to the
+    stateless ``query()`` launch path (proving a resume run took it)."""
+    sdk._ClaudeAgentOptions = _capturing_options(options_sink)
+    sdk._ResultMessage = _FakeResultMsg
+    sdk._SystemMessage = _FakeSystemMessage
+    sdk._ClaudeSDKClient = lambda **kwargs: _FakeClient(**kwargs)
+    sdk._HookMatcher = MagicMock()
+    sdk._StreamEvent = None
+    sdk._AssistantMessage = None
+    sdk._UserMessage = None
+    sdk._ToolResultBlock = None
+
+    async def _fake_query(prompt, options, init_session_id="sess-stateless-init"):
+        # The stateless fresh-launch path — record the options it was handed and
+        # emit the init/system message + result the SDK would.
+        stateless_options.append(options)
+        yield _FakeSystemMessage(subtype="init", data={"session_id": init_session_id})
+        yield _FakeResultMsg()
+
+    sdk._query = _fake_query
+
+
+def _make_sdk(options_sink, stateless_options, settings=None):
+    s = settings or _make_settings()
+    with patch.object(ClaudeSDKBackend, "_initialize"):
+        sdk = ClaudeAgentSDK(s)
+    sdk._sdk_available = True
+    sdk._cli_available = True
+    _wire_fakes(sdk, options_sink, stateless_options)
+    return sdk
+
+
+def _patched(fn):
+    """Run ``fn()`` under the standard LLM / router / MCP patches run() needs."""
+
+    async def _inner():
+        selection = ModelSelection(
+            complexity=TaskComplexity.MODERATE,
+            model="claude-sonnet-4-5-20250929",
+            reason="test",
+        )
+        with patch(_LLM_CLIENT) as mock_resolve:
+            mock_llm = MagicMock()
+            mock_llm.is_ollama = False
+            mock_llm.is_openai_compatible = False
+            mock_llm.is_gemini = False
+            mock_llm.is_litellm = False
+            mock_llm.is_openrouter = False
+            mock_llm.to_sdk_env.return_value = {"ANTHROPIC_API_KEY": "sk-test"}
+            mock_resolve.return_value = mock_llm
+            with patch(_MODEL_ROUTER) as MockRouter:
+                MockRouter.return_value.classify.return_value = selection
+                with patch.object(ClaudeSDKBackend, "_get_mcp_servers", return_value={}):
+                    return await fn()
+
+    return _inner
+
+
+async def _drive_run(sdk, message, *, system_prompt="identity", session_handle=None):
+    async def _go():
+        events = []
+        async for ev in sdk.run(
+            message,
+            system_prompt=system_prompt,
+            session_key="s1",
+            session_handle=session_handle,
+        ):
+            events.append(ev)
+        return events
+
+    return await _patched(_go)()
+
+
+# ===========================================================================
+# 0. Signature contract
+# ===========================================================================
+
+
+def test_run_accepts_session_handle_kwarg() -> None:
+    """``ClaudeSDKBackend.run`` accepts a keyword-only ``session_handle``
+    defaulting to ``None`` (the legacy / non-supervised path)."""
+    params = inspect.signature(ClaudeSDKBackend.run).parameters
+    assert "session_handle" in params, "run must accept a session_handle kwarg"
+    assert params["session_handle"].default is None, (
+        "session_handle must default to None so non-supervised runs are unaffected"
+    )
+
+
+def test_session_handle_carries_store_opaquely() -> None:
+    """SS-1 carries ``session_store`` as an inert pass-through field (SS-2 owns
+    it); the dataclass exposes both fields with None defaults."""
+    sentinel = object()
+    sh = SessionHandle(cli_session_id="abc", session_store=sentinel)
+    assert sh.cli_session_id == "abc"
+    assert sh.session_store is sentinel
+    assert SessionHandle().cli_session_id is None
+    assert SessionHandle().session_store is None
+
+
+# ===========================================================================
+# 1. Resume wiring — options carry resume + the fresh-launch path is taken
+# ===========================================================================
+
+
+async def test_resume_sets_options_resume_and_uses_fresh_launch_path() -> None:
+    """A run with ``SessionHandle(cli_session_id=...)`` constructs options
+    carrying ``resume=<id>`` AND dispatches down the stateless ``query()``
+    fresh-launch path (never the warm client, which would ignore the resume)."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    sdk = _make_sdk(options_sink, stateless_options)
+
+    handle = SessionHandle(cli_session_id="sess-xyz")
+    events = await _drive_run(
+        sdk, "turn two", system_prompt="IDENTITY-ALPHA", session_handle=handle
+    )
+
+    assert any(e.type == "done" for e in events)
+    assert options_sink, "options must have been constructed"
+    opt = options_sink[-1]
+    assert getattr(opt, "resume", None) == "sess-xyz", (
+        "the constructed ClaudeAgentOptions must carry resume=<cli_session_id> so "
+        "the CLI subprocess resumes that on-disk session natively"
+    )
+    # The SAME options object must reach the stateless launch path — proving the
+    # warm persistent client (which freezes options at connect()) was bypassed.
+    assert stateless_options and stateless_options[-1] is opt, (
+        "a resume-bearing run must take the fresh stateless query() launch path"
+    )
+
+
+# ===========================================================================
+# 2. Per-turn system prompt survives the resume seam
+# ===========================================================================
+
+
+async def test_per_turn_system_prompt_reflected_on_resume_path() -> None:
+    """Resume must NOT freeze a turn-1 prompt: a second resume turn with a
+    different system prompt builds options carrying THAT prompt, proving the
+    freshly-rebuilt per-turn system prompt is honored every turn."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    sdk = _make_sdk(options_sink, stateless_options)
+    handle = SessionHandle(cli_session_id="sess-1")
+
+    await _drive_run(sdk, "turn A", system_prompt="IDENTITY-ALPHA", session_handle=handle)
+    first = options_sink[-1]
+    assert "IDENTITY-ALPHA" in first.system_prompt
+
+    await _drive_run(sdk, "turn B", system_prompt="IDENTITY-BRAVO", session_handle=handle)
+    second = options_sink[-1]
+    assert "IDENTITY-BRAVO" in second.system_prompt, (
+        "the second turn's options must reflect the NEW per-turn system prompt"
+    )
+    assert "IDENTITY-ALPHA" not in second.system_prompt, (
+        "the per-turn prompt is rebuilt each turn — turn-1's prompt must not leak "
+        "into turn-2's options (resume does not freeze the system prompt)"
+    )
+
+
+# ===========================================================================
+# 3. Turn-1 native session-id capture surfaces on the event stream
+# ===========================================================================
+
+
+async def test_turn_one_session_id_is_captured_and_surfaced() -> None:
+    """Turn 1 (handle present, cli_session_id=None) extracts the native
+    ``session_id`` from the SDK init/system message and surfaces it once as a
+    ``session_id`` AgentEvent so the controller can persist it (SS-3)."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    sdk = _make_sdk(options_sink, stateless_options)
+
+    # Turn 1: no id yet → legacy warm path, but the handle opts into capture.
+    handle = SessionHandle(cli_session_id=None)
+    events = await _drive_run(sdk, "turn one", session_handle=handle)
+
+    sid_events = [e for e in events if e.type == "session_id"]
+    assert len(sid_events) == 1, "exactly one session_id event must be surfaced on turn 1"
+    assert sid_events[0].metadata.get("session_id") == "sess-warm-init", (
+        "the surfaced id must be the one carried in the init/system message data"
+    )
+    # Turn 1 has no cli_session_id, so no resume is set (capture-only).
+    assert getattr(options_sink[-1], "resume", None) is None
+
+
+# ===========================================================================
+# 4. Legacy path unchanged — no resume, no session_id event
+# ===========================================================================
+
+
+async def test_legacy_path_no_handle_is_unchanged() -> None:
+    """With NO session_handle, behavior is byte-identical to today: options carry
+    no ``resume`` and the stream emits no ``session_id`` event."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    sdk = _make_sdk(options_sink, stateless_options)
+
+    events = await _drive_run(sdk, "ordinary turn", session_handle=None)
+
+    assert any(e.type == "done" for e in events)
+    assert getattr(options_sink[-1], "resume", None) is None, (
+        "a no-handle run must not set resume on the options"
+    )
+    assert not any(e.type == "session_id" for e in events), (
+        "a no-handle run must not surface a session_id event (legacy stream is byte-identical)"
+    )
+    # And it must take the warm path, not the stateless fresh-launch path.
+    assert not stateless_options, "a legacy run must not take the stateless resume path"

--- a/tests/test_multitenant_session_isolation.py
+++ b/tests/test_multitenant_session_isolation.py
@@ -1,0 +1,338 @@
+# tests/test_multitenant_session_isolation.py
+# Created 2026-06-30 (feat/session-supervisor SS-7) — the consolidated, ADVERSARIAL
+# multi-tenant session-isolation GATE (OSS half — no Mongo). The captain treats
+# this suite as a merge gate: a single place that tries to make one tenant observe,
+# evict, or resume another tenant's agent session and proves it cannot.
+#
+# This file holds the assertions that need no live mongod (the durable Mongo twin
+# lives in tests/cloud/test_multitenant_session_isolation.py). It covers four of
+# the five SS-7 concerns:
+#   1. Store isolation over a SHARED backing dict — the real "two tenants on one
+#      SaaS box" shape. Two InMemorySessionStores over ONE backing, workspace A
+#      and B, colliding on the SAME (project_key, session_id). B can never load,
+#      list, or delete A's row; a both-write collision keeps two scoped rows.
+#   3. Supervisor quota isolation — one tenant filling its warm quota only evicts
+#      ITS OWN idle sessions; a busy runtime and another tenant's warm session are
+#      never the victims, even when the other tenant's session is globally oldest.
+#   4. End-to-end no-cross-tenant-resume — a leaked/guessed native id paired with a
+#      workspace-B-bound store resolves to NOTHING, asserted both at the store
+#      level and through the SDK's REAL resume path (materialize_resume_session).
+#   5. Reliance contract on the Claude Agent SDK's resume guards — we name the
+#      guarantees the design leans on and assert OUR side plus the SDK helpers
+#      directly (UUID guard, subpath validation, refreshToken redaction, perms,
+#      ephemeral mkdtemp+rmtree cleanup).
+#
+# Concern 2 (durable (workspace, session, agent) -> cli_session_id mapping
+# isolation) needs Beanie, so it lives in the cloud twin.
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+from claude_agent_sdk._internal.session_resume import (
+    _is_safe_subpath,
+    _rmtree_with_retry,
+    _write_redacted_credentials,
+    materialize_resume_session,
+)
+from claude_agent_sdk._internal.sessions import _validate_uuid, project_key_for_directory
+from claude_agent_sdk.types import ClaudeAgentOptions
+
+from pocketpaw.agents.backend import SessionHandle
+from pocketpaw.agents.session_store import InMemorySessionStore
+from pocketpaw.agents.session_supervisor import SessionSupervisor, SessionTier
+
+
+def _key(project_key="proj", session_id="sess-1", subpath=None):
+    k = {"project_key": project_key, "session_id": session_id}
+    if subpath is not None:
+        k["subpath"] = subpath
+    return k
+
+
+class FakeClock:
+    """Deterministic monotonic clock — advance it explicitly in the test."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class Teardown:
+    """Fake teardown callback that records how many times it was called."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> None:
+        self.calls += 1
+
+
+# ===========================================================================
+# 1. Store isolation over a SHARED backing dict (the real SaaS box)
+# ===========================================================================
+
+
+async def test_shared_backing_tenant_b_cannot_observe_or_delete_tenant_a() -> None:
+    """Two tenants on ONE backing dict, colliding on the SAME (project_key,
+    session_id). B never wrote it, yet the key string is identical to A's. B must
+    see NOTHING — load is None, the listings exclude A, and B deleting "its" key
+    (a no-op for B) leaves A's row fully intact. This is the adversarial version
+    of the per-slice tenancy test: same physical store, same key string."""
+    shared: dict = {}
+    store_a = InMemorySessionStore("ws-A", backing=shared)
+    store_b = InMemorySessionStore("ws-B", backing=shared)
+
+    # A owns a main transcript + a subagent transcript under (proj, sess-1).
+    await store_a.append(_key(), [{"type": "user", "uuid": "a1"}])
+    await store_a.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "as1"}])
+
+    # B, sharing the same backing, uses the SAME project_key + session_id string.
+    # Every read is scoped to ws-B's namespace, so A's rows are invisible.
+    assert await store_b.load(_key()) is None
+    assert await store_b.list_sessions("proj") == []
+    assert await store_b.list_subkeys(_key()) == []
+
+    # "Guessed id" attack: B targets a session_id that exists ONLY under A.
+    assert await store_b.load(_key(session_id="sess-1")) is None
+
+    # B deleting that key is a no-op for B and must NOT touch A's rows.
+    await store_b.delete(_key())
+    assert await store_a.load(_key()) == [{"type": "user", "uuid": "a1"}]
+    assert await store_a.list_subkeys(_key()) == ["subagents/agent-1"]
+
+
+async def test_shared_backing_same_key_two_tenants_coexist_and_delete_is_scoped() -> None:
+    """When BOTH tenants write the SAME (project_key, session_id) over one backing,
+    two namespaced rows coexist. Each tenant loads ITS OWN content (never the
+    other's), and a delete by B removes only B's row — A survives. Proves the
+    namespace keys the rows apart, not just the read filter."""
+    shared: dict = {}
+    store_a = InMemorySessionStore("ws-A", backing=shared)
+    store_b = InMemorySessionStore("ws-B", backing=shared)
+
+    await store_a.append(_key(), [{"type": "user", "uuid": "a-row"}])
+    await store_b.append(_key(), [{"type": "user", "uuid": "b-row"}])
+
+    # Each tenant sees only its own write — B's append did not clobber A's row.
+    assert await store_a.load(_key()) == [{"type": "user", "uuid": "a-row"}]
+    assert await store_b.load(_key()) == [{"type": "user", "uuid": "b-row"}]
+    assert [s["session_id"] for s in await store_a.list_sessions("proj")] == ["sess-1"]
+    assert [s["session_id"] for s in await store_b.list_sessions("proj")] == ["sess-1"]
+
+    # B deletes its row; A's identical-key row is untouched.
+    await store_b.delete(_key())
+    assert await store_b.load(_key()) is None
+    assert await store_a.load(_key()) == [{"type": "user", "uuid": "a-row"}]
+
+
+# ===========================================================================
+# 3. Supervisor quota isolation — one tenant can't starve another
+# ===========================================================================
+
+
+async def test_per_tenant_quota_evicts_only_offending_tenant_sparing_busy_and_peer() -> None:
+    """Tenant A floods its per-tenant warm quota; every eviction victim is one of
+    A's OWN idle warm sessions. A busy runtime (active_runs>0) is never evicted
+    even though it is A's oldest, and tenant B's warm session is never evicted
+    even though it is the GLOBALLY oldest slot (a naive global LRU would take it
+    first). Driven deterministically with the injected fake clock."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=10_000, max_warm_per_tenant=2, now=clock)
+
+    # Tenant B's warm session is bound FIRST → globally the oldest last_active.
+    # Per-tenant scoping must spare it from A's pressure.
+    b = sup.acquire("ws-b", "s-b1", "agent", cli_session_id="cli-b1")
+    td_b = Teardown()
+    sup.bind_warm_slot(b.runtime, slot="b-slot", teardown=td_b)
+
+    # Tenant A: a1 is the oldest AND busy — it must never be the victim.
+    clock.advance(1)
+    a1 = sup.acquire("ws-a", "s-a1", "agent", cli_session_id="cli-a1")
+    td_a1 = Teardown()
+    sup.bind_warm_slot(a1.runtime, slot="a1", teardown=td_a1)
+    sup.mark_run_start(a1.runtime)  # busy — protected from eviction
+
+    clock.advance(1)
+    a2 = sup.acquire("ws-a", "s-a2", "agent", cli_session_id="cli-a2")
+    td_a2 = Teardown()
+    sup.bind_warm_slot(a2.runtime, slot="a2", teardown=td_a2)
+
+    # 3rd warm for A → over cap (2). a1 is busy, so the oldest IDLE in A (a2) is
+    # the only legal victim. a2 evicted; b untouched.
+    clock.advance(1)
+    a3 = sup.acquire("ws-a", "s-a3", "agent", cli_session_id="cli-a3")
+    td_a3 = Teardown()
+    sup.bind_warm_slot(a3.runtime, slot="a3", teardown=td_a3)
+
+    assert td_a2.calls == 1 and a2.runtime.tier is SessionTier.COLD
+    assert td_a1.calls == 0 and a1.runtime.tier is SessionTier.WARM  # busy spared
+    assert td_a3.calls == 0 and a3.runtime.tier is SessionTier.WARM
+    assert td_b.calls == 0 and b.runtime.tier is SessionTier.WARM  # peer spared
+
+    # 4th warm for A → over cap again. a1 still busy, so the next oldest IDLE (a3)
+    # is evicted. Still no peer / busy victim.
+    clock.advance(1)
+    a4 = sup.acquire("ws-a", "s-a4", "agent", cli_session_id="cli-a4")
+    td_a4 = Teardown()
+    sup.bind_warm_slot(a4.runtime, slot="a4", teardown=td_a4)
+
+    assert td_a3.calls == 1 and a3.runtime.tier is SessionTier.COLD
+    assert td_a4.calls == 0 and a4.runtime.tier is SessionTier.WARM
+    # Final tally: every victim was tenant A's; a1 (busy) and b (peer) never touched.
+    assert td_a1.calls == 0 and a1.runtime.active_runs == 1
+    assert td_b.calls == 0 and b.runtime.warm_slot == "b-slot"
+
+
+# ===========================================================================
+# 4. End-to-end no-cross-tenant-resume — a leaked native id can't cross tenants
+# ===========================================================================
+
+
+async def test_leaked_native_id_paired_with_b_store_resolves_to_nothing() -> None:
+    """The strongest end-to-end property: even if tenant A's native cli_session_id
+    leaks (or is guessed) and is fed to a turn whose SessionHandle is bound to
+    tenant B's store, the resume resolves to NOTHING — because the store load is
+    tenant-scoped. Asserted (a) at the store level (the SessionHandle just pairs
+    the id with the B-bound store) and (b) through the SDK's REAL resume path,
+    materialize_resume_session, which returns None for the B-bound store while the
+    SAME id over A's store loads A's transcript."""
+    shared: dict = {}
+    cwd = "/tmp/paw-ss7-tenant-box"
+    project_key = project_key_for_directory(cwd)
+
+    # A real native session id is a UUID (the SDK mints one; run_core persists it
+    # verbatim). Use that shape so the SDK's _validate_uuid guard is satisfied and
+    # the only thing that can stop the resume is the tenancy filter.
+    leaked_native_id = str(uuid.uuid4())
+    transcript = [{"type": "user", "uuid": "a-u1"}, {"type": "assistant", "uuid": "a-u2"}]
+
+    store_a = InMemorySessionStore("ws-A", backing=shared)
+    await store_a.append({"project_key": project_key, "session_id": leaked_native_id}, transcript)
+
+    store_b = InMemorySessionStore("ws-B", backing=shared)
+
+    # (a) Store level: the handle pairs the leaked id with the B-bound store; the
+    # store load is tenant-scoped, so it returns None.
+    handle = SessionHandle(cli_session_id=leaked_native_id, session_store=store_b)
+    assert (
+        await handle.session_store.load(
+            {"project_key": project_key, "session_id": leaked_native_id}
+        )
+        is None
+    )
+    # Positive control: A's own store DOES load the same key (id isn't bogus).
+    assert (
+        await store_a.load({"project_key": project_key, "session_id": leaked_native_id})
+        == transcript
+    )
+
+    # (b) SDK real resume path: materialize_resume_session returns None for the
+    # B-bound store. It returns BEFORE any mkdtemp / auth-file copy (the load miss
+    # short-circuits), so this is hermetic — no temp dir, no credentials touched.
+    opts_b = ClaudeAgentOptions(cwd=cwd, resume=leaked_native_id, session_store=store_b)
+    assert await materialize_resume_session(opts_b) is None
+
+
+# ===========================================================================
+# 5. Reliance contract on the Claude Agent SDK's resume guards
+# ===========================================================================
+#
+# Native resume leans on guarantees inside
+# claude_agent_sdk/_internal/session_resume.py (and sessions.py). Naming them
+# here keeps the dependency explicit; a future SDK bump that weakens any of these
+# should break this gate:
+#
+#   * Ephemeral materialization — each resume writes the transcript to a fresh
+#     ``tempfile.mkdtemp(prefix="claude-resume-")`` (session_resume.py:147) and
+#     removes it via ``cleanup()`` -> ``_rmtree_with_retry`` (lines 170-174,
+#     201-231). No persistent, cross-tenant file is left on the box.
+#   * ``_validate_uuid(options.resume)`` traversal guard (session_resume.py:138):
+#     the resume id is a path component; a non-UUID is rejected, so a "../"
+#     traversal can never reach the filesystem layout step.
+#   * ``_is_safe_subpath`` subpath validation (session_resume.py:490-522): every
+#     subagent subpath from the store is rejected if empty / absolute / contains
+#     ``..`` / escapes the session dir before it is written.
+#   * ``refreshToken`` redaction before the subprocess
+#     (``_write_redacted_credentials``, lines 355-378): the single-use refresh
+#     token is stripped from the materialized ``.credentials.json``.
+#   * ``0o600`` file perms on every file the resume writes (lines 302, 378, 487).
+#
+# We assert OUR side of the contract where we can, and call the SDK helpers
+# directly where the guarantee is SDK-internal.
+
+
+async def test_native_ids_are_uuid_shaped_so_the_resume_uuid_guard_applies() -> None:
+    """OUR side: the native ids we persist/resume are UUID-shaped (run_core stores
+    the SDK's session_id event verbatim, and the SDK mints a UUID), so the SDK's
+    _validate_uuid traversal guard accepts a real id and rejects a forged one —
+    the resume path never treats attacker-controlled text as a path component."""
+    # A representative real native id (the shape the SDK emits) passes the guard.
+    assert _validate_uuid(str(uuid.uuid4())) is not None
+    # Forged / traversal-shaped ids are rejected before any filesystem step.
+    assert _validate_uuid("../../etc/passwd") is None
+    assert _validate_uuid("not-a-uuid") is None
+    assert _validate_uuid("") is None
+
+
+async def test_our_store_only_emits_subpaths_the_sdk_guard_accepts() -> None:
+    """OUR side: every subpath InMemorySessionStore.list_subkeys emits is one the
+    SDK's _is_safe_subpath guard accepts — our store never hands the resume
+    materializer an unsafe (escaping) subpath."""
+    store = InMemorySessionStore("ws-A")
+    await store.append(_key(), [{"type": "user", "uuid": "u1"}])
+    await store.append(_key(subpath="subagents/agent-1"), [{"type": "user", "uuid": "s1"}])
+    await store.append(_key(subpath="subagents/agent-2"), [{"type": "user", "uuid": "s2"}])
+
+    session_dir = Path("/tmp/paw-ss7-proj") / "sess-1"
+    emitted = await store.list_subkeys(_key())
+    assert sorted(emitted) == ["subagents/agent-1", "subagents/agent-2"]
+    for sub in emitted:
+        assert _is_safe_subpath(sub, session_dir), f"store emitted an unsafe subpath: {sub!r}"
+
+
+def test_sdk_subpath_guard_rejects_traversal(tmp_path) -> None:
+    """SDK guarantee (relied on): _is_safe_subpath rejects empty / absolute /
+    parent-traversal subpaths and accepts the legitimate ``subagents/...`` shape.
+    Called directly because the guard lives in the SDK we depend on."""
+    session_dir = tmp_path / "sess"
+    assert _is_safe_subpath("subagents/agent-7", session_dir) is True
+    assert _is_safe_subpath("../escape", session_dir) is False
+    assert _is_safe_subpath("subagents/../../escape", session_dir) is False
+    assert _is_safe_subpath("/abs/path", session_dir) is False
+    assert _is_safe_subpath("", session_dir) is False
+
+
+def test_sdk_redacts_refresh_token_and_writes_0600(tmp_path) -> None:
+    """SDK guarantee (relied on): _write_redacted_credentials strips the single-use
+    ``refreshToken`` and writes the materialized creds file 0o600. Called directly
+    because the redaction happens inside the SDK before it spawns the subprocess."""
+
+    creds = json.dumps({"claudeAiOauth": {"accessToken": "keep-me", "refreshToken": "burn-me"}})
+    dst = tmp_path / ".credentials.json"
+    _write_redacted_credentials(creds, dst)
+
+    written = json.loads(dst.read_text())
+    assert "refreshToken" not in written["claudeAiOauth"]
+    assert written["claudeAiOauth"]["accessToken"] == "keep-me"  # other fields kept
+    assert (dst.stat().st_mode & 0o777) == 0o600
+
+
+async def test_sdk_rmtree_cleanup_removes_materialized_dir(tmp_path) -> None:
+    """SDK guarantee (relied on): the per-resume temp dir is removed by
+    _rmtree_with_retry (the cleanup() the resume path schedules), so no
+    cross-tenant transcript file persists. Called directly on a populated dir."""
+    doomed = tmp_path / "claude-resume-xyz"
+    (doomed / "projects").mkdir(parents=True)
+    (doomed / "projects" / "x.jsonl").write_text("{}\n")
+    assert doomed.exists()
+
+    await _rmtree_with_retry(doomed)
+    assert not doomed.exists()

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -1,0 +1,330 @@
+# tests/test_session_supervisor.py
+# Created: 2026-06-30 (feat/session-supervisor SS-4) — pins the SessionSupervisor
+# policy/lifecycle engine WITHOUT a live model or real subprocess. A fake clock
+# (injected via now=) makes TTL/reaping deterministic, and fake teardown
+# recorders prove the supervisor releases slots at exactly the right moments.
+#
+# Coverage (the SS-4 done-when matrix):
+#   * WARM reuse — re-acquire within TTL reuses the bound slot, no teardown.
+#   * Idle reap — past warm_ttl, one reaper pass tears the idle slot down → COLD.
+#   * Busy guard — a slot with active_runs>0 is never reaped, even when stale;
+#     once the run ends and TTL passes it is.
+#   * Per-tenant quota — a 3rd warm session for tenant A LRU-evicts A's oldest
+#     IDLE warm; tenant B is untouched (quota is per-tenant).
+#   * Turn-1 routing — acquire(cli_session_id=None) is FRESH + owns_capture; a
+#     later acquire with a recorded id within TTL is WARM reuse.
+#   * Crash → COLD — mark_crashed drops the slot but keeps cli_session_id, so the
+#     next acquire is FRESH and resumes from the stored id.
+
+from __future__ import annotations
+
+from pocketpaw.agents.session_supervisor import (
+    Acquisition,
+    SessionSupervisor,
+    SessionTier,
+    get_session_supervisor,
+)
+
+
+class FakeClock:
+    """Deterministic monotonic clock — advance it explicitly in the test."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class Teardown:
+    """Fake teardown callback that records how many times it was called."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> None:
+        self.calls += 1
+
+
+# ===========================================================================
+# WARM reuse
+# ===========================================================================
+
+
+def test_warm_reuse_within_ttl() -> None:
+    """A bound warm slot is reused on the next acquire within TTL — no teardown."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    # Turn 1: fresh launch, owns capture.
+    acq1 = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    assert acq1.fresh and acq1.owns_capture
+
+    # Executor captures the native id and binds the warm slot it launched.
+    sup.record_cli_session_id(acq1.runtime, "cli-123")
+    td = Teardown()
+    sup.bind_warm_slot(acq1.runtime, slot="warm-client", teardown=td)
+    assert acq1.runtime.tier is SessionTier.WARM
+
+    # Turn 2 within TTL → WARM reuse, slot reused, teardown NOT called.
+    clock.advance(30)
+    acq2 = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-123")
+    assert acq2.warm_reuse is True
+    assert acq2.owns_capture is False
+    assert acq2.slot == "warm-client"
+    assert acq2.cli_session_id == "cli-123"
+    assert td.calls == 0
+
+
+# ===========================================================================
+# Idle reap
+# ===========================================================================
+
+
+def test_idle_warm_slot_reaped_past_ttl() -> None:
+    """Past warm_ttl with no activity, one reaper pass tears the slot down → COLD."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    td = Teardown()
+    sup.bind_warm_slot(acq.runtime, slot="slot", teardown=td)
+
+    # Not yet expired — no reap.
+    clock.advance(100)
+    assert sup.reap_once() == 0
+    assert td.calls == 0
+    assert acq.runtime.tier is SessionTier.WARM
+
+    # Past TTL — reaped.
+    clock.advance(50)  # 150 > 120
+    assert sup.reap_once() == 1
+    assert td.calls == 1
+    assert acq.runtime.tier is SessionTier.COLD
+    assert acq.runtime.warm_slot is None
+
+
+# ===========================================================================
+# Busy guard
+# ===========================================================================
+
+
+def test_busy_runtime_never_reaped() -> None:
+    """A busy slot (active_runs>0) is never reaped even when stale; idle+TTL is."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    td = Teardown()
+    sup.bind_warm_slot(acq.runtime, slot="slot", teardown=td)
+
+    # Run in flight — advance well past TTL, reaper must skip it.
+    sup.mark_run_start(acq.runtime)
+    clock.advance(500)
+    assert sup.reap_once() == 0
+    assert td.calls == 0
+    assert acq.runtime.tier is SessionTier.WARM
+
+    # Run ends; one more TTL window passes → now reapable.
+    sup.mark_run_end(acq.runtime)
+    assert acq.runtime.active_runs == 0
+    clock.advance(121)
+    assert sup.reap_once() == 1
+    assert td.calls == 1
+    assert acq.runtime.tier is SessionTier.COLD
+
+
+# ===========================================================================
+# Per-tenant quota
+# ===========================================================================
+
+
+def test_per_tenant_quota_lru_evicts_oldest_idle_in_tenant() -> None:
+    """A 3rd warm session for tenant A LRU-evicts A's oldest IDLE warm; tenant B
+    is untouched (quota is per-tenant)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=10_000, max_warm_per_tenant=2, now=clock)
+
+    # Tenant B has a warm session — it must survive A hitting its cap.
+    b = sup.acquire("ws-b", "sess-b1", "agent", cli_session_id="cli-b1")
+    td_b = Teardown()
+    sup.bind_warm_slot(b.runtime, slot="b1", teardown=td_b)
+
+    # Tenant A: two warm sessions (a1 older than a2).
+    clock.advance(1)
+    a1 = sup.acquire("ws-a", "sess-a1", "agent", cli_session_id="cli-a1")
+    td_a1 = Teardown()
+    sup.bind_warm_slot(a1.runtime, slot="a1", teardown=td_a1)
+
+    clock.advance(1)
+    a2 = sup.acquire("ws-a", "sess-a2", "agent", cli_session_id="cli-a2")
+    td_a2 = Teardown()
+    sup.bind_warm_slot(a2.runtime, slot="a2", teardown=td_a2)
+
+    # A 3rd warm session for A → over the per-tenant cap of 2 → evict A's oldest
+    # IDLE warm (a1), tearing it down. a2 and the new one stay; B is untouched.
+    clock.advance(1)
+    a3 = sup.acquire("ws-a", "sess-a3", "agent", cli_session_id="cli-a3")
+    td_a3 = Teardown()
+    sup.bind_warm_slot(a3.runtime, slot="a3", teardown=td_a3)
+
+    assert td_a1.calls == 1  # oldest idle in tenant A evicted
+    assert a1.runtime.tier is SessionTier.COLD
+    assert td_a2.calls == 0 and a2.runtime.tier is SessionTier.WARM
+    assert td_a3.calls == 0 and a3.runtime.tier is SessionTier.WARM
+    assert td_b.calls == 0 and b.runtime.tier is SessionTier.WARM  # per-tenant
+
+
+def test_per_tenant_quota_skips_busy_candidate() -> None:
+    """When the only over-cap candidate is busy, it is NOT evicted (busy-guard)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=10_000, max_warm_per_tenant=1, now=clock)
+
+    a1 = sup.acquire("ws-a", "sess-a1", "agent", cli_session_id="cli-a1")
+    td_a1 = Teardown()
+    sup.bind_warm_slot(a1.runtime, slot="a1", teardown=td_a1)
+    sup.mark_run_start(a1.runtime)  # busy — cannot be evicted
+
+    clock.advance(1)
+    a2 = sup.acquire("ws-a", "sess-a2", "agent", cli_session_id="cli-a2")
+    td_a2 = Teardown()
+    sup.bind_warm_slot(a2.runtime, slot="a2", teardown=td_a2)
+
+    # Over cap (2 > 1) but the only idle candidate is a2 itself (protected as the
+    # just-bound runtime); a1 is busy → nothing evicted this cycle.
+    assert td_a1.calls == 0 and a1.runtime.tier is SessionTier.WARM
+    assert td_a2.calls == 0 and a2.runtime.tier is SessionTier.WARM
+
+
+# ===========================================================================
+# Turn-1 routing / capture ownership
+# ===========================================================================
+
+
+def test_turn_one_routes_fresh_and_owns_capture() -> None:
+    """Turn 1 (cli_session_id=None) is a FRESH launch that OWNS capture; a later
+    acquire with the recorded id within TTL is WARM reuse."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq1 = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    assert isinstance(acq1, Acquisition)
+    assert acq1.warm_reuse is False
+    assert acq1.fresh is True
+    assert acq1.owns_capture is True
+    assert acq1.cli_session_id is None
+
+    # Executor captures the native id, records it, binds the slot it launched.
+    sup.record_cli_session_id(acq1.runtime, "cli-xyz")
+    sup.bind_warm_slot(acq1.runtime, slot="proc", teardown=Teardown())
+
+    # Next turn within TTL — recorded id resolves, warm slot reused.
+    clock.advance(10)
+    acq2 = sup.acquire("ws-a", "sess-1", "agent-x")  # caller passes no id
+    assert acq2.warm_reuse is True
+    assert acq2.owns_capture is False
+    assert acq2.cli_session_id == "cli-xyz"
+
+
+def test_turn_one_never_reuses_foreign_warm_slot() -> None:
+    """Even if a warm slot somehow exists, a turn with no known id stays FRESH so
+    capture binds to THIS session (the SS-1 turn-1 concern)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    sup.bind_warm_slot(acq.runtime, slot="proc", teardown=Teardown())
+    # Force the in-memory id back to unknown to simulate a not-yet-captured turn.
+    acq.runtime.cli_session_id = None
+
+    again = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    assert again.warm_reuse is False
+    assert again.owns_capture is True
+
+
+def test_expired_warm_slot_routes_fresh() -> None:
+    """A warm slot idle past TTL routes FRESH on the next acquire (resume path)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    sup.bind_warm_slot(acq.runtime, slot="proc", teardown=Teardown())
+
+    clock.advance(200)  # past TTL — slot stale, reaper hasn't run yet
+    nxt = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    assert nxt.warm_reuse is False  # stale slot not reused
+    assert nxt.owns_capture is False  # id known → resume, not turn 1
+    assert nxt.cli_session_id == "cli-1"
+
+
+# ===========================================================================
+# Crash → COLD
+# ===========================================================================
+
+
+def test_crash_drops_slot_keeps_id_next_acquire_fresh() -> None:
+    """mark_crashed → COLD + slot dropped; next acquire is FRESH and carries the
+    prior cli_session_id (resume-from-store path)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    sup.record_cli_session_id(acq.runtime, "cli-survives")
+    td = Teardown()
+    sup.bind_warm_slot(acq.runtime, slot="proc", teardown=td)
+
+    sup.mark_crashed(acq.runtime)
+    assert td.calls == 1  # best-effort teardown of the dead slot
+    assert acq.runtime.tier is SessionTier.COLD
+    assert acq.runtime.warm_slot is None
+    assert acq.runtime.cli_session_id == "cli-survives"  # kept for resume
+
+    nxt = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-survives")
+    assert nxt.warm_reuse is False  # FRESH launch
+    assert nxt.owns_capture is False  # id known → resume from store
+    assert nxt.cli_session_id == "cli-survives"
+
+
+# ===========================================================================
+# Identity helpers + singleton
+# ===========================================================================
+
+
+def test_runtime_key_is_tenancy_first() -> None:
+    """SessionRuntime.key is (workspace_id, session_id) — tenancy boundary first."""
+    sup = SessionSupervisor()
+    acq = sup.acquire("ws-a", "sess-1", "agent-x")
+    assert acq.runtime.key == ("ws-a", "sess-1")
+
+
+def test_get_session_supervisor_singleton() -> None:
+    """get_session_supervisor returns a stable process-global instance."""
+    assert get_session_supervisor() is get_session_supervisor()
+
+
+# ===========================================================================
+# Background reaper lifecycle (async)
+# ===========================================================================
+
+
+async def test_start_stop_tears_down_all_slots() -> None:
+    """stop() cancels the reaper and tears down every live warm slot."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+    await sup.start()
+
+    a = sup.acquire("ws-a", "sess-1", "agent", cli_session_id="cli-a")
+    td_a = Teardown()
+    sup.bind_warm_slot(a.runtime, slot="a", teardown=td_a)
+
+    b = sup.acquire("ws-b", "sess-2", "agent", cli_session_id="cli-b")
+    td_b = Teardown()
+    sup.bind_warm_slot(b.runtime, slot="b", teardown=td_b)
+
+    await sup.stop()
+    assert td_a.calls == 1 and td_b.calls == 1
+    assert a.runtime.tier is SessionTier.COLD
+    assert b.runtime.tier is SessionTier.COLD


### PR DESCRIPTION
Ships v1 of how PocketPaw maintains a per-user CLI agent session across turns: the agent continues by resuming its **own native session** rather than replaying chat history, backed by a tenancy-keyed store so a session survives a backend restart and stays isolated per tenant. **Off by default** behind `POCKETPAW_SESSION_SUPERVISOR` — merging this changes nothing until the flag is flipped.

## What's in it
The 6 slices (also reviewable individually as #1590–#1595):

- **SessionHandle + native resume** in the Claude SDK backend — a `cli_session_id` sets `ClaudeAgentOptions.resume` and routes the turn down the fresh launch path; the per-turn system prompt is still applied, so resumed turns honor fresh instructions and KB.
- **Tenancy-keyed SessionStore** (OSS reference + Mongo) — resume reads from our store, not local disk, and a store bound to one workspace can't see another's transcripts.
- **Durable `(workspace, session, agent) → cli_session_id` map** so a cold turn after a restart finds the right session to resume.
- **SessionSupervisor** — COLD/WARM tiers, per-tenant warm quota, idle reaper, busy-guard, and turn-1 capture routing (turn 1 takes its own process so the captured id binds to that session).
- **Flag-gated executor wiring** — degrades to the legacy path on any supervisor/store error, so a hiccup never breaks a run.
- **Adversarial multi-tenant isolation suite** — shared-backing collisions, guessed ids, quota cross-starvation. 0 leaks.

## Verified live (2026-06-30)
A real two-turn cloud chat captured the native session id into Mongo; killing and rebooting the backend (warm process gone) still answered correctly on turn 3 — resumed from the store. Flag-off wrote zero `agent_session_runtimes` rows. 180 test-surface re-run green.

## Docs
`docs/concepts/agent-session-management.mdx` (the core architecture page), a native-resume section on the claude-sdk backend doc, the flag in `CLAUDE.md`, and a smoke guide under `docs/handoff/`.

## Deferred (follow-ups)
WARM hot-process reuse, the LIVE/attach tier (cmux), atomic store append/upsert, a COLD-runtime memory prune, and codex native resume parity.
