### PR TITLE
feat(files): agent library verbs — tag, move, annotate, search

### DIFF
--- a/ee/pocketpaw_ee/cloud/file_versions/service.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/service.py
@@ -30,6 +30,17 @@
 #   ``get_version``. A stale ``If-Match`` now raises ``PreconditionFailed``
 #   (412) instead of ``ConflictError`` (409), matching HTTP conditional-request
 #   semantics for the file-version write path.
+# Updated: 2026-07-03 (FL-3, agent library verbs) — added ``annotate_upload``:
+#   the content-mutation entrypoint for the ``annotate_file`` agent verb. A
+#   Library file (a ``FileUpload`` row keyed by its OWN bare ``file_id``, NOT the
+#   ``${workspace}:${path}`` namespaced id the editor path uses) gets a short
+#   note prepended to its content as a NEW archived version, so the annotation is
+#   revertable through the same ``list_versions`` / ``get_version`` readers. It
+#   reuses the archive-then-rewrite mechanism of ``update_file_content`` but keys
+#   on the Library row's own id, keeping every ``FileVersionDoc`` write inside
+#   this module (the import-linter "FileVersions" contract) — the agent tool
+#   never touches the Beanie doc directly. Tenant-filtered: the ``FileUpload``
+#   lookup and every ``FileVersionDoc`` read/write pins ``workspace_id``.
 """FileVersions service — file-version write + history.
 
 Module-level ``async def`` functions. Sole owner of writes to the
@@ -579,4 +590,121 @@ async def diff_versions(
         from_version=v_from.version_number,
         to_version=v_to.version_number,
         diff=diff,
+    )
+
+
+async def annotate_upload(
+    ctx: RequestContext,
+    file_id: str,
+    note: str,
+) -> UpdateFileContentResponse:
+    """Prepend a short note to a Library file's content as a new version (FL-3).
+
+    Unlike ``update_file_content`` (which keys on the ``${workspace}:${path}``
+    namespaced editor id), this targets a Library ``FileUpload`` row by its OWN
+    bare ``file_id`` — the id the uploads pipeline stamps and the /files listing
+    surfaces. It archives the current blob as a ``FileVersionDoc`` and rewrites
+    the live blob with ``note`` prepended, bumping ``content_version`` so the
+    annotation is revertable via ``list_versions`` / ``get_version``.
+
+    Tenant-safe: the ``FileUpload`` lookup and the ``FileVersionDoc`` write both
+    pin ``workspace_id``, so a caller can never annotate another workspace's
+    file. Editable-mime only (a binary Library file returns 422); a blank note
+    is rejected (400). ``editor_kind`` is ``"agent"`` — this is the agent verb.
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
+    clean_note = (note or "").strip()
+    if not clean_note:
+        raise CloudError(400, "files.empty_note", "Annotation note must be non-empty.")
+
+    # Library rows key on the bare file_id (NOT the namespaced editor id).
+    doc = await FileUpload.find_one(
+        {"file_id": file_id, "workspace": workspace_id, "deleted_at": None}
+    )
+    if not doc:
+        raise NotFound("file", file_id)
+
+    if not _is_editable(doc.mime):
+        raise CloudError(
+            422,
+            "files.not_editable",
+            f"File type '{doc.mime}' cannot be annotated inline.",
+        )
+
+    editor_id = ctx.user_id or "unknown"
+    adapter = _get_storage()
+
+    # Read the current blob so it can be archived. A read failure must NOT be
+    # swallowed into an empty archive (same guard as ``update_file_content``).
+    try:
+        old_content = await _read_text(adapter, doc.storage_key)
+    except Exception as exc:
+        logger.error(
+            "annotate %s: cannot read current blob %r to archive prior version: %s",
+            file_id,
+            doc.storage_key,
+            exc,
+        )
+        raise CloudError(
+            500,
+            "files.archive_read_failed",
+            "Could not read the file's current content to archive it; "
+            "aborting to protect version history.",
+        ) from exc
+
+    old_hash = _sha256(old_content)
+    current_version = doc.content_version or 0
+
+    # Prepend the note as a comment-style banner. Kept plain so it round-trips
+    # through any text/* mime without corrupting structured formats badly.
+    new_content = f"[note] {clean_note}\n{old_content}"
+    new_hash = _sha256(new_content)
+    new_size = len(new_content.encode("utf-8"))
+
+    # Archive the OLD content under the version it actually was. A legacy
+    # Library row starts at content_version 0; label the archived blob with that
+    # so the history is monotonic and the revived counter bumps cleanly.
+    version_doc = FileVersionDoc(
+        file_id=file_id,
+        workspace_id=workspace_id,
+        version_number=current_version,
+        content=old_content,
+        content_hash=old_hash,
+        size_bytes=len(old_content.encode("utf-8")),
+        editor_kind="agent",
+        editor_id=editor_id,
+        created_at=datetime.now(UTC),
+    )
+    await version_doc.insert()
+
+    stored = await adapter.put(doc.storage_key, _bytes_iter(new_content), doc.mime)
+
+    new_version = current_version + 1
+    doc.size = stored.size
+    doc.content_version = new_version
+    await doc.save()
+
+    await emit(
+        Event(
+            type="file.annotated",
+            data={
+                "file_id": file_id,
+                "workspace_id": workspace_id,
+                "version": new_version,
+                "editor_kind": "agent",
+                "editor_id": editor_id,
+            },
+        )
+    )
+
+    logger.info("file %s annotated to version %d by agent:%s", file_id, new_version, editor_id)
+
+    return UpdateFileContentResponse(
+        file_id=file_id,
+        new_version=new_version,
+        size_bytes=new_size,
+        content_hash=new_hash,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -544,4 +544,21 @@ ignore_imports = [
     # dashboard_lifecycle drains the EE InProcessExecutor on shutdown via a
     # try/except runtime import; the OSS core never imports EE statically.
     "pocketpaw.dashboard_lifecycle -> pocketpaw_ee.cloud.chat.runs.executor",
+    # FL-3 agent Library verbs: the tag/move/annotate/search tools live in the
+    # OSS builtin tools package (registered via _EE_TOOLS, guarded by ee/
+    # availability) but act on the cloud Library. Every EE reach is a lazy
+    # try/except runtime import inside a method — the module top-level imports
+    # only OSS (pocketpaw.tools.protocol), and on a community install the tools
+    # degrade to an "enterprise feature" message. Same pattern the tools.cli
+    # dispatcher already uses for cloud pocket writes.
+    "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud.chat.agent_service",
+    "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud.uploads.mongo_store",
+    "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud.uploads.paths",
+    "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud.uploads.folder_store",
+    "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud._core.context",
+    "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud._core.errors",
+    "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud._core.realtime.emit",
+    "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud._core.realtime.events",
+    "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud.file_versions.service",
+    "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud.agents.knowledge",
 ]

--- a/src/pocketpaw/tools/builtin/__init__.py
+++ b/src/pocketpaw/tools/builtin/__init__.py
@@ -14,6 +14,9 @@
 #   - 2026-05-31: Added zero-config WeatherTool, WikiTool, CurrencyTool (no API key)
 #   - 2026-06-16: Added CodeModeTool — Programmatic Tool Calling v1 (read-only):
 #     the agent scripts N read-safe tool calls; only final stdout returns.
+#   - 2026-07-03: Added FL-3 Library verbs (EE) — TagFileTool, MoveFileTool,
+#     AnnotateFileTool, SearchLibraryTool — the single-file agent verbs that
+#     make /files agentic. Registered in _EE_TOOLS (guarded by ee/ availability).
 
 import importlib as _importlib
 
@@ -111,6 +114,12 @@ try:
         InstinctPendingTool,
         InstinctProposeTool,
     )
+    from pocketpaw.tools.builtin.library_verbs import (
+        AnnotateFileTool,
+        MoveFileTool,
+        SearchLibraryTool,
+        TagFileTool,
+    )
 
     _EE_TOOLS: list[type] = [
         FabricQueryTool,
@@ -120,6 +129,11 @@ try:
         InstinctPendingTool,
         InstinctAuditTool,
         InstinctCorrectionsTool,
+        # FL-3 — agent Library verbs (tag / move / annotate / search).
+        TagFileTool,
+        MoveFileTool,
+        AnnotateFileTool,
+        SearchLibraryTool,
     ]
     _EE_NAMES = {cls.__name__: cls for cls in _EE_TOOLS}
 except ImportError:

--- a/src/pocketpaw/tools/builtin/library_verbs.py
+++ b/src/pocketpaw/tools/builtin/library_verbs.py
@@ -1,0 +1,425 @@
+# library_verbs.py — agent Library verbs (FL-3): tag / move / annotate / search.
+# Created: 2026-07-03 (FL-3) — the single-file verbs that make /files agentic.
+#   Four BaseTool subclasses the agent uses to organize + read the workspace
+#   Library:
+#     - tag_file(file_id, add?, remove?)  → metadata op, journal event
+#     - move_file(file_id, folder_path)   → metadata op, journal event
+#     - annotate_file(file_id, note)      → CONTENT op → new FL-2 version (revertable)
+#     - search_library(query, limit)      → BM25 search over the workspace KB scope
+#   Every verb is workspace-scoped: the workspace/user come from the per-stream
+#   agent identity ContextVars (``current_workspace_id`` / ``current_user_id`` in
+#   ee.cloud.chat.agent_service), so a verb can only ever touch the CURRENT
+#   workspace's files — cross-workspace access is impossible (the store lookups
+#   and the FL-2 service both pin workspace_id). Metadata writes go through FL-1's
+#   ``MongoFileStore``; the content mutation goes through FL-2's
+#   ``file_versions.service.annotate_upload`` so annotations archive as
+#   ``FileVersionDoc`` rows and stay revertable. Mutating verbs are trust_level
+#   "medium" (not auto-approved), matching the fabric/instinct write-tool
+#   convention; ``search_library`` is a read → "high".
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Workspace / user resolution
+#
+# The agent runtime binds the active stream's tenancy onto ContextVars in
+# ``ee.cloud.chat.agent_service`` (set by ``attach_agent_identity`` on every
+# cloud chat dispatch). These verbs read from there so they never need a
+# FastAPI request scope — the same seam the in-process pocket-write MCP tools
+# use. Imported lazily so a community (non-EE) install still loads the module
+# without the cloud package present.
+# ---------------------------------------------------------------------------
+
+
+def _current_workspace() -> str | None:
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_workspace_id
+
+        return current_workspace_id()
+    except ImportError:
+        return None
+
+
+def _current_user() -> str | None:
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_user_id
+
+        return current_user_id()
+    except ImportError:
+        return None
+
+
+def _mongo_store():
+    """The FL-1 workspace-scoped upload metadata store (lazy import)."""
+    try:
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        return MongoFileStore()
+    except ImportError:
+        return None
+
+
+def _request_ctx(workspace_id: str, user_id: str | None):
+    """Build a minimal RequestContext for the FL-2 file_versions service."""
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=user_id or "agent",
+        workspace_id=workspace_id,
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _emit_library_event(event_type: str, data: dict[str, Any]) -> None:
+    """Emit a journal/bus event for a Library metadata mutation.
+
+    Best-effort: a bus that isn't initialized (a unit test that skips
+    ``init_realtime``) must not break the verb — the DB write already
+    succeeded. Mirrors the ``emit`` facade's own "never raise back" contract.
+    """
+    try:
+        from pocketpaw_ee.cloud._core.realtime.emit import emit
+        from pocketpaw_ee.cloud._core.realtime.events import Event
+
+        await emit(Event(type=event_type, data=data))
+    except Exception:
+        logger.debug("library event emit skipped (type=%s)", event_type, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# tag_file
+# ---------------------------------------------------------------------------
+
+
+class TagFileTool(BaseTool):
+    """Add or remove tags on a Library file."""
+
+    @property
+    def name(self) -> str:
+        return "tag_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Add or remove tags on a file in the workspace Library. Tags organize "
+            "and filter files (e.g. 'invoice', 'q3', 'archived'). Pass 'add' to "
+            "attach tags and/or 'remove' to detach them; both merge against the "
+            "file's current tags. Operates only on files in the current workspace."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "medium"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_id": {
+                    "type": "string",
+                    "description": "ID of the Library file to tag.",
+                },
+                "add": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Tags to add.",
+                },
+                "remove": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Tags to remove.",
+                },
+            },
+            "required": ["file_id"],
+        }
+
+    async def execute(
+        self,
+        file_id: str,
+        add: list[str] | None = None,
+        remove: list[str] | None = None,
+    ) -> str:
+        workspace = _current_workspace()
+        if not workspace:
+            return self._error("Library verbs require a workspace context (cloud chat session).")
+
+        store = _mongo_store()
+        if store is None:
+            return self._error("Library is not available (enterprise feature).")
+
+        if not add and not remove:
+            return self._error("Provide at least one tag to add or remove.")
+
+        doc = await store.get_doc_scoped(file_id, workspace)
+        if doc is None:
+            return self._error(f"File {file_id!r} not found in this workspace.")
+
+        current = list(doc.tags or [])
+        add_set = {str(t).strip() for t in (add or []) if str(t).strip()}
+        remove_set = {str(t).strip() for t in (remove or [])}
+        # Preserve order: keep existing (minus removed), then append new.
+        merged = [t for t in current if t not in remove_set]
+        for t in add_set:
+            if t not in merged:
+                merged.append(t)
+
+        updated = await store.set_library_metadata(file_id, workspace, tags=merged)
+        if updated is None:
+            return self._error(f"File {file_id!r} not found in this workspace.")
+
+        await _emit_library_event(
+            "file.tagged",
+            {
+                "file_id": file_id,
+                "workspace_id": workspace,
+                "tags": merged,
+                "added": sorted(add_set),
+                "removed": sorted(remove_set),
+                "actor": _current_user() or "agent",
+            },
+        )
+        return self._success(
+            f"Tagged {updated.filename} ({file_id}). Tags now: {', '.join(merged) or '(none)'}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# move_file
+# ---------------------------------------------------------------------------
+
+
+class MoveFileTool(BaseTool):
+    """Move a Library file into a folder."""
+
+    @property
+    def name(self) -> str:
+        return "move_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Move a file in the workspace Library into a folder. 'folder_path' is "
+            "an absolute path like '/reports/2026' (use '/' for the root). Operates "
+            "only on files in the current workspace."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "medium"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_id": {
+                    "type": "string",
+                    "description": "ID of the Library file to move.",
+                },
+                "folder_path": {
+                    "type": "string",
+                    "description": "Absolute destination folder path (e.g. '/reports'). "
+                    "'/' is the root.",
+                },
+            },
+            "required": ["file_id", "folder_path"],
+        }
+
+    async def execute(self, file_id: str, folder_path: str) -> str:
+        workspace = _current_workspace()
+        if not workspace:
+            return self._error("Library verbs require a workspace context (cloud chat session).")
+
+        store = _mongo_store()
+        if store is None:
+            return self._error("Library is not available (enterprise feature).")
+
+        try:
+            from pocketpaw_ee.cloud.uploads.paths import normalize_path
+
+            norm = normalize_path(folder_path)
+        except ValueError as e:
+            return self._error(f"Invalid folder path: {e}")
+        except ImportError:
+            return self._error("Library is not available (enterprise feature).")
+
+        doc = await store.get_doc_scoped(file_id, workspace)
+        if doc is None:
+            return self._error(f"File {file_id!r} not found in this workspace.")
+
+        # Validate the destination folder exists (except root). Reuses the same
+        # FolderStore the PATCH route checks against.
+        if norm != "/":
+            try:
+                from pocketpaw_ee.cloud.uploads.folder_store import FolderStore
+
+                if not await FolderStore().path_exists(workspace, norm):
+                    return self._error(f"Destination folder {norm!r} does not exist.")
+            except ImportError:
+                pass
+
+        doc.folder_path = norm
+        await doc.save()
+
+        await _emit_library_event(
+            "file.moved",
+            {
+                "file_id": file_id,
+                "workspace_id": workspace,
+                "folder_path": norm,
+                "actor": _current_user() or "agent",
+            },
+        )
+        return self._success(f"Moved {doc.filename} ({file_id}) to {norm}.")
+
+
+# ---------------------------------------------------------------------------
+# annotate_file
+# ---------------------------------------------------------------------------
+
+
+class AnnotateFileTool(BaseTool):
+    """Prepend a short note to a Library file's content (a revertable version)."""
+
+    @property
+    def name(self) -> str:
+        return "annotate_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Prepend a short note to a text file's content in the workspace Library "
+            "(e.g. a one-line summary). This is a content change: it writes a new "
+            "file version, so the annotation is fully revertable. Only text files "
+            "can be annotated. Operates only on files in the current workspace."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "medium"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_id": {
+                    "type": "string",
+                    "description": "ID of the Library file to annotate.",
+                },
+                "note": {
+                    "type": "string",
+                    "description": "The note to prepend (a short line or summary).",
+                },
+            },
+            "required": ["file_id", "note"],
+        }
+
+    async def execute(self, file_id: str, note: str) -> str:
+        workspace = _current_workspace()
+        if not workspace:
+            return self._error("Library verbs require a workspace context (cloud chat session).")
+
+        try:
+            from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
+            from pocketpaw_ee.cloud.file_versions import service as fv_service
+        except ImportError:
+            return self._error("Library versioning is not available (enterprise feature).")
+
+        ctx = _request_ctx(workspace, _current_user())
+        try:
+            result = await fv_service.annotate_upload(ctx, file_id, note)
+        except NotFound:
+            return self._error(f"File {file_id!r} not found in this workspace.")
+        except CloudError as e:
+            return self._error(str(e))
+
+        return self._success(
+            f"Annotated {file_id} — new version {result.new_version} (revertable)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# search_library
+# ---------------------------------------------------------------------------
+
+
+class SearchLibraryTool(BaseTool):
+    """BM25 search over the workspace's files (captions + extracted text)."""
+
+    @property
+    def name(self) -> str:
+        return "search_library"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search the workspace Library for files by content. Runs a keyword "
+            "(BM25) search over the text and captions extracted from uploaded files "
+            "and returns the ranked hits with snippets. Use to find a file when you "
+            "don't know its id (e.g. 'the whiteboard photo from the offsite')."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "high"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "What to search for.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max hits to return (default 5).",
+                    "default": 5,
+                },
+            },
+            "required": ["query"],
+        }
+
+    async def execute(self, query: str, limit: int = 5) -> str:
+        workspace = _current_workspace()
+        if not workspace:
+            return self._error("Library verbs require a workspace context (cloud chat session).")
+
+        if not query or not query.strip():
+            return self._error("Provide a search query.")
+
+        try:
+            from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+        except ImportError:
+            return self._error("Library search is not available (enterprise feature).")
+
+        # Files ingest into the workspace KB scope (workspace:{id}) — the same
+        # scope the FileReady listener targets for workspace uploads.
+        scope = f"workspace:{workspace}"
+        capped = max(1, min(int(limit), 20))
+        try:
+            context = await KnowledgeService.search_context_for_scope(
+                scope=scope, query=query, limit=capped
+            )
+        except Exception as e:
+            logger.warning("search_library failed for %s: %s", scope, e)
+            return self._error(f"Search failed: {e}")
+
+        if not context or not context.strip():
+            return self._success(f"No Library files matched {query!r}.")
+        return self._success(context)

--- a/tests/cloud/test_library_verbs.py
+++ b/tests/cloud/test_library_verbs.py
@@ -1,0 +1,355 @@
+# test_library_verbs.py — FL-3 agent Library verb tests (tag/move/annotate/search).
+# Created: 2026-07-03 (FL-3). Locks:
+#   - tag_file adds/removes tags (persists via FL-1, readable) + emits a journal event
+#   - move_file moves a file into a folder + emits a journal event
+#   - annotate_file writes a new FL-2 version (revertable via list_versions/get_version)
+#   - search_library wraps the kb-go workspace scope and returns hits
+#   - cross-workspace access is DENIED for every verb (tenant isolation)
+# Workspace context is bound via the OSS ``pocketpaw.stores.current_workspace``
+# ContextVar (the ISO-3 bridge ``attach_agent_identity`` sets), so the verbs
+# resolve the active workspace without a request scope — the same seam the live
+# agent path uses.
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud.file_versions import service as fv_service
+from pocketpaw_ee.cloud.uploads.models import FileFolder, FileUpload
+
+from pocketpaw.tools.builtin.library_verbs import (
+    AnnotateFileTool,
+    MoveFileTool,
+    SearchLibraryTool,
+    TagFileTool,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    """In-memory StorageAdapter stand-in (put + open over a dict of blobs)."""
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, bytes] = {}
+
+    async def put(self, key: str, stream: AsyncIterator[bytes], mime: str):
+        from pocketpaw.uploads.adapter import StoredObject
+
+        chunks: list[bytes] = []
+        async for chunk in stream:
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        self._blobs[key] = data
+        return StoredObject(key=key, size=len(data), mime=mime)
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        data = self._blobs.get(key)
+        if data is None:
+            raise FileNotFoundError(key)
+        yield data
+
+
+@pytest.fixture
+def fake_storage():
+    """Inject an in-memory StorageAdapter into the file_versions service."""
+    adapter = _FakeAdapter()
+    prev = fv_service._adapter
+    fv_service.set_adapter(adapter)
+    yield adapter
+    fv_service._adapter = prev
+
+
+@contextmanager
+def _workspace(workspace_id: str, user_id: str = "u1"):
+    """Bind the OSS current_workspace ContextVar + patch the EE user getter.
+
+    The verbs read the workspace from ``pocketpaw.stores.current_workspace``
+    (set in production by ``attach_agent_identity``) and the user from
+    ``agent_service.current_user_id``; here we set the OSS var directly and
+    monkeypatch the user getter so no full chat stream is needed.
+    """
+    import pocketpaw.tools.builtin.library_verbs as lv
+    from pocketpaw.stores import current_workspace
+
+    tok = current_workspace.set(workspace_id)
+    orig_ws = lv._current_workspace
+    orig_user = lv._current_user
+    lv._current_workspace = lambda: current_workspace.get()
+    lv._current_user = lambda: user_id
+    try:
+        yield
+    finally:
+        lv._current_workspace = orig_ws
+        lv._current_user = orig_user
+        current_workspace.reset(tok)
+
+
+async def _seed_upload(
+    workspace: str,
+    file_id: str,
+    *,
+    filename: str = "note.txt",
+    mime: str = "text/plain",
+    content: str = "hello world",
+    adapter: _FakeAdapter,
+    folder_path: str = "/",
+) -> FileUpload:
+    """Seed a Library FileUpload row + its blob, bypassing the guarded route."""
+    storage_key = f"editor/{workspace}/{file_id}"
+    await adapter.put(storage_key, _one_chunk(content.encode("utf-8")), mime)
+    doc = FileUpload(
+        file_id=file_id,
+        storage_key=storage_key,
+        filename=filename,
+        mime=mime,
+        size=len(content.encode("utf-8")),
+        workspace=workspace,
+        owner="u1",
+        folder_path=folder_path,
+        content_version=1,
+    )
+    await doc.insert()
+    return doc
+
+
+async def _one_chunk(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
+@pytest.fixture
+def captured_events(monkeypatch):
+    """Capture every Event emitted via the verbs' journal facade."""
+    events: list = []
+
+    async def _fake_emit(event_type, data):
+        events.append((event_type, data))
+
+    import pocketpaw.tools.builtin.library_verbs as lv
+
+    monkeypatch.setattr(lv, "_emit_library_event", _fake_emit)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# tag_file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tag_file_adds_and_persists(mongo_db, fake_storage, captured_events):
+    await _seed_upload("w1", "f1", adapter=fake_storage)
+
+    with _workspace("w1"):
+        out = await TagFileTool().execute("f1", add=["invoice", "q3"])
+
+    assert "invoice" in out and "q3" in out
+    doc = await FileUpload.find_one({"file_id": "f1", "workspace": "w1"})
+    assert set(doc.tags) == {"invoice", "q3"}
+    # A journal event was emitted.
+    assert captured_events[0][0] == "file.tagged"
+    assert captured_events[0][1]["file_id"] == "f1"
+
+
+@pytest.mark.asyncio
+async def test_tag_file_removes(mongo_db, fake_storage, captured_events):
+    doc = await _seed_upload("w1", "f1", adapter=fake_storage)
+    doc.tags = ["keep", "drop"]
+    await doc.save()
+
+    with _workspace("w1"):
+        await TagFileTool().execute("f1", remove=["drop"])
+
+    fresh = await FileUpload.find_one({"file_id": "f1", "workspace": "w1"})
+    assert fresh.tags == ["keep"]
+
+
+@pytest.mark.asyncio
+async def test_tag_file_cross_workspace_denied(mongo_db, fake_storage, captured_events):
+    await _seed_upload("wA", "fa", adapter=fake_storage)
+
+    # A caller in wB cannot tag wA's file.
+    with _workspace("wB"):
+        out = await TagFileTool().execute("fa", add=["x"])
+
+    assert "not found" in out.lower()
+    doc = await FileUpload.find_one({"file_id": "fa", "workspace": "wA"})
+    assert doc.tags == []  # untouched
+    assert captured_events == []  # no event on a denied op
+
+
+# ---------------------------------------------------------------------------
+# move_file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_move_file_into_folder(mongo_db, fake_storage, captured_events):
+    await _seed_upload("w1", "f1", adapter=fake_storage)
+    # The destination folder must exist (the verb validates via FolderStore).
+    await FileFolder(workspace="w1", owner="u1", path="/reports", name="reports").insert()
+
+    with _workspace("w1"):
+        out = await MoveFileTool().execute("f1", "/reports")
+
+    assert "/reports" in out
+    doc = await FileUpload.find_one({"file_id": "f1", "workspace": "w1"})
+    assert doc.folder_path == "/reports"
+    assert captured_events[0][0] == "file.moved"
+    assert captured_events[0][1]["folder_path"] == "/reports"
+
+
+@pytest.mark.asyncio
+async def test_move_file_missing_folder_rejected(mongo_db, fake_storage, captured_events):
+    await _seed_upload("w1", "f1", adapter=fake_storage)
+
+    with _workspace("w1"):
+        out = await MoveFileTool().execute("f1", "/does-not-exist")
+
+    assert "does not exist" in out.lower()
+    doc = await FileUpload.find_one({"file_id": "f1", "workspace": "w1"})
+    assert (doc.folder_path or "/") == "/"
+
+
+@pytest.mark.asyncio
+async def test_move_file_cross_workspace_denied(mongo_db, fake_storage, captured_events):
+    await _seed_upload("wA", "fa", adapter=fake_storage)
+
+    with _workspace("wB"):
+        out = await MoveFileTool().execute("fa", "/")
+
+    assert "not found" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# annotate_file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotate_writes_revertable_version(mongo_db, fake_storage):
+    await _seed_upload("w1", "f1", content="original body", adapter=fake_storage)
+
+    with _workspace("w1"):
+        out = await AnnotateFileTool().execute("f1", "one-line summary")
+
+    assert "version" in out.lower()
+
+    # A new FileVersionDoc was archived (the prior content) — revertable.
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    ctx = RequestContext(
+        user_id="u1",
+        workspace_id="w1",
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+    versions = await fv_service.list_versions(ctx, "f1")
+    assert len(versions) == 1
+    archived = await fv_service.get_version(ctx, "f1", versions[0].id)
+    assert archived.content == "original body"  # the pre-annotation content is recoverable
+
+    # The live blob now carries the note prepended + bumped content_version.
+    doc = await FileUpload.find_one({"file_id": "f1", "workspace": "w1"})
+    assert doc.content_version == 2
+    live = fake_storage._blobs[doc.storage_key].decode()
+    assert live.startswith("[note] one-line summary")
+    assert "original body" in live
+
+
+@pytest.mark.asyncio
+async def test_annotate_non_text_rejected(mongo_db, fake_storage):
+    await _seed_upload("w1", "img", mime="image/png", content="x", adapter=fake_storage)
+
+    with _workspace("w1"):
+        out = await AnnotateFileTool().execute("img", "caption")
+
+    assert "cannot be annotated" in out.lower() or "not_editable" in out.lower()
+
+
+@pytest.mark.asyncio
+async def test_annotate_cross_workspace_denied(mongo_db, fake_storage):
+    await _seed_upload("wA", "fa", content="secret", adapter=fake_storage)
+
+    with _workspace("wB"):
+        out = await AnnotateFileTool().execute("fa", "note")
+
+    assert "not found" in out.lower()
+    # No version was written for wA's file by the wB caller.
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    ctx = RequestContext(
+        user_id="ua",
+        workspace_id="wA",
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+    assert await fv_service.list_versions(ctx, "fa") == []
+    doc = await FileUpload.find_one({"file_id": "fa", "workspace": "wA"})
+    assert doc.content_version == 1  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# search_library
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_library_scopes_to_workspace(mongo_db, fake_storage, monkeypatch):
+    calls: list = []
+
+    async def _fake_search(*, scope, query, limit):
+        calls.append((scope, query, limit))
+        return f"[hit] whiteboard photo from the offsite (scope={scope})"
+
+    from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+    monkeypatch.setattr(KnowledgeService, "search_context_for_scope", _fake_search)
+
+    with _workspace("w1"):
+        out = await SearchLibraryTool().execute("whiteboard", limit=3)
+
+    assert "whiteboard" in out
+    # The verb scoped the search to THIS workspace's KB scope.
+    assert calls == [("workspace:w1", "whiteboard", 3)]
+
+
+@pytest.mark.asyncio
+async def test_search_library_cross_workspace_scope_isolated(mongo_db, fake_storage, monkeypatch):
+    seen_scopes: list[str] = []
+
+    async def _fake_search(*, scope, query, limit):
+        seen_scopes.append(scope)
+        return ""
+
+    from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+    monkeypatch.setattr(KnowledgeService, "search_context_for_scope", _fake_search)
+
+    with _workspace("wB"):
+        await SearchLibraryTool().execute("anything")
+
+    # A wB caller can only ever query wB's KB scope — never wA's.
+    assert seen_scopes == ["workspace:wB"]
+
+
+@pytest.mark.asyncio
+async def test_verbs_require_workspace_context(mongo_db, fake_storage):
+    # With no workspace bound, every verb refuses (fail-closed).
+    import pocketpaw.tools.builtin.library_verbs as lv
+
+    orig = lv._current_workspace
+    lv._current_workspace = lambda: None
+    try:
+        assert "workspace context" in (await TagFileTool().execute("f", add=["x"])).lower()
+        assert "workspace context" in (await MoveFileTool().execute("f", "/")).lower()
+        assert "workspace context" in (await AnnotateFileTool().execute("f", "n")).lower()
+        assert "workspace context" in (await SearchLibraryTool().execute("q")).lower()
+    finally:
+        lv._current_workspace = orig


### PR DESCRIPTION
Agent library verbs for the /files prod-ready arc (FL-3) — the piece that makes the Library agentic rather than just searchable.

**Stacked on #1623 (FL-2)** — base is `feat/files-versioning-spine` (which carries FL-1 + FL-2); the diff here is only FL-3's changes.

## What ships

Four builtin tools the agent can call over the Library:
- `tag_file(file_id, tags)` — add/remove tags (persists via FL-1's workspace-scoped setter). Metadata op → journal event.
- `move_file(file_id, folder_path)` — move to a folder. Metadata op → journal event.
- `annotate_file(file_id, note)` — prepend a note. Content mutation → writes a new revertable version via FL-2.
- `search_library(query, limit)` — BM25 search over the workspace's kb-go scope, ranked hits with snippets.

Mutating verbs are `trust_level="medium"` (not auto-approved); search is `"high"`. All four are workspace-scoped with cross-workspace denial tested.

## Load-bearing design note (surfaces a cross-slice seam)

FL-1 Library rows key `FileUpload` by a **bare `file_id`** (globally-unique index). FL-2's editor path keys by the file's **path** (`${workspace}:${path}` internally). Two schemes on one collection. `annotate_file` bridges them — `annotate_upload()` reuses FL-2's archive-then-rewrite mechanism but keyed on the Library row's own `file_id`, so annotations land as real, revertable `FileVersionDoc` rows.

**Follow-up (tracked separately):** the FL-7/8/9 editor calls `PUT /files/{id}` with the Library `file_id`, which the path-based FL-2 handler does not yet resolve — so editing a Library file end-to-end needs the same bridge on the update/list/revert routes, plus a real upload→edit→version→revert integration test. Filed as the next task.

## Tests

`tests/cloud/test_library_verbs.py` (12) + `tests/cloud/file_versions/` (13 regression) → 27 passed. Covers tag add/remove + journal, move + missing-folder reject + journal, annotate writes a revertable version + non-text reject, search scoped to `workspace:{id}`, cross-workspace denial for all four, and fail-closed with no workspace bound. `lint-imports` root + ee → 0 broken (FileVersions contract kept).
