### PR TITLE
feat(files): fail-closed hide-from-AI indexing gate

### DIFF
--- a/ee/pocketpaw_ee/cloud/uploads/listeners.py
+++ b/ee/pocketpaw_ee/cloud/uploads/listeners.py
@@ -29,6 +29,14 @@
 #   writes the result back through ``MongoFileStore.set_library_metadata``.
 #   Tag derivation/write failures are contained: a broken tag write must
 #   never lose the KB ingest that already succeeded.
+# Updated: 2026-07-03 — FL-11b "hide-from-AI enforcement". Hardened the hide
+#   gate to fail CLOSED: if the FileUpload row can't be resolved to confirm
+#   ``hide_from_ai``, the listener SKIPS indexing/tagging instead of proceeding
+#   (FL-6 failed open, which could index a hidden file on a metadata hiccup).
+#   NOTE: purging content ALREADY indexed when a file is later hidden requires
+#   a kb-go ``delete`` subcommand that does not exist yet — tracked as a
+#   follow-up; this change guarantees hidden files are never indexed going
+#   forward.
 """Upload bus subscribers.
 
 The upload pipeline emits :class:`FileReady` on every successful upload.
@@ -88,22 +96,34 @@ async def index_uploaded_file(event: Event) -> None:
         )
         return
 
-    # FL-6: load the library row up front so we can (a) honour the
+    # FL-6/FL-11b: load the library row up front so we can (a) honour the
     # ``hide_from_ai`` opt-out before touching the KB and (b) union derived
-    # tags with any pre-existing user tags later. A hidden file must never be
-    # indexed OR tagged — bail immediately. ``doc`` is ``None`` in test
-    # contexts without Beanie initialised or for rows the store can't see; we
-    # proceed with indexing in that case (fail-open on indexing, never on the
-    # hide gate — a genuinely hidden row is always found by the store).
+    # tags with any pre-existing user tags later.
+    #
+    # FL-11b hardening — FAIL CLOSED on the hide gate. ``hide_from_ai`` is a
+    # privacy control: if we cannot resolve the row to confirm the file is NOT
+    # hidden, we must NOT index it. FL-6 previously failed *open* here (``doc``
+    # is None -> proceed), which would index a genuinely hidden file whenever
+    # the metadata lookup hiccupped. There's no clean signal to distinguish
+    # "row genuinely absent" from "store unavailable", so any unresolvable
+    # status skips indexing/tagging. A resolvable, unhidden row proceeds.
     doc = await _load_upload_doc(file_id, str(workspace_id))
-    if doc is not None and getattr(doc, "hide_from_ai", False):
+    if doc is None:
+        logger.info(
+            "file_id=%s: could not resolve the library row to check "
+            "hide_from_ai; skipping KB index and auto-tagging (fail-closed "
+            "privacy gate)",
+            file_id,
+        )
+        return
+    if getattr(doc, "hide_from_ai", False):
         logger.info(
             "file_id=%s is hidden from AI (hide_from_ai=True); skipping KB "
             "index and auto-tagging",
             file_id,
         )
         return
-    existing_tags = list(getattr(doc, "tags", []) or []) if doc is not None else []
+    existing_tags = list(getattr(doc, "tags", []) or [])
 
     adapter = _resolve_adapter()
     if adapter is None or not storage_key:
@@ -362,12 +382,11 @@ async def _write_vector_to_kb(
 async def _load_upload_doc(file_id: str, workspace_id: str):
     """Load the workspace-scoped FileUpload row, or ``None`` on any failure.
 
-    Used for the FL-6 ``hide_from_ai`` gate and to read pre-existing user
-    tags for the union. Resilient by design: in test contexts without Beanie
-    initialised the store call raises, and we return ``None`` so the listener
-    proceeds with indexing (fail-open on indexing). The hide gate itself is
-    fail-open only when the row can't be found — a genuinely hidden row is
-    always visible to the workspace-scoped store lookup.
+    Used for the ``hide_from_ai`` gate and to read pre-existing user tags for
+    the union. Returns ``None`` when the store raises (e.g. Beanie not
+    initialised) or the row is genuinely absent. FL-11b: the caller treats
+    ``None`` as fail-CLOSED — indexing is skipped when the hide status can't be
+    confirmed, so a hidden file is never indexed on a metadata hiccup.
     """
     try:
         from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore

--- a/tests/cloud/uploads/test_listener.py
+++ b/tests/cloud/uploads/test_listener.py
@@ -63,6 +63,14 @@ class _FakeAdapter:
             raise self._raises
 
 
+class _StubUploadDoc:
+    """Minimal FileUpload stand-in for the fail-closed hide gate (FL-11b)."""
+
+    def __init__(self, *, hide_from_ai: bool = False, tags: list[str] | None = None):
+        self.hide_from_ai = hide_from_ai
+        self.tags = tags or []
+
+
 def _patch_listener(
     monkeypatch,
     *,
@@ -70,9 +78,25 @@ def _patch_listener(
     storage_path: Path | None = None,
     adapter: _FakeAdapter | None = None,
     ingest: AsyncMock | None = None,
+    hide_from_ai: bool = False,
+    resolve_doc: bool = True,
 ):
-    """Wire the listener's collaborators with test doubles."""
+    """Wire the listener's collaborators with test doubles.
+
+    FL-11b: the listener now fails CLOSED — it needs a resolvable, non-hidden
+    FileUpload row or it skips indexing. By default we return a non-hidden stub
+    doc so the collaborator tests exercise the index path. ``hide_from_ai``
+    drives the hidden branch; ``resolve_doc=False`` returns ``None`` to exercise
+    the fail-closed (unresolvable row) branch.
+    """
     from pocketpaw_ee.cloud.uploads import listeners
+
+    async def _fake_load(_file_id, _workspace_id):
+        if not resolve_doc:
+            return None
+        return _StubUploadDoc(hide_from_ai=hide_from_ai)
+
+    monkeypatch.setattr(listeners, "_load_upload_doc", _fake_load)
 
     if chain is not None:
         monkeypatch.setattr(
@@ -460,3 +484,68 @@ async def test_register_upload_listeners_subscribes_to_file_ready():
         assert index_uploaded_file in handlers
     finally:
         bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_hidden_file_skips_index_and_tags(monkeypatch, tmp_path):
+    """FL-11b: a file with hide_from_ai=True is never extracted or KB-indexed."""
+    from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+    chain = _FakeChain(ExtractionResult(text="secret", backend="local"))
+    ingest = AsyncMock(return_value={"id": "art-x"})
+    _patch_listener(
+        monkeypatch,
+        chain=chain,
+        storage_path=tmp_path / "hidden.pdf",
+        ingest=ingest,
+        hide_from_ai=True,
+    )
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f-hidden",
+                "filename": "hidden.pdf",
+                "mime": "application/pdf",
+                "storage_key": "ws/w1/f-hidden.pdf",
+            }
+        )
+    )
+
+    # Neither extraction nor KB ingest run for a hidden file.
+    assert chain.calls == []
+    ingest.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_when_row_unresolvable(monkeypatch, tmp_path):
+    """FL-11b: if the library row can't be resolved, indexing is SKIPPED
+    (fail-closed) rather than proceeding — a hidden file must never leak into
+    the KB on a metadata lookup hiccup."""
+    from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+    chain = _FakeChain(ExtractionResult(text="unconfirmed", backend="local"))
+    ingest = AsyncMock(return_value={"id": "art-y"})
+    _patch_listener(
+        monkeypatch,
+        chain=chain,
+        storage_path=tmp_path / "x.pdf",
+        ingest=ingest,
+        resolve_doc=False,
+    )
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f-unknown",
+                "filename": "x.pdf",
+                "mime": "application/pdf",
+                "storage_key": "ws/w1/f-unknown.pdf",
+            }
+        )
+    )
+
+    assert chain.calls == []
+    ingest.assert_not_awaited()

--- a/tests/cloud/uploads/test_listener_pocket_route.py
+++ b/tests/cloud/uploads/test_listener_pocket_route.py
@@ -39,6 +39,14 @@ def _patch(monkeypatch, *, chain, storage_path: Path, ingest):
 
     monkeypatch.setattr(listeners, "_resolve_adapter", lambda: _Adapter())
 
+    # FL-11b: the listener fails CLOSED — it needs a resolvable, non-hidden
+    # FileUpload row or it skips indexing. Provide a non-hidden stub so these
+    # pocket-scope-routing tests reach the ingest path.
+    async def _load_doc(_file_id, _workspace_id):
+        return type("_Doc", (), {"hide_from_ai": False, "tags": []})()
+
+    monkeypatch.setattr(listeners, "_load_upload_doc", _load_doc)
+
     from pocketpaw_ee.cloud.agents import knowledge as kn
 
     monkeypatch.setattr(kn.KnowledgeService, "ingest_text_to_scope", ingest)

--- a/tests/cloud/uploads/test_listener_vector.py
+++ b/tests/cloud/uploads/test_listener_vector.py
@@ -113,6 +113,14 @@ def _patch_pipeline(
     monkeypatch.setattr("pocketpaw_ee.cloud.extraction.build_chain", lambda settings: chain)
     monkeypatch.setattr(listeners, "_resolve_adapter", lambda: adapter)
 
+    # FL-11b: the listener fails CLOSED — it needs a resolvable, non-hidden
+    # FileUpload row or it skips indexing. Provide a non-hidden stub so the
+    # vector-path tests reach the ingest + embed pipeline.
+    async def _load_doc(_file_id, _workspace_id):
+        return type("_Doc", (), {"hide_from_ai": False, "tags": []})()
+
+    monkeypatch.setattr(listeners, "_load_upload_doc", _load_doc)
+
     from pocketpaw_ee.cloud.agents import knowledge as kn
 
     monkeypatch.setattr(kn.KnowledgeService, "ingest_text_to_scope", ingest)


### PR DESCRIPTION
Fail-closed hide-from-AI indexing gate (FL-11b).

**Stacked on #1628 (FL-6)** — base is `feat/files-auto-tagging`; the diff here is only FL-11b's changes.

## What changes

FL-6 added the `hide_from_ai` gate but failed **open**: if the metadata row couldn't be loaded to check the flag, it proceeded to index. For a privacy control that's the wrong default — a lookup hiccup could index a file the user marked hidden.

This hardens the gate to fail **closed**: an unresolvable hide status (row absent or store unavailable) skips KB indexing and auto-tagging. A resolvable, unhidden row proceeds as before. Hiding never removes the file from listing/download — it only affects AI indexing.

## Tests

`test_listener.py` — 34 passed. New: `test_hidden_file_skips_index_and_tags` (hidden → no extraction, no ingest) and `test_fail_closed_when_row_unresolvable` (unresolvable row → skipped). The pre-existing collaborator tests now seed a resolvable non-hidden row via the shared helper (they relied on the old fail-open default). `lint-imports` ee → 28 kept, 0 broken.

## Scoped out (needs a kb-go feature first)

Purging content **already** indexed when a file is later hidden requires a `kb delete` subcommand in kb-go, which does not exist today (kb-go stores articles as files with a BM25 index + concept graph; a delete must remove all three). This PR guarantees hidden files are **never indexed going forward**; the retroactive purge is filed as a follow-up gated on adding `kb delete`.
