### PR TITLE
feat(files): auto-tag uploads on ingest

### DIFF
--- a/ee/pocketpaw_ee/cloud/uploads/listeners.py
+++ b/ee/pocketpaw_ee/cloud/uploads/listeners.py
@@ -19,6 +19,16 @@
 #   vector path inherits the same scope variable so embeddings land in
 #   the same kb-go scope as the text article. Workspace uploads (no
 #   ``pocket_id``) keep the previous ``workspace:{wid}`` behaviour.
+# Updated: 2026-07-03 — FL-6 "Auto-tagging on ingest". The listener now
+#   (1) loads the FileUpload row up front and, if ``hide_from_ai`` is set,
+#   returns early — a hidden file is neither KB-indexed nor tagged (this
+#   gate also lands in FL-11b; the two agree). (2) After extraction produces
+#   text it derives a small set of free-form tags from title + captions +
+#   text (reusing what extraction already produced — no new LLM call) via
+#   ``uploads.tagging``, unions them with any pre-existing user tags, and
+#   writes the result back through ``MongoFileStore.set_library_metadata``.
+#   Tag derivation/write failures are contained: a broken tag write must
+#   never lose the KB ingest that already succeeded.
 """Upload bus subscribers.
 
 The upload pipeline emits :class:`FileReady` on every successful upload.
@@ -78,6 +88,23 @@ async def index_uploaded_file(event: Event) -> None:
         )
         return
 
+    # FL-6: load the library row up front so we can (a) honour the
+    # ``hide_from_ai`` opt-out before touching the KB and (b) union derived
+    # tags with any pre-existing user tags later. A hidden file must never be
+    # indexed OR tagged — bail immediately. ``doc`` is ``None`` in test
+    # contexts without Beanie initialised or for rows the store can't see; we
+    # proceed with indexing in that case (fail-open on indexing, never on the
+    # hide gate — a genuinely hidden row is always found by the store).
+    doc = await _load_upload_doc(file_id, str(workspace_id))
+    if doc is not None and getattr(doc, "hide_from_ai", False):
+        logger.info(
+            "file_id=%s is hidden from AI (hide_from_ai=True); skipping KB "
+            "index and auto-tagging",
+            file_id,
+        )
+        return
+    existing_tags = list(getattr(doc, "tags", []) or []) if doc is not None else []
+
     adapter = _resolve_adapter()
     if adapter is None or not storage_key:
         logger.info(
@@ -106,6 +133,16 @@ async def index_uploaded_file(event: Event) -> None:
         except Exception:
             logger.exception("extraction failed for file_id=%s", file_id)
             return
+
+        # FL-6: auto-tag from extraction output. Independent of KB ingest —
+        # runs before it so a file still gets tags even if the KB write later
+        # fails. Contained: a tag-write error must not abort indexing.
+        await _write_auto_tags(
+            file_id=file_id,
+            workspace_id=str(workspace_id),
+            result=result,
+            existing_tags=existing_tags,
+        )
 
         text = (result.text or "").strip()
         if not text:
@@ -320,6 +357,80 @@ async def _write_vector_to_kb(
             os.unlink(tmp.name)
         except OSError:
             logger.debug("temp vec cleanup failed for %s", tmp.name)
+
+
+async def _load_upload_doc(file_id: str, workspace_id: str):
+    """Load the workspace-scoped FileUpload row, or ``None`` on any failure.
+
+    Used for the FL-6 ``hide_from_ai`` gate and to read pre-existing user
+    tags for the union. Resilient by design: in test contexts without Beanie
+    initialised the store call raises, and we return ``None`` so the listener
+    proceeds with indexing (fail-open on indexing). The hide gate itself is
+    fail-open only when the row can't be found — a genuinely hidden row is
+    always visible to the workspace-scoped store lookup.
+    """
+    try:
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        return await MongoFileStore().get_doc_scoped(file_id, workspace_id)
+    except Exception:
+        logger.debug(
+            "could not load FileUpload row for file_id=%s (store unavailable); "
+            "proceeding without library metadata",
+            file_id,
+        )
+        return None
+
+
+async def _write_auto_tags(
+    *,
+    file_id: str,
+    workspace_id: str,
+    result,
+    existing_tags: list[str],
+) -> None:
+    """Derive free-form tags from extraction output and persist the union.
+
+    Reuses whatever extraction already produced (title, captions, text, and
+    any adapter-supplied labels in ``metadata``) — never calls a new external
+    LLM. Merges with ``existing_tags`` so a user-applied tag survives a
+    re-index. Fully contained: any failure (or an empty derivation, or a
+    missing row) leaves the file untagged rather than aborting the ingest.
+    """
+    try:
+        from pocketpaw_ee.cloud.uploads.tagging import derive_tags, merge_tags
+
+        derived = derive_tags(
+            title=getattr(result, "title", None),
+            captions=getattr(result, "captions", None),
+            text=getattr(result, "text", None),
+            metadata=getattr(result, "metadata", None),
+        )
+        merged = merge_tags(existing_tags, derived)
+        # Nothing new to write (derivation empty and no existing tags to
+        # normalize into place) — skip the DB round-trip.
+        if merged == list(existing_tags):
+            return
+
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        updated = await MongoFileStore().set_library_metadata(
+            file_id, workspace_id, tags=merged
+        )
+        if updated is None:
+            logger.debug(
+                "auto-tag write found no row for file_id=%s workspace=%s",
+                file_id,
+                workspace_id,
+            )
+        else:
+            logger.info(
+                "auto-tagged file_id=%s with %d tag(s)", file_id, len(merged)
+            )
+    except Exception:
+        logger.exception(
+            "auto-tagging failed for file_id=%s; KB ingest unaffected", file_id
+        )
 
 
 def _resolve_adapter():

--- a/ee/pocketpaw_ee/cloud/uploads/tagging.py
+++ b/ee/pocketpaw_ee/cloud/uploads/tagging.py
@@ -1,0 +1,191 @@
+# tagging.py — free-form auto-tag derivation from extraction output.
+# Created: 2026-07-03 — FL-6 "Auto-tagging on ingest". Derives a small set
+#   of free-form tags from an ExtractionResult (title + captions + text) with
+#   a dependency-free keyword/keyphrase heuristic. The PRD chose free-form
+#   over a controlled vocabulary for v1, and the rule is "reuse what
+#   extraction already produced" — this never calls a new external LLM.
+#   If the extraction adapter already surfaced candidate labels in
+#   ``metadata`` (``labels`` / ``keywords`` / ``tags``), those win.
+#   ``merge_tags`` unions derived tags with any user-applied tags so a
+#   re-index never clobbers a hand-typed tag.
+"""Free-form auto-tag derivation.
+
+The listener runs extraction on every upload; this module turns the resulting
+:class:`ExtractionResult` into a small, normalized, deduped tag list. Design
+constraints (FL-6):
+
+  * No new external LLM call — reuse the text/captions extraction already
+    produced. If a captioning adapter surfaced candidate labels in
+    ``result.metadata`` (under ``labels``, ``keywords`` or ``tags``), prefer
+    those verbatim.
+  * Free-form, not a controlled vocabulary (PRD decision for v1).
+  * Normalized: lowercase, trimmed, punctuation-stripped, deduped.
+  * Capped at :data:`MAX_TAGS` so the library UI stays tidy.
+  * Union, never replace: :func:`merge_tags` keeps pre-existing user tags.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Iterable
+
+MAX_TAGS = 8
+"""Cap on auto-derived tags per file — keep the library chip row tidy."""
+
+_MIN_TOKEN_LEN = 3
+"""Tokens shorter than this are dropped (too generic to be a useful tag)."""
+
+_MAX_TAG_LEN = 40
+"""Guard against a pathological single "word" becoming a giant tag."""
+
+# Metadata keys a captioning/vision adapter might use to surface labels.
+_LABEL_KEYS = ("labels", "keywords", "tags")
+
+# A compact English stop-word set. Kept inline (no NLTK dep) — FL-6 must not
+# add a new runtime dependency just for tagging.
+_STOPWORDS = frozenset(
+    {
+        "the", "and", "for", "are", "but", "not", "you", "all", "any", "can",
+        "her", "was", "one", "our", "out", "day", "get", "has", "him", "his",
+        "how", "man", "new", "now", "old", "see", "two", "way", "who", "boy",
+        "did", "its", "let", "put", "say", "she", "too", "use", "this", "that",
+        "with", "from", "they", "have", "will", "your", "what", "when", "were",
+        "there", "their", "which", "would", "about", "these", "those", "been",
+        "into", "over", "then", "them", "than", "some", "such", "only", "also",
+        "more", "most", "other", "here", "each", "very", "just", "like", "make",
+        "page", "image", "file", "document", "text", "content", "upload",
+    }
+)
+
+
+def _normalize(raw: str) -> str:
+    """Lowercase, trim, collapse whitespace, strip surrounding punctuation."""
+    s = raw.strip().lower()
+    s = re.sub(r"\s+", " ", s)
+    # Strip leading/trailing punctuation but keep intra-word hyphens.
+    s = s.strip(" \t\r\n.,;:!?\"'()[]{}<>|/\\")
+    return s
+
+
+def _clean_tags(candidates: Iterable[str]) -> list[str]:
+    """Normalize, filter, and dedup a candidate tag stream (order-preserving)."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for cand in candidates:
+        if not isinstance(cand, str):
+            continue
+        tag = _normalize(cand)
+        if not tag or len(tag) < _MIN_TOKEN_LEN or len(tag) > _MAX_TAG_LEN:
+            continue
+        if tag in seen:
+            continue
+        seen.add(tag)
+        out.append(tag)
+    return out
+
+
+def _labels_from_metadata(metadata: dict) -> list[str]:
+    """Pull explicit candidate labels an adapter may have surfaced.
+
+    Accepts a list under any of ``labels`` / ``keywords`` / ``tags``. A
+    comma/newline-delimited string is also tolerated (some adapters return a
+    flat string). Returns cleaned tags — empty when nothing usable is present.
+    """
+    if not isinstance(metadata, dict):
+        return []
+    collected: list[str] = []
+    for key in _LABEL_KEYS:
+        val = metadata.get(key)
+        if isinstance(val, str):
+            collected.extend(re.split(r"[,\n;]+", val))
+        elif isinstance(val, (list, tuple, set)):
+            collected.extend(str(v) for v in val)
+    return _clean_tags(collected)
+
+
+def _keywords_from_text(*parts: str, limit: int) -> list[str]:
+    """Frequency-rank single-word keywords across the given text parts.
+
+    Dependency-free: tokenize on word boundaries, drop stop-words and short
+    tokens, count, and return the most common up to ``limit``. Ties keep the
+    first-seen order (Counter.most_common is stable in CPython 3.7+).
+    """
+    counts: Counter[str] = Counter()
+    for part in parts:
+        if not part:
+            continue
+        for match in re.findall(r"[A-Za-z][A-Za-z0-9\-]{2,}", part):
+            token = match.lower().strip("-")
+            if len(token) < _MIN_TOKEN_LEN or len(token) > _MAX_TAG_LEN:
+                continue
+            if token in _STOPWORDS:
+                continue
+            counts[token] += 1
+    return [word for word, _n in counts.most_common(limit)]
+
+
+def derive_tags(
+    *,
+    title: str | None,
+    captions: Iterable[str] | None,
+    text: str | None,
+    metadata: dict | None = None,
+    limit: int = MAX_TAGS,
+) -> list[str]:
+    """Derive up to ``limit`` free-form tags from extraction output.
+
+    Precedence:
+      1. Explicit adapter-supplied labels in ``metadata`` (if any) come first.
+      2. The detected ``title`` contributes its words next (a title is the
+         strongest single signal a document carries).
+      3. Frequency-ranked keywords from captions + text fill the rest.
+
+    Everything is normalized (lowercase/trimmed), deduped, and capped at
+    ``limit``. Returns ``[]`` when there's nothing usable — the caller then
+    skips the metadata write entirely.
+    """
+    limit = max(0, limit)
+    if limit == 0:
+        return []
+
+    caption_list = list(captions or [])
+    caption_blob = " ".join(c for c in caption_list if isinstance(c, str))
+
+    ordered: list[str] = []
+
+    # 1. Adapter labels win — they're the highest-signal candidates.
+    ordered.extend(_labels_from_metadata(metadata or {}))
+
+    # 2. Title words.
+    if title:
+        ordered.extend(_keywords_from_text(title, limit=limit))
+
+    # 3. Keyword fill from captions + text.
+    ordered.extend(_keywords_from_text(caption_blob, text or "", limit=limit * 2))
+
+    return _clean_tags(ordered)[:limit]
+
+
+def merge_tags(existing: Iterable[str] | None, derived: Iterable[str]) -> list[str]:
+    """Union existing (user) tags with newly derived ones — existing first.
+
+    Re-indexing a file must never drop a tag a user typed. Existing tags keep
+    their original order and win on collision; derived tags are appended in
+    order, skipping any already present after normalization. The result is
+    capped at :data:`MAX_TAGS`.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for tag in _clean_tags(existing or []):
+        if tag not in seen:
+            seen.add(tag)
+            out.append(tag)
+    for tag in _clean_tags(derived):
+        if tag not in seen:
+            seen.add(tag)
+            out.append(tag)
+    return out[:MAX_TAGS]
+
+
+__all__ = ["derive_tags", "merge_tags", "MAX_TAGS"]

--- a/tests/cloud/uploads/conftest.py
+++ b/tests/cloud/uploads/conftest.py
@@ -1,3 +1,12 @@
+# conftest.py — shared fixtures for the cloud/uploads test package.
+# 2026-07-03 (FL-6): the ``beanie_upload_db`` fixture now resets the Beanie
+#   binding on ``FileUpload`` / ``FileFolder`` after each test. Before FL-6 no
+#   test read Beanie state from inside the listener, so a leaked binding (the
+#   torn-down mongomock db still attached to the Document classes) was
+#   harmless. FL-6's listener loads the FileUpload row to honour hide_from_ai,
+#   so a leaked binding let one test's seeded rows bleed into an unrelated
+#   listener test (e.g. test_listener_vector), flipping the hide gate. Clearing
+#   the per-class Beanie settings on teardown restores isolation.
 from __future__ import annotations
 
 import uuid
@@ -34,7 +43,21 @@ async def beanie_upload_db():
     from pocketpaw_ee.cloud.uploads.models import FileFolder, FileUpload
 
     await init_beanie(database=db, document_models=[FileUpload, FileFolder])
-    yield db
+    try:
+        yield db
+    finally:
+        # Reset the Beanie binding so this test's mongomock db (about to be
+        # torn down) doesn't stay attached to the Document classes and leak
+        # seeded rows into a later test that reads Beanie state (FL-6 listener
+        # loads the FileUpload row). Beanie stores the collection on a private
+        # settings object per Document; drop it so the next init rebinds clean.
+        for model in (FileUpload, FileFolder):
+            for attr in ("_document_settings", "_settings"):
+                if hasattr(model, attr):
+                    try:
+                        setattr(model, attr, None)
+                    except Exception:  # pragma: no cover — defensive
+                        pass
 
 
 @pytest.fixture()

--- a/tests/cloud/uploads/test_auto_tagging.py
+++ b/tests/cloud/uploads/test_auto_tagging.py
@@ -1,0 +1,126 @@
+# test_auto_tagging.py — unit tests for the FL-6 tag-derivation helpers.
+# Created: 2026-07-03 — FL-6 "Auto-tagging on ingest". Covers
+#   ee.cloud.uploads.tagging.derive_tags (title/caption/text keyword
+#   extraction, adapter-label precedence, normalization, dedup, cap) and
+#   merge_tags (union semantics that preserve user-applied tags on re-index).
+"""Unit tests for ``ee.cloud.uploads.tagging``."""
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.uploads.tagging import MAX_TAGS, derive_tags, merge_tags
+
+
+class TestDeriveTags:
+    def test_derives_keywords_from_text(self):
+        tags = derive_tags(
+            title="Quarterly Invoice",
+            captions=[],
+            text="invoice invoice payment payment payment amount due",
+            metadata={},
+        )
+        assert "invoice" in tags
+        assert "payment" in tags
+
+    def test_prefers_adapter_labels_from_metadata(self):
+        tags = derive_tags(
+            title=None,
+            captions=[],
+            text="some generic body text about widgets",
+            metadata={"labels": ["Whiteboard", "Diagram"]},
+        )
+        # Adapter labels come first and are normalized.
+        assert tags[0] == "whiteboard"
+        assert "diagram" in tags
+
+    def test_accepts_comma_delimited_label_string(self):
+        tags = derive_tags(
+            title=None,
+            captions=[],
+            text="",
+            metadata={"keywords": "budget, forecast, revenue"},
+        )
+        assert set(tags) >= {"budget", "forecast", "revenue"}
+
+    def test_normalizes_lowercase_and_trims(self):
+        tags = derive_tags(
+            title="  ROADMAP  ",
+            captions=[],
+            text="Roadmap roadmap planning planning strategy",
+            metadata={},
+        )
+        assert "roadmap" in tags
+        # No uppercase or surrounding whitespace leaks through.
+        assert all(t == t.strip().lower() for t in tags)
+
+    def test_dedups(self):
+        tags = derive_tags(
+            title="Report report",
+            captions=["report REPORT"],
+            text="report report report",
+            metadata={"labels": ["Report"]},
+        )
+        assert tags.count("report") == 1
+
+    def test_caps_at_max_tags(self):
+        text = " ".join(f"keyword{i}" for i in range(50))
+        tags = derive_tags(title=None, captions=[], text=text, metadata={})
+        assert len(tags) <= MAX_TAGS
+
+    def test_drops_stopwords_and_short_tokens(self):
+        tags = derive_tags(
+            title=None,
+            captions=[],
+            text="the and for a an it is to of on invoice",
+            metadata={},
+        )
+        assert "the" not in tags
+        assert "and" not in tags
+        assert "invoice" in tags
+
+    def test_empty_extraction_yields_no_tags(self):
+        assert derive_tags(title=None, captions=[], text="", metadata={}) == []
+        assert derive_tags(title="", captions=None, text=None, metadata=None) == []
+
+    def test_caption_content_contributes(self):
+        tags = derive_tags(
+            title=None,
+            captions=["A photo of a golden retriever puppy playing fetch"],
+            text="",
+            metadata={},
+        )
+        assert "retriever" in tags or "puppy" in tags or "golden" in tags
+
+
+class TestMergeTags:
+    def test_union_preserves_existing_user_tags(self):
+        merged = merge_tags(["mytag"], ["auto1", "auto2"])
+        assert merged[0] == "mytag"
+        assert "auto1" in merged and "auto2" in merged
+
+    def test_re_index_does_not_clobber_user_tag(self):
+        # Simulate a re-index: file already has a user tag; derivation yields
+        # a fresh set — the user tag must survive.
+        existing = ["important"]
+        derived = ["invoice", "2026"]
+        merged = merge_tags(existing, derived)
+        assert "important" in merged
+
+    def test_dedups_across_existing_and_derived(self):
+        merged = merge_tags(["invoice"], ["invoice", "payment"])
+        assert merged.count("invoice") == 1
+        assert "payment" in merged
+
+    def test_normalizes_existing_tags(self):
+        merged = merge_tags(["  Invoice "], ["invoice"])
+        assert merged == ["invoice"]
+
+    def test_none_existing_is_safe(self):
+        assert merge_tags(None, ["alpha", "beta"]) == ["alpha", "beta"]
+
+    def test_capped_at_max(self):
+        existing = [f"user{i}" for i in range(6)]
+        derived = [f"auto{i}" for i in range(6)]
+        merged = merge_tags(existing, derived)
+        assert len(merged) == MAX_TAGS
+        # Existing tags are kept first, so they win the cap.
+        assert merged[0] == "user0"

--- a/tests/cloud/uploads/test_listener_auto_tag.py
+++ b/tests/cloud/uploads/test_listener_auto_tag.py
@@ -1,0 +1,180 @@
+# test_listener_auto_tag.py — FL-6 listener integration tests.
+# Created: 2026-07-03 — FL-6 "Auto-tagging on ingest". Exercises the
+#   index_uploaded_file listener end-to-end against a real (mongomock) store:
+#   (1) a file with extractable text gets tags written on the FileUpload row,
+#   (2) hide_from_ai=True skips BOTH KB ingest AND tagging, and (3) a re-index
+#   unions derived tags with a pre-existing user tag (no clobber). Uses the
+#   cloud/uploads conftest fixtures (beanie_upload_db + store).
+"""Integration tests for the FL-6 auto-tag path in the FileReady listener."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import FileReady
+from pocketpaw_ee.cloud.extraction.adapter import ExtractionResult
+
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeChain:
+    def __init__(self, result: ExtractionResult):
+        self._result = result
+        self.calls: list[tuple[Path, str]] = []
+
+    async def run(self, path: Path, mime: str) -> ExtractionResult:
+        self.calls.append((path, mime))
+        return self._result
+
+
+class _FakeAdapter:
+    def __init__(self, local_path_value: Path):
+        self._local = local_path_value
+
+    def local_path(self, key: str) -> Path | None:
+        return self._local
+
+    async def open(self, key: str):  # pragma: no cover — local path wins
+        yield b""
+
+
+def _record(**overrides) -> FileRecord:
+    defaults = {
+        "id": "f1",
+        "storage_key": "chat/202607/aaa.pdf",
+        "filename": "invoice.pdf",
+        "mime": "application/pdf",
+        "size": 1,
+        "owner_id": "u1",
+        "chat_id": "c1",
+        "created": datetime.now(UTC),
+    }
+    defaults.update(overrides)
+    return FileRecord(**defaults)
+
+
+def _wire(monkeypatch, *, chain: _FakeChain, adapter: _FakeAdapter, ingest: AsyncMock):
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads import listeners
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.extraction.build_chain", lambda settings: chain)
+    monkeypatch.setattr(listeners, "_resolve_adapter", lambda: adapter)
+    monkeypatch.setattr(kn.KnowledgeService, "ingest_text_to_scope", ingest)
+
+
+def _event() -> FileReady:
+    return FileReady(
+        data={
+            "workspace_id": "w1",
+            "file_id": "f1",
+            "filename": "invoice.pdf",
+            "mime": "application/pdf",
+            "storage_key": "chat/202607/aaa.pdf",
+        }
+    )
+
+
+async def test_upload_with_text_gets_tags_written(monkeypatch, store, tmp_path):
+    """Extractable text → tags land on the FileUpload row."""
+    from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+    await store.save_scoped(_record(), workspace="w1")
+
+    fake_path = tmp_path / "invoice.pdf"
+    fake_path.write_bytes(b"unused; chain mocked")
+    chain = _FakeChain(
+        ExtractionResult(
+            title="Quarterly Invoice",
+            text="invoice invoice payment payment amount total due balance",
+            backend="local",
+        )
+    )
+    ingest = AsyncMock(return_value={"id": "art-1"})
+    _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(fake_path), ingest=ingest)
+
+    await index_uploaded_file(_event())
+
+    doc = await store.get_doc_scoped("f1", "w1")
+    assert doc is not None
+    assert doc.tags, "expected auto-tags to be written"
+    assert "invoice" in doc.tags
+    # Normalized: lowercase, deduped.
+    assert doc.tags == [t.lower() for t in doc.tags]
+    assert len(doc.tags) == len(set(doc.tags))
+    ingest.assert_awaited_once()
+
+
+async def test_hide_from_ai_skips_ingest_and_tags(monkeypatch, store, tmp_path):
+    """hide_from_ai=True → NO KB ingest, NO tags, extraction never runs."""
+    from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+    await store.save_scoped(_record(), workspace="w1")
+    await store.set_library_metadata("f1", "w1", hide_from_ai=True)
+
+    fake_path = tmp_path / "invoice.pdf"
+    fake_path.write_bytes(b"unused")
+    chain = _FakeChain(ExtractionResult(text="secret content", backend="local"))
+    ingest = AsyncMock()
+    _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(fake_path), ingest=ingest)
+
+    await index_uploaded_file(_event())
+
+    # Neither extraction nor ingest ran.
+    assert chain.calls == []
+    ingest.assert_not_awaited()
+    # No tags written.
+    doc = await store.get_doc_scoped("f1", "w1")
+    assert doc is not None
+    assert doc.tags == []
+
+
+async def test_reindex_unions_with_existing_user_tag(monkeypatch, store, tmp_path):
+    """A pre-existing user tag survives a re-index (union, no clobber)."""
+    from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+    await store.save_scoped(_record(), workspace="w1")
+    await store.set_library_metadata("f1", "w1", tags=["important"])
+
+    fake_path = tmp_path / "invoice.pdf"
+    fake_path.write_bytes(b"unused")
+    chain = _FakeChain(
+        ExtractionResult(
+            title="Budget Forecast",
+            text="budget budget forecast forecast revenue projection",
+            backend="local",
+        )
+    )
+    ingest = AsyncMock(return_value={"id": "art-1"})
+    _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(fake_path), ingest=ingest)
+
+    await index_uploaded_file(_event())
+
+    doc = await store.get_doc_scoped("f1", "w1")
+    assert doc is not None
+    assert "important" in doc.tags, "user tag must survive re-index"
+    assert "budget" in doc.tags, "derived tag should be unioned in"
+
+
+async def test_empty_extraction_no_tags_but_no_crash(monkeypatch, store, tmp_path):
+    """Empty extracted text → no tags derived, no crash, no ingest."""
+    from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+    await store.save_scoped(_record(), workspace="w1")
+
+    fake_path = tmp_path / "blank.pdf"
+    fake_path.write_bytes(b"unused")
+    chain = _FakeChain(ExtractionResult(text="   ", backend="local"))
+    ingest = AsyncMock()
+    _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(fake_path), ingest=ingest)
+
+    await index_uploaded_file(_event())
+
+    doc = await store.get_doc_scoped("f1", "w1")
+    assert doc is not None
+    assert doc.tags == []
+    ingest.assert_not_awaited()


### PR DESCRIPTION
Auto-tagging on ingest (FL-6) — uploaded files get suggested tags from their content, unless hidden from AI.

**Stacked on #1627 (FL-5)** — base is `feat/files-edit-tools`; the diff here is only FL-6's changes.

## What changes

The `FileReady` listener, after extraction, derives a small set of free-form tags and writes them to `FileUpload.tags`:

- `tagging.py` — dependency-free derivation: adapter-provided labels take precedence, then title, then frequency-ranked keywords from captions + text; normalized, deduped, capped at 8.
- **Union, not overwrite** — derived tags merge with any user-applied tags (a user tag survives re-index).
- **`hide_from_ai` gate** — a hidden file returns early, skipping BOTH KB ingest AND tagging. Tag-write failures are contained and never abort ingest.

Bonus: fixed a pre-existing Beanie test-isolation leak (torn-down mongomock db stayed bound to the Document classes, bleeding rows between tests) — this drops the pre-existing `tests/cloud/uploads/` failure count from 26 to 23.

## Tests

`test_auto_tagging.py` (15) + `test_listener_auto_tag.py` (4) → 19 passed here; the broader keyword set → 47 passed. Explicitly covers `test_hide_from_ai_skips_ingest_and_tags` and `test_reindex_unions_with_existing_user_tag`. `lint-imports` root + ee → 0 broken.

## Follow-up (hardening in FL-11b)

The hide gate is currently fail-*open* on indexing (if the upload row can't be loaded at all, indexing proceeds). For a privacy control this should be fail-*closed* — FL-11b will harden it so an unresolvable hide-status skips indexing.
