### PR TITLE
feat(notifications): add actor_id for sender identity

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/group_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/group_service.py
@@ -833,6 +833,7 @@ async def add_members(
             kind="group_invite",
             title=f"You were added to {group_name}" if group_name else "You were added to a group",
             body="",
+            actor_id=user_id,
             source=NotificationSource(
                 type="message",
                 id=group_id,

--- a/ee/pocketpaw_ee/cloud/chat/message_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/message_service.py
@@ -482,6 +482,7 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
                 kind="message",
                 title=title,
                 body=body.content[:200],
+                actor_id=user_id,
                 source=NotificationSource(
                     type="message",
                     id=domain_msg.id,
@@ -515,6 +516,7 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
             kind="mention",
             title=(f"You were mentioned in #{group_name}" if group_name else "You were mentioned"),
             body=body.content[:200],
+            actor_id=user_id,
             source=NotificationSource(
                 type="message",
                 id=domain_msg.id,
@@ -640,6 +642,7 @@ async def toggle_reaction(message_id: str, user_id: str, emoji: str) -> dict:
             kind="reaction",
             title=f"{emoji} on your message",
             body=(domain_msg.content or "")[:200],
+            actor_id=user_id,
             source=NotificationSource(
                 type="message",
                 id=domain_msg.id,

--- a/ee/pocketpaw_ee/cloud/meetings/bridges/notifications.py
+++ b/ee/pocketpaw_ee/cloud/meetings/bridges/notifications.py
@@ -58,6 +58,7 @@ async def _on_meeting_scheduled(data: dict[str, Any]) -> None:
         return
 
     provider = data.get("provider") or source or "meeting"
+    created_by = data.get("created_by") or data.get("organizer_user_id")
     for recipient in recipients:
         await _create(
             workspace_id=workspace_id,
@@ -66,6 +67,7 @@ async def _on_meeting_scheduled(data: dict[str, Any]) -> None:
             title="Meeting scheduled",
             body=f"A {_pretty(provider)} meeting was scheduled.",
             meeting_id=meeting_id,
+            actor_id=created_by,
         )
 
 
@@ -112,6 +114,7 @@ async def _on_meeting_cancelled(data: dict[str, Any]) -> None:
         title="Meeting cancelled",
         body="A scheduled meeting was cancelled.",
         meeting_id=meeting_id,
+        actor_id=data.get("cancelled_by_user_id"),
     )
 
 
@@ -184,6 +187,7 @@ async def _create(
     body: str,
     meeting_id: str,
     room_id: str | None = None,
+    actor_id: str | None = None,
 ) -> None:
     """Wrap notifications_service.create — late import to avoid circular
     deps and tolerate the service being unavailable in unit-test contexts."""
@@ -196,6 +200,7 @@ async def _create(
             kind=kind,
             title=title,
             body=body,
+            actor_id=actor_id,
             # type=kind so the frontend's sourceUrl switch can deep-link
             # (meeting_started → ?join=meeting-{id}, meeting_reminder → chat, etc.)
             source=NotificationSource(type=kind, id=meeting_id, room_id=room_id),

--- a/ee/pocketpaw_ee/cloud/models/notification.py
+++ b/ee/pocketpaw_ee/cloud/models/notification.py
@@ -22,6 +22,7 @@ class Notification(TimestampedDocument):
 
     workspace: Indexed(str)  # type: ignore[valid-type]
     recipient: Indexed(str)  # type: ignore[valid-type]
+    actor: str | None = None  # user id of the person who triggered this notification
     type: str  # notification type: mention, comment, reply, invite, agent_complete,
     # pocket_shared, meeting_scheduled, meeting_cancelled, meeting_started, meeting_reminder
     title: str

--- a/ee/pocketpaw_ee/cloud/notifications/domain.py
+++ b/ee/pocketpaw_ee/cloud/notifications/domain.py
@@ -48,6 +48,7 @@ class Notification:
     source: NotificationSource | None
     read: bool
     created_at: datetime
+    actor_id: str | None = None  # user id of the person who triggered this notification
     expires_at: datetime | None = None
 
 

--- a/ee/pocketpaw_ee/cloud/notifications/dto.py
+++ b/ee/pocketpaw_ee/cloud/notifications/dto.py
@@ -29,6 +29,7 @@ class NotificationOut(BaseModel):
     source_room_id: str | None = None
     read: bool
     created_at: str | None
+    actor_id: str | None = None
 
 
 def notification_to_dto(n: Notification) -> NotificationOut:
@@ -46,6 +47,7 @@ def notification_to_dto(n: Notification) -> NotificationOut:
         source_room_id=n.source.room_id if n.source else None,
         read=n.read,
         created_at=iso_utc(n.created_at),
+        actor_id=n.actor_id,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/notifications/service.py
+++ b/ee/pocketpaw_ee/cloud/notifications/service.py
@@ -72,6 +72,7 @@ def _to_domain(doc: _NotificationDoc) -> Notification:
         id=str(doc.id),
         workspace_id=doc.workspace,
         recipient_id=doc.recipient,
+        actor_id=doc.actor,
         kind=doc.type,  # Beanie field is `type`; domain renames to `kind`
         title=doc.title,
         body=doc.body,
@@ -98,10 +99,12 @@ async def create(
     title: str,
     body: str = "",
     source: _NotificationSourceDoc | NotificationSource | None = None,
+    actor_id: str | None = None,
 ) -> Notification:
     doc = _NotificationDoc(
         workspace=workspace_id,
         recipient=recipient,
+        actor=actor_id,
         type=kind,
         title=title,
         body=body,

--- a/ee/pocketpaw_ee/cloud/tasks/listeners.py
+++ b/ee/pocketpaw_ee/cloud/tasks/listeners.py
@@ -78,6 +78,7 @@ async def notify_human_assignee(event: Event) -> None:
             kind="task_assigned",
             title=title,
             body=body,
+            actor_id=creator_id,
             source=None,
         )
     except Exception:

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -1046,6 +1046,7 @@ async def create_invite(
             kind="invite",
             title=f"You were invited to join {doc.name}",
             body="",
+            actor_id=ctx.user_id,
             source=NotificationSource(
                 type="invite",
                 id=invite.id,  # the invite document id, not the token
@@ -1125,6 +1126,7 @@ async def bulk_create_invites(
                 kind="invite",
                 title=f"You were invited to join {doc.name}",
                 body="",
+                actor_id=ctx.user_id,
                 source=NotificationSource(
                     type="invite",
                     id=invite.id,


### PR DESCRIPTION
### Summary
Added `actor_id` field through the entire notification stack so the frontend can show the actual sender's avatar/initials in notification items instead of falling back to type-based icons.

### Changes

#### Core (4 files)
- **`cloud/models/notification.py`** — added `actor: str | None = None` field to Beanie `Notification` document
- **`cloud/notifications/domain.py`** — added `actor_id: str | None = None` to domain `Notification` dataclass (after required fields to satisfy Python dataclass ordering)
- **`cloud/notifications/dto.py`** — added `actor_id: str | None = None` to `NotificationOut` Pydantic model; `notification_to_dto()` maps it through
- **`cloud/notifications/service.py`** — `create()` now accepts `actor_id` param and stores it as `actor` on the document; `_to_domain()` reads `doc.actor → actor_id`

#### Callers updated (5 files)
All `notifications_service.create()` calls now pass the acting user's ID:

| File | Notification types | Field used |
|---|---|---|
| `cloud/chat/message_service.py` | message, mention, reaction | `user_id` |
| `cloud/chat/group_service.py` | group_invite | `user_id` |
| `cloud/workspace/service.py` | invite (single + bulk) | `ctx.user_id` |
| `cloud/tasks/listeners.py` | task_assigned | `creator_id` |
| `cloud/meetings/bridges/notifications.py` | meeting_scheduled, meeting_cancelled | `created_by` / `cancelled_by_user_id` |
