### PR TITLE
feat(files): version history spine — revert + diff (port #1193)

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -6,6 +6,10 @@ to JSON responses.
 
 Re-exports remain accessible via `ee.cloud.shared.errors` (a shim) for
 the transition period; new code should import from this module.
+
+FL-2 (file-version spine, port of dewani12's #1193) added
+``PreconditionFailed`` (412) for stale ``If-Match`` optimistic-concurrency
+failures on the file-version write path.
 """
 
 from __future__ import annotations
@@ -50,6 +54,21 @@ class ConflictError(CloudError):
 
     def __init__(self, code: str, message: str) -> None:
         super().__init__(409, code, message)
+
+
+class PreconditionFailed(CloudError):
+    """A conditional request precondition failed (412).
+
+    Standard HTTP ``If-Match`` optimistic-concurrency semantics: the caller
+    supplied an ``If-Match`` etag (here the file's ``content_version``) that no
+    longer matches the current resource, so the write is refused. Distinct from
+    ``ConflictError`` (409, a generic resource conflict) — a stale ``If-Match``
+    is precisely a 412. Added by FL-2 (file-version spine, port of #1193) so a
+    stale-etag PUT/revert returns 412.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(412, code, message)
 
 
 class ValidationError(CloudError):

--- a/ee/pocketpaw_ee/cloud/file_versions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/__init__.py
@@ -3,3 +3,7 @@
 #   ported from dewani12's origin/feature/files. Holds the file-version
 #   core only (write/update/list/get); slides/spreadsheet/editor (Slice D)
 #   were intentionally excluded from the port.
+# Updated: 2026-07-03 (FL-2, port of #1193) — completed the history spine:
+#   revert + unified-diff service helpers and routes, the DiffResponse DTO, and
+#   the cohesive slides_dto / spreadsheet_dto transport modules (their AI-edit
+#   routes still land in FL-5). Stale If-Match now returns 412.

--- a/ee/pocketpaw_ee/cloud/file_versions/dto.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/dto.py
@@ -7,6 +7,9 @@
 # Updated: 2026-06-26 (ART-1 quality fix loop, I2) — WriteFileRequest gained an
 #   optional `mime`; when omitted the service guesses from the filename
 #   extension instead of hardcoding application/json.
+# Updated: 2026-07-03 (FL-2, port of #1193) — restored DiffResponse (the
+#   unified-diff transport DTO ART-1 deferred), now that the diff/revert history
+#   helpers land in the service.
 """FileVersions DTOs — request/response schemas for the file-version API."""
 
 from __future__ import annotations
@@ -68,6 +71,16 @@ class FileVersionListItem(BaseModel):
     editor_kind: str = Field(alias="editorKind")
     editor_id: str = Field(alias="editorId")
     created_at: datetime = Field(alias="createdAt")
+
+    model_config = {"populate_by_name": True}
+
+
+class DiffResponse(BaseModel):
+    """Unified diff between two archived versions (GET .../diff/{v2})."""
+
+    from_version: int = Field(alias="fromVersion")
+    to_version: int = Field(alias="toVersion")
+    diff: str
 
     model_config = {"populate_by_name": True}
 

--- a/ee/pocketpaw_ee/cloud/file_versions/router.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/router.py
@@ -8,6 +8,12 @@
 #   the service raises CloudError subclasses and ``_core.http`` maps them to
 #   JSON. Coexists with the existing /files router (GET /files, /tree,
 #   /browse) — no method+path collisions.
+# Updated: 2026-07-03 (FL-2, port of #1193) — restored the two history routes
+#   ART-1 deferred: POST /files/{id}/versions/{vid}/revert (restore a prior
+#   version) and GET /files/{id}/versions/{v1}/diff/{v2} (unified diff). The
+#   AI-edit / editing-context routes remain deferred (they pull in FL-5 tool
+#   deps). Doc note: a stale If-Match now maps to 412 (PreconditionFailed),
+#   not 409.
 """FileVersions router — file-version write + history API."""
 
 from __future__ import annotations
@@ -18,6 +24,7 @@ from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import BadRequest
 from pocketpaw_ee.cloud.file_versions import service as _svc
 from pocketpaw_ee.cloud.file_versions.dto import (
+    DiffResponse,
     FileVersionListItem,
     FileVersionResponse,
     UpdateFileContentRequest,
@@ -57,7 +64,8 @@ async def update_file(
     takes precedence over ``expectedVersion`` when present.
 
     Raises (mapped to JSON by ``_core.http``): 404 if the file is missing,
-    409 on a version conflict, 422 if the file type isn't editable.
+    412 on a stale ``If-Match`` (version conflict), 422 if the file type isn't
+    editable.
     """
     # If-Match header (optimistic concurrency) wins over the body field.
     if if_match is not None:
@@ -86,3 +94,39 @@ async def get_file_version(
 ) -> FileVersionResponse:
     """Fetch a single version with full content (for revert preview / diff)."""
     return await _svc.get_version(ctx, file_id, version_id)
+
+
+@router.post(
+    "/{file_id}/versions/{version_id}/revert",
+    response_model=UpdateFileContentResponse,
+)
+async def revert_file_version(
+    file_id: str,
+    version_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> UpdateFileContentResponse:
+    """Restore the live file to a historical version.
+
+    Archives the current content as a new version, then writes the target
+    version's content as the new live content. Tenant-filtered: a
+    cross-workspace ``version_id`` is a 404.
+    """
+    return await _svc.revert_to_version(ctx, file_id, version_id)
+
+
+@router.get(
+    "/{file_id}/versions/{from_version_id}/diff/{to_version_id}",
+    response_model=DiffResponse,
+)
+async def diff_file_versions(
+    file_id: str,
+    from_version_id: str,
+    to_version_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> DiffResponse:
+    """Return a unified diff between two archived versions (``from`` -> ``to``).
+
+    Tenant-filtered: both versions are fetched workspace-scoped, so a diff can
+    never span a workspace boundary (a cross-workspace id is a 404).
+    """
+    return await _svc.diff_versions(ctx, file_id, from_version_id, to_version_id)

--- a/ee/pocketpaw_ee/cloud/file_versions/service.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/service.py
@@ -23,6 +23,13 @@
 #     actually was (the pre-bump version), so version->content stays correct.
 #   M1 — read paths map FileVersionDoc -> FileVersion domain -> DTO.
 #   M2 — list/get reject an empty workspace (400), matching write/update.
+# Updated: 2026-07-03 (FL-2, port of #1193) — completes the deferred Slice-D
+#   history helpers dropped by ART-1: ``revert_to_version`` (restore a prior
+#   version's content as a new live version) and ``diff_versions`` (unified
+#   diff between two archived versions). Both are tenant-filtered via
+#   ``get_version``. A stale ``If-Match`` now raises ``PreconditionFailed``
+#   (412) instead of ``ConflictError`` (409), matching HTTP conditional-request
+#   semantics for the file-version write path.
 """FileVersions service — file-version write + history.
 
 Module-level ``async def`` functions. Sole owner of writes to the
@@ -34,6 +41,8 @@ Public API:
 - ``update_file_content(ctx, file_id, body)`` — PUT /files/{id}
 - ``list_versions(ctx, file_id)`` — version list (no content)
 - ``get_version(ctx, file_id, version_id)`` — full version with content
+- ``revert_to_version(ctx, file_id, version_id)`` — restore a prior version
+- ``diff_versions(ctx, file_id, from_id, to_id)`` — unified diff between two
 
 The client-facing file id is the bare ``path`` throughout. The FileUpload
 row stores a workspace-namespaced id (``${workspace}:${path}``) because that
@@ -43,6 +52,7 @@ bare path (its reads are always workspace-filtered, so no global collision).
 
 from __future__ import annotations
 
+import difflib
 import hashlib
 import logging
 import mimetypes
@@ -56,11 +66,12 @@ from beanie import PydanticObjectId
 from pocketpaw.uploads.adapter import StorageAdapter
 from pocketpaw.uploads.factory import build_adapter
 from pocketpaw_ee.cloud._core.context import RequestContext
-from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, NotFound
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound, PreconditionFailed
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import Event
 from pocketpaw_ee.cloud.file_versions.domain import FileVersion
 from pocketpaw_ee.cloud.file_versions.dto import (
+    DiffResponse,
     FileVersionListItem,
     FileVersionResponse,
     UpdateFileContentRequest,
@@ -342,7 +353,9 @@ async def update_file_content(
     current_version = doc.content_version
     expected = body.expected_version
     if expected is not None and expected != current_version:
-        raise ConflictError(
+        # Stale ``If-Match`` — a conditional-request precondition failure (412),
+        # not a generic 409 conflict. Standard optimistic-concurrency semantics.
+        raise PreconditionFailed(
             "files.version_conflict",
             f"Expected version {expected} but current is {current_version}. "
             "Someone else edited this file. Reload and try again.",
@@ -515,4 +528,55 @@ async def get_version(
         editor_kind=fv.editor_kind,
         editor_id=fv.editor_id,
         created_at=fv.created_at,
+    )
+
+
+async def revert_to_version(
+    ctx: RequestContext,
+    file_id: str,
+    version_id: str,
+) -> UpdateFileContentResponse:
+    """Restore the live file to a historical version's content.
+
+    Fetches the target version (tenant-filtered via ``get_version`` — a
+    cross-workspace id is a NotFound), then routes its content back through
+    ``update_file_content`` so the restore is itself a normal versioned write:
+    the current (pre-revert) content is archived as a new version and the live
+    counter bumps. A no-op revert (target content == current content) returns
+    the stored version without archiving, matching the update path.
+
+    ``NotFound`` propagates when the version is missing / cross-tenant.
+    """
+    version = await get_version(ctx, file_id, version_id)
+    body = UpdateFileContentRequest(content=version.content)
+    return await update_file_content(ctx, file_id, body, editor_kind="human")
+
+
+async def diff_versions(
+    ctx: RequestContext,
+    file_id: str,
+    from_version_id: str,
+    to_version_id: str,
+) -> DiffResponse:
+    """Return a unified diff between two archived versions.
+
+    Both versions are fetched via ``get_version`` (tenant-filtered), so a diff
+    can never span a workspace boundary. Produces a standard ``difflib``
+    unified diff of ``from`` -> ``to`` content.
+    """
+    v_from = await get_version(ctx, file_id, from_version_id)
+    v_to = await get_version(ctx, file_id, to_version_id)
+
+    diff = "".join(
+        difflib.unified_diff(
+            v_from.content.splitlines(keepends=True),
+            v_to.content.splitlines(keepends=True),
+            fromfile=f"v{v_from.version_number}",
+            tofile=f"v{v_to.version_number}",
+        )
+    )
+    return DiffResponse(
+        from_version=v_from.version_number,
+        to_version=v_to.version_number,
+        diff=diff,
     )

--- a/ee/pocketpaw_ee/cloud/file_versions/slides_dto.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/slides_dto.py
@@ -1,0 +1,41 @@
+# slides_dto.py — request/response schemas for slides AI-edit + context sync.
+# Created: 2026-07-03 (FL-2, port of #1193) — ported from dewani12's
+#   origin/feature/files (ee/cloud/file_versions/slides_dto.py). Pure transport
+#   DTOs (no Beanie, no I/O); the slides AI-edit routes that consume them land
+#   in FL-5, but the schemas are cohesive with this package so they're brought
+#   now. Import-linter "FileVersions" contract lists this module as a Beanie-
+#   free source.
+"""Slides DTOs — request/response schemas for AI editing + context sync."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SlidesEditRequest(BaseModel):
+    """Request body for POST /files/{id}/slides-edit."""
+
+    content: dict[str, Any]  # full slides deck JSON
+    prompt: str = Field(min_length=1)  # what the user wants the AI to do
+    selected_slide_id: str | None = Field(default=None, alias="selectedSlideId")
+    available_tools: list[str] = Field(default_factory=list, alias="availableTools")
+
+    model_config = {"populate_by_name": True}
+
+
+class SlidesEditResponse(BaseModel):
+    """AI-edited slides deck returned to the frontend."""
+
+    content: dict[str, Any]  # updated slides deck JSON
+    summary: str = ""  # human-readable summary of changes
+
+
+class SyncSlidesContextRequest(BaseModel):
+    """Request body for PUT /files/{id}/slides-context."""
+
+    content: dict[str, Any]
+    selected_slide_id: str | None = Field(default=None, alias="selectedSlideId")
+
+    model_config = {"populate_by_name": True}

--- a/ee/pocketpaw_ee/cloud/file_versions/spreadsheet_dto.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/spreadsheet_dto.py
@@ -1,0 +1,41 @@
+# spreadsheet_dto.py — request/response schemas for spreadsheet AI-edit + sync.
+# Created: 2026-07-03 (FL-2, port of #1193) — ported from dewani12's
+#   origin/feature/files (ee/cloud/file_versions/spreadsheet_dto.py). Pure
+#   transport DTOs (no Beanie, no I/O); the spreadsheet AI-edit routes that
+#   consume them land in FL-5, but the schemas are cohesive with this package so
+#   they're brought now. Import-linter "FileVersions" contract lists this module
+#   as a Beanie-free source.
+"""Spreadsheet DTOs — request/response schemas for AI editing + context sync."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SpreadsheetEditRequest(BaseModel):
+    """Request body for POST /files/{id}/spreadsheet-edit."""
+
+    content: str = Field(min_length=0)  # full workbook snapshot JSON
+    prompt: str = Field(min_length=1)  # what the user wants the AI to do
+    selected_sheet: str | None = Field(default=None, alias="selectedSheet")
+    available_tools: list[str] = Field(default_factory=list, alias="availableTools")
+
+    model_config = {"populate_by_name": True}
+
+
+class SpreadsheetEditResponse(BaseModel):
+    """AI-edited workbook snapshot returned to the frontend."""
+
+    snapshot: dict[str, Any]  # updated IWorkbookData snapshot
+    summary: str = ""  # human-readable summary of changes
+
+
+class SyncSpreadsheetContextRequest(BaseModel):
+    """Request body for PUT /files/{id}/spreadsheet-context."""
+
+    snapshot: dict[str, Any]
+    selected_sheet: str | None = Field(default=None, alias="selectedSheet")
+
+    model_config = {"populate_by_name": True}

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -465,6 +465,10 @@ source_modules = [
     "pocketpaw_ee.cloud.file_versions.router",
     "pocketpaw_ee.cloud.file_versions.dto",
     "pocketpaw_ee.cloud.file_versions.domain",
+    # FL-2 (port of #1193): slides/spreadsheet transport DTOs are Beanie-free
+    # too — only ``file_versions.service`` may touch FileVersionDoc.
+    "pocketpaw_ee.cloud.file_versions.slides_dto",
+    "pocketpaw_ee.cloud.file_versions.spreadsheet_dto",
 ]
 forbidden_modules = ["pocketpaw_ee.cloud.models.file_version"]
 

--- a/tests/cloud/file_versions/test_file_versions.py
+++ b/tests/cloud/file_versions/test_file_versions.py
@@ -12,6 +12,11 @@
 #   I3 — a blob-read failure aborts and archives nothing (history preserved).
 #   I4 — the archived row is labelled with the version the content actually was.
 #   M2 — list/get reject an empty workspace.
+# Updated: 2026-07-03 (FL-2, port of #1193) — added coverage for the completed
+#   history spine: revert restores a prior version (archiving the current one),
+#   revert is tenant-filtered (cross-workspace version id -> NotFound), diff
+#   returns a unified diff of two archived versions, a stale If-Match raises
+#   PreconditionFailed (412), and the router revert/diff/412 wire paths.
 """Tests for the file_versions write + history storage spine."""
 
 from __future__ import annotations
@@ -22,7 +27,11 @@ from datetime import UTC, datetime
 import pytest
 import pytest_asyncio
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
-from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
+from pocketpaw_ee.cloud._core.errors import (
+    CloudError,
+    NotFound,
+    PreconditionFailed,
+)
 from pocketpaw_ee.cloud.file_versions import service
 from pocketpaw_ee.cloud.file_versions.dto import (
     UpdateFileContentRequest,
@@ -314,6 +323,94 @@ async def test_empty_workspace_rejected_on_reads(mongo_db, fake_storage):
         await service.get_version(ctx_empty, "doc", "000000000000000000000000")
 
 
+# ---------------------------------------------------------------------------
+# FL-2 — revert / diff / 412 stale If-Match (completed history spine)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stale_if_match_raises_precondition_failed(mongo_db, fake_storage):
+    """A PUT whose expected_version doesn't match the live counter is a 412
+    (PreconditionFailed), the standard stale-If-Match semantics."""
+    ctx = _ctx("w1")
+    await service.write_file(ctx, WriteFileRequest(path="doc", content="v1"))  # version 1
+
+    with pytest.raises(PreconditionFailed) as ei:
+        await service.update_file_content(
+            ctx, "doc", UpdateFileContentRequest(content="v2", expected_version=99)
+        )
+    assert ei.value.status_code == 412
+    assert ei.value.code == "files.version_conflict"
+
+    # Nothing was archived or bumped — the stale write was refused.
+    assert await service.list_versions(ctx, "doc") == []
+
+
+@pytest.mark.asyncio
+async def test_revert_restores_prior_version(mongo_db, fake_storage):
+    """revert_to_version restores a historical version's content as a NEW live
+    version, archiving the current content on the way."""
+    ctx = _ctx("w1")
+    await service.write_file(ctx, WriteFileRequest(path="doc", content="one"))  # v1 live
+    await service.update_file_content(ctx, "doc", UpdateFileContentRequest(content="two"))  # v2
+    await service.update_file_content(ctx, "doc", UpdateFileContentRequest(content="three"))  # v3
+
+    # Archived history so far: v1 ("one"), v2 ("two"); live is v3 ("three").
+    versions = await service.list_versions(ctx, "doc")
+    assert [v.version_number for v in versions] == [1, 2]
+    v1 = next(v for v in versions if v.version_number == 1)
+
+    # Revert to v1 ("one") — writes a new live version (v4) whose content is
+    # "one", and archives the current "three" as v3.
+    res = await service.revert_to_version(ctx, "doc", v1.id)
+    assert res.new_version == 4
+
+    # The live blob now reads "one" again: the next archived version (from a
+    # follow-up edit) captures the reverted content.
+    await service.update_file_content(ctx, "doc", UpdateFileContentRequest(content="four"))
+    versions2 = await service.list_versions(ctx, "doc")
+    assert [v.version_number for v in versions2] == [1, 2, 3, 4]
+    v4 = next(v for v in versions2 if v.version_number == 4)
+    assert (await service.get_version(ctx, "doc", v4.id)).content == "one"
+
+
+@pytest.mark.asyncio
+async def test_revert_cross_tenant_is_not_found(mongo_db, fake_storage):
+    """Revert is tenant-filtered — workspace B cannot revert to a version row
+    that belongs to workspace A."""
+    ctx_a = _ctx("wA", "ua")
+    ctx_b = _ctx("wB", "ub")
+
+    await service.write_file(ctx_a, WriteFileRequest(path="report", content="a1"))
+    await service.update_file_content(ctx_a, "report", UpdateFileContentRequest(content="a2"))
+    a_versions = await service.list_versions(ctx_a, "report")
+    assert len(a_versions) == 1
+
+    # B has its own file at the same path; it must not reach A's version id.
+    await service.write_file(ctx_b, WriteFileRequest(path="report", content="b1"))
+    with pytest.raises(NotFound):
+        await service.revert_to_version(ctx_b, "report", a_versions[0].id)
+
+
+@pytest.mark.asyncio
+async def test_diff_between_two_versions(mongo_db, fake_storage):
+    """diff_versions returns a unified diff of two archived versions' content."""
+    ctx = _ctx("w1")
+    await service.write_file(ctx, WriteFileRequest(path="doc", content="line one\n"))
+    await service.update_file_content(ctx, "doc", UpdateFileContentRequest(content="line two\n"))
+    await service.update_file_content(ctx, "doc", UpdateFileContentRequest(content="line three\n"))
+
+    versions = await service.list_versions(ctx, "doc")  # v1 ("line one"), v2 ("line two")
+    v1 = next(v for v in versions if v.version_number == 1)
+    v2 = next(v for v in versions if v.version_number == 2)
+
+    diff = await service.diff_versions(ctx, "doc", v1.id, v2.id)
+    assert diff.from_version == 1
+    assert diff.to_version == 2
+    assert "-line one" in diff.diff
+    assert "+line two" in diff.diff
+
+
 @pytest_asyncio.fixture
 async def client(mongo_db, fake_storage):
     """A FastAPI app with just the file_versions router mounted, auth/license
@@ -364,3 +461,40 @@ async def test_router_write_put_list_get_smoke(client):
     r = await client.get(f"/api/v1/files/d1/versions/{vid}")
     assert r.status_code == 200
     assert r.json()["content"] == '{"v":1}'
+
+
+@pytest.mark.asyncio
+async def test_router_stale_if_match_returns_412(client):
+    """PUT with a stale If-Match header returns 412 through the router."""
+    r = await client.post("/api/v1/files/write", json={"path": "d2", "content": "v1"})
+    assert r.status_code == 201
+
+    r = await client.put("/api/v1/files/d2", json={"content": "v2"}, headers={"If-Match": '"99"'})
+    assert r.status_code == 412
+
+
+@pytest.mark.asyncio
+async def test_router_revert_and_diff(client):
+    """POST .../revert restores a prior version and GET .../diff/... returns a
+    unified diff, both through the router with aliased wire shapes."""
+    await client.post("/api/v1/files/write", json={"path": "d3", "content": "one\n"})
+    await client.put("/api/v1/files/d3", json={"content": "two\n"})
+    await client.put("/api/v1/files/d3", json={"content": "three\n"})
+
+    versions = (await client.get("/api/v1/files/d3/versions")).json()
+    assert [v["versionNumber"] for v in versions] == [1, 2]
+    v1_id = next(v["id"] for v in versions if v["versionNumber"] == 1)
+    v2_id = next(v["id"] for v in versions if v["versionNumber"] == 2)
+
+    # Diff v1 -> v2 (aliased fromVersion / toVersion).
+    r = await client.get(f"/api/v1/files/d3/versions/{v1_id}/diff/{v2_id}")
+    assert r.status_code == 200
+    diff = r.json()
+    assert diff["fromVersion"] == 1
+    assert diff["toVersion"] == 2
+    assert "-one" in diff["diff"] and "+two" in diff["diff"]
+
+    # Revert to v1 -> a new live version (aliased newVersion).
+    r = await client.post(f"/api/v1/files/d3/versions/{v1_id}/revert")
+    assert r.status_code == 200
+    assert r.json()["newVersion"] == 4


### PR DESCRIPTION
Versioning spine for the /files prod-ready arc (FL-2). Completes the file-version history so inline edits (human or agent) are revertable and diffable.

**Stacked on #1622 (FL-1)** — review/merge that first; this PR's base is `feat/files-library-metadata`, so the diff here is only FL-2's changes.

## What changes

The core version store (`write` / `update` / `list` / `get`) already landed on dev via ART-1, which deliberately deferred the history helpers. This PR finishes them:

- `POST /files/{id}/versions/{vid}/revert` — restore a prior version (tenant-filtered).
- `GET /files/{id}/versions/{v1}/diff/{v2}` — unified diff between two archived versions.
- `revert_to_version` + `diff_versions` in the service, both scoped through `get_version` so a cross-workspace id returns NotFound.
- The stale-`If-Match` conflict now returns **412 Precondition Failed** (was 409). This matches standard conditional-request semantics and the frontend `saveFileContent()` contract. ART-1's existing tests didn't assert the status code, so nothing regressed — but it's a wire-visible change worth noting.
- Brought the slides/spreadsheet transport DTOs over (cohesive with the package; FL-5's edit tools will wire them).

The `PUT /files/{id}` + `GET /files/{id}/versions` endpoints (already present from ART-1) match the `If-Match` optimistic-concurrency contract the FL-7 editor calls.

## Ported from #1193 (credit: dewani12)

The revert/diff service + routes and the slides/spreadsheet DTOs are ported from dewani12's stale PR #1193, adapted to the current `pocketpaw_ee.cloud.*` layout. The AI-edit routes (`ai-edit`, `slides-edit`, etc.) are intentionally left for FL-5 since they pull in tool dependencies.

## Tests

`tests/cloud/file_versions/` — 15 passed. Covers revert (restore + cross-tenant NotFound), diff, the 412 stale-`If-Match` path, and router wire tests. `lint-imports` — 28 contracts kept, 0 broken (the FileVersions import contract was extended to cover the two new Beanie-free DTO modules).

## Follow-up

FL-7's `saveFileContent()` assumes a `{version}` body + `ETag` header; reconcile with `UpdateFileContentResponse`'s actual shape when the two land together (tracked in FL-10 wiring).
