### PR TITLE
feat(atlas): surface map + always-on OS primer

### DIFF
--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -1,0 +1,65 @@
+<!--
+docs/atlas.md — the atlas primitive: the runtime OS self-model and its
+two agent tools (atlas_search / atlas_describe).
+
+Created: 2026-07-02 (feat/atlas-core, AT-1) — first end-to-end slice:
+hand-authored paw.atlas/v1 seed (10 primitives), AtlasStore
+loader/search/describe, and the pocketpaw_atlas in-process MCP server
+registered on the Claude Agent SDK backend next to pocketpaw_widgets.
+-->
+
+# Atlas — the OS self-model
+
+Atlas is the runtime's self-model: a hand-authored capability map the
+product's runtime agents (chat agent, pocket specialist) query to learn what
+the OS itself is and can do. The paw primitives carry paw-specific meanings
+(Pocket = workspace app container, Instinct = human approval gate, Fabric =
+typed knowledge graph, Belt = code assembly line, ...) that differ from LLM
+default meanings — atlas gives an agent ground truth instead of priors.
+
+The v1 seed (`src/pocketpaw/atlas/data/atlas.json`, schema `paw.atlas/v1`)
+ships 10 `primitive` entries: Pocket, Instinct, Fabric, Connector, Ripple,
+Soul, Branch, workspace-jobs, Sites, Belt. Each entry carries a stable `id`
+(`primitive:pocket`), a one-line `summary`, a `narrative` (when to reach for
+it and what it pairs with), `how` (the tool/verb/API that exercises it), and
+search `keywords`. The kinds `capability`, `surface`, `connector`, `widget`,
+and `skill` are reserved for later slices.
+
+## Agent tools (`pocketpaw_atlas` MCP server)
+
+The `pocketpaw_atlas` in-process MCP server is registered on the Claude Agent
+SDK backend alongside `pocketpaw_widgets` (same policy gate and allowlist
+path), so it is ambient on every agent run. Two tools:
+
+### `atlas_search`
+
+- **Args:** `intent` (string, required) — what the agent is trying to do,
+  e.g. `"approve agent actions"` or `"publish a website"`.
+- **Returns:** ranked capability cards as JSON —
+  `{"results": [{id, kind, name, summary, surface?}, ...]}` (top 5). Simple
+  lexical scoring over name / keywords / summary / narrative; name and
+  keyword hits rank highest.
+- **When:** before guessing whether the OS can do something or which
+  primitive fits an intent.
+
+### `atlas_describe`
+
+- **Args:** `id` (string, required) — a stable entry id, e.g.
+  `"primitive:instinct"`.
+- **Returns:** the full entry as JSON (`narrative`, `how`, `requires`,
+  `surface`, ...). An unknown id returns an error envelope listing the known
+  ids so the agent can self-correct.
+- **When:** after `atlas_search` picks a candidate, or before explaining /
+  exercising a primitive.
+
+## Python surface
+
+```python
+from pocketpaw.atlas import get_atlas_store
+
+store = get_atlas_store()          # lazy singleton over the packaged seed
+store.search("approve agent actions", limit=5)  # ranked AtlasEntry list
+store.describe("primitive:instinct")            # full AtlasEntry or None
+```
+
+Tests: `tests/atlas/`.

--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -6,6 +6,11 @@ Created: 2026-07-02 (feat/atlas-core, AT-1) — first end-to-end slice:
 hand-authored paw.atlas/v1 seed (10 primitives), AtlasStore
 loader/search/describe, and the pocketpaw_atlas in-process MCP server
 registered on the Claude Agent SDK backend next to pocketpaw_widgets.
+Updated: 2026-07-02 (feat/atlas-surface, AT-3) — surface map + primer:
+the seed gains 21 kind="surface" entries (the paw-enterprise client's
+user-facing routes), primitives with a natural home route carry it in
+their `surface` field, and the context_builder injects an always-on
+"Paw OS Primer" block generated from the store.
 -->
 
 # Atlas — the OS self-model
@@ -17,13 +22,52 @@ the OS itself is and can do. The paw primitives carry paw-specific meanings
 typed knowledge graph, Belt = code assembly line, ...) that differ from LLM
 default meanings — atlas gives an agent ground truth instead of priors.
 
-The v1 seed (`src/pocketpaw/atlas/data/atlas.json`, schema `paw.atlas/v1`)
+The seed (`src/pocketpaw/atlas/data/atlas.json`, schema `paw.atlas/v1`)
 ships 10 `primitive` entries: Pocket, Instinct, Fabric, Connector, Ripple,
 Soul, Branch, workspace-jobs, Sites, Belt. Each entry carries a stable `id`
 (`primitive:pocket`), a one-line `summary`, a `narrative` (when to reach for
 it and what it pairs with), `how` (the tool/verb/API that exercises it), and
-search `keywords`. The kinds `capability`, `surface`, `connector`, `widget`,
-and `skill` are reserved for later slices.
+search `keywords`. The kinds `capability`, `connector`, `widget`, and
+`skill` are reserved for later slices.
+
+## Surface entries (`kind: "surface"`)
+
+The seed also maps the paw-enterprise client so agents know the frontend
+exists and can tell users where to go. Each `surface:*` entry mirrors a REAL
+user-facing route in `paw-enterprise/src/routes/` and carries the route path
+in its `surface` field:
+
+| id | route | what the user does there |
+|----|-------|--------------------------|
+| `surface:home` | `/` | OS home: widget grid, activity river, chat pill |
+| `surface:chat` | `/chat` | rooms rail (DMs, agents, groups, channels, entity rooms) |
+| `surface:pockets` | `/pockets` | pocket list + live canvas detail |
+| `surface:sites` | `/sites` | published-sites gallery, create→publish flow |
+| `surface:belt` | `/belt` | develop-station console: runs + diff viewer |
+| `surface:paw-print` | `/paw-print` | org-wide decision feed (Instinct corrections) |
+| `surface:decisions-graph` | `/decisions-graph` | visual query layer over decision history |
+| `surface:mission-control` | `/mission-control` | operator work feed (cycles, analytics) |
+| `surface:agents` | `/agents` | agent list + per-agent editor |
+| `surface:settings` | `/settings` | personal settings (profile, security, API keys, …) |
+| `surface:integrations` | `/settings/workspace/integrations` | third-party credentials |
+| `surface:workspace-admin` | `/settings/workspace` | workspace admin incl. plan info |
+| `surface:knowledge` | `/knowledge` | KB browser |
+| `surface:files` | `/files` | file browser |
+| `surface:studio` | `/studio` | media generation gallery |
+| `surface:code` | `/code` | in-browser IDE |
+| `surface:foresight` | `/foresight` | scenario rehearsal |
+| `surface:calendar` | `/calendar` | workspace calendar |
+| `surface:meetings` | `/meetings` | meetings timeline |
+| `surface:activity` | `/activity` | workspace activity feed |
+| `surface:audit` | `/audit` | audit log |
+
+Primitives with a natural home route cross-link it in their own `surface`
+field so `atlas_describe` answers include where to see the result:
+`primitive:pocket` → `/pockets`, `primitive:instinct` → `/paw-print`,
+`primitive:connector` → `/settings/workspace/integrations`,
+`primitive:sites` → `/sites`, `primitive:belt` → `/belt`. (There is no
+dedicated billing route in the client today; plan info lives on
+`/settings/workspace`.)
 
 ## Agent tools (`pocketpaw_atlas` MCP server)
 
@@ -51,6 +95,25 @@ path), so it is ambient on every agent run. Two tools:
   ids so the agent can self-correct.
 - **When:** after `atlas_search` picks a candidate, or before explaining /
   exercising a primitive.
+
+## Always-on primer block (context_builder)
+
+`AgentContextBuilder._build_atlas_primer()`
+(`src/pocketpaw/bootstrap/context_builder.py`) injects a compact "Paw OS
+Primer" block (block #8b, `atlas_primer`) into every built system prompt:
+
+- one-paragraph OS identity ("you run inside paw-os …"),
+- one line per primitive, generated at build time from the atlas store (a
+  seed edit can never drift from the prompt),
+- the standing instruction to call `atlas_search` before guessing about OS
+  capabilities and to include the `surface` route ("see it at /sites") when
+  pointing a user somewhere after an action.
+
+It renders at ~1.6K chars (~400 est. tokens) with a hard 2000-char
+(`_INJECTION_CAPS["atlas_primer"]`, ~500-token) ceiling, ships at the same
+MEDIUM priority as the skills block (#8), and is wrapped in try/except so an
+atlas load failure never breaks prompt building. Tests:
+`tests/atlas/test_primer_block.py`.
 
 ## Python surface
 

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,12 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-07-02 (feat/atlas-core AT-1) — registered the ``pocketpaw_atlas``
+  in-process MCP server (``agents/sdk_mcp_atlas.py``) alongside
+  ``pocketpaw_widgets``: built in ``_get_mcp_servers`` behind the same tool
+  policy gate, its two tool ids (``atlas_search`` / ``atlas_describe``) added to
+  the allowlist in ``_collect_mcp_tool_ids`` and to the mode-scope grant, so the
+  agent can query the OS self-model (paw primitive meanings) instead of guessing
+  capabilities from LLM priors. Pure core — the atlas seed is packaged data.
 Updated: 2026-07-01 (fix/warm-reuse session_id) — the native ``session_id`` is now
   ALSO captured from the terminal ``ResultMessage`` (``getattr(event,
   "session_id", None)``), as a robust FALLBACK to the SS-1 init-``SystemMessage``
@@ -918,6 +925,24 @@ class ClaudeSDKBackend(BaseAgentBackend):
         except Exception as exc:  # noqa: BLE001
             logger.debug("pocketpaw_widgets MCP server not registered: %s", exc)
 
+        # In-process MCP server: the atlas OS self-model (atlas_search,
+        # atlas_describe). Pure core — the hand-authored seed ships as
+        # packaged data (pocketpaw.atlas), no cloud dependency. Lets the
+        # agent query what the OS is and can do (paw meanings of Pocket /
+        # Instinct / Fabric / ...) before guessing from LLM priors.
+        try:
+            from pocketpaw.agents.sdk_mcp_atlas import build_atlas_context_server
+
+            atlas_server = build_atlas_context_server()
+            if atlas_server is not None:
+                name, cfg_entry = atlas_server
+                if self._policy.is_mcp_server_allowed(name):
+                    servers[name] = cfg_entry
+                else:
+                    logger.info("MCP server '%s' blocked by tool policy", name)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("pocketpaw_atlas MCP server not registered: %s", exc)
+
         # EE-provided in-process MCP servers — cloud pocket context, Mission
         # Control tasks, the planner, and the pocket specialist. Discovered
         # via the ``pocketpaw.mcp_servers`` entry-point (see
@@ -985,7 +1010,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         """Collect the in-process MCP tool ids to add to the SDK allowlist.
 
         An MCP tool is only callable if its id is on the allowlist. This
-        gathers the core ripple widget-spec ids plus every cloud
+        gathers the core ripple widget-spec + atlas self-model ids plus every cloud
         ``pocketpaw.mcp_servers`` provider's ``tool_ids()`` (which includes
         the ``pocketpaw_pocket`` server's writable ``add_widget`` tool).
 
@@ -995,9 +1020,10 @@ class ClaudeSDKBackend(BaseAgentBackend):
         server name is the segment between the first and second ``__``.
         """
         from pocketpaw._registry import providers as _ext_providers
+        from pocketpaw.agents.sdk_mcp_atlas import ATLAS_TOOL_IDS
         from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
 
-        ids: list[str] = list(WIDGET_TOOL_IDS)
+        ids: list[str] = list(WIDGET_TOOL_IDS) + list(ATLAS_TOOL_IDS)
         for provider in _ext_providers("pocketpaw.mcp_servers"):
             try:
                 tool_ids = list(provider.tool_ids())
@@ -1617,15 +1643,22 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # Per-MODE restrictive MCP allow-list (distinct from the additive
         # ``allow_sdk_tools`` above). ``None`` keeps every MCP tool (broad
         # surfaces like /chat). When set, keep only MCP tools that are in the
-        # mode's set, in the pocket-creation grant, a ripple widget tool, OR
-        # from an always-allowed server (connectors + pocket lifecycle).
+        # mode's set, in the pocket-creation grant, a ripple widget / atlas
+        # tool, OR from an always-allowed server (connectors + pocket
+        # lifecycle).
         # Built-in SDK tools (Read/Write/Bash/...) are NEVER filtered here —
         # only ``mcp__*`` ids — so scoping a mode can't strip core tools.
         # Applied AFTER deny so a denied id can't sneak back via the grant.
         if allow_mcp_tool_ids is not None:
+            from pocketpaw.agents.sdk_mcp_atlas import ATLAS_TOOL_IDS
             from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
 
-            grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT | frozenset(WIDGET_TOOL_IDS)
+            grant = (
+                allow_mcp_tool_ids
+                | POCKET_CREATION_GRANT
+                | frozenset(WIDGET_TOOL_IDS)
+                | frozenset(ATLAS_TOOL_IDS)
+            )
             before_count = len(allowed_tools)
             allowed_tools = [
                 t

--- a/src/pocketpaw/agents/sdk_mcp_atlas.py
+++ b/src/pocketpaw/agents/sdk_mcp_atlas.py
@@ -1,0 +1,186 @@
+# agents/sdk_mcp_atlas.py — in-process SDK MCP server exposing the atlas
+# OS self-model to backends (AT-1). Created: 2026-07-02 (feat/atlas-core).
+#
+# atlas is the runtime OS self-model: hand-authored capability cards for
+# the OS's own primitives (Pocket, Instinct, Fabric, Connector, Ripple,
+# Soul, Branch, workspace-jobs, Sites, Belt) in PAW meanings, not
+# LLM-default meanings. The ``atlas_search`` / ``atlas_describe`` tools
+# let an agent look up what the OS is and can do BEFORE guessing a
+# capability from its priors. Pure core: the seed ships as packaged data
+# (``pocketpaw.atlas``), no cloud dependency.
+#
+# Mirrors ``sdk_mcp_widgets.py`` — same server/tool registration shape,
+# ``mcp__<server>__<tool>`` id convention, text-block result envelope
+# with ``is_error`` on failures, and the same wiring points in
+# ``claude_sdk.py`` (``_get_mcp_servers`` + ``_collect_mcp_tool_ids`` +
+# the mode-scope grant).
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_atlas"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form.
+ATLAS_SEARCH_TOOL_ID = f"mcp__{SERVER_NAME}__atlas_search"
+ATLAS_DESCRIBE_TOOL_ID = f"mcp__{SERVER_NAME}__atlas_describe"
+
+ATLAS_TOOL_IDS = (
+    ATLAS_SEARCH_TOOL_ID,
+    ATLAS_DESCRIBE_TOOL_ID,
+)
+
+
+def _text_result(text: str, *, is_error: bool = False) -> dict:
+    """Shape an SDK MCP tool result from a single text block."""
+    out: dict = {"content": [{"type": "text", "text": text}]}
+    if is_error:
+        out["is_error"] = True
+    return out
+
+
+async def _atlas_search_handler(args: dict) -> dict:
+    """Rank atlas entries for an intent and return capability cards.
+
+    Backs the ``atlas_search`` MCP tool. Cards are intentionally thin
+    (id, kind, name, summary, surface when set) — the agent follows up
+    with ``atlas_describe`` on the id it picks.
+    """
+    from pocketpaw.atlas.store import get_atlas_store
+
+    intent = args.get("intent")
+    if not isinstance(intent, str) or not intent.strip():
+        return _text_result(
+            "Error: pass `intent` as a non-empty string describing what you "
+            "are trying to do (e.g. 'approve agent actions').",
+            is_error=True,
+        )
+
+    entries = get_atlas_store().search(intent, limit=5)
+    if not entries:
+        return _text_result(f"No atlas entries matched intent: {intent!r}. Try broader wording.")
+
+    cards: list[dict[str, Any]] = []
+    for entry in entries:
+        card: dict[str, Any] = {
+            "id": entry.id,
+            "kind": entry.kind,
+            "name": entry.name,
+            "summary": entry.summary,
+        }
+        if entry.surface:
+            card["surface"] = entry.surface
+        cards.append(card)
+    return _text_result(json.dumps({"results": cards}, ensure_ascii=False))
+
+
+async def _atlas_describe_handler(args: dict) -> dict:
+    """Return the full atlas entry for a stable id.
+
+    Backs the ``atlas_describe`` MCP tool. Unknown ids return an error
+    envelope listing the known ids so the agent can self-correct.
+    """
+    from pocketpaw.atlas.store import get_atlas_store
+
+    entry_id = args.get("id")
+    if not isinstance(entry_id, str) or not entry_id.strip():
+        return _text_result(
+            "Error: pass `id` as a non-empty string (e.g. 'primitive:instinct').",
+            is_error=True,
+        )
+
+    store = get_atlas_store()
+    entry = store.describe(entry_id.strip())
+    if entry is None:
+        known = ", ".join(sorted(e.id for e in store.entries))
+        return _text_result(
+            f"Error: unknown atlas id {entry_id!r}. Known ids: {known}",
+            is_error=True,
+        )
+    return _text_result(entry.model_dump_json(by_alias=True))
+
+
+def build_atlas_context_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server, or None if the SDK is unavailable."""
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_atlas MCP disabled")
+        return None
+
+    @tool(
+        "atlas_search",
+        (
+            "Search the OS self-model (atlas) for the capability that matches "
+            "an intent. Call this BEFORE guessing whether the OS can do "
+            "something or which primitive to reach for — atlas terms carry "
+            "paw-specific meanings (Pocket = workspace app container, "
+            "Instinct = human approval gate, Fabric = typed knowledge graph, "
+            "Belt = code assembly line...) that differ from their everyday "
+            "meanings. Pass `intent` as what you're trying to accomplish "
+            "(e.g. 'approve agent actions', 'publish a website'). Returns "
+            "ranked capability cards (id, kind, name, summary, surface if "
+            "set); follow up with atlas_describe on the best id. Cheap, "
+            "in-process, single round-trip."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "intent": {
+                    "type": "string",
+                    "description": (
+                        "What you are trying to do, in plain words "
+                        "(e.g. 'let a human review agent changes')."
+                    ),
+                }
+            },
+            "required": ["intent"],
+        },
+    )
+    async def atlas_search(args):  # type: ignore[no-untyped-def]
+        return await _atlas_search_handler(args)
+
+    @tool(
+        "atlas_describe",
+        (
+            "Fetch the full atlas entry for one capability by stable id "
+            "(e.g. 'primitive:instinct'). Returns the narrative (WHEN to "
+            "reach for it and what it pairs with), `how` (the tool / verb / "
+            "API that exercises it), `requires`, and `surface`. Use after "
+            "atlas_search picks a candidate, or whenever you're about to "
+            "explain or exercise an OS primitive and want ground truth "
+            "instead of guessing from the name."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Stable atlas entry id, e.g. 'primitive:pocket'.",
+                }
+            },
+            "required": ["id"],
+        },
+    )
+    async def atlas_describe(args):  # type: ignore[no-untyped-def]
+        return await _atlas_describe_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[atlas_search, atlas_describe],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "ATLAS_DESCRIBE_TOOL_ID",
+    "ATLAS_SEARCH_TOOL_ID",
+    "ATLAS_TOOL_IDS",
+    "SERVER_NAME",
+    "build_atlas_context_server",
+]

--- a/src/pocketpaw/atlas/__init__.py
+++ b/src/pocketpaw/atlas/__init__.py
@@ -1,0 +1,15 @@
+# atlas/__init__.py — package exports for the atlas primitive (AT-1).
+# Created: 2026-07-02 (feat/atlas-core) — atlas is the runtime OS
+# self-model: a hand-authored capability map the product's runtime agents
+# (chat agent, pocket specialist) query to learn what the OS itself is
+# and can do, instead of guessing from LLM priors.
+
+from pocketpaw.atlas.model import AtlasEntry, AtlasModel
+from pocketpaw.atlas.store import AtlasStore, get_atlas_store
+
+__all__ = [
+    "AtlasEntry",
+    "AtlasModel",
+    "AtlasStore",
+    "get_atlas_store",
+]

--- a/src/pocketpaw/atlas/data/atlas.json
+++ b/src/pocketpaw/atlas/data/atlas.json
@@ -1,0 +1,115 @@
+{
+  "schema": "paw.atlas/v1",
+  "entries": [
+    {
+      "id": "primitive:pocket",
+      "kind": "primitive",
+      "name": "Pocket",
+      "summary": "Workspace container holding agents, data, tools, connectors, KB scope, and Instinct rules; the \"app\" primitive.",
+      "narrative": "A Pocket is the 'app' primitive of the OS: one workspace container that holds agents, data, tools, connectors, KB scope, and Instinct rules. Reach for it when the user wants an interactive app, dashboard, or tracker — anything with a canvas and state. Pockets pair with Ripple (which renders their UI from a rippleSpec), with Connectors (which scope data into them), and with Sites (which publish a pocket as a standalone website). NOT clothing — a Pocket is a workspace app container.",
+      "how": "pocket_specialist__create / POST /api/v1/pockets (create), pocket_specialist__edit + POST /api/v1/pockets/<id>/spec/merge (edit)",
+      "surface": "",
+      "requires": [],
+      "keywords": ["app", "dashboard", "tracker", "workspace", "canvas", "container", "tool", "viewer", "kanban", "todo", "build"]
+    },
+    {
+      "id": "primitive:instinct",
+      "kind": "primitive",
+      "name": "Instinct",
+      "summary": "The decision pipeline: agents PROPOSE actions, humans approve/reject/edit at a gate; captures reasoning traces.",
+      "narrative": "Instinct is the governance primitive: agents PROPOSE actions instead of executing them, and humans approve, reject, or edit each proposal at a gate. Every decision captures a reasoning trace. It is becoming a multi-lane triage router (auto / optimistic / escalate / dry-run + a trust ledger), with ASK as the default lane. Reach for it whenever an agent action needs governance — approvals, human review of agent writes, gated side effects. It pairs with Branch (which builds propose→review→merge on top of the gate) and Belt (where the human mans the Instinct gate on proposed diffs). NOT a biology term — Instinct is the approval pipeline.",
+      "how": "Instinct action store + gate APIs; agents emit proposals, humans resolve them at the gate",
+      "surface": "",
+      "requires": [],
+      "keywords": ["approve", "approval", "reject", "review", "gate", "governance", "propose", "human in the loop", "permission", "triage", "trust", "audit"]
+    },
+    {
+      "id": "primitive:fabric",
+      "kind": "primitive",
+      "name": "Fabric",
+      "summary": "Typed ontology layer: typed objects (Customer, Competitor, Product…) and typed links (competes_with, raised, hired).",
+      "narrative": "Fabric is the workspace's knowledge graph: a typed ontology layer of typed objects (Customer, Competitor, Product, …) connected by typed links (competes_with, raised, hired). Reach for it when the user needs structured entities and relationships rather than free text — CRM-like records, competitor maps, org graphs. It pairs with Connectors (which feed external data into typed objects) and Pockets (which render fabric-backed views). NOT textile — Fabric is the typed object/link layer.",
+      "how": "fabric query surface (e.g. fabric_query / fabric_stats MCP tools where a fabric server is bound)",
+      "surface": "",
+      "requires": [],
+      "keywords": ["ontology", "knowledge graph", "typed objects", "entities", "relationships", "links", "crm", "records", "graph", "customer", "competitor"]
+    },
+    {
+      "id": "primitive:connector",
+      "kind": "primitive",
+      "name": "Connector",
+      "summary": "Workspace-scoped data integration to external systems (Gmail, GCalendar, GDrive, Postgres…), each a typed YAML definition declaring senses.",
+      "narrative": "A Connector is a workspace-scoped data integration to an external system — Gmail, Google Calendar, Google Drive, Postgres, GitHub, and so on. Each connector is a typed YAML definition declaring its senses (what it can read and act on). Reach for it when the user wants their external data or accounts wired into the workspace. Connectors pair with Pockets (they bind into a pocket's scope), Fabric (they feed typed objects), and skills (a bound connector auto-surfaces its skill into the room). NOT an electrical part — a Connector is a data integration.",
+      "how": "connector registry + typed YAML definitions; bind a connector to a pocket to expose its senses",
+      "surface": "",
+      "requires": [],
+      "keywords": ["integration", "gmail", "calendar", "drive", "postgres", "github", "external data", "sync", "bind", "senses", "oauth", "connect"]
+    },
+    {
+      "id": "primitive:ripple",
+      "kind": "primitive",
+      "name": "Ripple",
+      "summary": "Generative UI layer: pockets describe WHAT to show as a rippleSpec; Ripple renders it as live Svelte UI (~190 widgets).",
+      "narrative": "Ripple is the generative UI layer of the OS: a pocket (or the chat agent) describes WHAT to show as a rippleSpec — a declarative JSON tree — and Ripple renders it as live Svelte UI from a catalog of ~190 widgets. Reach for it whenever UI needs to be produced from a description: dashboards, charts, forms, feeds, flows. It pairs with Pockets (every pocket canvas is a rippleSpec) and Sites (landing pages render ripple specs on the edge). NOT a water effect — Ripple is the widget rendering layer.",
+      "how": "author a rippleSpec; get_widget_spec / get_inline_widget_help fetch canonical prop schemas, start_flow scaffolds multi-step flows",
+      "surface": "",
+      "requires": [],
+      "keywords": ["ui", "widgets", "render", "rippleSpec", "svelte", "chart", "form", "generative ui", "canvas", "spec", "component"]
+    },
+    {
+      "id": "primitive:soul",
+      "kind": "primitive",
+      "name": "Soul",
+      "summary": "Persistent agent identity/memory (.soul files, OCEAN personality, 5-tier memory: core/episodic/semantic/procedural/…).",
+      "narrative": "Soul is the persistent agent identity and memory primitive: identity lives in portable .soul files with an OCEAN personality model and a 5-tier memory architecture (core / episodic / semantic / procedural / …). Reach for it when an agent needs to remember across sessions, carry a stable personality, or migrate identity between platforms. It pairs with the chat agent (soul recall feeds prompt context) and the Digital Soul Protocol (the open spec behind the file format). NOT a religious term — Soul is agent identity + memory.",
+      "how": "soul CLI / soul memory APIs: soul remember, soul recall, soul status against a .soul file",
+      "surface": "",
+      "requires": [],
+      "keywords": ["memory", "identity", "personality", "remember", "recall", "persistent", "ocean", "episodic", "semantic", "procedural", ".soul"]
+    },
+    {
+      "id": "primitive:branch",
+      "kind": "primitive",
+      "name": "Branch",
+      "summary": "Universal version-control + review for any artifact keyed by (scope_type, scope_id): propose → branch → review → merge/publish + revert.",
+      "narrative": "Branch is universal version-control + review for ANY artifact, keyed by (scope_type, scope_id): propose → branch → review → merge/publish, plus diff and revert. It is built on the Instinct gate + Journal, so every merge is a governed decision with history. Reach for it when a change to an artifact (a site, a spec, a config) should be reviewed before it goes live, or when the user wants to compare or roll back versions. Sites are the first consumer. NOT only git — Branch versions any workspace artifact.",
+      "how": "branch primitive APIs: propose / review / merge / publish / revert on a (scope_type, scope_id) artifact",
+      "surface": "",
+      "requires": ["primitive:instinct"],
+      "keywords": ["version", "review", "merge", "publish", "revert", "diff", "propose", "draft", "rollback", "history", "changes"]
+    },
+    {
+      "id": "primitive:workspace-jobs",
+      "kind": "primitive",
+      "name": "workspace-jobs",
+      "summary": "ARQ-backed durable async-work primitive for long-running named jobs with writeback under a system identity.",
+      "narrative": "workspace-jobs is the durable async-work primitive: ARQ-backed, long-running named jobs that survive restarts and write results back under a system identity. Reach for it when work outlives a chat turn — imports, crawls, bulk enrichment, scheduled processing — anything that should keep running after the user walks away. It pairs with Connectors (long syncs run as jobs) and Pockets (job writeback lands in pocket data).",
+      "how": "enqueue a named job on the ARQ-backed workspace-jobs queue; results write back under the system identity",
+      "surface": "",
+      "requires": [],
+      "keywords": ["background", "async", "job", "queue", "long-running", "durable", "schedule", "worker", "arq", "batch", "import"]
+    },
+    {
+      "id": "primitive:sites",
+      "kind": "primitive",
+      "name": "Sites",
+      "summary": "Publish a pocket as a real standalone website on the edge (static landing or dynamic with per-tenant D1).",
+      "narrative": "Sites publishes a pocket as a real standalone website on the edge — either a static landing page or a dynamic site backed by a per-tenant D1 database (reads AND writes against the customer's own live data). Reach for it when the user wants something ON THE WEB: a marketing page, a public guestbook, a booking list. A site is always published FROM a pocket; Sites pairs with Pocket (the source artifact), Ripple (landing rendering), and Branch (sites are the first consumer of propose→review→publish).",
+      "how": "publish flow: build/pick a pocket stamped type=\"site\", then publish it to the edge",
+      "surface": "",
+      "requires": ["primitive:pocket"],
+      "keywords": ["website", "publish", "landing page", "edge", "domain", "public", "d1", "static", "dynamic", "deploy", "online"]
+    },
+    {
+      "id": "primitive:belt",
+      "kind": "primitive",
+      "name": "Belt",
+      "summary": "Autonomous software assembly line: AI runs the stations (orient → develop → propose), the human mans the Instinct gate; changes leave only as proposed diffs.",
+      "narrative": "Belt is the autonomous software assembly line: AI runs the stations — orient in the codebase, develop the change in a station worktree, propose the diff — and the human mans the Instinct gate. Changes NEVER land directly on the user's branches; they leave the station only as proposed diffs for review. Reach for it when the user asks to implement, fix, or refactor code with governed delivery. It pairs with Instinct (the gate every diff passes through) and Branch (governed change of artifacts generally). NOT a clothing item — Belt is the code assembly line.",
+      "how": "belt develop station: orient → develop → mcp__pocketpaw_belt__belt_propose_change through the Instinct gate",
+      "surface": "",
+      "requires": ["primitive:instinct"],
+      "keywords": ["code", "implement", "fix", "refactor", "assembly line", "diff", "station", "develop", "propose change", "coding", "autonomous"]
+    }
+  ]
+}

--- a/src/pocketpaw/atlas/data/atlas.json
+++ b/src/pocketpaw/atlas/data/atlas.json
@@ -8,7 +8,7 @@
       "summary": "Workspace container holding agents, data, tools, connectors, KB scope, and Instinct rules; the \"app\" primitive.",
       "narrative": "A Pocket is the 'app' primitive of the OS: one workspace container that holds agents, data, tools, connectors, KB scope, and Instinct rules. Reach for it when the user wants an interactive app, dashboard, or tracker — anything with a canvas and state. Pockets pair with Ripple (which renders their UI from a rippleSpec), with Connectors (which scope data into them), and with Sites (which publish a pocket as a standalone website). NOT clothing — a Pocket is a workspace app container.",
       "how": "pocket_specialist__create / POST /api/v1/pockets (create), pocket_specialist__edit + POST /api/v1/pockets/<id>/spec/merge (edit)",
-      "surface": "",
+      "surface": "/pockets",
       "requires": [],
       "keywords": ["app", "dashboard", "tracker", "workspace", "canvas", "container", "tool", "viewer", "kanban", "todo", "build"]
     },
@@ -19,7 +19,7 @@
       "summary": "The decision pipeline: agents PROPOSE actions, humans approve/reject/edit at a gate; captures reasoning traces.",
       "narrative": "Instinct is the governance primitive: agents PROPOSE actions instead of executing them, and humans approve, reject, or edit each proposal at a gate. Every decision captures a reasoning trace. It is becoming a multi-lane triage router (auto / optimistic / escalate / dry-run + a trust ledger), with ASK as the default lane. Reach for it whenever an agent action needs governance — approvals, human review of agent writes, gated side effects. It pairs with Branch (which builds propose→review→merge on top of the gate) and Belt (where the human mans the Instinct gate on proposed diffs). NOT a biology term — Instinct is the approval pipeline.",
       "how": "Instinct action store + gate APIs; agents emit proposals, humans resolve them at the gate",
-      "surface": "",
+      "surface": "/paw-print",
       "requires": [],
       "keywords": ["approve", "approval", "reject", "review", "gate", "governance", "propose", "human in the loop", "permission", "triage", "trust", "audit"]
     },
@@ -41,7 +41,7 @@
       "summary": "Workspace-scoped data integration to external systems (Gmail, GCalendar, GDrive, Postgres…), each a typed YAML definition declaring senses.",
       "narrative": "A Connector is a workspace-scoped data integration to an external system — Gmail, Google Calendar, Google Drive, Postgres, GitHub, and so on. Each connector is a typed YAML definition declaring its senses (what it can read and act on). Reach for it when the user wants their external data or accounts wired into the workspace. Connectors pair with Pockets (they bind into a pocket's scope), Fabric (they feed typed objects), and skills (a bound connector auto-surfaces its skill into the room). NOT an electrical part — a Connector is a data integration.",
       "how": "connector registry + typed YAML definitions; bind a connector to a pocket to expose its senses",
-      "surface": "",
+      "surface": "/settings/workspace/integrations",
       "requires": [],
       "keywords": ["integration", "gmail", "calendar", "drive", "postgres", "github", "external data", "sync", "bind", "senses", "oauth", "connect"]
     },
@@ -96,7 +96,7 @@
       "summary": "Publish a pocket as a real standalone website on the edge (static landing or dynamic with per-tenant D1).",
       "narrative": "Sites publishes a pocket as a real standalone website on the edge — either a static landing page or a dynamic site backed by a per-tenant D1 database (reads AND writes against the customer's own live data). Reach for it when the user wants something ON THE WEB: a marketing page, a public guestbook, a booking list. A site is always published FROM a pocket; Sites pairs with Pocket (the source artifact), Ripple (landing rendering), and Branch (sites are the first consumer of propose→review→publish).",
       "how": "publish flow: build/pick a pocket stamped type=\"site\", then publish it to the edge",
-      "surface": "",
+      "surface": "/sites",
       "requires": ["primitive:pocket"],
       "keywords": ["website", "publish", "landing page", "edge", "domain", "public", "d1", "static", "dynamic", "deploy", "online"]
     },
@@ -107,9 +107,240 @@
       "summary": "Autonomous software assembly line: AI runs the stations (orient → develop → propose), the human mans the Instinct gate; changes leave only as proposed diffs.",
       "narrative": "Belt is the autonomous software assembly line: AI runs the stations — orient in the codebase, develop the change in a station worktree, propose the diff — and the human mans the Instinct gate. Changes NEVER land directly on the user's branches; they leave the station only as proposed diffs for review. Reach for it when the user asks to implement, fix, or refactor code with governed delivery. It pairs with Instinct (the gate every diff passes through) and Branch (governed change of artifacts generally). NOT a clothing item — Belt is the code assembly line.",
       "how": "belt develop station: orient → develop → mcp__pocketpaw_belt__belt_propose_change through the Instinct gate",
-      "surface": "",
+      "surface": "/belt",
       "requires": ["primitive:instinct"],
       "keywords": ["code", "implement", "fix", "refactor", "assembly line", "diff", "station", "develop", "propose change", "coding", "autonomous"]
+    },
+    {
+      "id": "surface:home",
+      "kind": "surface",
+      "name": "Home",
+      "summary": "The OS home screen: live Ripple widget grid, workspace activity feed, greeting, and chat pill.",
+      "narrative": "Home is the landing surface of the paw-enterprise client: a live widget grid (pinned pockets, the member 'intent of the day' board), an activity river, and a chat pill. Point a user here when they want their day at a glance or a place to start — everything else is one hop away.",
+      "how": "",
+      "surface": "/",
+      "requires": [],
+      "keywords": ["home", "start", "overview", "widget grid", "landing", "today", "intent"]
+    },
+    {
+      "id": "surface:chat",
+      "kind": "surface",
+      "name": "Chat",
+      "summary": "Chat panel with the rooms rail: DMs, agent rooms, groups, channels, and entity rooms bound to pockets.",
+      "narrative": "Chat is where users talk to agents and each other: a rooms rail with DMs, agent rooms, groups, channels, plus entity rooms scoped to a pocket (/chat/<pocketId>). Point a user here to converse with an agent, resume a room, or work inside a pocket-bound conversation.",
+      "how": "",
+      "surface": "/chat",
+      "requires": [],
+      "keywords": ["chat", "rooms", "dm", "message", "conversation", "talk", "agent room", "channel", "group"]
+    },
+    {
+      "id": "surface:pockets",
+      "kind": "surface",
+      "name": "Pockets",
+      "summary": "Pockets dashboard: the list of workspace pockets plus the canvas detail view for each one.",
+      "narrative": "The Pockets surface lists every pocket in the workspace and opens each one's live canvas (/pockets/<id>). After creating or editing a pocket, point the user here to see and use it. This is the home surface of the Pocket primitive.",
+      "how": "",
+      "surface": "/pockets",
+      "requires": ["primitive:pocket"],
+      "keywords": ["pockets", "canvas", "dashboard", "apps", "open pocket", "workspace apps", "tracker"]
+    },
+    {
+      "id": "surface:sites",
+      "kind": "surface",
+      "name": "Sites",
+      "summary": "Sites gallery: published Paw Sites as cards, with a chat rail that drives the create-and-publish flow.",
+      "narrative": "The Sites surface shows the workspace's published websites as a card gallery and opens each site's detail (/sites/<siteId>). Describing a site in its chat rail triggers the create-then-publish flow. After publishing a website, point the user here to see the live site and manage it.",
+      "how": "",
+      "surface": "/sites",
+      "requires": ["primitive:sites"],
+      "keywords": ["sites", "website", "publish", "landing page", "gallery", "domain", "live site", "online"]
+    },
+    {
+      "id": "surface:belt",
+      "kind": "surface",
+      "name": "Belt",
+      "summary": "Belt develop-station console: repo picker, run cards, and a read-only diff viewer, chat-first.",
+      "narrative": "The Belt surface is where a human hands the develop station a coding task and watches it run: repo picker, run cards, and the read-only diff viewer, with the station agent in the chat rail. Point a user here to request code changes or review proposed diffs. This is the home surface of the Belt primitive.",
+      "how": "",
+      "surface": "/belt",
+      "requires": ["primitive:belt"],
+      "keywords": ["belt", "coding task", "diff", "station", "develop", "code change", "proposed change"]
+    },
+    {
+      "id": "surface:paw-print",
+      "kind": "surface",
+      "name": "Paw Print",
+      "summary": "Org-wide decision feed: recent Instinct corrections across the workspace's pockets, with diff viewers.",
+      "narrative": "Paw Print is the org-wide decision feed — recent Instinct corrections across the workspace, each rendered through a diff viewer. Point a user here to review what decisions agents and humans have been making. It is the decision-feed home of the Instinct primitive; the historical query layer is /decisions-graph.",
+      "how": "",
+      "surface": "/paw-print",
+      "requires": ["primitive:instinct"],
+      "keywords": ["decisions", "corrections", "feed", "governance", "what happened", "instinct", "review decisions"]
+    },
+    {
+      "id": "surface:decisions-graph",
+      "kind": "surface",
+      "name": "Decision Graph",
+      "summary": "Visual query layer over the historical Decision projection: trace a decision's graph by id, depth, and mode.",
+      "narrative": "Decision Graph lets an operator query the historical Decision projection visually — deep-linkable by decision id, depth, and mode. Point a user here to trace WHY a decision happened and what it connects to; for the live feed of recent decisions use /paw-print instead.",
+      "how": "",
+      "surface": "/decisions-graph",
+      "requires": ["primitive:instinct"],
+      "keywords": ["decision graph", "trace", "why", "history", "projection", "drill down", "audit trail"]
+    },
+    {
+      "id": "surface:mission-control",
+      "kind": "surface",
+      "name": "Mission Control",
+      "summary": "Operator surface: unified work feed with cycles, plan, activity, and analytics tabs, filterable by project.",
+      "narrative": "Mission Control is the operator surface — a unified work feed (Feed, Cycles, Analytics tabs) with per-item actions and project filters. Point a user here to run the workspace's ongoing work: what is in flight, what needs attention, and how it is trending.",
+      "how": "",
+      "surface": "/mission-control",
+      "requires": [],
+      "keywords": ["mission control", "operator", "work feed", "cycles", "plan", "analytics", "in flight"]
+    },
+    {
+      "id": "surface:agents",
+      "kind": "surface",
+      "name": "Agents",
+      "summary": "Agents shell: the agent list plus a per-agent editor (identity, reasoning, soul evolution).",
+      "narrative": "The Agents surface lists the workspace's agents and opens each one's editor (/agents/<id>) — identity, reasoning, and soul evolution. Point a user here to create, inspect, or tune an agent.",
+      "how": "",
+      "surface": "/agents",
+      "requires": [],
+      "keywords": ["agents", "agent editor", "personas", "configure agent", "plugins", "soul", "tune"]
+    },
+    {
+      "id": "surface:settings",
+      "kind": "surface",
+      "name": "Settings",
+      "summary": "Personal + workspace settings: profile, security, notifications, preferences, API keys, and the workspace admin area.",
+      "narrative": "Settings hosts per-user pages (profile, security, notifications, preferences, API keys) and the workspace admin area under /settings/workspace (members, channels, integrations, policy, memory, SSO, voice — including the workspace plan). Point a user here to change how their account or workspace behaves.",
+      "how": "",
+      "surface": "/settings",
+      "requires": [],
+      "keywords": ["settings", "profile", "preferences", "api keys", "security", "notifications", "configure"]
+    },
+    {
+      "id": "surface:integrations",
+      "kind": "surface",
+      "name": "Integrations",
+      "summary": "Workspace-level third-party credentials: web search, OAuth apps, image generation providers.",
+      "narrative": "The Integrations settings page manages workspace-level third-party credentials (web search, OAuth apps, image generation). Point a user here to wire up or fix an external service; connectors bound to pockets draw on these credentials. This is the home surface of the Connector primitive.",
+      "how": "",
+      "surface": "/settings/workspace/integrations",
+      "requires": ["primitive:connector"],
+      "keywords": ["integrations", "credentials", "oauth", "connect", "api key", "external service", "providers"]
+    },
+    {
+      "id": "surface:workspace-admin",
+      "kind": "surface",
+      "name": "Workspace Admin",
+      "summary": "Workspace administration: name, plan, members, channels, integrations, memory, policy, SSO, voice, advanced.",
+      "narrative": "Workspace Admin is the workspace-scoped settings area: workspace name and plan, members, channels, integrations, memory, policy, SSO, voice, and advanced options. Point a user here for anything that affects the whole workspace — including checking the current plan. There is no dedicated billing route today; plan info lives here.",
+      "how": "",
+      "surface": "/settings/workspace",
+      "requires": [],
+      "keywords": ["workspace", "admin", "members", "plan", "billing", "usage", "policy", "sso", "channels"]
+    },
+    {
+      "id": "surface:knowledge",
+      "kind": "surface",
+      "name": "Knowledge",
+      "summary": "Workspace knowledge-base browser: compiled articles from source files and documents, searchable.",
+      "narrative": "The Knowledge surface hosts the workspace-level KB browser — compiled, searchable articles built from the workspace's files and sources. Point a user here to read or verify what the workspace knows about a topic.",
+      "how": "",
+      "surface": "/knowledge",
+      "requires": [],
+      "keywords": ["knowledge base", "kb", "articles", "wiki", "search knowledge", "docs"]
+    },
+    {
+      "id": "surface:files",
+      "kind": "surface",
+      "name": "Files",
+      "summary": "Workspace file browser panel.",
+      "narrative": "The Files surface is the workspace file browser. Point a user here to browse, inspect, or manage the files the workspace holds — including files that feed the knowledge base.",
+      "how": "",
+      "surface": "/files",
+      "requires": [],
+      "keywords": ["files", "browser", "documents", "uploads", "folders"]
+    },
+    {
+      "id": "surface:studio",
+      "kind": "surface",
+      "name": "Studio",
+      "summary": "Media generation gallery: describe an image or short video in the rail and the agent generates it into the gallery.",
+      "narrative": "Studio is the media-generation surface: the user describes an image or short video in the chat rail, the agent generates it, and results land in a gallery pocket on the left. Point a user here for any describe-to-media request.",
+      "how": "",
+      "surface": "/studio",
+      "requires": [],
+      "keywords": ["studio", "image", "video", "generate", "media", "poster", "illustration", "gallery"]
+    },
+    {
+      "id": "surface:code",
+      "kind": "surface",
+      "name": "Code",
+      "summary": "In-browser IDE: real workspace file tree, editor tabs, and an agent-side edit-run-verify loop.",
+      "narrative": "The Code surface is an in-browser IDE over the shared workspace: a real file tree, editor tabs, and an honest activity indicator while the agent does the work agent-side. Point a user here to read or edit workspace code with the agent alongside.",
+      "how": "",
+      "surface": "/code",
+      "requires": [],
+      "keywords": ["code", "ide", "editor", "file tree", "scripts", "edit code"]
+    },
+    {
+      "id": "surface:foresight",
+      "kind": "surface",
+      "name": "Foresight",
+      "summary": "Scenario rehearsal: create, run, and compare what-if scenarios (runs, insights, fabric, aggregate views).",
+      "narrative": "Foresight is the rehearsal surface: create what-if scenarios, run them, and inspect runs, insights, and aggregate views before committing to a decision. Point a user here to rehearse, simulate, or forecast a decision.",
+      "how": "",
+      "surface": "/foresight",
+      "requires": [],
+      "keywords": ["foresight", "scenario", "simulate", "rehearse", "forecast", "what if", "runs", "insights"]
+    },
+    {
+      "id": "surface:calendar",
+      "kind": "surface",
+      "name": "Calendar",
+      "summary": "Workspace calendar (operator surface).",
+      "narrative": "The Calendar surface shows the workspace calendar. Point a user here to see upcoming events; calendar data arrives via bound connectors (e.g. Google Calendar).",
+      "how": "",
+      "surface": "/calendar",
+      "requires": [],
+      "keywords": ["calendar", "events", "schedule", "upcoming", "meetings schedule"]
+    },
+    {
+      "id": "surface:meetings",
+      "kind": "surface",
+      "name": "Meetings",
+      "summary": "Unified meetings timeline.",
+      "narrative": "The Meetings surface is the unified meetings timeline. Point a user here to review past and upcoming meetings and their details; meeting preferences live at /settings/meetings.",
+      "how": "",
+      "surface": "/meetings",
+      "requires": [],
+      "keywords": ["meetings", "timeline", "recordings", "notes", "transcript"]
+    },
+    {
+      "id": "surface:activity",
+      "kind": "surface",
+      "name": "Activity",
+      "summary": "Workspace activity feed, polled live; shares its source with the home river.",
+      "narrative": "The Activity surface is the workspace-wide activity feed (same source as the home screen's river, polled live). Point a user here to see what has been happening across the workspace recently.",
+      "how": "",
+      "surface": "/activity",
+      "requires": [],
+      "keywords": ["activity", "feed", "recent", "events", "river", "what happened"]
+    },
+    {
+      "id": "surface:audit",
+      "kind": "surface",
+      "name": "Audit",
+      "summary": "Workspace audit log.",
+      "narrative": "The Audit surface is the workspace audit log — the compliance-grade record of actions. Point a user here when they need the authoritative trail of who or what did something; for a lighter live feed use /activity.",
+      "how": "",
+      "surface": "/audit",
+      "requires": [],
+      "keywords": ["audit", "log", "compliance", "trail", "record", "who did what"]
     }
   ]
 }

--- a/src/pocketpaw/atlas/model.py
+++ b/src/pocketpaw/atlas/model.py
@@ -1,10 +1,13 @@
 # atlas/model.py — pydantic schema for the atlas OS self-model (AT-1).
 # Created: 2026-07-02 (feat/atlas-core). Defines paw.atlas/v1: a flat list
-# of capability entries (primitives today; capabilities, surfaces,
-# connectors, widgets, and skills reserved) that the seed data file
-# (``atlas/data/atlas.json``) must validate against. The store
-# (``atlas/store.py``) loads and searches these models; the
-# ``pocketpaw_atlas`` in-process MCP server serves them to agents.
+# of capability entries that the seed data file (``atlas/data/atlas.json``)
+# must validate against. The store (``atlas/store.py``) loads and searches
+# these models; the ``pocketpaw_atlas`` in-process MCP server serves them
+# to agents.
+# Updated: 2026-07-02 (feat/atlas-surface, AT-3) — the seed now carries
+# ``surface`` entries (the paw-enterprise client's user-facing routes) next
+# to the primitives, and primitives with a natural home route populate
+# their ``surface`` field. Docstrings updated to match; no schema change.
 
 from __future__ import annotations
 
@@ -15,7 +18,7 @@ from pydantic import BaseModel, Field
 # Schema identifier the seed file must carry at its top level.
 ATLAS_SCHEMA_V1 = "paw.atlas/v1"
 
-# ``primitive`` is the only kind seeded in v1; the rest are reserved so
+# ``primitive`` and ``surface`` are seeded today; the rest are reserved so
 # later tasks can add entries without a schema bump.
 AtlasKind = Literal["primitive", "capability", "surface", "connector", "widget", "skill"]
 
@@ -30,7 +33,7 @@ class AtlasEntry(BaseModel):
     """
 
     id: str = Field(description="Stable id, e.g. 'primitive:pocket'.")
-    kind: AtlasKind = Field(description="Entry kind; only 'primitive' is seeded in v1.")
+    kind: AtlasKind = Field(description="Entry kind; 'primitive' and 'surface' are seeded.")
     name: str = Field(description="Display name, e.g. 'Pocket'.")
     summary: str = Field(description="One-line description for ranked result cards.")
     narrative: str = Field(
@@ -42,11 +45,15 @@ class AtlasEntry(BaseModel):
     )
     surface: str = Field(
         default="",
-        description="Optional route pointer (e.g. '/belt'); empty in the v1 seed.",
+        description=(
+            "Optional route pointer to the frontend surface (e.g. '/belt'). "
+            "Set on every kind='surface' entry and on primitives with a "
+            "natural home route."
+        ),
     )
     requires: list[str] = Field(
         default_factory=list,
-        description="Optional entry ids this one depends on; empty in the v1 seed.",
+        description="Optional entry ids this one depends on.",
     )
     keywords: list[str] = Field(
         default_factory=list,

--- a/src/pocketpaw/atlas/model.py
+++ b/src/pocketpaw/atlas/model.py
@@ -1,0 +1,66 @@
+# atlas/model.py — pydantic schema for the atlas OS self-model (AT-1).
+# Created: 2026-07-02 (feat/atlas-core). Defines paw.atlas/v1: a flat list
+# of capability entries (primitives today; capabilities, surfaces,
+# connectors, widgets, and skills reserved) that the seed data file
+# (``atlas/data/atlas.json``) must validate against. The store
+# (``atlas/store.py``) loads and searches these models; the
+# ``pocketpaw_atlas`` in-process MCP server serves them to agents.
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# Schema identifier the seed file must carry at its top level.
+ATLAS_SCHEMA_V1 = "paw.atlas/v1"
+
+# ``primitive`` is the only kind seeded in v1; the rest are reserved so
+# later tasks can add entries without a schema bump.
+AtlasKind = Literal["primitive", "capability", "surface", "connector", "widget", "skill"]
+
+
+class AtlasEntry(BaseModel):
+    """One capability card in the OS self-model.
+
+    The ``narrative`` is the load-bearing field: it tells an agent WHEN to
+    reach for the primitive and what it pairs with, in paw meanings (not
+    LLM-default meanings — "Pocket" is a workspace app container, not
+    clothing).
+    """
+
+    id: str = Field(description="Stable id, e.g. 'primitive:pocket'.")
+    kind: AtlasKind = Field(description="Entry kind; only 'primitive' is seeded in v1.")
+    name: str = Field(description="Display name, e.g. 'Pocket'.")
+    summary: str = Field(description="One-line description for ranked result cards.")
+    narrative: str = Field(
+        description="When to reach for it and what it pairs with — the agent-facing story."
+    )
+    how: str = Field(
+        default="",
+        description="The tool / verb / API that exercises the primitive, if any.",
+    )
+    surface: str = Field(
+        default="",
+        description="Optional route pointer (e.g. '/belt'); empty in the v1 seed.",
+    )
+    requires: list[str] = Field(
+        default_factory=list,
+        description="Optional entry ids this one depends on; empty in the v1 seed.",
+    )
+    keywords: list[str] = Field(
+        default_factory=list,
+        description="Search keywords — intent words a user/agent would actually say.",
+    )
+
+
+class AtlasModel(BaseModel):
+    """The full self-model document: schema tag + entries."""
+
+    schema_: Literal["paw.atlas/v1"] = Field(alias="schema", default=ATLAS_SCHEMA_V1)
+    entries: list[AtlasEntry] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True}
+
+
+__all__ = ["ATLAS_SCHEMA_V1", "AtlasEntry", "AtlasKind", "AtlasModel"]

--- a/src/pocketpaw/atlas/store.py
+++ b/src/pocketpaw/atlas/store.py
@@ -1,0 +1,117 @@
+# atlas/store.py — loader + lexical search + describe for the atlas
+# OS self-model (AT-1). Created: 2026-07-02 (feat/atlas-core).
+# ``AtlasStore`` loads and validates the packaged seed
+# (``atlas/data/atlas.json``) against the paw.atlas/v1 pydantic schema,
+# ranks entries for an intent query with simple token-overlap scoring
+# (name/keyword hits weighted above summary/narrative — no external
+# deps), and returns a full entry by id. A module-level lazy singleton
+# (``get_atlas_store``) mirrors the repo's other registry getters so the
+# MCP tools and any future primer block share one parsed model.
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from pocketpaw.atlas.model import AtlasEntry, AtlasModel
+
+# The hand-authored seed ships inside the package (hatchling includes
+# non-Python files under src/pocketpaw in the wheel).
+_DATA_PATH = Path(__file__).parent / "data" / "atlas.json"
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# Score weights: a hit on the name or a keyword is a much stronger signal
+# of intent than a word that merely appears somewhere in the narrative.
+_NAME_WEIGHT = 5.0
+_KEYWORD_WEIGHT = 3.0
+_SUMMARY_WEIGHT = 1.5
+_NARRATIVE_WEIGHT = 1.0
+
+
+def _tokenize(text: str) -> list[str]:
+    return _TOKEN_RE.findall(text.lower())
+
+
+class AtlasStore:
+    """In-memory view over the atlas self-model with lexical search."""
+
+    def __init__(self, model: AtlasModel) -> None:
+        self._model = model
+        self._by_id: dict[str, AtlasEntry] = {e.id: e for e in model.entries}
+        # Pre-tokenized fields per entry, so search doesn't re-tokenize the
+        # narrative on every call.
+        self._index: list[tuple[AtlasEntry, set[str], set[str], set[str], set[str]]] = [
+            (
+                entry,
+                set(_tokenize(entry.name)),
+                set(_tokenize(" ".join(entry.keywords))),
+                set(_tokenize(entry.summary)),
+                set(_tokenize(entry.narrative)),
+            )
+            for entry in model.entries
+        ]
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> AtlasStore:
+        """Load and validate the seed JSON (packaged data file by default)."""
+        data_path = path or _DATA_PATH
+        raw = json.loads(data_path.read_text(encoding="utf-8"))
+        return cls(AtlasModel.model_validate(raw))
+
+    @property
+    def model(self) -> AtlasModel:
+        return self._model
+
+    @property
+    def entries(self) -> list[AtlasEntry]:
+        return list(self._model.entries)
+
+    def search(self, query: str, limit: int = 5) -> list[AtlasEntry]:
+        """Rank entries for an intent query by weighted token overlap.
+
+        Each query token scores per entry: name hit > keyword hit >
+        summary hit > narrative hit (a token counts once, at its best
+        field). Entries with zero overlap are dropped; ties keep seed
+        order (stable sort).
+        """
+        tokens = _tokenize(query)
+        if not tokens or limit <= 0:
+            return []
+
+        scored: list[tuple[float, AtlasEntry]] = []
+        for entry, name_t, keyword_t, summary_t, narrative_t in self._index:
+            score = 0.0
+            for token in tokens:
+                if token in name_t:
+                    score += _NAME_WEIGHT
+                elif token in keyword_t:
+                    score += _KEYWORD_WEIGHT
+                elif token in summary_t:
+                    score += _SUMMARY_WEIGHT
+                elif token in narrative_t:
+                    score += _NARRATIVE_WEIGHT
+            if score > 0:
+                scored.append((score, entry))
+
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        return [entry for _, entry in scored[:limit]]
+
+    def describe(self, entry_id: str) -> AtlasEntry | None:
+        """Return the full entry for a stable id, or None if unknown."""
+        return self._by_id.get(entry_id)
+
+
+_store: AtlasStore | None = None
+
+
+def get_atlas_store() -> AtlasStore:
+    """Module-level lazy singleton — one parsed model per process."""
+    global _store
+    if _store is None:
+        _store = AtlasStore.load()
+    return _store
+
+
+__all__ = ["AtlasStore", "get_atlas_store"]

--- a/src/pocketpaw/atlas/store.py
+++ b/src/pocketpaw/atlas/store.py
@@ -6,7 +6,10 @@
 # (name/keyword hits weighted above summary/narrative — no external
 # deps), and returns a full entry by id. A module-level lazy singleton
 # (``get_atlas_store``) mirrors the repo's other registry getters so the
-# MCP tools and any future primer block share one parsed model.
+# MCP tools and the context_builder primer block share one parsed model.
+# Updated: 2026-07-02 (feat/atlas-surface, AT-3) — no code change; the seed
+# now also carries kind="surface" entries (frontend routes), which search
+# and describe serve exactly like primitives.
 
 from __future__ import annotations
 

--- a/src/pocketpaw/atlas/store.py
+++ b/src/pocketpaw/atlas/store.py
@@ -83,7 +83,7 @@ class AtlasStore:
         scored: list[tuple[float, AtlasEntry]] = []
         for entry, name_t, keyword_t, summary_t, narrative_t in self._index:
             score = 0.0
-            for token in tokens:
+            for token in set(tokens):
                 if token in name_t:
                     score += _NAME_WEIGHT
                 elif token in keyword_t:

--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -567,9 +567,14 @@ class AgentContextBuilder:
             # the whole block stays comfortably under the token budget.
             gist = entry.summary.split(";")[0].strip().rstrip(".")
             if len(gist) > 110:
-                # Cut at a word boundary so a line never ends mid-word.
-                gist = gist[:108].rsplit(" ", 1)[0].rstrip(" ,:(") + "…"
-            lines.append(f"- {entry.name}: {gist}.")
+                # Cut at a word boundary so a line never ends mid-word, and
+                # drop an unclosed parenthetical so the cut reads clean.
+                gist = gist[:108].rsplit(" ", 1)[0]
+                if gist.count("(") > gist.count(")"):
+                    gist = gist[: gist.rindex("(")]
+                gist = gist.rstrip(" ,.:;(") + "…"
+            suffix = "" if gist.endswith("…") else "."
+            lines.append(f"- {entry.name}: {gist}{suffix}")
 
         return (
             "\n# Paw OS Primer\n"

--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -1,6 +1,14 @@
 """
 Builder for assembling the full agent context.
 Created: 2026-02-02
+Updated: 2026-07-02 (feat/atlas-surface, AT-3) — new always-on "Paw OS
+primer" block (#8b, ``atlas_primer``): a compact OS-identity paragraph, the
+primitive one-liners generated at build time from the atlas store (never
+hard-coded, so seed edits can't drift), and the instruction to call
+``atlas_search`` before guessing about OS capabilities and to include the
+``surface`` route when pointing a user somewhere. Same MEDIUM priority as
+the skills block (#8) and wrapped in try/except so an atlas load failure
+never breaks prompt building.
 Updated: 2026-06-08 (VIP Onboarding Phase B — session-gated per-user KB scope)
 — ``KbContext`` gains an optional ``user_id``; ``_resolve_kb_scopes`` emits a
 member-private ``user:{user_id}`` scope at the HEAD of the list (highest
@@ -143,6 +151,7 @@ _INJECTION_CAPS: dict[str, int | None] = {
     "file_context": 2000,
     "health_state": 300,
     "skills_list": 2000,
+    "atlas_primer": 2000,  # ~500 tokens hard ceiling for the Paw OS primer
     "agents_md": 3000,
     "gws_instructions": 1000,
 }
@@ -441,6 +450,18 @@ class AgentContextBuilder:
         except Exception as exc:
             logger.debug("Skill injection skipped: %s", exc)
 
+        # 8b. Inject the Paw OS primer (atlas) — OS identity, the primitive
+        # one-liners (generated from the atlas store so they can't drift from
+        # the seed), and the atlas_search / surface-route instructions. Same
+        # MEDIUM priority as the skills block; an atlas failure never breaks
+        # prompt building.
+        try:
+            primer = self._build_atlas_primer()
+            if primer:
+                blocks.append(("atlas_primer", _Priority.MEDIUM, primer))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Atlas primer skipped (non-fatal): %s", exc)
+
         # 9. Inject AGENTS.md constraints from the target repo
         if agents_md_dir:
             try:
@@ -512,6 +533,57 @@ class AgentContextBuilder:
             remaining -= len(content)
 
         return "\n\n".join(result_parts)
+
+    @staticmethod
+    def _build_atlas_primer() -> str:
+        """Build the compact always-on "Paw OS primer" block (AT-3).
+
+        Three parts, ~500 tokens hard ceiling (enforced twice: the seed keeps
+        each line short, and ``_INJECTION_CAPS['atlas_primer']`` caps the
+        rendered block at 2000 chars):
+
+        1. One-paragraph OS identity ("you run inside paw-os ...").
+        2. One line per primitive — name + gist, generated at build time from
+           the atlas store so a seed edit can never drift from the prompt.
+           The gist is the entry summary's first clause, hard-capped so ten
+           lines stay inside the budget.
+        3. The standing instruction: ``atlas_search`` before guessing about
+           OS capabilities, and include the ``surface`` route when pointing
+           a user somewhere.
+
+        Returns "" when the store has no primitives. Raises on store load
+        failure — the caller wraps this in try/except (same pattern as the
+        skills block) so prompt building never breaks.
+        """
+        from pocketpaw.atlas.store import get_atlas_store
+
+        primitives = [e for e in get_atlas_store().entries if e.kind == "primitive"]
+        if not primitives:
+            return ""
+
+        lines: list[str] = []
+        for entry in primitives:
+            # First clause of the one-line summary; keep each line short so
+            # the whole block stays comfortably under the token budget.
+            gist = entry.summary.split(";")[0].strip().rstrip(".")
+            if len(gist) > 110:
+                # Cut at a word boundary so a line never ends mid-word.
+                gist = gist[:108].rsplit(" ", 1)[0].rstrip(" ,:(") + "…"
+            lines.append(f"- {entry.name}: {gist}.")
+
+        return (
+            "\n# Paw OS Primer\n"
+            "You run inside paw-os, an agentic workspace OS. Its primitives "
+            "carry paw-specific meanings (a Pocket is a workspace app, not "
+            "clothing), and users see results on frontend surfaces — routes "
+            "like /sites.\n\n"
+            "OS primitives:\n" + "\n".join(lines) + "\n\n"
+            "Before guessing whether the OS can do something or which "
+            "primitive fits, call atlas_search with your intent, then "
+            "atlas_describe on the best id. When an action has a home "
+            "surface, tell the user where to see it by route (e.g. "
+            '"see it at /sites") — entries carry it in their `surface` field.'
+        )
 
     @staticmethod
     async def _get_kb_context(

--- a/tests/atlas/test_primer_block.py
+++ b/tests/atlas/test_primer_block.py
@@ -1,0 +1,109 @@
+# tests/atlas/test_primer_block.py — the "Paw OS Primer" context_builder
+# block (AT-3). Created: 2026-07-02 (feat/atlas-surface). Pins that
+# build_system_prompt renders the atlas primer: OS identity + one line per
+# primitive generated from the atlas store + the atlas_search / surface-route
+# instruction; that the block stays under the ~500-token budget (2000 chars,
+# the _INJECTION_CAPS['atlas_primer'] ceiling); and that an atlas load
+# failure degrades gracefully — the prompt still builds, minus the primer
+# (same try/except pattern as the skills block #8).
+
+from __future__ import annotations
+
+import pytest
+
+import pocketpaw.atlas.store as atlas_store_mod
+from pocketpaw.bootstrap.context_builder import _INJECTION_CAPS, AgentContextBuilder
+from pocketpaw.bootstrap.protocol import BootstrapContext
+
+pytestmark = pytest.mark.asyncio
+
+# Hard budget from the task brief: the primer must stay ≤ 500 tokens. The
+# builder budgets in chars; 4 chars/token is the standard approximation.
+_TOKEN_BUDGET = 500
+_CHARS_PER_TOKEN = 4
+
+
+class _StubBootstrap:
+    async def get_context(self) -> BootstrapContext:
+        return BootstrapContext(
+            name="Test",
+            identity="id",
+            soul="soul",
+            style="style",
+        )
+
+
+def _builder() -> AgentContextBuilder:
+    return AgentContextBuilder(bootstrap_provider=_StubBootstrap())
+
+
+@pytest.fixture(autouse=True)
+def _fresh_atlas_singleton(monkeypatch):
+    """Isolate the module-level atlas store singleton per test."""
+    monkeypatch.setattr(atlas_store_mod, "_store", None)
+    yield
+    atlas_store_mod._store = None
+
+
+class TestPrimerContent:
+    async def test_primer_renders_in_system_prompt(self):
+        prompt = await _builder().build_system_prompt(include_memory=False)
+        assert "# Paw OS Primer" in prompt
+        assert "you run inside paw-os" in prompt.lower()
+        assert "atlas_search" in prompt
+        # The surface-route instruction: point users at routes like /sites.
+        assert "/sites" in prompt
+
+    async def test_primer_lists_all_primitives_from_the_store(self):
+        """The primitive lines are generated from the atlas store at build
+        time — every primitive name must appear, none hard-coded."""
+        primer = AgentContextBuilder._build_atlas_primer()
+        for entry in atlas_store_mod.get_atlas_store().entries:
+            if entry.kind == "primitive":
+                assert f"- {entry.name}:" in primer
+
+    async def test_primer_excludes_surface_entries_from_the_list(self):
+        """Only the 10 primitives get a line; surface entries are pointed at
+        via atlas_search, not enumerated (budget)."""
+        primer = AgentContextBuilder._build_atlas_primer()
+        assert "- Mission Control:" not in primer
+        assert "- Decision Graph:" not in primer
+
+
+class TestPrimerBudget:
+    async def test_primer_stays_under_token_budget(self):
+        primer = AgentContextBuilder._build_atlas_primer()
+        assert primer
+        est_tokens = len(primer) / _CHARS_PER_TOKEN
+        assert est_tokens <= _TOKEN_BUDGET, (
+            f"primer is ~{est_tokens:.0f} est. tokens ({len(primer)} chars); "
+            f"budget is {_TOKEN_BUDGET}"
+        )
+
+    async def test_injection_cap_matches_budget(self):
+        """The assembler-side cap must also enforce the ~500-token ceiling."""
+        cap = _INJECTION_CAPS.get("atlas_primer")
+        assert cap is not None
+        assert cap <= _TOKEN_BUDGET * _CHARS_PER_TOKEN
+
+
+class TestPrimerResilience:
+    async def test_atlas_failure_does_not_break_prompt_building(self, monkeypatch):
+        """If the atlas store fails to load, the prompt still builds — the
+        primer block is simply absent (same pattern as skills / health)."""
+
+        def _boom():
+            raise RuntimeError("seed file corrupted")
+
+        monkeypatch.setattr(atlas_store_mod, "get_atlas_store", _boom)
+        prompt = await _builder().build_system_prompt(include_memory=False)
+        assert prompt  # identity block still present
+        assert "# Paw OS Primer" not in prompt
+
+    async def test_empty_store_yields_no_primer(self, monkeypatch):
+        from pocketpaw.atlas.model import AtlasModel
+        from pocketpaw.atlas.store import AtlasStore
+
+        empty = AtlasStore(AtlasModel(entries=[]))
+        monkeypatch.setattr(atlas_store_mod, "get_atlas_store", lambda: empty)
+        assert AgentContextBuilder._build_atlas_primer() == ""

--- a/tests/atlas/test_primer_block.py
+++ b/tests/atlas/test_primer_block.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 import pocketpaw.atlas.store as atlas_store_mod
@@ -34,7 +36,11 @@ class _StubBootstrap:
 
 
 def _builder() -> AgentContextBuilder:
-    return AgentContextBuilder(bootstrap_provider=_StubBootstrap())
+    # Hermetic: a mock memory manager keeps the builder off the machine-global
+    # memory backend config (pattern from tests/test_agents_md.py).
+    mock_memory = MagicMock()
+    mock_memory.get_context_for_agent = AsyncMock(return_value="")
+    return AgentContextBuilder(bootstrap_provider=_StubBootstrap(), memory_manager=mock_memory)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/atlas/test_sdk_mcp_atlas.py
+++ b/tests/atlas/test_sdk_mcp_atlas.py
@@ -1,0 +1,86 @@
+# tests/atlas/test_sdk_mcp_atlas.py — pocketpaw_atlas MCP tool handlers (AT-1).
+# Created: 2026-07-02 (feat/atlas-core). Mirrors tests/test_sdk_mcp_inline_help.py
+# (the pocketpaw_widgets handler tests): proves atlas_search returns ranked
+# capability cards with the Instinct card for an approval intent, atlas_describe
+# returns the full entry (narrative + how), unknown / missing args come back as
+# agent-readable error envelopes, and the exported tool ids follow the
+# mcp__<server>__<tool> allowlist convention.
+
+import json
+
+import pytest
+
+from pocketpaw.agents.sdk_mcp_atlas import (
+    ATLAS_TOOL_IDS,
+    SERVER_NAME,
+    _atlas_describe_handler,
+    _atlas_search_handler,
+)
+
+
+def _text_of(result: dict) -> str:
+    block = next((c for c in result.get("content", []) if c.get("type") == "text"), None)
+    assert block is not None, "handler must return a text content block"
+    return block["text"]
+
+
+class TestAtlasSearchHandler:
+    @pytest.mark.asyncio
+    async def test_approve_agent_actions_returns_instinct_card(self):
+        out = await _atlas_search_handler({"intent": "approve agent actions"})
+        assert not out.get("is_error")
+        cards = json.loads(_text_of(out))["results"]
+        top_ids = [c["id"] for c in cards[:3]]
+        assert "primitive:instinct" in top_ids, f"expected Instinct in top-3, got {top_ids}"
+        # Cards are the thin shape: id/kind/name/summary (+surface when set).
+        instinct = next(c for c in cards if c["id"] == "primitive:instinct")
+        assert instinct["kind"] == "primitive"
+        assert instinct["name"] == "Instinct"
+        assert instinct["summary"]
+        assert "narrative" not in instinct, "search cards stay thin; describe carries narrative"
+
+    @pytest.mark.asyncio
+    async def test_missing_intent_returns_error_envelope(self):
+        out = await _atlas_search_handler({})
+        assert out.get("is_error") is True
+        assert "intent" in _text_of(out)
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_agent_readable_text(self):
+        out = await _atlas_search_handler({"intent": "zzzz qqqq xyzzy"})
+        assert not out.get("is_error"), "an empty result set is not a tool error"
+        assert "No atlas entries matched" in _text_of(out)
+
+
+class TestAtlasDescribeHandler:
+    @pytest.mark.asyncio
+    async def test_describe_instinct_returns_narrative_and_how(self):
+        out = await _atlas_describe_handler({"id": "primitive:instinct"})
+        assert not out.get("is_error")
+        entry = json.loads(_text_of(out))
+        assert entry["id"] == "primitive:instinct"
+        assert "gate" in entry["narrative"].lower()
+        assert entry["how"]
+        assert "requires" in entry and "surface" in entry
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_returns_error_with_known_ids(self):
+        out = await _atlas_describe_handler({"id": "primitive:nope"})
+        assert out.get("is_error") is True
+        # The error names the valid ids so the model can self-correct.
+        assert "primitive:pocket" in _text_of(out)
+
+    @pytest.mark.asyncio
+    async def test_missing_id_returns_error_envelope(self):
+        out = await _atlas_describe_handler({})
+        assert out.get("is_error") is True
+        assert "id" in _text_of(out)
+
+
+class TestToolIds:
+    def test_tool_ids_follow_allowlist_convention(self):
+        assert SERVER_NAME == "pocketpaw_atlas"
+        assert ATLAS_TOOL_IDS == (
+            f"mcp__{SERVER_NAME}__atlas_search",
+            f"mcp__{SERVER_NAME}__atlas_describe",
+        )

--- a/tests/atlas/test_store.py
+++ b/tests/atlas/test_store.py
@@ -4,6 +4,12 @@
 # the right primitive into the top results ("approve agent actions" →
 # Instinct, "build an app dashboard" → Pocket), describe returns the full
 # narrative, unknown ids return None, and the seed round-trips the schema.
+# Updated: 2026-07-02 (feat/atlas-surface, AT-3) — the seed now also carries
+# kind="surface" entries (paw-enterprise routes). Loader tests split into
+# per-kind completeness checks (every surface entry must carry a route in
+# its ``surface`` field); new search/describe tests pin "publish a website"
+# → sites with the /sites route populated, and primitives cross-linked to
+# their home surfaces.
 
 import json
 
@@ -23,22 +29,76 @@ EXPECTED_PRIMITIVE_IDS = {
     "primitive:belt",
 }
 
+# Surface entries mirror REAL user-facing routes in
+# paw-enterprise/src/routes/ — verified against the dir, not invented.
+EXPECTED_SURFACE_IDS = {
+    "surface:home",
+    "surface:chat",
+    "surface:pockets",
+    "surface:sites",
+    "surface:belt",
+    "surface:paw-print",
+    "surface:decisions-graph",
+    "surface:mission-control",
+    "surface:agents",
+    "surface:settings",
+    "surface:integrations",
+    "surface:workspace-admin",
+    "surface:knowledge",
+    "surface:files",
+    "surface:studio",
+    "surface:code",
+    "surface:foresight",
+    "surface:calendar",
+    "surface:meetings",
+    "surface:activity",
+    "surface:audit",
+}
+
+# primitive id → the home route its ``surface`` field must carry (AT-3
+# cross-links, so atlas_describe answers include where to see the result).
+EXPECTED_PRIMITIVE_SURFACES = {
+    "primitive:pocket": "/pockets",
+    "primitive:instinct": "/paw-print",
+    "primitive:connector": "/settings/workspace/integrations",
+    "primitive:sites": "/sites",
+    "primitive:belt": "/belt",
+}
+
 
 class TestLoader:
     def test_loads_and_validates_seed(self):
         store = AtlasStore.load()
         assert store.model.schema_ == ATLAS_SCHEMA_V1
-        assert {e.id for e in store.entries} == EXPECTED_PRIMITIVE_IDS
+        assert {e.id for e in store.entries} == EXPECTED_PRIMITIVE_IDS | EXPECTED_SURFACE_IDS
 
-    def test_all_seed_entries_are_complete_primitives(self):
-        """Every v1 entry is a primitive with the load-bearing fields filled:
-        a one-line summary, a narrative, and search keywords."""
+    def test_all_seed_entries_are_complete(self):
+        """Every entry has the load-bearing fields filled: a one-line
+        summary, a narrative, and search keywords."""
         for entry in AtlasStore.load().entries:
-            assert entry.kind == "primitive"
+            assert entry.kind in ("primitive", "surface")
             assert entry.name
             assert entry.summary and "\n" not in entry.summary.strip()
             assert entry.narrative
             assert entry.keywords, f"{entry.id} must carry search keywords"
+
+    def test_surface_entries_carry_a_route(self):
+        """Every kind='surface' entry points at a real client route: the
+        ``surface`` field is a rooted path and the id is 'surface:<slug>'."""
+        surfaces = [e for e in AtlasStore.load().entries if e.kind == "surface"]
+        assert {e.id for e in surfaces} == EXPECTED_SURFACE_IDS
+        for entry in surfaces:
+            assert entry.id.startswith("surface:")
+            assert entry.surface.startswith("/"), f"{entry.id} must carry a rooted route"
+
+    def test_primitives_cross_link_home_surfaces(self):
+        """Primitives with a natural home route carry it in ``surface`` so
+        atlas_describe answers include where to see the result."""
+        store = AtlasStore.load()
+        for primitive_id, route in EXPECTED_PRIMITIVE_SURFACES.items():
+            entry = store.describe(primitive_id)
+            assert entry is not None
+            assert entry.surface == route
 
     def test_singleton_getter_returns_same_instance(self):
         assert get_atlas_store() is get_atlas_store()
@@ -73,6 +133,14 @@ class TestSearch:
     def test_empty_query_returns_empty(self):
         assert AtlasStore.load().search("   ") == []
 
+    def test_publish_a_website_surfaces_sites_with_route(self):
+        """'publish a website' must rank a sites entry (surface:sites or
+        primitive:sites) into the results, with the /sites route populated."""
+        results = AtlasStore.load().search("publish a website")
+        sites_hits = [e for e in results if e.id in ("surface:sites", "primitive:sites")]
+        assert sites_hits, f"expected a sites entry, got {[e.id for e in results]}"
+        assert all(e.surface == "/sites" for e in sites_hits)
+
 
 class TestDescribe:
     def test_describe_instinct_returns_narrative_and_how(self):
@@ -83,3 +151,14 @@ class TestDescribe:
 
     def test_unknown_id_returns_none(self):
         assert AtlasStore.load().describe("primitive:does-not-exist") is None
+
+    def test_describe_primitive_sites_includes_surface_route(self):
+        entry = AtlasStore.load().describe("primitive:sites")
+        assert entry is not None
+        assert entry.surface == "/sites"
+
+    def test_describe_surface_entry_returns_route(self):
+        entry = AtlasStore.load().describe("surface:sites")
+        assert entry is not None
+        assert entry.kind == "surface"
+        assert entry.surface == "/sites"

--- a/tests/atlas/test_store.py
+++ b/tests/atlas/test_store.py
@@ -1,0 +1,85 @@
+# tests/atlas/test_store.py — AtlasStore loader / search / describe (AT-1).
+# Created: 2026-07-02 (feat/atlas-core). Proves the packaged seed validates
+# against paw.atlas/v1 with all 10 primitive entries, intent search ranks
+# the right primitive into the top results ("approve agent actions" →
+# Instinct, "build an app dashboard" → Pocket), describe returns the full
+# narrative, unknown ids return None, and the seed round-trips the schema.
+
+import json
+
+from pocketpaw.atlas.model import ATLAS_SCHEMA_V1, AtlasModel
+from pocketpaw.atlas.store import _DATA_PATH, AtlasStore, get_atlas_store
+
+EXPECTED_PRIMITIVE_IDS = {
+    "primitive:pocket",
+    "primitive:instinct",
+    "primitive:fabric",
+    "primitive:connector",
+    "primitive:ripple",
+    "primitive:soul",
+    "primitive:branch",
+    "primitive:workspace-jobs",
+    "primitive:sites",
+    "primitive:belt",
+}
+
+
+class TestLoader:
+    def test_loads_and_validates_seed(self):
+        store = AtlasStore.load()
+        assert store.model.schema_ == ATLAS_SCHEMA_V1
+        assert {e.id for e in store.entries} == EXPECTED_PRIMITIVE_IDS
+
+    def test_all_seed_entries_are_complete_primitives(self):
+        """Every v1 entry is a primitive with the load-bearing fields filled:
+        a one-line summary, a narrative, and search keywords."""
+        for entry in AtlasStore.load().entries:
+            assert entry.kind == "primitive"
+            assert entry.name
+            assert entry.summary and "\n" not in entry.summary.strip()
+            assert entry.narrative
+            assert entry.keywords, f"{entry.id} must carry search keywords"
+
+    def test_singleton_getter_returns_same_instance(self):
+        assert get_atlas_store() is get_atlas_store()
+
+    def test_seed_round_trips_the_schema(self):
+        """Raw seed → model → dump (by alias) → model again, byte-stable."""
+        raw = json.loads(_DATA_PATH.read_text(encoding="utf-8"))
+        model = AtlasModel.model_validate(raw)
+        dumped = model.model_dump(by_alias=True)
+        assert dumped["schema"] == ATLAS_SCHEMA_V1
+        assert AtlasModel.model_validate(dumped) == model
+
+
+class TestSearch:
+    def test_approve_agent_actions_hits_instinct(self):
+        results = AtlasStore.load().search("approve agent actions")
+        top_ids = [e.id for e in results[:3]]
+        assert "primitive:instinct" in top_ids, f"expected Instinct in top-3, got {top_ids}"
+
+    def test_build_an_app_dashboard_top_hits_pocket(self):
+        results = AtlasStore.load().search("build an app dashboard")
+        assert results, "query must match at least one entry"
+        assert results[0].id == "primitive:pocket"
+
+    def test_limit_is_respected(self):
+        results = AtlasStore.load().search("workspace data agents", limit=2)
+        assert len(results) <= 2
+
+    def test_no_overlap_returns_empty(self):
+        assert AtlasStore.load().search("zzzz qqqq xyzzy") == []
+
+    def test_empty_query_returns_empty(self):
+        assert AtlasStore.load().search("   ") == []
+
+
+class TestDescribe:
+    def test_describe_instinct_returns_narrative_and_how(self):
+        entry = AtlasStore.load().describe("primitive:instinct")
+        assert entry is not None
+        assert "gate" in entry.narrative.lower()
+        assert entry.how, "Instinct must document how it is exercised"
+
+    def test_unknown_id_returns_none(self):
+        assert AtlasStore.load().describe("primitive:does-not-exist") is None

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -1,5 +1,12 @@
 """Tests for MCP + Claude Agent SDK integration — Sprint 17.
 
+Updated: 2026-07-03 (integration/atlas AT-1) — ``_strip_builtin_servers`` now
+  also drops ``pocketpaw_atlas`` (the new always-on capability-atlas server:
+  atlas_search / atlas_describe, registered unconditionally in core
+  ``claude_sdk._get_mcp_servers``), so the external-config assertions stay
+  focused. ``test_startup_summary_no_servers`` additionally patches
+  ``build_atlas_context_server`` to None (same regime as the widgets server)
+  to keep the empty-server scenario truly empty.
 Updated: 2026-06-11 (feat/fabric-instinct-mcp-providers) —
   ``_strip_builtin_servers`` now also drops ``pocketpaw_fabric`` (fabric_query /
   fabric_stats) and ``pocketpaw_instinct`` (instinct_pending / instinct_audit),
@@ -83,6 +90,7 @@ from pocketpaw_ee.agent.pocket_specialist.mcp_tool import (
 )
 
 from pocketpaw.agents.claude_sdk import ClaudeAgentSDK
+from pocketpaw.agents.sdk_mcp_atlas import SERVER_NAME as _ATLAS_MCP_SERVER_NAME
 from pocketpaw.agents.sdk_mcp_widgets import SERVER_NAME as _WIDGETS_MCP_SERVER_NAME
 from pocketpaw.config import Settings
 from pocketpaw.mcp.config import MCPServerConfig
@@ -135,6 +143,11 @@ def _strip_builtin_servers(result: dict) -> dict:
     # read-only.
     out.pop(_FABRIC_MCP_SERVER_NAME, None)
     out.pop(_INSTINCT_MCP_SERVER_NAME, None)
+    # ``pocketpaw_atlas`` is always-on too — the capability atlas
+    # (atlas_search / atlas_describe) is registered unconditionally in core
+    # ``claude_sdk._get_mcp_servers`` so every agent can ground PocketPaw
+    # capabilities instead of guessing from LLM priors (AT-1).
+    out.pop(_ATLAS_MCP_SERVER_NAME, None)
     return out
 
 
@@ -546,6 +559,13 @@ class TestMcpProviderLoadFailures:
             patch("pocketpaw._registry.providers", return_value=[]),
             patch(
                 "pocketpaw.agents.sdk_mcp_widgets.build_widgets_context_server",
+                return_value=None,
+            ),
+            # The atlas server is always-on (AT-1) — patch its builder to None
+            # (same regime as the widgets server above) so the empty-server
+            # scenario stays truly empty.
+            patch(
+                "pocketpaw.agents.sdk_mcp_atlas.build_atlas_context_server",
                 return_value=None,
             ),
             caplog.at_level(logging.INFO, logger="pocketpaw.agents.claude_sdk"),


### PR DESCRIPTION
## What ships

Agents learn the frontend exists (stacks on #1612, sibling of #1613):

- **21 surface entries** in the atlas seed, one per real paw-enterprise route (verified against `src/routes/`): /, /chat, /pockets, /sites, /belt, /paw-print, /decisions-graph, /mission-control, /agents, /settings, /settings/workspace(/integrations), /knowledge, /files, /studio, /code, /foresight, /calendar, /meetings, /activity, /audit.
- **Primitive → home-route cross-links**: pocket→/pockets, instinct→/paw-print, connector→/settings/workspace/integrations, sites→/sites, belt→/belt. `atlas_describe` answers now carry the route, so agents can say "see it at /sites" after an action.
- **Paw OS Primer** — new always-on block in `context_builder` (same priority + try/except pattern as the skills block): OS identity, one line per primitive generated from the atlas store at build time, and the instruction to call `atlas_search` before guessing and to point users at surface routes. Measured ~1.6K chars (≈400 est. tokens), hard-capped at 2000 chars by the injection budget; atlas load failure degrades to no block, never a broken prompt.

Two honest gaps found while mapping: no dedicated billing route exists (plan info lives on /settings/workspace — the entry says so), and Instinct's decision surfaces are /paw-print + /decisions-graph, not a /decisions route.

## Testing

`tests/atlas/` + `tests/test_agents_md.py` → 53 passed. Primer tests are hermetic (mock memory manager, no machine-global config reads). ruff clean. Reviewed (spec + quality): pass; review's one important finding (non-hermetic tests) fixed before this PR, truncation cosmetics cleaned up.

Known accepted: the primer mentions atlas_search on all backends while the MCP server registers on the SDK backend — same exposure class as the existing skills block.