### PR TITLE
feat(files): document, slides, and spreadsheet edit tools (port #1193)

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
@@ -27,6 +27,21 @@
 #   un-discriminated consumers keep working byte-for-byte and the
 #   coarse ``PocketUpdated`` realtime event remains the refetch fallback
 #   for clients that ignore ``kind`` entirely.
+# Changes: 2026-07-03 (FL-5, port of dewani12's #1193) — added the
+#   ``editor_blocks`` / ``spreadsheet_snapshot`` / ``slides_data`` transport
+#   carriers: when a chat is scoped to an open file editor, the client attaches
+#   the current Editor.js blocks / Univer snapshot / reveal.js deck so the agent
+#   can round-trip a structural edit. In #1193 the (now-removed) inline
+#   ``_run_agent_stream`` injected these into the agent's system prompt via
+#   ``build_*_prompt_context`` before running the agent inline. On current dev the
+#   chat run path is a ``RunSpec`` submitted to an out-of-process executor, so the
+#   router-time prompt injection has no counterpart yet — these fields are the
+#   minimal transport shim (they parse + round-trip on the request); threading
+#   them through ``RunSpec`` → executor → worker prompt assembly is a follow-up.
+#   The primary FL-5 editor round-trip today runs through the REST ai-edit +
+#   ``*-context`` routes on the file_versions router (which still use the inline
+#   ``pool.run`` path) and the registered ``EditDocumentTool`` family (which edit
+#   a Library file by id and write a revertable version).
 """Request and SSE-event payload schemas for the enterprise agent chat endpoint.
 
 The endpoint lives at ``POST /cloud/chat/{scope}/{scope_id}/agent`` and streams
@@ -89,6 +104,19 @@ class CloudAgentChatRequest(BaseModel):
     # / etc. Validated downstream by ``SurfaceMetaRequest``; unknown
     # fields are dropped. ``None`` is treated as an empty dict.
     surface_meta: dict[str, Any] | None = None
+    # FL-5 file-editor transport carriers (port of #1193). Set by the client when
+    # the chat is scoped to an open file editor so the agent can round-trip a
+    # structural edit. See the module docstring note: on current dev these carry
+    # on the request but are not yet threaded into the out-of-process run prompt
+    # (a follow-up); the working editor round-trip runs through the REST ai-edit
+    # routes and the registered edit_* tools.
+    #
+    # Editor.js blocks from an open document editor.
+    editor_blocks: list[dict[str, Any]] | None = None
+    # Univer workbook snapshot from an open spreadsheet editor.
+    spreadsheet_snapshot: dict[str, Any] | None = None
+    # reveal.js deck JSON from an open slides editor.
+    slides_data: dict[str, Any] | None = None
 
     @field_validator("intent")
     @classmethod

--- a/ee/pocketpaw_ee/cloud/file_versions/dto.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/dto.py
@@ -10,6 +10,13 @@
 # Updated: 2026-07-03 (FL-2, port of #1193) — restored DiffResponse (the
 #   unified-diff transport DTO ART-1 deferred), now that the diff/revert history
 #   helpers land in the service.
+# Updated: 2026-07-03 (FL-5, port of #1193) — restored the document editor
+#   transport DTOs ART-1 deferred: ``AiEditRequest`` / ``AiEditResponse`` (the
+#   POST /files/{id}/ai-edit body + reply) and ``SyncEditingContextRequest`` (the
+#   PUT /files/{id}/editing-context body), now that the ai-edit + editing-context
+#   routes land on the router. The slides/spreadsheet edit DTOs already live in
+#   ``slides_dto`` / ``spreadsheet_dto`` (brought by FL-2). Pure transport, no
+#   Beanie — the "FileVersions" import-linter contract still holds.
 """FileVersions DTOs — request/response schemas for the file-version API."""
 
 from __future__ import annotations
@@ -99,3 +106,27 @@ class FileVersionResponse(BaseModel):
     created_at: datetime = Field(alias="createdAt")
 
     model_config = {"populate_by_name": True}
+
+
+class AiEditRequest(BaseModel):
+    """Request body for POST /files/{id}/ai-edit (Editor.js document)."""
+
+    content: str = Field(min_length=0)  # full document content (Editor.js JSON)
+    prompt: str = Field(min_length=1)  # what the user wants the AI to do
+    selected_block_id: str | None = Field(default=None, alias="selectedBlockId")
+    available_tools: list[str] = Field(default_factory=list, alias="availableTools")
+
+    model_config = {"populate_by_name": True}
+
+
+class AiEditResponse(BaseModel):
+    """AI-edited document blocks returned to the frontend."""
+
+    blocks: list[dict]  # updated Editor.js blocks array
+    summary: str = ""  # human-readable summary of changes
+
+
+class SyncEditingContextRequest(BaseModel):
+    """Request body for PUT /files/{id}/editing-context."""
+
+    blocks: list[dict]

--- a/ee/pocketpaw_ee/cloud/file_versions/router.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/router.py
@@ -14,25 +14,61 @@
 #   AI-edit / editing-context routes remain deferred (they pull in FL-5 tool
 #   deps). Doc note: a stale If-Match now maps to 412 (PreconditionFailed),
 #   not 409.
+# Updated: 2026-07-03 (FL-5, port of #1193) — restored the AI-edit + context-sync
+#   editor routes ART-1/FL-2 deferred, now that the FL-5 edit tools land:
+#     - POST /files/{id}/ai-edit            (document AI edit)
+#     - PUT/GET /files/{id}/editing-context (sync/read Editor.js blocks)
+#     - POST /files/{id}/spreadsheet-edit   (workbook AI edit)
+#     - PUT/GET /files/{id}/spreadsheet-context
+#     - POST /files/{id}/slides-edit        (deck AI edit)
+#     - PUT/GET /files/{id}/slides-context
+#   The *-edit routes run the workspace's default agent inline via
+#   ``pocketpaw.agents.pool`` with the edit tool's in-memory session-store bound,
+#   so the ``edit_*`` MCP tool mutates the parsed blocks/deck/snapshot; the final
+#   state returns to the frontend, which persists it via ``PUT /files/{id}`` (a
+#   versioned write). The *-context routes are the ``editor_blocks`` /
+#   spreadsheet / slides transport round-trip: PUT stores the frontend's current
+#   state in the module store, GET reads it back (possibly mutated by a
+#   chat-initiated edit). These routes read the caller's ``current_user_id`` /
+#   ``current_workspace_id`` deps (dewani's #1193 signature) rather than the
+#   ``request_context`` the core write routes use — they run the agent, which
+#   needs the identity, not a RequestContext.
 """FileVersions router — file-version write + history API."""
 
 from __future__ import annotations
 
+import json
+
 from fastapi import APIRouter, Depends, Header
+from fastapi.responses import JSONResponse
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import BadRequest
 from pocketpaw_ee.cloud.file_versions import service as _svc
 from pocketpaw_ee.cloud.file_versions.dto import (
+    AiEditRequest,
+    AiEditResponse,
     DiffResponse,
     FileVersionListItem,
     FileVersionResponse,
+    SyncEditingContextRequest,
     UpdateFileContentRequest,
     UpdateFileContentResponse,
     WriteFileRequest,
     WriteFileResponse,
 )
+from pocketpaw_ee.cloud.file_versions.slides_dto import (
+    SlidesEditRequest,
+    SlidesEditResponse,
+    SyncSlidesContextRequest,
+)
+from pocketpaw_ee.cloud.file_versions.spreadsheet_dto import (
+    SpreadsheetEditRequest,
+    SpreadsheetEditResponse,
+    SyncSpreadsheetContextRequest,
+)
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
 
 router = APIRouter(
     prefix="/files",
@@ -130,3 +166,452 @@ async def diff_file_versions(
     never span a workspace boundary (a cross-workspace id is a 404).
     """
     return await _svc.diff_versions(ctx, file_id, from_version_id, to_version_id)
+
+
+# ===========================================================================
+# AI-edit + context-sync editor routes (FL-5, port of #1193)
+#
+# These run the workspace's default agent inline via ``pocketpaw.agents.pool``
+# with the relevant edit tool's in-memory session store bound, so the ``edit_*``
+# MCP tool mutates the parsed blocks/deck/snapshot; the final state returns to the
+# frontend (which persists it via ``PUT /files/{id}``, a versioned write). The
+# *-context routes are the transport round-trip: PUT stores the frontend's
+# current state, GET reads it back.
+# ===========================================================================
+
+
+async def _resolve_default_agent(workspace_id: str) -> str | None:
+    """The workspace's default (first) agent id, or None when it has none."""
+    from pocketpaw_ee.cloud.agents import service as agents_service
+
+    agents = await agents_service.list_agents(workspace_id)
+    return agents[0].id if agents else None
+
+
+# --- document -------------------------------------------------------------
+
+
+def _build_edit_system_prompt(
+    blocks: list[dict],
+    available_tools: list[str],
+    selected_block_id: str | None,
+    user_prompt: str,
+) -> str:
+    """Delegate to the canonical prompt builder so chat + REST share the format."""
+    from pocketpaw.tools.builtin.edit_document import build_editor_prompt_context
+
+    ctx = build_editor_prompt_context(
+        blocks=blocks,
+        available_tools=available_tools,
+        selected_block_id=selected_block_id,
+    )
+    if ctx is None:
+        ctx = (
+            "The document is currently empty (no blocks). "
+            "Use the edit_document tool to insert the first blocks."
+        )
+    return (
+        f"{ctx}\n\nThe user's request: {user_prompt}\n\n"
+        "After making your edits, briefly tell the user what you changed."
+    )
+
+
+@router.post("/{file_id}/ai-edit")
+async def ai_edit_file(
+    file_id: str,
+    body: AiEditRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Run an AI agent to edit document content.
+
+    Parses Editor.js blocks, stores them in a per-request ContextVar so the
+    ``edit_document`` MCP tool can access them, and runs the workspace's default
+    agent. Returns the final blocks array to the frontend.
+    """
+    try:
+        doc = json.loads(body.content) if body.content and body.content.strip() else {}
+        blocks: list[dict] = doc.get("blocks", []) if isinstance(doc, dict) else []
+    except (json.JSONDecodeError, TypeError):
+        blocks = []
+
+    # Deep-copy so the ContextVar stores a mutable list independent of the parse.
+    blocks = [json.loads(json.dumps(b)) for b in blocks]
+
+    system_prompt = _build_edit_system_prompt(
+        blocks=blocks,
+        available_tools=body.available_tools,
+        selected_block_id=body.selected_block_id,
+        user_prompt=body.prompt,
+    )
+
+    from pocketpaw.tools.builtin.edit_document import (
+        clear_edit_session,
+        clear_selected_block_id,
+        set_edit_session,
+        set_editor_blocks,
+        set_selected_block_id,
+    )
+
+    set_edit_session(blocks)
+    set_editor_blocks(file_id, blocks)
+    set_selected_block_id(body.selected_block_id)
+
+    try:
+        from pocketpaw.agents.pool import get_agent_pool
+
+        pool = get_agent_pool()
+        agent_id = await _resolve_default_agent(workspace_id)
+        if not agent_id:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "detail": "ai_edit.no_agent",
+                    "message": "No agent available in this workspace.",
+                },
+            )
+
+        session_key = f"cloud:file-edit:{file_id}:{agent_id}"
+        summary_parts: list[str] = []
+
+        async for event in pool.run(
+            agent_id,
+            body.prompt,
+            session_key,
+            knowledge_context=system_prompt,
+        ):
+            if event.type == "message":
+                summary_parts.append(str(event.content))
+            elif event.type == "error":
+                return JSONResponse(
+                    status_code=500,
+                    content={"detail": "ai_edit.agent_error", "message": str(event.content)},
+                )
+            elif event.type == "done":
+                break
+
+        return JSONResponse(
+            content=AiEditResponse(
+                blocks=blocks,
+                summary="".join(summary_parts).strip() or "Document edited.",
+            ).model_dump(by_alias=True)
+        )
+    except Exception as exc:
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "ai_edit.failed", "message": str(exc)},
+        )
+    finally:
+        clear_edit_session()
+        clear_selected_block_id()
+
+
+@router.put("/{file_id}/editing-context")
+async def sync_editing_context(
+    file_id: str,
+    body: SyncEditingContextRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Store the current Editor.js blocks so the chat agent's MCP tool can
+    access them during chat-initiated editing."""
+    from pocketpaw.tools.builtin.edit_document import set_editor_blocks
+
+    set_editor_blocks(file_id, body.blocks)
+    return JSONResponse(status_code=200, content={"ok": True})
+
+
+@router.get("/{file_id}/editing-context")
+async def get_editing_context(
+    file_id: str,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Return the current blocks for a file (may have been mutated by the
+    edit_document MCP tool during a chat session)."""
+    from pocketpaw.tools.builtin.edit_document import get_editor_blocks
+
+    blocks = get_editor_blocks(file_id)
+    if blocks is None:
+        return JSONResponse(status_code=404, content={"detail": "No editing session active."})
+    return JSONResponse(status_code=200, content={"blocks": blocks})
+
+
+# --- spreadsheet ----------------------------------------------------------
+
+
+def _build_spreadsheet_system_prompt(
+    snapshot: dict,
+    selected_sheet: str | None,
+    user_prompt: str,
+) -> str:
+    """Build the system prompt for spreadsheet AI editing."""
+    from pocketpaw.tools.builtin.edit_spreadsheet import build_spreadsheet_prompt_context
+
+    ctx = build_spreadsheet_prompt_context(snapshot=snapshot, selected_sheet=selected_sheet)
+    if ctx is None:
+        ctx = (
+            "The workbook is currently empty (no sheets). "
+            "Use the edit_spreadsheet tool to create the first sheet and populate it."
+        )
+    return (
+        f"{ctx}\n\nThe user's request: {user_prompt}\n\n"
+        "After making your edits, briefly tell the user what you changed."
+    )
+
+
+@router.post("/{file_id}/spreadsheet-edit")
+async def spreadsheet_ai_edit(
+    file_id: str,
+    body: SpreadsheetEditRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Run an AI agent to edit spreadsheet content. Returns the final snapshot."""
+    try:
+        snapshot = json.loads(body.content) if body.content and body.content.strip() else {}
+        if not isinstance(snapshot, dict):
+            snapshot = {}
+    except (json.JSONDecodeError, TypeError):
+        snapshot = {}
+
+    snapshot = json.loads(json.dumps(snapshot))
+
+    system_prompt = _build_spreadsheet_system_prompt(
+        snapshot=snapshot,
+        selected_sheet=body.selected_sheet,
+        user_prompt=body.prompt,
+    )
+
+    from pocketpaw.tools.builtin.edit_spreadsheet import (
+        clear_edit_session,
+        clear_selected_sheet,
+        set_edit_session,
+        set_selected_sheet,
+        set_spreadsheet_snapshot,
+    )
+
+    set_edit_session(snapshot)
+    set_spreadsheet_snapshot(file_id, snapshot)
+    set_selected_sheet(body.selected_sheet)
+
+    try:
+        from pocketpaw.agents.pool import get_agent_pool
+
+        pool = get_agent_pool()
+        agent_id = await _resolve_default_agent(workspace_id)
+        if not agent_id:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "detail": "spreadsheet_edit.no_agent",
+                    "message": "No agent available in this workspace.",
+                },
+            )
+
+        session_key = f"cloud:spreadsheet-edit:{file_id}:{agent_id}"
+        summary_parts: list[str] = []
+
+        async for event in pool.run(
+            agent_id,
+            body.prompt,
+            session_key,
+            knowledge_context=system_prompt,
+        ):
+            if event.type == "message":
+                summary_parts.append(str(event.content))
+            elif event.type == "error":
+                return JSONResponse(
+                    status_code=500,
+                    content={"detail": "spreadsheet_edit.agent_error", "message": str(event.content)},
+                )
+            elif event.type == "done":
+                break
+
+        return JSONResponse(
+            content=SpreadsheetEditResponse(
+                snapshot=snapshot,
+                summary="".join(summary_parts).strip() or "Spreadsheet edited.",
+            ).model_dump(by_alias=True)
+        )
+    except Exception as exc:
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "spreadsheet_edit.failed", "message": str(exc)},
+        )
+    finally:
+        clear_edit_session()
+        clear_selected_sheet()
+
+
+@router.put("/{file_id}/spreadsheet-context")
+async def sync_spreadsheet_context(
+    file_id: str,
+    body: SyncSpreadsheetContextRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Store the current workbook snapshot for chat-initiated spreadsheet editing."""
+    from pocketpaw.tools.builtin.edit_spreadsheet import (
+        set_selected_sheet,
+        set_spreadsheet_snapshot,
+    )
+
+    set_spreadsheet_snapshot(file_id, body.snapshot)
+    if body.selected_sheet:
+        set_selected_sheet(body.selected_sheet)
+    return JSONResponse(status_code=200, content={"ok": True})
+
+
+@router.get("/{file_id}/spreadsheet-context")
+async def get_spreadsheet_context(
+    file_id: str,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Return the current workbook snapshot (may have been mutated by a chat edit)."""
+    from pocketpaw.tools.builtin.edit_spreadsheet import get_spreadsheet_snapshot
+
+    snapshot = get_spreadsheet_snapshot(file_id)
+    if snapshot is None:
+        return JSONResponse(
+            status_code=404, content={"detail": "No spreadsheet editing session active."}
+        )
+    return JSONResponse(status_code=200, content={"snapshot": snapshot})
+
+
+# --- slides ---------------------------------------------------------------
+
+
+def _build_slides_system_prompt(
+    deck: dict,
+    selected_slide_id: str | None,
+    user_prompt: str,
+) -> str:
+    """Build the system prompt for slides AI editing."""
+    from pocketpaw.tools.builtin.edit_slides import build_slides_prompt_context
+
+    ctx = build_slides_prompt_context(deck=deck, selected_slide_id=selected_slide_id)
+    if ctx is None:
+        ctx = (
+            "The slide deck is currently empty (no slides). "
+            "Use the edit_slides tool to create slides and populate them."
+        )
+    return (
+        f"{ctx}\n\nThe user's request: {user_prompt}\n\n"
+        "After making your edits, briefly tell the user what you changed."
+    )
+
+
+@router.post("/{file_id}/slides-edit")
+async def slides_ai_edit(
+    file_id: str,
+    body: SlidesEditRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Run an AI agent to edit slides content. Returns the final deck."""
+    deck: dict = body.content if isinstance(body.content, dict) else {}
+    deck = json.loads(json.dumps(deck))
+
+    system_prompt = _build_slides_system_prompt(
+        deck=deck,
+        selected_slide_id=body.selected_slide_id,
+        user_prompt=body.prompt,
+    )
+
+    from pocketpaw.tools.builtin.edit_slides import (
+        clear_edit_session,
+        clear_selected_slide_id,
+        set_edit_session,
+        set_selected_slide_id,
+        set_slides_data,
+    )
+
+    set_edit_session(deck)
+    set_slides_data(file_id, deck)
+    set_selected_slide_id(body.selected_slide_id)
+
+    try:
+        from pocketpaw.agents.pool import get_agent_pool
+
+        pool = get_agent_pool()
+        agent_id = await _resolve_default_agent(workspace_id)
+        if not agent_id:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "detail": "slides_edit.no_agent",
+                    "message": "No agent available in this workspace.",
+                },
+            )
+
+        session_key = f"cloud:slides-edit:{file_id}:{agent_id}"
+        summary_parts: list[str] = []
+
+        async for event in pool.run(
+            agent_id,
+            body.prompt,
+            session_key,
+            knowledge_context=system_prompt,
+        ):
+            if event.type == "message":
+                summary_parts.append(str(event.content))
+            elif event.type == "error":
+                return JSONResponse(
+                    status_code=500,
+                    content={"detail": "slides_edit.agent_error", "message": str(event.content)},
+                )
+            elif event.type == "done":
+                break
+
+        return JSONResponse(
+            content=SlidesEditResponse(
+                content=deck,
+                summary="".join(summary_parts).strip() or "Slides edited.",
+            ).model_dump(by_alias=True)
+        )
+    except Exception as exc:
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "slides_edit.failed", "message": str(exc)},
+        )
+    finally:
+        clear_edit_session()
+        clear_selected_slide_id()
+
+
+@router.put("/{file_id}/slides-context")
+async def sync_slides_context(
+    file_id: str,
+    body: SyncSlidesContextRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Store the current slides deck for chat-initiated slides editing."""
+    from pocketpaw.tools.builtin.edit_slides import (
+        set_selected_slide_id,
+        set_slides_data,
+    )
+
+    set_slides_data(file_id, body.content)
+    if body.selected_slide_id:
+        set_selected_slide_id(body.selected_slide_id)
+    return JSONResponse(status_code=200, content={"ok": True})
+
+
+@router.get("/{file_id}/slides-context")
+async def get_slides_context(
+    file_id: str,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Return the current slides deck (may have been mutated by a chat edit)."""
+    from pocketpaw.tools.builtin.edit_slides import get_slides_data
+
+    deck = get_slides_data(file_id)
+    if deck is None:
+        return JSONResponse(
+            status_code=404, content={"detail": "No slides editing session active."}
+        )
+    return JSONResponse(status_code=200, content={"content": deck})

--- a/ee/pocketpaw_ee/cloud/file_versions/service.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/service.py
@@ -56,6 +56,17 @@
 #   this module (the import-linter "FileVersions" contract) — the agent tool
 #   never touches the Beanie doc directly. Tenant-filtered: the ``FileUpload``
 #   lookup and every ``FileVersionDoc`` read/write pins ``workspace_id``.
+# Updated: 2026-07-03 (FL-5, structural edit tools — port of dewani12's #1193)
+#   — added ``read_current_content``: the read half the FL-5 edit tools
+#   (edit_document / edit_slides / edit_spreadsheet) need to load a file's
+#   CURRENT text so they can apply structural block/deck/workbook operations and
+#   write the mutated result back through ``update_file_content`` (editor_kind
+#   ="agent"), so every structural edit lands as a NEW revertable version. It
+#   resolves BOTH id schemes via ``_resolve_upload`` (editor-namespaced id, then
+#   Library bare id) and reads the live blob through the shared adapter, keeping
+#   the FL-5 tools off the Beanie doc + storage adapter directly. Tenant-safe:
+#   the ``_resolve_upload`` lookup pins ``workspace_id``, so a cross-workspace
+#   file_id fails closed (NotFound).
 """FileVersions service — file-version write + history.
 
 Module-level ``async def`` functions. Sole owner of writes to the
@@ -513,6 +524,57 @@ async def update_file_content(
         size_bytes=new_size,
         content_hash=new_hash,
     )
+
+
+async def read_current_content(
+    ctx: RequestContext,
+    file_id: str,
+) -> str:
+    """Return a file's CURRENT live text content (FL-5 read half).
+
+    The structural edit tools (edit_document / edit_slides / edit_spreadsheet)
+    load the current content, apply their block/deck/workbook operations, then
+    write the result back via ``update_file_content`` so the edit archives as a
+    new revertable version. This is the read they need.
+
+    Resolves BOTH id schemes via ``_resolve_upload`` (the editor's
+    ``${workspace}:${path}`` id first, then a Library row's own bare ``file_id``)
+    and reads the live blob through the shared adapter — the FL-5 tools never
+    touch the Beanie doc or the adapter directly (import-linter "FileVersions"
+    contract). Tenant-filtered: ``_resolve_upload`` pins ``workspace_id``, so a
+    cross-workspace ``file_id`` raises ``NotFound``. A non-editable mime raises
+    422 (the same guard the write path uses).
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
+    doc = await _resolve_upload(workspace_id, file_id)
+    if not doc:
+        raise NotFound("file", file_id)
+
+    if not _is_editable(doc.mime):
+        raise CloudError(
+            422,
+            "files.not_editable",
+            f"File type '{doc.mime}' cannot be edited inline.",
+        )
+
+    adapter = _get_storage()
+    try:
+        return await _read_text(adapter, doc.storage_key)
+    except Exception as exc:
+        logger.error(
+            "read_current_content %s: cannot read blob %r: %s",
+            file_id,
+            doc.storage_key,
+            exc,
+        )
+        raise CloudError(
+            500,
+            "files.read_failed",
+            "Could not read the file's current content.",
+        ) from exc
 
 
 async def list_versions(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -561,4 +561,26 @@ ignore_imports = [
     "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud._core.realtime.events",
     "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud.file_versions.service",
     "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud.agents.knowledge",
+    # FL-5 structural edit tools (port of dewani12's #1193): the edit_document /
+    # edit_slides / edit_spreadsheet tools live in the OSS builtin tools package
+    # (registered via _EE_TOOLS, guarded by ee/ availability) but edit a cloud
+    # Library file through the FL-2 file_versions service. Same lazy try/except
+    # runtime-import pattern as the FL-3 verbs above: the module top-level imports
+    # only OSS (pocketpaw.tools.protocol); a community install degrades to an
+    # "enterprise feature" message.
+    "pocketpaw.tools.builtin.edit_document -> pocketpaw_ee.cloud.chat.agent_service",
+    "pocketpaw.tools.builtin.edit_document -> pocketpaw_ee.cloud._core.context",
+    "pocketpaw.tools.builtin.edit_document -> pocketpaw_ee.cloud._core.errors",
+    "pocketpaw.tools.builtin.edit_document -> pocketpaw_ee.cloud.file_versions.service",
+    "pocketpaw.tools.builtin.edit_document -> pocketpaw_ee.cloud.file_versions.dto",
+    "pocketpaw.tools.builtin.edit_slides -> pocketpaw_ee.cloud.chat.agent_service",
+    "pocketpaw.tools.builtin.edit_slides -> pocketpaw_ee.cloud._core.context",
+    "pocketpaw.tools.builtin.edit_slides -> pocketpaw_ee.cloud._core.errors",
+    "pocketpaw.tools.builtin.edit_slides -> pocketpaw_ee.cloud.file_versions.service",
+    "pocketpaw.tools.builtin.edit_slides -> pocketpaw_ee.cloud.file_versions.dto",
+    "pocketpaw.tools.builtin.edit_spreadsheet -> pocketpaw_ee.cloud.chat.agent_service",
+    "pocketpaw.tools.builtin.edit_spreadsheet -> pocketpaw_ee.cloud._core.context",
+    "pocketpaw.tools.builtin.edit_spreadsheet -> pocketpaw_ee.cloud._core.errors",
+    "pocketpaw.tools.builtin.edit_spreadsheet -> pocketpaw_ee.cloud.file_versions.service",
+    "pocketpaw.tools.builtin.edit_spreadsheet -> pocketpaw_ee.cloud.file_versions.dto",
 ]

--- a/src/pocketpaw/tools/builtin/__init__.py
+++ b/src/pocketpaw/tools/builtin/__init__.py
@@ -20,6 +20,13 @@
 #   - 2026-07-03: Added FL-4 OrganizeFolderTool (EE) — the folder-batch executor
 #     that fans an FL-3 verb (annotate | tag) over every file in a folder as
 #     separate metered invocations, capped + partial-failure isolated.
+#   - 2026-07-03: Added FL-5 structural edit tools (EE, port of dewani12's #1193)
+#     — EditDocumentTool / EditSlidesTool / EditSpreadsheetTool. Each edits a
+#     Library file by id (Editor.js document / reveal.js deck / Univer workbook),
+#     applies structural block/deck/cell operations, and writes the result back
+#     through file_versions.service.update_file_content so every edit lands as a
+#     new revertable version. Registered in _EE_TOOLS at trust_level "medium"
+#     (mutating, matching the FL-3 verbs).
 
 import importlib as _importlib
 
@@ -106,6 +113,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
 
 # Enterprise tools (require ee/ module) — guarded so community installs don't break.
 try:
+    from pocketpaw.tools.builtin.edit_document import EditDocumentTool
+    from pocketpaw.tools.builtin.edit_slides import EditSlidesTool
+    from pocketpaw.tools.builtin.edit_spreadsheet import EditSpreadsheetTool
     from pocketpaw.tools.builtin.fabric_tools import (
         FabricCreateTool,
         FabricQueryTool,
@@ -140,6 +150,11 @@ try:
         SearchLibraryTool,
         # FL-4 — folder-batch executor (fans an FL-3 verb over a folder).
         OrganizeFolderTool,
+        # FL-5 — structural edit tools (port of dewani12's #1193). Each edits a
+        # Library file by id + writes a revertable FL-2 version.
+        EditDocumentTool,
+        EditSlidesTool,
+        EditSpreadsheetTool,
     ]
     _EE_NAMES = {cls.__name__: cls for cls in _EE_TOOLS}
 except ImportError:

--- a/src/pocketpaw/tools/builtin/edit_document.py
+++ b/src/pocketpaw/tools/builtin/edit_document.py
@@ -1,0 +1,850 @@
+# edit_document.py — FL-5 structural document editing (port of dewani12's #1193).
+# Created: 2026-07-03 (FL-5, port of dewani12's origin/feature/files
+#   src/pocketpaw/tools/builtin/edit_document.py). Credit: dewani12 authored the
+#   Editor.js block operation engine, the normalization helpers, the prompt-context
+#   builder, the module-store transport, and the in-process MCP server — all ported
+#   here verbatim (adapted only for imports on current dev).
+#
+# WHAT THIS MODULE PROVIDES (three cooperating surfaces):
+#   1. ``apply_operations`` + ``_normalize_block`` + ``build_editor_prompt_context``
+#      — pure, side-effect-free operation engine over an Editor.js block list.
+#      Ported verbatim from #1193; the reusable, unit-testable core.
+#   2. Module-store transport (``set_editor_blocks`` / ``get_editor_blocks`` /
+#      ``get_active_blocks`` + the per-request ContextVars) — the ``editor_blocks``
+#      round-trip carrier the REST ai-edit + editing-context routes use, and the
+#      in-process MCP tool reads. Verbatim from #1193.
+#   3. ``EditDocumentTool`` — a workspace-scoped ``BaseTool`` (registered in
+#      ``_EE_TOOLS``, trust_level "medium") wired onto the FL-2 file_versions
+#      service: it loads a Library file's CURRENT content, parses the Editor.js
+#      JSON, applies the ops, and writes the mutated document back through
+#      ``update_file_content(editor_kind="agent")`` so every edit lands as a NEW
+#      revertable version. This is the FL-5 acceptance surface (revertable edit).
+#      It follows the FL-3 library-verb pattern (workspace from agent-identity
+#      ContextVars; every EE reach is a lazy try/except runtime import).
+"""edit_document tool — structural block editing for Editor.js documents.
+
+Two agent-facing surfaces share one operation engine:
+
+* ``EditDocumentTool`` (``BaseTool``, registered) — edits a Library file by id,
+  writing each edit as a revertable FL-2 version.
+* the in-process MCP server (``build_edit_document_mcp_server``) — edits the
+  session block-store synced from the frontend editor (used by the REST ai-edit
+  path); no version is written (the frontend persists via ``PUT /files/{id}``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from contextvars import ContextVar
+from typing import Any
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+_edit_session_blocks: ContextVar[list[dict] | None] = ContextVar(
+    "edit_session_blocks", default=None
+)
+
+# Per-request selected block ID for per-block editing mode.
+# When set, the tool enforces that only the selected block can be modified.
+_selected_block_id: ContextVar[str | None] = ContextVar("selected_block_id", default=None)
+
+# Module-level store keyed by file_id — used when blocks are synced from the
+# frontend editor (chat-initiated editing). The MCP handler falls back to this
+# when the ContextVar is empty.
+_editor_blocks_store: dict[str, list[dict]] = {}
+
+SERVER_NAME = "pocketpaw_edit_document"
+EDIT_DOCUMENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_document"
+
+
+def set_edit_session(blocks: list[dict]) -> None:
+    """Store the current editing session's blocks for MCP handler access."""
+    _edit_session_blocks.set(blocks)
+
+
+def clear_edit_session() -> None:
+    """Clear the editing session after the request completes."""
+    _edit_session_blocks.set(None)
+
+
+def set_selected_block_id(block_id: str | None) -> None:
+    """Store the selected block ID for per-block editing enforcement."""
+    _selected_block_id.set(block_id)
+
+
+def get_selected_block_id() -> str | None:
+    """Get the selected block ID for the current editing session."""
+    return _selected_block_id.get()
+
+
+def clear_selected_block_id() -> None:
+    """Clear the selected block ID after the request completes."""
+    _selected_block_id.set(None)
+
+
+def get_edit_session() -> list[dict] | None:
+    """Get the current editing session's blocks."""
+    return _edit_session_blocks.get()
+
+
+def set_editor_blocks(file_id: str, blocks: list[dict]) -> None:
+    """Store blocks from the frontend editor for MCP tool access during chat."""
+    _editor_blocks_store[file_id] = blocks
+
+
+def get_editor_blocks(file_id: str) -> list[dict] | None:
+    """Get blocks synced from the frontend editor by file_id."""
+    return _editor_blocks_store.get(file_id)
+
+
+def clear_editor_blocks(file_id: str) -> None:
+    """Drop the stored blocks for a file (end of an editing session)."""
+    _editor_blocks_store.pop(file_id, None)
+
+
+def sync_editor_blocks_from_contextvar() -> None:
+    """Copy ContextVar blocks to the module store so GET /files/{id}/editing-context
+    returns blocks mutated by the edit_document MCP tool during a chat session."""
+    blocks = _edit_session_blocks.get()
+    if not blocks or not _editor_blocks_store:
+        return
+    for fid in _editor_blocks_store:
+        _editor_blocks_store[fid] = blocks
+
+
+def get_active_blocks() -> list[dict] | None:
+    """Get whichever blocks are available — ContextVar first, then store.
+    Returns None only when no session is active at all. An empty list is
+    a valid state (empty document)."""
+    blocks = _edit_session_blocks.get()
+    if blocks is not None:
+        return blocks
+    if _editor_blocks_store:
+        return next(iter(_editor_blocks_store.values()))
+    return None
+
+
+def _format_block_for_prompt(b: dict, idx: int) -> str:
+    """Format a single Editor.js block as a readable line for the system prompt."""
+    import json as _json
+
+    bid = b.get("id", "?")
+    btype = b.get("type", "?")
+    data = b.get("data", {})
+    snippet = _json.dumps(data, separators=(",", ":"))
+    if len(snippet) > 120:
+        snippet = snippet[:117] + "..."
+    return f"[{idx}] id={bid} type={btype} data={snippet}"
+
+
+def build_editor_prompt_context(
+    blocks: list[dict] | None = None,
+    *,
+    available_tools: list[str] | None = None,
+    selected_block_id: str | None = None,
+) -> str | None:
+    """Build a system-prompt block describing the current editor document.
+
+    Accepts blocks directly (from the chat request body or ai-edit endpoint).
+    Falls back to ``get_active_blocks()`` if no blocks passed.
+
+    Returns None if no blocks are available anywhere.
+    """
+    resolved = blocks or get_active_blocks()
+    if not resolved:
+        return None
+
+    block_lines = [_format_block_for_prompt(b, i) for i, b in enumerate(resolved)]
+    block_summary = "\n".join(block_lines) if block_lines else "(empty document)"
+
+    editing_mode_block = ""
+    if selected_block_id:
+        editing_mode_block = (
+            "\n"
+            "============================================================\n"
+            "CRITICAL: PER-BLOCK EDITING MODE\n"
+            "============================================================\n"
+            "You are in per-block editing mode. You MUST follow these rules:\n"
+            "\n"
+            f"1. You are ONLY allowed to edit block id={selected_block_id}.\n"
+            "2. Do NOT modify, delete, move, or insert any other block.\n"
+            "3. Do NOT use the 'replaceAll' operation — it would overwrite\n"
+            "   the entire document and destroy content in other blocks.\n"
+            "4. Use ONLY the 'update' operation with id={selected_block_id}.\n"
+            "5. If the user's prompt asks you to modify other blocks or the\n"
+            "   whole document, politely explain that you can only edit the\n"
+            "   selected block. Suggest they use full-document editing instead.\n"
+            "\n"
+            f"Target block: id={selected_block_id}\n"
+            "Permitted operation: update (with id={selected_block_id}) only.\n"
+            "============================================================\n"
+        )
+
+    block_type_ref = (
+        "## Block type reference\n\n"
+        "You MUST use these EXACT type names. Any other name will cause a rendering error.\n\n"
+        "| Type       | Data shape |\n"
+        "|------------|------------|\n"
+        '| `paragraph` | `{"text": "..."}` |\n'
+        '| `header`    | `{"text": "...", "level": 1\\|2\\|3}` |\n'
+        '| `list`      | `{"style": "unordered"\\|"ordered", "meta": {}, "items": [{"content": "item1", "meta": {}, "items": []}]}` |\n'
+        '| `code`      | `{"code": "..."}` |\n'
+        '| `quote`     | `{"text": "...", "caption": "..."}` |\n'
+        '| `image`     | `{"file": {"url": "..."}, "caption": "..."}` |\n'
+        '| `checklist` | `{"items": [{"text": "...", "checked": true\\|false}]}` |\n'
+        '| `table`     | `{"content": [["cell", "cell"], ["cell", "cell"]]}` |\n'
+        "| `delimiter` | `{}` (no data needed) |\n"
+        '| `warning`   | `{"title": "...", "message": "..."}` |\n'
+        '| `embed`     | `{"embed": "url", ...}` |\n'
+        '| `linkTool`  | `{"link": "url", ...}` |\n'
+        '| `raw`       | `{"html": "..."}` |\n'
+        "\n"
+        "Common mistakes — these are NOT valid types and WILL break rendering:\n"
+        "  heading       → use `header` instead\n"
+        "  bullet_list_item → use `list` with style=unordered and items array\n"
+        "  numbered_list_item → use `list` with style=ordered and items array\n"
+        "  divider       → use `delimiter` instead\n"
+        "  blockquote     → use `quote` instead\n"
+        "  callout        → use `warning` instead\n"
+        "  check_list_item → use `checklist` with items array\n"
+        "  toggle         → not supported, use `paragraph` instead\n"
+        "\n"
+        "Lists are a SINGLE block with an `items` array — NOT one block per item.\n"
+        "Checklists are a SINGLE block with an `items` array of {text, checked} objects.\n"
+        "\n"
+    )
+
+    replaceall_note = ""
+    final_instruction = "After making your edits, briefly tell the user what you changed."
+    if selected_block_id:
+        replaceall_note = (
+            "\n---\n"
+            "NOTE: 'replaceAll' is BLOCKED in per-block editing mode. "
+            "It will be rejected if you attempt it.\n"
+        )
+        final_instruction = (
+            "After making your edit to the target block, briefly tell the user what you changed."
+        )
+
+    return (
+        "You are editing a document in PocketPaw's file editor.\n"
+        "The document uses Editor.js block format. Each block has an id, type, and data.\n\n"
+        f"{block_type_ref}\n"
+        "## Current document\n\n"
+        f"{block_summary}\n"
+        f"{editing_mode_block}\n"
+        "## How to edit\n\n"
+        "Call the `edit_document` tool with an array of operations. "
+        "You can call it multiple times — each call returns the updated state.\n\n"
+        "Operations:\n"
+        '- update: {"op":"update", "id":"<block_id>", "data":{...}}\n'
+        '- insert: {"op":"insert", "type":"paragraph", "data":{...}, "index":0}\n'
+        '- delete: {"op":"delete", "id":"<block_id>"}\n'
+        '- move: {"op":"move", "id":"<block_id>", "toIndex":0}\n'
+        '- replaceAll: {"op":"replaceAll", "blocks":[...]}\n'
+        f"{replaceall_note}\n"
+        f"{final_instruction}"
+    )
+
+
+def _normalize_block(block_type: str, data: dict) -> tuple[str, dict]:
+    """Normalize block type names and data shapes for Editor.js compatibility.
+
+    Fixes common LLM mistakes: Notion-style type names, wrong data shapes,
+    and list/checklist items sent as individual blocks instead of arrays.
+    """
+    bt = block_type.strip().lower()
+
+    # ── Type name normalization (only the cases that actually break) ──
+    if bt in ("heading", "headline", "h1", "h2", "h3"):
+        bt = "header"
+    elif bt in ("bullet_list_item", "bulleted_list", "unordered_list"):
+        bt = "list"
+        data = _coerce_list_data(data, style="unordered")
+    elif bt in ("numbered_list_item", "numbered_list", "ordered_list"):
+        bt = "list"
+        data = _coerce_list_data(data, style="ordered")
+    elif bt in ("divider", "horizontal_rule", "hr", "separator"):
+        bt = "delimiter"
+        data = {}
+    elif bt in ("blockquote", "block_quote"):
+        bt = "quote"
+    elif bt in ("callout", "note", "info", "alert"):
+        bt = "warning"
+        data = _coerce_warning_data(data)
+    elif bt in ("check_list_item", "check_list", "todo", "todo_list", "task_list"):
+        bt = "checklist"
+        data = _coerce_checklist_data(data)
+    elif bt in ("toggle", "collapsible", "accordion"):
+        bt = "paragraph"
+
+    # ── Data shape fixes for native names that still have wrong shapes ──
+    if bt == "list":
+        data = _coerce_list_data(data, style=None)
+    elif bt == "checklist":
+        data = _coerce_checklist_data(data)
+    elif bt == "delimiter":
+        data = {}
+    elif bt == "header" and "level" in data:
+        lvl = data["level"]
+        if not isinstance(lvl, int) or lvl < 1 or lvl > 3:
+            data = {**data, "level": 2}
+
+    return bt, data
+
+
+def _coerce_list_data(data: dict, *, style: str | None = None) -> dict:
+    """Normalize data for a ``list`` block into Editor.js list v2 format.
+
+    v2 format: {style, meta: {}, items: [{content, meta: {}, items: []}, ...]}
+    Also accepts v1 flat strings and Notion-style {text} items.
+    """
+    items = data.get("items", [])
+    # AI sent {text: "..."} instead of {items: [...]}
+    if not items and data.get("text"):
+        items = [str(data["text"])]
+    if isinstance(items, str):
+        items = [items]
+    if not isinstance(items, list):
+        items = []
+
+    normalized_items = []
+    for item in items:
+        if isinstance(item, str):
+            # v1 flat string → v2
+            normalized_items.append({"content": item, "meta": {}, "items": []})
+        elif isinstance(item, dict):
+            # Already v2 format (has "content") or Notion format (has "text")
+            content = str(item.get("content") or item.get("text") or "")
+            # Preserve nested items if present, otherwise empty list
+            nested = item.get("items", [])
+            if isinstance(nested, list):
+                nested = [
+                    {
+                        "content": str(s)
+                        if isinstance(s, str)
+                        else s.get("content", s.get("text", "")),
+                        "meta": s.get("meta", {}) if isinstance(s, dict) else {},
+                        "items": s.get("items", []) if isinstance(s, dict) else [],
+                    }
+                    if isinstance(s, (str, dict))
+                    else {"content": str(s), "meta": {}, "items": []}
+                    for s in nested
+                ]
+            else:
+                nested = []
+            normalized_items.append(
+                {
+                    "content": content,
+                    "meta": item.get("meta", {}),
+                    "items": nested,
+                }
+            )
+
+    resolved_style = style or data.get("style", "unordered")
+    if resolved_style not in ("unordered", "ordered"):
+        resolved_style = "unordered"
+
+    return {"style": resolved_style, "meta": {}, "items": normalized_items}
+
+
+def _coerce_checklist_data(data: dict) -> dict:
+    """Normalize data for a ``checklist`` block into {items: [{text, checked}, ...]}."""
+    items = data.get("items", [])
+    # AI sent {text: "...", checked: true} as a single item
+    if not items and data.get("text"):
+        items = [{"text": str(data["text"]), "checked": bool(data.get("checked", False))}]
+    if isinstance(items, dict):
+        items = [items]
+    if not isinstance(items, list):
+        items = []
+    normalized = []
+    for item in items:
+        if isinstance(item, str):
+            normalized.append({"text": item, "checked": False})
+        elif isinstance(item, dict):
+            normalized.append(
+                {
+                    "text": str(item.get("text", "")),
+                    "checked": bool(item.get("checked", False)),
+                }
+            )
+    return {"items": normalized}
+
+
+def _coerce_warning_data(data: dict) -> dict:
+    """Normalize data for a ``warning`` block into {title, message}."""
+    result: dict[str, str] = {}
+    result["title"] = str(data.get("title") or data.get("text") or "")
+    result["message"] = str(data.get("message") or data.get("text") or "")
+    if not result["title"] and not result["message"]:
+        result["title"] = "Note"
+    return result
+
+
+def apply_operations(
+    blocks: list[dict],
+    operations: list[dict],
+    selected_block_id: str | None = None,
+) -> tuple[list[dict], str]:
+    """Apply edit operations to a blocks list. Mutates in place.
+
+    When *selected_block_id* is set, only ``update`` on that specific block
+    is permitted.  ``replaceAll`` is rejected outright; other operations
+    targeting different block IDs are skipped with an error message.
+
+    Returns (blocks, summary) — blocks is the same list reference, mutated.
+    """
+    summaries: list[str] = []
+
+    # ── Pre-flight: reject replaceAll in per-block mode ──
+    if selected_block_id:
+        for op in operations:
+            if op.get("op") == "replaceAll":
+                return blocks, (
+                    "ERROR: replaceAll is not allowed in per-block editing mode. "
+                    "You may only update the selected block "
+                    f"(id={selected_block_id}). "
+                    "Use 'update' with the target block's id instead."
+                )
+
+    for op in operations:
+        op_type = op.get("op")
+
+        # ── Per-block editing enforcement ──
+        if selected_block_id and op_type != "update":
+            summaries.append(
+                f"SKIPPED: '{op_type}' is not allowed in per-block editing mode. "
+                f"Only 'update' is permitted (target block id={selected_block_id})."
+            )
+            continue
+
+        if selected_block_id and op.get("id") != selected_block_id:
+            summaries.append(
+                f"SKIPPED: update on block {op.get('id')} is not allowed in "
+                f"per-block editing mode. Target block is "
+                f"id={selected_block_id}."
+            )
+            continue
+
+        if op_type == "update":
+            block_id = op["id"]
+            new_data = op.get("data", {})
+            for b in blocks:
+                if b.get("id") == block_id:
+                    b["data"] = {**b.get("data", {}), **new_data}
+                    summaries.append(f"Updated block {block_id} ({b.get('type', '?')})")
+                    break
+            else:
+                summaries.append(f"Block {block_id} not found — skipped update")
+
+        elif op_type == "insert":
+            raw_type = op.get("type", "paragraph")
+            raw_data = op.get("data", {})
+            norm_type, norm_data = _normalize_block(raw_type, raw_data)
+            new_block: dict[str, Any] = {
+                "id": uuid.uuid4().hex[:6],
+                "type": norm_type,
+                "data": norm_data,
+            }
+            idx = op.get("index", len(blocks))
+            idx = max(0, min(idx, len(blocks)))
+            blocks.insert(idx, new_block)
+            normalized = " (normalized)" if raw_type != norm_type else ""
+            summaries.append(f"Inserted {norm_type} at index {idx}{normalized}")
+
+        elif op_type == "delete":
+            block_id = op["id"]
+            for i, b in enumerate(blocks):
+                if b.get("id") == block_id:
+                    blocks.pop(i)
+                    summaries.append(
+                        f"Deleted block {block_id} ({b.get('type', '?')}) at index {i}"
+                    )
+                    break
+            else:
+                summaries.append(f"Block {block_id} not found — skipped delete")
+
+        elif op_type == "move":
+            block_id = op["id"]
+            to_idx = op["toIndex"]
+            for i, b in enumerate(blocks):
+                if b.get("id") == block_id:
+                    moved = blocks.pop(i)
+                    to_idx = max(0, min(to_idx, len(blocks)))
+                    blocks.insert(to_idx, moved)
+                    summaries.append(
+                        f"Moved block {block_id} ({b.get('type', '?')}) from {i} to {to_idx}"
+                    )
+                    break
+            else:
+                summaries.append(f"Block {block_id} not found — skipped move")
+
+        elif op_type == "replaceAll":
+            new_blocks = op.get("blocks", [])
+            old_count = len(blocks)
+            blocks.clear()
+            for b in new_blocks:
+                if "id" not in b:
+                    b["id"] = uuid.uuid4().hex[:6]
+                raw_type = b.get("type", "paragraph")
+                raw_data = b.get("data", {})
+                norm_type, norm_data = _normalize_block(raw_type, raw_data)
+                b["type"] = norm_type
+                b["data"] = norm_data
+            blocks.extend(new_blocks)
+            summaries.append(f"Replaced all {old_count} blocks with {len(new_blocks)} blocks")
+
+        else:
+            summaries.append(f"Unknown operation '{op_type}' — skipped")
+
+    summary = "; ".join(summaries) if summaries else "No operations applied"
+    return blocks, summary
+
+
+# ---------------------------------------------------------------------------
+# FL-5 registered tool — workspace-scoped, wired onto the FL-2 versioned service.
+#
+# This is the surface the agent runtime discovers (registered in ``_EE_TOOLS``,
+# trust_level "medium"). Unlike the MCP server below (which mutates the in-memory
+# session store for the REST ai-edit path), this tool operates on a REAL Library
+# file by id: it loads the current content via ``file_versions.service
+# .read_current_content``, applies the ops, then writes the mutated document back
+# through ``update_file_content(editor_kind="agent")`` so each edit archives as a
+# new revertable version. Follows the FL-3 library-verb pattern: workspace comes
+# from the agent-identity ContextVars; every EE reach is a lazy runtime import so
+# a community install loads the module and degrades to an "enterprise" message.
+# ---------------------------------------------------------------------------
+
+
+def _current_workspace() -> str | None:
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_workspace_id
+
+        return current_workspace_id()
+    except ImportError:
+        return None
+
+
+def _current_user() -> str | None:
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_user_id
+
+        return current_user_id()
+    except ImportError:
+        return None
+
+
+def _request_ctx(workspace_id: str, user_id: str | None):
+    """Build a minimal RequestContext for the FL-2 file_versions service."""
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=user_id or "agent",
+        workspace_id=workspace_id,
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _parse_editorjs(content: str) -> tuple[dict, list[dict]]:
+    """Parse an Editor.js document JSON string into (doc, blocks).
+
+    Tolerates a bare block list, an empty/blank file, and malformed JSON
+    (treated as an empty document so the agent can build from scratch).
+    Returns the full doc dict (for round-tripping ``time`` / ``version`` keys)
+    and a deep-copied mutable blocks list.
+    """
+    try:
+        parsed = json.loads(content) if content and content.strip() else {}
+    except (json.JSONDecodeError, TypeError):
+        parsed = {}
+
+    if isinstance(parsed, list):
+        doc: dict = {"blocks": parsed}
+    elif isinstance(parsed, dict):
+        doc = parsed
+    else:
+        doc = {"blocks": []}
+
+    raw_blocks = doc.get("blocks", []) if isinstance(doc.get("blocks"), list) else []
+    # Deep-copy so mutations don't corrupt the parse result.
+    blocks = [json.loads(json.dumps(b)) for b in raw_blocks]
+    return doc, blocks
+
+
+class EditDocumentTool(BaseTool):
+    """Edit an Editor.js document in the Library, writing a revertable version.
+
+    Loads the file's current content, applies structural block operations
+    (update / insert / delete / move / replaceAll), and writes the mutated
+    document back through the FL-2 service so the change is a new archived
+    version. Operates only on files in the current workspace.
+    """
+
+    @property
+    def name(self) -> str:
+        return "edit_document"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Structurally edit a document file (Editor.js block format) in the "
+            "workspace Library. Provide the file's id and an array of operations "
+            "(update, insert, delete, move, or replaceAll a block). This writes a "
+            "new file version, so the edit is fully revertable. Blocks are "
+            "addressed by id (update/delete/move) or index (insert). Operates only "
+            "on files in the current workspace."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "medium"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_id": {
+                    "type": "string",
+                    "description": "ID of the Library document file to edit.",
+                },
+                "operations": {
+                    "type": "array",
+                    "description": "Ordered list of edit operations to apply.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "op": {
+                                "type": "string",
+                                "enum": ["update", "insert", "delete", "move", "replaceAll"],
+                                "description": "The operation to perform.",
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Block ID to update, delete, or move.",
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": (
+                                    "Block type name for insert (paragraph, header, list, etc.)."
+                                ),
+                            },
+                            "data": {
+                                "type": "object",
+                                "description": "Block data for update or insert.",
+                            },
+                            "index": {
+                                "type": "integer",
+                                "description": "Insert position (defaults to end).",
+                            },
+                            "toIndex": {
+                                "type": "integer",
+                                "description": "Destination index for move.",
+                            },
+                            "blocks": {
+                                "type": "array",
+                                "description": "Complete new blocks array for replaceAll.",
+                            },
+                        },
+                        "required": ["op"],
+                    },
+                },
+            },
+            "required": ["file_id", "operations"],
+        }
+
+    async def execute(self, file_id: str, operations: list[dict]) -> str:
+        workspace = _current_workspace()
+        if not workspace:
+            return self._error("Edit tools require a workspace context (cloud chat session).")
+
+        if not isinstance(operations, list) or not operations:
+            return self._error("Provide a non-empty `operations` array.")
+
+        try:
+            from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
+            from pocketpaw_ee.cloud.file_versions import service as fv_service
+            from pocketpaw_ee.cloud.file_versions.dto import UpdateFileContentRequest
+        except ImportError:
+            return self._error("Document editing is not available (enterprise feature).")
+
+        ctx = _request_ctx(workspace, _current_user())
+
+        try:
+            content = await fv_service.read_current_content(ctx, file_id)
+        except NotFound:
+            return self._error(f"File {file_id!r} not found in this workspace.")
+        except CloudError as e:
+            return self._error(str(e))
+
+        doc, blocks = _parse_editorjs(content)
+        try:
+            updated, summary = apply_operations(blocks, operations)
+        except Exception as exc:  # a malformed op must not crash the run
+            return self._error(f"Edit failed: {exc}")
+
+        doc["blocks"] = updated
+        new_content = json.dumps(doc, separators=(",", ":"))
+
+        try:
+            result = await fv_service.update_file_content(
+                ctx,
+                file_id,
+                UpdateFileContentRequest(content=new_content),
+                editor_kind="agent",
+            )
+        except NotFound:
+            return self._error(f"File {file_id!r} not found in this workspace.")
+        except CloudError as e:
+            return self._error(str(e))
+
+        return self._success(
+            f"{summary}. Saved {file_id} — new version {result.new_version} (revertable)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# In-process MCP server (Claude Agent SDK) — session-store editing.
+#
+# Ported verbatim from #1193. This surface mutates the in-memory block store
+# (synced from the frontend editor via the REST editing-context routes); it does
+# NOT write an FL-2 version — the frontend persists the result via PUT /files/{id}.
+# The registered ``EditDocumentTool`` above is the versioned surface.
+# ---------------------------------------------------------------------------
+
+
+def _edit_error(message: str) -> dict:
+    """Return a structured error with a hint to guide the agent to the correct format."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+async def _edit_document_handler(args: dict) -> dict:
+    """MCP handler for the edit_document tool. Reads blocks from ContextVar
+    first, falls back to the module-level editor store (chat-initiated editing)."""
+    blocks = get_active_blocks()
+    if blocks is None:
+        return _edit_error(
+            "No document is currently open for editing. Open a file in the editor first."
+        )
+
+    operations = args.get("operations")
+    if not operations:
+        # Detect common mistakes and give targeted help.
+        if args.get("operation"):  # wrong field name
+            return _edit_error(
+                "Use `operations` (plural) as the key, not `operation`. "
+                'Example: {"operations": [{"op": "update", ...}]}'
+            )
+        if any(k in args for k in ("update", "insert", "delete", "move", "replaceAll")):
+            return _edit_error(
+                "Wrap operations inside an `operations` array. "
+                'Example: {"operations": [{"op": "update", "id": "x", "data": {...}}]}'
+            )
+        if args.get("blocks"):  # replaceAll blocks at top level
+            return _edit_error(
+                'Wrap in operations array: {"operations": [{"op": "replaceAll", "blocks": [...]}]}'
+            )
+        return _edit_error(
+            "Missing `operations` array. "
+            'Format: {"operations": [{"op": "update|insert|delete|move|replaceAll", ...}]}'
+        )
+
+    if not isinstance(operations, list):
+        return _edit_error("`operations` must be an array (list), not a single object.")
+
+    try:
+        selected_id = get_selected_block_id()
+        updated, summary = apply_operations(blocks, operations, selected_block_id=selected_id)
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {"summary": summary, "blockCount": len(updated), "blocks": updated},
+                        separators=(",", ":"),
+                    ),
+                }
+            ]
+        }
+    except Exception as exc:
+        logger.exception("edit_document handler failed")
+        return _edit_error(str(exc))
+
+
+def build_edit_document_mcp_server() -> tuple[str, Any] | None:
+    """Build the in-process MCP server for the Claude Agent SDK.
+
+    Returns (server_name, server_config) or None if the SDK is unavailable.
+    Always registered — the handler returns an error when no editing session
+    is active, so the agent won't use it outside the file editing context.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; edit_document MCP disabled")
+        return None
+
+    @tool(
+        "edit_document",
+        (
+            "Edit the current document by performing operations on blocks. "
+            "Use this when the user asks you to edit, rewrite, fix, expand, "
+            "or restructure a document they have open in the editor.\n\n"
+            "You MUST call it with an `operations` array. Each item must have "
+            "an `op` field set to one of: update, insert, delete, move, replaceAll.\n\n"
+            "EXACT format (copy this pattern):\n"
+            '{"operations": [\n'
+            '  {"op": "update", "id": "<block_id>", "data": {"text": "new text"}},\n'
+            '  {"op": "insert", "type": "paragraph", "data": {"text": "new"}, "index": 1},\n'
+            '  {"op": "delete", "id": "<block_id>"},\n'
+            '  {"op": "move", "id": "<block_id>", "toIndex": 0},\n'
+            '  {"op": "replaceAll", "blocks": [{"type":"paragraph","data":{"text":"..."}}]}\n'
+            "]}\n\n"
+            "VALID BLOCK TYPES — use these exact names, anything else will break:\n"
+            "paragraph, header, list, code, quote, image, checklist, table,\n"
+            "delimiter, warning, embed, linkTool, raw\n\n"
+            "Data shape for each type:\n"
+            '- paragraph: {"text": "..."}\n'
+            '- header: {"text": "...", "level": 1|2|3}\n'
+            '- list: {"style": "unordered"|"ordered", "meta": {}, "items": [{"content": "item1", "meta": {}, "items": []}]}\n'
+            '- code: {"code": "..."}\n'
+            '- quote: {"text": "...", "caption": "..."}\n'
+            '- checklist: {"items": [{"text": "...", "checked": true|false}]}\n'
+            '- table: {"content": [["cell", "cell"], ["cell", "cell"]]}\n'
+            "- delimiter: {} (empty object)\n"
+            '- warning: {"title": "...", "message": "..."}\n'
+            '- embed: {"embed": "url", ...}\n'
+            '- linkTool: {"link": "url", ...}\n'
+            '- raw: {"html": "..."}\n\n'
+            "NEVER use these (they are NOT valid): heading, bullet_list_item,\n"
+            "numbered_list_item, divider, blockquote, callout, check_list_item, toggle.\n\n"
+            "Lists are ONE block with an items array — NOT one block per item.\n"
+            "Checklists are ONE block with an items array — NOT one block per item.\n\n"
+            "IMPORTANT: The field is `op` (not operation or action). "
+            "Everything goes inside the `operations` array — not at top level."
+        ),
+        {
+            "operations": list,
+        },
+    )
+    async def edit_document(args):
+        return await _edit_document_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[edit_document],
+    )
+    return SERVER_NAME, server

--- a/src/pocketpaw/tools/builtin/edit_slides.py
+++ b/src/pocketpaw/tools/builtin/edit_slides.py
@@ -1,0 +1,1014 @@
+# edit_slides.py — FL-5 structural slides editing (port of dewani12's #1193).
+# Created: 2026-07-03 (FL-5, port of dewani12's origin/feature/files
+#   src/pocketpaw/tools/builtin/edit_slides.py). Credit: dewani12 authored the
+#   reveal.js deck operation engine, the prompt-context builder, the module-store
+#   transport, and the in-process MCP server — all ported here verbatim (adapted
+#   only for imports on current dev).
+#
+# Two agent-facing surfaces share one deck operation engine:
+#   1. ``EditSlidesTool`` (``BaseTool``, registered in ``_EE_TOOLS``, trust_level
+#      "medium") — edits a Library slides file by id: loads the current deck JSON
+#      via ``file_versions.service.read_current_content``, applies the ops, and
+#      writes the mutated deck back through ``update_file_content(editor_kind=
+#      "agent")`` so every edit lands as a NEW revertable FL-2 version. Follows
+#      the FL-3 library-verb pattern (workspace from agent-identity ContextVars;
+#      lazy EE imports so a community install degrades gracefully).
+#   2. the in-process MCP server (``build_edit_slides_mcp_server``) — edits the
+#      session deck-store synced from the frontend slides UI (REST slides-edit
+#      path); no version is written (the frontend persists via PUT /files/{id}).
+"""edit_slides tool -- structural slide deck editing for reveal.js presentations."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from contextvars import ContextVar
+from typing import Any
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+# Per-request slides deck (REST ai-edit endpoint).
+_edit_session_slides: ContextVar[dict | None] = ContextVar("edit_session_slides", default=None)
+
+# Per-request selected slide ID for scoped editing.
+_selected_slide_id: ContextVar[str | None] = ContextVar("selected_slide_id", default=None)
+
+# Module-level store keyed by file_id -- used when decks are synced from
+# the frontend slides UI (chat-initiated editing).
+_slides_store: dict[str, dict] = {}
+
+SERVER_NAME = "pocketpaw_edit_slides"
+EDIT_SLIDES_TOOL_ID = f"mcp__{SERVER_NAME}__edit_slides"
+
+# Valid element types for slide content.
+_ELEMENT_TYPES = {"heading", "text", "list", "image", "code", "table", "quote"}
+
+# Valid reveal.js themes.
+_THEMES = {
+    "black",
+    "white",
+    "league",
+    "beige",
+    "sky",
+    "night",
+    "serif",
+    "simple",
+    "solarized",
+    "moon",
+    "dracula",
+}
+
+# Valid slide layouts.
+_LAYOUTS = {"title-slide", "content", "two-column", "image-full", "blank"}
+
+# Valid transitions.
+_TRANSITIONS = {"none", "fade", "slide", "convex", "concave", "zoom"}
+
+
+# ---------------------------------------------------------------------------
+# Session management (ContextVar + module dict -- mirrors edit_document.py)
+# ---------------------------------------------------------------------------
+
+
+def set_edit_session(deck: dict) -> None:
+    _edit_session_slides.set(deck)
+
+
+def clear_edit_session() -> None:
+    _edit_session_slides.set(None)
+
+
+def get_edit_session() -> dict | None:
+    return _edit_session_slides.get()
+
+
+def set_selected_slide_id(slide_id: str | None) -> None:
+    _selected_slide_id.set(slide_id)
+
+
+def get_selected_slide_id() -> str | None:
+    return _selected_slide_id.get()
+
+
+def clear_selected_slide_id() -> None:
+    _selected_slide_id.set(None)
+
+
+def set_slides_data(file_id: str, deck: dict) -> None:
+    _slides_store[file_id] = deck
+
+
+def get_slides_data(file_id: str) -> dict | None:
+    return _slides_store.get(file_id)
+
+
+def clear_slides_data(file_id: str) -> None:
+    _slides_store.pop(file_id, None)
+
+
+def get_active_deck() -> dict | None:
+    """Get whichever deck is available -- ContextVar first, then store."""
+    deck = _edit_session_slides.get()
+    if deck is not None:
+        return deck
+    if _slides_store:
+        return next(iter(_slides_store.values()))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Deck helpers
+# ---------------------------------------------------------------------------
+
+
+def _slide_ids(deck: dict) -> list[str]:
+    """Return ordered slide IDs from the deck."""
+    return [s["id"] for s in deck.get("slides", [])]
+
+
+def _get_slide(deck: dict, slide_id: str) -> dict | None:
+    """Get a slide dict by ID from the deck."""
+    for slide in deck.get("slides", []):
+        if slide.get("id") == slide_id:
+            return slide
+    return None
+
+
+def _get_element(slide: dict, element_id: str) -> dict | None:
+    """Get an element dict by ID from a slide."""
+    for el in slide.get("elements", []):
+        if el.get("id") == element_id:
+            return el
+    return None
+
+
+def _ensure_deck(deck: dict) -> None:
+    """Ensure the deck has minimal structure."""
+    deck.setdefault("version", 1)
+    deck.setdefault("theme", "black")
+    deck.setdefault("transition", "slide")
+    deck.setdefault("slideNumber", True)
+    deck.setdefault("slides", [])
+
+
+def _ensure_slide(deck: dict, slide_id: str | None = None) -> dict:
+    """Get a slide by ID or return the first slide. Returns None if no slides."""
+    if slide_id:
+        slide = _get_slide(deck, slide_id)
+        if slide:
+            return slide
+    slides = deck.get("slides", [])
+    return slides[0] if slides else None
+
+
+def _create_slide(
+    layout: str = "content",
+    elements: list[dict] | None = None,
+    *,
+    background: dict | None = None,
+    background_transition: str | None = None,
+    auto_animate: bool = False,
+) -> dict:
+    """Create a new slide dict with a UUID."""
+    slide: dict = {
+        "id": uuid.uuid4().hex[:12],
+        "layout": layout if layout in _LAYOUTS else "content",
+        "background": background,
+        "notes": "",
+        "elements": elements or [],
+    }
+    if background_transition:
+        slide["backgroundTransition"] = background_transition
+    if auto_animate:
+        slide["autoAnimate"] = True
+    return slide
+
+
+def _create_element(
+    el_type: str,
+    content: Any,
+    style: dict | None = None,
+    position: dict | None = None,
+    *,
+    fragment: str | None = None,
+) -> dict:
+    """Create a new element dict with a UUID."""
+    el: dict[str, Any] = {
+        "id": uuid.uuid4().hex[:8],
+        "type": el_type if el_type in _ELEMENT_TYPES else "text",
+        "content": content,
+        "style": style or {},
+        "position": position or {"x": 0, "y": 0, "width": 12, "height": 2},
+    }
+    el["style"].setdefault("fontSize", "1em")
+    el["style"].setdefault("alignment", "left")
+    el["style"].setdefault("color", None)
+    if fragment:
+        el["fragment"] = fragment
+    return el
+
+
+# ---------------------------------------------------------------------------
+# Prompt context builder
+# ---------------------------------------------------------------------------
+
+
+def _summarize_slide(slide: dict, index: int) -> str:
+    """Build a one-line summary of a slide for the system prompt."""
+    slide_id = slide.get("id", "?")
+    layout = slide.get("layout", "content")
+    elements = slide.get("elements", [])
+    notes = slide.get("notes", "")
+
+    parts = [f"Slide {index + 1} (id={slide_id[:8]}, layout={layout})"]
+
+    for el in elements:
+        el_type = el.get("type", "?")
+        content = el.get("content", "")
+        if el_type == "heading":
+            parts.append(f'  heading: "{_fmt_val(content)}"')
+        elif el_type == "text":
+            parts.append(f'  text: "{_fmt_val(content)}"')
+        elif el_type == "list":
+            items = content if isinstance(content, list) else []
+            preview = ", ".join(str(i)[:30] for i in items[:3])
+            if len(items) > 3:
+                preview += f", ... ({len(items)} items)"
+            parts.append(f"  list: [{preview}]")
+        elif el_type == "image":
+            src = content.get("src", "") if isinstance(content, dict) else str(content)
+            parts.append(f"  image: {_fmt_val(src)}")
+        elif el_type == "code":
+            code = content.get("code", "") if isinstance(content, dict) else str(content)
+            lang = content.get("language", "") if isinstance(content, dict) else ""
+            parts.append(f"  code ({lang or 'no lang'}): {_fmt_val(code)}")
+        elif el_type == "table":
+            if isinstance(content, dict):
+                rows = len(content.get("rows", []))
+                cols = len(content.get("headers", []))
+                parts.append(f"  table: {rows} rows x {cols} cols")
+            else:
+                parts.append(f"  table: {_fmt_val(str(content))}")
+        elif el_type == "quote":
+            parts.append(f'  quote: "{_fmt_val(str(content))}"')
+        else:
+            parts.append(f"  {el_type}: {_fmt_val(str(content))}")
+
+    if notes:
+        parts.append(f'  notes: "{_fmt_val(notes)}"')
+
+    return "\n".join(parts)
+
+
+def build_slides_prompt_context(
+    deck: dict | None = None,
+    *,
+    selected_slide_id: str | None = None,
+) -> str | None:
+    """Build a system-prompt block describing the current slide deck state.
+
+    When *selected_slide_id* is set, per-slide editing mode kicks in: the
+    prompt scopes the agent to only that slide and only element operations
+    on it are permitted.
+
+    Returns None if no deck is available.
+    """
+    resolved = deck or get_active_deck()
+    if not resolved:
+        return None
+
+    _ensure_deck(resolved)
+    slides = resolved.get("slides", [])
+    theme = resolved.get("theme", "black")
+    transition = resolved.get("transition", "slide")
+
+    if not slides:
+        return (
+            "You are editing a presentation in PocketPaw's slides editor.\n"
+            "The deck is currently empty (no slides). "
+            "Use the edit_slides tool to create slides.\n\n"
+            f"Theme: {theme} | Transition: {transition}"
+        )
+
+    parts = [
+        "You are editing a presentation in PocketPaw's slides editor.\n",
+        f"Theme: {theme} | Transition: {transition}",
+        f"Slides: {len(slides)}\n",
+        "## Slide overview\n",
+    ]
+
+    for i, slide in enumerate(slides):
+        parts.append(_summarize_slide(slide, i))
+        parts.append("")
+
+    scoping_notice = ""
+    if selected_slide_id:
+        scoping_notice = (
+            "\n"
+            "============================================================\n"
+            "CRITICAL: PER-SLIDE EDITING MODE\n"
+            "============================================================\n"
+            "You are in per-slide editing mode. You MUST follow these rules:\n"
+            "\n"
+            f"1. You are ONLY allowed to edit slide id={selected_slide_id}.\n"
+            "2. Do NOT modify, delete, or reorder any other slide.\n"
+            "3. Do NOT use 'replace_all' or 'set_theme' -- they would overwrite\n"
+            "   the entire deck and destroy content on other slides.\n"
+            "4. Do NOT create, delete, or reorder slides -- work within the\n"
+            "   selected slide only.\n"
+            "5. Use ONLY element operations (update_element, insert_element,\n"
+            f"   delete_element) with slide_id={selected_slide_id}.\n"
+            "6. If the user's prompt asks you to modify other slides or the\n"
+            "   whole deck, politely explain that you can only edit the\n"
+            "   selected slide. Suggest they deselect the slide for full-deck\n"
+            "   editing.\n"
+            "\n"
+            f"Target slide: id={selected_slide_id}\n"
+            "Permitted operations: update_element, insert_element, delete_element\n"
+            f"  (all with slide_id={selected_slide_id})\n"
+            "============================================================\n"
+        )
+        parts.insert(3, f"Selected slide: {selected_slide_id[:8]}\n")
+
+    parts.extend(
+        [
+            "## How to edit\n",
+            "Call the `edit_slides` tool with an array of operations. "
+            "You can call it multiple times -- each call returns the updated state.\n",
+            "Operations:",
+            '- create_slide: {"op":"create_slide", "layout":"content", "position":1, "background":{"type":"gradient","value":"linear-gradient(...)"}, "backgroundTransition":"zoom", "autoAnimate":true, "elements":[...]}',
+            '- delete_slide: {"op":"delete_slide", "slide_id":"abc123"}',
+            '- reorder_slides: {"op":"reorder_slides", "slide_ids":["id1","id2","id3"]}',
+            '- update_element: {"op":"update_element", "slide_id":"abc", "element_id":"def", "content":"New text", "fragment":"fade-in"}',
+            '- insert_element: {"op":"insert_element", "slide_id":"abc", "type":"heading", "content":"Title", "fragment":"grow"}',
+            '- delete_element: {"op":"delete_element", "slide_id":"abc", "element_id":"def"}',
+            '- set_theme: {"op":"set_theme", "theme":"night", "transition":"zoom", "backgroundTransition":"slide"}',
+            '- replace_all: {"op":"replace_all", "deck":{...}}',
+            "\nElement types: heading, text, list, image, code, table, quote\n",
+            'Background types: color, gradient, image, video. E.g.: {"type":"gradient","value":"linear-gradient(135deg, #1a1a2e, #16213e)"}\n',
+            "Fragment styles (per element): fade-in, fade-out, fade-up, fade-down, fade-left, fade-right, fade-in-then-out, grow, shrink, highlight-red, highlight-blue, highlight-green\n",
+            "After making your edits, briefly tell the user what you changed.",
+            scoping_notice,  # appended after the how-to guide so it overrides any conflicting instructions
+        ]
+    )
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Operations engine
+# ---------------------------------------------------------------------------
+
+
+def apply_slides_operations(
+    deck: dict,
+    operations: list[dict],
+    selected_slide_id: str | None = None,
+) -> tuple[dict, str]:
+    """Apply slide operations to a deck. Mutates in place.
+
+    When *selected_slide_id* is set, only element operations
+    (update_element, insert_element, delete_element) targeting that
+    specific slide are permitted.  Deck-level operations (create_slide,
+    delete_slide, reorder_slides, set_theme, replace_all) are rejected.
+
+    Returns (deck, summary) -- deck is the same dict reference, mutated.
+    """
+    _ensure_deck(deck)
+    summaries: list[str] = []
+
+    _ELEMENT_OPS = {"update_element", "insert_element", "delete_element"}
+
+    # Pre-flight: reject replace_all in per-slide mode (hard error, stops all).
+    if selected_slide_id:
+        for op in operations:
+            if op.get("op") == "replace_all":
+                return deck, (
+                    "ERROR: replace_all is not allowed in per-slide editing mode. "
+                    "You may only edit elements on the selected slide "
+                    f"(id={selected_slide_id}). "
+                    "Use update_element, insert_element, or delete_element instead."
+                )
+
+    for op in operations:
+        op_type = op.get("op")
+        try:
+            # Per-slide editing enforcement: gate non-element ops and cross-slide ops.
+            if selected_slide_id and op_type not in _ELEMENT_OPS:
+                summaries.append(
+                    f"SKIPPED: '{op_type}' is not allowed in per-slide editing mode. "
+                    f"Only update_element, insert_element, delete_element are permitted "
+                    f"(target slide id={selected_slide_id})."
+                )
+                continue
+
+            if selected_slide_id and op.get("slide_id") != selected_slide_id:
+                summaries.append(
+                    f"SKIPPED: {op_type} on slide '{str(op.get('slide_id', ''))[:8]}' "
+                    f"is not allowed in per-slide editing mode. Target slide is "
+                    f"id={selected_slide_id}."
+                )
+                continue
+
+            if op_type == "create_slide":
+                _op_create_slide(deck, op, summaries)
+            elif op_type == "delete_slide":
+                _op_delete_slide(deck, op, summaries)
+            elif op_type == "reorder_slides":
+                _op_reorder_slides(deck, op, summaries)
+            elif op_type == "update_element":
+                _op_update_element(deck, op, summaries)
+            elif op_type == "insert_element":
+                _op_insert_element(deck, op, summaries)
+            elif op_type == "delete_element":
+                _op_delete_element(deck, op, summaries)
+            elif op_type == "set_theme":
+                _op_set_theme(deck, op, summaries)
+            elif op_type == "replace_all":
+                _op_replace_all(deck, op, summaries)
+            else:
+                summaries.append(f"Unknown operation '{op_type}' -- skipped")
+        except ValueError as exc:
+            summaries.append(f"ERROR in '{op_type}': {exc}")
+
+    summary = "; ".join(summaries) if summaries else "No operations applied"
+    return deck, summary
+
+
+# ── Individual operation handlers ──
+
+
+def _op_create_slide(deck: dict, op: dict, summaries: list):
+    layout = op.get("layout", "content")
+    elements_raw = op.get("elements", [])
+    elements: list[dict] = []
+    for el in elements_raw:
+        if isinstance(el, dict) and "type" in el:
+            elements.append(
+                _create_element(
+                    el_type=el["type"],
+                    content=el.get("content", ""),
+                    style=el.get("style"),
+                    position=el.get("position"),
+                    fragment=el.get("fragment"),
+                )
+            )
+        else:
+            elements.append(el)
+
+    bg = op.get("background")
+    bg_transition = op.get("backgroundTransition")
+    auto_animate = op.get("autoAnimate", False)
+    slide = _create_slide(
+        layout=layout,
+        elements=elements,
+        background=bg,
+        background_transition=bg_transition,
+        auto_animate=auto_animate,
+    )
+    position = op.get("position")
+    slides = deck.setdefault("slides", [])
+    if position is not None and 0 <= position < len(slides):
+        slides.insert(position, slide)
+        actual_pos = position
+    else:
+        slides.append(slide)
+        actual_pos = len(slides) - 1
+    summaries.append(f"Created slide {slide['id'][:8]} (layout={layout}) at position {actual_pos}")
+
+
+def _op_delete_slide(deck: dict, op: dict, summaries: list):
+    slide_id = op.get("slide_id", "")
+    slides = deck.get("slides", [])
+    for i, slide in enumerate(slides):
+        if slide.get("id") == slide_id:
+            slides.pop(i)
+            summaries.append(f"Deleted slide {slide_id[:8]} (was position {i})")
+            return
+    summaries.append(f"Slide '{slide_id[:8]}' not found -- skipped delete_slide")
+
+
+def _op_reorder_slides(deck: dict, op: dict, summaries: list):
+    new_order = op.get("slide_ids", [])
+    slides = deck.get("slides", [])
+    if not new_order:
+        summaries.append("reorder_slides: slide_ids is empty -- nothing changed")
+        return
+    slide_map = {s["id"]: s for s in slides}
+    reordered = []
+    for sid in new_order:
+        if sid in slide_map:
+            reordered.append(slide_map.pop(sid))
+        else:
+            summaries.append(f"reorder_slides: slide '{sid[:8]}' not found -- skipping")
+    reordered.extend(slide_map.values())
+    deck["slides"] = reordered
+    summaries.append(f"Reordered {len(new_order)} slides")
+
+
+def _op_update_element(deck: dict, op: dict, summaries: list):
+    slide_id = op.get("slide_id", "")
+    element_id = op.get("element_id", "")
+    slide = _get_slide(deck, slide_id)
+    if slide is None:
+        summaries.append(f"update_element: slide '{slide_id[:8]}' not found")
+        return
+    el = _get_element(slide, element_id)
+    if el is None:
+        summaries.append(
+            f"update_element: element '{element_id[:8]}' not found in slide '{slide_id[:8]}'"
+        )
+        return
+
+    changed = []
+    if "content" in op:
+        el["content"] = op["content"]
+        changed.append("content")
+    if "style" in op and isinstance(op["style"], dict):
+        el.setdefault("style", {}).update(op["style"])
+        changed.append("style")
+    if "position" in op and isinstance(op["position"], dict):
+        el["position"] = op["position"]
+        changed.append("position")
+    if "fragment" in op:
+        el["fragment"] = op["fragment"] if op["fragment"] else None
+        changed.append(f"fragment={op['fragment']}")
+
+    summaries.append(
+        f"Updated element '{element_id[:8]}' on slide '{slide_id[:8]}': {', '.join(changed) or 'no fields'}"
+    )
+
+
+def _op_insert_element(deck: dict, op: dict, summaries: list):
+    slide_id = op.get("slide_id", "")
+    el_type = op.get("type", "text")
+    content = op.get("content", "")
+    style = op.get("style")
+    position = op.get("position")
+    fragment = op.get("fragment")
+
+    slide = _get_slide(deck, slide_id)
+    if slide is None:
+        summaries.append(f"insert_element: slide '{slide_id[:8]}' not found")
+        return
+
+    el = _create_element(
+        el_type=el_type, content=content, style=style, position=position, fragment=fragment
+    )
+    slide.setdefault("elements", []).append(el)
+    summaries.append(f"Inserted {el_type} element '{el['id'][:8]}' on slide '{slide_id[:8]}'")
+
+
+def _op_delete_element(deck: dict, op: dict, summaries: list):
+    slide_id = op.get("slide_id", "")
+    element_id = op.get("element_id", "")
+    slide = _get_slide(deck, slide_id)
+    if slide is None:
+        summaries.append(f"delete_element: slide '{slide_id[:8]}' not found")
+        return
+    elements = slide.get("elements", [])
+    for i, el in enumerate(elements):
+        if el.get("id") == element_id:
+            elements.pop(i)
+            summaries.append(f"Deleted element '{element_id[:8]}' from slide '{slide_id[:8]}'")
+            return
+    summaries.append(
+        f"delete_element: element '{element_id[:8]}' not found on slide '{slide_id[:8]}'"
+    )
+
+
+def _op_set_theme(deck: dict, op: dict, summaries: list):
+    changed = []
+    if "theme" in op and op["theme"] in _THEMES:
+        deck["theme"] = op["theme"]
+        changed.append(f"theme={op['theme']}")
+    elif "theme" in op:
+        summaries.append(f"set_theme: unknown theme '{op['theme']}' -- skipping")
+    if "transition" in op and op["transition"] in _TRANSITIONS:
+        deck["transition"] = op["transition"]
+        changed.append(f"transition={op['transition']}")
+    elif "transition" in op:
+        summaries.append(f"set_theme: unknown transition '{op['transition']}' -- skipping")
+    if "backgroundTransition" in op and op["backgroundTransition"] in _TRANSITIONS:
+        deck["backgroundTransition"] = op["backgroundTransition"]
+        changed.append(f"bgTransition={op['backgroundTransition']}")
+    elif "backgroundTransition" in op:
+        summaries.append(
+            f"set_theme: unknown backgroundTransition '{op['backgroundTransition']}' -- skipping"
+        )
+    if "slideNumber" in op:
+        deck["slideNumber"] = bool(op["slideNumber"])
+        changed.append(f"slideNumber={op['slideNumber']}")
+    if changed:
+        summaries.append(f"Updated deck settings: {', '.join(changed)}")
+
+
+def _op_replace_all(deck: dict, op: dict, summaries: list):
+    new_deck = op.get("deck", {})
+    deck.clear()
+    deck.update(new_deck)
+    _ensure_deck(deck)
+    summaries.append(f"Replaced entire deck ({len(deck.get('slides', []))} slides)")
+
+
+def _fmt_val(val: Any) -> str:
+    s = str(val)
+    return s[:60] + "..." if len(s) > 60 else s
+
+
+# ---------------------------------------------------------------------------
+# FL-5 registered tool — workspace-scoped, wired onto the FL-2 versioned service.
+# ---------------------------------------------------------------------------
+
+
+def _current_workspace() -> str | None:
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_workspace_id
+
+        return current_workspace_id()
+    except ImportError:
+        return None
+
+
+def _current_user() -> str | None:
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_user_id
+
+        return current_user_id()
+    except ImportError:
+        return None
+
+
+def _request_ctx(workspace_id: str, user_id: str | None):
+    """Build a minimal RequestContext for the FL-2 file_versions service."""
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=user_id or "agent",
+        workspace_id=workspace_id,
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _parse_deck(content: str) -> dict:
+    """Parse a slides deck JSON string into a mutable deck dict.
+
+    Tolerates a blank file or malformed JSON (treated as an empty deck so the
+    agent can build from scratch). Deep-copied so mutations don't corrupt any
+    shared reference.
+    """
+    try:
+        parsed = json.loads(content) if content and content.strip() else {}
+    except (json.JSONDecodeError, TypeError):
+        parsed = {}
+    if not isinstance(parsed, dict):
+        parsed = {}
+    return json.loads(json.dumps(parsed))
+
+
+class EditSlidesTool(BaseTool):
+    """Edit a reveal.js slide deck in the Library, writing a revertable version.
+
+    Loads the file's current deck JSON, applies slide/element operations, and
+    writes the mutated deck back through the FL-2 service so the change is a new
+    archived version. Operates only on files in the current workspace.
+    """
+
+    @property
+    def name(self) -> str:
+        return "edit_slides"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Structurally edit a slides (presentation) file in the workspace "
+            "Library. Provide the file's id and an array of operations to create, "
+            "delete, or reorder slides, insert/update/delete elements (heading, "
+            "text, list, image, code, table, quote), set backgrounds, add fragment "
+            "animations, change theme/transitions, or replace the deck. This writes "
+            "a new file version, so the edit is fully revertable. Operates only on "
+            "files in the current workspace."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "medium"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_id": {
+                    "type": "string",
+                    "description": "ID of the Library slides file to edit.",
+                },
+                "operations": {
+                    "type": "array",
+                    "description": "Ordered list of slide operations to apply.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "op": {
+                                "type": "string",
+                                "enum": [
+                                    "create_slide",
+                                    "delete_slide",
+                                    "reorder_slides",
+                                    "update_element",
+                                    "insert_element",
+                                    "delete_element",
+                                    "set_theme",
+                                    "replace_all",
+                                ],
+                            },
+                            "slide_id": {
+                                "type": "string",
+                                "description": "Target slide ID (12-char hex)",
+                            },
+                            "element_id": {
+                                "type": "string",
+                                "description": "Target element ID (8-char hex)",
+                            },
+                            "slide_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "New slide order (all slide IDs)",
+                            },
+                            "layout": {
+                                "type": "string",
+                                "enum": list(_LAYOUTS),
+                                "description": "Slide layout",
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": list(_ELEMENT_TYPES),
+                                "description": "Element type",
+                            },
+                            "content": {
+                                "description": "Element content: string for heading/text/quote, string[] for list, {src,alt} for image, {code,language} for code, {headers,rows} for table"
+                            },
+                            "elements": {
+                                "type": "array",
+                                "description": "Elements for a new slide",
+                            },
+                            "style": {
+                                "type": "object",
+                                "description": "CSS style overrides (fontSize, alignment, color)",
+                            },
+                            "position": {
+                                "type": "object",
+                                "properties": {
+                                    "x": {"type": "integer"},
+                                    "y": {"type": "integer"},
+                                    "width": {"type": "integer"},
+                                    "height": {"type": "integer"},
+                                },
+                                "description": "Grid position (12-column layout)",
+                            },
+                            "theme": {
+                                "type": "string",
+                                "enum": list(_THEMES),
+                                "description": "reveal.js theme (black, white, league, beige, sky, night, serif, simple, solarized, moon, dracula)",
+                            },
+                            "transition": {
+                                "type": "string",
+                                "enum": list(_TRANSITIONS),
+                                "description": "Slide transition (none, fade, slide, convex, concave, zoom)",
+                            },
+                            "backgroundTransition": {
+                                "type": "string",
+                                "enum": list(_TRANSITIONS),
+                                "description": "Background transition for set_theme or create_slide",
+                            },
+                            "slideNumber": {"type": "boolean", "description": "Show slide numbers"},
+                            "background": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": ["color", "gradient", "image", "video"],
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": "CSS color, gradient string, image URL, or video URL",
+                                    },
+                                },
+                                "description": "Slide background. Use type=gradient with value like 'linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)'",
+                            },
+                            "autoAnimate": {
+                                "type": "boolean",
+                                "description": "Enable auto-animate for this slide (create_slide)",
+                            },
+                            "fragment": {
+                                "type": "string",
+                                "description": "Fragment animation for an element: fade-in, fade-out, fade-up, fade-down, fade-left, fade-right, fade-in-then-out, grow, shrink, highlight-red, highlight-blue, highlight-green",
+                            },
+                            "deck": {
+                                "type": "object",
+                                "description": "Complete deck JSON for replace_all",
+                            },
+                        },
+                        "required": ["op"],
+                    },
+                },
+            },
+            "required": ["file_id", "operations"],
+        }
+
+    async def execute(self, file_id: str, operations: list[dict]) -> str:
+        workspace = _current_workspace()
+        if not workspace:
+            return self._error("Edit tools require a workspace context (cloud chat session).")
+
+        if not isinstance(operations, list) or not operations:
+            return self._error("Provide a non-empty `operations` array.")
+
+        try:
+            from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
+            from pocketpaw_ee.cloud.file_versions import service as fv_service
+            from pocketpaw_ee.cloud.file_versions.dto import UpdateFileContentRequest
+        except ImportError:
+            return self._error("Slides editing is not available (enterprise feature).")
+
+        ctx = _request_ctx(workspace, _current_user())
+
+        try:
+            content = await fv_service.read_current_content(ctx, file_id)
+        except NotFound:
+            return self._error(f"File {file_id!r} not found in this workspace.")
+        except CloudError as e:
+            return self._error(str(e))
+
+        deck = _parse_deck(content)
+        try:
+            updated, summary = apply_slides_operations(deck, operations)
+        except Exception as exc:
+            return self._error(f"Edit failed: {exc}")
+
+        new_content = json.dumps(updated, separators=(",", ":"))
+        try:
+            result = await fv_service.update_file_content(
+                ctx,
+                file_id,
+                UpdateFileContentRequest(content=new_content),
+                editor_kind="agent",
+            )
+        except NotFound:
+            return self._error(f"File {file_id!r} not found in this workspace.")
+        except CloudError as e:
+            return self._error(str(e))
+
+        return self._success(
+            f"{summary}. Saved {file_id} — new version {result.new_version} (revertable)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# In-process MCP server (Claude Agent SDK) — session-store editing.
+# Ported verbatim from #1193. Mutates the in-memory deck store (frontend sync);
+# does NOT write an FL-2 version (the frontend persists via PUT /files/{id}).
+# ---------------------------------------------------------------------------
+
+
+def _slides_error(message: str) -> dict:
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+async def _edit_slides_handler(args: dict) -> dict:
+    """MCP handler for the edit_slides tool."""
+    deck = get_active_deck()
+    if deck is None:
+        return _slides_error(
+            "No slide deck is currently open for editing. Open a slides file in the editor first."
+        )
+
+    operations = args.get("operations")
+    if not operations:
+        if args.get("operation"):
+            return _slides_error(
+                "Use `operations` (plural) as the key, not `operation`. "
+                'Example: {"operations": [{"op": "create_slide", ...}]}'
+            )
+        if any(k in args for k in ("create_slide", "slide_id", "type", "content")):
+            return _slides_error(
+                "Wrap operations inside an `operations` array. "
+                'Example: {"operations": [{"op": "create_slide", "layout": "content"}]}'
+            )
+        return _slides_error(
+            "Missing `operations` array. "
+            'Format: {"operations": [{"op": "create_slide|delete_slide|...", ...}]}'
+        )
+
+    if not isinstance(operations, list):
+        return _slides_error("`operations` must be an array (list), not a single object.")
+
+    try:
+        selected = get_selected_slide_id()
+        updated, summary = apply_slides_operations(deck, operations, selected_slide_id=selected)
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "summary": summary,
+                            "slideCount": len(updated.get("slides", [])),
+                            "deck": updated,
+                        },
+                        separators=(",", ":"),
+                    ),
+                }
+            ]
+        }
+    except Exception as exc:
+        logger.exception("edit_slides handler failed")
+        return _slides_error(str(exc))
+
+
+def build_edit_slides_mcp_server() -> tuple[str, Any] | None:
+    """Build the in-process MCP server for the Claude Agent SDK.
+
+    Returns (server_name, server_config) or None if the SDK is unavailable.
+    Always registered -- the handler returns an error when no editing session
+    is active, so the agent won't use it outside the slides editing context.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; edit_slides MCP disabled")
+        return None
+
+    @tool(
+        "edit_slides",
+        (
+            "Edit the current slide deck by performing operations on slides and "
+            "elements. Use this when the user asks you to edit, create, or "
+            "restructure a presentation they have open in the editor.\n\n"
+            "You MUST call it with an `operations` array. Each item must have "
+            "an `op` field set to one of: create_slide, delete_slide, "
+            "reorder_slides, update_element, insert_element, delete_element, "
+            "set_theme, replace_all.\n\n"
+            "EXACT format (copy this pattern):\n"
+            '{"operations": [\n'
+            '  {"op": "create_slide", "layout": "title-slide",\n'
+            '   "background": {"type": "gradient", "value": "linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)"},\n'
+            '   "backgroundTransition": "zoom",\n'
+            '   "elements": [\n'
+            '     {"type": "heading", "content": "My Title", "style": {"fontSize": "2.5em", "alignment": "center"}, "fragment": "fade-in"},\n'
+            '     {"type": "text", "content": "Subtitle", "style": {"fontSize": "1.2em", "alignment": "center"}, "fragment": "fade-up"}\n'
+            "  ]},\n"
+            '  {"op": "insert_element", "slide_id": "abc123def456", "type": "list", "content": ["Point 1", "Point 2"], "fragment": "grow"},\n'
+            '  {"op": "update_element", "slide_id": "abc123def456", "element_id": "a1b2c3d4", "content": "Updated text", "fragment": "highlight-blue"},\n'
+            '  {"op": "delete_slide", "slide_id": "abc123def456"},\n'
+            '  {"op": "reorder_slides", "slide_ids": ["id2", "id1", "id3"]},\n'
+            '  {"op": "set_theme", "theme": "night", "transition": "zoom", "backgroundTransition": "slide"},\n'
+            '  {"op": "replace_all", "deck": {...}}\n'
+            "]}\n\n"
+            "ELEMENT TYPES: heading, text, list, image, code, table, quote\n"
+            "CONTENT FORMATS:\n"
+            "- heading/text/quote: a string\n"
+            "- list: an array of strings\n"
+            '- image: {"src": "url", "alt": "description"}\n'
+            '- code: {"code": "...", "language": "python"}\n'
+            '- table: {"headers": ["Col1","Col2"], "rows": [["a","b"],["c","d"]]}\n\n'
+            'STYLE (optional): {"fontSize": "2em", "alignment": "left|center|right", "color": "#hex"}\n'
+            "FRAGMENT (optional, per element): fade-in, fade-out, fade-up, fade-down, fade-left, fade-right, fade-in-then-out, fade-in-then-semi-out, grow, shrink, highlight-red, highlight-blue, highlight-green\n"
+            'BACKGROUND (optional, per slide): {"type":"color","value":"#1a1a2e"} | {"type":"gradient","value":"linear-gradient(135deg, #1a1a2e, #16213e)"} | {"type":"image","value":"https://..."} | {"type":"video","value":"https://..."}\n'
+            "BACKGROUND TRANSITION (optional): none, fade, slide, convex, concave, zoom\n"
+            'AUTO-ANIMATE: add "autoAnimate":true to create_slide for matching elements across consecutive slides\n'
+            "SLIDE LAYOUTS: title-slide, content, two-column, image-full, blank\n"
+            "THEMES: black, white, league, beige, sky, night, serif, simple, solarized, moon, dracula\n"
+            "TRANSITIONS: none, fade, slide, convex, concave, zoom\n\n"
+            "DESIGN TIPS:\n"
+            "- For a professional deck, use gradient backgrounds with complementary colors\n"
+            "- Dark themes (night, dracula, moon, league) look more polished for tech presentations\n"
+            "- Use fragments to reveal content incrementally — headings first, then body text\n"
+            "- Pair 'zoom' transition with 'slide' background transition for smooth motion\n"
+            "- Code blocks auto-highlight when you specify the language\n\n"
+            "IMPORTANT: The field is `op` (not operation or action). "
+            "Everything goes inside the `operations` array -- not at top level."
+        ),
+        {
+            "operations": list,
+        },
+    )
+    async def edit_slides(args):
+        return await _edit_slides_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[edit_slides],
+    )
+    return SERVER_NAME, server

--- a/src/pocketpaw/tools/builtin/edit_spreadsheet.py
+++ b/src/pocketpaw/tools/builtin/edit_spreadsheet.py
@@ -1,0 +1,991 @@
+# edit_spreadsheet.py — FL-5 structural spreadsheet editing (port of dewani12's #1193).
+# Created: 2026-07-03 (FL-5, port of dewani12's origin/feature/files
+#   src/pocketpaw/tools/builtin/edit_spreadsheet.py). Credit: dewani12 authored the
+#   Univer workbook operation engine, the A1-notation parsers, the prompt-context
+#   builder, the module-store transport, and the in-process MCP server — all ported
+#   here verbatim (adapted only for imports on current dev).
+#
+# Two agent-facing surfaces share one workbook operation engine:
+#   1. ``EditSpreadsheetTool`` (``BaseTool``, registered in ``_EE_TOOLS``,
+#      trust_level "medium") — edits a Library spreadsheet file by id: loads the
+#      current workbook snapshot JSON via ``file_versions.service
+#      .read_current_content``, applies the ops, and writes the mutated snapshot
+#      back through ``update_file_content(editor_kind="agent")`` so every edit
+#      lands as a NEW revertable FL-2 version. Follows the FL-3 library-verb
+#      pattern (workspace from agent-identity ContextVars; lazy EE imports).
+#   2. the in-process MCP server (``build_edit_spreadsheet_mcp_server``) — edits
+#      the session snapshot-store synced from the frontend spreadsheet UI (REST
+#      spreadsheet-edit path); no version is written (the frontend persists via
+#      PUT /files/{id}).
+"""edit_spreadsheet tool — structural spreadsheet editing for Univer workbooks."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from contextvars import ContextVar
+from typing import Any
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+# Per-request workbook snapshot (REST ai-edit endpoint).
+_edit_session_snapshot: ContextVar[dict | None] = ContextVar("edit_session_snapshot", default=None)
+
+# Per-request selected sheet name for scoped editing.
+_selected_sheet: ContextVar[str | None] = ContextVar("selected_sheet", default=None)
+
+# Module-level store keyed by file_id — used when snapshots are synced from
+# the frontend spreadsheet UI (chat-initiated editing).
+_spreadsheet_snapshot_store: dict[str, dict] = {}
+
+SERVER_NAME = "pocketpaw_edit_spreadsheet"
+EDIT_SPREADSHEET_TOOL_ID = f"mcp__{SERVER_NAME}__edit_spreadsheet"
+
+# ---------------------------------------------------------------------------
+# Cell reference parsing (A1 notation)
+# ---------------------------------------------------------------------------
+
+_A1_RE = re.compile(
+    r"^(?:(?P<sheet>[A-Za-z0-9_ ]+)!)?"
+    r"(?P<col>[A-Z]+)(?P<row>\d+)$"
+)
+
+_RANGE_RE = re.compile(
+    r"^(?:(?P<sheet>[A-Za-z0-9_ ]+)!)?"
+    r"(?P<col1>[A-Z]+)(?P<row1>\d+)"
+    r":"
+    r"(?P<col2>[A-Z]+)(?P<row2>\d+)$"
+)
+
+
+def _col_to_index(col: str) -> int:
+    """Convert column letter(s) to 0-based index. A=0, B=1, ..., AA=26."""
+    idx = 0
+    for ch in col.upper():
+        idx = idx * 26 + (ord(ch) - ord("A") + 1)
+    return idx - 1
+
+
+def _index_to_col(idx: int) -> str:
+    """Convert 0-based column index to letters. 0='A', 25='Z', 26='AA'."""
+    result = ""
+    while idx >= 0:
+        result = chr(ord("A") + idx % 26) + result
+        idx = idx // 26 - 1
+    return result
+
+
+def parse_cell_ref(ref: str, default_sheet: str | None = None) -> tuple[str, int, int]:
+    """Parse an A1-style cell reference into (sheet_name, row_0, col_0).
+
+    ``Sheet1!B5`` → ("Sheet1", 4, 1).  ``B5`` → (default_sheet, 4, 1).
+    Raises ValueError if the reference is malformed.
+    """
+    m = _A1_RE.match(ref.strip())
+    if not m:
+        raise ValueError(
+            f"Invalid cell reference '{ref}'. Use A1 notation, e.g. 'B5' or 'Sheet1!B5'."
+        )
+    sheet = m.group("sheet") or default_sheet or ""
+    col_idx = _col_to_index(m.group("col"))
+    row_idx = int(m.group("row")) - 1
+    if row_idx < 0:
+        raise ValueError(f"Invalid row number in '{ref}'")
+    return sheet, row_idx, col_idx
+
+
+def parse_range_ref(ref: str, default_sheet: str | None = None) -> tuple[str, int, int, int, int]:
+    """Parse an A1-style range reference into (sheet, row1, col1, row2, col2).
+
+    ``A1:C10`` → (default_sheet, 0, 0, 9, 2). Supports ``Sheet1!A1:C10``.
+    """
+    m = _RANGE_RE.match(ref.strip())
+    if not m:
+        raise ValueError(f"Invalid range reference '{ref}'. Use A1 notation, e.g. 'A1:C10'.")
+    sheet = m.group("sheet") or default_sheet or ""
+    row1 = int(m.group("row1")) - 1
+    col1 = _col_to_index(m.group("col1"))
+    row2 = int(m.group("row2")) - 1
+    col2 = _col_to_index(m.group("col2"))
+    if row1 < 0 or row2 < 0:
+        raise ValueError(f"Invalid row range in '{ref}'")
+    return sheet, row1, col1, row2, col2
+
+
+# ---------------------------------------------------------------------------
+# Session management (ContextVar + module dict — mirrors edit_document.py)
+# ---------------------------------------------------------------------------
+
+
+def set_edit_session(snapshot: dict) -> None:
+    _edit_session_snapshot.set(snapshot)
+
+
+def clear_edit_session() -> None:
+    _edit_session_snapshot.set(None)
+
+
+def get_edit_session() -> dict | None:
+    return _edit_session_snapshot.get()
+
+
+def set_selected_sheet(sheet: str | None) -> None:
+    _selected_sheet.set(sheet)
+
+
+def get_selected_sheet() -> str | None:
+    return _selected_sheet.get()
+
+
+def clear_selected_sheet() -> None:
+    _selected_sheet.set(None)
+
+
+def set_spreadsheet_snapshot(file_id: str, snapshot: dict) -> None:
+    _spreadsheet_snapshot_store[file_id] = snapshot
+
+
+def get_spreadsheet_snapshot(file_id: str) -> dict | None:
+    return _spreadsheet_snapshot_store.get(file_id)
+
+
+def clear_spreadsheet_snapshot(file_id: str) -> None:
+    _spreadsheet_snapshot_store.pop(file_id, None)
+
+
+def get_active_snapshot() -> dict | None:
+    """Get whichever snapshot is available — ContextVar first, then store."""
+    snap = _edit_session_snapshot.get()
+    if snap is not None:
+        return snap
+    if _spreadsheet_snapshot_store:
+        return next(iter(_spreadsheet_snapshot_store.values()))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Snapshot helpers
+# ---------------------------------------------------------------------------
+
+
+def _sheet_names(snapshot: dict) -> list[str]:
+    """Return ordered sheet names from the workbook snapshot."""
+    return list(snapshot.get("sheetOrder", []) or snapshot.get("sheets", {}).keys())
+
+
+def _get_sheet(snapshot: dict, name: str) -> dict | None:
+    """Get a sheet dict by name from the workbook snapshot."""
+    sheets = snapshot.get("sheets", {})
+    return sheets.get(name)
+
+
+def _ensure_sheet(snapshot: dict, name: str) -> dict:
+    """Get or create a sheet dict. Initialises cellData if needed."""
+    sheets = snapshot.setdefault("sheets", {})
+    if name not in sheets:
+        sheet = {
+            "id": uuid.uuid4().hex[:8],
+            "name": name,
+            "rowCount": 1000,
+            "columnCount": 26,
+            "cellData": {},
+        }
+        sheets[name] = sheet
+        snapshot.setdefault("sheetOrder", []).append(name)
+        if "id" not in snapshot:
+            snapshot["id"] = uuid.uuid4().hex[:8]
+        if "name" not in snapshot:
+            snapshot["name"] = "Workbook"
+    return sheets[name]
+
+
+def _cell_data(sheet: dict) -> dict:
+    """Return the cellData dict for a sheet, initialising if needed."""
+    return sheet.setdefault("cellData", {})
+
+
+def _get_cell(sheet: dict, row: int, col: int) -> dict | None:
+    """Get a cell from a sheet by 0-based row/col. Returns None if empty."""
+    cd = _cell_data(sheet)
+    row_dict = cd.get(str(row))
+    if row_dict is None:
+        return None
+    return row_dict.get(str(col))
+
+
+def _set_cell(sheet: dict, row: int, col: int, value: Any, /, *, cell_type: int | None = None):
+    """Set a cell in a sheet. Auto-bumps rowCount/columnCount if needed."""
+    cd = sheet.setdefault("cellData", {})
+    row_key = str(row)
+    if row_key not in cd:
+        cd[row_key] = {}
+    col_key = str(col)
+    if cell_type is None:
+        cell_type = _infer_cell_type(value)
+    cd[row_key][col_key] = {"v": value, "t": cell_type}
+    if row >= sheet.get("rowCount", 0):
+        sheet["rowCount"] = row + 1
+    if col >= sheet.get("columnCount", 0):
+        sheet["columnCount"] = col + 1
+
+
+def _infer_cell_type(value: Any) -> int:
+    """Infer Univer cell type from Python value. 1=string, 2=number, 3=boolean."""
+    if isinstance(value, bool):
+        return 3
+    if isinstance(value, (int, float)):
+        return 2
+    return 1
+
+
+def _clear_cell(sheet: dict, row: int, col: int) -> bool:
+    """Remove a cell from cellData. Returns True if a cell was actually removed."""
+    cd = _cell_data(sheet)
+    row_dict = cd.get(str(row))
+    if row_dict is None:
+        return False
+    col_key = str(col)
+    if col_key in row_dict:
+        del row_dict[col_key]
+        if not row_dict:
+            del cd[str(row)]
+        return True
+    return False
+
+
+def _shift_rows(sheet: dict, from_row: int, delta: int):
+    """Shift cellData rows by delta starting from from_row. Positive = move down."""
+    cd = _cell_data(sheet)
+    if delta == 0:
+        return
+    rows_to_move = sorted(
+        (int(r) for r in cd if int(r) >= from_row),
+        reverse=(delta > 0),
+    )
+    for r in rows_to_move:
+        new_r = r + delta
+        if new_r < 0:
+            continue
+        cd[str(new_r)] = cd.pop(str(r), {})
+    sheet["rowCount"] = max(1, sheet.get("rowCount", 0) + delta)
+
+
+def _shift_columns(sheet: dict, from_col: int, delta: int):
+    """Shift cellData columns by delta starting from from_col. Positive = move right."""
+    cd = _cell_data(sheet)
+    if delta == 0:
+        return
+    for row_key in list(cd):
+        row_dict = cd.get(row_key)
+        if not row_dict:
+            continue
+        new_row: dict[str, dict] = {}
+        for col_key, cell in row_dict.items():
+            c = int(col_key)
+            if c >= from_col:
+                new_c = c + delta
+                if new_c >= 0:
+                    new_row[str(new_c)] = cell
+            else:
+                new_row[col_key] = cell
+        cd[row_key] = new_row
+    sheet["columnCount"] = max(1, sheet.get("columnCount", 0) + delta)
+
+
+def _collect_range(
+    sheet: dict, row1: int, col1: int, row2: int, col2: int
+) -> list[tuple[int, int, dict | None]]:
+    """Collect all cells in a range. Returns list of (row, col, cell_dict_or_none)."""
+    result = []
+    for r in range(min(row1, row2), max(row1, row2) + 1):
+        for c in range(min(col1, col2), max(col1, col2) + 1):
+            result.append((r, c, _get_cell(sheet, r, c)))
+    return result
+
+
+def _summarize_sheet(snapshot: dict, sheet_name: str) -> str:
+    """Build a compact summary of a sheet: dimensions, headers, sample data."""
+    sheet = _get_sheet(snapshot, sheet_name)
+    if not sheet:
+        return f"Sheet '{sheet_name}': (empty)"
+
+    cd = _cell_data(sheet)
+    rows = sorted({int(r) for r in cd} | {0})
+    cols = sorted({int(c) for row_dict in cd.values() for c in row_dict} | {0, 1, 2, 3, 4})
+
+    num_rows = sheet.get("rowCount", 0)
+    num_cols = sheet.get("columnCount", 0)
+    lines = [
+        f"Sheet '{sheet_name}': {num_rows} rows x {num_cols} columns, "
+        f"{sum(len(row_dict) for row_dict in cd.values())} cells with data",
+    ]
+
+    if rows:
+        top_rows = rows[:15]
+        top_cols = sorted(cols)[:10]
+        if top_cols:
+            header = "    | " + " | ".join(_index_to_col(c).rjust(5) for c in top_cols) + " |"
+            lines.append(header)
+            lines.append("    |-" + "-|-".join("-" * 5 for _ in top_cols) + "-|")
+            for r in top_rows:
+                row_parts = []
+                for c in top_cols:
+                    cell = _get_cell(sheet, r, c)
+                    if cell is None:
+                        row_parts.append("".rjust(5))
+                    else:
+                        val = str(cell.get("v", ""))[:4]
+                        row_parts.append(val.rjust(5))
+                lines.append(f"  {r + 1:2d} | " + " | ".join(row_parts) + " |")
+
+        if len(rows) > 15:
+            lines.append(f"  ... ({len(rows) - 15} more rows)")
+
+        if len(cols) > 10:
+            lines.append(f"  ... ({len(cols) - 10} more columns)")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Prompt context builder
+# ---------------------------------------------------------------------------
+
+
+def build_spreadsheet_prompt_context(
+    snapshot: dict | None = None,
+    *,
+    selected_sheet: str | None = None,
+) -> str | None:
+    """Build a system-prompt block describing the current workbook state.
+
+    Returns None if no snapshot is available.
+    """
+    resolved = snapshot or get_active_snapshot()
+    if not resolved:
+        return None
+
+    sheets = _sheet_names(resolved)
+    active = selected_sheet or (sheets[0] if sheets else "Sheet1")
+
+    if not sheets:
+        return (
+            "You are editing a spreadsheet in PocketPaw. "
+            "The workbook is currently empty (no sheets). "
+            "Use the edit_spreadsheet tool to create the first sheet."
+        )
+
+    parts = [
+        "You are editing a spreadsheet in PocketPaw's spreadsheet editor.\n",
+        f"Workbook: {resolved.get('name', 'Untitled')}",
+        f"Sheets: {', '.join(sheets)}",
+        f"Active sheet: {active}\n",
+        "## Workbook structure\n",
+    ]
+
+    for sn in sheets:
+        parts.append(_summarize_sheet(resolved, sn))
+        parts.append("")
+
+    parts.extend(
+        [
+            "## How to edit\n",
+            "Call the `edit_spreadsheet` tool with an array of operations. "
+            "You can call it multiple times — each call returns the updated state.\n",
+            "Operations:",
+            '- setCell: {"op":"setCell", "cell":"A1", "value":"hello"}',
+            '- setRange: {"op":"setRange", "range":"A1:C3", "values":[["a","b","c"],["d","e","f"],["g","h","i"]]}',
+            '- setFormula: {"op":"setFormula", "cell":"D1", "formula":"=SUM(A1:C1)"}',
+            '- clearRange: {"op":"clearRange", "range":"A1:C3"}',
+            '- insertRows: {"op":"insertRows", "sheet":"Sheet1", "atRow":2, "count":1}',
+            '- deleteRows: {"op":"deleteRows", "sheet":"Sheet1", "atRow":2, "count":1}',
+            '- insertColumns: {"op":"insertColumns", "sheet":"Sheet1", "atCol":"B", "count":1}',
+            '- deleteColumns: {"op":"deleteColumns", "sheet":"Sheet1", "atCol":"B", "count":1}',
+            '- insertSheet: {"op":"insertSheet", "name":"NewSheet"}',
+            '- deleteSheet: {"op":"deleteSheet", "name":"Sheet2"}',
+            '- renameSheet: {"op":"renameSheet", "name":"Sheet1", "newName":"Data"}',
+            '- mergeCells: {"op":"mergeCells", "range":"A1:B2"}',
+            '- replaceAll: {"op":"replaceAll", "snapshot":{...}}',
+            "\nCell references use A1 notation. Use 'SheetName!A1' for cross-sheet references.\n",
+            "After making your edits, briefly tell the user what you changed.",
+        ]
+    )
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Operations engine
+# ---------------------------------------------------------------------------
+
+
+def apply_spreadsheet_ops(
+    snapshot: dict,
+    operations: list[dict],
+    selected_sheet: str | None = None,
+) -> tuple[dict, str]:
+    """Apply spreadsheet operations to a workbook snapshot. Mutates in place.
+
+    Returns (snapshot, summary) — snapshot is the same dict reference, mutated.
+    """
+    summaries: list[str] = []
+    active_sheet = selected_sheet or (
+        _sheet_names(snapshot)[0] if _sheet_names(snapshot) else "Sheet1"
+    )
+
+    for op in operations:
+        op_type = op.get("op")
+        try:
+            if op_type == "setCell":
+                _op_set_cell(snapshot, op, active_sheet, summaries)
+            elif op_type == "setRange":
+                _op_set_range(snapshot, op, active_sheet, summaries)
+            elif op_type == "setFormula":
+                _op_set_formula(snapshot, op, active_sheet, summaries)
+            elif op_type == "clearRange":
+                _op_clear_range(snapshot, op, active_sheet, summaries)
+            elif op_type == "insertRows":
+                _op_insert_rows(snapshot, op, summaries)
+            elif op_type == "deleteRows":
+                _op_delete_rows(snapshot, op, summaries)
+            elif op_type == "insertColumns":
+                _op_insert_columns(snapshot, op, summaries)
+            elif op_type == "deleteColumns":
+                _op_delete_columns(snapshot, op, summaries)
+            elif op_type == "insertSheet":
+                _op_insert_sheet(snapshot, op, summaries)
+            elif op_type == "deleteSheet":
+                _op_delete_sheet(snapshot, op, summaries)
+            elif op_type == "renameSheet":
+                _op_rename_sheet(snapshot, op, summaries)
+            elif op_type == "mergeCells":
+                _op_merge_cells(snapshot, op, active_sheet, summaries)
+            elif op_type == "replaceAll":
+                _op_replace_all(snapshot, op, summaries)
+            else:
+                summaries.append(f"Unknown operation '{op_type}' — skipped")
+        except ValueError as exc:
+            summaries.append(f"ERROR in '{op_type}': {exc}")
+
+    summary = "; ".join(summaries) if summaries else "No operations applied"
+    return snapshot, summary
+
+
+def _resolve_sheet(snapshot: dict, op: dict, active: str) -> str:
+    """Get sheet name from op['sheet'] or the active sheet."""
+    return op.get("sheet") or active
+
+
+# ── Individual operation handlers ──
+
+
+def _op_set_cell(snapshot: dict, op: dict, active: str, summaries: list):
+    cell_ref = op.get("cell", "")
+    sheet, row, col = parse_cell_ref(cell_ref, active)
+    s = _ensure_sheet(snapshot, sheet)
+    _set_cell(s, row, col, op["value"])
+    summaries.append(f"Set {cell_ref} = {_fmt_val(op['value'])}")
+
+
+def _op_set_range(snapshot: dict, op: dict, active: str, summaries: list):
+    range_ref = op.get("range", "")
+    sheet, row1, col1, row2, col2 = parse_range_ref(range_ref, active)
+    values = op.get("values", [])
+    s = _ensure_sheet(snapshot, sheet)
+    count = 0
+    for ri, row_vals in enumerate(values):
+        if not isinstance(row_vals, list):
+            row_vals = [row_vals]
+        for ci, val in enumerate(row_vals):
+            _set_cell(s, row1 + ri, col1 + ci, val)
+            count += 1
+    summaries.append(f"Set {count} cells in {range_ref}")
+
+
+def _op_set_formula(snapshot: dict, op: dict, active: str, summaries: list):
+    cell_ref = op.get("cell", "")
+    sheet, row, col = parse_cell_ref(cell_ref, active)
+    s = _ensure_sheet(snapshot, sheet)
+    cd = _cell_data(s)
+    cd.setdefault(str(row), {})[str(col)] = {
+        "v": op.get("formula", ""),
+        "f": op.get("formula", ""),
+        "t": 2,
+    }
+    summaries.append(f"Set formula in {cell_ref}: {op.get('formula', '')}")
+
+
+def _op_clear_range(snapshot: dict, op: dict, active: str, summaries: list):
+    range_ref = op.get("range", "")
+    sheet, row1, col1, row2, col2 = parse_range_ref(range_ref, active)
+    s = _get_sheet(snapshot, sheet)
+    if s is None:
+        summaries.append(f"Sheet '{sheet}' not found — skipped clearRange")
+        return
+    count = 0
+    for r in range(min(row1, row2), max(row1, row2) + 1):
+        for c in range(min(col1, col2), max(col1, col2) + 1):
+            if _clear_cell(s, r, c):
+                count += 1
+    summaries.append(f"Cleared {count} cells in {range_ref}")
+
+
+def _op_insert_rows(snapshot: dict, op: dict, summaries: list):
+    sheet_name = op.get("sheet", "")
+    s = _get_sheet(snapshot, sheet_name)
+    if s is None:
+        summaries.append(f"Sheet '{sheet_name}' not found — skipped insertRows")
+        return
+    at_row = op.get("atRow", 0)
+    count = op.get("count", 1)
+    _shift_rows(s, at_row, count)
+    summaries.append(f"Inserted {count} row(s) at row {at_row + 1} in '{sheet_name}'")
+
+
+def _op_delete_rows(snapshot: dict, op: dict, summaries: list):
+    sheet_name = op.get("sheet", "")
+    s = _get_sheet(snapshot, sheet_name)
+    if s is None:
+        summaries.append(f"Sheet '{sheet_name}' not found — skipped deleteRows")
+        return
+    at_row = op.get("atRow", 0)
+    count = op.get("count", 1)
+    _shift_rows(s, at_row + count, -count)
+    summaries.append(f"Deleted {count} row(s) at row {at_row + 1} in '{sheet_name}'")
+
+
+def _op_insert_columns(snapshot: dict, op: dict, summaries: list):
+    sheet_name = op.get("sheet", "")
+    s = _get_sheet(snapshot, sheet_name)
+    if s is None:
+        summaries.append(f"Sheet '{sheet_name}' not found — skipped insertColumns")
+        return
+    at_col_str = op.get("atCol", "A")
+    at_col = _col_to_index(at_col_str)
+    count = op.get("count", 1)
+    _shift_columns(s, at_col, count)
+    summaries.append(f"Inserted {count} column(s) at column {at_col_str} in '{sheet_name}'")
+
+
+def _op_delete_columns(snapshot: dict, op: dict, summaries: list):
+    sheet_name = op.get("sheet", "")
+    s = _get_sheet(snapshot, sheet_name)
+    if s is None:
+        summaries.append(f"Sheet '{sheet_name}' not found — skipped deleteColumns")
+        return
+    at_col_str = op.get("atCol", "A")
+    at_col = _col_to_index(at_col_str)
+    count = op.get("count", 1)
+    _shift_columns(s, at_col + count, -count)
+    summaries.append(f"Deleted {count} column(s) at column {at_col_str} in '{sheet_name}'")
+
+
+def _op_insert_sheet(snapshot: dict, op: dict, summaries: list):
+    name = op.get("name", f"Sheet{len(_sheet_names(snapshot)) + 1}")
+    _ensure_sheet(snapshot, name)
+    summaries.append(f"Inserted sheet '{name}'")
+
+
+def _op_delete_sheet(snapshot: dict, op: dict, summaries: list):
+    name = op.get("name", "")
+    sheets = snapshot.get("sheets", {})
+    if name not in sheets:
+        summaries.append(f"Sheet '{name}' not found — skipped deleteSheet")
+        return
+    del sheets[name]
+    order = snapshot.get("sheetOrder", [])
+    if name in order:
+        order.remove(name)
+    summaries.append(f"Deleted sheet '{name}'")
+
+
+def _op_rename_sheet(snapshot: dict, op: dict, summaries: list):
+    name = op.get("name", "")
+    new_name = op.get("newName", "")
+    sheets = snapshot.get("sheets", {})
+    if name not in sheets:
+        summaries.append(f"Sheet '{name}' not found — skipped renameSheet")
+        return
+    sheets[new_name] = sheets.pop(name)
+    sheets[new_name]["name"] = new_name
+    order = snapshot.get("sheetOrder", [])
+    if name in order:
+        order[order.index(name)] = new_name
+    summaries.append(f"Renamed sheet '{name}' → '{new_name}'")
+
+
+def _op_merge_cells(snapshot: dict, op: dict, active: str, summaries: list):
+    range_ref = op.get("range", "")
+    sheet, row1, col1, row2, col2 = parse_range_ref(range_ref, active)
+    s = _ensure_sheet(snapshot, sheet)
+    merges = s.setdefault("mergeData", [])
+    merge = {
+        "startRow": min(row1, row2),
+        "endRow": max(row1, row2),
+        "startColumn": min(col1, col2),
+        "endColumn": max(col1, col2),
+    }
+    merges.append(merge)
+    summaries.append(f"Merged cells {range_ref}")
+
+
+def _op_replace_all(snapshot: dict, op: dict, summaries: list):
+    new_snapshot = op.get("snapshot", {})
+    snapshot.clear()
+    snapshot.update(new_snapshot)
+    summaries.append(f"Replaced entire workbook ({len(_sheet_names(snapshot))} sheets)")
+
+
+def _fmt_val(val: Any) -> str:
+    s = str(val)
+    return s[:40] + "..." if len(s) > 40 else s
+
+
+# ---------------------------------------------------------------------------
+# FL-5 registered tool — workspace-scoped, wired onto the FL-2 versioned service.
+# ---------------------------------------------------------------------------
+
+
+def _current_workspace() -> str | None:
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_workspace_id
+
+        return current_workspace_id()
+    except ImportError:
+        return None
+
+
+def _current_user() -> str | None:
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_user_id
+
+        return current_user_id()
+    except ImportError:
+        return None
+
+
+def _request_ctx(workspace_id: str, user_id: str | None):
+    """Build a minimal RequestContext for the FL-2 file_versions service."""
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=user_id or "agent",
+        workspace_id=workspace_id,
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _parse_snapshot(content: str) -> dict:
+    """Parse a workbook snapshot JSON string into a mutable snapshot dict.
+
+    Tolerates a blank file or malformed JSON (treated as an empty workbook so
+    the agent can build from scratch). Deep-copied so mutations don't corrupt
+    any shared reference.
+    """
+    try:
+        parsed = json.loads(content) if content and content.strip() else {}
+    except (json.JSONDecodeError, TypeError):
+        parsed = {}
+    if not isinstance(parsed, dict):
+        parsed = {}
+    return json.loads(json.dumps(parsed))
+
+
+class EditSpreadsheetTool(BaseTool):
+    """Edit a Univer workbook in the Library, writing a revertable version.
+
+    Loads the file's current workbook snapshot JSON, applies cell/range/row/
+    column/sheet operations, and writes the mutated snapshot back through the
+    FL-2 service so the change is a new archived version. Operates only on
+    files in the current workspace.
+    """
+
+    @property
+    def name(self) -> str:
+        return "edit_spreadsheet"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Structurally edit a spreadsheet file (Univer workbook) in the "
+            "workspace Library. Provide the file's id and an array of operations "
+            "to set cell values or formulas, set/clear ranges, insert/delete rows "
+            "and columns, manage sheets, merge cells, or replace the workbook. "
+            "This writes a new file version, so the edit is fully revertable. Cell "
+            "references use A1 notation. Operates only on files in the current "
+            "workspace."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "medium"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_id": {
+                    "type": "string",
+                    "description": "ID of the Library spreadsheet file to edit.",
+                },
+                "operations": {
+                    "type": "array",
+                    "description": "Ordered list of spreadsheet operations to apply.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "op": {
+                                "type": "string",
+                                "enum": [
+                                    "setCell",
+                                    "setRange",
+                                    "setFormula",
+                                    "clearRange",
+                                    "insertRows",
+                                    "deleteRows",
+                                    "insertColumns",
+                                    "deleteColumns",
+                                    "insertSheet",
+                                    "deleteSheet",
+                                    "renameSheet",
+                                    "mergeCells",
+                                    "replaceAll",
+                                ],
+                            },
+                            "cell": {
+                                "type": "string",
+                                "description": "Cell ref in A1 notation, e.g. 'B5' or 'Sheet1!B5'",
+                            },
+                            "value": {"description": "Cell value (string, number, or boolean)"},
+                            "range": {
+                                "type": "string",
+                                "description": "Range in A1 notation, e.g. 'A1:C10'",
+                            },
+                            "values": {
+                                "type": "array",
+                                "description": "2D array of values for setRange",
+                            },
+                            "formula": {
+                                "type": "string",
+                                "description": "Formula string, e.g. '=SUM(A1:A10)'",
+                            },
+                            "sheet": {"type": "string", "description": "Target sheet name"},
+                            "name": {
+                                "type": "string",
+                                "description": "Sheet name for insert/delete/rename",
+                            },
+                            "newName": {
+                                "type": "string",
+                                "description": "New sheet name for renameSheet",
+                            },
+                            "atRow": {
+                                "type": "integer",
+                                "description": "0-based row index for insertRows/deleteRows",
+                            },
+                            "atCol": {
+                                "type": "string",
+                                "description": "Column letter for insertColumns/deleteColumns, e.g. 'B'",
+                            },
+                            "count": {
+                                "type": "integer",
+                                "description": "Number of rows/columns to insert or delete (default 1)",
+                            },
+                            "snapshot": {
+                                "type": "object",
+                                "description": "Complete workbook snapshot for replaceAll",
+                            },
+                        },
+                        "required": ["op"],
+                    },
+                },
+            },
+            "required": ["file_id", "operations"],
+        }
+
+    async def execute(self, file_id: str, operations: list[dict]) -> str:
+        workspace = _current_workspace()
+        if not workspace:
+            return self._error("Edit tools require a workspace context (cloud chat session).")
+
+        if not isinstance(operations, list) or not operations:
+            return self._error("Provide a non-empty `operations` array.")
+
+        try:
+            from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
+            from pocketpaw_ee.cloud.file_versions import service as fv_service
+            from pocketpaw_ee.cloud.file_versions.dto import UpdateFileContentRequest
+        except ImportError:
+            return self._error("Spreadsheet editing is not available (enterprise feature).")
+
+        ctx = _request_ctx(workspace, _current_user())
+
+        try:
+            content = await fv_service.read_current_content(ctx, file_id)
+        except NotFound:
+            return self._error(f"File {file_id!r} not found in this workspace.")
+        except CloudError as e:
+            return self._error(str(e))
+
+        snapshot = _parse_snapshot(content)
+        try:
+            updated, summary = apply_spreadsheet_ops(snapshot, operations)
+        except Exception as exc:
+            return self._error(f"Edit failed: {exc}")
+
+        new_content = json.dumps(updated, separators=(",", ":"))
+        try:
+            result = await fv_service.update_file_content(
+                ctx,
+                file_id,
+                UpdateFileContentRequest(content=new_content),
+                editor_kind="agent",
+            )
+        except NotFound:
+            return self._error(f"File {file_id!r} not found in this workspace.")
+        except CloudError as e:
+            return self._error(str(e))
+
+        return self._success(
+            f"{summary}. Saved {file_id} — new version {result.new_version} (revertable)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# In-process MCP server (Claude Agent SDK) — session-store editing.
+# Ported verbatim from #1193. Mutates the in-memory snapshot store (frontend
+# sync); does NOT write an FL-2 version (frontend persists via PUT /files/{id}).
+# ---------------------------------------------------------------------------
+
+
+def _spreadsheet_error(message: str) -> dict:
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+async def _edit_spreadsheet_handler(args: dict) -> dict:
+    """MCP handler for the edit_spreadsheet tool."""
+    snapshot = get_active_snapshot()
+    if snapshot is None:
+        return _spreadsheet_error(
+            "No spreadsheet is currently open for editing. "
+            "Open a spreadsheet file in the editor first."
+        )
+
+    operations = args.get("operations")
+    if not operations:
+        if args.get("operation"):
+            return _spreadsheet_error(
+                "Use `operations` (plural) as the key, not `operation`. "
+                'Example: {"operations": [{"op": "setCell", ...}]}'
+            )
+        if any(k in args for k in ("setCell", "setRange", "cell", "range", "value")):
+            return _spreadsheet_error(
+                "Wrap operations inside an `operations` array. "
+                'Example: {"operations": [{"op": "setCell", "cell": "A1", "value": "hello"}]}'
+            )
+        return _spreadsheet_error(
+            "Missing `operations` array. "
+            'Format: {"operations": [{"op": "setCell|setRange|...", ...}]}'
+        )
+
+    if not isinstance(operations, list):
+        return _spreadsheet_error("`operations` must be an array (list), not a single object.")
+
+    try:
+        selected = get_selected_sheet()
+        updated, summary = apply_spreadsheet_ops(snapshot, operations, selected_sheet=selected)
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "summary": summary,
+                            "sheetCount": len(_sheet_names(updated)),
+                            "snapshot": updated,
+                        },
+                        separators=(",", ":"),
+                    ),
+                }
+            ]
+        }
+    except Exception as exc:
+        logger.exception("edit_spreadsheet handler failed")
+        return _spreadsheet_error(str(exc))
+
+
+def build_edit_spreadsheet_mcp_server() -> tuple[str, Any] | None:
+    """Build the in-process MCP server for the Claude Agent SDK.
+
+    Returns (server_name, server_config) or None if the SDK is unavailable.
+    Always registered — the handler returns an error when no editing session
+    is active, so the agent won't use it outside the spreadsheet editing context.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; edit_spreadsheet MCP disabled")
+        return None
+
+    @tool(
+        "edit_spreadsheet",
+        (
+            "Edit the current spreadsheet by performing operations on cells, "
+            "ranges, rows, columns, and sheets. "
+            "Use this when the user asks you to edit, populate, format, or "
+            "restructure a spreadsheet they have open in the editor.\n\n"
+            "You MUST call it with an `operations` array. Each item must have "
+            "an `op` field set to one of: setCell, setRange, setFormula, "
+            "clearRange, insertRows, deleteRows, insertColumns, deleteColumns, "
+            "insertSheet, deleteSheet, renameSheet, mergeCells, replaceAll.\n\n"
+            "EXACT format (copy this pattern):\n"
+            '{"operations": [\n'
+            '  {"op": "setCell", "cell": "A1", "value": "Revenue"},\n'
+            '  {"op": "setRange", "range": "B1:D1", "values": [["Q1","Q2","Q3"]]},\n'
+            '  {"op": "setFormula", "cell": "B6", "formula": "=SUM(B2:B5)"},\n'
+            '  {"op": "clearRange", "range": "E2:F10"},\n'
+            '  {"op": "insertRows", "sheet": "Sheet1", "atRow": 2, "count": 1},\n'
+            '  {"op": "deleteColumns", "sheet": "Sheet1", "atCol": "C", "count": 1},\n'
+            '  {"op": "insertSheet", "name": "Summary"},\n'
+            '  {"op": "renameSheet", "name": "Sheet1", "newName": "Data"},\n'
+            '  {"op": "mergeCells", "range": "A1:B1"},\n'
+            '  {"op": "replaceAll", "snapshot": {...}}\n'
+            "]}\n\n"
+            "RULES:\n"
+            "- Cell references use A1 notation: 'B5', 'A1', 'Sheet1!D10'\n"
+            "- Ranges use A1 notation: 'A1:C10', 'B2:D2'\n"
+            "- Row indices are 0-based (row 0 = row 1 in the UI)\n"
+            "- Column reference 'atCol' uses letters: 'A', 'B', 'C', ...\n"
+            "- Values can be strings, numbers, or booleans\n"
+            "- For cross-sheet references in formulas, use 'SheetName!A1'\n"
+            "- The `sheet` field in operations is optional; defaults to the "
+            "active sheet if omitted\n"
+            "- Sparse is fine — you don't need to fill every cell. Only set "
+            "cells that have meaningful data.\n\n"
+            "IMPORTANT: The field is `op` (not operation or action). "
+            "Everything goes inside the `operations` array — not at top level."
+        ),
+        {
+            "operations": list,
+        },
+    )
+    async def edit_spreadsheet(args):
+        return await _edit_spreadsheet_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[edit_spreadsheet],
+    )
+    return SERVER_NAME, server

--- a/tests/cloud/file_versions/test_edit_tools.py
+++ b/tests/cloud/file_versions/test_edit_tools.py
@@ -1,0 +1,397 @@
+# test_edit_tools.py — FL-5 structural edit tool tests (port of dewani12's #1193).
+# Created: 2026-07-03 (FL-5). Locks:
+#   - the pure operation engines (apply_operations / apply_slides_operations /
+#     apply_spreadsheet_ops) mutate blocks / deck / workbook correctly
+#   - EditDocumentTool edits an Editor.js document + writes a NEW revertable
+#     FL-2 version (the pre-edit content is recoverable via list/get_version)
+#   - EditSlidesTool / EditSpreadsheetTool each edit their structure + write a
+#     revertable version
+#   - the editor_blocks transport round-trips (set/get_editor_blocks + the
+#     get_active_blocks fallback)
+#   - cross-workspace access is DENIED (tenant isolation)
+# The tool resolves the workspace from ``agent_service.current_workspace_id``;
+# these tests patch the module getters directly (mirroring FL-3's
+# test_library_verbs harness) so no full chat stream is needed.
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud.file_versions import service as fv_service
+from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+from pocketpaw.tools.builtin import edit_document as ed
+from pocketpaw.tools.builtin import edit_slides as es
+from pocketpaw.tools.builtin import edit_spreadsheet as esp
+from pocketpaw.tools.builtin.edit_document import EditDocumentTool, apply_operations
+from pocketpaw.tools.builtin.edit_slides import EditSlidesTool, apply_slides_operations
+from pocketpaw.tools.builtin.edit_spreadsheet import (
+    EditSpreadsheetTool,
+    apply_spreadsheet_ops,
+    parse_cell_ref,
+    parse_range_ref,
+)
+
+# ---------------------------------------------------------------------------
+# Pure operation engine unit tests (no DB, no workspace)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_operations_update_insert_delete_move():
+    blocks = [
+        {"id": "a", "type": "paragraph", "data": {"text": "one"}},
+        {"id": "b", "type": "paragraph", "data": {"text": "two"}},
+    ]
+    out, _ = apply_operations(
+        blocks,
+        [
+            {"op": "update", "id": "a", "data": {"text": "ONE"}},
+            {"op": "insert", "type": "header", "data": {"text": "H", "level": 2}, "index": 0},
+            {"op": "delete", "id": "b"},
+        ],
+    )
+    assert out[0]["type"] == "header"
+    assert out[1]["data"]["text"] == "ONE"
+    assert all(b.get("id") != "b" for b in out)
+
+
+def test_apply_operations_normalizes_notion_types():
+    blocks: list[dict] = []
+    out, _ = apply_operations(
+        blocks,
+        [{"op": "insert", "type": "heading", "data": {"text": "Title"}}],
+    )
+    # "heading" is not a valid Editor.js type — normalized to "header".
+    assert out[0]["type"] == "header"
+
+
+def test_apply_operations_per_block_mode_blocks_replaceall():
+    blocks = [{"id": "a", "type": "paragraph", "data": {"text": "x"}}]
+    _, summary = apply_operations(
+        blocks, [{"op": "replaceAll", "blocks": []}], selected_block_id="a"
+    )
+    assert "not allowed" in summary.lower()
+    assert blocks[0]["data"]["text"] == "x"  # untouched
+
+
+def test_apply_slides_operations_create_and_update():
+    deck: dict = {"slides": []}
+    apply_slides_operations(
+        deck,
+        [
+            {
+                "op": "create_slide",
+                "layout": "content",
+                "elements": [{"type": "heading", "content": "T"}],
+            }
+        ],
+    )
+    assert len(deck["slides"]) == 1
+    slide_id = deck["slides"][0]["id"]
+    el_id = deck["slides"][0]["elements"][0]["id"]
+    apply_slides_operations(
+        deck,
+        [{"op": "update_element", "slide_id": slide_id, "element_id": el_id, "content": "T2"}],
+    )
+    assert deck["slides"][0]["elements"][0]["content"] == "T2"
+
+
+def test_apply_slides_per_slide_mode_blocks_replace_all():
+    deck = {"slides": [{"id": "s1", "elements": []}]}
+    _, summary = apply_slides_operations(
+        deck, [{"op": "replace_all", "deck": {}}], selected_slide_id="s1"
+    )
+    assert "not allowed" in summary.lower()
+    assert deck["slides"][0]["id"] == "s1"
+
+
+def test_a1_notation_parsers():
+    assert parse_cell_ref("B5") == ("", 4, 1)
+    assert parse_cell_ref("Sheet1!C1", "X") == ("Sheet1", 0, 2)
+    assert parse_range_ref("A1:C10") == ("", 0, 0, 9, 2)
+
+
+def test_apply_spreadsheet_ops_set_and_formula():
+    snap: dict = {}
+    apply_spreadsheet_ops(
+        snap,
+        [
+            {"op": "setCell", "cell": "A1", "value": "Revenue"},
+            {"op": "setCell", "cell": "B1", "value": 100},
+            {"op": "setFormula", "cell": "C1", "formula": "=SUM(A1:B1)"},
+        ],
+    )
+    sheet = snap["sheets"]["Sheet1"]
+    assert sheet["cellData"]["0"]["0"]["v"] == "Revenue"
+    assert sheet["cellData"]["0"]["1"]["v"] == 100
+    assert sheet["cellData"]["0"]["1"]["t"] == 2  # number
+    assert sheet["cellData"]["0"]["2"]["f"] == "=SUM(A1:B1)"
+
+
+# ---------------------------------------------------------------------------
+# editor_blocks transport round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_editor_blocks_transport_round_trip():
+    ed.clear_editor_blocks("f1")
+    blocks = [{"id": "a", "type": "paragraph", "data": {"text": "hi"}}]
+    ed.set_editor_blocks("f1", blocks)
+    assert ed.get_editor_blocks("f1") == blocks
+    # get_active_blocks falls back to the store when no ContextVar session.
+    assert ed.get_active_blocks() == blocks
+    ed.clear_editor_blocks("f1")
+    assert ed.get_editor_blocks("f1") is None
+
+
+def test_slides_and_spreadsheet_transport_round_trip():
+    es.clear_slides_data("s1")
+    esp.clear_spreadsheet_snapshot("x1")
+    es.set_slides_data("s1", {"slides": [{"id": "a"}]})
+    esp.set_spreadsheet_snapshot("x1", {"sheets": {"Sheet1": {}}})
+    assert es.get_slides_data("s1") == {"slides": [{"id": "a"}]}
+    assert esp.get_spreadsheet_snapshot("x1") == {"sheets": {"Sheet1": {}}}
+    es.clear_slides_data("s1")
+    esp.clear_spreadsheet_snapshot("x1")
+    assert es.get_slides_data("s1") is None
+    assert esp.get_spreadsheet_snapshot("x1") is None
+
+
+# ---------------------------------------------------------------------------
+# FL-2-wired tool tests (revertable version) — mirrors test_library_verbs harness
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    """In-memory StorageAdapter stand-in (put + open over a dict of blobs)."""
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, bytes] = {}
+
+    async def put(self, key: str, stream: AsyncIterator[bytes], mime: str):
+        from pocketpaw.uploads.adapter import StoredObject
+
+        chunks: list[bytes] = []
+        async for chunk in stream:
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        self._blobs[key] = data
+        return StoredObject(key=key, size=len(data), mime=mime)
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        data = self._blobs.get(key)
+        if data is None:
+            raise FileNotFoundError(key)
+        yield data
+
+
+@pytest.fixture
+def fake_storage():
+    adapter = _FakeAdapter()
+    prev = fv_service._adapter
+    fv_service.set_adapter(adapter)
+    yield adapter
+    fv_service._adapter = prev
+
+
+@contextmanager
+def _workspace(workspace_id: str, module, user_id: str = "u1"):
+    """Patch a tool module's ``_current_workspace`` / ``_current_user`` getters."""
+    orig_ws = module._current_workspace
+    orig_user = module._current_user
+    module._current_workspace = lambda: workspace_id
+    module._current_user = lambda: user_id
+    try:
+        yield
+    finally:
+        module._current_workspace = orig_ws
+        module._current_user = orig_user
+
+
+async def _one_chunk(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
+async def _seed_upload(
+    workspace: str,
+    file_id: str,
+    *,
+    filename: str,
+    mime: str,
+    content: str,
+    adapter: _FakeAdapter,
+) -> FileUpload:
+    """Seed a Library FileUpload row + its blob (bypassing the guarded route)."""
+    storage_key = f"editor/{workspace}/{file_id}"
+    await adapter.put(storage_key, _one_chunk(content.encode("utf-8")), mime)
+    doc = FileUpload(
+        file_id=file_id,
+        storage_key=storage_key,
+        filename=filename,
+        mime=mime,
+        size=len(content.encode("utf-8")),
+        workspace=workspace,
+        owner="u1",
+        folder_path="/",
+        content_version=1,
+    )
+    await doc.insert()
+    return doc
+
+
+def _ctx(workspace_id: str):
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id="u1",
+        workspace_id=workspace_id,
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_document_writes_revertable_version(mongo_db, fake_storage):
+    original = json.dumps(
+        {"blocks": [{"id": "a", "type": "paragraph", "data": {"text": "original"}}]}
+    )
+    await _seed_upload(
+        "w1",
+        "doc1",
+        filename="notes.json",
+        mime="application/json",
+        content=original,
+        adapter=fake_storage,
+    )
+
+    with _workspace("w1", ed):
+        out = await EditDocumentTool().execute(
+            "doc1", [{"op": "update", "id": "a", "data": {"text": "edited"}}]
+        )
+    assert "version" in out.lower() and "revertable" in out.lower()
+
+    ctx = _ctx("w1")
+    # The pre-edit content is archived + recoverable.
+    versions = await fv_service.list_versions(ctx, "doc1")
+    assert len(versions) == 1
+    archived = await fv_service.get_version(ctx, "doc1", versions[0].id)
+    assert json.loads(archived.content)["blocks"][0]["data"]["text"] == "original"
+
+    # The live blob now carries the edit, editor_kind agent, bumped version.
+    doc = await FileUpload.find_one({"file_id": "doc1", "workspace": "w1"})
+    assert doc.content_version == 2
+    live = json.loads(fake_storage._blobs[doc.storage_key].decode())
+    assert live["blocks"][0]["data"]["text"] == "edited"
+    assert versions[0].editor_kind == "agent"
+
+
+@pytest.mark.asyncio
+async def test_edit_document_cross_workspace_denied(mongo_db, fake_storage):
+    original = json.dumps(
+        {"blocks": [{"id": "a", "type": "paragraph", "data": {"text": "secret"}}]}
+    )
+    await _seed_upload(
+        "wA",
+        "docA",
+        filename="a.json",
+        mime="application/json",
+        content=original,
+        adapter=fake_storage,
+    )
+
+    with _workspace("wB", ed):
+        out = await EditDocumentTool().execute(
+            "docA", [{"op": "update", "id": "a", "data": {"text": "x"}}]
+        )
+    assert "not found" in out.lower()
+
+    ctx = _ctx("wA")
+    assert await fv_service.list_versions(ctx, "docA") == []
+    doc = await FileUpload.find_one({"file_id": "docA", "workspace": "wA"})
+    assert doc.content_version == 1  # untouched
+
+
+@pytest.mark.asyncio
+async def test_edit_slides_writes_revertable_version(mongo_db, fake_storage):
+    original = json.dumps({"slides": [{"id": "s1", "layout": "content", "elements": []}]})
+    await _seed_upload(
+        "w1",
+        "deck1",
+        filename="deck.json",
+        mime="application/json",
+        content=original,
+        adapter=fake_storage,
+    )
+
+    with _workspace("w1", es):
+        out = await EditSlidesTool().execute(
+            "deck1",
+            [{"op": "insert_element", "slide_id": "s1", "type": "heading", "content": "Hello"}],
+        )
+    assert "revertable" in out.lower()
+
+    ctx = _ctx("w1")
+    versions = await fv_service.list_versions(ctx, "deck1")
+    assert len(versions) == 1
+    doc = await FileUpload.find_one({"file_id": "deck1", "workspace": "w1"})
+    assert doc.content_version == 2
+    live = json.loads(fake_storage._blobs[doc.storage_key].decode())
+    assert live["slides"][0]["elements"][0]["content"] == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_edit_spreadsheet_writes_revertable_version(mongo_db, fake_storage):
+    await _seed_upload(
+        "w1",
+        "wb1",
+        filename="book.json",
+        mime="application/json",
+        content="{}",
+        adapter=fake_storage,
+    )
+
+    with _workspace("w1", esp):
+        out = await EditSpreadsheetTool().execute(
+            "wb1", [{"op": "setCell", "cell": "A1", "value": "Total"}]
+        )
+    assert "revertable" in out.lower()
+
+    ctx = _ctx("w1")
+    versions = await fv_service.list_versions(ctx, "wb1")
+    assert len(versions) == 1
+    archived = await fv_service.get_version(ctx, "wb1", versions[0].id)
+    assert archived.content == "{}"  # pre-edit content recoverable
+
+    doc = await FileUpload.find_one({"file_id": "wb1", "workspace": "w1"})
+    assert doc.content_version == 2
+    live = json.loads(fake_storage._blobs[doc.storage_key].decode())
+    assert live["sheets"]["Sheet1"]["cellData"]["0"]["0"]["v"] == "Total"
+
+
+@pytest.mark.asyncio
+async def test_edit_document_non_text_rejected(mongo_db, fake_storage):
+    await _seed_upload(
+        "w1",
+        "img1",
+        filename="pic.png",
+        mime="image/png",
+        content="binary",
+        adapter=fake_storage,
+    )
+    with _workspace("w1", ed):
+        out = await EditDocumentTool().execute(
+            "img1", [{"op": "insert", "type": "paragraph", "data": {"text": "x"}}]
+        )
+    assert "cannot be edited" in out.lower() or "not_editable" in out.lower()
+
+
+@pytest.mark.asyncio
+async def test_edit_document_requires_workspace(fake_storage):
+    # No workspace bound → refuses before any DB access.
+    with _workspace("", ed):
+        out = await EditDocumentTool().execute("f", [{"op": "delete", "id": "a"}])
+    assert "workspace context" in out.lower()


### PR DESCRIPTION
The document/slides/spreadsheet edit tools — the last dewani12 harvest (FL-5, port of #1193).

**Stacked on #1626 (FL-4)** — base is `feat/files-folder-batch`; the diff here is only FL-5's changes.

## What ships (ported from #1193, credit: dewani12)

Three builtin agent tools, each writing a **revertable version** via FL-2:
- `edit_document` — Editor.js block engine + normalization + transport.
- `edit_slides` — reveal.js deck engine.
- `edit_spreadsheet` — Univer workbook engine + A1 parsers.

Registered in `_EE_TOOLS` (trust `medium`). Backend: `read_current_content` (the read half the tools need, resolving both id schemes tenant-filtered), the restored `*-edit` / `*-context` REST routes, and the `AiEditRequest`/`AiEditResponse`/`SyncEditingContext` DTOs.

Each edit writes via `update_file_content(editor_kind="agent")` — pre-edit content recoverable through `list_versions`/`get_version`, live blob carries the edit, `content_version` bumps, cross-workspace denied.

## Tests

`test_edit_tools.py` (15) + file_versions/library regression → 46 passed. `tests/cloud/file_versions/ + test_library_verbs.py + chat/` → 157 passed (confirms the `CloudAgentChatRequest` change didn't break chat). `lint-imports` root + ee → 0 broken.

## Known follow-up (documented, not a regression)

The chat-side `editor_blocks` / `slides_data` / `spreadsheet_snapshot` transport is a **shim**. In #1193 the chat path injected these into the agent's system prompt via an inline `_run_agent_stream`; current dev replaced that with an out-of-process executor (`RunSpec` → executor → worker), so there's no router-time prompt-injection counterpart. The fields parse and round-trip on `CloudAgentChatRequest` but are **not** threaded through `RunSpec` → worker prompt assembly yet — a follow-up. **The working editor round-trip today** runs through the REST `*-edit`/`*-context` routes (inline `pool.run`, present on dev) + the module-store transport + the registered edit tools (edit-by-file_id, revertable — the primary surface, tested).
