### PR TITLE
feat(files): public share links with forced-attachment downloads

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,12 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-07-03 (feat/files-share-links, FL-12b) — Mounts two share-link
+    routers: ``share_router`` (owner + license gated POST/DELETE
+    /files/{id}/share) and ``public_share_router`` (intentionally
+    unauthenticated GET /share/{token} — the token is the capability). The
+    public route mints its download URL through EEUploadService.presigned_get so
+    it inherits the forced-attachment protection for non-inline mimes. Both are
+    feature-flagged behind POCKETPAW_SHARE_LINKS_ENABLED (default off).
 Modified: 2026-06-24 (integration/billing-credits, BC-6) — Mounts the
     Entitlements resolver router (``GET /entitlements`` -> the caller workspace's
     plan + features + monthly credit allotment). The plan CATALOG read
@@ -354,6 +361,10 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.push.router import router as push_router
     from pocketpaw_ee.cloud.tasks.router import router as tasks_router
     from pocketpaw_ee.cloud.uploads.router import router as uploads_router
+    from pocketpaw_ee.cloud.uploads.share_router import (
+        public_share_router,
+        share_router,
+    )
     from pocketpaw_ee.fabric.router import router as fabric_router
     from pocketpaw_ee.fleet.router import router as fleet_router
     from pocketpaw_ee.instinct.router import router as instinct_router
@@ -363,6 +374,12 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(kb_router, prefix="/api/v1")
     app.include_router(knowledge_router, prefix="/api/v1")
     app.include_router(uploads_router, prefix="/api/v1")
+    # FL-12b public share links. ``share_router`` (POST/DELETE /files/{id}/share)
+    # is owner + license gated; ``public_share_router`` (GET /share/{token}) is
+    # DELIBERATELY unauthenticated — the token is the capability. Both are dark
+    # unless POCKETPAW_SHARE_LINKS_ENABLED=true.
+    app.include_router(share_router, prefix="/api/v1")
+    app.include_router(public_share_router, prefix="/api/v1")
     app.include_router(notifications_router, prefix="/api/v1")
     # Web Push — VAPID public key + subscribe/unsubscribe (pocketpaw#1391).
     app.include_router(push_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,9 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-03 (feat/files-share-links FL-12b) — added ``ShareLink`` (the
+public, token-gated file share-link doc) to the lazy uploads loader,
+``get_all_documents()`` and ``__all__`` so the ``file_share_links`` collection
+is wired into ``init_beanie``. Only ``ee.cloud.uploads.share_store`` writes it.
 Updated: 2026-06-30 (feat/session-supervisor SS-3) — added
 ``AgentSessionRuntimeDoc`` (the durable, tenant-scoped
 ``(workspace, session_id, agent_id) -> cli_session_id`` mapping) to the
@@ -160,6 +164,9 @@ from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
 # Lazy import to avoid circular imports
 FileUpload: type = None  # type: ignore[assignment]
 FileFolder: type = None  # type: ignore[assignment]
+# FL-12b public share links. Lazy-loaded with FileUpload (same package) so
+# init_beanie registers it without ee.cloud.models hard-importing uploads.
+ShareLink: type = None  # type: ignore[assignment]
 _CalendarDoc: type = None  # type: ignore[assignment]
 _EventDoc: type = None  # type: ignore[assignment]
 # The Belt MANDATE docs live in ee.cloud.mandates.domain (4-file entity, sole
@@ -177,13 +184,15 @@ _ArtifactVersionDoc: type = None  # type: ignore[assignment]
 
 
 def _ensure_file_upload():
-    global FileUpload, FileFolder
+    global FileUpload, FileFolder, ShareLink
     if FileUpload is None:
         from pocketpaw_ee.cloud.uploads.models import FileFolder as _FileFolder
         from pocketpaw_ee.cloud.uploads.models import FileUpload as _FileUpload
+        from pocketpaw_ee.cloud.uploads.share_models import ShareLink as _ShareLink
 
         FileUpload = _FileUpload
         FileFolder = _FileFolder
+        ShareLink = _ShareLink
     return FileUpload
 
 
@@ -253,6 +262,7 @@ __all__ = [
     "FileObj",
     "FileUpload",
     "FileVersionDoc",
+    "ShareLink",
     "ForesightBacktest",
     "ForesightPredictionRecord",
     "ForesightProjectedDecision",
@@ -336,6 +346,9 @@ def get_all_documents():
         FileObj,
         FileUpload,
         FileFolder,
+        # Public file share links (FL-12b). Only ``uploads.share_store``
+        # writes these; the public GET /share/{token} route reads by token.
+        ShareLink,
         # file_versions edit history (ART-1). Only ``file_versions.service``
         # imports this class (import-linter "FileVersions" contract).
         FileVersionDoc,

--- a/ee/pocketpaw_ee/cloud/uploads/share_models.py
+++ b/ee/pocketpaw_ee/cloud/uploads/share_models.py
@@ -1,0 +1,79 @@
+# share_models.py — FL-12b "Public share links".
+#
+# Beanie document for a public, token-gated download link over one FileUpload.
+# A file owner mints a ShareLink; the unguessable ``token`` (secrets.token_urlsafe)
+# lets an unauthenticated recipient download that ONE file via the public
+# GET /api/v1/share/{token} route. Security posture:
+#   - ``token`` is the sole capability; it is unique-indexed and unguessable.
+#   - The link is single-file scoped (``file_id`` + ``workspace_id``), so a
+#     token for file A can never resolve file B — the public route only ever
+#     mints a presigned URL for the exact ``file_id`` on this row.
+#   - ``owner_id`` + ``workspace_id`` are captured at creation so the public
+#     route can replay the owner's read identity into
+#     ``EEUploadService.presigned_get`` (which forces attachment for
+#     non-inline mimes) WITHOUT weakening any check — the token stands in for
+#     the owner's authorization, and the forced-attachment gate is inherited.
+#   - ``expires_at`` defaults to 7 days out; ``revoked`` is an owner kill-switch.
+#     The public route treats expired/revoked as gone (410).
+# Independent of FileUpload.hide_from_ai — sharing and AI-visibility are
+# separate gates and are never coupled here.
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+
+from beanie import Document, Indexed
+from pydantic import Field
+
+# Default lifetime for a freshly minted share link.
+SHARE_LINK_TTL_DAYS = 7
+
+
+def _new_token() -> str:
+    """Unguessable URL-safe token (~256 bits of entropy)."""
+    return secrets.token_urlsafe(32)
+
+
+def _default_expiry() -> datetime:
+    return datetime.now(UTC) + timedelta(days=SHARE_LINK_TTL_DAYS)
+
+
+class ShareLink(Document):
+    """A public, token-gated download link for a single workspace file.
+
+    Workspace-scoped like the other upload stores. The ``token`` is the only
+    secret a recipient needs; everything else (owner, workspace, expiry) is
+    server-side state the public route consults but never leaks.
+    """
+
+    token: Indexed(str, unique=True) = Field(default_factory=_new_token)  # type: ignore[valid-type]
+    file_id: Indexed(str)  # type: ignore[valid-type]
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    owner_id: str
+    created: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    expires_at: datetime = Field(default_factory=_default_expiry)
+    revoked: bool = False
+
+    def is_active(self, *, now: datetime | None = None) -> bool:
+        """True when the link may still resolve to a download.
+
+        Not revoked AND not past ``expires_at``. ``expires_at`` may be a naive
+        datetime when a legacy/mongomock round-trip drops tzinfo, so compare
+        defensively in UTC.
+        """
+        if self.revoked:
+            return False
+        moment = now or datetime.now(UTC)
+        exp = self.expires_at
+        if exp.tzinfo is None:
+            exp = exp.replace(tzinfo=UTC)
+        return moment < exp
+
+    class Settings:
+        name = "file_share_links"
+        indexes = [
+            # Owner-side listing/revocation, and the public token lookup.
+            [("workspace_id", 1), ("file_id", 1)],
+            [("workspace_id", 1), ("owner_id", 1)],
+        ]

--- a/ee/pocketpaw_ee/cloud/uploads/share_router.py
+++ b/ee/pocketpaw_ee/cloud/uploads/share_router.py
@@ -1,0 +1,194 @@
+# share_router.py — FL-12b "Public share links".
+#
+# Two routers with DELIBERATELY different auth boundaries:
+#
+#   share_router  (prefix /files) — OWNER surface, license + membership gated:
+#       POST   /files/{file_id}/share          create a share link
+#       DELETE /files/{file_id}/share/{token}   revoke a share link
+#     Both require a workspace principal AND owner-or-admin write access on the
+#     file (reuses EEUploadService._assert_can_write), so create/revoke are
+#     workspace + owner scoped.
+#
+#   public_share_router  (prefix /share) — PUBLIC, NO auth, NO license gate:
+#       GET    /share/{token}                    redirect to a download URL
+#     Authorization here is the unguessable token ITSELF. The route looks the
+#     token up, checks active (not revoked, not expired) -> 410/404 otherwise,
+#     then mints the download URL by calling EEUploadService.presigned_get with
+#     the LINK's stored owner_id + workspace_id as the read identity. That path
+#     forces Content-Disposition: attachment for any non-inline mime (ART-4), so
+#     an agent-authored .html/.svg/.js downloads instead of rendering active
+#     content on the storage origin. We do NOT build a separate presign — the
+#     forced-attachment protection is inherited, not bypassed.
+#
+# The public route leaks nothing about the workspace/owner: a bad token is a
+# flat 404, an inactive one a flat 410, and success is an opaque redirect to a
+# short-TTL storage URL. Sharing is independent of FileUpload.hide_from_ai.
+#
+# Feature-flagged behind POCKETPAW_SHARE_LINKS_ENABLED (default OFF for a
+# cautious rollout): when disabled, BOTH the create route and the public GET
+# return 404 so the surface is fully dark.
+
+from __future__ import annotations
+
+import os
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import RedirectResponse
+
+from pocketpaw.uploads.errors import NotFound
+from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
+from pocketpaw_ee.cloud.shared.time import iso_utc
+from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+from pocketpaw_ee.cloud.uploads.router import _SVC, _is_workspace_admin
+from pocketpaw_ee.cloud.uploads.share_models import SHARE_LINK_TTL_DAYS
+from pocketpaw_ee.cloud.uploads.share_store import ShareLinkStore
+
+_META = MongoFileStore()
+_LINKS = ShareLinkStore()
+
+
+def _share_links_enabled() -> bool:
+    """Feature flag — default OFF for a cautious rollout."""
+    return os.environ.get("POCKETPAW_SHARE_LINKS_ENABLED", "false").strip().lower() == "true"
+
+
+# Owner-facing surface: license-gated, workspace + membership scoped.
+share_router = APIRouter(
+    prefix="/files",
+    tags=["Uploads", "ShareLinks"],
+    dependencies=[Depends(require_license)],
+)
+
+# Public surface: intentionally NO auth and NO license dependency. The token is
+# the authorization. Kept on its own router so no ambient gate leaks in.
+public_share_router = APIRouter(
+    prefix="/share",
+    tags=["ShareLinks"],
+)
+
+
+def _token_url(token: str) -> str:
+    """Relative public URL a recipient opens. Callers/FE may prefix an origin."""
+    return f"/api/v1/share/{token}"
+
+
+@share_router.post(
+    "/{file_id}/share",
+    dependencies=[Depends(require_action_any_workspace("uploads.write"))],
+)
+async def create_share_link(
+    file_id: str,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Create a public share link for ``file_id`` (owner / workspace-admin only).
+
+    Independent of the file's ``hide_from_ai`` flag — a file hidden from AI can
+    still be shared. Returns the token URL and its expiry.
+    """
+    if not _share_links_enabled():
+        raise HTTPException(status_code=404, detail="not found")
+
+    rec = await _META.get_scoped(file_id, workspace=workspace)
+    if rec is None:
+        raise HTTPException(status_code=404, detail="not found")
+
+    # Owner OR workspace admin only — same write ACL the PATCH/DELETE routes use.
+    try:
+        await _SVC._assert_can_write(rec, user_id, workspace)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail="files.forbidden") from e
+
+    link = await _LINKS.create(file_id=file_id, workspace=workspace, owner_id=user_id)
+    return {
+        "token": link.token,
+        "url": _token_url(link.token),
+        "expires_at": iso_utc(link.expires_at),
+        "ttl_days": SHARE_LINK_TTL_DAYS,
+        "revoked": link.revoked,
+    }
+
+
+@share_router.delete("/{file_id}/share/{token}", status_code=204)
+async def revoke_share_link(
+    file_id: str,
+    token: str,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+):
+    """Revoke a share link (owner / workspace-admin only, workspace + file scoped)."""
+    rec = await _META.get_scoped(file_id, workspace=workspace)
+    if rec is None:
+        raise HTTPException(status_code=404, detail="not found")
+
+    # Owner OR workspace admin only.
+    if rec.owner_id != user_id:
+        try:
+            is_admin = await _is_workspace_admin(user_id, workspace)
+        except Exception:
+            is_admin = False
+        if not is_admin:
+            raise HTTPException(status_code=403, detail="files.forbidden")
+
+    link = await _LINKS.revoke(token, file_id=file_id, workspace=workspace)
+    if link is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@public_share_router.get("/{token}")
+async def resolve_share_link(token: str):
+    """PUBLIC — resolve a share token to a download redirect. No auth.
+
+    Authorization is the token. Invalid/unknown -> 404; revoked or expired ->
+    410; the underlying file gone -> 404. On success, mints a short-TTL
+    presigned download URL via ``presigned_get`` (which forces attachment for
+    non-inline mimes) and 302-redirects to it. We NEVER expose workspace/owner
+    internals and NEVER require auth beyond the token.
+    """
+    if not _share_links_enabled():
+        raise HTTPException(status_code=404, detail="not found")
+
+    link = await _LINKS.get_by_token(token)
+    if link is None:
+        # Unknown token — flat 404, no distinction from a typo.
+        raise HTTPException(status_code=404, detail="not found")
+
+    if not link.is_active():
+        # Revoked or expired — gone.
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail="link expired")
+
+    # Mint the download as the LINK's owner, in the LINK's workspace. This
+    # replays the owner's read identity into presigned_get, which:
+    #   (a) re-checks the file still exists in that workspace (NotFound -> 404),
+    #   (b) forces Content-Disposition: attachment for non-inline mimes.
+    # The token is single-file scoped, so this only ever resolves link.file_id.
+    try:
+        _rec, presigned = await _SVC.presigned_get(
+            link.file_id,
+            link.owner_id,
+            link.workspace_id,
+            DEFAULT_TTL_SECONDS,
+        )
+    except NotFound as e:
+        # File deleted after the link was minted — treat as gone.
+        raise HTTPException(status_code=404, detail="not found") from e
+
+    if not presigned:
+        # No presigning adapter (local dev) — the authenticated cloud download
+        # route requires a JWT, which a public recipient does not have. Fail
+        # closed rather than hand back an unusable/authed URL.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="share links require a presigning storage backend",
+        )
+
+    # 302 to the short-TTL storage URL. The disposition (attachment for
+    # non-inline mimes) is baked into the presigned URL by presigned_get.
+    return RedirectResponse(url=presigned, status_code=status.HTTP_302_FOUND)

--- a/ee/pocketpaw_ee/cloud/uploads/share_store.py
+++ b/ee/pocketpaw_ee/cloud/uploads/share_store.py
@@ -1,0 +1,100 @@
+# share_store.py — FL-12b "Public share links".
+#
+# Workspace-scoped store for ShareLink documents (mirrors MongoFileStore's
+# tenant-filter discipline). Every WRITE and owner-side read carries a
+# ``workspace`` filter so a create/revoke can never cross tenants. The one
+# deliberate exception is ``get_by_token`` — the public GET /share/{token}
+# route has NO workspace principal (it is token-gated, not auth-gated), so the
+# lookup keys ONLY on the unguessable token. The token itself carries the
+# workspace binding (``ShareLink.workspace_id``), which the public route then
+# replays into presigned_get; there is no way to widen scope through it.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud.uploads.share_models import ShareLink
+
+
+class ShareLinkStore:
+    """Workspace-scoped store for public file share links."""
+
+    async def create(
+        self,
+        *,
+        file_id: str,
+        workspace: str,
+        owner_id: str,
+    ) -> ShareLink:
+        """Mint and persist a new share link for ``file_id`` in ``workspace``."""
+        link = ShareLink(
+            file_id=file_id,
+            workspace_id=workspace,
+            owner_id=owner_id,
+        )
+        await link.insert()
+        return link
+
+    async def get_by_token(self, token: str) -> ShareLink | None:
+        """Resolve a link by its token ALONE (public route).
+
+        No workspace filter by design — the public GET has no tenant principal.
+        The token is unique and unguessable; the returned row carries its own
+        ``workspace_id`` which the caller uses to mint the download. Callers
+        MUST still check ``is_active()`` before serving.
+        """
+        return await ShareLink.find_one(ShareLink.token == token)
+
+    async def get_owner_scoped(
+        self,
+        token: str,
+        *,
+        file_id: str,
+        workspace: str,
+    ) -> ShareLink | None:
+        """Resolve a link for owner-side operations (revoke).
+
+        Bound to ``(token, file_id, workspace)`` so an owner in workspace A can
+        never revoke a link that belongs to file B or workspace B.
+        """
+        return await ShareLink.find_one(
+            ShareLink.token == token,
+            ShareLink.file_id == file_id,
+            ShareLink.workspace_id == workspace,
+        )
+
+    async def revoke(
+        self,
+        token: str,
+        *,
+        file_id: str,
+        workspace: str,
+    ) -> ShareLink | None:
+        """Mark a link revoked, workspace + file scoped. Returns the row or None.
+
+        Idempotent: revoking an already-revoked link is a no-op that still
+        returns the row.
+        """
+        link = await self.get_owner_scoped(token, file_id=file_id, workspace=workspace)
+        if link is None:
+            return None
+        if not link.revoked:
+            link.revoked = True
+            await link.save()
+        return link
+
+    async def list_for_file(
+        self,
+        *,
+        file_id: str,
+        workspace: str,
+    ) -> list[ShareLink]:
+        """All (active + inactive) links for one file, workspace-scoped."""
+        return await ShareLink.find(
+            ShareLink.file_id == file_id,
+            ShareLink.workspace_id == workspace,
+        ).to_list()
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(UTC)

--- a/tests/cloud/uploads/conftest.py
+++ b/tests/cloud/uploads/conftest.py
@@ -1,3 +1,6 @@
+# conftest.py — shared fixtures for the EE uploads test package.
+# 2026-07-03 (FL-12b): ``beanie_upload_db`` now also registers ``ShareLink`` so
+# the public share-link store/route tests get a real (mongomock) collection.
 from __future__ import annotations
 
 import uuid
@@ -32,8 +35,9 @@ async def beanie_upload_db():
 
     # Import after db creation to avoid circular imports
     from pocketpaw_ee.cloud.uploads.models import FileFolder, FileUpload
+    from pocketpaw_ee.cloud.uploads.share_models import ShareLink
 
-    await init_beanie(database=db, document_models=[FileUpload, FileFolder])
+    await init_beanie(database=db, document_models=[FileUpload, FileFolder, ShareLink])
     yield db
 
 

--- a/tests/cloud/uploads/test_share_links.py
+++ b/tests/cloud/uploads/test_share_links.py
@@ -1,0 +1,253 @@
+# test_share_links.py — FL-12b "Public share links" security acceptance.
+#
+# Locks the security-critical behavior of the public share-link surface:
+#   - A shared text/html file resolves to a download with
+#     Content-Disposition: attachment (NEVER inline) — proving the public route
+#     mints its URL through EEUploadService.presigned_get and inherits the
+#     ART-4 forced-attachment gate instead of bypassing it.
+#   - An image (inline mime) still resolves (adapter default disposition).
+#   - Tokens are unguessable (secrets) and single-file scoped: a token for file
+#     A never resolves file B.
+#   - Expired -> 410, revoked -> 410, unknown -> 404.
+#   - The store is workspace + owner scoped for create/revoke.
+#   - The whole surface is dark (404) when the feature flag is off.
+#   - Sharing is independent of hide_from_ai.
+#
+# The public route is exercised WITHOUT any workspace/auth principal — it is
+# token-gated by design — by calling ``resolve_share_link`` directly with a
+# spy EEUploadService swapped into the router module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import RedirectResponse
+from pocketpaw_ee.cloud.uploads import share_router as sr
+from pocketpaw_ee.cloud.uploads.share_models import ShareLink
+from pocketpaw_ee.cloud.uploads.share_store import ShareLinkStore
+
+from pocketpaw.uploads.errors import NotFound
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Spy service — records the (file_id, requester_id, workspace) presigned_get is
+# called with and returns a disposition-aware fake URL, so we can assert the
+# public route replays the LINK's owner identity and inherits forced-attachment.
+# ---------------------------------------------------------------------------
+
+# Mirror the real service's inline policy so the spy is faithful.
+_INLINE = {"image/png", "image/jpeg", "image/gif", "image/webp", "application/pdf", "text/plain"}
+
+
+class _SpyService:
+    def __init__(self, files: dict[str, dict]) -> None:
+        # file_id -> {"mime":..., "owner":..., "workspace":...}
+        self._files = files
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def presigned_get(self, file_id, requester_id, workspace, ttl_seconds):
+        self.calls.append((file_id, requester_id, workspace))
+        f = self._files.get(file_id)
+        # Enforce the real read gate: only the owner in the right workspace
+        # resolves; anything else is NotFound (existence-hiding).
+        if f is None or f["owner"] != requester_id or f["workspace"] != workspace:
+            raise NotFound()
+        mime = f["mime"]
+        disposition = None if mime in _INLINE else 'attachment; filename="f.bin"'
+        # Bake the disposition into the URL so the test can assert on it, exactly
+        # like a real S3 presigned URL carries response-content-disposition.
+        url = f"https://signed.example/{file_id}"
+        if disposition:
+            url += "?response-content-disposition=" + disposition.replace(" ", "%20")
+        rec = SimpleNamespace(id=file_id, mime=mime, filename="f.bin")
+        return rec, url
+
+
+@pytest.fixture()
+def enable_flag(monkeypatch):
+    monkeypatch.setenv("POCKETPAW_SHARE_LINKS_ENABLED", "true")
+
+
+@pytest.fixture()
+def spy_service(monkeypatch):
+    files = {
+        "html1": {"mime": "text/html", "owner": "owner1", "workspace": "w1"},
+        "img1": {"mime": "image/png", "owner": "owner1", "workspace": "w1"},
+        "other": {"mime": "text/plain", "owner": "owner2", "workspace": "w2"},
+    }
+    spy = _SpyService(files)
+    monkeypatch.setattr(sr, "_SVC", spy)
+    return spy
+
+
+# ---------------------------------------------------------------------------
+# Model-level: unguessable token + activity logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestWarning")
+async def test_token_is_unguessable_and_unique():
+    # Generate via the field default_factory path (fresh docs, no DB needed).
+    from pocketpaw_ee.cloud.uploads.share_models import _new_token
+
+    seen = {_new_token() for _ in range(500)}
+    assert len(seen) == 500  # no collisions
+    # URL-safe token from 32 bytes -> ~43 chars, plenty of entropy.
+    assert all(len(t) >= 40 for t in seen)
+
+
+# ---------------------------------------------------------------------------
+# Store: workspace + file scoping (create / revoke / lookup)
+# ---------------------------------------------------------------------------
+
+
+async def test_store_create_and_token_lookup(beanie_upload_db):
+    store = ShareLinkStore()
+    link = await store.create(file_id="fA", workspace="w1", owner_id="owner1")
+    assert link.revoked is False
+    assert link.is_active()
+
+    got = await store.get_by_token(link.token)
+    assert got is not None
+    assert got.file_id == "fA"
+    assert got.workspace_id == "w1"
+    assert got.owner_id == "owner1"
+
+
+async def test_store_revoke_is_workspace_and_file_scoped(beanie_upload_db):
+    store = ShareLinkStore()
+    link = await store.create(file_id="fA", workspace="w1", owner_id="owner1")
+
+    # Wrong workspace cannot revoke.
+    assert await store.revoke(link.token, file_id="fA", workspace="w2") is None
+    # Wrong file cannot revoke.
+    assert await store.revoke(link.token, file_id="fB", workspace="w1") is None
+    # Still active.
+    assert (await store.get_by_token(link.token)).is_active()
+
+    # Correct scope revokes.
+    revoked = await store.revoke(link.token, file_id="fA", workspace="w1")
+    assert revoked is not None and revoked.revoked is True
+    assert not (await store.get_by_token(link.token)).is_active()
+
+
+async def test_store_get_owner_scoped_isolation(beanie_upload_db):
+    store = ShareLinkStore()
+    link = await store.create(file_id="fA", workspace="w1", owner_id="owner1")
+    # Token is real but scope mismatched -> None (no cross-tenant/file leak).
+    assert await store.get_owner_scoped(link.token, file_id="fB", workspace="w1") is None
+    assert await store.get_owner_scoped(link.token, file_id="fA", workspace="w2") is None
+    assert await store.get_owner_scoped(link.token, file_id="fA", workspace="w1") is not None
+
+
+# ---------------------------------------------------------------------------
+# Public route — the security acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+async def test_public_get_html_forces_attachment(beanie_upload_db, enable_flag, spy_service):
+    store = ShareLinkStore()
+    link = await store.create(file_id="html1", workspace="w1", owner_id="owner1")
+
+    resp = await sr.resolve_share_link(link.token)
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 302
+    location = resp.headers["location"]
+    # The forced-attachment disposition rode along on the presigned URL.
+    assert "response-content-disposition=attachment" in location
+    # And the public route replayed the LINK's owner identity + workspace,
+    # not any caller-supplied principal.
+    assert spy_service.calls[-1] == ("html1", "owner1", "w1")
+
+
+async def test_public_get_image_serves_inline_ok(beanie_upload_db, enable_flag, spy_service):
+    store = ShareLinkStore()
+    link = await store.create(file_id="img1", workspace="w1", owner_id="owner1")
+
+    resp = await sr.resolve_share_link(link.token)
+    assert resp.status_code == 302
+    # Inline mime -> no forced-attachment disposition (byte-identical default).
+    assert "response-content-disposition" not in resp.headers["location"]
+
+
+async def test_token_for_file_a_cannot_fetch_file_b(beanie_upload_db, enable_flag, spy_service):
+    """The token is single-file scoped: it only ever resolves its own file_id.
+
+    Even though 'other' exists, a link minted for 'html1' resolves 'html1'.
+    """
+    store = ShareLinkStore()
+    link = await store.create(file_id="html1", workspace="w1", owner_id="owner1")
+    await sr.resolve_share_link(link.token)
+    # Only html1 was ever requested — never 'other'.
+    assert all(c[0] == "html1" for c in spy_service.calls)
+
+
+async def test_expired_token_returns_410(beanie_upload_db, enable_flag, spy_service):
+    # Directly persist an expired link.
+    link = ShareLink(
+        file_id="html1",
+        workspace_id="w1",
+        owner_id="owner1",
+        expires_at=datetime.now(UTC) - timedelta(days=1),
+    )
+    await link.insert()
+    with pytest.raises(HTTPException) as ei:
+        await sr.resolve_share_link(link.token)
+    assert ei.value.status_code == 410
+    # presigned_get must NOT have been called for an expired link.
+    assert spy_service.calls == []
+
+
+async def test_revoked_token_returns_410(beanie_upload_db, enable_flag, spy_service):
+    store = ShareLinkStore()
+    link = await store.create(file_id="html1", workspace="w1", owner_id="owner1")
+    await store.revoke(link.token, file_id="html1", workspace="w1")
+    with pytest.raises(HTTPException) as ei:
+        await sr.resolve_share_link(link.token)
+    assert ei.value.status_code == 410
+    assert spy_service.calls == []
+
+
+async def test_unknown_token_returns_404(beanie_upload_db, enable_flag, spy_service):
+    with pytest.raises(HTTPException) as ei:
+        await sr.resolve_share_link("does-not-exist")
+    assert ei.value.status_code == 404
+
+
+async def test_deleted_file_returns_404(beanie_upload_db, enable_flag, spy_service):
+    """Link minted, then the underlying file goes away -> NotFound -> 404."""
+    store = ShareLinkStore()
+    # Mint a link for a file the spy service doesn't know about.
+    link = ShareLink(file_id="ghost", workspace_id="w1", owner_id="owner1")
+    await link.insert()
+    with pytest.raises(HTTPException) as ei:
+        await sr.resolve_share_link(link.token)
+    assert ei.value.status_code == 404
+
+
+async def test_flag_off_makes_public_route_dark(beanie_upload_db, spy_service, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_SHARE_LINKS_ENABLED", "false")
+    store = ShareLinkStore()
+    link = await store.create(file_id="html1", workspace="w1", owner_id="owner1")
+    with pytest.raises(HTTPException) as ei:
+        await sr.resolve_share_link(link.token)
+    assert ei.value.status_code == 404
+    # Never even looked at the file.
+    assert spy_service.calls == []
+
+
+async def test_share_independent_of_hide_from_ai(beanie_upload_db, enable_flag, spy_service):
+    """A file hidden from AI can still be shared — the two gates never couple.
+
+    The public route only consults the ShareLink + presigned_get; it never reads
+    hide_from_ai. This test proves resolution succeeds regardless.
+    """
+    store = ShareLinkStore()
+    link = await store.create(file_id="html1", workspace="w1", owner_id="owner1")
+    resp = await sr.resolve_share_link(link.token)
+    assert resp.status_code == 302


### PR DESCRIPTION
Public share links (FL-12b) — a file owner mints a link that lets a non-authenticated recipient download the file, safely.

**Stacked on #1627 (FL-5)** — base is `feat/files-edit-tools`; the diff here is only FL-12b's changes.

## Endpoints

- `POST /files/{id}/share` — owner/admin creates a link (license + `uploads.write` gated). Returns the token URL + 7-day expiry.
- `GET /share/{token}` — **PUBLIC, no auth.** The unguessable token is the authorization. Validates active → mints a download via `presigned_get` → 302 redirect. Unknown → 404, revoked/expired → 410.
- `DELETE /files/{id}/share/{token}` — owner/admin revoke.

Feature-flagged behind `POCKETPAW_SHARE_LINKS_ENABLED` (**default OFF**); when off, both surfaces are a flat 404.

## Security posture (reviewed — /security-review passed, no P0/P1)

- **Forced-attachment inherited, not bypassed.** The public route mints through the same `presigned_get` that forces `Content-Disposition: attachment` for non-inline mimes (ART-4), so agent-authored `.html`/`.svg`/`.js` downloads instead of rendering active content on the storage origin. Double-locked by `test_presigned_disposition.py` + the new e2e test.
- **Token:** `secrets.token_urlsafe(32)` (~256 bits), unique-indexed, single-file scoped — a token for file A can never resolve file B.
- **No leak:** flat 404/410, opaque redirect; the route never exposes workspace/owner internals and never requires auth beyond the token. Expired/revoked/unknown tokens never call `presigned_get`.
- **Owner replay identity:** the public route uses the link's stored `owner_id`/`workspace_id` as the read identity so `presigned_get`'s ACL passes — scoped to the one `link.file_id`, re-checks the file still exists.
- **Fails closed:** 503 (not an authed URL) when no presigning backend is configured.
- Independent of `hide_from_ai` (separate gates by design).

## Tests

`test_share_links.py` — 13 passed. Explicitly: HTML→forced-attachment, image→inline-ok, token-A-can't-fetch-B, expired→410, revoked→410 (presign not called), unknown→404, deleted-file→404, cross-workspace create/revoke scoping, flag-off-dark, share-independent-of-hide, token-unguessable-unique. `lint-imports` root + ee → 0 broken.

## P2 follow-ups (non-blocking)

- Add rate limiting to the public GET (defense against enumeration/DoS; the 256-bit token already makes brute-force infeasible).
- The revoke route duplicates the owner-or-admin check inline; could reuse `_assert_can_write` for consistency.
- No TTL cleanup job — expired rows are inert (`is_active()` rejects them); a Mongo TTL index on `expires_at` could prune them.
