### PR TITLE
Fix the /security proxy so it talks to shield's /v1 API

### DIFF
--- a/ee/pocketpaw_ee/cloud/security/router.py
+++ b/ee/pocketpaw_ee/cloud/security/router.py
@@ -1,5 +1,10 @@
 # ee/pocketpaw_ee/cloud/security/router.py — the /api/v1/security/* shield proxy.
 # Created: 2026-07-01 (feat/sec-5-security-proxy, SEC-5).
+# Fixed: 2026-07-02 (live-smoke) — shield serves its control API under a /v1
+#   prefix (GET /v1/config, /v1/stats, /v1/decisions, POST /v1/decisions/{id}/
+#   resolve — see paw-shield internal/api). The proxy was forwarding to the
+#   bare paths (/config, …), so every call 404'd against a real shield. Forward
+#   under _SHIELD_API_PREFIX so the read + write paths reach shield's routes.
 #
 # A FastAPI router that maps 1:1 to shield's control API (served on a same-box
 # UNIX socket) and fronts it for the dashboard:
@@ -47,6 +52,10 @@ from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.security import config as shield_config
 
 logger = logging.getLogger(__name__)
+
+# shield versions its control API under /v1 (internal/api). The per-route paths
+# below are the bare resource paths; the proxy prepends this prefix on the wire.
+_SHIELD_API_PREFIX = "/v1"
 
 router = APIRouter(
     prefix="/security",
@@ -153,7 +162,7 @@ async def _proxy_get(
         return _no_shield_read()
     try:
         async with client:
-            resp = await client.get(path, params=params)
+            resp = await client.get(f"{_SHIELD_API_PREFIX}{path}", params=params)
     except _UNREACHABLE_ERRORS:
         # Log the reason (never the token / Authorization header) so operators
         # can see shield is down without leaking the credential.
@@ -174,7 +183,7 @@ async def _proxy_write(
         return _no_shield_write()
     try:
         async with client:
-            resp = await client.request(method, path, json=json_body)
+            resp = await client.request(method, f"{_SHIELD_API_PREFIX}{path}", json=json_body)
     except _UNREACHABLE_ERRORS:
         logger.warning("shield unreachable on %s %s — returning 409", method, path)
         return _no_shield_write()

--- a/tests/cloud/test_security_proxy.py
+++ b/tests/cloud/test_security_proxy.py
@@ -146,10 +146,13 @@ def test_get_decisions_forwards_with_bearer_and_query_params():
     body = res.json()
     assert body["available"] is True
     assert body["decisions"] == [{"id": "d1"}]
-    # Forwarded to shield's /decisions with the query params + Bearer token.
+    # Forwarded to shield's /v1/decisions with the query params + Bearer token.
+    # shield versions its control API under /v1 (paw-shield internal/api); a
+    # live-smoke found the proxy was forwarding to the bare paths, which 404'd
+    # against a real shield — so these assert the /v1-prefixed contract.
     req = shield.last
     assert req.method == "GET"
-    assert req.url.path == "/decisions"
+    assert req.url.path == "/v1/decisions"
     assert dict(req.url.params) == {"status": "pending", "limit": "25"}
     assert req.headers["authorization"] == "Bearer sekret-token"
 
@@ -162,7 +165,7 @@ def test_get_stats_forwards_and_wraps_available_true():
     body = res.json()
     assert body["available"] is True
     assert body["egress_blocked"] == 3
-    assert shield.last.url.path == "/stats"
+    assert shield.last.url.path == "/v1/stats"
     assert shield.last.method == "GET"
 
 
@@ -174,7 +177,7 @@ def test_get_config_forwards():
     body = res.json()
     assert body["available"] is True
     assert body["mode"] == "deny"
-    assert shield.last.url.path == "/config"
+    assert shield.last.url.path == "/v1/config"
 
 
 # ---------------------------------------------------------------------------
@@ -191,7 +194,7 @@ def test_patch_config_forwards_json_body():
     assert res.json() == {"mode": "allow"}
     req = shield.last
     assert req.method == "PATCH"
-    assert req.url.path == "/config"
+    assert req.url.path == "/v1/config"
     import json as _json
 
     assert _json.loads(req.content) == {"mode": "allow"}
@@ -218,7 +221,7 @@ def test_resolve_forwards_and_injects_owner_as_actor():
     assert res.json() == {"id": "d9", "status": "resolved"}
     req = shield.last
     assert req.method == "POST"
-    assert req.url.path == "/decisions/d9/resolve"
+    assert req.url.path == "/v1/decisions/d9/resolve"
     import json as _json
 
     sent = _json.loads(req.content)


### PR DESCRIPTION
## What

The `/api/v1/security/*` proxy forwarded to shield's bare paths (`/config`, `/stats`, `/decisions`, `/decisions/{id}/resolve`), but shield serves its control API under a `/v1` prefix (see paw-shield `internal/api`). Against a real shield every call returned `404 page not found`, so the `/security` page could never load live data.

This forwards under a `_SHIELD_API_PREFIX` (`/v1`) in both proxy helpers and corrects the test assertions to shield's real routes.

## How it slipped through

The unit tests use a fake `MockTransport` that accepts any path, and the assertions pinned the bare paths — so they encoded the wrong contract and stayed green. Same shape as the arq-jobs `queue=` bug: the mock was permissive and the test asserted the mistake.

## How it was found

The first live smoke against a running shield + CrowdSec. Walked the whole loop on a local box: attacker traffic → CrowdSec alert → shield LLM verdict (BLOCK 0.95) → flip enforce → a real CrowdSec ban (origin=shield) → approve a pending escalation (actor stamped). The read path 404'd until this fix; after it, config/stats/decisions/enforce/resolve all work end to end.

## Test

`tests/cloud/test_security_proxy.py` now asserts the `/v1`-prefixed paths; 32 pass. Verified live: the proxy returns `available:true` with real shield data over the socket.