### PR TITLE
fix(mission-control): stop the Deep Work feed 500 on mixed created_at types

### DIFF
--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -125,6 +125,23 @@
 #       to ``WorkItemStatus.AWAITING_APPROVAL`` (the projection already maps
 #       ``ActionStatus.PENDING`` → that). ``status=None`` returns everything as
 #       before; ``status`` composes with the section/agent/pocket filters.
+# Updated: 2026-07-04 (fix/deep-work-feed-500-created-at-sort) — fixed a 500 on
+# the unfiltered Deep Work feed (``GET /items`` with no section). The final
+# ``items.sort`` compared ``(created_at, id)`` tuples across two projections
+# whose ``created_at`` types disagree: a Nudge carries ``Action.created_at`` —
+# a tz-NAIVE ``datetime`` — while a Task carries ``TaskResponse.created_at`` —
+# an ISO ``str`` (``iso_utc``). When both coexisted in one list, ``datetime <
+# str`` raised ``TypeError`` and the endpoint returned 500. Section-filtered
+# fetches (tray = nudges only, agents = tasks only) stayed homogeneous and
+# never crashed, so operators saw an EMPTY main feed but a populated in-flight
+# tab. Fixed at BOTH points: (1) ``_task_to_work_item`` now coerces
+# ``created_at`` / ``updated_at`` str→datetime, mirroring the existing
+# ``due_at`` coercion, so the projection is homogeneous; (2) the sort key is a
+# new module-level ``_sort_created_at`` that normalises ANY input — str, naive
+# datetime, aware datetime, or None — to a single tz-aware datetime, so the sort
+# can never raise regardless of caller (also fixes the naive-vs-aware case).
+# Sort semantics are unchanged (newest-first, ``id`` tiebreak); the fix restores
+# the full feed including completed/approved (Pawprints) items alongside pending.
 """Mission Control façade service.
 
 Every function is module-level ``async def`` per ee/cloud rule #5. The
@@ -473,6 +490,24 @@ def _task_to_work_item(task: Any, workspace_id: str, pocket_name: str = "") -> W
             due_at = datetime.fromisoformat(due_at.replace("Z", "+00:00"))
         except (ValueError, TypeError):
             due_at = None
+    # Same normalisation for created_at / updated_at. TaskResponse serialises
+    # both to ISO strings (``iso_utc``) while a domain Task keeps datetimes;
+    # the WorkItem model types them ``datetime | None``, and the unified feed
+    # sorts on ``created_at`` alongside Nudge WorkItems (whose created_at is a
+    # datetime). Leaving them as str crashes that sort with a TypeError when a
+    # Nudge and a Task coexist. Coerce here so the projection is homogeneous.
+    created_at = getattr(task, "created_at", None)
+    if isinstance(created_at, str):
+        try:
+            created_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            created_at = None
+    updated_at = getattr(task, "updated_at", None)
+    if isinstance(updated_at, str):
+        try:
+            updated_at = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            updated_at = None
     return WorkItem(
         id=f"task:{task.id}",
         workspace_id=workspace_id,
@@ -491,11 +526,46 @@ def _task_to_work_item(task: Any, workspace_id: str, pocket_name: str = "") -> W
         source_id=task.id,
         priority=task.priority,
         due_at=due_at,
-        created_at=task.created_at,
-        updated_at=task.updated_at,
+        created_at=created_at,
+        updated_at=updated_at,
         fabric_refs=(),
         blocked_by=blocked_by,
     )
+
+
+# A tz-aware floor for WorkItems that have no ``created_at`` — they sort last
+# under newest-first ordering. Kept tz-aware so it never re-introduces the
+# naive-vs-aware comparison the sort key is designed to avoid.
+_CREATED_AT_FLOOR = datetime.min.replace(tzinfo=UTC)
+
+
+def _sort_created_at(it: WorkItem) -> datetime:
+    """Return a mutually-comparable, tz-aware ``created_at`` for sorting.
+
+    The unified feed mixes WorkItems projected from two sources with
+    inconsistent ``created_at`` shapes:
+      - Nudges carry ``Action.created_at`` — a tz-NAIVE ``datetime``
+        (``datetime.now`` default).
+      - Tasks carry ``TaskResponse.created_at`` — an ISO ``str`` (``iso_utc``).
+    Sorting ``(created_at, id)`` tuples across the two raised
+    ``TypeError: '<' not supported between 'datetime' and 'str'`` (and would
+    likewise fail on naive-vs-aware datetimes). ``_task_to_work_item`` already
+    coerces str→datetime, but this is the last line of defence: it normalises
+    ANY input — str, naive datetime, aware datetime, or None — to a single
+    tz-aware datetime so the sort key can never raise regardless of caller.
+    """
+    value = it.created_at
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return _CREATED_AT_FLOOR
+    if value is None:
+        return _CREATED_AT_FLOOR
+    if value.tzinfo is None:
+        # Attach UTC to a naive datetime so all keys are mutually comparable.
+        return value.replace(tzinfo=UTC)
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -614,7 +684,11 @@ async def agent_list_work_items(
         target = _STATUS_FILTER_ALIASES.get(body.status, body.status)
         items = [it for it in items if it.status.value == target]
     # Stable order: newest first by created_at, falling back to id.
-    items.sort(key=lambda it: (it.created_at or datetime.min, it.id), reverse=True)
+    # ``_sort_created_at`` normalises every key to a tz-aware datetime so the
+    # tuple comparison can never raise on a mixed datetime/str or naive/aware
+    # feed (Nudge created_at is a naive datetime; Task created_at arrives as an
+    # ISO str). See the helper docstring for the full failure mode.
+    items.sort(key=lambda it: (_sort_created_at(it), it.id), reverse=True)
     return [work_item_to_response(it) for it in items[: body.limit]]
 
 

--- a/tests/cloud/test_mission_control_service.py
+++ b/tests/cloud/test_mission_control_service.py
@@ -294,6 +294,189 @@ class TestListWorkItems:
 
 
 # ---------------------------------------------------------------------------
+# mixed created_at types in one feed — the Deep Work 500 regression
+# ---------------------------------------------------------------------------
+
+
+class TestMixedCreatedAtSort:
+    """The unfiltered feed mixes two projections whose ``created_at`` types
+    disagree: a Nudge carries a tz-NAIVE ``datetime`` (Action.created_at
+    defaults to ``datetime.now``) and a Task carries a ``str`` (TaskResponse
+    serializes it via ``iso_utc``). The final ``items.sort`` compared
+    ``(created_at, id)`` tuples, so a datetime vs str comparison raised
+    ``TypeError`` and the endpoint returned 500 — but only when BOTH kinds
+    were present at once. Section-filtered fetches (tray = nudges only,
+    agents = tasks only) stayed homogeneous and never crashed, which is why
+    operators saw an EMPTY main feed but a populated in-flight tab.
+
+    ``test_includes_tasks_alongside_nudges`` misses this: it seeds a task
+    with zero coexisting nudges, so its feed is all-str and sorts fine.
+    These tests seed a nudge AND a task in the SAME workspace.
+    """
+
+    def _sample_task(
+        self,
+        *,
+        created_offset_seconds: float = 0.0,
+        assignee_kind: str = "human",
+        status: str = "in_progress",
+    ):
+        """A domain Task whose DTO carries a str/iso ``created_at``.
+
+        ``task_to_dto`` runs ``iso_utc`` over the datetime, so the WorkItem
+        projection receives ``created_at`` as a ``str`` — the other half of
+        the mixed-type sort.
+
+        ``assignee_kind`` picks the Mission Control section: an ``agent``
+        in-progress task lands in AGENTS; a ``human`` one falls through to
+        TRAY. ``status`` drives the projected WorkItemStatus (e.g.
+        ``awaiting_approval`` survives the ``?status=pending`` filter). Neither
+        changes that the pre-sort feed mixes str and datetime ``created_at``.
+        """
+        from datetime import UTC
+        from datetime import datetime as _dt
+
+        from pocketpaw_ee.cloud.tasks.domain import Task, TaskAssignee, TaskSource
+
+        ts = _dt.now(UTC) + timedelta(seconds=created_offset_seconds)
+        return Task(
+            id="t_mixed",
+            workspace_id="w1",
+            creator_id="u1",
+            assignee=TaskAssignee(kind=assignee_kind, id="a1", name="a1"),
+            status=status,
+            priority="normal",
+            kind="task",
+            source=TaskSource(type="user_request"),
+            title="Task with iso-str created_at",
+            summary="",
+            pocket_id=None,
+            created_at=ts,
+            updated_at=ts,
+        )
+
+    def _wire_task(self, monkeypatch, task) -> None:
+        from pocketpaw_ee.cloud.tasks.dto import task_to_dto
+
+        async def fake_list_tasks(_ctx_, _body):
+            return [task_to_dto(task)]
+
+        monkeypatch.setattr("pocketpaw_ee.cloud.tasks.service.agent_list_tasks", fake_list_tasks)
+
+    @pytest.mark.asyncio
+    async def test_unfiltered_feed_with_nudge_and_task_does_not_500(
+        self, monkeypatch, store: InstinctStore
+    ) -> None:
+        # (a) a Task whose created_at is a str/iso value
+        self._wire_task(monkeypatch, self._sample_task())
+        # (b) a Nudge whose created_at is a tz-NAIVE datetime (store default)
+        await store.propose("p1", "Nudge with naive datetime", "", "", _trigger())
+
+        # NO section filter — the crash surface. Both kinds coexist.
+        out = await mc_service.agent_list_work_items(_ctx(), {})
+        titles = {it.title for it in out}
+        assert "Task with iso-str created_at" in titles
+        assert "Nudge with naive datetime" in titles
+
+    @pytest.mark.asyncio
+    async def test_tray_section_still_returns_nudge_with_task_present(
+        self, monkeypatch, store: InstinctStore
+    ) -> None:
+        # Agent-assigned in-progress task → AGENTS section (out of the tray),
+        # so ?section=tray is nudge-only. Both kinds still coexist pre-sort.
+        self._wire_task(monkeypatch, self._sample_task(assignee_kind="agent"))
+        await store.propose("p1", "Nudge with naive datetime", "", "", _trigger())
+
+        tray = await mc_service.agent_list_work_items(
+            _ctx(), ListWorkItemsRequest(section=WorkItemSection.TRAY)
+        )
+        assert [it.title for it in tray] == ["Nudge with naive datetime"]
+
+    @pytest.mark.asyncio
+    async def test_status_pending_filter_with_nudge_and_task_does_not_500(
+        self, monkeypatch, store: InstinctStore
+    ) -> None:
+        # An awaiting_approval task (str created_at) survives the pending
+        # filter and mixes with the pending nudge (naive datetime) — so the
+        # sort runs over a genuinely mixed list even AFTER the status filter.
+        self._wire_task(monkeypatch, self._sample_task(status="awaiting_approval"))
+        await store.propose("p1", "Nudge with naive datetime", "", "", _trigger())
+
+        out = await mc_service.agent_list_work_items(_ctx(), ListWorkItemsRequest(status="pending"))
+        titles = {it.title for it in out}
+        assert "Nudge with naive datetime" in titles
+        assert "Task with iso-str created_at" in titles
+
+    @pytest.mark.asyncio
+    async def test_mixed_feed_sorts_newest_first(self, monkeypatch, store: InstinctStore) -> None:
+        # Task is the NEWEST item (created 60s in the future); the nudge's
+        # created_at is 'now'. Newest-first ordering must put the task first
+        # once str and datetime keys are made mutually comparable.
+        self._wire_task(monkeypatch, self._sample_task(created_offset_seconds=60))
+        await store.propose("p1", "Older nudge", "", "", _trigger())
+
+        out = await mc_service.agent_list_work_items(_ctx(), {})
+        assert [it.title for it in out] == [
+            "Task with iso-str created_at",
+            "Older nudge",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_completed_and_approved_items_visible_alongside_pending(
+        self, monkeypatch, store: InstinctStore
+    ) -> None:
+        """Captain ask: the unfiltered feed must surface approved/executed
+        nudges (Pawprints) and done tasks, not just pending ones — once the
+        sort no longer crashes on the mixed-type feed.
+        """
+        # A pending nudge (Tray) and a resolved nudge (approved → Pawprints).
+        await store.propose("p1", "pending nudge", "", "", _trigger())
+        approved = await store.propose("p1", "approved nudge", "", "", _trigger())
+        await store.approve(approved.id)
+        executed = await store.propose("p1", "executed nudge", "", "", _trigger())
+        await store.approve(executed.id)
+        await store.mark_executed(executed.id, "done")
+
+        # A done Task (str created_at) coexisting with the naive-datetime
+        # nudges — this is the mixed-type feed that used to 500.
+        from datetime import UTC
+        from datetime import datetime as _dt
+
+        from pocketpaw_ee.cloud.tasks.domain import Task, TaskAssignee, TaskSource
+
+        ts = _dt.now(UTC)
+        done_task = Task(
+            id="t_done",
+            workspace_id="w1",
+            creator_id="u1",
+            assignee=TaskAssignee(kind="human", id="u1", name="u1"),
+            status="done",
+            priority="normal",
+            kind="task",
+            source=TaskSource(type="user_request"),
+            title="Completed task",
+            summary="",
+            pocket_id=None,
+            created_at=ts,
+            updated_at=ts,
+        )
+        self._wire_task(monkeypatch, done_task)
+
+        out = await mc_service.agent_list_work_items(_ctx(), {})
+        by_title = {it.title: it for it in out}
+        # Pending is present.
+        assert "pending nudge" in by_title
+        # Approved + executed nudges are surfaced (Pawprints section).
+        assert by_title["approved nudge"].section == WorkItemSection.PAWPRINTS
+        assert by_title["approved nudge"].status == WorkItemStatus.APPROVED
+        assert by_title["executed nudge"].section == WorkItemSection.PAWPRINTS
+        assert by_title["executed nudge"].status == WorkItemStatus.DONE
+        # The completed task is surfaced too.
+        assert by_title["Completed task"].section == WorkItemSection.PAWPRINTS
+        assert by_title["Completed task"].status == WorkItemStatus.DONE
+
+
+# ---------------------------------------------------------------------------
 # workspace-scoped nudges (external-action proposals) must reach The Tray
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Symptom

`GET /api/v1/mission-control/items` with no section filter returned HTTP 500. The operator saw an empty main Deep Work feed while the in-flight (tasks) tab and the tray tab were both populated. Section-filtered fetches worked; the unfiltered one did not.

## Root cause

The final sort in `agent_list_work_items` compares `(created_at, id)` tuples. Work items come from two projections whose `created_at` types disagree:

- A Nudge carries `Action.created_at`, a tz-naive `datetime` (`datetime.now` default).
- A Task carries `TaskResponse.created_at`, an ISO `str` (serialized via `iso_utc`).

When a nudge and a task land in the same list, the sort does `datetime < str` and raises `TypeError`. The section-filtered feeds never hit this because each one is homogeneous: `?section=tray` is nudges only, `?section=agents` is tasks only. That is exactly why the operator saw an empty main feed but a populated tasks tab. The same class of failure also applies to naive vs tz-aware datetimes.

## The fix

Two points, for defense in depth:

1. `_task_to_work_item` now coerces `created_at` and `updated_at` from str to datetime, the same way it already coerces `due_at`. The task projection is now homogeneous with the nudge projection.
2. The sort key is a new module-level `_sort_created_at` helper. It normalizes any input (str, naive datetime, tz-aware datetime, or None) to a single tz-aware datetime, so the sort can never raise regardless of what a caller feeds it. None sorts last via a tz-aware floor.

Sort semantics are unchanged: still newest-first with an `id` tiebreak.

## Test

Added `TestMixedCreatedAtSort` in `tests/cloud/test_mission_control_service.py`. It seeds a nudge (naive datetime) and a task (iso str) in one workspace and covers the unfiltered feed, `?section=tray`, and `?status=pending`, plus newest-first ordering across the mixed types. The existing `test_includes_tasks_alongside_nudges` missed this because it seeded a task with no coexisting nudge, so its feed was all-str and sorted fine.

Confirmed the new tests fail with the `TypeError` before the fix and pass after. Full resolver file: 42 passed.

## Scope

This restores the full Deep Work feed, including completed and approved items. Once the sort no longer crashes, approved and executed nudges (Pawprints section) and done tasks surface in the unfiltered feed alongside pending ones. A test asserts this directly.
