### PR TITLE
feat(atlas): compiled artifact — connector + senses extraction, CLI, drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@
 # 3.13 matrix only on push to dev/main; PRs test 3.12 alone (the prod version,
 # per the Dockerfile), so version-specific breaks are still caught at the merge
 # gate. The duplicate full-suite run in tests.yaml was removed in the same pass.
+# Updated: 2026-07-02 — lint job gains the `atlas build --check` freshness
+# gate (AT-4): the compiled atlas artifact (src/pocketpaw/atlas/data/
+# atlas.json) must match a fresh compile of authored entries + connector/
+# senses extraction, or the step fails with a diff summary.
 name: CI
 
 on:
@@ -54,6 +58,12 @@ jobs:
 
       - name: Ruff format check
         run: uv run ruff format --check .
+
+      # AT-4 — the checked-in atlas artifact is compiled (lockfile-style);
+      # fail with a diff summary when it lags the authored files or the
+      # connector YAMLs. Cheap: compiles to memory, byte-compare only.
+      - name: Atlas artifact freshness (atlas build --check)
+        run: uv run pocketpaw atlas build --check
 
   build:
     name: Build wheels

--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -11,6 +11,11 @@ the seed gains 21 kind="surface" entries (the paw-enterprise client's
 user-facing routes), primitives with a natural home route carry it in
 their `surface` field, and the context_builder injects an always-on
 "Paw OS Primer" block generated from the store.
+Updated: 2026-07-02 (feat/atlas-compiler, AT-4) — compiler: the data
+file is now a COMPILED artifact built by `pocketpaw atlas build` from
+hand-authored sources (atlas/authored/) + extracted connector and sense
+entries; CI gates freshness via `atlas build --check`; the store logs a
+stale-artifact WARNING on connector drift at first load.
 -->
 
 # Atlas — the OS self-model
@@ -22,17 +27,63 @@ the OS itself is and can do. The paw primitives carry paw-specific meanings
 typed knowledge graph, Belt = code assembly line, ...) that differ from LLM
 default meanings — atlas gives an agent ground truth instead of priors.
 
-The seed (`src/pocketpaw/atlas/data/atlas.json`, schema `paw.atlas/v1`)
-ships 10 `primitive` entries: Pocket, Instinct, Fabric, Connector, Ripple,
-Soul, Branch, workspace-jobs, Sites, Belt. Each entry carries a stable `id`
-(`primitive:pocket`), a one-line `summary`, a `narrative` (when to reach for
-it and what it pairs with), `how` (the tool/verb/API that exercises it), and
-search `keywords`. The kinds `capability`, `connector`, `widget`, and
-`skill` are reserved for later slices.
+The packaged model (`src/pocketpaw/atlas/data/atlas.json`, schema
+`paw.atlas/v1`) is a **compiled artifact** (see "Compiler" below). It carries
+10 hand-authored `primitive` entries — Pocket, Instinct, Fabric, Connector,
+Ripple, Soul, Branch, workspace-jobs, Sites, Belt — plus 21 authored
+`surface` entries and the extracted `connector` / `sense` entries. Each
+entry carries a stable `id` (`primitive:pocket`), a one-line `summary`, a
+`narrative` (when to reach for it and what it pairs with), `how` (the
+tool/verb/API that exercises it), and search `keywords`. The kinds
+`capability`, `widget`, and `skill` are reserved for later slices.
+
+## Compiler (`pocketpaw atlas build`)
+
+Since AT-4 the data file is built, not hand-edited:
+
+- **Authored sources** live in `src/pocketpaw/atlas/authored/` —
+  `primitives.json` (10 entries) and `surfaces.json` (21 entries), same
+  paw.atlas/v1 entry schema. Edit THESE, never `data/atlas.json`.
+- **Extracted `connector` entries** — the compiler
+  (`src/pocketpaw/atlas/compile.py`) parses every YAML in the repo's
+  `connectors/` dir and emits one `connector:<name>` entry per connector:
+  summary (display name, type, action count), a narrative listing every
+  ACTION (name + one-liner + param names) and the declared senses, and
+  search keywords from name/actions/senses. This is the slice that lets an
+  agent discover e.g. that Stripe supports `list_invoices` via
+  `atlas_search` instead of guessing.
+- **Extracted `sense` entries** — one `sense:<sense-id>` entry per
+  `CORE_SENSES` vocabulary item (`src/pocketpaw/senses/vocabulary.py`),
+  cross-linking the connectors that declare the sense (via
+  `connectors_for_sense`) in both narrative and `requires`.
+- **Deterministic output** — authored + extracted entries are sorted by id
+  and serialized with sorted keys, indent 2, and a trailing newline, so the
+  same inputs always produce byte-identical output. The compiled artifact
+  carries a `"generated": true` provenance header (authored files omit it).
+
+Commands (run from the repo root — the compiler reads `./connectors/`):
+
+```bash
+pocketpaw atlas build           # recompile and write data/atlas.json
+pocketpaw atlas build --check   # compile to memory; exit 1 + diff summary if stale
+```
+
+`data/atlas.json` is checked in like a lockfile. CI runs
+`uv run pocketpaw atlas build --check` in the lint job
+(`.github/workflows/ci.yml`), so a PR that edits authored files or connector
+YAMLs without regenerating the artifact fails with a summary of the
+added/removed/changed entry ids.
+
+**Startup drift warning:** the first `get_atlas_store()` call in a process
+(MCP server, primer build, CLI) compares the artifact's `connector:*` name
+set against the live connector YAML scan (the same home-dir + `connectors/`
+dirs the ConnectorRegistry reads). On mismatch it logs a WARNING — "atlas is
+stale — run `pocketpaw atlas build`" with the missing/extra names — and
+keeps serving. Name-set compare only, no recompile, and it never raises.
 
 ## Surface entries (`kind: "surface"`)
 
-The seed also maps the paw-enterprise client so agents know the frontend
+The authored set also maps the paw-enterprise client so agents know the frontend
 exists and can tell users where to go. Each `surface:*` entry mirrors a REAL
 user-facing route in `paw-enterprise/src/routes/` and carries the route path
 in its `surface` field:
@@ -120,9 +171,16 @@ atlas load failure never breaks prompt building. Tests:
 ```python
 from pocketpaw.atlas import get_atlas_store
 
-store = get_atlas_store()          # lazy singleton over the packaged seed
+store = get_atlas_store()          # lazy singleton over the compiled artifact
 store.search("approve agent actions", limit=5)  # ranked AtlasEntry list
-store.describe("primitive:instinct")            # full AtlasEntry or None
+store.describe("connector:stripe")              # full AtlasEntry or None
+
+from pocketpaw.atlas import check_artifact, compile_atlas, write_artifact
+compile_atlas()      # authored + extracted entries, sorted by id
+write_artifact()     # what `pocketpaw atlas build` calls
+check_artifact()     # (fresh, diff_summary) — what `--check` calls
 ```
 
-Tests: `tests/atlas/`.
+Tests: `tests/atlas/` (`test_compile.py` pins byte-determinism, the
+authored/compiled split, connector/sense extraction, `--check`, and the
+drift warning).

--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -1,6 +1,10 @@
 """PocketPaw entry point.
 
 Changes:
+  - 2026-07-02: Added `atlas build [--check]` subcommand (AT-4) — compiles
+                the atlas OS self-model artifact from authored entries +
+                connector/senses extraction. Early command; `--check` is
+                the CI freshness gate.
   - 2026-06-13: Added `pocket reconcile <id> [--apply]` subcommand
                 (P2.4 Template Reconcile). Thin CLI adapter — calls the
                 running dashboard's reconcile REST endpoints over loopback
@@ -128,6 +132,7 @@ _EARLY_COMMANDS = {
     "logs",
     "template",
     "pocket",
+    "atlas",
 }
 
 
@@ -227,6 +232,14 @@ def _handle_early_command(args) -> int | None:
             verify_key_path=getattr(args, "verify_key", None),
             no_prompt=getattr(args, "no_prompt", False),
             registry_path=getattr(args, "registry", None),
+        )
+
+    if cmd == "atlas":
+        from pocketpaw.cli.atlas import run_atlas_cmd
+
+        return run_atlas_cmd(
+            action=getattr(args, "subaction", None),
+            check=getattr(args, "check", False),
         )
 
     if cmd == "pocket":
@@ -378,6 +391,7 @@ Examples:
             "logs",
             "template",
             "pocket",
+            "atlas",
         ],
         help="Subcommand to run",
     )
@@ -459,6 +473,15 @@ Examples:
             "registered-tier surfaces errors)."
         ),
     )
+    # ── AT-4 atlas build flag ──
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "For `atlas build`: compile to memory and exit non-zero with a "
+            "diff summary if the checked-in artifact is stale (CI gate)"
+        ),
+    )
     # ── P2.4 pocket reconcile flags ──
     parser.add_argument(
         "--apply",
@@ -532,6 +555,9 @@ def _resolve_subargs(args) -> None:
         args.subaction = subargs[0]
         if len(subargs) > 1:
             args.query = subargs[1]
+    elif cmd == "atlas" and subargs:
+        # pocketpaw atlas build [--check]
+        args.subaction = subargs[0]
 
     if args.limit is None:
         defaults = {"errors": 20, "logs": 50, "sessions": 20, "memory": 10}

--- a/src/pocketpaw/atlas/__init__.py
+++ b/src/pocketpaw/atlas/__init__.py
@@ -1,15 +1,23 @@
 # atlas/__init__.py — package exports for the atlas primitive (AT-1).
+# Updated: 2026-07-02 (feat/atlas-compiler, AT-4) — export the compiler
+# (compile_atlas / write_artifact / check_artifact) and the startup
+# connector-drift check next to the store.
 # Created: 2026-07-02 (feat/atlas-core) — atlas is the runtime OS
 # self-model: a hand-authored capability map the product's runtime agents
 # (chat agent, pocket specialist) query to learn what the OS itself is
 # and can do, instead of guessing from LLM priors.
 
+from pocketpaw.atlas.compile import check_artifact, compile_atlas, write_artifact
 from pocketpaw.atlas.model import AtlasEntry, AtlasModel
-from pocketpaw.atlas.store import AtlasStore, get_atlas_store
+from pocketpaw.atlas.store import AtlasStore, check_connector_drift, get_atlas_store
 
 __all__ = [
     "AtlasEntry",
     "AtlasModel",
     "AtlasStore",
+    "check_artifact",
+    "check_connector_drift",
+    "compile_atlas",
     "get_atlas_store",
+    "write_artifact",
 ]

--- a/src/pocketpaw/atlas/authored/primitives.json
+++ b/src/pocketpaw/atlas/authored/primitives.json
@@ -1,0 +1,243 @@
+{
+  "schema": "paw.atlas/v1",
+  "entries": [
+    {
+      "id": "primitive:pocket",
+      "kind": "primitive",
+      "name": "Pocket",
+      "summary": "Workspace container holding agents, data, tools, connectors, KB scope, and Instinct rules; the \"app\" primitive.",
+      "narrative": "A Pocket is the 'app' primitive of the OS: one workspace container that holds agents, data, tools, connectors, KB scope, and Instinct rules. Reach for it when the user wants an interactive app, dashboard, or tracker — anything with a canvas and state. Pockets pair with Ripple (which renders their UI from a rippleSpec), with Connectors (which scope data into them), and with Sites (which publish a pocket as a standalone website). NOT clothing — a Pocket is a workspace app container.",
+      "how": "pocket_specialist__create / POST /api/v1/pockets (create), pocket_specialist__edit + POST /api/v1/pockets/<id>/spec/merge (edit)",
+      "surface": "/pockets",
+      "requires": [],
+      "keywords": [
+        "app",
+        "dashboard",
+        "tracker",
+        "workspace",
+        "canvas",
+        "container",
+        "tool",
+        "viewer",
+        "kanban",
+        "todo",
+        "build"
+      ]
+    },
+    {
+      "id": "primitive:instinct",
+      "kind": "primitive",
+      "name": "Instinct",
+      "summary": "The decision pipeline: agents PROPOSE actions, humans approve/reject/edit at a gate; captures reasoning traces.",
+      "narrative": "Instinct is the governance primitive: agents PROPOSE actions instead of executing them, and humans approve, reject, or edit each proposal at a gate. Every decision captures a reasoning trace. It is becoming a multi-lane triage router (auto / optimistic / escalate / dry-run + a trust ledger), with ASK as the default lane. Reach for it whenever an agent action needs governance — approvals, human review of agent writes, gated side effects. It pairs with Branch (which builds propose→review→merge on top of the gate) and Belt (where the human mans the Instinct gate on proposed diffs). NOT a biology term — Instinct is the approval pipeline.",
+      "how": "Instinct action store + gate APIs; agents emit proposals, humans resolve them at the gate",
+      "surface": "/paw-print",
+      "requires": [],
+      "keywords": [
+        "approve",
+        "approval",
+        "reject",
+        "review",
+        "gate",
+        "governance",
+        "propose",
+        "human in the loop",
+        "permission",
+        "triage",
+        "trust",
+        "audit"
+      ]
+    },
+    {
+      "id": "primitive:fabric",
+      "kind": "primitive",
+      "name": "Fabric",
+      "summary": "Typed ontology layer: typed objects (Customer, Competitor, Product…) and typed links (competes_with, raised, hired).",
+      "narrative": "Fabric is the workspace's knowledge graph: a typed ontology layer of typed objects (Customer, Competitor, Product, …) connected by typed links (competes_with, raised, hired). Reach for it when the user needs structured entities and relationships rather than free text — CRM-like records, competitor maps, org graphs. It pairs with Connectors (which feed external data into typed objects) and Pockets (which render fabric-backed views). NOT textile — Fabric is the typed object/link layer.",
+      "how": "fabric query surface (e.g. fabric_query / fabric_stats MCP tools where a fabric server is bound)",
+      "surface": "",
+      "requires": [],
+      "keywords": [
+        "ontology",
+        "knowledge graph",
+        "typed objects",
+        "entities",
+        "relationships",
+        "links",
+        "crm",
+        "records",
+        "graph",
+        "customer",
+        "competitor"
+      ]
+    },
+    {
+      "id": "primitive:connector",
+      "kind": "primitive",
+      "name": "Connector",
+      "summary": "Workspace-scoped data integration to external systems (Gmail, GCalendar, GDrive, Postgres…), each a typed YAML definition declaring senses.",
+      "narrative": "A Connector is a workspace-scoped data integration to an external system — Gmail, Google Calendar, Google Drive, Postgres, GitHub, and so on. Each connector is a typed YAML definition declaring its senses (what it can read and act on). Reach for it when the user wants their external data or accounts wired into the workspace. Connectors pair with Pockets (they bind into a pocket's scope), Fabric (they feed typed objects), and skills (a bound connector auto-surfaces its skill into the room). NOT an electrical part — a Connector is a data integration.",
+      "how": "connector registry + typed YAML definitions; bind a connector to a pocket to expose its senses",
+      "surface": "/settings/workspace/integrations",
+      "requires": [],
+      "keywords": [
+        "integration",
+        "gmail",
+        "calendar",
+        "drive",
+        "postgres",
+        "github",
+        "external data",
+        "sync",
+        "bind",
+        "senses",
+        "oauth",
+        "connect"
+      ]
+    },
+    {
+      "id": "primitive:ripple",
+      "kind": "primitive",
+      "name": "Ripple",
+      "summary": "Generative UI layer: pockets describe WHAT to show as a rippleSpec; Ripple renders it as live Svelte UI (~190 widgets).",
+      "narrative": "Ripple is the generative UI layer of the OS: a pocket (or the chat agent) describes WHAT to show as a rippleSpec — a declarative JSON tree — and Ripple renders it as live Svelte UI from a catalog of ~190 widgets. Reach for it whenever UI needs to be produced from a description: dashboards, charts, forms, feeds, flows. It pairs with Pockets (every pocket canvas is a rippleSpec) and Sites (landing pages render ripple specs on the edge). NOT a water effect — Ripple is the widget rendering layer.",
+      "how": "author a rippleSpec; get_widget_spec / get_inline_widget_help fetch canonical prop schemas, start_flow scaffolds multi-step flows",
+      "surface": "",
+      "requires": [],
+      "keywords": [
+        "ui",
+        "widgets",
+        "render",
+        "rippleSpec",
+        "svelte",
+        "chart",
+        "form",
+        "generative ui",
+        "canvas",
+        "spec",
+        "component"
+      ]
+    },
+    {
+      "id": "primitive:soul",
+      "kind": "primitive",
+      "name": "Soul",
+      "summary": "Persistent agent identity/memory (.soul files, OCEAN personality, 5-tier memory: core/episodic/semantic/procedural/…).",
+      "narrative": "Soul is the persistent agent identity and memory primitive: identity lives in portable .soul files with an OCEAN personality model and a 5-tier memory architecture (core / episodic / semantic / procedural / …). Reach for it when an agent needs to remember across sessions, carry a stable personality, or migrate identity between platforms. It pairs with the chat agent (soul recall feeds prompt context) and the Digital Soul Protocol (the open spec behind the file format). NOT a religious term — Soul is agent identity + memory.",
+      "how": "soul CLI / soul memory APIs: soul remember, soul recall, soul status against a .soul file",
+      "surface": "",
+      "requires": [],
+      "keywords": [
+        "memory",
+        "identity",
+        "personality",
+        "remember",
+        "recall",
+        "persistent",
+        "ocean",
+        "episodic",
+        "semantic",
+        "procedural",
+        ".soul"
+      ]
+    },
+    {
+      "id": "primitive:branch",
+      "kind": "primitive",
+      "name": "Branch",
+      "summary": "Universal version-control + review for any artifact keyed by (scope_type, scope_id): propose → branch → review → merge/publish + revert.",
+      "narrative": "Branch is universal version-control + review for ANY artifact, keyed by (scope_type, scope_id): propose → branch → review → merge/publish, plus diff and revert. It is built on the Instinct gate + Journal, so every merge is a governed decision with history. Reach for it when a change to an artifact (a site, a spec, a config) should be reviewed before it goes live, or when the user wants to compare or roll back versions. Sites are the first consumer. NOT only git — Branch versions any workspace artifact.",
+      "how": "branch primitive APIs: propose / review / merge / publish / revert on a (scope_type, scope_id) artifact",
+      "surface": "",
+      "requires": [
+        "primitive:instinct"
+      ],
+      "keywords": [
+        "version",
+        "review",
+        "merge",
+        "publish",
+        "revert",
+        "diff",
+        "propose",
+        "draft",
+        "rollback",
+        "history",
+        "changes"
+      ]
+    },
+    {
+      "id": "primitive:workspace-jobs",
+      "kind": "primitive",
+      "name": "workspace-jobs",
+      "summary": "ARQ-backed durable async-work primitive for long-running named jobs with writeback under a system identity.",
+      "narrative": "workspace-jobs is the durable async-work primitive: ARQ-backed, long-running named jobs that survive restarts and write results back under a system identity. Reach for it when work outlives a chat turn — imports, crawls, bulk enrichment, scheduled processing — anything that should keep running after the user walks away. It pairs with Connectors (long syncs run as jobs) and Pockets (job writeback lands in pocket data).",
+      "how": "enqueue a named job on the ARQ-backed workspace-jobs queue; results write back under the system identity",
+      "surface": "",
+      "requires": [],
+      "keywords": [
+        "background",
+        "async",
+        "job",
+        "queue",
+        "long-running",
+        "durable",
+        "schedule",
+        "worker",
+        "arq",
+        "batch",
+        "import"
+      ]
+    },
+    {
+      "id": "primitive:sites",
+      "kind": "primitive",
+      "name": "Sites",
+      "summary": "Publish a pocket as a real standalone website on the edge (static landing or dynamic with per-tenant D1).",
+      "narrative": "Sites publishes a pocket as a real standalone website on the edge — either a static landing page or a dynamic site backed by a per-tenant D1 database (reads AND writes against the customer's own live data). Reach for it when the user wants something ON THE WEB: a marketing page, a public guestbook, a booking list. A site is always published FROM a pocket; Sites pairs with Pocket (the source artifact), Ripple (landing rendering), and Branch (sites are the first consumer of propose→review→publish).",
+      "how": "publish flow: build/pick a pocket stamped type=\"site\", then publish it to the edge",
+      "surface": "/sites",
+      "requires": [
+        "primitive:pocket"
+      ],
+      "keywords": [
+        "website",
+        "publish",
+        "landing page",
+        "edge",
+        "domain",
+        "public",
+        "d1",
+        "static",
+        "dynamic",
+        "deploy",
+        "online"
+      ]
+    },
+    {
+      "id": "primitive:belt",
+      "kind": "primitive",
+      "name": "Belt",
+      "summary": "Autonomous software assembly line: AI runs the stations (orient → develop → propose), the human mans the Instinct gate; changes leave only as proposed diffs.",
+      "narrative": "Belt is the autonomous software assembly line: AI runs the stations — orient in the codebase, develop the change in a station worktree, propose the diff — and the human mans the Instinct gate. Changes NEVER land directly on the user's branches; they leave the station only as proposed diffs for review. Reach for it when the user asks to implement, fix, or refactor code with governed delivery. It pairs with Instinct (the gate every diff passes through) and Branch (governed change of artifacts generally). NOT a clothing item — Belt is the code assembly line.",
+      "how": "belt develop station: orient → develop → mcp__pocketpaw_belt__belt_propose_change through the Instinct gate",
+      "surface": "/belt",
+      "requires": [
+        "primitive:instinct"
+      ],
+      "keywords": [
+        "code",
+        "implement",
+        "fix",
+        "refactor",
+        "assembly line",
+        "diff",
+        "station",
+        "develop",
+        "propose change",
+        "coding",
+        "autonomous"
+      ]
+    }
+  ]
+}

--- a/src/pocketpaw/atlas/authored/surfaces.json
+++ b/src/pocketpaw/atlas/authored/surfaces.json
@@ -1,0 +1,413 @@
+{
+  "schema": "paw.atlas/v1",
+  "entries": [
+    {
+      "id": "surface:home",
+      "kind": "surface",
+      "name": "Home",
+      "summary": "The OS home screen: live Ripple widget grid, workspace activity feed, greeting, and chat pill.",
+      "narrative": "Home is the landing surface of the paw-enterprise client: a live widget grid (pinned pockets, the member 'intent of the day' board), an activity river, and a chat pill. Point a user here when they want their day at a glance or a place to start — everything else is one hop away.",
+      "how": "",
+      "surface": "/",
+      "requires": [],
+      "keywords": [
+        "home",
+        "start",
+        "overview",
+        "widget grid",
+        "landing",
+        "today",
+        "intent"
+      ]
+    },
+    {
+      "id": "surface:chat",
+      "kind": "surface",
+      "name": "Chat",
+      "summary": "Chat panel with the rooms rail: DMs, agent rooms, groups, channels, and entity rooms bound to pockets.",
+      "narrative": "Chat is where users talk to agents and each other: a rooms rail with DMs, agent rooms, groups, channels, plus entity rooms scoped to a pocket (/chat/<pocketId>). Point a user here to converse with an agent, resume a room, or work inside a pocket-bound conversation.",
+      "how": "",
+      "surface": "/chat",
+      "requires": [],
+      "keywords": [
+        "chat",
+        "rooms",
+        "dm",
+        "message",
+        "conversation",
+        "talk",
+        "agent room",
+        "channel",
+        "group"
+      ]
+    },
+    {
+      "id": "surface:pockets",
+      "kind": "surface",
+      "name": "Pockets",
+      "summary": "Pockets dashboard: the list of workspace pockets plus the canvas detail view for each one.",
+      "narrative": "The Pockets surface lists every pocket in the workspace and opens each one's live canvas (/pockets/<id>). After creating or editing a pocket, point the user here to see and use it. This is the home surface of the Pocket primitive.",
+      "how": "",
+      "surface": "/pockets",
+      "requires": [
+        "primitive:pocket"
+      ],
+      "keywords": [
+        "pockets",
+        "canvas",
+        "dashboard",
+        "apps",
+        "open pocket",
+        "workspace apps",
+        "tracker"
+      ]
+    },
+    {
+      "id": "surface:sites",
+      "kind": "surface",
+      "name": "Sites",
+      "summary": "Sites gallery: published Paw Sites as cards, with a chat rail that drives the create-and-publish flow.",
+      "narrative": "The Sites surface shows the workspace's published websites as a card gallery and opens each site's detail (/sites/<siteId>). Describing a site in its chat rail triggers the create-then-publish flow. After publishing a website, point the user here to see the live site and manage it.",
+      "how": "",
+      "surface": "/sites",
+      "requires": [
+        "primitive:sites"
+      ],
+      "keywords": [
+        "sites",
+        "website",
+        "publish",
+        "landing page",
+        "gallery",
+        "domain",
+        "live site",
+        "online"
+      ]
+    },
+    {
+      "id": "surface:belt",
+      "kind": "surface",
+      "name": "Belt",
+      "summary": "Belt develop-station console: repo picker, run cards, and a read-only diff viewer, chat-first.",
+      "narrative": "The Belt surface is where a human hands the develop station a coding task and watches it run: repo picker, run cards, and the read-only diff viewer, with the station agent in the chat rail. Point a user here to request code changes or review proposed diffs. This is the home surface of the Belt primitive.",
+      "how": "",
+      "surface": "/belt",
+      "requires": [
+        "primitive:belt"
+      ],
+      "keywords": [
+        "belt",
+        "coding task",
+        "diff",
+        "station",
+        "develop",
+        "code change",
+        "proposed change"
+      ]
+    },
+    {
+      "id": "surface:paw-print",
+      "kind": "surface",
+      "name": "Paw Print",
+      "summary": "Org-wide decision feed: recent Instinct corrections across the workspace's pockets, with diff viewers.",
+      "narrative": "Paw Print is the org-wide decision feed — recent Instinct corrections across the workspace, each rendered through a diff viewer. Point a user here to review what decisions agents and humans have been making. It is the decision-feed home of the Instinct primitive; the historical query layer is /decisions-graph.",
+      "how": "",
+      "surface": "/paw-print",
+      "requires": [
+        "primitive:instinct"
+      ],
+      "keywords": [
+        "decisions",
+        "corrections",
+        "feed",
+        "governance",
+        "what happened",
+        "instinct",
+        "review decisions"
+      ]
+    },
+    {
+      "id": "surface:decisions-graph",
+      "kind": "surface",
+      "name": "Decision Graph",
+      "summary": "Visual query layer over the historical Decision projection: trace a decision's graph by id, depth, and mode.",
+      "narrative": "Decision Graph lets an operator query the historical Decision projection visually — deep-linkable by decision id, depth, and mode. Point a user here to trace WHY a decision happened and what it connects to; for the live feed of recent decisions use /paw-print instead.",
+      "how": "",
+      "surface": "/decisions-graph",
+      "requires": [
+        "primitive:instinct"
+      ],
+      "keywords": [
+        "decision graph",
+        "trace",
+        "why",
+        "history",
+        "projection",
+        "drill down",
+        "audit trail"
+      ]
+    },
+    {
+      "id": "surface:mission-control",
+      "kind": "surface",
+      "name": "Mission Control",
+      "summary": "Operator surface: unified work feed with cycles, plan, activity, and analytics tabs, filterable by project.",
+      "narrative": "Mission Control is the operator surface — a unified work feed (Feed, Cycles, Analytics tabs) with per-item actions and project filters. Point a user here to run the workspace's ongoing work: what is in flight, what needs attention, and how it is trending.",
+      "how": "",
+      "surface": "/mission-control",
+      "requires": [],
+      "keywords": [
+        "mission control",
+        "operator",
+        "work feed",
+        "cycles",
+        "plan",
+        "analytics",
+        "in flight"
+      ]
+    },
+    {
+      "id": "surface:agents",
+      "kind": "surface",
+      "name": "Agents",
+      "summary": "Agents shell: the agent list plus a per-agent editor (identity, reasoning, soul evolution).",
+      "narrative": "The Agents surface lists the workspace's agents and opens each one's editor (/agents/<id>) — identity, reasoning, and soul evolution. Point a user here to create, inspect, or tune an agent.",
+      "how": "",
+      "surface": "/agents",
+      "requires": [],
+      "keywords": [
+        "agents",
+        "agent editor",
+        "personas",
+        "configure agent",
+        "plugins",
+        "soul",
+        "tune"
+      ]
+    },
+    {
+      "id": "surface:settings",
+      "kind": "surface",
+      "name": "Settings",
+      "summary": "Personal + workspace settings: profile, security, notifications, preferences, API keys, and the workspace admin area.",
+      "narrative": "Settings hosts per-user pages (profile, security, notifications, preferences, API keys) and the workspace admin area under /settings/workspace (members, channels, integrations, policy, memory, SSO, voice — including the workspace plan). Point a user here to change how their account or workspace behaves.",
+      "how": "",
+      "surface": "/settings",
+      "requires": [],
+      "keywords": [
+        "settings",
+        "profile",
+        "preferences",
+        "api keys",
+        "security",
+        "notifications",
+        "configure"
+      ]
+    },
+    {
+      "id": "surface:integrations",
+      "kind": "surface",
+      "name": "Integrations",
+      "summary": "Workspace-level third-party credentials: web search, OAuth apps, image generation providers.",
+      "narrative": "The Integrations settings page manages workspace-level third-party credentials (web search, OAuth apps, image generation). Point a user here to wire up or fix an external service; connectors bound to pockets draw on these credentials. This is the home surface of the Connector primitive.",
+      "how": "",
+      "surface": "/settings/workspace/integrations",
+      "requires": [
+        "primitive:connector"
+      ],
+      "keywords": [
+        "integrations",
+        "credentials",
+        "oauth",
+        "connect",
+        "api key",
+        "external service",
+        "providers"
+      ]
+    },
+    {
+      "id": "surface:workspace-admin",
+      "kind": "surface",
+      "name": "Workspace Admin",
+      "summary": "Workspace administration: name, plan, members, channels, integrations, memory, policy, SSO, voice, advanced.",
+      "narrative": "Workspace Admin is the workspace-scoped settings area: workspace name and plan, members, channels, integrations, memory, policy, SSO, voice, and advanced options. Point a user here for anything that affects the whole workspace — including checking the current plan. There is no dedicated billing route today; plan info lives here.",
+      "how": "",
+      "surface": "/settings/workspace",
+      "requires": [],
+      "keywords": [
+        "workspace",
+        "admin",
+        "members",
+        "plan",
+        "billing",
+        "usage",
+        "policy",
+        "sso",
+        "channels"
+      ]
+    },
+    {
+      "id": "surface:knowledge",
+      "kind": "surface",
+      "name": "Knowledge",
+      "summary": "Workspace knowledge-base browser: compiled articles from source files and documents, searchable.",
+      "narrative": "The Knowledge surface hosts the workspace-level KB browser — compiled, searchable articles built from the workspace's files and sources. Point a user here to read or verify what the workspace knows about a topic.",
+      "how": "",
+      "surface": "/knowledge",
+      "requires": [],
+      "keywords": [
+        "knowledge base",
+        "kb",
+        "articles",
+        "wiki",
+        "search knowledge",
+        "docs"
+      ]
+    },
+    {
+      "id": "surface:files",
+      "kind": "surface",
+      "name": "Files",
+      "summary": "Workspace file browser panel.",
+      "narrative": "The Files surface is the workspace file browser. Point a user here to browse, inspect, or manage the files the workspace holds — including files that feed the knowledge base.",
+      "how": "",
+      "surface": "/files",
+      "requires": [],
+      "keywords": [
+        "files",
+        "browser",
+        "documents",
+        "uploads",
+        "folders"
+      ]
+    },
+    {
+      "id": "surface:studio",
+      "kind": "surface",
+      "name": "Studio",
+      "summary": "Media generation gallery: describe an image or short video in the rail and the agent generates it into the gallery.",
+      "narrative": "Studio is the media-generation surface: the user describes an image or short video in the chat rail, the agent generates it, and results land in a gallery pocket on the left. Point a user here for any describe-to-media request.",
+      "how": "",
+      "surface": "/studio",
+      "requires": [],
+      "keywords": [
+        "studio",
+        "image",
+        "video",
+        "generate",
+        "media",
+        "poster",
+        "illustration",
+        "gallery"
+      ]
+    },
+    {
+      "id": "surface:code",
+      "kind": "surface",
+      "name": "Code",
+      "summary": "In-browser IDE: real workspace file tree, editor tabs, and an agent-side edit-run-verify loop.",
+      "narrative": "The Code surface is an in-browser IDE over the shared workspace: a real file tree, editor tabs, and an honest activity indicator while the agent does the work agent-side. Point a user here to read or edit workspace code with the agent alongside.",
+      "how": "",
+      "surface": "/code",
+      "requires": [],
+      "keywords": [
+        "code",
+        "ide",
+        "editor",
+        "file tree",
+        "scripts",
+        "edit code"
+      ]
+    },
+    {
+      "id": "surface:foresight",
+      "kind": "surface",
+      "name": "Foresight",
+      "summary": "Scenario rehearsal: create, run, and compare what-if scenarios (runs, insights, fabric, aggregate views).",
+      "narrative": "Foresight is the rehearsal surface: create what-if scenarios, run them, and inspect runs, insights, and aggregate views before committing to a decision. Point a user here to rehearse, simulate, or forecast a decision.",
+      "how": "",
+      "surface": "/foresight",
+      "requires": [],
+      "keywords": [
+        "foresight",
+        "scenario",
+        "simulate",
+        "rehearse",
+        "forecast",
+        "what if",
+        "runs",
+        "insights"
+      ]
+    },
+    {
+      "id": "surface:calendar",
+      "kind": "surface",
+      "name": "Calendar",
+      "summary": "Workspace calendar (operator surface).",
+      "narrative": "The Calendar surface shows the workspace calendar. Point a user here to see upcoming events; calendar data arrives via bound connectors (e.g. Google Calendar).",
+      "how": "",
+      "surface": "/calendar",
+      "requires": [],
+      "keywords": [
+        "calendar",
+        "events",
+        "schedule",
+        "upcoming",
+        "meetings schedule"
+      ]
+    },
+    {
+      "id": "surface:meetings",
+      "kind": "surface",
+      "name": "Meetings",
+      "summary": "Unified meetings timeline.",
+      "narrative": "The Meetings surface is the unified meetings timeline. Point a user here to review past and upcoming meetings and their details; meeting preferences live at /settings/meetings.",
+      "how": "",
+      "surface": "/meetings",
+      "requires": [],
+      "keywords": [
+        "meetings",
+        "timeline",
+        "recordings",
+        "notes",
+        "transcript"
+      ]
+    },
+    {
+      "id": "surface:activity",
+      "kind": "surface",
+      "name": "Activity",
+      "summary": "Workspace activity feed, polled live; shares its source with the home river.",
+      "narrative": "The Activity surface is the workspace-wide activity feed (same source as the home screen's river, polled live). Point a user here to see what has been happening across the workspace recently.",
+      "how": "",
+      "surface": "/activity",
+      "requires": [],
+      "keywords": [
+        "activity",
+        "feed",
+        "recent",
+        "events",
+        "river",
+        "what happened"
+      ]
+    },
+    {
+      "id": "surface:audit",
+      "kind": "surface",
+      "name": "Audit",
+      "summary": "Workspace audit log.",
+      "narrative": "The Audit surface is the workspace audit log — the compliance-grade record of actions. Point a user here when they need the authoritative trail of who or what did something; for a lighter live feed use /activity.",
+      "how": "",
+      "surface": "/audit",
+      "requires": [],
+      "keywords": [
+        "audit",
+        "log",
+        "compliance",
+        "trail",
+        "record",
+        "who did what"
+      ]
+    }
+  ]
+}

--- a/src/pocketpaw/atlas/compile.py
+++ b/src/pocketpaw/atlas/compile.py
@@ -1,0 +1,271 @@
+# atlas/compile.py — deterministic compiler for the atlas OS self-model
+# (AT-4). Created: 2026-07-02 (feat/atlas-compiler).
+#
+# Turns the hand-authored seed into a COMPILED artifact:
+#   authored entries (``atlas/authored/primitives.json`` + ``surfaces.json``)
+#   + extracted ``connector`` entries (one per connector YAML in the repo's
+#     connectors/ dir — summary, ACTIONS with one-liners + param names,
+#     declared senses, search keywords)
+#   + extracted ``sense`` entries (one per CORE_SENSES vocabulary entry,
+#     cross-linking the connectors that declare it)
+# sorted by id and serialized with sorted keys + fixed indent + trailing
+# newline so the output is BYTE-DETERMINISTIC (same inputs → identical
+# file). ``atlas/data/atlas.json`` is the checked-in compiled artifact
+# (lockfile-style, ``"generated": true``); CI runs
+# ``pocketpaw atlas build --check`` to keep it fresh.
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pocketpaw.atlas.model import AtlasEntry, AtlasModel
+from pocketpaw.atlas.store import _DATA_PATH
+
+if TYPE_CHECKING:
+    from pocketpaw.connectors.yaml_engine import ConnectorDef
+
+logger = logging.getLogger(__name__)
+
+# Hand-authored source files, compiled in this order (before id-sorting).
+_AUTHORED_DIR = Path(__file__).parent / "authored"
+AUTHORED_FILES = (
+    _AUTHORED_DIR / "primitives.json",
+    _AUTHORED_DIR / "surfaces.json",
+)
+
+# Where connector YAML definitions live, relative to the repo root (the
+# same default dir ConnectorRegistry scans). The compiler reads ONLY the
+# repo dir — never ~/.pocketpaw/connectors — so the checked-in artifact
+# reflects the repo, not one developer's machine.
+DEFAULT_CONNECTORS_DIR = Path("connectors")
+
+# Every connector entry points users at the integrations surface.
+_INTEGRATIONS_ROUTE = "/settings/workspace/integrations"
+
+
+def load_authored_entries() -> list[AtlasEntry]:
+    """Load and validate the hand-authored entry files."""
+    entries: list[AtlasEntry] = []
+    for path in AUTHORED_FILES:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        entries.extend(AtlasModel.model_validate(raw).entries)
+    return entries
+
+
+def _load_connector_defs(connectors_dir: Path) -> list[ConnectorDef]:
+    """Parse every connector YAML in ``connectors_dir``, sorted by name.
+
+    Malformed YAMLs are skipped with a warning (mirrors the registry's
+    scan behavior) so one bad file can't block the build.
+    """
+    from pocketpaw.connectors.yaml_engine import parse_connector_yaml
+
+    defs = []
+    for path in sorted(connectors_dir.glob("*.yaml")):
+        try:
+            defs.append(parse_connector_yaml(path))
+        except Exception as exc:  # noqa: BLE001 — skip malformed, keep compiling
+            logger.warning("atlas compile: skipping malformed connector YAML %s: %s", path, exc)
+    return sorted(defs, key=lambda d: d.name)
+
+
+def _connector_entry(defn: ConnectorDef) -> AtlasEntry:
+    """Extract one ``kind:"connector"`` atlas entry from a parsed YAML def.
+
+    The narrative is the load-bearing slice: it lists every ACTION (name +
+    one-line description + param names) and the declared senses, so an
+    agent can discover e.g. that Stripe supports ``list_invoices`` without
+    guessing from priors.
+    """
+    action_names: list[str] = []
+    action_bits: list[str] = []
+    for action in defn.actions:
+        name = str(action.get("name", "")).strip()
+        if not name:
+            continue
+        action_names.append(name)
+        desc = str(action.get("description", "")).strip().rstrip(".")
+        params = list((action.get("params") or {}).keys())
+        bit = f"{name} — {desc}" if desc else name
+        if params:
+            bit += f" (params: {', '.join(params)})"
+        action_bits.append(bit)
+
+    preview = ", ".join(action_names[:4])
+    more = f", +{len(action_names) - 4} more" if len(action_names) > 4 else ""
+    summary = (
+        f"{defn.display_name} ({defn.type}) connector — "
+        f"{len(action_names)} actions: {preview}{more}."
+    )
+
+    narrative = (
+        f"The {defn.display_name} connector ({defn.type}) wires "
+        f"{defn.display_name} data into the workspace. "
+        f"ACTIONS: {'; '.join(action_bits)}."
+    )
+    if defn.senses:
+        narrative += f" Declared senses: {', '.join(defn.senses)}."
+
+    keywords: list[str] = []
+    for word in [defn.name, defn.display_name.lower(), defn.type, *action_names] + [
+        _sense_domain(s) for s in defn.senses
+    ]:
+        if word and word not in keywords:
+            keywords.append(word)
+
+    return AtlasEntry(
+        id=f"connector:{defn.name}",
+        kind="connector",
+        name=defn.display_name,
+        summary=summary,
+        narrative=narrative,
+        how=(
+            f"list_connector_actions / connector_execute over the "
+            f"'{defn.name}' connector once it is bound"
+        ),
+        surface=_INTEGRATIONS_ROUTE,
+        requires=["primitive:connector"],
+        keywords=keywords,
+    )
+
+
+def _sense_domain(sense_id: str) -> str:
+    """'paw.payments.v1' → 'payments' (the searchable domain word)."""
+    parts = sense_id.split(".")
+    return parts[1] if len(parts) >= 2 else sense_id
+
+
+def _sense_entries(defs: list[ConnectorDef]) -> list[AtlasEntry]:
+    """Extract one ``kind:"sense"`` entry per CORE_SENSES vocabulary item.
+
+    Each entry cross-links the connectors that declare the sense (via the
+    static ``connectors_for_sense`` index) so an agent can go from a
+    capability ("email") to the concrete connectors that fill it.
+    """
+    from pocketpaw.senses.vocabulary import CORE_SENSES, connectors_for_sense
+
+    entries: list[AtlasEntry] = []
+    for sense in CORE_SENSES:
+        declaring = connectors_for_sense(sense.id, defs)  # already sorted
+        narrative = (
+            f"{sense.description} A Sense is a provider-agnostic capability "
+            f"above connectors: templates and agents address the sense id "
+            f"({sense.id}) and the resolver binds it to whichever declaring "
+            f"connector the workspace enabled."
+        )
+        if declaring:
+            narrative += f" Connectors declaring this sense: {', '.join(declaring)}."
+
+        keywords: list[str] = []
+        for word in [_sense_domain(sense.id), sense.display_name.lower(), *declaring]:
+            if word and word not in keywords:
+                keywords.append(word)
+
+        entries.append(
+            AtlasEntry(
+                id=f"sense:{sense.id}",
+                kind="sense",
+                name=sense.display_name,
+                summary=sense.description,
+                narrative=narrative,
+                how=(
+                    "bind a declaring connector; connectors declare senses in "
+                    "their YAML (senses: [...]), resolved via connectors_for_sense"
+                ),
+                surface=_INTEGRATIONS_ROUTE,
+                requires=[f"connector:{name}" for name in declaring],
+                keywords=keywords,
+            )
+        )
+    return entries
+
+
+def compile_atlas(connectors_dir: Path | None = None) -> AtlasModel:
+    """Compile authored + extracted entries into one model, sorted by id."""
+    connectors_dir = connectors_dir or DEFAULT_CONNECTORS_DIR
+    defs = _load_connector_defs(connectors_dir)
+    entries = load_authored_entries()
+    entries.extend(_connector_entry(d) for d in defs)
+    entries.extend(_sense_entries(defs))
+    entries.sort(key=lambda e: e.id)
+    return AtlasModel(generated=True, entries=entries)
+
+
+def serialize_atlas(model: AtlasModel) -> bytes:
+    """Byte-deterministic serialization: sorted keys, indent 2, trailing \\n."""
+    payload = model.model_dump(by_alias=True)
+    return (json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n").encode(
+        "utf-8"
+    )
+
+
+def compile_atlas_bytes(connectors_dir: Path | None = None) -> bytes:
+    """Compile straight to the exact bytes the artifact file would hold."""
+    return serialize_atlas(compile_atlas(connectors_dir))
+
+
+def write_artifact(
+    output_path: Path | None = None, connectors_dir: Path | None = None
+) -> tuple[Path, AtlasModel]:
+    """Compile and write the artifact (default: the packaged data file)."""
+    path = output_path or _DATA_PATH
+    model = compile_atlas(connectors_dir)
+    path.write_bytes(serialize_atlas(model))
+    return path, model
+
+
+def check_artifact(
+    artifact_path: Path | None = None, connectors_dir: Path | None = None
+) -> tuple[bool, str]:
+    """Compile to memory and compare against the checked-in artifact.
+
+    Returns ``(fresh, diff_summary)`` — ``fresh`` is True when the bytes
+    match exactly; ``diff_summary`` explains the drift (added / removed /
+    changed entry ids, or a formatting-only note) for CI output.
+    """
+    path = artifact_path or _DATA_PATH
+    expected = compile_atlas_bytes(connectors_dir)
+    if not path.exists():
+        return False, f"artifact missing: {path}"
+    actual = path.read_bytes()
+    if actual == expected:
+        return True, ""
+
+    lines = [f"artifact stale: {path}"]
+    try:
+        actual_entries = {e["id"]: e for e in json.loads(actual)["entries"]}
+        expected_entries = {e["id"]: e for e in json.loads(expected)["entries"]}
+        added = sorted(set(expected_entries) - set(actual_entries))
+        removed = sorted(set(actual_entries) - set(expected_entries))
+        changed = sorted(
+            eid
+            for eid in set(actual_entries) & set(expected_entries)
+            if actual_entries[eid] != expected_entries[eid]
+        )
+        if added:
+            lines.append(f"  entries to add ({len(added)}): {', '.join(added[:10])}")
+        if removed:
+            lines.append(f"  entries to remove ({len(removed)}): {', '.join(removed[:10])}")
+        if changed:
+            lines.append(f"  entries changed ({len(changed)}): {', '.join(changed[:10])}")
+        if not (added or removed or changed):
+            lines.append("  entry content identical — header/formatting drift only")
+    except Exception:  # noqa: BLE001 — a corrupt artifact still reports stale
+        lines.append("  (checked-in artifact is not parseable JSON)")
+    lines.append("  fix: run `pocketpaw atlas build` from the repo root and commit the result")
+    return False, "\n".join(lines)
+
+
+__all__ = [
+    "AUTHORED_FILES",
+    "DEFAULT_CONNECTORS_DIR",
+    "check_artifact",
+    "compile_atlas",
+    "compile_atlas_bytes",
+    "load_authored_entries",
+    "serialize_atlas",
+    "write_artifact",
+]

--- a/src/pocketpaw/atlas/data/atlas.json
+++ b/src/pocketpaw/atlas/data/atlas.json
@@ -1,346 +1,1630 @@
 {
-  "schema": "paw.atlas/v1",
   "entries": [
     {
-      "id": "primitive:pocket",
-      "kind": "primitive",
-      "name": "Pocket",
-      "summary": "Workspace container holding agents, data, tools, connectors, KB scope, and Instinct rules; the \"app\" primitive.",
-      "narrative": "A Pocket is the 'app' primitive of the OS: one workspace container that holds agents, data, tools, connectors, KB scope, and Instinct rules. Reach for it when the user wants an interactive app, dashboard, or tracker — anything with a canvas and state. Pockets pair with Ripple (which renders their UI from a rippleSpec), with Connectors (which scope data into them), and with Sites (which publish a pocket as a standalone website). NOT clothing — a Pocket is a workspace app container.",
-      "how": "pocket_specialist__create / POST /api/v1/pockets (create), pocket_specialist__edit + POST /api/v1/pockets/<id>/spec/merge (edit)",
-      "surface": "/pockets",
-      "requires": [],
-      "keywords": ["app", "dashboard", "tracker", "workspace", "canvas", "container", "tool", "viewer", "kanban", "todo", "build"]
+      "how": "list_connector_actions / connector_execute over the 'airtable' connector once it is bound",
+      "id": "connector:airtable",
+      "keywords": [
+        "airtable",
+        "database",
+        "list_bases",
+        "list_tables",
+        "list_records",
+        "get_record",
+        "create_record",
+        "update_record",
+        "search_records",
+        "create_records_batch"
+      ],
+      "kind": "connector",
+      "name": "Airtable",
+      "narrative": "The Airtable connector (database) wires Airtable data into the workspace. ACTIONS: list_bases — List all accessible Airtable bases; list_tables — List tables in a base with their fields (params: base_id); list_records — List records from a table (params: base_id, table_id, maxRecords, view, filterByFormula, sort); get_record — Get a specific record by ID (params: base_id, table_id, record_id); create_record — Create a new record in a table (params: base_id, table_id); update_record — Update an existing record (params: base_id, table_id, record_id); search_records — Search records with a formula filter (params: base_id, table_id, filterByFormula, maxRecords); create_records_batch — Create multiple records at once (up to 10) (params: base_id, table_id).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Airtable (database) connector — 8 actions: list_bases, list_tables, list_records, get_record, +4 more.",
+      "surface": "/settings/workspace/integrations"
     },
     {
-      "id": "primitive:instinct",
-      "kind": "primitive",
-      "name": "Instinct",
-      "summary": "The decision pipeline: agents PROPOSE actions, humans approve/reject/edit at a gate; captures reasoning traces.",
-      "narrative": "Instinct is the governance primitive: agents PROPOSE actions instead of executing them, and humans approve, reject, or edit each proposal at a gate. Every decision captures a reasoning trace. It is becoming a multi-lane triage router (auto / optimistic / escalate / dry-run + a trust ledger), with ASK as the default lane. Reach for it whenever an agent action needs governance — approvals, human review of agent writes, gated side effects. It pairs with Branch (which builds propose→review→merge on top of the gate) and Belt (where the human mans the Instinct gate on proposed diffs). NOT a biology term — Instinct is the approval pipeline.",
-      "how": "Instinct action store + gate APIs; agents emit proposals, humans resolve them at the gate",
-      "surface": "/paw-print",
-      "requires": [],
-      "keywords": ["approve", "approval", "reject", "review", "gate", "governance", "propose", "human in the loop", "permission", "triage", "trust", "audit"]
+      "how": "list_connector_actions / connector_execute over the 'bigquery' connector once it is bound",
+      "id": "connector:bigquery",
+      "keywords": [
+        "bigquery",
+        "google bigquery",
+        "database",
+        "execute_query",
+        "list_datasets",
+        "list_tables",
+        "describe_table",
+        "preview_table",
+        "list_jobs",
+        "get_job"
+      ],
+      "kind": "connector",
+      "name": "Google BigQuery",
+      "narrative": "The Google BigQuery connector (database) wires Google BigQuery data into the workspace. ACTIONS: execute_query — Execute a SQL query against BigQuery (params: query, project_id, max_results, use_legacy_sql); list_datasets — List datasets in the project (params: project_id); list_tables — List tables in a dataset (params: dataset_id, project_id); describe_table — Get schema for a table (params: dataset_id, table_id, project_id); preview_table — Preview rows from a table (params: dataset_id, table_id, limit); list_jobs — List recent query jobs (params: project_id, max_results, state_filter); get_job — Get details of a specific job (params: job_id, project_id).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Google BigQuery (database) connector — 7 actions: execute_query, list_datasets, list_tables, describe_table, +3 more.",
+      "surface": "/settings/workspace/integrations"
     },
     {
-      "id": "primitive:fabric",
-      "kind": "primitive",
-      "name": "Fabric",
-      "summary": "Typed ontology layer: typed objects (Customer, Competitor, Product…) and typed links (competes_with, raised, hired).",
-      "narrative": "Fabric is the workspace's knowledge graph: a typed ontology layer of typed objects (Customer, Competitor, Product, …) connected by typed links (competes_with, raised, hired). Reach for it when the user needs structured entities and relationships rather than free text — CRM-like records, competitor maps, org graphs. It pairs with Connectors (which feed external data into typed objects) and Pockets (which render fabric-backed views). NOT textile — Fabric is the typed object/link layer.",
-      "how": "fabric query surface (e.g. fabric_query / fabric_stats MCP tools where a fabric server is bound)",
-      "surface": "",
-      "requires": [],
-      "keywords": ["ontology", "knowledge graph", "typed objects", "entities", "relationships", "links", "crm", "records", "graph", "customer", "competitor"]
+      "how": "list_connector_actions / connector_execute over the 'confluence' connector once it is bound",
+      "id": "connector:confluence",
+      "keywords": [
+        "confluence",
+        "knowledge",
+        "search",
+        "list_spaces",
+        "get_page",
+        "get_page_children",
+        "list_space_pages",
+        "create_page",
+        "update_page",
+        "get_page_comments"
+      ],
+      "kind": "connector",
+      "name": "Confluence",
+      "narrative": "The Confluence connector (knowledge) wires Confluence data into the workspace. ACTIONS: search — Search Confluence content using CQL (params: cql, limit, expand); list_spaces — List all accessible spaces (params: limit, type); get_page — Get a specific page by ID (params: page_id, expand); get_page_children — List child pages of a page (params: page_id, limit); list_space_pages — List pages in a specific space (params: spaceKey, limit); create_page — Create a new Confluence page; update_page — Update an existing Confluence page (params: page_id); get_page_comments — Get comments on a page (params: page_id, limit, expand).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Confluence (knowledge) connector — 8 actions: search, list_spaces, get_page, get_page_children, +4 more.",
+      "surface": "/settings/workspace/integrations"
     },
     {
-      "id": "primitive:connector",
-      "kind": "primitive",
-      "name": "Connector",
-      "summary": "Workspace-scoped data integration to external systems (Gmail, GCalendar, GDrive, Postgres…), each a typed YAML definition declaring senses.",
-      "narrative": "A Connector is a workspace-scoped data integration to an external system — Gmail, Google Calendar, Google Drive, Postgres, GitHub, and so on. Each connector is a typed YAML definition declaring its senses (what it can read and act on). Reach for it when the user wants their external data or accounts wired into the workspace. Connectors pair with Pockets (they bind into a pocket's scope), Fabric (they feed typed objects), and skills (a bound connector auto-surfaces its skill into the room). NOT an electrical part — a Connector is a data integration.",
-      "how": "connector registry + typed YAML definitions; bind a connector to a pocket to expose its senses",
-      "surface": "/settings/workspace/integrations",
-      "requires": [],
-      "keywords": ["integration", "gmail", "calendar", "drive", "postgres", "github", "external data", "sync", "bind", "senses", "oauth", "connect"]
+      "how": "list_connector_actions / connector_execute over the 'csv' connector once it is bound",
+      "id": "connector:csv",
+      "keywords": [
+        "csv",
+        "file import",
+        "file",
+        "import_file",
+        "list_tables",
+        "preview_table",
+        "table_stats",
+        "query_table",
+        "drop_table",
+        "export_table"
+      ],
+      "kind": "connector",
+      "name": "File Import",
+      "narrative": "The File Import connector (file) wires File Import data into the workspace. ACTIONS: import_file — Import a CSV, Excel, JSON, or Parquet file into a pocket table (params: file_path, table_name, delimiter, has_header, encoding, sheet_name); list_tables — List imported tables in this pocket; preview_table — Preview rows from an imported table (params: table_name, limit); table_stats — Get row count, column types, and basic stats for a table (params: table_name); query_table — Run a SQL query against imported tables (params: query); drop_table — Remove an imported table from the pocket (params: table_name); export_table — Export a table to CSV file (params: table_name, output_path, format).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "File Import (file) connector — 7 actions: import_file, list_tables, preview_table, table_stats, +3 more.",
+      "surface": "/settings/workspace/integrations"
     },
     {
-      "id": "primitive:ripple",
-      "kind": "primitive",
-      "name": "Ripple",
-      "summary": "Generative UI layer: pockets describe WHAT to show as a rippleSpec; Ripple renders it as live Svelte UI (~190 widgets).",
-      "narrative": "Ripple is the generative UI layer of the OS: a pocket (or the chat agent) describes WHAT to show as a rippleSpec — a declarative JSON tree — and Ripple renders it as live Svelte UI from a catalog of ~190 widgets. Reach for it whenever UI needs to be produced from a description: dashboards, charts, forms, feeds, flows. It pairs with Pockets (every pocket canvas is a rippleSpec) and Sites (landing pages render ripple specs on the edge). NOT a water effect — Ripple is the widget rendering layer.",
-      "how": "author a rippleSpec; get_widget_spec / get_inline_widget_help fetch canonical prop schemas, start_flow scaffolds multi-step flows",
-      "surface": "",
-      "requires": [],
-      "keywords": ["ui", "widgets", "render", "rippleSpec", "svelte", "chart", "form", "generative ui", "canvas", "spec", "component"]
+      "how": "list_connector_actions / connector_execute over the 'datadog' connector once it is bound",
+      "id": "connector:datadog",
+      "keywords": [
+        "datadog",
+        "observability",
+        "list_monitors",
+        "search_monitors",
+        "query_metrics",
+        "list_events",
+        "list_dashboards",
+        "list_hosts",
+        "list_downtimes",
+        "search_logs",
+        "mute_monitor"
+      ],
+      "kind": "connector",
+      "name": "Datadog",
+      "narrative": "The Datadog connector (observability) wires Datadog data into the workspace. ACTIONS: list_monitors — List configured monitors and their statuses (params: page_size, group_states); search_monitors — Search monitors by query (params: query, per_page); query_metrics — Query time-series metrics (params: query, from, to); list_events — List recent events (params: start, end, priority); list_dashboards — List all dashboards; list_hosts — List infrastructure hosts (params: count, filter); list_downtimes — List scheduled downtimes; search_logs — Search logs; mute_monitor — Mute a monitor (params: monitor_id).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Datadog (observability) connector — 9 actions: list_monitors, search_monitors, query_metrics, list_events, +5 more.",
+      "surface": "/settings/workspace/integrations"
     },
     {
-      "id": "primitive:soul",
-      "kind": "primitive",
-      "name": "Soul",
-      "summary": "Persistent agent identity/memory (.soul files, OCEAN personality, 5-tier memory: core/episodic/semantic/procedural/…).",
-      "narrative": "Soul is the persistent agent identity and memory primitive: identity lives in portable .soul files with an OCEAN personality model and a 5-tier memory architecture (core / episodic / semantic / procedural / …). Reach for it when an agent needs to remember across sessions, carry a stable personality, or migrate identity between platforms. It pairs with the chat agent (soul recall feeds prompt context) and the Digital Soul Protocol (the open spec behind the file format). NOT a religious term — Soul is agent identity + memory.",
-      "how": "soul CLI / soul memory APIs: soul remember, soul recall, soul status against a .soul file",
-      "surface": "",
-      "requires": [],
-      "keywords": ["memory", "identity", "personality", "remember", "recall", "persistent", "ocean", "episodic", "semantic", "procedural", ".soul"]
+      "how": "list_connector_actions / connector_execute over the 'firebase' connector once it is bound",
+      "id": "connector:firebase",
+      "keywords": [
+        "firebase",
+        "cloud",
+        "list_projects",
+        "get_project",
+        "firestore_list_collections",
+        "firestore_databases_list",
+        "firestore_get",
+        "firestore_delete",
+        "firestore_export",
+        "auth_list_users",
+        "auth_import_users",
+        "hosting_list_sites",
+        "hosting_deploy",
+        "functions_list",
+        "functions_log",
+        "functions_deploy",
+        "remoteconfig_get",
+        "extensions_list"
+      ],
+      "kind": "connector",
+      "name": "Firebase",
+      "narrative": "The Firebase connector (cloud) wires Firebase data into the workspace. ACTIONS: list_projects — List all Firebase projects you have access to; get_project — Get details of a specific Firebase project (params: project_id); firestore_list_collections — List Firestore indexes and collection info for the project (params: database); firestore_databases_list — List all Firestore databases in the project; firestore_get — Get a Firestore document or collection at the given path (params: path, database); firestore_delete — Delete a Firestore document at the given path (params: path, recursive, database); firestore_export — Export Firestore data to a GCS bucket (params: destination, collection_ids, database); auth_list_users — Export user accounts from Firebase Auth as JSON (params: format); auth_import_users — Import users into Firebase Auth from a data file (params: data_file); hosting_list_sites — List all Firebase Hosting sites in the project; hosting_deploy — Deploy to Firebase Hosting (params: site); functions_list — List all deployed Cloud Functions in the project; functions_log — View recent Cloud Functions logs (params: function_name, limit); functions_deploy — Deploy Cloud Functions to Firebase (params: function_name); remoteconfig_get — Get the current Remote Config template for the project (params: version_number); extensions_list — List installed Firebase Extensions in the project.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Firebase (cloud) connector — 16 actions: list_projects, get_project, firestore_list_collections, firestore_databases_list, +12 more.",
+      "surface": "/settings/workspace/integrations"
     },
     {
+      "how": "list_connector_actions / connector_execute over the 'freshdesk' connector once it is bound",
+      "id": "connector:freshdesk",
+      "keywords": [
+        "freshdesk",
+        "support",
+        "list_tickets",
+        "search_tickets",
+        "get_ticket",
+        "create_ticket",
+        "reply_to_ticket",
+        "update_ticket",
+        "list_agents",
+        "list_contacts"
+      ],
+      "kind": "connector",
+      "name": "Freshdesk",
+      "narrative": "The Freshdesk connector (support) wires Freshdesk data into the workspace. ACTIONS: list_tickets — List support tickets with optional filters (params: filter, order_by, order_type, per_page); search_tickets — Search tickets using Freshdesk query language (params: query); get_ticket — Get ticket details including conversations (params: ticket_id, include); create_ticket — Create a new support ticket; reply_to_ticket — Add a reply to a ticket (params: ticket_id); update_ticket — Update ticket properties (params: ticket_id); list_agents — List helpdesk agents (params: per_page); list_contacts — List customer contacts (params: per_page).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Freshdesk (support) connector — 8 actions: list_tickets, search_tickets, get_ticket, create_ticket, +4 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'gcalendar' connector once it is bound",
+      "id": "connector:gcalendar",
+      "keywords": [
+        "gcalendar",
+        "google calendar",
+        "communication",
+        "calendar_list",
+        "calendar_create",
+        "calendar_prep",
+        "calendar_summary",
+        "calendar"
+      ],
+      "kind": "connector",
+      "name": "Google Calendar",
+      "narrative": "The Google Calendar connector (communication) wires Google Calendar data into the workspace. ACTIONS: calendar_list — List upcoming calendar events; calendar_create — Create a new calendar event; calendar_prep — Briefing for the next upcoming meeting; calendar_summary — Aggregate calendar stats (today / this week / busy hours) for the home widget. Declared senses: paw.calendar.v1.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Google Calendar (communication) connector — 4 actions: calendar_list, calendar_create, calendar_prep, calendar_summary.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'gcp' connector once it is bound",
+      "id": "connector:gcp",
+      "keywords": [
+        "gcp",
+        "google cloud platform",
+        "cloud",
+        "list_projects",
+        "get_project",
+        "storage_list_buckets",
+        "storage_list_objects",
+        "storage_get_object",
+        "storage_copy",
+        "storage_delete",
+        "pubsub_list_topics",
+        "pubsub_list_subscriptions",
+        "pubsub_publish",
+        "run_list_services",
+        "run_describe_service",
+        "run_list_revisions",
+        "secrets_list",
+        "secrets_get",
+        "secrets_create",
+        "logs_read",
+        "compute_list_instances",
+        "compute_describe_instance",
+        "iam_list_accounts"
+      ],
+      "kind": "connector",
+      "name": "Google Cloud Platform",
+      "narrative": "The Google Cloud Platform connector (cloud) wires Google Cloud Platform data into the workspace. ACTIONS: list_projects — List all accessible GCP projects; get_project — Get details of a specific GCP project (params: project_id); storage_list_buckets — List Cloud Storage buckets in the project; storage_list_objects — List objects in a Cloud Storage bucket (params: bucket, prefix); storage_get_object — Read the contents of a Cloud Storage object (params: bucket, path); storage_copy — Copy a file to/from Cloud Storage (params: src, dest); storage_delete — Delete an object from Cloud Storage (params: bucket, path); pubsub_list_topics — List Pub/Sub topics in the project; pubsub_list_subscriptions — List Pub/Sub subscriptions in the project; pubsub_publish — Publish a message to a Pub/Sub topic (params: topic, message); run_list_services — List Cloud Run services; run_describe_service — Get details of a Cloud Run service (params: name); run_list_revisions — List Cloud Run revisions; secrets_list — List secrets in Secret Manager; secrets_get — Access the latest version of a secret (params: name); secrets_create — Create a new secret in Secret Manager (params: name); logs_read — Read log entries from Cloud Logging (params: filter, limit); compute_list_instances — List Compute Engine VM instances; compute_describe_instance — Get details of a Compute Engine VM instance (params: name, zone); iam_list_accounts — List IAM service accounts in the project.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Google Cloud Platform (cloud) connector — 20 actions: list_projects, get_project, storage_list_buckets, storage_list_objects, +16 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'gdocs' connector once it is bound",
+      "id": "connector:gdocs",
+      "keywords": [
+        "gdocs",
+        "google docs",
+        "knowledge",
+        "docs_read",
+        "docs_create",
+        "docs_search",
+        "docs"
+      ],
+      "kind": "connector",
+      "name": "Google Docs",
+      "narrative": "The Google Docs connector (knowledge) wires Google Docs data into the workspace. ACTIONS: docs_read — Read the full text content of a Google Doc by ID; docs_create — Create a new Google Doc with optional initial content; docs_search — Search your Google Docs by name / title. Declared senses: paw.docs.v1.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Google Docs (knowledge) connector — 3 actions: docs_read, docs_create, docs_search.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'github' connector once it is bound",
+      "id": "connector:github",
+      "keywords": [
+        "github",
+        "developer",
+        "list_repos",
+        "list_org_repos",
+        "list_issues",
+        "list_pull_requests",
+        "search_code",
+        "search_issues",
+        "get_repo",
+        "create_issue",
+        "list_actions_runs",
+        "list_releases",
+        "code"
+      ],
+      "kind": "connector",
+      "name": "GitHub",
+      "narrative": "The GitHub connector (developer) wires GitHub data into the workspace. ACTIONS: list_repos — List repositories for the authenticated user (params: sort, per_page, page, type); list_org_repos — List repositories for an organization (params: org, per_page, page, sort); list_issues — List issues for a repository (params: owner, repo, state, labels, per_page); list_pull_requests — List pull requests for a repository (params: owner, repo, state, per_page); search_code — Search code across GitHub repositories (params: q, per_page); search_issues — Search issues and PRs across repositories (params: q, per_page); get_repo — Get repository details (params: owner, repo); create_issue — Create a new issue (params: owner, repo); list_actions_runs — List recent GitHub Actions workflow runs (params: owner, repo, status, per_page); list_releases — List releases for a repository (params: owner, repo, per_page). Declared senses: paw.code.v1.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "GitHub (developer) connector — 10 actions: list_repos, list_org_repos, list_issues, list_pull_requests, +6 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'gitlab' connector once it is bound",
+      "id": "connector:gitlab",
+      "keywords": [
+        "gitlab",
+        "developer",
+        "list_projects",
+        "list_issues",
+        "list_merge_requests",
+        "list_pipelines",
+        "get_pipeline_jobs",
+        "search_projects",
+        "create_issue",
+        "list_environments",
+        "code"
+      ],
+      "kind": "connector",
+      "name": "GitLab",
+      "narrative": "The GitLab connector (developer) wires GitLab data into the workspace. ACTIONS: list_projects — List projects accessible to the authenticated user (params: membership, order_by, per_page); list_issues — List issues for a project (params: project_id, state, per_page); list_merge_requests — List merge requests for a project (params: project_id, state, per_page); list_pipelines — List CI/CD pipelines for a project (params: project_id, status, per_page); get_pipeline_jobs — List jobs in a specific pipeline (params: project_id, pipeline_id); search_projects — Search for projects by name (params: search, per_page); create_issue — Create a new project issue (params: project_id); list_environments — List deployment environments (params: project_id, per_page). Declared senses: paw.code.v1.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "GitLab (developer) connector — 8 actions: list_projects, list_issues, list_merge_requests, list_pipelines, +4 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'gmail' connector once it is bound",
+      "id": "connector:gmail",
+      "keywords": [
+        "gmail",
+        "communication",
+        "gmail_search",
+        "gmail_read",
+        "gmail_send",
+        "gmail_list_labels",
+        "gmail_create_label",
+        "gmail_modify",
+        "gmail_trash",
+        "gmail_batch_modify",
+        "gmail_summary",
+        "email"
+      ],
+      "kind": "connector",
+      "name": "Gmail",
+      "narrative": "The Gmail connector (communication) wires Gmail data into the workspace. ACTIONS: gmail_search — Search Gmail for emails matching a query (Gmail search syntax); gmail_read — Read the full body of a single Gmail message by ID; gmail_send — Send an email from the authenticated account; gmail_list_labels — List all labels in the mailbox; gmail_create_label — Create a new label; gmail_modify — Add or remove labels on a message; gmail_trash — Move a message to Trash; gmail_batch_modify — Apply label changes to many messages at once; gmail_summary — Aggregate inbox stats (unread, today, avg reply time) for the Email Stats widget. Declared senses: paw.email.v1.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Gmail (communication) connector — 9 actions: gmail_search, gmail_read, gmail_send, gmail_list_labels, +5 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'google_drive' connector once it is bound",
+      "id": "connector:google_drive",
+      "keywords": [
+        "google_drive",
+        "google drive",
+        "knowledge",
+        "list_files",
+        "search_files",
+        "get_file_content",
+        "get_file_revisions",
+        "docs"
+      ],
+      "kind": "connector",
+      "name": "Google Drive",
+      "narrative": "The Google Drive connector (knowledge) wires Google Drive data into the workspace. ACTIONS: list_files — List or browse files in Drive, newest first (params: q, page_size, order_by); search_files — Full-text search across Drive file contents and metadata (params: query, page_size); get_file_content — Fetch the content of a single file, exporting Google Docs to PDF (params: file_id, revision_id); get_file_revisions — List the edit history of a file for point-in-time retrieval (params: file_id, page_size). Declared senses: paw.docs.v1.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Google Drive (knowledge) connector — 4 actions: list_files, search_files, get_file_content, get_file_revisions.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'hubspot' connector once it is bound",
+      "id": "connector:hubspot",
+      "keywords": [
+        "hubspot",
+        "crm",
+        "list_contacts",
+        "list_companies",
+        "list_deals",
+        "list_tickets",
+        "search_contacts",
+        "create_contact",
+        "create_deal",
+        "list_owners"
+      ],
+      "kind": "connector",
+      "name": "HubSpot",
+      "narrative": "The HubSpot connector (crm) wires HubSpot data into the workspace. ACTIONS: list_contacts — List CRM contacts (params: limit, properties); list_companies — List CRM companies (params: limit, properties); list_deals — List sales deals (params: limit, properties); list_tickets — List support tickets (params: limit, properties); search_contacts — Search contacts by query; create_contact — Create a new CRM contact; create_deal — Create a new sales deal; list_owners — List HubSpot users/owners (params: limit).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "HubSpot (crm) connector — 8 actions: list_contacts, list_companies, list_deals, list_tickets, +4 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'intercom' connector once it is bound",
+      "id": "connector:intercom",
+      "keywords": [
+        "intercom",
+        "support",
+        "list_conversations",
+        "search_conversations",
+        "get_conversation",
+        "list_contacts",
+        "search_contacts",
+        "reply_to_conversation",
+        "create_contact",
+        "list_tags",
+        "list_segments"
+      ],
+      "kind": "connector",
+      "name": "Intercom",
+      "narrative": "The Intercom connector (support) wires Intercom data into the workspace. ACTIONS: list_conversations — List recent conversations (params: per_page, sort_field, sort_order); search_conversations — Search conversations by query; get_conversation — Get a specific conversation with messages (params: conversation_id); list_contacts — List contacts (users and leads) (params: per_page); search_contacts — Search contacts by email, name, or other fields; reply_to_conversation — Send a reply to a conversation (params: conversation_id); create_contact — Create a new contact; list_tags — List all tags; list_segments — List customer segments.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Intercom (support) connector — 9 actions: list_conversations, search_conversations, get_conversation, list_contacts, +5 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'jira' connector once it is bound",
+      "id": "connector:jira",
+      "keywords": [
+        "jira",
+        "project-management",
+        "search_issues",
+        "get_issue",
+        "list_projects",
+        "list_sprints",
+        "create_issue",
+        "transition_issue",
+        "add_comment",
+        "assign_issue"
+      ],
+      "kind": "connector",
+      "name": "Jira",
+      "narrative": "The Jira connector (project-management) wires Jira data into the workspace. ACTIONS: search_issues — Search issues using JQL (params: jql, maxResults, fields); get_issue — Get a specific issue by key (params: issue_key); list_projects — List all accessible projects (params: maxResults); list_sprints — List sprints for a board (params: board_id, state); create_issue — Create a new Jira issue; transition_issue — Move an issue to a new status (params: issue_key); add_comment — Add a comment to an issue (params: issue_key); assign_issue — Assign an issue to a user (params: issue_key).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Jira (project-management) connector — 8 actions: search_issues, get_issue, list_projects, list_sprints, +4 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'linear' connector once it is bound",
+      "id": "connector:linear",
+      "keywords": [
+        "linear",
+        "project-management",
+        "list_issues",
+        "list_my_issues",
+        "list_teams",
+        "list_projects",
+        "search_issues",
+        "create_issue",
+        "update_issue_state",
+        "list_cycles"
+      ],
+      "kind": "connector",
+      "name": "Linear",
+      "narrative": "The Linear connector (project-management) wires Linear data into the workspace. ACTIONS: list_issues — List issues assigned to you or filtered by team/project; list_my_issues — List issues assigned to the authenticated user; list_teams — List all teams in the workspace; list_projects — List all projects; search_issues — Search issues by query string; create_issue — Create a new Linear issue; update_issue_state — Update issue status/state; list_cycles — List active and upcoming cycles (sprints).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Linear (project-management) connector — 8 actions: list_issues, list_my_issues, list_teams, list_projects, +4 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'mongodb' connector once it is bound",
+      "id": "connector:mongodb",
+      "keywords": [
+        "mongodb",
+        "database",
+        "list_collections",
+        "find",
+        "find_one",
+        "count",
+        "distinct",
+        "aggregate",
+        "collection_stats",
+        "indexes",
+        "insert_one",
+        "update_many",
+        "delete_many",
+        "db"
+      ],
+      "kind": "connector",
+      "name": "MongoDB",
+      "narrative": "The MongoDB connector (database) wires MongoDB data into the workspace. ACTIONS: list_collections — List all collections in the database; find — Query documents in a collection (params: collection, filter, limit, sort); find_one — Get a single document by filter or _id (params: collection, filter); count — Count documents in a collection (params: collection, filter); distinct — Get distinct values for a field (params: collection, field); aggregate — Run an aggregation pipeline (params: collection, pipeline); collection_stats — Get stats for all collections (doc count, size); indexes — List indexes on a collection (params: collection); insert_one — Insert a document (params: collection, document); update_many — Update documents matching a filter (params: collection, filter, update); delete_many — Delete documents matching a filter (params: collection, filter). Declared senses: paw.db.v1.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "MongoDB (database) connector — 11 actions: list_collections, find, find_one, count, +7 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'ms_teams_data' connector once it is bound",
+      "id": "connector:ms_teams_data",
+      "keywords": [
+        "ms_teams_data",
+        "microsoft teams (data)",
+        "communication",
+        "list_teams",
+        "list_channels",
+        "channel_messages",
+        "list_chats",
+        "chat_messages",
+        "search_messages",
+        "list_team_members",
+        "send_channel_message"
+      ],
+      "kind": "connector",
+      "name": "Microsoft Teams (Data)",
+      "narrative": "The Microsoft Teams (Data) connector (communication) wires Microsoft Teams (Data) data into the workspace. ACTIONS: list_teams — List teams the user has joined; list_channels — List channels in a team (params: team_id); channel_messages — Get recent messages from a channel (params: team_id, channel_id); list_chats — List recent 1:1 and group chats (params: $top); chat_messages — Get messages from a chat (params: chat_id, $top); search_messages — Search across all Teams messages; list_team_members — List members of a team (params: team_id); send_channel_message — Send a message to a Teams channel (params: team_id, channel_id).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Microsoft Teams (Data) (communication) connector — 8 actions: list_teams, list_channels, channel_messages, list_chats, +4 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'notion' connector once it is bound",
+      "id": "connector:notion",
+      "keywords": [
+        "notion",
+        "knowledge",
+        "search",
+        "list_databases",
+        "query_database",
+        "get_page",
+        "get_page_content",
+        "create_page",
+        "update_page",
+        "append_blocks"
+      ],
+      "kind": "connector",
+      "name": "Notion",
+      "narrative": "The Notion connector (knowledge) wires Notion data into the workspace. ACTIONS: search — Search across all Notion pages and databases; list_databases — List all databases shared with the integration; query_database — Query a Notion database with filters and sorts (params: database_id); get_page — Retrieve a Notion page and its properties (params: page_id); get_page_content — Get the block content (body) of a page (params: block_id, page_size); create_page — Create a new page in a database or as a child of another page; update_page — Update page properties (params: page_id); append_blocks — Append content blocks to a page (params: block_id).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Notion (knowledge) connector — 8 actions: search, list_databases, query_database, get_page, +4 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'pagerduty' connector once it is bound",
+      "id": "connector:pagerduty",
+      "keywords": [
+        "pagerduty",
+        "incident-management",
+        "list_incidents",
+        "get_incident",
+        "list_oncalls",
+        "list_services",
+        "list_escalation_policies",
+        "acknowledge_incident",
+        "resolve_incident",
+        "create_incident",
+        "add_note"
+      ],
+      "kind": "connector",
+      "name": "PagerDuty",
+      "narrative": "The PagerDuty connector (incident-management) wires PagerDuty data into the workspace. ACTIONS: list_incidents — List recent incidents (params: statuses[], sort_by, limit); get_incident — Get details of a specific incident (params: incident_id); list_oncalls — List who is currently on call (params: limit); list_services — List monitored services (params: limit); list_escalation_policies — List escalation policies (params: limit); acknowledge_incident — Acknowledge an open incident (params: incident_id); resolve_incident — Resolve an incident (params: incident_id); create_incident — Trigger a new incident; add_note — Add a note to an incident (params: incident_id).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "PagerDuty (incident-management) connector — 9 actions: list_incidents, get_incident, list_oncalls, list_services, +5 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'postgresql' connector once it is bound",
+      "id": "connector:postgresql",
+      "keywords": [
+        "postgresql",
+        "database",
+        "execute_query",
+        "list_tables",
+        "describe_table",
+        "preview_table",
+        "list_schemas",
+        "table_stats",
+        "list_indexes",
+        "active_queries",
+        "db"
+      ],
+      "kind": "connector",
+      "name": "PostgreSQL",
+      "narrative": "The PostgreSQL connector (database) wires PostgreSQL data into the workspace. ACTIONS: execute_query — Execute a SQL query (SELECT, INSERT, UPDATE, etc.) (params: query, limit); list_tables — List all tables in the current database (params: schema); describe_table — Show column definitions for a table (params: table, schema); preview_table — Preview rows from a table (params: table, schema, limit); list_schemas — List all schemas in the database; table_stats — Get row counts and size estimates for tables (params: schema); list_indexes — List indexes on a table (params: table, schema); active_queries — List currently running queries. Declared senses: paw.db.v1.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "PostgreSQL (database) connector — 8 actions: execute_query, list_tables, describe_table, preview_table, +4 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'quickbooks' connector once it is bound",
+      "id": "connector:quickbooks",
+      "keywords": [
+        "quickbooks",
+        "quickbooks online",
+        "accounting",
+        "list_invoices",
+        "list_customers",
+        "list_bills",
+        "list_expenses",
+        "list_accounts",
+        "profit_loss",
+        "balance_sheet",
+        "query",
+        "list_vendors",
+        "create_invoice"
+      ],
+      "kind": "connector",
+      "name": "QuickBooks Online",
+      "narrative": "The QuickBooks Online connector (accounting) wires QuickBooks Online data into the workspace. ACTIONS: list_invoices — List invoices (params: query, max_results); list_customers — List customers (params: query, max_results); list_bills — List vendor bills (params: query, max_results); list_expenses — List recent expenses/purchases (params: query, max_results); list_accounts — List chart of accounts (params: query); profit_loss — Get Profit & Loss report (params: start_date, end_date, summarize_column_by); balance_sheet — Get Balance Sheet report (params: date, summarize_column_by); query — Run a custom QuickBooks query (params: query); list_vendors — List vendors (params: query); create_invoice — Create a new invoice.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "QuickBooks Online (accounting) connector — 10 actions: list_invoices, list_customers, list_bills, list_expenses, +6 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'reddit' connector once it is bound",
+      "id": "connector:reddit",
+      "keywords": [
+        "reddit",
+        "knowledge",
+        "reddit_search",
+        "reddit_read",
+        "reddit_trending"
+      ],
+      "kind": "connector",
+      "name": "Reddit",
+      "narrative": "The Reddit connector (knowledge) wires Reddit data into the workspace. ACTIONS: reddit_search — Search Reddit posts; reddit_read — Read a Reddit post + top comments; reddit_trending — Top posts in a subreddit.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Reddit (knowledge) connector — 3 actions: reddit_search, reddit_read, reddit_trending.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'rest_generic' connector once it is bound",
+      "id": "connector:rest_generic",
+      "keywords": [
+        "rest_generic",
+        "rest api",
+        "api",
+        "get_endpoint",
+        "post_endpoint",
+        "put_endpoint",
+        "patch_endpoint",
+        "delete_endpoint"
+      ],
+      "kind": "connector",
+      "name": "REST API",
+      "narrative": "The REST API connector (api) wires REST API data into the workspace. ACTIONS: get_endpoint — Make a GET request to any endpoint (params: path, query); post_endpoint — Make a POST request with JSON body (params: path); put_endpoint — Make a PUT request to replace a resource (params: path); patch_endpoint — Make a PATCH request to partially update a resource (params: path); delete_endpoint — Make a DELETE request to remove a resource (params: path).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "REST API (api) connector — 5 actions: get_endpoint, post_endpoint, put_endpoint, patch_endpoint, +1 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'salesforce' connector once it is bound",
+      "id": "connector:salesforce",
+      "keywords": [
+        "salesforce",
+        "crm",
+        "query_soql",
+        "list_accounts",
+        "list_contacts",
+        "list_opportunities",
+        "list_leads",
+        "list_cases",
+        "create_lead",
+        "create_contact",
+        "update_opportunity_stage"
+      ],
+      "kind": "connector",
+      "name": "Salesforce",
+      "narrative": "The Salesforce connector (crm) wires Salesforce data into the workspace. ACTIONS: query_soql — Run a SOQL query against Salesforce (params: q); list_accounts — List Salesforce accounts (companies) (params: q); list_contacts — List Salesforce contacts (params: q); list_opportunities — List open sales opportunities (params: q); list_leads — List recent leads (params: q); list_cases — List support cases (params: q); create_lead — Create a new lead in Salesforce; create_contact — Create a new contact; update_opportunity_stage — Update the stage of an opportunity (params: opportunity_id).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Salesforce (crm) connector — 9 actions: query_soql, list_accounts, list_contacts, list_opportunities, +5 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'servicenow' connector once it is bound",
+      "id": "connector:servicenow",
+      "keywords": [
+        "servicenow",
+        "itsm",
+        "list_incidents",
+        "get_incident",
+        "list_change_requests",
+        "list_service_requests",
+        "list_problems",
+        "create_incident",
+        "update_incident",
+        "list_cmdb_servers",
+        "search_knowledge"
+      ],
+      "kind": "connector",
+      "name": "ServiceNow",
+      "narrative": "The ServiceNow connector (itsm) wires ServiceNow data into the workspace. ACTIONS: list_incidents — List IT incidents (params: sysparm_limit, sysparm_query, sysparm_display_value, sysparm_fields); get_incident — Get a specific incident by number or sys_id (params: sys_id, sysparm_display_value); list_change_requests — List change requests (params: sysparm_limit, sysparm_query, sysparm_display_value, sysparm_fields); list_service_requests — List service requests (catalog items) (params: sysparm_limit, sysparm_query, sysparm_display_value); list_problems — List problem records (params: sysparm_limit, sysparm_query, sysparm_display_value); create_incident — Create a new incident; update_incident — Update an incident (params: sys_id); list_cmdb_servers — List CMDB server configuration items (params: sysparm_limit, sysparm_display_value, sysparm_fields); search_knowledge — Search the knowledge base (params: sysparm_query, sysparm_limit).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "ServiceNow (itsm) connector — 9 actions: list_incidents, get_incident, list_change_requests, list_service_requests, +5 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'sharepoint' connector once it is bound",
+      "id": "connector:sharepoint",
+      "keywords": [
+        "sharepoint",
+        "knowledge",
+        "list_sites",
+        "get_site",
+        "list_drives",
+        "list_files",
+        "search_files",
+        "get_file_content",
+        "list_lists",
+        "list_items",
+        "search_content",
+        "list_recent_files"
+      ],
+      "kind": "connector",
+      "name": "SharePoint",
+      "narrative": "The SharePoint connector (knowledge) wires SharePoint data into the workspace. ACTIONS: list_sites — List SharePoint sites accessible to the user (params: search); get_site — Get a specific SharePoint site (params: site_id); list_drives — List document libraries (drives) in a site (params: site_id); list_files — List files and folders in a drive or folder (params: site_id, drive_id, folder_path); search_files — Search for files across SharePoint (params: query); get_file_content — Download a file's content (params: site_id, drive_id, item_id); list_lists — List SharePoint lists in a site (params: site_id); list_items — Get items from a SharePoint list (params: site_id, list_id, expand); search_content — Full-text search across all SharePoint content; list_recent_files — List recently accessed files.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "SharePoint (knowledge) connector — 10 actions: list_sites, get_site, list_drives, list_files, +6 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'shopify' connector once it is bound",
+      "id": "connector:shopify",
+      "keywords": [
+        "shopify",
+        "ecommerce",
+        "list_orders",
+        "list_products",
+        "list_customers",
+        "search_customers",
+        "get_order",
+        "list_inventory",
+        "get_shop_info",
+        "list_collections",
+        "count_orders"
+      ],
+      "kind": "connector",
+      "name": "Shopify",
+      "narrative": "The Shopify connector (ecommerce) wires Shopify data into the workspace. ACTIONS: list_orders — List recent orders (params: status, limit, financial_status); list_products — List products in the store (params: limit, status, collection_id); list_customers — List customers (params: limit); search_customers — Search customers by query (params: query, limit); get_order — Get detailed order information (params: order_id); list_inventory — List inventory levels (params: location_ids, limit); get_shop_info — Get store information and settings; list_collections — List product collections (params: limit); count_orders — Get order count with optional filters (params: status, financial_status, created_at_min).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Shopify (ecommerce) connector — 9 actions: list_orders, list_products, list_customers, search_customers, +5 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'slack_data' connector once it is bound",
+      "id": "connector:slack_data",
+      "keywords": [
+        "slack_data",
+        "slack (data)",
+        "communication",
+        "search_messages",
+        "list_channels",
+        "channel_history",
+        "list_users",
+        "get_user_info",
+        "channel_info",
+        "list_pins",
+        "list_bookmarks"
+      ],
+      "kind": "connector",
+      "name": "Slack (Data)",
+      "narrative": "The Slack (Data) connector (communication) wires Slack (Data) data into the workspace. ACTIONS: search_messages — Search messages across all channels (params: query, count, sort); list_channels — List public and private channels (params: types, limit, exclude_archived); channel_history — Get recent messages from a channel (params: channel, limit); list_users — List workspace members (params: limit); get_user_info — Get detailed info about a user (params: user); channel_info — Get detailed channel information (params: channel); list_pins — List pinned messages in a channel (params: channel); list_bookmarks — List bookmarks in a channel (params: channel_id).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Slack (Data) (communication) connector — 8 actions: search_messages, list_channels, channel_history, list_users, +4 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'snowflake' connector once it is bound",
+      "id": "connector:snowflake",
+      "keywords": [
+        "snowflake",
+        "database",
+        "execute_query",
+        "list_databases",
+        "list_schemas",
+        "list_tables",
+        "describe_table",
+        "preview_table",
+        "list_warehouses",
+        "query_history"
+      ],
+      "kind": "connector",
+      "name": "Snowflake",
+      "narrative": "The Snowflake connector (database) wires Snowflake data into the workspace. ACTIONS: execute_query — Execute a SQL query against Snowflake (params: query, warehouse, database, schema, limit); list_databases — List all accessible databases (params: query); list_schemas — List schemas in a database (params: database, query); list_tables — List tables in a schema (params: database, schema, query); describe_table — Get column definitions for a table (params: table, query); preview_table — Preview rows from a table (params: table, limit, query); list_warehouses — List available warehouses (params: query); query_history — View recent query history (params: limit, query).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Snowflake (database) connector — 8 actions: execute_query, list_databases, list_schemas, list_tables, +4 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'spotify' connector once it is bound",
+      "id": "connector:spotify",
+      "keywords": [
+        "spotify",
+        "communication",
+        "spotify_search",
+        "spotify_now_playing",
+        "spotify_playback",
+        "spotify_playlist"
+      ],
+      "kind": "connector",
+      "name": "Spotify",
+      "narrative": "The Spotify connector (communication) wires Spotify data into the workspace. ACTIONS: spotify_search — Search Spotify for tracks, albums, or artists; spotify_now_playing — Show what's currently playing; spotify_playback — Control playback (play / pause / next / previous / volume); spotify_playlist — List or modify your playlists.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Spotify (communication) connector — 4 actions: spotify_search, spotify_now_playing, spotify_playback, spotify_playlist.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'stripe' connector once it is bound",
+      "id": "connector:stripe",
+      "keywords": [
+        "stripe",
+        "payment",
+        "list_invoices",
+        "list_customers",
+        "list_subscriptions",
+        "list_charges",
+        "list_balance_transactions",
+        "get_balance",
+        "list_payouts",
+        "list_disputes",
+        "list_refunds",
+        "list_products",
+        "list_prices",
+        "create_invoice",
+        "create_refund",
+        "payments"
+      ],
+      "kind": "connector",
+      "name": "Stripe",
+      "narrative": "The Stripe connector (payment) wires Stripe data into the workspace. ACTIONS: list_invoices — List recent invoices (params: limit, status, customer); list_customers — List customers (params: limit, email); list_subscriptions — List active subscriptions (params: limit, status, customer); list_charges — List recent charges/payments (params: limit, customer); list_balance_transactions — List balance transactions (funds movement) (params: limit, type); get_balance — Get current account balance; list_payouts — List payouts to your bank account (params: limit, status); list_disputes — List payment disputes (params: limit); list_refunds — List refunds (params: limit, charge); list_products — List products in your catalog (params: limit, active); list_prices — List prices for products (params: limit, product, active); create_invoice — Create a new invoice; create_refund — Create a refund for a charge. Declared senses: paw.payments.v1.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Stripe (payment) connector — 13 actions: list_invoices, list_customers, list_subscriptions, list_charges, +9 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "list_connector_actions / connector_execute over the 'zendesk' connector once it is bound",
+      "id": "connector:zendesk",
+      "keywords": [
+        "zendesk",
+        "support",
+        "list_tickets",
+        "search_tickets",
+        "get_ticket",
+        "list_ticket_comments",
+        "create_ticket",
+        "update_ticket",
+        "add_ticket_comment",
+        "list_users",
+        "ticket_metrics"
+      ],
+      "kind": "connector",
+      "name": "Zendesk",
+      "narrative": "The Zendesk connector (support) wires Zendesk data into the workspace. ACTIONS: list_tickets — List recent support tickets (params: sort_by, sort_order, per_page); search_tickets — Search tickets by query (params: query, per_page); get_ticket — Get a specific ticket with comments (params: ticket_id); list_ticket_comments — Get all comments/replies on a ticket (params: ticket_id, per_page); create_ticket — Create a new support ticket; update_ticket — Update a ticket (status, priority, assignee, etc.) (params: ticket_id); add_ticket_comment — Add a comment/reply to a ticket (params: ticket_id); list_users — List Zendesk users (agents and end-users) (params: role, per_page); ticket_metrics — Get ticket metrics and SLA data (params: ticket_id).",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Zendesk (support) connector — 9 actions: list_tickets, search_tickets, get_ticket, list_ticket_comments, +5 more.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "belt develop station: orient → develop → mcp__pocketpaw_belt__belt_propose_change through the Instinct gate",
+      "id": "primitive:belt",
+      "keywords": [
+        "code",
+        "implement",
+        "fix",
+        "refactor",
+        "assembly line",
+        "diff",
+        "station",
+        "develop",
+        "propose change",
+        "coding",
+        "autonomous"
+      ],
+      "kind": "primitive",
+      "name": "Belt",
+      "narrative": "Belt is the autonomous software assembly line: AI runs the stations — orient in the codebase, develop the change in a station worktree, propose the diff — and the human mans the Instinct gate. Changes NEVER land directly on the user's branches; they leave the station only as proposed diffs for review. Reach for it when the user asks to implement, fix, or refactor code with governed delivery. It pairs with Instinct (the gate every diff passes through) and Branch (governed change of artifacts generally). NOT a clothing item — Belt is the code assembly line.",
+      "requires": [
+        "primitive:instinct"
+      ],
+      "summary": "Autonomous software assembly line: AI runs the stations (orient → develop → propose), the human mans the Instinct gate; changes leave only as proposed diffs.",
+      "surface": "/belt"
+    },
+    {
+      "how": "branch primitive APIs: propose / review / merge / publish / revert on a (scope_type, scope_id) artifact",
       "id": "primitive:branch",
+      "keywords": [
+        "version",
+        "review",
+        "merge",
+        "publish",
+        "revert",
+        "diff",
+        "propose",
+        "draft",
+        "rollback",
+        "history",
+        "changes"
+      ],
       "kind": "primitive",
       "name": "Branch",
-      "summary": "Universal version-control + review for any artifact keyed by (scope_type, scope_id): propose → branch → review → merge/publish + revert.",
       "narrative": "Branch is universal version-control + review for ANY artifact, keyed by (scope_type, scope_id): propose → branch → review → merge/publish, plus diff and revert. It is built on the Instinct gate + Journal, so every merge is a governed decision with history. Reach for it when a change to an artifact (a site, a spec, a config) should be reviewed before it goes live, or when the user wants to compare or roll back versions. Sites are the first consumer. NOT only git — Branch versions any workspace artifact.",
-      "how": "branch primitive APIs: propose / review / merge / publish / revert on a (scope_type, scope_id) artifact",
-      "surface": "",
-      "requires": ["primitive:instinct"],
-      "keywords": ["version", "review", "merge", "publish", "revert", "diff", "propose", "draft", "rollback", "history", "changes"]
+      "requires": [
+        "primitive:instinct"
+      ],
+      "summary": "Universal version-control + review for any artifact keyed by (scope_type, scope_id): propose → branch → review → merge/publish + revert.",
+      "surface": ""
     },
     {
+      "how": "connector registry + typed YAML definitions; bind a connector to a pocket to expose its senses",
+      "id": "primitive:connector",
+      "keywords": [
+        "integration",
+        "gmail",
+        "calendar",
+        "drive",
+        "postgres",
+        "github",
+        "external data",
+        "sync",
+        "bind",
+        "senses",
+        "oauth",
+        "connect"
+      ],
+      "kind": "primitive",
+      "name": "Connector",
+      "narrative": "A Connector is a workspace-scoped data integration to an external system — Gmail, Google Calendar, Google Drive, Postgres, GitHub, and so on. Each connector is a typed YAML definition declaring its senses (what it can read and act on). Reach for it when the user wants their external data or accounts wired into the workspace. Connectors pair with Pockets (they bind into a pocket's scope), Fabric (they feed typed objects), and skills (a bound connector auto-surfaces its skill into the room). NOT an electrical part — a Connector is a data integration.",
+      "requires": [],
+      "summary": "Workspace-scoped data integration to external systems (Gmail, GCalendar, GDrive, Postgres…), each a typed YAML definition declaring senses.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "fabric query surface (e.g. fabric_query / fabric_stats MCP tools where a fabric server is bound)",
+      "id": "primitive:fabric",
+      "keywords": [
+        "ontology",
+        "knowledge graph",
+        "typed objects",
+        "entities",
+        "relationships",
+        "links",
+        "crm",
+        "records",
+        "graph",
+        "customer",
+        "competitor"
+      ],
+      "kind": "primitive",
+      "name": "Fabric",
+      "narrative": "Fabric is the workspace's knowledge graph: a typed ontology layer of typed objects (Customer, Competitor, Product, …) connected by typed links (competes_with, raised, hired). Reach for it when the user needs structured entities and relationships rather than free text — CRM-like records, competitor maps, org graphs. It pairs with Connectors (which feed external data into typed objects) and Pockets (which render fabric-backed views). NOT textile — Fabric is the typed object/link layer.",
+      "requires": [],
+      "summary": "Typed ontology layer: typed objects (Customer, Competitor, Product…) and typed links (competes_with, raised, hired).",
+      "surface": ""
+    },
+    {
+      "how": "Instinct action store + gate APIs; agents emit proposals, humans resolve them at the gate",
+      "id": "primitive:instinct",
+      "keywords": [
+        "approve",
+        "approval",
+        "reject",
+        "review",
+        "gate",
+        "governance",
+        "propose",
+        "human in the loop",
+        "permission",
+        "triage",
+        "trust",
+        "audit"
+      ],
+      "kind": "primitive",
+      "name": "Instinct",
+      "narrative": "Instinct is the governance primitive: agents PROPOSE actions instead of executing them, and humans approve, reject, or edit each proposal at a gate. Every decision captures a reasoning trace. It is becoming a multi-lane triage router (auto / optimistic / escalate / dry-run + a trust ledger), with ASK as the default lane. Reach for it whenever an agent action needs governance — approvals, human review of agent writes, gated side effects. It pairs with Branch (which builds propose→review→merge on top of the gate) and Belt (where the human mans the Instinct gate on proposed diffs). NOT a biology term — Instinct is the approval pipeline.",
+      "requires": [],
+      "summary": "The decision pipeline: agents PROPOSE actions, humans approve/reject/edit at a gate; captures reasoning traces.",
+      "surface": "/paw-print"
+    },
+    {
+      "how": "pocket_specialist__create / POST /api/v1/pockets (create), pocket_specialist__edit + POST /api/v1/pockets/<id>/spec/merge (edit)",
+      "id": "primitive:pocket",
+      "keywords": [
+        "app",
+        "dashboard",
+        "tracker",
+        "workspace",
+        "canvas",
+        "container",
+        "tool",
+        "viewer",
+        "kanban",
+        "todo",
+        "build"
+      ],
+      "kind": "primitive",
+      "name": "Pocket",
+      "narrative": "A Pocket is the 'app' primitive of the OS: one workspace container that holds agents, data, tools, connectors, KB scope, and Instinct rules. Reach for it when the user wants an interactive app, dashboard, or tracker — anything with a canvas and state. Pockets pair with Ripple (which renders their UI from a rippleSpec), with Connectors (which scope data into them), and with Sites (which publish a pocket as a standalone website). NOT clothing — a Pocket is a workspace app container.",
+      "requires": [],
+      "summary": "Workspace container holding agents, data, tools, connectors, KB scope, and Instinct rules; the \"app\" primitive.",
+      "surface": "/pockets"
+    },
+    {
+      "how": "author a rippleSpec; get_widget_spec / get_inline_widget_help fetch canonical prop schemas, start_flow scaffolds multi-step flows",
+      "id": "primitive:ripple",
+      "keywords": [
+        "ui",
+        "widgets",
+        "render",
+        "rippleSpec",
+        "svelte",
+        "chart",
+        "form",
+        "generative ui",
+        "canvas",
+        "spec",
+        "component"
+      ],
+      "kind": "primitive",
+      "name": "Ripple",
+      "narrative": "Ripple is the generative UI layer of the OS: a pocket (or the chat agent) describes WHAT to show as a rippleSpec — a declarative JSON tree — and Ripple renders it as live Svelte UI from a catalog of ~190 widgets. Reach for it whenever UI needs to be produced from a description: dashboards, charts, forms, feeds, flows. It pairs with Pockets (every pocket canvas is a rippleSpec) and Sites (landing pages render ripple specs on the edge). NOT a water effect — Ripple is the widget rendering layer.",
+      "requires": [],
+      "summary": "Generative UI layer: pockets describe WHAT to show as a rippleSpec; Ripple renders it as live Svelte UI (~190 widgets).",
+      "surface": ""
+    },
+    {
+      "how": "publish flow: build/pick a pocket stamped type=\"site\", then publish it to the edge",
+      "id": "primitive:sites",
+      "keywords": [
+        "website",
+        "publish",
+        "landing page",
+        "edge",
+        "domain",
+        "public",
+        "d1",
+        "static",
+        "dynamic",
+        "deploy",
+        "online"
+      ],
+      "kind": "primitive",
+      "name": "Sites",
+      "narrative": "Sites publishes a pocket as a real standalone website on the edge — either a static landing page or a dynamic site backed by a per-tenant D1 database (reads AND writes against the customer's own live data). Reach for it when the user wants something ON THE WEB: a marketing page, a public guestbook, a booking list. A site is always published FROM a pocket; Sites pairs with Pocket (the source artifact), Ripple (landing rendering), and Branch (sites are the first consumer of propose→review→publish).",
+      "requires": [
+        "primitive:pocket"
+      ],
+      "summary": "Publish a pocket as a real standalone website on the edge (static landing or dynamic with per-tenant D1).",
+      "surface": "/sites"
+    },
+    {
+      "how": "soul CLI / soul memory APIs: soul remember, soul recall, soul status against a .soul file",
+      "id": "primitive:soul",
+      "keywords": [
+        "memory",
+        "identity",
+        "personality",
+        "remember",
+        "recall",
+        "persistent",
+        "ocean",
+        "episodic",
+        "semantic",
+        "procedural",
+        ".soul"
+      ],
+      "kind": "primitive",
+      "name": "Soul",
+      "narrative": "Soul is the persistent agent identity and memory primitive: identity lives in portable .soul files with an OCEAN personality model and a 5-tier memory architecture (core / episodic / semantic / procedural / …). Reach for it when an agent needs to remember across sessions, carry a stable personality, or migrate identity between platforms. It pairs with the chat agent (soul recall feeds prompt context) and the Digital Soul Protocol (the open spec behind the file format). NOT a religious term — Soul is agent identity + memory.",
+      "requires": [],
+      "summary": "Persistent agent identity/memory (.soul files, OCEAN personality, 5-tier memory: core/episodic/semantic/procedural/…).",
+      "surface": ""
+    },
+    {
+      "how": "enqueue a named job on the ARQ-backed workspace-jobs queue; results write back under the system identity",
       "id": "primitive:workspace-jobs",
+      "keywords": [
+        "background",
+        "async",
+        "job",
+        "queue",
+        "long-running",
+        "durable",
+        "schedule",
+        "worker",
+        "arq",
+        "batch",
+        "import"
+      ],
       "kind": "primitive",
       "name": "workspace-jobs",
-      "summary": "ARQ-backed durable async-work primitive for long-running named jobs with writeback under a system identity.",
       "narrative": "workspace-jobs is the durable async-work primitive: ARQ-backed, long-running named jobs that survive restarts and write results back under a system identity. Reach for it when work outlives a chat turn — imports, crawls, bulk enrichment, scheduled processing — anything that should keep running after the user walks away. It pairs with Connectors (long syncs run as jobs) and Pockets (job writeback lands in pocket data).",
-      "how": "enqueue a named job on the ARQ-backed workspace-jobs queue; results write back under the system identity",
-      "surface": "",
       "requires": [],
-      "keywords": ["background", "async", "job", "queue", "long-running", "durable", "schedule", "worker", "arq", "batch", "import"]
+      "summary": "ARQ-backed durable async-work primitive for long-running named jobs with writeback under a system identity.",
+      "surface": ""
     },
     {
-      "id": "primitive:sites",
-      "kind": "primitive",
-      "name": "Sites",
-      "summary": "Publish a pocket as a real standalone website on the edge (static landing or dynamic with per-tenant D1).",
-      "narrative": "Sites publishes a pocket as a real standalone website on the edge — either a static landing page or a dynamic site backed by a per-tenant D1 database (reads AND writes against the customer's own live data). Reach for it when the user wants something ON THE WEB: a marketing page, a public guestbook, a booking list. A site is always published FROM a pocket; Sites pairs with Pocket (the source artifact), Ripple (landing rendering), and Branch (sites are the first consumer of propose→review→publish).",
-      "how": "publish flow: build/pick a pocket stamped type=\"site\", then publish it to the edge",
-      "surface": "/sites",
-      "requires": ["primitive:pocket"],
-      "keywords": ["website", "publish", "landing page", "edge", "domain", "public", "d1", "static", "dynamic", "deploy", "online"]
-    },
-    {
-      "id": "primitive:belt",
-      "kind": "primitive",
-      "name": "Belt",
-      "summary": "Autonomous software assembly line: AI runs the stations (orient → develop → propose), the human mans the Instinct gate; changes leave only as proposed diffs.",
-      "narrative": "Belt is the autonomous software assembly line: AI runs the stations — orient in the codebase, develop the change in a station worktree, propose the diff — and the human mans the Instinct gate. Changes NEVER land directly on the user's branches; they leave the station only as proposed diffs for review. Reach for it when the user asks to implement, fix, or refactor code with governed delivery. It pairs with Instinct (the gate every diff passes through) and Branch (governed change of artifacts generally). NOT a clothing item — Belt is the code assembly line.",
-      "how": "belt develop station: orient → develop → mcp__pocketpaw_belt__belt_propose_change through the Instinct gate",
-      "surface": "/belt",
-      "requires": ["primitive:instinct"],
-      "keywords": ["code", "implement", "fix", "refactor", "assembly line", "diff", "station", "develop", "propose change", "coding", "autonomous"]
-    },
-    {
-      "id": "surface:home",
-      "kind": "surface",
-      "name": "Home",
-      "summary": "The OS home screen: live Ripple widget grid, workspace activity feed, greeting, and chat pill.",
-      "narrative": "Home is the landing surface of the paw-enterprise client: a live widget grid (pinned pockets, the member 'intent of the day' board), an activity river, and a chat pill. Point a user here when they want their day at a glance or a place to start — everything else is one hop away.",
-      "how": "",
-      "surface": "/",
-      "requires": [],
-      "keywords": ["home", "start", "overview", "widget grid", "landing", "today", "intent"]
-    },
-    {
-      "id": "surface:chat",
-      "kind": "surface",
-      "name": "Chat",
-      "summary": "Chat panel with the rooms rail: DMs, agent rooms, groups, channels, and entity rooms bound to pockets.",
-      "narrative": "Chat is where users talk to agents and each other: a rooms rail with DMs, agent rooms, groups, channels, plus entity rooms scoped to a pocket (/chat/<pocketId>). Point a user here to converse with an agent, resume a room, or work inside a pocket-bound conversation.",
-      "how": "",
-      "surface": "/chat",
-      "requires": [],
-      "keywords": ["chat", "rooms", "dm", "message", "conversation", "talk", "agent room", "channel", "group"]
-    },
-    {
-      "id": "surface:pockets",
-      "kind": "surface",
-      "name": "Pockets",
-      "summary": "Pockets dashboard: the list of workspace pockets plus the canvas detail view for each one.",
-      "narrative": "The Pockets surface lists every pocket in the workspace and opens each one's live canvas (/pockets/<id>). After creating or editing a pocket, point the user here to see and use it. This is the home surface of the Pocket primitive.",
-      "how": "",
-      "surface": "/pockets",
-      "requires": ["primitive:pocket"],
-      "keywords": ["pockets", "canvas", "dashboard", "apps", "open pocket", "workspace apps", "tracker"]
-    },
-    {
-      "id": "surface:sites",
-      "kind": "surface",
-      "name": "Sites",
-      "summary": "Sites gallery: published Paw Sites as cards, with a chat rail that drives the create-and-publish flow.",
-      "narrative": "The Sites surface shows the workspace's published websites as a card gallery and opens each site's detail (/sites/<siteId>). Describing a site in its chat rail triggers the create-then-publish flow. After publishing a website, point the user here to see the live site and manage it.",
-      "how": "",
-      "surface": "/sites",
-      "requires": ["primitive:sites"],
-      "keywords": ["sites", "website", "publish", "landing page", "gallery", "domain", "live site", "online"]
-    },
-    {
-      "id": "surface:belt",
-      "kind": "surface",
-      "name": "Belt",
-      "summary": "Belt develop-station console: repo picker, run cards, and a read-only diff viewer, chat-first.",
-      "narrative": "The Belt surface is where a human hands the develop station a coding task and watches it run: repo picker, run cards, and the read-only diff viewer, with the station agent in the chat rail. Point a user here to request code changes or review proposed diffs. This is the home surface of the Belt primitive.",
-      "how": "",
-      "surface": "/belt",
-      "requires": ["primitive:belt"],
-      "keywords": ["belt", "coding task", "diff", "station", "develop", "code change", "proposed change"]
-    },
-    {
-      "id": "surface:paw-print",
-      "kind": "surface",
-      "name": "Paw Print",
-      "summary": "Org-wide decision feed: recent Instinct corrections across the workspace's pockets, with diff viewers.",
-      "narrative": "Paw Print is the org-wide decision feed — recent Instinct corrections across the workspace, each rendered through a diff viewer. Point a user here to review what decisions agents and humans have been making. It is the decision-feed home of the Instinct primitive; the historical query layer is /decisions-graph.",
-      "how": "",
-      "surface": "/paw-print",
-      "requires": ["primitive:instinct"],
-      "keywords": ["decisions", "corrections", "feed", "governance", "what happened", "instinct", "review decisions"]
-    },
-    {
-      "id": "surface:decisions-graph",
-      "kind": "surface",
-      "name": "Decision Graph",
-      "summary": "Visual query layer over the historical Decision projection: trace a decision's graph by id, depth, and mode.",
-      "narrative": "Decision Graph lets an operator query the historical Decision projection visually — deep-linkable by decision id, depth, and mode. Point a user here to trace WHY a decision happened and what it connects to; for the live feed of recent decisions use /paw-print instead.",
-      "how": "",
-      "surface": "/decisions-graph",
-      "requires": ["primitive:instinct"],
-      "keywords": ["decision graph", "trace", "why", "history", "projection", "drill down", "audit trail"]
-    },
-    {
-      "id": "surface:mission-control",
-      "kind": "surface",
-      "name": "Mission Control",
-      "summary": "Operator surface: unified work feed with cycles, plan, activity, and analytics tabs, filterable by project.",
-      "narrative": "Mission Control is the operator surface — a unified work feed (Feed, Cycles, Analytics tabs) with per-item actions and project filters. Point a user here to run the workspace's ongoing work: what is in flight, what needs attention, and how it is trending.",
-      "how": "",
-      "surface": "/mission-control",
-      "requires": [],
-      "keywords": ["mission control", "operator", "work feed", "cycles", "plan", "analytics", "in flight"]
-    },
-    {
-      "id": "surface:agents",
-      "kind": "surface",
-      "name": "Agents",
-      "summary": "Agents shell: the agent list plus a per-agent editor (identity, reasoning, soul evolution).",
-      "narrative": "The Agents surface lists the workspace's agents and opens each one's editor (/agents/<id>) — identity, reasoning, and soul evolution. Point a user here to create, inspect, or tune an agent.",
-      "how": "",
-      "surface": "/agents",
-      "requires": [],
-      "keywords": ["agents", "agent editor", "personas", "configure agent", "plugins", "soul", "tune"]
-    },
-    {
-      "id": "surface:settings",
-      "kind": "surface",
-      "name": "Settings",
-      "summary": "Personal + workspace settings: profile, security, notifications, preferences, API keys, and the workspace admin area.",
-      "narrative": "Settings hosts per-user pages (profile, security, notifications, preferences, API keys) and the workspace admin area under /settings/workspace (members, channels, integrations, policy, memory, SSO, voice — including the workspace plan). Point a user here to change how their account or workspace behaves.",
-      "how": "",
-      "surface": "/settings",
-      "requires": [],
-      "keywords": ["settings", "profile", "preferences", "api keys", "security", "notifications", "configure"]
-    },
-    {
-      "id": "surface:integrations",
-      "kind": "surface",
-      "name": "Integrations",
-      "summary": "Workspace-level third-party credentials: web search, OAuth apps, image generation providers.",
-      "narrative": "The Integrations settings page manages workspace-level third-party credentials (web search, OAuth apps, image generation). Point a user here to wire up or fix an external service; connectors bound to pockets draw on these credentials. This is the home surface of the Connector primitive.",
-      "how": "",
-      "surface": "/settings/workspace/integrations",
-      "requires": ["primitive:connector"],
-      "keywords": ["integrations", "credentials", "oauth", "connect", "api key", "external service", "providers"]
-    },
-    {
-      "id": "surface:workspace-admin",
-      "kind": "surface",
-      "name": "Workspace Admin",
-      "summary": "Workspace administration: name, plan, members, channels, integrations, memory, policy, SSO, voice, advanced.",
-      "narrative": "Workspace Admin is the workspace-scoped settings area: workspace name and plan, members, channels, integrations, memory, policy, SSO, voice, and advanced options. Point a user here for anything that affects the whole workspace — including checking the current plan. There is no dedicated billing route today; plan info lives here.",
-      "how": "",
-      "surface": "/settings/workspace",
-      "requires": [],
-      "keywords": ["workspace", "admin", "members", "plan", "billing", "usage", "policy", "sso", "channels"]
-    },
-    {
-      "id": "surface:knowledge",
-      "kind": "surface",
-      "name": "Knowledge",
-      "summary": "Workspace knowledge-base browser: compiled articles from source files and documents, searchable.",
-      "narrative": "The Knowledge surface hosts the workspace-level KB browser — compiled, searchable articles built from the workspace's files and sources. Point a user here to read or verify what the workspace knows about a topic.",
-      "how": "",
-      "surface": "/knowledge",
-      "requires": [],
-      "keywords": ["knowledge base", "kb", "articles", "wiki", "search knowledge", "docs"]
-    },
-    {
-      "id": "surface:files",
-      "kind": "surface",
-      "name": "Files",
-      "summary": "Workspace file browser panel.",
-      "narrative": "The Files surface is the workspace file browser. Point a user here to browse, inspect, or manage the files the workspace holds — including files that feed the knowledge base.",
-      "how": "",
-      "surface": "/files",
-      "requires": [],
-      "keywords": ["files", "browser", "documents", "uploads", "folders"]
-    },
-    {
-      "id": "surface:studio",
-      "kind": "surface",
-      "name": "Studio",
-      "summary": "Media generation gallery: describe an image or short video in the rail and the agent generates it into the gallery.",
-      "narrative": "Studio is the media-generation surface: the user describes an image or short video in the chat rail, the agent generates it, and results land in a gallery pocket on the left. Point a user here for any describe-to-media request.",
-      "how": "",
-      "surface": "/studio",
-      "requires": [],
-      "keywords": ["studio", "image", "video", "generate", "media", "poster", "illustration", "gallery"]
-    },
-    {
-      "id": "surface:code",
-      "kind": "surface",
-      "name": "Code",
-      "summary": "In-browser IDE: real workspace file tree, editor tabs, and an agent-side edit-run-verify loop.",
-      "narrative": "The Code surface is an in-browser IDE over the shared workspace: a real file tree, editor tabs, and an honest activity indicator while the agent does the work agent-side. Point a user here to read or edit workspace code with the agent alongside.",
-      "how": "",
-      "surface": "/code",
-      "requires": [],
-      "keywords": ["code", "ide", "editor", "file tree", "scripts", "edit code"]
-    },
-    {
-      "id": "surface:foresight",
-      "kind": "surface",
-      "name": "Foresight",
-      "summary": "Scenario rehearsal: create, run, and compare what-if scenarios (runs, insights, fabric, aggregate views).",
-      "narrative": "Foresight is the rehearsal surface: create what-if scenarios, run them, and inspect runs, insights, and aggregate views before committing to a decision. Point a user here to rehearse, simulate, or forecast a decision.",
-      "how": "",
-      "surface": "/foresight",
-      "requires": [],
-      "keywords": ["foresight", "scenario", "simulate", "rehearse", "forecast", "what if", "runs", "insights"]
-    },
-    {
-      "id": "surface:calendar",
-      "kind": "surface",
+      "how": "bind a declaring connector; connectors declare senses in their YAML (senses: [...]), resolved via connectors_for_sense",
+      "id": "sense:paw.calendar.v1",
+      "keywords": [
+        "calendar",
+        "gcalendar"
+      ],
+      "kind": "sense",
       "name": "Calendar",
-      "summary": "Workspace calendar (operator surface).",
-      "narrative": "The Calendar surface shows the workspace calendar. Point a user here to see upcoming events; calendar data arrives via bound connectors (e.g. Google Calendar).",
-      "how": "",
-      "surface": "/calendar",
-      "requires": [],
-      "keywords": ["calendar", "events", "schedule", "upcoming", "meetings schedule"]
+      "narrative": "Read and manage calendar events and availability. A Sense is a provider-agnostic capability above connectors: templates and agents address the sense id (paw.calendar.v1) and the resolver binds it to whichever declaring connector the workspace enabled. Connectors declaring this sense: gcalendar.",
+      "requires": [
+        "connector:gcalendar"
+      ],
+      "summary": "Read and manage calendar events and availability.",
+      "surface": "/settings/workspace/integrations"
     },
     {
-      "id": "surface:meetings",
-      "kind": "surface",
-      "name": "Meetings",
-      "summary": "Unified meetings timeline.",
-      "narrative": "The Meetings surface is the unified meetings timeline. Point a user here to review past and upcoming meetings and their details; meeting preferences live at /settings/meetings.",
-      "how": "",
-      "surface": "/meetings",
-      "requires": [],
-      "keywords": ["meetings", "timeline", "recordings", "notes", "transcript"]
+      "how": "bind a declaring connector; connectors declare senses in their YAML (senses: [...]), resolved via connectors_for_sense",
+      "id": "sense:paw.code.v1",
+      "keywords": [
+        "code",
+        "github",
+        "gitlab"
+      ],
+      "kind": "sense",
+      "name": "Code",
+      "narrative": "Access repositories, issues, pull requests, and code search. A Sense is a provider-agnostic capability above connectors: templates and agents address the sense id (paw.code.v1) and the resolver binds it to whichever declaring connector the workspace enabled. Connectors declaring this sense: github, gitlab.",
+      "requires": [
+        "connector:github",
+        "connector:gitlab"
+      ],
+      "summary": "Access repositories, issues, pull requests, and code search.",
+      "surface": "/settings/workspace/integrations"
     },
     {
+      "how": "bind a declaring connector; connectors declare senses in their YAML (senses: [...]), resolved via connectors_for_sense",
+      "id": "sense:paw.db.v1",
+      "keywords": [
+        "db",
+        "database",
+        "mongodb",
+        "postgresql"
+      ],
+      "kind": "sense",
+      "name": "Database",
+      "narrative": "Query structured data in a relational or document database. A Sense is a provider-agnostic capability above connectors: templates and agents address the sense id (paw.db.v1) and the resolver binds it to whichever declaring connector the workspace enabled. Connectors declaring this sense: mongodb, postgresql.",
+      "requires": [
+        "connector:mongodb",
+        "connector:postgresql"
+      ],
+      "summary": "Query structured data in a relational or document database.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "bind a declaring connector; connectors declare senses in their YAML (senses: [...]), resolved via connectors_for_sense",
+      "id": "sense:paw.docs.v1",
+      "keywords": [
+        "docs",
+        "documents",
+        "gdocs",
+        "google_drive"
+      ],
+      "kind": "sense",
+      "name": "Documents",
+      "narrative": "Read, search, and manage documents and files. A Sense is a provider-agnostic capability above connectors: templates and agents address the sense id (paw.docs.v1) and the resolver binds it to whichever declaring connector the workspace enabled. Connectors declaring this sense: gdocs, google_drive.",
+      "requires": [
+        "connector:gdocs",
+        "connector:google_drive"
+      ],
+      "summary": "Read, search, and manage documents and files.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "bind a declaring connector; connectors declare senses in their YAML (senses: [...]), resolved via connectors_for_sense",
+      "id": "sense:paw.email.v1",
+      "keywords": [
+        "email",
+        "gmail"
+      ],
+      "kind": "sense",
+      "name": "Email",
+      "narrative": "Read, search, and send email across providers. A Sense is a provider-agnostic capability above connectors: templates and agents address the sense id (paw.email.v1) and the resolver binds it to whichever declaring connector the workspace enabled. Connectors declaring this sense: gmail.",
+      "requires": [
+        "connector:gmail"
+      ],
+      "summary": "Read, search, and send email across providers.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "bind a declaring connector; connectors declare senses in their YAML (senses: [...]), resolved via connectors_for_sense",
+      "id": "sense:paw.payments.v1",
+      "keywords": [
+        "payments",
+        "stripe"
+      ],
+      "kind": "sense",
+      "name": "Payments",
+      "narrative": "Read payment, subscription, and billing data. A Sense is a provider-agnostic capability above connectors: templates and agents address the sense id (paw.payments.v1) and the resolver binds it to whichever declaring connector the workspace enabled. Connectors declaring this sense: stripe.",
+      "requires": [
+        "connector:stripe"
+      ],
+      "summary": "Read payment, subscription, and billing data.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "",
       "id": "surface:activity",
+      "keywords": [
+        "activity",
+        "feed",
+        "recent",
+        "events",
+        "river",
+        "what happened"
+      ],
       "kind": "surface",
       "name": "Activity",
-      "summary": "Workspace activity feed, polled live; shares its source with the home river.",
       "narrative": "The Activity surface is the workspace-wide activity feed (same source as the home screen's river, polled live). Point a user here to see what has been happening across the workspace recently.",
-      "how": "",
-      "surface": "/activity",
       "requires": [],
-      "keywords": ["activity", "feed", "recent", "events", "river", "what happened"]
+      "summary": "Workspace activity feed, polled live; shares its source with the home river.",
+      "surface": "/activity"
     },
     {
+      "how": "",
+      "id": "surface:agents",
+      "keywords": [
+        "agents",
+        "agent editor",
+        "personas",
+        "configure agent",
+        "plugins",
+        "soul",
+        "tune"
+      ],
+      "kind": "surface",
+      "name": "Agents",
+      "narrative": "The Agents surface lists the workspace's agents and opens each one's editor (/agents/<id>) — identity, reasoning, and soul evolution. Point a user here to create, inspect, or tune an agent.",
+      "requires": [],
+      "summary": "Agents shell: the agent list plus a per-agent editor (identity, reasoning, soul evolution).",
+      "surface": "/agents"
+    },
+    {
+      "how": "",
       "id": "surface:audit",
+      "keywords": [
+        "audit",
+        "log",
+        "compliance",
+        "trail",
+        "record",
+        "who did what"
+      ],
       "kind": "surface",
       "name": "Audit",
-      "summary": "Workspace audit log.",
       "narrative": "The Audit surface is the workspace audit log — the compliance-grade record of actions. Point a user here when they need the authoritative trail of who or what did something; for a lighter live feed use /activity.",
-      "how": "",
-      "surface": "/audit",
       "requires": [],
-      "keywords": ["audit", "log", "compliance", "trail", "record", "who did what"]
+      "summary": "Workspace audit log.",
+      "surface": "/audit"
+    },
+    {
+      "how": "",
+      "id": "surface:belt",
+      "keywords": [
+        "belt",
+        "coding task",
+        "diff",
+        "station",
+        "develop",
+        "code change",
+        "proposed change"
+      ],
+      "kind": "surface",
+      "name": "Belt",
+      "narrative": "The Belt surface is where a human hands the develop station a coding task and watches it run: repo picker, run cards, and the read-only diff viewer, with the station agent in the chat rail. Point a user here to request code changes or review proposed diffs. This is the home surface of the Belt primitive.",
+      "requires": [
+        "primitive:belt"
+      ],
+      "summary": "Belt develop-station console: repo picker, run cards, and a read-only diff viewer, chat-first.",
+      "surface": "/belt"
+    },
+    {
+      "how": "",
+      "id": "surface:calendar",
+      "keywords": [
+        "calendar",
+        "events",
+        "schedule",
+        "upcoming",
+        "meetings schedule"
+      ],
+      "kind": "surface",
+      "name": "Calendar",
+      "narrative": "The Calendar surface shows the workspace calendar. Point a user here to see upcoming events; calendar data arrives via bound connectors (e.g. Google Calendar).",
+      "requires": [],
+      "summary": "Workspace calendar (operator surface).",
+      "surface": "/calendar"
+    },
+    {
+      "how": "",
+      "id": "surface:chat",
+      "keywords": [
+        "chat",
+        "rooms",
+        "dm",
+        "message",
+        "conversation",
+        "talk",
+        "agent room",
+        "channel",
+        "group"
+      ],
+      "kind": "surface",
+      "name": "Chat",
+      "narrative": "Chat is where users talk to agents and each other: a rooms rail with DMs, agent rooms, groups, channels, plus entity rooms scoped to a pocket (/chat/<pocketId>). Point a user here to converse with an agent, resume a room, or work inside a pocket-bound conversation.",
+      "requires": [],
+      "summary": "Chat panel with the rooms rail: DMs, agent rooms, groups, channels, and entity rooms bound to pockets.",
+      "surface": "/chat"
+    },
+    {
+      "how": "",
+      "id": "surface:code",
+      "keywords": [
+        "code",
+        "ide",
+        "editor",
+        "file tree",
+        "scripts",
+        "edit code"
+      ],
+      "kind": "surface",
+      "name": "Code",
+      "narrative": "The Code surface is an in-browser IDE over the shared workspace: a real file tree, editor tabs, and an honest activity indicator while the agent does the work agent-side. Point a user here to read or edit workspace code with the agent alongside.",
+      "requires": [],
+      "summary": "In-browser IDE: real workspace file tree, editor tabs, and an agent-side edit-run-verify loop.",
+      "surface": "/code"
+    },
+    {
+      "how": "",
+      "id": "surface:decisions-graph",
+      "keywords": [
+        "decision graph",
+        "trace",
+        "why",
+        "history",
+        "projection",
+        "drill down",
+        "audit trail"
+      ],
+      "kind": "surface",
+      "name": "Decision Graph",
+      "narrative": "Decision Graph lets an operator query the historical Decision projection visually — deep-linkable by decision id, depth, and mode. Point a user here to trace WHY a decision happened and what it connects to; for the live feed of recent decisions use /paw-print instead.",
+      "requires": [
+        "primitive:instinct"
+      ],
+      "summary": "Visual query layer over the historical Decision projection: trace a decision's graph by id, depth, and mode.",
+      "surface": "/decisions-graph"
+    },
+    {
+      "how": "",
+      "id": "surface:files",
+      "keywords": [
+        "files",
+        "browser",
+        "documents",
+        "uploads",
+        "folders"
+      ],
+      "kind": "surface",
+      "name": "Files",
+      "narrative": "The Files surface is the workspace file browser. Point a user here to browse, inspect, or manage the files the workspace holds — including files that feed the knowledge base.",
+      "requires": [],
+      "summary": "Workspace file browser panel.",
+      "surface": "/files"
+    },
+    {
+      "how": "",
+      "id": "surface:foresight",
+      "keywords": [
+        "foresight",
+        "scenario",
+        "simulate",
+        "rehearse",
+        "forecast",
+        "what if",
+        "runs",
+        "insights"
+      ],
+      "kind": "surface",
+      "name": "Foresight",
+      "narrative": "Foresight is the rehearsal surface: create what-if scenarios, run them, and inspect runs, insights, and aggregate views before committing to a decision. Point a user here to rehearse, simulate, or forecast a decision.",
+      "requires": [],
+      "summary": "Scenario rehearsal: create, run, and compare what-if scenarios (runs, insights, fabric, aggregate views).",
+      "surface": "/foresight"
+    },
+    {
+      "how": "",
+      "id": "surface:home",
+      "keywords": [
+        "home",
+        "start",
+        "overview",
+        "widget grid",
+        "landing",
+        "today",
+        "intent"
+      ],
+      "kind": "surface",
+      "name": "Home",
+      "narrative": "Home is the landing surface of the paw-enterprise client: a live widget grid (pinned pockets, the member 'intent of the day' board), an activity river, and a chat pill. Point a user here when they want their day at a glance or a place to start — everything else is one hop away.",
+      "requires": [],
+      "summary": "The OS home screen: live Ripple widget grid, workspace activity feed, greeting, and chat pill.",
+      "surface": "/"
+    },
+    {
+      "how": "",
+      "id": "surface:integrations",
+      "keywords": [
+        "integrations",
+        "credentials",
+        "oauth",
+        "connect",
+        "api key",
+        "external service",
+        "providers"
+      ],
+      "kind": "surface",
+      "name": "Integrations",
+      "narrative": "The Integrations settings page manages workspace-level third-party credentials (web search, OAuth apps, image generation). Point a user here to wire up or fix an external service; connectors bound to pockets draw on these credentials. This is the home surface of the Connector primitive.",
+      "requires": [
+        "primitive:connector"
+      ],
+      "summary": "Workspace-level third-party credentials: web search, OAuth apps, image generation providers.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "",
+      "id": "surface:knowledge",
+      "keywords": [
+        "knowledge base",
+        "kb",
+        "articles",
+        "wiki",
+        "search knowledge",
+        "docs"
+      ],
+      "kind": "surface",
+      "name": "Knowledge",
+      "narrative": "The Knowledge surface hosts the workspace-level KB browser — compiled, searchable articles built from the workspace's files and sources. Point a user here to read or verify what the workspace knows about a topic.",
+      "requires": [],
+      "summary": "Workspace knowledge-base browser: compiled articles from source files and documents, searchable.",
+      "surface": "/knowledge"
+    },
+    {
+      "how": "",
+      "id": "surface:meetings",
+      "keywords": [
+        "meetings",
+        "timeline",
+        "recordings",
+        "notes",
+        "transcript"
+      ],
+      "kind": "surface",
+      "name": "Meetings",
+      "narrative": "The Meetings surface is the unified meetings timeline. Point a user here to review past and upcoming meetings and their details; meeting preferences live at /settings/meetings.",
+      "requires": [],
+      "summary": "Unified meetings timeline.",
+      "surface": "/meetings"
+    },
+    {
+      "how": "",
+      "id": "surface:mission-control",
+      "keywords": [
+        "mission control",
+        "operator",
+        "work feed",
+        "cycles",
+        "plan",
+        "analytics",
+        "in flight"
+      ],
+      "kind": "surface",
+      "name": "Mission Control",
+      "narrative": "Mission Control is the operator surface — a unified work feed (Feed, Cycles, Analytics tabs) with per-item actions and project filters. Point a user here to run the workspace's ongoing work: what is in flight, what needs attention, and how it is trending.",
+      "requires": [],
+      "summary": "Operator surface: unified work feed with cycles, plan, activity, and analytics tabs, filterable by project.",
+      "surface": "/mission-control"
+    },
+    {
+      "how": "",
+      "id": "surface:paw-print",
+      "keywords": [
+        "decisions",
+        "corrections",
+        "feed",
+        "governance",
+        "what happened",
+        "instinct",
+        "review decisions"
+      ],
+      "kind": "surface",
+      "name": "Paw Print",
+      "narrative": "Paw Print is the org-wide decision feed — recent Instinct corrections across the workspace, each rendered through a diff viewer. Point a user here to review what decisions agents and humans have been making. It is the decision-feed home of the Instinct primitive; the historical query layer is /decisions-graph.",
+      "requires": [
+        "primitive:instinct"
+      ],
+      "summary": "Org-wide decision feed: recent Instinct corrections across the workspace's pockets, with diff viewers.",
+      "surface": "/paw-print"
+    },
+    {
+      "how": "",
+      "id": "surface:pockets",
+      "keywords": [
+        "pockets",
+        "canvas",
+        "dashboard",
+        "apps",
+        "open pocket",
+        "workspace apps",
+        "tracker"
+      ],
+      "kind": "surface",
+      "name": "Pockets",
+      "narrative": "The Pockets surface lists every pocket in the workspace and opens each one's live canvas (/pockets/<id>). After creating or editing a pocket, point the user here to see and use it. This is the home surface of the Pocket primitive.",
+      "requires": [
+        "primitive:pocket"
+      ],
+      "summary": "Pockets dashboard: the list of workspace pockets plus the canvas detail view for each one.",
+      "surface": "/pockets"
+    },
+    {
+      "how": "",
+      "id": "surface:settings",
+      "keywords": [
+        "settings",
+        "profile",
+        "preferences",
+        "api keys",
+        "security",
+        "notifications",
+        "configure"
+      ],
+      "kind": "surface",
+      "name": "Settings",
+      "narrative": "Settings hosts per-user pages (profile, security, notifications, preferences, API keys) and the workspace admin area under /settings/workspace (members, channels, integrations, policy, memory, SSO, voice — including the workspace plan). Point a user here to change how their account or workspace behaves.",
+      "requires": [],
+      "summary": "Personal + workspace settings: profile, security, notifications, preferences, API keys, and the workspace admin area.",
+      "surface": "/settings"
+    },
+    {
+      "how": "",
+      "id": "surface:sites",
+      "keywords": [
+        "sites",
+        "website",
+        "publish",
+        "landing page",
+        "gallery",
+        "domain",
+        "live site",
+        "online"
+      ],
+      "kind": "surface",
+      "name": "Sites",
+      "narrative": "The Sites surface shows the workspace's published websites as a card gallery and opens each site's detail (/sites/<siteId>). Describing a site in its chat rail triggers the create-then-publish flow. After publishing a website, point the user here to see the live site and manage it.",
+      "requires": [
+        "primitive:sites"
+      ],
+      "summary": "Sites gallery: published Paw Sites as cards, with a chat rail that drives the create-and-publish flow.",
+      "surface": "/sites"
+    },
+    {
+      "how": "",
+      "id": "surface:studio",
+      "keywords": [
+        "studio",
+        "image",
+        "video",
+        "generate",
+        "media",
+        "poster",
+        "illustration",
+        "gallery"
+      ],
+      "kind": "surface",
+      "name": "Studio",
+      "narrative": "Studio is the media-generation surface: the user describes an image or short video in the chat rail, the agent generates it, and results land in a gallery pocket on the left. Point a user here for any describe-to-media request.",
+      "requires": [],
+      "summary": "Media generation gallery: describe an image or short video in the rail and the agent generates it into the gallery.",
+      "surface": "/studio"
+    },
+    {
+      "how": "",
+      "id": "surface:workspace-admin",
+      "keywords": [
+        "workspace",
+        "admin",
+        "members",
+        "plan",
+        "billing",
+        "usage",
+        "policy",
+        "sso",
+        "channels"
+      ],
+      "kind": "surface",
+      "name": "Workspace Admin",
+      "narrative": "Workspace Admin is the workspace-scoped settings area: workspace name and plan, members, channels, integrations, memory, policy, SSO, voice, and advanced options. Point a user here for anything that affects the whole workspace — including checking the current plan. There is no dedicated billing route today; plan info lives here.",
+      "requires": [],
+      "summary": "Workspace administration: name, plan, members, channels, integrations, memory, policy, SSO, voice, advanced.",
+      "surface": "/settings/workspace"
     }
-  ]
+  ],
+  "generated": true,
+  "schema": "paw.atlas/v1"
 }

--- a/src/pocketpaw/atlas/model.py
+++ b/src/pocketpaw/atlas/model.py
@@ -8,6 +8,12 @@
 # ``surface`` entries (the paw-enterprise client's user-facing routes) next
 # to the primitives, and primitives with a natural home route populate
 # their ``surface`` field. Docstrings updated to match; no schema change.
+# Updated: 2026-07-02 (feat/atlas-compiler, AT-4) — additive only, still
+# paw.atlas/v1: new ``sense`` kind (extracted from the senses vocabulary by
+# the compiler) and a top-level ``generated`` provenance flag that the
+# compiled artifact (``atlas/data/atlas.json``, now built by
+# ``atlas/compile.py`` from ``atlas/authored/*.json`` + the connector YAMLs)
+# sets to true. Hand-authored files omit it (defaults false).
 
 from __future__ import annotations
 
@@ -18,9 +24,10 @@ from pydantic import BaseModel, Field
 # Schema identifier the seed file must carry at its top level.
 ATLAS_SCHEMA_V1 = "paw.atlas/v1"
 
-# ``primitive`` and ``surface`` are seeded today; the rest are reserved so
+# ``primitive`` and ``surface`` are hand-authored; ``connector`` and
+# ``sense`` are extracted by the compiler (AT-4); the rest are reserved so
 # later tasks can add entries without a schema bump.
-AtlasKind = Literal["primitive", "capability", "surface", "connector", "widget", "skill"]
+AtlasKind = Literal["primitive", "capability", "surface", "connector", "sense", "widget", "skill"]
 
 
 class AtlasEntry(BaseModel):
@@ -62,9 +69,19 @@ class AtlasEntry(BaseModel):
 
 
 class AtlasModel(BaseModel):
-    """The full self-model document: schema tag + entries."""
+    """The full self-model document: schema tag + entries.
+
+    ``generated`` is the provenance header (AT-4): true on the compiled
+    artifact written by ``pocketpaw atlas build``, absent/false on the
+    hand-authored source files under ``atlas/authored/``. Additive field —
+    the schema stays paw.atlas/v1.
+    """
 
     schema_: Literal["paw.atlas/v1"] = Field(alias="schema", default=ATLAS_SCHEMA_V1)
+    generated: bool = Field(
+        default=False,
+        description="True when this document was written by the atlas compiler.",
+    )
     entries: list[AtlasEntry] = Field(default_factory=list)
 
     model_config = {"populate_by_name": True}

--- a/src/pocketpaw/atlas/store.py
+++ b/src/pocketpaw/atlas/store.py
@@ -10,17 +10,28 @@
 # Updated: 2026-07-02 (feat/atlas-surface, AT-3) — no code change; the seed
 # now also carries kind="surface" entries (frontend routes), which search
 # and describe serve exactly like primitives.
+# Updated: 2026-07-02 (feat/atlas-compiler, AT-4) — the data file is now the
+# COMPILED artifact (authored primitives/surfaces + extracted connector and
+# sense entries; see ``atlas/compile.py``). New lightweight startup drift
+# check: the first ``get_atlas_store()`` call compares the artifact's
+# ``connector:*`` name set against the live connector YAML scan (the same
+# dirs ConnectorRegistry reads) and logs a WARNING on mismatch — name-set
+# compare only, no recompile, never raises.
 
 from __future__ import annotations
 
 import json
+import logging
 import re
 from pathlib import Path
 
 from pocketpaw.atlas.model import AtlasEntry, AtlasModel
 
-# The hand-authored seed ships inside the package (hatchling includes
-# non-Python files under src/pocketpaw in the wheel).
+logger = logging.getLogger(__name__)
+
+# The compiled artifact ships inside the package (hatchling includes
+# non-Python files under src/pocketpaw in the wheel). Built by
+# ``pocketpaw atlas build`` from atlas/authored/ + the connector YAMLs.
 _DATA_PATH = Path(__file__).parent / "data" / "atlas.json"
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
@@ -106,15 +117,76 @@ class AtlasStore:
         return self._by_id.get(entry_id)
 
 
+def _scan_live_connector_names() -> set[str]:
+    """Names of connector definitions visible to the live registry.
+
+    Mirrors ``ConnectorRegistry._scan``'s directories (home dir +
+    CWD ``connectors/``) but reads only the YAML ``name:`` field — no
+    adapters, no state store, no registry construction. Cheap enough to
+    run once at first store load.
+    """
+    import yaml
+
+    from pocketpaw.connectors.registry import _default_home_connectors_dir
+
+    names: set[str] = set()
+    for directory in (_default_home_connectors_dir(), Path("connectors")):
+        if not directory.exists():
+            continue
+        for path in sorted(directory.glob("*.yaml")):
+            try:
+                raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+                name = raw.get("name")
+                if isinstance(name, str) and name:
+                    names.add(name)
+            except Exception:  # noqa: BLE001 — malformed YAML never breaks the check
+                continue
+    return names
+
+
+def check_connector_drift(store: AtlasStore, live_names: set[str] | None = None) -> bool:
+    """Warn (never raise) when the compiled artifact's connector set is stale.
+
+    Compares the ``connector:*`` ids in the artifact against the live
+    connector name set (scanned from the YAML dirs when not passed in).
+    Returns True when drift was detected and a WARNING was logged. Kept
+    deliberately cheap: a name-set compare, no recompile.
+    """
+    try:
+        atlas_names = {e.id.split(":", 1)[1] for e in store.entries if e.kind == "connector"}
+        if live_names is None:
+            live_names = _scan_live_connector_names()
+        if atlas_names == live_names:
+            return False
+        missing = sorted(live_names - atlas_names)
+        extra = sorted(atlas_names - live_names)
+        logger.warning(
+            "atlas is stale — run `pocketpaw atlas build` "
+            "(connectors missing from atlas: %s; in atlas but not live: %s)",
+            ", ".join(missing) or "none",
+            ", ".join(extra) or "none",
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — the drift check must never raise
+        logger.debug("atlas connector drift check skipped: %s", exc)
+        return False
+
+
 _store: AtlasStore | None = None
 
 
 def get_atlas_store() -> AtlasStore:
-    """Module-level lazy singleton — one parsed model per process."""
+    """Module-level lazy singleton — one parsed model per process.
+
+    The first load also runs the connector drift check (WARNING-only,
+    never raises) so a stale compiled artifact is visible in the logs of
+    whichever process serves atlas first (MCP server, primer build, CLI).
+    """
     global _store
     if _store is None:
         _store = AtlasStore.load()
+        check_connector_drift(_store)
     return _store
 
 
-__all__ = ["AtlasStore", "get_atlas_store"]
+__all__ = ["AtlasStore", "check_connector_drift", "get_atlas_store"]

--- a/src/pocketpaw/atlas/store.py
+++ b/src/pocketpaw/atlas/store.py
@@ -158,6 +158,14 @@ def check_connector_drift(store: AtlasStore, live_names: set[str] | None = None)
             live_names = _scan_live_connector_names()
         if atlas_names == live_names:
             return False
+        if not live_names:
+            # No connector YAMLs visible from this process (installed wheel,
+            # CWD outside the repo). That's an environment fact, not a stale
+            # artifact — rebuilding wouldn't change anything. Stay quiet.
+            logger.debug(
+                "atlas connector drift check skipped: no live connector definitions visible"
+            )
+            return False
         missing = sorted(live_names - atlas_names)
         extra = sorted(atlas_names - live_names)
         logger.warning(

--- a/src/pocketpaw/cli/atlas.py
+++ b/src/pocketpaw/cli/atlas.py
@@ -1,0 +1,52 @@
+# CLI atlas command — build/check the compiled atlas artifact (AT-4).
+# Created: 2026-07-02 (feat/atlas-compiler).
+# `pocketpaw atlas build` compiles authored entries + extracted connector
+# and sense knowledge into src/pocketpaw/atlas/data/atlas.json (the
+# checked-in, byte-deterministic artifact). `--check` compiles to memory
+# and exits non-zero with a diff summary when the checked-in artifact is
+# stale — the CI freshness gate. Must run from the repo root (the
+# compiler reads the repo's connectors/ dir).
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pocketpaw.cli.utils import print_fail, print_ok
+
+
+def run_atlas_cmd(action: str | None = None, check: bool = False) -> int:
+    """Manage the compiled atlas artifact.
+
+    - build: compile authored + extracted entries and write the artifact
+    - build --check: compile to memory; exit 1 with a diff summary if the
+      checked-in artifact is stale (for CI)
+    """
+    if action != "build":
+        print_fail("Usage: pocketpaw atlas build [--check]")
+        return 1
+
+    from pocketpaw.atlas.compile import DEFAULT_CONNECTORS_DIR, check_artifact, write_artifact
+
+    connectors_dir = Path(DEFAULT_CONNECTORS_DIR)
+    if not connectors_dir.is_dir():
+        print_fail(
+            f"connectors dir not found at ./{connectors_dir} — "
+            "run `pocketpaw atlas build` from the repo root"
+        )
+        return 1
+
+    if check:
+        fresh, summary = check_artifact(connectors_dir=connectors_dir)
+        if fresh:
+            print_ok("atlas artifact is up to date")
+            return 0
+        print_fail(summary)
+        return 1
+
+    path, model = write_artifact(connectors_dir=connectors_dir)
+    kinds: dict[str, int] = {}
+    for entry in model.entries:
+        kinds[entry.kind] = kinds.get(entry.kind, 0) + 1
+    breakdown = ", ".join(f"{count} {kind}" for kind, count in sorted(kinds.items()))
+    print_ok(f"wrote {path} ({len(model.entries)} entries: {breakdown})")
+    return 0

--- a/tests/atlas/test_compile.py
+++ b/tests/atlas/test_compile.py
@@ -1,0 +1,199 @@
+# tests/atlas/test_compile.py — atlas compiler + drift check (AT-4).
+# Created: 2026-07-02 (feat/atlas-compiler). Proves:
+#   * byte-determinism: compile twice → identical bytes;
+#   * the authored files validate and their entries survive the compile
+#     unchanged (authored ⊂ compiled, field-for-field);
+#   * connector extraction: a real repo connector (stripe) gets an entry
+#     whose narrative carries its actions, and intent search reaches
+#     connectors ("read my invoices" → a connector that lists invoices,
+#     "stripe invoices" → connector:stripe);
+#   * sense extraction: sense entries cross-link declaring connectors;
+#   * `atlas build --check` passes on a fresh artifact, fails with a diff
+#     summary on a tampered one, and the checked-in artifact is fresh;
+#   * the startup drift check warns on mismatch (caplog), stays silent on
+#     match, and never raises.
+
+import json
+import logging
+
+from pocketpaw.atlas.compile import (
+    AUTHORED_FILES,
+    check_artifact,
+    compile_atlas,
+    compile_atlas_bytes,
+    load_authored_entries,
+    serialize_atlas,
+    write_artifact,
+)
+from pocketpaw.atlas.model import ATLAS_SCHEMA_V1, AtlasModel
+from pocketpaw.atlas.store import _DATA_PATH, AtlasStore, check_connector_drift
+
+
+class TestDeterminism:
+    def test_compile_twice_yields_identical_bytes(self):
+        first = compile_atlas_bytes()
+        second = compile_atlas_bytes()
+        assert first == second, "compiler must be byte-deterministic"
+
+    def test_serialization_shape(self):
+        """Sorted entry ids, sorted keys, trailing newline, generated flag."""
+        raw = compile_atlas_bytes().decode("utf-8")
+        assert raw.endswith("\n") and not raw.endswith("\n\n")
+        doc = json.loads(raw)
+        assert doc["schema"] == ATLAS_SCHEMA_V1
+        assert doc["generated"] is True
+        ids = [e["id"] for e in doc["entries"]]
+        assert ids == sorted(ids), "entries must be sorted by id"
+
+    def test_checked_in_artifact_is_fresh(self):
+        """The committed data/atlas.json matches a fresh compile — the same
+        gate CI runs via `pocketpaw atlas build --check`."""
+        fresh, summary = check_artifact()
+        assert fresh, summary
+
+
+class TestAuthoredFiles:
+    def test_authored_files_validate_against_schema(self):
+        for path in AUTHORED_FILES:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            model = AtlasModel.model_validate(raw)
+            assert model.schema_ == ATLAS_SCHEMA_V1
+            assert model.generated is False, "authored files are sources, not compiled"
+            assert model.entries
+
+    def test_authored_kinds_are_split_by_file(self):
+        prims = AtlasModel.model_validate(json.loads(AUTHORED_FILES[0].read_text(encoding="utf-8")))
+        surfs = AtlasModel.model_validate(json.loads(AUTHORED_FILES[1].read_text(encoding="utf-8")))
+        assert {e.kind for e in prims.entries} == {"primitive"}
+        assert {e.kind for e in surfs.entries} == {"surface"}
+        assert len(prims.entries) == 10
+        assert len(surfs.entries) == 21
+
+    def test_authored_entries_survive_compile_unchanged(self):
+        """Every authored entry appears in the compiled model identical
+        field-for-field — the compiler never rewrites authored content."""
+        compiled = {e.id: e for e in compile_atlas().entries}
+        for entry in load_authored_entries():
+            assert compiled[entry.id] == entry
+
+
+class TestConnectorExtraction:
+    def test_stripe_entry_carries_actions_in_narrative(self):
+        entry = AtlasStore.load().describe("connector:stripe")
+        assert entry is not None, "stripe.yaml exists in connectors/ — must be extracted"
+        assert entry.kind == "connector"
+        assert "list_invoices" in entry.narrative
+        assert "list_subscriptions" in entry.narrative
+        assert entry.requires == ["primitive:connector"]
+        assert "stripe" in entry.keywords
+
+    def test_read_my_invoices_reaches_a_connector_that_lists_invoices(self):
+        """The slice this fixes: intent search must surface connector
+        knowledge, not just primitives."""
+        results = AtlasStore.load().search("read my invoices")
+        connector_hits = [
+            e for e in results if e.kind == "connector" and "invoice" in e.narrative.lower()
+        ]
+        assert connector_hits, (
+            f"expected an invoice-capable connector, got {[e.id for e in results]}"
+        )
+
+    def test_stripe_invoices_ranks_stripe_first(self):
+        results = AtlasStore.load().search("stripe invoices")
+        assert results and results[0].id == "connector:stripe", (
+            f"expected connector:stripe first, got {[e.id for e in results]}"
+        )
+
+    def test_every_repo_connector_yaml_has_an_entry(self):
+        from pathlib import Path
+
+        import yaml
+
+        store = AtlasStore.load()
+        for path in sorted(Path("connectors").glob("*.yaml")):
+            name = yaml.safe_load(path.read_text(encoding="utf-8"))["name"]
+            assert store.describe(f"connector:{name}") is not None, (
+                f"{path} missing from compiled atlas — run `pocketpaw atlas build`"
+            )
+
+
+class TestSenseExtraction:
+    def test_payments_sense_links_stripe(self):
+        entry = AtlasStore.load().describe("sense:paw.payments.v1")
+        assert entry is not None
+        assert entry.kind == "sense"
+        assert "stripe" in entry.narrative
+        assert "connector:stripe" in entry.requires
+
+    def test_all_core_senses_have_entries_with_declaring_connectors(self):
+        from pocketpaw.senses.vocabulary import CORE_SENSES
+
+        store = AtlasStore.load()
+        for sense in CORE_SENSES:
+            entry = store.describe(f"sense:{sense.id}")
+            assert entry is not None, f"sense {sense.id} missing from compiled atlas"
+            assert entry.summary == sense.description
+            # Every core sense is backed by >=1 connector (vocabulary guard
+            # rule), so the entry must cross-link at least one.
+            assert entry.requires, f"{entry.id} must link its declaring connectors"
+
+
+class TestCheckArtifact:
+    def test_check_passes_on_fresh_artifact(self, tmp_path):
+        path, _model = write_artifact(output_path=tmp_path / "atlas.json")
+        fresh, summary = check_artifact(artifact_path=path)
+        assert fresh and summary == ""
+
+    def test_check_fails_on_tampered_artifact(self, tmp_path):
+        path, _model = write_artifact(output_path=tmp_path / "atlas.json")
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        doc["entries"] = [e for e in doc["entries"] if e["id"] != "connector:stripe"]
+        path.write_text(json.dumps(doc), encoding="utf-8")
+        fresh, summary = check_artifact(artifact_path=path)
+        assert not fresh
+        assert "connector:stripe" in summary
+        assert "pocketpaw atlas build" in summary
+
+    def test_check_fails_on_missing_artifact(self, tmp_path):
+        fresh, summary = check_artifact(artifact_path=tmp_path / "nope.json")
+        assert not fresh and "missing" in summary
+
+
+class TestDriftCheck:
+    def test_warns_on_connector_mismatch(self, caplog):
+        store = AtlasStore.load(_DATA_PATH)
+        atlas_names = {e.id.split(":", 1)[1] for e in store.entries if e.kind == "connector"}
+        with caplog.at_level(logging.WARNING, logger="pocketpaw.atlas.store"):
+            drifted = check_connector_drift(store, live_names=atlas_names | {"brand-new-connector"})
+        assert drifted is True
+        assert any(
+            "atlas is stale" in r.message and "brand-new-connector" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_silent_on_match(self, caplog):
+        store = AtlasStore.load(_DATA_PATH)
+        atlas_names = {e.id.split(":", 1)[1] for e in store.entries if e.kind == "connector"}
+        with caplog.at_level(logging.WARNING, logger="pocketpaw.atlas.store"):
+            drifted = check_connector_drift(store, live_names=atlas_names)
+        assert drifted is False
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_never_raises_even_on_broken_input(self, caplog):
+        """The drift check must never take the store down with it."""
+
+        class _Boom:
+            @property
+            def entries(self):
+                raise RuntimeError("boom")
+
+        with caplog.at_level(logging.WARNING, logger="pocketpaw.atlas.store"):
+            assert check_connector_drift(_Boom()) is False  # type: ignore[arg-type]
+
+    def test_serialize_roundtrip_loads_in_store(self, tmp_path):
+        """A compiled artifact loads through the unchanged store API."""
+        path = tmp_path / "atlas.json"
+        path.write_bytes(serialize_atlas(compile_atlas()))
+        store = AtlasStore.load(path)
+        assert store.describe("primitive:pocket") is not None
+        assert store.describe("connector:stripe") is not None

--- a/tests/atlas/test_store.py
+++ b/tests/atlas/test_store.py
@@ -10,11 +10,19 @@
 # its ``surface`` field); new search/describe tests pin "publish a website"
 # → sites with the /sites route populated, and primitives cross-linked to
 # their home surfaces.
+# Updated: 2026-07-02 (feat/atlas-compiler, AT-4) — the data file is now the
+# COMPILED artifact carrying extracted ``connector`` and ``sense`` entries
+# next to the authored ones, with ``generated: true``. Loader assertions
+# updated: authored ids are a subset (still exact per authored kind), every
+# entry kind is one of the four compiled kinds, and search-ranking pins are
+# unchanged (they must survive the 41 new entries).
 
 import json
 
 from pocketpaw.atlas.model import ATLAS_SCHEMA_V1, AtlasModel
 from pocketpaw.atlas.store import _DATA_PATH, AtlasStore, get_atlas_store
+
+COMPILED_KINDS = ("primitive", "surface", "connector", "sense")
 
 EXPECTED_PRIMITIVE_IDS = {
     "primitive:pocket",
@@ -70,13 +78,21 @@ class TestLoader:
     def test_loads_and_validates_seed(self):
         store = AtlasStore.load()
         assert store.model.schema_ == ATLAS_SCHEMA_V1
-        assert {e.id for e in store.entries} == EXPECTED_PRIMITIVE_IDS | EXPECTED_SURFACE_IDS
+        assert store.model.generated is True, "the data file is the compiled artifact"
+        ids = {e.id for e in store.entries}
+        # Authored entries are exact per kind; extracted connector/sense
+        # entries ride alongside (their exact set is pinned by the compiler
+        # tests against the repo's connector YAMLs).
+        assert {i for i in ids if i.startswith("primitive:")} == EXPECTED_PRIMITIVE_IDS
+        assert {i for i in ids if i.startswith("surface:")} == EXPECTED_SURFACE_IDS
+        assert any(i.startswith("connector:") for i in ids)
+        assert any(i.startswith("sense:") for i in ids)
 
     def test_all_seed_entries_are_complete(self):
         """Every entry has the load-bearing fields filled: a one-line
         summary, a narrative, and search keywords."""
         for entry in AtlasStore.load().entries:
-            assert entry.kind in ("primitive", "surface")
+            assert entry.kind in COMPILED_KINDS
             assert entry.name
             assert entry.summary and "\n" not in entry.summary.strip()
             assert entry.narrative


### PR DESCRIPTION
## What ships

atlas becomes a compiled, deterministic artifact (stacks on #1615):

- **Authored/compiled split** — hand-authored entries move to `atlas/authored/{primitives,surfaces}.json` (verified field-identical through the move); `data/atlas.json` is now the compiled output, checked in like a lockfile with a `generated: true` header. 72 entries total.
- **Connector extraction** — one `connector:*` entry per YAML (35): actions with descriptions and key params in the narrative, declared senses, searchable keywords. `atlas_search("stripe invoices")` now top-hits stripe with `list_invoices` in the detail — the "agent doesn't know what a connector can do" gap is closed.
- **Senses extraction** — 6 `sense:*` entries from CORE_SENSES, each cross-linking its declaring connectors (e.g. `sense:paw.code.v1` → github, gitlab).
- **`pocketpaw atlas build`** CLI (+ `--check` for CI: exit 1 with a diff summary when the artifact is stale). `--check` added to the existing lint job in ci.yml.
- **Startup drift check** — first store load compares compiled vs live connector names; mismatch logs a warning, never raises. Stays quiet when the process can't see any connector YAMLs at all (installed wheel / foreign CWD) — that's an environment fact, not staleness.

## Testing

`tests/atlas/ + tests/test_agents_md.py` → 72 passed; determinism pinned by test AND proven live (built twice, diff empty); `--check` exercised against a genuinely tampered artifact (exit 1) and fresh one (exit 0); ruff clean. Reviewed (spec + quality): pass — the one important finding (drift false-positive with empty live set) fixed here; review verified all 35 connector entries match their YAMLs and the authored move byte-for-byte.

Known minors accepted: hypothetical duplicate connector `name:` across YAMLs isn't deduped by the compiler (registry dedupes; curated dir); extraction tests assume repo-root CWD (matches CI).