### PR TITLE
feat(atlas): live Fabric schema introspection (EE)

### DIFF
--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -29,6 +29,13 @@ and one `skill` entry per BUNDLED skill; the store's lexical search
 gains a cheap deterministic suffix normalizer (stemming) so inflected
 query words match singular keywords. Installed (non-bundled) skills
 stay with the system-prompt skills block.
+Updated: 2026-07-02 (feat/atlas-fabric, AT-7) — live Fabric schema
+introspection (EE-only, fail-closed): an optional per-run
+FabricIntrospector (atlas/fabric.py) lets atlas_search surface
+synthetic `fabric:<entity-type>` cards for the CALLING workspace's live
+ontology and atlas_describe answer `fabric:<type>` with properties +
+links. Never compiled into atlas.json; absent/erroring introspector →
+gracefully absent (OSS default).
 -->
 
 # Atlas — the OS self-model
@@ -236,6 +243,54 @@ workspace-connector view and pass it to
 `build_atlas_context_server(provider=...)`. The OSS `"default"` scope reads
 live file-store state and is fully functional today.
 
+## Live Fabric schema introspection (`atlas/fabric.py`, EE-only)
+
+Fabric — the typed workspace ontology (typed objects like Customer /
+Competitor, typed links like `competes_with`) — is EE cloud and **per
+tenant**: its entries are dynamic, so they are NEVER compiled into
+`atlas.json` (which stays global and byte-deterministic). Since AT-7 the
+atlas tools can still answer "what entity types exist in THIS workspace?"
+live, through an optional per-run introspector:
+
+- **`FabricIntrospector` protocol** — structural, like
+  `EntitlementProvider`: `list_entity_types() -> list[str]` and
+  `describe_entity_type(name) -> dict | None` (properties + link types).
+  `build_atlas_context_server(provider=..., introspector=...)` accepts it
+  next to the provider; the tool closures capture it per run.
+- **Search** — with an introspector, `atlas_search` additionally matches
+  the intent against live entity-type names and their property names
+  (exact/stemmed token match, camel-case split, the store's own suffix
+  normalizer) and APPENDS up to 3 synthetic cards — id
+  `fabric:<entity-type>`, tool-layer-only kind `fabric` (not part of
+  `AtlasKind`; fabric cards are built at answer time, never `AtlasEntry`
+  rows) — **after** the compiled-entry results. Compiled results are never
+  displaced or re-ranked by fabric hits.
+- **Describe** — `atlas_describe("fabric:<type>")` returns the live schema:
+  sorted `properties`, `links` (`{name, from_type, to_type}` dicts),
+  `workspace_scoped: true`, and a narrative pointing back at
+  `primitive:fabric`.
+- **OSS absence** — without an introspector (the OSS default) nothing about
+  live Fabric exists: `fabric:*` ids answer as unknown ids (and never
+  appear in the known-ids listing), no fabric cards ever surface, and the
+  only Fabric knowledge is the compiled `primitive:fabric` narrative.
+- **Fail-closed** — an introspector that raises (listing OR describing) is
+  treated exactly like an absent one: DEBUG log, no crash, no partial
+  leak. Malformed shapes (non-string names, non-list properties) are
+  dropped, not propagated.
+
+**EE wiring** (`claude_sdk.py` `_get_mcp_servers`): the introspector is
+built only when the run's tenant scope is a real `ws:<id>` (via
+`_tenant_scope_key()` — the OSS `"default"` scope and the blank-id
+sentinel get none; there is no ambient OSS fabric registry, the
+`JSONFileFabricRegistry` mock needs an explicit registry file) AND
+`pocketpaw_ee.fabric` imports. `build_workspace_fabric_introspector(ws_id)`
+binds a `WorkspaceFabricRegistry` (SQLite-backed, workspace-scoped) to the
+run's workspace id — per run, never a process-global — and degrades to
+`None` on import or construction failure (DEBUG log). Tests:
+`tests/atlas/test_fabric_introspection.py` (fake + raising introspectors;
+the real EE adapter test is import-guarded and skips when `pocketpaw_ee`
+isn't installed).
+
 ## Agent tools (`pocketpaw_atlas` MCP server)
 
 The `pocketpaw_atlas` in-process MCP server is registered on the Claude Agent
@@ -253,6 +308,9 @@ path), so it is ambient on every agent run. Two tools:
   and keyword hits rank highest. `available` appears on
   connector cards only (overlay, AT-5); available connectors rank above
   unavailable ones at equal relevance, and non-granted entries are absent.
+  With a fabric introspector (AT-7, EE), up to 3 synthetic
+  `fabric:<entity-type>` cards (kind `fabric`) ride AFTER the compiled
+  results when the intent matches live workspace entity types.
 - **When:** before guessing whether the OS can do something or which
   primitive fits an intent.
 
@@ -267,7 +325,9 @@ path), so it is ambient on every agent run. Two tools:
   `connect_hint` pointing at the integrations surface route (looked up from
   the seed's `surface:integrations` entry, not hard-coded), a filtered
   (non-granted) id answers exactly like an unknown id, and the known-ids
-  listing carries only ids the calling context may see.
+  listing carries only ids the calling context may see. With a fabric
+  introspector (AT-7, EE), `fabric:<type>` ids answer with the live
+  workspace schema (properties + links); without one they are unknown ids.
 - **When:** after `atlas_search` picks a candidate, or before explaining /
   exercising a primitive.
 
@@ -305,6 +365,10 @@ provider = DefaultEntitlementProvider(scope_key="default")  # or "ws:<id>"
 AtlasOverlay.search(store, "invoices", provider, limit=5)   # OverlaidEntry list
 AtlasOverlay.describe(store, "connector:stripe", provider)  # None if filtered
 
+from pocketpaw.atlas import FabricIntrospector, build_workspace_fabric_introspector
+introspector = build_workspace_fabric_introspector("ws-1")  # None on OSS installs
+# build_atlas_context_server(provider=..., introspector=...) serves fabric:* live
+
 from pocketpaw.atlas import check_artifact, compile_atlas, write_artifact
 compile_atlas()      # authored + extracted entries, sorted by id
 write_artifact()     # what `pocketpaw atlas build` calls
@@ -317,4 +381,7 @@ drift warning; `test_overlay.py` pins the fail-closed filter, availability
 annotation + re-ranking, no-leak describe, and the MCP handlers under
 stubbed providers; `test_widgets_skills.py` pins widget/skill extraction,
 intent-phrase search without exact names, the `get_widget_spec` routing in
-`how`, the bundled-only skill guarantee, and the exact stemming rules).
+`how`, the bundled-only skill guarantee, and the exact stemming rules;
+`test_fabric_introspection.py` pins the AT-7 fabric seam: fake-introspector
+search/describe, compiled results never displaced, OSS absence, raising →
+absent fail-closed, and the import-guarded real EE adapter).

--- a/ee/pocketpaw_ee/fabric/registry.py
+++ b/ee/pocketpaw_ee/fabric/registry.py
@@ -9,6 +9,9 @@
 # 2026-06-10: added ``list_entity_types()`` pass-through — the registry
 # exposed exists/properties but no way to enumerate the workspace
 # ontology without reaching around to the store.
+# 2026-07-02 (feat/atlas-fabric, AT-7): added ``list_entity_links()``
+# pass-through so the atlas Fabric introspector can enumerate a type's
+# declared links when describing the workspace schema. Read-only.
 """Concrete ``FabricRegistry`` implementation backed by
 :class:`WorkspaceFabricStore`.
 
@@ -103,6 +106,17 @@ class WorkspaceFabricRegistry:
         without reaching around the wrapper to the store.
         """
         return self._store.list_entity_types(self._workspace_id)
+
+    def list_entity_links(self, name: str) -> list[dict[str, str]]:
+        """Every declared link touching entity type ``name`` (either end)
+        in this workspace, as ``{"name", "from_type", "to_type"}`` dicts.
+
+        Pass-through to ``WorkspaceFabricStore.list_entity_links`` with
+        the bound ``workspace_id``. Added for the atlas Fabric
+        introspector (AT-7) — describing a type's schema needs its links
+        enumerated, not just existence-checked.
+        """
+        return self._store.list_entity_links(self._workspace_id, name)
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/fabric/storage.py
+++ b/ee/pocketpaw_ee/fabric/storage.py
@@ -8,6 +8,10 @@
 # sites if needed. Sibling to ``pocketpaw.fabric.store.FabricStore``
 # (OSS, async, holds the live ontology object data); the ``Workspace``
 # prefix flags the workspace-scoped, registry-only role.
+# Updated: 2026-07-02 (feat/atlas-fabric, AT-7) — added
+# ``list_entity_links()``: enumerate the declared links touching one
+# entity type (either end), so the atlas Fabric introspector can
+# describe a workspace's live schema. Read-only, additive.
 """SQLite-backed workspace-scoped Fabric registry store.
 
 The store is the write-side of the concrete ``FabricRegistry``
@@ -266,6 +270,26 @@ class WorkspaceFabricStore:
                 (workspace_id, name, from_type, to_type),
             )
             return cur.fetchone() is not None
+
+    def list_entity_links(self, workspace_id: str, entity_type: str) -> list[dict[str, str]]:
+        """Every declared link touching ``entity_type`` (either end) in
+        ``workspace_id``, as ``{"name", "from_type", "to_type"}`` dicts.
+
+        Ordered by (name, from_type, to_type) for stable callers. Added
+        for the atlas Fabric introspector (AT-7): the registry exposed
+        existence checks but no way to enumerate a type's links when
+        describing the workspace schema.
+        """
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT name, from_type, to_type FROM fabric_registry_links "
+                "WHERE workspace = ? AND (from_type = ? OR to_type = ?) "
+                "ORDER BY name, from_type, to_type",
+                (workspace_id, entity_type, entity_type),
+            )
+            return [
+                {"name": row[0], "from_type": row[1], "to_type": row[2]} for row in cur.fetchall()
+            ]
 
 
 __all__ = [

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,13 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-07-02 (feat/atlas-fabric AT-7) — the ``pocketpaw_atlas`` server
+  additionally gets a per-run live Fabric introspector (``atlas/fabric.py``)
+  when — and only when — the tenant scope is a real ``ws:<id>`` (not the OSS
+  ``"default"`` scope, not the blank-id sentinel, now the module constant
+  ``_SENTINEL_TENANT_SCOPE``) AND ``pocketpaw_ee.fabric`` imports; import or
+  construction failure degrades to no-introspector (fail-closed, DEBUG log).
+  Lets agents ask atlas "what entity types exist in THIS workspace" without
+  ever baking per-tenant ontology into the compiled artifact.
 Updated: 2026-07-02 (feat/atlas-overlay AT-5) — the ``pocketpaw_atlas`` server
   is now built with a per-run ``DefaultEntitlementProvider``
   (``atlas/overlay.py``): the connector scope key resolves from THIS backend
@@ -315,6 +323,12 @@ _DEFAULT_IDENTITY = (
 )
 
 _HTTP_TRANSPORTS: frozenset[str] = frozenset({"http", "sse", "streamable-http"})
+
+# Fail-closed sentinel scope minted by ``_tenant_scope_key`` when tenancy is
+# attached with a BLANK workspace id (AT-5). Matches no connector rows and
+# must never unlock per-workspace features (e.g. the AT-7 Fabric
+# introspector) — a half-attached tenancy degrades to "nothing available".
+_SENTINEL_TENANT_SCOPE = "ws:__missing-workspace-id__"
 
 # Universal pocket-creation grant. When a surface imposes a restrictive MCP
 # allow-list (``SurfaceProfile.allow_mcp_tool_ids``), these ids are always kept
@@ -949,12 +963,31 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # not enumerate tenant rows, so cloud runs conservatively report
         # every connector unavailable until the EE availability provider
         # lands. The OSS ``"default"`` scope reads live file-store state.
+        #
+        # AT-7: a real ``ws:<id>`` scope ALSO gets a live Fabric
+        # introspector (EE workspace ontology — entity types, properties,
+        # links) so atlas can answer "what entity types exist in THIS
+        # workspace". Built per run with the run's workspace id, never a
+        # process-global. The builder degrades to None (fail-closed, DEBUG
+        # log) when pocketpaw_ee isn't importable or construction fails;
+        # the "default" scope and the blank-id sentinel get NO introspector
+        # (the OSS JSONFileFabricRegistry needs an explicit registry file —
+        # there is no ambient OSS fabric registry to wire today).
         try:
             from pocketpaw.agents.sdk_mcp_atlas import build_atlas_context_server
             from pocketpaw.atlas.overlay import DefaultEntitlementProvider
 
+            tenant_scope = self._tenant_scope_key()
+            fabric_introspector = None
+            if tenant_scope.startswith("ws:") and tenant_scope != _SENTINEL_TENANT_SCOPE:
+                from pocketpaw.atlas.fabric import build_workspace_fabric_introspector
+
+                fabric_introspector = build_workspace_fabric_introspector(
+                    tenant_scope[len("ws:") :]
+                )
             atlas_server = build_atlas_context_server(
-                provider=DefaultEntitlementProvider(scope_key=self._tenant_scope_key())
+                provider=DefaultEntitlementProvider(scope_key=tenant_scope),
+                introspector=fabric_introspector,
             )
             if atlas_server is not None:
                 name, cfg_entry = atlas_server
@@ -1265,7 +1298,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         if raw is None:
             return DEFAULT_SCOPE_KEY
         ws = raw.strip()
-        return f"ws:{ws}" if ws else "ws:__missing-workspace-id__"
+        return f"ws:{ws}" if ws else _SENTINEL_TENANT_SCOPE
 
     @classmethod
     def _client_cache_key(

--- a/src/pocketpaw/agents/sdk_mcp_atlas.py
+++ b/src/pocketpaw/agents/sdk_mcp_atlas.py
@@ -23,6 +23,16 @@
 # connectors at the integrations surface, and non-granted entries are
 # ABSENT everywhere (search, describe, known-ids error — fail-closed, no
 # leakage). ``provider=None`` keeps the pre-AT-5 global behavior.
+#
+# Updated: 2026-07-02 (feat/atlas-fabric, AT-7) — the server also takes an
+# optional per-run ``FabricIntrospector`` (``atlas/fabric.py``): live
+# workspace-ontology (EE Fabric) introspection. With one, atlas_search
+# APPENDS synthetic ``fabric:<entity-type>`` cards (tool-layer kind
+# ``fabric``) after compiled-entry results — never displacing them — and
+# atlas_describe answers ``fabric:<type>`` ids with the live schema
+# (properties + links). Absent (OSS default) or erroring introspector →
+# fabric ids are unknown ids and no fabric cards appear (fail-closed);
+# workspace ontology is per-tenant and NEVER enters the compiled artifact.
 
 from __future__ import annotations
 
@@ -31,6 +41,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from pocketpaw.atlas.fabric import FabricIntrospector
     from pocketpaw.atlas.overlay import EntitlementProvider
 
 logger = logging.getLogger(__name__)
@@ -60,7 +71,11 @@ def _text_result(text: str, *, is_error: bool = False) -> dict:
     return out
 
 
-async def _atlas_search_handler(args: dict, provider: EntitlementProvider | None = None) -> dict:
+async def _atlas_search_handler(
+    args: dict,
+    provider: EntitlementProvider | None = None,
+    introspector: FabricIntrospector | None = None,
+) -> dict:
     """Rank atlas entries for an intent and return capability cards.
 
     Backs the ``atlas_search`` MCP tool. Cards are intentionally thin
@@ -68,7 +83,11 @@ async def _atlas_search_handler(args: dict, provider: EntitlementProvider | None
     with ``atlas_describe`` on the id it picks. With a *provider* (AT-5),
     results are the calling context's view: non-granted entries are
     absent, connector cards carry ``available``, and available
-    connectors rank above unavailable ones at equal relevance.
+    connectors rank above unavailable ones at equal relevance. With an
+    *introspector* (AT-7), live workspace entity types matching the
+    intent are APPENDED as synthetic ``fabric:*`` cards after the
+    compiled-entry results — never displacing them; an erroring
+    introspector contributes nothing (fail-closed).
     """
     from pocketpaw.atlas.store import get_atlas_store
 
@@ -89,7 +108,15 @@ async def _atlas_search_handler(args: dict, provider: EntitlementProvider | None
         overlaid = [
             (o.entry, o.available) for o in AtlasOverlay.search(store, intent, provider, limit=5)
         ]
-    if not overlaid:
+
+    fabric_cards: list[dict[str, Any]] = []
+    if introspector is not None:
+        # Fail-closed inside: any introspector error yields [] (DEBUG log).
+        from pocketpaw.atlas.fabric import search_entity_types
+
+        fabric_cards = search_entity_types(introspector, intent)
+
+    if not overlaid and not fabric_cards:
         return _text_result(f"No atlas entries matched intent: {intent!r}. Try broader wording.")
 
     cards: list[dict[str, Any]] = []
@@ -105,10 +132,17 @@ async def _atlas_search_handler(args: dict, provider: EntitlementProvider | None
         if available is not None:
             card["available"] = available
         cards.append(card)
+    # Fabric cards ride AFTER every compiled-entry card (AT-7): live
+    # ontology hits are additive context, never displacing OS answers.
+    cards.extend(fabric_cards)
     return _text_result(json.dumps({"results": cards}, ensure_ascii=False))
 
 
-async def _atlas_describe_handler(args: dict, provider: EntitlementProvider | None = None) -> dict:
+async def _atlas_describe_handler(
+    args: dict,
+    provider: EntitlementProvider | None = None,
+    introspector: FabricIntrospector | None = None,
+) -> dict:
     """Return the full atlas entry for a stable id.
 
     Backs the ``atlas_describe`` MCP tool. Unknown ids return an error
@@ -117,7 +151,11 @@ async def _atlas_describe_handler(args: dict, provider: EntitlementProvider | No
     unknown id (and the known-ids listing carries only visible ids), so
     describe can never confirm a filtered entry exists; an unavailable
     connector's card carries ``available: false`` plus a pointer to the
-    integrations surface (route looked up from the store).
+    integrations surface (route looked up from the store). With an
+    *introspector* (AT-7), ``fabric:<type>`` ids answer with the live
+    workspace schema (properties + links); absent or erroring
+    introspector, fabric ids fall through to the unknown-id path —
+    indistinguishable from ids that never existed (fail-closed).
     """
     from pocketpaw.atlas.store import get_atlas_store
 
@@ -127,6 +165,15 @@ async def _atlas_describe_handler(args: dict, provider: EntitlementProvider | No
             "Error: pass `id` as a non-empty string (e.g. 'primitive:instinct').",
             is_error=True,
         )
+
+    if introspector is not None:
+        # Fail-closed inside: a miss OR a raising introspector returns None,
+        # and the id falls through to the normal unknown-id error below.
+        from pocketpaw.atlas.fabric import describe_fabric_id
+
+        fabric_payload = describe_fabric_id(introspector, entry_id.strip())
+        if fabric_payload is not None:
+            return _text_result(json.dumps(fabric_payload, ensure_ascii=False))
 
     store = get_atlas_store()
     if provider is None:
@@ -167,13 +214,17 @@ async def _atlas_describe_handler(args: dict, provider: EntitlementProvider | No
 
 def build_atlas_context_server(
     provider: EntitlementProvider | None = None,
+    introspector: FabricIntrospector | None = None,
 ) -> tuple[str, Any] | None:
     """Build the in-process SDK MCP server, or None if the SDK is unavailable.
 
     ``provider`` is the per-run entitlement/availability context (AT-5);
     the tool closures capture it so every ``atlas_search`` /
     ``atlas_describe`` call answers for THAT context. ``None`` serves the
-    global (pre-overlay) view.
+    global (pre-overlay) view. ``introspector`` (AT-7) is the per-run live
+    Fabric (workspace-ontology) view — EE-wired, constructed with the run's
+    workspace id; ``None`` (the OSS default) means nothing about live
+    Fabric exists beyond the compiled ``primitive:fabric`` narrative.
     """
     try:
         from claude_agent_sdk import create_sdk_mcp_server, tool
@@ -211,7 +262,7 @@ def build_atlas_context_server(
         },
     )
     async def atlas_search(args):  # type: ignore[no-untyped-def]
-        return await _atlas_search_handler(args, provider)
+        return await _atlas_search_handler(args, provider, introspector)
 
     @tool(
         "atlas_describe",
@@ -236,7 +287,7 @@ def build_atlas_context_server(
         },
     )
     async def atlas_describe(args):  # type: ignore[no-untyped-def]
-        return await _atlas_describe_handler(args, provider)
+        return await _atlas_describe_handler(args, provider, introspector)
 
     server = create_sdk_mcp_server(
         name=SERVER_NAME,

--- a/src/pocketpaw/atlas/__init__.py
+++ b/src/pocketpaw/atlas/__init__.py
@@ -1,4 +1,9 @@
 # atlas/__init__.py — package exports for the atlas primitive (AT-1).
+# Updated: 2026-07-02 (feat/atlas-fabric, AT-7) — export the live Fabric
+# introspection seam (FabricIntrospector protocol, the EE-wired
+# build_workspace_fabric_introspector hook, and RegistryFabricIntrospector)
+# so EE wiring and tests can bind a workspace's live ontology to the atlas
+# tools; OSS installs get None from the builder (fail-closed).
 # Updated: 2026-07-02 (feat/atlas-overlay, AT-5) — export the live overlay
 # (AtlasOverlay / OverlaidEntry), the EntitlementProvider protocol, and the
 # OSS DefaultEntitlementProvider next to the store, so consumers can render
@@ -12,6 +17,11 @@
 # and can do, instead of guessing from LLM priors.
 
 from pocketpaw.atlas.compile import check_artifact, compile_atlas, write_artifact
+from pocketpaw.atlas.fabric import (
+    FabricIntrospector,
+    RegistryFabricIntrospector,
+    build_workspace_fabric_introspector,
+)
 from pocketpaw.atlas.model import AtlasEntry, AtlasModel
 from pocketpaw.atlas.overlay import (
     AtlasOverlay,
@@ -28,7 +38,10 @@ __all__ = [
     "AtlasStore",
     "DefaultEntitlementProvider",
     "EntitlementProvider",
+    "FabricIntrospector",
     "OverlaidEntry",
+    "RegistryFabricIntrospector",
+    "build_workspace_fabric_introspector",
     "check_artifact",
     "check_connector_drift",
     "compile_atlas",

--- a/src/pocketpaw/atlas/fabric.py
+++ b/src/pocketpaw/atlas/fabric.py
@@ -1,0 +1,262 @@
+# atlas/fabric.py — live Fabric (workspace ontology) introspection for the
+# atlas MCP tools (AT-7). Created: 2026-07-02 (feat/atlas-fabric).
+#
+# Fabric — the typed workspace ontology (typed objects like Customer /
+# Competitor, typed links like competes_with) — is EE cloud and PER-TENANT:
+# its entries are dynamic, so they must NEVER be baked into the compiled
+# artifact (atlas.json stays global and byte-deterministic). This module is
+# the seam that lets the atlas tools answer "what entity types exist in THIS
+# workspace?" live:
+#
+# * ``FabricIntrospector`` — a small structural protocol (like
+#   ``EntitlementProvider`` in overlay.py): ``list_entity_types()`` and
+#   ``describe_entity_type(name)``. The atlas MCP server builder accepts an
+#   optional introspector; absent (the OSS default) nothing about live
+#   Fabric exists — ``fabric:*`` ids are unknown ids and search surfaces no
+#   fabric cards. Only the compiled ``primitive:fabric`` narrative remains.
+# * ``search_entity_types`` / ``describe_fabric_id`` — the tool-layer
+#   helpers. Search is a simple exact/stemmed token match (the store's own
+#   ``_stem_set`` normalizer, plus camel-case splitting) over live
+#   entity-type names and their property names; results are synthetic cards
+#   (id ``fabric:<type>``, tool-layer-only kind ``fabric``) that the search
+#   handler APPENDS after compiled-entry results — never displacing them.
+# * FAIL-CLOSED: any introspector error (listing, describing, bad shapes)
+#   is logged at DEBUG and treated as "no introspector" — no crash, no
+#   partial leak.
+# * ``build_workspace_fabric_introspector`` — the EE wiring hook: imports
+#   ``pocketpaw_ee.fabric`` inside try/except (optional, like the runtime's
+#   other ee seams) and binds a ``WorkspaceFabricRegistry`` to ONE
+#   workspace id (never a process-global). Import or construction failure
+#   degrades to ``None``.
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# Synthetic-card id prefix and tool-layer kind. ``fabric`` is deliberately
+# NOT added to ``AtlasKind`` — live fabric cards are plain dicts built at
+# answer time, never ``AtlasEntry`` rows in the compiled artifact.
+FABRIC_ID_PREFIX = "fabric:"
+FABRIC_KIND = "fabric"
+
+# Cap on synthetic fabric cards appended to a search answer. Compiled-entry
+# results keep their own limit; fabric cards are extra, never displacing.
+MAX_FABRIC_RESULTS = 3
+
+# Entity-type names are commonly CamelCase ("CustomerAccount"); split on
+# case boundaries before stemming so "customer account" queries match.
+_CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+
+@runtime_checkable
+class FabricIntrospector(Protocol):
+    """Live view of ONE workspace's Fabric ontology (structural protocol).
+
+    Implementations are bound to a single workspace at construction —
+    per-run wiring, never a process-global. Both methods may raise; every
+    caller in this module treats a raise as "introspector absent"
+    (fail-closed).
+    """
+
+    def list_entity_types(self) -> list[str]:
+        """Names of every entity type registered in this workspace."""
+        ...
+
+    def describe_entity_type(self, name: str) -> dict | None:
+        """Schema for one entity type, or ``None`` if unknown.
+
+        Expected shape: ``{"name": str, "properties": list[str],
+        "links": list[dict]}`` (each link dict carries ``name`` /
+        ``from_type`` / ``to_type``).
+        """
+        ...
+
+
+def _fabric_tokens(text: str) -> set[str]:
+    """Stemmed token set for a fabric name — camel-split then the store's
+    own suffix normalizer, so query and index normalize identically."""
+    from pocketpaw.atlas.store import _stem_set
+
+    return _stem_set(_CAMEL_RE.sub(" ", text))
+
+
+def _clean_properties(described: dict) -> list[str]:
+    props = described.get("properties", [])
+    if not isinstance(props, (list, tuple, set, frozenset)):
+        return []
+    return sorted(p for p in props if isinstance(p, str) and p)
+
+
+def _clean_links(described: dict) -> list[dict]:
+    links = described.get("links", [])
+    if not isinstance(links, (list, tuple)):
+        return []
+    return [link for link in links if isinstance(link, dict)]
+
+
+def _summary(name: str, properties: list[str], links: list[dict]) -> str:
+    return (
+        f"Workspace entity type '{name}' — {len(properties)} properties, "
+        f"{len(links)} links. Live Fabric ontology (this workspace only)."
+    )
+
+
+def search_entity_types(
+    introspector: FabricIntrospector,
+    intent: str,
+    limit: int = MAX_FABRIC_RESULTS,
+) -> list[dict[str, Any]]:
+    """Match *intent* against the live entity-type list; return fabric cards.
+
+    Simple exact/stemmed token match: a query token hitting an entity-type
+    NAME token scores 2.0, a PROPERTY-name token 1.0 (best field only, like
+    the store's scoring spirit). Zero-overlap types are dropped; ties sort
+    by name for determinism. FAIL-CLOSED: any introspector error returns
+    ``[]`` (logged at DEBUG) — the compiled-entry answer is never harmed.
+    """
+    try:
+        query = _fabric_tokens(intent)
+        if not query or limit <= 0:
+            return []
+        scored: list[tuple[float, str, list[str], list[dict]]] = []
+        for name in introspector.list_entity_types():
+            if not isinstance(name, str) or not name:
+                continue
+            described = introspector.describe_entity_type(name) or {}
+            if not isinstance(described, dict):
+                described = {}
+            properties = _clean_properties(described)
+            links = _clean_links(described)
+            name_tokens = _fabric_tokens(name)
+            prop_tokens: set[str] = set()
+            for prop in properties:
+                prop_tokens |= _fabric_tokens(prop)
+            score = 2.0 * len(query & name_tokens)
+            score += 1.0 * len(query & (prop_tokens - name_tokens))
+            if score > 0:
+                scored.append((score, name, properties, links))
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        return [
+            {
+                "id": f"{FABRIC_ID_PREFIX}{name}",
+                "kind": FABRIC_KIND,
+                "name": name,
+                "summary": _summary(name, properties, links),
+            }
+            for _score, name, properties, links in scored[:limit]
+        ]
+    except Exception as exc:  # noqa: BLE001 — fail closed, never break the tool
+        logger.debug("atlas fabric introspection unavailable (search): %s", exc)
+        return []
+
+
+def describe_fabric_id(
+    introspector: FabricIntrospector,
+    entry_id: str,
+) -> dict[str, Any] | None:
+    """Live schema payload for a ``fabric:<type>`` id, or ``None``.
+
+    ``None`` covers every miss uniformly: a non-fabric id, an unknown
+    entity type, or a raising introspector (fail-closed, DEBUG-logged) —
+    the caller then falls through to the normal unknown-id path, so a
+    broken introspector is indistinguishable from an absent one.
+    """
+    if not entry_id.startswith(FABRIC_ID_PREFIX):
+        return None
+    name = entry_id[len(FABRIC_ID_PREFIX) :]
+    if not name:
+        return None
+    try:
+        described = introspector.describe_entity_type(name)
+        if not isinstance(described, dict):
+            return None
+        properties = _clean_properties(described)
+        links = _clean_links(described)
+        return {
+            "id": entry_id,
+            "kind": FABRIC_KIND,
+            "name": name,
+            "summary": _summary(name, properties, links),
+            "properties": properties,
+            "links": links,
+            "workspace_scoped": True,
+            "narrative": (
+                f"'{name}' is a typed Fabric entity registered in THIS workspace's "
+                "ontology (not a global OS primitive). Its schema is live and "
+                "tenant-specific: the properties and links listed here are what "
+                "this workspace declared. See primitive:fabric for what Fabric is."
+            ),
+        }
+    except Exception as exc:  # noqa: BLE001 — fail closed, never break the tool
+        logger.debug("atlas fabric introspection unavailable (describe %s): %s", entry_id, exc)
+        return None
+
+
+class RegistryFabricIntrospector:
+    """Adapter from the EE ``WorkspaceFabricRegistry`` read surface to
+    :class:`FabricIntrospector`.
+
+    Takes any registry-shaped object (``list_entity_types`` /
+    ``entity_type_exists`` / ``get_entity_properties`` /
+    ``list_entity_links``) so tests can wrap a tmp-path store without
+    importing ``pocketpaw_ee`` at module scope. The registry is already
+    bound to one workspace — this adapter adds no scoping of its own.
+    """
+
+    __slots__ = ("_registry",)
+
+    def __init__(self, registry: Any) -> None:
+        self._registry = registry
+
+    def list_entity_types(self) -> list[str]:
+        return list(self._registry.list_entity_types())
+
+    def describe_entity_type(self, name: str) -> dict | None:
+        if not self._registry.entity_type_exists(name):
+            return None
+        return {
+            "name": name,
+            "properties": sorted(self._registry.get_entity_properties(name)),
+            "links": list(self._registry.list_entity_links(name)),
+        }
+
+
+def build_workspace_fabric_introspector(workspace_id: str) -> FabricIntrospector | None:
+    """EE wiring hook: a live introspector bound to *workspace_id*, or None.
+
+    ``None`` on: blank workspace id, ``pocketpaw_ee.fabric`` not importable
+    (OSS install), or registry/store construction failure (e.g. unwritable
+    state dir) — all DEBUG-logged, all degrade to "no introspector"
+    (fail-closed). The returned introspector is constructed PER RUN with the
+    run's workspace id — never cached process-globally.
+    """
+    if not isinstance(workspace_id, str) or not workspace_id.strip():
+        return None
+    try:
+        from pocketpaw_ee.fabric import WorkspaceFabricRegistry, WorkspaceFabricStore
+    except ImportError:
+        logger.debug("pocketpaw_ee.fabric not importable; atlas fabric introspection off")
+        return None
+    try:
+        store = WorkspaceFabricStore()
+        registry = WorkspaceFabricRegistry(store=store, workspace_id=workspace_id.strip())
+        return RegistryFabricIntrospector(registry)
+    except Exception as exc:  # noqa: BLE001 — infra failure degrades, never crashes
+        logger.debug("atlas fabric introspector construction failed: %s", exc)
+        return None
+
+
+__all__ = [
+    "FABRIC_ID_PREFIX",
+    "FABRIC_KIND",
+    "MAX_FABRIC_RESULTS",
+    "FabricIntrospector",
+    "RegistryFabricIntrospector",
+    "build_workspace_fabric_introspector",
+    "describe_fabric_id",
+    "search_entity_types",
+]

--- a/tests/atlas/test_fabric_introspection.py
+++ b/tests/atlas/test_fabric_introspection.py
@@ -1,0 +1,306 @@
+# tests/atlas/test_fabric_introspection.py — live Fabric introspection for
+# the atlas MCP tools (AT-7). Created: 2026-07-02 (feat/atlas-fabric).
+#
+# Proves the FabricIntrospector seam end-to-end with a FAKE introspector
+# (no pocketpaw_ee required): search surfaces synthetic fabric:<type> cards
+# for entity-type / property queries APPENDED after compiled-entry results
+# (never displacing them); describe answers fabric:<type> with the live
+# schema (properties + links); absent introspector (OSS default) → fabric
+# ids are unknown ids and no fabric cards appear; a RAISING introspector is
+# treated exactly like an absent one (fail-closed, both tools, no crash).
+# Also pins the structural protocol check and the EE adapter: adapter
+# construction against a tmp-path WorkspaceFabricStore is import-guarded
+# (pytest.importorskip) so the test runs where pocketpaw_ee is installed
+# (or via PYTHONPATH=ee) and skips cleanly elsewhere.
+
+import json
+
+import pytest
+
+from pocketpaw.agents.sdk_mcp_atlas import (
+    _atlas_describe_handler,
+    _atlas_search_handler,
+)
+from pocketpaw.atlas.fabric import (
+    FABRIC_ID_PREFIX,
+    FABRIC_KIND,
+    FabricIntrospector,
+    build_workspace_fabric_introspector,
+    describe_fabric_id,
+    search_entity_types,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+_SCHEMA = {
+    "Customer": {
+        "name": "Customer",
+        "properties": ["churn_risk", "email", "plan"],
+        "links": [
+            {"name": "competes_with", "from_type": "Customer", "to_type": "Competitor"},
+        ],
+    },
+    "Competitor": {
+        "name": "Competitor",
+        "properties": ["pricing_page"],
+        "links": [
+            {"name": "competes_with", "from_type": "Customer", "to_type": "Competitor"},
+        ],
+    },
+}
+
+
+class FakeIntrospector:
+    """In-memory FabricIntrospector — the shape the EE adapter produces."""
+
+    def __init__(self, schema: dict | None = None) -> None:
+        self._schema = _SCHEMA if schema is None else schema
+
+    def list_entity_types(self) -> list[str]:
+        return sorted(self._schema)
+
+    def describe_entity_type(self, name: str) -> dict | None:
+        return self._schema.get(name)
+
+
+class RaisingIntrospector:
+    """Every call raises — must be indistinguishable from an absent one."""
+
+    def list_entity_types(self) -> list[str]:
+        raise RuntimeError("fabric backend down")
+
+    def describe_entity_type(self, name: str) -> dict | None:
+        raise RuntimeError("fabric backend down")
+
+
+def _text_of(result: dict) -> str:
+    block = next((c for c in result.get("content", []) if c.get("type") == "text"), None)
+    assert block is not None, "handler must return a text content block"
+    return block["text"]
+
+
+def _cards_of(result: dict) -> list[dict]:
+    return json.loads(_text_of(result))["results"]
+
+
+# ---------------------------------------------------------------------------
+# Protocol shape
+# ---------------------------------------------------------------------------
+
+
+class TestProtocol:
+    def test_fake_satisfies_structural_protocol(self):
+        assert isinstance(FakeIntrospector(), FabricIntrospector)
+        assert isinstance(RaisingIntrospector(), FabricIntrospector)
+
+
+# ---------------------------------------------------------------------------
+# Search — fabric cards
+# ---------------------------------------------------------------------------
+
+
+class TestSearchWithIntrospector:
+    @pytest.mark.asyncio
+    async def test_entity_type_query_surfaces_fabric_card(self):
+        out = await _atlas_search_handler(
+            {"intent": "customer churn"}, introspector=FakeIntrospector()
+        )
+        assert not out.get("is_error")
+        cards = _cards_of(out)
+        fabric = [c for c in cards if c["id"].startswith(FABRIC_ID_PREFIX)]
+        assert fabric, f"expected a fabric card, got ids {[c['id'] for c in cards]}"
+        card = fabric[0]
+        assert card["id"] == "fabric:Customer"
+        assert card["kind"] == FABRIC_KIND
+        assert card["name"] == "Customer"
+        assert card["summary"]
+        assert "properties" not in card, "search cards stay thin; describe carries the schema"
+
+    @pytest.mark.asyncio
+    async def test_property_token_match_surfaces_owning_type(self):
+        # "churn" only exists as a Customer PROPERTY token, not a type name.
+        out = await _atlas_search_handler({"intent": "churn risk"}, introspector=FakeIntrospector())
+        cards = _cards_of(out)
+        assert any(c["id"] == "fabric:Customer" for c in cards)
+
+    @pytest.mark.asyncio
+    async def test_compiled_results_never_displaced(self):
+        # An entity type engineered to match a classic compiled query.
+        introspector = FakeIntrospector(
+            {"Agent": {"name": "Agent", "properties": ["approval_state"], "links": []}}
+        )
+        baseline = _cards_of(await _atlas_search_handler({"intent": "approve agent actions"}))
+        out = _cards_of(
+            await _atlas_search_handler(
+                {"intent": "approve agent actions"}, introspector=introspector
+            )
+        )
+        # Every compiled card survives, same order, fabric strictly appended.
+        compiled = [c for c in out if not c["id"].startswith(FABRIC_ID_PREFIX)]
+        assert [c["id"] for c in compiled] == [c["id"] for c in baseline]
+        fabric_positions = [i for i, c in enumerate(out) if c["id"].startswith(FABRIC_ID_PREFIX)]
+        assert fabric_positions, "the Agent entity type should match this intent"
+        assert min(fabric_positions) >= len(compiled), "fabric cards must come last"
+
+    @pytest.mark.asyncio
+    async def test_fabric_only_match_still_answers(self):
+        # A query with no compiled-entry overlap but a live-ontology hit
+        # must return the fabric card, not "No atlas entries matched".
+        introspector = FakeIntrospector(
+            {"Zylkorb": {"name": "Zylkorb", "properties": [], "links": []}}
+        )
+        out = await _atlas_search_handler({"intent": "zylkorb"}, introspector=introspector)
+        assert not out.get("is_error")
+        cards = _cards_of(out)
+        assert [c["id"] for c in cards] == ["fabric:Zylkorb"]
+
+
+class TestSearchWithoutIntrospector:
+    @pytest.mark.asyncio
+    async def test_no_introspector_no_fabric_cards(self):
+        out = await _atlas_search_handler({"intent": "customer churn"})
+        assert not out.get("is_error")
+        text = _text_of(out)
+        if "No atlas entries matched" not in text:
+            cards = json.loads(text)["results"]
+            assert not any(c["id"].startswith(FABRIC_ID_PREFIX) for c in cards)
+
+    @pytest.mark.asyncio
+    async def test_raising_introspector_behaves_like_absent(self):
+        raising = await _atlas_search_handler(
+            {"intent": "approve agent actions"}, introspector=RaisingIntrospector()
+        )
+        absent = await _atlas_search_handler({"intent": "approve agent actions"})
+        assert not raising.get("is_error")
+        assert _cards_of(raising) == _cards_of(absent)
+
+
+# ---------------------------------------------------------------------------
+# Describe — live schema
+# ---------------------------------------------------------------------------
+
+
+class TestDescribe:
+    @pytest.mark.asyncio
+    async def test_describe_returns_properties_and_links(self):
+        out = await _atlas_describe_handler(
+            {"id": "fabric:Customer"}, introspector=FakeIntrospector()
+        )
+        assert not out.get("is_error")
+        payload = json.loads(_text_of(out))
+        assert payload["id"] == "fabric:Customer"
+        assert payload["kind"] == FABRIC_KIND
+        assert payload["properties"] == ["churn_risk", "email", "plan"]
+        assert payload["links"] == [
+            {"name": "competes_with", "from_type": "Customer", "to_type": "Competitor"}
+        ]
+        assert payload["workspace_scoped"] is True
+        assert "narrative" in payload
+
+    @pytest.mark.asyncio
+    async def test_unknown_entity_type_falls_through_to_unknown_id(self):
+        out = await _atlas_describe_handler(
+            {"id": "fabric:Nonexistent"}, introspector=FakeIntrospector()
+        )
+        assert out.get("is_error") is True
+        assert "unknown atlas id" in _text_of(out)
+
+    @pytest.mark.asyncio
+    async def test_absent_introspector_fabric_id_is_unknown(self):
+        out = await _atlas_describe_handler({"id": "fabric:Customer"})
+        assert out.get("is_error") is True
+        text = _text_of(out)
+        assert "unknown atlas id" in text
+        # No fabric ids leak into the known-ids listing.
+        assert FABRIC_ID_PREFIX not in text.split("Known ids:")[-1]
+
+    @pytest.mark.asyncio
+    async def test_raising_introspector_fabric_id_is_unknown(self):
+        out = await _atlas_describe_handler(
+            {"id": "fabric:Customer"}, introspector=RaisingIntrospector()
+        )
+        assert out.get("is_error") is True
+        assert "unknown atlas id" in _text_of(out)
+
+    @pytest.mark.asyncio
+    async def test_compiled_entries_still_describe_with_introspector(self):
+        out = await _atlas_describe_handler(
+            {"id": "primitive:fabric"}, introspector=FakeIntrospector()
+        )
+        assert not out.get("is_error")
+        assert json.loads(_text_of(out))["id"] == "primitive:fabric"
+
+
+# ---------------------------------------------------------------------------
+# Helper-level fail-closed behavior
+# ---------------------------------------------------------------------------
+
+
+class TestHelpersFailClosed:
+    def test_search_helper_returns_empty_on_raise(self):
+        assert search_entity_types(RaisingIntrospector(), "customer") == []
+
+    def test_describe_helper_returns_none_on_raise(self):
+        assert describe_fabric_id(RaisingIntrospector(), "fabric:Customer") is None
+
+    def test_describe_helper_ignores_non_fabric_ids(self):
+        assert describe_fabric_id(FakeIntrospector(), "primitive:fabric") is None
+        assert describe_fabric_id(FakeIntrospector(), "fabric:") is None
+
+    def test_search_helper_tolerates_malformed_shapes(self):
+        class Malformed:
+            def list_entity_types(self):
+                return ["Customer", 7, ""]
+
+            def describe_entity_type(self, name):
+                return {"properties": "not-a-list", "links": {"nope": 1}}
+
+        cards = search_entity_types(Malformed(), "customer")
+        assert [c["id"] for c in cards] == ["fabric:Customer"]
+
+
+# ---------------------------------------------------------------------------
+# EE adapter (import-guarded — skips when pocketpaw_ee isn't installed)
+# ---------------------------------------------------------------------------
+
+
+class TestEeAdapter:
+    def test_builder_returns_none_on_blank_workspace_id(self):
+        assert build_workspace_fabric_introspector("") is None
+        assert build_workspace_fabric_introspector("   ") is None
+
+    def test_real_adapter_against_tmp_store(self, tmp_path):
+        pytest.importorskip("pocketpaw_ee")
+        from pocketpaw_ee.fabric import WorkspaceFabricRegistry, WorkspaceFabricStore
+
+        store = WorkspaceFabricStore(tmp_path / "fabric_registry.db")
+        store.register_entity_type("ws-1", "Customer")
+        store.register_property("ws-1", "Customer", "email")
+        store.register_property("ws-1", "Customer", "churn_risk")
+        store.register_entity_type("ws-1", "Competitor")
+        store.register_link("ws-1", "competes_with", "Customer", "Competitor")
+        # Another workspace's ontology must be invisible.
+        store.register_entity_type("ws-2", "Secret")
+
+        from pocketpaw.atlas.fabric import RegistryFabricIntrospector
+
+        adapter = RegistryFabricIntrospector(
+            WorkspaceFabricRegistry(store=store, workspace_id="ws-1")
+        )
+        assert isinstance(adapter, FabricIntrospector)
+        assert adapter.list_entity_types() == ["Competitor", "Customer"]
+        described = adapter.describe_entity_type("Customer")
+        assert described == {
+            "name": "Customer",
+            "properties": ["churn_risk", "email"],
+            "links": [{"name": "competes_with", "from_type": "Customer", "to_type": "Competitor"}],
+        }
+        assert adapter.describe_entity_type("Secret") is None
+
+        # And the tool layer serves it end-to-end.
+        cards = search_entity_types(adapter, "customer churn")
+        assert cards and cards[0]["id"] == "fabric:Customer"
+        payload = describe_fabric_id(adapter, "fabric:Customer")
+        assert payload is not None and payload["properties"] == ["churn_risk", "email"]

--- a/tests/ee/test_fabric_registry.py
+++ b/tests/ee/test_fabric_registry.py
@@ -7,6 +7,9 @@
 # through the store directly. Coverage: per-method behaviour against a
 # populated store, empty-store defaults, workspace isolation, and
 # runtime Protocol conformance.
+# Updated: 2026-07-02 (feat/atlas-fabric, AT-7) — coverage for the new
+# ``list_entity_links()`` pass-through (workspace-bound, either-end
+# enumeration for the atlas Fabric introspector).
 """Tests for ``pocketpaw_ee.fabric.registry.WorkspaceFabricRegistry``.
 
 The registry satisfies the :class:`FabricRegistry` Protocol declared in
@@ -125,6 +128,24 @@ def test_list_entity_types_is_workspace_isolated(
     reg_a = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
     assert sorted(reg_a.list_entity_types()) == ["Lease", "Property", "Tenant"]
     assert "Customer" not in reg_a.list_entity_types()
+
+
+def test_list_entity_links_passes_through_bound_workspace(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    """AT-7 pass-through: links touching the type (either end) in the
+    bound workspace only, in the store's stable order."""
+    reg_a = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    assert reg_a.list_entity_links("Lease") == [
+        {"name": "lease_property", "from_type": "Lease", "to_type": "Property"},
+        {"name": "lease_tenant", "from_type": "Lease", "to_type": "Tenant"},
+    ]
+    assert reg_a.list_entity_links("Tenant") == [
+        {"name": "lease_tenant", "from_type": "Lease", "to_type": "Tenant"},
+    ]
+    # ws-b's invoice_customer link never leaks into ws-a's view.
+    assert reg_a.list_entity_links("Customer") == []
+    assert reg_a.list_entity_links("Ghost") == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ee/test_fabric_storage.py
+++ b/tests/ee/test_fabric_storage.py
@@ -7,6 +7,9 @@
 # round-trip, cascade delete, workspace isolation, and a smoke test
 # wiring the populated store through ``WorkspaceFabricRegistry`` into
 # the Wave 4b validator against ``lease-renewal-v2.yaml``.
+# Updated: 2026-07-02 (feat/atlas-fabric, AT-7) — coverage for the new
+# ``list_entity_links()`` (either-end enumeration, stable order,
+# workspace isolation) backing the atlas Fabric introspector.
 """Tests for ``pocketpaw_ee.fabric.storage.WorkspaceFabricStore``.
 
 The store is the write-side; ``WorkspaceFabricRegistry`` (covered in
@@ -121,6 +124,23 @@ def test_register_link_is_idempotent(store: WorkspaceFabricStore) -> None:
     store.register_link("ws-a", "lease_tenant", "Lease", "Tenant")
     # Sanity — single row, still exists.
     assert store.link_exists("ws-a", "lease_tenant", "Lease", "Tenant") is True
+
+
+def test_list_entity_links_enumerates_both_ends(store: WorkspaceFabricStore) -> None:
+    """AT-7: links touching a type on EITHER end are enumerated, ordered
+    by (name, from_type, to_type); other workspaces stay invisible."""
+    store.register_link("ws-a", "lease_tenant", "Lease", "Tenant")
+    store.register_link("ws-a", "renewed_as", "Lease", "Lease")
+    store.register_link("ws-a", "manages", "Agent", "Property")  # no Lease end
+    store.register_link("ws-b", "lease_tenant", "Lease", "Tenant")  # other ws
+    assert store.list_entity_links("ws-a", "Lease") == [
+        {"name": "lease_tenant", "from_type": "Lease", "to_type": "Tenant"},
+        {"name": "renewed_as", "from_type": "Lease", "to_type": "Lease"},
+    ]
+    assert store.list_entity_links("ws-a", "Tenant") == [
+        {"name": "lease_tenant", "from_type": "Lease", "to_type": "Tenant"},
+    ]
+    assert store.list_entity_links("ws-a", "Ghost") == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What ships

The last atlas v1 slice (stacks on #1619): agents can ask "what entity types exist in THIS workspace?"

- **FabricIntrospector protocol** (`atlas/fabric.py`, mirrors the overlay's provider seam): live per-workspace ontology served through the existing tools. `atlas_search` appends up to 3 `fabric:<type>` cards after compiled results (never displacing them); `atlas_describe("fabric:<type>")` returns live properties + link types.
- **Live, not compiled** — workspace ontology is per-tenant and dynamic, so it never enters `atlas.json` (artifact byte-unchanged; `--check` green).
- **EE-gated, fail-closed** — the introspector is built only for a real `ws:<id>` scope when `pocketpaw_ee.fabric` imports; construction failure, a raising introspector, and OSS are all indistinguishable from absent (`fabric:` ids are byte-identical unknown ids — no existence oracle). Workspace id binds immutably at construction; the new read-only `list_entity_links` store query is workspace-scoped and parameterized like its siblings.

## Testing

128 passed + 1 guarded skip on the OSS path; 50 passed with `PYTHONPATH=ee` — including a real-adapter end-to-end (actual `WorkspaceFabricStore`/`WorkspaceFabricRegistry` over tmp sqlite, cross-workspace invisibility pinned in three tests, no mocks). claude_sdk wiring seams green. Reviewed (spec + quality): pass.

## Accepted follow-ups (from review)

- `search_entity_types` describes every entity type per search to support property-token matching — fine at today's admin-driven registry sizes, needs a bulk-describe store method before large ontologies.
- Not verified against a live Mongo/cloud deployment — the EE gate is exercised at builder level; pairs with the EE availability-provider follow-up from #1618.