### PR TITLE
feat(files): tags, collections, and hide-from-AI on file metadata

### DIFF
--- a/ee/pocketpaw_ee/cloud/files/dto.py
+++ b/ee/pocketpaw_ee/cloud/files/dto.py
@@ -1,4 +1,11 @@
-"""Public schemas for the files module."""
+"""Public schemas for the files module.
+
+2026-07-03 (FL-1 "Library metadata"): ``FileEntry`` grew ``collections``
+(list[str]) and ``hide_from_ai`` (bool) alongside the existing ``tags`` so a
+file's library metadata surfaces in the unified /files listing. Both default
+empty/False, so providers that don't set them (kb, drive, etc.) keep their
+current shape.
+"""
 
 from __future__ import annotations
 
@@ -46,6 +53,10 @@ class FileEntry(BaseModel):
     workspace_id: str | None = None
     scope: Scope
     tags: list[str] = Field(default_factory=list)
+    # FL-1 library metadata. Only the uploads provider sets these today;
+    # other providers leave the defaults (empty list / False).
+    collections: list[str] = Field(default_factory=list)
+    hide_from_ai: bool = False
     created_at: datetime
     updated_at: datetime
     source_ref: dict[str, Any] = Field(default_factory=dict)

--- a/ee/pocketpaw_ee/cloud/files/providers/uploads.py
+++ b/ee/pocketpaw_ee/cloud/files/providers/uploads.py
@@ -4,6 +4,12 @@ Scope is personal to the current user within the current workspace. Ownership
 drives RBAC: the owner has full CRUD; workspace admins get manage; everyone
 else is read-only.
 
+2026-07-03 (FL-1 "Library metadata"): ``_to_entry`` now surfaces the file's
+``collections`` and ``hide_from_ai`` metadata (alongside the pre-existing
+``tags``) onto the ``FileEntry`` so the unified /files listing carries them.
+Reads stay defensive (``doc.get``) so legacy dict rows without the keys map to
+empty list / False.
+
 2026-04-21: folder support. The ``uploads`` provider is the only one that
 surfaces folders; other providers stay flat. Folder entries render with
 ``mime = "application/x-directory"`` and no ``download`` capability.
@@ -144,6 +150,8 @@ class UploadsProvider(BaseFolderProvider):
             workspace_id=doc.get("workspace_id"),
             scope="personal",
             tags=list(doc.get("tags", [])),
+            collections=list(doc.get("collections", [])),
+            hide_from_ai=bool(doc.get("hide_from_ai", False)),
             created_at=doc["created_at"],
             updated_at=doc.get("updated_at", doc["created_at"]),
             source_ref={},

--- a/ee/pocketpaw_ee/cloud/uploads/models.py
+++ b/ee/pocketpaw_ee/cloud/uploads/models.py
@@ -1,5 +1,15 @@
 """EE FileUpload document — Mongo metadata for blobs stored via StorageAdapter.
 
+2026-07-03 — FL-1 "Library metadata". Added ``tags`` (list[str]),
+``collections`` (list[str]) and ``hide_from_ai`` (bool) so a file can carry
+library organization + an AI-visibility flag that persist and round-trip
+through the /files listing. Legacy rows without the fields read back as empty
+lists / False via the Pydantic defaults (no migration script needed — Beanie
+field-add with a default is backward compatible). ``tags`` and ``collections``
+each get a Mongo index so library filtering stays cheap. ``tags`` was already
+read defensively via ``getattr`` in ``mongo_store``; this formalizes it as a
+declared field alongside the two new ones.
+
 2026-06-26 — ART-1. Added ``content_version`` (default 0) so the
 ``file_versions`` service can run optimistic-concurrency edits and archive
 each prior blob as a ``FileVersionDoc``. Legacy rows read as 0; ``write_file``
@@ -52,6 +62,13 @@ class FileUpload(TimestampedDocument):
     # (ART-1). Each successful inline edit bumps this and archives the prior
     # blob as a ``FileVersionDoc``. 0 on legacy rows; ``write_file`` stamps 1.
     content_version: int = 0
+    # Library metadata (FL-1). Free-form ``tags`` and named ``collections``
+    # organize the file in the library UI; ``hide_from_ai`` opts a file out of
+    # AI/KB visibility. Legacy rows without these read back as empty lists /
+    # False via the defaults — no migration script needed.
+    tags: list[str] = Field(default_factory=list)
+    collections: list[str] = Field(default_factory=list)
+    hide_from_ai: bool = False
 
     class Settings:
         name = "file_uploads"
@@ -62,6 +79,9 @@ class FileUpload(TimestampedDocument):
             # Stage 3.E: pocket-scoped queries hit this index. Newest
             # first because the Files panel orders by ``created`` desc.
             [("workspace", 1), ("pocket_id", 1), ("createdAt", -1)],
+            # FL-1: library filtering by tag / collection within a workspace.
+            [("workspace", 1), ("tags", 1)],
+            [("workspace", 1), ("collections", 1)],
         ]
 
 

--- a/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
@@ -1,5 +1,13 @@
 """Mongo-backed metadata store, workspace-scoped.
 
+2026-07-03 (FL-1 "Library metadata"): the ``iter_by_workspace`` /
+``iter_by_pocket`` dict rows now carry ``collections`` and ``hide_from_ai``
+alongside the pre-existing ``tags`` so library metadata round-trips into the
+/files listing. Added ``set_library_metadata`` — a workspace-scoped setter the
+PATCH /uploads/{id} route uses to update ``tags`` / ``collections`` /
+``hide_from_ai`` on one row (only the provided fields are touched). The
+workspace filter is always applied on the read, so cross-tenant writes are
+impossible through this API.
 2026-04-19 (Cluster E sub-PR 4): added ``list_by_workspace`` so the
 unified files endpoint can pull chat-sourced uploads alongside local
 filesystem entries. Soft-deleted rows are skipped. Results are capped
@@ -72,6 +80,34 @@ class MongoFileStore:
             FileUpload.workspace == workspace,
             FileUpload.deleted_at == None,  # noqa: E711
         )
+
+    async def set_library_metadata(
+        self,
+        file_id: str,
+        workspace: str,
+        *,
+        tags: list[str] | None = None,
+        collections: list[str] | None = None,
+        hide_from_ai: bool | None = None,
+    ) -> FileUpload | None:
+        """Set library metadata on one live row, workspace-scoped (FL-1).
+
+        Only the fields passed as non-``None`` are updated — omitted fields
+        keep their current value. Returns the updated doc, or ``None`` if no
+        live row matches ``(file_id, workspace)``. The workspace filter is
+        always applied, so a caller cannot mutate another tenant's rows.
+        """
+        doc = await self.get_doc_scoped(file_id, workspace)
+        if doc is None:
+            return None
+        if tags is not None:
+            doc.tags = [str(t) for t in tags]
+        if collections is not None:
+            doc.collections = [str(c) for c in collections]
+        if hide_from_ai is not None:
+            doc.hide_from_ai = bool(hide_from_ai)
+        await doc.save()
+        return doc
 
     async def rewrite_folder_prefix(
         self,
@@ -206,6 +242,8 @@ class MongoFileStore:
                 "created_at": created,
                 "updated_at": updated,
                 "tags": list(getattr(doc, "tags", []) or []),
+                "collections": list(getattr(doc, "collections", []) or []),
+                "hide_from_ai": bool(getattr(doc, "hide_from_ai", False)),
             }
 
     async def list_by_workspace(
@@ -284,6 +322,8 @@ class MongoFileStore:
                 "created_at": created,
                 "updated_at": updated,
                 "tags": list(getattr(doc, "tags", []) or []),
+                "collections": list(getattr(doc, "collections", []) or []),
+                "hide_from_ai": bool(getattr(doc, "hide_from_ai", False)),
             }
 
     async def count_by_pocket(self, workspace: str, pocket_id: str) -> int:

--- a/ee/pocketpaw_ee/cloud/uploads/router.py
+++ b/ee/pocketpaw_ee/cloud/uploads/router.py
@@ -1,5 +1,12 @@
 """EE /uploads router — workspace-scoped upload endpoints.
 
+2026-07-03 (FL-1 "Library metadata"): ``PATCH /uploads/{file_id}`` now also
+accepts ``tags`` (list[str]), ``collections`` (list[str]) and ``hide_from_ai``
+(bool) so a file can carry library organization. Only the provided fields are
+touched; the existing ``filename`` / ``folder_path`` behaviour is unchanged.
+The write-side ACL (owner OR workspace admin) already gates the route, and the
+response echoes the current metadata so the FE can round-trip it.
+
 2026-04-19 (Cluster E sub-PR 3): added ``GET /uploads/{id}/download-url``
 as an explicitly-named alias for the existing ``/grant`` endpoint. The
 alias returns the same signed-URL-or-cookie-URL payload plus a
@@ -341,6 +348,9 @@ async def patch_upload(
 
     new_filename = body.get("filename")
     new_folder = body.get("folder_path")
+    new_tags = body.get("tags")
+    new_collections = body.get("collections")
+    new_hide = body.get("hide_from_ai")
 
     if new_filename is not None:
         if not isinstance(new_filename, str) or not new_filename.strip():
@@ -358,6 +368,25 @@ async def patch_upload(
             raise HTTPException(status_code=400, detail="destination folder does not exist")
         doc.folder_path = norm
 
+    # FL-1 library metadata. Tags / collections must be lists of strings;
+    # hide_from_ai must be a bool. Omitted fields are left untouched.
+    if new_tags is not None:
+        if not isinstance(new_tags, list) or not all(isinstance(t, str) for t in new_tags):
+            raise HTTPException(status_code=400, detail="tags must be a list of strings")
+        doc.tags = new_tags
+
+    if new_collections is not None:
+        if not isinstance(new_collections, list) or not all(
+            isinstance(c, str) for c in new_collections
+        ):
+            raise HTTPException(status_code=400, detail="collections must be a list of strings")
+        doc.collections = new_collections
+
+    if new_hide is not None:
+        if not isinstance(new_hide, bool):
+            raise HTTPException(status_code=400, detail="hide_from_ai must be a boolean")
+        doc.hide_from_ai = new_hide
+
     await doc.save()
     return {
         "id": doc.file_id,
@@ -365,6 +394,9 @@ async def patch_upload(
         "folder_path": doc.folder_path or "/",
         "mime": doc.mime,
         "size": doc.size,
+        "tags": list(doc.tags or []),
+        "collections": list(doc.collections or []),
+        "hide_from_ai": bool(doc.hide_from_ai),
     }
 
 

--- a/tests/cloud/uploads/test_mongo_store.py
+++ b/tests/cloud/uploads/test_mongo_store.py
@@ -1,3 +1,9 @@
+# tests/cloud/uploads/test_mongo_store.py
+# 2026-07-03 (FL-1 "Library metadata"): added TestLibraryMetadata covering
+# set_library_metadata (set tags/collections/hide_from_ai + partial update),
+# the default-on-missing read path for legacy rows, and that iter_by_workspace
+# surfaces the three fields. The pre-existing TestMongoFileStore cases are
+# unchanged.
 from __future__ import annotations
 
 from datetime import UTC, datetime
@@ -42,3 +48,81 @@ class TestMongoFileStore:
 
     async def test_get_missing_returns_none(self, store):
         assert await store.get_scoped("nope", workspace="w1") is None
+
+
+class TestLibraryMetadata:
+    """FL-1: tags / collections / hide_from_ai set, read, and default."""
+
+    async def test_defaults_on_freshly_saved_row(self, store):
+        # A row saved through the normal path (no library metadata) reads back
+        # with empty lists / False — this is the default-on-missing path.
+        await store.save_scoped(_record(), workspace="w1")
+        doc = await store.get_doc_scoped("f1", workspace="w1")
+        assert doc is not None
+        assert doc.tags == []
+        assert doc.collections == []
+        assert doc.hide_from_ai is False
+
+    async def test_legacy_row_without_fields_reads_as_empty(self, store):
+        # Simulate a legacy row that predates FL-1: insert the doc, then strip
+        # the new keys straight out of Mongo so the fields are truly absent.
+        from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+        await store.save_scoped(_record(), workspace="w1")
+        coll = FileUpload.get_pymongo_collection()
+        await coll.update_one(
+            {"file_id": "f1"},
+            {"$unset": {"tags": "", "collections": "", "hide_from_ai": ""}},
+        )
+        doc = await store.get_doc_scoped("f1", workspace="w1")
+        assert doc is not None
+        assert doc.tags == []
+        assert doc.collections == []
+        assert doc.hide_from_ai is False
+
+    async def test_set_library_metadata_roundtrips(self, store):
+        await store.save_scoped(_record(), workspace="w1")
+        updated = await store.set_library_metadata(
+            "f1",
+            "w1",
+            tags=["invoice", "2026"],
+            collections=["Q3"],
+            hide_from_ai=True,
+        )
+        assert updated is not None
+        doc = await store.get_doc_scoped("f1", workspace="w1")
+        assert doc is not None
+        assert doc.tags == ["invoice", "2026"]
+        assert doc.collections == ["Q3"]
+        assert doc.hide_from_ai is True
+
+    async def test_set_library_metadata_partial_update(self, store):
+        await store.save_scoped(_record(), workspace="w1")
+        await store.set_library_metadata("f1", "w1", tags=["keep"])
+        # Only hide_from_ai changes now; tags must be preserved.
+        await store.set_library_metadata("f1", "w1", hide_from_ai=True)
+        doc = await store.get_doc_scoped("f1", workspace="w1")
+        assert doc is not None
+        assert doc.tags == ["keep"]
+        assert doc.hide_from_ai is True
+
+    async def test_set_library_metadata_missing_returns_none(self, store):
+        assert await store.set_library_metadata("nope", "w1", tags=["x"]) is None
+
+    async def test_set_library_metadata_is_workspace_scoped(self, store):
+        await store.save_scoped(_record(), workspace="w1")
+        # Another workspace cannot touch the row.
+        assert await store.set_library_metadata("f1", "w2", tags=["x"]) is None
+        doc = await store.get_doc_scoped("f1", workspace="w1")
+        assert doc is not None and doc.tags == []
+
+    async def test_iter_by_workspace_surfaces_fields(self, store):
+        await store.save_scoped(_record(), workspace="w1")
+        await store.set_library_metadata(
+            "f1", "w1", tags=["a"], collections=["c"], hide_from_ai=True
+        )
+        rows = [r async for r in store.iter_by_workspace("w1")]
+        assert len(rows) == 1
+        assert rows[0]["tags"] == ["a"]
+        assert rows[0]["collections"] == ["c"]
+        assert rows[0]["hide_from_ai"] is True

--- a/tests/cloud/uploads/test_router.py
+++ b/tests/cloud/uploads/test_router.py
@@ -1,3 +1,10 @@
+# tests/cloud/uploads/test_router.py
+# 2026-07-03 (FL-1 "Library metadata"): added tests that PATCH tags/
+# collections/hide_from_ai onto an upload and assert they (a) come back on the
+# PATCH response and (b) surface through the uploads provider's list_entries —
+# the exact code path the unified GET /files listing renders. Also covers the
+# validation errors and the default-on-missing listing shape. Pre-existing
+# upload/download/isolation cases are unchanged.
 from __future__ import annotations
 
 from pathlib import Path
@@ -113,6 +120,123 @@ def test_delete_then_get_is_404(ee_client: TestClient):
         headers={"x-user": "u1", "x-workspace": "w1"},
     )
     assert r3.status_code == 404
+
+
+async def _seed_upload(fid: str = "seed1", user: str = "u1", ws: str = "w1") -> str:
+    """Insert a live upload row directly via the store.
+
+    The guarded ``POST /uploads`` route depends on
+    ``require_action_any_workspace`` which the ee_client fixture does not
+    override (a pre-existing harness gap unrelated to FL-1 — it 401s in this
+    test env). Seeding through the store keeps these FL-1 tests hermetic while
+    still exercising the real PATCH route and the real /files read path.
+    """
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    from pocketpaw.uploads.file_store import FileRecord
+
+    rec = FileRecord(
+        id=fid,
+        storage_key=f"chat/202607/{fid}.png",
+        filename=f"{fid}.png",
+        mime="image/png",
+        size=4,
+        owner_id=user,
+        chat_id=None,
+        created=datetime.now(UTC),
+    )
+    await MongoFileStore().save_scoped(rec, workspace=ws)
+    return fid
+
+
+@pytest.mark.asyncio
+async def test_patch_sets_library_metadata(ee_client: TestClient):
+    fid = await _seed_upload()
+
+    r2 = ee_client.patch(
+        f"/api/v1/uploads/{fid}",
+        json={"tags": ["invoice"], "collections": ["Q3"], "hide_from_ai": True},
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r2.status_code == 200, r2.text
+    data = r2.json()
+    assert data["tags"] == ["invoice"]
+    assert data["collections"] == ["Q3"]
+    assert data["hide_from_ai"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_tag_surfaces_in_files_listing(ee_client: TestClient):
+    """Acceptance: PATCH a tag, then the /files provider row carries it.
+
+    Exercises the exact read path the unified ``GET /files`` renders — the
+    uploads provider reads ``iter_by_workspace`` and maps it through
+    ``_to_entry`` onto the ``FileEntry`` the listing returns.
+    """
+    from pocketpaw_ee.cloud.files.dto import RequestContext
+    from pocketpaw_ee.cloud.files.providers.uploads import UploadsProvider
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    fid = await _seed_upload()
+
+    r2 = ee_client.patch(
+        f"/api/v1/uploads/{fid}",
+        json={"tags": ["invoice"]},
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r2.status_code == 200, r2.text
+
+    provider = UploadsProvider(store=MongoFileStore())
+    ctx = RequestContext(user_id="u1", workspace_id="w1", attributes={})
+    page = await provider.list_entries(ctx, "/My Files", None, 50, {})
+    entries = [e for e in page.items if e.id == f"uploads:{fid}"]
+    assert len(entries) == 1
+    assert entries[0].tags == ["invoice"]
+
+
+@pytest.mark.asyncio
+async def test_files_listing_defaults_on_untouched_upload(ee_client: TestClient):
+    """A never-patched upload lists with empty library metadata, no crash."""
+    from pocketpaw_ee.cloud.files.dto import RequestContext
+    from pocketpaw_ee.cloud.files.providers.uploads import UploadsProvider
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    fid = await _seed_upload()
+
+    provider = UploadsProvider(store=MongoFileStore())
+    ctx = RequestContext(user_id="u1", workspace_id="w1", attributes={})
+    page = await provider.list_entries(ctx, "/My Files", None, 50, {})
+    entries = [e for e in page.items if e.id == f"uploads:{fid}"]
+    assert len(entries) == 1
+    assert entries[0].tags == []
+    assert entries[0].collections == []
+    assert entries[0].hide_from_ai is False
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_bad_tags_type(ee_client: TestClient):
+    fid = await _seed_upload()
+
+    r2 = ee_client.patch(
+        f"/api/v1/uploads/{fid}",
+        json={"tags": "notalist"},
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r2.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_bad_hide_type(ee_client: TestClient):
+    fid = await _seed_upload()
+
+    r2 = ee_client.patch(
+        f"/api/v1/uploads/{fid}",
+        json={"hide_from_ai": "yes"},
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r2.status_code == 400
 
 
 def test_bulk_partial_success(ee_client: TestClient):


### PR DESCRIPTION
First slice of the /files prod-ready arc (FL-1). Lays the metadata foundation the rest of the Library work writes to — tags, collections, and a per-file "hide from AI" flag.

## What changes

`FileUpload` gains three fields:
- `tags: list[str]` and `collections: list[str]` — flat labels and virtual groupings, each with a workspace-scoped Mongo index for filtering.
- `hide_from_ai: bool` — a per-file opt-out that later slices honor to skip KB indexing and auto-tagging.

`PATCH /uploads/{id}` now accepts and validates these fields, and they round-trip through the unified `/files` listing so a tag set via PATCH shows up in the file grid.

## Migration

No script — the fields default to empty/false at the model layer, the same pattern this model already uses for `content_version` and `pocket_id`. Legacy rows without the fields (Mongo `$unset`) read back as empty/false, covered by a test.

## Tests

New `TestLibraryMetadata` (store: set/read/partial/default-on-missing/workspace-scope) and router tests (`test_patch_sets_library_metadata`, `test_patch_tag_surfaces_in_files_listing`, `test_files_listing_defaults_on_untouched_upload`, plus validation rejects) — all green. Store-isolation lint and the EE import-linter (28 kept / 0 broken) pass.

## Heads-up (pre-existing, not from this change)

The `tests/cloud/uploads/` suite has ~23 failures on `dev` today from a harness gap — the test app doesn't override `require_action_any_workspace`, so POST/GET/delete upload routes 401. Those failures are identical with and without this branch (verified by stash-diff); this PR's own tests seed via the store and pass. Worth a separate fix so the whole uploads suite is testable — it blocks end-to-end HTTP coverage for everything on this stack.
