### PR TITLE
feat(notifications): add delete endpoint, service, and realtime event

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -569,6 +569,11 @@ class NotificationCleared(Event):
     EVENT_TYPE: ClassVar[str] = "notification.cleared"
 
 
+@dataclass
+class NotificationDeleted(Event):
+    EVENT_TYPE: ClassVar[str] = "notification.deleted"
+
+
 # Cycles — Mission Control time-boxed work windows.
 # The daily-snapshot job (``ee.cloud.cycles.snapshot_job``) emits
 # ``CycleSnapshotted`` after appending a new point to a cycle's daily

--- a/ee/pocketpaw_ee/cloud/notifications/router.py
+++ b/ee/pocketpaw_ee/cloud/notifications/router.py
@@ -61,3 +61,16 @@ async def clear_all(
 ) -> dict:
     count = await notifications_service.clear_all(ctx.user_id)
     return {"cleared": count}
+
+
+@router.delete("/{notification_id}")
+async def delete_notification(
+    notification_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    ok = await notifications_service.delete_notification(notification_id, ctx.user_id)
+    if not ok:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return {"status": "deleted"}

--- a/ee/pocketpaw_ee/cloud/notifications/service.py
+++ b/ee/pocketpaw_ee/cloud/notifications/service.py
@@ -27,6 +27,7 @@ from beanie import PydanticObjectId
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     NotificationCleared,
+    NotificationDeleted,
     NotificationNew,
     NotificationRead,
 )
@@ -164,11 +165,22 @@ async def clear_all(user_id: str) -> int:
     return count
 
 
+async def delete_notification(notification_id: str, user_id: str) -> bool:
+    """Delete a single notification. Returns True if deleted, False if not found."""
+    doc = await _NotificationDoc.get(PydanticObjectId(notification_id))
+    if not doc or doc.recipient != user_id:
+        return False
+    await doc.delete()
+    await emit(NotificationDeleted(data={"id": notification_id, "user_id": user_id}))
+    return True
+
+
 __all__ = [
     "Notification",
     "NotificationSource",
     "count_unread",
     "create",
+    "delete_notification",
     "list_for_user",
     "list_for_user_dicts",
     "mark_read",


### PR DESCRIPTION
## Summary
Adds backend support for deleting user notifications.

### Changes
| File | What |
|---|---|
| `events.py` | New `NotificationDeleted` event (`notification.deleted`) |
| `service.py` | `delete_notification()` — deletes Beanie doc, auth-checks recipient, emits realtime event |
| `router.py` | `DELETE /notifications/{id}` endpoint → `\{"status": "deleted"\}` or 404 |

### Companion PR
- Frontend: qbtrix/paw-enterprise#554