### PR TITLE
backend: /api/v1/security proxy to shield + security.manage RBAC (SEC-5)

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -425,6 +425,16 @@ def mount_cloud(app: FastAPI) -> None:
 
     app.include_router(belt_console_router, prefix="/api/v1")
 
+    # Security control plane — the /api/v1/security/* proxy to shield, the
+    # same-box Go daemon that serves an egress-decision control API on a UNIX
+    # socket (feat/sec-5-security-proxy SEC-5). GET decisions/stats/config,
+    # PATCH config, POST decisions/{id}/resolve — every route OWNER-gated
+    # (security.manage). Degrades to a typed available:false (reads) / 409
+    # (writes) when shield is absent, so the /security page renders without it.
+    from pocketpaw_ee.cloud.security.router import router as security_router
+
+    app.include_router(security_router, prefix="/api/v1")
+
     # Belt MANDATES — the standing-JOB primitive (feat/belt-mandates). The
     # /belt/mandates surface: charter CRUD, patrol intake (feedback), sightings
     # read, manual shift trigger (foreman → plan gate), and the pawprints feed.

--- a/ee/pocketpaw_ee/cloud/security/__init__.py
+++ b/ee/pocketpaw_ee/cloud/security/__init__.py
@@ -1,0 +1,9 @@
+# ee/pocketpaw_ee/cloud/security/__init__.py — the shield control-plane proxy.
+# Created: 2026-07-01 (feat/sec-5-security-proxy, SEC-5).
+#
+# Home of the cloud-side proxy to shield — the same-box Go security daemon that
+# serves a control API on a UNIX socket. The router (``router.py``) maps 1:1 to
+# shield's endpoints (decisions / stats / config read + PATCH, decision
+# resolve), OWNER-gates every route via ``require_action_any_workspace(
+# "security.manage")``, forwards shield's status + JSON through, and degrades
+# cleanly when shield is absent. The transport / config lives in ``config.py``.

--- a/ee/pocketpaw_ee/cloud/security/config.py
+++ b/ee/pocketpaw_ee/cloud/security/config.py
@@ -1,0 +1,54 @@
+# ee/pocketpaw_ee/cloud/security/config.py — shield connection config + UDS transport.
+# Created: 2026-07-01 (feat/sec-5-security-proxy, SEC-5).
+#
+# Reads the shield connection settings from the central pocketpaw Settings
+# (POCKETPAW_SHIELD_API_SOCKET / POCKETPAW_SHIELD_API_TOKEN) and builds the
+# httpx AsyncClient bound to shield's UNIX socket. Kept out of the router so the
+# router stays thin and tests can override ``shield_client_dep`` with a fake
+# transport instead of a real socket. The Bearer token is attached to the
+# client's default headers; it is NEVER logged (the router logs status codes and
+# reasons only, never the token or the Authorization header).
+
+from __future__ import annotations
+
+import httpx
+
+from pocketpaw.config import get_settings
+
+# shield is on the same box; the socket round-trip is sub-millisecond when it is
+# up. A tight timeout means a hung/slow shield fails fast into the "unreachable"
+# degrade path instead of hanging the caller's request.
+SHIELD_TIMEOUT_SECONDS: float = 5.0
+
+# Base URL is a placeholder authority — httpx requires an absolute URL, but the
+# UDS transport ignores the host and dials the socket. shield sees the path.
+_SHIELD_BASE_URL = "http://shield"
+
+
+def shield_socket_path() -> str:
+    """Return the configured shield control-API socket path (may be empty)."""
+    return (get_settings().shield_api_socket or "").strip()
+
+
+def shield_api_token() -> str:
+    """Return the Bearer token for the backend → shield hop. Never logged."""
+    return (get_settings().shield_api_token or "").strip()
+
+
+def build_shield_client() -> httpx.AsyncClient:
+    """Build an ``httpx.AsyncClient`` bound to shield's UNIX socket.
+
+    The caller is responsible for closing the client (use ``async with``). The
+    Authorization header carrying the shield token is set as a default header so
+    every request over this client authenticates. A tight timeout keeps a slow
+    shield from hanging the request — a timeout surfaces to the router as the
+    typed 'unreachable' degrade, not a 500.
+    """
+    transport = httpx.AsyncHTTPTransport(uds=shield_socket_path())
+    headers = {"Authorization": f"Bearer {shield_api_token()}"}
+    return httpx.AsyncClient(
+        transport=transport,
+        base_url=_SHIELD_BASE_URL,
+        headers=headers,
+        timeout=SHIELD_TIMEOUT_SECONDS,
+    )

--- a/ee/pocketpaw_ee/cloud/security/router.py
+++ b/ee/pocketpaw_ee/cloud/security/router.py
@@ -1,0 +1,266 @@
+# ee/pocketpaw_ee/cloud/security/router.py — the /api/v1/security/* shield proxy.
+# Created: 2026-07-01 (feat/sec-5-security-proxy, SEC-5).
+#
+# A FastAPI router that maps 1:1 to shield's control API (served on a same-box
+# UNIX socket) and fronts it for the dashboard:
+#   * GET   /security/decisions        — the agent-decision feed (fwd query params)
+#   * GET   /security/stats            — egress / decision counters
+#   * GET   /security/config           — the deny/allow egress config
+#   * PATCH /security/config           — mutate the egress config (fwd JSON body)
+#   * POST  /security/decisions/{id}/resolve — ban/allow a pending decision
+#                                       (fwd JSON body; the OWNER user is injected
+#                                        as ``actor`` so shield records who acted)
+#
+# EVERY route is OWNER-gated via ``require_action_any_workspace("security.manage")``
+# — shield fronts ban-capable writes AND its read feed exposes who-tried-to-
+# egress-what, so a mere admin must not reach any of it (mirrors the belt router's
+# use of ``require_action_any_workspace`` but at the OWNER tier). The workspace is
+# resolved from the caller's active workspace (these routes carry no {workspace_id}
+# path param), matching the belt / discovery routers.
+#
+# The proxy forwards shield's HTTP status + JSON body straight through (a shield
+# 400 on a bad PATCH reaches the caller as a 400). It NEVER logs the shield token.
+# When shield is absent — socket unset, missing, or unreachable
+# (ConnectError / FileNotFoundError / timeout) — the proxy degrades to a TYPED
+# response, never a 500:
+#   * GETs   → 200 {"available": false, "reason": "shield_not_deployed"|"unreachable"}
+#              so the UI can render an empty state. On success the body is
+#              {"available": true, ...shield's JSON...}.
+#   * writes → 409 {"detail": "shield_not_deployed"} — you can't act on an absent box.
+
+"""FastAPI router proxying the shield security control plane."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+
+from pocketpaw_ee.cloud._core.deps import (
+    current_user_id,
+    require_action_any_workspace,
+)
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.security import config as shield_config
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/security",
+    tags=["Security"],
+    dependencies=[Depends(require_license)],
+)
+
+# Errors that mean "shield is not reachable on this box right now". A missing
+# socket file raises FileNotFoundError from the transport; a refused / hung
+# connection raises httpx.ConnectError / httpx.TimeoutException. Any of these is
+# the "unreachable" degrade, distinct from "shield_not_deployed" (socket unset).
+_UNREACHABLE_ERRORS: tuple[type[Exception], ...] = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+    httpx.TimeoutException,
+    httpx.TransportError,
+    FileNotFoundError,
+    ConnectionError,
+    OSError,
+)
+
+
+def shield_client_dep() -> httpx.AsyncClient | None:
+    """Provide the httpx client bound to shield's socket, or ``None``.
+
+    Returns ``None`` when the socket path is unset (shield not deployed on this
+    box) so the routes take the typed no-shield branch WITHOUT attempting a
+    connection. Tests override this dependency to inject a fake client (a real
+    ``MockTransport``-backed ``AsyncClient``) so no actual socket is needed.
+    """
+    if not shield_config.shield_socket_path():
+        return None
+    return shield_config.build_shield_client()
+
+
+def _no_shield_read() -> JSONResponse:
+    """The typed available:false body for a GET when the socket is unset."""
+    return JSONResponse(
+        status_code=200,
+        content={"available": False, "reason": "shield_not_deployed"},
+    )
+
+
+def _unreachable_read() -> JSONResponse:
+    """The typed available:false body for a GET when shield can't be reached."""
+    return JSONResponse(
+        status_code=200,
+        content={"available": False, "reason": "unreachable"},
+    )
+
+
+def _no_shield_write() -> JSONResponse:
+    """The typed 409 body for a write when shield is absent/unreachable.
+
+    A write can't act on a box that isn't there — 409 Conflict (the state
+    required to perform the action does not exist), not a 200 empty state.
+    """
+    return JSONResponse(status_code=409, content={"detail": "shield_not_deployed"})
+
+
+def _passthrough(resp: httpx.Response) -> JSONResponse:
+    """Forward shield's status + JSON body straight through to the caller.
+
+    A shield 4xx (e.g. a 400 on a bad PATCH) is forwarded verbatim so the caller
+    sees shield's own validation error. A non-JSON body (shield shouldn't emit
+    one, but be defensive) is wrapped in a stable envelope rather than crashing.
+    """
+    try:
+        body = resp.json()
+    except ValueError:
+        body = {"detail": resp.text}
+    return JSONResponse(status_code=resp.status_code, content=body)
+
+
+def _available_read(resp: httpx.Response) -> JSONResponse:
+    """Wrap a successful shield GET as {"available": true, ...shield JSON...}.
+
+    On a shield error status the body is forwarded verbatim (not wrapped) so the
+    caller still sees shield's error shape rather than a spurious available:true.
+    """
+    if resp.status_code >= 400:
+        return _passthrough(resp)
+    try:
+        payload = resp.json()
+    except ValueError:
+        payload = {"detail": resp.text}
+    content: dict[str, Any] = {"available": True}
+    if isinstance(payload, dict):
+        content.update(payload)
+    else:
+        content["data"] = payload
+    return JSONResponse(status_code=resp.status_code, content=content)
+
+
+async def _proxy_get(
+    client: httpx.AsyncClient | None,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+) -> JSONResponse:
+    """Forward a GET to shield, degrading to a typed read on absence/failure."""
+    if client is None:
+        return _no_shield_read()
+    try:
+        async with client:
+            resp = await client.get(path, params=params)
+    except _UNREACHABLE_ERRORS:
+        # Log the reason (never the token / Authorization header) so operators
+        # can see shield is down without leaking the credential.
+        logger.warning("shield unreachable on GET %s — degrading to available:false", path)
+        return _unreachable_read()
+    return _available_read(resp)
+
+
+async def _proxy_write(
+    client: httpx.AsyncClient | None,
+    method: str,
+    path: str,
+    *,
+    json_body: Any,
+) -> JSONResponse:
+    """Forward a PATCH/POST to shield, degrading to a typed 409 on absence."""
+    if client is None:
+        return _no_shield_write()
+    try:
+        async with client:
+            resp = await client.request(method, path, json=json_body)
+    except _UNREACHABLE_ERRORS:
+        logger.warning("shield unreachable on %s %s — returning 409", method, path)
+        return _no_shield_write()
+    return _passthrough(resp)
+
+
+# ---------------------------------------------------------------------------
+# Reads — decisions / stats / config
+# ---------------------------------------------------------------------------
+
+
+@router.get("/decisions")
+async def get_decisions(
+    request: Request,
+    _user: Any = Depends(require_action_any_workspace("security.manage")),
+    client: httpx.AsyncClient | None = Depends(shield_client_dep),
+) -> JSONResponse:
+    """Proxy shield's agent-decision feed (OWNER only).
+
+    Query params are forwarded verbatim so shield owns the filter/paginate
+    contract (e.g. ``?status=pending&limit=50``). On success the body is
+    ``{"available": true, ...shield JSON...}``; when shield is absent it is
+    ``{"available": false, "reason": ...}`` at 200 so the UI renders an empty
+    state instead of erroring.
+    """
+    return await _proxy_get(client, "/decisions", params=dict(request.query_params))
+
+
+@router.get("/stats")
+async def get_stats(
+    _user: Any = Depends(require_action_any_workspace("security.manage")),
+    client: httpx.AsyncClient | None = Depends(shield_client_dep),
+) -> JSONResponse:
+    """Proxy shield's egress / decision counters (OWNER only)."""
+    return await _proxy_get(client, "/stats")
+
+
+@router.get("/config")
+async def get_config(
+    _user: Any = Depends(require_action_any_workspace("security.manage")),
+    client: httpx.AsyncClient | None = Depends(shield_client_dep),
+) -> JSONResponse:
+    """Proxy shield's egress deny/allow config (OWNER only)."""
+    return await _proxy_get(client, "/config")
+
+
+# ---------------------------------------------------------------------------
+# Writes — config PATCH, decision resolve
+# ---------------------------------------------------------------------------
+
+
+@router.patch("/config")
+async def patch_config(
+    body: dict[str, Any],
+    _user: Any = Depends(require_action_any_workspace("security.manage")),
+    client: httpx.AsyncClient | None = Depends(shield_client_dep),
+) -> JSONResponse:
+    """Proxy a config mutation to shield (OWNER only).
+
+    The JSON body is forwarded verbatim; shield validates it and a bad PATCH
+    (shield 400) is forwarded through as a 400. When shield is absent the write
+    returns 409 ``shield_not_deployed`` — you cannot mutate the config on a box
+    that has no shield.
+    """
+    return await _proxy_write(client, "PATCH", "/config", json_body=body)
+
+
+@router.post("/decisions/{decision_id}/resolve")
+async def resolve_decision(
+    decision_id: str,
+    body: dict[str, Any] | None = None,
+    user_id: str = Depends(current_user_id),
+    _user: Any = Depends(require_action_any_workspace("security.manage")),
+    client: httpx.AsyncClient | None = Depends(shield_client_dep),
+) -> JSONResponse:
+    """Resolve (ban/allow) a pending shield decision (OWNER only).
+
+    The OWNER user id is injected as the ``actor`` field on the forwarded body
+    so shield records WHO resolved the decision — the caller cannot spoof a
+    different actor (any client-supplied ``actor`` is overwritten). When shield
+    is absent the write returns 409 ``shield_not_deployed``.
+    """
+    payload: dict[str, Any] = dict(body or {})
+    # Server-authoritative actor — overwrite any client-supplied value so the
+    # audit trail on shield's side always names the authenticated OWNER.
+    payload["actor"] = user_id
+    return await _proxy_write(
+        client, "POST", f"/decisions/{decision_id}/resolve", json_body=payload
+    )

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -42,6 +42,13 @@
 # detail) and its add-repo route. ``belt.manage`` is ADMIN because adding a repo
 # root extends the code-change security boundary workspace-wide — it must not be
 # open to every member (mirrors connector.manage / skills.manage).
+#
+# Updated: 2026-07-01 (feat/sec-5-security-proxy, SEC-5) — added
+# ``security.manage`` (OWNER) gating EVERY route on the shield control-plane
+# proxy (ee.cloud.security.router). OWNER because the proxy fronts shield's
+# ban-capable writes (resolve a decision, PATCH the egress deny/allow config)
+# AND its read feed exposes who-tried-to-egress-what; the whole surface is
+# owner-only, mirroring workspace.delete / billing.manage / instinct.activate.
 
 from __future__ import annotations
 
@@ -230,6 +237,16 @@ ACTIONS: dict[str, ActionRule] = {
     # diffs), mirroring connector.manage / skills.manage.
     "belt.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
     "belt.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Security — the shield control-plane proxy (ee.cloud.security.router,
+    # SEC-5). OWNER-only, the most restrictive workspace tier (mirrors
+    # workspace.delete / billing.manage / instinct.activate). shield fronts the
+    # ban-capable write endpoints (resolve a decision, PATCH the deny/allow
+    # config) and IS the workspace's egress security gate, so read AND write
+    # must both be owner-gated: a mere admin must not be able to see the
+    # decision stream or flip the security posture for everyone. A single
+    # action guards every route (reads included) because the decision feed
+    # itself carries who-tried-to-egress-what, which is sensitive.
+    "security.manage": ActionRule(WorkspaceRole.OWNER, "workspace.insufficient_role"),
 }
 
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -74,6 +74,10 @@ Changes:
     Belt & Pulley code-change gate (BS-3). A ``belt_propose_change`` proposal's
     repo path must resolve inside one of these roots; empty defaults to the
     cwd's parent. Env: POCKETPAW_BELT_REPO_ALLOWLIST (JSON list).
+  - 2026-07-01: Added ``shield_api_socket`` + ``shield_api_token`` (SEC-5) —
+    the same-box shield daemon's control-API UNIX socket + Bearer token. The
+    cloud ``/api/v1/security/*`` proxy reads these to reach shield; the token
+    is never logged. Env: POCKETPAW_SHIELD_API_SOCKET / POCKETPAW_SHIELD_API_TOKEN.
   - 2026-06-10: Added ``loom_bin`` + ``loom_model_path`` — the codebase
     orientation (loom) MCP server settings. ``loom_model_path`` defaults
     to None, which disables the loom MCP server; set it to a built
@@ -986,6 +990,31 @@ class Settings(BaseSettings):
             "Allowlisted root directories a Belt code-change proposal's repo "
             "must live under. A repo path resolving outside every root is "
             "refused. Empty → defaults to the cwd's parent (the workspace root)."
+        ),
+    )
+
+    # Shield — the same-box Go security daemon (deny-by-default connector
+    # egress + agent-decision control plane). shield serves a control API on a
+    # UNIX socket; the cloud ``/api/v1/security/*`` router proxies it,
+    # OWNER-gated, and degrades cleanly when shield is absent (a socket that is
+    # unset / missing / unreachable → a typed available:false read or a 409
+    # write, never a 500). The Bearer token authenticates the backend → shield
+    # hop over the socket; it is NEVER logged. Env auto-derives
+    # POCKETPAW_SHIELD_API_SOCKET / POCKETPAW_SHIELD_API_TOKEN.
+    shield_api_socket: str = Field(
+        default="/run/shield/api.sock",
+        description=(
+            "Filesystem path to shield's control-API UNIX socket. The cloud "
+            "security proxy connects here via an httpx UDS transport. When the "
+            "socket is missing or unreachable the proxy degrades to a typed "
+            "'shield_not_deployed' / 'unreachable' response."
+        ),
+    )
+    shield_api_token: str = Field(
+        default="",
+        description=(
+            "Bearer token the cloud security proxy presents to shield over the "
+            "socket. Sent as 'Authorization: Bearer <token>'. Never logged."
         ),
     )
 

--- a/src/pocketpaw/credentials.py
+++ b/src/pocketpaw/credentials.py
@@ -64,6 +64,7 @@ SECRET_FIELDS: frozenset[str] = frozenset(
         "status_api_key",
         "dodo_payments_api_key",
         "dodo_webhook_secret",
+        "shield_api_token",
     }
 )
 

--- a/tests/cloud/test_security_proxy.py
+++ b/tests/cloud/test_security_proxy.py
@@ -1,0 +1,342 @@
+# tests/cloud/test_security_proxy.py — the /api/v1/security/* shield proxy (SEC-5).
+#
+# Created: 2026-07-01 (feat/sec-5-security-proxy) — pins the cloud-side proxy to
+# shield, the same-box Go daemon on a UNIX socket. Coverage:
+#   * FORWARDING — each route forwards to shield with the right method / path /
+#     JSON body / Bearer token; shield's status + JSON pass through; a shield 400
+#     (bad PATCH) is forwarded through as a 400.
+#   * RBAC — an OWNER passes; a non-OWNER (MEMBER / ADMIN) gets 403 on EVERY route.
+#   * NO-SHIELD — socket unset (client None) or unreachable (transport raises) →
+#     the typed available:false (GET) / 409 (write), NEVER a 500.
+#   * ACTOR INJECTION — resolve injects the OWNER user id as the ``actor`` field
+#     and overwrites any client-supplied actor.
+#
+# The shield hop is faked with an httpx.MockTransport-backed AsyncClient injected
+# via ``shield_client_dep`` — a real client so the Bearer header / JSON body are
+# exercised end-to-end, but no actual socket is dialed. RBAC runs the REAL guard
+# (the user's workspace role drives ``require_action_any_workspace``), mirroring
+# tests/cloud/test_belt_console.py::_build_app.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+import httpx  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fake shield — an httpx.MockTransport that records the last request it saw and
+# returns a scripted response.
+# ---------------------------------------------------------------------------
+
+
+class _FakeShield:
+    """A recording fake for shield's control API.
+
+    Builds a real ``httpx.AsyncClient`` over a ``MockTransport`` so the router's
+    actual request path (headers, JSON body, query params) is exercised. The
+    last request is captured for assertions; the response is scripted per-test.
+    """
+
+    def __init__(self, *, status: int = 200, json_body: Any = None) -> None:
+        self.status = status
+        self.json_body = json_body if json_body is not None else {"ok": True}
+        self.requests: list[httpx.Request] = []
+
+    def _handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(self.status, json=self.json_body)
+
+    def client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(self._handler),
+            base_url="http://shield",
+            headers={"Authorization": "Bearer sekret-token"},
+            timeout=5.0,
+        )
+
+    @property
+    def last(self) -> httpx.Request:
+        assert self.requests, "shield was never called"
+        return self.requests[-1]
+
+
+class _UnreachableShield:
+    """A client whose transport raises ConnectError — shield-is-down simulation."""
+
+    def _handler(self, request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    def client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(self._handler),
+            base_url="http://shield",
+            headers={"Authorization": "Bearer sekret-token"},
+            timeout=5.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# App builder — real RBAC guard, fake shield client injected per test.
+# ---------------------------------------------------------------------------
+
+
+def _build_app(
+    *,
+    role: str = "owner",
+    workspace_id: str = "w1",
+    user_id: str = "u1",
+    shield: _FakeShield | _UnreachableShield | None = None,
+    no_shield: bool = False,
+) -> FastAPI:
+    """A TestClient app over the security router with the REAL RBAC guard.
+
+    ``role`` drives ``require_action_any_workspace("security.manage")`` (OWNER):
+    an owner passes, a member/admin is 403. License is bypassed. The shield hop
+    is faked: ``shield`` injects a recording/unreachable client; ``no_shield``
+    forces the socket-unset branch (client is ``None``).
+    """
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.cloud.security.router import router, shield_client_dep
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+
+    user = SimpleNamespace(
+        id=user_id,
+        is_active=True,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role=role)],
+    )
+
+    async def _fake_user_dep():
+        return user
+
+    app.dependency_overrides[current_active_user] = _fake_user_dep
+
+    if no_shield:
+        app.dependency_overrides[shield_client_dep] = lambda: None
+    elif shield is not None:
+        app.dependency_overrides[shield_client_dep] = lambda: shield.client()
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Forwarding — reads
+# ---------------------------------------------------------------------------
+
+
+def test_get_decisions_forwards_with_bearer_and_query_params():
+    shield = _FakeShield(json_body={"decisions": [{"id": "d1"}]})
+    with TestClient(_build_app(shield=shield)) as client:
+        res = client.get("/api/v1/security/decisions?status=pending&limit=25")
+    assert res.status_code == 200, res.text
+    # available:true envelope wraps shield's JSON.
+    body = res.json()
+    assert body["available"] is True
+    assert body["decisions"] == [{"id": "d1"}]
+    # Forwarded to shield's /decisions with the query params + Bearer token.
+    req = shield.last
+    assert req.method == "GET"
+    assert req.url.path == "/decisions"
+    assert dict(req.url.params) == {"status": "pending", "limit": "25"}
+    assert req.headers["authorization"] == "Bearer sekret-token"
+
+
+def test_get_stats_forwards_and_wraps_available_true():
+    shield = _FakeShield(json_body={"egress_blocked": 3, "decisions_pending": 1})
+    with TestClient(_build_app(shield=shield)) as client:
+        res = client.get("/api/v1/security/stats")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["available"] is True
+    assert body["egress_blocked"] == 3
+    assert shield.last.url.path == "/stats"
+    assert shield.last.method == "GET"
+
+
+def test_get_config_forwards():
+    shield = _FakeShield(json_body={"mode": "deny", "allow": ["api.github.com"]})
+    with TestClient(_build_app(shield=shield)) as client:
+        res = client.get("/api/v1/security/config")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["available"] is True
+    assert body["mode"] == "deny"
+    assert shield.last.url.path == "/config"
+
+
+# ---------------------------------------------------------------------------
+# Forwarding — writes
+# ---------------------------------------------------------------------------
+
+
+def test_patch_config_forwards_json_body():
+    shield = _FakeShield(json_body={"mode": "allow"})
+    with TestClient(_build_app(shield=shield)) as client:
+        res = client.patch("/api/v1/security/config", json={"mode": "allow"})
+    assert res.status_code == 200, res.text
+    # Write bodies pass through verbatim (NOT wrapped in available:true).
+    assert res.json() == {"mode": "allow"}
+    req = shield.last
+    assert req.method == "PATCH"
+    assert req.url.path == "/config"
+    import json as _json
+
+    assert _json.loads(req.content) == {"mode": "allow"}
+    assert req.headers["authorization"] == "Bearer sekret-token"
+
+
+def test_patch_config_shield_400_passes_through_as_400():
+    """A shield validation failure (400) reaches the caller as a 400, verbatim."""
+    shield = _FakeShield(status=400, json_body={"detail": "unknown mode 'bogus'"})
+    with TestClient(_build_app(shield=shield)) as client:
+        res = client.patch("/api/v1/security/config", json={"mode": "bogus"})
+    assert res.status_code == 400, res.text
+    assert res.json() == {"detail": "unknown mode 'bogus'"}
+
+
+def test_resolve_forwards_and_injects_owner_as_actor():
+    shield = _FakeShield(json_body={"id": "d9", "status": "resolved"})
+    with TestClient(_build_app(user_id="owner-42", shield=shield)) as client:
+        res = client.post(
+            "/api/v1/security/decisions/d9/resolve",
+            json={"action": "ban"},
+        )
+    assert res.status_code == 200, res.text
+    assert res.json() == {"id": "d9", "status": "resolved"}
+    req = shield.last
+    assert req.method == "POST"
+    assert req.url.path == "/decisions/d9/resolve"
+    import json as _json
+
+    sent = _json.loads(req.content)
+    # The original field is preserved AND the OWNER is stamped as actor.
+    assert sent["action"] == "ban"
+    assert sent["actor"] == "owner-42"
+
+
+def test_resolve_overwrites_client_supplied_actor():
+    """A client cannot spoof the actor — the authenticated OWNER always wins."""
+    shield = _FakeShield(json_body={"ok": True})
+    with TestClient(_build_app(user_id="real-owner", shield=shield)) as client:
+        res = client.post(
+            "/api/v1/security/decisions/d1/resolve",
+            json={"action": "allow", "actor": "someone-else"},
+        )
+    assert res.status_code == 200, res.text
+    import json as _json
+
+    sent = _json.loads(shield.last.content)
+    assert sent["actor"] == "real-owner"
+
+
+def test_resolve_with_empty_body_still_injects_actor():
+    """No JSON body → the proxy still forwards {actor: <owner>}."""
+    shield = _FakeShield(json_body={"ok": True})
+    with TestClient(_build_app(user_id="u-solo", shield=shield)) as client:
+        res = client.post("/api/v1/security/decisions/d1/resolve")
+    assert res.status_code == 200, res.text
+    import json as _json
+
+    sent = _json.loads(shield.last.content)
+    assert sent == {"actor": "u-solo"}
+
+
+# ---------------------------------------------------------------------------
+# RBAC — OWNER passes, non-OWNER is 403 on every route
+# ---------------------------------------------------------------------------
+
+_ALL_ROUTES = [
+    ("GET", "/api/v1/security/decisions", None),
+    ("GET", "/api/v1/security/stats", None),
+    ("GET", "/api/v1/security/config", None),
+    ("PATCH", "/api/v1/security/config", {"mode": "deny"}),
+    ("POST", "/api/v1/security/decisions/d1/resolve", {"action": "ban"}),
+]
+
+
+@pytest.mark.parametrize("method,path,body", _ALL_ROUTES)
+@pytest.mark.parametrize("role", ["member", "admin"])
+def test_non_owner_is_forbidden_on_every_route(role, method, path, body):
+    shield = _FakeShield()
+    with TestClient(_build_app(role=role, shield=shield)) as client:
+        res = client.request(method, path, json=body)
+    assert res.status_code == 403, f"{role} {method} {path}: {res.text}"
+    # The guard rejected BEFORE any shield call — the proxy never reached out.
+    assert shield.requests == []
+
+
+@pytest.mark.parametrize("method,path,body", _ALL_ROUTES)
+def test_owner_passes_on_every_route(method, path, body):
+    shield = _FakeShield()
+    with TestClient(_build_app(role="owner", shield=shield)) as client:
+        res = client.request(method, path, json=body)
+    assert res.status_code in (200, 409), f"owner {method} {path}: {res.text}"
+    assert res.status_code != 403
+
+
+# ---------------------------------------------------------------------------
+# No-shield degrade — socket unset (client None)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path", ["/api/v1/security/decisions", "/api/v1/security/stats", "/api/v1/security/config"]
+)
+def test_reads_degrade_to_available_false_when_socket_unset(path):
+    with TestClient(_build_app(no_shield=True)) as client:
+        res = client.get(path)
+    assert res.status_code == 200, res.text
+    assert res.json() == {"available": False, "reason": "shield_not_deployed"}
+
+
+def test_patch_config_degrades_to_409_when_socket_unset():
+    with TestClient(_build_app(no_shield=True)) as client:
+        res = client.patch("/api/v1/security/config", json={"mode": "deny"})
+    assert res.status_code == 409, res.text
+    assert res.json() == {"detail": "shield_not_deployed"}
+
+
+def test_resolve_degrades_to_409_when_socket_unset():
+    with TestClient(_build_app(no_shield=True)) as client:
+        res = client.post("/api/v1/security/decisions/d1/resolve", json={"action": "ban"})
+    assert res.status_code == 409, res.text
+    assert res.json() == {"detail": "shield_not_deployed"}
+
+
+# ---------------------------------------------------------------------------
+# No-shield degrade — socket present but unreachable (transport raises)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path", ["/api/v1/security/decisions", "/api/v1/security/stats", "/api/v1/security/config"]
+)
+def test_reads_degrade_to_unreachable_when_shield_down(path):
+    with TestClient(_build_app(shield=_UnreachableShield())) as client:
+        res = client.get(path)
+    assert res.status_code == 200, res.text
+    assert res.json() == {"available": False, "reason": "unreachable"}
+
+
+def test_writes_degrade_to_409_when_shield_down():
+    with TestClient(_build_app(shield=_UnreachableShield())) as client:
+        res = client.patch("/api/v1/security/config", json={"mode": "deny"})
+    assert res.status_code == 409, res.text
+    assert res.json() == {"detail": "shield_not_deployed"}
+    with TestClient(_build_app(shield=_UnreachableShield())) as client:
+        res = client.post("/api/v1/security/decisions/d1/resolve", json={"action": "ban"})
+    assert res.status_code == 409, res.text
+    assert res.json() == {"detail": "shield_not_deployed"}

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -544,8 +544,18 @@ class TestSecretFieldsList:
             "status_api_key",
             "dodo_payments_api_key",
             "dodo_webhook_secret",
+            "shield_api_token",
         }
         assert SECRET_FIELDS == expected
+
+    def test_shield_api_token_is_secret(self):
+        """The shield control-API bearer token must be a SECRET_FIELD so it is
+        stored encrypted and never returned over REST (regression: it was added
+        to config as a plain field, which would have leaked it via
+        Settings.save() -> config.json and GET /api/v1/settings)."""
+        assert "shield_api_token" in SECRET_FIELDS
+        # The socket PATH is not a secret and must stay excluded.
+        assert "shield_api_socket" not in SECRET_FIELDS
 
     def test_non_secrets_excluded(self):
         """Common non-secret fields must NOT be in SECRET_FIELDS."""


### PR DESCRIPTION
## What ships

The backend `/api/v1/security/*` proxy — the OWNER-gated bridge between the paw-enterprise dashboard and paw-shield's local control API on a per-tenant box. This is SEC-5 of the `/security` live-wiring.

## Scope

- **`ee/pocketpaw_ee/cloud/security/router.py`** — a thin async proxy mapping 1:1 to shield's control API:
  - `GET /decisions`, `GET /stats`, `GET /config`
  - `PATCH /config`
  - `POST /decisions/{id}/resolve` (injects the OWNER user as the `actor` so shield records who resolved)
- **`ee/pocketpaw_ee/cloud/security/config.py`** — `httpx.AsyncHTTPTransport(uds=...)` to shield's unix socket, with the bearer token; reads `POCKETPAW_SHIELD_API_SOCKET` / `POCKETPAW_SHIELD_API_TOKEN` (added to `src/pocketpaw/config.py`).
- **`ee/pocketpaw_ee/guards/actions.py`** — a new `security.manage` action at the OWNER tier.

## Security

- **Every route is OWNER-gated** — each endpoint takes `Depends(require_action_any_workspace("security.manage"))`. A parametrized test asserts a non-OWNER (MEMBER/ADMIN) gets **403 on every route**, and an OWNER passes on every route. This is the gate in front of the ban-capable shield endpoints. (The ban *logic* itself was independently security-audited on the shield side.)
- The shield bearer token is **never logged**.
- shield's status + JSON pass through faithfully (a shield 400 on a bad PATCH reaches the caller as 400).

## Graceful no-shield

Most boxes won't have shield yet. When the socket is unset / missing / unreachable, the proxy returns a **typed** state, never a 500:
- GETs → `200 {"available": false, "reason": "shield_not_deployed"|"unreachable"}` (so the UI renders an empty state);
- writes → `409 {"detail": "shield_not_deployed"}` (can't act on an absent box).

## Tests

`uv run pytest tests/cloud/test_security_proxy.py` → **32 passed**. Coverage: forwarding (method/path/body/bearer, status + JSON passthrough, shield-400 passthrough), the OWNER-gate across every route, the no-shield degrade paths, and the actor injection on resolve.

## Reference

Fronts paw-shield PR #6 (the shield control API). Next: the frontend migration `/security-lab` → `/security` + wiring these endpoints (SEC-6/7).
