### PR TITLE
feat: WARM hot-process reuse for the session supervisor (flag-gated)

### DIFF
--- a/docs/concepts/agent-session-management.mdx
+++ b/docs/concepts/agent-session-management.mdx
@@ -143,19 +143,26 @@ native ids, and quota cross-starvation (see
 
 ## Status and deferred work
 
-**v1 (this design):** native resume substrate, durable tenancy-keyed store, the
-runtime mapping, the supervisor (COLD/WARM + per-tenant quota), and the
-flag-gated executor wiring. Every supervised turn resumes from the store.
+**Shipped (flag-gated, off by default):**
+
+- **v1 substrate** — native resume, durable tenancy-keyed store, the runtime
+  mapping, the supervisor (COLD/WARM + per-tenant quota), flag-gated executor
+  wiring.
+- **SaaS hardening** — atomic store `append`/upsert (no read-modify-write race)
+  and a COLD-runtime memory prune.
+- **WARM hot-process reuse** — the supervisor owns a per-session live
+  `ClaudeSDKClient`; turn 2+ reuses it (zero re-materialize), `resume` is the
+  cold-recovery path only. Bounded by the per-tenant warm quota + idle reaper, so
+  cold sessions still cost zero process. `claude_sdk` backend only.
 
 **Deferred / follow-up:**
 
-- **WARM hot-process reuse** — keeping a per-session client live to skip
-  re-materialization (v1 resumes cold each turn).
 - **LIVE / attach tier** — an attachable long-running process surfaced through
-  `cmux` for watch-and-steer.
-- Atomic store `append`/upsert (the v1 path is read-modify-write).
-- A COLD-runtime memory prune for very long SaaS uptime.
+  `cmux` for watch-and-steer (builds on WARM).
 - Codex native resume parity.
+- Skills + leased-client teardown reclaiming the materialized skills dir at
+  per-client teardown (currently reclaimed at backend `cleanup()` — benign
+  retention gap).
 
 ## Related
 

--- a/docs/handoff/2026-06-30-warm-reuse-smoke.md
+++ b/docs/handoff/2026-06-30-warm-reuse-smoke.md
@@ -1,0 +1,102 @@
+<!-- Smoke-test guide — WARM hot-process reuse (WH-1..WH-4). Created 2026-06-30.
+     Branch: the warm-reuse integration branch (dev + WH-1..WH-4). Run before shipping. -->
+
+# WARM hot-process reuse — Smoke Test Guide
+
+Built on top of Session Supervisor v1 (#1596/#1597). Same flag —
+**`POCKETPAW_SESSION_SUPERVISOR`** (default off). With it on, a supervised session
+now keeps its `claude` client **warm** across turns: turn 2+ reuses the live
+subprocess instead of resuming COLD (re-materialize + a fresh `claude` connect).
+
+## 0. Test-level (already green, re-run to confirm)
+
+```bash
+cd pocketPaw && uv sync --dev --group ee   # if the worktree venv isn't reused
+uv run pytest \
+  tests/test_claude_sdk_warm_lease.py tests/test_session_supervisor.py \
+  tests/cloud/runs/test_run_core_session_supervisor.py tests/cloud/runs/ -q -o addopts=""
+# expect: green (WH-1..WH-4 + the full chat-runs lane)
+```
+
+## 1. Prerequisites (cold box)
+
+Same as the v1 session-supervisor smoke (`docs/handoff/2026-06-30-session-supervisor-smoke.md`):
+cloud features 401 without a **`POCKETPAW_LICENSE_KEY`**, and you need a provisioned
+**workspace + `pocketpaw`-slug agent + a chat scope** (group/session/pocket).
+
+```bash
+cd pocketPaw
+POCKETPAW_SESSION_SUPERVISOR=true POCKETPAW_LICENSE_KEY=<your-key> \
+  uv run pocketpaw serve --port 8888
+```
+
+## 2. The headline check — turn 2 reuses the SAME `claude` process
+
+This is the whole point: warm reuse means the same live subprocess serves turn 2,
+not a fresh one.
+
+1. Open a chat. **Before** sending, note the baseline `claude` pids:
+   ```bash
+   pgrep -fl claude | grep -v 'claude-code\|Claude.app\|cmux'
+   ```
+2. Send **turn 1** (*"My favorite color is teal. Acknowledge."*). A new `claude` pid
+   appears (the per-session warm client). Record it:
+   ```bash
+   pgrep -fl claude | grep -v 'claude-code\|Claude.app\|cmux'
+   ```
+3. Send **turn 2** in the SAME chat (*"What's my favorite color?"* → "Teal"). Check the
+   pids again:
+   ```bash
+   pgrep -fl claude | grep -v 'claude-code\|Claude.app\|cmux'
+   ```
+   **PASS:** the turn-1 `claude` pid is **still there and unchanged** — turn 2 reused
+   it (no second `connect`, no re-materialize). A *new* pid for turn 2 means warm reuse
+   didn't fire (regression).
+
+## 3. Cold fallback after idle — a NEW pid that still answers
+
+4. Wait past the warm TTL (default `warm_ttl=120s`; the idle reaper disconnects the
+   warm client). Confirm the warm `claude` pid is gone:
+   ```bash
+   pgrep -fl claude | grep -v 'claude-code\|Claude.app\|cmux'
+   ```
+5. Send **turn 3** (*"Remind me my color?"* → still "Teal"). A **new** `claude` pid
+   appears (cold) and the answer is still correct — it resumed from the store.
+   **PASS:** new pid + correct answer = cold-recovery via resume works.
+
+## 4. Latency note (warm vs cold)
+
+Eyeball time-to-first-token: turn 2 (warm) should be noticeably faster than turn 1 /
+turn 3 (cold) — no materialize + no process startup. Record rough numbers; this is the
+payoff this tier exists for.
+
+## 5. Quota cap — no unbounded `claude` processes
+
+Under load (several active sessions in one workspace), the count of live `claude` pids
+stays bounded by `max_warm_per_tenant` (default 8) — the supervisor LRU-evicts +
+disconnects the oldest idle warm client when a tenant is over cap. This is asserted in
+the test soak (`tests/test_session_supervisor.py::test_quota_cap_soak_*`), but you can
+spot-check the live pid count stays ≤ the cap.
+
+## 6. Flag OFF — unchanged
+
+Restart without the flag. Chat behaves exactly as today; no warm clients are bound, the
+per-agent path is byte-identical. Merging is inert until you flip the flag.
+
+## Notes / known v1 limits
+
+- **WARM is `claude_sdk` only** this iteration (codex etc. still cold).
+- **Warm turns withhold the resume id** by design: the live client already carries the
+  conversation natively, and threading resume would force a cold re-materialize (the
+  backend's warm path is gated on `not resume_active`). Resume is the cold-recovery path
+  only. A warm turn still keeps the durable `(workspace,session,agent)→cli_session_id`
+  mapping for later cold resume.
+- **Skills + leased clients — follow-up:** a leased-client turn that carries skills
+  adopts a materialized skills dir that is reclaimed at the backend's `cleanup()` sweep
+  rather than at the per-leased-client teardown. Benign retention gap (not a process
+  leak; can't rug-pull since the flag is process-global). Fix: have the teardown also
+  drop the dir — folds into a later touch of the WH-1/WH-2 surface.
+
+## Ship
+
+Once §2–§3 pass live, the branch is ready to ship to dev (squash, like v1).

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,19 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-30 (fix/warm-noop-benign-error) — WARM hot-process reuse was a NO-OP
+  live: a benign backend ``error`` event flipped ``sup_run_failed`` True, so the
+  ``finally`` called ``mark_crashed`` and tore down the session's warm ``claude``
+  client EVERY turn — turn 2 never reused turn 1's slot. The real ``claude_sdk``
+  yields ``error`` THEN ``done`` for a non-fatal ResultMessage ``is_error`` (a turn
+  that still produced a response; the leased client stays healthy), but the error
+  branch ``break``-ed and flagged a crash before seeing the ``done``. Fixed: on the
+  supervised path the error branch now RECORDS the error (``sup_saw_error``) and
+  keeps consuming instead of breaking; ``sup_run_failed`` is decided at stream-end
+  — a trailing error followed by ``done`` (``sup_completed_ok``) keeps the slot
+  warm, while an ``error`` with no successful completion is still a genuine crash
+  that demotes the runtime to COLD (so the next turn cold-resumes from the store).
+  The legacy (flag-OFF) path keeps its original break-and-stop behavior byte-for-byte.
 - 2026-06-30 (feat/warm-reuse WH-3) — the supervised block now keeps a session's
   ``claude`` client WARM across turns. When ``acquire`` returns a live, eligible
   warm slot (``warm_reuse`` + ``slot``), the executor LEASES it to the backend
@@ -961,6 +974,16 @@ async def _drive_agent_loop(
     # on, so resume resolves the same row turn after turn.
     sup_acq: Any = None
     sup_run_failed = False
+    # WARM no-op fix (2026-06-30): a backend ``error`` event only demotes the warm
+    # slot to COLD when the run did NOT also reach a successful completion. The real
+    # ``claude_sdk`` yields ``error`` THEN ``done`` for a benign, non-fatal
+    # ResultMessage ``is_error`` (the leased client stays alive), so we record the
+    # error here and decide ``sup_run_failed`` at stream-end: a trailing error
+    # followed by ``done`` keeps the slot warm; an error with no completion is a
+    # genuine crash (demote → COLD). Both stay ``False`` on the legacy (flag-OFF)
+    # path, where the error branch keeps its original break-and-stop behavior.
+    sup_saw_error = False
+    sup_completed_ok = False
     sup_workspace_id = ctx.workspace_id
     sup_session_id = ctx.scope_id
     sup_agent_id = ctx.target_agent_id
@@ -1143,6 +1166,11 @@ async def _drive_agent_loop(
             etype = getattr(event, "type", None)
             econtent = getattr(event, "content", "")
             if etype == "done":
+                # The backend reached a successful completion (it only yields
+                # ``done`` when no exception aborted the stream). A preceding
+                # benign ``error`` event is therefore NOT a crash — the warm slot
+                # must survive (WARM no-op fix).
+                sup_completed_ok = True
                 next_event_task = None
                 break
             next_event_task = asyncio.create_task(_next_event())
@@ -1247,11 +1275,31 @@ async def _drive_agent_loop(
                     message[:200],
                 )
                 yield ("error", {"code": "agent.backend_error", "message": message})
-                # Supervised: a backend-yielded error is a run failure — flag it
-                # so ``finally`` demotes the runtime to COLD (keeping its
-                # cli_session_id so the next turn still resumes from the store).
+                if sup_acq is not None:
+                    # Supervised: a backend ``error`` event is NOT automatically a
+                    # crash. The leased ``claude`` client can stay alive and healthy
+                    # while the SDK reports a benign/non-fatal ResultMessage
+                    # ``is_error`` (a turn that still produced a response) — and the
+                    # real backend then yields ``done`` right after. Record the
+                    # error but KEEP consuming: a trailing ``done`` proves the run
+                    # completed (the warm slot must survive for reuse), while an
+                    # error with no completion is a genuine failure. ``sup_run_failed``
+                    # is decided at stream-end from ``sup_saw_error`` + the
+                    # ``sup_completed_ok`` ``done`` signal.
+                    sup_saw_error = True
+                    continue
+                # Legacy (flag-OFF) path: byte-for-byte unchanged — surface the
+                # error and stop the stream.
                 sup_run_failed = True
                 break
+        # Supervised crash determination (WARM no-op fix): an ``error`` event demotes
+        # the warm slot only when the stream did NOT also reach a successful
+        # completion. A benign trailing error followed by ``done`` (the leased client
+        # is healthy) keeps the slot warm for reuse; an error with no ``done`` is a
+        # genuine failure → ``mark_crashed`` (COLD) in the ``finally``. No-op on the
+        # legacy path (``sup_acq is None``) and on a clean run (``sup_saw_error`` False).
+        if sup_acq is not None and sup_saw_error and not sup_completed_ok:
+            sup_run_failed = True
         for ev in _drain_side_channel():
             yield ev
     except Exception:

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,26 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-30 (feat/warm-reuse WH-3) — the supervised block now keeps a session's
+  ``claude`` client WARM across turns. When ``acquire`` returns a live, eligible
+  warm slot (``warm_reuse`` + ``slot``), the executor LEASES it to the backend
+  via ``run_kwargs["warm_client"]`` so turn 2+ drives the existing subprocess
+  directly (no re-materialize, no reconnect). On such a warm-reuse turn it
+  WITHHOLDS the resume id from the ``SessionHandle`` (``cli_session_id=None``,
+  store still threaded): the backend's warm-reuse path is gated on
+  ``not resume_active``, and the live client already holds THIS session's
+  conversation, so threading resume would silently demote warm reuse to a cold
+  re-materialize. On every other supervised turn (turn 1, a reaped/COLD runtime,
+  crash recovery) the resume id is threaded exactly as SS-5 did (cold-resume).
+  The executor ALSO always hands the backend an ``on_client_built`` callback that
+  binds the freshly-built client back to the supervisor (``bind_warm_slot`` with a
+  ``LeasedClient``) so the NEXT turn can reuse it; it is a no-op on a warm-reuse
+  turn and rebinds the new slot on a key-drift (model/tools changed) turn. Flag
+  OFF is byte-for-byte unchanged: neither ``warm_client`` nor ``on_client_built``
+  is added. (Known follow-up: a leased turn that carries ``skill_names``
+  materializes a per-run skills dir that is cleaned at backend ``cleanup()``, not
+  at the supervisor's per-leased-client teardown — a benign retention gap, no run
+  correctness impact; the clean fix spans the WH-1/WH-2 surface.)
 - 2026-06-30 (feat/session-supervisor SS-5) — ``_drive_agent_loop`` now drives
   every supervised agent turn through the ``SessionSupervisor`` + the durable
   ``(workspace, session, agent) -> cli_session_id`` mapping (SS-3
@@ -153,6 +173,7 @@ from datetime import datetime
 from typing import Any
 
 from pocketpaw.agents.backend import (  # type: ignore[import-untyped]
+    LeasedClient,
     SessionHandle,
 )
 from pocketpaw.agents.pool import (  # type: ignore[import-untyped]
@@ -1030,10 +1051,44 @@ async def _drive_agent_loop(
                     cli_session_id=prior_cli,
                     project_key=None,
                 )
+                # WH-3: turn 2+ keeps this session's ``claude`` client WARM. When
+                # ``acquire`` hands back a live, key-eligible warm slot, LEASE it
+                # to the backend (``warm_client``) so the turn drives the existing
+                # subprocess directly — no re-materialize, no reconnect. The
+                # backend's warm-reuse path is gated on ``not resume_active`` (a
+                # resume id forces a fresh launch), so on a warm-reuse turn we
+                # WITHHOLD the resume id from the ``SessionHandle``: the live client
+                # already carries THIS session's conversation in memory, so resuming
+                # from the store would be redundant AND would silently demote warm
+                # reuse to a cold re-materialize. The store is still threaded
+                # (durable append unchanged). On every other supervised turn
+                # (turn 1, a reaped/COLD runtime, a crash recovery) the resume id IS
+                # threaded — the unchanged SS-5 cold-resume path.
+                warm_turn = sup_acq.warm_reuse and sup_acq.slot is not None
                 run_kwargs["session_handle"] = SessionHandle(
-                    cli_session_id=sup_acq.cli_session_id,
+                    cli_session_id=None if warm_turn else sup_acq.cli_session_id,
                     session_store=MongoSessionStore(sup_workspace_id),
                 )
+                if warm_turn:
+                    run_kwargs["warm_client"] = sup_acq.slot
+                # Always (on the supervised path) hand the backend a callback that
+                # BINDS the freshly-built client back to the supervisor as this
+                # session's warm slot, so the NEXT turn can reuse it. A no-op on a
+                # warm-reuse turn (the backend drives the leased client and never
+                # builds a fresh one); on a key-drift turn (model/tools changed
+                # mid-session) the backend rebuilds and this rebinds the new slot.
+                # ``_warm_acq`` captures THIS turn's acquisition so the closure
+                # never observes the ``except``-path reset of ``sup_acq``.
+                _warm_acq = sup_acq
+
+                def _on_client_built(client: Any, options_key: str, teardown: Any) -> None:
+                    get_session_supervisor().bind_warm_slot(
+                        _warm_acq.runtime,
+                        LeasedClient(client=client, options_key=options_key),
+                        teardown,
+                    )
+
+                run_kwargs["on_client_built"] = _on_client_built
                 supervisor.mark_run_start(sup_acq.runtime)
             except Exception:
                 logger.warning(
@@ -1045,6 +1100,8 @@ async def _drive_agent_loop(
                 )
                 sup_acq = None
                 run_kwargs.pop("session_handle", None)
+                run_kwargs.pop("warm_client", None)
+                run_kwargs.pop("on_client_built", None)
         agent_iter = pool.run(
             ctx.target_agent_id,
             user_content,

--- a/src/pocketpaw/agents/backend.py
+++ b/src/pocketpaw/agents/backend.py
@@ -3,6 +3,17 @@
 Every agent backend (Claude SDK, OpenAI Agents, Gemini CLI, OpenCode CLI)
 must expose a ``info()`` staticmethod and an async ``run()`` generator.
 
+Updated: 2026-06-30 (feat/warm-reuse WH-1) — adds the ``LeasedClient`` dataclass:
+a connected, CALLER-owned warm ``ClaudeSDKClient`` plus the backend cache key it
+was connected under. The ``SessionSupervisor`` (WH-2/WH-3) owns a per-(workspace,
+session) live client and LEASES it into ``ClaudeSDKBackend.run`` so turn 2+ reuses
+the live subprocess instead of resuming COLD. Generic by design (``client: Any``)
+so OSS / the supervisor hold it without importing the concrete SDK type — the same
+opaque pass-through discipline as ``SessionHandle.session_store`` — and it lives
+here (not in ``claude_sdk``) so the supervisor can import it without an import
+cycle. The backend never owns or tears down a leased client; the supervisor keeps
+it warm across turns and disconnects it on its own lifecycle.
+
 Updated: 2026-06-05 (feat/sites-svelte-engine) — the shared ``run`` signature
 grows a ``deny_mcp_tool_ids: frozenset[str] = frozenset()`` keyword: a
 per-surface MCP-tool deny set the chat loop threads through (resolved from the
@@ -117,6 +128,39 @@ class SessionHandle:
 
     cli_session_id: str | None = None
     session_store: Any | None = None
+
+
+@dataclass
+class LeasedClient:
+    """WH-1 — a connected, caller-owned warm SDK client leased into a backend run.
+
+    The ``SessionSupervisor`` (WH-2/WH-3) owns a per-(workspace, session) live
+    ``ClaudeSDKClient`` and LEASES it to ``ClaudeSDKBackend.run`` so turn 2+ reuses
+    the live subprocess instead of resuming COLD (re-materialize + a fresh
+    ``claude`` connect). The backend NEVER owns or tears down a leased client — the
+    supervisor keeps it warm across turns and disconnects it on its own lifecycle.
+
+    * ``client`` — a connected ``ClaudeSDKClient``. Typed ``Any`` so OSS / the
+      supervisor can hold it without importing the concrete SDK type, mirroring
+      ``SessionHandle.session_store``'s opaque pass-through.
+    * ``options_key`` — the backend's ``_client_cache_key`` for the options the
+      client was connected with (session + cwd + model + tools + system-prompt
+      behavioral-prefix digest + plugin-identity digest). The backend recomputes
+      THIS turn's key and reuses the leased client ONLY on an exact match; a
+      mismatch routes to a fresh build (and the supervisor rebinds the new slot).
+    * ``busy`` — set by the backend while it is driving a query on ``client`` so a
+      second concurrent turn never drives two queries on one subprocess. A busy
+      lease makes the second turn fall back to a fresh stateless client for that
+      turn (it does not block, corrupt the shared client, or rebind the slot).
+
+    Rides the same withhold-when-empty contract as ``SessionHandle``: ``AgentPool.run``
+    forwards ``warm_client`` to ``backend.run`` only when non-None, so backends that
+    keep the narrower signature are unaffected. Only the Claude SDK backend acts on it.
+    """
+
+    client: Any
+    options_key: str
+    busy: bool = False
 
 
 @runtime_checkable

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1053,20 +1053,120 @@ class ClaudeSDKBackend(BaseAgentBackend):
         "\n\n# Recent Conversation",
     )
 
+    # The soul "# Key Knowledge" block is a MID-prompt volatile section, unlike
+    # the tail markers above. ``AgentPool._assemble_system_prompt`` splices it in
+    # RIGHT AFTER the stable soul identity via
+    # ``f"{system_prompt}\n\n# Key Knowledge\n{knowledge_lines}"`` (pool.py:243-245),
+    # where ``knowledge_lines = "\n".join(f"- {k}" for k in ctx.knowledge)`` — so
+    # every item is a ``- ``-prefixed line and the block sits EARLY (char ~1.4k of
+    # a ~44k prefix), sandwiched between the stable ``ctx.identity`` before it and
+    # the stable authoritative ``instructions`` (ripple LAW) + ``<runtime-identity>``
+    # + tool docs after it. Its ``ctx.knowledge`` items are ALL volatile soul state
+    # (self-image confidences, an incrementing bond level, a growing memory count,
+    # recalled semantic/procedural memories — see ``soul/_bridge.py``), NONE of
+    # them behavioral instructions. Live instrumentation proved two consecutive
+    # turns' prefixes differed by exactly the incrementing "Bond level" / "Memories"
+    # digits inside this block, so the prefix digest changed every turn and the
+    # warm subprocess was rebuilt every turn (warm reuse NEVER fired).
+    #
+    # Because it is mid-prompt, the tail cut above cannot touch it, and adding it
+    # to ``_VOLATILE_PROMPT_MARKERS`` (a tail cut) would strip ~97% of the real
+    # behavioral prefix (over-strip — a real ``instructions``/identity change would
+    # then wrongly reuse a stale client). So we EXCISE it IN PLACE, keeping every
+    # stable byte before and after it.
+    _SOUL_KNOWLEDGE_BLOCK_HEADER = "\n\n# Key Knowledge\n"
+
+    @classmethod
+    def _strip_soul_knowledge_block(cls, text: str) -> str:
+        """Surgically remove the mid-prompt soul "# Key Knowledge" block.
+
+        Structure-anchored, not blank-line-anchored: pool.py builds the block as
+        the header followed by a run of ``- ``-prefixed item lines. A recalled
+        memory's ``content`` can itself contain newlines (soul/_bridge.py:106),
+        so an item may WRAP onto continuation lines — those are absorbed into the
+        block as long as they are not separated from the items by a blank line.
+        The block ENDS at the first blank line whose following line does NOT
+        resume ``- `` items: that blank line is the ``\\n\\n`` join before the
+        next stable section (the authoritative ``instructions`` / runtime docs).
+        This deliberately terminates at a blank line rather than swallowing text
+        up to a heuristic anchor, so a stable section that follows in plain prose
+        (e.g. the ripple LAW ``instructions``) is NEVER over-stripped.
+
+        Robustness:
+        * ``rfind`` + a ``- `` item guard select the MACHINE-built block, so a
+          user-authored "# Key Knowledge" heading in persona/identity prose (no
+          ``- `` items under it) is left untouched and still keys the prefix.
+        * Block as the LAST section (no trailing blank line) → removed to EOS.
+        * Header absent (empty ``ctx.knowledge`` / legacy path) → byte-identical.
+        """
+        header = cls._SOUL_KNOWLEDGE_BLOCK_HEADER
+        # Select the machine-built block: the LAST header immediately followed by
+        # a ``- `` item line. Walk backwards past any prose heading collisions.
+        search_from = len(text)
+        while True:
+            start = text.rfind(header, 0, search_from)
+            if start == -1:
+                return text
+            body_start = start + len(header)
+            if text[body_start : body_start + 2] == "- ":
+                break
+            search_from = start
+        n = len(text)
+        i = body_start
+        block_end = body_start
+        while i < n:
+            nl = text.find("\n", i)
+            line_end = n if nl == -1 else nl
+            line = text[i:line_end]
+            if line.startswith("- "):
+                # An item line — extend the block through it.
+                block_end = line_end
+                i = line_end + 1
+                continue
+            if line == "":
+                # A blank line: it is internal to the block only if a later line
+                # resumes ``- `` items; otherwise it is the ``\n\n`` join before
+                # the next stable section, so the block ends here.
+                j = line_end + 1
+                while j < n and text[j] == "\n":
+                    j += 1
+                nl2 = text.find("\n", j)
+                nxt_end = n if nl2 == -1 else nl2
+                if text[j:nxt_end].startswith("- "):
+                    i = line_end + 1
+                    continue
+                break
+            # A non-blank, non-item line with NO preceding blank line is a wrapped
+            # continuation of the current item's content — absorb it.
+            block_end = line_end
+            i = line_end + 1
+        return text[:start] + text[block_end:]
+
     @classmethod
     def _behavior_prefix(cls, system_prompt: Any) -> str:
         """Return the stable behavioral prefix of ``system_prompt``.
 
-        Strips the volatile per-turn tail (KB block, soul memories, injected
-        history) so two turns that differ only in retrieved context hash to the
-        same value. On Windows the SDK may pass ``system_prompt`` as a
-        ``{type: "file", path: ...}`` dict — there is no inline text to key on,
-        so fall back to the path (stable per connect) repr.
+        Two independent volatile strips run here so two turns that differ only
+        in per-turn soul/retrieval state hash to the same value:
+
+        1. The MID-prompt soul "# Key Knowledge" block is excised in place
+           (``_strip_soul_knowledge_block``) — its bond level / memory count /
+           recalled memories increment every turn but carry no behavioral
+           instructions.
+        2. The volatile per-turn TAIL (KB block, soul-memory recall, injected
+           history) is cut at the earliest ``_VOLATILE_PROMPT_MARKERS`` marker.
+
+        A REAL behavioral change (different persona/identity, override, or
+        ``instructions``) still lands in the retained text, so it changes the
+        digest and forces a warm-client rebuild. On Windows the SDK may pass
+        ``system_prompt`` as a ``{type: "file", path: ...}`` dict — there is no
+        inline text to key on, so fall back to the path (stable per connect).
         """
         if isinstance(system_prompt, dict):
             return f"file:{system_prompt.get('path', '')}"
         if not isinstance(system_prompt, str):
             return ""
+        system_prompt = cls._strip_soul_knowledge_block(system_prompt)
         cut = len(system_prompt)
         for marker in cls._VOLATILE_PROMPT_MARKERS:
             idx = system_prompt.find(marker)

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,20 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-07-01 (fix/warm-reuse session_id) — the native ``session_id`` is now
+  ALSO captured from the terminal ``ResultMessage`` (``getattr(event,
+  "session_id", None)``), as a robust FALLBACK to the SS-1 init-``SystemMessage``
+  capture. Root cause of a live WARM NO-OP: on the leased supervised-fresh path
+  the init ``SystemMessage``'s ``data["session_id"]`` did NOT surface at runtime,
+  so ``set_cli_session_id`` never ran, ``runtime.cli_session_id`` stayed None,
+  ``owns_capture`` stayed True forever, and ``warm_reuse`` (= warm_alive AND not
+  owns_capture) never fired. The ``ResultMessage.session_id`` is a direct str
+  field ALWAYS carried on the terminal message of every completed run, so
+  capturing it here guarantees turn-1 capture. Still gated on ``session_handle is
+  not None`` + emit-once (``_session_id_emitted``): the init ``SystemMessage``
+  path still wins first when it fires (no double-emit), and the no-handle legacy
+  stream stays byte-identical. Two INFO logs mark the capture moment + source
+  ("session_id captured from init SystemMessage" / "... from ResultMessage
+  (fallback)") so a live re-smoke can confirm capture now fires.
 Updated: 2026-06-30 (feat/warm-reuse WH-1) — ``run`` accepts two optional OSS-only
   params so the SessionSupervisor (WH-2/WH-3) can drive the turn against a
   caller-LEASED warm client instead of the backend's own ``self._client``:
@@ -2378,6 +2393,10 @@ class ClaudeSDKBackend(BaseAgentBackend):
                             _sid = _data.get("session_id") if isinstance(_data, dict) else None
                             if _sid:
                                 _session_id_emitted = True
+                                logger.info(
+                                    "session_id captured from init SystemMessage (id=%s)",
+                                    _sid,
+                                )
                                 yield AgentEvent(
                                     type="session_id",
                                     content="",
@@ -2447,6 +2466,35 @@ class ClaudeSDKBackend(BaseAgentBackend):
                     # ========== ResultMessage - final result ==========
                     if self._ResultMessage and isinstance(event, self._ResultMessage):
                         _saw_result = True
+                        # feat/warm-reuse fix: capture the native session_id from the
+                        # ResultMessage as a ROBUST FALLBACK. SS-1 captured it from the
+                        # init SystemMessage's ``data["session_id"]`` — that fired for
+                        # the persistent v1 path but NOT for the leased supervised-fresh
+                        # path (code-identical connect->query->receive, but the init's
+                        # session_id doesn't surface at runtime on the fresh client), so
+                        # ``owns_capture`` stayed True forever and WARM reuse / native
+                        # resume never engaged. The ``ResultMessage`` ALWAYS carries the
+                        # native ``session_id`` (types.py: a direct str field) and is the
+                        # terminal message every completed run processes, so capturing it
+                        # here guarantees turn-1 capture. Still gated on the handle +
+                        # emit-once, so the legacy stream stays byte-identical and no
+                        # double-emit if the SystemMessage already surfaced it.
+                        if session_handle is not None and not _session_id_emitted:
+                            _rsid = getattr(event, "session_id", None)
+                            if _rsid:
+                                _session_id_emitted = True
+                                logger.info(
+                                    "session_id captured from ResultMessage (fallback) (id=%s)",
+                                    _rsid,
+                                )
+                                yield AgentEvent(
+                                    type="session_id",
+                                    content="",
+                                    metadata={
+                                        "session_id": _rsid,
+                                        "backend": "claude_agent_sdk",
+                                    },
+                                )
                         is_error = getattr(event, "is_error", False)
                         result = getattr(event, "result", "")
 

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,33 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-06-30 (feat/warm-reuse WH-1) — ``run`` accepts two optional OSS-only
+  params so the SessionSupervisor (WH-2/WH-3) can drive the turn against a
+  caller-LEASED warm client instead of the backend's own ``self._client``:
+  ``warm_client: LeasedClient | None`` and
+  ``on_client_built: Callable[[client, options_key, teardown], None] | None``
+  (forwarded by ``AgentPool.run`` only when set — withhold-when-empty, like the
+  deny/allow/skill kwargs). When either is set, ``run`` computes THIS turn's
+  ``_client_cache_key`` ONCE (recomputed via the pure classmethod with the SAME
+  ``options``/``session_key``/``plugin_digest`` ``_get_or_create_client`` would
+  use, so it is byte-identical and the legacy ``self._client`` call stays
+  untouched) and routes through ``_leased_dispatch``:
+    • WARM REUSE — ``warm_client`` key MATCHES this turn (and not a resume turn,
+      and the lease is not ``busy``) → drive ``warm_client.client.query(message)``
+      directly: NO connect, NO resume, NO history injection (the live client
+      already carries the conversation natively), and it is NEVER disconnected
+      (the supervisor keeps it warm).
+    • SUPERVISED FRESH BUILD — ``on_client_built`` set AND (no ``warm_client`` OR
+      key mismatch OR busy) → build + ``connect()`` a fresh client (carrying
+      ``resume`` only when ``session_handle.cli_session_id`` is set — the
+      cold-recovery path), hand it to ``on_client_built(client, key, teardown)``
+      for the supervisor to OWN (``teardown`` disconnects it) instead of caching
+      on ``self._client``, then run the query against it.
+    • BUSY edge — a ``warm_client`` whose ``busy`` flag is already set (a sibling
+      turn is mid-query on it) falls back to a fresh stateless query for THIS turn
+      and does NOT rebind, so two turns never drive one subprocess concurrently.
+  Neither param → the existing ``self._client`` / ``_get_or_create_client`` path,
+  byte-for-byte unchanged. ``LeasedClient`` lives in ``backend.py`` (generic,
+  ``client: Any``) so the supervisor imports it without a cycle.
 Updated: 2026-06-30 (feat/session-supervisor SS-2) — ``_build_options`` now also
   forwards ``session_handle.session_store`` to the SDK as
   ``ClaudeAgentOptions.session_store`` when it is non-None. On a resume turn the
@@ -206,7 +234,7 @@ import asyncio
 import hashlib
 import logging
 import re
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -214,6 +242,7 @@ from pocketpaw.agents.backend import (
     BackendInfo,
     BaseAgentBackend,
     Capability,
+    LeasedClient,
     SessionHandle,
 )
 from pocketpaw.agents.protocol import AgentEvent
@@ -1851,6 +1880,137 @@ class ClaudeSDKBackend(BaseAgentBackend):
                         self._drop_skills_dir(adopted_digest)
                         self._client_plugin_digest = ""
 
+    async def _leased_dispatch(
+        self,
+        *,
+        message: str,
+        options: Any,
+        this_turn_key: str,
+        resume_active: bool,
+        warm_client: LeasedClient | None,
+        on_client_built: Callable[[Any, str, Callable], None] | None,
+    ) -> tuple[Any, LeasedClient | None]:
+        """feat/warm-reuse WH-1 — route a turn against a caller-LEASED warm client.
+
+        Called by ``run`` only when ``warm_client`` or ``on_client_built`` is set.
+        The backend's own ``self._client`` is NOT involved here — the supervisor
+        owns the leased client's lifecycle, so this never touches ``self._client``,
+        ``acquired_lease``, or ``self._client_in_use``.
+
+        Returns ``(event_stream, warm_lease)``:
+          * ``event_stream`` is the message iterator to stream, or ``None`` to make
+            the caller fall through to a fresh stateless ``query()`` for this turn.
+          * ``warm_lease`` is the ``LeasedClient`` whose ``busy`` flag THIS turn set
+            (the caller clears it in its finally), or ``None`` when no lease is held.
+
+        Three outcomes:
+          1. WARM REUSE — ``warm_client`` key matches, not a resume turn, lease not
+             ``busy`` → drive ``warm_client.client.query(message)`` directly (no
+             connect, no resume, no history injection) and return its receive
+             iterator. The lease stays ``busy`` for the stream's duration and is
+             NEVER disconnected.
+          2. SUPERVISED FRESH BUILD — ``on_client_built`` set and warm reuse did not
+             apply → build + ``connect()`` a fresh client (``options`` already carry
+             ``resume`` iff ``session_handle.cli_session_id`` was set), hand it to
+             ``on_client_built(client, this_turn_key, teardown)`` for the supervisor
+             to own, then query it.
+          3. STATELESS FALLBACK — a busy matching lease, any connect/query failure,
+             or a ``warm_client`` key mismatch with no ``on_client_built`` to rebind
+             → return ``(None, None)`` so the caller runs a fresh stateless query.
+        """
+        # ── 1. Warm reuse ────────────────────────────────────────────────
+        # A resume turn must take a fresh launch (the live client carries its OWN
+        # conversation, not the requested on-disk session), so warm reuse is gated
+        # on ``not resume_active`` as well as an exact key match.
+        if (
+            warm_client is not None
+            and not resume_active
+            and warm_client.options_key == this_turn_key
+        ):
+            # Busy detection: the lease's own ``busy`` flag. Single-threaded
+            # asyncio means the check-then-set below has no ``await`` between it, so
+            # it is atomic — a second concurrent turn can never both see "free" and
+            # then both drive a query. A busy lease falls back to a fresh stateless
+            # client for THIS turn (never blocks, never corrupts the shared client)
+            # and does NOT rebind the slot.
+            if warm_client.busy:
+                logger.info(
+                    "WH-1: leased warm client is busy (concurrent turn) — "
+                    "fresh stateless fallback for this turn"
+                )
+                return None, None
+            warm_client.busy = True
+            try:
+                logger.info(
+                    "WH-1: reusing leased warm client (key match) — "
+                    "no connect, no resume, no history injection"
+                )
+                await warm_client.client.query(message)
+                return self._resilient_receive(warm_client.client), warm_client
+            except Exception as exc:  # noqa: BLE001
+                # The leased client failed mid-send. Release its busy flag (we no
+                # longer drive it) but do NOT disconnect — the supervisor owns it.
+                warm_client.busy = False
+                logger.warning("WH-1: leased warm client query failed, stateless fallback: %s", exc)
+                return None, None
+
+        # ── 2. Supervised fresh build ────────────────────────────────────
+        if on_client_built is not None:
+            try:
+                fresh = self._ClaudeSDKClient(options=options)
+                await fresh.connect()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "WH-1: supervised fresh client connect failed, stateless fallback: %s",
+                    exc,
+                )
+                return None, None
+
+            async def _teardown() -> None:
+                """Disconnect the client THIS run built. The supervisor calls this
+                when it drops / replaces the slot — the backend never caches the
+                client on ``self._client``."""
+                try:
+                    await fresh.disconnect()
+                except Exception as disc_exc:  # noqa: BLE001
+                    logger.debug(
+                        "WH-1: leased fresh client teardown disconnect error (ignored): %s",
+                        disc_exc,
+                    )
+
+            try:
+                on_client_built(fresh, this_turn_key, _teardown)
+            except Exception as exc:  # noqa: BLE001
+                # The supervisor refused the slot — tear the client down so it
+                # doesn't leak, then fall back to stateless so the turn completes.
+                logger.warning(
+                    "WH-1: on_client_built raised, tearing down + stateless fallback: %s",
+                    exc,
+                )
+                await _teardown()
+                return None, None
+
+            try:
+                logger.info(
+                    "WH-1: supervised fresh client built + bound (resume=%s) — driving query",
+                    bool(getattr(options, "resume", None)),
+                )
+                await fresh.query(message)
+                # The supervisor now OWNS the client; the backend does not tear it
+                # down here even if the stream later aborts.
+                return self._resilient_receive(fresh), None
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "WH-1: supervised fresh client query failed, stateless fallback: %s",
+                    exc,
+                )
+                return None, None
+
+        # ── 3. Stateless fallback ────────────────────────────────────────
+        # ``warm_client`` provided but key-mismatched / resume / busy, and no
+        # ``on_client_built`` to build + rebind → run a fresh stateless query.
+        return None, None
+
     async def run(
         self,
         message: str,
@@ -1863,6 +2023,8 @@ class ClaudeSDKBackend(BaseAgentBackend):
         allow_mcp_tool_ids: frozenset[str] | None = None,
         skill_names: frozenset[str] = frozenset(),
         session_handle: SessionHandle | None = None,
+        warm_client: LeasedClient | None = None,
+        on_client_built: Callable[[Any, str, Callable], None] | None = None,
     ) -> AsyncIterator[AgentEvent]:
         """Process a message through Claude Agent SDK with streaming.
 
@@ -1914,6 +2076,15 @@ class ClaudeSDKBackend(BaseAgentBackend):
         is non-empty we BYPASS the warm client and run on a fresh stateless query
         whose options carry the materialized plugin. The temp dir is removed in a
         ``finally`` after the stream drains. Empty by default (a no-op).
+
+        ``warm_client`` / ``on_client_built`` (feat/warm-reuse WH-1) let the
+        SessionSupervisor drive the turn against a caller-LEASED warm client
+        instead of the backend's own ``self._client``. When either is set, this
+        turn's ``_client_cache_key`` is computed once and ``_leased_dispatch``
+        routes the turn (warm reuse on a key match, else a supervised fresh build
+        handed to ``on_client_built`` for the supervisor to own, with a busy lease
+        falling back to a fresh stateless query). Neither set → the unchanged
+        legacy ``self._client`` path. See the module docstring for the full table.
         """
         if not self._sdk_available:
             yield AgentEvent(
@@ -1985,6 +2156,12 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # non-owning run (stateless fallback, or a failure before acquisition)
         # can never release a sibling's lease or destroy its subprocess.
         acquired_lease = False
+        # feat/warm-reuse WH-1: the ``LeasedClient`` whose ``busy`` flag THIS run
+        # set on the warm-reuse path. Declared above the try so the finally /
+        # except can always release it (set ``busy=False``) without ever
+        # disconnecting it — the supervisor owns the leased client's lifecycle.
+        # None on every legacy / supervised-fresh / stateless run.
+        _warm_lease: LeasedClient | None = None
         # Resolved LLM client — bound by ``_build_options`` below. Declared above
         # the try (feat/claude-sdk-prewarm) so the ``except`` handler's
         # ``llm.format_api_error`` call is safe even when ``_build_options`` itself
@@ -2045,6 +2222,30 @@ class ClaudeSDKBackend(BaseAgentBackend):
             _resume_active = (
                 session_handle is not None and session_handle.cli_session_id is not None
             )
+            # feat/warm-reuse WH-1: when the caller LEASES a warm client
+            # (``warm_client``) or wants to OWN the freshly-built one
+            # (``on_client_built``), compute THIS turn's cache key ONCE and route
+            # through ``_leased_dispatch`` instead of the backend's own
+            # ``self._client`` path. The key is recomputed via the pure
+            # ``_client_cache_key`` classmethod with the SAME
+            # ``options``/``session_key``/``plugin_digest`` that
+            # ``_get_or_create_client`` would hash internally — byte-identical, so
+            # the legacy ``self._client`` branch below stays untouched. The
+            # supervised paths never set ``acquired_lease`` / ``self._client_in_use``
+            # (they don't own ``self._client``), so the finally / except teardown of
+            # the per-agent warm client cannot misfire on a leased client.
+            if warm_client is not None or on_client_built is not None:
+                this_turn_key = self._client_cache_key(
+                    options, session_key=session_key, plugin_digest=plugin_digest
+                )
+                event_stream, _warm_lease = await self._leased_dispatch(
+                    message=message,
+                    options=options,
+                    this_turn_key=this_turn_key,
+                    resume_active=_resume_active,
+                    warm_client=warm_client,
+                    on_client_built=on_client_built,
+                )
             # fix/claude-sdk-warm-client-skills: the warm-client bypass for skill
             # runs is REMOVED. ``_client_cache_key`` now folds in
             # ``plugin_digest`` (the skill-identity hash), so a warm client can
@@ -2054,7 +2255,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
             # subprocess keeps a valid path across turns. Fallbacks to the
             # stateless path: the original concurrency guard (a sibling run holds
             # the lease, ``_client_in_use``) OR a native-resume turn.
-            if not self._client_in_use and not _resume_active:
+            elif not self._client_in_use and not _resume_active:
                 try:
                     self._client_in_use = True
                     acquired_lease = True
@@ -2457,6 +2658,15 @@ class ClaudeSDKBackend(BaseAgentBackend):
                     content=f"❌ Claude Agent SDK error: {error_msg}",
                 )
         finally:
+            # feat/warm-reuse WH-1: release the leased warm client's ``busy`` flag
+            # (set only on the warm-reuse path) so the supervisor's NEXT turn can
+            # drive it again. Done in the OUTER finally so it runs on every exit
+            # path — normal completion, error, and the Bun-crash retry ``return``
+            # (the recursive retry never carries the lease, so it can't double-set
+            # busy). NEVER disconnect the leased client here — the supervisor owns
+            # its lifecycle and keeps it warm.
+            if _warm_lease is not None:
+                _warm_lease.busy = False
             # Remove the per-run materialized-skills plugin dir (entity-rooms
             # A2) ONLY when this run owns it — i.e. the genuine stateless-
             # fallback case where no warm client adopted the dir

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -77,7 +77,9 @@ from typing import TYPE_CHECKING, Any
 from pocketpaw.agents.errors import AgentBackendUnavailable, AgentNotFound
 
 if TYPE_CHECKING:
-    from pocketpaw.agents.backend import AgentBackend, SessionHandle
+    from collections.abc import Callable
+
+    from pocketpaw.agents.backend import AgentBackend, LeasedClient, SessionHandle
     from pocketpaw.soul import SoulManager
 
 logger = logging.getLogger(__name__)
@@ -404,6 +406,8 @@ class AgentPool:
         system_message_override: str | None = None,
         skill_names: frozenset[str] = frozenset(),
         session_handle: SessionHandle | None = None,
+        warm_client: LeasedClient | None = None,
+        on_client_built: Callable[[Any, str, Callable], None] | None = None,
     ) -> AsyncIterator[Any]:
         """Run an agent on a message. Yields AgentEvent stream.
 
@@ -447,6 +451,14 @@ class AgentPool:
         their narrower signature). The Claude SDK backend materializes exactly
         those skills into a throwaway local plugin so ONLY the named skills are
         surfaced to the agent for this run. Empty = legacy all-skills behavior.
+
+        ``warm_client`` / ``on_client_built`` (feat/warm-reuse WH-1) let the
+        SessionSupervisor (WH-2/WH-3) drive the turn against a caller-LEASED warm
+        client. They ride the SAME withhold-when-empty contract as the kwargs
+        above — forwarded to the backend's ``run`` ONLY when set, so the 6
+        non-Claude backends keep their narrower signature and only the Claude SDK
+        backend acts on them. Both unset (the default) = the unchanged legacy
+        warm-client path.
         """
         instance = await self.get(agent_id)
         instance.last_active = datetime.now(UTC)
@@ -528,6 +540,16 @@ class AgentPool:
             # None = legacy warm-client path, unchanged for every existing run.
             if session_handle is not None:
                 run_kwargs["session_handle"] = session_handle
+            # Leased warm-client seam (feat/warm-reuse WH-1). Same
+            # withhold-when-empty rule: only the Claude SDK backend accepts
+            # ``warm_client`` / ``on_client_built`` (it drives the turn against the
+            # leased client or hands the supervisor a freshly-built one); the other
+            # backends keep the narrower signature, so each is forwarded ONLY when
+            # set. Both unset = the unchanged legacy warm-client path.
+            if warm_client is not None:
+                run_kwargs["warm_client"] = warm_client
+            if on_client_built is not None:
+                run_kwargs["on_client_built"] = on_client_built
             async for event in instance.backend.run(message, **run_kwargs):
                 instance.last_active = datetime.now(UTC)
                 yield event

--- a/src/pocketpaw/agents/session_supervisor.py
+++ b/src/pocketpaw/agents/session_supervisor.py
@@ -29,6 +29,17 @@ so the runtime map stays bounded over long SaaS uptime. The durable
 pruned runtime COLD and re-resolves the id — the drop is safe. The busy-guard
 still holds: a runtime with ``active_runs > 0`` (e.g. a turn-1 launch in flight,
 which is COLD AND busy) is never pruned.
+
+Updated 2026-06-30 (feat/warm-reuse WH-2): the warm slot is now typed as WH-1's
+``LeasedClient | None`` (was ``Any | None``) on ``SessionRuntime.warm_slot`` and
+``Acquisition.slot`` — a typing/clarity change only. The supervisor still treats
+the slot opaquely and relies entirely on the injected ``teardown`` (WH-1 hands it
+an ASYNC ``_teardown`` that ``await client.disconnect()``s the live ``ClaudeSDKClient``),
+so every release path — idle reap, quota evict, crash, stop — disconnects the live
+client with no leaked process. ``_run_teardown`` now also holds a strong reference
+to each scheduled async-teardown task until it completes (the event loop keeps only
+a weak ref, so a discarded fire-and-forget disconnect could be GC'd mid-flight and
+leak the subprocess).
 """
 
 from __future__ import annotations
@@ -41,6 +52,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
+
+from pocketpaw.agents.backend import LeasedClient
 
 logger = logging.getLogger(__name__)
 
@@ -84,9 +97,12 @@ class SessionRuntime:
     # its live turn. ``last_active`` only ranks idle eviction candidates; this
     # counter is the authoritative "busy" signal (mirrors pool.AgentInstance).
     active_runs: int = 0
-    # Opaque live warm slot supplied by the executor (SS-5) — never interpreted
-    # here. Present only while ``tier is WARM``.
-    warm_slot: Any | None = None
+    # Live warm slot supplied by the executor (SS-5) — a WH-1 ``LeasedClient``
+    # holding a connected ``ClaudeSDKClient``. Still treated OPAQUELY here (the
+    # supervisor never reaches into ``.client`` — it releases via ``teardown``);
+    # the concrete type documents what the warm tier holds. Present only while
+    # ``tier is WARM``.
+    warm_slot: LeasedClient | None = None
     # How to release ``warm_slot``. Called best-effort on reap / quota-evict /
     # crash / stop. May be sync or return an awaitable.
     teardown: Callable[[], Any] | None = field(default=None, repr=False)
@@ -121,7 +137,7 @@ class Acquisition:
         return not self.warm_reuse
 
     @property
-    def slot(self) -> Any | None:
+    def slot(self) -> LeasedClient | None:
         """Convenience: the warm slot to reuse (only meaningful when ``warm_reuse``)."""
         return self.runtime.warm_slot
 
@@ -159,6 +175,11 @@ class SessionSupervisor:
         self._now: Callable[[], float] = now or time.monotonic
         self._runtimes: dict[tuple[str, str], SessionRuntime] = {}
         self._reaper_task: asyncio.Task | None = None
+        # Strong references to in-flight async-teardown tasks scheduled by
+        # ``_run_teardown`` from a running loop. The loop keeps only a WEAK ref
+        # to a bare ``create_task`` result, so without this a fire-and-forget
+        # disconnect could be GC'd before it finishes — leaking the live client.
+        self._pending_teardowns: set[asyncio.Task] = set()
         # The reaper wakes at least as often as it would need to honor the TTL,
         # capped so a long TTL doesn't leave slots resident much past expiry.
         self._reap_interval: float = max(1.0, min(30.0, float(warm_ttl)))
@@ -439,12 +460,16 @@ class SessionSupervisor:
         return teardown
 
     def _run_teardown(self, teardown: Callable[[], Any] | None) -> None:
-        """Best-effort sync teardown; schedules an awaitable result on the loop.
+        """Best-effort teardown from a SYNC caller (reap / quota-evict / crash).
 
-        Sync teardowns (the common case, and what tests use) run inline. If a
-        teardown returns a coroutine/awaitable and a loop is running, it is
-        scheduled; with no running loop it is closed so it never warns. Never
-        raises.
+        A sync teardown runs inline. WH-1's ``LeasedClient`` teardown is ASYNC
+        (it ``await client.disconnect()``s the live ``ClaudeSDKClient``), so the
+        call returns a coroutine: when a loop is running (the real callers — the
+        reaper task and the async executor — always run inside one) it is
+        scheduled AND a strong reference is held until it completes, so the
+        disconnect can't be GC'd mid-flight and leak the subprocess. With no
+        running loop the coroutine is closed so it never warns (unreachable for
+        the supervisor's real callers, which are all on the loop). Never raises.
         """
         if teardown is None:
             return
@@ -455,9 +480,12 @@ class SessionSupervisor:
             return
         if inspect.isawaitable(result):
             try:
-                asyncio.get_running_loop().create_task(result)
+                task = asyncio.get_running_loop().create_task(result)
             except RuntimeError:
                 result.close()
+            else:
+                self._pending_teardowns.add(task)
+                task.add_done_callback(self._pending_teardowns.discard)
 
     async def _run_teardown_async(self, teardown: Callable[[], Any] | None) -> None:
         """Await an async teardown to completion (used by ``stop``). Never raises."""

--- a/tests/cloud/runs/test_run_core_session_supervisor.py
+++ b/tests/cloud/runs/test_run_core_session_supervisor.py
@@ -34,6 +34,23 @@
 #     warm_client kwarg; the SessionHandle still carries the cli_session_id
 #     (cold-resume) and on_client_built is present to rebind a fresh slot.
 #   * Flag OFF: NEITHER warm_client NOR on_client_built is added (legacy identical).
+#
+# WARM no-op regression (live smoke 2026-06-30) added 2026-06-30:
+#   The WARM tier was a NO-OP live — every supervised turn rebuilt a fresh
+#   ``claude`` client and turn 1's warm slot was torn down before turn 2. Root
+#   cause: ``_drive_agent_loop`` flagged the run a CRASH (``mark_crashed`` →
+#   ``_drop_slot`` + teardown) on ANY backend ``error`` event, including a benign
+#   trailing one (the real ``claude_sdk`` yields ``error`` THEN ``done`` when a
+#   ResultMessage carries ``is_error`` on a turn that still produced a response —
+#   the leased client stays healthy). These two-turn tests drive the REAL
+#   ``_drive_agent_loop`` against the REAL ``SessionSupervisor`` with a realistic
+#   leased-backend fake pool (it BINDS via ``on_client_built`` like the backend
+#   does after a fresh ``connect()``) and assert: a clean run keeps the slot warm
+#   (baseline — passed pre-fix, isolating the trigger to the error event); a
+#   benign trailing ``error`` + ``done`` MUST keep the slot warm (the repro —
+#   FAILED pre-fix); and a genuine crash (``error`` with NO successful
+#   completion) MUST still drop the slot → COLD cold-resume next turn (no
+#   regression of the v1 crash semantics).
 
 from __future__ import annotations
 
@@ -455,3 +472,219 @@ async def test_wh3_after_reap_cold_resume_no_warm_client(monkeypatch):
 
     # The binding callback is present so the freshly-built client rebinds a slot.
     assert callable(pool.run_kwargs.get("on_client_built"))
+
+
+# --------------------------------------------------------------------------- #
+# WARM no-op regression — two full turns through the REAL supervisor.          #
+# A leased-backend fake pool that BINDS the slot (turn 1) and REUSES it        #
+# (turn 2) exactly as the claude_sdk leased path does.                         #
+# --------------------------------------------------------------------------- #
+
+
+class _RecordingTeardown:
+    """A leased-client teardown that records whether it fired.
+
+    ``True`` means the supervisor tore the warm ``claude`` subprocess down
+    (``mark_crashed`` → ``_drop_slot`` → ``_run_teardown``). On a healthy run the
+    slot must SURVIVE, so this must stay ``False``.
+    """
+
+    def __init__(self) -> None:
+        self.torn_down = False
+
+    def __call__(self) -> None:
+        self.torn_down = True
+
+
+class _StatefulRuntimeService:
+    """SS-3 stand-in that PERSISTS the captured native id across turns.
+
+    Unlike ``_FakeRuntimeService`` (fixed ``prior``), this returns on turn 2
+    whatever turn 1's ``("session_id", ...)`` event wrote — modelling the real
+    durable mapping so the two-turn resume/warm decision is exercised end-to-end.
+    """
+
+    def __init__(self) -> None:
+        self._id: str | None = None
+        self.get_calls = 0
+        self.set_calls = 0
+
+    async def get_cli_session_id(self, ws, session, agent):
+        self.get_calls += 1
+        return self._id
+
+    async def set_cli_session_id(self, ws, session, agent, cli_session_id, project_key=None):
+        self.set_calls += 1
+        self._id = cli_session_id
+
+
+class _LeasedBackendPool:
+    """Realistic fake AgentPool mirroring the claude_sdk leased path.
+
+    * Supervised FRESH-BUILD turn (``on_client_built`` set, no ``warm_client``):
+      build a fake client and BIND it via ``on_client_built`` (as the backend
+      does right after its fresh ``connect()``), stream a normal response + the
+      turn-1 ``session_id`` capture, then emit ``tail_events`` at end-of-stream
+      to mirror whatever the real backend trails the leased-fresh stream with
+      (the live trigger under test), then ``done`` — unless ``omit_done`` models
+      a genuine crash (an error with NO successful completion).
+    * WARM-REUSE turn (``warm_client`` leased): drive the leased client directly
+      — NO new build, NO bind — and stream a short response.
+    """
+
+    def __init__(self, *, tail_events=None, omit_done=False) -> None:
+        self.tail_events = list(tail_events or [])
+        self.omit_done = omit_done
+        self.turns: list[dict[str, Any]] = []
+        self.builds = 0
+        self.reuses = 0
+        self.teardowns: list[_RecordingTeardown] = []
+
+    async def get(self, _agent_id):
+        return SimpleNamespace(config={"backend": "claude_agent_sdk"}, agent_name="A")
+
+    def run(self, agent_id, content, session_key, **kwargs):
+        self.turns.append(kwargs)
+        warm_client = kwargs.get("warm_client")
+        on_built = kwargs.get("on_client_built")
+
+        async def _gen():
+            if warm_client is not None:
+                # Warm reuse: the live subprocess serves this turn directly.
+                self.reuses += 1
+                yield SimpleNamespace(type="message", content="reused-warm", metadata={})
+                yield SimpleNamespace(type="done", content="")
+                return
+            # Supervised fresh build: mirror the backend binding the new client.
+            if on_built is not None:
+                client = SimpleNamespace(name=f"claude-client-{self.builds}")
+                teardown = _RecordingTeardown()
+                on_built(client, "k-options", teardown)
+                self.teardowns.append(teardown)
+            self.builds += 1
+            yield SimpleNamespace(type="message", content="hi there", metadata={})
+            yield SimpleNamespace(
+                type="session_id",
+                content="",
+                metadata={"session_id": "native-abc", "backend": "claude_agent_sdk"},
+            )
+            for ev in self.tail_events:
+                yield ev
+            if not self.omit_done:
+                yield SimpleNamespace(type="done", content="")
+
+        return _gen()
+
+
+async def _drive_turn(monkeypatch, *, pool, sup, rs) -> list[tuple[str, dict]]:
+    """Drive ONE supervised turn of the REAL ``_drive_agent_loop`` against the
+    given (shared-across-turns) ``pool`` / ``sup`` / ``rs``."""
+    monkeypatch.setenv("POCKETPAW_SESSION_SUPERVISOR", "true")
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: pool)
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda *a, **k: "")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "runtime_service", rs)
+    monkeypatch.setattr(run_core, "MongoSessionStore", _FakeStore)
+    monkeypatch.setattr(run_core, "get_session_supervisor", lambda: sup)
+
+    async def _never_cancelled():
+        return False
+
+    out: list[tuple[str, dict]] = []
+    gen = run_core._drive_agent_loop(
+        _scope_ctx(),
+        user_content="hi",
+        attachments_in=None,
+        mentions_in=None,
+        history=[],
+        is_cancelled=_never_cancelled,
+        emit_stream_start=False,
+    )
+    async for ev in gen:
+        out.append(ev)
+    return out
+
+
+async def test_warm_slot_survives_clean_run_two_turns(monkeypatch):
+    """Baseline: a CLEAN leased-fresh turn 1 keeps its warm slot, so turn 2 reuses
+    it. This PASSED before the fix — it isolates the no-op trigger to the backend
+    error event (a clean fake does not reproduce the bug)."""
+    sup = _RecordingSupervisor()
+    rs = _StatefulRuntimeService()
+    pool = _LeasedBackendPool(tail_events=[])  # clean stream: message, session_id, done
+
+    await _drive_turn(monkeypatch, pool=pool, sup=sup, rs=rs)  # turn 1 (fresh build + bind)
+    # Turn 1 captured + persisted the native id and bound a live warm slot.
+    assert rs._id == "native-abc"
+    assert pool.builds == 1 and pool.teardowns and pool.teardowns[0].torn_down is False
+
+    await _drive_turn(monkeypatch, pool=pool, sup=sup, rs=rs)  # turn 2
+
+    # Turn 2 reused the warm slot — warm_reuse True, the slot was leased, no rebuild.
+    assert sup.acq.warm_reuse is True
+    assert pool.turns[1].get("warm_client") is not None
+    assert pool.reuses == 1
+    assert pool.builds == 1  # no second build
+    assert pool.teardowns[0].torn_down is False  # turn-1 client never torn down
+
+
+async def test_warm_slot_survives_benign_trailing_error_two_turns(monkeypatch):
+    """THE REPRODUCTION: the real claude_sdk yields a benign ``error`` (ResultMessage
+    ``is_error`` on a turn that still produced a response) FOLLOWED by ``done``. The
+    leased ``claude`` client is healthy, so the warm slot must SURVIVE and turn 2
+    must reuse it. Pre-fix, ``_drive_agent_loop`` flagged the run a crash on the
+    error event and dropped the slot → turn 2 ``warm_reuse=False`` (the no-op)."""
+    sup = _RecordingSupervisor()
+    rs = _StatefulRuntimeService()
+    # Mirror the backend: message, session_id, error (benign), done.
+    pool = _LeasedBackendPool(
+        tail_events=[SimpleNamespace(type="error", content="benign result error", metadata={})]
+    )
+
+    out1 = await _drive_turn(monkeypatch, pool=pool, sup=sup, rs=rs)  # turn 1
+    # The error is still surfaced to the stream (diagnostic preserved)...
+    assert any(name == "error" for name, _ in out1)
+    # ...but the warm slot must NOT be torn down (the client is healthy).
+    assert pool.teardowns[0].torn_down is False, "benign trailing error dropped the warm slot"
+
+    await _drive_turn(monkeypatch, pool=pool, sup=sup, rs=rs)  # turn 2
+
+    # The headline assertion: turn 2 reuses the warm slot.
+    assert sup.acq.warm_reuse is True, "WARM no-op: turn 2 rebuilt instead of reusing"
+    assert pool.turns[1].get("warm_client") is not None
+    assert pool.reuses == 1
+    assert pool.builds == 1  # no second build
+
+
+async def test_genuine_crash_two_turns_demotes_to_cold(monkeypatch):
+    """No regression: a GENUINE crash (an ``error`` with NO successful completion —
+    no ``done``) MUST still drop the warm slot → COLD, and turn 2 cold-resumes from
+    the store (resume id threaded, no warm_client)."""
+    sup = _RecordingSupervisor()
+    rs = _StatefulRuntimeService()
+    pool = _LeasedBackendPool(
+        tail_events=[SimpleNamespace(type="error", content="backend blew up", metadata={})],
+        omit_done=True,  # crash: the stream ends without a successful completion
+    )
+
+    await _drive_turn(monkeypatch, pool=pool, sup=sup, rs=rs)  # turn 1 crashes
+    # A real crash tears the warm slot down (demote to COLD).
+    assert pool.teardowns[0].torn_down is True
+    assert "mark_crashed" in sup.calls
+
+    await _drive_turn(monkeypatch, pool=pool, sup=sup, rs=rs)  # turn 2
+
+    # No warm reuse — fresh launch that cold-resumes from the durable mapping.
+    assert sup.acq.warm_reuse is False
+    assert "warm_client" not in pool.turns[1]
+    handle = pool.turns[1].get("session_handle")
+    assert handle is not None and handle.cli_session_id == "native-abc"
+    assert pool.builds == 2  # turn 2 rebuilt (correct for a crashed/COLD runtime)

--- a/tests/cloud/runs/test_run_core_session_supervisor.py
+++ b/tests/cloud/runs/test_run_core_session_supervisor.py
@@ -19,6 +19,21 @@
 #   * Flag OFF: pool.run is called WITHOUT a session_handle; zero
 #     supervisor/store/mapping calls — the legacy path is byte-for-byte unchanged.
 #   * Flag ON, backend error event: the run is flagged a crash → mark_crashed.
+#
+# WH-3 (feat/warm-reuse) coverage added 2026-06-30:
+#   * Flag ON, turn 1: pool.run gets an ``on_client_built`` callback; invoking it
+#     (as the backend would after a fresh build) calls ``bind_warm_slot`` with a
+#     ``LeasedClient`` wrapping the built client + its options key.
+#   * Flag ON, turn 2 WARM (a live slot is bound): pool.run gets
+#     ``warm_client=<that slot>`` and the SessionHandle WITHHOLDS the resume id
+#     (cli_session_id is None — the live client already holds the conversation;
+#     the store is still threaded) so the backend's ``not resume_active`` gate
+#     permits warm reuse. This is the skill-free supervised warm turn the WH-1
+#     carried concern asks for (skills+leased lifecycle is a documented follow-up).
+#   * Flag ON, after reap (COLD): the slot was reaped → warm_reuse=False → NO
+#     warm_client kwarg; the SessionHandle still carries the cli_session_id
+#     (cold-resume) and on_client_built is present to rebind a fresh slot.
+#   * Flag OFF: NEITHER warm_client NOR on_client_built is added (legacy identical).
 
 from __future__ import annotations
 
@@ -29,6 +44,7 @@ import pytest
 from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
 from pocketpaw_ee.cloud.chat.runs import run_core
 
+from pocketpaw.agents.backend import LeasedClient
 from pocketpaw.agents.session_supervisor import SessionSupervisor
 
 pytestmark = pytest.mark.asyncio
@@ -96,11 +112,17 @@ class _RecordingSupervisor:
         self.inner = SessionSupervisor()
         self.calls: list[str] = []
         self.acq: Any = None
+        self.bound_slot: Any = None
 
     def acquire(self, *a, **k):
         self.calls.append("acquire")
         self.acq = self.inner.acquire(*a, **k)
         return self.acq
+
+    def bind_warm_slot(self, runtime, slot, teardown=None):
+        self.calls.append("bind_warm_slot")
+        self.bound_slot = slot
+        self.inner.bind_warm_slot(runtime, slot, teardown)
 
     def mark_run_start(self, runtime):
         self.calls.append("mark_run_start")
@@ -272,6 +294,10 @@ async def test_flag_off_legacy_path_no_handle_no_supervisor(monkeypatch):
     assert pool.run_kwargs is not None
     assert "session_handle" not in pool.run_kwargs
 
+    # WH-3: neither warm-reuse kwarg is added on the legacy path — byte-identical.
+    assert "warm_client" not in pool.run_kwargs
+    assert "on_client_built" not in pool.run_kwargs
+
     # Zero supervisor / store / mapping interaction on the legacy path.
     assert rs.get_calls == []
     assert rs.set_calls == []
@@ -302,3 +328,130 @@ async def test_flag_on_backend_error_marks_crashed(monkeypatch):
     # mark_crashed keeps the resume id for the next turn.
     assert sup.acq.runtime.cli_session_id == "native-xyz"
     assert sup.acq.runtime.active_runs == 0
+
+
+# --------------------------------------------------------------------------- #
+# WH-3 — turn 1: the executor hands the backend an on_client_built callback    #
+# that binds the freshly-built client to the supervisor as the warm slot.      #
+# --------------------------------------------------------------------------- #
+
+
+async def test_wh3_turn1_provides_on_client_built_that_binds_warm_slot(monkeypatch):
+    rs = _FakeRuntimeService(prior=None)  # turn 1 → fresh build, no warm slot
+    sup = _RecordingSupervisor()
+    pool, _out = await _drive(
+        monkeypatch, events=_turn1_events(), flag_on=True, runtime_service=rs, supervisor=sup
+    )
+
+    # Turn 1 is a fresh build: no warm slot to lease.
+    assert "warm_client" not in pool.run_kwargs
+    # The executor ALWAYS hands the backend a binding callback on the supervised
+    # path so the next turn can reuse the client this turn builds.
+    on_built = pool.run_kwargs.get("on_client_built")
+    assert callable(on_built), "flag ON must thread an on_client_built callback"
+
+    # The supervisor has not been asked to bind anything yet (the fake pool never
+    # invokes the callback) — turn 1 just BUILDS the client.
+    assert "bind_warm_slot" not in sup.calls
+
+    # Simulate the backend calling the callback after its fresh connect(): the
+    # executor must register the built client as the session's warm slot.
+    built_client = SimpleNamespace(name="freshly-built-claude-client")
+    teardown_marker = SimpleNamespace(kind="teardown")
+    on_built(built_client, "options-key-abc", teardown_marker)
+
+    assert "bind_warm_slot" in sup.calls
+    assert isinstance(sup.bound_slot, LeasedClient)
+    assert sup.bound_slot.client is built_client
+    assert sup.bound_slot.options_key == "options-key-abc"
+    # The slot is now bound onto THIS turn's runtime, ready for warm reuse next turn.
+    assert sup.acq.runtime.warm_slot is sup.bound_slot
+    assert sup.acq.runtime.teardown is teardown_marker
+
+
+# --------------------------------------------------------------------------- #
+# WH-3 — turn 2 (WARM): a live, key-eligible slot is leased to the backend and  #
+# the resume id is WITHHELD so the backend's warm-reuse gate fires.             #
+# --------------------------------------------------------------------------- #
+
+
+async def test_wh3_turn2_warm_leases_slot_and_withholds_resume(monkeypatch):
+    # Pre-seed the supervisor exactly as turn 1 would have: a live warm slot bound
+    # for (w1, s1) with a known native id. The seeding uses the inner supervisor
+    # directly so it does NOT pollute the recorded call log.
+    sup = _RecordingSupervisor()
+    seed = sup.inner.acquire("w1", "s1", "a1", cli_session_id=None)  # turn-1 runtime
+    sup.inner.record_cli_session_id(seed.runtime, "native-xyz")
+    live_slot = LeasedClient(client=SimpleNamespace(name="live-warm-client"), options_key="k-live")
+    sup.inner.bind_warm_slot(seed.runtime, live_slot, None)
+
+    rs = _FakeRuntimeService(prior="native-xyz")  # the durable mapping resolves it
+    events = [
+        SimpleNamespace(type="message", content="again", metadata={}),
+        SimpleNamespace(type="done", content=""),
+    ]
+    pool, _out = await _drive(
+        monkeypatch, events=events, flag_on=True, runtime_service=rs, supervisor=sup
+    )
+
+    # acquire saw a live, eligible warm slot → WARM reuse.
+    assert sup.acq.warm_reuse is True
+    assert sup.acq.slot is live_slot
+
+    # The live slot is leased to the backend for direct reuse.
+    assert pool.run_kwargs.get("warm_client") is live_slot
+
+    # The resume id is WITHHELD on a warm-reuse turn (the live client already
+    # holds the conversation; threading resume would demote warm reuse to a cold
+    # re-materialize). The store is still threaded.
+    handle = pool.run_kwargs.get("session_handle")
+    assert handle is not None
+    assert handle.cli_session_id is None, "warm reuse must withhold the resume id"
+    assert isinstance(handle.session_store, _FakeStore)
+    assert handle.session_store.workspace_id == "w1"
+
+    # The binding callback is still provided (a no-op on a pure warm reuse, but it
+    # rebinds if the backend has to rebuild on a key drift).
+    assert callable(pool.run_kwargs.get("on_client_built"))
+
+    # No new native id this turn → no durable write, just the bracket.
+    assert rs.set_calls == []
+    assert sup.calls == ["acquire", "mark_run_start", "mark_run_end"]
+
+
+# --------------------------------------------------------------------------- #
+# WH-3 — after reap (COLD): the warm slot is gone → fall back to cold-resume.   #
+# --------------------------------------------------------------------------- #
+
+
+async def test_wh3_after_reap_cold_resume_no_warm_client(monkeypatch):
+    # Pre-seed a warm slot, then drop it (mark_crashed models a reaped/failed slot:
+    # warm_slot cleared, cli_session_id retained for resume).
+    sup = _RecordingSupervisor()
+    seed = sup.inner.acquire("w1", "s1", "a1", cli_session_id=None)
+    sup.inner.record_cli_session_id(seed.runtime, "native-xyz")
+    reaped_slot = LeasedClient(client=SimpleNamespace(name="reaped"), options_key="k-old")
+    sup.inner.bind_warm_slot(seed.runtime, reaped_slot, None)
+    sup.inner.mark_crashed(seed.runtime)  # the reaper / a failure dropped the slot
+    assert seed.runtime.warm_slot is None
+
+    rs = _FakeRuntimeService(prior="native-xyz")
+    events = [
+        SimpleNamespace(type="message", content="again", metadata={}),
+        SimpleNamespace(type="done", content=""),
+    ]
+    pool, _out = await _drive(
+        monkeypatch, events=events, flag_on=True, runtime_service=rs, supervisor=sup
+    )
+
+    # No live slot → fresh launch, NOT warm reuse.
+    assert sup.acq.warm_reuse is False
+    assert "warm_client" not in pool.run_kwargs
+
+    # The SessionHandle carries the resume id (cold-resume from the store).
+    handle = pool.run_kwargs.get("session_handle")
+    assert handle is not None
+    assert handle.cli_session_id == "native-xyz"
+
+    # The binding callback is present so the freshly-built client rebinds a slot.
+    assert callable(pool.run_kwargs.get("on_client_built"))

--- a/tests/test_claude_sdk_client_cache_key.py
+++ b/tests/test_claude_sdk_client_cache_key.py
@@ -43,6 +43,223 @@ _KB_HEADER = "## Your Knowledge Base\nUse the following information..."
 _MEM_HEADER = "## Relevant Past Memories\nBelow are memories..."
 
 
+# ---------------------------------------------------------------------------
+# Added 2026-07-01 (integration/warm-reuse): regression tests for the MID-prompt
+# soul "# Key Knowledge" block. ``AgentPool._assemble_system_prompt`` splices it
+# in right after the stable soul identity via
+# ``f"{system_prompt}\n\n# Key Knowledge\n{knowledge_lines}"`` (pool.py:243-245).
+# Its lines are ALL volatile soul state — self-image confidences, an
+# incrementing bond level, a growing memory count, recalled memories
+# (soul/_bridge.py) — none of them behavioral instructions. Live instrumentation
+# proved warm-client reuse NEVER fired: two consecutive supervised turns'
+# behavior prefixes differed by exactly 2 chars, the incrementing "Bond level"
+# and "Memories" digits inside this block, so the prefix digest changed every
+# turn and the subprocess was rebuilt every turn. The block sits EARLY (char
+# ~1.4k of a ~44k prefix) between the stable identity and ~43KB of stable
+# ``<runtime-identity>`` + tool docs, so it must be EXCISED IN PLACE — a naive
+# tail-cut marker would strip ~97% of the real behavioral prefix.
+
+
+# A realistic prompt shape: stable identity, then the mid-prompt soul block,
+# then a large stable ``<runtime-identity>`` + tool-docs section, matching the
+# real ``ctx.identity`` -> "# Key Knowledge" -> runtime layout in pool.py.
+_IDENTITY = "<soul-identity>\nI am Paw, a persistent companion." + ("X" * 1300)
+_RUNTIME_TAIL = "\n\n<runtime-identity>\nTool docs and skills...\n" + ("Y" * 43000)
+
+
+def _soul_block(*, bond: str, memories: int) -> str:
+    """The exact block pool.py builds: ``\\n\\n# Key Knowledge\\n`` + ``- `` lines
+    of volatile soul state (self-image, bond, memory count)."""
+    lines = "\n".join(
+        [
+            "- [creative] confidence=0.82",
+            f"- Bond level: {bond}/100",
+            f"- Memories: {memories}",
+        ]
+    )
+    return f"\n\n# Key Knowledge\n{lines}"
+
+
+def _full_prompt(*, bond: str, memories: int, kb: str) -> str:
+    """Assemble a full system prompt exactly as ``AgentPool`` would: stable
+    identity + soul block + stable runtime tail + a per-turn volatile KB tail."""
+    return (
+        _IDENTITY
+        + _soul_block(bond=bond, memories=memories)
+        + _RUNTIME_TAIL
+        + "\n\n"
+        + _KB_HEADER
+        + "\n"
+        + kb
+    )
+
+
+def test_incrementing_soul_block_keeps_key_stable():
+    """THE reproduction: two consecutive supervised turns whose ONLY difference
+    is the incrementing bond level / memory count inside the mid-prompt
+    "# Key Knowledge" block must produce the SAME cache key, so the warm
+    subprocess is reused instead of rebuilt every turn.
+
+    FAILS on pre-fix code — the tail-only strip leaves the mid-prompt block in
+    the hashed prefix, so the 50.0->50.5 / 0->1 drift changes the digest."""
+    turn1 = _full_prompt(bond="50.0", memories=0, kb="turn-1 kb snippet")
+    turn2 = _full_prompt(bond="50.5", memories=1, kb="turn-2 kb snippet")
+    k1 = ClaudeSDKBackend._client_cache_key(_opts(turn1), session_key="s1")
+    k2 = ClaudeSDKBackend._client_cache_key(_opts(turn2), session_key="s1")
+    assert k1 == k2, (
+        "an incrementing soul '# Key Knowledge' block (bond level / memory "
+        "count) must not rebuild the warm client — it carries no behavioral "
+        "instructions, only per-turn soul state"
+    )
+
+
+def test_soul_block_stripped_but_behavioral_change_still_rekeys():
+    """The excise must NOT over-strip: a genuinely different behavioral prefix
+    (different persona/identity BEFORE the soul block) must still change the key
+    even though both prompts carry an identical soul block, so a stale client is
+    NOT reused for a different persona."""
+    identity_a = "<soul-identity>\nI am Paw." + ("X" * 1300)
+    identity_b = "<soul-identity>\nI am Rex, a DIFFERENT persona." + ("X" * 1300)
+    block = _soul_block(bond="50.0", memories=0)
+    prompt_a = identity_a + block + _RUNTIME_TAIL + "\n\n" + _KB_HEADER + "\nkb"
+    prompt_b = identity_b + block + _RUNTIME_TAIL + "\n\n" + _KB_HEADER + "\nkb"
+    ka = ClaudeSDKBackend._client_cache_key(_opts(prompt_a), session_key="s1")
+    kb = ClaudeSDKBackend._client_cache_key(_opts(prompt_b), session_key="s1")
+    assert ka != kb, (
+        "a real behavioral change (different identity before the soul block) "
+        "must still rebuild the warm client — the excise must not over-strip"
+    )
+
+
+def test_soul_block_strip_preserves_stable_runtime_tail():
+    """Excising the mid-prompt block must keep the large stable section AFTER it
+    (``<runtime-identity>`` + tool docs) in the behavioral prefix, so a change
+    there still rekeys — proving we removed only the block, not everything after
+    the header (the over-strip failure mode of a tail-cut marker)."""
+    prompt = _full_prompt(bond="50.0", memories=0, kb="kb")
+    prefix = ClaudeSDKBackend._behavior_prefix(prompt)
+    assert "# Key Knowledge" not in prefix, "the soul block must be excised"
+    assert "<soul-identity>" in prefix, "stable identity before the block must remain"
+    assert "<runtime-identity>" in prefix, "stable runtime tail after the block must remain"
+    # A tail-cut marker would have shrunk this to ~1.3k; the surgical excise
+    # keeps the ~43KB runtime tail.
+    assert len(prefix) > 40000, "the ~43KB stable runtime tail must survive the excise"
+
+
+def test_soul_block_as_last_section_is_stripped():
+    """Edge case: the soul block is the LAST section (no trailing blank line, no
+    KB tail). The incrementing values must still be excised so the key is
+    stable, and everything before the block preserved."""
+    p1 = _IDENTITY + _soul_block(bond="50.0", memories=0)
+    p2 = _IDENTITY + _soul_block(bond="51.5", memories=3)
+    k1 = ClaudeSDKBackend._client_cache_key(_opts(p1), session_key="s1")
+    k2 = ClaudeSDKBackend._client_cache_key(_opts(p2), session_key="s1")
+    assert k1 == k2, "a block-as-last-section drift must not rebuild the warm client"
+    assert ClaudeSDKBackend._behavior_prefix(p1) == _IDENTITY
+
+
+def test_absent_soul_block_is_byte_identical():
+    """Edge case: empty ``ctx.knowledge`` means no block at all (and the legacy
+    flag-off path). The behavioral prefix must be byte-identical to the input's
+    stable head — the excise is a no-op when the header is absent."""
+    no_block = _IDENTITY + _RUNTIME_TAIL + "\n\n" + _KB_HEADER + "\nkb"
+    prefix = ClaudeSDKBackend._behavior_prefix(no_block)
+    assert prefix == _IDENTITY + _RUNTIME_TAIL, "no block present → excise is a no-op"
+
+
+# ---------------------------------------------------------------------------
+# Hardening (integration/warm-reuse): the block is excised by STRUCTURE (its
+# ``- ``-prefixed item run), not by "cut at the first blank line". These guard
+# the failure modes a blank-line cut has: (1) a recalled memory whose content
+# wraps onto a continuation line, (2) a plain-prose stable section (the ripple
+# LAW ``instructions``) that follows the block and must NOT be over-stripped,
+# and (3) a user-authored "# Key Knowledge" heading in persona prose that must
+# not be mistaken for the machine block.
+
+
+def _soul_block_with_memory(*, bond: str, memories: int, memory: str) -> str:
+    """The block with a trailing recalled-memory item (soul/_bridge.py:106 builds
+    it as ``- [semantic] {content}``). ``memory`` may contain newlines — a real
+    multi-line memory ``content``."""
+    return (
+        "\n\n# Key Knowledge\n"
+        "- [creative] confidence=0.82\n"
+        f"- Bond level: {bond}/100\n"
+        f"- Memories: {memories}\n"
+        f"- [semantic] {memory}"
+    )
+
+
+def test_wrapped_multiline_memory_keeps_key_stable():
+    """A recalled memory whose content wraps onto a continuation line (single
+    ``\\n``, no blank line) is absorbed into the block. Two turns differing only
+    in the incrementing bond/memory counts (and the wrapped memory text) must
+    still hash identically — the wrapped line must not leak into the prefix."""
+    turn1 = (
+        _IDENTITY
+        + _soul_block_with_memory(bond="50.0", memories=0, memory="note A\nwrapped tail 1")
+        + _RUNTIME_TAIL
+        + "\n\n"
+        + _KB_HEADER
+        + "\nturn-1 kb"
+    )
+    turn2 = (
+        _IDENTITY
+        + _soul_block_with_memory(bond="50.5", memories=1, memory="note B\nwrapped tail 2")
+        + _RUNTIME_TAIL
+        + "\n\n"
+        + _KB_HEADER
+        + "\nturn-2 kb"
+    )
+    k1 = ClaudeSDKBackend._client_cache_key(_opts(turn1), session_key="s1")
+    k2 = ClaudeSDKBackend._client_cache_key(_opts(turn2), session_key="s1")
+    assert k1 == k2, "a wrapped multi-line recalled memory must not rebuild the warm client"
+    prefix = ClaudeSDKBackend._behavior_prefix(turn1)
+    assert "wrapped tail 1" not in prefix, "the wrapped memory line must be excised"
+    assert "<runtime-identity>" in prefix, "the stable runtime tail must survive"
+
+
+def test_plain_prose_instructions_after_block_not_overstripped():
+    """The authoritative ``instructions`` (ripple LAW) are appended DIRECTLY
+    after the block (pool.py:268-269) as ``\\n\\n{instructions}`` and can start
+    in plain prose (no ``#``/``<`` anchor). Excising the block must keep them, so
+    a real instructions change still rekeys — the over-strip guard that a
+    heuristic "consume until the next heading/tag" terminator would fail."""
+    instr_a = "\n\nYou must ALWAYS cite your sources and stay terse."
+    instr_b = "\n\nYou must NEVER cite sources and may be verbose."
+    block = _soul_block(bond="50.0", memories=0)
+    p_a = _IDENTITY + block + instr_a + _RUNTIME_TAIL
+    p_b = _IDENTITY + block + instr_b + _RUNTIME_TAIL
+    prefix_a = ClaudeSDKBackend._behavior_prefix(p_a)
+    assert "# Key Knowledge" not in prefix_a, "the soul block must be excised"
+    assert "cite your sources" in prefix_a, "plain-prose instructions after the block must be kept"
+    k_a = ClaudeSDKBackend._client_cache_key(_opts(p_a), session_key="s1")
+    k_b = ClaudeSDKBackend._client_cache_key(_opts(p_b), session_key="s1")
+    assert k_a != k_b, "a real instructions change after the block must still rebuild the client"
+
+
+def test_persona_key_knowledge_heading_is_not_the_machine_block():
+    """A user-authored "# Key Knowledge" heading inside persona/identity prose
+    (NOT followed by ``- `` items) must not be mistaken for the machine block.
+    The machine block (``rfind`` + ``- `` item guard) is excised; the persona
+    prose stays in the prefix, so a persona edit still rekeys."""
+    persona_a = "PERSONA\n\n# Key Knowledge\nI value honesty above all.\n\nmore persona."
+    persona_b = "PERSONA\n\n# Key Knowledge\nI value brevity above all.\n\nmore persona."
+    block = _soul_block(bond="50.0", memories=0)
+    p_a = persona_a + block + _RUNTIME_TAIL
+    p_b = persona_b + block + _RUNTIME_TAIL
+    prefix_a = ClaudeSDKBackend._behavior_prefix(p_a)
+    assert "I value honesty above all" in prefix_a, "persona prose heading must be preserved"
+    assert "Bond level" not in prefix_a, "the machine soul block must still be excised"
+    k_a = ClaudeSDKBackend._client_cache_key(_opts(p_a), session_key="s1")
+    k_b = ClaudeSDKBackend._client_cache_key(_opts(p_b), session_key="s1")
+    assert k_a != k_b, "a persona change (even under a matching heading) must still rekey"
+    # And the machine block's own drift is still neutralized under a persona
+    # heading collision.
+    p_drift = persona_a + _soul_block(bond="99.9", memories=7) + _RUNTIME_TAIL
+    assert ClaudeSDKBackend._behavior_prefix(p_a) == ClaudeSDKBackend._behavior_prefix(p_drift)
+
+
 def test_config_flip_changes_key():
     """A home backend flipping configured:false -> configured:true changes the
     behavioral prefix, so the cache key must differ and force a client rebuild."""

--- a/tests/test_claude_sdk_warm_lease.py
+++ b/tests/test_claude_sdk_warm_lease.py
@@ -1,4 +1,14 @@
 # tests/test_claude_sdk_warm_lease.py
+# Updated: 2026-07-01 (fix/warm-reuse session_id) — added the session_id-capture
+#   suite (section 6) that pins the fix for the live WARM NO-OP: SS-1 captured the
+#   native session_id ONLY from the init SystemMessage, which never surfaced on the
+#   leased supervised-fresh client, so owns_capture stayed True and warm_reuse never
+#   fired. Three tests: (1) REPRODUCTION — a quirk stream (init SystemMessage with
+#   NO session_id, then a normal assistant message, then a ResultMessage carrying
+#   the id) surfaces exactly one session_id event via the ResultMessage fallback
+#   (pre-fix: zero events); (2) NO-DOUBLE-EMIT — both sources carry the id → exactly
+#   one event (SystemMessage wins, emit-once gate skips the ResultMessage); (3)
+#   LEGACY — session_handle=None → no session_id event from either source.
 # Created: 2026-06-30 (feat/warm-reuse WH-1) — pins the BACKEND half of the WARM
 # perf tier: ``ClaudeSDKBackend.run`` can drive a turn against a caller-LEASED
 # warm ``ClaudeSDKClient`` (owned by the SessionSupervisor, WH-2/WH-3) instead of
@@ -416,3 +426,197 @@ async def test_busy_warm_client_falls_back_to_stateless_without_rebind() -> None
     )
     assert len(client_sink) == 1, "the busy fallback must not build a new persistent client"
     assert lease.busy is True, "this run must not touch the busy flag the sibling turn owns"
+
+
+# ===========================================================================
+# 6. fix/warm-reuse — capture the native session_id from the ResultMessage
+# ===========================================================================
+#
+# The leased supervised-fresh path was a live WARM NO-OP: SS-1 captured the
+# native ``session_id`` ONLY from the init ``SystemMessage``'s
+# ``data["session_id"]``, but on the fresh client that id never surfaced at
+# runtime — so ``owns_capture`` stayed True forever and ``warm_reuse`` never
+# fired. The fix ALSO captures ``session_id`` from the terminal ``ResultMessage``
+# (a direct str field ALWAYS carried), gated on the handle + emit-once. These
+# tests pin: (1) the ResultMessage fallback fires on the quirk stream (real
+# reproduction — see the failing-pre-fix evidence in the PR/commit body), (2) the
+# emit-once gate prevents a double-emit when BOTH sources carry the id, and (3)
+# no handle → no session_id event from either source (legacy stream unchanged).
+
+_RESULT_SID = "11111111-1111-4111-8111-111111111111"
+_BOTH_SID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+
+class _FakeAssistantMsg:
+    """A normal assistant text message — carries NO session_id."""
+
+    def __init__(self, text: str = "hello from the model"):
+        self.content = text
+
+
+def _result_with_sid(sid: str) -> _FakeResultMsg:
+    """A terminal ResultMessage carrying the native ``session_id`` as a direct str
+    field (types.py: ``ResultMessage.session_id``) — the ALWAYS-present field the
+    fix reads via ``getattr(event, "session_id", None)``."""
+    r = _FakeResultMsg()
+    r.session_id = sid
+    return r
+
+
+class _LeasedFreshSpyClient:
+    """Mirrors the leased supervised-fresh RUNTIME QUIRK: the init ``SystemMessage``
+    arrives but its ``data`` carries NO ``session_id`` (the id never surfaces on
+    the fresh client), a normal assistant message follows, and only the terminal
+    ``ResultMessage`` carries the native id. This is exactly the stream on which
+    SS-1's SystemMessage-only capture was a NO-OP."""
+
+    def __init__(self, options=None, *, result_session_id=_RESULT_SID, **_kw):
+        self.options = options
+        self._result_session_id = result_session_id
+        self.queries: list[str] = []
+        self.connect_count = 0
+        self.disconnect_count = 0
+
+    async def connect(self, prompt=None):
+        self.connect_count += 1
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def receive_messages(self):
+        # init/system message WITH NO session_id — the runtime quirk.
+        yield _FakeSystemMessage(subtype="init", data={})
+        # a normal assistant message (carries no session_id).
+        yield _FakeAssistantMsg("hello from the model")
+        # terminal ResultMessage carrying the native session_id.
+        yield _result_with_sid(self._result_session_id)
+
+    async def disconnect(self):
+        self.disconnect_count += 1
+
+    async def interrupt(self):
+        pass
+
+
+class _BothSourcesSpyClient:
+    """A stream where BOTH the init ``SystemMessage`` (``data.session_id``) AND the
+    terminal ``ResultMessage`` (``session_id``) carry the SAME native id — proves
+    the emit-once gate: the SystemMessage wins first and the ResultMessage capture
+    is skipped, so exactly ONE ``session_id`` event is emitted."""
+
+    def __init__(self, options=None, *, sid=_BOTH_SID, **_kw):
+        self.options = options
+        self._sid = sid
+        self.queries: list[str] = []
+        self.connect_count = 0
+        self.disconnect_count = 0
+
+    async def connect(self, prompt=None):
+        self.connect_count += 1
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def receive_messages(self):
+        yield _FakeSystemMessage(subtype="init", data={"session_id": self._sid})
+        yield _FakeAssistantMsg("hello from the model")
+        yield _result_with_sid(self._sid)
+
+    async def disconnect(self):
+        self.disconnect_count += 1
+
+    async def interrupt(self):
+        pass
+
+
+def _spy_factory(cls, sink: list):
+    def _factory(**kwargs):
+        c = cls(**kwargs)
+        sink.append(c)
+        return c
+
+    return _factory
+
+
+async def test_session_id_captured_from_result_message_on_leased_fresh_path() -> None:
+    """REPRODUCTION — a leased supervised-fresh turn (``session_handle`` non-None,
+    ``on_client_built`` set) whose stream carries NO session_id in the init
+    ``SystemMessage`` but DOES carry it on the terminal ``ResultMessage`` must
+    surface EXACTLY ONE ``session_id`` ``AgentEvent`` with that id. Pre-fix (no
+    ResultMessage capture) this stream yields NO session_id event at all — the
+    live WARM NO-OP."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    client_sink: list[_SpyClient] = []
+    sdk = _make_sdk(options_sink, stateless_options, client_sink)
+    sdk._AssistantMessage = _FakeAssistantMsg
+    leased_sink: list[_LeasedFreshSpyClient] = []
+    sdk._ClaudeSDKClient = _spy_factory(_LeasedFreshSpyClient, leased_sink)
+
+    def _on_built(client, key, teardown):
+        pass
+
+    handle = SessionHandle()  # non-None, cli_session_id=None → turn-1 supervised fresh
+    events = await _drive_run(sdk, "turn one", session_handle=handle, on_client_built=_on_built)
+
+    sid_events = [e for e in events if e.type == "session_id"]
+    assert len(sid_events) == 1, (
+        "the ResultMessage fallback must surface exactly one session_id event; "
+        f"got {[e.metadata for e in sid_events]}"
+    )
+    assert sid_events[0].metadata["session_id"] == _RESULT_SID, (
+        "the captured id must be the one carried on the terminal ResultMessage"
+    )
+    # sanity: the leased-fresh spy really drove the supervised path for this turn.
+    assert leased_sink and leased_sink[0].queries == ["turn one"]
+
+
+async def test_no_double_emit_when_both_sources_carry_session_id() -> None:
+    """NO-DOUBLE-EMIT — when BOTH the init ``SystemMessage`` and the terminal
+    ``ResultMessage`` carry the id, EXACTLY ONE ``session_id`` event is emitted
+    (from the SystemMessage; the ResultMessage capture is skipped by the emit-once
+    gate)."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    client_sink: list[_SpyClient] = []
+    sdk = _make_sdk(options_sink, stateless_options, client_sink)
+    sdk._AssistantMessage = _FakeAssistantMsg
+    both_sink: list[_BothSourcesSpyClient] = []
+    sdk._ClaudeSDKClient = _spy_factory(_BothSourcesSpyClient, both_sink)
+
+    def _on_built(client, key, teardown):
+        pass
+
+    events = await _drive_run(
+        sdk, "turn one", session_handle=SessionHandle(), on_client_built=_on_built
+    )
+
+    sid_events = [e for e in events if e.type == "session_id"]
+    assert len(sid_events) == 1, (
+        "the emit-once gate must yield exactly one session_id event even when both "
+        f"the SystemMessage and ResultMessage carry the id; got {len(sid_events)}"
+    )
+    assert sid_events[0].metadata["session_id"] == _BOTH_SID
+
+
+async def test_no_handle_emits_no_session_id_from_either_source() -> None:
+    """LEGACY — with ``session_handle=None`` neither the init ``SystemMessage`` nor
+    the terminal ``ResultMessage`` may emit a ``session_id`` event, even when both
+    carry the id (the legacy stream stays byte-identical)."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    client_sink: list[_SpyClient] = []
+    sdk = _make_sdk(options_sink, stateless_options, client_sink)
+    sdk._AssistantMessage = _FakeAssistantMsg
+    both_sink: list[_BothSourcesSpyClient] = []
+    sdk._ClaudeSDKClient = _spy_factory(_BothSourcesSpyClient, both_sink)
+
+    def _on_built(client, key, teardown):
+        pass
+
+    events = await _drive_run(sdk, "turn one", session_handle=None, on_client_built=_on_built)
+
+    sid_events = [e for e in events if e.type == "session_id"]
+    assert sid_events == [], (
+        "no session_handle → no session_id event may be emitted from either source"
+    )

--- a/tests/test_claude_sdk_warm_lease.py
+++ b/tests/test_claude_sdk_warm_lease.py
@@ -1,0 +1,418 @@
+# tests/test_claude_sdk_warm_lease.py
+# Created: 2026-06-30 (feat/warm-reuse WH-1) — pins the BACKEND half of the WARM
+# perf tier: ``ClaudeSDKBackend.run`` can drive a turn against a caller-LEASED
+# warm ``ClaudeSDKClient`` (owned by the SessionSupervisor, WH-2/WH-3) instead of
+# always building / caching its own ``self._client``. Turn 2+ then reuses the live
+# subprocess instead of resuming COLD.
+#
+# Live ``claude`` model calls are BLOCKED here, so these tests SPY on the
+# construction/stream boundary (a fake ``ClaudeSDKClient`` recording connect /
+# disconnect / query, plus a capturing options factory) rather than making a real
+# call. They assert the four run paths plus the busy edge:
+#   1. WARM REUSE — a ``warm_client`` whose ``options_key`` MATCHES this turn drives
+#      the leased client's ``query`` directly: no ``connect``, no second client, no
+#      ``resume``, and the raw message (no injected history block) is sent.
+#   2. KEY MISMATCH — a stale ``warm_client`` + ``on_client_built`` builds a FRESH
+#      client and hands ``on_client_built`` the NEW key (not the stale one).
+#   3. SUPERVISED FRESH — no ``warm_client`` but ``on_client_built`` set →
+#      ``on_client_built(client, key, teardown)`` is invoked; ``resume`` is set on
+#      the options ONLY when ``session_handle.cli_session_id`` is present.
+#   4. LEGACY — neither param → the ``self._client`` warm path, unchanged
+#      (``on_client_built`` never called, ``self._client`` cached as before).
+#   5. BUSY edge — a matching but ``busy`` lease falls back to a fresh stateless
+#      query for the turn and does NOT re-drive or rebind the leased client.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from pocketpaw.agents.backend import LeasedClient, SessionHandle
+from pocketpaw.agents.claude_sdk import ClaudeAgentSDK, ClaudeSDKBackend
+from pocketpaw.agents.model_router import ModelSelection, TaskComplexity
+
+_LLM_CLIENT = "pocketpaw.llm.client.resolve_llm_client"
+_MODEL_ROUTER = "pocketpaw.agents.model_router.ModelRouter"
+
+
+# ===========================================================================
+# Fakes
+# ===========================================================================
+
+
+def _make_settings(**overrides):
+    defaults = {
+        "agent_backend": "claude_agent_sdk",
+        "tool_profile": "full",
+        "tools_allow": [],
+        "tools_deny": [],
+        "smart_routing_enabled": False,
+        "claude_sdk_provider": "anthropic",
+        "claude_sdk_model": None,
+        "claude_sdk_max_turns": None,
+        "sdk_load_bundled_skills": False,
+        "anthropic_api_key": "sk-test-key",
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class _Options:
+    """Real options stand-in so ``_client_cache_key`` / dispatch can read
+    ``system_prompt`` / ``model`` / ``allowed_tools`` / ``plugins`` / ``resume``."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.model = kwargs.get("model", "")
+        self.allowed_tools = kwargs.get("allowed_tools", [])
+        self.system_prompt = kwargs.get("system_prompt", "")
+        self.plugins = kwargs.get("plugins", [])
+        self.cwd = kwargs.get("cwd", "")
+        self.resume = kwargs.get("resume", None)
+
+
+def _capturing_options(sink: list[_Options]):
+    def _factory(**kwargs):
+        opt = _Options(**kwargs)
+        sink.append(opt)
+        return opt
+
+    return _factory
+
+
+class _FakeSystemMessage:
+    def __init__(self, subtype: str, data: dict):
+        self.subtype = subtype
+        self.data = data
+
+
+class _FakeResultMsg:
+    def __init__(self):
+        self.is_error = False
+        self.result = "ok"
+        self.total_cost_usd = None
+        self.usage = {}
+
+
+class _SpyClient:
+    """Spy ``ClaudeSDKClient``. Records connect / disconnect / query so a test can
+    prove which path drove it. ``receive_messages()`` yields the SDK init/system
+    message then a ResultMessage."""
+
+    def __init__(self, options=None, *, init_session_id="sess-init", **_kw):
+        self.options = options
+        self._init_session_id = init_session_id
+        self.queries: list[str] = []
+        self.connect_count = 0
+        self.disconnect_count = 0
+
+    async def connect(self, prompt=None):
+        self.connect_count += 1
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def receive_messages(self):
+        yield _FakeSystemMessage(subtype="init", data={"session_id": self._init_session_id})
+        yield _FakeResultMsg()
+
+    async def disconnect(self):
+        self.disconnect_count += 1
+
+    async def interrupt(self):
+        pass
+
+
+def _capturing_clients(sink: list[_SpyClient]):
+    def _factory(**kwargs):
+        c = _SpyClient(**kwargs)
+        sink.append(c)
+        return c
+
+    return _factory
+
+
+def _make_sdk(options_sink, stateless_options, client_sink, settings=None):
+    s = settings or _make_settings()
+    with patch.object(ClaudeSDKBackend, "_initialize"):
+        sdk = ClaudeAgentSDK(s)
+    sdk._sdk_available = True
+    sdk._cli_available = True
+    sdk._ClaudeAgentOptions = _capturing_options(options_sink)
+    sdk._ResultMessage = _FakeResultMsg
+    sdk._SystemMessage = _FakeSystemMessage
+    sdk._ClaudeSDKClient = _capturing_clients(client_sink)
+    sdk._HookMatcher = MagicMock()
+    sdk._StreamEvent = None
+    sdk._AssistantMessage = None
+    sdk._UserMessage = None
+    sdk._ToolResultBlock = None
+
+    async def _fake_query(prompt, options, init_session_id="sess-stateless-init"):
+        stateless_options.append(options)
+        yield _FakeSystemMessage(subtype="init", data={"session_id": init_session_id})
+        yield _FakeResultMsg()
+
+    sdk._query = _fake_query
+    return sdk
+
+
+def _patched(fn):
+    """Run ``fn()`` under the LLM / router / MCP patches run() needs."""
+
+    async def _inner():
+        selection = ModelSelection(
+            complexity=TaskComplexity.MODERATE,
+            model="claude-sonnet-4-5-20250929",
+            reason="test",
+        )
+        with patch(_LLM_CLIENT) as mock_resolve:
+            mock_llm = MagicMock()
+            mock_llm.is_ollama = False
+            mock_llm.is_openai_compatible = False
+            mock_llm.is_gemini = False
+            mock_llm.is_litellm = False
+            mock_llm.is_openrouter = False
+            mock_llm.to_sdk_env.return_value = {"ANTHROPIC_API_KEY": "sk-test"}
+            mock_resolve.return_value = mock_llm
+            with patch(_MODEL_ROUTER) as MockRouter:
+                MockRouter.return_value.classify.return_value = selection
+                with patch.object(ClaudeSDKBackend, "_get_mcp_servers", return_value={}):
+                    return await fn()
+
+    return _inner
+
+
+async def _drive_run(
+    sdk,
+    message,
+    *,
+    system_prompt="identity",
+    history=None,
+    session_handle=None,
+    warm_client=None,
+    on_client_built=None,
+):
+    async def _go():
+        events = []
+        async for ev in sdk.run(
+            message,
+            system_prompt=system_prompt,
+            history=history,
+            session_key="s1",
+            session_handle=session_handle,
+            warm_client=warm_client,
+            on_client_built=on_client_built,
+        ):
+            events.append(ev)
+        return events
+
+    return await _patched(_go)()
+
+
+# ===========================================================================
+# 1. Warm reuse — key match drives the leased client directly
+# ===========================================================================
+
+
+async def test_warm_client_key_match_reuses_no_connect_no_resume_no_history() -> None:
+    """A ``warm_client`` whose ``options_key`` MATCHES this turn drives the leased
+    client's ``query`` directly: no ``connect``, no fresh client, no ``resume``,
+    and the raw message (no injected history block) is sent."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    client_sink: list[_SpyClient] = []
+    sdk = _make_sdk(options_sink, stateless_options, client_sink)
+
+    # Phase 1 — supervised fresh build captures the live client + its options key
+    # (mirrors the real supervisor binding the slot on turn 1).
+    captured: dict = {}
+
+    def _on_built(client, key, teardown):
+        captured.update(client=client, key=key, teardown=teardown)
+
+    await _drive_run(sdk, "turn one", on_client_built=_on_built)
+    leased_client = captured["client"]
+    leased_key = captured["key"]
+    assert leased_client is client_sink[0]
+    assert leased_client.connect_count == 1
+    assert leased_client.queries == ["turn one"]
+
+    # Phase 2 — lease it back with a MATCHING key + a history block. Warm reuse
+    # must drive the SAME client with the raw message, never reconnect, never
+    # build a second client, never inject the history into the query.
+    lease = LeasedClient(client=leased_client, options_key=leased_key)
+    events = await _drive_run(
+        sdk,
+        "turn two",
+        history=[{"role": "user", "content": "an earlier turn"}],
+        warm_client=lease,
+    )
+
+    assert any(e.type == "done" for e in events)
+    assert len(client_sink) == 1, "warm reuse must NOT construct a second client"
+    assert leased_client.connect_count == 1, "warm reuse must NOT reconnect the leased client"
+    assert leased_client.queries == ["turn one", "turn two"], (
+        "the second turn must drive the SAME leased client with the raw message"
+    )
+    assert leased_client.queries[-1] == "turn two", (
+        "no history block may be injected into the query"
+    )
+    assert leased_client.disconnect_count == 0, "warm reuse must NEVER disconnect the leased client"
+    assert not stateless_options, "a matching warm lease must not take the stateless path"
+    assert lease.busy is False, "the busy flag must be released after the stream drains"
+
+
+# ===========================================================================
+# 2. Key mismatch — fresh build + on_client_built gets the NEW key
+# ===========================================================================
+
+
+async def test_warm_client_key_mismatch_builds_fresh_and_rebinds() -> None:
+    """A ``warm_client`` whose key MISMATCHES + ``on_client_built`` builds a FRESH
+    client and hands ``on_client_built`` the NEW key (not the stale one). The
+    stale leased client is NOT driven."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    client_sink: list[_SpyClient] = []
+    sdk = _make_sdk(options_sink, stateless_options, client_sink)
+
+    stale = _SpyClient(init_session_id="stale")
+    lease = LeasedClient(client=stale, options_key="STALE-MISMATCH-KEY")
+
+    captured: dict = {}
+
+    def _on_built(client, key, teardown):
+        captured.update(client=client, key=key, teardown=teardown)
+
+    events = await _drive_run(sdk, "turn two", warm_client=lease, on_client_built=_on_built)
+
+    assert any(e.type == "done" for e in events)
+    assert stale.queries == [], "the stale (mismatched) leased client must NOT be driven"
+    assert captured, "on_client_built must be called to rebind the new slot"
+    assert captured["client"] is client_sink[-1], "the bound client must be the freshly built one"
+    assert captured["client"].connect_count == 1
+    assert captured["client"].queries == ["turn two"]
+    assert captured["key"] != "STALE-MISMATCH-KEY", (
+        "on_client_built must receive THIS turn's key, not the stale lease key"
+    )
+
+
+# ===========================================================================
+# 3. Supervised fresh build — callback invoked; resume only when cli_session_id
+# ===========================================================================
+
+
+async def test_supervised_fresh_build_invokes_callback_no_resume_on_turn_one() -> None:
+    """No ``warm_client`` but ``on_client_built`` set → a fresh client is built,
+    handed to the callback, and queried. With no resume id the options carry no
+    ``resume`` (a true turn-1)."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    client_sink: list[_SpyClient] = []
+    sdk = _make_sdk(options_sink, stateless_options, client_sink)
+
+    captured: dict = {}
+
+    def _on_built(client, key, teardown):
+        captured.update(client=client, key=key, teardown=teardown)
+
+    events = await _drive_run(sdk, "turn one", on_client_built=_on_built)
+
+    assert any(e.type == "done" for e in events)
+    assert captured["client"] is client_sink[-1]
+    assert isinstance(captured["key"], str) and captured["key"]
+    assert callable(captured["teardown"]), "teardown must be a callable the supervisor can await"
+    assert captured["client"].queries == ["turn one"]
+    assert getattr(options_sink[-1], "resume", None) is None, (
+        "a turn-1 supervised build must not set resume on the options"
+    )
+    # teardown disconnects exactly the built client (the supervisor owns it).
+    await captured["teardown"]()
+    assert captured["client"].disconnect_count == 1
+
+
+async def test_supervised_fresh_build_sets_resume_when_cli_session_id_present() -> None:
+    """``on_client_built`` set AND ``session_handle.cli_session_id`` present → the
+    fresh client's options carry ``resume=<id>`` (the cold-recovery path)."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    client_sink: list[_SpyClient] = []
+    sdk = _make_sdk(options_sink, stateless_options, client_sink)
+
+    captured: dict = {}
+
+    def _on_built(client, key, teardown):
+        captured.update(client=client, key=key, teardown=teardown)
+
+    handle = SessionHandle(cli_session_id="sess-recover")
+    events = await _drive_run(sdk, "resume turn", session_handle=handle, on_client_built=_on_built)
+
+    assert any(e.type == "done" for e in events)
+    assert captured, "on_client_built must be invoked on the supervised cold-recovery build"
+    assert getattr(options_sink[-1], "resume", None) == "sess-recover", (
+        "a supervised build with a cli_session_id must set resume on the options"
+    )
+
+
+# ===========================================================================
+# 4. Legacy path — neither param → self._client warm path unchanged
+# ===========================================================================
+
+
+async def test_legacy_no_lease_params_uses_self_client_path() -> None:
+    """With neither ``warm_client`` nor ``on_client_built`` the run takes the
+    unchanged ``self._client`` warm path: a client is cached on ``self._client``
+    and the stateless path is not used."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    client_sink: list[_SpyClient] = []
+    sdk = _make_sdk(options_sink, stateless_options, client_sink)
+
+    events = await _drive_run(sdk, "ordinary turn")
+
+    assert any(e.type == "done" for e in events)
+    assert sdk._client is not None, "the legacy warm path must cache the client on self._client"
+    assert sdk._client is client_sink[0]
+    assert sdk._client.queries == ["ordinary turn"]
+    assert not stateless_options, "the legacy warm path must not fall back to stateless"
+
+
+# ===========================================================================
+# 5. Busy edge — a matching but busy lease falls back to stateless, no rebind
+# ===========================================================================
+
+
+async def test_busy_warm_client_falls_back_to_stateless_without_rebind() -> None:
+    """A ``warm_client`` whose key matches but whose ``busy`` flag is already set
+    (a sibling turn mid-query) falls back to a fresh stateless query for THIS turn
+    and does NOT re-drive or rebind the leased client."""
+    options_sink: list[_Options] = []
+    stateless_options: list[_Options] = []
+    client_sink: list[_SpyClient] = []
+    sdk = _make_sdk(options_sink, stateless_options, client_sink)
+
+    # Phase 1 — supervised build to capture a real matching key.
+    captured: dict = {}
+
+    def _on_built(client, key, teardown):
+        captured.update(client=client, key=key, teardown=teardown)
+
+    await _drive_run(sdk, "turn one", on_client_built=_on_built)
+    leased_client = captured["client"]
+    leased_key = captured["key"]
+
+    # Phase 2 — lease it back as BUSY. The turn must take the stateless path and
+    # leave the busy lease untouched.
+    lease = LeasedClient(client=leased_client, options_key=leased_key, busy=True)
+    events = await _drive_run(sdk, "turn two", warm_client=lease)
+
+    assert any(e.type == "done" for e in events)
+    assert stateless_options, "a busy matching lease must fall back to the stateless path"
+    assert leased_client.queries == ["turn one"], (
+        "the busy leased client must NOT be driven a second time"
+    )
+    assert len(client_sink) == 1, "the busy fallback must not build a new persistent client"
+    assert lease.busy is True, "this run must not touch the busy flag the sibling turn owns"

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -243,6 +243,45 @@ def test_per_tenant_quota_skips_busy_candidate() -> None:
     assert td_a2.calls == 0 and a2.runtime.tier is SessionTier.WARM
 
 
+def test_quota_cap_soak_no_unbounded_warm_clients() -> None:
+    """Soak (WH-4): binding warm clients across tenants far beyond the caps never
+    lets the held warm count exceed ``max_warm_per_tenant`` (per tenant) or
+    ``max_warm_global`` (overall), and every evicted slot is disconnected. Proves
+    WARM can't grow unbounded — no leaked ``claude`` processes under load."""
+    clock = FakeClock()
+    PER_TENANT, GLOBAL = 2, 4
+    sup = SessionSupervisor(
+        warm_ttl=10_000, max_warm_per_tenant=PER_TENANT, max_warm_global=GLOBAL, now=clock
+    )
+
+    tenants = ["ws-a", "ws-b", "ws-c"]
+    acqs = []
+    teardowns = []
+    for i in range(12):  # 12 binds round-robin across 3 tenants, all idle
+        clock.advance(1)
+        acq = sup.acquire(tenants[i % 3], f"sess-{i}", "agent", cli_session_id=f"cli-{i}")
+        td = Teardown()
+        sup.bind_warm_slot(acq.runtime, slot=f"slot-{i}", teardown=td)
+        acqs.append(acq)
+        teardowns.append(td)
+
+    warm = [
+        a.runtime
+        for a in acqs
+        if a.runtime.tier is SessionTier.WARM and a.runtime.warm_slot is not None
+    ]
+    # Global cap holds — never more live warm clients than the global ceiling.
+    assert len(warm) <= GLOBAL
+    # Per-tenant cap holds for every tenant.
+    for ws in tenants:
+        assert len([r for r in warm if r.workspace_id == ws]) <= PER_TENANT
+    # Every evicted slot's teardown (the ``disconnect``) fired exactly once — the
+    # released clients can't pile up. evicted == binds - held.
+    evicted = sum(td.calls for td in teardowns)
+    assert evicted == 12 - len(warm)
+    assert evicted > 0  # the soak actually exercised eviction
+
+
 # ===========================================================================
 # Turn-1 routing / capture ownership
 # ===========================================================================

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -24,6 +24,9 @@
 
 from __future__ import annotations
 
+import asyncio
+
+from pocketpaw.agents.backend import LeasedClient
 from pocketpaw.agents.session_supervisor import (
     Acquisition,
     SessionSupervisor,
@@ -53,6 +56,41 @@ class Teardown:
 
     def __call__(self) -> None:
         self.calls += 1
+
+
+class LeaseSpy:
+    """WH-2 — a fake live ``ClaudeSDKClient`` plus the ASYNC teardown the Claude
+    SDK backend hands the supervisor (mirrors ``claude_sdk._teardown``, which
+    ``await client.disconnect()``s).
+
+    ``disconnect_count`` increments only AFTER the disconnect coroutine runs to
+    completion — so it proves the supervisor actually released the live client on
+    a given path, not merely scheduled something. ``lease()`` wraps the spy in a
+    real WH-1 ``LeasedClient`` so the supervisor holds the exact production type.
+    """
+
+    def __init__(self) -> None:
+        self.disconnect_count = 0
+
+    async def disconnect(self) -> None:
+        # A realistic yield point, like a real subprocess disconnect — exercises
+        # the "awaited to completion" path rather than a no-await fast finish.
+        await asyncio.sleep(0)
+        self.disconnect_count += 1
+
+    async def teardown(self) -> None:
+        """The async callback the supervisor stores as ``runtime.teardown``."""
+        await self.disconnect()
+
+    def lease(self, options_key: str = "opts-key") -> LeasedClient:
+        return LeasedClient(client=self, options_key=options_key)
+
+
+async def _drain() -> None:
+    """Let fire-and-forget async-teardown tasks scheduled by ``_run_teardown``
+    (the sync reap / quota-evict / crash callers) run to completion."""
+    for _ in range(5):
+        await asyncio.sleep(0)
 
 
 # ===========================================================================
@@ -423,3 +461,154 @@ async def test_start_stop_tears_down_all_slots() -> None:
     assert td_a.calls == 1 and td_b.calls == 1
     assert a.runtime.tier is SessionTier.COLD
     assert b.runtime.tier is SessionTier.COLD
+
+
+# ===========================================================================
+# WH-2 — the WARM tier holds a real LeasedClient and DISCONNECTS the live
+# claude client on every release path (idle reap, quota evict, crash, stop).
+# Fakes only: a LeaseSpy whose async ``teardown`` mirrors claude_sdk._teardown.
+# ===========================================================================
+
+
+def test_warm_reuse_returns_leased_client_within_ttl() -> None:
+    """A bound ``LeasedClient`` slot is returned via ``Acquisition.slot`` on a
+    warm-reuse turn within TTL — and the live client is NOT disconnected."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq1 = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    sup.record_cli_session_id(acq1.runtime, "cli-1")
+
+    spy = LeaseSpy()
+    lease = spy.lease()
+    sup.bind_warm_slot(acq1.runtime, slot=lease, teardown=spy.teardown)
+    assert isinstance(acq1.runtime.warm_slot, LeasedClient)
+
+    clock.advance(30)
+    acq2 = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    assert acq2.warm_reuse is True
+    assert acq2.slot is lease  # the exact LeasedClient is handed back for reuse
+    assert acq2.slot.client is spy
+    assert spy.disconnect_count == 0  # warm reuse never disconnects
+
+
+async def test_idle_reap_disconnects_leased_client() -> None:
+    """Past ``warm_ttl``, one reaper pass disconnects the live client (releases it)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    spy = LeaseSpy()
+    sup.bind_warm_slot(acq.runtime, slot=spy.lease(), teardown=spy.teardown)
+
+    clock.advance(150)  # 150 > 120
+    assert sup.reap_once() == 1
+    await _drain()  # let the scheduled async disconnect complete
+    assert spy.disconnect_count == 1
+    assert acq.runtime.tier is SessionTier.COLD
+    assert acq.runtime.warm_slot is None
+
+
+async def test_quota_evict_disconnects_evicted_client_and_spares_busy() -> None:
+    """A per-tenant over-cap bind disconnects the evicted (oldest idle) client; a
+    BUSY warm runtime is never disconnected."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=10_000, max_warm_per_tenant=2, now=clock)
+
+    # a1: oldest, idle. a2: busy (must be spared). Both warm for tenant A.
+    a1 = sup.acquire("ws-a", "sess-a1", "agent", cli_session_id="cli-a1")
+    spy1 = LeaseSpy()
+    sup.bind_warm_slot(a1.runtime, slot=spy1.lease(), teardown=spy1.teardown)
+
+    clock.advance(1)
+    a2 = sup.acquire("ws-a", "sess-a2", "agent", cli_session_id="cli-a2")
+    spy2 = LeaseSpy()
+    sup.bind_warm_slot(a2.runtime, slot=spy2.lease(), teardown=spy2.teardown)
+    sup.mark_run_start(a2.runtime)  # busy — cannot be evicted
+
+    # a3 → over the cap of 2. Only idle candidate is a1 (a2 busy, a3 protected).
+    clock.advance(1)
+    a3 = sup.acquire("ws-a", "sess-a3", "agent", cli_session_id="cli-a3")
+    spy3 = LeaseSpy()
+    sup.bind_warm_slot(a3.runtime, slot=spy3.lease(), teardown=spy3.teardown)
+    await _drain()
+
+    assert spy1.disconnect_count == 1  # oldest idle evicted → live client released
+    assert a1.runtime.tier is SessionTier.COLD
+    assert spy2.disconnect_count == 0  # busy runtime never torn down
+    assert a2.runtime.tier is SessionTier.WARM
+    assert spy3.disconnect_count == 0  # the just-bound runtime is protected
+    assert a3.runtime.tier is SessionTier.WARM
+
+
+async def test_crash_disconnects_leased_client_and_demotes_cold() -> None:
+    """mark_crashed disconnects the live client and demotes the runtime to COLD,
+    keeping ``cli_session_id`` for the resume-from-store path."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id=None)
+    sup.record_cli_session_id(acq.runtime, "cli-survives")
+    spy = LeaseSpy()
+    sup.bind_warm_slot(acq.runtime, slot=spy.lease(), teardown=spy.teardown)
+
+    sup.mark_crashed(acq.runtime)
+    await _drain()
+    assert spy.disconnect_count == 1
+    assert acq.runtime.tier is SessionTier.COLD
+    assert acq.runtime.warm_slot is None
+    assert acq.runtime.cli_session_id == "cli-survives"
+
+
+async def test_stop_awaits_every_leased_client_disconnect() -> None:
+    """stop() awaits each slot's async disconnect to completion (no _drain needed —
+    _run_teardown_async awaits inline)."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, now=clock)
+    await sup.start()
+
+    a = sup.acquire("ws-a", "sess-1", "agent", cli_session_id="cli-a")
+    spy_a = LeaseSpy()
+    sup.bind_warm_slot(a.runtime, slot=spy_a.lease(), teardown=spy_a.teardown)
+
+    b = sup.acquire("ws-b", "sess-2", "agent", cli_session_id="cli-b")
+    spy_b = LeaseSpy()
+    sup.bind_warm_slot(b.runtime, slot=spy_b.lease(), teardown=spy_b.teardown)
+
+    await sup.stop()
+    assert spy_a.disconnect_count == 1
+    assert spy_b.disconnect_count == 1
+    assert a.runtime.tier is SessionTier.COLD
+    assert b.runtime.tier is SessionTier.COLD
+
+
+async def test_reaped_lease_then_cold_pruned_without_second_disconnect() -> None:
+    """SS-4 COLD-prune still holds with a real lease: a warm-reaped runtime (now
+    COLD, no slot) is pruned past ``cold_ttl`` with NO second disconnect; a busy
+    runtime is never pruned."""
+    clock = FakeClock()
+    sup = SessionSupervisor(warm_ttl=120, cold_ttl=3600, now=clock)
+
+    acq = sup.acquire("ws-a", "sess-1", "agent-x", cli_session_id="cli-1")
+    spy = LeaseSpy()
+    sup.bind_warm_slot(acq.runtime, slot=spy.lease(), teardown=spy.teardown)
+
+    # Warm reap disconnects once and demotes to COLD (slot dropped).
+    clock.advance(200)  # > warm_ttl, < cold_ttl
+    assert sup.reap_once() == 1
+    await _drain()
+    assert spy.disconnect_count == 1
+    assert acq.runtime.tier is SessionTier.COLD
+    assert ("ws-a", "sess-1") in sup._runtimes  # resident as COLD, not yet pruned
+
+    # A busy COLD runtime past cold_ttl is never pruned (busy-guard).
+    busy = sup.acquire("ws-a", "sess-busy", "agent-x", cli_session_id=None)
+    sup.mark_run_start(busy.runtime)
+
+    # Past cold_ttl → the slotless COLD runtime is pruned; no extra disconnect.
+    clock.advance(3601)
+    assert sup.reap_once() == 1  # only sess-1 pruned; busy spared
+    await _drain()
+    assert spy.disconnect_count == 1  # NOT torn down a second time
+    assert ("ws-a", "sess-1") not in sup._runtimes
+    assert ("ws-a", "sess-busy") in sup._runtimes  # busy survives


### PR DESCRIPTION
The performance tier for the session supervisor (on dev in #1596/#1597). Flag-on, a supervised session keeps its `claude` client warm across turns: turn 2+ reuses the live subprocess instead of resuming cold (re-materialize + a fresh connect). `resume` becomes the cold-recovery path only. Off by default behind `POCKETPAW_SESSION_SUPERVISOR`, so merging changes nothing until the flag is flipped. `claude_sdk` backend only this iteration.

## What's in it
- The supervisor owns a per-`(workspace, session)` live `ClaudeSDKClient` slot, bound on turn 1 and reused on turn 2+, governed by the existing per-tenant warm quota + idle reaper + busy-guard (so warm clients stay bounded — cold sessions cost zero process).
- The Claude SDK backend runs against a caller-leased client when one is passed, and hands a freshly-built one back to the supervisor; the legacy per-agent path is untouched.

## Getting it to actually fire live took three fixes
Live smokes caught what the unit fakes couldn't:
- keep the warm slot alive on a benign backend `error` event (a non-fatal `ResultMessage.is_error` was being treated as a crash and dropping the slot).
- capture the native `session_id` from the `ResultMessage` (the init `SystemMessage` didn't surface it on the fresh leased client, so the session was never recorded and warm reuse never engaged).
- excise the soul `# Key Knowledge` block (per-turn bond level / memory count) from the warm-client cache-key digest — it changed every turn, so the key never matched and the subprocess rebuilt each time. A real persona / identity / tools / skills change still flips the key and rebuilds, guarded by new cache-key regression tests.

## Verified
Live: same `claude` pid across turn 2 ("reusing leased warm client"), cold resume still works after idle. Tests: the full warm-lease, cache-key, supervisor, chat-runs, and multi-tenant-isolation lanes are green. A captain-run smoke guide lives under `docs/handoff/`.

## Deferred (documented)
Codex resume parity; the LIVE/attach tier via cmux; the skills + leased-client teardown reclaiming the materialized skills dir at per-client teardown (a benign retention gap).
