### PR TITLE
feat(ee): workspace-admin agent tools — RBAC-gated, Instinct-approved, role-filtered

### DIFF
--- a/ee/pocketpaw_ee/agent/atlas_provider.py
+++ b/ee/pocketpaw_ee/agent/atlas_provider.py
@@ -1,0 +1,189 @@
+# atlas_provider.py — role-aware atlas EntitlementProvider for the cloud chat
+#   agent (WA-3). Created: 2026-07-03 (feat/workspace-admin-tools).
+#
+# The DISCOVERY layer for the workspace-admin tools — NOT the security gate.
+# The RBAC checks INSIDE each admin tool (workspace_admin.py) are the real lock
+# and are already audited; this provider only decides what a member SEES in
+# atlas_search / atlas_describe, so a non-admin doesn't see admin capabilities
+# they can't use. It must NEVER be relied on as the execution gate.
+#
+# Shape: implements the core ``EntitlementProvider`` protocol (overlay.py):
+#   * ``is_granted(entry)`` — a role-BLIND entry (no ``role:*`` in requires)
+#     delegates to the wrapped ``DefaultEntitlementProvider`` (grant, subject to
+#     the existing connector/availability logic). A role-GATED entry is granted
+#     only if the CALLER's resolved workspace role >= the entry's required tier
+#     (owner > admin > member). FAIL-CLOSED: if the role can't be resolved (no
+#     identity, user not found, not a member, error) the role stays ``None`` and
+#     every role-gated entry is hidden. Never raises.
+#   * ``connected_connector_names()`` — pure delegation to the wrapped default
+#     provider (reuse the connector-state seam; don't reimplement).
+#   * ``prime()`` — async. Resolves the caller's role ONCE (cached) via the same
+#     identity the admin tools use: ``current_user_id`` / ``current_workspace_id``
+#     ContextVars → load the ``User`` Beanie doc → ``resolve_workspace_role``.
+#     The sdk_mcp_atlas handler awaits this before the sync grant filter so the
+#     async DB load runs in the handler's own event loop (``is_granted`` stays
+#     sync, per the protocol). Priming is idempotent; a failure leaves the role
+#     unresolved (fail-closed) and is swallowed by the caller.
+#
+# Wiring: core's ``atlas.overlay.build_role_aware_provider(scope_key)`` imports
+# this module inside a try/except (optional EE seam, mirrors
+# ``atlas.fabric.build_workspace_fabric_introspector``) and constructs one per
+# run bound to the run's ``ws:<id>`` scope. claude_sdk.py selects it over the
+# role-blind default when a real ``ws:<id>`` scope exists.
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pocketpaw.atlas.overlay import (
+    ROLE_LEVELS,
+    DefaultEntitlementProvider,
+    entry_role_requirement,
+)
+
+if TYPE_CHECKING:
+    from pocketpaw.atlas.model import AtlasEntry
+
+logger = logging.getLogger(__name__)
+
+
+class RoleAwareEntitlementProvider:
+    """Entitlement provider that grants ``role:*`` atlas entries by workspace role.
+
+    Wraps a ``DefaultEntitlementProvider`` for all non-role behavior (connector
+    availability + granting role-blind entries) and adds a role gate on top for
+    entries carrying a ``role:<tier>`` marker. Bound to ONE ``ws:<id>`` scope at
+    construction — per-run, never a process-global. The caller's role is
+    resolved from the per-stream identity ContextVars at ``prime()`` time and
+    cached for the sync ``is_granted`` calls that follow.
+    """
+
+    def __init__(self, scope_key: str, registry: Any | None = None) -> None:
+        if not isinstance(scope_key, str) or not scope_key.startswith("ws:"):
+            # A role-aware provider only makes sense under a real workspace scope.
+            # Refuse anything else so the core bridge falls back to the default.
+            raise ValueError(
+                f"RoleAwareEntitlementProvider needs a ws:<id> scope, got {scope_key!r}"
+            )
+        self._scope_key = scope_key
+        # Reuse the OSS default for connector availability + role-blind grants.
+        self._default = DefaultEntitlementProvider(scope_key=scope_key, registry=registry)
+        # Resolved caller role level (int from ROLE_LEVELS) or None = unresolved.
+        # ``_primed`` guards against re-resolving on every call within one query.
+        self._role_level: int | None = None
+        self._primed = False
+
+    # -- connector delegation ------------------------------------------------
+
+    def connected_connector_names(self) -> set[str]:
+        """Delegate to the default provider's connector-state seam (WA-3 adds no
+        connector logic — only a role gate)."""
+        return self._default.connected_connector_names()
+
+    # -- role resolution -----------------------------------------------------
+
+    async def prime(self) -> None:
+        """Resolve the caller's workspace role once (cached), fail-closed.
+
+        Uses the SAME identity the admin tools read: the per-stream
+        ``current_user_id`` / ``current_workspace_id`` ContextVars, the ``User``
+        Beanie doc, and ``resolve_workspace_role``. On ANY failure — no identity,
+        user not found, not a member of this workspace, a scope/workspace
+        mismatch, or a DB error — the role stays ``None`` (unresolved) so every
+        role-gated entry is hidden. Never raises. Idempotent within a run: once
+        primed it does not re-load (the atlas server is built per run/stream)."""
+        if self._primed:
+            return
+        self._primed = True  # mark first so a raise below still leaves us "primed but unresolved"
+        try:
+            from pocketpaw_ee.cloud.chat.agent_service import (
+                current_user_id,
+                current_workspace_id,
+            )
+
+            user_id = current_user_id()
+            workspace_id = current_workspace_id()
+            if not user_id or not workspace_id:
+                logger.debug("atlas role-aware provider: no identity on stream — role unresolved")
+                return
+
+            # Defense in depth: the provider is bound to ws:<id>; the identity's
+            # workspace must match it, or we refuse to resolve (fail-closed).
+            if self._scope_key != f"ws:{workspace_id}":
+                logger.debug(
+                    "atlas role-aware provider: scope %s != identity workspace ws:%s — unresolved",
+                    self._scope_key,
+                    workspace_id,
+                )
+                return
+
+            user = await self._load_user(user_id)
+            if user is None:
+                logger.debug(
+                    "atlas role-aware provider: user %s not found — role unresolved", user_id
+                )
+                return
+
+            from pocketpaw_ee.guards.deps import resolve_workspace_role
+            from pocketpaw_ee.guards.rbac import Forbidden
+
+            try:
+                role = resolve_workspace_role(user, workspace_id)
+            except Forbidden:
+                # Not a member of this workspace → no role, hide gated entries.
+                logger.debug(
+                    "atlas role-aware provider: user %s not a member of %s — role unresolved",
+                    user_id,
+                    workspace_id,
+                )
+                return
+
+            self._role_level = ROLE_LEVELS.get(str(role.value), None)
+        except Exception as exc:  # noqa: BLE001 — fail-closed: unresolved role hides gated entries
+            logger.debug("atlas role-aware provider: role resolution failed: %s", exc)
+
+    @staticmethod
+    async def _load_user(user_id: str) -> Any | None:
+        """Load the ``User`` Beanie doc (the same load the admin tools use). Lazy
+        import keeps the module's top-level surface free of an ee.cloud
+        dependency. Returns ``None`` on a bad id / missing user / DB error."""
+        from beanie import PydanticObjectId
+
+        from pocketpaw_ee.cloud.models.user import User as _UserDoc
+
+        try:
+            return await _UserDoc.get(PydanticObjectId(user_id))
+        except Exception:  # noqa: BLE001 — malformed id / DB error → treat as no user
+            return None
+
+    # -- grant gate ----------------------------------------------------------
+
+    def is_granted(self, entry: AtlasEntry) -> bool:
+        """Grant *entry* for the caller's resolved role, fail-closed.
+
+        A role-blind entry delegates to the default provider (unchanged OSS
+        grant). A role-gated entry is granted only if the caller's resolved role
+        level clears the entry's required tier; an unresolved role (prime never
+        ran, or failed) or an unknown required tier hides it. Never raises."""
+        required_tier = entry_role_requirement(entry)
+        if required_tier is None:
+            # Not role-gated — the default provider decides (grants role-blind
+            # entries; it also hides role-gated ones, but that branch is dead
+            # here since required_tier is None).
+            return self._default.is_granted(entry) is True
+
+        required_level = ROLE_LEVELS.get(required_tier)
+        if required_level is None:
+            # Unknown role marker — fail-closed, hide it.
+            logger.debug(
+                "atlas role-aware provider: unknown role tier %r on %s", required_tier, entry.id
+            )
+            return False
+        if self._role_level is None:
+            # Role unresolved → hide every role-gated entry (fail-closed).
+            return False
+        return self._role_level >= required_level
+
+
+__all__ = ["RoleAwareEntitlementProvider"]

--- a/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
@@ -1,0 +1,421 @@
+# workspace_admin.py — in-process MCP server letting the cloud chat agent perform
+#   WORKSPACE ADMINISTRATION, gated by the existing RBAC system (guards/), with
+#   mutations routed through the Instinct approval gate (NEVER inline).
+# Created: 2026-07-03 (feat/workspace-admin-tools, WA-1) — the first slice of the
+#   workspace-admin tool surface. Mirrors the connectors.py / external_actions.py
+#   shape: an SDK import-guard, ``SERVER_NAME`` / ``*_TOOL_ID`` allowlist
+#   constants, ContextVar-sourced identity (the SAME ``current_workspace_id`` /
+#   ``current_user_id`` accessors in ``ee.cloud.chat.agent_service`` the connector
+#   / belt / sites servers read), and the ``_error_response`` / ``_success_response``
+#   envelopes. Tool ids namespace as ``mcp__pocketpaw_workspace_admin__*``.
+#
+#   Two tools in WA-1:
+#     * members_list() — READ. Gated at ``workspace.view`` (MEMBER — matches how
+#       the REST list-members route gates it: any member may read the roster).
+#       Resolves identity → loads the User doc → check_workspace_action → calls
+#       ``workspace.service.list_members`` → structured envelope. A Forbidden is
+#       CAUGHT and returned as a deny envelope (never raised out of the tool);
+#       check_workspace_action already audits the denial via guards/audit.py.
+#     * member_update_role(user_id, role) — WRITE, ADMIN-gated at
+#       ``workspace.member.role_change``. THE load-bearing security rule: this
+#       NEVER calls ``update_member_role`` inline. On an ADMIN pass it returns a
+#       "proposed for approval" envelope WITHOUT firing the mutation.
+#
+#   WA-1 STATUS — member_update_role is a DOCUMENTED PROPOSAL-ONLY STUB, not a
+#   live Instinct proposal. The Instinct approve→execute spine is a FIXED N-way
+#   dispatch on bespoke blob param-keys (``_external_action``, ``_pocket_write``,
+#   ``_code_change``, ``_fabric_objects``, ``_pocket_create``, ``_instinct_rule``,
+#   ``_artifact_change``), each with its own executor hard-wired into the ee
+#   instinct router's approve/reject/bulk paths. EVERY existing executor dispatches
+#   to a domain-specific sink — the external-action one is HARDWIRED to
+#   ``connectors.service.execute`` and cannot carry a workspace-admin service call
+#   (``update_member_role``). Making an admin mutation actually FIRE on approval
+#   requires inventing an 8th proposal kind: an ``_admin_action`` blob + an
+#   ``admin_proposals/executor.py`` that dispatches to the workspace-admin services
+#   + router wiring on approve/reject/bulk. That is out of scope for WA-1 and is
+#   flagged as NEEDS_CONTEXT. Until that seam exists, member_update_role
+#   authorizes (ADMIN gate, fail-closed) and returns a "pending — approval spine
+#   not yet wired" envelope; it does NOT mutate and does NOT file a phantom
+#   proposal. A member is denied before we ever reach that path.
+#
+#   OSS-EE boundary: this module imports only ``workspace.service`` +
+#   ``guards.deps`` + the User Beanie load, all lazily inside handlers, so the
+#   import surface stays minimal (mirrors connectors.py's function-local imports).
+"""Agent-side MCP surface for workspace administration.
+
+Tools registered:
+
+  - ``members_list()`` — READ the current workspace's member roster (email,
+    name, role, joined-at). Gated at ``workspace.view`` (any member may read).
+    No arguments — the workspace is inferred from the active chat stream. A
+    Forbidden is returned as a structured deny envelope, never raised.
+  - ``member_update_role(user_id, role)`` — WRITE: change a member's workspace
+    role. ADMIN-gated at ``workspace.member.role_change``. This does NOT mutate
+    inline — an admin write is proposed for human approval through the Instinct
+    Tray and fires only on approval. WA-1: the approve→execute spine for admin
+    actions is not yet wired, so this authorizes and returns a "pending" envelope
+    without mutating (see the module header).
+
+Identity comes from ``agent_service.current_workspace_id`` /
+``current_user_id``. Outside an SSE chat stream those are empty → the tools
+return a clear error rather than silently mis-tenanting.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_workspace_admin"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form.
+MEMBERS_LIST_TOOL_ID = f"mcp__{SERVER_NAME}__members_list"
+MEMBER_UPDATE_ROLE_TOOL_ID = f"mcp__{SERVER_NAME}__member_update_role"
+
+ADMIN_TOOL_IDS = (
+    MEMBERS_LIST_TOOL_ID,
+    MEMBER_UPDATE_ROLE_TOOL_ID,
+)
+
+# The RBAC action keys these tools gate on (canonical entries in
+# ``guards.actions.ACTIONS``). ``workspace.view`` = MEMBER (read the roster),
+# ``workspace.member.role_change`` = ADMIN (change a member's role).
+_READ_ACTION = "workspace.view"
+_ROLE_CHANGE_ACTION = "workspace.member.role_change"
+
+# The workspace roles a member may be assigned via member_update_role. Kept in
+# sync with ``guards.rbac.WorkspaceRole`` — an out-of-set value is refused
+# before any gate check (defense in depth; the tool schema also constrains it).
+_VALID_ROLES = frozenset({"member", "admin", "owner"})
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape the SDK expects."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None, str | None]:
+    """Resolve workspace / user / pocket from the per-stream ContextVars set by
+    ``run_core`` via ``agent_service.attach_agent_identity`` — the same
+    chokepoint the connectors / belt / sites servers read.
+
+    Returns ``(workspace_id, user_id, pocket_id)``. Any may be ``None`` when the
+    tool is called outside an SSE chat stream (e.g. a unit test) — the handlers
+    treat a missing workspace as "no room context" and refuse rather than
+    silently mis-tenanting.
+    """
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_pocket_id,
+            current_user_id,
+            current_workspace_id,
+        )
+
+        return current_workspace_id(), current_user_id(), current_pocket_id()
+    except Exception:  # noqa: BLE001 — agent_service import only fails off-stream
+        return None, None, None
+
+
+async def _load_user(user_id: str) -> Any | None:
+    """Load the User Beanie doc for ``user_id`` so ``check_workspace_action`` has
+    the ``.workspaces`` membership list it reads. Returns ``None`` on a bad id /
+    missing user — the caller maps that to an error envelope. Lazy import keeps
+    the module's top-level import surface minimal (mirrors connectors.py)."""
+    from beanie import PydanticObjectId
+
+    from pocketpaw_ee.cloud.models.user import User as _UserDoc
+
+    try:
+        return await _UserDoc.get(PydanticObjectId(user_id))
+    except Exception:  # noqa: BLE001 — malformed id / DB error → treat as no user
+        return None
+
+
+def _legacy_ctx(user_id: str, workspace_id: str) -> Any:
+    """Build a minimal ``RequestContext`` for the workspace service read path.
+
+    ``workspace.service.list_members`` takes a ``ctx`` and reads ``ctx.user_id``
+    (for the membership self-check) — the workspace is passed explicitly. We
+    build the context from the resolved identity. Lazy import to keep the top
+    level free of an ee.cloud dependency."""
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="mcp-workspace-admin",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+async def _members_list_handler(args: dict) -> dict:  # noqa: ARG001 — no args
+    """READ the workspace member roster. Gated at ``workspace.view`` (MEMBER)."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — members_list can only be called from inside a "
+            "cloud chat stream (it has no workspace context outside the chat "
+            "stream)."
+        )
+
+    from pocketpaw_ee.guards.deps import check_workspace_action
+    from pocketpaw_ee.guards.rbac import Forbidden
+
+    user = await _load_user(user_id)
+    if user is None:
+        return _error_response("could not resolve the calling user for the RBAC check.")
+
+    # RBAC gate — MEMBER may read the roster. A Forbidden is CAUGHT and returned
+    # as a structured deny envelope (never raised out of the tool). The gate
+    # already audits the denial via guards/audit.log_denial.
+    try:
+        check_workspace_action(user, workspace_id, _READ_ACTION)
+    except Forbidden as exc:
+        logger.info(
+            "members_list denied: user=%s workspace=%s code=%s",
+            user_id,
+            workspace_id,
+            exc.code,
+        )
+        return _success_response(
+            {
+                "ok": False,
+                "denied": True,
+                "code": exc.code,
+                "message": (
+                    "You don't have permission to view this workspace's members "
+                    f"({exc.code})."
+                ),
+            }
+        )
+
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    try:
+        members = await workspace_service.list_members(
+            _legacy_ctx(user_id, workspace_id), workspace_id
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500
+        logger.warning("members_list failed", exc_info=True)
+        return _error_response(f"members_list failed: {exc}")
+
+    return _success_response(
+        {
+            "ok": True,
+            "workspace_id": workspace_id,
+            "members": [
+                {
+                    "user_id": m.user_id,
+                    "email": m.email,
+                    "name": m.name,
+                    "role": m.role,
+                    "joined_at": m.joined_at,
+                }
+                for m in members
+            ],
+            "count": len(members),
+        }
+    )
+
+
+async def _member_update_role_handler(args: dict) -> dict:
+    """WRITE: change a member's workspace role. ADMIN-gated; Instinct-proposed.
+
+    THE load-bearing security rule: this NEVER calls ``update_member_role``
+    inline. On an ADMIN pass it returns a "proposed for approval" envelope
+    WITHOUT firing the mutation. WA-1: the Instinct approve→execute spine for
+    admin actions is not yet wired (no ``_admin_action`` proposal kind exists —
+    see the module header), so this authorizes and returns a "pending" envelope
+    without mutating and without filing a phantom proposal.
+    """
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — member_update_role can only be called from "
+            "inside a cloud chat stream."
+        )
+
+    target_user_id = args.get("user_id")
+    if not isinstance(target_user_id, str) or not target_user_id.strip():
+        return _error_response("user_id is required (string — the member to change).")
+    role = args.get("role")
+    if not isinstance(role, str) or role not in _VALID_ROLES:
+        return _error_response(
+            f"role is required and must be one of {sorted(_VALID_ROLES)}."
+        )
+
+    from pocketpaw_ee.guards.deps import check_workspace_action
+    from pocketpaw_ee.guards.rbac import Forbidden
+
+    user = await _load_user(user_id)
+    if user is None:
+        return _error_response("could not resolve the calling user for the RBAC check.")
+
+    # RBAC gate — ADMIN required. A Forbidden is CAUGHT and returned as a deny
+    # envelope (never raised); the gate audits the denial via log_denial. The
+    # deny is enforced BEFORE any proposal/mutation path — a member never
+    # reaches the write.
+    try:
+        check_workspace_action(user, workspace_id, _ROLE_CHANGE_ACTION)
+    except Forbidden as exc:
+        logger.info(
+            "member_update_role denied: actor=%s workspace=%s target=%s code=%s",
+            user_id,
+            workspace_id,
+            target_user_id,
+            exc.code,
+        )
+        return _success_response(
+            {
+                "ok": False,
+                "denied": True,
+                "code": exc.code,
+                "message": (
+                    "You don't have permission to change member roles in this "
+                    f"workspace ({exc.code})."
+                ),
+            }
+        )
+
+    # ADMIN passed. DO NOT MUTATE — an admin write is human-gated. WA-1: the
+    # Instinct approve→execute spine for admin actions is not yet wired (no
+    # ``_admin_action`` proposal kind), so we return a pending envelope WITHOUT
+    # filing a proposal and WITHOUT calling update_member_role. This is the
+    # fail-closed default: no phantom "done", no ungated mutation.
+    logger.info(
+        "member_update_role authorized but NOT executed (WA-1 stub): actor=%s "
+        "workspace=%s target=%s role=%s — admin-action Instinct spine not yet wired",
+        user_id,
+        workspace_id,
+        target_user_id,
+        role,
+    )
+    return _success_response(
+        {
+            "ok": True,
+            "executed": False,
+            "status": "pending_approval_unavailable",
+            "proposed_change": {
+                "user_id": target_user_id,
+                "role": role,
+                "workspace_id": workspace_id,
+            },
+            "message": (
+                "Role changes are admin-gated and must be approved by a human — "
+                "they are never applied directly from chat. The approval spine "
+                "for workspace-admin changes isn't wired up yet, so I can't file "
+                "this for approval right now. No change was made. (Tell the user "
+                "to change the role from the workspace members settings for now.)"
+            ),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Server factory
+# ---------------------------------------------------------------------------
+
+
+def build_admin_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for workspace administration, or
+    return ``None`` if the Claude Agent SDK isn't installed.
+
+    Matches the ``(name, server)`` shape the other servers return so the
+    backend's MCP registration loop in ``claude_sdk.py`` treats them uniformly.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_workspace_admin MCP disabled")
+        return None
+
+    @tool(
+        "members_list",
+        (
+            "List the members of the CURRENT workspace — their email, name, "
+            "workspace role (member / admin / owner), and when they joined. Call "
+            "this when the user asks who is in the workspace, who the admins are, "
+            "or to look up a member before changing their role. No arguments — "
+            "the workspace is inferred from the active chat. Any workspace member "
+            "may read the roster. If you don't have permission, the result says "
+            "so (denied) — relay that; don't invent a member list."
+        ),
+        {},
+    )
+    async def members_list(args):  # type: ignore[no-untyped-def]
+        return await _members_list_handler(args)
+
+    @tool(
+        "member_update_role",
+        (
+            "Propose changing a workspace member's ROLE (member / admin / owner). "
+            "This is an ADMIN action and it is NEVER applied directly from chat — "
+            "a role change is proposed for a human to approve and only takes "
+            "effect once approved. Args: `user_id` (the member to change, from "
+            "members_list) and `role` (the new role: 'member', 'admin', or "
+            "'owner'). If you lack admin permission, the result says so (denied) "
+            "— relay that. On success the result says the change is PENDING "
+            "approval, not done — tell the user you've requested the change and "
+            "it needs approval; do NOT claim the role was changed."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string",
+                    "description": "The member's user id (from members_list) to change.",
+                },
+                "role": {
+                    "type": "string",
+                    "enum": ["member", "admin", "owner"],
+                    "description": "The new workspace role for the member.",
+                },
+            },
+            "required": ["user_id", "role"],
+            "additionalProperties": False,
+        },
+    )
+    async def member_update_role(args):  # type: ignore[no-untyped-def]
+        return await _member_update_role_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[members_list, member_update_role],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "ADMIN_TOOL_IDS",
+    "MEMBERS_LIST_TOOL_ID",
+    "MEMBER_UPDATE_ROLE_TOOL_ID",
+    "SERVER_NAME",
+    "build_admin_server",
+]

--- a/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
@@ -33,9 +33,39 @@
 #   STILL never called inline from this tool; the "pending_approval_unavailable"
 #   stub is retired.
 #
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-4 — five READ-only tools).
+#   All EXECUTE directly once their RBAC gate passes (reads are not Instinct-gated
+#   — that's writes only). Each mirrors members_list exactly: _identity() →
+#   _load_user → check_workspace_action in a try/except that returns a deny
+#   ENVELOPE (never raises) → existing service → _success_response. New tools and
+#   the REST route each mirrors:
+#     * workspace_settings_read() — READ workspace name/slug/plan/seats/branding.
+#       Gate ``workspace.view`` (MEMBER — same read gate as members_list; the REST
+#       GET /{id} uses require_membership). Service: workspace.service.get. Returns
+#       a COMPACT view (no internal ids/secrets — owner user-id + branding asset
+#       refs are intentionally omitted).
+#     * invites_list() — READ pending invites. Gate ``invite.create`` (ADMIN —
+#       EXACTLY what the REST GET /{id}/invites route gates on). Service:
+#       workspace.service.list_invites.
+#     * connectors_list() — READ connectors + enabled/connected status. Gate
+#       ``workspace.view`` (MEMBER). The REST GET /connectors route is
+#       membership-only (no explicit action) + does its own per-user connector-
+#       permission filtering inside the service; workspace.view is the MEMBER read
+#       gate that mirrors that membership requirement fail-closed. Service passes
+#       user_id so the service applies the same permission filter the route does.
+#     * billing_usage_read(start?, end?) — READ usage/spend. Gate ``workspace.view``
+#       (MEMBER) — the REST GET /billing/usage route is membership-only (any role
+#       may read its own workspace's usage; it does NOT gate on billing.manage), so
+#       we match it and do NOT over-gate to OWNER. Service:
+#       billing.usage.get_workspace_usage (start/end → start_date/end_date).
+#     * audit_read(limit?) — READ recent audit rows. Gate ``audit.read`` (ADMIN —
+#       EXACTLY what the REST GET /{id}/audit route gates on). Service:
+#       audit.service.list_events_response (limit → AuditQueryRequest.limit).
+#
 #   OSS-EE boundary: this module imports only ``workspace.service`` +
-#   ``guards.deps`` + the User Beanie load, all lazily inside handlers, so the
-#   import surface stays minimal (mirrors connectors.py's function-local imports).
+#   ``guards.deps`` + the read services (connectors / billing.usage / audit) +
+#   the User Beanie load, all lazily inside handlers, so the import surface stays
+#   minimal (mirrors connectors.py's function-local imports).
 """Agent-side MCP surface for workspace administration.
 
 Tools registered:
@@ -50,6 +80,23 @@ Tools registered:
     Tray (WA-2: a live ``_admin_action`` proposal) and fires only on approval,
     after an execute-time re-check of the proposer's CURRENT role. Returns a
     "pending in the Tray" envelope carrying the proposal/action id.
+  - ``workspace_settings_read()`` — READ the workspace's name / slug / plan /
+    seat usage / branding. Gated at ``workspace.view`` (MEMBER). Compact view —
+    no internal ids or secrets.
+  - ``invites_list()`` — READ pending invites. Gated at ``invite.create``
+    (ADMIN — same as the REST invites route).
+  - ``connectors_list()`` — READ connectors + enabled/connected status. Gated at
+    ``workspace.view`` (MEMBER); the service applies the caller's connector
+    permissions.
+  - ``billing_usage_read(start, end)`` — READ daily usage/spend over an optional
+    date window. Gated at ``workspace.view`` (MEMBER — matching the
+    membership-only REST usage route).
+  - ``audit_read(limit)`` — READ recent audit-log rows. Gated at ``audit.read``
+    (ADMIN — same as the REST audit route).
+
+All READ tools EXECUTE directly once their RBAC gate passes (reads are not
+Instinct-gated). A Forbidden is returned as a structured deny envelope, never
+raised.
 
 Identity comes from ``agent_service.current_workspace_id`` /
 ``current_user_id``. Outside an SSE chat stream those are empty → the tools
@@ -69,17 +116,31 @@ SERVER_NAME = "pocketpaw_workspace_admin"
 # Allowlist entries must use this exact form.
 MEMBERS_LIST_TOOL_ID = f"mcp__{SERVER_NAME}__members_list"
 MEMBER_UPDATE_ROLE_TOOL_ID = f"mcp__{SERVER_NAME}__member_update_role"
+WORKSPACE_SETTINGS_READ_TOOL_ID = f"mcp__{SERVER_NAME}__workspace_settings_read"
+INVITES_LIST_TOOL_ID = f"mcp__{SERVER_NAME}__invites_list"
+CONNECTORS_LIST_TOOL_ID = f"mcp__{SERVER_NAME}__connectors_list"
+BILLING_USAGE_READ_TOOL_ID = f"mcp__{SERVER_NAME}__billing_usage_read"
+AUDIT_READ_TOOL_ID = f"mcp__{SERVER_NAME}__audit_read"
 
 ADMIN_TOOL_IDS = (
     MEMBERS_LIST_TOOL_ID,
     MEMBER_UPDATE_ROLE_TOOL_ID,
+    WORKSPACE_SETTINGS_READ_TOOL_ID,
+    INVITES_LIST_TOOL_ID,
+    CONNECTORS_LIST_TOOL_ID,
+    BILLING_USAGE_READ_TOOL_ID,
+    AUDIT_READ_TOOL_ID,
 )
 
 # The RBAC action keys these tools gate on (canonical entries in
-# ``guards.actions.ACTIONS``). ``workspace.view`` = MEMBER (read the roster),
-# ``workspace.member.role_change`` = ADMIN (change a member's role).
+# ``guards.actions.ACTIONS``). ``workspace.view`` = MEMBER (read the roster /
+# settings / connectors / usage), ``workspace.member.role_change`` = ADMIN
+# (change a member's role), ``invite.create`` = ADMIN (read/manage invites —
+# the REST invites route's action), ``audit.read`` = ADMIN (read the audit log).
 _READ_ACTION = "workspace.view"
 _ROLE_CHANGE_ACTION = "workspace.member.role_change"
+_INVITE_ACTION = "invite.create"
+_AUDIT_ACTION = "audit.read"
 
 # The workspace roles a member may be assigned via member_update_role. Kept in
 # sync with ``guards.rbac.WorkspaceRole`` — an out-of-set value is refused
@@ -162,6 +223,54 @@ def _legacy_ctx(user_id: str, workspace_id: str) -> Any:
         scope=ScopeKind.NONE,
         started_at=datetime.now(UTC),
     )
+
+
+async def _gate_read(
+    tool: str, action: str, deny_message: str
+) -> tuple[str, str, None] | dict:
+    """Shared identity-resolve + RBAC-gate for a READ tool.
+
+    Returns ``(workspace_id, user_id, None)`` when the gate PASSES, or a ready-to-
+    return response dict when it fails (no active workspace / unresolvable user /
+    Forbidden). Mirrors ``members_list``'s handling EXACTLY: a Forbidden is CAUGHT
+    and returned as a structured deny envelope (never raised); the gate already
+    audits the denial via ``guards/audit.log_denial``. Callers branch on the
+    return type: a ``tuple`` means proceed, a ``dict`` means return it.
+    """
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            f"no active workspace — {tool} can only be called from inside a cloud "
+            "chat stream (it has no workspace context outside the chat stream)."
+        )
+
+    from pocketpaw_ee.guards.deps import check_workspace_action
+    from pocketpaw_ee.guards.rbac import Forbidden
+
+    user = await _load_user(user_id)
+    if user is None:
+        return _error_response("could not resolve the calling user for the RBAC check.")
+
+    try:
+        check_workspace_action(user, workspace_id, action)
+    except Forbidden as exc:
+        logger.info(
+            "%s denied: user=%s workspace=%s code=%s",
+            tool,
+            user_id,
+            workspace_id,
+            exc.code,
+        )
+        return _success_response(
+            {
+                "ok": False,
+                "denied": True,
+                "code": exc.code,
+                "message": f"{deny_message} ({exc.code}).",
+            }
+        )
+
+    return workspace_id, user_id, None
 
 
 # ---------------------------------------------------------------------------
@@ -352,6 +461,255 @@ async def _member_update_role_handler(args: dict) -> dict:
     )
 
 
+async def _workspace_settings_read_handler(args: dict) -> dict:  # noqa: ARG001 — no args
+    """READ the workspace's name / slug / plan / seats / branding. Gated at
+    ``workspace.view`` (MEMBER). EXECUTES directly on a gate pass (a read is not
+    Instinct-gated). Returns a COMPACT view — no internal ids or secrets (the
+    owner user-id and branding asset refs are intentionally omitted)."""
+    gate = await _gate_read(
+        "workspace_settings_read",
+        _READ_ACTION,
+        "You don't have permission to view this workspace's settings",
+    )
+    if isinstance(gate, dict):
+        return gate
+    workspace_id, user_id, _ = gate
+
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    try:
+        ws = await workspace_service.get(_legacy_ctx(user_id, workspace_id), workspace_id)
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500
+        logger.warning("workspace_settings_read failed", exc_info=True)
+        return _error_response(f"workspace_settings_read failed: {exc}")
+
+    branding = None
+    if ws.branding is not None:
+        # Only the display-facing branding fields — asset refs (logo/favicon
+        # storage ids) are internal and intentionally omitted.
+        branding = {
+            "display_name": ws.branding.display_name,
+            "tab_title": ws.branding.tab_title,
+            "accent_color": ws.branding.accent_color,
+            "show_paw_mark": ws.branding.show_paw_mark,
+        }
+
+    return _success_response(
+        {
+            "ok": True,
+            "workspace_id": workspace_id,
+            "name": ws.name,
+            "slug": ws.slug,
+            "plan": ws.plan,
+            "seats": ws.seats,
+            "member_count": ws.member_count,
+            "seats_used": ws.member_count,
+            "seats_available": max(ws.seats - ws.member_count, 0),
+            "branding": branding,
+        }
+    )
+
+
+async def _invites_list_handler(args: dict) -> dict:  # noqa: ARG001 — no args
+    """READ the workspace's PENDING invites. Gated at ``invite.create`` (ADMIN —
+    the same action the REST GET /{id}/invites route gates on). EXECUTES directly
+    on a gate pass."""
+    gate = await _gate_read(
+        "invites_list",
+        _INVITE_ACTION,
+        "You don't have permission to view this workspace's invites",
+    )
+    if isinstance(gate, dict):
+        return gate
+    workspace_id, _user_id, _ = gate
+
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    try:
+        invites = await workspace_service.list_invites(workspace_id)
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500
+        logger.warning("invites_list failed", exc_info=True)
+        return _error_response(f"invites_list failed: {exc}")
+
+    return _success_response(
+        {
+            "ok": True,
+            "workspace_id": workspace_id,
+            "invites": [
+                {
+                    "id": inv.id,
+                    "email": inv.email,
+                    "role": inv.role,
+                    "invited_by": inv.invited_by,
+                    "group_id": inv.group_id,
+                    "expires_at": inv.expires_at,
+                }
+                for inv in invites
+            ],
+            "count": len(invites),
+        }
+    )
+
+
+async def _connectors_list_handler(args: dict) -> dict:  # noqa: ARG001 — no args
+    """READ the connectors available/enabled in this workspace + their connected
+    status. Gated at ``workspace.view`` (MEMBER); the service applies the caller's
+    per-user connector permissions (the same filter the REST route runs). EXECUTES
+    directly on a gate pass."""
+    gate = await _gate_read(
+        "connectors_list",
+        _READ_ACTION,
+        "You don't have permission to view this workspace's connectors",
+    )
+    if isinstance(gate, dict):
+        return gate
+    workspace_id, user_id, _ = gate
+
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    try:
+        connectors = await connectors_service.list_connectors(workspace_id, user_id=user_id)
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500
+        logger.warning("connectors_list failed", exc_info=True)
+        return _error_response(f"connectors_list failed: {exc}")
+
+    return _success_response(
+        {
+            "ok": True,
+            "workspace_id": workspace_id,
+            "connectors": [
+                {
+                    "name": c.name,
+                    "display_name": c.display_name,
+                    "type": c.type,
+                    "enabled": c.enabled,
+                    "status": c.status,
+                    "last_sync_status": c.last_sync_status,
+                    "last_sync_at": c.last_sync_at,
+                }
+                for c in connectors
+            ],
+            "count": len(connectors),
+        }
+    )
+
+
+async def _billing_usage_read_handler(args: dict) -> dict:
+    """READ the workspace's daily usage/spend over an optional date window. Gated
+    at ``workspace.view`` (MEMBER — the REST GET /billing/usage route is
+    membership-only; it does NOT gate on billing.manage, so we match it and do NOT
+    over-gate to OWNER). EXECUTES directly on a gate pass. ``start`` / ``end`` are
+    optional ``YYYY-MM-DD`` strings (default: the trailing 30 days)."""
+    start = args.get("start")
+    end = args.get("end")
+    if start is not None and not isinstance(start, str):
+        return _error_response("start must be a YYYY-MM-DD date string when provided.")
+    if end is not None and not isinstance(end, str):
+        return _error_response("end must be a YYYY-MM-DD date string when provided.")
+
+    gate = await _gate_read(
+        "billing_usage_read",
+        _READ_ACTION,
+        "You don't have permission to view this workspace's usage",
+    )
+    if isinstance(gate, dict):
+        return gate
+    workspace_id, _user_id, _ = gate
+
+    from pocketpaw_ee.cloud.billing import usage as usage_service
+
+    try:
+        usage = await usage_service.get_workspace_usage(
+            workspace_id, start_date=start, end_date=end
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500
+        logger.warning("billing_usage_read failed", exc_info=True)
+        return _error_response(f"billing_usage_read failed: {exc}")
+
+    return _success_response(
+        {
+            "ok": True,
+            "workspace_id": workspace_id,
+            "start_date": usage.start_date,
+            "end_date": usage.end_date,
+            "models": usage.models,
+            "total_credits": usage.total_credits,
+            "buckets": [
+                {
+                    "date": b.date,
+                    "total_credits": b.total_credits,
+                    "by_model": {
+                        model: {
+                            "credits": stats.credits,
+                            "requests": stats.requests,
+                            "tokens": stats.tokens,
+                        }
+                        for model, stats in b.by_model.items()
+                    },
+                }
+                for b in usage.buckets
+            ],
+        }
+    )
+
+
+async def _audit_read_handler(args: dict) -> dict:
+    """READ recent audit-log rows for the workspace. Gated at ``audit.read``
+    (ADMIN — the same action the REST GET /{id}/audit route gates on). EXECUTES
+    directly on a gate pass. ``limit`` is optional (1–100; the service defaults to
+    50 and clamps out-of-range values)."""
+    limit = args.get("limit")
+    if limit is not None and not isinstance(limit, int):
+        return _error_response("limit must be an integer (1–100) when provided.")
+
+    gate = await _gate_read(
+        "audit_read",
+        _AUDIT_ACTION,
+        "You don't have permission to view this workspace's audit log",
+    )
+    if isinstance(gate, dict):
+        return gate
+    workspace_id, _user_id, _ = gate
+
+    from pocketpaw_ee.cloud.audit import service as audit_service
+    from pocketpaw_ee.cloud.audit.dto import AuditQueryRequest
+
+    # The DTO validator constrains limit to 1–100 (422 on out-of-range at the
+    # route boundary). Build it defensively so a bad limit maps to a clean MCP
+    # error rather than an exception.
+    try:
+        query = AuditQueryRequest(limit=limit) if limit is not None else AuditQueryRequest()
+    except Exception as exc:  # noqa: BLE001 — pydantic validation → clean error
+        return _error_response(f"invalid limit: {exc}")
+
+    try:
+        page = await audit_service.list_events_response(workspace_id, query)
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500
+        logger.warning("audit_read failed", exc_info=True)
+        return _error_response(f"audit_read failed: {exc}")
+
+    return _success_response(
+        {
+            "ok": True,
+            "workspace_id": workspace_id,
+            "items": [
+                {
+                    "id": item.id,
+                    "actor_id": item.actorId,
+                    "action": item.action,
+                    "target_type": item.targetType,
+                    "target_id": item.targetId,
+                    "metadata": item.metadata,
+                    "at": item.at,
+                }
+                for item in page.items
+            ],
+            "count": len(page.items),
+            "next_cursor": page.nextCursor,
+        }
+    )
+
+
 # ---------------------------------------------------------------------------
 # Server factory
 # ---------------------------------------------------------------------------
@@ -419,18 +777,128 @@ def build_admin_server() -> tuple[str, Any] | None:
     async def member_update_role(args):  # type: ignore[no-untyped-def]
         return await _member_update_role_handler(args)
 
+    @tool(
+        "workspace_settings_read",
+        (
+            "Read the CURRENT workspace's settings — its name, slug (URL handle), "
+            "plan tier, seat usage (used / available), and any custom branding. "
+            "Call this when the user asks about their workspace's plan, seat count, "
+            "name, or branding. No arguments — the workspace is inferred from the "
+            "active chat. Any workspace member may read this. If you don't have "
+            "permission, the result says so (denied) — relay that."
+        ),
+        {},
+    )
+    async def workspace_settings_read(args):  # type: ignore[no-untyped-def]
+        return await _workspace_settings_read_handler(args)
+
+    @tool(
+        "invites_list",
+        (
+            "List the CURRENT workspace's PENDING invites — the email invited, the "
+            "role they'll get, who invited them, and when the invite expires. Call "
+            "this when the user asks who has been invited or which invites are "
+            "outstanding. No arguments. This is an ADMIN read — if you're not an "
+            "admin, the result says so (denied); relay that, don't invent invites."
+        ),
+        {},
+    )
+    async def invites_list(args):  # type: ignore[no-untyped-def]
+        return await _invites_list_handler(args)
+
+    @tool(
+        "connectors_list",
+        (
+            "List the connectors (integrations like Gmail, GitHub) available in the "
+            "CURRENT workspace and whether each is enabled and connected. Call this "
+            "when the user asks which integrations are set up or connected. No "
+            "arguments — the workspace is inferred from the active chat, and the "
+            "result is filtered to the connectors you're allowed to see. If you "
+            "don't have permission, the result says so (denied) — relay that."
+        ),
+        {},
+    )
+    async def connectors_list(args):  # type: ignore[no-untyped-def]
+        return await _connectors_list_handler(args)
+
+    @tool(
+        "billing_usage_read",
+        (
+            "Read the CURRENT workspace's usage and spend (daily credits and "
+            "request counts, broken down by model) over an optional date window. "
+            "Call this when the user asks how much they've spent or used. Optional "
+            "args: `start` and `end` (YYYY-MM-DD); omit both for the last 30 days. "
+            "Any workspace member may read their workspace's usage. If you don't "
+            "have permission, the result says so (denied) — relay that."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "start": {
+                    "type": "string",
+                    "description": "Window start, YYYY-MM-DD. Defaults to 30 days ago.",
+                },
+                "end": {
+                    "type": "string",
+                    "description": "Window end, YYYY-MM-DD. Defaults to today.",
+                },
+            },
+            "additionalProperties": False,
+        },
+    )
+    async def billing_usage_read(args):  # type: ignore[no-untyped-def]
+        return await _billing_usage_read_handler(args)
+
+    @tool(
+        "audit_read",
+        (
+            "Read the CURRENT workspace's recent audit-log rows — who did what "
+            "(action, actor, target) and when. Call this when the user asks what "
+            "recently happened in the workspace or wants an activity/audit history. "
+            "Optional arg: `limit` (1-100, default 50). This is an ADMIN read — if "
+            "you're not an admin, the result says so (denied); relay that."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "How many recent rows to return (default 50).",
+                },
+            },
+            "additionalProperties": False,
+        },
+    )
+    async def audit_read(args):  # type: ignore[no-untyped-def]
+        return await _audit_read_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[members_list, member_update_role],
+        tools=[
+            members_list,
+            member_update_role,
+            workspace_settings_read,
+            invites_list,
+            connectors_list,
+            billing_usage_read,
+            audit_read,
+        ],
     )
     return SERVER_NAME, server
 
 
 __all__ = [
     "ADMIN_TOOL_IDS",
+    "AUDIT_READ_TOOL_ID",
+    "BILLING_USAGE_READ_TOOL_ID",
+    "CONNECTORS_LIST_TOOL_ID",
+    "INVITES_LIST_TOOL_ID",
     "MEMBERS_LIST_TOOL_ID",
     "MEMBER_UPDATE_ROLE_TOOL_ID",
     "SERVER_NAME",
+    "WORKSPACE_SETTINGS_READ_TOOL_ID",
     "build_admin_server",
 ]

--- a/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
@@ -89,6 +89,39 @@
 #       proposed; any stray key an agent adds is dropped here AND in the strict
 #       adapter. The write-side helpers ``_gate_write`` + ``_propose_write`` are
 #       the shared chokepoint (parallel to WA-4's ``_gate_read``).
+#
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-6 — three OWNER WRITE tools).
+#   The most security-sensitive tools in the surface: OWNER-only, destructive /
+#   financial workspace ops. Each PROPOSES through the SAME ``_admin_action``
+#   Instinct gate (validate → _gate_write deny-envelope → _propose_write pending),
+#   NEVER mutates inline, and fires only on human approval after the executor
+#   re-checks the proposer STILL holds OWNER. The new tools + their OWNER RBAC
+#   action + the executor whitelist entry each extends:
+#     * instinct_approval_level_set(level) → ``instinct.activate`` (OWNER) →
+#       workspace.service.set_instinct_approval_level. ``level`` is constrained to
+#       the canonical ``ApprovalLevel`` enum {ASK, TRIAGE, TRUSTED}; a non-ASK
+#       level turns ON workspace-wide auto-approval of agent writes, so it's the
+#       single most governance-sensitive switch — OWNER-gated + human-approved.
+#     * workspace_delete() → ``workspace.delete`` (OWNER) →
+#       workspace.service.delete. DESTRUCTIVE + IRREVERSIBLE (cascades every
+#       member / room / agent / file). No args beyond identity. The envelope is
+#       emphatic that it's irreversible and pending human approval — the tool only
+#       proposes; the cascade fires on approval.
+#     * billing_plan_change(plan) → ``billing.manage`` (OWNER) →
+#       billing.service.subscribe. IMPORTANT (payment honesty): a paid-plan change
+#       flows through Dodo's HOSTED CHECKOUT — the plan flips ONLY when Dodo posts
+#       a verified ``subscription.active`` webhook, NOT synchronously. So the
+#       executor does NOT fake a plan mutation: on approval it calls ``subscribe``,
+#       which returns a ``{checkout_url}`` the human must complete. The webhook-
+#       internal ``set_workspace_plan`` (which bypasses payment) is DELIBERATELY
+#       NOT wired — an agent must never flip a paid plan without the real payment
+#       flow. ``plan`` is constrained to the plan catalog keys.
+#     * seats_manage — DELIBERATELY NOT BUILT. There is NO seat-change service and
+#       no billing/checkout seat flow anywhere in the codebase (seats are a
+#       workspace-doc field set at creation; ``UpdateWorkspaceRequest`` has no
+#       ``seats`` field). With no safe, honest execution path, wiring it would mean
+#       either a silent seat DB write (bypassing billing) or a fabricated flow —
+#       both refused. Skipped; escalated as NEEDS_CONTEXT.
 """Agent-side MCP surface for workspace administration.
 
 Tools registered:
@@ -153,6 +186,12 @@ CONNECTOR_ENABLE_TOOL_ID = f"mcp__{SERVER_NAME}__connector_enable"
 CONNECTOR_DISABLE_TOOL_ID = f"mcp__{SERVER_NAME}__connector_disable"
 CONNECTOR_CONFIG_TOOL_ID = f"mcp__{SERVER_NAME}__connector_config"
 WORKSPACE_UPDATE_TOOL_ID = f"mcp__{SERVER_NAME}__workspace_update"
+# WA-6 — OWNER WRITE tools (the most security-sensitive: destructive / financial /
+# governance ops). Each PROPOSES through the ``_admin_action`` Instinct gate
+# exactly like the ADMIN writes, but gates on an OWNER RBAC action.
+INSTINCT_APPROVAL_LEVEL_SET_TOOL_ID = f"mcp__{SERVER_NAME}__instinct_approval_level_set"
+WORKSPACE_DELETE_TOOL_ID = f"mcp__{SERVER_NAME}__workspace_delete"
+BILLING_PLAN_CHANGE_TOOL_ID = f"mcp__{SERVER_NAME}__billing_plan_change"
 
 ADMIN_TOOL_IDS = (
     MEMBERS_LIST_TOOL_ID,
@@ -169,6 +208,9 @@ ADMIN_TOOL_IDS = (
     CONNECTOR_DISABLE_TOOL_ID,
     CONNECTOR_CONFIG_TOOL_ID,
     WORKSPACE_UPDATE_TOOL_ID,
+    INSTINCT_APPROVAL_LEVEL_SET_TOOL_ID,
+    WORKSPACE_DELETE_TOOL_ID,
+    BILLING_PLAN_CHANGE_TOOL_ID,
 )
 
 # The RBAC action keys these tools gate on (canonical entries in
@@ -186,6 +228,13 @@ _MEMBER_REMOVE_ACTION = "workspace.member.remove"
 _INVITE_REVOKE_ACTION = "invite.revoke"  # the REST revoke route's action (not invite.create)
 _CONNECTOR_ACTION = "connector.manage"
 _WORKSPACE_UPDATE_ACTION = "workspace.update"
+# WA-6 OWNER WRITE actions (all OWNER in guards.actions.ACTIONS — the top tier,
+# mirroring each other). The tool RBAC-gates on these; the executor whitelists +
+# re-checks the SAME keys (a proposer demoted from OWNER after proposing fails
+# closed at approve time).
+_INSTINCT_ACTIVATE_ACTION = "instinct.activate"
+_WORKSPACE_DELETE_ACTION = "workspace.delete"
+_BILLING_MANAGE_ACTION = "billing.manage"
 
 # The roles a member may be INVITED as (mirrors CreateInviteRequest / the REST
 # invite DTO — an invite can never mint an owner).
@@ -195,6 +244,19 @@ _VALID_INVITE_ROLES = frozenset({"admin", "member"})
 # sync with ``guards.rbac.WorkspaceRole`` — an out-of-set value is refused
 # before any gate check (defense in depth; the tool schema also constrains it).
 _VALID_ROLES = frozenset({"member", "admin", "owner"})
+
+# The Instinct-gate activation levels a workspace may be set to. Kept in sync with
+# ``cloud.pockets.instinct_triage.ApprovalLevel`` (a StrEnum: ASK / TRIAGE /
+# TRUSTED). A non-ASK level turns ON workspace-wide auto-approval of agent WRITE
+# actions — the single most governance-sensitive switch — so an out-of-set value
+# is refused before any gate (defense in depth; the service re-validates too).
+_VALID_APPROVAL_LEVELS = frozenset({"ASK", "TRIAGE", "TRUSTED"})
+
+# The plan tiers ``billing_plan_change`` may target. Mirrors the billing plan
+# catalog (cloud.billing.plans). ``subscribe`` re-validates against the live
+# catalog and refuses an unconfigured tier — this frozenset is the tool's own
+# fast-fail so an obvious typo never opens a proposal.
+_VALID_PLANS = frozenset({"free", "go", "pro", "pro_max", "enterprise"})
 
 
 def _error_response(message: str) -> dict[str, Any]:
@@ -1119,6 +1181,204 @@ async def _workspace_update_handler(args: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# WA-6 OWNER WRITE tool handlers — the most security-sensitive: destructive /
+# financial / governance ops. Same propose-only shape as the ADMIN writes
+# (validate → _gate_write deny-envelope → _propose_write pending) but gated on an
+# OWNER RBAC action. The mutation / checkout fires ONLY on human approval, after
+# the executor re-checks the proposer STILL holds OWNER. NONE mutates inline.
+# ---------------------------------------------------------------------------
+
+
+async def _instinct_approval_level_set_handler(args: dict) -> dict:
+    """WRITE: set the workspace's Instinct-gate activation level. OWNER-gated;
+    Instinct-proposed.
+
+    A non-ASK level enables workspace-wide AUTO-APPROVAL of agent WRITE actions —
+    the single most governance-sensitive switch in the gate — so this is OWNER-
+    only AND still human-approved (the agent can't flip its own leash off). The
+    ``level`` is constrained to the ApprovalLevel enum before any gate."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — instinct_approval_level_set can only be called "
+            "from inside a cloud chat stream."
+        )
+    level = args.get("level")
+    if not isinstance(level, str) or level not in _VALID_APPROVAL_LEVELS:
+        return _error_response(
+            f"level is required and must be one of {sorted(_VALID_APPROVAL_LEVELS)}."
+        )
+
+    gate = await _gate_write(
+        "instinct_approval_level_set",
+        _INSTINCT_ACTIVATE_ACTION,
+        "You don't have permission to change this workspace's approval level",
+    )
+    if isinstance(gate, dict):
+        return gate
+
+    return await _propose_write(
+        tool="instinct_approval_level_set",
+        action=_INSTINCT_ACTIVATE_ACTION,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        args={"level": level},
+        summary=f"Set the Instinct approval level to '{level}'.",
+        title=f"Instinct approval level → {level}",
+        proposed_change={"level": level, "workspace_id": workspace_id},
+        what="Instinct approval-level change",
+    )
+
+
+async def _workspace_delete_handler(args: dict) -> dict:  # noqa: ARG001 — no args
+    """WRITE: DELETE the entire workspace. OWNER-gated; Instinct-proposed.
+
+    DESTRUCTIVE + IRREVERSIBLE — the service cascade strips the workspace from
+    every member and (on the delete path) purges rooms / agents / files. This
+    tool ONLY proposes it; the cascade fires on human approval. No args beyond
+    identity. The envelope is emphatic about irreversibility."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — workspace_delete can only be called from inside "
+            "a cloud chat stream."
+        )
+
+    gate = await _gate_write(
+        "workspace_delete",
+        _WORKSPACE_DELETE_ACTION,
+        "You don't have permission to delete this workspace",
+    )
+    if isinstance(gate, dict):
+        return gate
+
+    # Bespoke pending envelope (not _propose_write) so the message can be emphatic
+    # about the IRREVERSIBLE cascade — a generic "pending" line under-warns for a
+    # workspace deletion.
+    from pocketpaw_ee.cloud.admin_proposals.propose import propose_admin_action
+
+    try:
+        action_id = await propose_admin_action(
+            workspace_id=workspace_id,
+            action=_WORKSPACE_DELETE_ACTION,
+            args={},  # identity only — nothing steers the delete
+            proposer_user_id=user_id,
+            summary="Delete the ENTIRE workspace (irreversible — cascades all members and data).",
+            title="Delete workspace (IRREVERSIBLE)",
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500
+        logger.warning("workspace_delete: propose_admin_action failed", exc_info=True)
+        return _error_response(f"could not file the workspace deletion for approval: {exc}")
+
+    logger.info(
+        "workspace_delete PROPOSED (WA-6): actor=%s workspace=%s proposal=%s — "
+        "pending human approval in the Tray (IRREVERSIBLE)",
+        user_id,
+        workspace_id,
+        action_id,
+    )
+    return _success_response(
+        {
+            "ok": True,
+            "executed": False,
+            "status": "pending_approval",
+            "action_id": action_id,
+            "proposal_id": action_id,
+            "proposed_change": {"workspace_id": workspace_id, "irreversible": True},
+            "message": (
+                "DANGER: this permanently DELETES the entire workspace and cascades "
+                "to EVERY member, room, agent, and file — it is IRREVERSIBLE and "
+                "cannot be undone. It is an owner-level action and is NEVER applied "
+                "directly from chat: I've proposed it and it is now PENDING approval "
+                "in the Tray. NOTHING has been deleted yet, and nothing will be "
+                "unless a human explicitly approves it. Tell the user you've "
+                "requested the deletion, that it is irreversible, and that it needs "
+                "a human to approve it — do NOT claim the workspace was deleted."
+            ),
+        }
+    )
+
+
+async def _billing_plan_change_handler(args: dict) -> dict:
+    """WRITE: change the workspace's paid PLAN. OWNER-gated; Instinct-proposed.
+
+    PAYMENT HONESTY: a paid-plan change flows through Dodo's HOSTED CHECKOUT — the
+    plan flips ONLY when Dodo posts a verified ``subscription.active`` webhook, not
+    synchronously. So on approval the executor does NOT fake a plan mutation: it
+    calls ``billing.service.subscribe``, which returns a ``{checkout_url}`` a human
+    must complete. The webhook-internal ``set_workspace_plan`` (which would bypass
+    payment) is DELIBERATELY not wired. ``plan`` is constrained to the catalog."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — billing_plan_change can only be called from "
+            "inside a cloud chat stream."
+        )
+    plan = args.get("plan")
+    if not isinstance(plan, str) or plan not in _VALID_PLANS:
+        return _error_response(
+            f"plan is required and must be one of {sorted(_VALID_PLANS)}."
+        )
+
+    gate = await _gate_write(
+        "billing_plan_change",
+        _BILLING_MANAGE_ACTION,
+        "You don't have permission to change this workspace's billing plan",
+    )
+    if isinstance(gate, dict):
+        return gate
+
+    # Bespoke pending envelope so the message can explain that approval PRODUCES a
+    # checkout link the human must complete — the plan does NOT flip on approval
+    # alone (it flips on the payment webhook), and the agent must relay that
+    # honestly rather than claim the plan changed.
+    from pocketpaw_ee.cloud.admin_proposals.propose import propose_admin_action
+
+    try:
+        action_id = await propose_admin_action(
+            workspace_id=workspace_id,
+            action=_BILLING_MANAGE_ACTION,
+            args={"plan_key": plan},
+            proposer_user_id=user_id,
+            summary=f"Change the workspace plan to '{plan}' (opens a checkout on approval).",
+            title=f"Billing plan change → {plan}",
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500
+        logger.warning("billing_plan_change: propose_admin_action failed", exc_info=True)
+        return _error_response(f"could not file the plan change for approval: {exc}")
+
+    logger.info(
+        "billing_plan_change PROPOSED (WA-6): actor=%s workspace=%s plan=%s "
+        "proposal=%s — pending human approval; approval opens a Dodo checkout",
+        user_id,
+        workspace_id,
+        plan,
+        action_id,
+    )
+    return _success_response(
+        {
+            "ok": True,
+            "executed": False,
+            "status": "pending_approval",
+            "action_id": action_id,
+            "proposal_id": action_id,
+            "proposed_change": {"plan": plan, "workspace_id": workspace_id},
+            "message": (
+                "Changing the paid plan is an owner-level action and is NEVER "
+                "applied directly from chat. It also can't be flipped instantly: a "
+                "paid plan changes only after checkout is completed and the payment "
+                "provider confirms it. I've proposed this change; it's now PENDING "
+                "approval in the Tray. When a human approves it, they'll get a "
+                "secure CHECKOUT LINK to finish the change — the plan does NOT "
+                "change until that checkout is completed. No plan change has been "
+                "made yet. Tell the user you've requested it, that it needs approval "
+                "and a checkout step — do NOT claim the plan was changed."
+            ),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # Server factory
 # ---------------------------------------------------------------------------
 
@@ -1478,6 +1738,84 @@ def build_admin_server() -> tuple[str, Any] | None:
     async def workspace_update(args):  # type: ignore[no-untyped-def]
         return await _workspace_update_handler(args)
 
+    @tool(
+        "instinct_approval_level_set",
+        (
+            "Propose changing the CURRENT workspace's Instinct APPROVAL LEVEL — how "
+            "much agent write activity is auto-approved. This is an OWNER-level "
+            "action and is NEVER applied directly from chat — it's proposed for a "
+            "human to approve. A non-ASK level turns ON workspace-wide "
+            "auto-approval of agent write actions, so it's highly sensitive. Arg: "
+            "`level` — 'ASK' (every write goes to a human), 'TRIAGE', or 'TRUSTED'. "
+            "If you lack owner permission, the result says so (denied) — relay that. "
+            "On success the result says the change is PENDING approval — do NOT "
+            "claim the level was changed."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": ["ASK", "TRIAGE", "TRUSTED"],
+                    "description": "The Instinct-gate approval level to set.",
+                },
+            },
+            "required": ["level"],
+            "additionalProperties": False,
+        },
+    )
+    async def instinct_approval_level_set(args):  # type: ignore[no-untyped-def]
+        return await _instinct_approval_level_set_handler(args)
+
+    @tool(
+        "workspace_delete",
+        (
+            "Propose DELETING the ENTIRE current workspace. This is an OWNER-level, "
+            "IRREVERSIBLE action — it permanently removes the workspace and every "
+            "member, room, agent, and file in it, and it CANNOT be undone. It is "
+            "NEVER applied directly from chat — it's proposed for a human to "
+            "approve, and nothing is deleted unless a human explicitly approves it. "
+            "No arguments — the workspace is inferred from the active chat. If you "
+            "lack owner permission, the result says so (denied) — relay that. On "
+            "success the result says the deletion is PENDING approval and is "
+            "irreversible — warn the user clearly and do NOT claim the workspace "
+            "was deleted."
+        ),
+        {},
+    )
+    async def workspace_delete(args):  # type: ignore[no-untyped-def]
+        return await _workspace_delete_handler(args)
+
+    @tool(
+        "billing_plan_change",
+        (
+            "Propose changing the CURRENT workspace's paid PLAN. This is an "
+            "OWNER-level action and is NEVER applied directly from chat — it's "
+            "proposed for a human to approve. It also can't be flipped instantly: a "
+            "paid plan changes only after a secure CHECKOUT is completed and the "
+            "payment provider confirms it. When a human approves, they get a "
+            "checkout link to finish the change. Arg: `plan` — one of 'free', 'go', "
+            "'pro', 'pro_max', 'enterprise'. If you lack owner permission, the "
+            "result says so (denied). On success the result says the change is "
+            "PENDING approval and needs a checkout step — do NOT claim the plan was "
+            "changed."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "type": "string",
+                    "enum": ["free", "go", "pro", "pro_max", "enterprise"],
+                    "description": "The plan tier to change to.",
+                },
+            },
+            "required": ["plan"],
+            "additionalProperties": False,
+        },
+    )
+    async def billing_plan_change(args):  # type: ignore[no-untyped-def]
+        return await _billing_plan_change_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
@@ -1496,6 +1834,9 @@ def build_admin_server() -> tuple[str, Any] | None:
             connector_disable,
             connector_config,
             workspace_update,
+            instinct_approval_level_set,
+            workspace_delete,
+            billing_plan_change,
         ],
     )
     return SERVER_NAME, server
@@ -1504,11 +1845,13 @@ def build_admin_server() -> tuple[str, Any] | None:
 __all__ = [
     "ADMIN_TOOL_IDS",
     "AUDIT_READ_TOOL_ID",
+    "BILLING_PLAN_CHANGE_TOOL_ID",
     "BILLING_USAGE_READ_TOOL_ID",
     "CONNECTORS_LIST_TOOL_ID",
     "CONNECTOR_CONFIG_TOOL_ID",
     "CONNECTOR_DISABLE_TOOL_ID",
     "CONNECTOR_ENABLE_TOOL_ID",
+    "INSTINCT_APPROVAL_LEVEL_SET_TOOL_ID",
     "INVITES_LIST_TOOL_ID",
     "INVITE_CREATE_TOOL_ID",
     "INVITE_REVOKE_TOOL_ID",
@@ -1516,6 +1859,7 @@ __all__ = [
     "MEMBER_REMOVE_TOOL_ID",
     "MEMBER_UPDATE_ROLE_TOOL_ID",
     "SERVER_NAME",
+    "WORKSPACE_DELETE_TOOL_ID",
     "WORKSPACE_SETTINGS_READ_TOOL_ID",
     "WORKSPACE_UPDATE_TOOL_ID",
     "build_admin_server",

--- a/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
@@ -66,6 +66,29 @@
 #   ``guards.deps`` + the read services (connectors / billing.usage / audit) +
 #   the User Beanie load, all lazily inside handlers, so the import surface stays
 #   minimal (mirrors connectors.py's function-local imports).
+#
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-5 — seven ADMIN WRITE tools).
+#   Each PROPOSES through the existing ``_admin_action`` Instinct gate exactly like
+#   member_update_role (WA-2) — validate args → RBAC-gate (deny envelope on
+#   Forbidden, never raised) → ``propose_admin_action`` → PENDING envelope. NONE
+#   mutates inline; the write fires only on human approval, after the executor
+#   re-checks the proposer's CURRENT role. The new tools + their RBAC action + the
+#   executor whitelist entry each extends (in admin_proposals/executor.py):
+#     * member_remove(user_id) → ``workspace.member.remove`` (ADMIN) →
+#       remove_member (cascades keys/sessions/member-data — the service's job).
+#     * invite_create(email, role) → ``invite.create`` (ADMIN) → create_invite
+#       (role constrained to admin|member).
+#     * invite_revoke(invite_id) → ``invite.revoke`` (ADMIN — the REST revoke
+#       route's action, NOT invite.create) → revoke_invite.
+#     * connector_enable(name) / connector_disable(name) / connector_config(name,
+#       config) → ``connector.manage`` (ADMIN) → the connectors enable / disable /
+#       update_config services. connector_config's ``config`` is carried as an
+#       OPAQUE dict the service validates — it never becomes top-level kwargs.
+#     * workspace_update(name?, settings?, branding?) → ``workspace.update``
+#       (ADMIN) → workspace.service.update. ONLY the recognized fields are
+#       proposed; any stray key an agent adds is dropped here AND in the strict
+#       adapter. The write-side helpers ``_gate_write`` + ``_propose_write`` are
+#       the shared chokepoint (parallel to WA-4's ``_gate_read``).
 """Agent-side MCP surface for workspace administration.
 
 Tools registered:
@@ -121,6 +144,15 @@ INVITES_LIST_TOOL_ID = f"mcp__{SERVER_NAME}__invites_list"
 CONNECTORS_LIST_TOOL_ID = f"mcp__{SERVER_NAME}__connectors_list"
 BILLING_USAGE_READ_TOOL_ID = f"mcp__{SERVER_NAME}__billing_usage_read"
 AUDIT_READ_TOOL_ID = f"mcp__{SERVER_NAME}__audit_read"
+# WA-5 — ADMIN WRITE tools. Each PROPOSES through the ``_admin_action`` Instinct
+# gate (never mutates inline), exactly like member_update_role.
+MEMBER_REMOVE_TOOL_ID = f"mcp__{SERVER_NAME}__member_remove"
+INVITE_CREATE_TOOL_ID = f"mcp__{SERVER_NAME}__invite_create"
+INVITE_REVOKE_TOOL_ID = f"mcp__{SERVER_NAME}__invite_revoke"
+CONNECTOR_ENABLE_TOOL_ID = f"mcp__{SERVER_NAME}__connector_enable"
+CONNECTOR_DISABLE_TOOL_ID = f"mcp__{SERVER_NAME}__connector_disable"
+CONNECTOR_CONFIG_TOOL_ID = f"mcp__{SERVER_NAME}__connector_config"
+WORKSPACE_UPDATE_TOOL_ID = f"mcp__{SERVER_NAME}__workspace_update"
 
 ADMIN_TOOL_IDS = (
     MEMBERS_LIST_TOOL_ID,
@@ -130,6 +162,13 @@ ADMIN_TOOL_IDS = (
     CONNECTORS_LIST_TOOL_ID,
     BILLING_USAGE_READ_TOOL_ID,
     AUDIT_READ_TOOL_ID,
+    MEMBER_REMOVE_TOOL_ID,
+    INVITE_CREATE_TOOL_ID,
+    INVITE_REVOKE_TOOL_ID,
+    CONNECTOR_ENABLE_TOOL_ID,
+    CONNECTOR_DISABLE_TOOL_ID,
+    CONNECTOR_CONFIG_TOOL_ID,
+    WORKSPACE_UPDATE_TOOL_ID,
 )
 
 # The RBAC action keys these tools gate on (canonical entries in
@@ -141,6 +180,16 @@ _READ_ACTION = "workspace.view"
 _ROLE_CHANGE_ACTION = "workspace.member.role_change"
 _INVITE_ACTION = "invite.create"
 _AUDIT_ACTION = "audit.read"
+# WA-5 ADMIN WRITE actions (all ADMIN in guards.actions.ACTIONS). The tool RBAC-
+# gates on these; the executor whitelists + re-checks the SAME keys.
+_MEMBER_REMOVE_ACTION = "workspace.member.remove"
+_INVITE_REVOKE_ACTION = "invite.revoke"  # the REST revoke route's action (not invite.create)
+_CONNECTOR_ACTION = "connector.manage"
+_WORKSPACE_UPDATE_ACTION = "workspace.update"
+
+# The roles a member may be INVITED as (mirrors CreateInviteRequest / the REST
+# invite DTO — an invite can never mint an owner).
+_VALID_INVITE_ROLES = frozenset({"admin", "member"})
 
 # The workspace roles a member may be assigned via member_update_role. Kept in
 # sync with ``guards.rbac.WorkspaceRole`` — an out-of-set value is refused
@@ -271,6 +320,82 @@ async def _gate_read(
         )
 
     return workspace_id, user_id, None
+
+
+async def _gate_write(
+    tool: str, action: str, deny_message: str
+) -> tuple[str, str, None] | dict:
+    """Shared identity-resolve + RBAC-gate for a WRITE tool.
+
+    IDENTICAL control flow to ``_gate_read`` — a Forbidden is CAUGHT and returned
+    as a deny envelope, never raised; the gate audits the denial. The difference
+    is purely semantic: a write tool that passes this gate does NOT execute — it
+    goes on to ``propose_admin_action`` (WA-2). Kept as its own name so the call
+    sites read as writes. Returns ``(workspace_id, user_id, None)`` on PASS or a
+    ready-to-return response ``dict`` on any failure."""
+    return await _gate_read(tool, action, deny_message)
+
+
+async def _propose_write(
+    *,
+    tool: str,
+    action: str,
+    workspace_id: str,
+    user_id: str,
+    args: dict[str, Any],
+    summary: str,
+    title: str,
+    proposed_change: dict[str, Any],
+    what: str,
+) -> dict:
+    """File a live ``_admin_action`` proposal and return a PENDING envelope.
+
+    The single write-side chokepoint (mirrors member_update_role's WA-2 tail):
+    the tool NEVER mutates inline — it proposes and returns "pending in the
+    Tray". ``args`` is the STRICT arg set the executor's adapter will read (only
+    the keys the matching ``_adapt_*`` expects). ``proposed_change`` is the
+    human-facing echo. ``what`` is a short noun phrase for the relay message."""
+    from pocketpaw_ee.cloud.admin_proposals.propose import propose_admin_action
+
+    try:
+        action_id = await propose_admin_action(
+            workspace_id=workspace_id,
+            action=action,
+            args=args,
+            proposer_user_id=user_id,
+            summary=summary,
+            title=title,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500
+        logger.warning("%s: propose_admin_action failed", tool, exc_info=True)
+        return _error_response(f"could not file the {what} for approval: {exc}")
+
+    logger.info(
+        "%s PROPOSED (WA-5): actor=%s workspace=%s action=%s proposal=%s — "
+        "pending human approval in the Tray",
+        tool,
+        user_id,
+        workspace_id,
+        action,
+        action_id,
+    )
+    return _success_response(
+        {
+            "ok": True,
+            "executed": False,
+            "status": "pending_approval",
+            "action_id": action_id,
+            "proposal_id": action_id,
+            "proposed_change": proposed_change,
+            "message": (
+                f"This is an admin action ({what}) and must be approved by a human "
+                "— it is never applied directly from chat. I've proposed it; it's "
+                "now PENDING approval in the Tray and will take effect only once a "
+                "human approves it. No change has been made yet. Tell the user "
+                "you've requested it and it needs approval; do NOT claim it's done."
+            ),
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -711,6 +836,289 @@ async def _audit_read_handler(args: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# WA-5 ADMIN WRITE tool handlers — each PROPOSES through the ``_admin_action``
+# gate (never mutates inline). Shape: validate args → _gate_write (deny envelope
+# on Forbidden) → _propose_write (pending envelope). The mutation fires ONLY on
+# human approval, after the executor re-checks the proposer's CURRENT role.
+# ---------------------------------------------------------------------------
+
+
+async def _member_remove_handler(args: dict) -> dict:
+    """WRITE: remove a member from the workspace. ADMIN-gated; Instinct-proposed.
+
+    The service cascade (API keys, sessions, member data) is the service's job —
+    the tool only proposes it. The proposal carries ONLY the target user id."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — member_remove can only be called from inside a "
+            "cloud chat stream."
+        )
+    target_user_id = args.get("user_id")
+    if not isinstance(target_user_id, str) or not target_user_id.strip():
+        return _error_response("user_id is required (string — the member to remove).")
+
+    gate = await _gate_write(
+        "member_remove",
+        _MEMBER_REMOVE_ACTION,
+        "You don't have permission to remove members from this workspace",
+    )
+    if isinstance(gate, dict):
+        return gate
+
+    return await _propose_write(
+        tool="member_remove",
+        action=_MEMBER_REMOVE_ACTION,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        args={"target_user_id": target_user_id},
+        summary=f"Remove member {target_user_id} from the workspace.",
+        title=f"Remove member {target_user_id}",
+        proposed_change={"user_id": target_user_id, "workspace_id": workspace_id},
+        what="member removal",
+    )
+
+
+async def _invite_create_handler(args: dict) -> dict:
+    """WRITE: invite someone to the workspace. ADMIN-gated; Instinct-proposed.
+
+    The proposal carries ONLY email + role (constrained to admin | member — an
+    invite can't mint an owner)."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — invite_create can only be called from inside a "
+            "cloud chat stream."
+        )
+    email = args.get("email")
+    if not isinstance(email, str) or not email.strip():
+        return _error_response("email is required (string — who to invite).")
+    role = args.get("role", "member")
+    if not isinstance(role, str) or role not in _VALID_INVITE_ROLES:
+        return _error_response(
+            f"role must be one of {sorted(_VALID_INVITE_ROLES)} (an invite can't be owner)."
+        )
+
+    gate = await _gate_write(
+        "invite_create",
+        _INVITE_ACTION,
+        "You don't have permission to invite members to this workspace",
+    )
+    if isinstance(gate, dict):
+        return gate
+
+    return await _propose_write(
+        tool="invite_create",
+        action=_INVITE_ACTION,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        args={"email": email, "role": role},
+        summary=f"Invite {email} as '{role}'.",
+        title=f"Invite {email} → {role}",
+        proposed_change={"email": email, "role": role, "workspace_id": workspace_id},
+        what="invite",
+    )
+
+
+async def _invite_revoke_handler(args: dict) -> dict:
+    """WRITE: revoke a pending invite. ADMIN-gated (``invite.revoke`` — the same
+    action the REST revoke route uses); Instinct-proposed. Carries ONLY the
+    invite id."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — invite_revoke can only be called from inside a "
+            "cloud chat stream."
+        )
+    invite_id = args.get("invite_id")
+    if not isinstance(invite_id, str) or not invite_id.strip():
+        return _error_response("invite_id is required (string — from invites_list).")
+
+    gate = await _gate_write(
+        "invite_revoke",
+        _INVITE_REVOKE_ACTION,
+        "You don't have permission to revoke invites in this workspace",
+    )
+    if isinstance(gate, dict):
+        return gate
+
+    return await _propose_write(
+        tool="invite_revoke",
+        action=_INVITE_REVOKE_ACTION,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        args={"invite_id": invite_id},
+        summary=f"Revoke invite {invite_id}.",
+        title=f"Revoke invite {invite_id}",
+        proposed_change={"invite_id": invite_id, "workspace_id": workspace_id},
+        what="invite revocation",
+    )
+
+
+async def _connector_enable_handler(args: dict) -> dict:
+    """WRITE: enable a connector for the workspace. ADMIN-gated
+    (``connector.manage``); Instinct-proposed. Carries op=enable + name."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — connector_enable can only be called from inside "
+            "a cloud chat stream."
+        )
+    name = args.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return _error_response("name is required (string — the connector to enable).")
+
+    gate = await _gate_write(
+        "connector_enable",
+        _CONNECTOR_ACTION,
+        "You don't have permission to manage connectors in this workspace",
+    )
+    if isinstance(gate, dict):
+        return gate
+
+    return await _propose_write(
+        tool="connector_enable",
+        action=_CONNECTOR_ACTION,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        args={"op": "enable", "name": name},
+        summary=f"Enable the '{name}' connector.",
+        title=f"Enable connector '{name}'",
+        proposed_change={"op": "enable", "name": name, "workspace_id": workspace_id},
+        what="connector enable",
+    )
+
+
+async def _connector_disable_handler(args: dict) -> dict:
+    """WRITE: disable a connector for the workspace. ADMIN-gated
+    (``connector.manage``); Instinct-proposed. Carries op=disable + name."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — connector_disable can only be called from inside "
+            "a cloud chat stream."
+        )
+    name = args.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return _error_response("name is required (string — the connector to disable).")
+
+    gate = await _gate_write(
+        "connector_disable",
+        _CONNECTOR_ACTION,
+        "You don't have permission to manage connectors in this workspace",
+    )
+    if isinstance(gate, dict):
+        return gate
+
+    return await _propose_write(
+        tool="connector_disable",
+        action=_CONNECTOR_ACTION,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        args={"op": "disable", "name": name},
+        summary=f"Disable the '{name}' connector.",
+        title=f"Disable connector '{name}'",
+        proposed_change={"op": "disable", "name": name, "workspace_id": workspace_id},
+        what="connector disable",
+    )
+
+
+async def _connector_config_handler(args: dict) -> dict:
+    """WRITE: patch a connector's saved config. ADMIN-gated (``connector.manage``);
+    Instinct-proposed. ``config`` is a structured dict passed to the executor as
+    OPAQUE data — the connectors service validates it and only merges it into the
+    connector row's config (it never becomes top-level kwargs)."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — connector_config can only be called from inside "
+            "a cloud chat stream."
+        )
+    name = args.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return _error_response("name is required (string — the connector to configure).")
+    config = args.get("config")
+    if not isinstance(config, dict):
+        return _error_response("config is required (object — the config patch to apply).")
+
+    gate = await _gate_write(
+        "connector_config",
+        _CONNECTOR_ACTION,
+        "You don't have permission to manage connectors in this workspace",
+    )
+    if isinstance(gate, dict):
+        return gate
+
+    return await _propose_write(
+        tool="connector_config",
+        action=_CONNECTOR_ACTION,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        args={"op": "config", "name": name, "config": config},
+        summary=f"Update the '{name}' connector config.",
+        title=f"Configure connector '{name}'",
+        proposed_change={"op": "config", "name": name, "workspace_id": workspace_id},
+        what="connector configuration",
+    )
+
+
+async def _workspace_update_handler(args: dict) -> dict:
+    """WRITE: update workspace name / settings / branding. ADMIN-gated
+    (``workspace.update``); Instinct-proposed. ONLY the recognized fields are
+    proposed — any other key is dropped here (and again in the strict adapter)."""
+    workspace_id, user_id, _pocket_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "no active workspace — workspace_update can only be called from inside "
+            "a cloud chat stream."
+        )
+
+    name = args.get("name")
+    settings = args.get("settings")
+    branding = args.get("branding")
+    if name is not None and not isinstance(name, str):
+        return _error_response("name must be a string when provided.")
+    if settings is not None and not isinstance(settings, dict):
+        return _error_response("settings must be an object when provided.")
+    if branding is not None and not isinstance(branding, dict):
+        return _error_response("branding must be an object when provided.")
+
+    # Build the STRICT proposed-args set from ONLY the recognized fields that were
+    # actually supplied (an agent's stray keys never make it into the proposal).
+    proposed_args: dict[str, Any] = {}
+    if name is not None:
+        proposed_args["name"] = name
+    if settings is not None:
+        proposed_args["settings"] = settings
+    if branding is not None:
+        proposed_args["branding"] = branding
+    if not proposed_args:
+        return _error_response(
+            "provide at least one of name / settings / branding to update."
+        )
+
+    gate = await _gate_write(
+        "workspace_update",
+        _WORKSPACE_UPDATE_ACTION,
+        "You don't have permission to update this workspace",
+    )
+    if isinstance(gate, dict):
+        return gate
+
+    return await _propose_write(
+        tool="workspace_update",
+        action=_WORKSPACE_UPDATE_ACTION,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        args=proposed_args,
+        summary="Update workspace settings.",
+        title="Update workspace settings",
+        proposed_change={"fields": sorted(proposed_args.keys()), "workspace_id": workspace_id},
+        what="workspace update",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Server factory
 # ---------------------------------------------------------------------------
 
@@ -874,6 +1282,202 @@ def build_admin_server() -> tuple[str, Any] | None:
     async def audit_read(args):  # type: ignore[no-untyped-def]
         return await _audit_read_handler(args)
 
+    @tool(
+        "member_remove",
+        (
+            "Propose REMOVING a member from the CURRENT workspace. This is an ADMIN "
+            "action and is NEVER applied directly from chat — it's proposed for a "
+            "human to approve and only takes effect once approved. Removing a member "
+            "also revokes their API keys and sessions and purges their personal "
+            "connector data. Arg: `user_id` (the member to remove, from "
+            "members_list). If you lack admin permission, the result says so "
+            "(denied) — relay that. On success the result says the removal is "
+            "PENDING approval, not done — do NOT claim the member was removed."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string",
+                    "description": "The member's user id (from members_list) to remove.",
+                },
+            },
+            "required": ["user_id"],
+            "additionalProperties": False,
+        },
+    )
+    async def member_remove(args):  # type: ignore[no-untyped-def]
+        return await _member_remove_handler(args)
+
+    @tool(
+        "invite_create",
+        (
+            "Propose INVITING someone to the CURRENT workspace by email. This is an "
+            "ADMIN action and is NEVER applied directly from chat — it's proposed "
+            "for a human to approve. Args: `email` (who to invite) and `role` "
+            "('admin' or 'member' — an invite can't be owner; defaults to 'member'). "
+            "If you lack admin permission, the result says so (denied). On success "
+            "the result says the invite is PENDING approval — do NOT claim it was "
+            "sent."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "description": "The email address to invite.",
+                },
+                "role": {
+                    "type": "string",
+                    "enum": ["admin", "member"],
+                    "description": "The role the invitee will get. Defaults to member.",
+                },
+            },
+            "required": ["email"],
+            "additionalProperties": False,
+        },
+    )
+    async def invite_create(args):  # type: ignore[no-untyped-def]
+        return await _invite_create_handler(args)
+
+    @tool(
+        "invite_revoke",
+        (
+            "Propose REVOKING a pending invite in the CURRENT workspace. This is an "
+            "ADMIN action and is NEVER applied directly from chat — it's proposed "
+            "for a human to approve. Arg: `invite_id` (from invites_list). If you "
+            "lack admin permission, the result says so (denied). On success the "
+            "result says the revocation is PENDING approval — do NOT claim it was "
+            "revoked."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "invite_id": {
+                    "type": "string",
+                    "description": "The invite id (from invites_list) to revoke.",
+                },
+            },
+            "required": ["invite_id"],
+            "additionalProperties": False,
+        },
+    )
+    async def invite_revoke(args):  # type: ignore[no-untyped-def]
+        return await _invite_revoke_handler(args)
+
+    @tool(
+        "connector_enable",
+        (
+            "Propose ENABLING a connector (integration like Gmail, GitHub) for the "
+            "CURRENT workspace. This is an ADMIN action and is NEVER applied "
+            "directly from chat — it's proposed for a human to approve. Arg: `name` "
+            "(the connector name, from connectors_list). If you lack admin "
+            "permission, the result says so (denied). On success the result says "
+            "the change is PENDING approval — do NOT claim it was enabled."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The connector name (from connectors_list) to enable.",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+    )
+    async def connector_enable(args):  # type: ignore[no-untyped-def]
+        return await _connector_enable_handler(args)
+
+    @tool(
+        "connector_disable",
+        (
+            "Propose DISABLING a connector for the CURRENT workspace. This is an "
+            "ADMIN action and is NEVER applied directly from chat — it's proposed "
+            "for a human to approve. Arg: `name` (from connectors_list). If you lack "
+            "admin permission, the result says so (denied). On success the result "
+            "says the change is PENDING approval — do NOT claim it was disabled."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The connector name (from connectors_list) to disable.",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+    )
+    async def connector_disable(args):  # type: ignore[no-untyped-def]
+        return await _connector_disable_handler(args)
+
+    @tool(
+        "connector_config",
+        (
+            "Propose UPDATING a connector's saved configuration in the CURRENT "
+            "workspace. This is an ADMIN action and is NEVER applied directly from "
+            "chat — it's proposed for a human to approve. Args: `name` (from "
+            "connectors_list) and `config` (an object of config keys to patch — the "
+            "connector validates it). If you lack admin permission, the result says "
+            "so (denied). On success the result says the change is PENDING approval "
+            "— do NOT claim it was applied."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The connector name (from connectors_list) to configure.",
+                },
+                "config": {
+                    "type": "object",
+                    "description": "The config keys to patch (merged into the saved config).",
+                },
+            },
+            "required": ["name", "config"],
+            "additionalProperties": False,
+        },
+    )
+    async def connector_config(args):  # type: ignore[no-untyped-def]
+        return await _connector_config_handler(args)
+
+    @tool(
+        "workspace_update",
+        (
+            "Propose UPDATING the CURRENT workspace's name, settings, or branding. "
+            "This is an ADMIN action and is NEVER applied directly from chat — it's "
+            "proposed for a human to approve. Optional args: `name` (new workspace "
+            "name), `settings` (a settings object), `branding` (a branding object); "
+            "provide at least one. Only these fields are proposed — anything else is "
+            "ignored. If you lack admin permission, the result says so (denied). On "
+            "success the result says the change is PENDING approval — do NOT claim "
+            "it was updated."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "New workspace name.",
+                },
+                "settings": {
+                    "type": "object",
+                    "description": "Workspace settings object to apply.",
+                },
+                "branding": {
+                    "type": "object",
+                    "description": "Branding object (display_name, tab_title, accent_color, ...).",
+                },
+            },
+            "additionalProperties": False,
+        },
+    )
+    async def workspace_update(args):  # type: ignore[no-untyped-def]
+        return await _workspace_update_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
@@ -885,6 +1489,13 @@ def build_admin_server() -> tuple[str, Any] | None:
             connectors_list,
             billing_usage_read,
             audit_read,
+            member_remove,
+            invite_create,
+            invite_revoke,
+            connector_enable,
+            connector_disable,
+            connector_config,
+            workspace_update,
         ],
     )
     return SERVER_NAME, server
@@ -895,10 +1506,17 @@ __all__ = [
     "AUDIT_READ_TOOL_ID",
     "BILLING_USAGE_READ_TOOL_ID",
     "CONNECTORS_LIST_TOOL_ID",
+    "CONNECTOR_CONFIG_TOOL_ID",
+    "CONNECTOR_DISABLE_TOOL_ID",
+    "CONNECTOR_ENABLE_TOOL_ID",
     "INVITES_LIST_TOOL_ID",
+    "INVITE_CREATE_TOOL_ID",
+    "INVITE_REVOKE_TOOL_ID",
     "MEMBERS_LIST_TOOL_ID",
+    "MEMBER_REMOVE_TOOL_ID",
     "MEMBER_UPDATE_ROLE_TOOL_ID",
     "SERVER_NAME",
     "WORKSPACE_SETTINGS_READ_TOOL_ID",
+    "WORKSPACE_UPDATE_TOOL_ID",
     "build_admin_server",
 ]

--- a/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
@@ -21,22 +21,17 @@
 #       NEVER calls ``update_member_role`` inline. On an ADMIN pass it returns a
 #       "proposed for approval" envelope WITHOUT firing the mutation.
 #
-#   WA-1 STATUS — member_update_role is a DOCUMENTED PROPOSAL-ONLY STUB, not a
-#   live Instinct proposal. The Instinct approve→execute spine is a FIXED N-way
-#   dispatch on bespoke blob param-keys (``_external_action``, ``_pocket_write``,
-#   ``_code_change``, ``_fabric_objects``, ``_pocket_create``, ``_instinct_rule``,
-#   ``_artifact_change``), each with its own executor hard-wired into the ee
-#   instinct router's approve/reject/bulk paths. EVERY existing executor dispatches
-#   to a domain-specific sink — the external-action one is HARDWIRED to
-#   ``connectors.service.execute`` and cannot carry a workspace-admin service call
-#   (``update_member_role``). Making an admin mutation actually FIRE on approval
-#   requires inventing an 8th proposal kind: an ``_admin_action`` blob + an
-#   ``admin_proposals/executor.py`` that dispatches to the workspace-admin services
-#   + router wiring on approve/reject/bulk. That is out of scope for WA-1 and is
-#   flagged as NEEDS_CONTEXT. Until that seam exists, member_update_role
-#   authorizes (ADMIN gate, fail-closed) and returns a "pending — approval spine
-#   not yet wired" envelope; it does NOT mutate and does NOT file a phantom
-#   proposal. A member is denied before we ever reach that path.
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-2 — member_update_role now
+#   files a LIVE Instinct proposal). The 8th gated proposal kind (the
+#   ``_admin_action`` blob + ``ee.cloud.admin_proposals`` propose/executor +
+#   router wiring on approve/reject/bulk) now exists, so member_update_role's
+#   ADMIN pass calls ``admin_proposals.propose.propose_admin_action`` and returns
+#   a "pending in the Tray" envelope carrying the proposal/action id. The role
+#   change fires ONLY when a human approves the Action — and only after the
+#   executor RE-CHECKS this proposer's CURRENT workspace role at approve time (a
+#   since-demoted proposer's approved action fails closed). update_member_role is
+#   STILL never called inline from this tool; the "pending_approval_unavailable"
+#   stub is retired.
 #
 #   OSS-EE boundary: this module imports only ``workspace.service`` +
 #   ``guards.deps`` + the User Beanie load, all lazily inside handlers, so the
@@ -52,9 +47,9 @@ Tools registered:
   - ``member_update_role(user_id, role)`` — WRITE: change a member's workspace
     role. ADMIN-gated at ``workspace.member.role_change``. This does NOT mutate
     inline — an admin write is proposed for human approval through the Instinct
-    Tray and fires only on approval. WA-1: the approve→execute spine for admin
-    actions is not yet wired, so this authorizes and returns a "pending" envelope
-    without mutating (see the module header).
+    Tray (WA-2: a live ``_admin_action`` proposal) and fires only on approval,
+    after an execute-time re-check of the proposer's CURRENT role. Returns a
+    "pending in the Tray" envelope carrying the proposal/action id.
 
 Identity comes from ``agent_service.current_workspace_id`` /
 ``current_user_id``. Outside an SSE chat stream those are empty → the tools
@@ -248,11 +243,11 @@ async def _member_update_role_handler(args: dict) -> dict:
     """WRITE: change a member's workspace role. ADMIN-gated; Instinct-proposed.
 
     THE load-bearing security rule: this NEVER calls ``update_member_role``
-    inline. On an ADMIN pass it returns a "proposed for approval" envelope
-    WITHOUT firing the mutation. WA-1: the Instinct approve→execute spine for
-    admin actions is not yet wired (no ``_admin_action`` proposal kind exists —
-    see the module header), so this authorizes and returns a "pending" envelope
-    without mutating and without filing a phantom proposal.
+    inline. On an ADMIN pass it files a live Instinct ``_admin_action`` proposal
+    (WA-2) via ``admin_proposals.propose.propose_admin_action`` and returns a
+    "pending in the Tray" envelope carrying the proposal/action id — WITHOUT
+    firing the mutation. The role change fires only when a human approves the
+    Action, and only after the executor re-checks THIS proposer's CURRENT role.
     """
     workspace_id, user_id, _pocket_id = _identity()
     if not workspace_id or not user_id:
@@ -303,24 +298,43 @@ async def _member_update_role_handler(args: dict) -> dict:
             }
         )
 
-    # ADMIN passed. DO NOT MUTATE — an admin write is human-gated. WA-1: the
-    # Instinct approve→execute spine for admin actions is not yet wired (no
-    # ``_admin_action`` proposal kind), so we return a pending envelope WITHOUT
-    # filing a proposal and WITHOUT calling update_member_role. This is the
-    # fail-closed default: no phantom "done", no ungated mutation.
+    # ADMIN passed. DO NOT MUTATE INLINE — an admin write is human-gated. WA-2:
+    # file a real Instinct proposal carrying an ``_admin_action`` blob and return
+    # a "pending in Tray" envelope. The mutation fires ONLY when a human approves
+    # the Action in the Tray — and only after the executor re-checks THIS
+    # proposer's CURRENT role at approve time. update_member_role is NEVER called
+    # from here.
+    from pocketpaw_ee.cloud.admin_proposals.propose import propose_admin_action
+
+    try:
+        action_id = await propose_admin_action(
+            workspace_id=workspace_id,
+            action=_ROLE_CHANGE_ACTION,
+            args={"target_user_id": target_user_id, "role": role},
+            proposer_user_id=user_id,
+            summary=f"Change member {target_user_id} to role '{role}'.",
+            title=f"Role change — member {target_user_id} → {role}",
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500
+        logger.warning("member_update_role: propose_admin_action failed", exc_info=True)
+        return _error_response(f"could not file the role change for approval: {exc}")
+
     logger.info(
-        "member_update_role authorized but NOT executed (WA-1 stub): actor=%s "
-        "workspace=%s target=%s role=%s — admin-action Instinct spine not yet wired",
+        "member_update_role PROPOSED (WA-2): actor=%s workspace=%s target=%s "
+        "role=%s action=%s — pending human approval in the Tray",
         user_id,
         workspace_id,
         target_user_id,
         role,
+        action_id,
     )
     return _success_response(
         {
             "ok": True,
             "executed": False,
-            "status": "pending_approval_unavailable",
+            "status": "pending_approval",
+            "action_id": action_id,
+            "proposal_id": action_id,
             "proposed_change": {
                 "user_id": target_user_id,
                 "role": role,
@@ -328,10 +342,11 @@ async def _member_update_role_handler(args: dict) -> dict:
             },
             "message": (
                 "Role changes are admin-gated and must be approved by a human — "
-                "they are never applied directly from chat. The approval spine "
-                "for workspace-admin changes isn't wired up yet, so I can't file "
-                "this for approval right now. No change was made. (Tell the user "
-                "to change the role from the workspace members settings for now.)"
+                "they are never applied directly from chat. I've proposed this "
+                "change; it's now PENDING approval in the Tray and will take "
+                "effect only once a human approves it. No change has been made "
+                "yet. Tell the user you've requested the change and it needs "
+                "approval; do NOT claim the role was changed."
             ),
         }
     )

--- a/ee/pocketpaw_ee/cloud/admin_proposals/__init__.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/__init__.py
@@ -1,0 +1,30 @@
+# ee/cloud/admin_proposals/__init__.py — the gated workspace-ADMIN-action proposal
+#   kind (the 8th Instinct gate kind, alongside _external_action / _pocket_write /
+#   _code_change / _fabric_objects / _pocket_create / _instinct_rule /
+#   _artifact_change).
+# Created: 2026-07-03 (feat/workspace-admin-tools, WA-2) — an agent-proposed
+#   workspace-admin write (e.g. a member role change) files an Instinct Action
+#   carrying an ``_admin_action`` blob. A human approves it in the Tray; only then
+#   does the executor fire the whitelisted workspace-admin service call — after
+#   RE-CHECKING the proposer's CURRENT RBAC role at execute time (fail-closed if
+#   the proposer was demoted since proposing). This package is the propose + apply
+#   halves of that gate.
+"""Gated workspace-admin-action proposals (the ``_admin_action`` Instinct kind)."""
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.admin_proposals.propose import (
+    ADMIN_ACTION_KIND,
+    ADMIN_ACTION_PARAM_KEY,
+    ADMIN_ACTION_SCHEMA,
+    compute_args_hash,
+    propose_admin_action,
+)
+
+__all__ = [
+    "ADMIN_ACTION_KIND",
+    "ADMIN_ACTION_PARAM_KEY",
+    "ADMIN_ACTION_SCHEMA",
+    "compute_args_hash",
+    "propose_admin_action",
+]

--- a/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
@@ -25,6 +25,24 @@
 #     * ``workspace.update`` → ``workspace.service.update`` (adapter passes ONLY
 #       the recognized name / settings / branding fields; any other key an agent
 #       puts in args is ignored, never forwarded).
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-6) — added the three OWNER
+#   write whitelist entries (destructive / financial / governance ops):
+#     * ``instinct.activate`` → ``workspace.service.set_instinct_approval_level``
+#       (adapter reads ONLY ``level``, constrained to the ApprovalLevel enum {ASK,
+#       TRIAGE, TRUSTED}; the proposer is the actor). A non-ASK level turns ON
+#       workspace-wide auto-approval of agent writes — hence OWNER + human-gated.
+#     * ``workspace.delete`` → ``workspace.service.delete`` (adapter reads NOTHING
+#       from args — a delete has no steering params; DESTRUCTIVE + IRREVERSIBLE,
+#       the service owns the cascade over members / rooms / agents / files).
+#     * ``billing.manage`` → ``billing.service.subscribe`` — PAYMENT-HONEST: this
+#       does NOT flip the plan. ``subscribe`` opens a Dodo HOSTED CHECKOUT and
+#       returns a ``{checkout_url}``; the plan changes only on the verified
+#       ``subscription.active`` webhook. The executor records the checkout url as
+#       the outcome (an artifact the human completes) — it never fakes a plan
+#       mutation. The webhook-internal ``set_workspace_plan`` (which would bypass
+#       payment) is DELIBERATELY not exposed. The adapter reads ONLY ``plan_key``,
+#       constrained to the plan catalog. (Seat management is NOT wired at all —
+#       there is no seat-change service / checkout flow in the codebase.)
 #   Every new adapter is STRICT (fixed known keys → fixed kwargs; unknown keys
 #   never reach the service — no ``**args`` splat), exactly like
 #   ``_adapt_member_role_change``. The execute-time RBAC re-check + args-hash +
@@ -380,6 +398,118 @@ async def _call_update_workspace(**kwargs: Any) -> Any:
     return await workspace_service.update(ctx, kwargs["workspace_id"], body)
 
 
+# --- instinct.activate (WA-6, OWNER) ---------------------------------------
+
+# The valid Instinct-gate activation levels (mirrors ApprovalLevel: ASK / TRIAGE
+# / TRUSTED). Constrained here too so a hand-crafted blob can't set an off-enum
+# level (the service re-validates and raises, but fail early + clearly).
+_APPROVAL_LEVELS = frozenset({"ASK", "TRIAGE", "TRUSTED"})
+
+
+def _adapt_instinct_activate(
+    args: dict[str, Any], workspace_id: str, proposer_user_id: str
+) -> dict[str, Any]:
+    """STRICT adapter for ``workspace.service.set_instinct_approval_level``.
+
+    Reads ONLY ``level`` and constrains it to the ApprovalLevel enum. A non-ASK
+    level turns ON workspace-wide auto-approval of agent writes — the single most
+    governance-sensitive switch — so no other key is read. The proposer is the
+    actor (audit attribution)."""
+    level = str(args.get("level") or "")
+    if level not in _APPROVAL_LEVELS:
+        raise ValueError(f"instinct.activate level must be one of {sorted(_APPROVAL_LEVELS)}")
+    return {
+        "workspace_id": workspace_id,
+        "proposer_user_id": proposer_user_id,
+        "level": level,
+    }
+
+
+async def _call_set_instinct_approval_level(**kwargs: Any) -> Any:
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    ctx = _proposer_ctx(kwargs["workspace_id"], kwargs["proposer_user_id"])
+    return await workspace_service.set_instinct_approval_level(
+        ctx, kwargs["workspace_id"], kwargs["level"]
+    )
+
+
+# --- workspace.delete (WA-6, OWNER) ----------------------------------------
+
+
+def _adapt_workspace_delete(
+    args: dict[str, Any],  # noqa: ARG001 — delete takes no steering args
+    workspace_id: str,
+    proposer_user_id: str,
+) -> dict[str, Any]:
+    """STRICT adapter for ``workspace.service.delete``.
+
+    Reads NOTHING from ``args`` — a workspace delete has no parameters that could
+    steer it; the only inputs are the tenancy (workspace_id) and the proposer
+    (audit attribution). This is DESTRUCTIVE + IRREVERSIBLE; the service owns the
+    cascade over members / rooms / agents / files."""
+    return {
+        "workspace_id": workspace_id,
+        "proposer_user_id": proposer_user_id,
+    }
+
+
+async def _call_delete_workspace(**kwargs: Any) -> Any:
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    ctx = _proposer_ctx(kwargs["workspace_id"], kwargs["proposer_user_id"])
+    return await workspace_service.delete(ctx, kwargs["workspace_id"])
+
+
+# --- billing.manage (WA-6, OWNER) — propose→checkout-URL, NOT a plan mutation
+
+
+# The plan tiers a billing-plan change may target (mirrors the billing plan
+# catalog). ``subscribe`` re-validates against the live catalog; constraining
+# here too rejects an obvious typo before the provider call.
+_PLAN_KEYS = frozenset({"free", "go", "pro", "pro_max", "enterprise"})
+
+
+def _adapt_billing_manage(
+    args: dict[str, Any], workspace_id: str, proposer_user_id: str
+) -> dict[str, Any]:
+    """STRICT adapter for the billing-plan change.
+
+    Reads ONLY ``plan_key`` and constrains it to the catalog. IMPORTANT: this does
+    NOT map to a synchronous plan mutation. The service (``subscribe``) opens a
+    Dodo HOSTED CHECKOUT and returns a ``{checkout_url}``; the plan flips only when
+    Dodo posts a verified ``subscription.active`` webhook. The webhook-internal
+    ``set_workspace_plan`` (which bypasses payment) is deliberately NOT wired —
+    an approved plan change PRODUCES a checkout the human completes, it never
+    silently flips a paid plan. The proposer is threaded as the subscribing user."""
+    plan_key = str(args.get("plan_key") or "")
+    if plan_key not in _PLAN_KEYS:
+        raise ValueError(f"billing.manage plan_key must be one of {sorted(_PLAN_KEYS)}")
+    return {
+        "workspace_id": workspace_id,
+        "proposer_user_id": proposer_user_id,
+        "plan_key": plan_key,
+    }
+
+
+async def _call_billing_subscribe(**kwargs: Any) -> Any:
+    """Open a subscription checkout for the requested plan and return its result.
+
+    Returns the ``{"checkout_url": ...}`` dict from ``subscribe`` — the honest
+    artifact the human must complete. The executor records this (via the outcome
+    ``response_summary``); the plan does NOT change here (it changes on the Dodo
+    ``subscription.active`` webhook). ``origin`` is None on the approve path (no
+    Origin header) — ``subscribe`` falls back to the ``dodo_checkout_return_base``
+    config for the return_url, so the checkout still works."""
+    from pocketpaw_ee.cloud.billing import service as billing_service
+
+    return await billing_service.subscribe(
+        kwargs["workspace_id"],
+        kwargs["proposer_user_id"],
+        kwargs["plan_key"],
+    )
+
+
 # THE WHITELIST — the ONLY workspace-admin actions an approved ``_admin_action``
 # can ever fire. Seeded (WA-2) with member.role_change; extended (WA-5) with the
 # member.remove / invite.create / invite.revoke / connector.manage /
@@ -409,6 +539,21 @@ _DISPATCH: dict[str, _Dispatch] = {
     "workspace.update": _Dispatch(
         service=_call_update_workspace,
         adapt=_adapt_workspace_update,
+    ),
+    # WA-6 OWNER writes — destructive / financial / governance. Each STRICT +
+    # OWNER-re-checked at execute time. billing.manage maps to a checkout-URL
+    # producer, NOT a plan mutation (payment honesty).
+    "instinct.activate": _Dispatch(
+        service=_call_set_instinct_approval_level,
+        adapt=_adapt_instinct_activate,
+    ),
+    "workspace.delete": _Dispatch(
+        service=_call_delete_workspace,
+        adapt=_adapt_workspace_delete,
+    ),
+    "billing.manage": _Dispatch(
+        service=_call_billing_subscribe,
+        adapt=_adapt_billing_manage,
     ),
 }
 

--- a/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
@@ -1,0 +1,528 @@
+# ee/cloud/admin_proposals/executor.py — apply an approved workspace-admin action.
+# Created: 2026-07-03 (feat/workspace-admin-tools, WA-2).
+#
+# What this module does (the apply-on-approve half of the admin-action gate): the
+# propose helper (``admin_proposals.propose.propose_admin_action``) files an
+# Instinct Action carrying an ``_admin_action`` blob THROUGH Instinct (the human
+# approve/reject layer). After a human approves the Action, the ee instinct
+# router's ``approve_action`` fires ``execute_approved_admin_action`` here —
+# exactly mirroring how ``external_actions.executor.execute_approved_external_action``
+# fires for an external connector call. This function:
+#
+#   1. Reads the ``_admin_action`` blob from ``action.parameters``. A missing blob
+#      → return (no chain was opened). A schema-mismatched blob → mark_failed +
+#      close the chain, return.
+#   2. WHITELIST dispatch — the blob's RBAC ``action`` key must resolve to an entry
+#      in ``_DISPATCH`` (the whitelist). An unknown / absent key → HARD FAIL
+#      (mark_failed + close); a write is NEVER fired for an unrecognised action.
+#   3. Re-validates the args hash off the persisted blob — an args edit between
+#      propose and approve → mark_failed + close, no call fires (a human approved a
+#      SPECIFIC write).
+#   4. Idempotency guard — if the blob's outcome is already recorded, or the Action
+#      is already terminal, the write is NOT re-fired.
+#   5. RE-CHECKS RBAC AT EXECUTE TIME (the load-bearing security rule): loads the
+#      PROPOSER's User doc FRESH and calls ``check_workspace_action(proposer,
+#      workspace_id, action)`` against their CURRENT workspace role. If the
+#      proposer was demoted since proposing (or removed from the workspace), the
+#      approved action FAILS CLOSED (mark_failed + close) — the whitelisted service
+#      is NEVER called. This is what stops a since-revoked admin's approved write.
+#   6. Calls the whitelisted service via its arg adapter and records the outcome the
+#      same way the external-action executor does, closing the chain exactly once.
+#
+# EXACTLY-ONE-TERMINAL discipline (critical): on APPROVE the EXECUTOR owns the
+# ``decision.completed`` chain close — the router does NOT emit it (mirrors the
+# external-action executor). On REJECT the ROUTER owns the close and the executor
+# never runs. Every terminal path here goes through the single ``_fail`` chokepoint
+# (failure) or the one success emit at the end — never both.
+#
+# Never raises — a failure here must not break the approve response. The router
+# wraps the call too; this is belt-and-braces. A service error / RBAC re-check
+# denial / whitelist miss is captured as ``status=failed`` with a ``failed``
+# terminal, NOT re-raised.
+#
+# Security (this code performs a workspace-admin WRITE on approval):
+#   * WHITELIST-only — only actions seeded in ``_DISPATCH`` can ever fire; an
+#     unknown action key hard-fails.
+#   * RBAC is RE-CHECKED at execute time against the proposer's CURRENT role — a
+#     demoted / removed proposer's approved action fails closed.
+#   * the args hash is re-validated — a tampered blob is refused, not fired.
+#   * tenancy: the write is scoped by the blob's ``workspace_id``; an empty
+#     workspace_id is refused. The router's ``_assert_admin_action_workspace`` is
+#     the primary gate; this is belt-and-braces.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.admin_proposals.propose import (
+    ADMIN_ACTION_PARAM_KEY,
+    ADMIN_ACTION_SCHEMA,
+    compute_args_hash,
+)
+
+logger = logging.getLogger(__name__)
+
+# Max length of the outcome summary persisted onto the blob.
+_OUTCOME_SUMMARY_MAX = 500
+
+
+@dataclass(frozen=True)
+class _Dispatch:
+    """One whitelist entry: the service callable to invoke + an arg adapter that
+    maps the blob's ``args`` dict to the callable's kwargs.
+
+    ``service`` is an async callable. ``adapt`` receives ``(args, workspace_id,
+    proposer_user_id)`` and returns the kwargs dict passed to ``service``. An
+    adapter that raises ``KeyError`` / ``ValueError`` on missing/invalid args
+    surfaces as a MalformedArgs failure (caught by the caller) — the write never
+    fires with half-resolved args.
+    """
+
+    service: Callable[..., Awaitable[Any]]
+    adapt: Callable[[dict[str, Any], str, str], dict[str, Any]]
+
+
+def _adapt_member_role_change(
+    args: dict[str, Any], workspace_id: str, proposer_user_id: str
+) -> dict[str, Any]:
+    """Adapt an ``args`` blob to ``workspace.service.update_member_role`` kwargs.
+
+    Required args: ``target_user_id`` + ``role``. The actor is the PROPOSER (the
+    one whose CURRENT role was just re-checked), so the audit row records who
+    authored the change — not the approving operator.
+    """
+    target_user_id = str(args.get("target_user_id") or "")
+    role = str(args.get("role") or "")
+    if not target_user_id or not role:
+        raise ValueError("member.role_change requires target_user_id and role")
+    return {
+        "workspace_id": workspace_id,
+        "target_user_id": target_user_id,
+        "role": role,
+        "actor_user_id": proposer_user_id,
+    }
+
+
+async def _call_update_member_role(**kwargs: Any) -> Any:
+    """Lazy-import wrapper so the whitelist table doesn't import the workspace
+    service at module load (matches the router's lazy-import discipline)."""
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    return await workspace_service.update_member_role(
+        kwargs["workspace_id"],
+        kwargs["target_user_id"],
+        kwargs["role"],
+        kwargs["actor_user_id"],
+    )
+
+
+# THE WHITELIST — the ONLY workspace-admin actions an approved ``_admin_action``
+# can ever fire. Seeded with member.role_change; extend deliberately, never
+# dynamically. An action key absent from this table hard-fails at execute time.
+_DISPATCH: dict[str, _Dispatch] = {
+    "workspace.member.role_change": _Dispatch(
+        service=_call_update_member_role,
+        adapt=_adapt_member_role_change,
+    ),
+}
+
+
+def _coerce_uuid(raw: Any) -> UUID | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be."""
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _summarize(text: str) -> str:
+    """Bound + single-line an outcome summary."""
+    text = str(text).replace("\n", " ").strip()
+    if len(text) > _OUTCOME_SUMMARY_MAX:
+        text = text[:_OUTCOME_SUMMARY_MAX] + "…"
+    return text
+
+
+async def _persist_outcome(
+    *,
+    store: Any,
+    action_id: str,
+    status: str,
+    response_summary: str,
+    executed_at: str,
+) -> None:
+    """Back-write the outcome onto the persisted ``_admin_action`` blob.
+
+    Direct SQL update — the same pattern the external-action executor's
+    ``_persist_outcome`` uses. Best-effort: a write failure leaves the blob
+    without the structured outcome but the free-text ``mark_executed`` /
+    ``mark_failed`` outcome still records it. The structured outcome is ALSO the
+    idempotency signal ``_already_executed`` reads.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(ADMIN_ACTION_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["outcome"] = {
+            "status": status,
+            "response_summary": response_summary,
+            "executed_at": executed_at,
+        }
+        params[ADMIN_ACTION_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — back-write is best-effort
+        logger.warning(
+            "admin_action: failed to persist outcome onto action %s — the "
+            "structured outcome is unavailable (free-text outcome still recorded)",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: UUID | None,
+    response_summary: str | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for an admin action.
+
+    Mirrors the external-action executor's ``_emit_chain_close`` — the executor
+    owns the chain close on the approve path. Returns early when
+    ``correlation_id`` is None. Best-effort: a Decision-Graph wiring failure must
+    never break the approve response.
+    """
+    if correlation_id is None:
+        return
+
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {"passed": passed, "action_outcome": action_outcome}
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if response_summary:
+        payload["response_summary"] = response_summary
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "admin_action decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+def _already_executed(action: Any, blob: dict[str, Any]) -> bool:
+    """Idempotency guard — True when this admin write already fired.
+
+    Either signal is sufficient: the blob already carries an ``outcome`` (a prior
+    run back-wrote it), or the Action is already terminal (executed / failed).
+    Re-invocation (bulk re-approve, retry) must never double-fire the write.
+    """
+    if isinstance(blob.get("outcome"), dict):
+        return True
+    status = getattr(action, "status", None)
+    status_value = getattr(status, "value", status)
+    return str(status_value) in ("executed", "failed")
+
+
+async def _recheck_rbac(workspace_id: str, proposer_user_id: str, rbac_action: str) -> None:
+    """RE-CHECK the proposer's CURRENT RBAC role at execute time. FAIL-CLOSED.
+
+    THE load-bearing security rule of WA-2: an admin action approved in the Tray
+    must fire ONLY if the PROPOSER still holds the required role RIGHT NOW. If the
+    proposer was demoted (or removed from the workspace) between proposing and the
+    approval landing, the approved action must NOT execute.
+
+    Loads the proposer's User doc FRESH (so ``.workspaces`` reflects the current
+    role) and runs ``check_workspace_action`` — the same helper the tool ran at
+    propose time — which resolves the CURRENT role and raises ``Forbidden`` if it's
+    below the action's minimum. A missing proposer (removed from the workspace, or
+    a bad id) is ``resolve_workspace_role`` → ``Forbidden`` too. Raises ``Forbidden``
+    on any deny; the caller turns that into a ``failed`` outcome (never executes).
+    """
+    from beanie import PydanticObjectId
+
+    from pocketpaw_ee.cloud.models.user import User as _UserDoc
+    from pocketpaw_ee.guards.deps import check_workspace_action
+    from pocketpaw_ee.guards.rbac import Forbidden
+
+    try:
+        proposer = await _UserDoc.get(PydanticObjectId(proposer_user_id))
+    except Exception as exc:  # noqa: BLE001 — malformed id / DB error → fail closed
+        raise Forbidden(
+            "admin_action.proposer_unresolved",
+            f"could not resolve the proposer for the execute-time RBAC re-check: {exc}",
+        ) from exc
+    if proposer is None:
+        raise Forbidden(
+            "admin_action.proposer_unresolved",
+            "the proposer no longer exists — refusing the approved admin write",
+        )
+    # Raises Forbidden if the proposer's CURRENT role is below the action minimum
+    # (e.g. demoted to MEMBER since proposing). Audits the denial via log_denial.
+    check_workspace_action(proposer, workspace_id, rbac_action)
+
+
+async def execute_approved_admin_action(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """Execute the workspace-admin write carried by a freshly-approved Action.
+
+    Called best-effort from the instinct router's ``approve_action`` /
+    ``bulk_approve_actions`` after ``store.approve()`` succeeds — the same hook
+    shape the external-action executor uses.
+
+    ``human_event_id`` is the id of the ``human.corrected`` event the router
+    emitted just before calling this — threaded through so the terminal
+    ``decision.completed`` chains its ``causation_id`` back to the approval.
+    ``None`` is tolerated.
+
+    Never raises. The Action is marked executed on a successful service call, or
+    failed (with a clear outcome) on ANY of: whitelist miss, schema/args mismatch,
+    execute-time RBAC denial, or service error. The Decision-Graph chain is closed
+    exactly once.
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(ADMIN_ACTION_PARAM_KEY)
+    if not isinstance(blob, dict):
+        # Not an admin-action Action at all — no chain was opened; nothing to
+        # close, and no workspace to scope a store to.
+        logger.warning(
+            "approved action %s carries no _admin_action blob", getattr(action, "id", "?")
+        )
+        return
+
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    # HTTP approve path (no ``current_workspace`` ContextVar) — scope the store to
+    # the blob's workspace so the terminal audit row + chain-close land in the
+    # tenant's file, not the shared ledger.
+    store = get_instinct_store(workspace_id=workspace_id or None)
+    proposer_user_id = str(blob.get("proposer_user_id") or "")
+    # The chain actor on the terminal is the proposer (the write's author).
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str, response_summary: str | None = None) -> None:
+        """Mark the Action failed AND close the chain with one terminal — the
+        single failure-path chokepoint so a path can never both fail and
+        double-fire the terminal."""
+        await store.mark_failed(action.id, reason)
+        await _persist_outcome(
+            store=store,
+            action_id=str(action.id),
+            status="failed",
+            response_summary=_summarize(response_summary or reason),
+            executed_at=datetime.now(UTC).isoformat(),
+        )
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=proposer_user_id,
+            causation_id=causation,
+            response_summary=_summarize(response_summary or reason),
+        )
+
+    # Schema guard — a stale blob from an incompatible build fails loud rather
+    # than firing a misinterpreted admin write.
+    if blob.get("schema") != ADMIN_ACTION_SCHEMA:
+        await _fail(
+            "admin-action schema mismatch — the blob is from an incompatible "
+            "build and cannot be executed",
+            error_class="SchemaMismatch",
+        )
+        return
+
+    # Tenancy — an admin action with no workspace is unexecutable.
+    if not workspace_id:
+        await _fail(
+            "admin-action blob carries no workspace_id — cannot scope the write",
+            error_class="MissingWorkspace",
+        )
+        return
+
+    if not proposer_user_id:
+        await _fail(
+            "admin-action blob carries no proposer_user_id — cannot re-check RBAC",
+            error_class="MissingProposer",
+        )
+        return
+
+    rbac_action = str(blob.get("action") or "")
+    call_args = blob.get("args")
+    if not rbac_action or not isinstance(call_args, dict):
+        await _fail(
+            "admin-action blob is missing the action key or args",
+            error_class="MalformedBlob",
+        )
+        return
+
+    # WHITELIST — an action key NOT in the dispatch table NEVER executes. This is
+    # the hard fail for an unknown/absent action: the executor is not a generic
+    # RPC surface; only seeded workspace-admin actions can fire.
+    dispatch = _DISPATCH.get(rbac_action)
+    if dispatch is None:
+        await _fail(
+            f"admin-action '{rbac_action}' is not in the execute whitelist — refusing to run it",
+            error_class="ActionNotWhitelisted",
+        )
+        return
+
+    # Hash guard — a human approved a SPECIFIC write. If the args were edited
+    # between propose and approve the recomputed hash won't match; refuse.
+    stored_hash = str(blob.get("params_hash") or "")
+    recomputed = compute_args_hash(rbac_action, call_args)
+    if stored_hash and stored_hash != recomputed:
+        await _fail(
+            "admin-action args hash mismatch — the write args changed after the "
+            "proposal was approved; refusing to fire a different write",
+            error_class="ArgsHashMismatch",
+        )
+        return
+
+    # Idempotency — never double-fire the write on a re-invocation.
+    if _already_executed(action, blob):
+        logger.info(
+            "admin_action: action %s already executed (idempotency guard) — "
+            "skipping the service call",
+            action.id,
+        )
+        return
+
+    # EXECUTE-TIME RBAC RE-CHECK (the load-bearing security rule). The proposer's
+    # CURRENT role is resolved fresh; a demoted / removed proposer fails closed
+    # here BEFORE any service call. A Forbidden → failed outcome, NOT an exception.
+    try:
+        await _recheck_rbac(workspace_id, proposer_user_id, rbac_action)
+    except Exception as exc:  # noqa: BLE001 — Forbidden (deny) or a resolve error → fail closed
+        await _fail(
+            f"execute-time RBAC re-check failed for proposer {proposer_user_id} on "
+            f"'{rbac_action}' — the proposer no longer holds the required role; "
+            f"refusing the approved admin write: {exc}",
+            error_class=type(exc).__name__,
+            response_summary=str(exc),
+        )
+        return
+
+    # Adapt the args to the whitelisted service's kwargs. A missing/invalid arg
+    # surfaces as a MalformedArgs failure — the write never fires half-resolved.
+    try:
+        kwargs = dispatch.adapt(call_args, workspace_id, proposer_user_id)
+    except Exception as exc:  # noqa: BLE001 — never let a bad adapter break approve
+        await _fail(
+            f"admin-action args could not be adapted for '{rbac_action}': {exc}",
+            error_class="MalformedArgs",
+            response_summary=str(exc),
+        )
+        return
+
+    # Fire the whitelisted service. Any failure is captured as a failed outcome —
+    # NEVER re-raised into the router.
+    try:
+        result = await dispatch.service(**kwargs)
+    except Exception as exc:  # noqa: BLE001 — never let a service crash break approve
+        logger.warning(
+            "admin_action: service call failed for action %s (action=%s)",
+            action.id,
+            rbac_action,
+            exc_info=True,
+        )
+        await _fail(
+            f"admin action '{rbac_action}' failed: {exc}",
+            error_class=type(exc).__name__,
+            response_summary=str(exc),
+        )
+        return
+
+    response_summary = _summarize("ok" if result is None else repr(result))
+
+    # Success — mark executed, back-write the structured outcome, close the chain.
+    await store.mark_executed(
+        action.id,
+        f"admin action '{rbac_action}' executed: {response_summary}",
+    )
+    await _persist_outcome(
+        store=store,
+        action_id=str(action.id),
+        status="executed",
+        response_summary=response_summary,
+        executed_at=datetime.now(UTC).isoformat(),
+    )
+    # The ONLY terminal on the happy path (every failure path above closed via
+    # ``_fail`` and returned), so exactly one ``decision.completed`` lands.
+    _emit_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=proposer_user_id,
+        causation_id=causation,
+        response_summary=response_summary,
+    )
+    logger.info(
+        "admin_action: executed action %s → '%s' (ok)",
+        action.id,
+        rbac_action,
+    )
+
+
+__all__ = ["execute_approved_admin_action"]

--- a/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
@@ -1,5 +1,35 @@
 # ee/cloud/admin_proposals/executor.py — apply an approved workspace-admin action.
 # Created: 2026-07-03 (feat/workspace-admin-tools, WA-2).
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-5) — extended the ``_DISPATCH``
+#   whitelist from the single ``workspace.member.role_change`` entry to the full set
+#   of ADMIN write actions the workspace_admin MCP server proposes:
+#     * ``workspace.member.remove`` → ``workspace.service.remove_member`` (cascades
+#       API keys / sessions / member data — the service's job; the adapter passes
+#       ONLY workspace_id + target user_id + the proposer as actor).
+#     * ``invite.create`` → ``workspace.service.create_invite`` (adapter builds a
+#       CreateInviteRequest from ONLY email + role, and a RequestContext from the
+#       proposer so the invite is attributed to them). NOTE: this ONE action key
+#       covers BOTH invite create AND revoke — the two tools carry different args
+#       shapes under the same RBAC action (the routes gate create on
+#       ``invite.create`` and revoke on ``invite.revoke``, but the executor
+#       whitelist keys on the RBAC action the PROPOSER was gated on; see below).
+#     * ``invite.revoke`` → ``workspace.service.revoke_invite`` (adapter passes
+#       ONLY workspace_id + invite_id + the proposer as actor).
+#     * ``connector.manage`` → connectors enable / disable / update-config. This
+#       ONE action key fans out to THREE services keyed on an ``op`` discriminator
+#       the adapter reads from the args (enable | disable | config) — a single
+#       whitelist entry can't map to three callables, so the ``connector.manage``
+#       dispatch's service is a router that switches on ``op`` and its adapter is
+#       op-aware + STRICT (config passes ``config`` as an OPAQUE dict the service
+#       validates; no top-level arg smuggles into the service call).
+#     * ``workspace.update`` → ``workspace.service.update`` (adapter passes ONLY
+#       the recognized name / settings / branding fields; any other key an agent
+#       puts in args is ignored, never forwarded).
+#   Every new adapter is STRICT (fixed known keys → fixed kwargs; unknown keys
+#   never reach the service — no ``**args`` splat), exactly like
+#   ``_adapt_member_role_change``. The execute-time RBAC re-check + args-hash +
+#   idempotency + fail-closed chokepoint are UNCHANGED and already apply to every
+#   whitelist entry (they key off the blob, not the specific action).
 #
 # What this module does (the apply-on-approve half of the admin-action gate): the
 # propose helper (``admin_proposals.propose.propose_admin_action``) files an
@@ -49,6 +79,10 @@
 #   * tenancy: the write is scoped by the blob's ``workspace_id``; an empty
 #     workspace_id is refused. The router's ``_assert_admin_action_workspace`` is
 #     the primary gate; this is belt-and-braces.
+#   * every WA-5 adapter is STRICT — it reads a FIXED set of known keys and never
+#     splats ``args`` into the service, so an agent cannot smuggle an extra kwarg
+#     (e.g. a ``role="owner"`` on an invite, or a ``seats`` bump on a workspace
+#     update) into a call the human didn't approve.
 
 from __future__ import annotations
 
@@ -121,13 +155,260 @@ async def _call_update_member_role(**kwargs: Any) -> Any:
     )
 
 
+# Valid roles for an invite (mirrors the CreateInviteRequest / route DTO, which
+# constrains role to ``admin | member`` — an invite can never mint an owner).
+_INVITE_ROLES = frozenset({"admin", "member"})
+
+
+def _proposer_ctx(workspace_id: str, proposer_user_id: str) -> Any:
+    """Build a minimal ``RequestContext`` for the ctx-taking workspace services
+    (``create_invite`` / ``update``), attributing the write to the PROPOSER.
+
+    Mirrors ``workspace_admin._legacy_ctx`` — the service reads ``ctx.user_id``
+    (audit attribution + invite ``invited_by``). Lazy import keeps this table
+    free of an ee.cloud dependency at module load."""
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=proposer_user_id,
+        workspace_id=workspace_id,
+        request_id="admin-action",
+        scope=ScopeKind.NONE,
+        started_at=_dt.now(_UTC),
+    )
+
+
+# --- member.remove ---------------------------------------------------------
+
+
+def _adapt_member_remove(
+    args: dict[str, Any], workspace_id: str, proposer_user_id: str
+) -> dict[str, Any]:
+    """STRICT adapter for ``workspace.service.remove_member``.
+
+    Reads ONLY ``target_user_id``. The service owns the cascade (API keys,
+    sessions, member data); we pass nothing that could steer it. The actor is
+    the PROPOSER (audit attribution)."""
+    target_user_id = str(args.get("target_user_id") or "")
+    if not target_user_id:
+        raise ValueError("member.remove requires target_user_id")
+    return {
+        "workspace_id": workspace_id,
+        "target_user_id": target_user_id,
+        "actor_user_id": proposer_user_id,
+    }
+
+
+async def _call_remove_member(**kwargs: Any) -> Any:
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    return await workspace_service.remove_member(
+        kwargs["workspace_id"],
+        kwargs["target_user_id"],
+        kwargs["actor_user_id"],
+    )
+
+
+# --- invite.create ---------------------------------------------------------
+
+
+def _adapt_invite_create(
+    args: dict[str, Any], workspace_id: str, proposer_user_id: str
+) -> dict[str, Any]:
+    """STRICT adapter for ``workspace.service.create_invite``.
+
+    Reads ONLY ``email`` + ``role``, constrains role to ``admin | member`` (an
+    invite can't mint an owner), and threads the proposer as the inviter. No
+    other key (e.g. ``group_id``, ``context``) is read — an agent can't attach a
+    surprise onboarding payload to an approved invite."""
+    email = str(args.get("email") or "")
+    role = str(args.get("role") or "member")
+    if not email:
+        raise ValueError("invite.create requires email")
+    if role not in _INVITE_ROLES:
+        raise ValueError(f"invite.create role must be one of {sorted(_INVITE_ROLES)}")
+    return {
+        "workspace_id": workspace_id,
+        "proposer_user_id": proposer_user_id,
+        "email": email,
+        "role": role,
+    }
+
+
+async def _call_create_invite(**kwargs: Any) -> Any:
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+    from pocketpaw_ee.cloud.workspace.dto import CreateInviteRequest
+
+    ctx = _proposer_ctx(kwargs["workspace_id"], kwargs["proposer_user_id"])
+    body = CreateInviteRequest(email=kwargs["email"], role=kwargs["role"])
+    return await workspace_service.create_invite(ctx, kwargs["workspace_id"], body)
+
+
+# --- invite.revoke ---------------------------------------------------------
+
+
+def _adapt_invite_revoke(
+    args: dict[str, Any], workspace_id: str, proposer_user_id: str
+) -> dict[str, Any]:
+    """STRICT adapter for ``workspace.service.revoke_invite``. Reads ONLY
+    ``invite_id``; the proposer is the actor (audit attribution)."""
+    invite_id = str(args.get("invite_id") or "")
+    if not invite_id:
+        raise ValueError("invite.revoke requires invite_id")
+    return {
+        "workspace_id": workspace_id,
+        "invite_id": invite_id,
+        "actor_user_id": proposer_user_id,
+    }
+
+
+async def _call_revoke_invite(**kwargs: Any) -> Any:
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    return await workspace_service.revoke_invite(
+        kwargs["workspace_id"],
+        kwargs["invite_id"],
+        kwargs["actor_user_id"],
+    )
+
+
+# --- connector.manage (enable / disable / config) --------------------------
+
+
+def _adapt_connector_manage(
+    args: dict[str, Any], workspace_id: str, proposer_user_id: str  # noqa: ARG001
+) -> dict[str, Any]:
+    """STRICT, OP-AWARE adapter for the connector-manage fan-out.
+
+    One RBAC action (``connector.manage``) covers three writes; the ``op``
+    discriminator selects which. Reads ONLY ``op`` + ``name`` (+ ``config`` for
+    the config op). For ``config``, ``config`` is passed through as an OPAQUE
+    dict — the connectors service validates it and only ever merges it into the
+    row's config blob (it never splats it into kwargs), so no top-level key
+    smuggles into the service call. Any other arg key is ignored."""
+    op = str(args.get("op") or "")
+    name = str(args.get("name") or "")
+    if op not in ("enable", "disable", "config"):
+        raise ValueError("connector.manage requires op in {enable, disable, config}")
+    if not name:
+        raise ValueError("connector.manage requires name")
+    out: dict[str, Any] = {"op": op, "workspace_id": workspace_id, "name": name}
+    if op == "config":
+        config = args.get("config")
+        if not isinstance(config, dict):
+            raise ValueError("connector.manage op=config requires a config object")
+        out["config"] = config  # opaque data — the service validates + merges it
+    return out
+
+
+async def _call_connector_manage(**kwargs: Any) -> Any:
+    """Fan out to the connectors enable / disable / update-config service by op.
+
+    ``config`` (op=config) is handed to the service inside its typed request DTO,
+    so the config dict is data the service validates — never kwargs on the call."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    op = kwargs["op"]
+    workspace_id = kwargs["workspace_id"]
+    name = kwargs["name"]
+    if op == "enable":
+        from pocketpaw_ee.cloud.connectors.dto import EnableConnectorRequest
+
+        return await connectors_service.enable_connector(
+            workspace_id, name, EnableConnectorRequest()
+        )
+    if op == "disable":
+        return await connectors_service.disable_connector(workspace_id, name)
+    # op == "config"
+    from pocketpaw_ee.cloud.connectors.dto import UpdateConnectorConfigRequest
+
+    return await connectors_service.update_config(
+        workspace_id, name, UpdateConnectorConfigRequest(config=kwargs["config"])
+    )
+
+
+# --- workspace.update ------------------------------------------------------
+
+
+def _adapt_workspace_update(
+    args: dict[str, Any], workspace_id: str, proposer_user_id: str
+) -> dict[str, Any]:
+    """STRICT adapter for ``workspace.service.update``.
+
+    Reads ONLY the recognized ``name`` / ``settings`` / ``branding`` fields — any
+    other key an agent puts in args (``seats``, ``plan``, ``owner``, …) is
+    IGNORED, never forwarded. At least one recognized field must be present.
+    ``settings`` / ``branding`` must be dicts (or absent). The typed
+    UpdateWorkspaceRequest is built in the wrapper so the service's own
+    validation (accent_color format, asset ownership) runs."""
+    recognized: dict[str, Any] = {}
+    if "name" in args:
+        name = args.get("name")
+        if name is not None and not isinstance(name, str):
+            raise ValueError("workspace.update name must be a string")
+        recognized["name"] = name
+    if "settings" in args:
+        settings = args.get("settings")
+        if settings is not None and not isinstance(settings, dict):
+            raise ValueError("workspace.update settings must be an object")
+        recognized["settings"] = settings
+    if "branding" in args:
+        branding = args.get("branding")
+        if branding is not None and not isinstance(branding, dict):
+            raise ValueError("workspace.update branding must be an object")
+        recognized["branding"] = branding
+    if not recognized:
+        raise ValueError("workspace.update requires at least one of name/settings/branding")
+    return {
+        "workspace_id": workspace_id,
+        "proposer_user_id": proposer_user_id,
+        "fields": recognized,
+    }
+
+
+async def _call_update_workspace(**kwargs: Any) -> Any:
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+    from pocketpaw_ee.cloud.workspace.dto import UpdateWorkspaceRequest
+
+    ctx = _proposer_ctx(kwargs["workspace_id"], kwargs["proposer_user_id"])
+    # Only the recognized fields reach the DTO — the adapter already stripped any
+    # unknown keys, so this is a fixed known set.
+    body = UpdateWorkspaceRequest(**kwargs["fields"])
+    return await workspace_service.update(ctx, kwargs["workspace_id"], body)
+
+
 # THE WHITELIST — the ONLY workspace-admin actions an approved ``_admin_action``
-# can ever fire. Seeded with member.role_change; extend deliberately, never
-# dynamically. An action key absent from this table hard-fails at execute time.
+# can ever fire. Seeded (WA-2) with member.role_change; extended (WA-5) with the
+# member.remove / invite.create / invite.revoke / connector.manage /
+# workspace.update ADMIN writes. Extend deliberately, never dynamically. An action
+# key absent from this table hard-fails at execute time.
 _DISPATCH: dict[str, _Dispatch] = {
     "workspace.member.role_change": _Dispatch(
         service=_call_update_member_role,
         adapt=_adapt_member_role_change,
+    ),
+    "workspace.member.remove": _Dispatch(
+        service=_call_remove_member,
+        adapt=_adapt_member_remove,
+    ),
+    "invite.create": _Dispatch(
+        service=_call_create_invite,
+        adapt=_adapt_invite_create,
+    ),
+    "invite.revoke": _Dispatch(
+        service=_call_revoke_invite,
+        adapt=_adapt_invite_revoke,
+    ),
+    "connector.manage": _Dispatch(
+        service=_call_connector_manage,
+        adapt=_adapt_connector_manage,
+    ),
+    "workspace.update": _Dispatch(
+        service=_call_update_workspace,
+        adapt=_adapt_workspace_update,
     ),
 }
 

--- a/ee/pocketpaw_ee/cloud/admin_proposals/propose.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/propose.py
@@ -245,8 +245,11 @@ async def propose_admin_action(
     call_args = dict(args or {})
     args_hash = compute_args_hash(action, call_args)
     # Deterministic idempotency key when the caller doesn't supply one — keyed on
-    # workspace + action + args hash so an identical re-propose dedupes at the
-    # executor (the executor never double-fires a key it already ran).
+    # workspace + action + args hash. NOTE: dedup is per-Action, not cross-Action:
+    # the executor's guard stops a SINGLE approved Action from firing twice (via
+    # its recorded outcome/status), but two distinct proposals with the same key
+    # each execute independently. The key is stored for future cross-Action dedup
+    # and for tracing; it does not itself prevent a re-propose from running.
     idem = idempotency_key or f"{workspace_id}:{action}:{args_hash[:16]}"
 
     corr = correlation_id or str(uuid4())

--- a/ee/pocketpaw_ee/cloud/admin_proposals/propose.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/propose.py
@@ -1,0 +1,334 @@
+# ee/cloud/admin_proposals/propose.py — propose a gated workspace-admin action.
+# Created: 2026-07-03 (feat/workspace-admin-tools, WA-2).
+#
+# What this module does (the propose half of the admin-action gate): a
+# workspace-admin tool (e.g. ``member_update_role`` in the workspace_admin MCP
+# server) proposes a WRITE to a workspace-admin service — "run RBAC action
+# ``workspace.member.role_change`` with args ``{...}``". This files an Instinct
+# ``Action`` carrying an ``_admin_action`` blob (schema 1) under
+# ``Action.parameters``. A human approves it in The Tray; the apply-on-approve
+# executor (``admin_proposals.executor.execute_approved_admin_action``) then
+# fires the whitelisted service call — AFTER re-checking the proposer's CURRENT
+# RBAC role. This module does NOT mutate — it only gates.
+#
+# The blob is the 8th gated proposal kind, sitting alongside the external-action
+# ``_external_action`` and the pocket-write ``_pocket_write``. The router +
+# executor dispatch on the presence of the ``_admin_action`` parameters key. The
+# blob shape (minimal + typed):
+#   * ``schema`` / ``kind`` — version + discriminator;
+#   * ``workspace_id`` — the originating tenant (the executor's tenancy gate +
+#     RBAC re-check are scoped to it; the router's tenancy gate reads it HERE);
+#   * ``action`` — the RBAC action KEY the executor whitelists + re-checks (e.g.
+#     ``"workspace.member.role_change"``). An unknown/absent key → hard fail;
+#   * ``args`` — the service-call args (DATA — passed to the whitelisted service
+#     adapter; never interpolated into a shell);
+#   * ``proposer_user_id`` — the user who proposed the write. The executor loads
+#     THIS user fresh at approve time and RE-CHECKS their CURRENT workspace role
+#     (a demoted proposer's approved action fails closed);
+#   * ``params_hash`` — a stable hash of ``action`` + ``args`` so the executor
+#     refuses if the args were tampered with between propose and approve (the
+#     human approved a SPECIFIC write);
+#   * ``idempotency_key`` — so the executor never double-fires on re-invocation
+#     (bulk re-approve, retry);
+#   * ``correlation_id`` / ``proposed_event_id`` — the Decision-Graph chain ids.
+#   * ``summary`` — a human-readable one-liner for the gate UI (The Tray).
+#
+# Security:
+#   * NO privilege is granted by proposing — the executor RE-RESOLVES the
+#     proposer's CURRENT role and re-checks the RBAC action before firing.
+#   * The args hash is re-checked at execution — an args edit between propose and
+#     approve refuses the write.
+#   * Tenancy is bound on the router's approve / reject paths via
+#     ``_assert_admin_action_workspace`` and re-validated at execution.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# The Instinct Action kind discriminator for an admin-action proposal. The
+# blob also carries ``kind="admin_action"`` for readers that introspect it.
+ADMIN_ACTION_KIND = "admin_action"
+
+# The parameters key under which the admin-action blob rides — peer of the
+# external-action bridge's ``_external_action``. The router + executor dispatch
+# on this key being present.
+ADMIN_ACTION_PARAM_KEY = "_admin_action"
+
+# Schema version stamped on the ``_admin_action`` blob. Bump when the blob shape
+# changes so a stale pending Action approved after a deploy fails loud instead of
+# firing a misinterpreted admin write (same discipline as the external-action
+# ``EXTERNAL_ACTION_SCHEMA``). Starts at 1 — this is the first version.
+ADMIN_ACTION_SCHEMA = 1
+
+
+def compute_args_hash(action: str, args: dict[str, Any]) -> str:
+    """Return a stable SHA-256 hex digest of the RBAC ``action`` + ``args``.
+
+    Canonical JSON (sorted keys, no whitespace) so the same logical write hashes
+    identically regardless of dict ordering. The executor recomputes this off the
+    persisted blob and refuses the write if it no longer matches — a human
+    approved a SPECIFIC write, and an args edit between propose and approve must
+    not silently fire a different one.
+    """
+    canonical = json.dumps(
+        {"action": action, "args": args or {}},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    rbac_action: str,
+    workspace_id: str,
+    user_id: str,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for an admin action.
+
+    Mirrors external_actions.propose's ``_emit_agent_proposed``: the proposing
+    caller is the actor (``kind="agent"`` with the requesting user on its id, the
+    workspace on its scope_context). An admin action isn't bound to a pocket — its
+    tenancy is the workspace — so ``pocket_id`` on the chain carries the workspace
+    id.
+
+    Returns the emitted event id so the caller can persist it on the blob's
+    ``proposed_event_id`` field for the ``human.corrected`` causation chain, or
+    ``None`` when the emit raised — best-effort; the reconciler picks up orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = f"workspace-admin action '{rbac_action}'"
+    payload: dict[str, Any] = {
+        "intent": intent,
+        "action": "admin_action",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        "proposal_kind": "admin_action",
+        "proposal": {"rbac_action": rbac_action},
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "admin_action agent.proposed emit failed for correlation_id=%s "
+            "(action_id=%s) — reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted
+    Action's ``parameters._admin_action`` blob after ``agent.proposed`` fired.
+
+    Direct SQL update — the same pattern external_actions.propose's
+    ``_persist_chain_ids`` uses. Best-effort: a write failure leaves
+    ``proposed_event_id`` None and the eventual ``human.corrected`` emits without
+    a causation_id (the chain still folds; causation_id is optional).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(ADMIN_ACTION_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[ADMIN_ACTION_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "admin_action: failed to persist chain ids onto action %s — the "
+            "chain's human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+async def propose_admin_action(
+    *,
+    workspace_id: str,
+    action: str,
+    args: dict[str, Any] | None = None,
+    proposer_user_id: str,
+    idempotency_key: str | None = None,
+    summary: str | None = None,
+    title: str | None = None,
+    correlation_id: str | None = None,
+    assignee: str | None = None,
+) -> str:
+    """Build + store an Instinct ``Action`` for a gated workspace-admin write.
+
+    Files an Action carrying the ``_admin_action`` blob (schema 1) and opens the
+    Decision-Graph chain (``agent.proposed``). Returns the proposed Action id.
+    Proposing grants NO privilege — the executor re-resolves the proposer's
+    CURRENT role and re-checks the RBAC action before firing on approval.
+
+    Args:
+        workspace_id: the originating tenant. Bound on the router's approve /
+            reject paths and re-validated at execution. Required.
+        action: the RBAC action KEY the executor whitelists + re-checks (e.g.
+            ``"workspace.member.role_change"``).
+        args: the service-call args (e.g. ``{"target_user_id": "...",
+            "role": "admin"}``). Hashed into ``params_hash`` so the executor can
+            refuse a post-propose args edit.
+        proposer_user_id: the user id that proposed the write. The executor loads
+            THIS user fresh at approve time and re-checks their CURRENT role.
+        idempotency_key: caller-supplied key so the executor never double-fires.
+            Defaults to a deterministic value derived from the args hash.
+        summary / title: human-readable strings for the gate UI (defaults built
+            from the action when omitted).
+        correlation_id: an optional pre-minted chain id (a fresh one is minted
+            when omitted — the common case).
+        assignee: the workspace member who should approve. Defaults to
+            ``proposer_user_id``.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("propose_admin_action requires a non-empty workspace_id")
+    action = str(action or "")
+    if not action:
+        raise ValueError("propose_admin_action requires a non-empty action")
+    proposer_user_id = str(proposer_user_id or "")
+    if not proposer_user_id:
+        raise ValueError("propose_admin_action requires a non-empty proposer_user_id")
+
+    call_args = dict(args or {})
+    args_hash = compute_args_hash(action, call_args)
+    # Deterministic idempotency key when the caller doesn't supply one — keyed on
+    # workspace + action + args hash so an identical re-propose dedupes at the
+    # executor (the executor never double-fires a key it already ran).
+    idem = idempotency_key or f"{workspace_id}:{action}:{args_hash[:16]}"
+
+    corr = correlation_id or str(uuid4())
+    human_summary = summary or f"Run admin action '{action}' (scope: workspace)."
+    human_title = title or f"Workspace admin — {action}"
+
+    blob: dict[str, Any] = {
+        "kind": ADMIN_ACTION_KIND,
+        "schema": ADMIN_ACTION_SCHEMA,
+        "workspace_id": workspace_id,
+        "action": action,
+        "args": call_args,
+        "proposer_user_id": proposer_user_id,
+        "params_hash": args_hash,
+        "idempotency_key": idem,
+        "summary": human_summary,
+        # Decision-Graph chain-correlation fields (schema 1 carries them).
+        "correlation_id": corr,
+        "proposed_event_id": None,
+    }
+
+    recommendation = f"Approve to run admin action '{action}'. {human_summary}"
+    trigger = ActionTrigger(
+        type="agent",
+        source=proposer_user_id or "admin_action",
+        reason=f"workspace-admin action '{action}' requires human approval",
+    )
+
+    # Scope the store to the caller's workspace (validated non-empty above) so the
+    # proposal lands in the tenant's file — this propose path has no
+    # ``current_workspace`` ContextVar set.
+    store = get_instinct_store(workspace_id=workspace_id or None)
+    action_obj = await store.propose(
+        # ``pocket_id`` carries the workspace for admin actions — they aren't
+        # bound to a pocket (mirrors external_actions). The workspace also rides
+        # on the blob (the executor's tenancy gate + RBAC re-check read it there).
+        pocket_id=workspace_id,
+        title=human_title,
+        description=recommendation,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.WORKFLOW,
+        priority=ActionPriority.HIGH,
+        parameters={ADMIN_ACTION_PARAM_KEY: blob},
+        assignee=assignee or proposer_user_id or None,
+        workspace_id=workspace_id,
+    )
+
+    logger.info(
+        "admin_action: proposed action '%s' → Instinct action %s "
+        "(workspace=%s, proposer=%s, correlation_id=%s)",
+        action,
+        action_obj.id,
+        workspace_id,
+        proposer_user_id,
+        corr,
+    )
+
+    # Open the Decision-Graph chain now that the Action is stored. Best-effort: a
+    # wiring failure must NOT fail the propose response.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=UUID(corr),
+        action_id=action_obj.id,
+        rbac_action=action,
+        workspace_id=workspace_id,
+        user_id=proposer_user_id,
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action_obj.id,
+            correlation_id=corr,
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    return action_obj.id
+
+
+__all__ = [
+    "ADMIN_ACTION_KIND",
+    "ADMIN_ACTION_PARAM_KEY",
+    "ADMIN_ACTION_SCHEMA",
+    "compute_args_hash",
+    "propose_admin_action",
+]

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -905,6 +905,43 @@ class CloudExternalActionsMcpProvider:
         return list(EXTERNAL_ACTIONS_TOOL_IDS)
 
 
+class CloudWorkspaceAdminMcpProvider:
+    """`pocketpaw.mcp_servers` — the workspace-administration in-process server
+    (``pocketpaw_workspace_admin``, feat/workspace-admin-tools WA-1).
+
+    Lets the cloud chat agent perform workspace administration, gated by the
+    EXISTING RBAC system (``guards/``). Hosts two tools in WA-1: ``members_list``
+    (READ, gated at ``workspace.view`` — any member) and ``member_update_role``
+    (WRITE, gated at ``workspace.member.role_change`` — ADMIN). The write is
+    NEVER applied inline — an admin mutation is human-gated through Instinct. WA-1
+    ships the read fully; the write authorizes (fail-closed ADMIN gate) and
+    returns a pending envelope without mutating, because the Instinct
+    approve→execute spine for admin actions isn't wired yet (see the module
+    header on ``agent.mcp_servers.workspace_admin``).
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) — the same regime the sibling
+    connectors / belt / external_actions servers use; the RBAC gate is the
+    security boundary, not registration. ``build_admin_server`` returns None —
+    and the registration loop skips it — when the claude_agent_sdk isn't
+    installed, so chat never breaks.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from pocketpaw_ee.agent.mcp_servers.workspace_admin import build_admin_server
+
+            return build_admin_server()
+        except ImportError:
+            # claude_agent_sdk not installed — the server is unavailable, same as
+            # the other in-process servers.
+            return None
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.workspace_admin import ADMIN_TOOL_IDS
+
+        return list(ADMIN_TOOL_IDS)
+
+
 class CloudFabricMcpProvider:
     """`pocketpaw.mcp_servers` — read-only Fabric ontology access in-process
     server (``pocketpaw_fabric``). Hosts ``fabric_query`` + ``fabric_stats``.

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,23 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-2 — _admin_action proposal
+#   type) — added the 8th gated proposal kind: a gated workspace-admin write.
+#   ``_admin_action_blob`` + ``_assert_admin_action_workspace`` are the peers of
+#   the existing blob accessors + tenancy guards. The blob
+#   (``Action.parameters._admin_action``) carries {action=RBAC key, args,
+#   proposer_user_id, params_hash, idempotency_key, workspace_id}. On APPROVE the
+#   router emits ``human.corrected`` then fires
+#   ``admin_proposals.executor.execute_approved_admin_action`` — which whitelists
+#   the RBAC action, RE-CHECKS the PROPOSER's CURRENT workspace role (a demoted /
+#   removed proposer fails closed — the write never fires), then calls the seeded
+#   workspace-admin service (member.role_change → workspace.service.
+#   update_member_role) and OWNS the chain close. On REJECT the router emits
+#   ``human.corrected`` + ``decision.completed(rejected)`` itself (the executor
+#   never runs on reject — no admin write happens). The
+#   ``_assert_admin_action_workspace`` 403 runs in ALL FOUR locations (approve /
+#   bulk-approve / reject / bulk-reject) BEFORE any mutation — asymmetric tenant
+#   scope is no tenant scope (pocketpaw#1183 / #1250). Same exactly-one-terminal
+#   discipline as the external-action gate; the other 7 kinds are unchanged.
 # Updated: 2026-06-26 (ISO-2 — physical per-workspace isolation) — the store is
 #   no longer one shared ``~/.pocketpaw/instinct.db``. ``_store`` now takes the
 #   caller's ``workspace_id`` and routes through
@@ -760,6 +778,60 @@ def _assert_external_action_workspace(action: Any, current_workspace: str) -> No
         )
 
 
+def _admin_action_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_admin_action`` blob on an Action, or ``None``.
+
+    The blob is the gated workspace-admin-action payload
+    ``ee.cloud.admin_proposals.propose`` stores under
+    ``Action.parameters._admin_action`` (action=RBAC key / args / proposer_user_id
+    / params_hash / idempotency_key + the originating ``workspace_id``). This is
+    the 8th gated proposal kind (WA-2) — the approve path dispatches the
+    apply-on-approve executor on its presence, exactly as it dispatches the
+    external-action executor on ``_external_action``. On APPROVE the executor
+    RE-CHECKS the proposer's CURRENT RBAC role before firing the whitelisted
+    admin write; on REJECT the router closes the chain and nothing runs. Anything
+    that is not a dict is treated as "no admin action".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_admin_action")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_admin_action_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting an admin action from another workspace.
+
+    Mirror of ``_assert_external_action_workspace`` for the ``_admin_action``
+    blob. ``require_action_any_workspace("instinct.approve")`` only proves the
+    caller holds the role SOMEWHERE; this binds the admin-action Action to the
+    caller's active workspace. An admin action carries no pocket the way a parked
+    write does, so its tenancy lives entirely on the blob's ``workspace_id``. A
+    blob whose ``workspace_id`` differs from the caller's active workspace → 403,
+    on BOTH the approve and reject side (asymmetric tenant scope is no tenant
+    scope — pocketpaw#1183 / #1250). A non-admin-action Action (no blob) is
+    unaffected.
+
+    FAIL-CLOSED on an empty claim — an admin action's tenancy is mandatory; the
+    executor scopes the RBAC re-check + service call by this workspace, so an
+    empty one is a HARD 403, never a pass-through.
+    """
+    blob = _admin_action_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if not blob_workspace:
+        raise Forbidden(
+            "instinct.missing_workspace_in_blob",
+            "This admin action has no workspace claim — cannot verify tenancy",
+        )
+    if blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This admin action belongs to a different workspace",
+        )
+
+
 def _fabric_objects_blob(action: Any) -> dict[str, Any] | None:
     """Return the ``_fabric_objects`` blob on an Action, or ``None``.
 
@@ -1283,6 +1355,7 @@ async def bulk_approve_actions(
             _assert_instinct_rule_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
+            _assert_admin_action_workspace(action, workspace_id)
 
     approved, missing, bulk_id = await store.bulk_approve(
         list(req.ids), approver=approver_id, note=req.note
@@ -1523,6 +1596,39 @@ async def bulk_approve_actions(
                 )
             continue
 
+        # WA-2 — a bulk-approved gated ``_admin_action`` Action fires the
+        # whitelisted workspace-admin write (with an execute-time RBAC re-check
+        # inside the executor). Mirrors the external-action branch above: per-item
+        # ``human.corrected(accepted)`` (bulk-approve has no edit surface), the
+        # ``agent.proposed`` event id (off the blob's ``proposed_event_id``) as
+        # causation, then the executor (which owns the chain close). Matched BEFORE
+        # the pocket-write fallthrough and ``continue``d so the kinds never cross.
+        admin_action_blob = _admin_action_blob(action)
+        if admin_action_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=admin_action_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(admin_action_blob),
+            )
+            try:
+                from pocketpaw_ee.cloud.admin_proposals import (
+                    executor as admin_action_executor,
+                )
+
+                await admin_action_executor.execute_approved_admin_action(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve admin-action execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
         action_blob = _pocket_write_blob(action)
         if action_blob is None:
             continue
@@ -1604,6 +1710,7 @@ async def bulk_reject_actions(
             _assert_instinct_rule_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
+            _assert_admin_action_workspace(action, workspace_id)
 
     rejected, missing, bulk_id = await store.bulk_reject(
         list(req.ids), reason=req.reason, rejector=rejector_id
@@ -1824,6 +1931,31 @@ async def bulk_reject_actions(
                     "bulk-reject artifact-change discard failed for %s (non-fatal)",
                     action.id,
                 )
+            continue
+
+        # WA-2 — a bulk-rejected gated ``_admin_action`` Action closes its chain
+        # HERE (the executor never runs on reject — the router owns the close). NO
+        # admin write happens. Mirrors the external-action reject branch above.
+        admin_action_blob = _admin_action_blob(action)
+        if admin_action_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=admin_action_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(admin_action_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=admin_action_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            continue
 
     return BulkActionResponse(bulk_id=bulk_id, affected=rejected, missing=missing)
 
@@ -1889,6 +2021,11 @@ async def approve_action(
     # ``_artifact_change`` blob carries the workspace). Approving it moves the
     # published pointer + deploys, so the cross-workspace gate is mandatory here.
     _assert_artifact_change_workspace(before, workspace_id)
+    # WA-2 — same tenancy gate for a gated workspace-admin Action — its
+    # ``_admin_action`` blob carries the workspace, not a pocket. Approving it
+    # fires a workspace-admin write (e.g. a member role change) after an
+    # execute-time RBAC re-check, so the cross-workspace gate is mandatory here.
+    _assert_admin_action_workspace(before, workspace_id)
 
     req = req or ApproveRequest()
     # SHOULD-FIX 1 — the audit actor is the authenticated identity, not
@@ -2223,6 +2360,41 @@ async def approve_action(
         except Exception:
             logger.exception("artifact-change merge after approval failed (non-fatal)")
 
+    # WA-2 — when the approved Action carries a gated ``_admin_action`` blob, fire
+    # the whitelisted workspace-admin write (e.g. a member role change) via
+    # ``admin_proposals.executor``. Same best-effort, lazy-import,
+    # never-break-the-approve-response shape as the external-action hook above; the
+    # executor RE-CHECKS the proposer's CURRENT RBAC role before firing and records
+    # success / failure on the Action itself. A non-admin-action Action skips this.
+    #
+    # The admin action is part of its own Decision-Graph chain (the propose helper
+    # minted the ``correlation_id`` + emitted ``agent.proposed``). The router owns
+    # the ``human.corrected`` emit HERE (citing ``agent.proposed`` off the blob's
+    # ``proposed_event_id`` as causation, same field the external-action path
+    # reads); the EXECUTOR owns the chain CLOSE (success or failure). The router
+    # does NOT emit ``decision.completed`` here — no double terminal.
+    admin_action_blob = _admin_action_blob(approved)
+    if admin_action_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=admin_action_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(admin_action_blob),
+        )
+        try:
+            from pocketpaw_ee.cloud.admin_proposals import executor as admin_action_executor
+
+            await admin_action_executor.execute_approved_admin_action(
+                approved, human_event_id=human_event_id
+            )
+        except Exception:
+            logger.exception("admin-action execution after approval failed (non-fatal)")
+
     # gap2 — when the approved Action carries a ``_customer_reply`` blob (a
     # paw-print customer event awaiting a decision), deliver the owner's reply
     # back to the customer surface. Same best-effort, lazy-import,
@@ -2325,6 +2497,10 @@ async def reject_action(
     # would discard another tenant's candidate) must 403 before any mutation,
     # exactly like the approve side (pocketpaw#1183 / #1250).
     _assert_artifact_change_workspace(before, workspace_id)
+    # WA-2 — same tenancy gate for a gated workspace-admin Action on the REJECT
+    # side. Asymmetric tenant scope is no tenant scope: a cross-workspace reject
+    # must 403 before any mutation, exactly like the approve side.
+    _assert_admin_action_workspace(before, workspace_id)
 
     reason = req.reason if req else ""
     rejector_id = str(user.id)
@@ -2551,6 +2727,33 @@ async def reject_action(
             await artifact_executor.discard_rejected_change(action)
         except Exception:
             logger.exception("artifact-change discard after rejection failed (non-fatal)")
+
+    # WA-2 — a rejected gated ``_admin_action`` Action closes its chain HERE (the
+    # executor never runs on reject — the router owns the close, mirroring the
+    # external-action reject path). NO admin write happens.
+    # ``human.corrected(rejected)`` cites the ``agent.proposed`` event (off the
+    # blob's ``proposed_event_id``); ``decision.completed(rejected)`` cites the
+    # human event so the chain reads ``agent.proposed → human.corrected →
+    # decision.completed``.
+    admin_action_blob = _admin_action_blob(action)
+    if admin_action_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=admin_action_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(admin_action_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=admin_action_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
+        )
 
     # gap2 — a rejected ``_customer_reply`` Action delivers a DECLINED decision
     # (carrying the rejection reason) back to the customer surface. Same

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -242,6 +242,7 @@ belt = "pocketpaw_ee.extensions:CloudBeltMcpProvider"
 external_actions = "pocketpaw_ee.extensions:CloudExternalActionsMcpProvider"
 fabric = "pocketpaw_ee.extensions:CloudFabricMcpProvider"
 instinct = "pocketpaw_ee.extensions:CloudInstinctMcpProvider"
+workspace_admin = "pocketpaw_ee.extensions:CloudWorkspaceAdminMcpProvider"
 
 [project.entry-points."pocketpaw.agent_extensions"]
 cloud = "pocketpaw_ee.extensions:CloudAgentExtension"

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -975,18 +975,32 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # there is no ambient OSS fabric registry to wire today).
         try:
             from pocketpaw.agents.sdk_mcp_atlas import build_atlas_context_server
-            from pocketpaw.atlas.overlay import DefaultEntitlementProvider
+            from pocketpaw.atlas.overlay import (
+                DefaultEntitlementProvider,
+                build_role_aware_provider,
+            )
 
             tenant_scope = self._tenant_scope_key()
             fabric_introspector = None
+            atlas_provider: Any = DefaultEntitlementProvider(scope_key=tenant_scope)
             if tenant_scope.startswith("ws:") and tenant_scope != _SENTINEL_TENANT_SCOPE:
                 from pocketpaw.atlas.fabric import build_workspace_fabric_introspector
 
                 fabric_introspector = build_workspace_fabric_introspector(
                     tenant_scope[len("ws:") :]
                 )
+                # WA-3: a real ws:<id> run gets the role-aware provider so
+                # non-admins don't see admin capabilities in atlas. It resolves
+                # the caller's role at query time and grants ``role:*`` entries
+                # by role tier; a None return (OSS install / EE provider not
+                # importable / construction failure) leaves the fail-closed
+                # default in place — which HIDES every role-gated entry, so admin
+                # capabilities never leak without the role-aware provider.
+                role_aware = build_role_aware_provider(tenant_scope)
+                if role_aware is not None:
+                    atlas_provider = role_aware
             atlas_server = build_atlas_context_server(
-                provider=DefaultEntitlementProvider(scope_key=tenant_scope),
+                provider=atlas_provider,
                 introspector=fabric_introspector,
             )
             if atlas_server is not None:

--- a/src/pocketpaw/agents/sdk_mcp_atlas.py
+++ b/src/pocketpaw/agents/sdk_mcp_atlas.py
@@ -33,6 +33,22 @@
 # (properties + links). Absent (OSS default) or erroring introspector →
 # fabric ids are unknown ids and no fabric cards appear (fail-closed);
 # workspace ontology is per-tenant and NEVER enters the compiled artifact.
+#
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-3) — before overlay
+# filtering, each handler AWAITS an optional async ``prime()`` on the provider
+# (``_prime_provider``). The EE role-aware provider (WA-3) resolves the caller's
+# workspace role via an async Beanie ``User`` load; its ``is_granted`` is sync
+# (the ``EntitlementProvider`` protocol shape) and reads a role resolved+cached
+# by ``prime()``. Priming here does the async DB work in the handler's own
+# event loop (never a nested ``asyncio.run`` inside sync ``is_granted``). A
+# provider WITHOUT ``prime`` (the default, fakes in tests) is untouched; a
+# priming FAILURE is swallowed (DEBUG-logged) so the provider falls back to its
+# own fail-closed "role unresolved → hide role-gated entries" behavior.
+# ALSO WA-3: the ``provider is None`` path (pre-AT-5 global view) now HIDES
+# role-gated (``role:*``) entries too — search skips them, describe answers a
+# role-gated id like an unknown id, and the known-ids error listing excludes
+# them. Belt-and-braces: admin capabilities can never leak from ANY atlas server
+# wiring, provider or not (matches DefaultEntitlementProvider's role hiding).
 
 from __future__ import annotations
 
@@ -71,6 +87,25 @@ def _text_result(text: str, *, is_error: bool = False) -> dict:
     return out
 
 
+async def _prime_provider(provider: EntitlementProvider | None) -> None:
+    """Await an optional async ``prime()`` on the provider before filtering.
+
+    The EE role-aware provider (WA-3) resolves the caller's workspace role
+    lazily via an async ``User`` load; ``prime`` does that DB work in THIS
+    handler's event loop so the sync ``is_granted`` protocol method can read a
+    cached role. Providers without a ``prime`` (the default, test fakes) are a
+    no-op. A priming error is swallowed (DEBUG log) — the provider then falls
+    back to its own fail-closed default (role unresolved → hide role-gated
+    entries), so a DB blip HIDES admin entries rather than leaking them."""
+    prime = getattr(provider, "prime", None)
+    if prime is None:
+        return
+    try:
+        await prime()
+    except Exception as exc:  # noqa: BLE001 — fail-closed: unresolved role hides gated entries
+        logger.debug("atlas provider prime failed (role stays unresolved): %s", exc)
+
+
 async def _atlas_search_handler(
     args: dict,
     provider: EntitlementProvider | None = None,
@@ -101,10 +136,23 @@ async def _atlas_search_handler(
 
     store = get_atlas_store()
     if provider is None:
-        overlaid = [(entry, None) for entry in store.search(intent, limit=5)]
+        # No provider = the pre-AT-5 global view, BUT role-gated entries (WA-3
+        # admin capabilities) must STILL be hidden: without a provider there is
+        # no role context, so surfacing them would leak admin capabilities.
+        # Fail-closed here matches DefaultEntitlementProvider (which also hides
+        # ``role:*`` entries) so no atlas server wiring can ever expose them.
+        from pocketpaw.atlas.overlay import entry_role_requirement
+
+        overlaid = [
+            (entry, None)
+            for entry in store.search(intent, limit=5)
+            if entry_role_requirement(entry) is None
+        ]
     else:
         from pocketpaw.atlas.overlay import AtlasOverlay
 
+        # WA-3: resolve the caller's role (async) before the sync grant filter.
+        await _prime_provider(provider)
         overlaid = [
             (o.entry, o.available) for o in AtlasOverlay.search(store, intent, provider, limit=5)
         ]
@@ -177,9 +225,18 @@ async def _atlas_describe_handler(
 
     store = get_atlas_store()
     if provider is None:
+        # No provider = the pre-AT-5 global view, BUT role-gated entries (WA-3
+        # admin capabilities) must STILL be hidden — describing one, or listing
+        # it in the known-ids error, would leak an admin capability with no role
+        # context to grant it. A role-gated id answers exactly like an unknown
+        # id (no leakage), and the known-ids listing excludes them.
+        from pocketpaw.atlas.overlay import entry_role_requirement
+
         entry = store.describe(entry_id.strip())
-        if entry is None:
-            known = ", ".join(sorted(e.id for e in store.entries))
+        if entry is None or entry_role_requirement(entry) is not None:
+            known = ", ".join(
+                sorted(e.id for e in store.entries if entry_role_requirement(e) is None)
+            )
             return _text_result(
                 f"Error: unknown atlas id {entry_id!r}. Known ids: {known}",
                 is_error=True,
@@ -188,6 +245,8 @@ async def _atlas_describe_handler(
 
     from pocketpaw.atlas.overlay import AtlasOverlay
 
+    # WA-3: resolve the caller's role (async) before the sync grant filter.
+    await _prime_provider(provider)
     overlaid = AtlasOverlay.describe(store, entry_id.strip(), provider)
     if overlaid is None:
         # Unknown AND filtered ids land here — same envelope, no leakage.

--- a/src/pocketpaw/atlas/authored/capabilities.json
+++ b/src/pocketpaw/atlas/authored/capabilities.json
@@ -1,0 +1,329 @@
+{
+  "schema": "paw.atlas/v1",
+  "entries": [
+    {
+      "id": "capability:admin.members_list",
+      "kind": "capability",
+      "name": "List workspace members",
+      "summary": "Read the workspace member roster (email, name, role, joined-at). Any member may read it.",
+      "narrative": "Reads the current workspace's member roster — email, name, workspace role, and joined-at — for every member. A MEMBER-level read: any member may see who is in the workspace. No mutation, so it runs directly (reads are not human-gated). Reach for it when the user asks who is in the workspace or what someone's role is.",
+      "how": "member_update_role's read sibling — mcp__pocketpaw_workspace_admin__members_list (no args; the workspace is the active chat stream's)",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:member"
+      ],
+      "keywords": [
+        "members",
+        "roster",
+        "who is in the workspace",
+        "team",
+        "people",
+        "member list"
+      ]
+    },
+    {
+      "id": "capability:admin.workspace_settings_read",
+      "kind": "capability",
+      "name": "Read workspace settings",
+      "summary": "Read the workspace name, slug, plan, seat usage, and branding. A member-level read.",
+      "narrative": "Reads a compact view of the workspace's own settings — name, slug, plan tier, seat usage (used / available), and display branding — with no internal ids or secrets. A MEMBER-level read that runs directly. Reach for it when the user asks about the current plan, seat count, or workspace name; changing any of these is a separate, human-gated admin action.",
+      "how": "mcp__pocketpaw_workspace_admin__workspace_settings_read (no args)",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:member"
+      ],
+      "keywords": [
+        "workspace settings",
+        "plan",
+        "seats",
+        "workspace name",
+        "branding",
+        "current plan"
+      ]
+    },
+    {
+      "id": "capability:admin.connectors_list",
+      "kind": "capability",
+      "name": "List workspace connectors",
+      "summary": "Read the workspace's connectors and their enabled / connected status. A member-level read.",
+      "narrative": "Reads the connectors available in the workspace with their enabled and live connected status, filtered to what the calling member is permitted to see. A MEMBER-level read that runs directly. Reach for it when the user asks which integrations are set up or connected; enabling, disabling, or configuring a connector is a separate, human-gated admin action.",
+      "how": "mcp__pocketpaw_workspace_admin__connectors_list (no args)",
+      "surface": "/settings/workspace/integrations",
+      "requires": [
+        "role:member"
+      ],
+      "keywords": [
+        "connectors",
+        "integrations",
+        "connected",
+        "enabled",
+        "list integrations",
+        "which connectors"
+      ]
+    },
+    {
+      "id": "capability:admin.billing_usage_read",
+      "kind": "capability",
+      "name": "Read workspace usage",
+      "summary": "Read the workspace's daily usage and spend over an optional date window. A member-level read.",
+      "narrative": "Reads the workspace's usage and credit spend by day and by model over an optional start/end window (default: the trailing 30 days). A MEMBER-level read — any member may read their own workspace's usage — that runs directly. Reach for it when the user asks how much the workspace has spent or used; changing the paid plan is a separate, owner-level human-gated action.",
+      "how": "mcp__pocketpaw_workspace_admin__billing_usage_read (optional start / end YYYY-MM-DD)",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:member"
+      ],
+      "keywords": [
+        "usage",
+        "spend",
+        "credits",
+        "billing usage",
+        "how much have we used",
+        "cost"
+      ]
+    },
+    {
+      "id": "capability:admin.invites_list",
+      "kind": "capability",
+      "name": "List pending invites",
+      "summary": "Read the workspace's pending invites (email, role, expiry). Admin-only read.",
+      "narrative": "Reads the workspace's pending invitations — invited email, offered role, who invited them, and expiry. An ADMIN-level read (the same gate the invites management route uses), so a member never sees it. It runs directly once the admin gate passes. Reach for it when an admin asks who has been invited but has not yet joined.",
+      "how": "mcp__pocketpaw_workspace_admin__invites_list (no args)",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:admin"
+      ],
+      "keywords": [
+        "invites",
+        "pending invites",
+        "invited",
+        "outstanding invitations",
+        "who was invited"
+      ]
+    },
+    {
+      "id": "capability:admin.audit_read",
+      "kind": "capability",
+      "name": "Read the audit log",
+      "summary": "Read recent workspace audit-log rows (who did what, when). Admin-only read.",
+      "narrative": "Reads recent rows from the workspace audit log — the compliance-grade record of actor, action, target, and time. An ADMIN-level read (the same gate the audit route uses), so a member never sees it. It runs directly once the admin gate passes. Reach for it when an admin asks for the authoritative trail of who or what did something in the workspace.",
+      "how": "mcp__pocketpaw_workspace_admin__audit_read (optional limit 1-100)",
+      "surface": "/audit",
+      "requires": [
+        "role:admin"
+      ],
+      "keywords": [
+        "audit log",
+        "who did what",
+        "compliance trail",
+        "history",
+        "audit events",
+        "record"
+      ]
+    },
+    {
+      "id": "capability:admin.member_update_role",
+      "kind": "capability",
+      "name": "Change a member's role",
+      "summary": "Change a member's workspace role (member / admin / owner). Admin-only; every change needs human approval.",
+      "narrative": "Proposes changing a member's workspace role. An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the role change fires only when a human approves it in the Tray, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to promote or demote a member; tell the user it needs approval, do not claim it is done.",
+      "how": "mcp__pocketpaw_workspace_admin__member_update_role (user_id, role) — proposes for human approval; never mutates inline",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:admin"
+      ],
+      "keywords": [
+        "change role",
+        "promote member",
+        "demote member",
+        "make admin",
+        "member role",
+        "update role"
+      ]
+    },
+    {
+      "id": "capability:admin.member_remove",
+      "kind": "capability",
+      "name": "Remove a member",
+      "summary": "Remove a member from the workspace. Admin-only; the removal needs human approval.",
+      "narrative": "Proposes removing a member from the workspace (the service cascade also strips their keys and sessions). An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the removal fires only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to remove someone; tell the user it needs approval, do not claim it is done.",
+      "how": "mcp__pocketpaw_workspace_admin__member_remove (user_id) — proposes for human approval; never mutates inline",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:admin"
+      ],
+      "keywords": [
+        "remove member",
+        "kick",
+        "offboard",
+        "delete member",
+        "revoke access"
+      ]
+    },
+    {
+      "id": "capability:admin.invite_create",
+      "kind": "capability",
+      "name": "Invite a member",
+      "summary": "Invite someone to the workspace as admin or member. Admin-only; the invite needs human approval.",
+      "narrative": "Proposes inviting someone to the workspace as admin or member (an invite can never mint an owner). An ADMIN-level WRITE that is NEVER sent from chat — it files an Instinct proposal and the invite goes out only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to invite someone; tell the user it needs approval, do not claim it was sent.",
+      "how": "mcp__pocketpaw_workspace_admin__invite_create (email, role) — proposes for human approval; never mutates inline",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:admin"
+      ],
+      "keywords": [
+        "invite",
+        "add member",
+        "send invite",
+        "onboard",
+        "invite user"
+      ]
+    },
+    {
+      "id": "capability:admin.invite_revoke",
+      "kind": "capability",
+      "name": "Revoke an invite",
+      "summary": "Revoke a pending workspace invite. Admin-only; the revocation needs human approval.",
+      "narrative": "Proposes revoking a pending invitation. An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the revocation fires only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to cancel an outstanding invite; tell the user it needs approval, do not claim it is done.",
+      "how": "mcp__pocketpaw_workspace_admin__invite_revoke (invite_id) — proposes for human approval; never mutates inline",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:admin"
+      ],
+      "keywords": [
+        "revoke invite",
+        "cancel invite",
+        "withdraw invitation",
+        "delete invite"
+      ]
+    },
+    {
+      "id": "capability:admin.connector_enable",
+      "kind": "capability",
+      "name": "Enable a connector",
+      "summary": "Enable a connector for the workspace. Admin-only; the change needs human approval.",
+      "narrative": "Proposes enabling a connector for the workspace. An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the connector is enabled only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to turn on an integration; tell the user it needs approval, do not claim it is done.",
+      "how": "mcp__pocketpaw_workspace_admin__connector_enable (name) — proposes for human approval; never mutates inline",
+      "surface": "/settings/workspace/integrations",
+      "requires": [
+        "role:admin"
+      ],
+      "keywords": [
+        "enable connector",
+        "turn on integration",
+        "activate connector",
+        "connect"
+      ]
+    },
+    {
+      "id": "capability:admin.connector_disable",
+      "kind": "capability",
+      "name": "Disable a connector",
+      "summary": "Disable a connector for the workspace. Admin-only; the change needs human approval.",
+      "narrative": "Proposes disabling a connector for the workspace. An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the connector is disabled only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to turn off an integration; tell the user it needs approval, do not claim it is done.",
+      "how": "mcp__pocketpaw_workspace_admin__connector_disable (name) — proposes for human approval; never mutates inline",
+      "surface": "/settings/workspace/integrations",
+      "requires": [
+        "role:admin"
+      ],
+      "keywords": [
+        "disable connector",
+        "turn off integration",
+        "deactivate connector",
+        "disconnect"
+      ]
+    },
+    {
+      "id": "capability:admin.connector_config",
+      "kind": "capability",
+      "name": "Configure a connector",
+      "summary": "Patch a connector's saved config. Admin-only; the change needs human approval.",
+      "narrative": "Proposes patching a connector's saved configuration (the config is opaque data the connectors service validates and merges). An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the config change lands only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to change an integration's settings; tell the user it needs approval, do not claim it is done.",
+      "how": "mcp__pocketpaw_workspace_admin__connector_config (name, config) — proposes for human approval; never mutates inline",
+      "surface": "/settings/workspace/integrations",
+      "requires": [
+        "role:admin"
+      ],
+      "keywords": [
+        "configure connector",
+        "connector config",
+        "integration settings",
+        "update connector"
+      ]
+    },
+    {
+      "id": "capability:admin.workspace_update",
+      "kind": "capability",
+      "name": "Update workspace settings",
+      "summary": "Update the workspace name, settings, or branding. Admin-only; the change needs human approval.",
+      "narrative": "Proposes updating the workspace's name, settings, or branding (only recognized fields are carried). An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the update lands only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to rename the workspace or change its branding; tell the user it needs approval, do not claim it is done.",
+      "how": "mcp__pocketpaw_workspace_admin__workspace_update (name?, settings?, branding?) — proposes for human approval; never mutates inline",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:admin"
+      ],
+      "keywords": [
+        "rename workspace",
+        "workspace name",
+        "branding",
+        "workspace settings",
+        "update workspace"
+      ]
+    },
+    {
+      "id": "capability:admin.instinct_approval_level_set",
+      "kind": "capability",
+      "name": "Set the Instinct approval level",
+      "summary": "Set the workspace's Instinct-gate approval level (ASK / TRIAGE / TRUSTED). Owner-only; needs human approval.",
+      "narrative": "Proposes setting the workspace's Instinct-gate approval level — a non-ASK level turns on workspace-wide auto-approval of agent writes, the single most governance-sensitive switch, so it is OWNER-only. It is NEVER applied from chat: it files an Instinct proposal and the level changes only on human approval, after re-checking the proposer still holds owner (the agent can't flip its own leash off). Members and admins never see this. Tell the user it needs owner approval; do not claim it is done.",
+      "how": "mcp__pocketpaw_workspace_admin__instinct_approval_level_set (level) — proposes for human approval; never mutates inline",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:owner"
+      ],
+      "keywords": [
+        "approval level",
+        "auto-approve",
+        "instinct level",
+        "trust level",
+        "governance"
+      ]
+    },
+    {
+      "id": "capability:admin.workspace_delete",
+      "kind": "capability",
+      "name": "Delete the workspace",
+      "summary": "Permanently delete the entire workspace. Owner-only, irreversible; needs human approval.",
+      "narrative": "Proposes permanently DELETING the entire workspace — an irreversible cascade across every member, room, agent, and file. OWNER-only and NEVER applied from chat: it files an Instinct proposal and the deletion fires only on explicit human approval, after re-checking the proposer still holds owner. Members and admins never see this. Tell the user it is irreversible and needs owner approval; do not claim the workspace was deleted.",
+      "how": "mcp__pocketpaw_workspace_admin__workspace_delete (no args) — proposes for human approval; never mutates inline",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:owner"
+      ],
+      "keywords": [
+        "delete workspace",
+        "destroy workspace",
+        "remove workspace",
+        "irreversible"
+      ]
+    },
+    {
+      "id": "capability:admin.billing_plan_change",
+      "kind": "capability",
+      "name": "Change the billing plan",
+      "summary": "Change the workspace's paid plan via hosted checkout. Owner-only; needs human approval, then payment.",
+      "narrative": "Proposes changing the workspace's paid plan. OWNER-only and NEVER applied from chat: it files an Instinct proposal and, on human approval, produces a hosted checkout link a human must complete — the plan flips only when the payment provider confirms via webhook, never synchronously. Members and admins never see this. Tell the user it needs owner approval and then payment; do not claim the plan changed.",
+      "how": "mcp__pocketpaw_workspace_admin__billing_plan_change (plan) — proposes for human approval; opens checkout, never mutates inline",
+      "surface": "/settings/workspace",
+      "requires": [
+        "role:owner"
+      ],
+      "keywords": [
+        "change plan",
+        "upgrade plan",
+        "downgrade plan",
+        "billing plan",
+        "subscribe"
+      ]
+    }
+  ]
+}

--- a/src/pocketpaw/atlas/compile.py
+++ b/src/pocketpaw/atlas/compile.py
@@ -47,10 +47,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Hand-authored source files, compiled in this order (before id-sorting).
+# ``capabilities.json`` (WA-3) carries ``kind:"capability"`` cards for the
+# workspace-admin tools, each gated by a ``role:<tier>`` marker in ``requires``
+# so a member never sees admin capabilities in atlas.
 _AUTHORED_DIR = Path(__file__).parent / "authored"
 AUTHORED_FILES = (
     _AUTHORED_DIR / "primitives.json",
     _AUTHORED_DIR / "surfaces.json",
+    _AUTHORED_DIR / "capabilities.json",
 )
 
 # Where connector YAML definitions live, relative to the repo root (the

--- a/src/pocketpaw/atlas/data/atlas.json
+++ b/src/pocketpaw/atlas/data/atlas.json
@@ -1,6 +1,330 @@
 {
   "entries": [
     {
+      "how": "mcp__pocketpaw_workspace_admin__audit_read (optional limit 1-100)",
+      "id": "capability:admin.audit_read",
+      "keywords": [
+        "audit log",
+        "who did what",
+        "compliance trail",
+        "history",
+        "audit events",
+        "record"
+      ],
+      "kind": "capability",
+      "name": "Read the audit log",
+      "narrative": "Reads recent rows from the workspace audit log — the compliance-grade record of actor, action, target, and time. An ADMIN-level read (the same gate the audit route uses), so a member never sees it. It runs directly once the admin gate passes. Reach for it when an admin asks for the authoritative trail of who or what did something in the workspace.",
+      "requires": [
+        "role:admin"
+      ],
+      "summary": "Read recent workspace audit-log rows (who did what, when). Admin-only read.",
+      "surface": "/audit"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__billing_plan_change (plan) — proposes for human approval; opens checkout, never mutates inline",
+      "id": "capability:admin.billing_plan_change",
+      "keywords": [
+        "change plan",
+        "upgrade plan",
+        "downgrade plan",
+        "billing plan",
+        "subscribe"
+      ],
+      "kind": "capability",
+      "name": "Change the billing plan",
+      "narrative": "Proposes changing the workspace's paid plan. OWNER-only and NEVER applied from chat: it files an Instinct proposal and, on human approval, produces a hosted checkout link a human must complete — the plan flips only when the payment provider confirms via webhook, never synchronously. Members and admins never see this. Tell the user it needs owner approval and then payment; do not claim the plan changed.",
+      "requires": [
+        "role:owner"
+      ],
+      "summary": "Change the workspace's paid plan via hosted checkout. Owner-only; needs human approval, then payment.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__billing_usage_read (optional start / end YYYY-MM-DD)",
+      "id": "capability:admin.billing_usage_read",
+      "keywords": [
+        "usage",
+        "spend",
+        "credits",
+        "billing usage",
+        "how much have we used",
+        "cost"
+      ],
+      "kind": "capability",
+      "name": "Read workspace usage",
+      "narrative": "Reads the workspace's usage and credit spend by day and by model over an optional start/end window (default: the trailing 30 days). A MEMBER-level read — any member may read their own workspace's usage — that runs directly. Reach for it when the user asks how much the workspace has spent or used; changing the paid plan is a separate, owner-level human-gated action.",
+      "requires": [
+        "role:member"
+      ],
+      "summary": "Read the workspace's daily usage and spend over an optional date window. A member-level read.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__connector_config (name, config) — proposes for human approval; never mutates inline",
+      "id": "capability:admin.connector_config",
+      "keywords": [
+        "configure connector",
+        "connector config",
+        "integration settings",
+        "update connector"
+      ],
+      "kind": "capability",
+      "name": "Configure a connector",
+      "narrative": "Proposes patching a connector's saved configuration (the config is opaque data the connectors service validates and merges). An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the config change lands only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to change an integration's settings; tell the user it needs approval, do not claim it is done.",
+      "requires": [
+        "role:admin"
+      ],
+      "summary": "Patch a connector's saved config. Admin-only; the change needs human approval.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__connector_disable (name) — proposes for human approval; never mutates inline",
+      "id": "capability:admin.connector_disable",
+      "keywords": [
+        "disable connector",
+        "turn off integration",
+        "deactivate connector",
+        "disconnect"
+      ],
+      "kind": "capability",
+      "name": "Disable a connector",
+      "narrative": "Proposes disabling a connector for the workspace. An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the connector is disabled only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to turn off an integration; tell the user it needs approval, do not claim it is done.",
+      "requires": [
+        "role:admin"
+      ],
+      "summary": "Disable a connector for the workspace. Admin-only; the change needs human approval.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__connector_enable (name) — proposes for human approval; never mutates inline",
+      "id": "capability:admin.connector_enable",
+      "keywords": [
+        "enable connector",
+        "turn on integration",
+        "activate connector",
+        "connect"
+      ],
+      "kind": "capability",
+      "name": "Enable a connector",
+      "narrative": "Proposes enabling a connector for the workspace. An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the connector is enabled only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to turn on an integration; tell the user it needs approval, do not claim it is done.",
+      "requires": [
+        "role:admin"
+      ],
+      "summary": "Enable a connector for the workspace. Admin-only; the change needs human approval.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__connectors_list (no args)",
+      "id": "capability:admin.connectors_list",
+      "keywords": [
+        "connectors",
+        "integrations",
+        "connected",
+        "enabled",
+        "list integrations",
+        "which connectors"
+      ],
+      "kind": "capability",
+      "name": "List workspace connectors",
+      "narrative": "Reads the connectors available in the workspace with their enabled and live connected status, filtered to what the calling member is permitted to see. A MEMBER-level read that runs directly. Reach for it when the user asks which integrations are set up or connected; enabling, disabling, or configuring a connector is a separate, human-gated admin action.",
+      "requires": [
+        "role:member"
+      ],
+      "summary": "Read the workspace's connectors and their enabled / connected status. A member-level read.",
+      "surface": "/settings/workspace/integrations"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__instinct_approval_level_set (level) — proposes for human approval; never mutates inline",
+      "id": "capability:admin.instinct_approval_level_set",
+      "keywords": [
+        "approval level",
+        "auto-approve",
+        "instinct level",
+        "trust level",
+        "governance"
+      ],
+      "kind": "capability",
+      "name": "Set the Instinct approval level",
+      "narrative": "Proposes setting the workspace's Instinct-gate approval level — a non-ASK level turns on workspace-wide auto-approval of agent writes, the single most governance-sensitive switch, so it is OWNER-only. It is NEVER applied from chat: it files an Instinct proposal and the level changes only on human approval, after re-checking the proposer still holds owner (the agent can't flip its own leash off). Members and admins never see this. Tell the user it needs owner approval; do not claim it is done.",
+      "requires": [
+        "role:owner"
+      ],
+      "summary": "Set the workspace's Instinct-gate approval level (ASK / TRIAGE / TRUSTED). Owner-only; needs human approval.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__invite_create (email, role) — proposes for human approval; never mutates inline",
+      "id": "capability:admin.invite_create",
+      "keywords": [
+        "invite",
+        "add member",
+        "send invite",
+        "onboard",
+        "invite user"
+      ],
+      "kind": "capability",
+      "name": "Invite a member",
+      "narrative": "Proposes inviting someone to the workspace as admin or member (an invite can never mint an owner). An ADMIN-level WRITE that is NEVER sent from chat — it files an Instinct proposal and the invite goes out only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to invite someone; tell the user it needs approval, do not claim it was sent.",
+      "requires": [
+        "role:admin"
+      ],
+      "summary": "Invite someone to the workspace as admin or member. Admin-only; the invite needs human approval.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__invite_revoke (invite_id) — proposes for human approval; never mutates inline",
+      "id": "capability:admin.invite_revoke",
+      "keywords": [
+        "revoke invite",
+        "cancel invite",
+        "withdraw invitation",
+        "delete invite"
+      ],
+      "kind": "capability",
+      "name": "Revoke an invite",
+      "narrative": "Proposes revoking a pending invitation. An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the revocation fires only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to cancel an outstanding invite; tell the user it needs approval, do not claim it is done.",
+      "requires": [
+        "role:admin"
+      ],
+      "summary": "Revoke a pending workspace invite. Admin-only; the revocation needs human approval.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__invites_list (no args)",
+      "id": "capability:admin.invites_list",
+      "keywords": [
+        "invites",
+        "pending invites",
+        "invited",
+        "outstanding invitations",
+        "who was invited"
+      ],
+      "kind": "capability",
+      "name": "List pending invites",
+      "narrative": "Reads the workspace's pending invitations — invited email, offered role, who invited them, and expiry. An ADMIN-level read (the same gate the invites management route uses), so a member never sees it. It runs directly once the admin gate passes. Reach for it when an admin asks who has been invited but has not yet joined.",
+      "requires": [
+        "role:admin"
+      ],
+      "summary": "Read the workspace's pending invites (email, role, expiry). Admin-only read.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__member_remove (user_id) — proposes for human approval; never mutates inline",
+      "id": "capability:admin.member_remove",
+      "keywords": [
+        "remove member",
+        "kick",
+        "offboard",
+        "delete member",
+        "revoke access"
+      ],
+      "kind": "capability",
+      "name": "Remove a member",
+      "narrative": "Proposes removing a member from the workspace (the service cascade also strips their keys and sessions). An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the removal fires only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to remove someone; tell the user it needs approval, do not claim it is done.",
+      "requires": [
+        "role:admin"
+      ],
+      "summary": "Remove a member from the workspace. Admin-only; the removal needs human approval.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__member_update_role (user_id, role) — proposes for human approval; never mutates inline",
+      "id": "capability:admin.member_update_role",
+      "keywords": [
+        "change role",
+        "promote member",
+        "demote member",
+        "make admin",
+        "member role",
+        "update role"
+      ],
+      "kind": "capability",
+      "name": "Change a member's role",
+      "narrative": "Proposes changing a member's workspace role. An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the role change fires only when a human approves it in the Tray, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to promote or demote a member; tell the user it needs approval, do not claim it is done.",
+      "requires": [
+        "role:admin"
+      ],
+      "summary": "Change a member's workspace role (member / admin / owner). Admin-only; every change needs human approval.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "member_update_role's read sibling — mcp__pocketpaw_workspace_admin__members_list (no args; the workspace is the active chat stream's)",
+      "id": "capability:admin.members_list",
+      "keywords": [
+        "members",
+        "roster",
+        "who is in the workspace",
+        "team",
+        "people",
+        "member list"
+      ],
+      "kind": "capability",
+      "name": "List workspace members",
+      "narrative": "Reads the current workspace's member roster — email, name, workspace role, and joined-at — for every member. A MEMBER-level read: any member may see who is in the workspace. No mutation, so it runs directly (reads are not human-gated). Reach for it when the user asks who is in the workspace or what someone's role is.",
+      "requires": [
+        "role:member"
+      ],
+      "summary": "Read the workspace member roster (email, name, role, joined-at). Any member may read it.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__workspace_delete (no args) — proposes for human approval; never mutates inline",
+      "id": "capability:admin.workspace_delete",
+      "keywords": [
+        "delete workspace",
+        "destroy workspace",
+        "remove workspace",
+        "irreversible"
+      ],
+      "kind": "capability",
+      "name": "Delete the workspace",
+      "narrative": "Proposes permanently DELETING the entire workspace — an irreversible cascade across every member, room, agent, and file. OWNER-only and NEVER applied from chat: it files an Instinct proposal and the deletion fires only on explicit human approval, after re-checking the proposer still holds owner. Members and admins never see this. Tell the user it is irreversible and needs owner approval; do not claim the workspace was deleted.",
+      "requires": [
+        "role:owner"
+      ],
+      "summary": "Permanently delete the entire workspace. Owner-only, irreversible; needs human approval.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__workspace_settings_read (no args)",
+      "id": "capability:admin.workspace_settings_read",
+      "keywords": [
+        "workspace settings",
+        "plan",
+        "seats",
+        "workspace name",
+        "branding",
+        "current plan"
+      ],
+      "kind": "capability",
+      "name": "Read workspace settings",
+      "narrative": "Reads a compact view of the workspace's own settings — name, slug, plan tier, seat usage (used / available), and display branding — with no internal ids or secrets. A MEMBER-level read that runs directly. Reach for it when the user asks about the current plan, seat count, or workspace name; changing any of these is a separate, human-gated admin action.",
+      "requires": [
+        "role:member"
+      ],
+      "summary": "Read the workspace name, slug, plan, seat usage, and branding. A member-level read.",
+      "surface": "/settings/workspace"
+    },
+    {
+      "how": "mcp__pocketpaw_workspace_admin__workspace_update (name?, settings?, branding?) — proposes for human approval; never mutates inline",
+      "id": "capability:admin.workspace_update",
+      "keywords": [
+        "rename workspace",
+        "workspace name",
+        "branding",
+        "workspace settings",
+        "update workspace"
+      ],
+      "kind": "capability",
+      "name": "Update workspace settings",
+      "narrative": "Proposes updating the workspace's name, settings, or branding (only recognized fields are carried). An ADMIN-level WRITE that is NEVER applied from chat — it files an Instinct proposal and the update lands only on human approval, after re-checking the proposer still holds admin. A member never sees this. Reach for it when an admin asks to rename the workspace or change its branding; tell the user it needs approval, do not claim it is done.",
+      "requires": [
+        "role:admin"
+      ],
+      "summary": "Update the workspace name, settings, or branding. Admin-only; the change needs human approval.",
+      "surface": "/settings/workspace"
+    },
+    {
       "how": "list_connector_actions / connector_execute over the 'airtable' connector once it is bound",
       "id": "connector:airtable",
       "keywords": [

--- a/src/pocketpaw/atlas/overlay.py
+++ b/src/pocketpaw/atlas/overlay.py
@@ -1,7 +1,23 @@
 # atlas/overlay.py — live workspace overlay + fail-closed entitlement filter
 # for the atlas OS self-model (AT-5). Created: 2026-07-02 (feat/atlas-overlay).
 #
-# The compiled artifact is GLOBAL — the same 72 entries in every workspace.
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-3 — role-aware atlas
+# entitlement). Admin ``kind:"capability"`` entries carry a ``role:<tier>``
+# marker in ``requires`` (role:member / role:admin / role:owner). Two changes
+# land here:
+#   * ROLE_REQUIRE_PREFIX + role helpers (``entry_role_requirement``) — the
+#     one place that reads a role marker off an entry's ``requires``.
+#   * ``DefaultEntitlementProvider.is_granted`` now HIDES any entry carrying a
+#     ``role:*`` requirement (returns False): the default provider has no role
+#     context, so it must never expose an admin capability. Non-role entries
+#     stay granted (unchanged OSS behavior). This keeps admin entries hidden
+#     EVERYWHERE except when the EE role-aware provider explicitly grants them
+#     — OSS never leaks admin capabilities even though the compiled artifact is
+#     global. The EE provider lives in ``pocketpaw_ee.agent.atlas_provider`` and
+#     is wired via the ``build_role_aware_provider`` bridge below (mirrors
+#     ``atlas.fabric.build_workspace_fabric_introspector``).
+#
+# The compiled artifact is GLOBAL — the same entries in every workspace.
 # This module makes atlas answers reflect the CALLING workspace's reality:
 #
 # * ``EntitlementProvider`` — a small structural protocol (like the repo's
@@ -44,6 +60,33 @@ logger = logging.getLogger(__name__)
 # Default connector scope in a single-user OSS install — the same literal
 # the builtin connector tools default their ``pocket_id`` argument to.
 DEFAULT_SCOPE_KEY = "default"
+
+# Marker prefix carried in an entry's ``requires`` list to gate it behind a
+# minimum workspace role (WA-3). ``role:member`` / ``role:admin`` / ``role:owner``
+# are additive ``requires`` values — NOT a schema change (``requires`` already
+# exists). An entry carrying ANY ``role:*`` marker is a role-gated entry: the
+# only provider that may grant it is the EE role-aware one; every role-blind
+# provider (the OSS default, a fail-closed fallback) hides it.
+ROLE_REQUIRE_PREFIX = "role:"
+
+# Role tier ordering for the ``role:*`` markers. Mirrors
+# ``pocketpaw_ee.guards.rbac._ROLE_LEVELS`` (owner > admin > member) so the EE
+# provider and this core module agree without an EE import at core scope.
+ROLE_LEVELS: dict[str, int] = {"member": 1, "admin": 2, "owner": 3}
+
+
+def entry_role_requirement(entry: AtlasEntry) -> str | None:
+    """The role tier an entry requires (``'member'`` / ``'admin'`` / ``'owner'``),
+    or ``None`` when the entry carries no ``role:*`` marker.
+
+    Reads the FIRST ``role:<tier>`` value in ``requires``. An unrecognized tier
+    (not in ``ROLE_LEVELS``) still counts as "role-gated" — it returns the raw
+    tier string so a role-blind provider hides it (fail-closed: an unknown
+    marker is treated as gated, never as ungated)."""
+    for req in entry.requires:
+        if isinstance(req, str) and req.startswith(ROLE_REQUIRE_PREFIX):
+            return req[len(ROLE_REQUIRE_PREFIX) :] or req
+    return None
 
 
 @runtime_checkable
@@ -201,9 +244,15 @@ class DefaultEntitlementProvider:
     the connector state scope: the tools' ``"default"`` pocket scope in a
     single-user install, or a cloud run's ``ws:<workspace_id>``.
 
-    Nothing is entitlement-gated in OSS: ``is_granted`` is always True,
-    so primitives, surfaces, senses, and connectors all stay visible —
-    connectors merely carry their live availability annotation.
+    Nothing is entitlement-gated in OSS EXCEPT role-gated entries: an entry
+    carrying a ``role:*`` marker in ``requires`` (admin capabilities, WA-3) is
+    HIDDEN — the default provider has no workspace-role context, so it must
+    never expose an admin capability. Every non-role entry (primitives,
+    surfaces, senses, connectors) stays visible, connectors merely carrying
+    their live availability annotation. Only the EE role-aware provider
+    (``pocketpaw_ee.agent.atlas_provider``) can grant a role-gated entry, so
+    admin capabilities are absent from atlas everywhere except a cloud run where
+    the caller's resolved role clears the bar.
     """
 
     def __init__(self, scope_key: str = DEFAULT_SCOPE_KEY, registry: Any | None = None) -> None:
@@ -226,14 +275,50 @@ class DefaultEntitlementProvider:
         rows = self._resolve_registry().status(self._scope_key)
         return {row["name"] for row in rows if row.get("status") == ConnectorStatus.CONNECTED}
 
-    def is_granted(self, entry: AtlasEntry) -> bool:  # noqa: ARG002 — protocol shape
-        return True
+    def is_granted(self, entry: AtlasEntry) -> bool:
+        # Role-gated entries (WA-3) require a workspace-role context this
+        # role-blind default provider does not have — hide them (fail-closed).
+        # Everything else is ungated in OSS.
+        return entry_role_requirement(entry) is None
+
+
+def build_role_aware_provider(scope_key: str) -> EntitlementProvider | None:
+    """EE wiring hook: a role-aware entitlement provider for *scope_key*, or None.
+
+    Mirrors ``atlas.fabric.build_workspace_fabric_introspector`` — the seam that
+    lets a cloud run swap the role-blind ``DefaultEntitlementProvider`` for the
+    EE provider that resolves the CALLER's workspace role and grants ``role:*``
+    entries only when the role clears the bar. Returns ``None`` (caller falls
+    back to the fail-closed default) on: a non-``ws:<id>`` scope (OSS / sentinel),
+    ``pocketpaw_ee.agent.atlas_provider`` not importable (OSS install), or
+    construction failure — all DEBUG-logged, all degrading to "no role-aware
+    provider" so admin entries stay hidden rather than leaking.
+
+    A ``None`` return is SAFE: the default provider hides every ``role:*`` entry,
+    so admin capabilities never surface without the EE provider explicitly
+    granting them."""
+    if not isinstance(scope_key, str) or not scope_key.startswith("ws:"):
+        return None
+    try:
+        from pocketpaw_ee.agent.atlas_provider import RoleAwareEntitlementProvider
+    except ImportError:
+        logger.debug("pocketpaw_ee.agent.atlas_provider not importable; role-aware atlas off")
+        return None
+    try:
+        return RoleAwareEntitlementProvider(scope_key=scope_key)
+    except Exception as exc:  # noqa: BLE001 — construction failure degrades, never crashes
+        logger.debug("atlas role-aware provider construction failed: %s", exc)
+        return None
 
 
 __all__ = [
     "DEFAULT_SCOPE_KEY",
+    "ROLE_LEVELS",
+    "ROLE_REQUIRE_PREFIX",
     "AtlasOverlay",
     "DefaultEntitlementProvider",
     "EntitlementProvider",
     "OverlaidEntry",
+    "build_role_aware_provider",
+    "entry_role_requirement",
 ]

--- a/src/pocketpaw/atlas/overlay.py
+++ b/src/pocketpaw/atlas/overlay.py
@@ -299,6 +299,13 @@ def build_role_aware_provider(scope_key: str) -> EntitlementProvider | None:
     granting them."""
     if not isinstance(scope_key, str) or not scope_key.startswith("ws:"):
         return None
+    # Reject the fail-closed sentinel and an empty workspace id in the helper
+    # itself (not only at the call site) so a role-aware provider is never built
+    # for a scope that can't resolve a real tenant — honors this docstring's
+    # "sentinel -> None" contract regardless of caller.
+    _ws_id = scope_key[len("ws:") :]
+    if not _ws_id or _ws_id == "__missing-workspace-id__":
+        return None
     try:
         from pocketpaw_ee.agent.atlas_provider import RoleAwareEntitlementProvider
     except ImportError:

--- a/src/pocketpaw/atlas/store.py
+++ b/src/pocketpaw/atlas/store.py
@@ -29,6 +29,14 @@
 # inflected query words match singular keywords ("competitors" now hits a
 # "competitor" keyword). Field weights and the search_scored / search /
 # describe signatures are unchanged.
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-3) — a tiny function-word
+# stoplist (``_STOPWORDS``) is dropped by ``_tokenize`` from both index and
+# query tokens. Without it, an entry whose NAME is a natural phrase (the WA-3
+# admin-capability cards, e.g. "Change a member's role") scored a full
+# name-weight hit on a query's bare "a"/"the"/"make", letting admin cards hijack
+# unrelated intents. Stopwords carry no intent signal, so removing them can only
+# drop spurious matches — no entry is ever the right answer *because of* a
+# stopword. Weights and signatures unchanged.
 
 from __future__ import annotations
 
@@ -48,6 +56,77 @@ _DATA_PATH = Path(__file__).parent / "data" / "atlas.json"
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 
+# Function-word stoplist (WA-3). These carry no intent signal — an entry whose
+# NAME is a natural phrase ("Change a member's role") would otherwise score a
+# full name-weight hit on a query's bare "a", letting admin-capability cards
+# hijack unrelated intents ("make a landing page"). Dropped identically from
+# index and query tokens (via ``_stem_set`` → ``_tokenize``), so this can only
+# REMOVE spurious matches, never break a real one: no atlas entry is ever the
+# right answer *because of* a stopword. Kept deliberately tiny (closed-class
+# articles / prepositions / pronouns / auxiliaries + a couple of ubiquitous
+# instruction verbs) so it never swallows a content word.
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "this",
+        "that",
+        "these",
+        "those",
+        "it",
+        "its",
+        "i",
+        "me",
+        "my",
+        "we",
+        "our",
+        "us",
+        "you",
+        "your",
+        "they",
+        "them",
+        "of",
+        "to",
+        "for",
+        "in",
+        "on",
+        "at",
+        "by",
+        "with",
+        "from",
+        "into",
+        "and",
+        "or",
+        "but",
+        "as",
+        "so",
+        "if",
+        "then",
+        "is",
+        "are",
+        "be",
+        "been",
+        "am",
+        "was",
+        "were",
+        "do",
+        "does",
+        "did",
+        "can",
+        "will",
+        "would",
+        "should",
+        "could",
+        "make",
+        "let",
+        "want",
+        "need",
+        "please",
+        "just",
+    }
+)
+
 # Score weights: a hit on the name or a keyword is a much stronger signal
 # of intent than a word that merely appears somewhere in the narrative.
 _NAME_WEIGHT = 5.0
@@ -57,7 +136,7 @@ _NARRATIVE_WEIGHT = 1.0
 
 
 def _tokenize(text: str) -> list[str]:
-    return _TOKEN_RE.findall(text.lower())
+    return [t for t in _TOKEN_RE.findall(text.lower()) if t not in _STOPWORDS]
 
 
 def _stem(token: str) -> str:

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -586,6 +586,12 @@ class InstinctStore:
         return await self._update_status(
             action_id,
             ActionStatus.APPROVED,
+            # Only a PENDING action may be approved — same guard auto_approve /
+            # bulk_approve already carry. Without it, re-approving an action that
+            # already flipped to APPROVED (e.g. after an executor that mutated but
+            # then failed to record its outcome) would re-enter the executor and
+            # double-fire the underlying write. Returns None on a non-pending row.
+            require_status=ActionStatus.PENDING,
             approved_by=approver,
             approved_at=datetime.now().isoformat(),
             event="action_approved",

--- a/tests/atlas/test_eval.py
+++ b/tests/atlas/test_eval.py
@@ -11,6 +11,13 @@
 # Updated: 2026-07-03 — re-baselined against the full compiled model
 # (237 entries) + fixpoint stemmer: baseline 16/18 → 21/22 (cases
 # re-pointed / promoted / added in eval_cases.json; see its note fields).
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-3) — the model grew to
+# 254 entries (17 role-gated admin ``capability`` cards added). Those cards
+# are hidden from the UNFILTERED store the eval uses, but their natural-phrase
+# names would have polluted rankings via bare stopwords; the store now drops a
+# tiny function-word stoplist (``store._STOPWORDS``). Net effect on the eval:
+# strict-hit baseline UNCHANGED at 21/22 (the "review the agent's edit" case
+# even tightened from rank 3 to rank 2, still within its rank_within budget).
 
 from __future__ import annotations
 

--- a/tests/atlas/test_overlay.py
+++ b/tests/atlas/test_overlay.py
@@ -14,6 +14,13 @@
 # the known-ids error listing hides filtered ids, and describe of an
 # unavailable connector points at the integrations surface route (looked up
 # from the seed, not hard-coded).
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-3) — role-gating tests:
+# ``entry_role_requirement`` reads a ``role:<tier>`` marker off ``requires``;
+# the OSS ``DefaultEntitlementProvider`` HIDES any entry carrying a ``role:*``
+# marker (is_granted False — it has no role context) while still granting every
+# non-role entry, proving OSS never leaks admin capabilities; and
+# ``build_role_aware_provider`` returns None for a non-``ws:`` scope so the
+# fail-closed default stays in place.
 
 import json
 
@@ -26,10 +33,13 @@ from pocketpaw.agents.sdk_mcp_atlas import (
 from pocketpaw.atlas.model import AtlasEntry, AtlasModel
 from pocketpaw.atlas.overlay import (
     DEFAULT_SCOPE_KEY,
+    ROLE_LEVELS,
     AtlasOverlay,
     DefaultEntitlementProvider,
     EntitlementProvider,
     OverlaidEntry,
+    build_role_aware_provider,
+    entry_role_requirement,
 )
 from pocketpaw.atlas.store import AtlasStore
 
@@ -284,6 +294,93 @@ class TestDefaultProvider:
         assert by_id["connector:beta_crm"].available is False
 
 
+# ── WA-3: role markers + the default provider hides role:* entries ─────────
+
+
+def _cap(entry_id: str, tier: str | None) -> AtlasEntry:
+    """A capability entry, optionally carrying a ``role:<tier>`` requirement."""
+    requires = [f"role:{tier}"] if tier else []
+    return _entry(entry_id, "capability", entry_id.split(":", 1)[1], requires=requires)
+
+
+class TestRoleRequirementHelper:
+    def test_reads_the_role_marker_off_requires(self):
+        assert entry_role_requirement(_cap("capability:admin.x", "admin")) == "admin"
+        assert entry_role_requirement(_cap("capability:admin.y", "owner")) == "owner"
+        assert entry_role_requirement(_cap("capability:admin.z", "member")) == "member"
+
+    def test_none_when_no_role_marker(self):
+        # A non-role entry (primitive) and a capability with only non-role
+        # requires both return None.
+        assert entry_role_requirement(_entry("primitive:pocket", "primitive", "Pocket")) is None
+        entry = _entry("capability:x", "capability", "X", requires=["primitive:pocket"])
+        assert entry_role_requirement(entry) is None
+
+    def test_unknown_tier_still_counts_as_gated(self):
+        # An unrecognized tier is returned raw (not None) so a role-blind
+        # provider hides it — fail-closed on a bad marker.
+        entry = _cap("capability:admin.weird", "superuser")
+        assert entry_role_requirement(entry) == "superuser"
+
+
+class TestDefaultProviderHidesRoleEntries:
+    """The OSS default provider has NO role context, so it must HIDE every
+    ``role:*`` entry — this is what keeps admin capabilities from leaking in
+    OSS even though the compiled artifact is global (WA-3)."""
+
+    def test_role_gated_entries_are_hidden(self):
+        provider = DefaultEntitlementProvider()
+        for tier in ("member", "admin", "owner"):
+            assert provider.is_granted(_cap(f"capability:admin.{tier}", tier)) is False
+
+    def test_unknown_tier_is_hidden(self):
+        provider = DefaultEntitlementProvider()
+        assert provider.is_granted(_cap("capability:admin.weird", "superuser")) is False
+
+    def test_non_role_entries_still_granted(self):
+        provider = DefaultEntitlementProvider()
+        assert provider.is_granted(_entry("primitive:pocket", "primitive", "Pocket")) is True
+        assert provider.is_granted(_cap("capability:public", None)) is True
+
+    def test_search_and_describe_never_surface_role_entries(self):
+        """Through the overlay: role-gated entries are ABSENT from search /
+        describe / visible_ids under the default provider (OSS)."""
+        store = AtlasStore(
+            AtlasModel(
+                entries=[
+                    _entry("primitive:pocket", "primitive", "Pocket", keywords=["manage"]),
+                    _cap("capability:admin.workspace_delete", "owner"),
+                    _cap("capability:admin.members_list", "member"),
+                ]
+            )
+        )
+        provider = DefaultEntitlementProvider()
+        # The admin cards share the "manage" intent but never surface.
+        for cap_entry in store.entries:
+            if cap_entry.kind == "capability":
+                cap_entry.keywords.append("manage")
+        ids = [o.entry.id for o in AtlasOverlay.search(store, "manage", provider, limit=10)]
+        assert "capability:admin.workspace_delete" not in ids
+        assert "capability:admin.members_list" not in ids
+        assert AtlasOverlay.describe(store, "capability:admin.workspace_delete", provider) is None
+        visible = AtlasOverlay.visible_ids(store, provider)
+        assert not any(v.startswith("capability:admin.") for v in visible)
+        assert "primitive:pocket" in visible
+
+
+class TestRoleAwareBridge:
+    """The core bridge is import-optional and returns None outside a real
+    ``ws:`` scope, so the fail-closed default stays in place (WA-3)."""
+
+    def test_returns_none_for_non_ws_scope(self):
+        assert build_role_aware_provider(DEFAULT_SCOPE_KEY) is None
+        assert build_role_aware_provider("") is None
+        assert build_role_aware_provider("nonsense") is None
+
+    def test_role_levels_order(self):
+        assert ROLE_LEVELS["owner"] > ROLE_LEVELS["admin"] > ROLE_LEVELS["member"]
+
+
 # ── MCP tool handlers with stubbed providers (real packaged store) ──────
 
 
@@ -405,3 +502,106 @@ class TestTenantScopeKey:
             scope = backend._tenant_scope_key()
             assert scope == "ws:__missing-workspace-id__"
             assert scope != DEFAULT_SCOPE_KEY
+
+
+# ── WA-3: sdk_mcp_atlas awaits an optional async prime() before filtering ───
+
+
+class _PrimingRoleProvider:
+    """A provider whose role resolves in an async ``prime()`` (like the EE
+    role-aware one): before prime, role-gated entries are hidden (fail-closed);
+    after prime the caller's role grants them. Proves the sdk_mcp_atlas handler
+    awaits ``prime`` so a sync ``is_granted`` can read a resolved role."""
+
+    def __init__(self, tier_level: int):
+        self._tier_level = tier_level
+        self._role_level: int | None = None
+        self.primed = 0
+
+    async def prime(self):
+        self.primed += 1
+        self._role_level = self._tier_level
+
+    def connected_connector_names(self):
+        return set()
+
+    def is_granted(self, entry):
+        req = entry_role_requirement(entry)
+        if req is None:
+            return True
+        if self._role_level is None:
+            return False
+        return self._role_level >= ROLE_LEVELS.get(req, 999)
+
+
+class TestHandlerAwaitsPrime:
+    @pytest.mark.asyncio
+    async def test_describe_role_entry_needs_prime_then_grants(self):
+        # A real packaged role-gated admin id.
+        entry_id = "capability:admin.workspace_delete"
+        # OWNER-level provider: prime resolves owner, so describe finds it.
+        provider = _PrimingRoleProvider(ROLE_LEVELS["owner"])
+        out = await _atlas_describe_handler({"id": entry_id}, provider)
+        assert provider.primed == 1, "handler must await prime()"
+        assert not out.get("is_error"), "owner sees the owner card after prime"
+        entry = json.loads(_text_of(out))
+        assert entry["id"] == entry_id
+
+    @pytest.mark.asyncio
+    async def test_member_level_provider_hides_owner_card_through_handler(self):
+        provider = _PrimingRoleProvider(ROLE_LEVELS["member"])
+        out = await _atlas_describe_handler({"id": "capability:admin.workspace_delete"}, provider)
+        assert provider.primed == 1
+        assert out.get("is_error") is True  # unknown-id envelope, no leak
+        text = _text_of(out)
+        assert "capability:admin.workspace_delete" not in text.split("Known ids:")[1]
+
+    @pytest.mark.asyncio
+    async def test_member_search_hides_admin_capabilities_through_handler(self):
+        provider = _PrimingRoleProvider(ROLE_LEVELS["member"])
+        out = await _atlas_search_handler({"intent": "manage the workspace"}, provider)
+        ids = [c["id"] for c in _cards(out)]
+        assert provider.primed == 1
+        # No owner/admin admin-capability card surfaces for a member.
+        assert not any(
+            i in ids
+            for i in (
+                "capability:admin.workspace_delete",
+                "capability:admin.member_update_role",
+                "capability:admin.billing_plan_change",
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_provider_without_prime_is_untouched(self):
+        # The existing FakeProvider has no prime(); the handler must not choke.
+        out = await _atlas_search_handler({"intent": "approve agent actions"}, FakeProvider())
+        assert not out.get("is_error")
+
+
+# ── WA-3: the provider-less (None) path also hides role-gated entries ───────
+
+
+class TestNoProviderHidesRoleEntries:
+    @pytest.mark.asyncio
+    async def test_search_without_provider_omits_admin_capabilities(self):
+        # Admin cards carry these intent words; without a provider they must NOT
+        # surface (the result is either non-admin cards or a no-match message,
+        # never an admin capability id in the response text).
+        for intent in ("manage the workspace", "invite a member", "delete the workspace"):
+            out = await _atlas_search_handler({"intent": intent})
+            assert "capability:admin." not in _text_of(out), intent
+
+    @pytest.mark.asyncio
+    async def test_describe_without_provider_hides_admin_capability(self):
+        out = await _atlas_describe_handler({"id": "capability:admin.workspace_delete"})
+        assert out.get("is_error") is True
+        text = _text_of(out)
+        # answers like an unknown id, and the known-ids listing excludes it.
+        assert "capability:admin.workspace_delete" not in text.split("Known ids:")[1]
+
+    @pytest.mark.asyncio
+    async def test_describe_without_provider_still_serves_non_role_entry(self):
+        out = await _atlas_describe_handler({"id": "primitive:instinct"})
+        assert not out.get("is_error")
+        assert json.loads(_text_of(out))["id"] == "primitive:instinct"

--- a/tests/atlas/test_store.py
+++ b/tests/atlas/test_store.py
@@ -21,13 +21,25 @@
 # skills) entries; COMPILED_KINDS widened to six. Search-ranking pins are
 # otherwise unchanged and must survive the ~165 new entries (widget/skill
 # specific pins live in tests/atlas/test_widgets_skills.py).
+# Updated: 2026-07-03 (feat/workspace-admin-tools, WA-3) — the artifact now also
+# carries hand-authored ``capability`` cards (the workspace-admin tools, one per
+# tool, each role-gated); COMPILED_KINDS widened to seven so the
+# seed-completeness check accepts them.
 
 import json
 
 from pocketpaw.atlas.model import ATLAS_SCHEMA_V1, AtlasModel
 from pocketpaw.atlas.store import _DATA_PATH, AtlasStore, get_atlas_store
 
-COMPILED_KINDS = ("primitive", "surface", "connector", "sense", "widget", "skill")
+COMPILED_KINDS = (
+    "primitive",
+    "surface",
+    "connector",
+    "sense",
+    "widget",
+    "skill",
+    "capability",
+)
 
 EXPECTED_PRIMITIVE_IDS = {
     "primitive:pocket",

--- a/tests/cloud/test_admin_action_gate.py
+++ b/tests/cloud/test_admin_action_gate.py
@@ -1,0 +1,547 @@
+# tests/cloud/test_admin_action_gate.py — the gated workspace-admin-action proposal
+# type (the 8th gated Instinct kind, WA-2).
+#
+# Created: 2026-07-03 (feat/workspace-admin-tools, WA-2).
+#
+# What this pins:
+#   * propose_admin_action — blob shape (schema 1, RBAC action key, args,
+#     proposer_user_id, params_hash, idempotency_key, correlation_id, summary),
+#     tenancy (workspace + proposer required).
+#   * execute_approved_admin_action with the workspace service spied:
+#       - happy path: the whitelisted service (update_member_role) is called
+#         EXACTLY ONCE with the adapted args, action marked EXECUTED, structured
+#         outcome back-written.
+#       - EXECUTE-TIME RBAC RE-CHECK (the key security test): the proposer is
+#         DEMOTED to MEMBER after proposing → approve path FAILS CLOSED,
+#         update_member_role is NOT called.
+#       - unknown action key in the blob → executor HARD-FAILS, no service call.
+#       - idempotency: a second invocation does NOT re-fire the service.
+#       - args-hash mismatch: an args edit between propose and approve → FAILED,
+#         no call.
+#       - schema mismatch: a stale schema blob → FAILED, no call.
+#       - service failure (raise) → FAILED status, NOT an exception.
+#   * the production-path integration tests: propose → approve/reject via the REAL
+#     router handler → walk the decision chain and assert EXACTLY the expected
+#     events (agent.proposed → human.corrected → decision.completed), one terminal;
+#     reject fires no service call.
+#   * cross-workspace approval → 403, nothing fires.
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The store is patched to
+# a tmp-file InstinctStore; the workspace service + RBAC re-check are patched so
+# nothing touches Mongo.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.admin_proposals import executor as aa_executor  # noqa: E402
+from pocketpaw_ee.cloud.admin_proposals import propose as aa_propose  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.guards.rbac import Forbidden  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fakes + fixtures
+# ---------------------------------------------------------------------------
+
+
+class SpyWorkspaceService:
+    """Records update_member_role calls; returns None (matches the real sink).
+    Injected by monkeypatching ``workspace.service.update_member_role``."""
+
+    def __init__(self, *, raises: Exception | None = None):
+        self.calls: list[dict[str, Any]] = []
+        self._raises = raises
+
+    async def update_member_role(self, workspace_id, target_user_id, role, actor_user_id):
+        self.calls.append(
+            {
+                "workspace_id": workspace_id,
+                "target_user_id": target_user_id,
+                "role": role,
+                "actor_user_id": actor_user_id,
+            }
+        )
+        if self._raises is not None:
+            raise self._raises
+        return None
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired everywhere the gate reads it."""
+    st = InstinctStore(tmp_path / "instinct_admin_action_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    return st
+
+
+def _patch_service(monkeypatch, spy: SpyWorkspaceService) -> None:
+    """Patch the workspace service's ``update_member_role`` to the spy."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.update_member_role",
+        spy.update_member_role,
+    )
+
+
+def _allow_rbac(monkeypatch) -> None:
+    """Stub the execute-time RBAC re-check to PASS (proposer still holds the
+    role). The demotion test replaces this with a denying stub."""
+
+    async def _ok(workspace_id, proposer_user_id, rbac_action):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(aa_executor, "_recheck_rbac", _ok)
+
+
+def _deny_rbac(monkeypatch) -> None:
+    """Stub the execute-time RBAC re-check to FAIL — the proposer was demoted /
+    removed since proposing. The executor must fail closed."""
+
+    async def _deny(workspace_id, proposer_user_id, rbac_action):  # noqa: ANN001
+        raise Forbidden("workspace.insufficient_role", "proposer demoted to member since proposing")
+
+    monkeypatch.setattr(aa_executor, "_recheck_rbac", _deny)
+
+
+# ---------------------------------------------------------------------------
+# propose — blob shape + tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_builds_admin_action_blob(store):
+    """propose_admin_action files an Action carrying a well-formed schema-1
+    ``_admin_action`` blob — RBAC action key, args, proposer, params_hash,
+    idempotency_key, summary."""
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="workspace.member.role_change",
+        args={"target_user_id": "u2", "role": "admin"},
+        proposer_user_id="admin1",
+    )
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.status == ActionStatus.PENDING
+
+    blob = action.parameters["_admin_action"]
+    assert blob["kind"] == "admin_action"
+    assert blob["schema"] == 1
+    assert blob["workspace_id"] == "w1"
+    assert blob["action"] == "workspace.member.role_change"
+    assert blob["args"] == {"target_user_id": "u2", "role": "admin"}
+    assert blob["proposer_user_id"] == "admin1"
+    assert blob["params_hash"] == aa_propose.compute_args_hash(
+        "workspace.member.role_change", {"target_user_id": "u2", "role": "admin"}
+    )
+    assert blob["idempotency_key"]
+    assert blob["correlation_id"]
+    assert blob["summary"]
+
+
+async def test_propose_requires_workspace_and_proposer(store):
+    """A propose with no workspace / proposer is rejected up front."""
+    with pytest.raises(ValueError, match="workspace_id"):
+        await aa_propose.propose_admin_action(
+            workspace_id="",
+            action="workspace.member.role_change",
+            args={},
+            proposer_user_id="admin1",
+        )
+    with pytest.raises(ValueError, match="proposer_user_id"):
+        await aa_propose.propose_admin_action(
+            workspace_id="w1",
+            action="workspace.member.role_change",
+            args={},
+            proposer_user_id="",
+        )
+
+
+# ---------------------------------------------------------------------------
+# executor — happy path, RBAC re-check, whitelist, idempotency, hash, schema
+# ---------------------------------------------------------------------------
+
+
+async def _propose_and_approve(store, **kwargs) -> Any:
+    """Propose then approve via the store, returning the approved Action."""
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="workspace.member.role_change",
+        args={"target_user_id": "u2", "role": "admin"},
+        proposer_user_id="admin1",
+        **kwargs,
+    )
+    return await store.approve(action_id, approver="approver1")
+
+
+async def test_executor_happy_path_calls_service_once(store, monkeypatch):
+    """On approve the executor re-checks RBAC (stubbed pass), calls
+    update_member_role EXACTLY ONCE with the adapted args, marks EXECUTED, and
+    back-writes the structured outcome."""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    approved = await _propose_and_approve(store)
+    await aa_executor.execute_approved_admin_action(approved)
+
+    # APPROVE-FIRES-ONCE assertion.
+    assert len(spy.calls) == 1
+    call = spy.calls[0]
+    assert call["workspace_id"] == "w1"
+    assert call["target_user_id"] == "u2"
+    assert call["role"] == "admin"
+    # The actor recorded is the PROPOSER (the write's author).
+    assert call["actor_user_id"] == "admin1"
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.EXECUTED
+    blob = final.parameters["_admin_action"]
+    assert blob["outcome"]["status"] == "executed"
+    assert "executed_at" in blob["outcome"]
+
+
+async def test_executor_demoted_proposer_fails_closed(store, monkeypatch):
+    """THE KEY SECURITY TEST — the proposer was demoted to MEMBER after
+    proposing. The execute-time RBAC re-check DENIES, so the approved action
+    FAILS CLOSED: update_member_role is NOT called."""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+    _deny_rbac(monkeypatch)  # proposer no longer holds ADMIN
+
+    approved = await _propose_and_approve(store)
+    await aa_executor.execute_approved_admin_action(approved)  # must not raise
+
+    # DEMOTED-PROPOSER-BLOCKED assertion — the write NEVER fired.
+    assert spy.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "rbac" in str(final.error).lower() or "role" in str(final.error).lower()
+    assert final.parameters["_admin_action"]["outcome"]["status"] == "failed"
+
+
+async def test_executor_unknown_action_hard_fails(store, monkeypatch):
+    """An action key NOT in the execute whitelist → HARD FAIL, no service call.
+    (RBAC re-check is never reached — the whitelist miss precedes it.)"""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="workspace.member.delete_everything",  # not whitelisted
+        args={"target_user_id": "u2"},
+        proposer_user_id="admin1",
+    )
+    approved = await store.approve(action_id, approver="approver1")
+    await aa_executor.execute_approved_admin_action(approved)
+
+    assert spy.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "whitelist" in str(final.error).lower()
+
+
+async def test_executor_idempotent_never_double_fires(store, monkeypatch):
+    """Re-invoking the executor on an already-executed Action does NOT call the
+    service a second time."""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    approved = await _propose_and_approve(store)
+    await aa_executor.execute_approved_admin_action(approved)
+    assert len(spy.calls) == 1
+
+    reloaded = await store.get_action(approved.id)
+    await aa_executor.execute_approved_admin_action(reloaded)
+    assert len(spy.calls) == 1  # still ONE
+
+
+async def test_executor_args_hash_mismatch_refuses(store, monkeypatch):
+    """An args edit between propose and approve → FAILED, no service call."""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    approved = await _propose_and_approve(store)
+    approved.parameters["_admin_action"]["args"] = {"target_user_id": "u2", "role": "owner"}
+
+    await aa_executor.execute_approved_admin_action(approved)
+
+    assert spy.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "hash" in str(final.error).lower()
+
+
+async def test_executor_schema_mismatch_refuses(store, monkeypatch):
+    """A stale blob with an incompatible schema version → FAILED, no call."""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    approved = await _propose_and_approve(store)
+    approved.parameters["_admin_action"]["schema"] = 999
+
+    await aa_executor.execute_approved_admin_action(approved)
+
+    assert spy.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "schema" in str(final.error).lower()
+
+
+async def test_executor_service_crash_marks_failed_not_exception(store, monkeypatch):
+    """A service call that RAISES → the Action is FAILED, the executor swallows
+    the exception (best-effort, never breaks the approve response)."""
+    spy = SpyWorkspaceService(raises=RuntimeError("update blew up"))
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    approved = await _propose_and_approve(store)
+    await aa_executor.execute_approved_admin_action(approved)  # must not raise
+
+    assert len(spy.calls) == 1  # it was called, then raised
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "blew up" in str(final.error)
+
+
+async def test_executor_no_blob_is_noop(store, monkeypatch):
+    """An Action with no ``_admin_action`` blob is a clean no-op."""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+
+    from pocketpaw.instinct.models import ActionTrigger
+
+    action = await store.propose(
+        pocket_id="w1",
+        title="not admin",
+        description="",
+        recommendation="",
+        trigger=ActionTrigger(type="agent", source="x", reason="y"),
+    )
+    approved = await store.approve(action.id, approver="approver1")
+    await aa_executor.execute_approved_admin_action(approved)
+    assert spy.calls == []
+
+
+# ---------------------------------------------------------------------------
+# production-path integration — propose → approve/reject via the REAL router
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "approver1", workspace_id: str = "w1") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _make_client(user: _FakeUser, monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _events_by_correlation(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+async def test_production_path_approve_runs_executor_one_terminal(
+    store, journal, graph, monkeypatch
+):
+    """propose → approve through the REAL router handler → the executor fires the
+    whitelisted service → walk the chain and assert EXACTLY agent.proposed →
+    human.corrected → decision.completed. One terminal."""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="workspace.member.role_change",
+        args={"target_user_id": "u2", "role": "admin"},
+        proposer_user_id="admin1",
+    )
+    blob = (await store.get_action(action_id)).parameters["_admin_action"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("approver1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 200, resp.text
+
+    # The executor fired the service exactly once.
+    assert len(spy.calls) == 1
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is True
+    assert (terminal.payload or {})["action_outcome"] == "landed"
+    hc = chain[1]
+    assert terminal.causation_id == hc.id
+
+
+async def test_production_path_reject_router_closes_no_service_call(
+    store, journal, graph, monkeypatch
+):
+    """Reject path: the ROUTER emits human.corrected + decision.completed
+    (rejected); the executor is NEVER called (no service call)."""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="workspace.member.role_change",
+        args={"target_user_id": "u2", "role": "admin"},
+        proposer_user_id="admin1",
+    )
+    blob = (await store.get_action(action_id)).parameters["_admin_action"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("approver1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
+    assert resp.status_code == 200, resp.text
+
+    # REJECT-NO-FIRE assertion.
+    assert spy.calls == []
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.REJECTED
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is False
+    assert (terminal.payload or {})["action_outcome"] == "rejected"
+
+
+async def test_router_cross_workspace_approval_forbidden(store, journal, graph, monkeypatch):
+    """A caller whose active workspace differs from the blob's workspace_id gets
+    403 on approve — the tenancy gate binds the Action to the caller's
+    workspace."""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w-OTHER",
+        action="workspace.member.role_change",
+        args={"target_user_id": "u2", "role": "admin"},
+        proposer_user_id="admin1",
+    )
+
+    user = _FakeUser("approver1", "w1")  # caller in w1, action in w-OTHER
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 403, resp.text
+    assert spy.calls == []
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+
+
+async def test_recheck_rbac_denies_demoted_proposer(monkeypatch):
+    """Unit-test the REAL ``_recheck_rbac``: a proposer whose CURRENT role is
+    MEMBER (loaded fresh) is denied for an ADMIN-gated action — the executor's
+    fail-closed hinge. Patches the User doc load + the RBAC check seam so no DB
+    is touched."""
+
+    class _M:
+        def __init__(self, ws, role):
+            self.workspace = ws
+            self.role = role
+
+    class _DemotedUser:
+        id = "admin1"
+        workspaces = [_M("w1", "member")]  # demoted since proposing
+
+    async def _get(_id):  # noqa: ANN001
+        return _DemotedUser()
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.models.user.User.get", staticmethod(_get))
+    # PydanticObjectId(proposer) must not choke on a non-ObjectId test id — patch it.
+    monkeypatch.setattr("beanie.PydanticObjectId", lambda x: x)
+
+    with pytest.raises(Forbidden):
+        await aa_executor._recheck_rbac("w1", "admin1", "workspace.member.role_change")

--- a/tests/cloud/test_admin_action_gate.py
+++ b/tests/cloud/test_admin_action_gate.py
@@ -1,7 +1,15 @@
 # tests/cloud/test_admin_action_gate.py — the gated workspace-admin-action proposal
-# type (the 8th gated Instinct kind, WA-2).
+# type (the 8th gated Instinct kind, WA-2), plus the WA-5 whitelist extensions.
 #
 # Created: 2026-07-03 (feat/workspace-admin-tools, WA-2).
+# Updated: 2026-07-03 (WA-5) — coverage for the five additional whitelisted ADMIN
+#   writes (member.remove / invite.create / invite.revoke / connector.manage
+#   {enable,disable,config} / workspace.update). Per action: approve → the
+#   whitelisted service fires EXACTLY ONCE with the adapted args; the STRICT
+#   adapter drops a smuggled key (or fails closed on an invalid one, e.g. an invite
+#   role=owner or an unknown connector op); reject via the REAL router → no service
+#   call (parametrized). The connector-config test asserts the config rides INSIDE
+#   the typed DTO, never as top-level kwargs.
 #
 # What this pins:
 #   * propose_admin_action — blob shape (schema 1, RBAC action key, args,
@@ -545,3 +553,268 @@ async def test_recheck_rbac_denies_demoted_proposer(monkeypatch):
 
     with pytest.raises(Forbidden):
         await aa_executor._recheck_rbac("w1", "admin1", "workspace.member.role_change")
+
+
+# ---------------------------------------------------------------------------
+# WA-5 — the additional whitelisted ADMIN writes (member.remove / invite.create /
+# invite.revoke / connector.manage / workspace.update). Per action:
+#   * approve → the whitelisted service fires EXACTLY ONCE with the adapted args;
+#   * reject  → the service is NEVER called;
+#   * the STRICT adapter drops an unknown key an agent smuggled into args.
+# The store/journal/graph fixtures + _make_client + _allow_rbac are reused.
+# ---------------------------------------------------------------------------
+
+
+class _CallSpy:
+    """Generic async spy — records (args, kwargs) per call, returns None (matches
+    the void workspace/connector service sinks)."""
+
+    def __init__(self, *, raises: Exception | None = None):
+        self.calls: list[tuple[tuple, dict]] = []
+        self._raises = raises
+
+    async def __call__(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        self.calls.append((args, kwargs))
+        if self._raises is not None:
+            raise self._raises
+        return None
+
+
+async def _propose_approve_execute(store, monkeypatch, *, action: str, args: dict) -> Any:
+    """Propose the given admin action, approve it via the store, run the executor
+    (RBAC re-check stubbed to PASS). Returns the approved Action."""
+    _allow_rbac(monkeypatch)
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action=action,
+        args=args,
+        proposer_user_id="admin1",
+    )
+    approved = await store.approve(action_id, approver="approver1")
+    await aa_executor.execute_approved_admin_action(approved)
+    return approved
+
+
+# ---- member.remove --------------------------------------------------------
+
+
+async def test_executor_member_remove_fires_once(store, monkeypatch):
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.remove_member", spy)
+    await _propose_approve_execute(
+        store, monkeypatch, action="workspace.member.remove", args={"target_user_id": "u2"}
+    )
+    # APPROVE-FIRES-ONCE — remove_member(workspace_id, target_user_id, actor).
+    assert len(spy.calls) == 1
+    assert spy.calls[0][0] == ("w1", "u2", "admin1")
+
+
+async def test_executor_member_remove_adapter_drops_extra(store, monkeypatch):
+    """A smuggled ``role='owner'`` in args never reaches remove_member."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.remove_member", spy)
+    await _propose_approve_execute(
+        store,
+        monkeypatch,
+        action="workspace.member.remove",
+        args={"target_user_id": "u2", "role": "owner", "cascade": "all"},
+    )
+    assert len(spy.calls) == 1
+    # Only (workspace_id, target_user_id, actor) — no smuggled kwargs.
+    assert spy.calls[0] == (("w1", "u2", "admin1"), {})
+
+
+# ---- invite.create --------------------------------------------------------
+
+
+async def test_executor_invite_create_fires_once(store, monkeypatch):
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.create_invite", spy)
+    await _propose_approve_execute(
+        store,
+        monkeypatch,
+        action="invite.create",
+        args={"email": "a@b.com", "role": "member"},
+    )
+    assert len(spy.calls) == 1
+    call_args = spy.calls[0][0]
+    ctx, workspace_id, body = call_args
+    # The ctx attributes the write to the PROPOSER; the DTO carries ONLY email+role.
+    assert ctx.user_id == "admin1"
+    assert workspace_id == "w1"
+    assert body.email == "a@b.com"
+    assert body.role == "member"
+    assert body.group_id is None  # a smuggle-free DTO
+
+
+async def test_executor_invite_create_adapter_drops_extra(store, monkeypatch):
+    """A smuggled ``group_id`` / ``role='owner'`` in args never reaches the DTO —
+    the strict adapter rejects owner and ignores group_id."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.create_invite", spy)
+    # role=owner is invalid for an invite → the adapter raises → MalformedArgs
+    # failure, service never called.
+    approved = await _propose_approve_execute(
+        store,
+        monkeypatch,
+        action="invite.create",
+        args={"email": "a@b.com", "role": "owner", "group_id": "sneaky"},
+    )
+    assert spy.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+
+
+# ---- invite.revoke --------------------------------------------------------
+
+
+async def test_executor_invite_revoke_fires_once(store, monkeypatch):
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.revoke_invite", spy)
+    await _propose_approve_execute(
+        store, monkeypatch, action="invite.revoke", args={"invite_id": "inv1"}
+    )
+    # revoke_invite(workspace_id, invite_id, actor_user_id).
+    assert len(spy.calls) == 1
+    assert spy.calls[0][0] == ("w1", "inv1", "admin1")
+
+
+# ---- connector.manage (enable / disable / config) -------------------------
+
+
+async def test_executor_connector_enable_fires_once(store, monkeypatch):
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.enable_connector", spy)
+    await _propose_approve_execute(
+        store, monkeypatch, action="connector.manage", args={"op": "enable", "name": "gmail"}
+    )
+    assert len(spy.calls) == 1
+    call_args = spy.calls[0][0]
+    workspace_id, name, body = call_args
+    assert workspace_id == "w1"
+    assert name == "gmail"
+
+
+async def test_executor_connector_disable_fires_once(store, monkeypatch):
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.disable_connector", spy)
+    await _propose_approve_execute(
+        store, monkeypatch, action="connector.manage", args={"op": "disable", "name": "gmail"}
+    )
+    assert len(spy.calls) == 1
+    assert spy.calls[0][0] == ("w1", "gmail")
+
+
+async def test_executor_connector_config_passes_opaque_config(store, monkeypatch):
+    """op=config → update_config(workspace_id, name, UpdateConnectorConfigRequest)
+    with the config carried INSIDE the DTO (never as top-level kwargs)."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.update_config", spy)
+    await _propose_approve_execute(
+        store,
+        monkeypatch,
+        action="connector.manage",
+        args={"op": "config", "name": "gmail", "config": {"label": "Inbox"}},
+    )
+    assert len(spy.calls) == 1
+    call_args, call_kwargs = spy.calls[0]
+    workspace_id, name, body = call_args
+    assert workspace_id == "w1"
+    assert name == "gmail"
+    assert body.config == {"label": "Inbox"}  # opaque config inside the DTO
+    assert call_kwargs == {}  # nothing smuggled as kwargs
+
+
+async def test_executor_connector_manage_bad_op_fails(store, monkeypatch):
+    """An unknown ``op`` → the adapter raises → MalformedArgs failure, no call."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.enable_connector", spy)
+    approved = await _propose_approve_execute(
+        store, monkeypatch, action="connector.manage", args={"op": "delete", "name": "gmail"}
+    )
+    assert spy.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+
+
+# ---- workspace.update -----------------------------------------------------
+
+
+async def test_executor_workspace_update_fires_once_only_recognized(store, monkeypatch):
+    """approve → update(ctx, workspace_id, UpdateWorkspaceRequest) with ONLY the
+    recognized field; a smuggled ``seats`` never reaches the DTO."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.update", spy)
+    await _propose_approve_execute(
+        store,
+        monkeypatch,
+        action="workspace.update",
+        # NOTE: only ``name`` is a recognized field — the tool would have stripped
+        # the rest, but even a hand-crafted blob with extras is stripped by the
+        # strict adapter (the ``fields`` key only carries recognized fields).
+        args={"name": "New Name"},
+    )
+    assert len(spy.calls) == 1
+    ctx, workspace_id, body = spy.calls[0][0]
+    assert ctx.user_id == "admin1"
+    assert workspace_id == "w1"
+    assert body.name == "New Name"
+    assert body.settings is None
+    assert body.branding is None
+
+
+# ---- reject path — the executor never runs for any new action -------------
+
+
+@pytest.mark.parametrize(
+    ("action", "args", "svc_path"),
+    [
+        (
+            "workspace.member.remove",
+            {"target_user_id": "u2"},
+            "pocketpaw_ee.cloud.workspace.service.remove_member",
+        ),
+        (
+            "invite.create",
+            {"email": "a@b.com", "role": "member"},
+            "pocketpaw_ee.cloud.workspace.service.create_invite",
+        ),
+        (
+            "invite.revoke",
+            {"invite_id": "inv1"},
+            "pocketpaw_ee.cloud.workspace.service.revoke_invite",
+        ),
+        (
+            "connector.manage",
+            {"op": "enable", "name": "gmail"},
+            "pocketpaw_ee.cloud.connectors.service.enable_connector",
+        ),
+        (
+            "workspace.update",
+            {"name": "New Name"},
+            "pocketpaw_ee.cloud.workspace.service.update",
+        ),
+    ],
+)
+async def test_production_path_reject_no_service_call_wa5(
+    store, journal, graph, monkeypatch, action, args, svc_path
+):
+    """REJECT-NO-FIRE for every WA-5 write: reject via the REAL router handler →
+    the executor never runs → the whitelisted service is NEVER called."""
+    spy = _CallSpy()
+    monkeypatch.setattr(svc_path, spy)
+    _allow_rbac(monkeypatch)
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1", action=action, args=args, proposer_user_id="admin1"
+    )
+
+    user = _FakeUser("approver1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "no"})
+    assert resp.status_code == 200, resp.text
+
+    assert spy.calls == []
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.REJECTED

--- a/tests/cloud/test_admin_action_gate.py
+++ b/tests/cloud/test_admin_action_gate.py
@@ -2,6 +2,16 @@
 # type (the 8th gated Instinct kind, WA-2), plus the WA-5 whitelist extensions.
 #
 # Created: 2026-07-03 (feat/workspace-admin-tools, WA-2).
+# Updated: 2026-07-03 (WA-6) — coverage for the three OWNER writes
+#   (instinct.activate / workspace.delete / billing.manage). Per action: approve →
+#   the whitelisted service fires EXACTLY ONCE with the adapted args; reject via
+#   the REAL router → no service call. billing.manage is PAYMENT-HONEST: approve
+#   calls ``subscribe`` (which returns a {checkout_url}) — the executor records the
+#   checkout url as the outcome, and the test asserts NO ``set_workspace_plan``
+#   mutation is called (an agent must never flip a paid plan without checkout). The
+#   execute-time OWNER re-check is proven with the REAL ``_recheck_rbac``: a
+#   proposer DEMOTED from OWNER to ADMIN after proposing → approve FAILS CLOSED for
+#   an OWNER-gated action, the service is NOT called.
 # Updated: 2026-07-03 (WA-5) — coverage for the five additional whitelisted ADMIN
 #   writes (member.remove / invite.create / invite.revoke / connector.manage
 #   {enable,disable,config} / workspace.update). Per action: approve → the
@@ -807,6 +817,220 @@ async def test_production_path_reject_no_service_call_wa5(
 
     action_id = await aa_propose.propose_admin_action(
         workspace_id="w1", action=action, args=args, proposer_user_id="admin1"
+    )
+
+    user = _FakeUser("approver1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "no"})
+    assert resp.status_code == 200, resp.text
+
+    assert spy.calls == []
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.REJECTED
+
+
+# ---------------------------------------------------------------------------
+# WA-6 — the three OWNER writes (instinct.activate / workspace.delete /
+# billing.manage). Per action: approve → the whitelisted service fires EXACTLY
+# ONCE with the adapted args; reject → the service is NEVER called. billing.manage
+# produces a checkout url (an artifact), NOT a plan mutation. The demoted-OWNER
+# execute-time re-check is proven with the REAL _recheck_rbac.
+# ---------------------------------------------------------------------------
+
+
+# ---- instinct.activate ----------------------------------------------------
+
+
+async def test_executor_instinct_activate_fires_once(store, monkeypatch):
+    """approve → set_instinct_approval_level(ctx, workspace_id, level) fires once
+    with the adapted level; the proposer is the ctx actor."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.set_instinct_approval_level", spy)
+    await _propose_approve_execute(
+        store, monkeypatch, action="instinct.activate", args={"level": "TRUSTED"}
+    )
+    assert len(spy.calls) == 1
+    ctx, workspace_id, level = spy.calls[0][0]
+    assert ctx.user_id == "admin1"  # proposer attribution
+    assert workspace_id == "w1"
+    assert level == "TRUSTED"
+
+
+async def test_executor_instinct_activate_bad_level_fails(store, monkeypatch):
+    """An off-enum level → the strict adapter raises → MalformedArgs failure, no
+    service call (a hand-crafted blob can't set an invalid level)."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.set_instinct_approval_level", spy)
+    approved = await _propose_approve_execute(
+        store, monkeypatch, action="instinct.activate", args={"level": "YOLO"}
+    )
+    assert spy.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+
+
+# ---- workspace.delete -----------------------------------------------------
+
+
+async def test_executor_workspace_delete_fires_once(store, monkeypatch):
+    """approve → delete(ctx, workspace_id) fires once; the delete takes NO steering
+    args (a smuggled key never reaches it)."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.delete", spy)
+    await _propose_approve_execute(
+        store,
+        monkeypatch,
+        action="workspace.delete",
+        # A hand-crafted blob with a smuggled key — the adapter ignores it entirely.
+        args={"force": True, "target_user_id": "evil"},
+    )
+    assert len(spy.calls) == 1
+    ctx, workspace_id = spy.calls[0][0]
+    assert ctx.user_id == "admin1"
+    assert workspace_id == "w1"
+    assert spy.calls[0][1] == {}  # nothing smuggled as kwargs
+
+
+# ---- billing.manage (propose→checkout-URL, NOT a plan mutation) -----------
+
+
+async def test_executor_billing_manage_produces_checkout_not_plan_mutation(store, monkeypatch):
+    """PAYMENT HONESTY — approve calls ``subscribe`` (which returns a checkout
+    url); the executor records that url as the outcome. The webhook-internal
+    ``set_workspace_plan`` is NEVER called — an agent can't flip a paid plan."""
+    subscribe_spy = _CallSpy()
+
+    async def _subscribe(*args, **kwargs):  # noqa: ANN002, ANN003
+        subscribe_spy.calls.append((args, kwargs))
+        return {"checkout_url": "https://checkout.dodo.test/session/abc"}
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.billing.service.subscribe", _subscribe)
+
+    # set_workspace_plan is the payment-bypassing sink that must NEVER be reached.
+    plan_mutation_spy = _CallSpy()
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.set_workspace_plan", plan_mutation_spy
+    )
+
+    approved = await _propose_approve_execute(
+        store, monkeypatch, action="billing.manage", args={"plan_key": "pro"}
+    )
+
+    # subscribe fired once with (workspace_id, proposer, plan_key).
+    assert len(subscribe_spy.calls) == 1
+    assert subscribe_spy.calls[0][0] == ("w1", "admin1", "pro")
+    # THE payment-honesty assertion: the plan was NOT silently mutated.
+    assert plan_mutation_spy.calls == []
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.EXECUTED
+    # The checkout url is recorded as the outcome artifact (not a "plan changed").
+    outcome = final.parameters["_admin_action"]["outcome"]
+    assert outcome["status"] == "executed"
+    assert "checkout.dodo.test" in outcome["response_summary"]
+
+
+async def test_executor_billing_manage_bad_plan_fails(store, monkeypatch):
+    """An unknown plan tier → the strict adapter raises → MalformedArgs, no call."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.billing.service.subscribe", spy)
+    approved = await _propose_approve_execute(
+        store, monkeypatch, action="billing.manage", args={"plan_key": "platinum"}
+    )
+    assert spy.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+
+
+# ---- execute-time OWNER re-check — demoted proposer fails closed ----------
+
+
+async def test_recheck_rbac_denies_demoted_owner_on_owner_action(monkeypatch):
+    """THE KEY OWNER SECURITY TEST (real _recheck_rbac): a proposer DEMOTED from
+    OWNER to ADMIN after proposing is DENIED for an OWNER-gated action
+    (instinct.activate) — the executor's fail-closed hinge for the OWNER ops."""
+
+    class _M:
+        def __init__(self, ws, role):
+            self.workspace = ws
+            self.role = role
+
+    class _DemotedOwner:
+        id = "owner1"
+        workspaces = [_M("w1", "admin")]  # was OWNER at propose, now only ADMIN
+
+    async def _get(_id):  # noqa: ANN001
+        return _DemotedOwner()
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.models.user.User.get", staticmethod(_get))
+    monkeypatch.setattr("beanie.PydanticObjectId", lambda x: x)
+
+    # instinct.activate is OWNER-gated → an ADMIN proposer is refused.
+    with pytest.raises(Forbidden):
+        await aa_executor._recheck_rbac("w1", "owner1", "instinct.activate")
+    with pytest.raises(Forbidden):
+        await aa_executor._recheck_rbac("w1", "owner1", "workspace.delete")
+    with pytest.raises(Forbidden):
+        await aa_executor._recheck_rbac("w1", "owner1", "billing.manage")
+
+
+async def test_executor_owner_action_demoted_proposer_fails_closed(store, monkeypatch):
+    """End-to-end: an OWNER-gated action (workspace.delete) approved after the
+    proposer was demoted → the execute-time re-check DENIES → FAILS CLOSED, the
+    delete service is NOT called."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.delete", spy)
+    _deny_rbac(monkeypatch)  # proposer no longer holds OWNER
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="workspace.delete",
+        args={},
+        proposer_user_id="owner1",
+    )
+    approved = await store.approve(action_id, approver="approver1")
+    await aa_executor.execute_approved_admin_action(approved)  # must not raise
+
+    assert spy.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+
+
+# ---- reject path — the executor never runs for any OWNER action -----------
+
+
+@pytest.mark.parametrize(
+    ("action", "args", "svc_path"),
+    [
+        (
+            "instinct.activate",
+            {"level": "TRUSTED"},
+            "pocketpaw_ee.cloud.workspace.service.set_instinct_approval_level",
+        ),
+        (
+            "workspace.delete",
+            {},
+            "pocketpaw_ee.cloud.workspace.service.delete",
+        ),
+        (
+            "billing.manage",
+            {"plan_key": "pro"},
+            "pocketpaw_ee.cloud.billing.service.subscribe",
+        ),
+    ],
+)
+async def test_production_path_reject_no_service_call_wa6(
+    store, journal, graph, monkeypatch, action, args, svc_path
+):
+    """REJECT-NO-FIRE for every WA-6 OWNER write: reject via the REAL router →
+    the executor never runs → the whitelisted service is NEVER called."""
+    spy = _CallSpy()
+    monkeypatch.setattr(svc_path, spy)
+    _allow_rbac(monkeypatch)
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1", action=action, args=args, proposer_user_id="owner1"
     )
 
     user = _FakeUser("approver1", "w1")

--- a/tests/cloud/test_admin_action_gate.py
+++ b/tests/cloud/test_admin_action_gate.py
@@ -240,6 +240,25 @@ async def test_executor_happy_path_calls_service_once(store, monkeypatch):
     assert "executed_at" in blob["outcome"]
 
 
+async def test_reapprove_of_resolved_action_is_noop_no_double_fire(store, monkeypatch):
+    """A second approve of an already-approved action must NOT re-run the
+    executor (store.approve now guards require_status=PENDING). Prevents the
+    double-fire window where an executor mutated but failed to record its
+    outcome, leaving the row APPROVED."""
+    spy = SpyWorkspaceService()
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    approved = await _propose_and_approve(store)
+    await aa_executor.execute_approved_admin_action(approved)
+    assert len(spy.calls) == 1
+
+    # Re-approving the now-EXECUTED (non-pending) action is a no-op.
+    reapproved = await store.approve(approved.id, approver="approver1")
+    assert reapproved is None
+    assert len(spy.calls) == 1  # service did NOT fire a second time
+
+
 async def test_executor_demoted_proposer_fails_closed(store, monkeypatch):
     """THE KEY SECURITY TEST — the proposer was demoted to MEMBER after
     proposing. The execute-time RBAC re-check DENIES, so the approved action

--- a/tests/ee/agent/test_atlas_role_provider.py
+++ b/tests/ee/agent/test_atlas_role_provider.py
@@ -1,0 +1,285 @@
+# tests/ee/agent/test_atlas_role_provider.py — the role-aware atlas
+#   EntitlementProvider (feat/workspace-admin-tools, WA-3).
+#
+# Created: 2026-07-03 (feat/workspace-admin-tools, WA-3).
+#
+# What this pins — the DISCOVERY-layer filter that hides admin capabilities a
+# member can't use from atlas_search / atlas_describe (NOT the security gate;
+# the RBAC checks inside the tools are the real lock). Driven through the REAL
+# core overlay + the REAL packaged store so the provider is exercised end to end:
+#   * MEMBER role → member-level admin ``capability`` cards are PRESENT; ADMIN
+#     and OWNER cards are ABSENT (filtered). A non-role entry (a primitive) is
+#     present regardless.
+#   * ADMIN role → member + admin cards present, owner cards absent.
+#   * OWNER role → every admin card present.
+#   * Role UNRESOLVABLE (no identity on the stream / user not found / not a
+#     member) → EVERY ``role:*`` card hidden (fail-closed), never a raise.
+#   * ``connected_connector_names`` delegates to the wrapped default provider.
+#   * The scope/identity-workspace mismatch fails closed.
+#
+# Identity is set via the same ``attach_agent_identity`` ContextVars the admin
+# tools read; the ``User`` doc load (``_load_user``) is patched so nothing
+# touches Mongo — the fake user carries a duck-typed ``.workspaces`` list that
+# ``resolve_workspace_role`` reads (``.workspace`` / ``.role``). ``prime()`` is
+# awaited exactly as the sdk_mcp_atlas handler awaits it before the sync grant
+# filter.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+import pocketpaw_ee.agent.atlas_provider as ap  # noqa: E402
+from pocketpaw_ee.agent.atlas_provider import RoleAwareEntitlementProvider  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+
+from pocketpaw.atlas.model import AtlasEntry, AtlasModel  # noqa: E402
+from pocketpaw.atlas.overlay import AtlasOverlay  # noqa: E402
+from pocketpaw.atlas.store import AtlasStore  # noqa: E402
+
+WS = "w1"
+SCOPE = f"ws:{WS}"
+
+
+# ── fakes ──────────────────────────────────────────────────────────────────
+
+
+class _Membership:
+    def __init__(self, workspace: str, role: str):
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    """Duck-typed User: a ``.workspaces`` list resolve_workspace_role reads."""
+
+    def __init__(self, memberships: list[_Membership]):
+        self.workspaces = memberships
+        self.id = "u1"
+
+
+class _identity:
+    """Set the identity ContextVars the provider reads, then reset them."""
+
+    def __init__(self, *, workspace=WS, user="u1"):
+        self._ws, self._user = workspace, user
+        self._tokens = None
+
+    def __enter__(self):
+        self._tokens = attach_agent_identity(workspace_id=self._ws, user_id=self._user)
+        return self
+
+    def __exit__(self, *exc):
+        detach_agent_identity(self._tokens)
+        return False
+
+
+def _cap(entry_id: str, tier: str) -> AtlasEntry:
+    return AtlasEntry(
+        id=entry_id,
+        kind="capability",
+        name=entry_id.split(":", 1)[1],
+        summary=f"{entry_id} summary",
+        narrative=f"{entry_id} narrative",
+        requires=[f"role:{tier}"],
+        keywords=["manage", "workspace", "admin"],
+    )
+
+
+def _store() -> AtlasStore:
+    """One primitive (role-blind) + one admin card per tier."""
+    return AtlasStore(
+        AtlasModel(
+            entries=[
+                AtlasEntry(
+                    id="primitive:pocket",
+                    kind="primitive",
+                    name="Pocket",
+                    summary="Pocket summary",
+                    narrative="Pocket narrative",
+                    keywords=["manage", "workspace"],
+                ),
+                _cap("capability:admin.members_list", "member"),
+                _cap("capability:admin.member_update_role", "admin"),
+                _cap("capability:admin.workspace_delete", "owner"),
+            ]
+        )
+    )
+
+
+@pytest.fixture
+def _patch_user(monkeypatch):
+    """Patch the provider's User load to return a fake user for the CURRENT
+    identity's role — configured per test via the ``role`` closure var."""
+
+    def _install(role: str | None, *, member_of=WS):
+        async def _fake_load_user(user_id: str):  # noqa: ANN001, ARG001
+            if role is None:
+                return None
+            return _FakeUser([_Membership(member_of, role)])
+
+        monkeypatch.setattr(
+            ap.RoleAwareEntitlementProvider, "_load_user", staticmethod(_fake_load_user)
+        )
+
+    return _install
+
+
+async def _primed(role_provider: RoleAwareEntitlementProvider):
+    await role_provider.prime()
+    return role_provider
+
+
+def _visible_admin_ids(store, provider) -> set[str]:
+    return {
+        e.id
+        for e in (o.entry for o in AtlasOverlay.apply(store.entries, provider))
+        if e.id.startswith("capability:admin.")
+    }
+
+
+# ── the three role tiers ────────────────────────────────────────────────────
+
+
+class TestRoleTiersFilterAdminEntries:
+    @pytest.mark.asyncio
+    async def test_member_sees_only_member_admin_cards(self, _patch_user):
+        _patch_user("member")
+        store = _store()
+        with _identity():
+            provider = await _primed(RoleAwareEntitlementProvider(scope_key=SCOPE))
+            admin_ids = _visible_admin_ids(store, provider)
+            # member-level read card present; admin + owner cards ABSENT.
+            assert admin_ids == {"capability:admin.members_list"}
+            # a non-admin describe (delete) reads exactly like an unknown id.
+            assert (
+                AtlasOverlay.describe(store, "capability:admin.workspace_delete", provider) is None
+            )
+            # the role-blind primitive is always present.
+            assert AtlasOverlay.describe(store, "primitive:pocket", provider) is not None
+
+    @pytest.mark.asyncio
+    async def test_member_search_hides_admin_entries(self, _patch_user):
+        _patch_user("member")
+        store = _store()
+        with _identity():
+            provider = await _primed(RoleAwareEntitlementProvider(scope_key=SCOPE))
+            ids = [o.entry.id for o in AtlasOverlay.search(store, "manage the workspace", provider)]
+            assert "capability:admin.member_update_role" not in ids
+            assert "capability:admin.workspace_delete" not in ids
+
+    @pytest.mark.asyncio
+    async def test_admin_sees_member_and_admin_not_owner(self, _patch_user):
+        _patch_user("admin")
+        store = _store()
+        with _identity():
+            provider = await _primed(RoleAwareEntitlementProvider(scope_key=SCOPE))
+            assert _visible_admin_ids(store, provider) == {
+                "capability:admin.members_list",
+                "capability:admin.member_update_role",
+            }
+
+    @pytest.mark.asyncio
+    async def test_owner_sees_all_admin_cards(self, _patch_user):
+        _patch_user("owner")
+        store = _store()
+        with _identity():
+            provider = await _primed(RoleAwareEntitlementProvider(scope_key=SCOPE))
+            assert _visible_admin_ids(store, provider) == {
+                "capability:admin.members_list",
+                "capability:admin.member_update_role",
+                "capability:admin.workspace_delete",
+            }
+
+
+# ── fail-closed ──────────────────────────────────────────────────────────────
+
+
+class TestFailClosed:
+    @pytest.mark.asyncio
+    async def test_no_identity_hides_all_role_entries(self, _patch_user):
+        # No _identity() context → the ContextVars are unset → role unresolved.
+        _patch_user("owner")  # even though the user WOULD be owner, no identity → hidden
+        store = _store()
+        provider = await _primed(RoleAwareEntitlementProvider(scope_key=SCOPE))
+        assert _visible_admin_ids(store, provider) == set()
+        # the role-blind primitive is still visible.
+        assert AtlasOverlay.describe(store, "primitive:pocket", provider) is not None
+
+    @pytest.mark.asyncio
+    async def test_user_not_found_hides_all_role_entries(self, _patch_user):
+        _patch_user(None)  # _load_user returns None
+        store = _store()
+        with _identity():
+            provider = await _primed(RoleAwareEntitlementProvider(scope_key=SCOPE))
+            assert _visible_admin_ids(store, provider) == set()
+
+    @pytest.mark.asyncio
+    async def test_not_a_member_hides_all_role_entries(self, _patch_user):
+        # The user IS loaded but is a member of a DIFFERENT workspace → Forbidden
+        # inside resolve_workspace_role → role unresolved → hidden.
+        _patch_user("owner", member_of="other-workspace")
+        store = _store()
+        with _identity():
+            provider = await _primed(RoleAwareEntitlementProvider(scope_key=SCOPE))
+            assert _visible_admin_ids(store, provider) == set()
+
+    @pytest.mark.asyncio
+    async def test_scope_identity_workspace_mismatch_hides(self, _patch_user):
+        # Provider bound to ws:w1 but the stream identity is ws:other → refuse.
+        _patch_user("owner")
+        store = _store()
+        with _identity(workspace="other"):
+            provider = await _primed(RoleAwareEntitlementProvider(scope_key=SCOPE))
+            assert _visible_admin_ids(store, provider) == set()
+
+    @pytest.mark.asyncio
+    async def test_prime_never_raises_on_load_error(self, monkeypatch):
+        async def _boom(user_id):  # noqa: ANN001, ARG001
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(ap.RoleAwareEntitlementProvider, "_load_user", staticmethod(_boom))
+        store = _store()
+        with _identity():
+            provider = RoleAwareEntitlementProvider(scope_key=SCOPE)
+            await provider.prime()  # must not raise
+            assert _visible_admin_ids(store, provider) == set()
+
+    @pytest.mark.asyncio
+    async def test_is_granted_without_prime_hides_role_entries(self, _patch_user):
+        # If prime() never runs, the role stays unresolved → role entries hidden.
+        _patch_user("owner")
+        store = _store()
+        with _identity():
+            provider = RoleAwareEntitlementProvider(scope_key=SCOPE)  # NOT primed
+            assert _visible_admin_ids(store, provider) == set()
+
+
+# ── construction + delegation ────────────────────────────────────────────────
+
+
+class TestConstructionAndDelegation:
+    def test_rejects_non_ws_scope(self):
+        with pytest.raises(ValueError):
+            RoleAwareEntitlementProvider(scope_key="default")
+
+    def test_connected_connector_names_delegates(self, monkeypatch):
+        provider = RoleAwareEntitlementProvider(scope_key=SCOPE)
+        monkeypatch.setattr(provider._default, "connected_connector_names", lambda: {"stripe"})
+        assert provider.connected_connector_names() == {"stripe"}
+
+    def test_non_role_entries_grant_via_default(self):
+        provider = RoleAwareEntitlementProvider(scope_key=SCOPE)
+        primitive = AtlasEntry(
+            id="primitive:pocket",
+            kind="primitive",
+            name="Pocket",
+            summary="s",
+            narrative="n",
+        )
+        # No prime needed — a role-blind entry delegates to the default (grant).
+        assert provider.is_granted(primitive) is True

--- a/tests/ee/agent/test_workspace_admin_mcp/__init__.py
+++ b/tests/ee/agent/test_workspace_admin_mcp/__init__.py
@@ -1,0 +1,2 @@
+# tests/ee/agent/test_workspace_admin_mcp package marker.
+# Created: 2026-07-03 (feat/workspace-admin-tools, WA-1).

--- a/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
+++ b/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
@@ -1,9 +1,16 @@
 # tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py — the agent-facing MCP
-# surface for workspace administration (feat/workspace-admin-tools, WA-1).
+# surface for workspace administration (feat/workspace-admin-tools, WA-1/WA-2/WA-4).
 #
 # Created: 2026-07-03 (feat/workspace-admin-tools, WA-1).
+# Updated: 2026-07-03 (WA-4) — added coverage for the five READ-only tools:
+#   workspace_settings_read, invites_list, connectors_list, billing_usage_read,
+#   audit_read. Each has a PASS case (correct role → the service is called and its
+#   data is returned) and a DENY case (insufficient role → a deny envelope with
+#   ok=False/denied=True/code, and the service is SPIED and asserted NOT called).
+#   READ tools EXECUTE directly on a gate pass (no Instinct proposal — that's
+#   writes only). The contract test now asserts all seven tool ids.
 #
-# What this pins — the two WA-1 MCP tools, driven through the REAL handlers:
+# What this pins — the WA-1/WA-2 tools, driven through the REAL handlers:
 #   * tool-id / server-name contract (SERVER_NAME, *_TOOL_ID, ADMIN_TOOL_IDS)
 #     and the provider exposing the server + tool ids (extensions wiring).
 #   * members_list (READ): a MEMBER identity → returns the roster (read allowed);
@@ -20,8 +27,8 @@
 #
 # ``pocketpaw_ee`` is import-skipped on an OSS-only install. The handlers read
 # identity through ee.cloud.chat.agent_service ContextVars (set in-test via
-# attach_agent_identity). RBAC + the workspace service are patched so nothing
-# touches Mongo — this pins the tool's gate + envelope behaviour, not the DB.
+# attach_agent_identity). RBAC + the services are patched so nothing touches
+# Mongo — this pins the tool's gate + envelope behaviour, not the DB.
 
 from __future__ import annotations
 
@@ -103,9 +110,22 @@ def test_server_name_and_tool_ids_contract():
     assert wa_mcp.SERVER_NAME == "pocketpaw_workspace_admin"
     assert wa_mcp.MEMBERS_LIST_TOOL_ID == "mcp__pocketpaw_workspace_admin__members_list"
     assert wa_mcp.MEMBER_UPDATE_ROLE_TOOL_ID == "mcp__pocketpaw_workspace_admin__member_update_role"
+    assert (
+        wa_mcp.WORKSPACE_SETTINGS_READ_TOOL_ID
+        == "mcp__pocketpaw_workspace_admin__workspace_settings_read"
+    )
+    assert wa_mcp.INVITES_LIST_TOOL_ID == "mcp__pocketpaw_workspace_admin__invites_list"
+    assert wa_mcp.CONNECTORS_LIST_TOOL_ID == "mcp__pocketpaw_workspace_admin__connectors_list"
+    assert wa_mcp.BILLING_USAGE_READ_TOOL_ID == "mcp__pocketpaw_workspace_admin__billing_usage_read"
+    assert wa_mcp.AUDIT_READ_TOOL_ID == "mcp__pocketpaw_workspace_admin__audit_read"
     assert set(wa_mcp.ADMIN_TOOL_IDS) == {
         wa_mcp.MEMBERS_LIST_TOOL_ID,
         wa_mcp.MEMBER_UPDATE_ROLE_TOOL_ID,
+        wa_mcp.WORKSPACE_SETTINGS_READ_TOOL_ID,
+        wa_mcp.INVITES_LIST_TOOL_ID,
+        wa_mcp.CONNECTORS_LIST_TOOL_ID,
+        wa_mcp.BILLING_USAGE_READ_TOOL_ID,
+        wa_mcp.AUDIT_READ_TOOL_ID,
     }
 
 
@@ -297,3 +317,406 @@ async def test_member_update_role_outside_stream_errors():
     res = await wa_mcp._member_update_role_handler({"user_id": "u2", "role": "admin"})
     assert res.get("is_error") is True
     assert "no active workspace" in res["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# WA-4 READ tools — shared helpers
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+
+
+def _allow(role=WorkspaceRole.MEMBER):
+    """Patch factory: check_workspace_action passes, returning ``role``."""
+    return lambda *a, **k: role
+
+
+def _deny_forbidden(code="workspace.insufficient_role", detail="nope"):
+    """Patch factory: check_workspace_action raises Forbidden."""
+
+    def _deny(*a, **k):  # noqa: ANN001, ANN002
+        raise Forbidden(code=code, detail=detail)
+
+    return _deny
+
+
+# ---------------------------------------------------------------------------
+# workspace_settings_read — READ (workspace.view / MEMBER)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_settings_read_member_allowed(monkeypatch, _patch_user):
+    """A MEMBER may read settings — gate passes, the service is called, and a
+    compact view (no owner id / asset refs) comes back."""
+    monkeypatch.setattr("pocketpaw_ee.guards.deps.check_workspace_action", _allow())
+
+    called = {}
+
+    async def _get(ctx, workspace_id):  # noqa: ANN001
+        called["ctx_user"] = ctx.user_id
+        called["ws"] = workspace_id
+        return SimpleNamespace(
+            name="Acme",
+            slug="acme",
+            plan="business",
+            seats=10,
+            member_count=3,
+            branding=SimpleNamespace(
+                display_name="Acme Inc",
+                tab_title="Acme",
+                accent_color="#123456",
+                show_paw_mark=False,
+                logo_asset="secret-asset-id",  # must NOT leak into the view
+            ),
+        )
+
+    import pocketpaw_ee.cloud.workspace.service as ws_service
+
+    monkeypatch.setattr(ws_service, "get", _get)
+
+    with _identity(workspace="w1", user="u1"):
+        res = await wa_mcp._workspace_settings_read_handler({})
+
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["name"] == "Acme"
+    assert body["plan"] == "business"
+    assert body["seats"] == 10
+    assert body["seats_used"] == 3
+    assert body["seats_available"] == 7
+    assert body["branding"] == {
+        "display_name": "Acme Inc",
+        "tab_title": "Acme",
+        "accent_color": "#123456",
+        "show_paw_mark": False,
+    }
+    assert "logo_asset" not in body["branding"]  # asset refs are internal
+    assert "owner" not in body
+    assert called == {"ctx_user": "u1", "ws": "w1"}
+
+
+@pytest.mark.asyncio
+async def test_workspace_settings_read_denied_no_service_call(monkeypatch, _patch_user):
+    """A gate failure → deny envelope (not raised); the service is NOT reached."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.not_member"),
+    )
+    hit = {"called": False}
+
+    async def _get(ctx, workspace_id):  # noqa: ANN001
+        hit["called"] = True
+
+    import pocketpaw_ee.cloud.workspace.service as ws_service
+
+    monkeypatch.setattr(ws_service, "get", _get)
+
+    with _identity(workspace="w1", user="outsider"):
+        res = await wa_mcp._workspace_settings_read_handler({})
+
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert body["code"] == "workspace.not_member"
+    assert hit["called"] is False
+
+
+# ---------------------------------------------------------------------------
+# invites_list — READ (invite.create / ADMIN)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invites_list_admin_allowed(monkeypatch, _patch_user):
+    """An ADMIN may read pending invites — gate passes, the service returns rows."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action", _allow(WorkspaceRole.ADMIN)
+    )
+
+    called = {}
+
+    async def _list_invites(workspace_id):  # noqa: ANN001
+        called["ws"] = workspace_id
+        return [
+            SimpleNamespace(
+                id="inv1",
+                email="a@example.com",
+                role="member",
+                invited_by="admin1",
+                group_id=None,
+                expires_at=datetime.now(UTC),
+            )
+        ]
+
+    import pocketpaw_ee.cloud.workspace.service as ws_service
+
+    monkeypatch.setattr(ws_service, "list_invites", _list_invites)
+
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._invites_list_handler({})
+
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["count"] == 1
+    assert body["invites"][0]["email"] == "a@example.com"
+    assert called == {"ws": "w1"}
+
+
+@pytest.mark.asyncio
+async def test_invites_list_member_denied_no_service_call(monkeypatch, _patch_user):
+    """A MEMBER (insufficient role) → deny envelope; the service is NOT reached."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.insufficient_role"),
+    )
+    hit = {"called": False}
+
+    async def _list_invites(workspace_id):  # noqa: ANN001
+        hit["called"] = True
+        return []
+
+    import pocketpaw_ee.cloud.workspace.service as ws_service
+
+    monkeypatch.setattr(ws_service, "list_invites", _list_invites)
+
+    with _identity(workspace="w1", user="member1"):
+        res = await wa_mcp._invites_list_handler({})
+
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert body["code"] == "workspace.insufficient_role"
+    assert hit["called"] is False
+
+
+# ---------------------------------------------------------------------------
+# connectors_list — READ (workspace.view / MEMBER)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connectors_list_member_allowed(monkeypatch, _patch_user):
+    """A MEMBER may list connectors — gate passes; the service is called with the
+    caller's user_id (so its per-user permission filter runs)."""
+    monkeypatch.setattr("pocketpaw_ee.guards.deps.check_workspace_action", _allow())
+
+    called = {}
+
+    async def _list_connectors(workspace_id, *, user_id=None):  # noqa: ANN001
+        called["ws"] = workspace_id
+        called["user_id"] = user_id
+        return [
+            SimpleNamespace(
+                name="gmail",
+                display_name="Gmail",
+                type="oauth",
+                enabled=True,
+                status="connected",
+                last_sync_status="ok",
+                last_sync_at=datetime.now(UTC),
+            )
+        ]
+
+    import pocketpaw_ee.cloud.connectors.service as conn_service
+
+    monkeypatch.setattr(conn_service, "list_connectors", _list_connectors)
+
+    with _identity(workspace="w1", user="u1"):
+        res = await wa_mcp._connectors_list_handler({})
+
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["count"] == 1
+    assert body["connectors"][0]["name"] == "gmail"
+    assert body["connectors"][0]["status"] == "connected"
+    # The caller's user_id is threaded so the service applies their permissions.
+    assert called == {"ws": "w1", "user_id": "u1"}
+
+
+@pytest.mark.asyncio
+async def test_connectors_list_denied_no_service_call(monkeypatch, _patch_user):
+    """A gate failure → deny envelope; the connectors service is NOT reached."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.not_member"),
+    )
+    hit = {"called": False}
+
+    async def _list_connectors(workspace_id, *, user_id=None):  # noqa: ANN001
+        hit["called"] = True
+        return []
+
+    import pocketpaw_ee.cloud.connectors.service as conn_service
+
+    monkeypatch.setattr(conn_service, "list_connectors", _list_connectors)
+
+    with _identity(workspace="w1", user="outsider"):
+        res = await wa_mcp._connectors_list_handler({})
+
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert hit["called"] is False
+
+
+# ---------------------------------------------------------------------------
+# billing_usage_read — READ (workspace.view / MEMBER)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_billing_usage_read_member_allowed(monkeypatch, _patch_user):
+    """A MEMBER may read usage — gate passes; start/end are threaded to the
+    service as start_date/end_date and the summary comes back."""
+    monkeypatch.setattr("pocketpaw_ee.guards.deps.check_workspace_action", _allow())
+
+    called = {}
+
+    async def _get_workspace_usage(workspace_id, *, start_date=None, end_date=None):  # noqa: ANN001
+        called["ws"] = workspace_id
+        called["start_date"] = start_date
+        called["end_date"] = end_date
+        return SimpleNamespace(
+            start_date="2026-06-01",
+            end_date="2026-06-30",
+            models=["gpt-4o"],
+            total_credits=42,
+            buckets=[
+                SimpleNamespace(
+                    date="2026-06-01",
+                    total_credits=42,
+                    by_model={"gpt-4o": SimpleNamespace(credits=42, requests=3, tokens=0)},
+                )
+            ],
+        )
+
+    import pocketpaw_ee.cloud.billing.usage as usage_service
+
+    monkeypatch.setattr(usage_service, "get_workspace_usage", _get_workspace_usage)
+
+    with _identity(workspace="w1", user="u1"):
+        res = await wa_mcp._billing_usage_read_handler({"start": "2026-06-01", "end": "2026-06-30"})
+
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["total_credits"] == 42
+    assert body["models"] == ["gpt-4o"]
+    assert body["buckets"][0]["by_model"]["gpt-4o"]["credits"] == 42
+    assert called == {"ws": "w1", "start_date": "2026-06-01", "end_date": "2026-06-30"}
+
+
+@pytest.mark.asyncio
+async def test_billing_usage_read_denied_no_service_call(monkeypatch, _patch_user):
+    """A gate failure → deny envelope; the usage service is NOT reached."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.not_member"),
+    )
+    hit = {"called": False}
+
+    async def _get_workspace_usage(workspace_id, *, start_date=None, end_date=None):  # noqa: ANN001
+        hit["called"] = True
+
+    import pocketpaw_ee.cloud.billing.usage as usage_service
+
+    monkeypatch.setattr(usage_service, "get_workspace_usage", _get_workspace_usage)
+
+    with _identity(workspace="w1", user="outsider"):
+        res = await wa_mcp._billing_usage_read_handler({})
+
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert hit["called"] is False
+
+
+# ---------------------------------------------------------------------------
+# audit_read — READ (audit.read / ADMIN)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_read_admin_allowed(monkeypatch, _patch_user):
+    """An ADMIN may read the audit log — gate passes; limit is threaded into the
+    AuditQueryRequest and rows come back in the wire shape."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action", _allow(WorkspaceRole.ADMIN)
+    )
+
+    called = {}
+
+    async def _list_events_response(workspace_id, query):  # noqa: ANN001
+        called["ws"] = workspace_id
+        called["limit"] = query.limit
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    id="ev1",
+                    actorId="admin1",
+                    action="workspace.updated",
+                    targetType="workspace",
+                    targetId="w1",
+                    metadata={"patched": {"name": "New"}},
+                    at="2026-07-03T00:00:00Z",
+                )
+            ],
+            nextCursor="cursor-xyz",
+        )
+
+    import pocketpaw_ee.cloud.audit.service as audit_service
+
+    monkeypatch.setattr(audit_service, "list_events_response", _list_events_response)
+
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._audit_read_handler({"limit": 5})
+
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["count"] == 1
+    assert body["items"][0]["action"] == "workspace.updated"
+    assert body["items"][0]["actor_id"] == "admin1"
+    assert body["next_cursor"] == "cursor-xyz"
+    assert called == {"ws": "w1", "limit": 5}
+
+
+@pytest.mark.asyncio
+async def test_audit_read_member_denied_no_service_call(monkeypatch, _patch_user):
+    """A MEMBER (insufficient role) → deny envelope; the audit service is NOT
+    reached (fail-closed — audit is ADMIN-only)."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.insufficient_role"),
+    )
+    hit = {"called": False}
+
+    async def _list_events_response(workspace_id, query):  # noqa: ANN001
+        hit["called"] = True
+
+    import pocketpaw_ee.cloud.audit.service as audit_service
+
+    monkeypatch.setattr(audit_service, "list_events_response", _list_events_response)
+
+    with _identity(workspace="w1", user="member1"):
+        res = await wa_mcp._audit_read_handler({"limit": 5})
+
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert body["code"] == "workspace.insufficient_role"
+    assert hit["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_read_tools_outside_stream_error():
+    """Every WA-4 READ tool refuses (error envelope) with no identity context."""
+    for handler in (
+        wa_mcp._workspace_settings_read_handler,
+        wa_mcp._invites_list_handler,
+        wa_mcp._connectors_list_handler,
+        wa_mcp._billing_usage_read_handler,
+        wa_mcp._audit_read_handler,
+    ):
+        res = await handler({})
+        assert res.get("is_error") is True
+        assert "no active workspace" in res["content"][0]["text"]

--- a/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
+++ b/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
@@ -1,7 +1,16 @@
 # tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py — the agent-facing MCP
-# surface for workspace administration (feat/workspace-admin-tools, WA-1/WA-2/WA-4).
+# surface for workspace administration (feat/workspace-admin-tools, WA-1/2/4/5).
 #
 # Created: 2026-07-03 (feat/workspace-admin-tools, WA-1).
+# Updated: 2026-07-03 (WA-5) — added propose+deny coverage for the seven ADMIN
+#   WRITE tools (member_remove, invite_create, invite_revoke, connector_enable,
+#   connector_disable, connector_config, workspace_update). Each pins: (a) an ADMIN
+#   identity → a PENDING (executed=False) envelope, the STRICT proposed args are
+#   right, and the underlying service is SPIED and asserted NOT called inline; (b)
+#   a non-ADMIN identity → a deny envelope, propose_admin_action NOT called; plus
+#   an unknown-arg-key-is-dropped test (an agent's stray key never reaches the
+#   proposal). The propose→approve→executor fires-once / reject-no-fire / adapter-
+#   drops-extras coverage lives in tests/cloud/test_admin_action_gate.py.
 # Updated: 2026-07-03 (WA-4) — added coverage for the five READ-only tools:
 #   workspace_settings_read, invites_list, connectors_list, billing_usage_read,
 #   audit_read. Each has a PASS case (correct role → the service is called and its
@@ -118,6 +127,14 @@ def test_server_name_and_tool_ids_contract():
     assert wa_mcp.CONNECTORS_LIST_TOOL_ID == "mcp__pocketpaw_workspace_admin__connectors_list"
     assert wa_mcp.BILLING_USAGE_READ_TOOL_ID == "mcp__pocketpaw_workspace_admin__billing_usage_read"
     assert wa_mcp.AUDIT_READ_TOOL_ID == "mcp__pocketpaw_workspace_admin__audit_read"
+    # WA-5 write tool ids.
+    assert wa_mcp.MEMBER_REMOVE_TOOL_ID == "mcp__pocketpaw_workspace_admin__member_remove"
+    assert wa_mcp.INVITE_CREATE_TOOL_ID == "mcp__pocketpaw_workspace_admin__invite_create"
+    assert wa_mcp.INVITE_REVOKE_TOOL_ID == "mcp__pocketpaw_workspace_admin__invite_revoke"
+    assert wa_mcp.CONNECTOR_ENABLE_TOOL_ID == "mcp__pocketpaw_workspace_admin__connector_enable"
+    assert wa_mcp.CONNECTOR_DISABLE_TOOL_ID == "mcp__pocketpaw_workspace_admin__connector_disable"
+    assert wa_mcp.CONNECTOR_CONFIG_TOOL_ID == "mcp__pocketpaw_workspace_admin__connector_config"
+    assert wa_mcp.WORKSPACE_UPDATE_TOOL_ID == "mcp__pocketpaw_workspace_admin__workspace_update"
     assert set(wa_mcp.ADMIN_TOOL_IDS) == {
         wa_mcp.MEMBERS_LIST_TOOL_ID,
         wa_mcp.MEMBER_UPDATE_ROLE_TOOL_ID,
@@ -126,6 +143,13 @@ def test_server_name_and_tool_ids_contract():
         wa_mcp.CONNECTORS_LIST_TOOL_ID,
         wa_mcp.BILLING_USAGE_READ_TOOL_ID,
         wa_mcp.AUDIT_READ_TOOL_ID,
+        wa_mcp.MEMBER_REMOVE_TOOL_ID,
+        wa_mcp.INVITE_CREATE_TOOL_ID,
+        wa_mcp.INVITE_REVOKE_TOOL_ID,
+        wa_mcp.CONNECTOR_ENABLE_TOOL_ID,
+        wa_mcp.CONNECTOR_DISABLE_TOOL_ID,
+        wa_mcp.CONNECTOR_CONFIG_TOOL_ID,
+        wa_mcp.WORKSPACE_UPDATE_TOOL_ID,
     }
 
 
@@ -718,5 +742,340 @@ async def test_read_tools_outside_stream_error():
         wa_mcp._audit_read_handler,
     ):
         res = await handler({})
+        assert res.get("is_error") is True
+        assert "no active workspace" in res["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# WA-5 ADMIN WRITE tools — propose (never inline) + deny. Shared helpers.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _spy_propose(monkeypatch):
+    """Spy ``propose_admin_action`` (imported function-locally by _propose_write)
+    and return a fixed action id. Captures the kwargs so tests can assert the
+    STRICT proposed args + proposer identity + RBAC action key."""
+    captured: dict = {}
+
+    async def _propose(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+        return "action-wa5"
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action", _propose)
+    return captured
+
+
+def _admin(monkeypatch):
+    """check_workspace_action passes as ADMIN."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.ADMIN
+    )
+
+
+def _spy_service(monkeypatch, module_path: str, fn_name: str) -> dict:
+    """Spy a service function so a write tool can assert it was NOT called inline.
+    Returns a dict whose ``called`` flag flips True if the service is ever hit."""
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    spy = {"called": False}
+
+    async def _fn(*a, **k):  # noqa: ANN002, ANN003
+        spy["called"] = True
+
+    monkeypatch.setattr(mod, fn_name, _fn)
+    return spy
+
+
+# ---- member_remove --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_remove_admin_proposes_not_inline(monkeypatch, _patch_user, _spy_propose):
+    """ADMIN → PENDING envelope; propose filed with STRICT args (only the target
+    user id); remove_member is spied and asserted NOT called inline."""
+    _admin(monkeypatch)
+    svc = _spy_service(monkeypatch, "pocketpaw_ee.cloud.workspace.service", "remove_member")
+
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._member_remove_handler({"user_id": "u2"})
+
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["executed"] is False
+    assert body["status"] == "pending_approval"
+    assert body["action_id"] == "action-wa5"
+    assert _spy_propose["action"] == "workspace.member.remove"
+    assert _spy_propose["args"] == {"target_user_id": "u2"}
+    assert _spy_propose["proposer_user_id"] == "admin1"
+    assert svc["called"] is False  # the write did NOT fire inline
+
+
+@pytest.mark.asyncio
+async def test_member_remove_member_denied_no_propose(monkeypatch, _patch_user):
+    """A MEMBER → deny envelope; propose_admin_action is NOT called."""
+    propose_hit = {"called": False}
+
+    async def _propose(**kwargs):  # noqa: ANN003
+        propose_hit["called"] = True
+        return "x"
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action", _propose)
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.insufficient_role"),
+    )
+
+    with _identity(workspace="w1", user="member1"):
+        res = await wa_mcp._member_remove_handler({"user_id": "u2"})
+
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert body["code"] == "workspace.insufficient_role"
+    assert propose_hit["called"] is False
+
+
+# ---- invite_create --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invite_create_admin_proposes_strict_args(monkeypatch, _patch_user, _spy_propose):
+    """ADMIN → PENDING; propose carries ONLY email + role; create_invite not inline."""
+    _admin(monkeypatch)
+    svc = _spy_service(monkeypatch, "pocketpaw_ee.cloud.workspace.service", "create_invite")
+
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._invite_create_handler({"email": "a@b.com", "role": "admin"})
+
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["executed"] is False
+    assert _spy_propose["action"] == "invite.create"
+    assert _spy_propose["args"] == {"email": "a@b.com", "role": "admin"}
+    assert svc["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_invite_create_rejects_owner_role(monkeypatch, _patch_user):
+    """An invite can't mint an owner — refused before any gate/propose."""
+    _admin(monkeypatch)
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._invite_create_handler({"email": "a@b.com", "role": "owner"})
+    assert res.get("is_error") is True
+    assert "role must be one of" in res["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_invite_create_member_denied_no_propose(monkeypatch, _patch_user):
+    """A MEMBER → deny envelope; no proposal."""
+    propose_hit = {"called": False}
+
+    async def _propose(**kwargs):  # noqa: ANN003
+        propose_hit["called"] = True
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action", _propose)
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.insufficient_role"),
+    )
+    with _identity(workspace="w1", user="member1"):
+        res = await wa_mcp._invite_create_handler({"email": "a@b.com", "role": "member"})
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert propose_hit["called"] is False
+
+
+# ---- invite_revoke --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invite_revoke_admin_proposes_correct_action(monkeypatch, _patch_user, _spy_propose):
+    """ADMIN → PENDING; the RBAC action is ``invite.revoke`` (the revoke route's
+    action, NOT invite.create); revoke_invite not inline."""
+    _admin(monkeypatch)
+    svc = _spy_service(monkeypatch, "pocketpaw_ee.cloud.workspace.service", "revoke_invite")
+
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._invite_revoke_handler({"invite_id": "inv1"})
+
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["executed"] is False
+    assert _spy_propose["action"] == "invite.revoke"
+    assert _spy_propose["args"] == {"invite_id": "inv1"}
+    assert svc["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_invite_revoke_member_denied_no_propose(monkeypatch, _patch_user):
+    propose_hit = {"called": False}
+
+    async def _propose(**kwargs):  # noqa: ANN003
+        propose_hit["called"] = True
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action", _propose)
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.insufficient_role"),
+    )
+    with _identity(workspace="w1", user="member1"):
+        res = await wa_mcp._invite_revoke_handler({"invite_id": "inv1"})
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert propose_hit["called"] is False
+
+
+# ---- connector_enable / disable / config ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connector_enable_admin_proposes(monkeypatch, _patch_user, _spy_propose):
+    _admin(monkeypatch)
+    svc = _spy_service(monkeypatch, "pocketpaw_ee.cloud.connectors.service", "enable_connector")
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._connector_enable_handler({"name": "gmail"})
+    body = _body(res)
+    assert body["ok"] is True and body["executed"] is False
+    assert _spy_propose["action"] == "connector.manage"
+    assert _spy_propose["args"] == {"op": "enable", "name": "gmail"}
+    assert svc["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_connector_disable_admin_proposes(monkeypatch, _patch_user, _spy_propose):
+    _admin(monkeypatch)
+    svc = _spy_service(monkeypatch, "pocketpaw_ee.cloud.connectors.service", "disable_connector")
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._connector_disable_handler({"name": "gmail"})
+    body = _body(res)
+    assert body["ok"] is True and body["executed"] is False
+    assert _spy_propose["action"] == "connector.manage"
+    assert _spy_propose["args"] == {"op": "disable", "name": "gmail"}
+    assert svc["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_connector_config_admin_proposes_opaque_config(
+    monkeypatch, _patch_user, _spy_propose
+):
+    """The structured config dict rides as OPAQUE data in the args — under a
+    single ``config`` key, never smuggled as top-level args."""
+    _admin(monkeypatch)
+    svc = _spy_service(monkeypatch, "pocketpaw_ee.cloud.connectors.service", "update_config")
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._connector_config_handler(
+            {"name": "gmail", "config": {"label": "Inbox", "max": 50}}
+        )
+    body = _body(res)
+    assert body["ok"] is True and body["executed"] is False
+    assert _spy_propose["action"] == "connector.manage"
+    assert _spy_propose["args"] == {
+        "op": "config",
+        "name": "gmail",
+        "config": {"label": "Inbox", "max": 50},
+    }
+    assert svc["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_connector_config_requires_config_object(monkeypatch, _patch_user):
+    """A missing / non-object config is refused before any gate/propose."""
+    _admin(monkeypatch)
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._connector_config_handler({"name": "gmail", "config": "not-an-object"})
+    assert res.get("is_error") is True
+    assert "config is required" in res["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_connector_enable_member_denied_no_propose(monkeypatch, _patch_user):
+    propose_hit = {"called": False}
+
+    async def _propose(**kwargs):  # noqa: ANN003
+        propose_hit["called"] = True
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action", _propose)
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.insufficient_role"),
+    )
+    with _identity(workspace="w1", user="member1"):
+        res = await wa_mcp._connector_enable_handler({"name": "gmail"})
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert propose_hit["called"] is False
+
+
+# ---- workspace_update -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_update_admin_proposes_only_recognized_fields(
+    monkeypatch, _patch_user, _spy_propose
+):
+    """UNKNOWN-KEY-DROPPED — an agent's stray ``seats`` / ``plan`` keys never reach
+    the proposal; only name / settings / branding are proposed."""
+    _admin(monkeypatch)
+    svc = _spy_service(monkeypatch, "pocketpaw_ee.cloud.workspace.service", "update")
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._workspace_update_handler(
+            {"name": "New Name", "seats": 999, "plan": "enterprise", "owner": "evil"}
+        )
+    body = _body(res)
+    assert body["ok"] is True and body["executed"] is False
+    assert _spy_propose["action"] == "workspace.update"
+    # Only the recognized field survived — the stray keys were dropped.
+    assert _spy_propose["args"] == {"name": "New Name"}
+    assert svc["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_workspace_update_requires_a_field(monkeypatch, _patch_user):
+    """No recognized field → refused before any gate/propose."""
+    _admin(monkeypatch)
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._workspace_update_handler({"seats": 5})
+    assert res.get("is_error") is True
+    assert "at least one of name / settings / branding" in res["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_workspace_update_member_denied_no_propose(monkeypatch, _patch_user):
+    propose_hit = {"called": False}
+
+    async def _propose(**kwargs):  # noqa: ANN003
+        propose_hit["called"] = True
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action", _propose)
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.insufficient_role"),
+    )
+    with _identity(workspace="w1", user="member1"):
+        res = await wa_mcp._workspace_update_handler({"name": "New Name"})
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert propose_hit["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_write_tools_outside_stream_error():
+    """Every WA-5 WRITE tool refuses (error envelope) with no identity context."""
+    for handler, args in (
+        (wa_mcp._member_remove_handler, {"user_id": "u2"}),
+        (wa_mcp._invite_create_handler, {"email": "a@b.com"}),
+        (wa_mcp._invite_revoke_handler, {"invite_id": "inv1"}),
+        (wa_mcp._connector_enable_handler, {"name": "gmail"}),
+        (wa_mcp._connector_disable_handler, {"name": "gmail"}),
+        (wa_mcp._connector_config_handler, {"name": "gmail", "config": {}}),
+        (wa_mcp._workspace_update_handler, {"name": "X"}),
+    ):
+        res = await handler(args)
         assert res.get("is_error") is True
         assert "no active workspace" in res["content"][0]["text"]

--- a/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
+++ b/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
@@ -1,0 +1,277 @@
+# tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py — the agent-facing MCP
+# surface for workspace administration (feat/workspace-admin-tools, WA-1).
+#
+# Created: 2026-07-03 (feat/workspace-admin-tools, WA-1).
+#
+# What this pins — the two WA-1 MCP tools, driven through the REAL handlers:
+#   * tool-id / server-name contract (SERVER_NAME, *_TOOL_ID, ADMIN_TOOL_IDS)
+#     and the provider exposing the server + tool ids (extensions wiring).
+#   * members_list (READ): a MEMBER identity → returns the roster (read allowed);
+#     the workspace service is mocked. An identity that fails the RBAC gate →
+#     a structured deny envelope (ok=False, denied=True, code), NOT a raised
+#     exception; the service is never reached.
+#   * member_update_role (WRITE): an ADMIN identity → a NON-executing envelope
+#     (executed=False) and — the load-bearing assertion — the
+#     ``update_member_role`` service call is spied and asserted NOT called inline
+#     (an admin write is human-gated, never fired from the tool). A MEMBER →
+#     deny envelope, no service call.
+#   * outside-a-stream: no identity ContextVars → an explicit error envelope, no
+#     service call.
+#
+# ``pocketpaw_ee`` is import-skipped on an OSS-only install. The handlers read
+# identity through ee.cloud.chat.agent_service ContextVars (set in-test via
+# attach_agent_identity). RBAC + the workspace service are patched so nothing
+# touches Mongo — this pins the tool's gate + envelope behaviour, not the DB.
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+import pocketpaw_ee.agent.mcp_servers.workspace_admin as wa_mcp  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+from pocketpaw_ee.cloud.workspace.domain import WorkspaceMember  # noqa: E402
+from pocketpaw_ee.extensions import CloudWorkspaceAdminMcpProvider  # noqa: E402
+from pocketpaw_ee.guards.rbac import Forbidden, WorkspaceRole  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+class _identity:
+    """Context manager that sets the workspace/user/pocket ContextVars the
+    handler reads, then resets them."""
+
+    def __init__(self, *, workspace="w1", user="u1", pocket=None):
+        self._ws, self._user, self._pocket = workspace, user, pocket
+        self._tokens = None
+
+    def __enter__(self):
+        self._tokens = attach_agent_identity(
+            workspace_id=self._ws, user_id=self._user, pocket_id=self._pocket
+        )
+        return self
+
+    def __exit__(self, *exc):
+        detach_agent_identity(self._tokens)
+        return False
+
+
+def _body(res: dict) -> dict:
+    """Parse the JSON body out of a success MCP response."""
+    assert res.get("is_error") is not True, res
+    return json.loads(res["content"][0]["text"])
+
+
+def _member(user_id="u1", role="member") -> WorkspaceMember:
+    return WorkspaceMember(
+        user_id=user_id,
+        email=f"{user_id}@example.com",
+        name=user_id.title(),
+        avatar="",
+        role=role,
+        joined_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def _patch_user(monkeypatch):
+    """Stub the User doc load so the handler has a user for the RBAC check
+    without touching Mongo. The object is opaque — the RBAC gate is itself
+    patched per-test, so the loaded user is only a non-None sentinel."""
+    monkeypatch.setattr(wa_mcp, "_load_user", _fake_load_user)
+
+
+async def _fake_load_user(user_id: str):  # noqa: ANN001
+    return object()  # non-None sentinel; RBAC is patched separately
+
+
+# ---------------------------------------------------------------------------
+# Contract / wiring
+# ---------------------------------------------------------------------------
+
+
+def test_server_name_and_tool_ids_contract():
+    assert wa_mcp.SERVER_NAME == "pocketpaw_workspace_admin"
+    assert wa_mcp.MEMBERS_LIST_TOOL_ID == "mcp__pocketpaw_workspace_admin__members_list"
+    assert wa_mcp.MEMBER_UPDATE_ROLE_TOOL_ID == "mcp__pocketpaw_workspace_admin__member_update_role"
+    assert set(wa_mcp.ADMIN_TOOL_IDS) == {
+        wa_mcp.MEMBERS_LIST_TOOL_ID,
+        wa_mcp.MEMBER_UPDATE_ROLE_TOOL_ID,
+    }
+
+
+def test_provider_exposes_server_and_tool_ids():
+    provider = CloudWorkspaceAdminMcpProvider()
+    assert set(provider.tool_ids()) == set(wa_mcp.ADMIN_TOOL_IDS)
+    built = provider.build_server()
+    # None only when the claude_agent_sdk isn't installed; the ee test env has it.
+    if built is not None:
+        name, _server = built
+        assert name == wa_mcp.SERVER_NAME
+
+
+# ---------------------------------------------------------------------------
+# members_list — READ
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_members_list_member_allowed_returns_roster(monkeypatch, _patch_user):
+    """A MEMBER may read the roster — gate passes, service returns members."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.MEMBER
+    )
+
+    called = {}
+
+    async def _list_members(ctx, workspace_id):  # noqa: ANN001
+        called["ctx_user"] = ctx.user_id
+        called["ws"] = workspace_id
+        return [_member("u1", "member"), _member("u2", "admin")]
+
+    import pocketpaw_ee.cloud.workspace.service as ws_service
+
+    monkeypatch.setattr(ws_service, "list_members", _list_members)
+
+    with _identity(workspace="w1", user="u1"):
+        res = await wa_mcp._members_list_handler({})
+
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["workspace_id"] == "w1"
+    assert body["count"] == 2
+    assert {m["role"] for m in body["members"]} == {"member", "admin"}
+    assert called == {"ctx_user": "u1", "ws": "w1"}
+
+
+@pytest.mark.asyncio
+async def test_members_list_denied_returns_envelope_not_raised(monkeypatch, _patch_user):
+    """A gate failure is CAUGHT and returned as a deny envelope, not raised —
+    and the workspace service is never reached."""
+
+    def _deny(*a, **k):  # noqa: ANN001, ANN002
+        raise Forbidden(code="workspace.not_member", detail="nope")
+
+    monkeypatch.setattr("pocketpaw_ee.guards.deps.check_workspace_action", _deny)
+
+    service_called = {"hit": False}
+
+    async def _list_members(ctx, workspace_id):  # noqa: ANN001
+        service_called["hit"] = True
+        return []
+
+    import pocketpaw_ee.cloud.workspace.service as ws_service
+
+    monkeypatch.setattr(ws_service, "list_members", _list_members)
+
+    with _identity(workspace="w1", user="outsider"):
+        res = await wa_mcp._members_list_handler({})
+
+    body = _body(res)  # a SUCCESS-shaped envelope carrying the denial
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert body["code"] == "workspace.not_member"
+    assert service_called["hit"] is False  # gate blocked before the read
+
+
+@pytest.mark.asyncio
+async def test_members_list_outside_stream_errors():
+    """No identity ContextVars → an explicit error envelope, no service call."""
+    res = await wa_mcp._members_list_handler({})
+    assert res.get("is_error") is True
+    assert "no active workspace" in res["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# member_update_role — WRITE (Instinct-gated; never inline)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_update_role_admin_does_not_execute_inline(monkeypatch, _patch_user):
+    """An ADMIN passes the gate but the mutation is NEVER fired inline — the
+    ``update_member_role`` service call is spied and asserted NOT called. The
+    tool returns a non-executing (executed=False) envelope."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.ADMIN
+    )
+
+    spy = {"called": False}
+
+    async def _update_member_role(*a, **k):  # noqa: ANN002, ANN003
+        spy["called"] = True
+
+    import pocketpaw_ee.cloud.workspace.service as ws_service
+
+    monkeypatch.setattr(ws_service, "update_member_role", _update_member_role)
+
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._member_update_role_handler({"user_id": "u2", "role": "admin"})
+
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["executed"] is False  # the load-bearing rule
+    assert body["proposed_change"] == {
+        "user_id": "u2",
+        "role": "admin",
+        "workspace_id": "w1",
+    }
+    # THE assertion: the admin write did NOT fire inline.
+    assert spy["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_member_update_role_member_denied_no_service_call(monkeypatch, _patch_user):
+    """A MEMBER is denied — deny envelope, no proposal, no service call."""
+
+    def _deny(*a, **k):  # noqa: ANN001, ANN002
+        raise Forbidden(code="workspace.insufficient_role", detail="need admin")
+
+    monkeypatch.setattr("pocketpaw_ee.guards.deps.check_workspace_action", _deny)
+
+    spy = {"called": False}
+
+    async def _update_member_role(*a, **k):  # noqa: ANN002, ANN003
+        spy["called"] = True
+
+    import pocketpaw_ee.cloud.workspace.service as ws_service
+
+    monkeypatch.setattr(ws_service, "update_member_role", _update_member_role)
+
+    with _identity(workspace="w1", user="member1"):
+        res = await wa_mcp._member_update_role_handler({"user_id": "u2", "role": "admin"})
+
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert body["code"] == "workspace.insufficient_role"
+    assert spy["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_member_update_role_rejects_bad_role(monkeypatch, _patch_user):
+    """An out-of-set role is refused before any gate/mutation."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.ADMIN
+    )
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._member_update_role_handler({"user_id": "u2", "role": "superuser"})
+    assert res.get("is_error") is True
+    assert "role is required" in res["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_member_update_role_outside_stream_errors():
+    """No identity ContextVars → an explicit error envelope."""
+    res = await wa_mcp._member_update_role_handler({"user_id": "u2", "role": "admin"})
+    assert res.get("is_error") is True
+    assert "no active workspace" in res["content"][0]["text"]

--- a/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
+++ b/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
@@ -197,18 +197,32 @@ async def test_members_list_outside_stream_errors():
 
 
 @pytest.mark.asyncio
-async def test_member_update_role_admin_does_not_execute_inline(monkeypatch, _patch_user):
-    """An ADMIN passes the gate but the mutation is NEVER fired inline — the
-    ``update_member_role`` service call is spied and asserted NOT called. The
-    tool returns a non-executing (executed=False) envelope."""
+async def test_member_update_role_admin_files_proposal_not_inline(monkeypatch, _patch_user):
+    """WA-2 — an ADMIN passes the gate; the tool files a live Instinct proposal
+    (``propose_admin_action`` is spied) and returns a PENDING (executed=False)
+    envelope carrying the action id. The ``update_member_role`` service call is
+    spied and asserted NOT called inline (an admin write is human-gated)."""
     monkeypatch.setattr(
         "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.ADMIN
     )
 
-    spy = {"called": False}
+    # Spy the propose helper (the tool imports it function-locally).
+    propose_spy = {}
+
+    async def _propose_admin_action(**kwargs):  # noqa: ANN003
+        propose_spy.update(kwargs)
+        return "action-abc123"
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action",
+        _propose_admin_action,
+    )
+
+    # Spy the mutation sink — it must NOT be called inline.
+    mutate_spy = {"called": False}
 
     async def _update_member_role(*a, **k):  # noqa: ANN002, ANN003
-        spy["called"] = True
+        mutate_spy["called"] = True
 
     import pocketpaw_ee.cloud.workspace.service as ws_service
 
@@ -220,13 +234,21 @@ async def test_member_update_role_admin_does_not_execute_inline(monkeypatch, _pa
     body = _body(res)
     assert body["ok"] is True
     assert body["executed"] is False  # the load-bearing rule
+    assert body["status"] == "pending_approval"
+    assert body["action_id"] == "action-abc123"
     assert body["proposed_change"] == {
         "user_id": "u2",
         "role": "admin",
         "workspace_id": "w1",
     }
+    # The proposal was filed with the right shape — RBAC action key, args, and
+    # the PROPOSER identity (used for the execute-time RBAC re-check).
+    assert propose_spy["workspace_id"] == "w1"
+    assert propose_spy["action"] == "workspace.member.role_change"
+    assert propose_spy["args"] == {"target_user_id": "u2", "role": "admin"}
+    assert propose_spy["proposer_user_id"] == "admin1"
     # THE assertion: the admin write did NOT fire inline.
-    assert spy["called"] is False
+    assert mutate_spy["called"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
+++ b/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
@@ -2,6 +2,14 @@
 # surface for workspace administration (feat/workspace-admin-tools, WA-1/2/4/5).
 #
 # Created: 2026-07-03 (feat/workspace-admin-tools, WA-1).
+# Updated: 2026-07-03 (WA-6) — added propose+deny coverage for the three OWNER
+#   WRITE tools (instinct_approval_level_set, workspace_delete, billing_plan_change).
+#   Each pins: (a) an OWNER identity → a PENDING (executed=False) envelope, the
+#   STRICT proposed args are right, and the underlying service is SPIED and
+#   asserted NOT called inline; (b) a NON-OWNER identity (an ADMIN — proving ADMIN
+#   can't perform an OWNER op) → a deny envelope, propose_admin_action NOT called;
+#   plus arg-validation refusals (bad level / bad plan). billing_plan_change's
+#   envelope names the checkout step; workspace_delete's names irreversibility.
 # Updated: 2026-07-03 (WA-5) — added propose+deny coverage for the seven ADMIN
 #   WRITE tools (member_remove, invite_create, invite_revoke, connector_enable,
 #   connector_disable, connector_config, workspace_update). Each pins: (a) an ADMIN
@@ -135,6 +143,15 @@ def test_server_name_and_tool_ids_contract():
     assert wa_mcp.CONNECTOR_DISABLE_TOOL_ID == "mcp__pocketpaw_workspace_admin__connector_disable"
     assert wa_mcp.CONNECTOR_CONFIG_TOOL_ID == "mcp__pocketpaw_workspace_admin__connector_config"
     assert wa_mcp.WORKSPACE_UPDATE_TOOL_ID == "mcp__pocketpaw_workspace_admin__workspace_update"
+    # WA-6 OWNER write tool ids.
+    assert (
+        wa_mcp.INSTINCT_APPROVAL_LEVEL_SET_TOOL_ID
+        == "mcp__pocketpaw_workspace_admin__instinct_approval_level_set"
+    )
+    assert wa_mcp.WORKSPACE_DELETE_TOOL_ID == "mcp__pocketpaw_workspace_admin__workspace_delete"
+    assert (
+        wa_mcp.BILLING_PLAN_CHANGE_TOOL_ID == "mcp__pocketpaw_workspace_admin__billing_plan_change"
+    )
     assert set(wa_mcp.ADMIN_TOOL_IDS) == {
         wa_mcp.MEMBERS_LIST_TOOL_ID,
         wa_mcp.MEMBER_UPDATE_ROLE_TOOL_ID,
@@ -150,6 +167,9 @@ def test_server_name_and_tool_ids_contract():
         wa_mcp.CONNECTOR_DISABLE_TOOL_ID,
         wa_mcp.CONNECTOR_CONFIG_TOOL_ID,
         wa_mcp.WORKSPACE_UPDATE_TOOL_ID,
+        wa_mcp.INSTINCT_APPROVAL_LEVEL_SET_TOOL_ID,
+        wa_mcp.WORKSPACE_DELETE_TOOL_ID,
+        wa_mcp.BILLING_PLAN_CHANGE_TOOL_ID,
     }
 
 
@@ -1075,6 +1095,195 @@ async def test_write_tools_outside_stream_error():
         (wa_mcp._connector_disable_handler, {"name": "gmail"}),
         (wa_mcp._connector_config_handler, {"name": "gmail", "config": {}}),
         (wa_mcp._workspace_update_handler, {"name": "X"}),
+    ):
+        res = await handler(args)
+        assert res.get("is_error") is True
+        assert "no active workspace" in res["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# WA-6 OWNER WRITE tools — propose (never inline) + deny. The deny case uses an
+# ADMIN actor to prove ADMIN CANNOT perform an OWNER op (the gate is OWNER-only).
+# ---------------------------------------------------------------------------
+
+
+def _owner(monkeypatch):
+    """check_workspace_action passes as OWNER."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.OWNER
+    )
+
+
+def _deny_not_owner(monkeypatch):
+    """check_workspace_action DENIES an OWNER-gated action for a non-owner — the
+    exact Forbidden the RBAC layer raises when an ADMIN attempts an OWNER op."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        _deny_forbidden("workspace.insufficient_role", "owner required"),
+    )
+
+
+# ---- instinct_approval_level_set ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_instinct_approval_level_set_owner_proposes_not_inline(
+    monkeypatch, _patch_user, _spy_propose
+):
+    """OWNER → PENDING envelope; propose carries ONLY the level;
+    set_instinct_approval_level is spied and asserted NOT called inline."""
+    _owner(monkeypatch)
+    svc = _spy_service(
+        monkeypatch, "pocketpaw_ee.cloud.workspace.service", "set_instinct_approval_level"
+    )
+    with _identity(workspace="w1", user="owner1"):
+        res = await wa_mcp._instinct_approval_level_set_handler({"level": "TRUSTED"})
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["executed"] is False
+    assert body["status"] == "pending_approval"
+    assert body["action_id"] == "action-wa5"
+    assert _spy_propose["action"] == "instinct.activate"
+    assert _spy_propose["args"] == {"level": "TRUSTED"}
+    assert _spy_propose["proposer_user_id"] == "owner1"
+    assert svc["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_instinct_approval_level_set_rejects_bad_level(monkeypatch, _patch_user):
+    """An out-of-enum level is refused before any gate/propose."""
+    _owner(monkeypatch)
+    with _identity(workspace="w1", user="owner1"):
+        res = await wa_mcp._instinct_approval_level_set_handler({"level": "YOLO"})
+    assert res.get("is_error") is True
+    assert "level is required" in res["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_instinct_approval_level_set_admin_denied_no_propose(monkeypatch, _patch_user):
+    """AN ADMIN CANNOT DO AN OWNER OP — deny envelope, propose NOT called."""
+    propose_hit = {"called": False}
+
+    async def _propose(**kwargs):  # noqa: ANN003
+        propose_hit["called"] = True
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action", _propose)
+    _deny_not_owner(monkeypatch)
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._instinct_approval_level_set_handler({"level": "TRIAGE"})
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert body["code"] == "workspace.insufficient_role"
+    assert propose_hit["called"] is False
+
+
+# ---- workspace_delete -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_delete_owner_proposes_not_inline(monkeypatch, _patch_user, _spy_propose):
+    """OWNER → PENDING envelope flagged irreversible; propose carries NO args;
+    the delete service is spied and asserted NOT called inline."""
+    _owner(monkeypatch)
+    svc = _spy_service(monkeypatch, "pocketpaw_ee.cloud.workspace.service", "delete")
+    with _identity(workspace="w1", user="owner1"):
+        res = await wa_mcp._workspace_delete_handler({})
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["executed"] is False
+    assert body["status"] == "pending_approval"
+    assert body["proposed_change"]["irreversible"] is True
+    # The message must warn about irreversibility.
+    assert "IRREVERSIBLE" in body["message"]
+    assert _spy_propose["action"] == "workspace.delete"
+    assert _spy_propose["args"] == {}  # identity only — nothing steers the delete
+    assert _spy_propose["proposer_user_id"] == "owner1"
+    assert svc["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_workspace_delete_admin_denied_no_propose(monkeypatch, _patch_user):
+    """AN ADMIN CANNOT DELETE THE WORKSPACE — deny envelope, propose NOT called."""
+    propose_hit = {"called": False}
+
+    async def _propose(**kwargs):  # noqa: ANN003
+        propose_hit["called"] = True
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action", _propose)
+    _deny_not_owner(monkeypatch)
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._workspace_delete_handler({})
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert body["code"] == "workspace.insufficient_role"
+    assert propose_hit["called"] is False
+
+
+# ---- billing_plan_change --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_billing_plan_change_owner_proposes_checkout_model(
+    monkeypatch, _patch_user, _spy_propose
+):
+    """OWNER → PENDING envelope; propose carries ONLY plan_key; the subscribe
+    service is spied and asserted NOT called inline; the message names the
+    checkout step (the plan does NOT flip on approval alone)."""
+    _owner(monkeypatch)
+    svc = _spy_service(monkeypatch, "pocketpaw_ee.cloud.billing.service", "subscribe")
+    with _identity(workspace="w1", user="owner1"):
+        res = await wa_mcp._billing_plan_change_handler({"plan": "pro"})
+    body = _body(res)
+    assert body["ok"] is True
+    assert body["executed"] is False
+    assert body["status"] == "pending_approval"
+    assert body["proposed_change"] == {"plan": "pro", "workspace_id": "w1"}
+    # Payment-honesty: the relay must name the checkout step.
+    assert "CHECKOUT" in body["message"] or "checkout" in body["message"]
+    assert _spy_propose["action"] == "billing.manage"
+    assert _spy_propose["args"] == {"plan_key": "pro"}
+    assert _spy_propose["proposer_user_id"] == "owner1"
+    assert svc["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_billing_plan_change_rejects_bad_plan(monkeypatch, _patch_user):
+    """An unknown plan tier is refused before any gate/propose."""
+    _owner(monkeypatch)
+    with _identity(workspace="w1", user="owner1"):
+        res = await wa_mcp._billing_plan_change_handler({"plan": "platinum"})
+    assert res.get("is_error") is True
+    assert "plan is required" in res["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_billing_plan_change_admin_denied_no_propose(monkeypatch, _patch_user):
+    """AN ADMIN CANNOT CHANGE BILLING — deny envelope, propose NOT called."""
+    propose_hit = {"called": False}
+
+    async def _propose(**kwargs):  # noqa: ANN003
+        propose_hit["called"] = True
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action", _propose)
+    _deny_not_owner(monkeypatch)
+    with _identity(workspace="w1", user="admin1"):
+        res = await wa_mcp._billing_plan_change_handler({"plan": "pro"})
+    body = _body(res)
+    assert body["ok"] is False
+    assert body["denied"] is True
+    assert body["code"] == "workspace.insufficient_role"
+    assert propose_hit["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_owner_write_tools_outside_stream_error():
+    """Every WA-6 OWNER WRITE tool refuses (error envelope) with no identity."""
+    for handler, args in (
+        (wa_mcp._instinct_approval_level_set_handler, {"level": "ASK"}),
+        (wa_mcp._workspace_delete_handler, {}),
+        (wa_mcp._billing_plan_change_handler, {"plan": "pro"}),
     ):
         res = await handler(args)
         assert res.get("is_error") is True

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -85,6 +85,9 @@ from pocketpaw_ee.agent.mcp_servers.planner import SERVER_NAME as _PLANNER_MCP_S
 from pocketpaw_ee.agent.mcp_servers.pockets import SERVER_NAME as _POCKET_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.sites import SERVER_NAME as _SITES_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.tasks import SERVER_NAME as _TASKS_MCP_SERVER_NAME
+from pocketpaw_ee.agent.mcp_servers.workspace_admin import (
+    SERVER_NAME as _WORKSPACE_ADMIN_MCP_SERVER_NAME,
+)
 from pocketpaw_ee.agent.pocket_specialist.mcp_tool import (
     SERVER_NAME as _POCKET_SPECIALIST_MCP_SERVER_NAME,
 )
@@ -148,6 +151,11 @@ def _strip_builtin_servers(result: dict) -> dict:
     # ``claude_sdk._get_mcp_servers`` so every agent can ground PocketPaw
     # capabilities instead of guessing from LLM priors (AT-1).
     out.pop(_ATLAS_MCP_SERVER_NAME, None)
+    # ``pocketpaw_workspace_admin`` is always-on too — the workspace-admin tool
+    # surface (members_list / member_update_role) is registered unconditionally;
+    # the RBAC gate on each tool is the security boundary, not registration
+    # (WA-1, feat/workspace-admin-tools).
+    out.pop(_WORKSPACE_ADMIN_MCP_SERVER_NAME, None)
     return out
 
 


### PR DESCRIPTION
A complete agent-facing workspace-administration surface: ~15 tools the runtime chat agent can use to run a workspace, gated by the existing RBAC matrix, with every mutation routed through the Instinct approval gate, and discovery filtered by role so members don't see admin tools they can't use. Design: `docs/design/drafts/2026-07-03-workspace-admin-tools.md`. Stacks on the atlas PR chain (base `feat/atlas-eval`).

## The three layers

- **RBAC is the execution lock.** Every tool calls `check_workspace_action(user, workspace_id, action)` — the existing, tested, audited matrix. Reads execute directly once the gate passes; a failed gate returns a structured deny envelope, never a crash.
- **The Instinct gate is the second lock on writes.** No agent-initiated mutation fires inline. Each write files an `_admin_action` proposal into the Tray; a human approves; the change fires only then, with RBAC **re-checked at execute time** (a proposer demoted after proposing is blocked).
- **Atlas discovery is role-filtered.** A member's `atlas_search("manage the workspace")` doesn't surface admin tools — a role-aware entitlement provider hides `role:*` capability cards the caller can't reach, fail-closed (unknown role → hidden). This is discovery only; the RBAC checks are the real gate.

## Slices

- **WA-1/2** — admin MCP server + the `_admin_action` Instinct gate kind (an 8th proposal kind) + `member_update_role` as the first human-approved gated write. Live-smoked end to end (propose → approve → execute flips the role; a member is denied).
- **WA-4** — 5 read tools (members, settings, connectors, billing usage, audit), each gated to the tier its REST route actually uses.
- **WA-5** — 7 ADMIN writes (member remove, invite create/revoke, connector enable/disable/config, workspace update), each a whitelist entry with a strict arg adapter.
- **WA-6** — 3 OWNER writes (instinct approval level, workspace delete, billing plan change). Billing executes as **propose → Dodo checkout URL**, never a plan mutation — the payment-bypassing `set_workspace_plan` is webhook-only and unreachable from any agent path. **seats_manage was deliberately skipped** — no seat-change service exists; faking one would mean a silent DB write bypassing billing.
- **WA-3** — role-aware atlas provider + 17 admin capability cards (role-tiered to match each tool's gate). Includes a scoped stopword fix to `store._tokenize` (the admin card names were about to pollute already-shipped atlas ranking; adversarial review confirmed it removes that pollution with zero eval regressions and 4 improvements).

## Security

Two adversarial security passes (WA-2 gate kind; WA-5+WA-6 write surface) and a 4-dimension adversarial review workflow on WA-3 — all **PASS**. Verified: no execute-without-approval path, adapters don't smuggle kwargs, invite role capped at admin|member, the plan can't flip without payment, no ADMIN-gated tool reaches an OWNER effect, the discovery filter fails closed at every branch, and OSS never leaks admin cards (the default provider hides all `role:*` entries).

## Follow-ups filed (not silently shipped)

- #1631 — generalize the Instinct approve/execute spine into a pluggable registry.
- #1633 — cap assignable member role at the actor's level (an ADMIN shouldn't grant OWNER; pre-existing in REST, now human-gated on the agent path).
- Seats management has no service in the codebase — a product decision, flagged for the captain.

## Testing

Full admin + gate + atlas suites green (204 in the atlas/ee slice; instinct-router regression intact — the 7 existing proposal kinds unchanged). Artifact deterministic (`atlas build --check`), eval 21/22 held honestly. Live-smoked against real Mongo. Nothing merged — captain review gate.