### PR TITLE
feat(sites): native site-editing endpoints (leaf-edits + native-artifact)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -59,6 +59,12 @@ Updated: 2026-06-26 (ART-4) — documented the Agent Artifact Delivery
 (deliver_artifact) in-process MCP tool: routes a built file/dir through the
 workspace upload pipeline (file as-is, dir zipped) and returns a presigned
 download URL; jail-scoped path safety; POCKETPAW_DELIVER_MAX_MB cap.
+Updated: 2026-07-02 (NE-4b / NE-5b) — documented the Sites — Native Editing
+section: POST /sites/by-pocket/{id}/leaf-edits (splice editor edits into the
+svelte source via the apply-leaf-edit CLI and persist as a Branch draft, no
+rebuild — dynamic-source split + input-keyspace confinement) and GET
+/sites/by-pocket/{id}/native-artifact (serve the armed build's body_html + css
+for shadow render — per-GET arm-build cost, path-traversal-guarded CSS reader).
 -->
 
 # Cloud REST API Reference
@@ -1059,3 +1065,127 @@ whose mime is not in `INLINE_MIMES` (HTML, SVG, JS, …) is served with
 does not render inline on the storage origin. Inline-safe types (images, pdf,
 plain text) still embed as before. The whole tool is gated on
 `is_multi_tenant_cloud()`.
+
+## Sites — Native Editing
+
+NE-4b / NE-5b. The **native site editor** renders a svelte Paw Site directly in
+the dashboard — the built page's markup is injected into a shadow root rather
+than framed in an iframe — and persists in-place text / prop edits by splicing
+them back into the pocket's component source as a **reviewable Branch draft**.
+Two endpoints back it: one serves the render, one persists the edits. Source:
+`ee/pocketpaw_ee/sites/router.py`.
+
+Both require an authenticated workspace context, the `fabric.write` action, and
+the `sites` plan feature (the whole sites router is gated on it). Both operate
+on a **svelte** Paw Site — a pocket with `engine: "svelte"` and a `source`
+component map; a ripple-engine or non-site pocket is a `422`
+(`pocket.not_svelte_site`). A missing or access-denied pocket surfaces as `404`
+(`pocket.not_found`) / `403` (`pocket.access_denied`) from the pockets service,
+exactly like every other `by-pocket` route. All work is tenant-scoped on the
+request context (`workspace_id`, `user_id`).
+
+### `POST /sites/by-pocket/{pocket_id}/leaf-edits`
+
+Persist a batch of native-editor leaf edits as a Branch draft. The editor has
+already rendered each edit optimistically; this splices them into the pocket's
+svelte source and writes the draft — **there is no rebuild**. Skipping the
+per-edit iframe rebuild is the UX win over the older `edit_svelte_component`
+path; an approved review is what later takes the draft live.
+
+Request body:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `edits` | array | Required, non-empty. Each entry is one leaf edit. An empty list is a `422` (`site_leaf_edit.empty_edits`). |
+
+Each edit:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `uid` | string | The stable id of the edited leaf, e.g. `"Hero:headline:0"`. |
+| `op` | object | The change. One of `{ "kind": "setText", "html": "<new inner HTML>" }` or `{ "kind": "setProp", "name": "<prop>", "value": <any> }`. The `op` shape is validated downstream by the `apply-leaf-edit` CLI, not at the request boundary. |
+
+Response `200`:
+
+```json
+{
+  "pocket_id": "p_abc123",
+  "results": [
+    { "uid": "Hero:headline:0", "applied": true, "reason": null },
+    { "uid": "Pricing:cta:2", "applied": false, "reason": "uid not found in current source" }
+  ]
+}
+```
+
+One verdict per submitted edit, in submission order. `applied` is whether the
+splice landed; `reason` (CLI-produced) explains a rejection and is `null` on
+success. The caller keeps the whole-file re-author path for any leaf that comes
+back `applied: false`.
+
+**How it persists.** Edits apply **in order** through the paw-sites
+`apply-leaf-edit` CLI — a pure source transform, no build or workerd. Only the
+files whose contents actually changed are persisted (each write auto-writes the
+Branch-draft snapshot), so a rejected edit churns no draft. A **dynamic** svelte
+site carries its live-data bindings (`objects` / `sources` / `actions` / `auth`)
+as sibling keys of the `{path: contents}` file map; the service splits those out
+before the splice (the CLI treats every source key as a file) and **confines the
+persist loop to the original file keyspace** — a binding key, or a brand-new
+path the CLI might echo, is never written back as a component file.
+
+Errors:
+
+| HTTP | Code | When |
+|------|------|------|
+| 422 | `site_leaf_edit.empty_edits` | The `edits` list is empty. |
+| 422 | `pocket.not_svelte_site` | The pocket is not a svelte Paw Site (no component source map). |
+| 404 | `pocket.not_found` | Unknown pocket id. |
+| 403 | `pocket.access_denied` | The caller lacks access to the pocket. |
+| 500 | `sites.leaf_edit_failed` | The `apply-leaf-edit` CLI exited non-zero, timed out, or returned unparseable output. |
+
+### `GET /sites/by-pocket/{pocket_id}/native-artifact`
+
+Serve the armed svelte build's body markup and CSS so the native editor can
+shadow-render the site.
+
+Response `200`:
+
+```json
+{
+  "pocket_id": "p_abc123",
+  "body_html": "<div data-uid=\"Hero:root:0\">…<script id=\"paw-edit-manifest\">…</script></div>",
+  "css": "/* concatenated stylesheets */"
+}
+```
+
+- `body_html` is the built page's `<body>` **inner** HTML — the `data-uid`-stamped
+  editable leaves plus the embedded `<script id="paw-edit-manifest">`. The
+  frontend injects it into a shadow root.
+- `css` is the built stylesheet(s) — inline `<style>` blocks plus every linked
+  stylesheet — concatenated into one string, injected as a single `<style>`.
+
+**Auth is `fabric.write`, not a read scope,** because the GET **arms a build**:
+it (re)builds the pocket with a builder origin set so the generator stamps
+`data-uid` on the editable leaves and embeds the edit manifest. The builder
+origin is resolved from the request's `Origin` header, falling back to the
+configured `PAW_SITES_BUILDER_ORIGIN` when absent (the same precedence as
+`/editable` and `/dev-preview`), so the call works with no header. **Every GET
+rebuilds** — the arm build runs on each request. The build is keyed on
+`pocket_id` in a stable directory, so `node_modules` / `bun install` stay cached
+across requests, but the compile still runs on each call; treat this as a
+heavier read. The arm build skips the SSR smoke fail-gate (`smoke=False`) but
+still emits the static output that is read.
+
+**CSS reader is path-traversal-guarded.** Stylesheet `href`s from the built
+`index.html` are resolved against the build tree (relative `./_app/…` and
+absolute `/_app/…` hrefs both) and each resolved path is checked to be contained
+inside the tree before it is read — a `../` traversal in a hand-authored
+component's `<link>` is refused.
+
+Errors:
+
+| HTTP | Code | When |
+|------|------|------|
+| 422 | `pocket.not_svelte_site` | The pocket is not a svelte Paw Site (no component build to render). |
+| 404 | `pocket.not_found` | Unknown pocket id. |
+| 403 | `pocket.access_denied` | The caller lacks access to the pocket. |
+| 500 | `sites.generator_failed` | The arm build failed (missing toolchain, non-zero build, or smoke-gate failure). |

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -87,6 +87,13 @@
 # leading/trailing/double dots, total length capped) so an obviously-malformed
 # host is rejected at the DTO (422) before it reaches Cloudflare. Kept permissive
 # — it accepts any real registrable hostname, it only blocks garbage.
+# Updated 2026-07-01 (NE-4b — native-editing leaf-edit persist): added the request
+# / response models for POST /sites/by-pocket/{pocket_id}/leaf-edits — LeafEdit
+# ({uid, op}), LeafEditsRequest ({edits}), LeafEditVerdict ({uid, applied, reason?})
+# and LeafEditsResponse ({pocket_id, results}). The native editor forwards its
+# already-rendered {uid, op} edits and the endpoint returns one verdict per edit.
+# ``op`` rides as an open dict — its {kind:setText|setProp,...} shape is validated
+# downstream by the paw-sites apply-leaf-edit CLI, not at this DTO boundary.
 
 from __future__ import annotations
 
@@ -337,3 +344,40 @@ class DomainStatusResponse(BaseModel):
     hostname: str
     cname_target: str
     status: str  # pending | verifying | live | error
+
+
+class LeafEdit(BaseModel):
+    """One native-editor leaf edit (NE-4b): the stable ``uid`` of the edited leaf
+    (e.g. ``"Hero:headline:0"``) plus the ``op`` describing the change. ``op`` is an
+    open dict — ``{"kind":"setText","html":...}`` or
+    ``{"kind":"setProp","name":...,"value":...}`` — because its shape is validated
+    downstream by the paw-sites apply-leaf-edit CLI, not at this DTO boundary."""
+
+    uid: str
+    op: dict[str, Any]
+
+
+class LeafEditsRequest(BaseModel):
+    """Body for POST /sites/by-pocket/{pocket_id}/leaf-edits (NE-4b): the batch of
+    ``{uid, op}`` leaf edits the native editor forwards to persist as a Branch
+    draft. An empty batch is rejected by the service (422)."""
+
+    edits: list[LeafEdit]
+
+
+class LeafEditVerdict(BaseModel):
+    """The apply-leaf-edit CLI's per-uid verdict (NE-4b): ``applied`` is whether the
+    splice landed; ``reason`` explains a rejection (the caller keeps the whole-file
+    re-author for that leaf). ``reason`` is None on an applied edit."""
+
+    uid: str
+    applied: bool
+    reason: str | None = None
+
+
+class LeafEditsResponse(BaseModel):
+    """Response of POST /sites/by-pocket/{pocket_id}/leaf-edits (NE-4b): the pocket
+    id plus one verdict per forwarded edit, in submission order."""
+
+    pocket_id: str
+    results: list[LeafEditVerdict]

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -94,6 +94,13 @@
 # already-rendered {uid, op} edits and the endpoint returns one verdict per edit.
 # ``op`` rides as an open dict — its {kind:setText|setProp,...} shape is validated
 # downstream by the paw-sites apply-leaf-edit CLI, not at this DTO boundary.
+# Updated 2026-07-01 (NE-5b — native-artifact endpoint): added NativeArtifactResponse
+# ({pocket_id, body_html, css}) — the response of GET
+# /sites/by-pocket/{pocket_id}/native-artifact. ``body_html`` is the armed svelte
+# build's ``<body>`` inner HTML (the data-uid-stamped leaves + the embedded
+# ``paw-edit-manifest`` script); ``css`` is the built stylesheet(s) concatenated into
+# one string. The native editor injects both into a shadow root to render the site
+# natively instead of framing an iframe.
 
 from __future__ import annotations
 
@@ -381,3 +388,17 @@ class LeafEditsResponse(BaseModel):
 
     pocket_id: str
     results: list[LeafEditVerdict]
+
+
+class NativeArtifactResponse(BaseModel):
+    """Response of GET /sites/by-pocket/{pocket_id}/native-artifact (NE-5b): the armed
+    svelte build's body + CSS, so the native editor can shadow-render the site
+    instead of framing an iframe. ``body_html`` is the built page's ``<body>`` INNER
+    HTML — the data-uid-stamped editable leaves plus the embedded
+    ``<script id="paw-edit-manifest">`` — which the FE injects into a shadow root.
+    ``css`` is the built stylesheet(s) concatenated into one string the FE injects as
+    a single ``<style>``."""
+
+    pocket_id: str
+    body_html: str
+    css: str

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -8,6 +8,13 @@
 # behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-07-02 (harden apply_leaf_edits temp-file cleanup): ``apply_leaf_edits``
+# now assigns ``input_path = fh.name`` BEFORE ``json.dump`` inside the ``with`` and
+# wraps creation + write + exec in ONE guarded try/finally, so a serialization
+# failure mid-``json.dump`` no longer leaves ``input_path`` unbound (NameError in the
+# cleanup) nor leaks the delete=False tempfile — the finally only unlinks a path that
+# was assigned and still exists.
+#
 # Updated 2026-07-01 (NE-4b — native-editing leaf-edit bridge): added the
 # module-level ``apply_leaf_edits(source, edits, *, _exec=None)`` coroutine — the
 # Python bridge to the paw-sites ``apply-leaf-edit`` CLI (NE-4a). It shells out to
@@ -671,11 +678,18 @@ async def apply_leaf_edits(
     ``asyncio.create_subprocess_exec``): a test passes a fake returning a stub proc
     with a canned ``communicate()`` so the bridge is unit-testable without Bun.
     """
-    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
-        json.dump({"source": source, "edits": edits}, fh)
-        input_path = fh.name
-    timeout_s = _build_timeout_sec()
+    # Assign input_path FIRST (before json.dump) so a serialization failure can't
+    # leave the created temp file un-tracked: NamedTemporaryFile(delete=False)
+    # materializes the file immediately, so if json.dump raises mid-write we still
+    # need its path to clean it up. ONE outer try/finally covers creation + write +
+    # exec, and the finally is guarded (only unlink a path that was assigned AND still
+    # exists) so it never NameErrors on an early failure and never leaks the tempfile.
+    input_path = ""
     try:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            input_path = fh.name
+            json.dump({"source": source, "edits": edits}, fh)
+        timeout_s = _build_timeout_sec()
         # start_new_session=True: own process group so a wedged splice (and any
         # children it leaked) can be killed as a group on timeout — same as generate().
         proc = await (_exec or asyncio.create_subprocess_exec)(
@@ -696,7 +710,8 @@ async def apply_leaf_edits(
             raise RuntimeError(f"apply-leaf-edit failed: {stderr.decode()}")
         return json.loads(stdout.decode().strip().splitlines()[-1])
     finally:
-        os.unlink(input_path)
+        if input_path and os.path.exists(input_path):
+            os.unlink(input_path)
 
 
 class GeneratorClient:

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -8,6 +8,19 @@
 # behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-07-01 (NE-4b — native-editing leaf-edit bridge): added the
+# module-level ``apply_leaf_edits(source, edits, *, _exec=None)`` coroutine — the
+# Python bridge to the paw-sites ``apply-leaf-edit`` CLI (NE-4a). It shells out to
+# the SAME tokenised generator command (``_gen_cmd_argv()``) but with the
+# ``apply-leaf-edit`` subcommand: it writes ``{source, edits}`` to a tempfile
+# ``--input`` and parses the single JSON stdout line
+# ``{source, results:[{uid,applied,reason?}]}``. It reuses the build path's
+# ``_communicate_bounded`` timeout guard (a timed-out splice raises RuntimeError,
+# mirroring ``generate``); a non-zero exit raises RuntimeError with the CLI stderr.
+# Unlike ``build`` it is a PURE transform — no install, no ``bun run build``, no
+# workerd — so it is safe to call inline on the NE-4b persist path. ``_exec`` is an
+# injectable subprocess-exec seam so the bridge is unit-testable without Bun.
+#
 # Updated 2026-06-26 (fix/sites-build-subprocess-timeout — stop-gap: bound the build
 # subprocesses): all THREE _SubprocessRunner subprocesses (the generator, `bun
 # install`, and the `bun run build` static build) ran a bare ``await
@@ -623,6 +636,67 @@ class _SubprocessRunner:
         # The real path now routes through build_static; this delegates to it with
         # the gate ON so any direct/legacy caller keeps the publish-time semantics.
         return await self.build_static(project_dir, gate=True)
+
+
+async def apply_leaf_edits(
+    source: dict[str, str],
+    edits: list[dict[str, Any]],
+    *,
+    _exec: Any = None,
+) -> dict[str, Any]:
+    """Splice native-editor leaf edits into a svelte source map via the paw-sites
+    ``apply-leaf-edit`` CLI (NE-4b) and return its per-uid verdict.
+
+    The Python bridge to NE-4a's ``apply-leaf-edit`` subcommand. It shells out to
+    the SAME tokenised generator command as the build path (``_gen_cmd_argv()``) but
+    with ``apply-leaf-edit --input <tempfile>``, where the tempfile carries
+    ``{"source": {<relpath>: <contents>}, "edits": [{"uid","op"}, ...]}`` (``op`` is
+    ``{"kind":"setText","html":...}`` or ``{"kind":"setProp","name":...,"value":...}``).
+    The CLI applies each edit IN ORDER to the file that carries that leaf and emits
+    exactly ONE JSON line on stdout:
+    ``{"source": {<relpath>: <contents>}, "results": [{"uid","applied","reason"?}]}``.
+    A rejected edit (``applied: false`` + ``reason``) leaves ITS file byte-identical
+    in the returned ``source`` (the caller keeps the whole-file re-author for it).
+
+    Unlike ``build`` this is a PURE transform — no ``bun install``, no
+    ``bun run build``, no workerd — so it is fast and safe to call inline on the
+    NE-4b persist path (the native editor already rendered the edit optimistically;
+    persisting the spliced draft is the whole job).
+
+    Failure surfaces as a ``RuntimeError`` the caller must handle: a non-zero exit
+    (carrying the CLI's stderr) or a timed-out splice — a wedged splice is a failed
+    splice, mirroring how ``_SubprocessRunner.generate`` converts ``_BuildTimeout``.
+
+    ``_exec`` is an injectable subprocess-exec seam (defaults to
+    ``asyncio.create_subprocess_exec``): a test passes a fake returning a stub proc
+    with a canned ``communicate()`` so the bridge is unit-testable without Bun.
+    """
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        json.dump({"source": source, "edits": edits}, fh)
+        input_path = fh.name
+    timeout_s = _build_timeout_sec()
+    try:
+        # start_new_session=True: own process group so a wedged splice (and any
+        # children it leaked) can be killed as a group on timeout — same as generate().
+        proc = await (_exec or asyncio.create_subprocess_exec)(
+            *_gen_cmd_argv(),
+            "apply-leaf-edit",
+            "--input",
+            input_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            stdout, stderr = await _communicate_bounded(proc, timeout_s, "apply-leaf-edit")
+        except _BuildTimeout as exc:
+            # A timed-out splice is a failed splice (mirror generate()'s raise-on-timeout).
+            raise RuntimeError(f"apply-leaf-edit timed out after {exc.timeout_s}s") from exc
+        if proc.returncode != 0:
+            raise RuntimeError(f"apply-leaf-edit failed: {stderr.decode()}")
+        return json.loads(stdout.decode().strip().splitlines()[-1])
+    finally:
+        os.unlink(input_path)
 
 
 class GeneratorClient:

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -110,6 +110,14 @@
 #   Both delegate to sites_service; a NON-dynamic pocket → 422 (not_dynamic), a
 #   missing / access-denied pocket → 404 / 403 (the pockets service raises it).
 #   Tenant-scoped on ctx — the data view is read-only (no request body).
+#
+# Updated 2026-07-01 (NE-4b — native-editing leaf-edit persist): added POST
+# /sites/by-pocket/{pocket_id}/leaf-edits — the native editor forwards its
+# already-rendered {uid, op} leaf edits and this persists them as a reviewable
+# Branch draft (splice via the apply-leaf-edit CLI → set_svelte_source_file), NO
+# rebuild. fabric.write; tenant-scoped; returns one verdict per edit. A non-svelte
+# pocket or empty batch → 422; a missing / access-denied pocket → 404 / 403 (the
+# pockets service raises it). Delegates to sites_service.apply_leaf_edits.
 
 from __future__ import annotations
 
@@ -123,6 +131,9 @@ from pocketpaw_ee.sites.dto import (
     DevPreviewResponse,
     DomainRequest,
     DomainStatusResponse,
+    LeafEditsRequest,
+    LeafEditsResponse,
+    LeafEditVerdict,
     MakeEditableRequest,
     PublishRequest,
     RequestPublishResponse,
@@ -207,6 +218,33 @@ async def make_site_editable(
         builder_origin=builder_origin,
     )
     return sites_service._to_response(doc)
+
+
+@router.post("/sites/by-pocket/{pocket_id}/leaf-edits", response_model=LeafEditsResponse)
+async def apply_leaf_edits_by_pocket(
+    pocket_id: str,
+    body: LeafEditsRequest,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> LeafEditsResponse:
+    """Persist native-editor leaf edits as a reviewable Branch draft (NE-4b).
+
+    Splices the forwarded ``{uid, op}`` edits into the pocket's svelte source via the
+    paw-sites apply-leaf-edit CLI and writes a draft — NO rebuild (the native editor
+    already renders the change optimistically; skipping the per-edit iframe rebuild
+    is the UX win over the old edit path). Returns one verdict per edit. A missing /
+    access-denied pocket is a 404 (the pockets service raises NotFound); a non-svelte
+    pocket or an empty edit batch is a 422."""
+    results = await sites_service.apply_leaf_edits(
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user_id,
+        pocket_id=pocket_id,
+        edits=[e.model_dump() for e in body.edits],
+    )
+    return LeafEditsResponse(
+        pocket_id=pocket_id,
+        results=[LeafEditVerdict(**r) for r in results],
+    )
 
 
 @router.get("/sites", response_model=list[SiteResponse])

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -118,6 +118,16 @@
 # rebuild. fabric.write; tenant-scoped; returns one verdict per edit. A non-svelte
 # pocket or empty batch → 422; a missing / access-denied pocket → 404 / 403 (the
 # pockets service raises it). Delegates to sites_service.apply_leaf_edits.
+#
+# Updated 2026-07-01 (NE-5b — native-artifact endpoint): added GET
+# /sites/by-pocket/{pocket_id}/native-artifact — serves the armed svelte build's
+# <body> inner HTML + concatenated CSS as {pocket_id, body_html, css} so the native
+# editor shadow-renders the site instead of framing an iframe. fabric.write (it
+# ensures/triggers the armed build); the builder_origin is resolved from the request
+# Origin header (the service applies the PAW_SITES_BUILDER_ORIGIN env fallback),
+# mirroring /editable + /dev-preview. A non-svelte pocket → 422; a missing /
+# access-denied pocket → 404 / 403 (the pockets service raises it). Delegates to
+# sites_service.get_native_artifact.
 
 from __future__ import annotations
 
@@ -135,6 +145,7 @@ from pocketpaw_ee.sites.dto import (
     LeafEditsResponse,
     LeafEditVerdict,
     MakeEditableRequest,
+    NativeArtifactResponse,
     PublishRequest,
     RequestPublishResponse,
     SiteDataRowsResponse,
@@ -245,6 +256,44 @@ async def apply_leaf_edits_by_pocket(
         pocket_id=pocket_id,
         results=[LeafEditVerdict(**r) for r in results],
     )
+
+
+@router.get(
+    "/sites/by-pocket/{pocket_id}/native-artifact",
+    response_model=NativeArtifactResponse,
+)
+async def native_artifact_by_pocket(
+    pocket_id: str,
+    request: Request,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> NativeArtifactResponse:
+    """Serve the armed svelte build's {pocket_id, body_html, css} for native shadow
+    render (NE-5b).
+
+    ``body_html`` is the built page's ``<body>`` inner HTML (the data-uid-stamped
+    leaves + the embedded ``paw-edit-manifest`` script); ``css`` is the built
+    stylesheet(s) concatenated. The native editor injects both into a shadow root
+    instead of framing an iframe.
+
+    Carries fabric.write because it ENSURES/triggers the armed build (mutates the
+    on-disk build). The builder origin — which the armed build needs to stamp
+    data-uid + the manifest — is resolved from the request's ``Origin`` header, with
+    the service applying the ``PAW_SITES_BUILDER_ORIGIN`` env fallback when it is
+    absent (the same precedence as ``/editable`` / ``/dev-preview``), so the call
+    works with no header. A non-svelte pocket is a 422; a missing / access-denied
+    pocket surfaces as a 404 / 403 (the pockets service raises it inside the
+    service)."""
+    # Mirror /editable + /dev-preview origin resolution: the request Origin header
+    # here; the service applies the PAW_SITES_BUILDER_ORIGIN env fallback when blank.
+    builder_origin = request.headers.get("origin") or ""
+    result = await sites_service.get_native_artifact(
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user_id,
+        pocket_id=pocket_id,
+        builder_origin=builder_origin,
+    )
+    return NativeArtifactResponse(**result)
 
 
 @router.get("/sites", response_model=list[SiteResponse])

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,18 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-02 (harden native-editing endpoints): (1) ``get_native_artifact``
+# now routes its arm build through ``_build_or_cloud_error`` (like the publish paths)
+# so a missing-toolchain / non-zero build / SmokeGateFailed becomes a clean
+# CloudError (``sites.generator_failed``) instead of an opaque 500 (DEP-3); (2)
+# ``apply_leaf_edits`` wraps the leaf-edit CLI bridge + result parse and maps its
+# RuntimeError / KeyError / IndexError / TypeError to ``Internal("sites.leaf_edit_failed")``
+# — a structured envelope, not a 500; and (3) it now SPLITS a dynamic svelte pocket's
+# source envelope (``_split_svelte_source``) so the CLI receives ONLY the file map and
+# the persist loop is CONFINED to the input file keyspace — a binding key
+# (objects/sources/actions/auth) or a CLI-invented path is never written back as a
+# component file.
+#
 # Updated 2026-07-01 (NE-5b — native-artifact endpoint): added
 # ``get_native_artifact`` — the backend of the native shadow-render path. It ensures
 # the pocket's ARMED svelte build (builder_origin set, so the paw-sites generator
@@ -2275,18 +2287,51 @@ async def apply_leaf_edits(
         )
     source_map = pocket["source"]
 
-    # Splice the {uid, op} edits into the source via the apply-leaf-edit CLI. A
-    # RuntimeError (non-zero exit / timed-out splice) propagates to the caller.
-    out = await (_apply or generator_client.apply_leaf_edits)(source=source_map, edits=edits)
-    new_map, results = out["source"], out["results"]
+    # DSV-5 binding-key safety: a DYNAMIC svelte pocket's source envelope carries its
+    # live-data bindings (objects/sources/actions/auth) as SIBLING keys of the
+    # {path: contents} SvelteKit files. Split them out exactly like the build path
+    # (_split_svelte_source): the leaf-edit CLI must receive ONLY the file map (it
+    # treats every source key as a file, so a binding key mixed in would break the
+    # splice), and the persist loop below is CONFINED to this input file keyspace so a
+    # binding key is never written back as a component file and a brand-new key the
+    # CLI might invent is never persisted.
+    files, _bindings = generator_client._split_svelte_source(source_map)
 
-    # Persist ONLY the files that actually changed. A rejected edit leaves its file
-    # byte-identical (the CLI contract), so this comparison naturally skips it — no
-    # empty draft churn. Each set_svelte_source_file write auto-writes a Branch draft
-    # snapshotting the FULL edited map, so after the loop the draft == the fully
-    # edited source. Multi-file safe.
+    # Splice the {uid, op} edits into the file map via the apply-leaf-edit CLI. The
+    # bridge raises a bare RuntimeError on a non-zero exit / timed-out splice, and the
+    # result parse can KeyError / IndexError / TypeError on malformed CLI output — map
+    # them all to a clean CloudError (sites.leaf_edit_failed → 5xx) so the client gets
+    # a structured envelope with a reason instead of an opaque unhandled 500 (the
+    # cloud error handler maps ONLY CloudError). A CloudError raised inside is
+    # re-raised unchanged; the cause is chained for logs, never leaked to the client.
+    try:
+        out = await (_apply or generator_client.apply_leaf_edits)(source=files, edits=edits)
+        new_map, results = out["source"], out["results"]
+    except CloudError:
+        raise
+    except (RuntimeError, KeyError, IndexError, TypeError) as exc:
+        logger.error("sites.apply_leaf_edits: leaf-edit bridge failed", exc_info=True)
+        raise with_cause(
+            Internal(
+                "sites.leaf_edit_failed",
+                "Applying the edits failed — the editing toolchain is unavailable or "
+                "returned an unexpected result. See server logs for details.",
+            ),
+            exc,
+        ) from exc
+
+    # Persist ONLY the files that actually changed, CONFINED to the input file
+    # keyspace. A rejected edit leaves its file byte-identical (the CLI contract), so
+    # this comparison naturally skips it — no empty draft churn. A binding key or a
+    # brand-new path the CLI echoed / invented is NOT in ``files``, so it is skipped
+    # too (never persisted as a component file — set_svelte_source_file would
+    # otherwise overwrite a live-data binding or 404 on an unknown path). Each write
+    # auto-writes a Branch draft snapshotting the FULL edited map, so after the loop
+    # the draft == the fully edited source. Multi-file safe.
     for path, contents in new_map.items():
-        if source_map.get(path) != contents:
+        if path not in files:
+            continue
+        if files.get(path) != contents:
             await pockets_service.set_svelte_source_file(
                 pocket_id, user_id, component_path=path, new_source=contents
             )
@@ -2354,7 +2399,16 @@ async def get_native_artifact(
     # the caller passes none, exactly like make_site_editable.
     origin = (builder_origin or "").strip() or _builder_origin()
     generator = _generator or GeneratorClient()
-    build = await generator.build(
+    # DEP-3: route the arm build through _build_or_cloud_error (the SAME helper the
+    # publish paths at ~1152 / ~1293 use) so a missing-toolchain / non-zero build /
+    # SmokeGateFailed becomes a clean CloudError (sites.generator_failed → 5xx)
+    # instead of escaping as an opaque unhandled 500. Unlike edit_svelte_component's
+    # preview build (map_smoke_gate=False, which preserves its
+    # rollback-on-SmokeGateFailed contract), this is a READ-ONLY render with no source
+    # mutation to roll back, so SmokeGateFailed is mapped too (default
+    # map_smoke_gate=True) — the caller just gets a structured error.
+    build = await _build_or_cloud_error(
+        generator,
         ripple_spec=ripple_spec,
         theme=theme,
         # Transient, per-pocket-stable id — cosmetic here (it only rides the built

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,21 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-01 (NE-5b — native-artifact endpoint): added
+# ``get_native_artifact`` — the backend of the native shadow-render path. It ensures
+# the pocket's ARMED svelte build (builder_origin set, so the paw-sites generator
+# stamps ``data-uid`` on the editable leaves + embeds the ``paw-edit-manifest``
+# script) via a DIRECT ``GeneratorClient.build`` (smoke=False, the same arm/preview
+# gate ``make_site_editable`` uses) and returns the built ``<body>`` inner HTML +
+# concatenated CSS as a dict, so the native editor can inject it into a shadow root
+# instead of framing an iframe. The built static output is located by the returned
+# ``BuildResult.project_dir`` + ``.svelte-kit/cloudflare/index.html`` — the SAME tree
+# ``_default_bundle_reader`` reads ``_worker.js`` from and ``local_server`` copies to
+# serve. A non-svelte pocket raises ValidationError (422); a missing / cross-tenant
+# pocket surfaces the pockets service's NotFound / Forbidden (404 / 403).
+# ``_generator`` + ``_read_built`` are injectable seams so the path is unit-testable
+# without Bun / a real build.
+#
 # Updated 2026-07-01 (NE-4b — native-editing leaf-edit persist): added
 # ``apply_leaf_edits`` — the backend of the native site-editing persist path. It
 # splices the native editor's forwarded ``{uid, op}`` leaf edits into the pocket's
@@ -435,6 +450,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import secrets
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
@@ -474,6 +490,12 @@ logger = logging.getLogger(__name__)
 # The control plane reads the Worker bundle adapter-cloudflare emits here.
 _WORKER_BUNDLE_REL = ".svelte-kit/cloudflare/_worker.js"
 
+# The prerendered static site adapter-cloudflare emits (index.html + the
+# ``_app/...`` assets) — the SAME tree ``_default_bundle_reader`` reads
+# ``_worker.js`` from and ``local_server.persist_site`` copies to serve. NE-5b reads
+# the armed build's index.html + CSS from here.
+_CLOUDFLARE_BUILD_REL = ".svelte-kit/cloudflare"
+
 # BP-2: the source pocket is the versionable artifact behind a site. The Branch
 # primitive (BP-1) keys every version on (scope_type, scope_id); for a site the
 # scope is the pocket it is published from.
@@ -504,6 +526,74 @@ _MAX_PENDING_DEPLOY_INPUT_BYTES = 4_000_000
 
 def _default_bundle_reader(project_dir: str) -> bytes:
     return Path(project_dir, _WORKER_BUNDLE_REL).read_bytes()
+
+
+def _extract_body_inner(html: str) -> str:
+    """Return the INNER HTML of the built page's ``<body>`` (NE-5b).
+
+    The prerendered ``index.html`` wraps the data-uid-stamped leaves + the embedded
+    ``<script id="paw-edit-manifest">`` in ``<body>…</body>``; the native editor
+    injects only that inner markup into a shadow root, so the ``<html>``/``<head>``
+    chrome is stripped. Falls back to the whole document if (defensively) no body tag
+    is present — a prerendered SvelteKit page always has one."""
+    m = re.search(r"<body[^>]*>(.*)</body>", html, re.DOTALL | re.IGNORECASE)
+    return (m.group(1) if m else html).strip()
+
+
+def _extract_css(html: str, cloudflare_dir: Path) -> str:
+    """Concatenate the built page's CSS into ONE string the native editor injects as
+    a single ``<style>`` (NE-5b).
+
+    Collects, in document order: (1) any inline ``<style>…</style>`` blocks
+    (SvelteKit can inline critical CSS), then (2) every ``<link rel="stylesheet">``
+    stylesheet, read from disk under the built ``.svelte-kit/cloudflare/`` tree. The
+    prerendered index links assets with either a RELATIVE (``./_app/…``) or ABSOLUTE
+    (``/_app/…``) href, so both are resolved against the build dir. Each resolved
+    path is contained to the build tree (a ``../`` traversal in a hand-authored
+    component's link is refused) before it is read."""
+    parts: list[str] = []
+    for style in re.findall(r"<style[^>]*>(.*?)</style>", html, re.DOTALL | re.IGNORECASE):
+        if style.strip():
+            parts.append(style.strip())
+
+    root = cloudflare_dir.resolve()
+    for tag in re.findall(r"<link\b[^>]*>", html, re.IGNORECASE):
+        if not re.search(r"""rel\s*=\s*["']?stylesheet""", tag, re.IGNORECASE):
+            continue
+        href_m = re.search(r"""href\s*=\s*["']([^"']+)["']""", tag, re.IGNORECASE)
+        if not href_m:
+            continue
+        rel = href_m.group(1).split("?", 1)[0].split("#", 1)[0]
+        if rel.startswith("./"):
+            rel = rel[2:]
+        rel = rel.lstrip("/")
+        if not rel:
+            continue
+        css_path = (cloudflare_dir / rel).resolve()
+        # Refuse to read outside the built output tree (defensive — the hrefs come
+        # from our own generator, but a component author controls the leaf markup).
+        try:
+            css_path.relative_to(root)
+        except ValueError:
+            continue
+        if css_path.is_file():
+            text = css_path.read_text(encoding="utf-8").strip()
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def _read_native_artifact(project_dir: str) -> tuple[str, str]:
+    """Read the armed build's ``<body>`` inner HTML + concatenated CSS from the built
+    static output (NE-5b) — the default ``_read_built`` seam.
+
+    ``project_dir`` is the ``BuildResult.project_dir`` the generator returns; the
+    prerendered site lives under ``<project_dir>/.svelte-kit/cloudflare/`` (the SAME
+    tree ``_default_bundle_reader`` / ``local_server`` read). Returns
+    ``(body_html, css)``."""
+    cloudflare_dir = Path(project_dir, _CLOUDFLARE_BUILD_REL)
+    html = (cloudflare_dir / "index.html").read_text(encoding="utf-8")
+    return _extract_body_inner(html), _extract_css(html, cloudflare_dir)
 
 
 async def _build_or_cloud_error(
@@ -2202,6 +2292,92 @@ async def apply_leaf_edits(
             )
 
     return results
+
+
+async def get_native_artifact(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    builder_origin: str | None = None,
+    _generator: GeneratorClient | None = None,
+    _read_built: Callable[[str], tuple[str, str]] | None = None,
+) -> dict[str, str]:
+    """Serve a svelte Paw Site's ARMED build as ``{pocket_id, body_html, css}`` so the
+    native editor can shadow-render it (NE-5b) instead of framing an iframe.
+
+    The native-editing render path. It:
+      1. reads the pocket (the pockets service's PUBLIC ``get`` raises NotFound /
+         Forbidden itself — a missing / cross-tenant pocket surfaces as 404 / 403)
+         and asserts it is a svelte site (else ``ValidationError`` → 422), mirroring
+         ``apply_leaf_edits`` / ``edit_svelte_component``;
+      2. ENSURES the ARMED build: it builds the pocket with ``builder_origin`` set so
+         the paw-sites generator stamps ``data-uid`` on the editable leaves AND embeds
+         the ``<script id="paw-edit-manifest">`` (SE-1 / EP-6 gate on ``builderOrigin``).
+         ``builder_origin`` defaults to the configured dashboard origin
+         (``PAW_SITES_BUILDER_ORIGIN``) exactly like ``make_site_editable``, so the
+         call works with no explicit origin. It builds via a DIRECT
+         ``GeneratorClient.build`` — the SAME arm/preview gate ``make_site_editable``
+         uses (``smoke=False`` skips the SSR FAIL-check but the static build still
+         runs; ``static_build`` stays the default ``True`` so ``.svelte-kit/cloudflare/``
+         is emitted) — instead of the full ``publish_pocket`` preview path, because
+         this is a READ: it needs neither a deploy, a Site doc, a promote, nor billing,
+         and ``build()`` RETURNS the ``project_dir`` so the built output is located
+         without reconstructing a path. PERF-3 builds into the stable
+         ``build_home()/<pocket_id>/`` so node_modules / bun install stay cached;
+      3. reads the built ``<body>`` inner HTML + concatenated CSS from that
+         ``project_dir``'s ``.svelte-kit/cloudflare/index.html`` (the SAME tree
+         ``_default_bundle_reader`` / ``local_server`` read) and returns them.
+
+    ``_generator`` (defaults to a real ``GeneratorClient``) and ``_read_built``
+    (defaults to ``_read_native_artifact`` — the disk read + HTML/CSS extraction) are
+    injectable seams so the path is unit-testable without Bun / a real build."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    # The pockets service's PUBLIC get raises NotFound / Forbidden itself (entity
+    # isolation) — a missing / cross-tenant pocket surfaces as 404 / 403.
+    pocket = await pockets_service.get(pocket_id, user_id)
+    if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(pocket.get("source"), dict):
+        raise ValidationError(
+            "pocket.not_svelte_site",
+            "This pocket is not a svelte Paw Site — it has no component build to render.",
+        )
+    source = pocket["source"]
+    # theme rides the build on both engine tracks (mirrors publish_pocket); a svelte
+    # pocket has no rippleSpec, so it resolves to {}.
+    ripple_spec = pocket.get("rippleSpec") or {}
+    theme = (ripple_spec.get("theme") if isinstance(ripple_spec, dict) else {}) or {}
+    site_name = (pocket.get("name") or "").strip() or "Untitled site"
+
+    # Arm the build: a NON-EMPTY builder_origin is what makes the generator stamp
+    # data-uid + embed the manifest. Default to the configured dashboard origin when
+    # the caller passes none, exactly like make_site_editable.
+    origin = (builder_origin or "").strip() or _builder_origin()
+    generator = _generator or GeneratorClient()
+    build = await generator.build(
+        ripple_spec=ripple_spec,
+        theme=theme,
+        # Transient, per-pocket-stable id — cosmetic here (it only rides the built
+        # page's capture config, which the native editor ignores). The build DIR is
+        # keyed on pocket_id (PERF-3), not this, so it does not affect where the
+        # output lands.
+        site_id=_preview_id(pocket_id),
+        title=site_name,
+        capture_api_base=_capture_base(),
+        capture_signed_key=f"site_key_{secrets.token_urlsafe(24)}",
+        engine="svelte",
+        source=source,
+        builder_origin=origin,
+        pocket_id=pocket_id,
+        # Arm/preview gate: skip the SSR FAIL-check but STILL emit the static
+        # .svelte-kit/cloudflare/ output (static_build defaults True) so there is an
+        # index.html to read.
+        smoke=False,
+    )
+
+    read = _read_built or _read_native_artifact
+    body_html, css = read(build.project_dir)
+    return {"pocket_id": pocket_id, "body_html": body_html, "css": css}
 
 
 async def edit_svelte_component(

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,19 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-01 (NE-4b — native-editing leaf-edit persist): added
+# ``apply_leaf_edits`` — the backend of the native site-editing persist path. It
+# splices the native editor's forwarded ``{uid, op}`` leaf edits into the pocket's
+# svelte ``source`` map via ``generator_client.apply_leaf_edits`` (the paw-sites
+# apply-leaf-edit CLI, a PURE transform — no build/workerd) and persists ONLY the
+# changed files through ``pockets_service.set_svelte_source_file`` (each write
+# auto-writes a Branch draft). Unlike ``edit_svelte_component`` it does NOT
+# republish/rebuild — the editor already rendered the edit optimistically, so
+# persisting the reviewable draft is the whole job. Empty edits / a non-svelte
+# pocket raise ValidationError (422); a missing / cross-tenant pocket surfaces as
+# the pockets service's NotFound / Forbidden (404 / 403). ``_apply`` is an
+# injectable bridge seam so the path is unit-testable without Bun.
+#
 # Updated 2026-06-26 (feat/sites-dev-bridge-source, S1 — dev source carries the
 # edit-bridge): ``dev_preview_pocket`` gained an optional ``builder_origin`` and
 # threads it to ``get_manager().ensure_dev_server(builder_origin=...)`` so the
@@ -2115,6 +2128,80 @@ def apply_edits(source: str, edits: list[dict[str, str]]) -> str:
             )
         result = result.replace(old, new, 1)
     return result
+
+
+async def apply_leaf_edits(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    edits: list[dict[str, Any]],
+    _apply: Any = None,
+) -> list[dict[str, Any]]:
+    """Persist native-editor leaf edits as a reviewable Branch draft (NE-4b).
+
+    The backend of the native site-editing persist path. The native editor forwards
+    a batch of ``{uid, op}`` leaf edits it has ALREADY rendered optimistically; this
+    splices them into the pocket's svelte ``source`` map via the paw-sites
+    ``apply-leaf-edit`` CLI (a PURE transform — no build, no workerd) and persists
+    each CHANGED file through the pockets service, which auto-writes a Branch draft
+    ArtifactVersion snapshotting the full edited source map. There is NO
+    republish/rebuild: persisting the draft is the whole job — the deliberate UX win
+    over ``edit_svelte_component``'s per-edit iframe rebuild (the editor already
+    shows the change; an approved review is what later takes it live).
+
+    Steps:
+      1. reject an empty edit batch (``ValidationError`` → 422);
+      2. read the pocket (the pockets service's public ``get`` raises NotFound /
+         Forbidden itself — a missing / cross-tenant pocket is 404 / 403) and assert
+         it is a svelte site (else ``ValidationError`` → 422);
+      3. splice via the generator bridge — edits apply IN ORDER, and a rejected edit
+         leaves ITS file byte-identical in the returned source;
+      4. persist ONLY the files whose contents actually changed (so a rejected edit
+         naturally persists nothing and never churns an empty draft), each write
+         auto-writing the Branch draft snapshot;
+      5. return the per-uid verdicts unchanged.
+
+    ``_apply`` is an injectable seam for the generator bridge (defaults to
+    ``generator_client.apply_leaf_edits``) so the orchestration is unit-testable
+    without Bun / workerd.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.sites import generator_client
+
+    if not isinstance(edits, list) or not edits:
+        raise ValidationError(
+            "site_leaf_edit.empty_edits",
+            "apply_leaf_edits requires a non-empty list of {uid, op} leaf edits.",
+        )
+
+    # The pockets service's PUBLIC get raises NotFound / Forbidden itself (entity
+    # isolation) — a missing / cross-tenant pocket surfaces as 404 / 403.
+    pocket = await pockets_service.get(pocket_id, user_id)
+    if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(pocket.get("source"), dict):
+        raise ValidationError(
+            "pocket.not_svelte_site",
+            "This pocket is not a svelte Paw Site — it has no component source map to edit.",
+        )
+    source_map = pocket["source"]
+
+    # Splice the {uid, op} edits into the source via the apply-leaf-edit CLI. A
+    # RuntimeError (non-zero exit / timed-out splice) propagates to the caller.
+    out = await (_apply or generator_client.apply_leaf_edits)(source=source_map, edits=edits)
+    new_map, results = out["source"], out["results"]
+
+    # Persist ONLY the files that actually changed. A rejected edit leaves its file
+    # byte-identical (the CLI contract), so this comparison naturally skips it — no
+    # empty draft churn. Each set_svelte_source_file write auto-writes a Branch draft
+    # snapshotting the FULL edited map, so after the loop the draft == the fully
+    # edited source. Multi-file safe.
+    for path, contents in new_map.items():
+        if source_map.get(path) != contents:
+            await pockets_service.set_svelte_source_file(
+                pocket_id, user_id, component_path=path, new_source=contents
+            )
+
+    return results
 
 
 async def edit_svelte_component(

--- a/tests/ee/sites/test_leaf_edits.py
+++ b/tests/ee/sites/test_leaf_edits.py
@@ -1,0 +1,270 @@
+# tests/ee/sites/test_leaf_edits.py — the native-editing leaf-edit persist path
+# (NE-4b). Created 2026-07-01 (feat/native-editing-ne4b).
+#
+# Two layers under test, both hermetic (no Bun / workerd — the external CLI is
+# faked at its seam):
+#   * generator_client.apply_leaf_edits — the Python bridge to the paw-sites
+#     apply-leaf-edit CLI. A fake ``_exec`` returns a stub proc with a canned
+#     ``communicate()`` so we assert (a) it invokes the tokenised generator command
+#     + the apply-leaf-edit subcommand, writes the {source, edits} input file, and
+#     parses the single JSON stdout line; and (b) a non-zero exit raises RuntimeError.
+#   * sites_service.apply_leaf_edits — the orchestration. These use the shared
+#     ``beanie_test_db`` (in-memory Mongo) so the pockets service persists a REAL
+#     svelte Pocket and writes a REAL Branch draft; only the CLI bridge (``_apply``)
+#     is faked. They prove: a changed file is persisted exactly once and lands a
+#     reviewable draft; a rejected edit (source unchanged) persists nothing and
+#     surfaces the reason; a non-svelte pocket and an empty batch raise
+#     ValidationError before the bridge ever runs.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import generator_client
+from pocketpaw_ee.sites import service as sites_service
+
+_HERO_V1 = "<section class='hero'><h1>Bright Smile</h1></section>"
+_HERO_V2 = "<section class='hero'><h1>Brighter Smiles, Whiter Teeth</h1></section>"
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/lib/components/Hero.svelte": _HERO_V1,
+    "src/app.css": ":root{--brand:#0A84FF}",
+}
+
+
+class _FakeProc:
+    """Stub subprocess: a canned ``communicate()`` + ``returncode`` so the bridge is
+    exercised without spawning Bun. ``pid`` is only touched on the timeout path,
+    which these tests do not drive."""
+
+    def __init__(self, *, stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0) -> None:
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self.pid = 4321
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+
+def _fake_exec(proc: _FakeProc, record: dict | None = None):
+    """Build a fake ``asyncio.create_subprocess_exec`` seam that returns ``proc`` and
+    (optionally) records the argv + the parsed ``--input`` file so a test can assert
+    the CLI invocation and input contract."""
+
+    async def _exec(*args, **kwargs):
+        if record is not None:
+            record["argv"] = args
+            record["kwargs"] = kwargs
+            path = args[args.index("--input") + 1]
+            record["input"] = json.loads(Path(path).read_text())
+        return proc
+
+    return _exec
+
+
+# ---------------------------------------------------------------------------
+# generator bridge (generator_client.apply_leaf_edits)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generator_bridge_parses_cli_output(monkeypatch):
+    """The bridge shells out to the tokenised generator command + the apply-leaf-edit
+    subcommand, writes the {source, edits} input file, and returns the parsed single
+    JSON stdout line."""
+    monkeypatch.setenv("PAW_SITES_GEN_CMD", "paw-sites-gen")
+    out = {
+        "source": {"src/lib/components/Hero.svelte": _HERO_V2},
+        "results": [{"uid": "Hero:headline:0", "applied": True}],
+    }
+    proc = _FakeProc(stdout=(json.dumps(out) + "\n").encode(), returncode=0)
+    record: dict = {}
+
+    result = await generator_client.apply_leaf_edits(
+        source={"src/lib/components/Hero.svelte": _HERO_V1},
+        edits=[{"uid": "Hero:headline:0", "op": {"kind": "setText", "html": "Brighter"}}],
+        _exec=_fake_exec(proc, record),
+    )
+
+    assert result == out
+    # Invoked "<gen cmd> apply-leaf-edit --input <path>" with its own process group.
+    assert record["argv"][:3] == ("paw-sites-gen", "apply-leaf-edit", "--input")
+    assert record["kwargs"]["start_new_session"] is True
+    # The input file carried the {source, edits} contract.
+    assert record["input"]["source"] == {"src/lib/components/Hero.svelte": _HERO_V1}
+    assert record["input"]["edits"][0]["uid"] == "Hero:headline:0"
+
+
+@pytest.mark.asyncio
+async def test_generator_bridge_nonzero_exit_raises(monkeypatch):
+    """A non-zero CLI exit is a failed splice → RuntimeError carrying the stderr."""
+    monkeypatch.setenv("PAW_SITES_GEN_CMD", "paw-sites-gen")
+    proc = _FakeProc(stderr=b"apply-leaf-edit: unparseable op", returncode=1)
+
+    with pytest.raises(RuntimeError, match="apply-leaf-edit failed"):
+        await generator_client.apply_leaf_edits(
+            source={"a.svelte": "x"},
+            edits=[{"uid": "a:0", "op": {"kind": "setText", "html": "y"}}],
+            _exec=_fake_exec(proc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# service orchestration (sites_service.apply_leaf_edits) — real DB, faked CLI
+# ---------------------------------------------------------------------------
+
+
+async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
+    """Persist a real svelte-engine Pocket via the pockets service and return its id
+    (mirrors how create_svelte_site lands a pocket)."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source=dict(_SVELTE_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+def _spy_set_svelte_source_file(monkeypatch) -> list[str]:
+    """Wrap pockets_service.set_svelte_source_file with a spy that records the
+    component_path of every call AND still performs the real persist (so the DB +
+    Branch draft actually update). Returns the recording list."""
+    calls: list[str] = []
+    real = pockets_service.set_svelte_source_file
+
+    async def _spy(*args, **kwargs):
+        calls.append(kwargs.get("component_path"))
+        return await real(*args, **kwargs)
+
+    monkeypatch.setattr(pockets_service, "set_svelte_source_file", _spy)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_apply_leaf_edits_persists_changed_file_as_draft(beanie_test_db, monkeypatch):
+    """A landed edit persists ONLY the changed file (once) and leaves a reviewable
+    Branch draft snapshotting the edited source. The verdict passes straight
+    through. The CLI bridge is faked — no Bun runs."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    async def _fake_apply(*, source, edits):
+        new = dict(source)
+        new["src/lib/components/Hero.svelte"] = _HERO_V2
+        return {"source": new, "results": [{"uid": edits[0]["uid"], "applied": True}]}
+
+    calls = _spy_set_svelte_source_file(monkeypatch)
+
+    results = await sites_service.apply_leaf_edits(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        edits=[{"uid": "Hero:headline:0", "op": {"kind": "setText", "html": "Brighter Smiles"}}],
+        _apply=_fake_apply,
+    )
+
+    # Verdict passes through unchanged.
+    assert results == [{"uid": "Hero:headline:0", "applied": True}]
+    # Persisted EXACTLY the one changed file — untouched siblings are skipped.
+    assert calls == ["src/lib/components/Hero.svelte"]
+    # The edit landed on the pocket (real persist; a re-read shows the new source,
+    # siblings verbatim).
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == _HERO_V2
+    assert wire["source"]["src/app.css"] == ":root{--brand:#0A84FF}"
+    # And it left a reviewable Branch draft of the full edited map.
+    from pocketpaw_ee.versions import service as versions
+
+    draft = await versions.get_draft(scope_type="pocket", scope_id=pocket_id)
+    assert draft is not None
+    assert draft.content["src/lib/components/Hero.svelte"] == _HERO_V2
+
+
+@pytest.mark.asyncio
+async def test_apply_leaf_edits_rejected_edit_persists_nothing(beanie_test_db, monkeypatch):
+    """A rejected edit comes back with the source byte-identical + applied:false +
+    reason. Nothing changed → set_svelte_source_file is never called and the pocket
+    source is untouched; the reason is surfaced to the caller."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    async def _fake_apply(*, source, edits):
+        # Source returned UNCHANGED (the whole-file re-author stays with the caller).
+        return {
+            "source": dict(source),
+            "results": [{"uid": edits[0]["uid"], "applied": False, "reason": "no unique match"}],
+        }
+
+    calls = _spy_set_svelte_source_file(monkeypatch)
+
+    results = await sites_service.apply_leaf_edits(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        edits=[{"uid": "Hero:headline:0", "op": {"kind": "setText", "html": "x"}}],
+        _apply=_fake_apply,
+    )
+
+    assert calls == []  # nothing changed → nothing persisted
+    assert results == [{"uid": "Hero:headline:0", "applied": False, "reason": "no unique match"}]
+    # The pocket source is untouched.
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_apply_leaf_edits_non_svelte_pocket_rejected(beanie_test_db):
+    """A ripple-engine pocket has no svelte source map — apply_leaf_edits raises
+    ValidationError (422) BEFORE the bridge runs."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Ripple Pocket",
+        type_="site",
+        pattern="landing",
+        ripple_spec={"type": "container"},
+    )
+    assert err is None, err
+
+    async def _fake_apply(*, source, edits):  # pragma: no cover - must not be reached
+        raise AssertionError("the bridge must not run for a non-svelte pocket")
+
+    with pytest.raises(ValidationError):
+        await sites_service.apply_leaf_edits(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            edits=[{"uid": "x:0", "op": {"kind": "setText", "html": "y"}}],
+            _apply=_fake_apply,
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_leaf_edits_empty_batch_rejected():
+    """An empty edit batch raises ValidationError (422) before any pocket read or
+    bridge call — so it needs no DB and the bridge must never run."""
+
+    async def _fake_apply(*, source, edits):  # pragma: no cover - must not be reached
+        raise AssertionError("the bridge must not run for an empty batch")
+
+    with pytest.raises(ValidationError):
+        await sites_service.apply_leaf_edits(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="0123456789abcdef01234567",
+            edits=[],
+            _apply=_fake_apply,
+        )

--- a/tests/ee/sites/test_leaf_edits.py
+++ b/tests/ee/sites/test_leaf_edits.py
@@ -1,5 +1,11 @@
 # tests/ee/sites/test_leaf_edits.py — the native-editing leaf-edit persist path
 # (NE-4b). Created 2026-07-01 (feat/native-editing-ne4b).
+# Updated 2026-07-02 (harden the persist path): + a bridge RuntimeError and a
+# malformed CLI result (missing ``results``) both map to a clean CloudError
+# (sites.leaf_edit_failed), not a 500; + a DYNAMIC pocket splits its binding keys so
+# the CLI gets ONLY files and the persist loop is confined to the input file keyspace
+# (a binding key / invented path is never written back); + a json.dump serialization
+# failure in the bridge cleans up its tempfile (no leak, no NameError).
 #
 # Two layers under test, both hermetic (no Bun / workerd — the external CLI is
 # faked at its seam):
@@ -22,7 +28,7 @@ import json
 from pathlib import Path
 
 import pytest
-from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud._core.errors import CloudError, ValidationError
 from pocketpaw_ee.cloud.pockets import service as pockets_service
 from pocketpaw_ee.sites import generator_client
 from pocketpaw_ee.sites import service as sites_service
@@ -35,6 +41,21 @@ _SVELTE_SOURCE = {
     ),
     "src/lib/components/Hero.svelte": _HERO_V1,
     "src/app.css": ":root{--brand:#0A84FF}",
+}
+
+# A DYNAMIC svelte pocket (DSV-5): the live-data bindings (objects/sources/actions/
+# auth) ride as SIBLING keys of the {path: contents} SvelteKit files on the SAME
+# source envelope. apply_leaf_edits must split these out before the CLI splice.
+_DYNAMIC_OBJECTS = [{"name": "signups", "columns": [{"name": "email", "type": "text"}]}]
+_DYNAMIC_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/lib/components/Hero.svelte": _HERO_V1,
+    "objects": _DYNAMIC_OBJECTS,
+    "sources": [{"object": "signups", "as": "signups"}],
+    "actions": [{"object": "signups", "op": "insert"}],
+    "auth": False,
 }
 
 
@@ -268,3 +289,166 @@ async def test_apply_leaf_edits_empty_batch_rejected():
             edits=[],
             _apply=_fake_apply,
         )
+
+
+# ---------------------------------------------------------------------------
+# hardening — graceful CloudError envelopes, dynamic binding-key safety,
+# and the bridge temp-file cleanup (2026-07-02)
+# ---------------------------------------------------------------------------
+
+
+async def _make_dynamic_svelte_pocket(workspace_id: str, user_id: str) -> str:
+    """Persist a real DYNAMIC svelte-engine Pocket (source carries the DSV-5 binding
+    keys as siblings of the files) and return its id."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Signups",
+        type_="site",
+        pattern="dynamic",
+        ripple_spec=None,
+        engine="svelte",
+        source=dict(_DYNAMIC_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+@pytest.mark.asyncio
+async def test_apply_leaf_edits_bridge_runtime_error_maps_to_cloud_error(beanie_test_db):
+    """The bridge raises a bare RuntimeError on a non-zero CLI exit / timed-out splice.
+    The service maps it to a clean CloudError (sites.leaf_edit_failed) so the client
+    gets a structured envelope — NOT an opaque, unhandled 500."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    async def _fake_apply(*, source, edits):
+        raise RuntimeError("apply-leaf-edit failed: unparseable op")
+
+    with pytest.raises(CloudError) as excinfo:
+        await sites_service.apply_leaf_edits(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            edits=[{"uid": "Hero:headline:0", "op": {"kind": "setText", "html": "x"}}],
+            _apply=_fake_apply,
+        )
+
+    assert excinfo.value.code == "sites.leaf_edit_failed"
+    assert excinfo.value.status_code >= 500
+    # The raw RuntimeError did not escape — the mapped CloudError did.
+    assert not isinstance(excinfo.value, RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_apply_leaf_edits_malformed_result_maps_to_cloud_error(beanie_test_db):
+    """A CLI result missing the ``results`` key (malformed output) would KeyError on
+    the parse. The service maps that to a CloudError too — a structured envelope, not
+    a 500."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    async def _fake_apply(*, source, edits):
+        # ``source`` present but ``results`` missing → KeyError on the parse.
+        return {"source": dict(source)}
+
+    with pytest.raises(CloudError) as excinfo:
+        await sites_service.apply_leaf_edits(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            edits=[{"uid": "Hero:headline:0", "op": {"kind": "setText", "html": "x"}}],
+            _apply=_fake_apply,
+        )
+
+    assert excinfo.value.code == "sites.leaf_edit_failed"
+
+
+@pytest.mark.asyncio
+async def test_apply_leaf_edits_dynamic_pocket_splits_bindings_and_confines_persist(
+    beanie_test_db, monkeypatch
+):
+    """A DYNAMIC svelte pocket carries binding keys (objects/sources/actions/auth) as
+    siblings of the files. apply_leaf_edits must (a) send ONLY the file map to the CLI
+    (never a binding key), and (b) confine the persist loop to the input file keyspace
+    — so a binding key echoed back CHANGED, or a brand-new path the CLI invents, is
+    NEVER written via set_svelte_source_file (which would corrupt a live-data binding
+    or 404 on the unknown path)."""
+    pocket_id = await _make_dynamic_svelte_pocket("ws1", "u1")
+
+    captured: dict = {}
+
+    async def _fake_apply(*, source, edits):
+        captured["source"] = source
+        new = dict(source)
+        new["src/lib/components/Hero.svelte"] = _HERO_V2  # a real file changed
+        # The CLI misbehaves: echoes a binding key back CHANGED and invents a new path
+        # — neither may be persisted as a component file.
+        new["objects"] = "CORRUPTED-BINDING"
+        new["src/lib/components/Invented.svelte"] = "<section>invented</section>"
+        return {"source": new, "results": [{"uid": edits[0]["uid"], "applied": True}]}
+
+    calls = _spy_set_svelte_source_file(monkeypatch)
+
+    results = await sites_service.apply_leaf_edits(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        edits=[{"uid": "Hero:headline:0", "op": {"kind": "setText", "html": "Brighter"}}],
+        _apply=_fake_apply,
+    )
+
+    # (a) The CLI received ONLY the file map — no binding keys mixed in.
+    assert set(captured["source"].keys()) == {
+        "src/routes/+page.svelte",
+        "src/lib/components/Hero.svelte",
+    }
+    for binding_key in ("objects", "sources", "actions", "auth"):
+        assert binding_key not in captured["source"]
+
+    # (b) Persist was CONFINED to the input file keyspace: only the one real changed
+    # file — never the echoed binding key, never the invented path.
+    assert calls == ["src/lib/components/Hero.svelte"]
+
+    # Verdict passes through; the changed file landed; the live-data binding is intact
+    # (NOT overwritten with the CLI's "CORRUPTED-BINDING"); the invented path was not
+    # created.
+    assert results == [{"uid": "Hero:headline:0", "applied": True}]
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == _HERO_V2
+    assert wire["source"]["objects"] == _DYNAMIC_OBJECTS
+    assert "src/lib/components/Invented.svelte" not in wire["source"]
+
+
+@pytest.mark.asyncio
+async def test_generator_bridge_cleans_temp_on_dump_failure(monkeypatch):
+    """Temp-file leak fix: if ``json.dump`` fails mid-write (a non-serializable
+    source), the created tempfile is STILL cleaned up — ``input_path`` is assigned
+    BEFORE the write and the guarded finally unlinks it. No NameError, no leak."""
+    monkeypatch.setenv("PAW_SITES_GEN_CMD", "paw-sites-gen")
+
+    created: list[str] = []
+    real_ntf = generator_client.tempfile.NamedTemporaryFile
+
+    def _spy_ntf(*args, **kwargs):
+        fh = real_ntf(*args, **kwargs)
+        created.append(fh.name)
+        return fh
+
+    monkeypatch.setattr(generator_client.tempfile, "NamedTemporaryFile", _spy_ntf)
+
+    class _Unserializable:
+        pass
+
+    # json.dump can't serialize _Unserializable → raises TypeError mid-write, AFTER
+    # NamedTemporaryFile has already materialized the (delete=False) tempfile on disk.
+    with pytest.raises(TypeError):
+        await generator_client.apply_leaf_edits(
+            source={"a.svelte": _Unserializable()},
+            edits=[{"uid": "a:0", "op": {"kind": "setText", "html": "y"}}],
+            _exec=_fake_exec(_FakeProc(returncode=0)),
+        )
+
+    assert created, "expected a temp file to be created"
+    for path in created:
+        assert not Path(path).exists(), f"temp file leaked after dump failure: {path}"

--- a/tests/ee/sites/test_native_artifact.py
+++ b/tests/ee/sites/test_native_artifact.py
@@ -1,5 +1,9 @@
 # tests/ee/sites/test_native_artifact.py — the native-artifact render path (NE-5b).
 # Created 2026-07-01 (feat/native-editing-ne4b).
+# Updated 2026-07-02: + test_native_artifact_build_failure_maps_to_cloud_error — DEP-3
+# hardening: a generator build failure (SmokeGateFailed / missing toolchain) now
+# surfaces as a clean CloudError (sites.generator_failed), not an opaque 500, because
+# get_native_artifact routes its build through _build_or_cloud_error.
 #
 # Under test: sites_service.get_native_artifact — the backend of the native
 # shadow-render path. It ensures the pocket's ARMED svelte build (builder_origin set,
@@ -24,7 +28,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound, ValidationError
 from pocketpaw_ee.cloud.pockets import service as pockets_service
 from pocketpaw_ee.sites import service as sites_service
 
@@ -233,3 +237,41 @@ async def test_native_artifact_missing_pocket_raises_not_found(beanie_test_db):
             builder_origin="https://dash.paw.example",
             _generator=_NoBuildGenerator(),
         )
+
+
+class _SmokeGateFailGenerator:
+    """A generator whose build raises SmokeGateFailed — the failure a misconfigured
+    toolchain / broken build produces. DEP-3 routes get_native_artifact's build
+    through _build_or_cloud_error, so this must surface as a clean CloudError, not an
+    opaque 500."""
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+        raise SmokeGateFailed("workerd SSR render failed")
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_build_failure_maps_to_cloud_error(beanie_test_db):
+    """DEP-3: a generator build failure (SmokeGateFailed / missing toolchain / non-zero
+    build) is mapped to a clean CloudError (sites.generator_failed) instead of escaping
+    as an opaque unhandled 500 — get_native_artifact routes its build through
+    _build_or_cloud_error like the publish paths, NOT a bare generator.build()."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    with pytest.raises(CloudError) as excinfo:
+        await sites_service.get_native_artifact(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            builder_origin="https://dash.paw.example",
+            _generator=_SmokeGateFailGenerator(),
+        )
+
+    # A structured envelope with the DEP-3 machine code + a 5xx status — not a bare
+    # RuntimeError / SmokeGateFailed escaping as an unhandled 500.
+    assert excinfo.value.code == "sites.generator_failed"
+    assert excinfo.value.status_code >= 500
+    # SmokeGateFailed is a RuntimeError subclass, so confirm what surfaced is the
+    # mapped CloudError, not the raw RuntimeError.
+    assert not isinstance(excinfo.value, RuntimeError)

--- a/tests/ee/sites/test_native_artifact.py
+++ b/tests/ee/sites/test_native_artifact.py
@@ -1,0 +1,235 @@
+# tests/ee/sites/test_native_artifact.py — the native-artifact render path (NE-5b).
+# Created 2026-07-01 (feat/native-editing-ne4b).
+#
+# Under test: sites_service.get_native_artifact — the backend of the native
+# shadow-render path. It ensures the pocket's ARMED svelte build (builder_origin set,
+# so the generator stamps data-uid + embeds the paw-edit-manifest) and returns its
+# <body> inner HTML + concatenated CSS as {pocket_id, body_html, css}. These use the
+# shared ``beanie_test_db`` fixture (in-memory Mongo) so the pockets service persists
+# a REAL svelte Pocket; the generator is faked at its ``build`` seam to return a
+# hand-written built-output dir (a real .svelte-kit/cloudflare/index.html + a linked
+# css file), so the REAL body/CSS extraction runs end-to-end WITHOUT Bun. They prove:
+#   * happy path — returns {pocket_id, body_html, css}; body_html is the built
+#     <body> INNER (data-uid leaf + paw-edit-manifest present, no <body>/<head>
+#     wrapper); css concatenates the inline <style> + the linked stylesheet; and the
+#     build was ARMED (builder_origin threaded, smoke=False) with the pocket source;
+#   * no builder_origin → the configured PAW_SITES_BUILDER_ORIGIN fallback fires so
+#     the armed build still gets a non-empty origin;
+#   * the _read_built seam is injectable (a caller can bypass disk);
+#   * a non-svelte (ripple) pocket → ValidationError (422) before any build;
+#   * a missing / cross-tenant pocket → NotFound (404) from the pockets service.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+
+_HERO_V1 = "<section class='hero'><h1>Bright Smile</h1></section>"
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/lib/components/Hero.svelte": _HERO_V1,
+    "src/app.css": ":root{--brand:#0A84FF}",
+}
+
+# A hand-written stand-in for the paw-sites ARMED build's prerendered index.html: the
+# data-uid-stamped leaf + the embedded manifest live in <body>; the <head> links a
+# stylesheet (relative ./_app href, as adapter-cloudflare emits) and inlines a
+# critical <style>.
+_ARMED_INDEX_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" href="./_app/immutable/assets/page.css" />
+  <style>.inline-critical{margin:0}</style>
+</head>
+<body data-sveltekit-preload-data="hover">
+  <section class="hero" data-paw-section="Hero">
+    <h1 data-uid="Hero:headline:0">Bright Smile</h1>
+  </section>
+  <script id="paw-edit-manifest" type="application/json">{"leaves":["Hero:headline:0"]}</script>
+</body>
+</html>
+"""
+_LINKED_CSS = ".hero{color:#0A84FF}"
+
+
+class _FakeGenerator:
+    """Records the build kwargs and returns a BuildResult pointing at a pre-populated
+    ``project_dir`` (a real .svelte-kit/cloudflare/ tree the test wrote), so the REAL
+    ``_read_native_artifact`` extraction runs without Bun."""
+
+    def __init__(self, project_dir: str) -> None:
+        self.project_dir = project_dir
+        self.built: dict | None = None
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir=self.project_dir, ripple_version=None)
+
+
+class _NoBuildGenerator:
+    """A generator whose build MUST NOT run — used by the reject paths (a non-svelte
+    or missing pocket must fail before any build is triggered)."""
+
+    async def build(self, **kw):  # pragma: no cover - must not be reached
+        raise AssertionError("the build must not run on the reject path")
+
+
+def _write_built_output(project_dir: Path) -> None:
+    """Write a real armed build's static output under
+    <project_dir>/.svelte-kit/cloudflare/ — index.html + the linked stylesheet —
+    mirroring what a real bun build + adapter-cloudflare leave on disk."""
+    cf = project_dir / ".svelte-kit" / "cloudflare"
+    (cf / "_app" / "immutable" / "assets").mkdir(parents=True, exist_ok=True)
+    (cf / "index.html").write_text(_ARMED_INDEX_HTML, encoding="utf-8")
+    (cf / "_app" / "immutable" / "assets" / "page.css").write_text(_LINKED_CSS, encoding="utf-8")
+
+
+async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
+    """Persist a real svelte-engine Pocket via the pockets service and return its id
+    (mirrors how create_svelte_site lands a pocket)."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source=dict(_SVELTE_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_returns_body_and_css(beanie_test_db, tmp_path):
+    """A svelte pocket → {pocket_id, body_html, css}: body_html is the built <body>
+    INNER (data-uid leaf + manifest, no <body>/<head> wrapper); css concatenates the
+    inline <style> + the linked stylesheet; and the build was ARMED with the source."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    _write_built_output(tmp_path)
+    gen = _FakeGenerator(str(tmp_path))
+
+    result = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="https://dash.paw.example",
+        _generator=gen,
+    )
+
+    assert result["pocket_id"] == pocket_id
+    # body_html is the <body> INNER — the data-uid leaf + the manifest script, and
+    # NOT the wrapping <body> tag / <head> chrome.
+    assert 'data-uid="Hero:headline:0"' in result["body_html"]
+    assert 'id="paw-edit-manifest"' in result["body_html"]
+    assert "<body" not in result["body_html"]
+    assert "<head" not in result["body_html"]
+    # css concatenates the inline critical style AND the linked stylesheet.
+    assert ".inline-critical{margin:0}" in result["css"]
+    assert _LINKED_CSS in result["css"]
+    # The build was ARMED (the resolved builder_origin threaded through) and carried
+    # the pocket's svelte source on the svelte track, with the arm/preview smoke gate.
+    assert gen.built is not None
+    assert gen.built["builder_origin"] == "https://dash.paw.example"
+    assert gen.built["engine"] == "svelte"
+    assert gen.built["pocket_id"] == pocket_id
+    assert gen.built["smoke"] is False
+    assert gen.built["source"]["src/lib/components/Hero.svelte"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_default_origin_from_config(beanie_test_db, tmp_path, monkeypatch):
+    """With no builder_origin passed, the service falls back to the configured
+    PAW_SITES_BUILDER_ORIGIN — the armed build still gets a non-empty origin so the
+    generator stamps data-uid + the manifest."""
+    monkeypatch.setenv("PAW_SITES_BUILDER_ORIGIN", "https://configured.paw.example")
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    _write_built_output(tmp_path)
+    gen = _FakeGenerator(str(tmp_path))
+
+    result = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="",
+        _generator=gen,
+    )
+
+    assert result["pocket_id"] == pocket_id
+    assert gen.built["builder_origin"] == "https://configured.paw.example"
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_read_seam_is_injectable(beanie_test_db):
+    """The _read_built seam is honored: the service returns whatever it yields, keyed
+    on the build's project_dir — so a caller can bypass disk entirely."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen = _FakeGenerator("/tmp/paw-native-artifact-nonexistent")
+
+    def _fake_read(project_dir: str) -> tuple[str, str]:
+        assert project_dir == "/tmp/paw-native-artifact-nonexistent"
+        return "<h1 data-uid='x:0'>hi</h1>", ".x{color:red}"
+
+    result = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="https://dash.paw.example",
+        _generator=gen,
+        _read_built=_fake_read,
+    )
+    assert result == {
+        "pocket_id": pocket_id,
+        "body_html": "<h1 data-uid='x:0'>hi</h1>",
+        "css": ".x{color:red}",
+    }
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_non_svelte_pocket_rejected(beanie_test_db):
+    """A ripple-engine pocket has no svelte build — get_native_artifact raises
+    ValidationError (422) BEFORE any build is triggered."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Ripple Pocket",
+        type_="site",
+        pattern="landing",
+        ripple_spec={"type": "container"},
+    )
+    assert err is None, err
+
+    with pytest.raises(ValidationError):
+        await sites_service.get_native_artifact(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            builder_origin="https://dash.paw.example",
+            _generator=_NoBuildGenerator(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_missing_pocket_raises_not_found(beanie_test_db):
+    """A missing / cross-tenant pocket surfaces the pockets service's NotFound (404),
+    before any build."""
+    with pytest.raises(NotFound):
+        await sites_service.get_native_artifact(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="0123456789abcdef01234567",
+            builder_origin="https://dash.paw.example",
+            _generator=_NoBuildGenerator(),
+        )

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -37,6 +37,12 @@
 # (over the real versions spine) and returns the new draft as a SiteVersionResponse;
 # an unknown version_no is a 404. Also asserts the seeded-site status response now
 # carries a ``deployed_at`` ISO string (None before any deploy).
+#
+# Updated 2026-07-01 (NE-4b — native-editing leaf-edit persist): adds coverage for
+# POST /sites/by-pocket/{pocket_id}/leaf-edits. The happy path creates a REAL svelte
+# pocket, fakes ONLY the apply-leaf-edit CLI (generator_client.apply_leaf_edits), and
+# asserts the endpoint returns per-uid verdicts AND persists the edit through the real
+# service→pockets path. A non-svelte pocket is a 422; a missing pocket is a 404.
 
 from __future__ import annotations
 
@@ -851,4 +857,99 @@ async def test_data_rows_by_pocket_unknown_table_is_404(beanie_test_db, monkeypa
     app = _build_app("ws_owner", monkeypatch)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         resp = await c.get("/api/v1/sites/by-pocket/pk_dyn/data/unknown_table")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# native-editing leaf edits (NE-4b): POST /sites/by-pocket/{pocket_id}/leaf-edits
+# persists the native editor's forwarded {uid, op} edits as a reviewable Branch
+# draft (splice via the apply-leaf-edit CLI → set_svelte_source_file), NO rebuild.
+# fabric.write; tenant-scoped; a non-svelte pocket is a 422; a missing pocket a 404.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_leaf_edits_route_persists_and_returns_verdicts(beanie_test_db, monkeypatch):
+    """The endpoint splices + persists a real svelte pocket's edit and returns one
+    verdict per uid. Only the external Bun CLI is faked; the service→pockets persist
+    runs for real, so a re-read shows the new source."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws_owner",
+        owner_id="user-test-1",
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source={
+            "src/lib/components/Hero.svelte": "<h1>Bright Smile</h1>",
+            "src/app.css": ":root{}",
+        },
+        trusted=True,
+    )
+    assert err is None, err
+
+    async def _fake_apply(*, source, edits):
+        new = dict(source)
+        new["src/lib/components/Hero.svelte"] = "<h1>Brighter</h1>"
+        return {"source": new, "results": [{"uid": edits[0]["uid"], "applied": True}]}
+
+    monkeypatch.setattr("pocketpaw_ee.sites.generator_client.apply_leaf_edits", _fake_apply)
+
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            f"/api/v1/sites/by-pocket/{pocket_id}/leaf-edits",
+            json={
+                "edits": [{"uid": "Hero:headline:0", "op": {"kind": "setText", "html": "Brighter"}}]
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["pocket_id"] == pocket_id
+    assert body["results"] == [{"uid": "Hero:headline:0", "applied": True, "reason": None}]
+    # The edit persisted through the real service → pockets path.
+    wire = await pockets_service.get(pocket_id, "user-test-1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == "<h1>Brighter</h1>"
+
+
+@pytest.mark.asyncio
+async def test_leaf_edits_route_non_svelte_is_422(beanie_test_db, monkeypatch):
+    """A ripple pocket has no svelte source map → 422 (the service ValidationError
+    maps to a 422); the CLI bridge is never reached."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(return_value={"name": "x", "engine": "ripple", "rippleSpec": {"type": "c"}}),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/by-pocket/pk_ripple/leaf-edits",
+            json={"edits": [{"uid": "x:0", "op": {"kind": "setText", "html": "y"}}]},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_leaf_edits_route_missing_pocket_is_404(beanie_test_db, monkeypatch):
+    """A missing / access-denied pocket surfaces as a 404 (the pockets service's
+    NotFound flows through the standard error handler)."""
+    from unittest.mock import AsyncMock
+
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(side_effect=NotFound("pocket", "pk_missing")),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/by-pocket/pk_missing/leaf-edits",
+            json={"edits": [{"uid": "x:0", "op": {"kind": "setText", "html": "y"}}]},
+        )
     assert resp.status_code == 404

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -43,6 +43,13 @@
 # pocket, fakes ONLY the apply-leaf-edit CLI (generator_client.apply_leaf_edits), and
 # asserts the endpoint returns per-uid verdicts AND persists the edit through the real
 # service→pockets path. A non-svelte pocket is a 422; a missing pocket is a 404.
+#
+# Updated 2026-07-01 (NE-5b — native-artifact endpoint): adds coverage for GET
+# /sites/by-pocket/{pocket_id}/native-artifact. The happy path patches
+# sites_service.get_native_artifact (a real build would spawn bun) and asserts the
+# route returns {pocket_id, body_html, css} AND threads the request Origin header as
+# the builder_origin the armed build needs. A non-svelte pocket (real service, mocked
+# ripple pocket read) is a 422.
 
 from __future__ import annotations
 
@@ -953,3 +960,62 @@ async def test_leaf_edits_route_missing_pocket_is_404(beanie_test_db, monkeypatc
             json={"edits": [{"uid": "x:0", "op": {"kind": "setText", "html": "y"}}]},
         )
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# native artifact (NE-5b): GET /sites/by-pocket/{pocket_id}/native-artifact serves
+# the armed svelte build's <body> inner HTML + concatenated CSS as {pocket_id,
+# body_html, css} so the native editor shadow-renders the site. fabric.write (it
+# ensures/triggers the armed build); builder_origin from the request Origin header;
+# a non-svelte pocket is a 422.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_route_returns_body_and_css(beanie_test_db, monkeypatch):
+    """The endpoint returns {pocket_id, body_html, css} and threads the request Origin
+    header as the builder_origin (the armed build needs it to stamp data-uid + the
+    manifest). The service is patched — a real build would spawn bun."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_get_native_artifact(*, builder_origin=None, **kw):
+        captured["builder_origin"] = builder_origin
+        captured["pocket_id"] = kw.get("pocket_id")
+        return {
+            "pocket_id": "pk1",
+            "body_html": '<h1 data-uid="Hero:headline:0">Hi</h1>',
+            "css": ".hero{color:#0A84FF}",
+        }
+
+    monkeypatch.setattr(sites_service, "get_native_artifact", _fake_get_native_artifact)
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/v1/sites/by-pocket/pk1/native-artifact",
+            headers={"Origin": "https://dash.paw.example"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["pocket_id"] == "pk1"
+    assert "data-uid" in body["body_html"]
+    assert body["css"] == ".hero{color:#0A84FF}"
+    # The route derived builder_origin from the request Origin header and forwarded
+    # the path's pocket_id.
+    assert captured["builder_origin"] == "https://dash.paw.example"
+    assert captured["pocket_id"] == "pk1"
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_route_non_svelte_is_422(beanie_test_db, monkeypatch):
+    """A ripple pocket has no svelte build → 422 (the service ValidationError maps to
+    422); no build is triggered (the service raises before constructing a generator)."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(return_value={"name": "x", "engine": "ripple", "rippleSpec": {"type": "c"}}),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk_ripple/native-artifact")
+    assert resp.status_code == 422


### PR DESCRIPTION
Backend for the native (in-app, no-iframe) site editor. Two authed endpoints on the sites control plane.

## Endpoints
- `POST /sites/by-pocket/{id}/leaf-edits`: takes the editor's forwarded `{uid, op}` edits, splices them into the pocket's svelte source via the paw-sites `apply-leaf-edit` CLI, and persists each changed file as a reviewable Branch draft. No rebuild, since the editor already shows the change.
- `GET /sites/by-pocket/{id}/native-artifact`: arms the build and returns `{body_html, css}` so the frontend can shadow-render the site instead of framing it.

## Safety
- Both `fabric.write`; the pocket read (owner and tenant scope) runs before any build or subprocess.
- The artifact's CSS reader resolves each linked stylesheet and contains it under the build tree, refusing `../` and symlink escape.
- The subprocess is parameterized (a temp `--input` file, no shell).
- Build and splice failures map to a `CloudError` envelope instead of an opaque 500.
- On dynamic sites the source's binding keys (`objects`/`sources`/`actions`/`auth`) are split out before the CLI, and the persist loop is confined to the input file keyspace, so a binding key or an invented path can't be written.

## Tests
307 sites tests pass (1 pre-existing skip). New coverage for the two endpoints, the auth and scheme guards, the error envelopes, and the dynamic-source split.

Reviewed pre-ship. No open blockers. The branch is a few commits behind dev and rebases clean.
