### PR TITLE
Harden the atlas and workspace-admin ownership and approval paths

### DIFF
--- a/ee/pocketpaw_ee/agent/atlas_provider.py
+++ b/ee/pocketpaw_ee/agent/atlas_provider.py
@@ -1,5 +1,19 @@
 # atlas_provider.py — role-aware atlas EntitlementProvider for the cloud chat
 #   agent (WA-3). Created: 2026-07-03 (feat/workspace-admin-tools).
+# Updated: 2026-07-05 (fix/atlas-admin-security-hardening, FINDING D) — prime()
+#   now RE-RESOLVES the caller's role every turn instead of once per provider
+#   instance. The provider rides the WARM ClaudeSDKClient, which is shared across
+#   users of a workspace/public/shared pocket (its cache key omits user_id). The
+#   old ``_primed`` idempotency cached the FIRST caller's role for the provider's
+#   lifetime, so a MEMBER querying atlas after an OWNER saw the OWNER's
+#   role:admin / role:owner capability cards (and a mid-session role change stayed
+#   frozen — the P3). prime() now drops ``_primed`` and resets ``_role_level`` to
+#   None up front (fail-closed) before re-resolving from the CURRENT identity
+#   ContextVars, so ``is_granted`` reflects the live caller. DISCOVERY-LAYER ONLY:
+#   the RBAC gate inside each admin tool already re-checks the live role, so this
+#   is a capability-DISCLOSURE leak (a member seeing cards they can't use), not an
+#   enforcement bypass — but a real leak worth fixing. Warm-client sharing is left
+#   untouched (the surgical option).
 #
 # The DISCOVERY layer for the workspace-admin tools — NOT the security gate.
 # The RBAC checks INSIDE each admin tool (workspace_admin.py) are the real lock
@@ -17,12 +31,13 @@
 #     every role-gated entry is hidden. Never raises.
 #   * ``connected_connector_names()`` — pure delegation to the wrapped default
 #     provider (reuse the connector-state seam; don't reimplement).
-#   * ``prime()`` — async. Resolves the caller's role ONCE (cached) via the same
-#     identity the admin tools use: ``current_user_id`` / ``current_workspace_id``
-#     ContextVars → load the ``User`` Beanie doc → ``resolve_workspace_role``.
-#     The sdk_mcp_atlas handler awaits this before the sync grant filter so the
-#     async DB load runs in the handler's own event loop (``is_granted`` stays
-#     sync, per the protocol). Priming is idempotent; a failure leaves the role
+#   * ``prime()`` — async. Resolves the caller's role EACH TURN (FINDING D — no
+#     longer cached for the provider's lifetime) via the same identity the admin
+#     tools use: ``current_user_id`` / ``current_workspace_id`` ContextVars → load
+#     the ``User`` Beanie doc → ``resolve_workspace_role``. The sdk_mcp_atlas
+#     handler awaits this before the sync grant filter so the async DB load runs
+#     in the handler's own event loop (``is_granted`` stays sync, per the
+#     protocol). It resets the cached level up front, so a failure leaves the role
 #     unresolved (fail-closed) and is swallowed by the caller.
 #
 # Wiring: core's ``atlas.overlay.build_role_aware_provider(scope_key)`` imports
@@ -55,8 +70,10 @@ class RoleAwareEntitlementProvider:
     availability + granting role-blind entries) and adds a role gate on top for
     entries carrying a ``role:<tier>`` marker. Bound to ONE ``ws:<id>`` scope at
     construction — per-run, never a process-global. The caller's role is
-    resolved from the per-stream identity ContextVars at ``prime()`` time and
-    cached for the sync ``is_granted`` calls that follow.
+    re-resolved from the per-stream identity ContextVars on EVERY ``prime()`` (once
+    per turn — FINDING D), then read by the sync ``is_granted`` calls that follow.
+    It is NOT cached for the provider's lifetime, because the provider can ride a
+    warm client shared across users.
     """
 
     def __init__(self, scope_key: str, registry: Any | None = None) -> None:
@@ -70,9 +87,13 @@ class RoleAwareEntitlementProvider:
         # Reuse the OSS default for connector availability + role-blind grants.
         self._default = DefaultEntitlementProvider(scope_key=scope_key, registry=registry)
         # Resolved caller role level (int from ROLE_LEVELS) or None = unresolved.
-        # ``_primed`` guards against re-resolving on every call within one query.
+        # FINDING D: re-resolved on EVERY prime() (once per turn), not cached for
+        # the provider's lifetime. The provider rides the WARM ClaudeSDKClient,
+        # which is shared across users of a workspace/public pocket (its cache key
+        # omits user_id), so a once-per-instance cache froze the FIRST caller's
+        # role and leaked their admin/owner cards to later callers. There is no
+        # ``_primed`` flag any more — prime() always reflects the CURRENT identity.
         self._role_level: int | None = None
-        self._primed = False
 
     # -- connector delegation ------------------------------------------------
 
@@ -84,18 +105,26 @@ class RoleAwareEntitlementProvider:
     # -- role resolution -----------------------------------------------------
 
     async def prime(self) -> None:
-        """Resolve the caller's workspace role once (cached), fail-closed.
+        """Resolve the CURRENT caller's workspace role, per turn, fail-closed.
 
         Uses the SAME identity the admin tools read: the per-stream
         ``current_user_id`` / ``current_workspace_id`` ContextVars, the ``User``
         Beanie doc, and ``resolve_workspace_role``. On ANY failure — no identity,
         user not found, not a member of this workspace, a scope/workspace
         mismatch, or a DB error — the role stays ``None`` (unresolved) so every
-        role-gated entry is hidden. Never raises. Idempotent within a run: once
-        primed it does not re-load (the atlas server is built per run/stream)."""
-        if self._primed:
-            return
-        self._primed = True  # mark first so a raise below still leaves us "primed but unresolved"
+        role-gated entry is hidden. Never raises.
+
+        FINDING D: this RE-RESOLVES on every call (the sdk_mcp_atlas handler awaits
+        it before each turn's grant filter), it is NOT cached for the provider's
+        lifetime. The provider rides the warm ClaudeSDKClient shared across users
+        of a workspace/public pocket, so a once-per-instance cache would freeze the
+        first caller's role and leak their admin/owner cards to a later member (and
+        would also freeze a mid-session role change). ``_role_level`` is reset to
+        ``None`` up front so a failed re-resolution can never leave a STALE role
+        behind — fail-closed on every turn."""
+        # Reset first: an unresolved (or newly-restricted) caller must never
+        # inherit the previous turn's role level.
+        self._role_level = None
         try:
             from pocketpaw_ee.cloud.chat.agent_service import (
                 current_user_id,

--- a/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
@@ -1,5 +1,18 @@
 # ee/cloud/admin_proposals/executor.py — apply an approved workspace-admin action.
 # Created: 2026-07-03 (feat/workspace-admin-tools, WA-2).
+# Updated: 2026-07-05 (fix/atlas-admin-security-hardening, FINDING C) — serialize
+#   the executor per action_id. The idempotency guard (``_already_executed``) was
+#   check-then-act: it read status/outcome, THEN the executor did async work (RBAC
+#   re-check, arg adaptation, the service call) before ``mark_executed``
+#   back-wrote the outcome. Two concurrent invocations on ONE approved action both
+#   passed the guard and fired the whitelisted write twice. ``execute_approved_
+#   admin_action`` now wraps its whole body in a per-action_id ``asyncio.Lock``
+#   (``_lock_for``) and, INSIDE the lock, re-fetches the Action fresh from the
+#   store before reading the guard — so the concurrent loser blocks, then reads
+#   the winner's committed EXECUTED/outcome and no-ops. Defense-in-depth atop the
+#   atomic ``store.approve`` claim (FINDING B, the main double-approve trigger);
+#   this closes the executor's own guard-to-mark window. In-process (one backend
+#   runs the executor).
 # Updated: 2026-07-03 (feat/workspace-admin-tools, WA-5) — extended the ``_DISPATCH``
 #   whitelist from the single ``workspace.member.role_change`` entry to the full set
 #   of ADMIN write actions the workspace_admin MCP server proposes:
@@ -104,6 +117,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -121,6 +135,36 @@ logger = logging.getLogger(__name__)
 
 # Max length of the outcome summary persisted onto the blob.
 _OUTCOME_SUMMARY_MAX = 500
+
+# FINDING C — per-action_id serialization. ``execute_approved_admin_action`` reads
+# the ``_already_executed`` idempotency guard, THEN does async work (RBAC re-check,
+# arg adaptation, the service call) before ``mark_executed`` back-writes the
+# outcome. Two concurrent invocations on the SAME approved action both pass the
+# guard and fire the whitelisted write twice (a doubled role change / member
+# removal / connector write, or two checkouts). Serializing per action_id closes
+# that guard-to-mark window: the loser blocks until the winner's outcome is
+# committed, then re-reads it as executed and no-ops. This is defense-in-depth on
+# top of the atomic ``store.approve`` claim (FINDING B, which removes the main
+# production double-approve trigger); the lock covers the executor's own window.
+#
+# In-process only (one backend runs the executor). Locks are minted lazily and
+# never evicted — an admin-action's id is a short-lived UUID and the volume is low
+# (human-gated writes), so the dict stays small; a global registry keyed by id is
+# simpler and safer than an evictable cache for this cardinality.
+_action_locks: dict[str, asyncio.Lock] = {}
+
+
+def _lock_for(action_id: str) -> asyncio.Lock:
+    """Return the process-wide lock for ``action_id`` (minted on first use).
+
+    Lazily created on the running loop, mirroring the instinct store's
+    db_path-keyed audit lock. Keying on the id means two DIFFERENT actions never
+    contend — only concurrent invocations for the SAME action serialize."""
+    lock = _action_locks.get(action_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _action_locks[action_id] = lock
+    return lock
 
 
 @dataclass(frozen=True)
@@ -761,7 +805,33 @@ async def execute_approved_admin_action(
     failed (with a clear outcome) on ANY of: whitelist miss, schema/args mismatch,
     execute-time RBAC denial, or service error. The Decision-Graph chain is closed
     exactly once.
+
+    FINDING C — the whole body runs under a per-action_id lock so two concurrent
+    invocations of THIS function on the same Action can never interleave between
+    the ``_already_executed`` guard and the ``mark_executed`` back-write. Inside
+    the lock the Action is re-fetched from the store, so the loser reads the
+    winner's committed EXECUTED/outcome and no-ops via the idempotency guard. A
+    missing id (never a real Action) skips the lock and runs the body — it will
+    fail the blob/tenancy guards harmlessly.
     """
+    action_id = str(getattr(action, "id", "") or "")
+    if not action_id:
+        await _execute_approved_admin_action_locked(action, human_event_id=human_event_id)
+        return
+    async with _lock_for(action_id):
+        await _execute_approved_admin_action_locked(action, human_event_id=human_event_id)
+
+
+async def _execute_approved_admin_action_locked(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """The body of ``execute_approved_admin_action``, run while holding the
+    per-action_id lock (FINDING C). For the idempotency guard it reads the
+    Action's FRESH persisted state from the store, so a concurrent loser sees the
+    winner's committed EXECUTED/outcome and no-ops. The schema/args-hash tamper
+    guards stay on the passed-in blob (a re-read would mask a mutated object)."""
     from pocketpaw.stores import get_instinct_store
 
     params = getattr(action, "parameters", None) or {}
@@ -781,6 +851,7 @@ async def execute_approved_admin_action(
     # tenant's file, not the shared ledger.
     store = get_instinct_store(workspace_id=workspace_id or None)
     proposer_user_id = str(blob.get("proposer_user_id") or "")
+    action_id = str(getattr(action, "id", "") or "")
     # The chain actor on the terminal is the proposer (the write's author).
     causation = _coerce_uuid(human_event_id)
 
@@ -865,8 +936,25 @@ async def execute_approved_admin_action(
         )
         return
 
-    # Idempotency — never double-fire the write on a re-invocation.
-    if _already_executed(action, blob):
+    # Idempotency — never double-fire the write on a re-invocation. FINDING C:
+    # read the guard against the action's CURRENT persisted state, not the
+    # passed-in (possibly stale) object. Under the per-action lock the concurrent
+    # loser reaches here only after the winner's ``mark_executed`` + outcome
+    # back-write committed, so the fresh copy reports EXECUTED / an outcome blob
+    # and we no-op. The fresh read is used ONLY for this idempotency check; the
+    # schema/args-hash tamper guards above deliberately stay on the passed-in blob
+    # (they detect a mutated in-flight object, which a re-read would mask).
+    guard_action = action
+    guard_blob = blob
+    if action_id:
+        fresh = await store.get_action(action_id)
+        if fresh is not None:
+            guard_action = fresh
+            fresh_params = getattr(fresh, "parameters", None) or {}
+            fresh_blob = fresh_params.get(ADMIN_ACTION_PARAM_KEY)
+            if isinstance(fresh_blob, dict):
+                guard_blob = fresh_blob
+    if _already_executed(guard_action, guard_blob):
         logger.info(
             "admin_action: action %s already executed (idempotency guard) — "
             "skipping the service call",

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -67,6 +67,16 @@ ensure_tenant_key(workspace) call. A proxy outage / mint failure is logged and
 swallowed (workspace creation NEVER fails on a provisioning error); the call is
 idempotent, so the billing-cutover sweep and any later workspace touch back-fill
 a key that didn't mint here. Mirrors the best-effort seed_default_agent step.
+2026-07-05 (fix/atlas-admin-security-hardening, FINDING A): privilege-escalation
+guard on ownership. ``update_member_role`` now refuses to GRANT the ``owner``
+role unless the ACTOR already holds owner (code ``owner_grant_requires_owner``),
+and ``remove_member`` refuses to REMOVE an owner-role member unless the actor
+holds owner (code ``owner_removal_requires_owner``). The admin-tool RBAC action
+(workspace.member.role_change / .remove) is only ADMIN-gated, so without the
+actor-role check an ADMIN could self-promote to owner or evict a sitting owner on
+approval. The guard lives in the service so every caller (admin tool, executor,
+route) inherits it; it mirrors the existing "an invite can never mint an owner"
+rule. The last-owner + cannot_demote/remove-doc-owner guards are unchanged.
 """
 
 from __future__ import annotations
@@ -697,6 +707,19 @@ async def update_member_role(
     doc = await _fetch_workspace(workspace_id)
     if doc is None:
         raise NotFound("workspace", workspace_id)
+    # FINDING A — privilege-escalation guard. Granting the ``owner`` role is
+    # OWNER-only: the caller's RBAC action (workspace.member.role_change) is gated
+    # at ADMIN, so without this an ADMIN could promote any member — themselves
+    # included — to owner and it would land on approval. Mirror how an invite can
+    # never mint an owner: only a sitting owner may create another. The check is
+    # in the service so every path (admin tool, executor, route) inherits it.
+    if role == "owner":
+        actor_role = await _get_member_role(workspace_id, actor_user_id)
+        if actor_role != "owner":
+            raise Forbidden(
+                "workspace.owner_grant_requires_owner",
+                "Only an owner can grant the owner role.",
+            )
     if doc.owner == target_user_id and role != "owner":
         raise Forbidden(
             "workspace.cannot_demote_owner",
@@ -787,6 +810,16 @@ async def remove_member(
     # Role-based last-owner guard (independent of doc.owner field).
     target_role = await _get_member_role(workspace_id, target_user_id)
     if target_role == "owner":
+        # FINDING A — evicting an owner is OWNER-only. Same escalation class as
+        # granting owner: an ADMIN (gated at workspace.member.role_change) must
+        # not be able to remove a sitting owner. Checked before the last-owner
+        # guard so an ADMIN gets the actor-role denial regardless of owner count.
+        actor_role = await _get_member_role(workspace_id, actor_user_id)
+        if actor_role != "owner":
+            raise Forbidden(
+                "workspace.owner_removal_requires_owner",
+                "Only an owner can remove an owner.",
+            )
         owner_count = await _count_owners(workspace_id)
         if owner_count <= 1:
             raise Forbidden(

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,17 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-07-05 (fix/atlas-admin-security-hardening, FINDING B) — closed a
+#   TOCTOU double-flip in ``_update_status``. The ``require_status`` guard was a
+#   Python pre-check between ``get_action`` and the UPDATE, whose WHERE was
+#   ``id = ?`` only — so two concurrent ``approve()`` on one PENDING action both
+#   read PENDING, both flipped to APPROVED, both returned a non-None Action, and
+#   the admin executor fired the whitelisted write (role change / member removal /
+#   connector write) or opened two checkouts TWICE. The flip is now ATOMIC: when a
+#   required status is given the UPDATE carries ``AND status = ?`` and a
+#   ``rowcount==0`` (the concurrent loser, or a row not in the required state)
+#   rolls the transaction back and returns None — exactly one approver wins. The
+#   Python pre-check stays only as a cheap early-out. Unconditional lifecycle
+#   writes (mark_executed / mark_failed, no require_status) are unchanged.
 # Updated: 2026-06-26 (ISO-4 — audit-lock keyed outside the evictable instance)
 #   — the audit-append lock (``_log_lock``, which serializes the chain
 #   read-head + insert in ``_log``) is no longer a per-instance
@@ -790,7 +802,12 @@ class InstinctStore:
             return None
         # ``require_status`` lets bulk callers enforce "only act on rows
         # still in this state" without breaking the existing pending →
-        # approved → executed flow used by mark_executed / mark_failed.
+        # approved → executed flow used by mark_executed / mark_failed. This
+        # Python read is a cheap early-out ONLY — the authoritative guard is the
+        # atomic ``AND status = ?`` on the UPDATE below (FINDING B). Between this
+        # read and the UPDATE a concurrent approver can flip the row, so the
+        # pre-check alone was a TOCTOU: two approve() both saw PENDING, both
+        # flipped, both returned an Action, and the admin executor double-fired.
         if require_status is not None and action.status != require_status:
             return None
 
@@ -800,7 +817,17 @@ class InstinctStore:
             if v is not None:
                 sets.append(f"{k} = ?")
                 params.append(v)
+        # FINDING B — make the flip ATOMIC. When a required status is given, the
+        # UPDATE only matches a row STILL in that status; the SQLite engine
+        # serializes the write, so of two concurrent flips exactly one matches
+        # (rowcount==1) and the other matches nothing (rowcount==0) — the loser is
+        # a no-op. This, not the Python pre-check above, is what stops the
+        # double-fire.
+        where = "id = ?"
         params.append(action_id)
+        if require_status is not None:
+            where += " AND status = ?"
+            params.append(require_status.value)
 
         await self._ensure_schema()
         # FIX 2 — the status UPDATE and the lifecycle audit row must land
@@ -824,9 +851,19 @@ class InstinctStore:
         try:
             async with self._log_lock, self._conn() as db:
                 await db.execute("BEGIN")
-                await db.execute(
-                    f"UPDATE instinct_actions SET {', '.join(sets)} WHERE id = ?", params
+                cur = await db.execute(
+                    f"UPDATE instinct_actions SET {', '.join(sets)} WHERE {where}", params
                 )
+                # FINDING B — rowcount==0 means the required-status guard did not
+                # match: another approver already flipped this row (the concurrent
+                # loser) or it was never in the required state. Roll the
+                # transaction back so NO audit row lands, and return None — the
+                # no-op, exactly what the Python pre-check returned for the serial
+                # case. Only run this when a status was required; unconditional
+                # lifecycle writes (mark_executed / mark_failed) keep firing.
+                if require_status is not None and cur.rowcount == 0:
+                    await db.execute("ROLLBACK")
+                    return None
                 # W4a — read back the action's owning workspace so the lifecycle
                 # audit row (approve / reject / execute / fail) is stamped with
                 # the same tenant the action belongs to. Done with a tiny direct

--- a/tests/cloud/test_admin_action_gate.py
+++ b/tests/cloud/test_admin_action_gate.py
@@ -1061,3 +1061,52 @@ async def test_production_path_reject_no_service_call_wa6(
     assert spy.calls == []
     final = await store.get_action(action_id)
     assert final.status == ActionStatus.REJECTED
+
+
+# ---------------------------------------------------------------------------
+# FINDING C — executor idempotency is check-then-act; serialize per action_id
+#
+# ``_already_executed`` reads status/outcome, THEN the executor does async work
+# (RBAC re-check, adapter, service call) before ``mark_executed`` back-writes.
+# Two concurrent invocations on ONE approved action can both pass the guard and
+# fire the whitelisted write twice. The fix serializes the executor per
+# action_id so the guard-to-mark window can't interleave: the service fires once.
+# ---------------------------------------------------------------------------
+
+
+async def test_executor_concurrent_invocations_fire_service_once(store, monkeypatch):
+    """Two concurrent execute() calls on ONE approved action → the whitelisted
+    service fires EXACTLY ONCE.
+
+    Without the per-action serialization both invocations read the idempotency
+    guard as 'not yet executed', both clear it, and both call the service — a
+    double role-change. The per-action_id lock (or the atomic claim) closes the
+    check-then-act window.
+    """
+    import asyncio
+
+    # A slow spy widens the guard-to-mark window: the second invocation enters
+    # while the first is still awaiting the service call, so an unserialized
+    # executor would double-fire.
+    class SlowSpy(SpyWorkspaceService):
+        async def update_member_role(self, workspace_id, target_user_id, role, actor_user_id):
+            await asyncio.sleep(0.05)
+            return await super().update_member_role(
+                workspace_id, target_user_id, role, actor_user_id
+            )
+
+    spy = SlowSpy()
+    _patch_service(monkeypatch, spy)
+    _allow_rbac(monkeypatch)
+
+    approved = await _propose_and_approve(store)
+    reloaded = await store.get_action(approved.id)
+
+    await asyncio.gather(
+        aa_executor.execute_approved_admin_action(approved),
+        aa_executor.execute_approved_admin_action(reloaded),
+    )
+
+    assert len(spy.calls) == 1, f"executor double-fired: {spy.calls!r}"
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.EXECUTED

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -363,6 +363,99 @@ async def test_remove_member_allows_removing_one_of_many_owners(
 
 
 # ---------------------------------------------------------------------------
+# Owner-grant / owner-removal actor guard (FINDING A — privilege escalation)
+#
+# Granting OR removing the ``owner`` role requires the ACTOR to already hold
+# owner. Otherwise an ADMIN (gated at ``workspace.member.role_change``) could
+# promote any member — including themselves — to owner, or evict a sitting
+# owner. The actor-must-be-owner guard lives in the service so every caller
+# (the admin tool, the executor, a route) inherits it.
+# ---------------------------------------------------------------------------
+
+
+async def test_update_member_role_admin_cannot_grant_owner(owner) -> None:
+    """An ADMIN actor promoting a member to owner is Forbidden (escalation)."""
+    admin = await _seed_user(email="admin@x.c", full_name="Admin")
+    target = await _seed_user(email="target@x.c", full_name="Target")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(admin.id), role="admin")
+    await workspace_service._add_member(ws.id, str(target.id), role="member")
+
+    with pytest.raises(Forbidden) as exc:
+        await workspace_service.update_member_role(ws.id, str(target.id), "owner", str(admin.id))
+    assert exc.value.code == "workspace.owner_grant_requires_owner"
+    # The target was NOT promoted.
+    assert await workspace_service._get_member_role(ws.id, str(target.id)) == "member"
+
+
+async def test_update_member_role_admin_cannot_self_promote_to_owner(owner) -> None:
+    """An ADMIN cannot promote THEMSELVES to owner (the escalation-to-self case)."""
+    admin = await _seed_user(email="admin@x.c", full_name="Admin")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(admin.id), role="admin")
+
+    with pytest.raises(Forbidden) as exc:
+        await workspace_service.update_member_role(ws.id, str(admin.id), "owner", str(admin.id))
+    assert exc.value.code == "workspace.owner_grant_requires_owner"
+    assert await workspace_service._get_member_role(ws.id, str(admin.id)) == "admin"
+
+
+async def test_update_member_role_owner_can_grant_owner(
+    owner, recording_bus, resolver_mock
+) -> None:
+    """An OWNER actor CAN promote a member to owner (co-owner transfer)."""
+    target = await _seed_user(email="target@x.c", full_name="Target")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(target.id), role="member")
+
+    await workspace_service.update_member_role(ws.id, str(target.id), "owner", str(owner.id))
+
+    assert await workspace_service._get_member_role(ws.id, str(target.id)) == "owner"
+
+
+async def test_remove_member_admin_cannot_remove_owner(owner) -> None:
+    """An ADMIN actor removing a (non-doc-owner) owner is Forbidden.
+
+    Seeds a second owner so the last-owner guard is not what fires — the block
+    must come from the actor-not-owner check, proven by the error code.
+    """
+    admin = await _seed_user(email="admin@x.c", full_name="Admin")
+    co_owner = await _seed_user(email="co@x.c", full_name="Co")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(admin.id), role="admin")
+    await workspace_service._add_member(ws.id, str(co_owner.id), role="owner")
+
+    with pytest.raises(Forbidden) as exc:
+        await workspace_service.remove_member(ws.id, str(co_owner.id), str(admin.id))
+    assert exc.value.code == "workspace.owner_removal_requires_owner"
+    # co_owner is still a member with the owner role.
+    assert await workspace_service._get_member_role(ws.id, str(co_owner.id)) == "owner"
+
+
+async def test_remove_member_owner_can_remove_owner(
+    owner, recording_bus, captured_legacy_events, resolver_mock
+) -> None:
+    """An OWNER actor CAN remove another owner (still governed by last-owner)."""
+    co_owner = await _seed_user(email="co@x.c", full_name="Co")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(co_owner.id), role="owner")
+
+    await workspace_service.remove_member(ws.id, str(co_owner.id), str(owner.id))
+
+    assert await workspace_service._get_member_role(ws.id, str(co_owner.id)) is None
+
+
+# ---------------------------------------------------------------------------
 # Invites
 # ---------------------------------------------------------------------------
 

--- a/tests/ee/agent/test_atlas_role_provider.py
+++ b/tests/ee/agent/test_atlas_role_provider.py
@@ -262,6 +262,86 @@ class TestFailClosed:
 # ── construction + delegation ────────────────────────────────────────────────
 
 
+# ── FINDING D — cross-user role bleed on a shared (warm-client) provider ─────
+#
+# The provider instance lives on the atlas MCP server, which is built once and
+# carried on the WARM ClaudeSDKClient shared across users of a workspace/public
+# pocket (its cache key omits user_id). ``prime()`` was idempotent (``_primed``),
+# so it cached the FIRST caller's role forever: a MEMBER querying atlas after an
+# OWNER saw the OWNER's admin/owner capability cards. The fix re-resolves the
+# caller's role per turn from the CURRENT identity ContextVars. This is a
+# DISCOVERY-layer leak (the RBAC gate inside each admin tool still re-checks the
+# live role), but a real capability-disclosure leak worth closing.
+
+
+class TestCrossUserRoleBleed:
+    @pytest.fixture
+    def _patch_user_by_id(self, monkeypatch):
+        """Patch ``_load_user`` to map user_id → role, so priming as one user
+        then switching identity to another reflects the SECOND user's role."""
+
+        def _install(roles_by_user: dict[str, str]):
+            async def _fake_load_user(user_id: str):  # noqa: ANN001
+                role = roles_by_user.get(user_id)
+                if role is None:
+                    return None
+                return _FakeUser([_Membership(WS, role)])
+
+            monkeypatch.setattr(
+                ap.RoleAwareEntitlementProvider, "_load_user", staticmethod(_fake_load_user)
+            )
+
+        return _install
+
+    @pytest.mark.asyncio
+    async def test_member_after_owner_does_not_see_admin_cards(self, _patch_user_by_id):
+        """Prime as OWNER, then a MEMBER queries on the SAME provider instance
+        (shared warm client). The member must NOT inherit the owner's cards.
+
+        BEFORE the fix: ``prime()`` was a no-op on the second turn (``_primed``),
+        so the cached OWNER role level leaked and every admin card stayed visible
+        to the member. AFTER: the role is re-resolved per turn, so the member sees
+        only member-level cards.
+        """
+        _patch_user_by_id({"owner_uid": "owner", "member_uid": "member"})
+        store = _store()
+        provider = RoleAwareEntitlementProvider(scope_key=SCOPE)
+
+        # Turn 1 — OWNER primes the shared provider and sees every admin card.
+        with _identity(user="owner_uid"):
+            await provider.prime()
+            assert _visible_admin_ids(store, provider) == {
+                "capability:admin.members_list",
+                "capability:admin.member_update_role",
+                "capability:admin.workspace_delete",
+            }
+
+        # Turn 2 — a MEMBER on the SAME provider instance. Re-priming must reflect
+        # the member's role, not the owner's cached one.
+        with _identity(user="member_uid"):
+            await provider.prime()
+            assert _visible_admin_ids(store, provider) == {"capability:admin.members_list"}
+
+    @pytest.mark.asyncio
+    async def test_mid_session_role_change_is_reflected(self, _patch_user_by_id):
+        """The P3 case — the SAME user's role changes mid-session (owner→member).
+        A re-prime on the next turn reflects the downgrade instead of freezing the
+        first-seen role."""
+        roles = {"u1": "owner"}
+        _patch_user_by_id(roles)
+        store = _store()
+        provider = RoleAwareEntitlementProvider(scope_key=SCOPE)
+
+        with _identity(user="u1"):
+            await provider.prime()
+            assert "capability:admin.workspace_delete" in _visible_admin_ids(store, provider)
+
+            # The user is demoted to member mid-session.
+            roles["u1"] = "member"
+            await provider.prime()
+            assert _visible_admin_ids(store, provider) == {"capability:admin.members_list"}
+
+
 class TestConstructionAndDelegation:
     def test_rejects_non_ws_scope(self):
         with pytest.raises(ValueError):

--- a/tests/instinct/test_approve_toctou.py
+++ b/tests/instinct/test_approve_toctou.py
@@ -1,0 +1,95 @@
+# tests/instinct/test_approve_toctou.py — NEW (2026-07-05,
+#   fix/atlas-admin-security-hardening, FINDING B).
+# Store-level coverage that InstinctStore._update_status flips status ATOMICALLY:
+# the UPDATE's WHERE now carries ``AND status = ?`` (the required status), so two
+# concurrent approve() calls on the same PENDING action cannot BOTH win. Exactly
+# one returns the Action; the loser returns None (rowcount==0). This closes the
+# TOCTOU where the Python-side require_status pre-check (after get_action) let two
+# approvers both read PENDING and both flip to APPROVED, double-firing the admin
+# executor. Exercises the OSS store directly (no EE import), matching the
+# test_update_status_atomic.py convention.
+
+from __future__ import annotations
+
+import asyncio
+
+from pocketpaw.instinct.models import ActionStatus, ActionTrigger
+from pocketpaw.instinct.store import InstinctStore
+
+
+def _trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="tester", reason="toctou test")
+
+
+async def _propose(store: InstinctStore, *, pocket_id="p1"):
+    return await store.propose(
+        pocket_id=pocket_id,
+        title="do a thing",
+        description="",
+        recommendation="rec",
+        trigger=_trigger(),
+    )
+
+
+async def test_two_concurrent_approves_exactly_one_wins(tmp_path):
+    """Two interleaved approve() calls on ONE pending action: exactly one
+    returns the Action, the other returns None.
+
+    Both are forced to observe the PENDING status (the require_status pre-check
+    passes for both) before either UPDATE lands — the classic TOCTOU. Only the
+    atomic ``AND status = ?`` in the UPDATE's WHERE can make the second flip a
+    no-op. Without the fix BOTH return a non-None Action and the executor
+    double-fires.
+    """
+    store = InstinctStore(tmp_path / "instinct.db")
+    action = await _propose(store)
+    assert action.status == ActionStatus.PENDING
+
+    real_get_action = store.get_action
+    # A barrier both coroutines pass through AFTER their initial get_action but
+    # BEFORE their UPDATE, guaranteeing both saw PENDING (the check-then-act race).
+    both_read = asyncio.Event()
+    read_count = {"n": 0}
+
+    async def _gated_get_action(action_id: str):
+        result = await real_get_action(action_id)
+        # Only gate the FIRST read inside each _update_status (the require_status
+        # check). The trailing get_action (return value reload) must not block.
+        if read_count["n"] < 2:
+            read_count["n"] += 1
+            if read_count["n"] == 2:
+                both_read.set()
+            await both_read.wait()
+        return result
+
+    store.get_action = _gated_get_action  # type: ignore[method-assign]
+
+    results = await asyncio.gather(
+        store.approve(action.id, approver="alice"),
+        store.approve(action.id, approver="bob"),
+    )
+
+    non_none = [r for r in results if r is not None]
+    assert len(non_none) == 1, (
+        f"expected exactly one approve() to win, got {len(non_none)} "
+        f"(TOCTOU double-fire): {results!r}"
+    )
+
+    # The action is APPROVED exactly once and stays there.
+    reloaded = await real_get_action(action.id)
+    assert reloaded is not None
+    assert reloaded.status == ActionStatus.APPROVED
+
+
+async def test_reapprove_after_flip_is_noop(tmp_path):
+    """A serial re-approve of an already-APPROVED action returns None — the
+    atomic WHERE (not just the Python pre-check) enforces it."""
+    store = InstinctStore(tmp_path / "instinct.db")
+    action = await _propose(store)
+
+    first = await store.approve(action.id, approver="alice")
+    assert first is not None
+    assert first.status == ActionStatus.APPROVED
+
+    second = await store.approve(action.id, approver="bob")
+    assert second is None


### PR DESCRIPTION
Four confirmed defects in the atlas/workspace-admin arc, each fixed with a reproduction test that fails on `dev` and passes here. Two are P1 (privilege escalation, cross-user role bleed), two are P2 (concurrency double-fires). Security-sensitive, so please review the diff at the gate rather than merging on green.

## A — ADMIN could grant OWNER (P1, privilege escalation)

**Root cause.** The `member_update_role` admin tool is gated at ADMIN (`workspace.member.role_change`), but the underlying `update_member_role` service never checked whether the actor themselves held owner before writing an owner grant. So an admin could propose promoting any member — including themselves — to owner, and it landed on approval. Same class in `remove_member`: an admin could evict a sitting owner.

**Fix.** `update_member_role` now refuses to grant the `owner` role unless the actor already holds owner (`owner_grant_requires_owner`), and `remove_member` refuses to remove an owner-role member unless the actor holds owner (`owner_removal_requires_owner`). This mirrors the rule that already stops an invite from minting an owner. The guard sits in the service so every caller — the admin tool, the executor, any route — inherits it. The existing last-owner and cannot-demote-owner guards are untouched.

**Tests.** ADMIN granting owner → Forbidden; ADMIN self-promoting to owner → Forbidden; OWNER granting owner → ok; ADMIN removing an owner → Forbidden; OWNER removing an owner → ok.

## B — Concurrent approve double-fired the admin write (P2, TOCTOU)

**Root cause.** `InstinctStore._update_status` checked `require_status=PENDING` in Python after `get_action`, but the UPDATE matched on `id = ?` with no status condition. Two concurrent `approve()` calls both read PENDING, both flipped to APPROVED, both returned a non-None Action — so the router fired the executor twice: a doubled role change / member removal / connector write, or two billing checkouts.

**Fix.** The flip is now atomic. When a required status is given, the UPDATE carries `AND status = ?`, and a `rowcount == 0` rolls the transaction back and returns None. The engine serializes the write, so of two concurrent flips exactly one matches and the other no-ops. The Python pre-check stays only as a cheap early-out. Unconditional lifecycle writes (`mark_executed` / `mark_failed`) are unchanged.

**Test.** Two interleaved `approve()` calls on one PENDING action → exactly one returns the Action, the other returns None; the action ends APPROVED once.

## C — Executor idempotency guard was check-then-act (P2)

**Root cause.** `execute_approved_admin_action` read the `_already_executed` guard, then did async work (RBAC re-check, arg adaptation, the service call) before `mark_executed` back-wrote the outcome — no per-action lock. Two concurrent invocations both passed the guard and fired the whitelisted service twice.

**Fix.** The whole executor body now runs under a per-action-id `asyncio.Lock`, and inside the lock the idempotency guard reads the action's fresh persisted state — so the concurrent loser blocks until the winner's outcome commits, then reads it as executed and no-ops. The schema and args-hash tamper guards deliberately stay on the passed-in blob (a re-read would mask a mutated in-flight object). This is defense in depth on top of the atomic approve claim in B, which removes the main production trigger.

**Test.** Two concurrent execute calls on one approved action (with a slow service to widen the window) → the service fires exactly once.

## D — Cross-user role bleed via the warm SDK client (P1 disclosure + P3)

**Root cause.** In a workspace/public/shared pocket chat, users of different roles share one warm `ClaudeSDKClient` (its cache key omits `user_id`). The atlas `RoleAwareEntitlementProvider` primed once per instance and cached the first caller's role, so a MEMBER querying atlas after an OWNER saw the owner's `role:admin` / `role:owner` capability cards. The same freeze kept a mid-session role change from taking effect (the P3).

**Fix (surgical, option b).** `prime()` now re-resolves the caller's role every turn from the current identity ContextVars instead of caching for the provider's lifetime. It resets the cached level to None up front, so a failed re-resolution can never leave a stale role behind — fail-closed on every turn. Warm-client sharing is left untouched.

**Discovery vs enforcement.** This is a discovery-layer fix only. The RBAC gate inside each admin tool already re-checks the live role at call time, so this was never an enforcement bypass — a member could see admin capability cards they still could not use. It is a real capability-disclosure leak, so worth closing, but the security boundary was already held by the tool-level checks.

**Test.** Prime as OWNER, switch identity to a MEMBER on the same provider → admin/owner cards hidden on the next turn; a mid-session owner→member demotion is reflected on re-prime.

## Validation

- Targeted tests for the four touched modules (instinct store, workspace service, admin-proposals executor, atlas provider) pass; 136 in the core targeted set plus 173 across the wider atlas/sdk surface.
- Two pre-existing `test_delete_preview_*` failures in the workspace service suite are unrelated to this change — they fail identically on the clean base (a mongomock aggregate quirk).
- `ruff format --check .`, `ruff check` on the touched files, and both import-linter configs (`lint-imports` and `lint-imports --config ee/pyproject.toml`) are clean.
