### PR TITLE
fix: SaaS hardening for the session supervisor — atomic store writes + COLD-runtime prune

### DIFF
--- a/ee/pocketpaw_ee/cloud/agent_sessions/runtime_service.py
+++ b/ee/pocketpaw_ee/cloud/agent_sessions/runtime_service.py
@@ -25,10 +25,18 @@
 # client, so there is nothing to emit. (ee write-event convention.)
 #
 # Created 2026-06-30 (feat/session-supervisor SS-3): new entity service.
+#
+# Updated 2026-06-30 (fix/session-supervisor-saas-hardening SH-1b):
+# ``set_cli_session_id`` is now a single ATOMIC ``update_one(..., upsert=True)``
+# on the unique ``(workspace, session_id, agent_id)`` key instead of
+# find-then-insert-or-update. Two concurrent turn-1s for the same key no longer
+# race into a DuplicateKeyError — one inserts, the other updates in place.
 
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
+from typing import Any
 
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.models.agent_session_runtime import AgentSessionRuntimeDoc
@@ -68,33 +76,50 @@ async def set_cli_session_id(
     cli_session_id: str,
     project_key: str | None = None,
 ) -> None:
-    """UPSERT the native ``cli_session_id`` for ``(ws, session, agent)``.
+    """UPSERT the native ``cli_session_id`` for ``(ws, session, agent)`` ATOMICALLY.
 
-    Inserts the row on turn 1 and updates it on a later resume/backfill — the
-    unique ``(workspace, session_id, agent_id)`` index guarantees a single row
-    per key, so this never produces a duplicate. ``project_key`` is recorded
-    when supplied (and left unchanged on update when omitted) so a cold resume
-    can rebuild the full ``SessionHandle``.
+    A single ``update_one(filter, update, upsert=True)`` on the unique
+    ``(workspace, session_id, agent_id)`` key. Mongo's upsert is atomic on that
+    key, so two concurrent turn-1s for the same session no longer race into a
+    DuplicateKeyError — one wins the insert, the other falls through to an update
+    in place. (The old find-then-insert path let both find nothing and both try to
+    insert, so the loser hit the unique index unhandled.)
+
+    ``cli_session_id`` is ``$set`` on every call. ``project_key`` is recorded when
+    supplied (``$set``) and left unchanged on update when omitted; on a fresh
+    insert with no ``project_key`` it is seeded to ``None`` via ``$setOnInsert`` so
+    the row shape is stable. ``updatedAt`` is refreshed on every call and
+    ``createdAt`` stamped only on insert (the raw update bypasses Beanie's
+    timestamp hooks).
     """
     workspace_id = _require("workspace_id", workspace_id)
     session_id = _require("session_id", session_id)
     agent_id = _require("agent_id", agent_id)
     cli_session_id = _require("cli_session_id", cli_session_id)
 
-    doc = await _find_row(workspace_id, session_id, agent_id)
-    if doc is None:
-        doc = AgentSessionRuntimeDoc(
-            workspace=workspace_id,
-            session_id=session_id,
-            agent_id=agent_id,
-            cli_session_id=cli_session_id,
-            project_key=project_key,
-        )
+    now = datetime.now(UTC)
+    update: dict[str, Any] = {
+        "$set": {"cli_session_id": cli_session_id, "updatedAt": now},
+        "$setOnInsert": {"createdAt": now},
+    }
+    if project_key is not None:
+        # Provided → set on both insert and update (only in ``$set`` so it never
+        # collides with ``$setOnInsert``).
+        update["$set"]["project_key"] = project_key
     else:
-        doc.cli_session_id = cli_session_id
-        if project_key is not None:
-            doc.project_key = project_key
-    await doc.save()
+        # Omitted → seed ``None`` on a fresh insert only; leave a prior value
+        # untouched on update.
+        update["$setOnInsert"]["project_key"] = None
+
+    await AgentSessionRuntimeDoc.get_pymongo_collection().update_one(
+        {
+            "workspace": workspace_id,
+            "session_id": session_id,
+            "agent_id": agent_id,
+        },
+        update,
+        upsert=True,
+    )
 
 
 async def get_cli_session_id(

--- a/ee/pocketpaw_ee/cloud/agent_sessions/store.py
+++ b/ee/pocketpaw_ee/cloud/agent_sessions/store.py
@@ -21,10 +21,18 @@
 #
 # Created 2026-06-30 (feat/session-supervisor SS-2): new entity. Only this module
 # imports ``SessionTranscriptDoc``.
+#
+# Updated 2026-06-30 (fix/session-supervisor-saas-hardening SH-1a): ``append`` is
+# now a single ATOMIC aggregation-pipeline ``update_one(..., upsert=True)`` instead
+# of find-modify-save, so two concurrent appends to one session both land (no
+# read-modify-write lost update). uuid-dedup against the stored rows stays atomic
+# (the pipeline appends only entries whose uuid is not already present); within-
+# batch duplicate uuids are collapsed locally first.
 
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from pocketpaw_ee.cloud.models.session_transcript import SessionTranscriptDoc
@@ -77,32 +85,92 @@ class MongoSessionStore:
     # -- SessionStore protocol ---------------------------------------------
 
     async def append(self, key: SessionKey, entries: list[SessionStoreEntry]) -> None:
-        """Mirror a batch of transcript entries for ``key``.
+        """Mirror a batch of transcript entries for ``key`` with ONE atomic write.
 
-        Find-or-create the row, then extend its ``entries`` array, deduping any
-        entry that carries a ``uuid`` already present (the protocol's
-        idempotency contract). Read-modify-write — see the concurrency note in
-        the module/PR; v1 keeps it simple and correct for the de-risk slice.
+        A single aggregation-pipeline ``update_one(filter, pipeline, upsert=True)``
+        replaces the old find-modify-save: it appends to ``entries`` in-place on
+        the server, so two concurrent appends to the same session BOTH land (no
+        read-modify-write lost update — the old path let one clobber the other).
+
+        uuid-dedup (the protocol's idempotency contract — the SDK mirror batcher
+        re-sends a batch verbatim on reconnect, and double-writing it would corrupt
+        the resumed transcript) stays correct AND atomic: the pipeline appends only
+        the entries whose ``uuid`` is not already present in the stored array.
+        Within-batch duplicate uuids are collapsed first in Python (cheap, local,
+        no shared state); entries with NO ``uuid`` are always appended (never
+        deduped). ``updatedAt`` (the ``mtime`` source ``list_sessions`` reads) is
+        refreshed on every call; ``createdAt`` is stamped only on the upsert-insert.
+
+        The pipeline bypasses Beanie's ``before_event`` timestamp hooks (it is a
+        raw collection update), so the timestamps are set explicitly here.
         """
         subpath = self._subpath_of(key)
-        doc = await self._find_row(key["project_key"], key["session_id"], subpath)
-        if doc is None:
-            doc = SessionTranscriptDoc(
-                workspace=self._workspace_id,
-                project_key=key["project_key"],
-                session_id=key["session_id"],
-                subpath=subpath,
-                entries=[],
-            )
-        seen = {e.get("uuid") for e in doc.entries if isinstance(e, dict) and e.get("uuid")}
+
+        # Collapse within-batch duplicate uuids (keep first occurrence); no-uuid
+        # entries always survive. Purely local — preserves the old per-call dedup
+        # without reading the stored row, so no race is reintroduced.
+        deduped: list[dict[str, Any]] = []
+        seen_in_batch: set[Any] = set()
         for entry in entries:
             uuid = entry.get("uuid")
             if uuid is not None:
-                if uuid in seen:
+                if uuid in seen_in_batch:
                     continue
-                seen.add(uuid)
-            doc.entries.append(dict(entry))
-        await doc.save()
+                seen_in_batch.add(uuid)
+            deduped.append(dict(entry))
+
+        now = datetime.now(UTC)
+        existing = {"$ifNull": ["$entries", []]}
+        # uuids already stored (stored no-uuid entries are excluded — they never
+        # participate in dedup and their missing ``uuid`` would corrupt ``$in``).
+        existing_uuids = {
+            "$map": {
+                "input": {
+                    "$filter": {
+                        "input": existing,
+                        "as": "x",
+                        "cond": {"$ne": [{"$ifNull": ["$$x.uuid", None]}, None]},
+                    }
+                },
+                "as": "x",
+                "in": "$$x.uuid",
+            }
+        }
+        # ``$literal`` keeps the entry blobs as plain data (a stray ``$``-prefixed
+        # key would otherwise be evaluated as an aggregation expression).
+        new_to_keep = {
+            "$filter": {
+                "input": {"$literal": deduped},
+                "as": "e",
+                "cond": {
+                    "$or": [
+                        # No uuid → always append (not an idempotency key).
+                        {"$eq": [{"$ifNull": ["$$e.uuid", None]}, None]},
+                        # uuid not already stored → append (dedup re-sends).
+                        {"$not": {"$in": ["$$e.uuid", existing_uuids]}},
+                    ]
+                },
+            }
+        }
+        pipeline = [
+            {
+                "$set": {
+                    "entries": {"$concatArrays": [existing, new_to_keep]},
+                    "updatedAt": now,
+                    "createdAt": {"$ifNull": ["$createdAt", now]},
+                }
+            }
+        ]
+        await SessionTranscriptDoc.get_pymongo_collection().update_one(
+            {
+                "workspace": self._workspace_id,
+                "project_key": key["project_key"],
+                "session_id": key["session_id"],
+                "subpath": subpath,
+            },
+            pipeline,
+            upsert=True,
+        )
 
     async def load(self, key: SessionKey) -> list[SessionStoreEntry] | None:
         """Return the full transcript for ``key``, or ``None`` if never written.

--- a/src/pocketpaw/agents/session_supervisor.py
+++ b/src/pocketpaw/agents/session_supervisor.py
@@ -21,6 +21,14 @@ Tier model: COLD (no live slot — next acquire is a fresh launch, resuming from
 the store via ``cli_session_id`` when one exists), WARM (a live slot bound, reused
 within TTL), LIVE (a declared enum value reserved for a future always-on tier —
 no behavior in v1).
+
+Updated 2026-06-30 (fix/session-supervisor-saas-hardening SH-2): ``reap_once`` now
+also PRUNES idle COLD runtimes (removes them from ``_runtimes`` past ``cold_ttl``)
+so the runtime map stays bounded over long SaaS uptime. The durable
+``cli_session_id`` lives in SS-3's Mongo map, so a later ``acquire`` re-creates a
+pruned runtime COLD and re-resolves the id — the drop is safe. The busy-guard
+still holds: a runtime with ``active_runs > 0`` (e.g. a turn-1 launch in flight,
+which is COLD AND busy) is never pruned.
 """
 
 from __future__ import annotations
@@ -134,11 +142,17 @@ class SessionSupervisor:
         self,
         *,
         warm_ttl: float = 120,
+        cold_ttl: float = 3600,
         max_warm_per_tenant: int = 8,
         max_warm_global: int = 64,
         now: Callable[[], float] | None = None,
     ) -> None:
         self._warm_ttl = warm_ttl
+        # How long a COLD runtime (no live slot) may sit idle in ``_runtimes``
+        # before the reaper prunes the descriptor entirely. Much larger than
+        # ``warm_ttl``: freeing the live slot is urgent, dropping the cheap
+        # in-memory descriptor is just memory hygiene (resume rebuilds it).
+        self._cold_ttl = cold_ttl
         self._max_warm_per_tenant = max_warm_per_tenant
         self._max_warm_global = max_warm_global
         # Injected clock — tests pass a fake closure so reap/TTL is deterministic.
@@ -364,25 +378,57 @@ class SessionSupervisor:
             )
 
     def reap_once(self) -> int:
-        """Run one reaper pass: tear down idle warm slots past ``warm_ttl``.
+        """Run one reaper pass: tear down idle WARM slots AND prune idle COLD runtimes.
 
-        Skips any runtime with ``active_runs > 0`` (busy-guard) regardless of how
-        stale ``last_active`` looks. Returns the number of slots reaped. Exposed
-        (not ``_``-private) so tests can drive a deterministic pass with the fake
-        clock instead of waiting on the background loop.
+        Two independent jobs, both gated by the busy-guard:
+
+        * WARM reap — a runtime holding a live warm slot, idle past ``warm_ttl``,
+          has its slot torn down (demoting it to COLD; the descriptor stays
+          resident for a fast resume). Unchanged from v1.
+        * COLD prune — a runtime with NO live slot (``tier is COLD``,
+          ``warm_slot is None``), idle past ``cold_ttl``, is REMOVED from
+          ``_runtimes`` entirely so the map stays bounded over long uptime. Safe
+          because the durable ``cli_session_id`` lives in SS-3's Mongo map: a later
+          ``acquire`` re-creates the runtime COLD and re-resolves the id.
+
+        The busy-guard skips ANY runtime with ``active_runs > 0`` regardless of how
+        stale ``last_active`` looks — a turn-1 fresh launch is COLD AND busy while
+        in flight (v1 binds no warm slot), and pruning it mid-turn would drop live
+        bookkeeping. WARM reaping stays governed by ``warm_ttl`` only; cold pruning
+        by ``cold_ttl`` only.
+
+        Returns the count of runtimes acted on (warm slots reaped + cold runtimes
+        pruned). Exposed (not ``_``-private) so tests can drive a deterministic pass
+        with the fake clock instead of waiting on the background loop.
         """
         now = self._now()
         reaped = 0
+        pruned_keys: list[tuple[str, str]] = []
         for runtime in list(self._runtimes.values()):
+            # Busy-guard — never touch an in-flight runtime (covers a COLD+busy
+            # turn-1 launch as well as a busy warm slot).
+            if runtime.active_runs > 0:
+                continue
+            idle = now - runtime.last_active
             if (
                 runtime.tier is SessionTier.WARM
                 and runtime.warm_slot is not None
-                and runtime.active_runs == 0
-                and (now - runtime.last_active) > self._warm_ttl
+                and idle > self._warm_ttl
             ):
                 self._run_teardown(self._drop_slot(runtime))
                 reaped += 1
-        return reaped
+            elif (
+                runtime.tier is SessionTier.COLD
+                and runtime.warm_slot is None
+                and idle > self._cold_ttl
+            ):
+                # A just-reaped warm runtime (now COLD) is NOT pruned in the same
+                # pass — the ``elif`` skips it; it stays resident until a later pass
+                # finds it idle past ``cold_ttl``.
+                pruned_keys.append(runtime.key)
+        for key in pruned_keys:
+            self._runtimes.pop(key, None)
+        return reaped + len(pruned_keys)
 
     def _drop_slot(self, runtime: SessionRuntime) -> Callable[[], Any] | None:
         """Null the slot fields, demote to COLD, and return the old teardown."""

--- a/tests/cloud/test_agent_session_runtime_service.py
+++ b/tests/cloud/test_agent_session_runtime_service.py
@@ -6,6 +6,12 @@
 # the unique index holds), tenancy isolation (a foreign workspace reads None),
 # and an absent key reading None. Uses the shared ``mongo_db`` fixture which
 # init_beanie's ALL_DOCUMENTS (now including AgentSessionRuntimeDoc).
+#
+# Updated: 2026-06-30 (fix/session-supervisor-saas-hardening SH-1b) — adds
+# ``test_set_cli_session_id_atomic_upsert`` pinning the atomic-upsert contract:
+# repeated sets for one key yield exactly one row (second updates the id, no
+# DuplicateKeyError), project_key is preserved when omitted, and a distinct
+# workspace gets its own row (tenancy holds on the unique key).
 
 from __future__ import annotations
 
@@ -64,6 +70,40 @@ async def test_upsert_preserves_project_key_when_omitted(mongo_db) -> None:  # n
     assert row is not None
     assert row.cli_session_id == "cli-2"
     assert row.project_key == "proj-1"
+
+
+async def test_set_cli_session_id_atomic_upsert(mongo_db) -> None:  # noqa: ARG001
+    """SH-1b: the atomic-upsert contract on the unique key.
+
+    Calling set twice for the same (ws, session, agent) yields EXACTLY ONE row —
+    the second updates ``cli_session_id`` in place, never raising DuplicateKeyError
+    (the old find-then-insert path would, under a turn-1 race). ``project_key`` is
+    preserved when the second call omits it. A different workspace is a SEPARATE
+    row (tenancy holds on the leading index component).
+    """
+    # First set (insert) carries a project_key.
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-1", project_key="proj-1")
+    # Second set (update) omits project_key — must not duplicate the row or raise.
+    await runtime_service.set_cli_session_id(WS, SESSION, AGENT, "cli-2")
+
+    rows = await AgentSessionRuntimeDoc.find(
+        AgentSessionRuntimeDoc.workspace == WS,
+        AgentSessionRuntimeDoc.session_id == SESSION,
+        AgentSessionRuntimeDoc.agent_id == AGENT,
+    ).to_list()
+    assert len(rows) == 1
+    assert rows[0].cli_session_id == "cli-2"
+    assert rows[0].project_key == "proj-1"  # preserved across the omitting update
+
+    # A different workspace with the same (session, agent) is its own row.
+    await runtime_service.set_cli_session_id("ws-B", SESSION, AGENT, "cli-b")
+    assert await runtime_service.get_cli_session_id("ws-B", SESSION, AGENT) == "cli-b"
+    assert await runtime_service.get_cli_session_id(WS, SESSION, AGENT) == "cli-2"
+    all_rows = await AgentSessionRuntimeDoc.find(
+        AgentSessionRuntimeDoc.session_id == SESSION,
+        AgentSessionRuntimeDoc.agent_id == AGENT,
+    ).to_list()
+    assert len(all_rows) == 2  # one per workspace
 
 
 async def test_tenancy_isolation(mongo_db) -> None:  # noqa: ARG001

--- a/tests/cloud/test_session_transcript_store.py
+++ b/tests/cloud/test_session_transcript_store.py
@@ -7,6 +7,11 @@
 # and tenancy isolation (a store bound to workspace B can't read workspace A's
 # session). Uses the shared ``mongo_db`` fixture which init_beanie's
 # ALL_DOCUMENTS (now including SessionTranscriptDoc).
+#
+# Updated: 2026-06-30 (fix/session-supervisor-saas-hardening SH-1a) — adds
+# ``test_append_atomic_both_batches_land_and_dedup``, pinning the atomic-append
+# contract: two separate batches both land (no clobber), a re-appended uuid is
+# not duplicated (dedup preserved), and a no-uuid entry always appends.
 
 from __future__ import annotations
 
@@ -50,6 +55,39 @@ async def test_append_dedups_by_uuid(mongo_db) -> None:  # noqa: ARG001
     await store.append(_key(), [no_uuid])
     await store.append(_key(), [no_uuid])
     assert await store.load(_key()) == [e, no_uuid, no_uuid]
+
+
+async def test_append_atomic_both_batches_land_and_dedup(mongo_db) -> None:  # noqa: ARG001
+    """SH-1a: the atomic-append contract.
+
+    Two SEPARATE append calls (distinct batches) both land — no read-modify-write
+    clobber. A re-append of an entry with an already-stored ``uuid`` is NOT
+    duplicated (idempotency preserved atomically). An entry with no ``uuid`` always
+    appends, even when it repeats.
+    """
+    store = MongoSessionStore("ws-A")
+    a = {"type": "user", "uuid": "a"}
+    b = {"type": "assistant", "uuid": "b"}
+
+    # Two separate batches → both present, in order (no clobber).
+    await store.append(_key(), [a])
+    await store.append(_key(), [b])
+    assert await store.load(_key()) == [a, b]
+
+    # Re-appending an already-stored uuid is a no-op (dedup against the store).
+    await store.append(_key(), [a, b])
+    assert await store.load(_key()) == [a, b]
+
+    # A batch that mixes a fresh uuid with a stored one keeps only the fresh one.
+    c = {"type": "user", "uuid": "c"}
+    await store.append(_key(), [b, c])
+    assert await store.load(_key()) == [a, b, c]
+
+    # No-uuid entries always append (and repeat).
+    note = {"type": "summary"}
+    await store.append(_key(), [note])
+    await store.append(_key(), [note])
+    assert await store.load(_key()) == [a, b, c, note, note]
 
 
 async def test_durability_across_fresh_instance(mongo_db) -> None:  # noqa: ARG001

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -15,6 +15,12 @@
 #     later acquire with a recorded id within TTL is WARM reuse.
 #   * Crash → COLD — mark_crashed drops the slot but keeps cli_session_id, so the
 #     next acquire is FRESH and resumes from the stored id.
+#
+# Updated 2026-06-30 (fix/session-supervisor-saas-hardening SH-2): adds the
+# cold-prune coverage — reap_once now removes idle COLD runtimes (past cold_ttl,
+# not busy) from _runtimes to bound memory, never prunes a COLD+busy turn-1 launch,
+# keeps WARM governed by warm_ttl (not cold_ttl), and a pruned key re-creates COLD
+# (and re-resolves its cli_session_id) on the next acquire — proving the drop safe.
 
 from __future__ import annotations
 
@@ -286,6 +292,95 @@ def test_crash_drops_slot_keeps_id_next_acquire_fresh() -> None:
     assert nxt.warm_reuse is False  # FRESH launch
     assert nxt.owns_capture is False  # id known → resume from store
     assert nxt.cli_session_id == "cli-survives"
+
+
+# ===========================================================================
+# Cold-runtime pruning (SH-2 — bounded supervisor memory)
+# ===========================================================================
+
+
+def test_cold_runtime_pruned_past_cold_ttl() -> None:
+    """A COLD runtime idle past cold_ttl is removed from _runtimes by a reaper pass."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, cold_ttl=3600, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    assert acq.runtime.tier is SessionTier.COLD  # no warm slot bound → COLD
+    assert ("ws-a", "sess-1") in sup._runtimes
+
+    # Idle but under cold_ttl → not pruned.
+    clock.advance(3000)
+    assert sup.reap_once() == 0
+    assert ("ws-a", "sess-1") in sup._runtimes
+
+    # Past cold_ttl → pruned out of the map entirely.
+    clock.advance(601)  # 3601 > 3600
+    assert sup.reap_once() == 1
+    assert ("ws-a", "sess-1") not in sup._runtimes
+
+
+def test_cold_busy_runtime_never_pruned() -> None:
+    """A COLD runtime with active_runs>0 (a turn-1 launch in flight) is never pruned,
+    even far past cold_ttl — the busy-guard wins."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, cold_ttl=3600, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)  # turn-1
+    sup.mark_run_start(acq.runtime)  # COLD + busy while the turn is in flight
+    assert acq.runtime.tier is SessionTier.COLD and acq.runtime.active_runs == 1
+
+    clock.advance(10_000)  # way past cold_ttl
+    assert sup.reap_once() == 0
+    assert ("ws-a", "sess-1") in sup._runtimes  # survived — busy-guard held
+
+    # Once the turn ends and cold_ttl passes, it becomes prunable.
+    sup.mark_run_end(acq.runtime)
+    clock.advance(3601)
+    assert sup.reap_once() == 1
+    assert ("ws-a", "sess-1") not in sup._runtimes
+
+
+def test_warm_governed_by_warm_ttl_not_cold_ttl() -> None:
+    """A WARM runtime is reaped on warm_ttl (not held to cold_ttl), and a fresh COLD
+    runtime (idle < cold_ttl) survives the same pass."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, cold_ttl=3600, now=clock)
+
+    warm = sup.acquire("ws-a", "warm-1", "agent", cli_session_id="cli-w")
+    td = Teardown()
+    sup.bind_warm_slot(warm.runtime, slot="s", teardown=td)
+
+    fresh_cold = sup.acquire("ws-a", "cold-1", "agent", cli_session_id="cli-c")
+    assert fresh_cold.runtime.tier is SessionTier.COLD
+
+    # Past warm_ttl but well under cold_ttl: the warm slot is reaped; the fresh
+    # COLD runtime is untouched (and the just-reaped warm stays resident as COLD).
+    clock.advance(200)  # 200 > warm_ttl(120), < cold_ttl(3600)
+    assert sup.reap_once() == 1
+    assert td.calls == 1
+    assert warm.runtime.tier is SessionTier.COLD
+    assert ("ws-a", "warm-1") in sup._runtimes  # demoted, not yet cold-pruned
+    assert ("ws-a", "cold-1") in sup._runtimes  # fresh cold survives
+
+
+def test_acquire_after_cold_prune_recreates_and_resolves() -> None:
+    """After a COLD prune, an acquire for that key re-creates the runtime COLD and
+    re-resolves the cli_session_id from the (durable) store arg — the drop is safe."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, cold_ttl=3600, now=clock)
+
+    sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    clock.advance(3601)
+    assert sup.reap_once() == 1
+    assert ("ws-a", "sess-1") not in sup._runtimes
+
+    # Caller re-acquires (passing the id recovered from SS-3's Mongo map).
+    again = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    assert ("ws-a", "sess-1") in sup._runtimes
+    assert again.runtime.tier is SessionTier.COLD
+    assert again.warm_reuse is False
+    assert again.owns_capture is False  # id known → resume, not turn 1
+    assert again.cli_session_id == "cli-1"
 
 
 # ===========================================================================


### PR DESCRIPTION
Two small hardening follow-ups on the session supervisor (shipped in #1596), for the multi-tenant SaaS path. No behavior change to a single-tenant run — these close correctness and memory gaps that only bite under concurrency and long uptime.

## Atomic store writes (no read-modify-write race)
- **`MongoSessionStore.append`** was find-modify-save, so two concurrent appends to one session could lose an update. It is now a single atomic aggregation-pipeline `update_one(upsert=True)`: concurrent appends both land, and uuid-dedup stays atomic — the pipeline appends only entries whose `uuid` isn't already stored, within-batch duplicates are collapsed locally first, and entries with no `uuid` always append.
- **`runtime_service.set_cli_session_id`** was find-then-insert, so two concurrent turn-1s for one session raced into a `DuplicateKeyError` on the unique index. It is now an atomic upsert on that key — one wins the insert, the other updates in place. `project_key` is preserved when omitted.

## COLD-runtime memory prune
- The `SessionSupervisor` kept COLD `SessionRuntime`s resident forever, so the in-memory map grew unbounded over long uptime. `reap_once` now also prunes COLD runtimes idle past a new `cold_ttl` (default 1h). Safe because the durable `cli_session_id` lives in Mongo — a later turn re-creates the runtime and re-resolves the id. A busy runtime (including a COLD turn-1 launch in flight) is never pruned.

## Tests
Concurrent-append-both-land + dedup-preserved + no-uuid-appended; concurrent `set` yields one row with no dup-key + `project_key` preserved; COLD prune past TTL + busy-skip + re-acquire-after-prune. 53 green across the touched modules and the v1 regression.

Atomicity is a real-MongoDB single-document-update property; the mongomock tests assert the observable contract (the prior races are gone), not concurrency itself.
