### PR TITLE
fix(atlas): harden the compiler and fabric search against edge cases

### DIFF
--- a/src/pocketpaw/atlas/compile.py
+++ b/src/pocketpaw/atlas/compile.py
@@ -29,6 +29,22 @@
 #     installed skills change per install and are deliberately NOT baked
 #     into the artifact (their discovery stays with the system-prompt
 #     skills block).
+# Updated: 2026-07-05 (fix/atlas-compiler-robustness) — three robustness fixes,
+# all output-preserving (atlas.json bytes unchanged):
+#   * FINDING A: ``_connector_entry`` coerces ``display_name`` to a safe string
+#     (``display = defn.display_name or defn.name``) before ``.lower()`` / any
+#     f-string, so a connector YAML with explicit ``display_name: null`` no
+#     longer crashes the WHOLE compile (and CI drift gate) on AttributeError —
+#     honoring the module's "one bad file can't block the build" posture.
+#   * FINDING C: ``DEFAULT_CONNECTORS_DIR`` is anchored to the package location
+#     (``Path(__file__).parents[3] / "connectors"``) instead of a CWD-relative
+#     ``Path("connectors")``, so a default-arg compile / write / check from any
+#     dir still finds the connector YAMLs instead of silently dropping every
+#     connector + sense entry (and persisting a truncated artifact).
+#   * FINDING E: ``check_artifact`` detects duplicate entry ids explicitly
+#     (``_duplicate_ids``) before the id->entry map collapses them, so the drift
+#     summary can't misreport a same-id collision; ``compile_atlas`` also asserts
+#     id uniqueness so an authoring collision fails loudly at build time.
 
 from __future__ import annotations
 
@@ -57,11 +73,21 @@ AUTHORED_FILES = (
     _AUTHORED_DIR / "capabilities.json",
 )
 
-# Where connector YAML definitions live, relative to the repo root (the
-# same default dir ConnectorRegistry scans). The compiler reads ONLY the
-# repo dir — never ~/.pocketpaw/connectors — so the checked-in artifact
-# reflects the repo, not one developer's machine.
-DEFAULT_CONNECTORS_DIR = Path("connectors")
+# Where connector YAML definitions live: the repo's top-level ``connectors/``
+# dir (the same one ConnectorRegistry scans). The compiler reads ONLY the repo
+# dir — never ~/.pocketpaw/connectors — so the checked-in artifact reflects the
+# repo, not one developer's machine.
+#
+# Anchored to the package location, NOT the CWD. A bare ``Path("connectors")``
+# is CWD-relative, so ``compile_atlas`` / ``write_artifact`` / ``check_artifact``
+# called with defaults from any dir other than the repo root would read ZERO
+# YAMLs and silently drop every connector + sense entry (and write_artifact
+# would then persist a truncated artifact). ``compile.py`` lives at
+# ``src/pocketpaw/atlas/compile.py``, so ``parents[3]`` is the repo root. The
+# compiler is a source-checkout build tool (it never runs from an installed
+# wheel — it reads the repo's YAMLs), so ``__file__``-anchoring is safe here,
+# the same pattern ``store.py`` uses for the packaged data file.
+DEFAULT_CONNECTORS_DIR = Path(__file__).resolve().parents[3] / "connectors"
 
 # Every connector entry points users at the integrations surface.
 _INTEGRATIONS_ROUTE = "/settings/workspace/integrations"
@@ -101,6 +127,14 @@ def _connector_entry(defn: ConnectorDef) -> AtlasEntry:
     agent can discover e.g. that Stripe supports ``list_invoices`` without
     guessing from priors.
     """
+    # A YAML with an explicit ``display_name: null`` parses cleanly (the
+    # dataclass default only fills an ABSENT key, not a present null), so
+    # coerce to a safe string before any ``.lower()`` / f-string use —
+    # otherwise one such file would abort the WHOLE compile (and the CI drift
+    # gate) with AttributeError, contradicting "one bad file can't block the
+    # build". Fall back to the connector name.
+    display = defn.display_name or defn.name
+
     action_names: list[str] = []
     action_bits: list[str] = []
     for action in defn.actions:
@@ -117,21 +151,18 @@ def _connector_entry(defn: ConnectorDef) -> AtlasEntry:
 
     preview = ", ".join(action_names[:4])
     more = f", +{len(action_names) - 4} more" if len(action_names) > 4 else ""
-    summary = (
-        f"{defn.display_name} ({defn.type}) connector — "
-        f"{len(action_names)} actions: {preview}{more}."
-    )
+    summary = f"{display} ({defn.type}) connector — {len(action_names)} actions: {preview}{more}."
 
     narrative = (
-        f"The {defn.display_name} connector ({defn.type}) wires "
-        f"{defn.display_name} data into the workspace. "
+        f"The {display} connector ({defn.type}) wires "
+        f"{display} data into the workspace. "
         f"ACTIONS: {'; '.join(action_bits)}."
     )
     if defn.senses:
         narrative += f" Declared senses: {', '.join(defn.senses)}."
 
     keywords: list[str] = []
-    for word in [defn.name, defn.display_name.lower(), defn.type, *action_names] + [
+    for word in [defn.name, display.lower(), defn.type, *action_names] + [
         _sense_domain(s) for s in defn.senses
     ]:
         if word and word not in keywords:
@@ -140,7 +171,7 @@ def _connector_entry(defn: ConnectorDef) -> AtlasEntry:
     return AtlasEntry(
         id=f"connector:{defn.name}",
         kind="connector",
-        name=defn.display_name,
+        name=display,
         summary=summary,
         narrative=narrative,
         how=(
@@ -483,6 +514,14 @@ def compile_atlas(connectors_dir: Path | None = None) -> AtlasModel:
     entries.extend(_widget_entries())
     entries.extend(_skill_entries())
     entries.sort(key=lambda e: e.id)
+    # Fail loudly on an authoring collision: two sources minting the same id
+    # (e.g. a connector named the same as a widget) would otherwise ship a
+    # silently-deduped artifact whose drift diff can't explain itself. The
+    # extractors mint disjoint id namespaces today, so this only trips on a
+    # real regression.
+    dupes = _duplicate_ids([{"id": e.id} for e in entries])
+    if dupes:
+        raise ValueError(f"atlas compile: duplicate entry ids: {', '.join(dupes)}")
     return AtlasModel(generated=True, entries=entries)
 
 
@@ -509,6 +548,24 @@ def write_artifact(
     return path, model
 
 
+def _duplicate_ids(entries: list[dict]) -> list[str]:
+    """Ids that appear more than once in ``entries`` (sorted, unique).
+
+    An id->entry map silently collapses duplicates, so the diff summary must
+    detect them from the raw list length before mapping.
+    """
+    seen: set[str] = set()
+    dupes: set[str] = set()
+    for entry in entries:
+        eid = entry.get("id")
+        if not isinstance(eid, str):
+            continue
+        if eid in seen:
+            dupes.add(eid)
+        seen.add(eid)
+    return sorted(dupes)
+
+
 def check_artifact(
     artifact_path: Path | None = None, connectors_dir: Path | None = None
 ) -> tuple[bool, str]:
@@ -528,8 +585,20 @@ def check_artifact(
 
     lines = [f"artifact stale: {path}"]
     try:
-        actual_entries = {e["id"]: e for e in json.loads(actual)["entries"]}
-        expected_entries = {e["id"]: e for e in json.loads(expected)["entries"]}
+        actual_list = json.loads(actual)["entries"]
+        expected_list = json.loads(expected)["entries"]
+        # Surface duplicate ids explicitly BEFORE the id->entry map collapses
+        # them. The added/removed/changed diff below is keyed by id, so two
+        # entries sharing an id would otherwise vanish into one and misreport
+        # the drift — the artifact fails on bytes but the summary lies about
+        # why. A compiled artifact never carries duplicates (compile_atlas
+        # sorts unique-id entries), so any duplicate is an authoring/tamper
+        # collision worth naming.
+        dupes = _duplicate_ids(actual_list)
+        if dupes:
+            lines.append(f"  duplicate ids in artifact ({len(dupes)}): {', '.join(dupes[:10])}")
+        actual_entries = {e["id"]: e for e in actual_list}
+        expected_entries = {e["id"]: e for e in expected_list}
         added = sorted(set(expected_entries) - set(actual_entries))
         removed = sorted(set(actual_entries) - set(expected_entries))
         changed = sorted(
@@ -543,7 +612,7 @@ def check_artifact(
             lines.append(f"  entries to remove ({len(removed)}): {', '.join(removed[:10])}")
         if changed:
             lines.append(f"  entries changed ({len(changed)}): {', '.join(changed[:10])}")
-        if not (added or removed or changed):
+        if not (added or removed or changed or dupes):
             lines.append("  entry content identical — header/formatting drift only")
     except Exception:  # noqa: BLE001 — a corrupt artifact still reports stale
         lines.append("  (checked-in artifact is not parseable JSON)")

--- a/src/pocketpaw/atlas/fabric.py
+++ b/src/pocketpaw/atlas/fabric.py
@@ -28,6 +28,23 @@
 #   other ee seams) and binds a ``WorkspaceFabricRegistry`` to ONE
 #   workspace id (never a process-global). Import or construction failure
 #   degrades to ``None``.
+#
+# Updated: 2026-07-05 (fix/atlas-compiler-robustness) — two search fixes:
+#   * FINDING B: ``search_entity_types`` no longer calls the full
+#     ``describe_entity_type`` per type. Search scores on names + property
+#     names only and never uses links, but describe on the live EE adapter
+#     opens 3 sqlite connections per type (exists + properties + links) → 3N
+#     per query, two-thirds wasted. It now reads properties only via
+#     ``_search_properties`` (prefers a new optional, duck-typed
+#     ``list_entity_properties`` — one connection on the EE adapter — and falls
+#     back to describe for older introspectors). The thin search card reports a
+#     property count only (``_search_summary``); the link count stays on the
+#     detail view (``describe_fabric_id``), so search never triggers the link
+#     fetch just to print a number.
+#   * FINDING D: ``_CAMEL_RE`` gains an acronym-boundary alternative
+#     ``(?<=[A-Z])(?=[A-Z][a-z])`` so consecutive-capital names split
+#     ("HTTPServer" → "HTTP Server", "APIKey" → "API Key"); "http server" /
+#     "api key" queries now match acronym-named entity types.
 
 from __future__ import annotations
 
@@ -48,8 +65,14 @@ FABRIC_KIND = "fabric"
 MAX_FABRIC_RESULTS = 3
 
 # Entity-type names are commonly CamelCase ("CustomerAccount"); split on
-# case boundaries before stemming so "customer account" queries match.
-_CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+# case boundaries before stemming so "customer account" queries match. Two
+# boundaries: the lower/digit->upper transition ("CustomerAccount" ->
+# "Customer Account") AND the acronym boundary where a run of capitals is
+# followed by a capitalized word ("HTTPServer" -> "HTTP Server", "APIKey" ->
+# "API Key", "IOError" -> "IO Error"). Without the acronym alternative,
+# consecutive-capital names never split and "http server" / "api key" queries
+# miss them.
+_CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
 
 
 @runtime_checkable
@@ -75,6 +98,19 @@ class FabricIntrospector(Protocol):
         """
         ...
 
+    # OPTIONAL — a cheap properties-only read path for the search scorer.
+    #
+    # ``search_entity_types`` scores on names + property names and never uses
+    # links, so calling the full ``describe_entity_type`` per type is wasteful
+    # (on the live EE adapter it opens 3 sqlite connections per type). An
+    # implementation MAY expose ``list_entity_properties(name) -> list[str]``
+    # to serve just the property names; ``search`` uses it via ``getattr`` when
+    # present and falls back to ``describe_entity_type`` otherwise. It is NOT
+    # part of the required structural contract — adding it here would break the
+    # ``isinstance`` check for introspectors (including test fakes) that only
+    # implement the two required methods — so it stays a documented, duck-typed
+    # extension rather than a Protocol member.
+
 
 def _fabric_tokens(text: str) -> set[str]:
     """Stemmed token set for a fabric name — camel-split then the store's
@@ -99,10 +135,49 @@ def _clean_links(described: dict) -> list[dict]:
 
 
 def _summary(name: str, properties: list[str], links: list[dict]) -> str:
+    """Detail-view summary (describe): reports both property and link counts."""
     return (
         f"Workspace entity type '{name}' — {len(properties)} properties, "
         f"{len(links)} links. Live Fabric ontology (this workspace only)."
     )
+
+
+def _search_summary(name: str, properties: list[str]) -> str:
+    """Thin search-card summary: property count only.
+
+    The search path deliberately never fetches a type's links (see
+    ``search_entity_types``), so the card can't report a link count without
+    paying for a read it doesn't need. The link count stays on the detail
+    view (``describe_fabric_id`` via ``_summary``).
+    """
+    return (
+        f"Workspace entity type '{name}' — {len(properties)} properties. "
+        "Live Fabric ontology (this workspace only)."
+    )
+
+
+def _search_properties(introspector: FabricIntrospector, name: str) -> list[str]:
+    """Property names for one type on the SEARCH path — properties only.
+
+    Search scores on entity-type NAMES and PROPERTY names; it never uses a
+    type's links. So it must NOT call ``describe_entity_type``, which on the
+    live EE adapter opens three sqlite connections per type (exists +
+    properties + links) — 3N connections/queries per query, two-thirds of it
+    wasted (the existence check the search already knows passed, plus the link
+    fetch it discards). Prefer the properties-only ``list_entity_properties``
+    read path (one connection); fall back to ``describe_entity_type`` only for
+    older introspectors that don't expose it, so no caller regresses.
+    """
+    getter = getattr(introspector, "list_entity_properties", None)
+    if callable(getter):
+        props = getter(name)
+        if isinstance(props, (list, tuple, set, frozenset)):
+            return sorted(p for p in props if isinstance(p, str) and p)
+        return []
+    described = introspector.describe_entity_type(name) or {}
+    if not isinstance(described, dict):
+        return []
+    return _clean_properties(described)
 
 
 def search_entity_types(
@@ -117,20 +192,20 @@ def search_entity_types(
     the store's scoring spirit). Zero-overlap types are dropped; ties sort
     by name for determinism. FAIL-CLOSED: any introspector error returns
     ``[]`` (logged at DEBUG) — the compiled-entry answer is never harmed.
+
+    Reads properties only (never links) via ``_search_properties`` — the thin
+    search card reports a property count, not a link count, so the per-type
+    link fetch is never triggered on the search path (see FINDING B).
     """
     try:
         query = _fabric_tokens(intent)
         if not query or limit <= 0:
             return []
-        scored: list[tuple[float, str, list[str], list[dict]]] = []
+        scored: list[tuple[float, str, list[str]]] = []
         for name in introspector.list_entity_types():
             if not isinstance(name, str) or not name:
                 continue
-            described = introspector.describe_entity_type(name) or {}
-            if not isinstance(described, dict):
-                described = {}
-            properties = _clean_properties(described)
-            links = _clean_links(described)
+            properties = _search_properties(introspector, name)
             name_tokens = _fabric_tokens(name)
             prop_tokens: set[str] = set()
             for prop in properties:
@@ -138,16 +213,16 @@ def search_entity_types(
             score = 2.0 * len(query & name_tokens)
             score += 1.0 * len(query & (prop_tokens - name_tokens))
             if score > 0:
-                scored.append((score, name, properties, links))
+                scored.append((score, name, properties))
         scored.sort(key=lambda item: (-item[0], item[1]))
         return [
             {
                 "id": f"{FABRIC_ID_PREFIX}{name}",
                 "kind": FABRIC_KIND,
                 "name": name,
-                "summary": _summary(name, properties, links),
+                "summary": _search_summary(name, properties),
             }
-            for _score, name, properties, links in scored[:limit]
+            for _score, name, properties in scored[:limit]
         ]
     except Exception as exc:  # noqa: BLE001 — fail closed, never break the tool
         logger.debug("atlas fabric introspection unavailable (search): %s", exc)
@@ -223,6 +298,19 @@ class RegistryFabricIntrospector:
             "properties": sorted(self._registry.get_entity_properties(name)),
             "links": list(self._registry.list_entity_links(name)),
         }
+
+    def list_entity_properties(self, name: str) -> list[str]:
+        """Property names for one type — the cheap search read path.
+
+        One registry call (``get_entity_properties`` → one sqlite connection)
+        instead of the three ``describe_entity_type`` opens (exists +
+        properties + links). Search scores on property names only, so it never
+        needs the existence check (a name that came from ``list_entity_types``
+        already exists) or the link list. An unknown type returns ``[]`` — the
+        store's ``get_properties`` already returns an empty set for it, matching
+        the ``NullFabricRegistry`` contract.
+        """
+        return sorted(self._registry.get_entity_properties(name))
 
 
 def build_workspace_fabric_introspector(workspace_id: str) -> FabricIntrospector | None:

--- a/tests/atlas/test_compile.py
+++ b/tests/atlas/test_compile.py
@@ -28,10 +28,13 @@
 
 import json
 import logging
+import os
 import re
+from pathlib import Path
 
 from pocketpaw.atlas.compile import (
     AUTHORED_FILES,
+    DEFAULT_CONNECTORS_DIR,
     check_artifact,
     compile_atlas,
     compile_atlas_bytes,
@@ -182,7 +185,6 @@ class TestConnectorExtraction:
         )
 
     def test_every_repo_connector_yaml_has_an_entry(self):
-        from pathlib import Path
 
         import yaml
 
@@ -274,3 +276,90 @@ class TestDriftCheck:
         store = AtlasStore.load(path)
         assert store.describe("primitive:pocket") is not None
         assert store.describe("connector:stripe") is not None
+
+
+class TestNullDisplayName:
+    """FINDING A — a connector YAML with an explicit ``display_name: null``
+    parses cleanly but must not crash the whole compiler on ``.lower()``.
+
+    The module's own posture ("one bad file can't block the build") is
+    broken if a single well-formed-but-null field aborts the entire build
+    (and the CI drift gate) with AttributeError.
+    """
+
+    def test_connector_with_null_display_name_compiles(self, tmp_path):
+        (tmp_path / "quiet.yaml").write_text(
+            "name: quiet\n"
+            "display_name: null\n"
+            "type: generic\n"
+            "actions:\n"
+            "  - name: ping\n"
+            "    description: check liveness\n",
+            encoding="utf-8",
+        )
+        model = compile_atlas(connectors_dir=tmp_path)
+        entry = next(e for e in model.entries if e.id == "connector:quiet")
+        # Falls back to the connector name — never the string "None".
+        assert entry.name == "quiet"
+        assert "None" not in entry.summary
+        assert "None" not in entry.narrative
+        assert "quiet" in entry.keywords
+
+
+class TestConnectorsDirAnchoring:
+    """FINDING C — the default connectors dir must not be CWD-relative.
+
+    ``compile_atlas`` / ``write_artifact`` / ``check_artifact`` called with
+    defaults from any dir other than the repo root would otherwise read ZERO
+    connector YAMLs and silently drop every connector + sense entry;
+    ``write_artifact`` would then persist a truncated artifact.
+    """
+
+    def test_default_connectors_dir_is_absolute(self):
+        assert DEFAULT_CONNECTORS_DIR.is_absolute(), (
+            "DEFAULT_CONNECTORS_DIR must be anchored to a stable location, not CWD-relative"
+        )
+        assert DEFAULT_CONNECTORS_DIR.is_dir(), "the anchored connectors dir must exist"
+
+    def test_compile_from_other_cwd_still_finds_connectors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # A CWD-relative default would find nothing here.
+        assert not (Path(os.getcwd()) / "connectors").exists()
+        model = compile_atlas()
+        connectors = [e for e in model.entries if e.kind == "connector"]
+        senses = [e for e in model.entries if e.kind == "sense"]
+        assert connectors, "connectors must still be extracted from a different CWD"
+        assert senses, "senses must still be extracted from a different CWD"
+        assert any(e.id == "connector:stripe" for e in connectors)
+
+    def test_check_artifact_fresh_from_other_cwd(self, tmp_path, monkeypatch):
+        """The CI drift gate runs from repo root today; anchoring keeps it
+        correct even if invoked elsewhere — no truncated-artifact false
+        'stale' with everything dropped."""
+        monkeypatch.chdir(tmp_path)
+        fresh, summary = check_artifact()
+        assert fresh, summary
+
+
+class TestDuplicateIdDiff:
+    """FINDING E — the drift diff collapses duplicate-id entries.
+
+    ``check_artifact`` built its per-id map with a dict comprehension, so two
+    entries sharing an id silently collapse to one: CI still fails on bytes,
+    but the printed added/removed/changed lists misreport what actually
+    differs. Duplicate ids should be surfaced explicitly.
+    """
+
+    def test_duplicate_ids_reported(self, tmp_path):
+        path, _model = write_artifact(output_path=tmp_path / "atlas.json")
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        # Inject a duplicate of an existing id (authoring collision shape).
+        first = doc["entries"][0]
+        doc["entries"].append(dict(first))
+        path.write_text(json.dumps(doc), encoding="utf-8")
+        fresh, summary = check_artifact(artifact_path=path)
+        assert not fresh
+        assert "duplicate" in summary.lower(), (
+            f"duplicate id must be surfaced in the diff summary, got:\n{summary}"
+        )
+        assert first["id"] in summary

--- a/tests/atlas/test_fabric_introspection.py
+++ b/tests/atlas/test_fabric_introspection.py
@@ -238,6 +238,144 @@ class TestDescribe:
 # ---------------------------------------------------------------------------
 
 
+class TestSearchReadEfficiency:
+    """FINDING B — search must not run the full N-describe read path.
+
+    ``search_entity_types`` scores on entity-type NAMES and PROPERTY names
+    only; it never uses a type's link count. The live EE adapter's
+    ``describe_entity_type`` opens three sqlite connections per type
+    (exists + properties + links), so a full describe per type is 3N
+    connections/queries per query — and the link count it pays for is
+    discarded. Search must fetch properties only.
+    """
+
+    def test_search_does_not_call_full_describe(self):
+        """Search prefers a properties-only read path over describe_entity_type,
+        so it never pays for the per-type link fetch it doesn't score on."""
+        calls = {"describe": 0, "properties": 0}
+
+        class CountingIntrospector:
+            def list_entity_types(self):
+                return ["Customer", "Competitor"]
+
+            def describe_entity_type(self, name):
+                calls["describe"] += 1
+                return _SCHEMA.get(name)
+
+            def list_entity_properties(self, name):
+                calls["properties"] += 1
+                return _SCHEMA.get(name, {}).get("properties", [])
+
+        cards = search_entity_types(CountingIntrospector(), "customer churn")
+        assert cards and cards[0]["id"] == "fabric:Customer"
+        assert calls["describe"] == 0, (
+            "search must not call the full describe_entity_type (it fetches "
+            f"unused links); describe called {calls['describe']}x"
+        )
+        assert calls["properties"] >= 1, "search must use the properties-only read path"
+
+    def test_search_card_summary_has_no_link_count(self):
+        """The thin search card must not carry a DB-derived link count — that
+        would force the link fetch just to print a number. describe still
+        carries links for the detail view."""
+        cards = search_entity_types(FakeIntrospector(), "customer churn")
+        assert cards and cards[0]["id"] == "fabric:Customer"
+        assert "links" not in cards[0]["summary"].lower(), (
+            f"search card summary should not report links, got: {cards[0]['summary']!r}"
+        )
+
+    def test_search_still_falls_back_when_no_properties_path(self):
+        """An introspector without ``list_entity_properties`` (older shape)
+        must still work — the describe path remains the fallback."""
+
+        class OnlyDescribe:
+            def list_entity_types(self):
+                return ["Customer"]
+
+            def describe_entity_type(self, name):
+                return _SCHEMA.get(name)
+
+        cards = search_entity_types(OnlyDescribe(), "churn risk")
+        assert any(c["id"] == "fabric:Customer" for c in cards)
+
+
+class TestEeAdapterReadPath:
+    """FINDING B — the EE adapter exposes a properties-only read path that
+    opens fewer connections than a full describe."""
+
+    def test_adapter_properties_only_skips_links(self, tmp_path):
+        pytest.importorskip("pocketpaw_ee")
+        from pocketpaw_ee.fabric import WorkspaceFabricRegistry, WorkspaceFabricStore
+
+        from pocketpaw.atlas.fabric import RegistryFabricIntrospector
+
+        store = WorkspaceFabricStore(tmp_path / "fabric_registry.db")
+        store.register_entity_type("ws-1", "Customer")
+        store.register_property("ws-1", "Customer", "email")
+        store.register_property("ws-1", "Customer", "churn_risk")
+
+        registry = WorkspaceFabricRegistry(store=store, workspace_id="ws-1")
+
+        # Spy on the registry via a counting proxy (the registry uses __slots__,
+        # so its methods can't be monkeypatched in place). The properties-only
+        # read path must NOT touch links or run an existence check.
+        calls = {"properties": 0, "links": 0, "exists": 0}
+
+        class CountingRegistry:
+            def get_entity_properties(self, name):
+                calls["properties"] += 1
+                return registry.get_entity_properties(name)
+
+            def list_entity_links(self, name):
+                calls["links"] += 1
+                return registry.list_entity_links(name)
+
+            def entity_type_exists(self, name):
+                calls["exists"] += 1
+                return registry.entity_type_exists(name)
+
+            def list_entity_types(self):
+                return registry.list_entity_types()
+
+        adapter = RegistryFabricIntrospector(CountingRegistry())
+        props = adapter.list_entity_properties("Customer")
+        assert sorted(props) == ["churn_risk", "email"]
+        assert calls["properties"] == 1, "properties-only read hits get_entity_properties once"
+        assert calls["links"] == 0, "properties-only read must not fetch links"
+        assert calls["exists"] == 0, "properties-only read must not run the existence check"
+
+
+class TestCamelSplit:
+    """FINDING D — the camel split must break consecutive-capital acronyms.
+
+    The old regex only broke lower→upper, so 'APIKey' / 'HTTPServer' /
+    'IOError' never split and 'api key' / 'http server' queries missed them.
+    """
+
+    def test_acronym_boundary_splits(self):
+        from pocketpaw.atlas.fabric import _CAMEL_RE
+
+        def split(text):
+            return _CAMEL_RE.sub(" ", text)
+
+        assert split("HTTPServer") == "HTTP Server"
+        assert split("APIKey") == "API Key"
+        assert split("IOError") == "IO Error"
+        # The existing lower->upper boundary still works.
+        assert split("CustomerAccount") == "Customer Account"
+        # A pure acronym with no trailing word stays intact.
+        assert split("HTTP") == "HTTP"
+
+    def test_acronym_type_name_matches_spaced_query(self):
+        introspector = FakeIntrospector(
+            {"APIKey": {"name": "APIKey", "properties": [], "links": []}}
+        )
+        cards = search_entity_types(introspector, "api key")
+        assert any(c["id"] == "fabric:APIKey" for c in cards), (
+            f"'api key' should match the APIKey entity type, got {[c['id'] for c in cards]}"
+        )
+
+
 class TestHelpersFailClosed:
     def test_search_helper_returns_empty_on_raise(self):
         assert search_entity_types(RaisingIntrospector(), "customer") == []


### PR DESCRIPTION
Five robustness defects in the atlas compiler (`compile.py`) and live Fabric search (`fabric.py`). All are code-only — the compiled `atlas.json` content does not change, so `pocketpaw atlas build --check` still reports up-to-date and no regenerated artifact is committed.

> Stacks on the `/files` atlas-data PR (`fix/atlas-data-accuracy-and-relevance`). The base of this PR is that branch, not `dev`, so the diff here is only the compiler-robustness changes. Merge the base first.

## A — compiler crashed on `display_name: null` (P2)

A connector YAML that parses cleanly but sets `display_name: null` took down the whole compiler — and the CI drift gate — with an `AttributeError` on `.lower()`. The dataclass default only fills an absent key, not a present null, so the null flowed straight into the f-strings. That contradicts the module's own "one bad file can't block the build" stance. Fixed by coercing to `defn.display_name or defn.name` before any string use.

## B — Fabric search ran a 3N sqlite N+1 per query (P2)

`search_entity_types` called `describe_entity_type` for every type on every search. Through the live EE adapter each describe opens three sqlite connections (`entity_exists` + `get_entity_properties` + `list_entity_links`), so a search was 3N connections — and the link list it paid for is never scored on. Search now reads property names only, through a new `list_entity_properties` path on the adapter (one connection), and falls back to describe for older introspectors. The thin search card drops the DB-derived link count; describe still carries links for the detail view.

## C — default connectors dir was CWD-relative (P3)

`DEFAULT_CONNECTORS_DIR` was `Path("connectors")`. Run `compile_atlas` / `write_artifact` / `check_artifact` with defaults from anywhere other than the repo root and it read zero YAMLs, silently dropped every connector and sense entry, and `write_artifact` would then persist a truncated artifact. Anchored to the package location instead, matching how `store.py` locates the packaged data file.

## D — search missed consecutive-capital CamelCase (P3)

The camel-split regex only broke lower→upper, so acronym names (`APIKey`, `HTTPServer`, `IOError`) never split and `api key` / `http server` queries missed them. Added an acronym-boundary alternative so `HTTPServer` → `http server` and `APIKey` → `api key`.

## E — drift diff hid duplicate-id entries (P3)

`check_artifact` built its per-id map with a dict comprehension, so two entries sharing an id collapsed into one: CI failed on bytes, but the printed added/removed/changed lists misreported why. `check_artifact` now surfaces duplicate ids explicitly, and `compile_atlas` asserts id uniqueness so an authoring collision fails loud at build time instead of shipping a silently-deduped artifact.

## Testing

- `uv run pytest tests/atlas -q` — 168 passed (11 new tests across the five findings, each red before the fix and green after).
- `uv run pocketpaw atlas build --check` — up to date; `atlas.json` is not modified.
- `ruff format --check`, `ruff check` on the touched files, and both `lint-imports` configs (main + `ee/pyproject.toml`) all clean.
