### PR TITLE
fix(files): resolve Library file_id in the editor version path

### DIFF
--- a/ee/pocketpaw_ee/cloud/file_versions/service.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/service.py
@@ -30,6 +30,21 @@
 #   ``get_version``. A stale ``If-Match`` now raises ``PreconditionFailed``
 #   (412) instead of ``ConflictError`` (409), matching HTTP conditional-request
 #   semantics for the file-version write path.
+# Updated: 2026-07-03 (FL-16, editor↔Library bridge) — the editor version path
+#   (``update_file_content`` and, transitively, ``revert_to_version``) now
+#   resolves BOTH id schemes via the new ``_resolve_upload`` helper: it tries the
+#   editor's workspace-namespaced id (``${workspace}:${path}``) first, then falls
+#   back to a Library ``FileUpload`` row keyed by its OWN bare ``file_id`` (a
+#   uuid). Before this, the frontend editor (FL-7/8/9) opened a Library file with
+#   its bare ``file_id`` and ``PUT /files/{file_id}`` resolved nothing (the
+#   path-based lookup namespaced the uuid and missed the row), so editing a real
+#   Library file end-to-end was broken. Both lookups pin ``workspace``, so the
+#   bridge keeps tenant isolation (a cross-workspace bare id fails closed).
+#   ``FileVersionDoc`` is still keyed on the client-facing ``file_id`` inside this
+#   module (the import-linter "FileVersions" contract), so ``list_versions`` /
+#   ``get_version`` / ``revert_to_version`` find the archived rows for either
+#   scheme. The path-based flow FL-2's tests cover is preserved (namespaced id
+#   tried first).
 # Updated: 2026-07-03 (FL-3, agent library verbs) — added ``annotate_upload``:
 #   the content-mutation entrypoint for the ``annotate_file`` agent verb. A
 #   Library file (a ``FileUpload`` row keyed by its OWN bare ``file_id``, NOT the
@@ -139,6 +154,36 @@ _UPLOAD_ROOT = Path.home() / ".pocketpaw" / "uploads"
 
 def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+async def _resolve_upload(workspace_id: str, file_id: str) -> FileUpload | None:
+    """Resolve the live ``FileUpload`` row a client ``file_id`` refers to (FL-16).
+
+    Two id schemes reach the version path and BOTH must resolve:
+
+    * The editor's own ``write_file``-created files store the FileUpload under
+      the workspace-namespaced id ``${workspace}:${path}`` (see ``_storage_id``);
+      the client passes the bare ``path``.
+    * A Library file (uploaded via the /files pipeline, FL-1) keys the FileUpload
+      by its OWN globally-unique bare ``file_id`` (a uuid); the frontend editor
+      (FL-7/8/9) opens it with exactly that bare id.
+
+    Try the namespaced editor id first (the historical behavior the FL-2 tests
+    cover), then fall back to the bare Library id. Both lookups pin
+    ``workspace`` so a caller can never resolve another tenant's row — the bare
+    ``file_id`` is globally unique but the workspace filter still fail-closes
+    cross-tenant access. Returns the live (non-tombstoned) row or ``None``.
+    """
+    stored_id = _storage_id(workspace_id, file_id)
+    doc = await FileUpload.find_one(
+        {"file_id": stored_id, "workspace": workspace_id, "deleted_at": None}
+    )
+    if doc is not None:
+        return doc
+    # Fall back to a Library row keyed by its own bare file_id.
+    return await FileUpload.find_one(
+        {"file_id": file_id, "workspace": workspace_id, "deleted_at": None}
+    )
 
 
 def _storage_id(workspace_id: str, path: str) -> str:
@@ -335,22 +380,28 @@ async def update_file_content(
 ) -> UpdateFileContentResponse:
     """Replace a text file's content with optimistic concurrency.
 
-    ``file_id`` is the bare client path. Steps:
-    1. Fetch the ``FileUpload`` doc by the workspace-namespaced stored id.
+    ``file_id`` is the client-facing id. It resolves to a ``FileUpload`` row via
+    ``_resolve_upload`` — either the editor's workspace-namespaced id
+    (``${workspace}:${path}``) for a ``write_file``-created file, OR a Library
+    row's own bare ``file_id`` (FL-16 bridge), so the frontend editor can save a
+    real Library file end-to-end. Steps:
+    1. Resolve the ``FileUpload`` doc (editor-namespaced id, then Library id).
     2. Check the ``If-Match`` precondition against ``content_version``.
     3. Read + archive the current blob as a ``FileVersionDoc`` (labelled with
        the version it actually was). A read failure aborts — never archive an
        empty "prior" version.
     4. Upload the new content and bump the version counter.
+
+    ``FileVersionDoc`` is always keyed on the client-facing ``file_id`` passed
+    here, so ``list_versions`` / ``get_version`` / ``revert_to_version`` — which
+    query by that same id — find the archived rows regardless of which id scheme
+    resolved the FileUpload.
     """
     workspace_id = ctx.workspace_id
     if not workspace_id:
         raise CloudError(400, "files.missing_workspace", "Workspace is required.")
 
-    stored_id = _storage_id(workspace_id, file_id)
-    doc = await FileUpload.find_one(
-        {"file_id": stored_id, "workspace": workspace_id, "deleted_at": None}
-    )
+    doc = await _resolve_upload(workspace_id, file_id)
     if not doc:
         raise NotFound("file", file_id)
 

--- a/tests/cloud/file_versions/test_editor_library_bridge.py
+++ b/tests/cloud/file_versions/test_editor_library_bridge.py
@@ -1,0 +1,214 @@
+# test_editor_library_bridge.py — FL-16 end-to-end bridge tests (real objects, no mocks at the seam).
+# Created: 2026-07-03 (FL-16). Proves the cross-slice bug and its fix: the frontend
+#   editor opens a Library file with the file's OWN bare ``file_id`` (a uuid,
+#   FL-1) and saves via the FL-2 version path (``update_file_content`` /
+#   ``PUT /files/{id}``). Before FL-16 that path namespaced the id to
+#   ``${workspace}:${path}`` and resolved NOTHING, so editing a real Library file
+#   end-to-end was broken. These tests seed a REAL ``FileUpload`` Library row via
+#   the store (like FL-1/FL-3, NOT the guarded POST route which 401s), then drive
+#   ``update_file_content`` / ``list_versions`` / ``revert_to_version`` against the
+#   bare ``file_id`` and assert versions archive, live content updates, prior
+#   content restores, and a DIFFERENT workspace can never touch it (tenant denial).
+# The FL-2 path-based flow (editor's own ``write_file`` files, namespaced id) is
+#   still covered by test_file_versions.py and preserved by the resolver order.
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.file_versions import service
+from pocketpaw_ee.cloud.file_versions.dto import UpdateFileContentRequest
+from pocketpaw_ee.cloud.models.file_version import FileVersionDoc
+from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+from pocketpaw.uploads.adapter import StoredObject
+
+
+class _FakeAdapter:
+    """In-memory StorageAdapter stand-in (put + open over a dict of blobs).
+
+    This is the STORAGE adapter — a legitimate seam (real blob I/O would need a
+    disk/S3). The FileUpload row, FileVersionDoc rows, and the service functions
+    under test are all REAL objects hitting the mongomock db; nothing at the
+    bridge seam (id resolution, version archival, tenant filter) is mocked.
+    """
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, bytes] = {}
+
+    async def put(self, key: str, stream: AsyncIterator[bytes], mime: str) -> StoredObject:
+        chunks: list[bytes] = []
+        async for chunk in stream:
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        self._blobs[key] = data
+        return StoredObject(key=key, size=len(data), mime=mime)
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        data = self._blobs.get(key)
+        if data is None:
+            raise FileNotFoundError(key)
+        yield data
+
+
+def _ctx(workspace_id: str, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def fake_storage():
+    """Inject an in-memory StorageAdapter for the duration of a test."""
+    adapter = _FakeAdapter()
+    prev = service._adapter
+    service.set_adapter(adapter)
+    yield adapter
+    service._adapter = prev
+
+
+async def _one_chunk(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
+async def _seed_library_file(
+    workspace: str,
+    file_id: str,
+    *,
+    filename: str = "note.txt",
+    mime: str = "text/plain",
+    content: str = "original body",
+    adapter: _FakeAdapter,
+) -> FileUpload:
+    """Seed a REAL Library FileUpload row keyed by its OWN bare ``file_id`` + its
+    blob — the FL-1 shape the /files pipeline produces, bypassing the guarded
+    (401-ing) POST route. This is the row the frontend editor opens by bare id."""
+    storage_key = f"editor/{workspace}/{file_id}"
+    await adapter.put(storage_key, _one_chunk(content.encode("utf-8")), mime)
+    doc = FileUpload(
+        file_id=file_id,  # bare uuid — NOT the ${workspace}:${path} editor id
+        storage_key=storage_key,
+        filename=filename,
+        mime=mime,
+        size=len(content.encode("utf-8")),
+        workspace=workspace,
+        owner="u1",
+        content_version=1,
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.mark.asyncio
+async def test_editor_saves_library_file_by_bare_id(mongo_db, fake_storage):
+    """THE bug fixed by FL-16: the editor opens a Library file by its bare
+    ``file_id`` and saves via ``update_file_content``. Before the fix the id was
+    namespaced and resolved nothing -> NotFound. After the fix the Library row's
+    content updates and a FileVersionDoc archives the prior content."""
+    ctx = _ctx("w1")
+    file_id = "11111111-1111-1111-1111-111111111111"  # bare Library uuid
+    await _seed_library_file("w1", file_id, content="original body", adapter=fake_storage)
+
+    # Editor save path — keyed on the BARE Library file_id.
+    res = await service.update_file_content(
+        ctx, file_id, UpdateFileContentRequest(content="edited body")
+    )
+    assert res.new_version == 2
+
+    # The live Library blob + counter updated.
+    doc = await FileUpload.find_one({"file_id": file_id, "workspace": "w1"})
+    assert doc is not None
+    assert doc.content_version == 2
+    assert fake_storage._blobs[doc.storage_key].decode() == "edited body"
+
+    # A FileVersionDoc archived the prior content, keyed on the bare file_id.
+    raw = await FileVersionDoc.find({"file_id": file_id, "workspace_id": "w1"}).to_list()
+    assert len(raw) == 1
+    assert raw[0].content == "original body"
+
+    # And it's readable through the version readers on the same bare id.
+    versions = await service.list_versions(ctx, file_id)
+    assert len(versions) == 1
+    assert versions[0].version_number == 1
+    archived = await service.get_version(ctx, file_id, versions[0].id)
+    assert archived.content == "original body"
+
+
+@pytest.mark.asyncio
+async def test_editor_revert_restores_library_file(mongo_db, fake_storage):
+    """list_versions + revert_to_version work on a Library bare id: reverting
+    restores the prior content as a new live version."""
+    ctx = _ctx("w1")
+    file_id = "22222222-2222-2222-2222-222222222222"
+    await _seed_library_file("w1", file_id, content="one", adapter=fake_storage)
+
+    await service.update_file_content(ctx, file_id, UpdateFileContentRequest(content="two"))
+    await service.update_file_content(ctx, file_id, UpdateFileContentRequest(content="three"))
+
+    versions = await service.list_versions(ctx, file_id)
+    assert [v.version_number for v in versions] == [1, 2]
+    v1 = next(v for v in versions if v.version_number == 1)  # content "one"
+
+    # Revert to v1 -> a new live version whose content is "one" again.
+    res = await service.revert_to_version(ctx, file_id, v1.id)
+    assert res.new_version == 4
+
+    # Confirm the live blob was restored to "one".
+    doc = await FileUpload.find_one({"file_id": file_id, "workspace": "w1"})
+    assert fake_storage._blobs[doc.storage_key].decode() == "one"
+
+    # A follow-up edit archives the reverted "one" as the next version.
+    await service.update_file_content(ctx, file_id, UpdateFileContentRequest(content="four"))
+    versions2 = await service.list_versions(ctx, file_id)
+    v4 = next(v for v in versions2 if v.version_number == 4)
+    assert (await service.get_version(ctx, file_id, v4.id)).content == "one"
+
+
+@pytest.mark.asyncio
+async def test_cross_workspace_cannot_edit_library_file(mongo_db, fake_storage):
+    """Tenant isolation: a caller in workspace B cannot edit / list / revert a
+    Library file that belongs to workspace A, even with its exact bare file_id.
+    The bare id is globally unique but the workspace filter fails closed."""
+    ctx_b = _ctx("wB", "ub")
+    file_id = "33333333-3333-3333-3333-333333333333"
+    await _seed_library_file("wA", file_id, content="secret", adapter=fake_storage)
+
+    # B tries to save A's file by its exact bare id -> NotFound (fail-closed).
+    with pytest.raises(NotFound):
+        await service.update_file_content(
+            ctx_b, file_id, UpdateFileContentRequest(content="hijacked")
+        )
+
+    # B sees no versions for A's file, and A's live blob is untouched.
+    assert await service.list_versions(ctx_b, file_id) == []
+    doc = await FileUpload.find_one({"file_id": file_id, "workspace": "wA"})
+    assert doc.content_version == 1
+    assert fake_storage._blobs[doc.storage_key].decode() == "secret"
+    # No version rows were written for A's file at all.
+    assert await FileVersionDoc.find({"file_id": file_id}).to_list() == []
+
+
+@pytest.mark.asyncio
+async def test_editor_namespaced_path_still_resolves(mongo_db, fake_storage):
+    """Regression guard: the editor's OWN write_file-created files (keyed by the
+    ${workspace}:${path} namespaced id, bare path client-side) still resolve —
+    the FL-16 resolver tries the namespaced id first, so FL-2's flow is intact."""
+    ctx = _ctx("w1")
+    from pocketpaw_ee.cloud.file_versions.dto import WriteFileRequest
+
+    await service.write_file(ctx, WriteFileRequest(path="doc1", content="v1"))
+    res = await service.update_file_content(ctx, "doc1", UpdateFileContentRequest(content="v2"))
+    assert res.new_version == 2
+
+    # Stored under the namespaced id, not the bare path.
+    doc = await FileUpload.find_one(
+        {"file_id": service._storage_id("w1", "doc1"), "workspace": "w1"}
+    )
+    assert doc is not None and doc.content_version == 2


### PR DESCRIPTION
Fixes a cross-slice bug that every green PR in this arc hid (FL-16).

**Stacked on #1624 (FL-3)** — base is `feat/files-agent-verbs`; the diff here is only FL-16's changes.

## The bug

The Library and the editor version path key files two different ways on the same collection:
- FL-1 Library rows key `FileUpload` by a **bare `file_id`** (a globally-unique uuid).
- FL-2's editor path (`update_file_content` / `PUT /files/{id}`, list versions, revert) treats the client id as a **path**, namespacing internally to `${workspace}:${path}`.

So when the editor (FL-7/8/9) opens a Library file, it holds the bare uuid and calls `PUT /files/{uuid}` — which the path-based handler resolved to nothing. **Editing a real Library file end-to-end was broken**, even though FL-2's own tests (path-based) and the frontend's tests (mocked fetch) all passed. The seam was invisible to every isolated test.

## The fix

A single `_resolve_upload(workspace, file_id)` helper: try the editor's namespaced id first (preserves the FL-2 path flow exactly), then fall back to a Library row keyed by its bare `file_id`. Both lookups pin `workspace`, so tenant isolation holds. `FileVersionDoc` still keys on the client-facing id inside `service.py` (import-linter contract intact), so list/get/revert find archived rows for either scheme. The router passes `file_id` straight through, so the HTTP path inherits the fix with no router change.

## The test that proves it (no mocks at the seam)

`test_editor_library_bridge.py` — seeds a **real** `FileUpload` Library row by its bare uuid and drives `update_file_content` / `list_versions` / `revert_to_version` against it; only blob-IO is faked (a legitimate storage seam).

- **Red-before** (fix stashed): the two bridge tests fail with `NotFound: file not found` — exactly the bug.
- **Green-after**: `tests/cloud/file_versions/` + `test_library_verbs.py` → 31 passed. `lint-imports` root + ee → 0 broken. Cross-workspace access denied (tested).
