### PR TITLE
feat(billing): monthly credit-quota enforcement at run-start (PEE)

### DIFF
--- a/docs/api/configuration-reference.mdx
+++ b/docs/api/configuration-reference.mdx
@@ -53,6 +53,16 @@ When `llm_provider` is `auto`, PocketPaw uses Anthropic if an API key is set, ot
 | `litellm_model` | `POCKETPAW_LITELLM_MODEL` | string | `""` | Model name (use LiteLLM-prefixed names in direct mode) |
 | `litellm_max_tokens` | `POCKETPAW_LITELLM_MAX_TOKENS` | integer | `0` | Max output tokens (0 = provider default) |
 
+## Billing & Credits
+
+Cloud / subscription (PEE) only. The credit ledger and these knobs are inert on OSS / self-host deployments (no wallet), so the defaults are safe everywhere.
+
+| Setting | Env Variable | Type | Default | Description |
+|---------|-------------|------|---------|-------------|
+| `billing_enforced` | `POCKETPAW_BILLING_ENFORCED` | bool | `false` | Run-start hard-block. When `true`, starting a chat run is rejected with HTTP 402 if the workspace balance is `<= 0` (`credits.insufficient`) **or** its month-to-date spend has hit the monthly credit ceiling (`credits.quota_exceeded`), at both the chat HTTP path and the worker/executor, before any model call. In-flight runs are never killed. **Subscription / PEE deployments must set this to `1`** — left at the default, a Free workspace runs past its cap into a negative balance (see the [cloud GA runbook](/runbooks/cloud-ga-two-tenant-smoke), step 3c). Per-plan ceilings come from the catalog (`billing/plans.py` `_CEILING`; `enterprise` is uncapped), not from this flag. |
+| `billing_markup` | `POCKETPAW_BILLING_MARKUP` | float | `2.5` | Flat markup applied to a run's real compute cost before it is billed to the wallet. Metered charge = `round(cost_usd * billing_markup / credit_usd)`. |
+| `credit_usd` | `POCKETPAW_CREDIT_USD` | float | `0.01` | USD value of one credit (1 credit == $0.01). Divides the marked-up compute cost to yield integer credits. |
+
 ## Tool Policy
 
 | Setting | Env Variable | Type | Default | Description |

--- a/docs/runbooks/cloud-ga-two-tenant-smoke.md
+++ b/docs/runbooks/cloud-ga-two-tenant-smoke.md
@@ -3,7 +3,11 @@
      The AUTOMATED proof is tests/cloud/test_ga_two_tenant_pentest.py (9 tests,
      no creds, signed-webhook sim). THIS runbook is the captain's LIVE acceptance
      pass on the real Coolify box with real Dodo checkouts. Grounded against the
-     shipped ISO-1..4 stack + the billing/credits/entitlements services. -->
+     shipped ISO-1..4 stack + the billing/credits/entitlements services.
+     Updated 2026-06-30 (feat/billing-quota-enforcement, chunk 4): step 3c now
+     leads with the POCKETPAW_BILLING_ENFORCED=1 deploy requirement (enforcement
+     is OFF by default) and adds the monthly-credit-ceiling 402 case
+     (credits.quota_exceeded) beside the existing balance 402; sign-off updated. -->
 
 # Cloud Paw-OS — Two-Tenant GA Smoke (live acceptance)
 
@@ -155,12 +159,29 @@ Any single leak here is a **GA blocker**.
 
 ### 3c. Entitlement + credit enforcement
 
+> **Enforcement is OFF by default — set `POCKETPAW_BILLING_ENFORCED=1`.**
+> The run-start credit gates (balance AND monthly-ceiling, below) only fire when
+> `billing_enforced` is on. It defaults to `false` so OSS / self-host (no ledger)
+> are unaffected, which means a subscription / PEE deployment that forgets this
+> flag enforces **nothing** — a Free workspace keeps running on every chat turn
+> and spends straight past its cap into a negative balance. Set it as a Coolify
+> RUNTIME var on the cloud box and recreate the app before running the steps
+> below, or they will all pass for the wrong reason. Per-plan ceilings come from
+> the catalog (`billing/plans.py` `_CEILING`; `enterprise` is uncapped), not from
+> this flag.
+
 - **Plan gate** — exercise a feature gated to a higher tier from the lower-tier
   tenant; it must be denied (the per-plan ABAC feature set, resolved from
   `Workspace.plan`).
 - **402 at zero** — drain one tenant's wallet (or use a fresh tenant with no
   allotment) and start a chat run; it must hard-block with a 402
   `credits.insufficient`. The OTHER tenant, with balance, is unaffected.
+- **402 at the monthly ceiling** — take a tenant whose month-to-date spend has
+  reached its plan's monthly credit ceiling (cap from the catalog + any top-ups
+  bought this period) while the wallet still holds credits, and start a chat run;
+  it must hard-block with a 402 `credits.quota_exceeded` — at both the chat HTTP
+  path and the worker/executor, BEFORE any model call. The OTHER tenant, under
+  its ceiling, is unaffected.
 
 ### 3d. Fail-closed spot check
 
@@ -180,10 +201,13 @@ GA is accepted when:
       `POCKETPAW_REQUIRE_WORKSPACE_SCOPE=1` and (if needed) the store migration run;
 - [ ] Dodo creds + per-tier products are live runtime vars and
       `GET /billing/plans` returns a product id for every tier;
+- [ ] `POCKETPAW_BILLING_ENFORCED=1` is a live runtime var (without it the credit
+      gates below enforce nothing — a Free workspace runs past its cap);
 - [ ] both tenants provisioned via a **real Dodo checkout** (plan stamped +
       credits granted);
 - [ ] **zero cross-leak** across Pockets, Fabric, Instinct, KB (3b);
-- [ ] entitlement gate + 402-at-zero enforced and tenant-isolated (3c);
+- [ ] entitlement gate + 402-at-zero + 402-at-ceiling enforced and
+      tenant-isolated (3c);
 - [ ] fail-closed confirmed (3d).
 
 When all boxes are checked, the offering is build-complete and smoke-passed for

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -6,6 +6,13 @@ to JSON responses.
 
 Re-exports remain accessible via `ee.cloud.shared.errors` (a shim) for
 the transition period; new code should import from this module.
+
+Changed 2026-06-30 (feat/billing-quota-enforcement, chunk 2): added
+`QuotaExceeded` (402, `credits.quota_exceeded`) — the monthly-credit-cap
+sibling of `InsufficientCredits`. Same 402 status (the client can't spend
+right now) but a distinct code so the UI can prompt a plan upgrade / top-up
+rather than a balance refill; it carries the effective `ceiling` and the
+`spent` figure that crossed it.
 """
 
 from __future__ import annotations
@@ -90,6 +97,29 @@ class InsufficientCredits(CloudError):
         )
 
 
+class QuotaExceeded(CloudError):
+    """Workspace hit its monthly credit ceiling for the period (402).
+
+    Distinct from ``InsufficientCredits`` (the wallet is empty): the wallet may
+    still hold credits, but the workspace has spent up to its plan's monthly cap
+    (the ``monthly_ceiling`` entitlement, extended by any purchased top-ups in the
+    period). Same 402 status as ``InsufficientCredits`` so the client treats both
+    as "can't spend right now", but a distinct machine code so the UI can prompt a
+    plan upgrade / top-up rather than just a balance refill. ``ceiling`` is the
+    EFFECTIVE cap (plan ceiling + period top-ups) and ``spent`` is the
+    month-to-date spend that met or crossed it.
+    """
+
+    def __init__(self, ceiling: int, spent: int) -> None:
+        self.ceiling = ceiling
+        self.spent = spent
+        super().__init__(
+            402,
+            "credits.quota_exceeded",
+            f"Monthly credit quota exceeded: spent {spent} of {ceiling} this month",
+        )
+
+
 class RateLimited(CloudError):
     """Rate limit exceeded (429)."""
 
@@ -124,6 +154,7 @@ __all__ = [
     "InsufficientCredits",
     "Internal",
     "NotFound",
+    "QuotaExceeded",
     "RateLimited",
     "SeatLimitError",
     "ValidationError",

--- a/ee/pocketpaw_ee/cloud/billing/plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/plans.py
@@ -7,6 +7,10 @@
 #   * ``monthly_credit_allotment`` — credits granted per renewal (integer credits,
 #     1 credit == $0.01). Config-tunable constants live below; BC-7 will grant
 #     these on a subscription renewal.
+#   * ``monthly_ceiling`` — the per-plan monthly credit CAP (integer credits, or
+#     None = uncapped) that credit-quota enforcement caps spend against. Tunable
+#     ``_CEILING`` constants live below, mirroring ``_MONTHLY_CREDIT_ALLOTMENT``;
+#     later quota chunks consume this field.
 #   * ``dodo_product_id`` — the Dodo recurring-product id for the tier, or None
 #     until BC-7 / config populates it (optionally read from the
 #     ``POCKETPAW_DODO_PLAN_PRODUCTS`` mapping setting when configured).
@@ -28,6 +32,13 @@
 #   credits. ``monthly_credit_allotment`` stays in the catalog as a back-office
 #   field; it is NOT the headline the UI shows. Enterprise prices are None ("talk
 #   to us").
+# Updated 2026-06-30 (feat/billing-quota-enforcement, chunk 1) — ADDED a per-plan
+#   ``monthly_ceiling`` (the credit-quota cap later chunks enforce): a tunable
+#   ``_CEILING`` constants dict mirroring ``_MONTHLY_CREDIT_ALLOTMENT``, surfaced on
+#   ``PlanTier`` next to ``monthly_credit_allotment``. The cap is allotment × 1.5 for
+#   the paid usage tiers; Free is an explicit trial cap (1000 — its 0 allotment can't
+#   derive it) and Enterprise is uncapped (None). The ``_build`` default for an
+#   unknown key FAILS CLOSED to the Free ceiling, never None/uncapped.
 
 from __future__ import annotations
 
@@ -56,6 +67,34 @@ _MONTHLY_CREDIT_ALLOTMENT: dict[str, int] = {
     "pro": 7_500,
     "pro_max": 30_000,
     "enterprise": 1_000_000,
+}
+
+# ---------------------------------------------------------------------------
+# Tunable constants — the monthly credit CEILING per tier.
+# ---------------------------------------------------------------------------
+#
+# The per-plan cap (integer credits, 1 credit == $0.01, or None = uncapped) that
+# credit-quota enforcement caps a workspace's monthly spend against. Mirrors
+# ``_MONTHLY_CREDIT_ALLOTMENT`` above. The RULE for the paid usage tiers is
+# ``allotment × 1.5`` — headroom over the grant before the cap bites. Two
+# deliberate exceptions:
+#   * ``free`` is an EXPLICIT trial cap (1000) — its allotment is 0, so the ×1.5
+#     rule can't derive a usable ceiling; we set the trial cap directly. It is
+#     also the FAIL-CLOSED floor: an unknown/unresolvable plan caps here, never
+#     uncapped (see ``_build``).
+#   * ``enterprise`` is UNCAPPED (None) — custom contracts set their own limits.
+#
+#   free        =     1_000 credits  — explicit trial cap (allotment is 0)
+#   go          =     2_250 credits  — 1_500 × 1.5
+#   pro         =    11_250 credits  — 7_500 × 1.5
+#   pro_max     =    45_000 credits  — 30_000 × 1.5
+#   enterprise  =      None          — uncapped (custom)
+_CEILING: dict[str, int | None] = {
+    "free": 1_000,
+    "go": 2_250,
+    "pro": 11_250,
+    "pro_max": 45_000,
+    "enterprise": None,
 }
 
 # Order the catalog is listed in — the price ladder, cheapest first. Any tier in
@@ -142,8 +181,11 @@ class PlanTier:
     ``features`` is a copy of the tier's ``PLAN_FEATURES`` set (the source of
     truth), so a caller can read it without reaching into the policy module.
     ``monthly_credit_allotment`` is integer credits (1 credit == $0.01) granted
-    per renewal — a BACK-OFFICE field, NOT the headline. ``dodo_product_id`` is
-    the recurring-product id, or None until BC-7 / config populates it.
+    per renewal — a BACK-OFFICE field, NOT the headline. ``monthly_ceiling`` is
+    the per-plan monthly credit CAP (integer credits, or None = uncapped) that
+    credit-quota enforcement caps spend against (allotment × 1.5 for paid tiers;
+    Free is the explicit 1000 trial cap; Enterprise is None). ``dodo_product_id``
+    is the recurring-product id, or None until BC-7 / config populates it.
 
     The display + price fields are what the billing UI renders: ``display_name``
     ("Paw Pro"), ``usage_label`` (the ChatGPT/Claude-style "5x the usage" headline
@@ -154,6 +196,7 @@ class PlanTier:
 
     key: str
     monthly_credit_allotment: int
+    monthly_ceiling: int | None
     dodo_product_id: str | None
     features: frozenset[str]
     display_name: str
@@ -195,12 +238,15 @@ def _build(key: str) -> PlanTier:
     from ``_PLAN_DISPLAY`` (a missing row degrades to ``_DISPLAY_FALLBACK`` rather
     than NPE-ing). An unknown ``key`` yields an empty feature set and a 0
     allotment — but callers go through ``get_plan`` / ``list_plans``, which only
-    ever pass known keys.
+    ever pass known keys. ``monthly_ceiling`` FAILS CLOSED: an unknown key defaults
+    to the Free ceiling (the trial cap), never None/uncapped.
     """
     display = _PLAN_DISPLAY.get(key, _DISPLAY_FALLBACK)
     return PlanTier(
         key=key,
         monthly_credit_allotment=_MONTHLY_CREDIT_ALLOTMENT.get(key, 0),
+        # Fail closed: an unknown key caps at the Free ceiling, never uncapped.
+        monthly_ceiling=_CEILING.get(key, _CEILING["free"]),
         dodo_product_id=_dodo_product_for(key),
         features=frozenset(PLAN_FEATURES.get(key, set())),
         display_name=str(display["display_name"]),

--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -5,6 +5,17 @@ message, submitting a ``Run`` to the configured executor, and tailing the
 run's Redis Stream so durability sits underneath the wire shape the
 frontend already speaks.
 
+Changes: 2026-06-30 (feat/billing-quota-enforcement, chunk 3) — the run-start
+credit gate now also enforces the MONTHLY QUOTA. Beside the existing BC-4
+``check_balance`` call (inside the same ``if get_settings().billing_enforced:``
+block, before ``create_run``/submit), ``post_agent_chat`` now also
+``await credits_service.check_quota(workspace_id)`` so a workspace that has spent
+up to its monthly ceiling gets a clean 402 ``credits.quota_exceeded`` with NO DB
+trace — the same universal cap the executor enforces in
+``run_core.execute_run``, mirrored here for the synchronous HTTP path.
+``check_balance`` is unchanged and stays FIRST (balance <= 0 is the secondary
+guard). Both are no-ops when the flag is OFF.
+
 Changes: 2026-06-25 (fix/worker-trusts-spec-workspace) — ``post_agent_chat``
 threads the authenticated ``workspace_id`` into ``resolve_scope_context`` via
 ``expected_workspace_id``, matching the run worker. The HTTP route already
@@ -163,19 +174,31 @@ async def post_agent_chat(
     except InvalidScope:
         raise CloudError(400, "scope.invalid", "Invalid scope") from None
 
-    # BC-4 run-start hard-block. Sit the credit gate at the SINGLE run-start
-    # chokepoint — BEFORE any DB write (no user message, no ChatRunDoc) and
-    # BEFORE the executor submit — so a blocked run leaves no trace and
-    # IN-FLIGHT runs (already past this point) are never killed. Flag-gated:
-    # OFF by default (OSS / self-host run no ledger), ON for the cloud via
-    # ``POCKETPAW_BILLING_ENFORCED``. ``check_balance`` raises
-    # ``InsufficientCredits`` (402, credits.insufficient), which the CloudError
-    # handler maps to the wire — we never raise HTTPException here. Imported
-    # locally to keep the credits package off this hot module's import graph.
+    # BC-4 run-start hard-block + chunk-3 monthly-quota fast-reject. Sit BOTH
+    # credit gates at the SINGLE run-start chokepoint — BEFORE any DB write (no
+    # user message, no ChatRunDoc) and BEFORE the executor submit — so a blocked
+    # run leaves no trace and IN-FLIGHT runs (already past this point) are never
+    # killed. Flag-gated: OFF by default (OSS / self-host run no ledger), ON for
+    # the cloud via ``POCKETPAW_BILLING_ENFORCED``. We never raise HTTPException
+    # here; both gates raise a ``CloudError`` the handler maps to the 402 wire.
+    # The credits package is imported locally to keep it off this hot module's
+    # import graph.
+    #
+    #   * ``check_balance`` (BC-4) — the wallet is empty (balance <= 0): raises
+    #     ``InsufficientCredits`` (402, credits.insufficient). The SECONDARY
+    #     guard; stays first and unchanged.
+    #   * ``check_quota`` (chunk 3) — the wallet may still hold credits but the
+    #     workspace has spent up to its monthly ceiling (plan cap + period
+    #     top-ups): raises ``QuotaExceeded`` (402, credits.quota_exceeded). This
+    #     is the universal monthly cap; the same assertion the run-start gate in
+    #     ``run_core.execute_run`` enforces, mirrored here so the synchronous
+    #     chat HTTP path returns a clean 402 with no DB trace instead of starting
+    #     a run that the executor would only reject afterward.
     if get_settings().billing_enforced:
         from pocketpaw_ee.cloud.credits import service as credits_service
 
         await credits_service.check_balance(workspace_id)
+        await credits_service.check_quota(workspace_id)
 
     transport = get_stream_transport()
     # Resolve the surface-aware context preamble AFTER scope is resolved

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -39,6 +39,20 @@ Changes:
   materializes a per-run skills dir that is cleaned at backend ``cleanup()``, not
   at the supervisor's per-leased-client teardown — a benign retention gap, no run
   correctness impact; the clean fix spans the WH-1/WH-2 surface.)
+- 2026-06-30 (feat/billing-quota-enforcement, chunk 3) — ``execute_run`` now
+  enforces the UNIVERSAL monthly-credit-quota gate at run-start. A new
+  ``_reject_if_over_credit_quota`` helper (the credit-spend sibling of the ART-3
+  ``_reject_if_over_jail_quota``) is called right AFTER the jail-quota gate —
+  after ``resolve_scope_context`` validates ``ctx.workspace_id`` and BEFORE the
+  prewarm / mark-running / agent spin-up. It is flag-gated on
+  ``get_settings().billing_enforced`` (a no-op otherwise — OSS / self-host),
+  calls ``credits.service.check_quota`` (the pure, flag-free assertion), and on
+  ``QuotaExceeded`` rejects the run the SAME clean way the jail-quota reject
+  does: a terminal ``error`` stream frame (``code=credits.quota_exceeded``) +
+  ``mark_terminal(failed)`` + an early return WITHOUT invoking the agent (no
+  model call — the no-overspend money guarantee). This is the universal cap that
+  covers the worker/executor path; the chat HTTP route ALSO fast-rejects in
+  ``agent_router`` so its synchronous caller gets a clean 402 with no DB trace.
 - 2026-06-30 (feat/session-supervisor SS-5) — ``_drive_agent_loop`` now drives
   every supervised agent turn through the ``SessionSupervisor`` + the durable
   ``(workspace, session, agent) -> cli_session_id`` mapping (SS-3
@@ -201,6 +215,7 @@ from pocketpaw.agents.pool import (  # type: ignore[import-untyped]
 from pocketpaw.agents.session_supervisor import (  # type: ignore[import-untyped]
     get_session_supervisor,
 )
+from pocketpaw.config import get_settings  # type: ignore[import-untyped]
 from pocketpaw_ee.cloud._core.realtime import xproc
 from pocketpaw_ee.cloud.agent_sessions import runtime_service
 from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore
@@ -1442,6 +1457,61 @@ async def _reject_if_over_jail_quota(spec: RunSpec, ctx: ScopeContext, transport
     return True
 
 
+async def _reject_if_over_credit_quota(spec: RunSpec, ctx: ScopeContext, transport: Any) -> bool:
+    """Universal monthly-CREDIT-QUOTA gate, enforced at RUN-START (chunk 3).
+
+    The credit-spend sibling of ``_reject_if_over_jail_quota`` (ART-3): measure
+    the workspace's month-to-date spend against its effective monthly ceiling
+    ONCE here — before any model/agent work — and reject the run CLEANLY when it
+    has hit the cap, the SAME way the jail-quota reject does (a terminal ``error``
+    stream frame + a ``mark_terminal(failed)`` doc, then an early return — never
+    a model call). This is the universal gate: it covers EVERY run-start path
+    (the synchronous chat HTTP route also fast-rejects in ``agent_router`` so its
+    caller gets a clean 402 with no DB trace, but the worker/executor path only
+    passes through HERE, so this is the one that guarantees a queued/resumed run
+    can't spend past the ceiling).
+
+    Flag-gated: a no-op unless ``get_settings().billing_enforced`` is on (OSS /
+    self-host run no ledger). ``credits.service.check_quota`` is the pure,
+    flag-free assertion — it raises ``QuotaExceeded`` (402 ``credits.quota_exceeded``)
+    when month-to-date spend ``>=`` the effective ceiling, and is itself a no-op
+    for an uncapped (Enterprise) plan. We catch that exception here and translate
+    it into the clean terminal rejection. Returns ``True`` when the run was
+    rejected (the caller returns early), ``False`` to proceed. The credits package
+    is imported locally to keep it off this hot module's import graph (mirrors
+    the BC-4 chat-router gate).
+    """
+    if not get_settings().billing_enforced:
+        return False
+
+    from pocketpaw_ee.cloud._core.errors import QuotaExceeded
+    from pocketpaw_ee.cloud.credits import service as credits_service
+
+    try:
+        await credits_service.check_quota(ctx.workspace_id)
+        return False
+    except QuotaExceeded as exc:
+        quota_error = str(exc)
+        logger.warning(
+            "run %s rejected — monthly credit quota exceeded: %s", spec.run_id, quota_error
+        )
+        try:
+            await transport.append_event(
+                spec.run_id, "error", {"code": exc.code, "message": quota_error}
+            )
+        except Exception:
+            logger.debug("quota error frame append failed for %s", spec.run_id, exc_info=True)
+        try:
+            await run_service.mark_terminal(spec.run_id, status="failed", error=quota_error)
+        except Exception:
+            logger.exception("mark_terminal(failed) failed for over-quota run %s", spec.run_id)
+        try:
+            await transport.set_ttl(spec.run_id, _stream_ttl())
+        except Exception:
+            logger.debug("quota stream ttl set failed for %s", spec.run_id, exc_info=True)
+        return True
+
+
 async def execute_run(spec: RunSpec) -> None:
     """Run the agent for ``spec`` and write every event to the transport.
 
@@ -1525,6 +1595,19 @@ async def execute_run(spec: RunSpec) -> None:
     # prewarm + mark-running + agent spin-up, so a tenant that filled its scratch
     # quota fails fast and cleanly instead of crashing the shared box mid-run.
     if await _reject_if_over_jail_quota(spec, ctx, transport):
+        return
+
+    # Chunk 3 — the UNIVERSAL monthly-credit-quota gate. ``ctx.workspace_id`` is
+    # validated/in-scope above (the ``scope.no_workspace`` guard), so check the
+    # workspace's month-to-date spend against its effective ceiling NOW — after
+    # scope resolution, BEFORE the prewarm + mark-running + any model/agent work.
+    # A workspace at/over its cap is rejected the SAME clean way the jail-quota
+    # reject above is (terminal ``error`` frame + ``mark_terminal(failed)``, then
+    # an early return WITHOUT running the agent — the no-overspend money
+    # guarantee). Flag-gated inside the helper: a no-op unless
+    # ``billing_enforced`` is on, so OSS / self-host is unaffected and IN-FLIGHT
+    # runs (already past this point) are never killed.
+    if await _reject_if_over_credit_quota(spec, ctx, transport):
         return
 
     # Mark this dispatch as a live cloud CHAT run for the per-tenant cwd jail's

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -16,6 +16,13 @@
 #   * ``check_balance`` — raise ``InsufficientCredits`` when the wallet is
 #                     out of credits (balance <= 0). The pure, flag-free
 #                     assertion behind BC-4's run-start hard-block.
+#   * ``month_to_date_spend`` — server-side ``$sum`` of this UTC month's APPLIED
+#                     spend debits (compute_spend + litellm_spend). The read the
+#                     monthly-quota gate compares against.
+#   * ``check_quota`` — raise ``QuotaExceeded`` (402) when month-to-date spend
+#                     meets the workspace's effective monthly ceiling (plan
+#                     ceiling + purchased top-ups this period). Pure + flag-free,
+#                     mirroring ``check_balance``; a no-op for an uncapped plan.
 #   * ``history``   — page the append-only ledger, newest first.
 #   * ``reconcile`` — recompute ``balance == sum(amount_delta)`` and repair the
 #                     CreditBalance doc if it drifted (covers a crash between
@@ -123,6 +130,23 @@
 # must not read ``CreditLedgerEntry`` itself, so this owns the read (sibling to
 # ``sum_debits_by_cause``). It performs NO writes and changes NOTHING that is
 # charged — a pure re-source of the display.
+# Changed 2026-06-30 (feat/billing-quota-enforcement, chunk 2): added the monthly
+# credit-QUOTA reads + assertion. ``month_to_date_spend`` sums this UTC calendar
+# month's APPLIED spend debits (compute_spend + litellm_spend, the same two
+# ``spend_by_model`` reads) via a SERVER-SIDE Mongo ``$match`` + ``$group`` (not
+# pull-all-then-sum) — iterated with ``async for`` because the mongomock-motor
+# test harness cannot ``await`` a latent command cursor (Beanie's
+# ``aggregate().to_list()`` raises there), so async-iteration is the call style
+# that runs the aggregation in both real Mongo and tests. ``check_quota`` is the
+# pure, flag-free monthly-cap assertion (the credit-spend sibling of
+# ``check_balance``): it resolves the plan ``monthly_ceiling`` via
+# ``entitlements.resolve_entitlements`` (no-op when None/uncapped), adds the
+# PURCHASED top-ups granted this period (``cause="top_up"`` only — the recurring
+# ``subscription_grant`` allotment is the ceiling's own baseline and is NOT
+# counted, which would otherwise double-credit the cap), and raises
+# ``QuotaExceeded`` (402 ``credits.quota_exceeded``) when month-to-date spend is
+# ``>=`` that effective ceiling. Reads only; charges nothing. Chunk 3 wires the
+# gate at run-start — this chunk owns only the reusable read + assertion.
 
 from __future__ import annotations
 
@@ -134,7 +158,11 @@ from beanie import PydanticObjectId
 from pymongo import ReturnDocument
 from pymongo.errors import DuplicateKeyError
 
-from pocketpaw_ee.cloud._core.errors import InsufficientCredits, ValidationError
+from pocketpaw_ee.cloud._core.errors import (
+    InsufficientCredits,
+    QuotaExceeded,
+    ValidationError,
+)
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import CreditMovement
 from pocketpaw_ee.cloud.credits.domain import GrantResult, LedgerEntry, ModelSpendRow
@@ -408,6 +436,82 @@ async def check_balance(workspace: str) -> None:
         raise InsufficientCredits(1, max(bal, 0))
 
 
+# The grant cause that EXTENDS the monthly ceiling — a PURCHASED one-time top-up
+# (``billing.service.handle_webhook`` records ``payment.succeeded`` as
+# ``cause="top_up"``, a positive grant). It is the only cause that raises the cap:
+# a top-up is credits the workspace bought ON TOP of its plan, so its monthly cap
+# rises by what it purchased this period. The RECURRING monthly allotment is
+# recorded under a DIFFERENT cause (``subscription_grant``, in
+# ``_handle_subscription_event``) and is deliberately NOT here — the allotment is
+# the baseline the plan ``monthly_ceiling`` already accounts for (the ceiling is
+# allotment × 1.5 for paid tiers), so counting it would double-credit the cap.
+_TOPUP_CAUSE = "top_up"
+
+
+async def _period_topup_credits(workspace: str) -> int:
+    """Sum of PURCHASED top-up credits granted to ``workspace`` this UTC month.
+
+    The amount the effective monthly ceiling is raised by: the POSITIVE
+    ``amount_delta`` summed over the APPLIED ``top_up`` grants with
+    ``createdAt >= start-of-current-UTC-month``. Only ``top_up`` (a bought
+    extension) counts — NOT ``subscription_grant`` (the recurring allotment, which
+    is the plan ceiling's own baseline). Runs server-side ``$match`` + ``$group``,
+    same as ``month_to_date_spend``. A top-up grant's ``amount_delta`` is positive,
+    so the grouped sum is ``>= 0``; a (should-never-happen) net-negative under the
+    top-up cause is clamped to 0 so a stray debit can't SHRINK the ceiling.
+    """
+    month_start = _utc_month_start(datetime.now(UTC))
+    query: dict[str, Any] = {
+        "workspace": workspace,
+        "cause": _TOPUP_CAUSE,
+        "applied": True,
+        "createdAt": {"$gte": month_start},
+    }
+    net = await _sum_amount_delta(query)
+    return max(net, 0)
+
+
+async def check_quota(workspace: str) -> None:
+    """Raise ``QuotaExceeded`` when the workspace has hit its monthly credit cap.
+
+    The monthly-quota assertion, the credit-spend sibling of ``check_balance``: a
+    PURE, flag-free read (it carries NO ``billing_enforced`` logic so the caller
+    owns the on/off decision and the check stays reusable by any future gate).
+
+    Resolves the workspace's plan ``monthly_ceiling``
+    (``entitlements.resolve_entitlements``). An UNCAPPED plan (Enterprise →
+    ceiling is ``None``) is a no-op. Otherwise the EFFECTIVE ceiling is the plan
+    ceiling PLUS any credits the workspace PURCHASED via top-ups this period
+    (``_period_topup_credits``) — a bought top-up raises the cap; the recurring
+    allotment does not (it is already the ceiling's baseline). Raises
+    ``QuotaExceeded`` (402 ``credits.quota_exceeded``) when month-to-date spend is
+    AT or ABOVE the effective ceiling (boundary is ``>=`` — exactly-at-ceiling
+    raises); a no-op below it.
+
+    A workspace with no/unknown plan resolves (via the entitlements resolver) to
+    the Free trial ceiling (1000), so this fails CLOSED — an unresolvable plan is
+    capped, never uncapped.
+    """
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+
+    # Lazy import — keeps this module free of the entitlements/billing import chain
+    # at load (it pulls the plan catalog + workspace service), mirroring how
+    # ``entitlements.service`` itself lazy-imports the workspace service.
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = await entitlements_service.resolve_entitlements(workspace)
+    ceiling = ent.monthly_ceiling
+    # None == uncapped (Enterprise / custom). No cap to enforce — no-op.
+    if ceiling is None:
+        return
+
+    effective_ceiling = ceiling + await _period_topup_credits(workspace)
+    spent = await month_to_date_spend(workspace)
+    if spent >= effective_ceiling:
+        raise QuotaExceeded(ceiling=effective_ceiling, spent=spent)
+
+
 async def is_recorded(workspace: str, idempotency_key: str) -> bool:
     """Whether a movement with this ``(workspace, idempotency_key)`` already exists.
 
@@ -480,6 +584,82 @@ async def sum_debits_by_cause(
     # can't make the spend total read as a refund.
     total = sum(-int(e.amount_delta) for e in entries if int(e.amount_delta) < 0)
     return total, len(entries)
+
+
+# The spend causes that count toward the monthly quota — the SAME two the usage
+# graph reads (``spend_by_model``). ``compute_spend`` is the default off-mode
+# debit a finished run records against the ledger; ``litellm_spend`` is the
+# post-cutover live-proxy debit. They are mutually exclusive per run, so summing
+# both is safe (a given run is billed under exactly one). Grants
+# (``top_up`` / ``subscription_grant`` / ``genesis`` / ``promo``) are NOT spend
+# and never count here.
+_SPEND_CAUSES: tuple[str, ...] = ("compute_spend", "litellm_spend")
+
+
+def _utc_month_start(now: datetime) -> datetime:
+    """Start-of-current-UTC-calendar-month (midnight on the 1st), tz-aware UTC."""
+    return datetime(now.year, now.month, 1, tzinfo=UTC)
+
+
+async def _sum_amount_delta(query: dict[str, Any]) -> int:
+    """Server-side ``$sum`` of ``amount_delta`` over the entries matching ``query``.
+
+    Runs a Mongo ``$match`` + ``$group`` aggregation in the DB (NOT a
+    pull-all-then-sum in Python) and returns the summed ``amount_delta`` (signed),
+    or 0 when nothing matches. We iterate the raw pymongo command cursor with
+    ``async for`` because awaiting it directly (``await coll.aggregate(...)``)
+    raises ``TypeError`` under the mongomock-motor test harness; ``async for`` runs
+    the server-side ``$match`` + ``$group`` in BOTH real Mongo and the harness.
+    (Beanie's ``Document.aggregate(...).to_list()`` also works under the harness
+    and is the form used elsewhere, e.g. ``workspace/service.py`` — either is
+    genuinely DB-side; this module uses the cursor form.)
+    """
+    coll = CreditLedgerEntry.get_pymongo_collection()
+    cursor = coll.aggregate(
+        [
+            {"$match": query},
+            {"$group": {"_id": None, "total": {"$sum": "$amount_delta"}}},
+        ]
+    )
+    async for row in cursor:
+        return int(row.get("total") or 0)
+    return 0
+
+
+async def month_to_date_spend(workspace: str) -> int:
+    """Total credits spent by ``workspace`` this UTC calendar month.
+
+    Returns the POSITIVE credits debited under a SPEND cause
+    (``compute_spend`` / ``litellm_spend``) with ``applied is True`` and
+    ``createdAt >= start-of-current-UTC-month``. Grants (``top_up`` /
+    ``subscription_grant`` / …) are excluded by the cause filter, and a
+    committed-but-unapplied phantom is excluded by ``applied is True`` (it never
+    moved the wallet) — the same windowing / applied discipline as
+    ``sum_debits_by_cause``.
+
+    The sum runs SERVER-SIDE: a Mongo ``$match`` (workspace + spend causes +
+    applied + month window) feeds a ``$group`` ``$sum`` of ``amount_delta``, so a
+    busy tenant's full ledger is never pulled into the process. A debit's
+    ``amount_delta`` is negative, so the grouped sum is ``<= 0``; we flip the sign
+    to a positive "credits spent" figure and CLAMP a (should-never-happen) net
+    positive to 0 — a stray positive delta under a spend cause must not read as
+    negative spend (the same clamp ``sum_debits_by_cause`` applies). The reusable,
+    flag-free read the monthly-quota gate (``check_quota``) compares against.
+    """
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+
+    month_start = _utc_month_start(datetime.now(UTC))
+    query: dict[str, Any] = {
+        "workspace": workspace,
+        "cause": {"$in": list(_SPEND_CAUSES)},
+        "applied": True,
+        "createdAt": {"$gte": month_start},
+    }
+    # ``amount_delta`` is negative for a debit, so the grouped sum is <= 0. Flip to
+    # positive credits spent; clamp a stray net-positive to 0 (spend is debit-only).
+    net = await _sum_amount_delta(query)
+    return max(-net, 0)
 
 
 async def spend_by_model(
@@ -756,10 +936,12 @@ __all__ = [
     "ModelSpendRow",
     "balance",
     "check_balance",
+    "check_quota",
     "debit",
     "grant",
     "history",
     "is_recorded",
+    "month_to_date_spend",
     "reconcile",
     "spend_by_model",
     "sum_debits_by_cause",

--- a/ee/pocketpaw_ee/cloud/entitlements/domain.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/domain.py
@@ -3,13 +3,18 @@
 # primitive).
 #
 # ``Entitlements`` is the normalized "what is this workspace entitled to" shape:
-# its resolved plan key, the plan's feature set, and its monthly credit
-# allotment. It carries no framework type (no Beanie, no FastAPI) so the service
-# can build it and the DTO layer can map it without either reaching into the
-# other. It is derived from the EXISTING ``Workspace.plan`` field + the billing
-# plan catalog — there is no event projection here.
+# its resolved plan key, the plan's feature set, its monthly credit allotment, and
+# its monthly credit ceiling (the quota cap). It carries no framework type (no
+# Beanie, no FastAPI) so the service can build it and the DTO layer can map it
+# without either reaching into the other. It is derived from the EXISTING
+# ``Workspace.plan`` field + the billing plan catalog — there is no event
+# projection here.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-6): new entity.
+# Updated 2026-06-30 (feat/billing-quota-enforcement, chunk 1): added
+#   ``monthly_ceiling: int | None`` next to ``monthly_credit_allotment`` — the
+#   per-plan monthly credit CAP (None = uncapped) the resolver populates from the
+#   plan catalog and later quota chunks enforce against.
 
 from __future__ import annotations
 
@@ -25,10 +30,14 @@ class Entitlements:
     ``free`` tier). ``features`` is that tier's feature set (the same set
     ``PLAN_FEATURES`` and the policy gate use — one source of truth).
     ``monthly_credit_allotment`` is integer credits (1 credit == $0.01) granted
-    per renewal for the tier.
+    per renewal for the tier. ``monthly_ceiling`` is the per-plan monthly credit
+    CAP (integer credits, or None = uncapped) credit-quota enforcement caps spend
+    against; a workspace with no/unknown plan resolves to the Free ceiling (the
+    fail-closed trial cap), never None/uncapped.
     """
 
     workspace_id: str
     plan: str
     monthly_credit_allotment: int
+    monthly_ceiling: int | None
     features: frozenset[str] = field(default_factory=frozenset)

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -6,7 +6,7 @@
 #   * ``resolve_entitlements(workspace_id)`` — read the workspace's CURRENT plan
 #     (``workspace.service.get_workspace_plan``), look it up in the billing plan
 #     catalog (``billing.plans``), and return an ``Entitlements`` (plan +
-#     features + monthly credit allotment).
+#     features + monthly credit allotment + monthly credit ceiling).
 #
 # READ-ONLY: no writes, no emit (EE cloud rule 9 only fires on mutation; this
 # entity mutates nothing). Tenancy: ``get_workspace_plan`` resolves the plan from
@@ -16,11 +16,17 @@
 #
 # FALLBACK: a workspace with no plan, an unknown plan string, or a missing
 # workspace resolves to the ``free`` base tier (``plans.BASE_PLAN_KEY``) — never
-# a crash, never a silent upgrade to a paid tier. (Subscription EVENTS that
-# CHANGE the plan are BC-7's job; here entitlements derive from the existing
-# ``Workspace.plan`` field as it stands.)
+# a crash, never a silent upgrade to a paid tier. The Free tier carries the
+# explicit 1000 credit ceiling, so the fallback also fails closed on the quota cap
+# (never None/uncapped). (Subscription EVENTS that CHANGE the plan are BC-7's job;
+# here entitlements derive from the existing ``Workspace.plan`` field as it stands.)
 #
 # Created 2026-06-24 (integration/billing-credits, BC-6): new entity.
+# Updated 2026-06-30 (feat/billing-quota-enforcement, chunk 1): ``Entitlements``
+#   now also carries ``monthly_ceiling`` — populated from the resolved tier's
+#   ``monthly_ceiling`` exactly as ``monthly_credit_allotment`` is. The defensive
+#   base-floor branch sets the Free trial ceiling (1000), so every path fails
+#   closed and no path leaves the cap uncapped.
 
 from __future__ import annotations
 
@@ -61,6 +67,9 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
                 workspace_id=workspace_id,
                 plan=plan_catalog.BASE_PLAN_KEY,
                 monthly_credit_allotment=0,
+                # Fail closed: the Free trial cap, never None/uncapped — even when
+                # the catalog itself is somehow missing the base tier.
+                monthly_ceiling=1_000,
                 features=frozenset(),
             )
 
@@ -68,5 +77,6 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
         workspace_id=workspace_id,
         plan=tier.key,
         monthly_credit_allotment=tier.monthly_credit_allotment,
+        monthly_ceiling=tier.monthly_ceiling,
         features=tier.features,
     )

--- a/ee/pocketpaw_ee/cloud/models/credit.py
+++ b/ee/pocketpaw_ee/cloud/models/credit.py
@@ -37,6 +37,12 @@
 # invariant: the balance MAY go slightly negative from metered compute overage
 # (BC-3) — the no-overdraft guarantee is enforced at run-start, not by clamping
 # the balance to >= 0 here.
+# Changed 2026-06-30 (feat/billing-quota-enforcement, chunk 2): added a second
+# ``CreditLedgerEntry`` index ``ix_workspace_created_at`` on
+# ``(workspace, createdAt)``. The monthly-quota read (``month_to_date_spend``)
+# and the sibling windowed reads (``sum_debits_by_cause`` / ``spend_by_model``)
+# all ``$match`` on ``workspace`` + a ``createdAt`` range; this compound index
+# keeps that scan off the full per-tenant ledger.
 
 from __future__ import annotations
 
@@ -138,5 +144,15 @@ class CreditLedgerEntry(TimestampedDocument):
                 [("workspace", 1), ("idempotency_key", 1)],
                 unique=True,
                 name="uq_workspace_idempotency_key",
+            ),
+            # Windowed-read index. ``month_to_date_spend`` /
+            # ``sum_debits_by_cause`` / ``spend_by_model`` all filter the ledger by
+            # ``workspace`` + a ``createdAt`` range (and group/sum server-side). This
+            # compound index serves that ``$match`` (workspace equality + createdAt
+            # range scan) so the monthly-quota aggregation never collection-scans a
+            # busy tenant's full ledger.
+            IndexModel(
+                [("workspace", 1), ("createdAt", 1)],
+                name="ix_workspace_created_at",
             ),
         ]

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -21,6 +21,14 @@ Changes:
     deep_work_verify_* pair at the ee/cloud planner terminal
     (``_execute_ready_plan_tasks`` → ``_run_one``). Env:
     POCKETPAW_CLOUD_PLAN_VERIFY_* .
+  - 2026-06-30 (feat/billing-quota-enforcement, chunk 4): Expanded the
+    ``billing_enforced`` field docstring — when the flag is on the run-start 402
+    hard-block now covers TWO conditions (was: balance <= 0 only): balance <= 0
+    (credits.insufficient) AND month-to-date spend >= the per-plan monthly credit
+    ceiling (credits.quota_exceeded), enforced at run start across both the chat
+    HTTP path and the worker/executor. No logic change — the gate was wired in
+    chunk 3; this only documents it. Kept the "default False -> OSS/self-host
+    unaffected" note.
   - 2026-06-28 (AW-7 template gate deny-on-no-match): Added
     ``instinct_template_default_deny`` (default False, env
     POCKETPAW_INSTINCT_TEMPLATE_DEFAULT_DENY) — the host-wide default for the
@@ -1799,12 +1807,18 @@ class Settings(BaseSettings):
     billing_enforced: bool = Field(
         default=False,
         description=(
-            "Run-start hard-block (BC-4). When True, STARTING a new chat run on a "
-            "workspace whose credit balance is <= 0 is rejected with HTTP 402 "
-            "(credits.insufficient) BEFORE any run row is written; in-flight runs "
-            "are never killed. Default False so OSS / self-host deployments (which "
-            "run no credit ledger) are unaffected; the cloud turns it on via "
-            "POCKETPAW_BILLING_ENFORCED."
+            "Run-start hard-block (BC-4). When True, STARTING a new chat run is "
+            "rejected with HTTP 402 BEFORE any run row is written, on two "
+            "conditions, both gated by this flag and both enforced at run start "
+            "across the synchronous chat HTTP path (chat/agent_router) AND the "
+            "worker/executor path (chat/runs/run_core.execute_run): (1) the "
+            "workspace credit balance is <= 0 -> 402 credits.insufficient; (2) the "
+            "workspace has hit its monthly credit CEILING (per-plan cap from the "
+            "catalog plus any top-ups bought this period; month-to-date spend >= "
+            "that ceiling) -> 402 credits.quota_exceeded. In-flight runs are never "
+            "killed. Default False so OSS / self-host deployments (which run no "
+            "credit ledger) are unaffected; the cloud / subscription (PEE) "
+            "deployments turn it on via POCKETPAW_BILLING_ENFORCED."
         ),
     )
 

--- a/tests/cloud/billing/test_plans.py
+++ b/tests/cloud/billing/test_plans.py
@@ -17,6 +17,11 @@
 #   (0/1500/7500/30000/1_000_000); added coverage for the new user-facing display +
 #   price fields (display_name, usage_label, usage_detail, INR/USD prices) the
 #   billing UI renders instead of raw credits.
+# Updated 2026-06-30 (feat/billing-quota-enforcement, chunk 1): added coverage for
+#   the per-plan ``monthly_ceiling`` (the credit-quota cap later chunks enforce):
+#   each tier carries the approved ceiling (free=1000 explicit trial, go/pro/pro_max
+#   = allotment × 1.5, enterprise=None uncapped), and an unknown key built directly
+#   FAILS CLOSED to the Free ceiling (never None/uncapped).
 
 from __future__ import annotations
 
@@ -36,6 +41,16 @@ EXPECTED_ALLOTMENTS = {
     "pro": 7_500,
     "pro_max": 30_000,
     "enterprise": 1_000_000,
+}
+# The per-plan monthly credit CEILING (the cap later chunks enforce). The rule is
+# allotment × 1.5 for the paid usage tiers; Free is an explicit trial cap (its
+# allotment is 0, so ×1.5 can't derive it); Enterprise is uncapped (None).
+EXPECTED_CEILINGS: dict[str, int | None] = {
+    "free": 1_000,
+    "go": 2_250,
+    "pro": 11_250,
+    "pro_max": 45_000,
+    "enterprise": None,
 }
 # The user-facing usage labels the UI shows INSTEAD of raw credits.
 EXPECTED_USAGE_LABELS = {
@@ -83,6 +98,48 @@ def test_list_plans_allotments_are_the_exact_ladder():
     by_key = {p.key: p for p in plans.list_plans()}
     for key, expected in EXPECTED_ALLOTMENTS.items():
         assert by_key[key].monthly_credit_allotment == expected, key
+
+
+def test_list_plans_ceilings_are_the_exact_ladder():
+    """Each tier carries the approved monthly_ceiling, incl. enterprise=None.
+
+    free=1000 (explicit trial cap), go/pro/pro_max = allotment × 1.5, enterprise
+    uncapped (None). This is the cap later chunks enforce against the wallet.
+    """
+    by_key = {p.key: p for p in plans.list_plans()}
+    for key, expected in EXPECTED_CEILINGS.items():
+        assert by_key[key].monthly_ceiling == expected, key
+
+
+def test_paid_tier_ceilings_are_allotment_times_one_point_five():
+    """The go/pro/pro_max ceilings are exactly 1.5× their allotment (the rule)."""
+    by_key = {p.key: p for p in plans.list_plans()}
+    for key in ("go", "pro", "pro_max"):
+        assert by_key[key].monthly_ceiling == int(by_key[key].monthly_credit_allotment * 1.5), key
+
+
+def test_enterprise_ceiling_is_uncapped():
+    """Enterprise is the one uncapped tier — its ceiling is None, never a number."""
+    assert plans.get_plan("enterprise").monthly_ceiling is None
+
+
+def test_free_ceiling_is_the_explicit_trial_cap():
+    """Free's ceiling is the explicit 1000 trial cap (its 0 allotment can't derive it)."""
+    free = plans.get_plan("free")
+    assert free.monthly_credit_allotment == 0
+    assert free.monthly_ceiling == 1_000
+
+
+def test_build_unknown_key_fails_closed_to_free_ceiling():
+    """An unknown key built directly never yields None/uncapped — it caps at Free.
+
+    Callers reach the catalog via get_plan/list_plans (known keys only), but the
+    ceiling default is the fail-closed floor regardless: a stray key must NOT
+    produce an uncapped (None) ceiling.
+    """
+    bogus = plans._build("definitely_not_a_tier")
+    assert bogus.monthly_ceiling == EXPECTED_CEILINGS["free"]
+    assert bogus.monthly_ceiling is not None
 
 
 def test_list_plans_is_cheapest_first():

--- a/tests/cloud/credits/test_enforcement.py
+++ b/tests/cloud/credits/test_enforcement.py
@@ -20,6 +20,12 @@
 # ``check_quota`` chat fast-reject cases (5-7). They fund the wallet so the
 # ``check_balance`` guard is a no-op, then stub ``credits_service.check_quota``
 # to isolate the quota wiring (the chunk-2 quota math is owned by test_quota.py).
+# Changed 2026-06-30 (feat/billing-quota-enforcement, chunk 4): added case 8 —
+# with the flag OFF, the WHOLE pre-flight is skipped: BOTH ``check_balance`` and
+# ``check_quota`` (which live side-by-side in this one chat chokepoint) are never
+# called, even at balance 0. Cases 3 and 7 each assert ONE half; this locks that
+# the single ``if billing_enforced:`` guard gates the entire pre-flight, not just
+# the quota leg.
 
 from __future__ import annotations
 
@@ -401,5 +407,62 @@ async def test_not_enforced_never_calls_check_quota(
 
     assert resp.status_code == 200
     assert quota_calls == []  # the flag-off path never gates
+    assert len(submitted) == 1
+    assert await ChatRunDoc.find_all().count() == 1
+
+
+# ---------------------------------------------------------------------------
+# 8 — NOT enforced -> the WHOLE pre-flight is a no-op: NEITHER check_balance NOR
+#     check_quota is called, even at balance 0.
+#
+# The chat router is the one chokepoint where both credit gates sit side-by-side
+# under a single ``if billing_enforced:``. Case 3 proves balance isn't gated and
+# case 7 proves quota isn't gated; this asserts the guard skips the ENTIRE
+# pre-flight at once (both calls), so a future edit that moves either gate outside
+# the flag would fail here.
+# ---------------------------------------------------------------------------
+
+
+async def test_not_enforced_skips_entire_preflight(
+    cloud_app_client: AsyncClient,
+    mongo_db,  # noqa: ARG001 — forces Beanie init so create_run can persist
+    monkeypatch,
+):
+    from pocketpaw_ee.cloud.chat import agent_router as mod
+    from pocketpaw_ee.cloud.credits import service as credits_service
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    calls: list[str] = []
+
+    async def _balance_should_not_run(workspace_id):
+        calls.append(f"balance:{workspace_id}")
+        raise AssertionError("check_balance must NOT be called when the flag is OFF")
+
+    async def _quota_should_not_run(workspace_id):
+        calls.append(f"quota:{workspace_id}")
+        raise AssertionError("check_quota must NOT be called when the flag is OFF")
+
+    monkeypatch.setattr(credits_service, "check_balance", _balance_should_not_run)
+    monkeypatch.setattr(credits_service, "check_quota", _quota_should_not_run)
+
+    # Flag OFF, wallet empty (balance 0) — neither gate may fire.
+    _enforce(monkeypatch, mod, on=False)
+    submitted, _FakeExecutor = _patch_run_internals(mod)
+    monkeypatch.setattr(mod, "get_executor", lambda: _FakeExecutor())
+    monkeypatch.setattr(mod, "get_stream_transport", lambda: _StubTransport())
+
+    with (
+        patch.object(mod, "resolve_scope_context", _fake_resolve),
+        patch.object(mod, "load_history_for_scope", _fake_load_history),
+        patch.object(mod, "_persist_user_message", _fake_persist_user_message),
+        patch.object(mod, "_ensure_scope_session", _fake_ensure_session),
+    ):
+        resp = await cloud_app_client.post(
+            "/cloud/chat/session/s1/agent",
+            json={"content": "hello", "client_message_id": "cq4"},
+        )
+
+    assert resp.status_code == 200
+    assert calls == []  # the entire pre-flight (balance AND quota) was skipped
     assert len(submitted) == 1
     assert await ChatRunDoc.find_all().count() == 1

--- a/tests/cloud/credits/test_enforcement.py
+++ b/tests/cloud/credits/test_enforcement.py
@@ -1,6 +1,7 @@
-# tests/cloud/credits/test_enforcement.py — BC-4 run-start hard-block.
+# tests/cloud/credits/test_enforcement.py — BC-4 run-start hard-block +
+# the chunk-3 monthly-quota fast-reject (feat/billing-quota-enforcement).
 #
-# Proves the credit gate at the SINGLE chat run-start chokepoint
+# Proves the credit gates at the SINGLE chat run-start chokepoint
 # (chat/agent_router.py::post_agent_chat):
 #   1. billing_enforced=True + balance 0  -> POST returns 402 credits.insufficient
 #      and NO ChatRunDoc is created (the gate runs before create_run/submit).
@@ -8,8 +9,17 @@
 #   3. billing_enforced=False (default)   -> never gates, even at balance 0.
 #   4. credits.service.check_balance raises InsufficientCredits at balance <= 0
 #      and is a no-op at balance > 0 (unit level).
+#   5. billing_enforced=True + over monthly QUOTA (balance still > 0) -> POST
+#      returns 402 credits.quota_exceeded and NO ChatRunDoc is created — the
+#      ``check_quota`` fast-reject sits beside ``check_balance`` (chunk 3).
+#   6. billing_enforced=True + under quota -> proceeds past the gate.
+#   7. billing_enforced=False -> the quota gate never fires either.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-4).
+# Changed 2026-06-30 (feat/billing-quota-enforcement, chunk 3): added the
+# ``check_quota`` chat fast-reject cases (5-7). They fund the wallet so the
+# ``check_balance`` guard is a no-op, then stub ``credits_service.check_quota``
+# to isolate the quota wiring (the chunk-2 quota math is owned by test_quota.py).
 
 from __future__ import annotations
 
@@ -252,3 +262,144 @@ async def test_check_balance_noop_when_positive(mongo_db):  # noqa: ARG001 — B
     await credits_service.grant("w-funded", 5, cause="seed", idempotency_key="g1")
     # No exception -> returns None.
     assert await credits_service.check_balance("w-funded") is None
+
+
+# ---------------------------------------------------------------------------
+# 5 — enforced + OVER monthly quota (wallet still funded) -> 402
+#     credits.quota_exceeded and NO ChatRunDoc created.
+#
+# ``check_balance`` runs FIRST and must pass (the wallet is funded), then the
+# new ``check_quota`` fast-reject fires. We stub ``check_quota`` to raise so the
+# test isolates the chunk-3 WIRING (the quota math lives in test_quota.py).
+# ---------------------------------------------------------------------------
+
+
+async def test_enforced_over_quota_blocks_with_402_and_creates_no_run(
+    cloud_app_client: AsyncClient,
+    mongo_db,  # noqa: ARG001 — forces Beanie init
+    monkeypatch,
+):
+    from pocketpaw_ee.cloud._core.errors import QuotaExceeded
+    from pocketpaw_ee.cloud.chat import agent_router as mod
+    from pocketpaw_ee.cloud.credits import service as credits_service
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    # Fund w1 so the balance guard is a no-op and we reach the quota gate.
+    await credits_service.grant("w1", 100, cause="test.seed", idempotency_key="seed-q1")
+
+    async def _over_quota(workspace_id):
+        raise QuotaExceeded(ceiling=1000, spent=1000)
+
+    monkeypatch.setattr(credits_service, "check_quota", _over_quota)
+
+    _enforce(monkeypatch, mod, on=True)
+    submitted, _FakeExecutor = _patch_run_internals(mod)
+    monkeypatch.setattr(mod, "get_executor", lambda: _FakeExecutor())
+    monkeypatch.setattr(mod, "get_stream_transport", lambda: _StubTransport())
+
+    with (
+        patch.object(mod, "resolve_scope_context", _fake_resolve),
+        patch.object(mod, "load_history_for_scope", _fake_load_history),
+        patch.object(mod, "_persist_user_message", _fake_persist_user_message),
+        patch.object(mod, "_ensure_scope_session", _fake_ensure_session),
+    ):
+        resp = await cloud_app_client.post(
+            "/cloud/chat/session/s1/agent",
+            json={"content": "hello", "client_message_id": "cq1"},
+        )
+
+    assert resp.status_code == 402
+    assert resp.json()["error"]["code"] == "credits.quota_exceeded"
+    # The gate ran before create_run / submit: no run reached the executor and
+    # no ChatRunDoc was written (clean fast-reject, no DB trace).
+    assert submitted == []
+    assert await ChatRunDoc.find_all().count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 6 — enforced + UNDER quota -> proceeds past the gate (run created/submitted).
+# ---------------------------------------------------------------------------
+
+
+async def test_enforced_under_quota_proceeds(
+    cloud_app_client: AsyncClient,
+    mongo_db,  # noqa: ARG001 — forces Beanie init so create_run can persist
+    monkeypatch,
+):
+    from pocketpaw_ee.cloud.chat import agent_router as mod
+    from pocketpaw_ee.cloud.credits import service as credits_service
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    await credits_service.grant("w1", 100, cause="test.seed", idempotency_key="seed-q2")
+
+    quota_calls: list[str] = []
+
+    async def _under_quota(workspace_id):
+        quota_calls.append(workspace_id)  # no-op (under ceiling)
+
+    monkeypatch.setattr(credits_service, "check_quota", _under_quota)
+
+    _enforce(monkeypatch, mod, on=True)
+    submitted, _FakeExecutor = _patch_run_internals(mod)
+    monkeypatch.setattr(mod, "get_executor", lambda: _FakeExecutor())
+    monkeypatch.setattr(mod, "get_stream_transport", lambda: _StubTransport())
+
+    with (
+        patch.object(mod, "resolve_scope_context", _fake_resolve),
+        patch.object(mod, "load_history_for_scope", _fake_load_history),
+        patch.object(mod, "_persist_user_message", _fake_persist_user_message),
+        patch.object(mod, "_ensure_scope_session", _fake_ensure_session),
+    ):
+        resp = await cloud_app_client.post(
+            "/cloud/chat/session/s1/agent",
+            json={"content": "hello", "client_message_id": "cq2"},
+        )
+
+    assert resp.status_code == 200
+    assert quota_calls == ["w1"]  # the quota gate ran and passed
+    assert len(submitted) == 1
+    assert await ChatRunDoc.find_all().count() == 1
+
+
+# ---------------------------------------------------------------------------
+# 7 — NOT enforced -> the quota gate never fires (check_quota not called).
+# ---------------------------------------------------------------------------
+
+
+async def test_not_enforced_never_calls_check_quota(
+    cloud_app_client: AsyncClient,
+    mongo_db,  # noqa: ARG001 — forces Beanie init so create_run can persist
+    monkeypatch,
+):
+    from pocketpaw_ee.cloud.chat import agent_router as mod
+    from pocketpaw_ee.cloud.credits import service as credits_service
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    quota_calls: list[str] = []
+
+    async def _should_not_run(workspace_id):
+        quota_calls.append(workspace_id)
+        raise AssertionError("check_quota must NOT be called when the flag is OFF")
+
+    monkeypatch.setattr(credits_service, "check_quota", _should_not_run)
+
+    _enforce(monkeypatch, mod, on=False)
+    submitted, _FakeExecutor = _patch_run_internals(mod)
+    monkeypatch.setattr(mod, "get_executor", lambda: _FakeExecutor())
+    monkeypatch.setattr(mod, "get_stream_transport", lambda: _StubTransport())
+
+    with (
+        patch.object(mod, "resolve_scope_context", _fake_resolve),
+        patch.object(mod, "load_history_for_scope", _fake_load_history),
+        patch.object(mod, "_persist_user_message", _fake_persist_user_message),
+        patch.object(mod, "_ensure_scope_session", _fake_ensure_session),
+    ):
+        resp = await cloud_app_client.post(
+            "/cloud/chat/session/s1/agent",
+            json={"content": "hello", "client_message_id": "cq3"},
+        )
+
+    assert resp.status_code == 200
+    assert quota_calls == []  # the flag-off path never gates
+    assert len(submitted) == 1
+    assert await ChatRunDoc.find_all().count() == 1

--- a/tests/cloud/credits/test_quota.py
+++ b/tests/cloud/credits/test_quota.py
@@ -1,0 +1,310 @@
+# tests/cloud/credits/test_quota.py — proves the chunk-2 monthly credit-quota
+# reads + assertion in the BC-1 credits service.
+#
+# Covers:
+#   * ``month_to_date_spend`` — sums ONLY the current-UTC-month
+#     ``compute_spend`` / ``litellm_spend`` APPLIED debits; excludes the prior
+#     month, non-spend causes (top_up / subscription_grant / grant), and
+#     ``applied=False`` phantoms. Server-side ``$sum`` (run via async-iteration so
+#     it survives the mongomock-motor harness, which cannot ``await`` an
+#     aggregation cursor). Tenant-scoped.
+#   * ``check_quota`` — raises ``QuotaExceeded`` (402 ``credits.quota_exceeded``)
+#     when month-to-date spend >= the effective ceiling; no-op below; no-op when
+#     the plan ceiling is None (Enterprise / uncapped); the boundary is ``>=``
+#     (exactly-at-ceiling raises).
+#   * TOP-UP NETTING (the money-adjacent invariant): a ``top_up`` grant in the
+#     current month RAISES the effective ceiling (spend between the plan ceiling
+#     and ceiling+topup does NOT raise; above DOES). The recurring
+#     ``subscription_grant`` allotment does NOT inflate the ceiling.
+#   * a no-plan / unknown-plan workspace FAILS CLOSED to the Free 1000 ceiling
+#     (via ``resolve_entitlements``).
+#
+# Uses the shared ``mongo_db`` fixture (mongomock-motor + Beanie over
+# ALL_DOCUMENTS). ``createdAt`` is back-dated via the raw collection (the Insert
+# event stamps createdAt=now, so a controlled date can't be set through the
+# constructor) — the same seeding style as test_spend_by_model.py. The plan is set
+# by inserting a real ``Workspace(plan=...)`` so ``resolve_entitlements`` resolves
+# the real catalog ceiling (Free=1000, Go=2250, Enterprise=None).
+#
+# Created 2026-06-30 (feat/billing-quota-enforcement, chunk 2): new test module —
+# locks the monthly credit-quota contract before chunk 3 wires the gate.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import QuotaExceeded
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+from pocketpaw_ee.cloud.models.workspace import Workspace
+
+pytestmark = pytest.mark.asyncio
+
+WS = "ws_quota"
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed(
+    *,
+    when: datetime,
+    amount_delta: int,
+    cause: str,
+    applied: bool = True,
+    idem: str,
+    ws: str = WS,
+) -> None:
+    """Insert one ledger entry stamped at ``when`` (back-dated via the raw
+    collection so the month-window boundary can be asserted)."""
+    entry = CreditLedgerEntry(
+        workspace=ws,
+        kind="grant" if amount_delta > 0 else "spend",
+        amount_delta=amount_delta,
+        balance_after=0,
+        applied=applied,
+        conditional=False,
+        cause=cause,
+        ref={},
+        idempotency_key=idem,
+    )
+    await entry.insert()
+    await CreditLedgerEntry.get_pymongo_collection().update_one(
+        {"_id": entry.id}, {"$set": {"createdAt": when}}
+    )
+
+
+async def _make_workspace(plan: str, *, slug: str) -> str:
+    """Insert a real Workspace doc so ``resolve_entitlements`` reads its plan."""
+    ws = Workspace(name="Tenant", slug=slug, owner="u-owner", plan=plan)
+    await ws.insert()
+    return str(ws.id)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _this_month(day: int = 15, hour: int = 12) -> datetime:
+    """A timestamp inside the CURRENT UTC calendar month."""
+    n = _now()
+    return datetime(n.year, n.month, day, hour, tzinfo=UTC)
+
+
+def _last_month() -> datetime:
+    """A timestamp in the PREVIOUS UTC calendar month (before this month's 1st)."""
+    n = _now()
+    month_start = datetime(n.year, n.month, 1, tzinfo=UTC)
+    return month_start - timedelta(days=2)
+
+
+# ===========================================================================
+# month_to_date_spend
+# ===========================================================================
+
+
+async def test_mtd_sums_current_month_spend_causes(mongo_db):
+    await _seed(when=_this_month(2), amount_delta=-100, cause="compute_spend", idem="a")
+    await _seed(when=_this_month(10), amount_delta=-50, cause="litellm_spend", idem="b")
+
+    assert await credits.month_to_date_spend(WS) == 150  # 100 + 50, both spend causes
+
+
+async def test_mtd_excludes_prior_month(mongo_db):
+    await _seed(when=_last_month(), amount_delta=-9999, cause="compute_spend", idem="old")
+    await _seed(when=_this_month(5), amount_delta=-40, cause="compute_spend", idem="new")
+
+    assert await credits.month_to_date_spend(WS) == 40  # last month's -9999 excluded
+
+
+async def test_mtd_excludes_non_spend_causes(mongo_db):
+    # Real spend.
+    await _seed(when=_this_month(3), amount_delta=-30, cause="compute_spend", idem="spend")
+    # Grants under non-spend causes — must not subtract from / count toward spend.
+    await _seed(when=_this_month(3), amount_delta=5000, cause="top_up", idem="topup")
+    await _seed(when=_this_month(3), amount_delta=1500, cause="subscription_grant", idem="allot")
+    await _seed(when=_this_month(3), amount_delta=1000, cause="genesis", idem="gen")
+
+    assert await credits.month_to_date_spend(WS) == 30  # only the compute_spend debit
+
+
+async def test_mtd_excludes_unapplied_phantom(mongo_db):
+    await _seed(when=_this_month(4), amount_delta=-20, cause="compute_spend", idem="real")
+    await _seed(
+        when=_this_month(4),
+        amount_delta=-1000,
+        cause="compute_spend",
+        applied=False,  # phantom: committed but never moved the wallet
+        idem="phantom",
+    )
+
+    assert await credits.month_to_date_spend(WS) == 20  # phantom -1000 excluded
+
+
+async def test_mtd_zero_when_no_spend(mongo_db):
+    assert await credits.month_to_date_spend("ws-never-spent") == 0
+
+
+async def test_mtd_is_tenant_scoped(mongo_db):
+    await _seed(when=_this_month(6), amount_delta=-25, cause="compute_spend", idem="mine")
+    await _seed(
+        when=_this_month(6),
+        amount_delta=-999,
+        cause="compute_spend",
+        idem="theirs",
+        ws="other_ws",
+    )
+
+    assert await credits.month_to_date_spend(WS) == 25  # not 25 + 999
+
+
+async def test_mtd_clamps_stray_positive_to_zero(mongo_db):
+    # A (should-never-happen) net-positive under a spend cause must not read as
+    # negative spend — clamp to 0.
+    await _seed(when=_this_month(7), amount_delta=500, cause="compute_spend", idem="stray")
+
+    assert await credits.month_to_date_spend(WS) == 0
+
+
+# ===========================================================================
+# check_quota — basic raise / no-op / None
+# ===========================================================================
+
+
+async def test_check_quota_raises_at_ceiling_boundary(mongo_db):
+    # Free plan → ceiling 1000. Spend EXACTLY 1000 → boundary is >=, so it raises.
+    ws = await _make_workspace("free", slug="q-free-boundary")
+    await _seed(when=_this_month(2), amount_delta=-1000, cause="compute_spend", idem="s", ws=ws)
+
+    with pytest.raises(QuotaExceeded) as exc:
+        await credits.check_quota(ws)
+    assert exc.value.status_code == 402
+    assert exc.value.code == "credits.quota_exceeded"
+    assert exc.value.ceiling == 1000
+    assert exc.value.spent == 1000
+
+
+async def test_check_quota_raises_above_ceiling(mongo_db):
+    ws = await _make_workspace("free", slug="q-free-above")
+    await _seed(when=_this_month(2), amount_delta=-1200, cause="compute_spend", idem="s", ws=ws)
+
+    with pytest.raises(QuotaExceeded):
+        await credits.check_quota(ws)
+
+
+async def test_check_quota_noop_below_ceiling(mongo_db):
+    # Free ceiling 1000, spend 999 → just under → no raise (returns None).
+    ws = await _make_workspace("free", slug="q-free-under")
+    await _seed(when=_this_month(2), amount_delta=-999, cause="compute_spend", idem="s", ws=ws)
+
+    assert await credits.check_quota(ws) is None
+
+
+async def test_check_quota_noop_when_uncapped_enterprise(mongo_db):
+    # Enterprise → ceiling None → no cap to enforce, even with huge spend.
+    ws = await _make_workspace("enterprise", slug="q-ent")
+    await _seed(
+        when=_this_month(2), amount_delta=-5_000_000, cause="compute_spend", idem="s", ws=ws
+    )
+
+    assert await credits.check_quota(ws) is None
+
+
+async def test_check_quota_uses_paid_tier_ceiling(mongo_db):
+    # Go plan → ceiling 2250 (1500 allotment × 1.5). 2000 spent → under → no raise.
+    ws = await _make_workspace("go", slug="q-go-under")
+    await _seed(when=_this_month(2), amount_delta=-2000, cause="compute_spend", idem="s", ws=ws)
+    assert await credits.check_quota(ws) is None
+    # 2250 spent → at the ceiling → raises.
+    await _seed(when=_this_month(3), amount_delta=-250, cause="compute_spend", idem="s2", ws=ws)
+    with pytest.raises(QuotaExceeded):
+        await credits.check_quota(ws)
+
+
+# ===========================================================================
+# check_quota — fail-closed on no/unknown plan
+# ===========================================================================
+
+
+async def test_check_quota_no_plan_fails_closed_to_free_1000(mongo_db):
+    # A workspace id with NO Workspace doc → resolve_entitlements falls back to the
+    # Free base tier → ceiling 1000 (never None/uncapped). Spend 1000 → raises.
+    await _seed(
+        when=_this_month(2),
+        amount_delta=-1000,
+        cause="compute_spend",
+        idem="s",
+        ws="ws-no-plan",
+    )
+    with pytest.raises(QuotaExceeded) as exc:
+        await credits.check_quota("ws-no-plan")
+    assert exc.value.ceiling == 1000
+
+
+async def test_check_quota_unknown_plan_fails_closed_to_free_1000(mongo_db):
+    # An unknown/typo'd plan string also resolves to the Free ceiling.
+    ws = await _make_workspace("bogus_tier", slug="q-unknown")
+    await _seed(when=_this_month(2), amount_delta=-1000, cause="compute_spend", idem="s", ws=ws)
+    with pytest.raises(QuotaExceeded) as exc:
+        await credits.check_quota(ws)
+    assert exc.value.ceiling == 1000
+
+
+# ===========================================================================
+# TOP-UP NETTING (the money-adjacent invariant)
+# ===========================================================================
+
+
+async def test_topup_raises_effective_ceiling_below_extended_cap_noop(mongo_db):
+    # Free ceiling 1000 + a 500-credit top_up THIS month → effective ceiling 1500.
+    # Spend 1200 (between 1000 and 1500) → NO raise (the top-up extended the cap).
+    ws = await _make_workspace("free", slug="q-topup-under")
+    await _seed(when=_this_month(1), amount_delta=500, cause="top_up", idem="tu", ws=ws)
+    await _seed(when=_this_month(2), amount_delta=-1200, cause="compute_spend", idem="s", ws=ws)
+
+    assert await credits.check_quota(ws) is None
+
+
+async def test_topup_raises_effective_ceiling_above_extended_cap_raises(mongo_db):
+    # Free 1000 + 500 top_up → effective 1500. Spend 1500 → at the EXTENDED ceiling
+    # → raises (boundary >=), and the reported ceiling is the EXTENDED 1500.
+    ws = await _make_workspace("free", slug="q-topup-over")
+    await _seed(when=_this_month(1), amount_delta=500, cause="top_up", idem="tu", ws=ws)
+    await _seed(when=_this_month(2), amount_delta=-1500, cause="compute_spend", idem="s", ws=ws)
+
+    with pytest.raises(QuotaExceeded) as exc:
+        await credits.check_quota(ws)
+    assert exc.value.ceiling == 1500  # plan 1000 + top-up 500
+    assert exc.value.spent == 1500
+
+
+async def test_subscription_grant_does_not_inflate_ceiling(mongo_db):
+    # The recurring monthly allotment (cause="subscription_grant") is the ceiling's
+    # OWN baseline — it must NOT raise the effective cap. Free 1000 + a
+    # subscription_grant of 5000 → effective ceiling STAYS 1000. Spend 1000 →
+    # raises with ceiling == 1000 (the allotment did not extend it).
+    ws = await _make_workspace("free", slug="q-allot")
+    await _seed(
+        when=_this_month(1), amount_delta=5000, cause="subscription_grant", idem="al", ws=ws
+    )
+    await _seed(when=_this_month(2), amount_delta=-1000, cause="compute_spend", idem="s", ws=ws)
+
+    with pytest.raises(QuotaExceeded) as exc:
+        await credits.check_quota(ws)
+    assert exc.value.ceiling == 1000  # NOT 1000 + 5000
+
+
+async def test_prior_month_topup_does_not_extend_this_month(mongo_db):
+    # A top-up granted LAST month must not raise THIS month's ceiling — the cap is
+    # per current-UTC-month. Free 1000 + last-month top_up 5000 → effective 1000.
+    # Spend 1000 this month → raises with ceiling 1000.
+    ws = await _make_workspace("free", slug="q-topup-prior")
+    await _seed(when=_last_month(), amount_delta=5000, cause="top_up", idem="oldtu", ws=ws)
+    await _seed(when=_this_month(2), amount_delta=-1000, cause="compute_spend", idem="s", ws=ws)
+
+    with pytest.raises(QuotaExceeded) as exc:
+        await credits.check_quota(ws)
+    assert exc.value.ceiling == 1000  # last month's top-up excluded

--- a/tests/cloud/entitlements/test_entitlements.py
+++ b/tests/cloud/entitlements/test_entitlements.py
@@ -21,6 +21,10 @@
 #   {free, go, pro, pro_max, enterprise}. The business-tier assertions now target
 #   ``pro`` (its consumer-ladder successor: the tier that carries fabric +
 #   automations + knowledge_base). Fallback-to-free invariants are unchanged.
+# Updated 2026-06-30 (feat/billing-quota-enforcement, chunk 1): proves the resolver
+#   now also populates ``monthly_ceiling`` from the plan catalog — every known tier
+#   carries the catalog's ceiling (incl. enterprise=None uncapped), and an unknown
+#   / missing plan FAILS CLOSED to the Free ceiling (1000), never None/uncapped.
 
 from __future__ import annotations
 
@@ -63,10 +67,12 @@ async def test_pro_plan_resolves_pro_features_and_allotment(patch_plan):
     assert ent.plan == "pro"
     assert set(ent.features) == PLAN_FEATURES["pro"]
     assert ent.monthly_credit_allotment > 0
-    # The catalog's pro allotment is exactly what resolves.
+    # The catalog's pro allotment AND ceiling are exactly what resolves.
     from pocketpaw_ee.cloud.billing import plans
 
     assert ent.monthly_credit_allotment == plans.get_plan("pro").monthly_credit_allotment
+    assert ent.monthly_ceiling == plans.get_plan("pro").monthly_ceiling
+    assert ent.monthly_ceiling == 11_250
 
 
 @pytest.mark.parametrize("plan", ["free", "go", "pro", "pro_max", "enterprise"])
@@ -75,6 +81,18 @@ async def test_every_known_plan_resolves_its_own_features(patch_plan, plan):
     ent = await entitlements.resolve_entitlements(WS)
     assert ent.plan == plan
     assert set(ent.features) == PLAN_FEATURES[plan]
+
+
+@pytest.mark.parametrize("plan", ["free", "go", "pro", "pro_max", "enterprise"])
+async def test_every_known_plan_resolves_its_catalog_ceiling(patch_plan, plan):
+    """The resolver mirrors the catalog's monthly_ceiling for every known tier."""
+    from pocketpaw_ee.cloud.billing import plans
+
+    patch_plan(plan)
+    ent = await entitlements.resolve_entitlements(WS)
+    assert ent.monthly_ceiling == plans.get_plan(plan).monthly_ceiling
+    if plan == "enterprise":
+        assert ent.monthly_ceiling is None  # the one uncapped tier
 
 
 # ---------------------------------------------------------------------------
@@ -89,6 +107,8 @@ async def test_unknown_plan_falls_back_to_free(patch_plan):
     assert ent.plan == "free"
     assert set(ent.features) == PLAN_FEATURES["free"]
     assert ent.monthly_credit_allotment == 0
+    # FAIL-CLOSED: an unknown plan caps at the Free ceiling, never None/uncapped.
+    assert ent.monthly_ceiling == 1_000
 
 
 async def test_missing_workspace_falls_back_to_free(patch_plan):
@@ -97,6 +117,8 @@ async def test_missing_workspace_falls_back_to_free(patch_plan):
     ent = await entitlements.resolve_entitlements(WS)
     assert ent.plan == "free"
     assert ent.monthly_credit_allotment == 0
+    # FAIL-CLOSED: a missing workspace caps at the Free ceiling, never uncapped.
+    assert ent.monthly_ceiling == 1_000
     # Crucially, free must NOT carry any paid-tier feature.
     assert "fabric" not in ent.features
     assert "instinct" not in ent.features

--- a/tests/cloud/runs/test_run_core_credit_quota.py
+++ b/tests/cloud/runs/test_run_core_credit_quota.py
@@ -1,0 +1,200 @@
+# tests/cloud/runs/test_run_core_credit_quota.py
+# Created 2026-06-30 (feat/billing-quota-enforcement, chunk 3) — locks the
+# universal run-start MONTHLY-CREDIT-QUOTA gate in
+# run_core (the credit-spend sibling of the ART-3 jail-quota reject):
+#   * billing_enforced + over-quota -> the run is rejected CLEANLY (terminal
+#     ``error`` stream frame + ``mark_terminal(failed)``) and the agent/model
+#     (``_iter_agent_events``) is NEVER invoked (the money guarantee).
+#   * billing_enforced + under-quota -> the run proceeds normally (the agent
+#     loop runs, ``stream_end`` is written).
+#   * flag OFF (default) -> ``check_quota`` is NEVER called — the gate never
+#     fires, even when the workspace is over its ceiling.
+#
+# Harness mirrors test_run_core.py (fakeredis transport + a stubbed
+# ``_iter_agent_events``) and test_run_core_jail_quota.py (a clean reject, not a
+# crash). ``check_quota`` is stubbed at the run_core seam (it is called via the
+# locally-imported ``credits_service`` module, patched on that module) so these
+# tests assert the WIRING, not the chunk-2 quota math (test_quota.py owns that).
+
+from __future__ import annotations
+
+from typing import Any
+
+import fakeredis.aioredis
+import pytest
+from pocketpaw_ee.cloud._core.errors import QuotaExceeded
+from pocketpaw_ee.cloud.chat.runs import run_core
+from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+from pocketpaw_ee.cloud.chat.runs.redis_stream import RedisStreamTransport
+
+pytestmark = pytest.mark.asyncio
+
+
+def _spec() -> RunSpec:
+    return RunSpec(
+        run_id="r1",
+        workspace_id="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c1",
+        user_message_id="m1",
+        content="hi",
+        history=[],
+        intent=None,
+    )
+
+
+async def _noop(*a, **k):
+    return None
+
+
+async def _persist_stub(spec, ctx, full_text, attachments, usage=None):
+    return "assistant-msg-1"
+
+
+async def fake_resolve_scope_context(**_):
+    class _Ctx:
+        kind = type("K", (), {"value": "session"})()
+        scope_id = "s1"
+        workspace_id = "w1"
+        user_id = "u1"
+        target_agent_id = "a1"
+        members = ["u1"]
+        session_id = None
+        intent = None
+        surface_context = None
+        resolved_profile = None
+        pocket_id = None
+
+    return _Ctx()
+
+
+def _wire_common(monkeypatch, transport, *, enforced: bool) -> dict[str, bool]:
+    """Patch the side-effecting collaborators the executor calls AND record
+    whether the agent loop (``_iter_agent_events``) ever ran. Returns the
+    ``called`` dict so a test can assert the model was / was not invoked."""
+    called: dict[str, bool] = {"agent_loop": False}
+
+    async def tracking_agent_events(spec, ctx):
+        called["agent_loop"] = True
+        yield ("chunk", {"content": "hello", "type": "text"})
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", tracking_agent_events)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _persist_stub)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+    # The executor mirrors agent_router._ensure_scope_session via the sessions
+    # service — stub it so no real Mongo is needed.
+    monkeypatch.setattr("pocketpaw_ee.cloud.sessions.service.ensure_for_agent_scope", _noop)
+    # Resolve the entity profile to None (the legacy/no-pocket path) without a DB.
+    monkeypatch.setattr(run_core, "_resolve_entity_profile", _noop)
+
+    # The ART-3 jail-quota gate is a no-op here (off cloud / no jail) — keep it
+    # out of the way so we isolate the credit-quota gate.
+    async def _no_jail_reject(spec, ctx, transport):
+        return False
+
+    monkeypatch.setattr(run_core, "_reject_if_over_jail_quota", _no_jail_reject)
+    # Point the executor's flag at a stub carrying the desired posture.
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        run_core, "get_settings", lambda: SimpleNamespace(billing_enforced=enforced)
+    )
+    return called
+
+
+# ---------------------------------------------------------------------------
+# 1 — enforced + OVER quota -> run rejected, agent/model NOT called.
+# ---------------------------------------------------------------------------
+
+
+async def test_enforced_over_quota_rejects_and_does_not_call_model(monkeypatch):
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+    called = _wire_common(monkeypatch, transport, enforced=True)
+
+    # check_quota raises QuotaExceeded -> the gate rejects the run.
+    async def _over_quota(workspace_id):
+        raise QuotaExceeded(ceiling=1000, spent=1000)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.credits.service.check_quota", _over_quota)
+
+    mark_calls: list[dict[str, Any]] = []
+
+    async def _track_terminal(run_id, *, status, error=None, **k):
+        mark_calls.append({"run_id": run_id, "status": status, "error": error})
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.run_core.run_service.mark_terminal", _track_terminal
+    )
+
+    await run_core.execute_run(_spec())
+
+    # THE MONEY GUARANTEE: the agent loop (model) never ran.
+    assert called["agent_loop"] is False, "model must NOT be invoked on an over-quota block"
+
+    # A terminal ``error`` frame went to the stream (mirrors the jail-quota reject).
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    assert [e.event for e in events] == ["error"]
+    assert events[0].data["code"] == "credits.quota_exceeded"
+    # The run was marked terminally failed (and ONLY that — no completed mark).
+    assert mark_calls == [{"run_id": "r1", "status": "failed", "error": events[0].data["message"]}]
+
+
+# ---------------------------------------------------------------------------
+# 2 — enforced + UNDER quota -> proceeds normally (agent loop runs).
+# ---------------------------------------------------------------------------
+
+
+async def test_enforced_under_quota_proceeds(monkeypatch):
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+    called = _wire_common(monkeypatch, transport, enforced=True)
+
+    quota_calls: list[str] = []
+
+    async def _under_quota(workspace_id):
+        quota_calls.append(workspace_id)  # no-op (under ceiling)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.credits.service.check_quota", _under_quota)
+
+    await run_core.execute_run(_spec())
+
+    # The gate ran (flag on) and passed, so the agent loop proceeded.
+    assert quota_calls == ["w1"]
+    assert called["agent_loop"] is True
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    assert [e.event for e in events] == ["chunk", "stream_end"]
+
+
+# ---------------------------------------------------------------------------
+# 3 — flag OFF (default) -> check_quota is NEVER called; run proceeds.
+# ---------------------------------------------------------------------------
+
+
+async def test_not_enforced_never_calls_check_quota(monkeypatch):
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+    called = _wire_common(monkeypatch, transport, enforced=False)
+
+    quota_calls: list[str] = []
+
+    async def _should_not_run(workspace_id):
+        quota_calls.append(workspace_id)
+        raise AssertionError("check_quota must NOT be called when the flag is OFF")
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.credits.service.check_quota", _should_not_run)
+
+    await run_core.execute_run(_spec())
+
+    assert quota_calls == [], "the flag-off path must never gate"
+    assert called["agent_loop"] is True
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    assert [e.event for e in events] == ["chunk", "stream_end"]


### PR DESCRIPTION
## What

Adds a per-workspace **monthly credit-quota** gate that blocks the next AI run once a workspace has hit its plan's generous monthly ceiling. The gate sits at the run-dispatch convergence (`run_core.execute_run`), so one check covers every cloud run path, and it's behind the existing `POCKETPAW_BILLING_ENFORCED` flag (default off).

## Why

Enforcement was effectively off in prod. The only pre-flight gate (`check_balance`) lived at the chat HTTP endpoint and sits behind a flag that's unset on the box, so a workspace that runs out keeps running. A Free workspace (monthly allotment 0) is currently at −5,155 credits. On a shared flat-rate Claude subscription one runaway tenant can starve the box, and LiteLLM can't gate a flat-rate sub (the proxy can't meter a subscription pass-through), so enforcement has to be app-layer.

## How it works

- New `check_quota(workspace)` in `credits.service`: a pure assertion that raises `QuotaExceeded` (402 `credits.quota_exceeded`) when month-to-date spend reaches the effective monthly ceiling. Spend is a server-side aggregation over `compute_spend`/`litellm_spend` ledger debits in the current UTC calendar month; the ceiling is plan-derived, plus any purchased `top_up` grants for the period (the recurring allotment is the ceiling's baseline and is not double-counted).
- Gate at `run_core.execute_run`, beside the existing jail-quota reject: on a block it emits a terminal error frame, marks the run failed, and returns **before the model is ever called**. The chat HTTP route also fast-rejects in `agent_router` for a clean 402 with no DB trace.
- All of it runs under `POCKETPAW_BILLING_ENFORCED` (default off, so OSS / self-host are unaffected). `check_balance` is unchanged and stays as the secondary balance ≤ 0 guard.

## Ceilings (per plan, 1 credit = $0.01)

| Plan | allotment/mo | monthly ceiling |
|------|--------------|-----------------|
| Free | 0 | 1,000 (explicit trial) |
| Go | 1,500 | 2,250 |
| Pro | 7,500 | 11,250 |
| Pro Max | 30,000 | 45,000 |
| Enterprise | 1,000,000 | uncapped (None) |

Paid ceilings are `allotment × 1.5` (a generous overage buffer). A workspace with no resolvable plan fails closed to the Free 1,000 ceiling, never uncapped.

## To actually turn it on

Set `POCKETPAW_BILLING_ENFORCED=1` on the subscription / PEE box. It is off by default, which is why the bleed above is unbounded today. Deploy note added to the cloud-ops runbook and the config reference.

## Not in this PR (deliberate)

- The "approaching quota" soft-warn UX (fast-follow).
- Channel-gateway gating (Slack/WhatsApp run the OSS loop, not started by the cloud server).
- Pocket dispatch (no LLM, no gate needed).
- The cloud / API-key LiteLLM meter path (a different deployment model).
- Structured `ceiling`/`spent` fields in the 402 body, kept consistent with the existing `InsufficientCredits` (the soft-warn fast-follow can enrich both).

## Tests

385 passing across `tests/cloud/{credits,billing,entitlements,chat,runs}` (targeted). Covers the money guarantee that the model is not invoked on a block, the UTC month boundary, the applied-only spend sum with a refund clamp, the `subscription_grant`-excluded top-up netting, the enterprise-uncapped no-op, fail-closed for an unknown plan, and flag-off = the whole pre-flight is a no-op.

Design + decisions: `docs/design/drafts/2026-06-30-subscription-quota-enforcement-prd.md`.
