### PR TITLE
feat(cloud): push notifications for user-to-user messages, with send coalescing

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/unread_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/unread_service.py
@@ -76,6 +76,27 @@ async def list_unreads(user_id: str, workspace_id: str) -> list[dict]:
     return out
 
 
+async def unread_count(user_id: str, group_id: str) -> int:
+    """Unread message count for a single ``(user, group)`` pair.
+
+    The per-group half of :func:`list_unreads`, exposed so callers that only
+    care about one conversation (e.g. the push new-message notifier) can get a
+    count without scanning every group the user belongs to. Same safe default:
+    a user with no ReadState row — or a row whose ``last_read_message_id`` is
+    the empty string — counts the group's full ``message_count`` (everything
+    is unread until a ``mark_read`` corrects it).
+    """
+    state = await _get_read_state(user_id, group_id)
+    if state is not None and state.last_read_message_id:
+        return await _count_messages_after(group_id, state.last_read_message_id)
+
+    try:
+        group = await _GroupDoc.get(PydanticObjectId(group_id))
+    except Exception:
+        group = None
+    return group.message_count if group else 0
+
+
 async def mark_read(user_id: str, group_id: str, last_message_id: str) -> None:
     """Upsert read state for (user, group). Resets mention_unread to 0.
 
@@ -123,4 +144,4 @@ async def bump_mention(user_id: str, group_id: str) -> None:
     )
 
 
-__all__ = ["bump_mention", "list_unreads", "mark_read"]
+__all__ = ["bump_mention", "list_unreads", "mark_read", "unread_count"]

--- a/ee/pocketpaw_ee/cloud/push/coalesce.py
+++ b/ee/pocketpaw_ee/cloud/push/coalesce.py
@@ -26,6 +26,13 @@
 # Named ``CLOUD_*`` to match the sibling ``CLOUD_PUSH_CONTACT`` — this cloud
 # layer reads its own knobs from ``os.environ`` directly.
 #
+# Updated 2026-07-02: the leading edge now fires DETACHED (a background task,
+# like the trailing flush) instead of being awaited inline. ``submit`` is
+# awaited by the realtime bus handler, which the bus dispatches on the chat-send
+# request path — awaiting the push fan-out there coupled send latency to
+# delivery. ``submit`` now returns promptly and the leading push runs in the
+# background.
+#
 # Scope: in-process (single backend). The state lives in module-level dicts, so
 # two backend replicas would each fire their own leading push. That's the
 # documented v1 limit; the ``submit`` seam is the swap point for a Redis-backed
@@ -53,6 +60,36 @@ _Emit = Callable[[], Awaitable[None]]
 
 _tasks: dict[_Key, asyncio.Task] = {}
 _pending: dict[_Key, _Emit] = {}
+# In-flight DETACHED leading-edge emits. Held only to keep a strong reference so
+# the event loop can't garbage-collect a leading push mid-send; each removes
+# itself on completion. See ``_spawn_detached`` / ``submit``.
+_leading: set[asyncio.Task] = set()
+
+
+async def _guarded_emit(emit: _Emit) -> None:
+    """Await one emit, logging (not raising) on failure.
+
+    The leading edge runs detached (no caller to catch its exception), so a
+    failed send must be swallowed here or it would surface as an unretrieved
+    task exception.
+    """
+    try:
+        await emit()
+    except Exception:
+        logger.exception("push: leading-edge emit failed")
+
+
+def _spawn_detached(emit: _Emit) -> None:
+    """Fire one emit as a background task, decoupled from the caller.
+
+    ``submit`` is awaited by the realtime bus handler, which the bus dispatches
+    INLINE on the chat-send request path — awaiting delivery there would couple
+    send latency to the Web Push fan-out. Running the leading emit detached
+    (like the trailing flush already is) lets ``submit`` return promptly.
+    """
+    task = asyncio.create_task(_guarded_emit(emit))
+    _leading.add(task)
+    task.add_done_callback(_leading.discard)
 
 
 def _coalesce_seconds() -> float:
@@ -95,11 +132,13 @@ async def submit(key: _Key, emit: _Emit) -> None:
         _pending[key] = emit
         return
 
-    # Leading edge. Reserve the window SYNCHRONOUSLY (before the await) so a
+    # Leading edge. Reserve the window SYNCHRONOUSLY (before scheduling) so a
     # second submit arriving while this leading emit is in flight coalesces
-    # instead of racing to a second leading push.
+    # instead of racing to a second leading push. Fire the leading emit DETACHED
+    # (not awaited) so this ``submit`` — dispatched inline by the realtime bus on
+    # the chat-send request path — returns without blocking on the push fan-out.
     _tasks[key] = asyncio.create_task(_cooldown(key, seconds))
-    await emit()
+    _spawn_detached(emit)
 
 
 async def _cooldown(key: _Key, seconds: float) -> None:
@@ -130,10 +169,11 @@ def reset() -> None:
     caller that needs the cancellations to finish cleanly on a live loop (tests,
     graceful shutdown) should use :func:`aclose` instead.
     """
-    for task in _tasks.values():
+    for task in (*_tasks.values(), *_leading):
         task.cancel()
     _tasks.clear()
     _pending.clear()
+    _leading.clear()
 
 
 async def aclose() -> None:
@@ -143,13 +183,14 @@ async def aclose() -> None:
     its ``finally`` before the loop moves on, so no cancellation callback lands
     on an already-closed loop.
     """
-    tasks = list(_tasks.values())
+    tasks = [*_tasks.values(), *_leading]
     for task in tasks:
         task.cancel()
     if tasks:
         await asyncio.gather(*tasks, return_exceptions=True)
     _tasks.clear()
     _pending.clear()
+    _leading.clear()
 
 
 __all__ = ["aclose", "reset", "submit"]

--- a/ee/pocketpaw_ee/cloud/push/coalesce.py
+++ b/ee/pocketpaw_ee/cloud/push/coalesce.py
@@ -1,0 +1,155 @@
+# Leading-edge push coalescer (feat/push-user-message-notifications).
+# Created: 2026-07-02 — throttles per-recipient notification sends so a burst of
+# messages in one conversation doesn't fan out one Web Push per message (which
+# wastes encrypt+POST work and can trip the push vendor's per-endpoint rate
+# limit with 429s). The OS already collapses same-``tag`` notifications on the
+# view side; this bounds the SEND side.
+#
+# Semantics — LEADING-EDGE throttle, keyed by (workspace_id, user_id, group_id):
+#   - First submit for an idle key   → emit IMMEDIATELY (zero added latency),
+#                                        then open a cooldown window.
+#   - Submits during the cooldown     → suppressed; the latest emit is remembered.
+#   - When the window elapses          → if anything was suppressed, emit ONCE
+#                                        (a trailing flush carrying the freshest
+#                                        payload + a recomputed count) and keep
+#                                        the window open one more cycle so a
+#                                        sustained stream fires at most once per
+#                                        window. An idle window closes and frees
+#                                        the key.
+#
+# So a 20-message burst becomes at most 2 sends (leading + one coalesced), the
+# recipient is still pinged the instant the first message lands, and a
+# continuous stream is capped at 1 send per window.
+#
+# Window length: ``CLOUD_PUSH_COALESCE_SECONDS`` (default 5.0). ``0`` disables
+# coalescing entirely — every submit emits immediately (pre-throttle behaviour).
+# Named ``CLOUD_*`` to match the sibling ``CLOUD_PUSH_CONTACT`` — this cloud
+# layer reads its own knobs from ``os.environ`` directly.
+#
+# Scope: in-process (single backend). The state lives in module-level dicts, so
+# two backend replicas would each fire their own leading push. That's the
+# documented v1 limit; the ``submit`` seam is the swap point for a Redis-backed
+# coordinator (POCKETPAW_REDIS_URL is already wired) when multi-replica push
+# delivery lands. NO Beanie writes happen here — the emit callback routes
+# through push/dispatch.py exactly as the direct path did.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+_ENV_SECONDS = "CLOUD_PUSH_COALESCE_SECONDS"
+_DEFAULT_SECONDS = 5.0
+
+# A key is (workspace_id, user_id, group_id). ``_tasks`` holds the open cooldown
+# window for a key; ``_pending`` holds the latest suppressed emit awaiting the
+# next flush. Both are cleared when a window closes.
+_Key = tuple[str, str, str]
+_Emit = Callable[[], Awaitable[None]]
+
+_tasks: dict[_Key, asyncio.Task] = {}
+_pending: dict[_Key, _Emit] = {}
+
+
+def _coalesce_seconds() -> float:
+    """Window length in seconds. ``<= 0`` (or unset-to-default) tunable via env.
+
+    Malformed values fall back to the default rather than raising — a bad env
+    value must not break notification delivery.
+    """
+    raw = os.environ.get(_ENV_SECONDS, "").strip()
+    if not raw:
+        return _DEFAULT_SECONDS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a number; using default %s", _ENV_SECONDS, raw, _DEFAULT_SECONDS
+        )
+        return _DEFAULT_SECONDS
+
+
+async def submit(key: _Key, emit: _Emit) -> None:
+    """Route one notification through the leading-edge throttle.
+
+    ``emit`` is an idempotent-safe coroutine that sends exactly one notification
+    when awaited (it recomputes the unread count at send time, so a trailing
+    flush carries a current count). It is called at most once on the leading
+    edge and at most once per window thereafter.
+
+    With coalescing disabled (window ``<= 0``) this is a pass-through: ``emit``
+    is awaited immediately and no window is opened.
+    """
+    seconds = _coalesce_seconds()
+    if seconds <= 0:
+        await emit()
+        return
+
+    if key in _tasks:
+        # Inside the cooldown window: suppress now, remember the freshest emit
+        # to fire at the next flush.
+        _pending[key] = emit
+        return
+
+    # Leading edge. Reserve the window SYNCHRONOUSLY (before the await) so a
+    # second submit arriving while this leading emit is in flight coalesces
+    # instead of racing to a second leading push.
+    _tasks[key] = asyncio.create_task(_cooldown(key, seconds))
+    await emit()
+
+
+async def _cooldown(key: _Key, seconds: float) -> None:
+    """Hold a key's window open, flushing one coalesced emit per cycle.
+
+    Sleeps ``seconds``; if a submit was suppressed meanwhile, fires it once and
+    loops (so a sustained stream is capped at one send per window). An empty
+    cycle closes the window and frees the key.
+    """
+    try:
+        while True:
+            await asyncio.sleep(seconds)
+            emit = _pending.pop(key, None)
+            if emit is None:
+                return  # nothing suppressed this cycle → close the window
+            try:
+                await emit()
+            except Exception:
+                logger.exception("push: coalesced flush failed for key=%s", key)
+    finally:
+        _tasks.pop(key, None)
+
+
+def reset() -> None:
+    """Cancel all open windows and drop pending emits (best-effort, sync).
+
+    Fire-and-forget: it requests cancellation but does not await the tasks, so a
+    caller that needs the cancellations to finish cleanly on a live loop (tests,
+    graceful shutdown) should use :func:`aclose` instead.
+    """
+    for task in _tasks.values():
+        task.cancel()
+    _tasks.clear()
+    _pending.clear()
+
+
+async def aclose() -> None:
+    """Cancel all open windows and AWAIT their teardown on the running loop.
+
+    Awaiting the cancelled tasks lets each process ``CancelledError`` and run
+    its ``finally`` before the loop moves on, so no cancellation callback lands
+    on an already-closed loop.
+    """
+    tasks = list(_tasks.values())
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    _tasks.clear()
+    _pending.clear()
+
+
+__all__ = ["aclose", "reset", "submit"]

--- a/ee/pocketpaw_ee/cloud/push/listeners.py
+++ b/ee/pocketpaw_ee/cloud/push/listeners.py
@@ -7,6 +7,14 @@
 # resolving recipients + a small {title, body, url?} payload, registered from
 # ``mount_cloud`` after ``init_realtime`` installs the singleton bus.
 #
+# Updated: 2026-07-02 (feat/push-user-message-notifications) — wired
+# ``message.sent`` → ``on_new_message`` so a human-to-human message notifies the
+# group's OTHER human members. The body is generic-with-a-count ("N new
+# messages") — the message text never reaches the OS notification surface
+# (lock-screen privacy). Only the human ``message_add`` path emits
+# ``message.sent``; agent replies ride ``agent.stream_end`` (on_agent_complete),
+# so there is no double-notify.
+#
 # v1 events wired (those with a real emission point + a resolvable recipient):
 #   - agent.stream_end           → agent-complete. Recipients = the group's
 #                                  human members (resolved off the group the
@@ -35,7 +43,7 @@ import logging
 from typing import Any
 
 from pocketpaw_ee.cloud._core.realtime.events import Event
-from pocketpaw_ee.cloud.push import dispatch
+from pocketpaw_ee.cloud.push import coalesce, dispatch
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +91,32 @@ async def _dispatch(workspace_id: str, user_id: str, payload: dict[str, Any]) ->
             workspace_id,
             user_id,
         )
+
+
+async def _unread_count(user_id: str, group_id: str) -> int:
+    """Unread count for one (user, group), for the new-message body. Best-effort.
+
+    Falls back to ``1`` on any error so the notification body still reads
+    sensibly ("1 new message") rather than "0 new messages".
+    """
+    try:
+        from pocketpaw_ee.cloud.chat import unread_service
+
+        return await unread_service.unread_count(user_id, group_id)
+    except Exception:
+        logger.exception(
+            "push: unread count failed for user=%s group=%s", user_id, group_id
+        )
+        return 1
+
+
+def _count_body(count: int) -> str:
+    """Generic, content-free body carrying only the unread count.
+
+    The message text is deliberately NOT included — a human-to-human push
+    lands on the lock screen, so only the count crosses that surface.
+    """
+    return "1 new message" if count <= 1 else f"{count} new messages"
 
 
 # ---------------------------------------------------------------------------
@@ -160,6 +194,69 @@ async def on_meeting_started(event: Event) -> None:
         await _dispatch(workspace_id, recipient, payload)
 
 
+async def on_new_message(event: Event) -> None:
+    """message.sent → notify a group's OTHER human members of a new message.
+
+    Generic-with-a-count: the title names the sender, the body is only the
+    unread count ("N new messages") — the message text never reaches the OS
+    notification surface. The sender is excluded (no self-ping), and the
+    WS-vs-Web-Push dedupe in ``dispatch.notify`` means only members with no
+    live connection actually receive a Web Push.
+
+    Only the human ``message_add`` path emits ``message.sent``; the
+    ``senderType != "user"`` guard is defensive belt-and-braces so an
+    agent-authored message can never double-fire alongside
+    ``on_agent_complete`` (agent.stream_end).
+
+    ``message.sent`` carries the wire dict (camelCase ``senderName`` /
+    ``senderType``) plus ``group_id`` + ``sender_id`` but NO ``workspace_id``,
+    so the workspace is resolved from the group — mirroring on_agent_complete.
+
+    Each send is routed through the leading-edge coalescer (push/coalesce.py):
+    the first message pings instantly, a burst within the cooldown collapses to
+    one trailing send. The emit closure recomputes the unread count at send
+    time, so both the leading and any trailing push carry a current count.
+    """
+    data = event.data or {}
+    group_id = data.get("group_id")
+    if not group_id:
+        return
+    if data.get("senderType") not in (None, "user"):
+        return
+
+    workspace_id = await _group_workspace_id(group_id)
+    if not workspace_id:
+        return
+
+    sender_id = data.get("sender_id")
+    recipients = [uid for uid in await _group_member_ids(group_id) if uid != sender_id]
+    if not recipients:
+        return
+
+    title = data.get("senderName") or "New message"
+    url = f"/?join={group_id}"
+    for recipient in recipients:
+        # ``recipient`` is bound as a default arg so the closure captures THIS
+        # iteration's value (the other captured names are constant per call).
+        # The count is recomputed inside so a coalesced trailing send reflects
+        # the accumulated unread total. ``tag`` is the group id so the OS
+        # collapses a conversation's notifications into one updating toast.
+        async def _emit(recipient: str = recipient) -> None:
+            count = await _unread_count(recipient, group_id)
+            await _dispatch(
+                workspace_id,
+                recipient,
+                {
+                    "title": title,
+                    "body": _count_body(count),
+                    "url": url,
+                    "tag": group_id,
+                },
+            )
+
+        await coalesce.submit((workspace_id, recipient, group_id), _emit)
+
+
 # ---------------------------------------------------------------------------
 # Registration — called from mount_cloud() after init_realtime.
 # ---------------------------------------------------------------------------
@@ -178,6 +275,7 @@ def register_push_event_listeners() -> None:
     bus.subscribe("agent.stream_end", on_agent_complete)
     bus.subscribe("instinct.approval.created", on_guardian_block)
     bus.subscribe("meeting.started", on_meeting_started)
+    bus.subscribe("message.sent", on_new_message)
     logger.info("registered v1 product events → push notification dispatch")
 
 
@@ -185,5 +283,6 @@ __all__ = [
     "on_agent_complete",
     "on_guardian_block",
     "on_meeting_started",
+    "on_new_message",
     "register_push_event_listeners",
 ]

--- a/tests/cloud/push/test_coalesce.py
+++ b/tests/cloud/push/test_coalesce.py
@@ -7,6 +7,11 @@
 #   - window <= 0 disables coalescing (pass-through).
 # Uses a tiny window (0.05s) and real asyncio.sleep so the timing is exercised
 # for real; ``reset()`` between cases prevents window state from leaking.
+#
+# Updated 2026-07-02: the leading edge now fires DETACHED (a background task) so
+# ``submit`` returns without blocking the caller. It still fires "immediately"
+# (next loop tick, sub-ms), but the tests must ``_drain()`` one tick before
+# asserting the leading emit has landed.
 
 from __future__ import annotations
 
@@ -38,10 +43,21 @@ def _counter():
     return calls, emit
 
 
+async def _drain() -> None:
+    """Yield a loop tick so detached leading-edge emits run before we assert.
+
+    The leading edge is fired via ``asyncio.create_task``, so it runs on the
+    next tick rather than synchronously inside ``submit``. One short sleep lets
+    every currently-ready leading emit complete without waiting for a window.
+    """
+    await asyncio.sleep(0.01)
+
+
 async def test_leading_edge_fires_immediately() -> None:
     calls, emit = _counter()
     await coalesce.submit(("w", "u", "g"), emit)
-    # Fired synchronously on the leading edge — no wait for the window.
+    await _drain()
+    # Fired on the leading edge (detached, next tick) — no wait for the window.
     assert len(calls) == 1
 
 
@@ -51,6 +67,7 @@ async def test_burst_collapses_to_leading_plus_one() -> None:
     for _ in range(10):
         await coalesce.submit(key, emit)
 
+    await _drain()
     # Only the leading push has gone out so far; the other 9 are suppressed.
     assert len(calls) == 1
 
@@ -65,6 +82,7 @@ async def test_sustained_stream_capped_per_window() -> None:
 
     # Leading push.
     await coalesce.submit(key, emit)
+    await _drain()
     assert len(calls) == 1
 
     # Two more windows, each fed a suppressed message → each yields one flush.
@@ -80,6 +98,7 @@ async def test_distinct_keys_are_independent() -> None:
     calls, emit = _counter()
     await coalesce.submit(("w", "alice", "g"), emit)
     await coalesce.submit(("w", "bob", "g"), emit)
+    await _drain()
     # Two different recipients → two leading pushes, neither suppresses the other.
     assert len(calls) == 2
 
@@ -100,4 +119,5 @@ async def test_malformed_window_uses_default(monkeypatch) -> None:
     monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "not-a-number")
     calls, emit = _counter()
     await coalesce.submit(("w", "u", "g"), emit)
+    await _drain()
     assert len(calls) == 1

--- a/tests/cloud/push/test_coalesce.py
+++ b/tests/cloud/push/test_coalesce.py
@@ -1,0 +1,103 @@
+# Tests for the leading-edge push coalescer (feat/push-user-message-notifications).
+# Created: 2026-07-02 — proves the throttle contract without real sockets or DB:
+#   - leading edge fires immediately (zero added latency);
+#   - a burst on one key collapses to leading + one trailing flush;
+#   - a sustained stream is capped at one send per window;
+#   - distinct keys throttle independently;
+#   - window <= 0 disables coalescing (pass-through).
+# Uses a tiny window (0.05s) and real asyncio.sleep so the timing is exercised
+# for real; ``reset()`` between cases prevents window state from leaking.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud.push import coalesce
+
+# Small enough to keep the suite fast; large enough to be robust on a loaded CI.
+_WINDOW = 0.05
+
+
+@pytest.fixture(autouse=True)
+async def _clean(monkeypatch):
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", str(_WINDOW))
+    await coalesce.aclose()
+    yield
+    # Await the cancellations so a still-sleeping window task can't schedule a
+    # callback on the loop after it closes.
+    await coalesce.aclose()
+
+
+def _counter():
+    calls: list[int] = []
+
+    async def emit() -> None:
+        calls.append(1)
+
+    return calls, emit
+
+
+async def test_leading_edge_fires_immediately() -> None:
+    calls, emit = _counter()
+    await coalesce.submit(("w", "u", "g"), emit)
+    # Fired synchronously on the leading edge — no wait for the window.
+    assert len(calls) == 1
+
+
+async def test_burst_collapses_to_leading_plus_one() -> None:
+    calls, emit = _counter()
+    key = ("w", "u", "g")
+    for _ in range(10):
+        await coalesce.submit(key, emit)
+
+    # Only the leading push has gone out so far; the other 9 are suppressed.
+    assert len(calls) == 1
+
+    # Let the window elapse: exactly one trailing flush for the whole burst.
+    await asyncio.sleep(_WINDOW * 3)
+    assert len(calls) == 2
+
+
+async def test_sustained_stream_capped_per_window() -> None:
+    calls, emit = _counter()
+    key = ("w", "u", "g")
+
+    # Leading push.
+    await coalesce.submit(key, emit)
+    assert len(calls) == 1
+
+    # Two more windows, each fed a suppressed message → each yields one flush.
+    for _ in range(2):
+        await coalesce.submit(key, emit)  # suppressed, remembered
+        await asyncio.sleep(_WINDOW * 2)  # window elapses → one trailing flush
+
+    # 1 leading + 2 per-window trailing flushes.
+    assert len(calls) == 3
+
+
+async def test_distinct_keys_are_independent() -> None:
+    calls, emit = _counter()
+    await coalesce.submit(("w", "alice", "g"), emit)
+    await coalesce.submit(("w", "bob", "g"), emit)
+    # Two different recipients → two leading pushes, neither suppresses the other.
+    assert len(calls) == 2
+
+
+async def test_disabled_is_passthrough(monkeypatch) -> None:
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "0")
+    calls, emit = _counter()
+    key = ("w", "u", "g")
+    for _ in range(3):
+        await coalesce.submit(key, emit)
+    # No throttling: every submit emits immediately.
+    assert len(calls) == 3
+
+
+async def test_malformed_window_uses_default(monkeypatch) -> None:
+    # A bad env value must not break delivery: it falls back to the default
+    # (a positive window), so the first submit still fires on the leading edge.
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "not-a-number")
+    calls, emit = _counter()
+    await coalesce.submit(("w", "u", "g"), emit)
+    assert len(calls) == 1

--- a/tests/cloud/push/test_listeners.py
+++ b/tests/cloud/push/test_listeners.py
@@ -15,6 +15,7 @@ import pytest
 from pocketpaw_ee.cloud._core.realtime.events import (
     AgentStreamEnd,
     InstinctApprovalCreated,
+    MessageSent,
 )
 from pocketpaw_ee.cloud.meetings.events import MeetingStarted
 from pocketpaw_ee.cloud.push import listeners
@@ -29,6 +30,18 @@ def notify_calls(monkeypatch):
 
     monkeypatch.setattr(listeners.dispatch, "notify", fake_notify)
     return calls
+
+
+@pytest.fixture(autouse=True)
+def _no_coalesce(monkeypatch):
+    """Run on_new_message with the coalescer OFF (pass-through) so these tests
+    assert the recipient/payload logic directly. The leading-edge throttle has
+    its own dedicated suite in test_coalesce.py. ``reset()`` clears any window
+    state so a lingering task can't leak into the next test."""
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "0")
+    listeners.coalesce.reset()
+    yield
+    listeners.coalesce.reset()
 
 
 # ---------------------------------------------------------------------------
@@ -138,4 +151,127 @@ async def test_meeting_started_notifies_group_for_livekit(notify_calls, monkeypa
 
 async def test_meeting_started_noop_without_meeting(notify_calls) -> None:
     await listeners.on_meeting_started(MeetingStarted(data={"workspace_id": "w1"}))
+    assert notify_calls == []
+
+
+# ---------------------------------------------------------------------------
+# new-message (message.sent) — user↔user notifications
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def new_message_env(monkeypatch):
+    """Patch the group + unread lookups so on_new_message needs no Mongo."""
+
+    async def fake_ws_id(group_id):
+        return "w-msg"
+
+    async def fake_members(group_id):
+        return ["alice", "bob", "carol"]
+
+    async def fake_count(user_id, group_id):
+        return 3
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+    monkeypatch.setattr(listeners, "_unread_count", fake_count)
+
+
+async def test_new_message_notifies_other_members_with_count(
+    notify_calls, new_message_env
+) -> None:
+    event = MessageSent(
+        data={
+            "group_id": "g1",
+            "sender_id": "alice",
+            "senderName": "Alice",
+            "senderType": "user",
+        }
+    )
+    await listeners.on_new_message(event)
+
+    # Alice is the sender → excluded; only bob + carol are notified.
+    assert {uid for _, uid, _ in notify_calls} == {"bob", "carol"}
+    assert all(ws == "w-msg" for ws, _, _ in notify_calls)
+    # Title names the sender; body carries ONLY the count (no message text).
+    assert all(p["title"] == "Alice" for _, _, p in notify_calls)
+    assert all(p["body"] == "3 new messages" for _, _, p in notify_calls)
+    # Collapse per-conversation so a later message updates the same toast.
+    assert all(p["tag"] == "g1" for _, _, p in notify_calls)
+
+
+async def test_new_message_body_never_leaks_content(notify_calls, new_message_env) -> None:
+    secret = "wire me $10k to account 12345"
+    event = MessageSent(
+        data={
+            "group_id": "g1",
+            "sender_id": "alice",
+            "senderName": "Alice",
+            "senderType": "user",
+            "content": secret,
+        }
+    )
+    await listeners.on_new_message(event)
+
+    assert notify_calls  # sanity: it did notify
+    for _, _, payload in notify_calls:
+        assert secret not in payload["body"]
+        assert secret not in payload["title"]
+
+
+async def test_new_message_singular_count_body(notify_calls, monkeypatch) -> None:
+    async def fake_ws_id(group_id):
+        return "w"
+
+    async def fake_members(group_id):
+        return ["a", "b"]
+
+    async def fake_count(user_id, group_id):
+        return 1
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+    monkeypatch.setattr(listeners, "_unread_count", fake_count)
+
+    event = MessageSent(
+        data={"group_id": "g", "sender_id": "a", "senderName": "A", "senderType": "user"}
+    )
+    await listeners.on_new_message(event)
+
+    assert notify_calls
+    assert all(p["body"] == "1 new message" for _, _, p in notify_calls)
+
+
+async def test_new_message_skips_agent_authored(notify_calls, monkeypatch) -> None:
+    # An agent-authored message.sent (senderType != "user") must not fire here;
+    # agent replies are covered by on_agent_complete (agent.stream_end).
+    async def boom(*_a, **_k):
+        raise AssertionError("agent-authored message must not resolve recipients")
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", boom)
+
+    await listeners.on_new_message(
+        MessageSent(data={"group_id": "g", "sender_id": "bot", "senderType": "agent"})
+    )
+    assert notify_calls == []
+
+
+async def test_new_message_noop_without_group(notify_calls) -> None:
+    await listeners.on_new_message(MessageSent(data={"sender_id": "a", "senderType": "user"}))
+    assert notify_calls == []
+
+
+async def test_new_message_noop_when_sender_is_only_member(notify_calls, monkeypatch) -> None:
+    async def fake_ws_id(group_id):
+        return "w"
+
+    async def fake_members(group_id):
+        return ["solo"]
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+
+    await listeners.on_new_message(
+        MessageSent(data={"group_id": "g", "sender_id": "solo", "senderType": "user"})
+    )
     assert notify_calls == []


### PR DESCRIPTION
## Why

Human-to-human messages already emit `message.sent`, but nothing on the push side subscribed to it. So an offline recipient got a notification when an *agent* replied, when an action was gated, or when a meeting started — but not when another person actually messaged them. This closes that gap, and adds a throttle so a chatty conversation doesn't hammer the push vendor.

Stacked on `feat/push-wire-events` (#1397).

## What changed

**Wire `message.sent` → `on_new_message`** (`push/listeners.py`)
- Notifies the group's other human members; the sender is excluded (no self-ping).
- Resolves the workspace from the group, since `message.sent` carries `group_id` + `sender_id` but no `workspace_id` — same approach `on_agent_complete` already uses.
- Body is generic with a count (`"3 new messages"`), so the message text never reaches the OS notification surface / lock screen. Title names the sender; `tag=group_id` lets the OS collapse a conversation into one updating toast.
- Only the human `message_add` path emits `message.sent`, so there's no double-fire with the agent path; a defensive `senderType == "user"` guard keeps it that way if that ever changes.

**Leading-edge send throttle** (`push/coalesce.py`, new)
- The first message fires instantly (no added latency). Further messages inside a cooldown window are suppressed and coalesced into one trailing send that carries the current count.
- A 20-message burst becomes at most two sends instead of 20, which keeps the push vendor's per-endpoint rate limit out of the picture and avoids redundant encrypt+POST work (the OS was going to collapse them by `tag` anyway).
- Window is `CLOUD_PUSH_COALESCE_SECONDS` (default `5`; `0` disables and reverts to per-message). Named to match the sibling `CLOUD_PUSH_CONTACT` in this module.

**Supporting**
- `unread_service.unread_count(user, group)` — the per-group half of `list_unreads`, so the notification body can show a real count without scanning every group.

## Scope / limits

- The coalescer keeps its window state in-process, so multiple backend replicas would each fire their own leading push. That's the v1 limit; `submit()` is the seam for a Redis-backed coordinator (`POCKETPAW_REDIS_URL` is already wired) when multi-replica delivery lands.
- Vendor `429`s during a burst are still logged and skipped, not retried. Coalescing cuts send volume enough that this is a separate follow-up rather than a blocker.

## Tests

- `test_coalesce.py` (new): leading-edge fires immediately, burst collapses to leading + one, sustained stream capped per window, keys are independent, disabled = pass-through, malformed env falls back to default.
- `test_listeners.py`: recipient fan-out, sender exclusion, count pluralization, an assertion that the message content never appears in the payload, agent-message skip, empty-group no-op.
- Full push suite: 55 passing. `ruff` clean.

The one failing test in `tests/cloud/notifications/test_router_golden.py` is pre-existing — it fails identically on the base branch and is unrelated to this change.