### PR TITLE
fix(auth): show real MFA state in Settings

### DIFF
--- a/ee/pocketpaw_ee/cloud/auth/domain.py
+++ b/ee/pocketpaw_ee/cloud/auth/domain.py
@@ -38,6 +38,7 @@ class AuthUser:
     workspaces: tuple[WorkspaceMembershipRef, ...]
     is_verified: bool
     is_superuser: bool
+    mfa_enabled: bool = False
 
 
 __all__ = ["AuthUser", "WorkspaceMembershipRef"]

--- a/ee/pocketpaw_ee/cloud/auth/dto.py
+++ b/ee/pocketpaw_ee/cloud/auth/dto.py
@@ -44,6 +44,7 @@ class ProfileOut(BaseModel):
     emailVerified: bool  # noqa: N815 - intentional camelCase wire key
     activeWorkspace: str | None  # noqa: N815 - intentional camelCase wire key
     workspaces: list[WorkspaceMembershipDto]
+    mfa_enabled: bool  # snake_case: matches the paw-enterprise auth types wire key
 
 
 def auth_user_to_profile_out(user: AuthUser) -> ProfileOut:
@@ -57,6 +58,7 @@ def auth_user_to_profile_out(user: AuthUser) -> ProfileOut:
         workspaces=[
             WorkspaceMembershipDto(workspace=m.workspace, role=m.role) for m in user.workspaces
         ],
+        mfa_enabled=user.mfa_enabled,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/auth/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/service.py
@@ -48,6 +48,7 @@ def _to_domain(doc: _UserDoc) -> AuthUser:
         workspaces=tuple(_membership_to_domain(m) for m in doc.workspaces),
         is_verified=doc.is_verified,
         is_superuser=doc.is_superuser,
+        mfa_enabled=doc.mfa_enabled,
     )
 
 

--- a/tests/cloud/auth/test_dto.py
+++ b/tests/cloud/auth/test_dto.py
@@ -46,6 +46,7 @@ def test_profile_out_keys_match_existing_wire_shape() -> None:
         "emailVerified",
         "activeWorkspace",
         "workspaces",
+        "mfa_enabled",
     }
 
 
@@ -59,6 +60,8 @@ def test_auth_user_to_profile_out_field_mapping() -> None:
     assert dump["emailVerified"] is True
     assert dump["activeWorkspace"] == "w1"
     assert dump["workspaces"] == [{"workspace": "w1", "role": "owner"}]
+    assert dump["mfa_enabled"] is False
+    assert auth_user_to_profile_out(_user(mfa_enabled=True)).model_dump()["mfa_enabled"] is True
 
 
 def test_auth_user_with_no_active_workspace() -> None:

--- a/tests/cloud/auth/test_mfa.py
+++ b/tests/cloud/auth/test_mfa.py
@@ -135,6 +135,42 @@ async def test_setup_when_already_enabled_returns_409(app_client: AsyncClient) -
 
 
 # ---------------------------------------------------------------------------
+# Profile reflects MFA state (regression: /auth/me must expose mfa_enabled so
+# the Settings UI can show "Enable" vs "Disable" correctly). Without it the UI
+# always shows "Enable" and clicking setup 409s with mfa_already_enabled.
+# ---------------------------------------------------------------------------
+
+
+async def test_profile_reports_mfa_disabled_by_default(app_client: AsyncClient) -> None:
+    resp = await app_client.get("/api/v1/auth/me")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["mfa_enabled"] is False
+
+
+async def test_profile_reports_mfa_enabled_after_enrollment(app_client: AsyncClient) -> None:
+    setup = (await app_client.post("/api/v1/auth/mfa/setup")).json()
+    await app_client.post("/api/v1/auth/mfa/verify", json={"code": _code_for(setup["secret"])})
+
+    resp = await app_client.get("/api/v1/auth/me")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["mfa_enabled"] is True
+
+
+async def test_profile_reports_mfa_disabled_after_disable(app_client: AsyncClient) -> None:
+    setup = (await app_client.post("/api/v1/auth/mfa/setup")).json()
+    secret = setup["secret"]
+    await app_client.post("/api/v1/auth/mfa/verify", json={"code": _code_for(secret)})
+    await app_client.post(
+        "/api/v1/auth/mfa/disable",
+        json={"password": _PASSWORD, "code": _code_for(secret)},
+    )
+
+    resp = await app_client.get("/api/v1/auth/me")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["mfa_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
 # Disable
 # ---------------------------------------------------------------------------
 

--- a/tests/cloud/auth/test_router_golden.py
+++ b/tests/cloud/auth/test_router_golden.py
@@ -69,12 +69,14 @@ async def test_get_me_returns_dto_shape(app_client) -> None:
         "emailVerified",
         "activeWorkspace",
         "workspaces",
+        "mfa_enabled",
     }
     assert body["id"] == str(user_doc.id)
     assert body["name"] == "Alice"
     assert body["emailVerified"] is True
     assert body["activeWorkspace"] == "w1"
     assert body["workspaces"] == [{"workspace": "w1", "role": "owner"}]
+    assert body["mfa_enabled"] is False
 
 
 async def test_patch_me_updates_full_name(app_client) -> None:


### PR DESCRIPTION
## The bug

Disable MFA, and Settings still shows an **Enable** button. Click it and you get:

```json
{ "detail": "mfa_already_enabled" }
```

## Why

The Settings security page reads its two-factor toggle from `authStore.user.mfa_enabled`. But `GET /auth/me` never sent that field back, and the `AuthUser` domain object didn't carry it either. So the client always saw `undefined`, treated it as `false`, and rendered "Enable" no matter what — including for accounts that already had MFA turned on in the database. Clicking Enable then called `/auth/mfa/setup`, which correctly rejected the already-enrolled account with a 409.

So the button was never wrong-on-purpose; the client just had no way to know the real state.

## The fix

Thread `mfa_enabled` through the three layers that dropped it:

- `AuthUser` gains `mfa_enabled` (defaults to `False`)
- `service._to_domain` maps it from the stored user document
- `ProfileOut` exposes it — snake_case, matching the key paw-enterprise already reads

No client change needed: the frontend already re-pulls `/auth/me` after enroll and disable, and its `AuthUser` type already declared `mfa_enabled`. It was waiting on a value the server never sent.

## Tests

- New `/auth/me` regression cases: disabled by default, enabled after enrollment, disabled again after disable. All three failed before the change.
- Updated the two wire-shape golden tests that pin the exact `ProfileOut` key set.
- `32 passed` across `test_mfa.py`, `test_dto.py`, `test_router_golden.py`.

## Note on existing accounts

Any account that got stuck (MFA on in the DB, UI showing Enable) will now correctly show **Disable**, and can be turned off through the normal flow with a password and current TOTP code.