### PR TITLE
feat(files): organize_folder batch executor — capped, metered, revertable

### DIFF
--- a/src/pocketpaw/tools/builtin/__init__.py
+++ b/src/pocketpaw/tools/builtin/__init__.py
@@ -17,6 +17,9 @@
 #   - 2026-07-03: Added FL-3 Library verbs (EE) — TagFileTool, MoveFileTool,
 #     AnnotateFileTool, SearchLibraryTool — the single-file agent verbs that
 #     make /files agentic. Registered in _EE_TOOLS (guarded by ee/ availability).
+#   - 2026-07-03: Added FL-4 OrganizeFolderTool (EE) — the folder-batch executor
+#     that fans an FL-3 verb (annotate | tag) over every file in a folder as
+#     separate metered invocations, capped + partial-failure isolated.
 
 import importlib as _importlib
 
@@ -117,6 +120,7 @@ try:
     from pocketpaw.tools.builtin.library_verbs import (
         AnnotateFileTool,
         MoveFileTool,
+        OrganizeFolderTool,
         SearchLibraryTool,
         TagFileTool,
     )
@@ -134,6 +138,8 @@ try:
         MoveFileTool,
         AnnotateFileTool,
         SearchLibraryTool,
+        # FL-4 — folder-batch executor (fans an FL-3 verb over a folder).
+        OrganizeFolderTool,
     ]
     _EE_NAMES = {cls.__name__: cls for cls in _EE_TOOLS}
 except ImportError:

--- a/src/pocketpaw/tools/builtin/library_verbs.py
+++ b/src/pocketpaw/tools/builtin/library_verbs.py
@@ -1,11 +1,24 @@
-# library_verbs.py — agent Library verbs (FL-3): tag / move / annotate / search.
+# library_verbs.py — agent Library verbs (FL-3 + FL-4): tag / move / annotate /
+#   search / organize_folder.
 # Created: 2026-07-03 (FL-3) — the single-file verbs that make /files agentic.
+# Updated: 2026-07-03 (FL-4) — added ``organize_folder``, the folder-batch
+#   executor (the Poly headline demo: "add a one-line summary to every file in
+#   this folder"). It fans FL-3's single-file verbs (``annotate`` | ``tag``) over
+#   every file in a folder as SEPARATE metered invocations — it reuses the FL-3
+#   tool internals (``AnnotateFileTool`` / ``TagFileTool``), it does NOT duplicate
+#   their logic. Enumeration is workspace-scoped via ``MongoFileStore.iter_by_workspace``
+#   filtered on ``folder_path``. A hard cap (``max_files``, default 200) bounds the
+#   sweep; over-cap returns a clear count-vs-cap message (never a silent
+#   truncation); the default cap is only raised for an admin scope. Partial
+#   failures are isolated — one file's error is recorded and the batch continues.
 #   Four BaseTool subclasses the agent uses to organize + read the workspace
 #   Library:
 #     - tag_file(file_id, add?, remove?)  → metadata op, journal event
 #     - move_file(file_id, folder_path)   → metadata op, journal event
 #     - annotate_file(file_id, note)      → CONTENT op → new FL-2 version (revertable)
 #     - search_library(query, limit)      → BM25 search over the workspace KB scope
+#   plus the FL-4 batch verb:
+#     - organize_folder(folder_path, action, ...) → fans a verb over a folder
 #   Every verb is workspace-scoped: the workspace/user come from the per-stream
 #   agent identity ContextVars (``current_workspace_id`` / ``current_user_id`` in
 #   ee.cloud.chat.agent_service), so a verb can only ever touch the CURRENT
@@ -55,6 +68,29 @@ def _current_user() -> str | None:
         return current_user_id()
     except ImportError:
         return None
+
+
+def _current_is_admin() -> bool:
+    """True when the active agent stream runs under an admin scope (FL-4).
+
+    Only an admin scope may raise ``organize_folder``'s ``max_files`` above the
+    default cap. The signal is read from ``agent_service.current_is_admin`` when
+    that getter exists; absent it (older EE build, or a community install), the
+    answer is a conservative ``False`` so the default cap always holds. Matches
+    the lazy-import / degrade-gracefully pattern the other ``_current_*`` getters
+    use.
+    """
+    try:
+        from pocketpaw_ee.cloud.chat import agent_service
+
+        getter = getattr(agent_service, "current_is_admin", None)
+        if getter is None:
+            return False
+        return bool(getter())
+    except ImportError:
+        return False
+    except Exception:  # pragma: no cover — a broken getter must not gate the verb
+        return False
 
 
 def _mongo_store():
@@ -423,3 +459,240 @@ class SearchLibraryTool(BaseTool):
         if not context or not context.strip():
             return self._success(f"No Library files matched {query!r}.")
         return self._success(context)
+
+
+# ---------------------------------------------------------------------------
+# organize_folder  (FL-4 — the folder-batch executor)
+# ---------------------------------------------------------------------------
+
+# The default hard cap on a single batch. A folder larger than this returns a
+# clear over-cap message rather than a silent truncation. Only an admin scope
+# (``_current_is_admin``) may raise ``max_files`` above this via the param.
+_DEFAULT_MAX_FILES = 200
+
+
+class OrganizeFolderTool(BaseTool):
+    """Apply an FL-3 verb (annotate | tag) to every file in a folder.
+
+    This is the folder-batch executor: it enumerates the workspace files in one
+    folder and fans the chosen single-file verb over each as a SEPARATE, metered
+    tool invocation (the same ``AnnotateFileTool`` / ``TagFileTool`` the agent
+    calls one-off), bounded by a hard cap and with per-file failure isolation.
+    """
+
+    @property
+    def name(self) -> str:
+        return "organize_folder"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Apply the same action to every file in a Library folder — the batch "
+            "version of the single-file verbs. 'action' is 'annotate' (prepend a "
+            "one-line note to each text file as a revertable version) or 'tag' (add "
+            "tags to each file). For 'annotate' pass 'note'; for 'tag' pass 'add' "
+            "and/or 'remove'. The sweep is capped at "
+            f"{_DEFAULT_MAX_FILES} files (a larger folder is refused, not "
+            "truncated), runs only over the current workspace, and reports a "
+            "per-file result — one file failing does not abort the rest."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        # Mutating, not auto-approved — matches the FL-3 single-file verbs it fans out.
+        return "medium"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "folder_path": {
+                    "type": "string",
+                    "description": "Absolute folder to sweep (e.g. '/reports'). '/' is the root.",
+                },
+                "action": {
+                    "type": "string",
+                    "enum": ["annotate", "tag"],
+                    "description": "The per-file verb to apply: 'annotate' or 'tag'.",
+                },
+                "note": {
+                    "type": "string",
+                    "description": "For action='annotate': the note to prepend to each file.",
+                },
+                "add": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "For action='tag': tags to add to each file.",
+                },
+                "remove": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "For action='tag': tags to remove from each file.",
+                },
+                "max_files": {
+                    "type": "integer",
+                    "description": "Max files to process (default "
+                    f"{_DEFAULT_MAX_FILES}). Raising it above the default requires "
+                    "an admin scope; otherwise it is clamped to the default.",
+                },
+            },
+            "required": ["folder_path", "action"],
+        }
+
+    async def execute(
+        self,
+        folder_path: str,
+        action: str,
+        note: str | None = None,
+        add: list[str] | None = None,
+        remove: list[str] | None = None,
+        max_files: int | None = None,
+    ) -> str:
+        workspace = _current_workspace()
+        if not workspace:
+            return self._error("Library verbs require a workspace context (cloud chat session).")
+
+        store = _mongo_store()
+        if store is None:
+            return self._error("Library is not available (enterprise feature).")
+
+        action = (action or "").strip().lower()
+        if action not in ("annotate", "tag"):
+            return self._error("action must be 'annotate' or 'tag'.")
+
+        # Validate the inner verb's own required args up front so we fail fast
+        # before enumerating (and don't half-run a batch of no-op calls).
+        if action == "annotate":
+            if not note or not note.strip():
+                return self._error("action='annotate' requires a non-empty 'note'.")
+        else:  # tag
+            if not add and not remove:
+                return self._error("action='tag' requires at least one tag in 'add' or 'remove'.")
+
+        # Normalize the folder path the same way move_file / the PATCH route do.
+        try:
+            from pocketpaw_ee.cloud.uploads.paths import normalize_path
+
+            norm = normalize_path(folder_path)
+        except ValueError as e:
+            return self._error(f"Invalid folder path: {e}")
+        except ImportError:
+            return self._error("Library is not available (enterprise feature).")
+
+        # Resolve the effective cap. The default always holds for a normal scope;
+        # only an admin scope may raise it via ``max_files``.
+        effective_cap = _DEFAULT_MAX_FILES
+        if max_files is not None:
+            try:
+                requested = int(max_files)
+            except (TypeError, ValueError):
+                return self._error("max_files must be an integer.")
+            if requested < 1:
+                return self._error("max_files must be at least 1.")
+            if requested > _DEFAULT_MAX_FILES and not _current_is_admin():
+                return self._error(
+                    f"max_files={requested} exceeds the default cap of "
+                    f"{_DEFAULT_MAX_FILES}; only an admin scope may raise it."
+                )
+            effective_cap = requested
+
+        # Enumerate the workspace's files, filter to this folder. iter_by_workspace
+        # is workspace-pinned, so cross-workspace files can never enter the batch.
+        # We read up to (cap + 1) matching rows so we can DETECT over-cap without
+        # loading an unbounded folder into memory.
+        matches: list[dict[str, Any]] = []
+        over_cap = False
+        async for row in store.iter_by_workspace(workspace, limit=10000):
+            fp = (row.get("folder_path") or "/") or "/"
+            if fp != norm:
+                continue
+            if len(matches) >= effective_cap:
+                over_cap = True
+                break
+            matches.append(row)
+
+        if over_cap:
+            return self._error(
+                f"Folder {norm!r} has more than {effective_cap} files, which "
+                f"exceeds the batch cap of {effective_cap}. Narrow the folder or "
+                "ask an admin to raise the cap — the batch was not run to avoid "
+                "silently processing only part of the folder."
+            )
+
+        if not matches:
+            return self._success(f"No files in {norm!r} to {action}.")
+
+        # Fan the FL-3 verb over each file as a separate, metered invocation.
+        # Reuse the FL-3 tool instances rather than re-implementing their logic.
+        annotate_tool = AnnotateFileTool() if action == "annotate" else None
+        tag_tool = TagFileTool() if action == "tag" else None
+
+        ok: list[str] = []
+        failed: list[tuple[str, str]] = []
+        for row in matches:
+            file_id = row.get("file_id")
+            filename = row.get("filename") or file_id
+            if not file_id:
+                continue
+            try:
+                if action == "annotate":
+                    result = await annotate_tool.execute(file_id, note)  # type: ignore[arg-type]
+                else:
+                    result = await tag_tool.execute(file_id, add=add, remove=remove)  # type: ignore[union-attr]
+            except Exception as e:  # one file's crash must not abort the batch
+                logger.warning("organize_folder: %s on %s crashed: %s", action, file_id, e)
+                failed.append((str(filename), f"error: {e}"))
+                continue
+
+            # The inner verbs return a string that starts with a failure marker on
+            # error (BaseTool._error) — treat that as a per-file failure, not a stop.
+            if _looks_like_error(result):
+                failed.append((str(filename), _strip_marker(result)))
+            else:
+                ok.append(str(filename))
+
+        await _emit_library_event(
+            "folder.batch",
+            {
+                "workspace_id": workspace,
+                "folder_path": norm,
+                "action": action,
+                "ok": len(ok),
+                "failed": len(failed),
+                "actor": _current_user() or "agent",
+            },
+        )
+
+        summary = [
+            f"Batch {action} on {norm}: {len(ok)} succeeded, {len(failed)} failed "
+            f"(of {len(matches)} files)."
+        ]
+        if ok:
+            summary.append("Succeeded: " + ", ".join(ok))
+        if failed:
+            summary.append("Failed: " + "; ".join(f"{name} ({reason})" for name, reason in failed))
+        return self._success("\n".join(summary))
+
+
+def _looks_like_error(result: str) -> bool:
+    """Best-effort: does an inner-verb return string signal a failure?
+
+    ``BaseTool._error`` prefixes a stable marker; if that marker moves this
+    degrades to treating everything as success, which is why the batch ALSO
+    catches raised exceptions above — the two guards together keep partial
+    failures isolated.
+    """
+    if not result:
+        return False
+    # ``BaseTool._error`` formats as ``"Error: <message>"``.
+    return result.strip().lower().startswith("error")
+
+
+def _strip_marker(result: str) -> str:
+    """Trim the leading ``Error:`` marker so the per-file reason reads cleanly."""
+    text = (result or "").strip()
+    for marker in ("Error:", "error:"):
+        if text.startswith(marker):
+            return text[len(marker) :].strip()
+    return text

--- a/tests/cloud/test_folder_batch.py
+++ b/tests/cloud/test_folder_batch.py
@@ -1,0 +1,334 @@
+# test_folder_batch.py — FL-4 organize_folder (folder-batch executor) tests.
+# Created: 2026-07-03 (FL-4). Locks the folder-batch executor behaviour:
+#   - batch-annotate over a small folder writes a revertable FL-2 version per
+#     file and returns a per-file summary (the Poly headline demo)
+#   - batch-tag adds tags to every file in the folder
+#   - a folder exceeding max_files returns a clear over-cap message and runs
+#     NOTHING (no silent truncation)
+#   - a non-admin scope cannot raise max_files above the default cap
+#   - one file failing (a binary file for 'annotate') does NOT abort the batch —
+#     the rest still process and the failure is reported per-file
+#   - the sweep is workspace-scoped: files in another workspace / another folder
+#     are never touched
+# Reuses the FL-3 test seam: the workspace is bound via the OSS
+# ``pocketpaw.stores.current_workspace`` ContextVar and the EE user getter is
+# monkeypatched, so no full chat stream is needed. The verb reuses the FL-3
+# AnnotateFileTool / TagFileTool internals, so a passing FL-3 suite underpins
+# these batch assertions.
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import contextmanager
+
+import pytest
+from pocketpaw_ee.cloud.file_versions import service as fv_service
+from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+from pocketpaw.tools.builtin.library_verbs import OrganizeFolderTool
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures (mirrors tests/cloud/test_library_verbs.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    """In-memory StorageAdapter stand-in (put + open over a dict of blobs)."""
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, bytes] = {}
+
+    async def put(self, key: str, stream: AsyncIterator[bytes], mime: str):
+        from pocketpaw.uploads.adapter import StoredObject
+
+        chunks: list[bytes] = []
+        async for chunk in stream:
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        self._blobs[key] = data
+        return StoredObject(key=key, size=len(data), mime=mime)
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        data = self._blobs.get(key)
+        if data is None:
+            raise FileNotFoundError(key)
+        yield data
+
+
+@pytest.fixture
+def fake_storage():
+    """Inject an in-memory StorageAdapter into the file_versions service."""
+    adapter = _FakeAdapter()
+    prev = fv_service._adapter
+    fv_service.set_adapter(adapter)
+    yield adapter
+    fv_service._adapter = prev
+
+
+async def _one_chunk(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
+async def _seed_upload(
+    workspace: str,
+    file_id: str,
+    *,
+    filename: str = "note.txt",
+    mime: str = "text/plain",
+    content: str = "hello world",
+    adapter: _FakeAdapter,
+    folder_path: str = "/",
+) -> FileUpload:
+    """Seed a Library FileUpload row + its blob, bypassing the guarded route."""
+    storage_key = f"editor/{workspace}/{file_id}"
+    await adapter.put(storage_key, _one_chunk(content.encode("utf-8")), mime)
+    doc = FileUpload(
+        file_id=file_id,
+        storage_key=storage_key,
+        filename=filename,
+        mime=mime,
+        size=len(content.encode("utf-8")),
+        workspace=workspace,
+        owner="u1",
+        folder_path=folder_path,
+        content_version=1,
+    )
+    await doc.insert()
+    return doc
+
+
+@contextmanager
+def _workspace(workspace_id: str, user_id: str = "u1", *, is_admin: bool = False):
+    """Bind the OSS current_workspace ContextVar + patch the EE getters.
+
+    The verb reads the workspace from ``pocketpaw.stores.current_workspace``,
+    the user from ``_current_user``, and the admin flag from ``_current_is_admin``.
+    We set the OSS var and monkeypatch the two getters so no chat stream is needed.
+    """
+    import pocketpaw.tools.builtin.library_verbs as lv
+    from pocketpaw.stores import current_workspace
+
+    tok = current_workspace.set(workspace_id)
+    orig_ws = lv._current_workspace
+    orig_user = lv._current_user
+    orig_admin = lv._current_is_admin
+    lv._current_workspace = lambda: current_workspace.get()
+    lv._current_user = lambda: user_id
+    lv._current_is_admin = lambda: is_admin
+    try:
+        yield
+    finally:
+        lv._current_workspace = orig_ws
+        lv._current_user = orig_user
+        lv._current_is_admin = orig_admin
+        current_workspace.reset(tok)
+
+
+@pytest.fixture
+def captured_events(monkeypatch):
+    """Capture every Event emitted via the verbs' journal facade."""
+    events: list = []
+
+    async def _fake_emit(event_type, data):
+        events.append((event_type, data))
+
+    import pocketpaw.tools.builtin.library_verbs as lv
+
+    monkeypatch.setattr(lv, "_emit_library_event", _fake_emit)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# batch annotate — the headline demo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batch_annotate_writes_a_version_per_file(mongo_db, fake_storage, captured_events):
+    # Four text files in /reports, plus one decoy in the root that must be untouched.
+    for i in range(4):
+        await _seed_upload(
+            "w1", f"r{i}", filename=f"r{i}.txt", adapter=fake_storage, folder_path="/reports"
+        )
+    await _seed_upload("w1", "root1", filename="root.txt", adapter=fake_storage, folder_path="/")
+
+    with _workspace("w1"):
+        out = await OrganizeFolderTool().execute("/reports", "annotate", note="one-line summary")
+
+    assert "4 succeeded, 0 failed" in out
+
+    # Each in-folder file got a new revertable version (content_version bumped 1 -> 2).
+    for i in range(4):
+        doc = await FileUpload.find_one({"file_id": f"r{i}", "workspace": "w1"})
+        assert doc.content_version == 2
+        versions = await fv_service.list_versions(_ctx("w1"), f"r{i}")
+        assert len(versions) >= 1  # the pre-annotation blob is archived
+
+    # The decoy outside the folder is untouched.
+    decoy = await FileUpload.find_one({"file_id": "root1", "workspace": "w1"})
+    assert decoy.content_version == 1
+
+    # A single batch event summarizes the run.
+    assert captured_events[-1][0] == "folder.batch"
+    assert captured_events[-1][1]["ok"] == 4
+    assert captured_events[-1][1]["failed"] == 0
+
+
+def _ctx(workspace: str):
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id="u1",
+        workspace_id=workspace,
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_tag_adds_to_every_file(mongo_db, fake_storage, captured_events):
+    for i in range(3):
+        await _seed_upload(
+            "w1", f"t{i}", filename=f"t{i}.txt", adapter=fake_storage, folder_path="/inbox"
+        )
+
+    with _workspace("w1"):
+        out = await OrganizeFolderTool().execute("/inbox", "tag", add=["reviewed"])
+
+    assert "3 succeeded, 0 failed" in out
+    for i in range(3):
+        doc = await FileUpload.find_one({"file_id": f"t{i}", "workspace": "w1"})
+        assert "reviewed" in (doc.tags or [])
+
+
+# ---------------------------------------------------------------------------
+# cap — over-cap refuses, no silent truncation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_over_cap_refuses_without_truncation(mongo_db, fake_storage, captured_events):
+    # Seed 5 files; force a cap of 3 (a normal scope may LOWER the cap freely).
+    for i in range(5):
+        await _seed_upload(
+            "w1", f"c{i}", filename=f"c{i}.txt", adapter=fake_storage, folder_path="/big"
+        )
+
+    with _workspace("w1"):
+        out = await OrganizeFolderTool().execute("/big", "tag", add=["x"], max_files=3)
+
+    lowered = out.lower()
+    assert "exceeds" in lowered or "more than" in lowered
+    assert "3" in out  # names the cap
+
+    # Nothing was tagged — the batch did not run at all.
+    for i in range(5):
+        doc = await FileUpload.find_one({"file_id": f"c{i}", "workspace": "w1"})
+        assert doc.tags == []
+    # No batch-completion event was emitted for the refused run.
+    assert all(evt[0] != "folder.batch" for evt in captured_events)
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_raise_cap(mongo_db, fake_storage, captured_events):
+    with _workspace("w1", is_admin=False):
+        out = await OrganizeFolderTool().execute("/x", "tag", add=["y"], max_files=500)
+    assert "admin" in out.lower()
+    assert "500" in out
+
+
+@pytest.mark.asyncio
+async def test_admin_may_raise_cap(mongo_db, fake_storage, captured_events):
+    # With admin scope, a max_files above the default is accepted (empty folder ⇒
+    # a clean "nothing to do", proving the cap check did not reject the request).
+    with _workspace("w1", is_admin=True):
+        out = await OrganizeFolderTool().execute("/empty", "tag", add=["y"], max_files=500)
+    assert "no files" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# partial-failure isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_does_not_abort_batch(mongo_db, fake_storage, captured_events):
+    # Two annotatable text files + one binary file (annotate → 422 not_editable).
+    await _seed_upload("w1", "ok1", filename="a.txt", adapter=fake_storage, folder_path="/mix")
+    await _seed_upload(
+        "w1",
+        "bad",
+        filename="pic.png",
+        mime="image/png",
+        content="\x89PNGbinary",
+        adapter=fake_storage,
+        folder_path="/mix",
+    )
+    await _seed_upload("w1", "ok2", filename="b.txt", adapter=fake_storage, folder_path="/mix")
+
+    with _workspace("w1"):
+        out = await OrganizeFolderTool().execute("/mix", "annotate", note="summary")
+
+    # 2 of 3 succeeded; the binary file is reported as failed, not fatal.
+    assert "2 succeeded, 1 failed" in out
+    assert "pic.png" in out
+
+    # Both text files still got their new version despite the middle file failing.
+    for fid in ("ok1", "ok2"):
+        doc = await FileUpload.find_one({"file_id": fid, "workspace": "w1"})
+        assert doc.content_version == 2
+    # The binary file was left at its original version.
+    bad = await FileUpload.find_one({"file_id": "bad", "workspace": "w1"})
+    assert bad.content_version == 1
+
+    assert captured_events[-1][1]["ok"] == 2
+    assert captured_events[-1][1]["failed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# workspace isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_workspace_files_not_touched(mongo_db, fake_storage, captured_events):
+    # Same folder path, two workspaces. A batch in wA must never touch wB's file.
+    await _seed_upload("wA", "a1", filename="a.txt", adapter=fake_storage, folder_path="/shared")
+    await _seed_upload("wB", "b1", filename="b.txt", adapter=fake_storage, folder_path="/shared")
+
+    with _workspace("wA"):
+        out = await OrganizeFolderTool().execute("/shared", "tag", add=["done"])
+
+    assert "1 succeeded" in out
+    a = await FileUpload.find_one({"file_id": "a1", "workspace": "wA"})
+    assert "done" in (a.tags or [])
+    b = await FileUpload.find_one({"file_id": "b1", "workspace": "wB"})
+    assert b.tags == []  # untouched
+
+
+# ---------------------------------------------------------------------------
+# arg validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotate_requires_note(mongo_db, fake_storage):
+    with _workspace("w1"):
+        out = await OrganizeFolderTool().execute("/x", "annotate")
+    assert "note" in out.lower()
+
+
+@pytest.mark.asyncio
+async def test_tag_requires_a_tag(mongo_db, fake_storage):
+    with _workspace("w1"):
+        out = await OrganizeFolderTool().execute("/x", "tag")
+    assert "tag" in out.lower()
+
+
+@pytest.mark.asyncio
+async def test_bad_action_rejected(mongo_db, fake_storage):
+    with _workspace("w1"):
+        out = await OrganizeFolderTool().execute("/x", "delete")
+    assert "annotate" in out.lower() and "tag" in out.lower()


### PR DESCRIPTION
The folder-batch executor — the headline Poly-style demo (FL-4): "add a one-line summary to every file in this folder," run as capped, metered, revertable operations.

**Stacked on #1625 (FL-16)** — base is `feat/files-editor-library-bridge`; the diff here is only FL-4's changes.

## What ships

`organize_folder` — a builtin tool that fans out FL-3's single-file verbs (`annotate` / `tag`) over every file in a folder:

- Enumerates the folder's files workspace-scoped, applies the inner verb to each as a **separate metered invocation** (reuses FL-3 internals, no duplication).
- **Hard cap `max_files` (default 200).** Over the cap, it refuses with a clear count-vs-cap message and runs nothing — no silent truncation.
- **Partial-failure isolation:** one file's error doesn't abort the batch; per-file results are collected and a `folder.batch` summary is emitted.
- Annotations write revertable versions (via FL-3 → FL-2), so a batch is undoable file-by-file.

Registered in `_EE_TOOLS`, trust level `medium` (mutating, not auto-approved).

## Tests

`test_folder_batch.py` (10) + FL-3/versions regression → 41 passed. Covers: cap refusal with zero side effects, admin-may-raise / non-admin-cannot, partial failure (2 text succeed + 1 binary fails → both text reach v2, binary untouched), and cross-workspace isolation. `lint-imports` root + ee → 0 broken.

## Follow-ups (flagged, not guessed)

- **Admin cap-raise is dormant** until EE wires a `current_is_admin` marker into `attach_agent_identity` — there's no admin ContextVar today, so `_current_is_admin()` reads an optional getter and defaults to `False`. The default 200 cap works for everyone now; the raise path is implemented and tested against that seam but won't unlock until EE provides the marker. No fake API was committed.
- Over-cap detection scans up to 10000 workspace rows; a folder-scoped query would be cleaner if libraries grow very large.
