### PR TITLE
fix(mission-control): make resolver counters, section validation, and agent filter consistent with the list

### DIFF
--- a/ee/pocketpaw_ee/cloud/mission_control/router.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/router.py
@@ -23,6 +23,13 @@
 # filter but never accepted the param, so ``?status=pending`` was silently
 # ignored and terminal (done/failed) items leaked into the awaiting-approval
 # feed; the service now honors it (``pending`` → awaiting-approval).
+# Updated: 2026-07-05 (fix/mission-control-resolver-consistency) — ``GET /items``
+# now validates ``section`` at the router boundary and raises a
+# ``ValidationError`` (422 ``mission_control.invalid_section``) on an out-of-enum
+# value. Before, an unknown ``section`` raised a raw pydantic
+# ``ValidationError`` when the router built ``ListWorkItemsRequest``, which
+# escaped as HTTP 500. The check mirrors the lenient ``status`` handling
+# (typed ``str``, normalised downstream); valid section values are unchanged.
 """Mission Control façade router.
 
 Thin per ee/cloud rule #4 — parses requests, delegates to
@@ -48,10 +55,11 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Query, Request
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
-from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud._core.errors import CloudError, ValidationError
 from pocketpaw_ee.cloud.cycles.dto import CycleResponse
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.mission_control import service as mc_service
+from pocketpaw_ee.cloud.mission_control.domain import WorkItemSection
 from pocketpaw_ee.cloud.mission_control.dto import (
     ActivityEventResponse,
     AnalyticsResponse,
@@ -100,6 +108,16 @@ async def list_items(
     awaiting-approval feed (excludes terminal done/failed items); omit
     ``status`` for the full feed.
     """
+    # Validate ``section`` at the boundary so an out-of-enum value degrades to
+    # a clean 422 instead of the raw pydantic ``ValidationError`` (HTTP 500)
+    # that building ``ListWorkItemsRequest`` would otherwise raise. Mirrors the
+    # lenient ``status`` handling (typed ``str``, normalised in the service).
+    if section is not None and section not in WorkItemSection.__members__.values():
+        valid = ", ".join(s.value for s in WorkItemSection)
+        raise ValidationError(
+            "mission_control.invalid_section",
+            f"section must be one of: {valid}",
+        )
     body = ListWorkItemsRequest(
         section=section,
         agent=agent,

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -142,6 +142,22 @@
 # can never raise regardless of caller (also fixes the naive-vs-aware case).
 # Sort semantics are unchanged (newest-first, ``id`` tiebreak); the fix restores
 # the full feed including completed/approved (Pawprints) items alongside pending.
+# Updated: 2026-07-05 (fix/mission-control-resolver-consistency) — two resolver
+# consistency fixes so the counters and the agent filter agree with the list:
+#   (A) ``agent_outcomes_summary`` now admits ``a.pocket_id == workspace_id`` in
+#       its in-window predicate, matching ``agent_list_work_items`` and
+#       ``_split_ids_by_tenancy``. Before, the summary filtered ``pocket_id in
+#       visible`` ONLY, so workspace-scoped nudges (every ``_admin_action`` /
+#       ``_external_action`` / connector proposal, whose ``pocket_id`` IS the
+#       workspace id) were DROPPED from the counters even though they list in
+#       Pawprints/Snags — the summary undercounted vs the list.
+#   (C) The ``?agent=`` filter in ``agent_list_work_items`` now matches BOTH the
+#       raw ``trigger.source`` id AND its resolved display name. The feed
+#       projects ``agent_name`` as the RESOLVED display name, but the filter
+#       compared ``body.agent`` to the raw ``trigger.source`` ObjectId hex only,
+#       so filtering by the visible name matched zero items. The collect →
+#       resolve-names → filter order was reordered so the display name is
+#       available when the filter runs (still ONE batched name-resolution query).
 """Mission Control façade service.
 
 Every function is module-level ``async def`` per ee/cloud rule #5. The
@@ -611,24 +627,40 @@ async def agent_list_work_items(
     pending = await store.pending(pocket_id=body.pocket, workspace_id=workspace_id)
     resolved = await store.list_actions(pocket_id=body.pocket, limit=200, workspace_id=workspace_id)
 
-    actions: list[Action] = []
+    # Collect every tenancy-visible action FIRST, then resolve actor names,
+    # then apply the agent filter. The agent filter has to run after name
+    # resolution because the feed renders ``agent_name`` as the RESOLVED
+    # display name (not the raw ``trigger.source`` id), so ``?agent=<name>``
+    # must match the rendered value — see the agent-filter block below.
+    visible_actions: list[Action] = []
     seen: set[str] = set()
     for a in (*pending, *resolved):
         if a.id in seen:
             continue
         if a.pocket_id not in visible and a.pocket_id != workspace_id:
             continue
-        if body.agent and a.trigger.source != body.agent:
-            continue
         seen.add(a.id)
-        actions.append(a)
+        visible_actions.append(a)
     # Batch-resolve every trigger.source (the proposer user id on a gated
     # Nudge) to a display name ONCE — a single _UserDoc.find over the union
     # of source ids, mirroring how name_map resolves pockets once — so The
     # Tray renders a person, not a raw ObjectId hex.
     actor_name_map = await _resolve_actor_names(
-        {a.trigger.source for a in actions if a.trigger and a.trigger.source}
+        {a.trigger.source for a in visible_actions if a.trigger and a.trigger.source}
     )
+    # Agent filter — the feed projects ``agent_name`` as the RESOLVED display
+    # name, so filtering must accept EITHER the raw ``trigger.source`` id OR
+    # its resolved display name. Comparing only against the raw id (as before)
+    # matched ZERO items when the operator filtered by the visible name.
+    if body.agent:
+        actions = [
+            a
+            for a in visible_actions
+            if a.trigger.source == body.agent
+            or actor_name_map.get(a.trigger.source, a.trigger.source) == body.agent
+        ]
+    else:
+        actions = visible_actions
     items.extend(
         _action_to_work_item(
             a,
@@ -1183,7 +1215,16 @@ async def agent_outcomes_summary(
     in_window = [
         a
         for a in actions
-        if a.pocket_id in visible and (a.updated_at or a.created_at or datetime.min) >= cutoff
+        # Tenancy MUST match ``agent_list_work_items`` / ``_split_ids_by_tenancy``:
+        # admit an action if it's in a visible pocket OR it's workspace-scoped
+        # (``pocket_id == workspace_id`` — every ``_admin_action`` /
+        # ``_external_action`` / connector proposal). Without the second clause
+        # the summary DROPS workspace-scoped nudges that DO list in
+        # Pawprints/Snags, so the counters undercount vs the list. The store
+        # read is already tenant-scoped, so ``== workspace_id`` only ever
+        # matches the caller's own rows.
+        if (a.pocket_id in visible or a.pocket_id == workspace_id)
+        and (a.updated_at or a.created_at or datetime.min) >= cutoff
     ]
 
     counters: dict[str, int] = {s.value: 0 for s in ActionStatus}

--- a/tests/cloud/test_mission_control_router.py
+++ b/tests/cloud/test_mission_control_router.py
@@ -109,6 +109,25 @@ class TestItemsEndpoint:
         assert [it["title"] for it in tray] == ["Pending"]
         assert [it["title"] for it in pawprints] == ["Approved"]
 
+    @pytest.mark.asyncio
+    async def test_invalid_section_returns_422_not_500(self, store: InstinctStore) -> None:
+        # An out-of-enum ``section`` used to raise a raw pydantic
+        # ValidationError when the router built ``ListWorkItemsRequest``,
+        # escaping as HTTP 500. It must degrade to a clean 422 instead.
+        with TestClient(_build_app()) as client:
+            resp = client.get("/api/v1/mission-control/items?section=bogus")
+        assert resp.status_code == 422
+        assert resp.json()["error"]["code"] == "mission_control.invalid_section"
+
+    @pytest.mark.asyncio
+    async def test_valid_sections_unaffected(self, store: InstinctStore) -> None:
+        # The four valid section values still return 200 after the guard.
+        await store.propose("p1", "Pending", "", "", _trigger())
+        with TestClient(_build_app()) as client:
+            for section in ("tray", "pawprints", "snags", "agents"):
+                resp = client.get(f"/api/v1/mission-control/items?section={section}")
+                assert resp.status_code == 200, section
+
 
 class TestBulkApproveEndpoint:
     @pytest.mark.asyncio

--- a/tests/cloud/test_mission_control_service.py
+++ b/tests/cloud/test_mission_control_service.py
@@ -1075,6 +1075,33 @@ class TestOutcomesSummary:
         # Only the "recent" row falls in the 24h window.
         assert summary.total == 1
 
+    @pytest.mark.asyncio
+    async def test_counts_workspace_scoped_nudge(self, store: InstinctStore) -> None:
+        # Regression — a workspace-scoped nudge (``pocket_id == workspace_id``,
+        # e.g. an ``_admin_action`` / ``_external_action`` proposal) LISTS in
+        # The Tray / Pawprints but was DROPPED from the outcomes counters
+        # because the in-window filter only admitted ``a.pocket_id in visible``.
+        # A workspace id is never a visible POCKET id, so the summary
+        # undercounted vs the list. The filter must match the list path's
+        # ``in visible OR == workspace_id`` clause.
+        a = await store.propose(
+            "w1",  # pocket_id carries the workspace for gated proposals
+            "External action — send invoice",
+            "gated call",
+            "approve to call 'send_invoice'",
+            _trigger(),
+            parameters={"_external_action": {"connector": "stripe", "action": "send_invoice"}},
+            workspace_id="w1",
+        )
+        await store.approve(a.id)
+
+        summary = await mc_service.agent_outcomes_summary(
+            _ctx(workspace_id="w1"), OutcomesQueryRequest(window="24h")
+        )
+        # The resolved workspace-scoped nudge must be counted (was 0).
+        assert summary.total == 1
+        assert summary.approved == 1
+
 
 # ---------------------------------------------------------------------------
 # W4c — store-level workspace scoping on the instinct reads
@@ -1298,6 +1325,45 @@ class TestActorNameResolution:
         assert names == {"Alice", "Bob"}
         # Three actions, two distinct proposers — resolved in ONE find call.
         assert calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_agent_filter_matches_resolved_display_name(
+        self, mongo_db, store: InstinctStore
+    ) -> None:
+        # Regression — the feed projects ``agent_name`` as the RESOLVED display
+        # name, but ``?agent=`` filtered against the raw ``trigger.source``
+        # ObjectId hex. Filtering by the visible name matched ZERO items. The
+        # filter must accept the display name too (or the raw source id).
+        from pocketpaw_ee.cloud.models.user import User
+
+        proposer = User(email="captain@x.dev", hashed_password="x", full_name="Atlas Captain")
+        await proposer.insert()
+        proposer_id = str(proposer.id)
+
+        a = await store.propose(
+            "w1",
+            "gated by the captain",
+            "",
+            "",
+            ActionTrigger(type="agent", source=proposer_id, reason="admin action"),
+            parameters={"_external_action": {"connector": "s", "action": "send"}},
+            workspace_id="w1",
+        )
+        # Sanity: unfiltered, the item renders the resolved display name.
+        unfiltered = await mc_service.agent_list_work_items(_ctx(workspace_id="w1"), {})
+        assert [it.agent_name for it in unfiltered] == ["Atlas Captain"]
+
+        # Filtering by the DISPLAY NAME returns the item.
+        by_name = await mc_service.agent_list_work_items(
+            _ctx(workspace_id="w1"), ListWorkItemsRequest(agent="Atlas Captain")
+        )
+        assert [it.id for it in by_name] == [f"nudge:{a.id}"]
+
+        # Filtering by the raw source id still works (backward compatible).
+        by_id = await mc_service.agent_list_work_items(
+            _ctx(workspace_id="w1"), ListWorkItemsRequest(agent=proposer_id)
+        )
+        assert [it.id for it in by_id] == [f"nudge:{a.id}"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three places in the Mission Control façade where the counters and the query filters disagreed with what the item list actually returns. All three trace back to workspace-scoped nudges (proposals stamped with `pocket_id == workspace_id`: every `_admin_action`, `_external_action`, and connector proposal) and to the resolver that turns raw ids into display names.

## Finding A (P2) — outcomes summary dropped workspace-scoped nudges

The in-window filter in `agent_outcomes_summary` admitted `a.pocket_id in visible` only. A workspace id is never a visible pocket id, so every workspace-scoped nudge fell out of the counters even though the same rows list fine in Pawprints and Snags. The summary undercounted against the list.

Fix: the filter now admits `a.pocket_id in visible or a.pocket_id == workspace_id`, matching `agent_list_work_items` and `_split_ids_by_tenancy`. The store read is already tenant-scoped, so the new clause only ever matches the caller's own rows.

## Finding B (P2) — `GET /items?section=<invalid>` returned 500

An out-of-enum `section` value raised a raw pydantic `ValidationError` when the router built `ListWorkItemsRequest`, and that escaped as a 500. The neighboring `status` param is typed `str` and degrades cleanly, so the two params behaved differently for the same class of bad input.

Fix: the router validates `section` at the boundary and raises `mission_control.invalid_section` (422) for an unknown value, mirroring the lenient `status` handling. Valid sections are unchanged.

## Finding C (P3) — `GET /items?agent=` filtered by raw id, not the display name

The agent filter compared `body.agent` to `Action.trigger.source`, a raw ObjectId hex. The feed now projects `agent_name` as the resolved display name, so filtering by the name a user actually sees matched zero items.

Fix: the filter accepts both the raw source id and its resolved display name. The collect then resolve-names then filter order was reordered so the name is available when the filter runs. It stays one batched lookup, so the single-query efficiency guard still holds. Low urgency in practice (the frontend agent chip is guarded to agent-kind assignees), but the wire is now consistent.

## Tests

Each defect got a failing test first, then the fix:

- `TestOutcomesSummary::test_counts_workspace_scoped_nudge` — a resolved workspace-scoped nudge counts (was 0, now 1).
- `TestItemsEndpoint::test_invalid_section_returns_422_not_500` plus `test_valid_sections_unaffected` — `?section=bogus` is a 422; the four valid sections still return 200.
- `TestActorNameResolution::test_agent_filter_matches_resolved_display_name` — filtering by the display name returns the item; the raw id still works too.

Full `test_mission_control_service.py` + `test_mission_control_router.py`: 60 passed. Broader mission_control suite: 177 passed. The one red in `test_mission_control_project_filter.py::test_project_id_empty_string_filters_for_unassigned` is pre-existing on the base commit (confirmed with the changes stashed) and untouched by this branch.

`ruff format --check` clean, `ruff check` on the touched files clean, and both `lint-imports` contracts pass (28 kept under `ee/pyproject.toml`, including "Mission Control — no Beanie touches from façade layer").
