### PR TITLE
feat(extraction): caption image-heavy PDF pages

### DIFF
--- a/ee/pocketpaw_ee/cloud/extraction/gemini_flash.py
+++ b/ee/pocketpaw_ee/cloud/extraction/gemini_flash.py
@@ -1,16 +1,31 @@
 # gemini_flash.py — Gemini Flash extraction adapter.
 # Created: 2026-04-30 — Phase 1 of "Files as Knowledge" plan, Stage 1.A.
-# Cloud captioning sibling to LocalExtractor: rich descriptions for images,
-# per-page captions for sparse PDF pages. No replacement of pypdf — it
-# augments where pypdf returns near-empty text.
+# Updated: 2026-07-03 (FL-15) — implement the deferred image-heavy PDF path:
+#   sparse pages (pypdf text < _SPARSE_PAGE_THRESHOLD) are now RENDERED to a
+#   PNG via PyMuPDF (fitz, lazy-imported like the genai client) and captioned
+#   through the same Gemini call the image path uses. A per-PDF cost cap
+#   (_MAX_SPARSE_PAGES_CAPTIONED) bounds render+caption calls. Text-heavy
+#   pages stay pypdf-only (no Gemini call); the genai call was factored into a
+#   shared _caption_image_bytes helper reused by both the image and PDF paths.
 """GeminiFlashExtractor — google-genai SDK adapter.
 
 Captions images with `gemini-2.5-flash` (or whatever model is configured).
-For PDFs the strategy is hybrid: pypdf extracts text per page; pages with
-<200 chars of extracted text are marked image-heavy and *not* captioned in
-this stage (heavy PDF→image rendering deferred to a later PR — Stage 1.A
-ships without a new dep). When network is unavailable the chain falls
-through to LocalExtractor before this adapter is asked to run.
+For PDFs the strategy is hybrid: pypdf extracts text per page. Pages with
+>=200 chars of extracted text keep their pypdf text verbatim and are *not*
+sent to Gemini. Pages with <200 chars are treated as image-heavy: the page
+is rendered to a PNG with PyMuPDF and captioned via the same Gemini call the
+image path uses, so scanned/diagram pages become BM25-searchable instead of
+being silently skipped.
+
+A cost guard caps the number of sparse pages captioned per PDF at
+`_MAX_SPARSE_PAGES_CAPTIONED` — pages beyond the cap fall back to the old
+"image-heavy, no caption" marker so a huge scanned PDF can't fan out into an
+unbounded number of Gemini calls.
+
+Heavy deps (google-genai, PyMuPDF) are lazy-imported so the module still
+imports where they aren't installed (tests mock them). When network is
+unavailable the chain falls through to LocalExtractor before this adapter is
+asked to run.
 """
 
 from __future__ import annotations
@@ -28,8 +43,39 @@ CAPTION_PROMPT = (
 )
 
 # Below this character count per pypdf-extracted page we treat the page
-# as image-heavy and skip captioning. 200 is a heuristic; tune later.
+# as image-heavy and render+caption it. 200 is a heuristic; tune later.
 _SPARSE_PAGE_THRESHOLD = 200
+
+# Cost guard: cap how many sparse pages we render+caption per PDF. A scanned
+# 500-page document would otherwise fan out into 500 Gemini calls. Pages past
+# the cap keep the "image-heavy, no caption" marker.
+_MAX_SPARSE_PAGES_CAPTIONED = 20
+
+# DPI for rasterizing a sparse PDF page before captioning. 150 balances legible
+# text/diagrams against payload size.
+_RENDER_DPI = 150
+
+
+def _render_pdf_page_to_png(path: Path, page_index: int, *, dpi: int = _RENDER_DPI) -> bytes:
+    """Render a single PDF page (0-based) to PNG bytes via PyMuPDF (fitz).
+
+    Lazy-imported so the module imports without the dep installed; tests patch
+    this function or the `fitz` module to avoid a real render.
+    """
+    try:
+        import fitz  # PyMuPDF
+    except ImportError as exc:  # pragma: no cover - exercised via mock in tests
+        raise RuntimeError(
+            "PyMuPDF not installed — run: pip install 'pocketpaw-ee[extraction]'"
+        ) from exc
+
+    doc = fitz.open(str(path))
+    try:
+        page = doc.load_page(page_index)
+        pix = page.get_pixmap(dpi=dpi)
+        return pix.tobytes("png")
+    finally:
+        doc.close()
 
 
 class GeminiFlashExtractor:
@@ -55,20 +101,27 @@ class GeminiFlashExtractor:
             return await self._extract_pdf_with_captions(path)
         raise ValueError(f"unsupported mime: {mime}")
 
-    async def _extract_image(self, path: Path, mime: str) -> ExtractionResult:
+    async def _caption_image_bytes(self, data: bytes, mime: str) -> str:
+        """Send raw image bytes to Gemini and return the stripped caption.
+
+        Shared by the image path and the rendered-PDF-page path so both use an
+        identical request shape (model, prompt, inline Part).
+        """
         from google.genai import types
 
-        img = path.read_bytes()
         contents: list = [
             CAPTION_PROMPT,
-            types.Part.from_bytes(data=img, mime_type=mime),
+            types.Part.from_bytes(data=data, mime_type=mime),
         ]
         response = await asyncio.to_thread(
             self._client.models.generate_content,
             model=self._model,
             contents=contents,
         )
-        caption = (response.text or "").strip()
+        return (response.text or "").strip()
+
+    async def _extract_image(self, path: Path, mime: str) -> ExtractionResult:
+        caption = await self._caption_image_bytes(path.read_bytes(), mime)
         return ExtractionResult(
             text=caption,
             captions=[caption],
@@ -86,16 +139,35 @@ class GeminiFlashExtractor:
         sections: list[str] = []
         captions: list[str] = []
         sparse_pages: list[int] = []
+        captioned_pages: list[int] = []
 
         for idx, page in enumerate(reader.pages, start=1):
             page_text = (page.extract_text() or "").strip()
-            if len(page_text) < _SPARSE_PAGE_THRESHOLD:
-                # Stage 1.A doesn't ship a PDF-to-image renderer dependency.
-                # Mark the page so downstream search knows the gap exists.
-                sections.append(f"[page {idx}: image-heavy, no caption]")
-                sparse_pages.append(idx)
+            if len(page_text) >= _SPARSE_PAGE_THRESHOLD:
+                # Text-heavy page: keep pypdf text verbatim, no Gemini call.
+                sections.append(f"[page {idx}]\n{page_text}")
                 continue
-            sections.append(f"[page {idx}]\n{page_text}")
+
+            # Image-heavy page: render + caption, respecting the per-PDF cap.
+            sparse_pages.append(idx)
+            if len(captioned_pages) >= _MAX_SPARSE_PAGES_CAPTIONED:
+                # Cost guard tripped — mark the gap instead of captioning.
+                sections.append(f"[page {idx}: image-heavy, caption cap reached]")
+                continue
+
+            try:
+                png = await asyncio.to_thread(_render_pdf_page_to_png, path, idx - 1)
+                caption = await self._caption_image_bytes(png, "image/png")
+            except Exception:  # noqa: BLE001 - render/caption failure must not sink the PDF
+                sections.append(f"[page {idx}: image-heavy, caption failed]")
+                continue
+
+            if caption:
+                sections.append(f"[page {idx} — image caption]\n{caption}")
+                captions.append(caption)
+                captioned_pages.append(idx)
+            else:
+                sections.append(f"[page {idx}: image-heavy, empty caption]")
 
         text = "\n\n".join(sections)
         return ExtractionResult(
@@ -107,6 +179,8 @@ class GeminiFlashExtractor:
                 "model": self._model,
                 "page_count": len(reader.pages),
                 "sparse_pages": sparse_pages,
+                "captioned_pages": captioned_pages,
+                "max_captioned_pages": _MAX_SPARSE_PAGES_CAPTIONED,
             },
             backend=self.name,
         )

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -161,6 +161,11 @@ extraction = [
     "trafilatura",
     "python-docx>=1.1.0",
     "pytesseract>=0.3.10",
+    # PyMuPDF (fitz) rasterizes image-heavy PDF pages so the Gemini adapter can
+    # caption scanned/diagram pages (FL-15). Pure-wheel, no system poppler.
+    # Lazy-imported in gemini_flash.py, so it stays optional. Floor 1.24.0
+    # (released 2024, well past the workspace 7-day supply-chain min-age rule).
+    "pymupdf>=1.24.0",
 ]
 # Firestore→Fabric ingest worker (ee/pocketpaw_ee/cloud/fabric_ingest). The
 # reader lazy-imports google-cloud-firestore behind a Protocol, so it stays

--- a/tests/cloud/extraction/test_gemini_flash.py
+++ b/tests/cloud/extraction/test_gemini_flash.py
@@ -1,7 +1,12 @@
 # test_gemini_flash.py — GeminiFlashExtractor tests.
 # Created: 2026-04-30 — Phase 1 of "Files as Knowledge" plan, Stage 1.A.
+# Updated: 2026-07-03 (FL-15) — cover the now-implemented image-heavy PDF path:
+#   sparse pages render to PNG (renderer mocked) and get captioned via Gemini;
+#   text-heavy pages still make no Gemini call; the per-PDF caption cap is
+#   enforced. No real network / render — google.genai.Client and the page
+#   renderer are both mocked.
 # Asserts request structure (model, MIME on Part, image bytes) plus PDF
-# strategy (pypdf text per page, sparse-page marker for image-heavy pages).
+# strategy (pypdf text per page, render+caption for image-heavy pages, cap).
 # No real network calls — google.genai.Client is mocked.
 """Tests for `ee.cloud.extraction.gemini_flash.GeminiFlashExtractor`.
 
@@ -61,6 +66,32 @@ def tmp_blank_pdf(tmp_path: Path) -> Path:
     return p
 
 
+@pytest.fixture
+def mock_renderer(monkeypatch: pytest.MonkeyPatch):
+    """Patch the PDF-page renderer so sparse-page tests need no PyMuPDF.
+
+    Returns the MagicMock standing in for _render_pdf_page_to_png; it yields
+    deterministic PNG bytes so we never touch fitz or a real rasterizer.
+    """
+    from pocketpaw_ee.cloud.extraction import gemini_flash
+
+    fake_render = MagicMock(return_value=b"\x89PNG\r\n\x1a\nrendered-page")
+    monkeypatch.setattr(gemini_flash, "_render_pdf_page_to_png", fake_render)
+    return fake_render
+
+
+def _multipage_pdf(tmp_path: Path, n_pages: int) -> Path:
+    """Write an n-page all-blank (sparse) PDF for cap/count assertions."""
+    writer = PdfWriter()
+    for _ in range(n_pages):
+        writer.add_blank_page(width=72, height=72)
+    buf = io.BytesIO()
+    writer.write(buf)
+    p = tmp_path / f"blank-{n_pages}.pdf"
+    p.write_bytes(buf.getvalue())
+    return p
+
+
 async def test_image_extract_calls_gemini_with_inline_bytes(
     mock_genai_client, tmp_image: Path
 ) -> None:
@@ -116,21 +147,106 @@ async def test_image_extract_handles_empty_response(mock_genai_client, tmp_image
     assert result.captions == [""]
 
 
-async def test_pdf_extract_blank_page_marked_sparse(mock_genai_client, tmp_blank_pdf: Path) -> None:
+async def test_pdf_sparse_page_is_rendered_and_captioned(
+    mock_genai_client, mock_renderer, tmp_blank_pdf: Path
+) -> None:
+    """FL-15: an image-heavy (sparse) page is rendered to PNG and captioned."""
     from pocketpaw_ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+
+    fake_client, fake_response = mock_genai_client
+    fake_response.text = "A scanned invoice showing line items."
+
+    extractor = GeminiFlashExtractor(api_key="fake-key")
+    result = await extractor.extract(tmp_blank_pdf, "application/pdf")
+
+    # The sparse page now yields a non-empty caption, not a "no caption" marker.
+    assert "A scanned invoice showing line items." in result.text
+    assert result.captions == ["A scanned invoice showing line items."]
+    assert result.metadata["sparse_pages"] == [1]
+    assert result.metadata["captioned_pages"] == [1]
+    assert result.metadata["page_count"] == 1
+    assert result.backend == "gemini-flash"
+
+    # Renderer was called for the (0-based) sparse page; Gemini was invoked with
+    # image/png bytes from the render.
+    mock_renderer.assert_called_once()
+    assert mock_renderer.call_args.args[1] == 0  # page_index (0-based)
+    fake_client.models.generate_content.assert_called_once()
+    contents = fake_client.models.generate_content.call_args.kwargs["contents"]
+    assert getattr(contents[1].inline_data, "mime_type", None) == "image/png"
+
+
+async def test_pdf_text_heavy_page_makes_no_gemini_call(
+    mock_genai_client, mock_renderer, tmp_blank_pdf: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A page with plenty of extractable text keeps pypdf text, no captioning."""
+    from pocketpaw_ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+    from pypdf import PageObject
+
+    # Force the single page to report dense text (> threshold).
+    dense = "Lorem ipsum dolor sit amet. " * 40
+    monkeypatch.setattr(PageObject, "extract_text", lambda self, *a, **k: dense)
 
     fake_client, _ = mock_genai_client
     extractor = GeminiFlashExtractor(api_key="fake-key")
     result = await extractor.extract(tmp_blank_pdf, "application/pdf")
 
-    # Stage 1.A doesn't ship a PDF→image renderer; sparse pages get a marker.
-    assert "[page 1: image-heavy, no caption]" in result.text
-    assert result.metadata["sparse_pages"] == [1]
-    assert result.metadata["page_count"] == 1
-    assert result.backend == "gemini-flash"
+    assert "[page 1]" in result.text
+    assert "Lorem ipsum" in result.text
+    assert result.metadata["sparse_pages"] == []
+    assert result.metadata["captioned_pages"] == []
+    # No render, no Gemini call for text-heavy pages.
+    mock_renderer.assert_not_called()
+    fake_client.models.generate_content.assert_not_called()
 
-    # No Gemini call is made when every page is sparse — the renderer is
-    # the missing piece, not the API. This pins the "no heavy dep" promise.
+
+async def test_pdf_sparse_page_cap_is_enforced(
+    mock_genai_client, mock_renderer, tmp_path: Path
+) -> None:
+    """FL-15 cost guard: only _MAX_SPARSE_PAGES_CAPTIONED pages get captioned."""
+    from pocketpaw_ee.cloud.extraction import gemini_flash
+    from pocketpaw_ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+
+    cap = gemini_flash._MAX_SPARSE_PAGES_CAPTIONED
+    over = cap + 3
+    pdf = _multipage_pdf(tmp_path, over)
+
+    fake_client, fake_response = mock_genai_client
+    fake_response.text = "caption text"
+
+    extractor = GeminiFlashExtractor(api_key="fake-key")
+    result = await extractor.extract(pdf, "application/pdf")
+
+    # All pages are sparse, but only `cap` were captioned; the rest are marked.
+    assert len(result.metadata["sparse_pages"]) == over
+    assert len(result.metadata["captioned_pages"]) == cap
+    assert result.metadata["max_captioned_pages"] == cap
+    assert "caption cap reached" in result.text
+    # Render + Gemini were each called exactly `cap` times, not `over` times.
+    assert mock_renderer.call_count == cap
+    assert fake_client.models.generate_content.call_count == cap
+
+
+async def test_pdf_render_failure_degrades_gracefully(
+    mock_genai_client, monkeypatch: pytest.MonkeyPatch, tmp_blank_pdf: Path
+) -> None:
+    """A render error on a sparse page must not sink the whole PDF."""
+    from pocketpaw_ee.cloud.extraction import gemini_flash
+    from pocketpaw_ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+
+    def _boom(*a, **k):
+        raise RuntimeError("PyMuPDF not installed")
+
+    monkeypatch.setattr(gemini_flash, "_render_pdf_page_to_png", _boom)
+
+    fake_client, _ = mock_genai_client
+    extractor = GeminiFlashExtractor(api_key="fake-key")
+    result = await extractor.extract(tmp_blank_pdf, "application/pdf")
+
+    assert "[page 1: image-heavy, caption failed]" in result.text
+    assert result.metadata["sparse_pages"] == [1]
+    assert result.metadata["captioned_pages"] == []
+    # Gemini is never reached when the render fails.
     fake_client.models.generate_content.assert_not_called()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -5357,6 +5357,7 @@ requires-dist = [
     { name = "pocketpaw", specifier = "~=0.4.16" },
     { name = "pwdlib", extras = ["argon2"], specifier = ">=0.2.0" },
     { name = "py-vapid", specifier = ">=1.9.0" },
+    { name = "pymupdf", marker = "extra == 'extraction'", specifier = ">=1.24.0" },
     { name = "pyotp", specifier = ">=2.9.0" },
     { name = "pypdf", marker = "extra == 'extraction'" },
     { name = "pytesseract", marker = "extra == 'extraction'", specifier = ">=0.3.10" },


### PR DESCRIPTION
Part of the /files prod-ready arc (FL-15). Finishes the image-heavy PDF path that the Gemini Flash extractor left as a TODO.

## What changes

Scanned and diagram-heavy PDF pages used to be dropped. `pypdf` pulls almost no text from them, so the extractor tagged them "image-heavy" and moved on — the content never reached the knowledge base, so BM25 search couldn't find it.

Now those pages get rendered to a PNG with PyMuPDF and captioned through the same Gemini call the image path already uses. The caption merges into the page text, so a whiteboard photo saved as a PDF or a slide deck exported flat becomes searchable like any other file.

Text-heavy pages are untouched — they keep their `pypdf` text verbatim and never hit Gemini.

## Guards

- Per-PDF cap of 20 captioned sparse pages, so a 500-page scan can't fan out into 500 model calls. Pages past the cap keep the old no-caption marker.
- PyMuPDF is lazy-imported (like the genai client), so the module still imports where the dep isn't installed. Added to the ee `[extraction]` optional group.
- Per-page render/caption failures degrade to a marker rather than failing the whole extraction.

## Tests

`tests/cloud/extraction` — 31 passed. Covers the render+caption path (mocked renderer), text-heavy pages making no Gemini call, the per-PDF cap, and graceful render-failure degradation.

## Heads-up

PyMuPDF resolved to 1.28.0 (declared floor `>=1.24.0`). The local `uv.toml` has no `exclude-newer` set, so the min-release-age gate didn't apply — worth confirming that's intended on this machine.
