### PR TITLE
feat(shield): real-client-IP access log for CrowdSec (opt-in)

### DIFF
--- a/src/pocketpaw/api/access_log.py
+++ b/src/pocketpaw/api/access_log.py
@@ -1,0 +1,158 @@
+# nginx-combined HTTP access-log middleware for ``pocketpaw serve``.
+#
+# What this does:
+#   A raw ASGI middleware (matching the AuthMiddleware pattern in
+#   dashboard_auth.py — no BaseHTTPMiddleware, so WebSocket scopes pass through
+#   untouched) that, for every HTTP request, appends ONE nginx-combined-format
+#   line to ``Settings.access_log_path``. shield's CrowdSec parses that file to
+#   detect probing/scanning.
+#
+#   The backend sits behind Cloudflare → Traefik, so the socket peer is a proxy.
+#   The log records the REAL client IP resolved by precedence:
+#     CF-Connecting-IP header → leftmost hop of X-Forwarded-For → peer host.
+#   Recording the proxy IP would make CrowdSec ban the proxy (self-DoS).
+#
+#   Robustness: the parent dir is created on first use; any write failure logs a
+#   warning ONCE and is swallowed — a logging failure must NEVER 500 a request.
+#   The middleware is only added by create_api_app() when access_log_path is set,
+#   so default deploys are byte-for-byte unchanged.
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# nginx "combined" log format:
+#   $remote_addr - $remote_user [$time_local] "$request" $status
+#   $body_bytes_sent "$http_referer" "$http_user_agent"
+# We emit remote_user as "-" (no HTTP basic auth) and use a fixed +0000
+# strftime so CrowdSec's nginx parser reads it cleanly.
+_LOG_FORMAT = '{ip} - - [{ts}] "{method} {path} HTTP/{ver}" {status} {size} "{referer}" "{ua}"\n'
+_TS_FORMAT = "%d/%b/%Y:%H:%M:%S +0000"
+
+
+def _first_header(headers: list[tuple[bytes, bytes]], name: bytes) -> str | None:
+    """Return the first value for ``name`` (lowercased) from raw ASGI headers."""
+    for k, v in headers:
+        if k.lower() == name:
+            try:
+                return v.decode("latin-1")
+            except Exception:
+                return None
+    return None
+
+
+def _resolve_client_ip(headers: list[tuple[bytes, bytes]], peer: str) -> str:
+    """Resolve the real client IP by proxy-aware precedence.
+
+    Order: ``CF-Connecting-IP`` → leftmost hop of ``X-Forwarded-For`` → peer.
+    The deploy sits behind Cloudflare + Traefik, so the forwarded headers are
+    trusted here (they'd be strippable/spoofable on a direct-to-internet box).
+    """
+    cf_ip = _first_header(headers, b"cf-connecting-ip")
+    if cf_ip and cf_ip.strip():
+        return cf_ip.strip()
+
+    xff = _first_header(headers, b"x-forwarded-for")
+    if xff and xff.strip():
+        # Leftmost entry is the originating client; the rest are proxy hops.
+        first_hop = xff.split(",")[0].strip()
+        if first_hop:
+            return first_hop
+
+    return peer
+
+
+class AccessLogMiddleware:
+    """Pure ASGI middleware that appends nginx-combined access-log lines.
+
+    Only HTTP scopes are logged; WebSocket and lifespan scopes pass straight
+    through. Wired into create_api_app() ONLY when ``access_log_path`` is set.
+    """
+
+    def __init__(self, app, log_path: str):
+        self.app = app
+        self.log_path = Path(log_path)
+        self._dir_ready = False
+        self._warned = False
+
+    def _ensure_dir(self) -> None:
+        if self._dir_ready:
+            return
+        parent = self.log_path.parent
+        if parent and not parent.exists():
+            parent.mkdir(parents=True, exist_ok=True)
+        self._dir_ready = True
+
+    def _write(self, line: str) -> None:
+        """Append one line; swallow (and warn-once on) any I/O failure."""
+        try:
+            self._ensure_dir()
+            with open(self.log_path, "a", encoding="utf-8") as fh:
+                fh.write(line)
+        except Exception:
+            if not self._warned:
+                self._warned = True
+                logger.warning(
+                    "access-log write to %s failed; access logging disabled for "
+                    "this process until it recovers",
+                    self.log_path,
+                    exc_info=True,
+                )
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            # WebSocket / lifespan — never logged.
+            await self.app(scope, receive, send)
+            return
+
+        headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+        peer = "-"
+        client = scope.get("client")
+        if client:
+            peer = client[0] or "-"
+
+        status_holder = {"status": 0, "size": 0}
+
+        async def send_wrapper(message):
+            mtype = message.get("type")
+            if mtype == "http.response.start":
+                status_holder["status"] = message.get("status", 0)
+            elif mtype == "http.response.body":
+                body = message.get("body", b"")
+                if body:
+                    status_holder["size"] += len(body)
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            try:
+                ip = _resolve_client_ip(headers, peer)
+                method = scope.get("method", "-")
+                raw_path = scope.get("path", "-") or "-"
+                qs = scope.get("query_string", b"")
+                if qs:
+                    raw_path = f"{raw_path}?{qs.decode('latin-1', 'replace')}"
+                http_version = scope.get("http_version", "1.1")
+                referer = _first_header(headers, b"referer") or "-"
+                ua = _first_header(headers, b"user-agent") or "-"
+                ts = datetime.now(UTC).strftime(_TS_FORMAT)
+                line = _LOG_FORMAT.format(
+                    ip=ip,
+                    ts=ts,
+                    method=method,
+                    path=raw_path,
+                    ver=http_version,
+                    status=status_holder["status"],
+                    size=status_holder["size"],
+                    referer=referer,
+                    ua=ua,
+                )
+                self._write(line)
+            except Exception:
+                # Building/writing the log line must never break the request.
+                if not self._warned:
+                    self._warned = True
+                    logger.warning("access-log line build failed", exc_info=True)

--- a/src/pocketpaw/api/serve.py
+++ b/src/pocketpaw/api/serve.py
@@ -113,6 +113,23 @@ def create_api_app():
         allow_headers=["*"],
     )
 
+    # --- Access log (outermost, opt-in) ----------------------------------
+    # When POCKETPAW_ACCESS_LOG_PATH is set, append one nginx-combined line per
+    # request so shield's CrowdSec can detect probing. Added LAST so it wraps
+    # every other layer and records the final status. Recording the REAL client
+    # IP (CF-Connecting-IP / X-Forwarded-For) matters — the deploy sits behind
+    # Cloudflare + Traefik, so logging the proxy IP would make CrowdSec ban the
+    # proxy. When the path is unset the middleware is NOT added — default
+    # deploys are byte-for-byte unchanged.
+    try:
+        _access_log_path = Settings.load().access_log_path
+    except Exception:
+        _access_log_path = None
+    if _access_log_path:
+        from pocketpaw.api.access_log import AccessLogMiddleware
+
+        app.add_middleware(AccessLogMiddleware, log_path=_access_log_path)
+
     # --- WebSocket handler helper ----------------------------------------
     async def _handle_ws(
         websocket: WebSocket,

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -65,6 +65,12 @@ Changes:
     bools' SHIPPED meaning is the full acting loop, and mapping them to
     shadow would silently strip requeue/escalate from any deployment that
     already set them. The legacy bools stay for back-compat.
+  - 2026-07-02 (feat/shield-access-log): Added ``access_log_path`` (default None,
+    env POCKETPAW_ACCESS_LOG_PATH) — when set, ``pocketpaw serve`` appends an
+    nginx-combined HTTP access log there (via the access_log middleware) so
+    shield's CrowdSec can detect probing. The logged IP is the REAL client IP
+    (CF-Connecting-IP → X-Forwarded-For leftmost → peer), never the CF/Traefik
+    proxy. Unset → middleware not added; default deploys byte-for-byte unchanged.
   - 2026-07-02 (feat/judge-shadow-1168): Added the LLM-as-judge SHADOW settings
     (J-1, issue #1168) — ``deep_work_verify_judge_shadow_enabled`` (default
     False; when True AND deep_work_verify_loop_enabled is on, every completing
@@ -1644,6 +1650,18 @@ class Settings(BaseSettings):
         description=(
             "Bearer token the cloud security proxy presents to shield over the "
             "socket. Sent as 'Authorization: Bearer <token>'. Never logged."
+        ),
+    )
+    access_log_path: str | None = Field(
+        default=None,
+        description=(
+            "Filesystem path for an nginx-combined HTTP access log emitted by "
+            "``pocketpaw serve``. When set, one access-log line per request is "
+            "appended here so shield's CrowdSec can detect probing/scanning. The "
+            "real client IP is resolved from CF-Connecting-IP / X-Forwarded-For "
+            "(the deploy sits behind Cloudflare + Traefik) so CrowdSec bans the "
+            "attacker, not the proxy. Unset/empty → no access log is written and "
+            "the middleware is not added (default deploys are unchanged)."
         ),
     )
 

--- a/tests/test_api_access_log.py
+++ b/tests/test_api_access_log.py
@@ -1,0 +1,218 @@
+# Tests for the nginx-combined HTTP access-log middleware (feat/shield-access-log).
+#
+# Covers:
+#   - real client IP precedence: CF-Connecting-IP → X-Forwarded-For leftmost →
+#     socket peer (request.client.host).
+#   - the emitted line matches nginx-combined shape (method, path, status, UA).
+#   - default (access_log_path unset) → no file written, middleware NOT added by
+#     create_api_app().
+#
+# The IP/format cases mount AccessLogMiddleware on a minimal FastAPI app (fast,
+# focused) via FastAPI's TestClient. The wiring cases exercise create_api_app()
+# with Settings.load patched, since the middleware is opt-in at build time.
+
+import re
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from pocketpaw.api.access_log import AccessLogMiddleware, _resolve_client_ip
+
+# nginx-combined:
+#   <ip> - - [<time>] "<METHOD> <path> HTTP/<ver>" <status> <bytes> "<ref>" "<ua>"
+_COMBINED_RE = re.compile(
+    r"^(?P<ip>\S+) - - "
+    r"\[(?P<ts>[^\]]+)\] "
+    r'"(?P<method>\S+) (?P<path>\S+) HTTP/(?P<ver>[\d.]+)" '
+    r"(?P<status>\d{3}) (?P<size>\d+) "
+    r'"(?P<referer>[^"]*)" "(?P<ua>[^"]*)"$'
+)
+
+
+@pytest.fixture
+def logged_app(tmp_path):
+    """A minimal app wrapped in AccessLogMiddleware writing to a tmp file."""
+    log_file = tmp_path / "nested" / "access.log"
+    app = FastAPI()
+
+    @app.get("/hello")
+    async def hello():
+        return {"ok": True}
+
+    app.add_middleware(AccessLogMiddleware, log_path=str(log_file))
+    return app, log_file
+
+
+def _read_last_line(path):
+    lines = path.read_text().splitlines()
+    assert lines, f"no lines written to {path}"
+    return lines[-1]
+
+
+# ---------------------------------------------------------------------------
+# Real client IP precedence
+# ---------------------------------------------------------------------------
+
+
+def test_cf_connecting_ip_wins(logged_app):
+    app, log_file = logged_app
+    client = TestClient(app)
+    resp = client.get(
+        "/hello",
+        headers={
+            "CF-Connecting-IP": "203.0.113.9",
+            "X-Forwarded-For": "198.51.100.7, 10.0.0.1",
+            "User-Agent": "probe/1.0",
+        },
+    )
+    assert resp.status_code == 200
+    m = _COMBINED_RE.match(_read_last_line(log_file))
+    assert m is not None
+    assert m.group("ip") == "203.0.113.9"
+
+
+def test_x_forwarded_for_leftmost_when_no_cf(logged_app):
+    app, log_file = logged_app
+    client = TestClient(app)
+    resp = client.get(
+        "/hello",
+        headers={"X-Forwarded-For": "198.51.100.7, 10.0.0.1"},
+    )
+    assert resp.status_code == 200
+    m = _COMBINED_RE.match(_read_last_line(log_file))
+    assert m is not None
+    assert m.group("ip") == "198.51.100.7"
+
+
+def test_peer_ip_when_no_proxy_headers(logged_app):
+    app, log_file = logged_app
+    # TestClient sets request.client.host to "testclient".
+    client = TestClient(app)
+    resp = client.get("/hello")
+    assert resp.status_code == 200
+    m = _COMBINED_RE.match(_read_last_line(log_file))
+    assert m is not None
+    assert m.group("ip") == "testclient"
+
+
+def test_resolve_client_ip_precedence_unit():
+    """Direct unit test of the precedence helper."""
+    cf = (b"cf-connecting-ip", b"203.0.113.9")
+    xff = (b"x-forwarded-for", b"198.51.100.7, 10.0.0.1")
+    assert _resolve_client_ip([cf, xff], "peer") == "203.0.113.9"
+    assert _resolve_client_ip([xff], "peer") == "198.51.100.7"
+    assert _resolve_client_ip([], "peer") == "peer"
+    # Empty header values fall through to the next source.
+    assert _resolve_client_ip([(b"cf-connecting-ip", b"  ")], "peer") == "peer"
+
+
+# ---------------------------------------------------------------------------
+# nginx-combined shape
+# ---------------------------------------------------------------------------
+
+
+def test_line_matches_nginx_combined_shape(logged_app):
+    app, log_file = logged_app
+    client = TestClient(app)
+    resp = client.get("/hello", headers={"User-Agent": "curl/8.0"})
+    assert resp.status_code == 200
+
+    line = _read_last_line(log_file)
+    m = _COMBINED_RE.match(line)
+    assert m is not None, f"line did not match nginx-combined: {line!r}"
+    assert m.group("method") == "GET"
+    assert m.group("path") == "/hello"
+    assert m.group("status") == "200"
+    assert m.group("ua") == "curl/8.0"
+    assert m.group("ver")  # HTTP version present
+
+
+def test_query_string_included_in_path(logged_app):
+    app, log_file = logged_app
+    client = TestClient(app)
+    resp = client.get("/hello?probe=../../etc/passwd")
+    assert resp.status_code == 200
+    m = _COMBINED_RE.match(_read_last_line(log_file))
+    assert m is not None
+    assert m.group("path").startswith("/hello?")
+    assert "probe=" in m.group("path")
+
+
+# ---------------------------------------------------------------------------
+# Robustness — a write failure must never break the request
+# ---------------------------------------------------------------------------
+
+
+def test_write_failure_does_not_break_request(tmp_path, caplog):
+    # Point the log at a path whose "parent" is an existing FILE, so mkdir and
+    # open both fail. The request must still succeed.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("i am a file, not a dir")
+    bad_path = blocker / "sub" / "access.log"
+
+    app = FastAPI()
+
+    @app.get("/hello")
+    async def hello():
+        return {"ok": True}
+
+    app.add_middleware(AccessLogMiddleware, log_path=str(bad_path))
+    client = TestClient(app)
+    resp = client.get("/hello")
+    assert resp.status_code == 200  # request unaffected by the logging failure
+
+
+# ---------------------------------------------------------------------------
+# Opt-in wiring — middleware added only when access_log_path is set
+# ---------------------------------------------------------------------------
+
+
+def _has_access_log_middleware(app) -> bool:
+    return any(mw.cls is AccessLogMiddleware for mw in app.user_middleware)
+
+
+def _force_oss_backend(monkeypatch):
+    """Pin the OSS ``file`` memory backend so create_api_app() doesn't try to
+    build the ee-only mongodb backend from a developer's local config.json —
+    keeps these wiring tests hermetic (CI has no mongodb config; a dev box may).
+    """
+    monkeypatch.setenv("POCKETPAW_MEMORY_BACKEND", "file")
+    monkeypatch.setenv("POCKETPAW_IGNORE_CONFIG_JSON", "true")
+
+
+def _patch_access_log_path(monkeypatch, value):
+    """Make Settings.load() return the given access_log_path, preserving the
+    real load path for everything else."""
+    from pocketpaw.config import Settings
+
+    real_load = Settings.load.__func__
+
+    def _load(cls):
+        s = real_load(cls)
+        s.access_log_path = value
+        return s
+
+    monkeypatch.setattr(Settings, "load", classmethod(_load))
+
+
+def test_middleware_absent_by_default(monkeypatch):
+    """access_log_path unset → create_api_app() does NOT add the middleware."""
+    _force_oss_backend(monkeypatch)
+    _patch_access_log_path(monkeypatch, None)
+
+    from pocketpaw.api.serve import create_api_app
+
+    app = create_api_app()
+    assert not _has_access_log_middleware(app)
+
+
+def test_middleware_present_when_path_set(monkeypatch, tmp_path):
+    """access_log_path set → create_api_app() adds the middleware."""
+    _force_oss_backend(monkeypatch)
+    _patch_access_log_path(monkeypatch, str(tmp_path / "access.log"))
+
+    from pocketpaw.api.serve import create_api_app
+
+    app = create_api_app()
+    assert _has_access_log_middleware(app)


### PR DESCRIPTION
## What

Adds an opt-in HTTP access log to `pocketpaw serve` so a co-located paw-shield / CrowdSec can see traffic. When `POCKETPAW_ACCESS_LOG_PATH` is set, an ASGI middleware appends one nginx-combined line per request to that file; when it's unset (the default), the middleware isn't even added, so existing deploys are unchanged.

## Why

The backend sits behind Cloudflare → Traefik, so the socket peer is a proxy. CrowdSec needs the **real** client IP or it would fingerprint and ban the proxy itself. The middleware resolves the client by precedence: `CF-Connecting-IP` → leftmost `X-Forwarded-For` hop → socket peer. nginx-combined format so the maintained `crowdsecurity/nginx` collection parses it as-is.

## Notes

- Raw ASGI middleware (mirrors `AuthMiddleware`), so WebSocket and lifespan scopes pass through untouched — only HTTP is logged.
- A logging failure can never break a request: the write is wrapped, warns once, and is swallowed in a `finally`.
- Part of the paw-shield containerized-deploy work; the deploy overlay that mounts the log volume + points CrowdSec at it lands separately. This PR is safe on its own (off by default).

## Test

`tests/test_api_access_log.py` — 9 tests covering the IP precedence (CF / XFF / peer), the nginx-combined shape, query-string handling, write-failure safety, and that the middleware is absent when the path is unset. All green locally.