### PR TITLE
feat(atlas): per-workspace live overlay with fail-closed entitlement filter

### DIFF
--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -16,6 +16,12 @@ file is now a COMPILED artifact built by `pocketpaw atlas build` from
 hand-authored sources (atlas/authored/) + extracted connector and sense
 entries; CI gates freshness via `atlas build --check`; the store logs a
 stale-artifact WARNING on connector drift at first load.
+Updated: 2026-07-02 (feat/atlas-overlay, AT-5) — live overlay +
+fail-closed entitlement filter: atlas answers now reflect the CALLING
+workspace via a per-run EntitlementProvider (atlas/overlay.py) —
+connector cards carry `available`, unavailable connectors rank below
+available ones at equal relevance and describe points them at the
+integrations surface, and non-granted entries are absent everywhere.
 -->
 
 # Atlas — the OS self-model
@@ -120,6 +126,50 @@ field so `atlas_describe` answers include where to see the result:
 dedicated billing route in the client today; plan info lives on
 `/settings/workspace`.)
 
+## Live overlay + entitlement filter (`atlas/overlay.py`)
+
+The compiled artifact is global — the same entries in every workspace. Since
+AT-5 the MCP tools view it through a per-run **overlay** so answers reflect
+the calling workspace's reality:
+
+- **`EntitlementProvider` protocol** — a small structural protocol (duck
+  typed, like the repo's other protocols) answering two per-context
+  questions: `connected_connector_names() -> set[str]` (which connectors
+  are connected in THIS context) and `is_granted(entry) -> bool` (whether
+  this context may see the entry at all).
+- **Availability annotation** — connector entries gain `available: bool`:
+  connected in this context or not. Availability is a live fact, not an
+  entitlement — an unavailable connector stays visible, it just tells the
+  agent it isn't wired up yet.
+- **Fail-closed filtering** — an entry whose grant check does not answer a
+  literal `True` (returns `False`/`None`, or the provider raises) is
+  REMOVED: absent from search results, not describable (`atlas_describe`
+  answers exactly like an unknown id), and absent from the known-ids error
+  listing. No "upgrade to see this" leakage in v1. If
+  `connected_connector_names` raises, every connector is annotated
+  `available: false` (unavailable, not filtered).
+- **Re-ranking** — search results get a stable re-sort so an available
+  connector ranks above an unavailable one at EQUAL relevance; the store's
+  base scoring is untouched (an unavailable-but-more-relevant entry still
+  wins). Filtering happens before the result limit, so non-granted entries
+  never eat result slots.
+- **No mutation** — the overlay wraps store entries in `OverlaidEntry`
+  (result layer); the shared `AtlasStore` singleton's entries are never
+  modified, and the primer / drift check keep the unfiltered OS-level view.
+
+**`DefaultEntitlementProvider` (OSS default)** gates nothing —
+`is_granted` is always `True`, so primitives, surfaces, senses, and
+connectors all stay visible in OSS. Availability comes from the real
+connector seam: `ConnectorRegistry.status(scope_key)` (the same
+durable-state view the `connector_list` builtin reports, on the same shared
+registry), resolved per call so mid-session connects are reflected. The
+scope key is per run, never a process-global: the Claude Agent SDK backend
+builds the provider with `ws:<POCKETPAW_WORKSPACE_ID>` when an isolated
+cloud run attached tenancy via `attach_subprocess_env`, else the OSS
+single-user `"default"` scope. An EE provider that consults a tenant plan
+just implements the same two-method protocol and is passed to
+`build_atlas_context_server(provider=...)`.
+
 ## Agent tools (`pocketpaw_atlas` MCP server)
 
 The `pocketpaw_atlas` in-process MCP server is registered on the Claude Agent
@@ -131,9 +181,11 @@ path), so it is ambient on every agent run. Two tools:
 - **Args:** `intent` (string, required) — what the agent is trying to do,
   e.g. `"approve agent actions"` or `"publish a website"`.
 - **Returns:** ranked capability cards as JSON —
-  `{"results": [{id, kind, name, summary, surface?}, ...]}` (top 5). Simple
-  lexical scoring over name / keywords / summary / narrative; name and
-  keyword hits rank highest.
+  `{"results": [{id, kind, name, summary, surface?, available?}, ...]}`
+  (top 5). Simple lexical scoring over name / keywords / summary /
+  narrative; name and keyword hits rank highest. `available` appears on
+  connector cards only (overlay, AT-5); available connectors rank above
+  unavailable ones at equal relevance, and non-granted entries are absent.
 - **When:** before guessing whether the OS can do something or which
   primitive fits an intent.
 
@@ -143,7 +195,12 @@ path), so it is ambient on every agent run. Two tools:
   `"primitive:instinct"`.
 - **Returns:** the full entry as JSON (`narrative`, `how`, `requires`,
   `surface`, ...). An unknown id returns an error envelope listing the known
-  ids so the agent can self-correct.
+  ids so the agent can self-correct. With the overlay (AT-5): a connector
+  entry also carries `available`, an UNAVAILABLE connector adds a
+  `connect_hint` pointing at the integrations surface route (looked up from
+  the seed's `surface:integrations` entry, not hard-coded), a filtered
+  (non-granted) id answers exactly like an unknown id, and the known-ids
+  listing carries only ids the calling context may see.
 - **When:** after `atlas_search` picks a candidate, or before explaining /
   exercising a primitive.
 
@@ -173,7 +230,13 @@ from pocketpaw.atlas import get_atlas_store
 
 store = get_atlas_store()          # lazy singleton over the compiled artifact
 store.search("approve agent actions", limit=5)  # ranked AtlasEntry list
+store.search_scored("approve agent actions")    # (score, AtlasEntry) pairs (AT-5)
 store.describe("connector:stripe")              # full AtlasEntry or None
+
+from pocketpaw.atlas import AtlasOverlay, DefaultEntitlementProvider
+provider = DefaultEntitlementProvider(scope_key="default")  # or "ws:<id>"
+AtlasOverlay.search(store, "invoices", provider, limit=5)   # OverlaidEntry list
+AtlasOverlay.describe(store, "connector:stripe", provider)  # None if filtered
 
 from pocketpaw.atlas import check_artifact, compile_atlas, write_artifact
 compile_atlas()      # authored + extracted entries, sorted by id
@@ -183,4 +246,6 @@ check_artifact()     # (fresh, diff_summary) — what `--check` calls
 
 Tests: `tests/atlas/` (`test_compile.py` pins byte-determinism, the
 authored/compiled split, connector/sense extraction, `--check`, and the
-drift warning).
+drift warning; `test_overlay.py` pins the fail-closed filter, availability
+annotation + re-ranking, no-leak describe, and the MCP handlers under
+stubbed providers).

--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -166,9 +166,19 @@ registry), resolved per call so mid-session connects are reflected. The
 scope key is per run, never a process-global: the Claude Agent SDK backend
 builds the provider with `ws:<POCKETPAW_WORKSPACE_ID>` when an isolated
 cloud run attached tenancy via `attach_subprocess_env`, else the OSS
-single-user `"default"` scope. An EE provider that consults a tenant plan
-just implements the same two-method protocol and is passed to
-`build_atlas_context_server(provider=...)`.
+single-user `"default"` scope. Tenancy attached with a BLANK workspace id
+fails closed to a sentinel scope that matches no rows — never the shared
+`"default"` bucket.
+
+**Cloud availability caveat (honest scope of v1):** the `ws:<id>` plumbing
+is in place, but the cloud connector state store intentionally does not
+enumerate tenant rows, so under a real cloud scope every connector currently
+reports `available: false` (conservative — nothing leaks, hints still point
+at the integrations surface). Live per-tenant availability lands with the EE
+provider slice: implement the same two-method protocol against the EE
+workspace-connector view and pass it to
+`build_atlas_context_server(provider=...)`. The OSS `"default"` scope reads
+live file-store state and is fully functional today.
 
 ## Agent tools (`pocketpaw_atlas` MCP server)
 

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,12 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-07-02 (feat/atlas-overlay AT-5) — the ``pocketpaw_atlas`` server
+  is now built with a per-run ``DefaultEntitlementProvider``
+  (``atlas/overlay.py``): the connector scope key resolves from THIS backend
+  instance's ``_extra_subprocess_env`` (``ws:<POCKETPAW_WORKSPACE_ID>`` when an
+  isolated cloud run attached tenancy, else the OSS ``"default"`` scope), so
+  atlas answers carry the calling workspace's connector availability and the
+  fail-closed entitlement filter — never keyed off a process-global flag.
 Updated: 2026-07-02 (feat/atlas-core AT-1) — registered the ``pocketpaw_atlas``
   in-process MCP server (``agents/sdk_mcp_atlas.py``) alongside
   ``pocketpaw_widgets``: built in ``_get_mcp_servers`` behind the same tool
@@ -930,10 +937,26 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # packaged data (pocketpaw.atlas), no cloud dependency. Lets the
         # agent query what the OS is and can do (paw meanings of Pocket /
         # Instinct / Fabric / ...) before guessing from LLM priors.
+        #
+        # AT-5: the server carries a per-run entitlement/availability
+        # provider so atlas answers reflect the CALLING workspace, not a
+        # global view. The connector scope key comes from THIS backend
+        # instance's per-run context — ``_extra_subprocess_env`` carries
+        # ``POCKETPAW_WORKSPACE_ID`` when an isolated cloud run attached
+        # tenancy via ``attach_subprocess_env`` (cloud connector rows are
+        # keyed ``ws:<workspace_id>``, see ee cloud connectors service);
+        # otherwise the OSS single-user ``"default"`` scope the builtin
+        # connector tools use. Never a process-global mode flag
+        # (repo lesson #1570/#1574).
         try:
             from pocketpaw.agents.sdk_mcp_atlas import build_atlas_context_server
+            from pocketpaw.atlas.overlay import DEFAULT_SCOPE_KEY, DefaultEntitlementProvider
 
-            atlas_server = build_atlas_context_server()
+            _atlas_ws_id = self._extra_subprocess_env.get("POCKETPAW_WORKSPACE_ID", "")
+            _atlas_scope = f"ws:{_atlas_ws_id}" if _atlas_ws_id else DEFAULT_SCOPE_KEY
+            atlas_server = build_atlas_context_server(
+                provider=DefaultEntitlementProvider(scope_key=_atlas_scope)
+            )
             if atlas_server is not None:
                 name, cfg_entry = atlas_server
                 if self._policy.is_mcp_server_allowed(name):

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -940,22 +940,21 @@ class ClaudeSDKBackend(BaseAgentBackend):
         #
         # AT-5: the server carries a per-run entitlement/availability
         # provider so atlas answers reflect the CALLING workspace, not a
-        # global view. The connector scope key comes from THIS backend
-        # instance's per-run context — ``_extra_subprocess_env`` carries
-        # ``POCKETPAW_WORKSPACE_ID`` when an isolated cloud run attached
-        # tenancy via ``attach_subprocess_env`` (cloud connector rows are
-        # keyed ``ws:<workspace_id>``, see ee cloud connectors service);
-        # otherwise the OSS single-user ``"default"`` scope the builtin
-        # connector tools use. Never a process-global mode flag
-        # (repo lesson #1570/#1574).
+        # global view. Scope resolution lives in ``_tenant_scope_key``
+        # (per-run env, fail-closed on a blank workspace id, never a
+        # process-global mode flag — repo lesson #1570/#1574).
+        #
+        # Honesty note: under a ``ws:<id>`` scope the availability read is
+        # plumbed but currently INERT — the cloud connector state store does
+        # not enumerate tenant rows, so cloud runs conservatively report
+        # every connector unavailable until the EE availability provider
+        # lands. The OSS ``"default"`` scope reads live file-store state.
         try:
             from pocketpaw.agents.sdk_mcp_atlas import build_atlas_context_server
-            from pocketpaw.atlas.overlay import DEFAULT_SCOPE_KEY, DefaultEntitlementProvider
+            from pocketpaw.atlas.overlay import DefaultEntitlementProvider
 
-            _atlas_ws_id = self._extra_subprocess_env.get("POCKETPAW_WORKSPACE_ID", "")
-            _atlas_scope = f"ws:{_atlas_ws_id}" if _atlas_ws_id else DEFAULT_SCOPE_KEY
             atlas_server = build_atlas_context_server(
-                provider=DefaultEntitlementProvider(scope_key=_atlas_scope)
+                provider=DefaultEntitlementProvider(scope_key=self._tenant_scope_key())
             )
             if atlas_server is not None:
                 name, cfg_entry = atlas_server
@@ -1246,9 +1245,36 @@ class ClaudeSDKBackend(BaseAgentBackend):
         payload = ("b1:" if bundled else "b0:") + ",".join(sorted(skill_names))
         return hashlib.sha256(payload.encode("utf-8", "replace")).hexdigest()[:16]
 
+    def _tenant_scope_key(self) -> str:
+        """Connector/entitlement scope for THIS backend instance.
+
+        Resolved from the per-run ``_extra_subprocess_env`` (never a
+        process-global mode flag — repo lesson #1570/#1574):
+
+        - no ``POCKETPAW_WORKSPACE_ID`` attached → the OSS single-user
+          ``"default"`` scope the builtin connector tools use;
+        - a non-blank id → ``ws:<id>`` (the EE cloud connector row keying);
+        - tenancy attached but BLANK id → fail CLOSED to a sentinel scope
+          that matches no rows. Never the shared ``"default"`` bucket:
+          a half-attached tenancy must degrade to "nothing available",
+          not to another scope's connector availability.
+        """
+        from pocketpaw.atlas.overlay import DEFAULT_SCOPE_KEY
+
+        raw = self._extra_subprocess_env.get("POCKETPAW_WORKSPACE_ID")
+        if raw is None:
+            return DEFAULT_SCOPE_KEY
+        ws = raw.strip()
+        return f"ws:{ws}" if ws else "ws:__missing-workspace-id__"
+
     @classmethod
     def _client_cache_key(
-        cls, options: Any, *, session_key: str | None = None, plugin_digest: str = ""
+        cls,
+        options: Any,
+        *,
+        session_key: str | None = None,
+        plugin_digest: str = "",
+        tenant_scope: str = "",
     ) -> str:
         """Persistent-client cache key: session + cwd + model + tools + a digest
         of the system prompt's stable behavioral prefix + the plugin-identity
@@ -1271,6 +1297,11 @@ class ClaudeSDKBackend(BaseAgentBackend):
         session_key, a stale warm subprocess can never be reused across two
         different working directories (i.e. two tenants). The SDK fixes cwd at
         connect() time, so a changed cwd MUST force a fresh subprocess.
+
+        ``tenant_scope`` (AT-5) extends the same argument to the atlas
+        entitlement scope: the per-run provider is baked into the MCP server
+        set at connect() time, so a changed scope must also force a fresh
+        subprocess rather than reusing one warmed for another tenant.
         """
         prefix = cls._behavior_prefix(getattr(options, "system_prompt", None))
         prefix_digest = hashlib.sha256(prefix.encode("utf-8", "replace")).hexdigest()[:16]
@@ -1280,7 +1311,8 @@ class ClaudeSDKBackend(BaseAgentBackend):
             f"{getattr(options, 'model', '')}:"
             f"{sorted(getattr(options, 'allowed_tools', []) or [])}:"
             f"{prefix_digest}:"
-            f"{plugin_digest}"
+            f"{plugin_digest}:"
+            f"{tenant_scope}"
         )
 
     async def _get_or_create_client(
@@ -1314,7 +1346,12 @@ class ClaudeSDKBackend(BaseAgentBackend):
         if self._client_lock is None:
             self._client_lock = asyncio.Lock()
 
-        key = self._client_cache_key(options, session_key=session_key, plugin_digest=plugin_digest)
+        key = self._client_cache_key(
+            options,
+            session_key=session_key,
+            plugin_digest=plugin_digest,
+            tenant_scope=self._tenant_scope_key(),
+        )
 
         async with self._client_lock:
             # Re-check INSIDE the lock: a prewarm (or sibling) may have connected
@@ -2407,7 +2444,10 @@ class ClaudeSDKBackend(BaseAgentBackend):
             # the per-agent warm client cannot misfire on a leased client.
             if warm_client is not None or on_client_built is not None:
                 this_turn_key = self._client_cache_key(
-                    options, session_key=session_key, plugin_digest=plugin_digest
+                    options,
+                    session_key=session_key,
+                    plugin_digest=plugin_digest,
+                    tenant_scope=self._tenant_scope_key(),
                 )
                 event_stream, _warm_lease = await self._leased_dispatch(
                     message=message,

--- a/src/pocketpaw/agents/sdk_mcp_atlas.py
+++ b/src/pocketpaw/agents/sdk_mcp_atlas.py
@@ -14,14 +14,31 @@
 # with ``is_error`` on failures, and the same wiring points in
 # ``claude_sdk.py`` (``_get_mcp_servers`` + ``_collect_mcp_tool_ids`` +
 # the mode-scope grant).
+#
+# Updated: 2026-07-02 (feat/atlas-overlay, AT-5) — the server takes an
+# optional per-run ``EntitlementProvider`` (``atlas/overlay.py``) so
+# answers reflect the CALLING workspace: connector cards carry
+# ``available`` (connected in this context), unavailable connectors rank
+# below available ones at equal relevance, describe points unavailable
+# connectors at the integrations surface, and non-granted entries are
+# ABSENT everywhere (search, describe, known-ids error — fail-closed, no
+# leakage). ``provider=None`` keeps the pre-AT-5 global behavior.
 
 from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pocketpaw.atlas.overlay import EntitlementProvider
 
 logger = logging.getLogger(__name__)
+
+# Seed id of the surface entry whose route is the integrations page —
+# looked up from the store at answer time (the route itself is never
+# hard-coded here).
+_INTEGRATIONS_SURFACE_ID = "surface:integrations"
 
 SERVER_NAME = "pocketpaw_atlas"
 # Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
@@ -43,12 +60,15 @@ def _text_result(text: str, *, is_error: bool = False) -> dict:
     return out
 
 
-async def _atlas_search_handler(args: dict) -> dict:
+async def _atlas_search_handler(args: dict, provider: EntitlementProvider | None = None) -> dict:
     """Rank atlas entries for an intent and return capability cards.
 
     Backs the ``atlas_search`` MCP tool. Cards are intentionally thin
     (id, kind, name, summary, surface when set) — the agent follows up
-    with ``atlas_describe`` on the id it picks.
+    with ``atlas_describe`` on the id it picks. With a *provider* (AT-5),
+    results are the calling context's view: non-granted entries are
+    absent, connector cards carry ``available``, and available
+    connectors rank above unavailable ones at equal relevance.
     """
     from pocketpaw.atlas.store import get_atlas_store
 
@@ -60,12 +80,20 @@ async def _atlas_search_handler(args: dict) -> dict:
             is_error=True,
         )
 
-    entries = get_atlas_store().search(intent, limit=5)
-    if not entries:
+    store = get_atlas_store()
+    if provider is None:
+        overlaid = [(entry, None) for entry in store.search(intent, limit=5)]
+    else:
+        from pocketpaw.atlas.overlay import AtlasOverlay
+
+        overlaid = [
+            (o.entry, o.available) for o in AtlasOverlay.search(store, intent, provider, limit=5)
+        ]
+    if not overlaid:
         return _text_result(f"No atlas entries matched intent: {intent!r}. Try broader wording.")
 
     cards: list[dict[str, Any]] = []
-    for entry in entries:
+    for entry, available in overlaid:
         card: dict[str, Any] = {
             "id": entry.id,
             "kind": entry.kind,
@@ -74,15 +102,22 @@ async def _atlas_search_handler(args: dict) -> dict:
         }
         if entry.surface:
             card["surface"] = entry.surface
+        if available is not None:
+            card["available"] = available
         cards.append(card)
     return _text_result(json.dumps({"results": cards}, ensure_ascii=False))
 
 
-async def _atlas_describe_handler(args: dict) -> dict:
+async def _atlas_describe_handler(args: dict, provider: EntitlementProvider | None = None) -> dict:
     """Return the full atlas entry for a stable id.
 
     Backs the ``atlas_describe`` MCP tool. Unknown ids return an error
-    envelope listing the known ids so the agent can self-correct.
+    envelope listing the known ids so the agent can self-correct. With a
+    *provider* (AT-5), a non-granted entry answers exactly like an
+    unknown id (and the known-ids listing carries only visible ids), so
+    describe can never confirm a filtered entry exists; an unavailable
+    connector's card carries ``available: false`` plus a pointer to the
+    integrations surface (route looked up from the store).
     """
     from pocketpaw.atlas.store import get_atlas_store
 
@@ -94,18 +129,50 @@ async def _atlas_describe_handler(args: dict) -> dict:
         )
 
     store = get_atlas_store()
-    entry = store.describe(entry_id.strip())
-    if entry is None:
-        known = ", ".join(sorted(e.id for e in store.entries))
+    if provider is None:
+        entry = store.describe(entry_id.strip())
+        if entry is None:
+            known = ", ".join(sorted(e.id for e in store.entries))
+            return _text_result(
+                f"Error: unknown atlas id {entry_id!r}. Known ids: {known}",
+                is_error=True,
+            )
+        return _text_result(entry.model_dump_json(by_alias=True))
+
+    from pocketpaw.atlas.overlay import AtlasOverlay
+
+    overlaid = AtlasOverlay.describe(store, entry_id.strip(), provider)
+    if overlaid is None:
+        # Unknown AND filtered ids land here — same envelope, no leakage.
+        known = ", ".join(AtlasOverlay.visible_ids(store, provider))
         return _text_result(
             f"Error: unknown atlas id {entry_id!r}. Known ids: {known}",
             is_error=True,
         )
-    return _text_result(entry.model_dump_json(by_alias=True))
+
+    payload = overlaid.entry.model_dump(mode="json", by_alias=True)
+    if overlaid.available is not None:
+        payload["available"] = overlaid.available
+        if overlaid.available is False:
+            integrations = store.describe(_INTEGRATIONS_SURFACE_ID)
+            route = integrations.surface if integrations is not None else ""
+            if route:
+                payload["connect_hint"] = (
+                    f"Not connected in this workspace yet — connect it at {route}."
+                )
+    return _text_result(json.dumps(payload, ensure_ascii=False))
 
 
-def build_atlas_context_server() -> tuple[str, Any] | None:
-    """Build the in-process SDK MCP server, or None if the SDK is unavailable."""
+def build_atlas_context_server(
+    provider: EntitlementProvider | None = None,
+) -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server, or None if the SDK is unavailable.
+
+    ``provider`` is the per-run entitlement/availability context (AT-5);
+    the tool closures capture it so every ``atlas_search`` /
+    ``atlas_describe`` call answers for THAT context. ``None`` serves the
+    global (pre-overlay) view.
+    """
     try:
         from claude_agent_sdk import create_sdk_mcp_server, tool
     except ImportError:
@@ -142,7 +209,7 @@ def build_atlas_context_server() -> tuple[str, Any] | None:
         },
     )
     async def atlas_search(args):  # type: ignore[no-untyped-def]
-        return await _atlas_search_handler(args)
+        return await _atlas_search_handler(args, provider)
 
     @tool(
         "atlas_describe",
@@ -167,7 +234,7 @@ def build_atlas_context_server() -> tuple[str, Any] | None:
         },
     )
     async def atlas_describe(args):  # type: ignore[no-untyped-def]
-        return await _atlas_describe_handler(args)
+        return await _atlas_describe_handler(args, provider)
 
     server = create_sdk_mcp_server(
         name=SERVER_NAME,

--- a/src/pocketpaw/agents/sdk_mcp_atlas.py
+++ b/src/pocketpaw/agents/sdk_mcp_atlas.py
@@ -154,8 +154,10 @@ async def _atlas_describe_handler(args: dict, provider: EntitlementProvider | No
     if overlaid.available is not None:
         payload["available"] = overlaid.available
         if overlaid.available is False:
-            integrations = store.describe(_INTEGRATIONS_SURFACE_ID)
-            route = integrations.surface if integrations is not None else ""
+            # Route the lookup through the overlay: a provider that filters
+            # the integrations surface must not leak its route via the hint.
+            integrations = AtlasOverlay.describe(store, _INTEGRATIONS_SURFACE_ID, provider)
+            route = integrations.entry.surface if integrations is not None else ""
             if route:
                 payload["connect_hint"] = (
                     f"Not connected in this workspace yet — connect it at {route}."

--- a/src/pocketpaw/atlas/__init__.py
+++ b/src/pocketpaw/atlas/__init__.py
@@ -1,4 +1,8 @@
 # atlas/__init__.py — package exports for the atlas primitive (AT-1).
+# Updated: 2026-07-02 (feat/atlas-overlay, AT-5) — export the live overlay
+# (AtlasOverlay / OverlaidEntry), the EntitlementProvider protocol, and the
+# OSS DefaultEntitlementProvider next to the store, so consumers can render
+# context-aware (workspace-scoped, fail-closed) atlas answers.
 # Updated: 2026-07-02 (feat/atlas-compiler, AT-4) — export the compiler
 # (compile_atlas / write_artifact / check_artifact) and the startup
 # connector-drift check next to the store.
@@ -9,12 +13,22 @@
 
 from pocketpaw.atlas.compile import check_artifact, compile_atlas, write_artifact
 from pocketpaw.atlas.model import AtlasEntry, AtlasModel
+from pocketpaw.atlas.overlay import (
+    AtlasOverlay,
+    DefaultEntitlementProvider,
+    EntitlementProvider,
+    OverlaidEntry,
+)
 from pocketpaw.atlas.store import AtlasStore, check_connector_drift, get_atlas_store
 
 __all__ = [
     "AtlasEntry",
     "AtlasModel",
+    "AtlasOverlay",
     "AtlasStore",
+    "DefaultEntitlementProvider",
+    "EntitlementProvider",
+    "OverlaidEntry",
     "check_artifact",
     "check_connector_drift",
     "compile_atlas",

--- a/src/pocketpaw/atlas/overlay.py
+++ b/src/pocketpaw/atlas/overlay.py
@@ -1,0 +1,239 @@
+# atlas/overlay.py — live workspace overlay + fail-closed entitlement filter
+# for the atlas OS self-model (AT-5). Created: 2026-07-02 (feat/atlas-overlay).
+#
+# The compiled artifact is GLOBAL — the same 72 entries in every workspace.
+# This module makes atlas answers reflect the CALLING workspace's reality:
+#
+# * ``EntitlementProvider`` — a small structural protocol (like the repo's
+#   other protocols) that answers two per-context questions: which connectors
+#   are CONNECTED in this context, and whether a given entry is GRANTED.
+# * ``AtlasOverlay`` — applies a provider to store results at the RESULT
+#   layer (never mutating the shared ``AtlasStore`` singleton's entries):
+#   connector entries gain an ``available: bool`` annotation; entries whose
+#   grant check fails are REMOVED (absent from search, describe, and the
+#   known-ids listing — no "upgrade to see this" leakage). Search re-ranks
+#   available connectors above unavailable ones at EQUAL relevance via a
+#   stable re-sort on top of the store's unchanged base scoring.
+# * FAIL-CLOSED: a provider that raises (or answers anything other than a
+#   literal ``True``) on ``is_granted`` filters that entry; a provider that
+#   raises on ``connected_connector_names`` marks every connector
+#   unavailable. Grant decisions key off the provider instance built for
+#   THIS run/workspace — never a module-level "is cloud mode" flag (repo
+#   lesson #1570/#1574).
+# * ``DefaultEntitlementProvider`` — the OSS default, built on the real
+#   connector seam: ``ConnectorRegistry.status(scope_key)`` (the same
+#   durable-state view ``connector_list`` reports), with the same
+#   ``"default"`` scope the connector tools use; a cloud run passes its
+#   ``ws:<workspace_id>`` scope instead. Nothing is entitlement-gated in
+#   OSS — ``is_granted`` is always True, so OS-level entries (primitives,
+#   surfaces, senses) are never filtered by default.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from pocketpaw.atlas.model import AtlasEntry
+
+if TYPE_CHECKING:
+    from pocketpaw.atlas.store import AtlasStore
+
+logger = logging.getLogger(__name__)
+
+# Default connector scope in a single-user OSS install — the same literal
+# the builtin connector tools default their ``pocket_id`` argument to.
+DEFAULT_SCOPE_KEY = "default"
+
+
+@runtime_checkable
+class EntitlementProvider(Protocol):
+    """Per-run context answering what THIS workspace can see and use.
+
+    Structural (duck-typed) like the repo's other protocols — any object
+    with these two methods works, including EE providers that consult a
+    tenant's plan. Implementations should be cheap: both methods are called
+    on every atlas tool invocation.
+    """
+
+    def connected_connector_names(self) -> set[str]:
+        """Names of connectors CONNECTED in this context (e.g. {'stripe'})."""
+        ...
+
+    def is_granted(self, entry: AtlasEntry) -> bool:
+        """Whether this context is entitled to see *entry* at all.
+
+        Return a literal ``True`` to grant. Anything else — ``False``,
+        ``None``, a raise — is treated as NOT granted by the overlay
+        (fail-closed) and the entry is filtered from every answer.
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class OverlaidEntry:
+    """A store entry viewed through one context's overlay.
+
+    ``available`` is a connector-only annotation: True/False for
+    ``kind="connector"`` entries (connected in this context or not), None
+    for every other kind. The wrapped ``entry`` is the shared store's
+    object — treat it as read-only.
+    """
+
+    entry: AtlasEntry
+    available: bool | None = None
+
+
+def _connector_name(entry: AtlasEntry) -> str:
+    """The registry-facing name for a connector entry (id minus the kind)."""
+    return entry.id.split(":", 1)[1] if ":" in entry.id else entry.id
+
+
+def _connected_names(provider: EntitlementProvider) -> set[str] | None:
+    """Resolve the connected set once per overlay pass, fail-closed.
+
+    ``None`` means resolution failed — every connector is then annotated
+    ``available=False`` (unavailable, NOT filtered: availability is a live
+    fact, not an entitlement).
+    """
+    try:
+        names = provider.connected_connector_names()
+        return {n for n in names if isinstance(n, str)}
+    except Exception as exc:  # noqa: BLE001 — fail closed, never break the tool
+        logger.warning("atlas overlay: connected-connector resolution failed: %s", exc)
+        return None
+
+
+def _is_granted(provider: EntitlementProvider, entry: AtlasEntry) -> bool:
+    """Grant check, fail-closed: only a literal ``True`` grants."""
+    try:
+        return provider.is_granted(entry) is True
+    except Exception as exc:  # noqa: BLE001 — a raising provider must filter, not leak
+        logger.warning("atlas overlay: grant check failed for %s: %s", entry.id, exc)
+        return False
+
+
+def _overlay_one(entry: AtlasEntry, connected: set[str] | None) -> OverlaidEntry:
+    if entry.kind == "connector":
+        available = connected is not None and _connector_name(entry) in connected
+        return OverlaidEntry(entry=entry, available=available)
+    return OverlaidEntry(entry=entry, available=None)
+
+
+class AtlasOverlay:
+    """Applies an :class:`EntitlementProvider` to atlas store results.
+
+    Stateless — every method takes the provider explicitly, so one shared
+    store singleton serves any number of concurrent contexts without
+    cross-talk. Nothing here mutates ``AtlasStore`` or its entries.
+    """
+
+    @staticmethod
+    def apply(entries: list[AtlasEntry], provider: EntitlementProvider) -> list[OverlaidEntry]:
+        """Filter non-granted entries and annotate connector availability.
+
+        Order-preserving; use :meth:`search` when availability re-ranking
+        is wanted on scored results.
+        """
+        connected = _connected_names(provider)
+        return [_overlay_one(entry, connected) for entry in entries if _is_granted(provider, entry)]
+
+    @staticmethod
+    def search(
+        store: AtlasStore,
+        query: str,
+        provider: EntitlementProvider,
+        limit: int = 5,
+    ) -> list[OverlaidEntry]:
+        """Context-aware search: score, filter, re-rank, then truncate.
+
+        Base relevance scoring is the store's (unchanged); the overlay only
+        applies a STABLE re-sort so an available connector ranks above an
+        unavailable one at equal score. Filtering happens BEFORE the limit,
+        so non-granted entries never eat result slots.
+        """
+        if limit <= 0:
+            return []
+        connected = _connected_names(provider)
+        ranked: list[tuple[float, int, OverlaidEntry]] = []
+        for score, entry in store.search_scored(query):
+            if not _is_granted(provider, entry):
+                continue
+            overlaid = _overlay_one(entry, connected)
+            demoted = 1 if overlaid.available is False else 0
+            ranked.append((score, demoted, overlaid))
+        # Stable sort: score desc, then available-before-unavailable; ties
+        # keep the store's seed order (list.sort is stable).
+        ranked.sort(key=lambda item: (-item[0], item[1]))
+        return [overlaid for _, _, overlaid in ranked[:limit]]
+
+    @staticmethod
+    def describe(
+        store: AtlasStore, entry_id: str, provider: EntitlementProvider
+    ) -> OverlaidEntry | None:
+        """Describe one entry through the overlay.
+
+        A non-granted entry returns ``None`` — indistinguishable from an
+        unknown id, so describe can never confirm a filtered entry exists.
+        """
+        entry = store.describe(entry_id)
+        if entry is None or not _is_granted(provider, entry):
+            return None
+        return _overlay_one(entry, _connected_names(provider))
+
+    @staticmethod
+    def visible_ids(store: AtlasStore, provider: EntitlementProvider) -> list[str]:
+        """Sorted ids this context may see — for known-ids error listings.
+
+        Enumerations shown to the agent must come from here, never from
+        ``store.entries``, or filtered ids leak through error messages.
+        """
+        return sorted(e.id for e in store.entries if _is_granted(provider, e))
+
+
+class DefaultEntitlementProvider:
+    """OSS default provider on the real connector seam.
+
+    Availability comes from ``ConnectorRegistry.status(scope_key)`` — the
+    same durable-state answer (definition present + config persisted)
+    that the ``connector_list`` builtin reports, resolved lazily per call
+    so mid-session connects/disconnects are reflected. ``scope_key`` is
+    the connector state scope: the tools' ``"default"`` pocket scope in a
+    single-user install, or a cloud run's ``ws:<workspace_id>``.
+
+    Nothing is entitlement-gated in OSS: ``is_granted`` is always True,
+    so primitives, surfaces, senses, and connectors all stay visible —
+    connectors merely carry their live availability annotation.
+    """
+
+    def __init__(self, scope_key: str = DEFAULT_SCOPE_KEY, registry: Any | None = None) -> None:
+        self._scope_key = scope_key
+        self._registry = registry
+
+    def _resolve_registry(self) -> Any:
+        if self._registry is None:
+            # The builtin connector tools' shared registry — the exact
+            # instance connector_list answers from, so atlas availability
+            # can never disagree with connector_list in the same process.
+            from pocketpaw.tools.builtin.connector_tools import _get_registry
+
+            self._registry = _get_registry()
+        return self._registry
+
+    def connected_connector_names(self) -> set[str]:
+        from pocketpaw.connectors.protocol import ConnectorStatus
+
+        rows = self._resolve_registry().status(self._scope_key)
+        return {row["name"] for row in rows if row.get("status") == ConnectorStatus.CONNECTED}
+
+    def is_granted(self, entry: AtlasEntry) -> bool:  # noqa: ARG002 — protocol shape
+        return True
+
+
+__all__ = [
+    "DEFAULT_SCOPE_KEY",
+    "AtlasOverlay",
+    "DefaultEntitlementProvider",
+    "EntitlementProvider",
+    "OverlaidEntry",
+]

--- a/src/pocketpaw/atlas/store.py
+++ b/src/pocketpaw/atlas/store.py
@@ -17,6 +17,12 @@
 # ``connector:*`` name set against the live connector YAML scan (the same
 # dirs ConnectorRegistry reads) and logs a WARNING on mismatch — name-set
 # compare only, no recompile, never raises.
+# Updated: 2026-07-02 (feat/atlas-overlay, AT-5) — additive ``search_scored``
+# (``search`` now delegates to it): returns ``(score, entry)`` pairs so the
+# overlay (``atlas/overlay.py``) can re-rank available connectors above
+# unavailable ones at equal relevance without touching the base scoring.
+# Store API otherwise unchanged; the primer and drift check keep the
+# unfiltered OS-level view.
 
 from __future__ import annotations
 
@@ -90,8 +96,20 @@ class AtlasStore:
         field). Entries with zero overlap are dropped; ties keep seed
         order (stable sort).
         """
+        if limit <= 0:
+            return []
+        return [entry for _, entry in self.search_scored(query, limit=limit)]
+
+    def search_scored(self, query: str, limit: int | None = None) -> list[tuple[float, AtlasEntry]]:
+        """Like :meth:`search` but returns ``(score, entry)`` pairs.
+
+        Added for the overlay (AT-5), which needs the base relevance score
+        to re-rank available connectors above unavailable ones WITHOUT
+        changing this scoring. ``limit=None`` returns every match so the
+        overlay can filter before truncating.
+        """
         tokens = _tokenize(query)
-        if not tokens or limit <= 0:
+        if not tokens:
             return []
 
         scored: list[tuple[float, AtlasEntry]] = []
@@ -110,7 +128,7 @@ class AtlasStore:
                 scored.append((score, entry))
 
         scored.sort(key=lambda pair: pair[0], reverse=True)
-        return [entry for _, entry in scored[:limit]]
+        return scored if limit is None else scored[:limit]
 
     def describe(self, entry_id: str) -> AtlasEntry | None:
         """Return the full entry for a stable id, or None if unknown."""

--- a/tests/atlas/test_overlay.py
+++ b/tests/atlas/test_overlay.py
@@ -25,6 +25,7 @@ from pocketpaw.agents.sdk_mcp_atlas import (
 )
 from pocketpaw.atlas.model import AtlasEntry, AtlasModel
 from pocketpaw.atlas.overlay import (
+    DEFAULT_SCOPE_KEY,
     AtlasOverlay,
     DefaultEntitlementProvider,
     EntitlementProvider,
@@ -374,3 +375,33 @@ class TestMcpHandlersWithProvider:
         cards = _cards(out)
         assert "primitive:instinct" in [c["id"] for c in cards[:3]]
         assert all("available" not in c for c in cards)
+
+
+class TestTenantScopeKey:
+    """The backend's scope resolution fails CLOSED on a blank workspace id
+    (security audit AT-5 IMPORTANT-1): tenancy attached with an empty
+    POCKETPAW_WORKSPACE_ID must resolve to a sentinel scope that matches no
+    connector rows — never the shared "default" bucket."""
+
+    def _backend(self):
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+        return ClaudeSDKBackend.__new__(ClaudeSDKBackend)
+
+    def test_no_tenancy_env_is_default_scope(self):
+        backend = self._backend()
+        backend._extra_subprocess_env = {}
+        assert backend._tenant_scope_key() == DEFAULT_SCOPE_KEY
+
+    def test_workspace_id_maps_to_ws_scope(self):
+        backend = self._backend()
+        backend._extra_subprocess_env = {"POCKETPAW_WORKSPACE_ID": "w-123"}
+        assert backend._tenant_scope_key() == "ws:w-123"
+
+    def test_blank_workspace_id_fails_closed_to_sentinel(self):
+        backend = self._backend()
+        for blank in ("", "   "):
+            backend._extra_subprocess_env = {"POCKETPAW_WORKSPACE_ID": blank}
+            scope = backend._tenant_scope_key()
+            assert scope == "ws:__missing-workspace-id__"
+            assert scope != DEFAULT_SCOPE_KEY

--- a/tests/atlas/test_overlay.py
+++ b/tests/atlas/test_overlay.py
@@ -1,0 +1,376 @@
+# tests/atlas/test_overlay.py — live overlay + fail-closed entitlement filter
+# (AT-5). Created: 2026-07-02 (feat/atlas-overlay). Proves, on a synthetic
+# store: non-granted entries are ABSENT from search and describe (describe of
+# a filtered id answers exactly like an unknown id — no leakage); a RAISING
+# provider filters gated entries (fail-closed) and marks connectors
+# unavailable when the connected-set resolution raises (annotated, not
+# filtered); an ambiguous grant (None) filters; connector cards carry the
+# ``available`` annotation and available connectors re-rank above unavailable
+# ones at EQUAL score without touching base scoring; the shared store's
+# entries are never mutated; the OSS DefaultEntitlementProvider (fed a fake
+# registry) gates nothing and reads availability from the registry's durable
+# status. MCP handler tests run the REAL packaged store through stubbed
+# providers: same query in two contexts returns context-appropriate results,
+# the known-ids error listing hides filtered ids, and describe of an
+# unavailable connector points at the integrations surface route (looked up
+# from the seed, not hard-coded).
+
+import json
+
+import pytest
+
+from pocketpaw.agents.sdk_mcp_atlas import (
+    _atlas_describe_handler,
+    _atlas_search_handler,
+)
+from pocketpaw.atlas.model import AtlasEntry, AtlasModel
+from pocketpaw.atlas.overlay import (
+    AtlasOverlay,
+    DefaultEntitlementProvider,
+    EntitlementProvider,
+    OverlaidEntry,
+)
+from pocketpaw.atlas.store import AtlasStore
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+
+def _entry(entry_id: str, kind: str, name: str, **kw) -> AtlasEntry:
+    return AtlasEntry(
+        id=entry_id,
+        kind=kind,
+        name=name,
+        summary=kw.pop("summary", f"{name} summary"),
+        narrative=kw.pop("narrative", f"{name} narrative"),
+        **kw,
+    )
+
+
+def _synthetic_store() -> AtlasStore:
+    """Small store: one primitive, one surface, one sense, three connectors.
+
+    ``alpha_crm`` and ``beta_crm`` share the keyword "crm" so a "crm" query
+    scores them EQUALLY (keyword hit each) — the equal-relevance re-rank
+    case. Seed order puts beta before alpha to prove the re-sort is doing
+    the work, not the base order.
+    """
+    return AtlasStore(
+        AtlasModel(
+            entries=[
+                _entry("primitive:pocket", "primitive", "Pocket", keywords=["app", "crm"]),
+                _entry("surface:integrations", "surface", "Integrations", surface="/x/int"),
+                _entry("sense:paw.email.v1", "sense", "Email"),
+                _entry("connector:beta_crm", "connector", "Beta CRM", keywords=["crm"]),
+                _entry("connector:alpha_crm", "connector", "Alpha CRM", keywords=["crm"]),
+                _entry("connector:gamma_pay", "connector", "Gamma Pay", keywords=["payments"]),
+            ]
+        )
+    )
+
+
+class FakeProvider:
+    """Configurable provider: connected set + granted-id predicate."""
+
+    def __init__(self, connected=frozenset(), denied_ids=frozenset(), grant_result=True):
+        self._connected = set(connected)
+        self._denied = set(denied_ids)
+        self._grant_result = grant_result
+
+    def connected_connector_names(self):
+        return set(self._connected)
+
+    def is_granted(self, entry):
+        if entry.id in self._denied:
+            return False
+        return self._grant_result
+
+
+class RaisingGrantProvider:
+    def connected_connector_names(self):
+        return set()
+
+    def is_granted(self, entry):
+        raise RuntimeError("entitlement service down")
+
+
+class RaisingConnectedProvider:
+    def connected_connector_names(self):
+        raise RuntimeError("registry unavailable")
+
+    def is_granted(self, entry):
+        return True
+
+
+# ── protocol shape ──────────────────────────────────────────────────────
+
+
+def test_fake_and_default_providers_satisfy_protocol():
+    assert isinstance(FakeProvider(), EntitlementProvider)
+    assert isinstance(DefaultEntitlementProvider(), EntitlementProvider)
+
+
+# ── filtering: absent means absent ──────────────────────────────────────
+
+
+class TestGrantFiltering:
+    def test_denied_entry_absent_from_apply_and_search(self):
+        store = _synthetic_store()
+        provider = FakeProvider(denied_ids={"connector:alpha_crm"})
+        applied_ids = {o.entry.id for o in AtlasOverlay.apply(store.entries, provider)}
+        assert "connector:alpha_crm" not in applied_ids
+        assert "connector:beta_crm" in applied_ids  # siblings unaffected
+
+        result_ids = [o.entry.id for o in AtlasOverlay.search(store, "crm", provider)]
+        assert "connector:alpha_crm" not in result_ids
+        assert "connector:beta_crm" in result_ids
+
+    def test_denied_entry_describe_returns_none_like_unknown(self):
+        store = _synthetic_store()
+        provider = FakeProvider(denied_ids={"connector:alpha_crm"})
+        assert AtlasOverlay.describe(store, "connector:alpha_crm", provider) is None
+        assert AtlasOverlay.describe(store, "connector:no_such", provider) is None
+
+    def test_visible_ids_excludes_denied(self):
+        store = _synthetic_store()
+        provider = FakeProvider(denied_ids={"connector:alpha_crm"})
+        visible = AtlasOverlay.visible_ids(store, provider)
+        assert "connector:alpha_crm" not in visible
+        assert "primitive:pocket" in visible
+
+    def test_ambiguous_grant_is_filtered(self):
+        """A non-True grant answer (None) is ambiguous → fail-closed."""
+        store = _synthetic_store()
+        provider = FakeProvider(grant_result=None)
+        assert AtlasOverlay.apply(store.entries, provider) == []
+        assert AtlasOverlay.describe(store, "primitive:pocket", provider) is None
+
+    def test_filtering_frees_result_slots(self):
+        """Filtered entries never eat limit slots — filter happens pre-truncate."""
+        store = _synthetic_store()
+        provider = FakeProvider(denied_ids={"connector:beta_crm"})
+        results = [o.entry.id for o in AtlasOverlay.search(store, "crm", provider, limit=2)]
+        assert len(results) == 2
+        assert "connector:beta_crm" not in results
+
+
+# ── fail-closed on provider errors ──────────────────────────────────────
+
+
+class TestFailClosed:
+    def test_raising_grant_filters_everything_it_gates(self):
+        store = _synthetic_store()
+        provider = RaisingGrantProvider()
+        assert AtlasOverlay.search(store, "crm", provider) == []
+        assert AtlasOverlay.describe(store, "primitive:pocket", provider) is None
+        assert AtlasOverlay.visible_ids(store, provider) == []
+
+    def test_raising_connected_set_marks_connectors_unavailable_not_filtered(self):
+        store = _synthetic_store()
+        provider = RaisingConnectedProvider()
+        overlaid = AtlasOverlay.apply(store.entries, provider)
+        connectors = [o for o in overlaid if o.entry.kind == "connector"]
+        assert connectors, "connectors stay VISIBLE — availability is not a grant"
+        assert all(o.available is False for o in connectors)
+        others = [o for o in overlaid if o.entry.kind != "connector"]
+        assert all(o.available is None for o in others)
+
+
+# ── availability annotation + re-ranking ────────────────────────────────
+
+
+class TestAvailabilityAndRanking:
+    def test_connector_annotation_and_os_entries_unannotated(self):
+        store = _synthetic_store()
+        provider = FakeProvider(connected={"alpha_crm"})
+        by_id = {o.entry.id: o for o in AtlasOverlay.apply(store.entries, provider)}
+        assert by_id["connector:alpha_crm"].available is True
+        assert by_id["connector:beta_crm"].available is False
+        assert by_id["primitive:pocket"].available is None
+        assert by_id["surface:integrations"].available is None
+        assert by_id["sense:paw.email.v1"].available is None
+
+    def test_available_ranks_above_unavailable_at_equal_score(self):
+        store = _synthetic_store()
+        # Base order for "crm": beta before alpha (seed order, equal score).
+        base = [e.id for e in store.search("crm", limit=10)]
+        assert base.index("connector:beta_crm") < base.index("connector:alpha_crm")
+
+        provider = FakeProvider(connected={"alpha_crm"})
+        overlaid = [o.entry.id for o in AtlasOverlay.search(store, "crm", provider, limit=10)]
+        assert overlaid.index("connector:alpha_crm") < overlaid.index("connector:beta_crm")
+
+    def test_rerank_never_overrides_base_relevance(self):
+        """An unavailable connector with a HIGHER score stays above an
+        available one with a lower score — the re-sort is availability at
+        equal relevance only."""
+        store = _synthetic_store()
+        provider = FakeProvider(connected={"alpha_crm"})
+        # "beta crm" → double name hit on "Beta CRM" (score 10) vs Alpha
+        # CRM's single name hit (5): beta wins on relevance despite being
+        # the unavailable one.
+        ids = [o.entry.id for o in AtlasOverlay.search(store, "beta crm", provider, limit=10)]
+        assert ids[0] == "connector:beta_crm"  # unavailable but most relevant
+
+    def test_search_scored_backward_compat(self):
+        """store.search delegates to search_scored with identical results."""
+        store = _synthetic_store()
+        assert store.search("crm", limit=3) == [e for _, e in store.search_scored("crm", limit=3)]
+        assert store.search("", limit=5) == []
+        assert store.search_scored("") == []
+
+
+# ── no mutation of the shared store ─────────────────────────────────────
+
+
+def test_overlay_never_mutates_store_entries():
+    store = _synthetic_store()
+    before = [e.model_dump() for e in store.entries]
+    provider = FakeProvider(connected={"alpha_crm"}, denied_ids={"connector:gamma_pay"})
+    overlaid = AtlasOverlay.apply(store.entries, provider)
+    AtlasOverlay.search(store, "crm", provider)
+    assert [e.model_dump() for e in store.entries] == before
+    # The annotation lives on the wrapper, never on the entry model.
+    assert all(isinstance(o, OverlaidEntry) for o in overlaid)
+    assert all("available" not in o.entry.model_dump() for o in overlaid)
+
+
+# ── DefaultEntitlementProvider (OSS default, real seam shape) ───────────
+
+
+class _FakeRegistry:
+    """Mimics ConnectorRegistry.status(scope_key) durable-state rows."""
+
+    def __init__(self, connected_by_scope):
+        self._by_scope = connected_by_scope
+        self.calls: list[str] = []
+
+    def status(self, scope_key):
+        from pocketpaw.connectors.protocol import ConnectorStatus
+
+        self.calls.append(scope_key)
+        connected = self._by_scope.get(scope_key, set())
+        return [
+            {
+                "name": name,
+                "display_name": name,
+                "icon": "plug",
+                "status": ConnectorStatus.CONNECTED
+                if name in connected
+                else ConnectorStatus.DISCONNECTED,
+            }
+            for name in ("alpha_crm", "beta_crm", "gamma_pay")
+        ]
+
+
+class TestDefaultProvider:
+    def test_reads_connected_names_from_registry_scope(self):
+        registry = _FakeRegistry({"ws:t1": {"alpha_crm"}, "default": {"gamma_pay"}})
+        p_ws = DefaultEntitlementProvider(scope_key="ws:t1", registry=registry)
+        p_local = DefaultEntitlementProvider(registry=registry)
+        assert p_ws.connected_connector_names() == {"alpha_crm"}
+        assert p_local.connected_connector_names() == {"gamma_pay"}
+        assert registry.calls == ["ws:t1", "default"]
+
+    def test_oss_default_gates_nothing(self):
+        """OS-level entries (and everything else) are never filtered in OSS."""
+        store = _synthetic_store()
+        registry = _FakeRegistry({"default": {"alpha_crm"}})
+        provider = DefaultEntitlementProvider(registry=registry)
+        overlaid = AtlasOverlay.apply(store.entries, provider)
+        assert {o.entry.id for o in overlaid} == {e.id for e in store.entries}
+        by_id = {o.entry.id: o for o in overlaid}
+        assert by_id["connector:alpha_crm"].available is True
+        assert by_id["connector:beta_crm"].available is False
+
+
+# ── MCP tool handlers with stubbed providers (real packaged store) ──────
+
+
+def _cards(result: dict) -> list[dict]:
+    block = next(c for c in result["content"] if c["type"] == "text")
+    return json.loads(block["text"])["results"]
+
+
+def _text_of(result: dict) -> str:
+    return next(c for c in result["content"] if c["type"] == "text")["text"]
+
+
+class TestMcpHandlersWithProvider:
+    @pytest.mark.asyncio
+    async def test_same_query_two_contexts_returns_context_appropriate_results(self):
+        query = {"intent": "stripe invoices payments"}
+        ctx_granted = FakeProvider(connected={"stripe"})
+        ctx_filtered = FakeProvider(denied_ids={"connector:stripe"})
+
+        out_a = await _atlas_search_handler(query, ctx_granted)
+        out_b = await _atlas_search_handler(query, ctx_filtered)
+        ids_a = [c["id"] for c in _cards(out_a)]
+        ids_b = [c["id"] for c in _cards(out_b)]
+        assert "connector:stripe" in ids_a
+        assert "connector:stripe" not in ids_b
+        assert ids_a != ids_b
+
+    @pytest.mark.asyncio
+    async def test_search_cards_carry_available_on_connectors_only(self):
+        out = await _atlas_search_handler(
+            {"intent": "stripe invoices"}, FakeProvider(connected={"stripe"})
+        )
+        cards = _cards(out)
+        for card in cards:
+            if card["kind"] == "connector":
+                assert card["available"] is (card["id"] == "connector:stripe")
+            else:
+                assert "available" not in card
+
+    @pytest.mark.asyncio
+    async def test_describe_filtered_entry_is_not_found_without_leak(self):
+        provider = FakeProvider(denied_ids={"connector:stripe"})
+        out = await _atlas_describe_handler({"id": "connector:stripe"}, provider)
+        assert out.get("is_error") is True
+        text = _text_of(out)
+        assert "unknown atlas id" in text
+        assert "connector:stripe" not in text.split("Known ids:")[1]
+
+    @pytest.mark.asyncio
+    async def test_describe_unavailable_connector_points_at_integrations(self):
+        provider = FakeProvider(connected=set())  # nothing connected
+        out = await _atlas_describe_handler({"id": "connector:stripe"}, provider)
+        assert not out.get("is_error")
+        entry = json.loads(_text_of(out))
+        assert entry["available"] is False
+        # Route comes from the seed's integrations surface entry.
+        from pocketpaw.atlas.store import get_atlas_store
+
+        route = get_atlas_store().describe("surface:integrations").surface
+        assert route and route in entry["connect_hint"]
+
+    @pytest.mark.asyncio
+    async def test_describe_available_connector_has_no_hint(self):
+        provider = FakeProvider(connected={"stripe"})
+        out = await _atlas_describe_handler({"id": "connector:stripe"}, provider)
+        entry = json.loads(_text_of(out))
+        assert entry["available"] is True
+        assert "connect_hint" not in entry
+
+    @pytest.mark.asyncio
+    async def test_describe_os_entry_unaffected_by_provider(self):
+        out = await _atlas_describe_handler({"id": "primitive:instinct"}, FakeProvider())
+        entry = json.loads(_text_of(out))
+        assert entry["id"] == "primitive:instinct"
+        assert "available" not in entry
+
+    @pytest.mark.asyncio
+    async def test_raising_provider_fails_closed_through_the_tools(self):
+        provider = RaisingGrantProvider()
+        out = await _atlas_search_handler({"intent": "approve agent actions"}, provider)
+        assert not out.get("is_error")
+        assert "No atlas entries matched" in _text_of(out)
+        out = await _atlas_describe_handler({"id": "primitive:instinct"}, provider)
+        assert out.get("is_error") is True
+
+    @pytest.mark.asyncio
+    async def test_no_provider_keeps_global_behavior(self):
+        out = await _atlas_search_handler({"intent": "approve agent actions"})
+        cards = _cards(out)
+        assert "primitive:instinct" in [c["id"] for c in cards[:3]]
+        assert all("available" not in c for c in cards)


### PR DESCRIPTION
## What ships

atlas answers now reflect the calling workspace, not a global view (stacks on #1616):

- **EntitlementProvider protocol + AtlasOverlay** — entries a provider doesn't grant are removed (absent from search, describe, and the known-ids listing; a filtered id is byte-identical to an unknown one — no existence oracle). Connector entries gain `available: true/false` from the real connector seam: `ConnectorRegistry.status(scope_key)`, the same durable-state view `connector_list` answers from. Available connectors rank above unavailable ones only at equal relevance — base scoring untouched.
- **Per-run scope, no process-globals** — the SDK backend resolves the scope from its own run env (`ws:<POCKETPAW_WORKSPACE_ID>` when an isolated cloud run attached tenancy, else the OSS `default` scope). Tenancy attached with a blank id fails closed to a sentinel scope that matches no rows.
- **Warm-client hardening** — the tenant scope is folded into the client cache key, so a scope change structurally forces a fresh subprocess (extends the ART-2 cwd argument).
- **`connect_hint`** — describing an unavailable connector points at the integrations surface, with the route looked up through the overlay so a filtering provider can't leak it.

## Review trail

Spec+quality review: pass. Adversarial security audit: one important finding — blank-workspace-id fail-open toward the shared default scope — **fixed here** (sentinel scope + tests), plus its two defensive recommendations applied (cache-key fold, overlay-routed hint). Audit verified: no store mutation/poisoning, no cross-tenant oracle in error envelopes, scope-key injection contained by the state store's segment sanitizer, no shared-backend route between tenants.

## Honest v1 scope

Two things this does NOT yet do, on purpose:
- Cloud `ws:` availability is plumbed but inert — the cloud connector state store doesn't enumerate tenant rows, so cloud scopes conservatively report all connectors unavailable until the EE availability provider lands (docs + code comments say so explicitly).
- Entitlement filtering is dormant: the OSS default provider grants everything. The filter paths are built and tested; a plan-aware EE provider is the follow-up (tracked with the Fabric slice).

## Testing

119 passed: 23 overlay tests (two-context divergence, fail-closed on raising AND ambiguous grants, no-leak describe, both re-rank cases, no singleton mutation) + 3 new scope-key tests + full atlas suite + claude_sdk allow/deny/warm-lease/prewarm consumers. ruff clean. Live smoke on this machine: genuinely-connected connector shows available, stripe shows unavailable.