### PR TITLE
feat(cloud): verify plan-task outcomes at the planner terminal (SVL-5)

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/task.py
+++ b/ee/pocketpaw_ee/cloud/models/task.py
@@ -15,6 +15,13 @@
 #   empty) carrying the planner's machine-verifiable criteria. No
 #   migration — Mongo absorbs them on next write; old docs read back as
 #   ``[]``. Unblocks completion-time verification (pocketpaw#1162).
+# Updated: 2026-07-02 (feat/svl-5-cloud-verify) — added ``verify``
+#   (dict, default empty): Self-Verifying Loop state stamped by the
+#   cloud planner terminal (SVL-5). Keys: ``verdict`` (last
+#   OutcomeVerdict dump), ``feedback`` (cumulative rejected-attempt
+#   records), ``requeue_count`` (verify-driven requeues, SEPARATE from
+#   error retries), ``escalation_reason`` (budget_exhausted |
+#   no_progress). No migration — old docs read back as ``{}``.
 """Task document — Mission Control work-item primitive.
 
 Embedded sub-documents:
@@ -117,6 +124,17 @@ class Task(TimestampedDocument):
     # verification (pocketpaw#1162). Old docs read back as ``[]``.
     success_criteria: list[str] = Field(default_factory=list)
     preconditions: list[str] = Field(default_factory=list)
+
+    # Self-Verifying Loop state stamped by the cloud planner terminal
+    # (SVL-5). Keys: ``verdict`` — the last OutcomeVerdict dump for a
+    # verified run; ``feedback`` — cumulative rejected-attempt records
+    # (attempt, status, summary, unmet_criteria[{criterion, detail}]);
+    # ``requeue_count`` — verify-driven requeues, SEPARATE from any
+    # error-retry counter; ``escalation_reason`` — ``budget_exhausted``
+    # | ``no_progress`` when the loop gave up. Empty when the
+    # ``cloud_plan_verify_loop_enabled`` flag is off or the task never
+    # ran through the planner terminal. Old docs read back as ``{}``.
+    verify: dict[str, Any] = Field(default_factory=dict)
 
     due_at: datetime | None = None
     blocked_reason: str | None = None

--- a/ee/pocketpaw_ee/cloud/planner/service.py
+++ b/ee/pocketpaw_ee/cloud/planner/service.py
@@ -29,6 +29,30 @@
 #   ``preconditions`` from each OSS TaskSpec onto the cloud Task it
 #   creates, so completion-time verification (pocketpaw#1162) can read
 #   machine-checkable criteria off the materialized Task.
+# Updated: 2026-07-02 (feat/svl-5-cloud-verify) — Self-Verifying Loop at
+#   the CLOUD planner terminal (SVL-5), behind
+#   ``cloud_plan_verify_loop_enabled`` (default False ⇒ byte-for-byte
+#   today's behaviour). ``_run_one`` now judges each finished run's
+#   output against the Task's ``success_criteria`` via the OSS
+#   ``DeterministicVerdictProvider`` BEFORE any DONE side-effect fires
+#   (``_verify_plan_task_outcome``): SOLVED / UNKNOWN stamp the verdict
+#   on ``Task.verify`` and complete exactly as today; PARTIAL /
+#   NOT_SOLVED is REQUEUED — unmet criteria appended to the cumulative
+#   ``verify.feedback`` record, a verify counter (SEPARATE from error
+#   retries) bumped, status back to ``proposed`` so the EXISTING
+#   dispatch path re-runs it (``_execute_ready_plan_tasks`` tail-calls
+#   itself when a batch requeued anything; no new dispatch machinery).
+#   The re-run's instructions carry a "Why the last attempt was
+#   rejected" section mirroring the OSS executor's prompt block. A
+#   no-progress guard (unmet-criteria frozenset repeats or count
+#   non-decreasing across two consecutive attempts) escalates EARLY;
+#   exhausting ``cloud_plan_verify_max_requeues`` escalates too — both
+#   terminate as ``failed`` (the existing terminal that already
+#   unblocks dependents here) with ``verify.escalation_reason`` stamped
+#   (``no_progress`` | ``budget_exhausted``) and emit TaskResolved so
+#   the dependent-dispatch cascade still fires. A requeued or escalated
+#   attempt never saves its output file, uploads artifacts, or
+#   auto-completes.
 """Planner entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -1223,6 +1247,7 @@ async def _execute_ready_plan_tasks(
     from types import SimpleNamespace
 
     from pocketpaw.agents.pool import get_agent_pool
+    from pocketpaw.config import get_settings
     from pocketpaw_ee.cloud.tasks.dto import ClaimTaskRequest
     from pocketpaw_ee.cloud.tasks.service import agent_claim_task as cloud_claim_task
 
@@ -1263,6 +1288,33 @@ async def _execute_ready_plan_tasks(
             instr += "## Success Criteria\\n"
             for i, sc in enumerate(d.success_criteria, 1):
                 instr += str(i) + ". " + sc + "\\n"
+        # SVL-5: if a prior attempt was rejected by the verify loop,
+        # surface the SPECIFIC unmet criteria — cumulative, most recent
+        # first — so the re-dispatched agent sees exactly what to fix
+        # rather than a bare "try again". Mirrors the OSS executor's
+        # ``_build_task_prompt`` "Why the last attempt was rejected"
+        # block. Flag-gated so a disabled loop renders today's
+        # instructions byte-for-byte even if old feedback is on the doc.
+        if get_settings().cloud_plan_verify_loop_enabled:
+            feedback = (getattr(d, "verify", None) or {}).get("feedback") or []
+            if feedback:
+                instr += "\\n## Why the last attempt was rejected\\n"
+                instr += (
+                    "A previous attempt did NOT meet the success criteria below. "
+                    "Address each unmet criterion in your work this time:\\n"
+                )
+                for record in reversed(feedback):
+                    attempt = record.get("attempt")
+                    summary = record.get("summary", "")
+                    if attempt:
+                        instr += "Attempt " + str(attempt) + " (" + summary + "):\\n"
+                    else:
+                        instr += summary + ":\\n"
+                    for item in record.get("unmet_criteria", []):
+                        line = "- " + item.get("criterion", "")
+                        if item.get("detail"):
+                            line += " — " + item.get("detail", "")
+                        instr += line + "\\n"
         instr += "\\n## Workflow\\n"
         instr += "1. Review the task and create the required output.\\n"
         instr += "2. When done, call the MCP tool complete_task\\n"
@@ -1284,6 +1336,27 @@ async def _execute_ready_plan_tasks(
                     pass
             full_output = "".join(output_chunks)[:50000] if output_chunks else ""
             logger.info("agent done task=%s output_len=%d", tid, len(full_output))
+
+            # SVL-5 (Self-Verifying Loop, cloud planner terminal): judge
+            # the run's output against the Task's success_criteria BEFORE
+            # any DONE side-effect fires. "done" = SOLVED / UNKNOWN (or
+            # flag off) — fall through to today's completion path
+            # untouched. "requeued" / "escalated" = the verify helper
+            # already moved the task (back to ``proposed`` / to
+            # ``failed``) and stamped why; a rejected attempt must NOT
+            # save its output file, upload artifacts, or auto-complete —
+            # returning here is what enforces that invariant.
+            resolution = "done"
+            if get_settings().cloud_plan_verify_loop_enabled:
+                resolution = await _verify_plan_task_outcome(
+                    workspace_id=workspace_id,
+                    project_id=project_id,
+                    task_id=tid,
+                    full_output=full_output,
+                )
+            if resolution != "done":
+                return resolution
+
             if full_output:
                 await _save_task_output_file(workspace_id, tid, d.title, full_output, project_id)
                 uf = await _scan_and_upload_agent_files(
@@ -1301,10 +1374,26 @@ async def _execute_ready_plan_tasks(
                 project_id,
                 result_summary=full_output[:2000],
             )
+            return "done"
         except Exception as e:
             logger.exception("agent exec failed for task %s: %s", tid, e)
+            return "error"
 
-    await asyncio.gather(*[_run_one(tid, aid, d) for tid, aid, d in batch])
+    results = await asyncio.gather(*[_run_one(tid, aid, d) for tid, aid, d in batch])
+
+    # SVL-5: a verify-requeued task is back to ``proposed`` with feedback
+    # stamped, but nothing emits TaskResolved for it — so re-enter the
+    # EXISTING dispatch path (this very function, same as the
+    # ``on_plan_task_resolved`` cascade does) to claim and re-run it.
+    # Bounded: each pass either solves, requeues within the budget, or
+    # escalates to ``failed``, so the recursion depth is capped by
+    # ``cloud_plan_verify_max_requeues``. Flag off ⇒ every result is
+    # "done"/"error" and this never fires.
+    if any(r == "requeued" for r in results):
+        await _execute_ready_plan_tasks(
+            workspace_id=workspace_id,
+            project_id=project_id,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1376,6 +1465,174 @@ async def _reassign_task(workspace_id: str, task_id: str, agent_id: str, agent_n
     except Exception as e:
         logger.warning("_reassign_task: failed for %s: %s", task_id, e)
         return False
+
+
+def _plan_task_event_payload(doc: Any, workspace_id: str, project_id: str) -> dict:
+    """Event payload for a planner-terminal task write (SVL-5).
+
+    Same shape ``_auto_complete_task`` hand-builds for TaskResolved —
+    ``cascade_plan_tasks`` reads ``workspace_id`` + ``task.project_id``
+    off it — with ``status`` taken from the doc's CURRENT state so a
+    requeue ships ``proposed`` and an escalation ships ``failed``.
+    """
+    return {
+        "task_id": str(doc.id),
+        "workspace_id": workspace_id,
+        "project_id": project_id,
+        "task": {
+            "id": str(doc.id),
+            "workspace_id": workspace_id,
+            "project_id": project_id,
+            "title": doc.title,
+            "summary": doc.summary,
+            "status": doc.status,
+            "assignee": {
+                "kind": doc.assignee.kind,
+                "id": doc.assignee.id,
+                "name": doc.assignee.name,
+            },
+        },
+    }
+
+
+async def _verify_plan_task_outcome(
+    *,
+    workspace_id: str,
+    project_id: str,
+    task_id: str,
+    full_output: str,
+) -> str:
+    """SVL-5 verify hook — judge a finished plan-task run before completion.
+
+    Called from ``_run_one`` only when ``cloud_plan_verify_loop_enabled``
+    is on, after the agent run produced ``full_output`` and BEFORE any
+    DONE side-effect. The verifier is the OSS
+    ``DeterministicVerdictProvider`` — external to the agent that
+    produced the output. Returns the resolution the caller must honour:
+
+      - ``"done"`` — SOLVED / UNKNOWN (or the task doc vanished): a
+        passing or uncheckable result is NEVER requeued or mutated. The
+        verdict is stamped on ``Task.verify['verdict']``; the caller
+        completes exactly as today.
+      - ``"requeued"`` — PARTIAL / NOT_SOLVED, still progressing and
+        within budget: this attempt's unmet criteria (criterion +
+        detail) are APPENDED to the cumulative ``verify['feedback']``
+        record, the verify counter (``verify['requeue_count']``,
+        SEPARATE from any error-retry counter) is bumped, and status
+        goes back to ``proposed`` so the existing claim/dispatch path
+        re-runs it.
+      - ``"escalated"`` — the no-progress guard tripped (this attempt's
+        unmet-criteria frozenset equals the previous attempt's, or its
+        count is non-decreasing) OR the requeue budget is exhausted:
+        status flips to ``failed`` — the existing terminal that already
+        unblocks dependents in ``_execute_ready_plan_tasks`` — with
+        ``verify['escalation_reason']`` stamped (``no_progress`` |
+        ``budget_exhausted``). Emits TaskResolved so the same cascade
+        that dispatches dependents after a completion fires here too.
+
+    Mirrors the OSS executor's SVL-2/SVL-3 semantics at this seam.
+    """
+    from pocketpaw.config import get_settings
+    from pocketpaw.instinct.models import OutcomeStatus
+    from pocketpaw.instinct.verdict_provider import DeterministicVerdictProvider
+    from pocketpaw_ee.cloud._core.realtime.emit import emit
+    from pocketpaw_ee.cloud._core.realtime.events import TaskResolved, TaskUpdated
+    from pocketpaw_ee.cloud.models.task import Task as _TaskDoc
+
+    doc = await _TaskDoc.get(task_id)
+    if not doc or doc.workspace_id != workspace_id:
+        # Tenant guard on the read. A vanished / foreign doc falls
+        # through to the caller's normal completion path, which
+        # re-checks existence itself — same posture as today.
+        return "done"
+
+    verdict = DeterministicVerdictProvider().verify(full_output, list(doc.success_criteria or []))
+    verify_state = dict(doc.verify or {})
+    verify_state["verdict"] = verdict.model_dump()
+    logger.info(
+        "task %s verify verdict: %s (%s)",
+        task_id,
+        verdict.status,
+        verdict.summary,
+    )
+
+    if verdict.status not in (OutcomeStatus.PARTIAL, OutcomeStatus.NOT_SOLVED):
+        # SOLVED / UNKNOWN — stamp the verdict and pass through.
+        doc.verify = verify_state
+        await doc.save()
+        # no-event: the TaskResolved emitted by _auto_complete_task
+        # moments later announces this same completion; a separate
+        # TaskUpdated here would double-fire the feed for one logical
+        # completion write.
+        return "done"
+
+    unmet = [cr for cr in verdict.criteria_results if not cr.met]
+    n = int(verify_state.get("requeue_count", 0))
+    max_requeues = get_settings().cloud_plan_verify_max_requeues
+
+    # No-progress / oscillation guard (mirrors OSS SVL-3), checked
+    # BEFORE the budget: compare THIS attempt's unmet set against the
+    # PREVIOUS attempt's. Exact same criteria still failing, or the
+    # unmet count not shrinking — escalate early instead of burning the
+    # whole requeue budget circling a dead end.
+    prior_feedback = verify_state.get("feedback") or []
+    no_progress = False
+    if prior_feedback:
+        current = frozenset(cr.criterion for cr in unmet)
+        prev = frozenset(item["criterion"] for item in prior_feedback[-1].get("unmet_criteria", []))
+        no_progress = current == prev or len(current) >= len(prev)
+
+    if not no_progress and n < max_requeues:
+        # REQUEUE: append this attempt's rejections to the CUMULATIVE
+        # feedback log (attempt N's instructions carry 1..N-1), bump the
+        # verify counter, and put the task back where the existing
+        # dispatch machinery picks it up.
+        verify_state["feedback"] = [
+            *prior_feedback,
+            {
+                "attempt": n + 1,
+                "status": verdict.status.value,
+                "summary": verdict.summary,
+                "unmet_criteria": [
+                    {"criterion": cr.criterion, "detail": cr.detail} for cr in unmet
+                ],
+            },
+        ]
+        verify_state["requeue_count"] = n + 1
+        doc.verify = verify_state
+        doc.status = "proposed"
+        await doc.save()
+        await emit(TaskUpdated(data=_plan_task_event_payload(doc, workspace_id, project_id)))
+        logger.info(
+            "task %s failed verify (%s); requeue %d/%d with %d unmet criterion(s)",
+            task_id,
+            verdict.status,
+            n + 1,
+            max_requeues,
+            len(unmet),
+        )
+        return "requeued"
+
+    # ESCALATE: ``failed`` is the existing terminal — it already
+    # unblocks dependents in ``_execute_ready_plan_tasks``'s resolved
+    # set, and it surfaces in the operator's Snags. Stamp WHY so the
+    # operator sees the cause, and emit TaskResolved so the
+    # dependent-dispatch cascade fires exactly as it would after a
+    # completion.
+    reason = "no_progress" if no_progress else "budget_exhausted"
+    verify_state["escalation_reason"] = reason
+    doc.verify = verify_state
+    doc.status = "failed"
+    await doc.save()
+    await emit(TaskResolved(data=_plan_task_event_payload(doc, workspace_id, project_id)))
+    logger.info(
+        "task %s failed verify (%s) after %d requeue(s); escalating to failed (%s)",
+        task_id,
+        verdict.status,
+        n,
+        reason,
+    )
+    return "escalated"
 
 
 async def _auto_complete_task(

--- a/ee/pocketpaw_ee/cloud/tasks/domain.py
+++ b/ee/pocketpaw_ee/cloud/tasks/domain.py
@@ -12,6 +12,11 @@
 #   machine-verifiable criteria the planner emits on each TaskSpec.
 #   Read-only on the frozen dataclass; the service maps them from the
 #   Beanie doc. Unblocks completion-time verification (pocketpaw#1162).
+# Updated: 2026-07-02 (feat/svl-5-cloud-verify) — added ``verify``
+#   (dict, default empty): read-only Self-Verifying Loop state (verdict,
+#   feedback, requeue_count, escalation_reason) stamped by the cloud
+#   planner terminal (SVL-5). Mapped from the Beanie doc; not writable
+#   through any Task endpoint.
 """Domain value objects for the Tasks entity.
 
 Pure-Python frozen dataclasses. ``tasks/service.py`` owns the
@@ -104,6 +109,7 @@ class Task:
     blocked_by: tuple[str, ...] = ()
     success_criteria: tuple[str, ...] = ()
     preconditions: tuple[str, ...] = ()
+    verify: dict[str, Any] = field(default_factory=dict)
     due_at: datetime | None = None
     blocked_reason: str | None = None
     created_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/tasks/dto.py
+++ b/ee/pocketpaw_ee/cloud/tasks/dto.py
@@ -16,6 +16,12 @@
 # Updated: 2026-05-21 (PR #1164 review) — bounded the CreateTaskRequest
 #   success_criteria / preconditions lists at max_length=20 so a
 #   hallucinating planner LLM can't write a runaway list.
+# Updated: 2026-07-02 (feat/svl-5-cloud-verify) — added read-only
+#   ``verify`` (dict, default empty) to TaskResponse + ``task_to_dto``:
+#   the Self-Verifying Loop state (verdict, feedback, requeue_count,
+#   escalation_reason) stamped by the cloud planner terminal (SVL-5).
+#   Deliberately absent from Create/Update requests — the planner
+#   terminal is the sole writer.
 """Tasks entity — request/response DTOs."""
 
 from __future__ import annotations
@@ -199,6 +205,10 @@ class TaskResponse(BaseModel):
     blocked_by: list[str] = Field(default_factory=list)
     success_criteria: list[str] = Field(default_factory=list)
     preconditions: list[str] = Field(default_factory=list)
+    # Read-only Self-Verifying Loop state (SVL-5): verdict, feedback,
+    # requeue_count, escalation_reason. Stamped by the cloud planner
+    # terminal; no request DTO accepts it.
+    verify: dict[str, Any] = Field(default_factory=dict)
     due_at: str | None = None
     blocked_reason: str | None = None
     created_at: str | None = None
@@ -238,6 +248,7 @@ def task_to_dto(task: Task) -> TaskResponse:
         blocked_by=list(task.blocked_by),
         success_criteria=list(task.success_criteria),
         preconditions=list(task.preconditions),
+        verify=dict(task.verify),
         due_at=iso_utc(task.due_at),
         blocked_reason=task.blocked_reason,
         created_at=iso_utc(task.created_at),

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -29,6 +29,11 @@
 # Updated: 2026-05-21 (PR #1164 review) — documented in
 #   ``agent_update_task`` that success_criteria / preconditions are
 #   intentionally not patchable (planner-set, not ad-hoc editable).
+# Updated: 2026-07-02 (feat/svl-5-cloud-verify) — ``_to_domain`` threads
+#   the new ``verify`` dict (Self-Verifying Loop state stamped by the
+#   cloud planner terminal, SVL-5) from the Beanie doc onto the domain
+#   Task so the DTO surfaces it read-only. Not patchable through any
+#   endpoint — the planner terminal is the sole writer.
 """Tasks entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -127,6 +132,7 @@ def _to_domain(doc: _TaskDoc) -> Task:
         blocked_by=tuple(getattr(doc, "blocked_by", None) or ()),
         success_criteria=tuple(getattr(doc, "success_criteria", None) or ()),
         preconditions=tuple(getattr(doc, "preconditions", None) or ()),
+        verify=dict(getattr(doc, "verify", None) or {}),
         due_at=doc.due_at,
         blocked_reason=doc.blocked_reason,
         created_at=getattr(doc, "createdAt", None),

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,14 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-07-02 (feat/svl-5-cloud-verify): Added the CLOUD planner-terminal
+    Self-Verifying Loop flags (SVL-5) — ``cloud_plan_verify_loop_enabled``
+    (default False; kill-switch — when False cloud plan tasks auto-complete
+    exactly as before) and ``cloud_plan_verify_max_requeues`` (default 2; the
+    verify-requeue bound, SEPARATE from any error-retry budget). Mirrors the
+    deep_work_verify_* pair at the ee/cloud planner terminal
+    (``_execute_ready_plan_tasks`` → ``_run_one``). Env:
+    POCKETPAW_CLOUD_PLAN_VERIFY_* .
   - 2026-06-28 (AW-7 template gate deny-on-no-match): Added
     ``instinct_template_default_deny`` (default False, env
     POCKETPAW_INSTINCT_TEMPLATE_DEFAULT_DENY) — the host-wide default for the
@@ -566,6 +574,34 @@ class Settings(BaseSettings):
             "the requeue slice (SVL-2); landed here so later slices don't have "
             "to touch config. SVL-1 only READS deep_work_verify_loop_enabled "
             "and ignores this bound."
+        ),
+    )
+    cloud_plan_verify_loop_enabled: bool = Field(
+        default=False,
+        description=(
+            "Kill-switch for the Self-Verifying Loop at the CLOUD planner "
+            "terminal (ee/cloud plan-task execution — the paw-enterprise "
+            "product path). When False (default) plan tasks auto-complete "
+            "exactly as before — no outcome verification, byte-for-byte "
+            "today's behaviour. When True, every plan task that finishes its "
+            "agent run has its output checked against the cloud Task's "
+            "success_criteria and the OutcomeVerdict is stamped on the task "
+            "(``verify.verdict``). SOLVED / UNKNOWN complete exactly as "
+            "today; PARTIAL / NOT_SOLVED is requeued with the unmet criteria "
+            "fed back to the next attempt, bounded by "
+            "cloud_plan_verify_max_requeues, then failed with a stamped "
+            "``verify.escalation_reason``."
+        ),
+    )
+    cloud_plan_verify_max_requeues: int = Field(
+        default=2,
+        description=(
+            "Max verify-driven requeues a single CLOUD plan task may take "
+            "before the loop stops requeuing and fails the task with "
+            "``verify.escalation_reason='budget_exhausted'``. SEPARATE from "
+            "any error-retry budget — verify requeues and error retries "
+            "never share a counter. Mirrors deep_work_verify_max_requeues "
+            "at the cloud planner terminal (SVL-5)."
         ),
     )
     auto_install_bundled_skills: bool = Field(

--- a/tests/cloud/test_planner_verify_loop.py
+++ b/tests/cloud/test_planner_verify_loop.py
@@ -1,0 +1,277 @@
+# Created: 2026-07-02 (feat/svl-5-cloud-verify) — SVL-5: the Self-Verifying
+#   Loop at the CLOUD planner terminal. Drives the real
+#   ``_execute_ready_plan_tasks`` → ``_run_one`` → ``_verify_plan_task_outcome``
+#   path against mongomock Beanie docs with a fake AgentPool that scripts one
+#   output per attempt, and asserts the loop's contract:
+#     - SOLVED → done untouched, verdict stamped, output file saved as today;
+#     - failing-but-progressing → requeued (status back to ``proposed``) with
+#       the unmet criteria rendered into the SECOND run's instructions,
+#       bounded by ``cloud_plan_verify_max_requeues``, then ``failed`` with
+#       ``verify.escalation_reason == 'budget_exhausted'``;
+#     - identical unmet set on two consecutive attempts → ``failed`` with
+#       ``verify.escalation_reason == 'no_progress'`` BEFORE the budget;
+#     - flag off → no verdict, no requeue, byte-for-byte today's behaviour;
+#     - a requeued or escalated attempt NEVER saves the output file, uploads
+#       artifacts, or emits the done-completion (TaskResolved status=done).
+"""SVL-5 — Self-Verifying Loop at the cloud planner terminal."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import TaskResolved, TaskUpdated
+from pocketpaw_ee.cloud.models.task import Task as TaskDoc
+from pocketpaw_ee.cloud.models.task import TaskAssignee as TaskAssigneeDoc
+from pocketpaw_ee.cloud.planner import service as planner_service
+
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.config import get_settings
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_PROJECT = "p-verify"
+_AGENT_ID = "agent-1"
+
+# Deterministic-verifier-friendly criteria: each keys off one distinctive
+# token ("alpha"/"bravo"/"charlie") plus the shared "mentions" stem, so a
+# scripted output meets exactly the criteria whose keyword it contains.
+_C_ALPHA = "mentions alpha"
+_C_BRAVO = "mentions bravo"
+_C_CHARLIE = "mentions charlie"
+
+
+class _FakePool:
+    """AgentPool stand-in scripting one output per run; records instructions.
+
+    ``outputs[i]`` is what attempt ``i+1`` streams back; the last entry
+    repeats if the loop runs longer than scripted (defensive — a correct
+    loop never does). ``calls`` captures each run's ``message`` so tests
+    can assert the verify feedback landed in the re-run's instructions.
+    """
+
+    def __init__(self, outputs: list[str]) -> None:
+        self.outputs = list(outputs)
+        self.calls: list[str] = []
+
+    def run(self, *, agent_id: str, message: str, session_key: str, instructions: str):  # noqa: ARG002
+        self.calls.append(message)
+        content = self.outputs[min(len(self.calls) - 1, len(self.outputs) - 1)]
+
+        async def _gen():
+            yield AgentEvent(type="message", content=content)
+            yield AgentEvent(type="done", content="")
+
+        return _gen()
+
+
+def _settings(enabled: bool, max_requeues: int = 2):
+    """A Settings copy with the SVL-5 flag and requeue budget forced."""
+    return get_settings().model_copy(
+        update={
+            "cloud_plan_verify_loop_enabled": enabled,
+            "cloud_plan_verify_max_requeues": max_requeues,
+        }
+    )
+
+
+async def _make_plan_task(criteria: list[str]) -> str:
+    doc = TaskDoc(
+        workspace_id=_WS,
+        project_id=_PROJECT,
+        creator_id="u1",
+        title="Pull the vendor report",
+        summary="Compile the report the plan asked for.",
+        assignee=TaskAssigneeDoc(kind="agent", id=_AGENT_ID, name="PlanBot"),
+        assignee_id=_AGENT_ID,
+        assignee_kind="agent",
+        status="proposed",
+        success_criteria=list(criteria),
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _drive(pool: _FakePool, *, enabled: bool, max_requeues: int = 2):
+    """Run the real dispatch path with the pool, settings, and DONE
+    side-effects (output-file save + artifact scan) patched. Returns the
+    two side-effect mocks so tests assert fired / not-fired."""
+    save_mock = AsyncMock()
+    scan_mock = AsyncMock(return_value=[])
+    with (
+        patch("pocketpaw.agents.pool.get_agent_pool", return_value=pool),
+        patch(
+            "pocketpaw.config.get_settings",
+            return_value=_settings(enabled, max_requeues),
+        ),
+        patch.object(planner_service, "_save_task_output_file", save_mock),
+        patch.object(planner_service, "_scan_and_upload_agent_files", scan_mock),
+    ):
+        await planner_service._execute_ready_plan_tasks(workspace_id=_WS, project_id=_PROJECT)
+    return save_mock, scan_mock
+
+
+def _resolved_done_events(bus) -> list:
+    return [
+        e for e in bus.events if isinstance(e, TaskResolved) and e.data["task"]["status"] == "done"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# SOLVED / UNKNOWN pass through
+# ---------------------------------------------------------------------------
+
+
+async def test_solved_completes_as_today_with_verdict_stamped(recording_bus) -> None:
+    """A passing result is never requeued or mutated: one run, status done,
+    verdict stamped on ``Task.verify``, output file saved as today."""
+
+    tid = await _make_plan_task([_C_ALPHA])
+    pool = _FakePool(["The summary mentions alpha clearly."])
+
+    save_mock, scan_mock = await _drive(pool, enabled=True)
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 1
+    assert doc.status == "done"
+    assert doc.verify["verdict"]["status"] == "solved"
+    assert "feedback" not in doc.verify
+    assert "escalation_reason" not in doc.verify
+    # DONE side-effects fired exactly as today.
+    assert save_mock.await_count == 1
+    assert save_mock.await_args.args[3] == "The summary mentions alpha clearly."
+    assert scan_mock.await_count == 1
+    assert len(_resolved_done_events(recording_bus)) == 1
+
+
+async def test_unknown_no_criteria_passes_through(recording_bus) -> None:
+    """No criteria captured → UNKNOWN → complete exactly as today."""
+
+    tid = await _make_plan_task([])
+    pool = _FakePool(["Some output with no checkable contract."])
+
+    save_mock, _ = await _drive(pool, enabled=True)
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 1
+    assert doc.status == "done"
+    assert doc.verify["verdict"]["status"] == "unknown"
+    assert save_mock.await_count == 1
+    assert len(_resolved_done_events(recording_bus)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Requeue with feedback, then budget exhaustion
+# ---------------------------------------------------------------------------
+
+
+async def test_failing_requeues_with_feedback_then_budget_exhausts(recording_bus) -> None:
+    """Shrinking-but-never-solved: each attempt meets one more criterion so
+    the no-progress guard never fires, the task requeues exactly
+    ``max_requeues`` times with the prior rejections in the re-run's
+    instructions, then lands ``failed`` with reason=budget_exhausted. A
+    rejected attempt never fires the DONE side-effects."""
+
+    tid = await _make_plan_task([_C_ALPHA, _C_BRAVO, _C_CHARLIE])
+    pool = _FakePool(
+        [
+            "The agent mentions nothing useful here.",  # unmet: alpha,bravo,charlie
+            "The report mentions alpha throughout.",  # unmet: bravo,charlie
+            "The report mentions alpha and bravo now.",  # unmet: charlie
+        ]
+    )
+
+    save_mock, scan_mock = await _drive(pool, enabled=True, max_requeues=2)
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 3  # initial + 2 requeues
+    assert doc.status == "failed"
+    assert doc.verify["escalation_reason"] == "budget_exhausted"
+    # Verify counter is its own budget — bumped once per requeue only.
+    assert doc.verify["requeue_count"] == 2
+    assert [f["attempt"] for f in doc.verify["feedback"]] == [1, 2]
+    assert doc.verify["verdict"]["status"] == "partial"  # last attempt: 2/3 met
+
+    # The SECOND run's instructions carry attempt 1's specific rejections.
+    assert "Why the last attempt was rejected" not in pool.calls[0]
+    assert "Why the last attempt was rejected" in pool.calls[1]
+    for criterion in (_C_ALPHA, _C_BRAVO, _C_CHARLIE):
+        assert criterion in pool.calls[1]
+    # The THIRD run carries the cumulative log (attempts 1 and 2).
+    assert "Attempt 1" in pool.calls[2]
+    assert "Attempt 2" in pool.calls[2]
+
+    # No DONE side-effect ever fired for the rejected attempts.
+    assert save_mock.await_count == 0
+    assert scan_mock.await_count == 0
+    assert _resolved_done_events(recording_bus) == []
+    # Each requeue announced the task back at ``proposed``; the escalation
+    # emitted TaskResolved (status=failed) so the dependent cascade fires.
+    requeue_events = [
+        e
+        for e in recording_bus.events
+        if isinstance(e, TaskUpdated) and e.data["task"]["status"] == "proposed"
+    ]
+    assert len(requeue_events) == 2
+    failed_events = [
+        e
+        for e in recording_bus.events
+        if isinstance(e, TaskResolved) and e.data["task"]["status"] == "failed"
+    ]
+    assert len(failed_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# No-progress guard escalates before the budget
+# ---------------------------------------------------------------------------
+
+
+async def test_identical_unmet_set_twice_escalates_no_progress(recording_bus) -> None:
+    """Two consecutive attempts failing the exact same criterion escalate
+    to ``failed`` with reason=no_progress BEFORE the requeue budget is
+    spent (budget is 2; only 1 requeue happened)."""
+
+    tid = await _make_plan_task([_C_ALPHA])
+    pool = _FakePool(
+        [
+            "This mentions bravo.",  # unmet: alpha
+            "Still mentions bravo.",  # unmet: alpha — identical set
+        ]
+    )
+
+    save_mock, scan_mock = await _drive(pool, enabled=True, max_requeues=2)
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 2
+    assert doc.status == "failed"
+    assert doc.verify["escalation_reason"] == "no_progress"
+    assert doc.verify["requeue_count"] == 1  # budget of 2 NOT exhausted
+    assert save_mock.await_count == 0
+    assert scan_mock.await_count == 0
+    assert _resolved_done_events(recording_bus) == []
+
+
+# ---------------------------------------------------------------------------
+# Flag off — byte-for-byte today's behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_flag_off_no_verdict_no_requeue(recording_bus) -> None:
+    """Loop disabled: a failing output completes exactly as before — one
+    run, no verdict stamped, no feedback section in the instructions,
+    DONE side-effects fire."""
+
+    tid = await _make_plan_task([_C_ALPHA])
+    pool = _FakePool(["This mentions bravo."])  # would fail the criterion
+
+    save_mock, scan_mock = await _drive(pool, enabled=False)
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 1
+    assert doc.status == "done"
+    assert doc.verify == {}
+    assert "Why the last attempt was rejected" not in pool.calls[0]
+    assert save_mock.await_count == 1
+    assert scan_mock.await_count == 1
+    assert len(_resolved_done_events(recording_bus)) == 1


### PR DESCRIPTION
## What this does

Brings the Self-Verifying Loop to the cloud planner terminal — the execution path paw-enterprise Mission Control actually uses. When `cloud_plan_verify_loop_enabled` is on, a plan task that finishes has its output checked against its `success_criteria` (already first-class on the cloud Task). Failing results are requeued with the specific unmet criteria injected into the re-run instructions, bounded by `cloud_plan_verify_max_requeues` (default 2) with the same no-progress guard as the OSS terminal; stuck or exhausted tasks land `failed` with `verify.escalation_reason` stamped so the operator sees why. Both flags default off: flag-off is byte-for-byte today's behavior.

The OSS-terminal loop shipped earlier (#1540) only fired on the local runtime path; the enterprise client rides `_execute_ready_plan_tasks` -> AgentPool, which never touched it. This closes that gap.

## How

- Hook sits before any DONE side-effect: a rejected attempt never saves its output file, uploads artifacts, or auto-completes (early return enforces it; test-guarded).
- Requeue = status back to `proposed` + re-entering the existing dispatch path (`_execute_ready_plan_tasks`, the same function the resolved-cascade calls). No new dispatch machinery; recursion depth capped by the budget.
- Escalation uses the existing `failed` terminal (already unblocks dependents) + a stamped reason; emits `TaskResolved` so the cascade fires.
- New read-only `verify` dict on the Task doc, threaded through domain -> DTO so the verdict/feedback are visible to the client. No request DTO accepts it.

## Verification

`tests/cloud/test_planner_verify_loop.py` (new, 5 scenarios: solved-untouched, requeue-with-feedback-then-budget, no-progress-early, flag-off, no-side-effects-on-rejection) - 5 passed. Combined verify selection 17 passed. OSS loop tests unaffected (12 passed). Ruff clean. The 14 pre-existing failures in `tests/cloud/tasks/` reproduce identically on clean dev (verified by checkout comparison) and are unrelated.

## Out of scope

The LLM-judge tier (#1168, separate PR), calibration, FE changes (existing Mission Control surfaces the statuses), and the pre-existing `tests/cloud/tasks/` failures.