### PR TITLE
Green dev CI: format, allowlist guarded atlas imports, route actor names through a service

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
@@ -336,9 +336,7 @@ def _legacy_ctx(user_id: str, workspace_id: str) -> Any:
     )
 
 
-async def _gate_read(
-    tool: str, action: str, deny_message: str
-) -> tuple[str, str, None] | dict:
+async def _gate_read(tool: str, action: str, deny_message: str) -> tuple[str, str, None] | dict:
     """Shared identity-resolve + RBAC-gate for a READ tool.
 
     Returns ``(workspace_id, user_id, None)`` when the gate PASSES, or a ready-to-
@@ -384,9 +382,7 @@ async def _gate_read(
     return workspace_id, user_id, None
 
 
-async def _gate_write(
-    tool: str, action: str, deny_message: str
-) -> tuple[str, str, None] | dict:
+async def _gate_write(tool: str, action: str, deny_message: str) -> tuple[str, str, None] | dict:
     """Shared identity-resolve + RBAC-gate for a WRITE tool.
 
     IDENTICAL control flow to ``_gate_read`` — a Forbidden is CAUGHT and returned
@@ -500,8 +496,7 @@ async def _members_list_handler(args: dict) -> dict:  # noqa: ARG001 — no args
                 "denied": True,
                 "code": exc.code,
                 "message": (
-                    "You don't have permission to view this workspace's members "
-                    f"({exc.code})."
+                    f"You don't have permission to view this workspace's members ({exc.code})."
                 ),
             }
         )
@@ -557,9 +552,7 @@ async def _member_update_role_handler(args: dict) -> dict:
         return _error_response("user_id is required (string — the member to change).")
     role = args.get("role")
     if not isinstance(role, str) or role not in _VALID_ROLES:
-        return _error_response(
-            f"role is required and must be one of {sorted(_VALID_ROLES)}."
-        )
+        return _error_response(f"role is required and must be one of {sorted(_VALID_ROLES)}.")
 
     from pocketpaw_ee.guards.deps import check_workspace_action
     from pocketpaw_ee.guards.rbac import Forbidden
@@ -1155,9 +1148,7 @@ async def _workspace_update_handler(args: dict) -> dict:
     if branding is not None:
         proposed_args["branding"] = branding
     if not proposed_args:
-        return _error_response(
-            "provide at least one of name / settings / branding to update."
-        )
+        return _error_response("provide at least one of name / settings / branding to update.")
 
     gate = await _gate_write(
         "workspace_update",
@@ -1316,9 +1307,7 @@ async def _billing_plan_change_handler(args: dict) -> dict:
         )
     plan = args.get("plan")
     if not isinstance(plan, str) or plan not in _VALID_PLANS:
-        return _error_response(
-            f"plan is required and must be one of {sorted(_VALID_PLANS)}."
-        )
+        return _error_response(f"plan is required and must be one of {sorted(_VALID_PLANS)}.")
 
     gate = await _gate_write(
         "billing_plan_change",

--- a/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
@@ -297,7 +297,9 @@ async def _call_revoke_invite(**kwargs: Any) -> Any:
 
 
 def _adapt_connector_manage(
-    args: dict[str, Any], workspace_id: str, proposer_user_id: str  # noqa: ARG001
+    args: dict[str, Any],
+    workspace_id: str,
+    proposer_user_id: str,  # noqa: ARG001
 ) -> dict[str, Any]:
     """STRICT, OP-AWARE adapter for the connector-manage fan-out.
 

--- a/ee/pocketpaw_ee/cloud/auth/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/service.py
@@ -174,10 +174,38 @@ async def suggest_workspace_members(workspace_id: str, q: str, *, limit: int = 8
     ]
 
 
+async def resolve_display_names(user_ids: set[str]) -> dict[str, str]:
+    """Batch-resolve a set of user ids → display names in one query.
+
+    Name preference: ``full_name`` → ``email`` → the id. A non-ObjectId id
+    (an agent name, or a sentinel like ``"external_action"`` /
+    ``"admin_action"``) is skipped, and an id with no matching user simply
+    isn't in the returned map — in both cases the caller's ``.get(id, id)``
+    fallback keeps the raw id. Resolves across the whole user set, not just
+    current members, so a proposer who has since left still renders as a
+    name. Callers (e.g. the Mission Control façade) route through here so the
+    façade layer never touches the Beanie user model directly.
+    """
+    object_ids: list[PydanticObjectId] = []
+    for uid in user_ids:
+        try:
+            object_ids.append(PydanticObjectId(uid))
+        except Exception:
+            continue
+    if not object_ids:
+        return {}
+    docs = await _UserDoc.find({"_id": {"$in": object_ids}}).to_list()
+    return {
+        str(u.id): ((u.full_name or "").strip() or (u.email or "").strip() or str(u.id))
+        for u in docs
+    }
+
+
 __all__ = [
     "claim_home_pocket_id",
     "get_home_pocket_id",
     "get_profile",
+    "resolve_display_names",
     "set_active_workspace",
     "set_avatar_path",
     "suggest_workspace_members",

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -177,6 +177,7 @@ from pocketpaw_ee.api import get_instinct_store
 from pocketpaw_ee.cloud._core.context import RequestContext
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.activity.buffer import ActivityEvent, get_buffer
+from pocketpaw_ee.cloud.auth import service as auth_service
 from pocketpaw_ee.cloud.mission_control.domain import (
     AssigneeKind,
     WorkItem,
@@ -300,37 +301,18 @@ async def _resolve_actor_names(source_ids: set[str]) -> dict[str, str]:
     name so The Tray never renders the raw id.
 
     Built ONCE per ``agent_list_work_items`` call from the union of all
-    projected actions' sources — a single ``_UserDoc.find`` over the id
-    set, mirroring how ``_pocket_name_map`` resolves pocket names once
-    (and the ``ripple_sources`` / ``chat.group_service`` batch pattern).
+    projected actions' sources, mirroring how ``_pocket_name_map`` resolves
+    pocket names once. Routes through ``auth_service.resolve_display_names``
+    (a single ``User.find`` over the id set) rather than touching the Beanie
+    user model here — the façade layer must not read models directly (the
+    "Mission Control — no Beanie touches from façade layer" contract).
 
-    Name preference: ``full_name`` → ``email`` → the id. Never raises: a
-    non-ObjectId / malformed source is skipped (stays the id via the
-    caller's ``.get(source, source)`` fallback), and an id with no
-    matching user simply isn't in the returned map (same fallback). We
-    resolve names across the workspace's user set, not just members, so a
-    proposer who has since left still renders as a name.
+    Name preference (``full_name`` → ``email`` → the id) and the skip/
+    fallback behavior for a non-ObjectId source or an id with no matching
+    user both live in ``resolve_display_names``; the caller's
+    ``.get(source, source)`` fallback keeps unresolved ids as the raw id.
     """
-    from beanie import PydanticObjectId
-
-    from pocketpaw_ee.cloud.models.user import User as _UserDoc
-
-    object_ids: list[PydanticObjectId] = []
-    for sid in source_ids:
-        try:
-            object_ids.append(PydanticObjectId(sid))
-        except Exception:
-            # Non-ObjectId source (e.g. an agent name, or a sentinel like
-            # "external_action" / "admin_action") — leave it as the id.
-            logger.debug("mission_control: skipping non-ObjectId trigger source %r", sid)
-    if not object_ids:
-        return {}
-
-    users = await _UserDoc.find({"_id": {"$in": object_ids}}).to_list()
-    return {
-        str(u.id): ((u.full_name or "").strip() or (u.email or "").strip() or str(u.id))
-        for u in users
-    }
+    return await auth_service.resolve_display_names(source_ids)
 
 
 def _status_to_section_status(s: ActionStatus) -> tuple[WorkItemSection, WorkItemStatus]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -544,4 +544,10 @@ ignore_imports = [
     # dashboard_lifecycle drains the EE InProcessExecutor on shutdown via a
     # try/except runtime import; the OSS core never imports EE statically.
     "pocketpaw.dashboard_lifecycle -> pocketpaw_ee.cloud.chat.runs.executor",
+    # atlas resolves optional EE introspection (Fabric schema) and the
+    # role-aware entitlement provider via try/except ImportError seams — an
+    # OSS-only install degrades to "no introspection"/default overlay and
+    # never imports EE statically.
+    "pocketpaw.atlas.fabric -> pocketpaw_ee.fabric",
+    "pocketpaw.atlas.overlay -> pocketpaw_ee.agent.atlas_provider",
 ]


### PR DESCRIPTION
## What

Dev CI has been red since the atlas / workspace-admin / resolver arc landed. Three pre-existing failures, none tied to new feature work — hygiene that slipped through the collapse-merge. This restores a green baseline so feature PRs show green on their own merits.

**1. Lint (ruff format)** — two files were unformatted:
- `ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py`
- `ee/pocketpaw_ee/cloud/admin_proposals/executor.py`

Reformatted, no logic change.

**2. OSS-EE boundary, core contract** — two atlas seams tripped "OSS core may not import from EE":
- `pocketpaw.atlas.fabric → pocketpaw_ee.fabric`
- `pocketpaw.atlas.overlay → pocketpaw_ee.agent.atlas_provider`

Both are `try/except ImportError` lazy imports — an OSS-only install degrades to "no Fabric introspection" / the default entitlement overlay and never imports EE statically. Added to `ignore_imports` next to the existing `dashboard_lifecycle → executor` seam (same sanctioned pattern).

**3. OSS-EE boundary, enterprise contract** — the Mission Control façade read the Beanie user model directly:
- `mission_control.service → pocketpaw_ee.cloud.models.user` in `_resolve_actor_names`

That breaks "Mission Control — no Beanie touches from façade layer." Moved the batch lookup into `auth_service.resolve_display_names` (the service layer may touch models) and had the façade delegate — mirroring how `_pocket_name_map` routes through `pockets_service`. Behavior unchanged.

## Verified

- `ruff format --check .` → all 2279 files formatted; `ruff check` on touched files → clean.
- `lint-imports` (core) → 1 kept, 0 broken.
- `lint-imports --config ee/pyproject.toml` (enterprise) → 28 kept, 0 broken.
- `pytest tests/cloud/test_mission_control_service.py` → 37 passed (actor-name resolution behavior preserved through the delegation).