### PR TITLE
feat(files): purge KB article on hide-from-AI toggle

### DIFF
--- a/ee/pocketpaw_ee/cloud/agents/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/agents/knowledge.py
@@ -1,4 +1,10 @@
 # knowledge.py — Agent knowledge service via the kb-go binary.
+# Updated: 2026-07-03 — FL-11b "hide-from-AI purge". Added
+#   KnowledgeService.remove_article(scope, article_id) → `kb delete
+#   <article_id> --scope <scope>`, mirroring get_article. Resilient: logs and
+#   swallows subprocess errors (returns False) like the other kb calls, so a
+#   purge failure never propagates back into the PATCH handler that hides a
+#   file. kb-go's `delete` is idempotent (deleting a missing id is a no-op).
 # Updated: 2026-04-30 — Stage 1.B of "Files as Knowledge". Added
 #   ingest_text_to_scope so callers (notably the FileReady listener) can
 #   target arbitrary kb-go scopes (workspace:{wid}, pocket:{pid}) without
@@ -158,6 +164,32 @@ class KnowledgeService:
         """Fetch a single article's full body."""
         result = await asyncio.to_thread(_kb, "show", article_id, "--scope", f"agent:{agent_id}")
         return result if isinstance(result, dict) else {"content": str(result)}
+
+    @staticmethod
+    async def remove_article(scope: str, article_id: str) -> bool:
+        """Delete a single article from a kb-go scope (FL-11b purge path).
+
+        Mirrors :meth:`get_article` but calls ``kb delete``. Used to
+        retroactively purge a file's KB content when it's hidden from AI after
+        having been indexed. Resilient like the other kb calls: any subprocess
+        error is logged and swallowed (returns ``False``) so a purge failure
+        never breaks the caller (the hide flag is still applied; a sweeper can
+        re-purge). kb-go's ``delete`` is idempotent — deleting a missing id is a
+        no-op. Returns ``True`` when the subprocess call completed without
+        raising.
+        """
+        try:
+            await asyncio.to_thread(_kb, "delete", article_id, "--scope", scope)
+            return True
+        except Exception:
+            logger.warning(
+                "kb delete failed for article_id=%s scope=%s; KB content may "
+                "still be retrievable (retry/sweeper can re-purge)",
+                article_id,
+                scope,
+                exc_info=True,
+            )
+            return False
 
     @staticmethod
     async def search(agent_id: str, query: str, limit: int = 5) -> list[str]:

--- a/ee/pocketpaw_ee/cloud/uploads/listeners.py
+++ b/ee/pocketpaw_ee/cloud/uploads/listeners.py
@@ -37,6 +37,13 @@
 #   a kb-go ``delete`` subcommand that does not exist yet — tracked as a
 #   follow-up; this change guarantees hidden files are never indexed going
 #   forward.
+# Updated: 2026-07-03 — FL-11b "hide-from-AI purge" (retroactive). After a
+#   successful KB ingest the listener now records the kb-go ``article_id`` and
+#   the ``scope`` it landed in onto the FileUpload row (via
+#   ``MongoFileStore.set_kb_article``). This lets the PATCH route retroactively
+#   purge exactly that article when the file is later hidden from AI (the
+#   companion delete path lives in ``uploads/router.py``). The tracking write is
+#   contained — a failure logs but never undoes the ingest that succeeded.
 """Upload bus subscribers.
 
 The upload pipeline emits :class:`FileReady` on every successful upload.
@@ -198,6 +205,18 @@ async def index_uploaded_file(event: Event) -> None:
                 file_id,
             )
             return
+
+        # FL-11b: record the article id + scope on the row so a later
+        # hide-from-AI toggle can purge exactly this article. Contained — a
+        # tracking-write failure must not break the ingest that already
+        # succeeded (worst case: the file can't be auto-purged and a sweeper
+        # handles it).
+        await _record_kb_article(
+            file_id=file_id,
+            workspace_id=str(workspace_id),
+            article_id=article_id,
+            scope=scope,
+        )
 
         await _maybe_attach_vector(
             path=path,
@@ -377,6 +396,39 @@ async def _write_vector_to_kb(
             os.unlink(tmp.name)
         except OSError:
             logger.debug("temp vec cleanup failed for %s", tmp.name)
+
+
+async def _record_kb_article(
+    *,
+    file_id: str,
+    workspace_id: str,
+    article_id: str,
+    scope: str,
+) -> None:
+    """Persist the kb-go article id + scope on the FileUpload row (FL-11b).
+
+    Lets a later hide-from-AI toggle purge exactly this article from the KB.
+    Fully contained: any failure (store unavailable, row already gone) is
+    logged and swallowed so the ingest that already succeeded is never undone.
+    """
+    try:
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        updated = await MongoFileStore().set_kb_article(
+            file_id, workspace_id, article_id=article_id, scope=scope
+        )
+        if updated is None:
+            logger.debug(
+                "kb-article tracking found no row for file_id=%s workspace=%s",
+                file_id,
+                workspace_id,
+            )
+    except Exception:
+        logger.exception(
+            "recording kb_article_id failed for file_id=%s; KB content is "
+            "ingested but won't auto-purge on hide (sweeper can reconcile)",
+            file_id,
+        )
 
 
 async def _load_upload_doc(file_id: str, workspace_id: str):

--- a/ee/pocketpaw_ee/cloud/uploads/models.py
+++ b/ee/pocketpaw_ee/cloud/uploads/models.py
@@ -1,5 +1,13 @@
 """EE FileUpload document — Mongo metadata for blobs stored via StorageAdapter.
 
+2026-07-03 — FL-11b "hide-from-AI purge". Added ``kb_article_id`` and
+``kb_scope`` (both ``str | None``, default ``None``) so a row remembers the
+kb-go article it was ingested into. The FileReady listener records them after a
+successful ingest; the PATCH route reads them to purge that article when a file
+is later hidden from AI (``hide_from_ai`` flips false→true). Legacy rows read
+back ``None`` via the defaults — no migration needed (Beanie field-add). Not
+indexed: they're read only after resolving a row by ``file_id``.
+
 2026-07-03 — FL-1 "Library metadata". Added ``tags`` (list[str]),
 ``collections`` (list[str]) and ``hide_from_ai`` (bool) so a file can carry
 library organization + an AI-visibility flag that persist and round-trip
@@ -69,6 +77,13 @@ class FileUpload(TimestampedDocument):
     tags: list[str] = Field(default_factory=list)
     collections: list[str] = Field(default_factory=list)
     hide_from_ai: bool = False
+    # KB tracking (FL-11b). After a successful ingest the FileReady listener
+    # records the kb-go article id and the scope it landed in, so the file can
+    # be retroactively purged from the KB if it's later hidden from AI. ``None``
+    # means "not (currently) indexed" — a hide toggle then skips the purge, and
+    # a later re-index re-populates these. Legacy rows read ``None``.
+    kb_article_id: str | None = None
+    kb_scope: str | None = None
 
     class Settings:
         name = "file_uploads"

--- a/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
@@ -1,5 +1,11 @@
 """Mongo-backed metadata store, workspace-scoped.
 
+2026-07-03 (FL-11b "hide-from-AI purge"): added ``set_kb_article`` — a
+workspace-scoped setter the FileReady listener uses to record the kb-go
+``article_id`` + ``scope`` on a row after a successful ingest, and the PATCH
+route uses (with ``None`` args) to clear that tracking after a purge. The
+workspace filter is always applied on the read, so cross-tenant writes are
+impossible through this API.
 2026-07-03 (FL-1 "Library metadata"): the ``iter_by_workspace`` /
 ``iter_by_pocket`` dict rows now carry ``collections`` and ``hide_from_ai``
 alongside the pre-existing ``tags`` so library metadata round-trips into the
@@ -106,6 +112,32 @@ class MongoFileStore:
             doc.collections = [str(c) for c in collections]
         if hide_from_ai is not None:
             doc.hide_from_ai = bool(hide_from_ai)
+        await doc.save()
+        return doc
+
+    async def set_kb_article(
+        self,
+        file_id: str,
+        workspace: str,
+        *,
+        article_id: str | None,
+        scope: str | None,
+    ) -> FileUpload | None:
+        """Record (or clear) the tracked kb-go article on one row (FL-11b).
+
+        Workspace-scoped: the workspace filter is always applied, so a caller
+        cannot mutate another tenant's rows. Pass a non-empty ``article_id`` +
+        ``scope`` after a successful ingest to enable a later purge; pass
+        ``None`` for both to clear the tracking after a purge (so a re-index
+        re-populates it). Both fields are always written to the given values.
+        Returns the updated doc, or ``None`` if no live row matches
+        ``(file_id, workspace)``.
+        """
+        doc = await self.get_doc_scoped(file_id, workspace)
+        if doc is None:
+            return None
+        doc.kb_article_id = article_id
+        doc.kb_scope = scope
         await doc.save()
         return doc
 

--- a/ee/pocketpaw_ee/cloud/uploads/router.py
+++ b/ee/pocketpaw_ee/cloud/uploads/router.py
@@ -1,5 +1,15 @@
 """EE /uploads router — workspace-scoped upload endpoints.
 
+2026-07-03 (FL-11b "hide-from-AI purge"): ``PATCH /uploads/{file_id}`` now
+retroactively purges a file's KB content when ``hide_from_ai`` flips false→true
+AND the row tracks a kb-go article (``kb_article_id`` + ``kb_scope`` recorded on
+ingest by the FileReady listener). It calls
+``KnowledgeService.remove_article`` then clears the tracking so a later re-index
+re-tracks. Best-effort: a purge failure logs a warning but the hide flag still
+applies (a sweeper can re-purge); no article tracked → no purge; already-hidden
+or a PATCH that doesn't change the flag → no purge. The file stays
+browsable/downloadable — only the KB copy is removed.
+
 2026-07-03 (FL-1 "Library metadata"): ``PATCH /uploads/{file_id}`` now also
 accepts ``tags`` (list[str]), ``collections`` (list[str]) and ``hide_from_ai``
 (bool) so a file can carry library organization. Only the provided fields are
@@ -37,6 +47,7 @@ into it.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated
@@ -68,6 +79,8 @@ from pocketpaw_ee.cloud.uploads.folder_store import FolderStore
 from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
 from pocketpaw_ee.cloud.uploads.paths import normalize_path, parent_of
 from pocketpaw_ee.cloud.uploads.service import EEUploadService
+
+logger = logging.getLogger(__name__)
 
 # Module-level singletons — one adapter + store per process
 _ROOT = Path.home() / ".pocketpaw" / "uploads"
@@ -382,12 +395,53 @@ async def patch_upload(
             raise HTTPException(status_code=400, detail="collections must be a list of strings")
         doc.collections = new_collections
 
+    # FL-11b: detect a false→true hide transition so we can retroactively
+    # purge the file's KB article after the row is saved. Capture the pre-edit
+    # state + tracked article BEFORE mutating ``doc``.
+    was_hidden = bool(doc.hide_from_ai)
+    tracked_article_id = doc.kb_article_id
+    tracked_scope = doc.kb_scope
+
     if new_hide is not None:
         if not isinstance(new_hide, bool):
             raise HTTPException(status_code=400, detail="hide_from_ai must be a boolean")
         doc.hide_from_ai = new_hide
 
+    became_hidden = new_hide is True and not was_hidden
+
     await doc.save()
+
+    # FL-11b purge: a file that WAS indexed (has a tracked article) and is now
+    # being hidden gets its KB content removed so it stops being retrievable.
+    # Best-effort — a purge failure logs a warning but the hide flag stays
+    # applied (a retry/sweeper can re-purge). We do NOT purge when the file
+    # wasn't indexed (no tracked article) or was already hidden. On success we
+    # clear the tracking so a later re-index re-tracks the fresh article.
+    if became_hidden and tracked_article_id and tracked_scope:
+        from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+        purged = await KnowledgeService.remove_article(tracked_scope, tracked_article_id)
+        if purged:
+            try:
+                await _META.set_kb_article(
+                    file_id, workspace=workspace, article_id=None, scope=None
+                )
+            except Exception:
+                logger.warning(
+                    "cleared-tracking write failed for file_id=%s after KB purge; "
+                    "re-index may re-purge harmlessly (idempotent delete)",
+                    file_id,
+                )
+        else:
+            logger.warning(
+                "KB purge failed for file_id=%s (article_id=%s scope=%s); hide "
+                "flag applied but content may still be retrievable until a "
+                "sweeper re-purges",
+                file_id,
+                tracked_article_id,
+                tracked_scope,
+            )
+
     return {
         "id": doc.file_id,
         "filename": doc.filename,

--- a/tests/cloud/uploads/test_kb_purge.py
+++ b/tests/cloud/uploads/test_kb_purge.py
@@ -1,0 +1,394 @@
+# test_kb_purge.py — FL-11b retroactive KB-purge tests.
+# Created: 2026-07-03 — FL-11b "hide-from-AI purge". Covers the full slice:
+#   (1) a successful ingest records kb_article_id + kb_scope on the FileUpload
+#       row (listener → store).
+#   (2) PATCH hide_from_ai false→true on a TRACKED file calls
+#       KnowledgeService.remove_article with the tracked id + scope and clears
+#       the tracking fields (router → service, mocked _kb).
+#   (3) PATCH on an UNTRACKED file (no article) triggers no kb delete.
+#   (4) A PATCH that doesn't change hide_from_ai, or a file already hidden,
+#       triggers no purge.
+#   (5) The store setter round-trips + clears; remove_article maps to `kb
+#       delete` and swallows subprocess errors.
+# Uses the cloud/uploads conftest fixtures (beanie_upload_db + store) and the
+# ee_client router harness pattern (seed via the store since guarded POST 401s
+# in this env — a pre-existing harness gap, not our regression).
+"""Integration tests for the FL-11b hide-from-AI KB purge path."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud._core.realtime.events import FileReady
+from pocketpaw_ee.cloud.extraction.adapter import ExtractionResult
+
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- listener wiring (mirrors test_listener_auto_tag) ---------------------
+
+
+class _FakeChain:
+    def __init__(self, result: ExtractionResult):
+        self._result = result
+
+    async def run(self, path: Path, mime: str) -> ExtractionResult:
+        return self._result
+
+
+class _FakeAdapter:
+    def __init__(self, local_path_value: Path):
+        self._local = local_path_value
+
+    def local_path(self, key: str) -> Path | None:
+        return self._local
+
+    async def open(self, key: str):  # pragma: no cover — local path wins
+        yield b""
+
+
+def _record(**overrides) -> FileRecord:
+    defaults = {
+        "id": "f1",
+        "storage_key": "chat/202607/aaa.pdf",
+        "filename": "invoice.pdf",
+        "mime": "application/pdf",
+        "size": 1,
+        "owner_id": "u1",
+        "chat_id": "c1",
+        "created": datetime.now(UTC),
+    }
+    defaults.update(overrides)
+    return FileRecord(**defaults)
+
+
+def _wire(monkeypatch, *, chain: _FakeChain, adapter: _FakeAdapter, ingest: AsyncMock):
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads import listeners
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.extraction.build_chain", lambda settings: chain)
+    monkeypatch.setattr(listeners, "_resolve_adapter", lambda: adapter)
+    monkeypatch.setattr(kn.KnowledgeService, "ingest_text_to_scope", ingest)
+
+
+def _event() -> FileReady:
+    return FileReady(
+        data={
+            "workspace_id": "w1",
+            "file_id": "f1",
+            "filename": "invoice.pdf",
+            "mime": "application/pdf",
+            "storage_key": "chat/202607/aaa.pdf",
+        }
+    )
+
+
+async def test_ingest_records_kb_article_and_scope(monkeypatch, store, tmp_path):
+    """A successful ingest persists kb_article_id + kb_scope on the row."""
+    from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+    await store.save_scoped(_record(), workspace="w1")
+
+    fake_path = tmp_path / "invoice.pdf"
+    fake_path.write_bytes(b"unused; chain mocked")
+    chain = _FakeChain(
+        ExtractionResult(title="Invoice", text="payable amount total due", backend="local")
+    )
+    ingest = AsyncMock(return_value={"id": "art-42"})
+    _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(fake_path), ingest=ingest)
+
+    await index_uploaded_file(_event())
+
+    doc = await store.get_doc_scoped("f1", "w1")
+    assert doc is not None
+    assert doc.kb_article_id == "art-42"
+    # Workspace-scoped upload → workspace:{wid} scope recorded.
+    assert doc.kb_scope == "workspace:w1"
+    ingest.assert_awaited_once()
+
+
+async def test_ingest_records_pocket_scope(monkeypatch, store, tmp_path):
+    """A pocket-scoped upload records the pocket:{id} scope, not workspace."""
+    from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+    rec = _record(id="f2")
+    await store.save_scoped(rec, workspace="w1", pocket_id="p9")
+
+    fake_path = tmp_path / "invoice.pdf"
+    fake_path.write_bytes(b"x")
+    chain = _FakeChain(ExtractionResult(text="content here", backend="local"))
+    ingest = AsyncMock(return_value={"id": "art-9"})
+    _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(fake_path), ingest=ingest)
+
+    ev = FileReady(
+        data={
+            "workspace_id": "w1",
+            "pocket_id": "p9",
+            "file_id": "f2",
+            "filename": "invoice.pdf",
+            "mime": "application/pdf",
+            "storage_key": "chat/202607/aaa.pdf",
+        }
+    )
+    await index_uploaded_file(ev)
+
+    doc = await store.get_doc_scoped("f2", "w1")
+    assert doc is not None
+    assert doc.kb_article_id == "art-9"
+    assert doc.kb_scope == "pocket:p9"
+
+
+# --- store setter --------------------------------------------------------
+
+
+async def test_set_kb_article_roundtrips_and_clears(store):
+    await store.save_scoped(_record(id="f3"), workspace="w1")
+
+    updated = await store.set_kb_article("f3", "w1", article_id="a1", scope="workspace:w1")
+    assert updated is not None
+    doc = await store.get_doc_scoped("f3", "w1")
+    assert doc.kb_article_id == "a1"
+    assert doc.kb_scope == "workspace:w1"
+
+    # Clearing to None round-trips.
+    await store.set_kb_article("f3", "w1", article_id=None, scope=None)
+    doc = await store.get_doc_scoped("f3", "w1")
+    assert doc.kb_article_id is None
+    assert doc.kb_scope is None
+
+
+async def test_set_kb_article_workspace_scoped(store):
+    """Cannot set tracking on another tenant's row."""
+    await store.save_scoped(_record(id="f4"), workspace="w1")
+    # Wrong workspace → no row matched → None, and w1's row untouched.
+    result = await store.set_kb_article("f4", "w2", article_id="a1", scope="s")
+    assert result is None
+    doc = await store.get_doc_scoped("f4", "w1")
+    assert doc.kb_article_id is None
+
+
+# --- service remove_article ---------------------------------------------
+
+
+async def test_remove_article_calls_kb_delete(monkeypatch):
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+
+    calls: list[tuple] = []
+
+    def _fake_kb(*args, **kwargs):
+        calls.append(args)
+        return {}
+
+    monkeypatch.setattr(kn, "_kb", _fake_kb)
+
+    ok = await kn.KnowledgeService.remove_article("workspace:w1", "art-1")
+    assert ok is True
+    assert calls == [("delete", "art-1", "--scope", "workspace:w1")]
+
+
+async def test_remove_article_swallows_errors(monkeypatch):
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("kb delete failed: boom")
+
+    monkeypatch.setattr(kn, "_kb", _boom)
+
+    # Resilient: returns False, does not raise.
+    ok = await kn.KnowledgeService.remove_article("workspace:w1", "art-1")
+    assert ok is False
+
+
+# --- PATCH route purge trigger ------------------------------------------
+
+
+@pytest.fixture()
+def ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
+    """EE uploads router with license + identity deps overridden."""
+    import pocketpaw_ee.cloud.uploads.router as uploads_module
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+    from pocketpaw_ee.cloud.uploads.service import EEUploadService
+
+    from pocketpaw.uploads.config import UploadSettings
+    from pocketpaw.uploads.local import LocalStorageAdapter
+
+    root = tmp_path / "u"
+    root.mkdir()
+    test_cfg = UploadSettings(local_root=root)
+    test_adapter = LocalStorageAdapter(root=root)
+    test_meta = MongoFileStore()
+    test_svc = EEUploadService(adapter=test_adapter, meta=test_meta, cfg=test_cfg)
+    monkeypatch.setattr(uploads_module, "_SVC", test_svc)
+
+    app = FastAPI()
+    from fastapi import Header
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+    app.dependency_overrides[require_license] = lambda: None
+
+    async def _user_dep(x_user: str = Header(default="u1")) -> str:
+        return x_user
+
+    async def _workspace_dep(x_workspace: str = Header(default="w1")) -> str:
+        return x_workspace
+
+    app.dependency_overrides[current_user_id] = _user_dep
+    app.dependency_overrides[current_workspace_id] = _workspace_dep
+    app.include_router(uploads_module.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+async def _seed(fid: str, *, ws: str = "w1", user: str = "u1", **meta) -> None:
+    """Seed a live upload row directly (guarded POST 401s in this env)."""
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    rec = FileRecord(
+        id=fid,
+        storage_key=f"chat/202607/{fid}.png",
+        filename=f"{fid}.png",
+        mime="image/png",
+        size=4,
+        owner_id=user,
+        chat_id=None,
+        created=datetime.now(UTC),
+    )
+    s = MongoFileStore()
+    await s.save_scoped(rec, workspace=ws)
+    if "article_id" in meta or "scope" in meta:
+        await s.set_kb_article(fid, ws, article_id=meta.get("article_id"), scope=meta.get("scope"))
+
+
+async def test_patch_hide_purges_tracked_article(ee_client, monkeypatch):
+    """false→true on a tracked file → remove_article(id, scope) + tracking cleared."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    await _seed("p1", article_id="art-7", scope="workspace:w1")
+
+    remove = AsyncMock(return_value=True)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    r = ee_client.patch(
+        "/api/v1/uploads/p1",
+        json={"hide_from_ai": True},
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["hide_from_ai"] is True
+
+    remove.assert_awaited_once_with("workspace:w1", "art-7")
+
+    # Tracking cleared so a re-index re-tracks.
+    doc = await MongoFileStore().get_doc_scoped("p1", "w1")
+    assert doc.hide_from_ai is True
+    assert doc.kb_article_id is None
+    assert doc.kb_scope is None
+
+
+async def test_patch_hide_untracked_file_no_purge(ee_client, monkeypatch):
+    """A file with no tracked article → no kb delete call."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+
+    await _seed("p2")  # no article tracked
+
+    remove = AsyncMock(return_value=True)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    r = ee_client.patch(
+        "/api/v1/uploads/p2",
+        json={"hide_from_ai": True},
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 200, r.text
+    remove.assert_not_awaited()
+
+
+async def test_patch_already_hidden_no_purge(ee_client, monkeypatch):
+    """A file already hidden (true→true) → no purge even if tracked."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    await _seed("p3", article_id="art-x", scope="workspace:w1")
+    await MongoFileStore().set_library_metadata("p3", "w1", hide_from_ai=True)
+
+    remove = AsyncMock(return_value=True)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    r = ee_client.patch(
+        "/api/v1/uploads/p3",
+        json={"hide_from_ai": True},
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 200, r.text
+    remove.assert_not_awaited()
+
+
+async def test_patch_no_hide_change_no_purge(ee_client, monkeypatch):
+    """A PATCH that doesn't touch hide_from_ai → no purge."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+
+    await _seed("p4", article_id="art-y", scope="workspace:w1")
+
+    remove = AsyncMock(return_value=True)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    r = ee_client.patch(
+        "/api/v1/uploads/p4",
+        json={"tags": ["invoice"]},
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 200, r.text
+    remove.assert_not_awaited()
+
+
+async def test_patch_unhide_true_to_false_no_purge(ee_client, monkeypatch):
+    """Un-hiding (true→false) is not a purge trigger."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    await _seed("p5", article_id="art-z", scope="workspace:w1")
+    await MongoFileStore().set_library_metadata("p5", "w1", hide_from_ai=True)
+
+    remove = AsyncMock(return_value=True)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    r = ee_client.patch(
+        "/api/v1/uploads/p5",
+        json={"hide_from_ai": False},
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 200, r.text
+    remove.assert_not_awaited()
+
+
+async def test_patch_purge_failure_still_hides(ee_client, monkeypatch):
+    """A purge failure logs but the hide flag still applies; tracking kept."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    await _seed("p6", article_id="art-q", scope="workspace:w1")
+
+    remove = AsyncMock(return_value=False)  # purge failed
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    r = ee_client.patch(
+        "/api/v1/uploads/p6",
+        json={"hide_from_ai": True},
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["hide_from_ai"] is True
+    remove.assert_awaited_once()
+
+    # Hide applied; tracking NOT cleared (so a sweeper can re-purge).
+    doc = await MongoFileStore().get_doc_scoped("p6", "w1")
+    assert doc.hide_from_ai is True
+    assert doc.kb_article_id == "art-q"


### PR DESCRIPTION
Completes the "hide from AI" control: hiding an already-indexed file now purges its content from the knowledge base (FL-11b follow-up).

**Stacked on #1630 (FL-11b)** — base is `feat/files-hide-from-ai`; the diff here is only this change.

## Background

FL-11b (#1630) made indexing fail closed — a file marked hidden is never indexed *going forward*. But content indexed *before* it was hidden stayed in kb-go, because kb-go had no delete surface. That surface now exists (kb-go's new `kb delete`), so this wires the retroactive purge.

## What changes

- **Track the article.** `FileUpload` gains `kb_article_id` + `kb_scope` (backward-compatible defaults). The `FileReady` listener already extracts the article id after ingest — it now persists it (and the scope) to the row via a workspace-scoped `set_kb_article` setter. A tracking-write failure never breaks ingest.
- **Delete method.** `KnowledgeService.remove_article(scope, article_id)` shells to `kb delete` (resilient — logs and returns False on subprocess error, like the other kb calls).
- **Purge on toggle.** When `PATCH /uploads/{id}` flips `hide_from_ai` false→true on a tracked file, it calls `remove_article` then clears the tracking (so a later re-index re-tracks). Best-effort: a purge failure logs a warning but the hide flag still applies and the tracking is kept for a retry. No purge when the file wasn't indexed, was already hidden, or the flag didn't change. The file stays browsable and downloadable — only the KB content is removed.

## Tests

`test_kb_purge.py` — 12 passed: ingest records id+scope (workspace and pocket), hide-toggle purges with the tracked id+scope and clears tracking, untracked/already-hidden/no-change/un-hide paths do NOT purge, a purge failure still hides and keeps tracking, store round-trip + workspace isolation, and `remove_article` maps to `kb delete` and swallows errors. `lint-imports` root + ee → 0 broken.

Also includes a small test fix carried from the rebase: two listener test files now seed a row for FL-11b's fail-closed gate (full listener suite: 32 passed).

## Depends on

kb-go's `kb delete <id> --scope <s>` (separate PR). The purge is unit-tested against that CLI contract with a mocked subprocess, so it verifies without the kb-go build present.
