### PR TITLE
Add the DesignBrief contract for the Sites authoring crew

### DIFF
--- a/ee/pocketpaw_ee/sites_crew/__init__.py
+++ b/ee/pocketpaw_ee/sites_crew/__init__.py
@@ -1,0 +1,34 @@
+# pocketpaw_ee/sites_crew/__init__.py — the Paw Sites authoring-crew package.
+#
+# Created: 2026-07-06 (SC-1 / feat/sites-crew-brief) — a multi-stage
+# site-authoring crew (Designer → Branding → Frontend) threads a shared
+# ``DesignBrief`` baton between stages. This module currently exports only the
+# pure data contract (``models``); orchestration lands in later tasks.
+
+from __future__ import annotations
+
+from pocketpaw_ee.sites_crew.models import (
+    AssetRef,
+    Branding,
+    ColorScale,
+    DesignBrief,
+    DesignDirection,
+    DesignSystem,
+    Section,
+    StageResult,
+    StageStatus,
+    Typography,
+)
+
+__all__ = [
+    "AssetRef",
+    "Branding",
+    "ColorScale",
+    "DesignBrief",
+    "DesignDirection",
+    "DesignSystem",
+    "Section",
+    "StageResult",
+    "StageStatus",
+    "Typography",
+]

--- a/ee/pocketpaw_ee/sites_crew/models.py
+++ b/ee/pocketpaw_ee/sites_crew/models.py
@@ -1,0 +1,165 @@
+# pocketpaw_ee/sites_crew/models.py — the DesignBrief baton for the Paw Sites crew.
+#
+# Created: 2026-07-06 (SC-1 / feat/sites-crew-brief) — the pydantic v2 data
+# contract a multi-stage site-authoring crew (Designer → Branding → Frontend)
+# threads between stages. Pure data, no I/O and no orchestration: each stage
+# reads the incoming ``DesignBrief``, enriches its layer, and hands the same
+# baton forward. ``DesignSystem`` mirrors the DESIGN.md-format design-system
+# layer (color scales, typography, spacing, component tokens, compiled
+# ``tokens_css``) so both the ripple and svelte engines share one source of
+# truth. ``StageResult`` wraps a brief with a stage outcome for the runner.
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+__all__ = [
+    "AssetRef",
+    "Section",
+    "Typography",
+    "ColorScale",
+    "DesignSystem",
+    "Branding",
+    "DesignDirection",
+    "DesignBrief",
+    "StageStatus",
+    "StageResult",
+]
+
+
+class AssetRef(BaseModel):
+    """A resolved asset — always a real fetchable URL, never a local path.
+
+    ``url`` must be an ``http(s)`` URL: a stock-provider link (pexels /
+    unsplash) or a ``deliver.py`` blob URL. Container paths, ``file://``, and
+    bare local paths are rejected so a downstream engine never emits a broken
+    or host-leaking reference.
+    """
+
+    url: str
+    kind: Literal["image", "logo", "favicon", "icon", "video"]
+    alt: str = ""
+    source: str = ""
+
+    @field_validator("url")
+    @classmethod
+    def _url_must_be_http(cls, v: str) -> str:
+        if not v or not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError(
+                "AssetRef.url must be an http(s) URL (stock provider or blob URL), "
+                f"not a local/empty/file path: {v!r}"
+            )
+        return v
+
+
+class Section(BaseModel):
+    """One ordered site section with its conversion role."""
+
+    id: str  # lowercase slug, e.g. "hero"
+    role: str  # nav/hero/services/proof/pricing/cta/lead_form/footer/faq/custom
+    heading: str = ""
+    notes: str = ""
+
+
+class Typography(BaseModel):
+    """A named type style (display / heading / body / caption …)."""
+
+    family: str
+    size: str = ""
+    weight: str = ""
+    line_height: str = ""
+    letter_spacing: str = ""
+
+
+class ColorScale(BaseModel):
+    """A role color scale, keyed by the conventional 50..900 steps.
+
+    Fields are addressable both by python name (``s500``) and by the CSS-scale
+    alias (``"500"``) via ``populate_by_name=True``. Every step is optional so a
+    partial scale (just a few anchors) is valid.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    s50: str | None = Field(default=None, alias="50")
+    s100: str | None = Field(default=None, alias="100")
+    s200: str | None = Field(default=None, alias="200")
+    s300: str | None = Field(default=None, alias="300")
+    s400: str | None = Field(default=None, alias="400")
+    s500: str | None = Field(default=None, alias="500")
+    s600: str | None = Field(default=None, alias="600")
+    s700: str | None = Field(default=None, alias="700")
+    s800: str | None = Field(default=None, alias="800")
+    s900: str | None = Field(default=None, alias="900")
+
+
+class DesignSystem(BaseModel):
+    """The DESIGN.md-format design-system layer — shared by both engines.
+
+    Carries the token surface (colors, typography, spacing, rounded, elevation,
+    component tokens with states), a prose ``rationale`` (mood, do's/don'ts,
+    anti-patterns), and the compiled ``tokens_css`` (CSS custom properties) that
+    is the single source of truth downstream.
+    """
+
+    name: str
+    colors: dict[str, ColorScale] = Field(default_factory=dict)  # primary/secondary/…
+    typography: dict[str, Typography] = Field(default_factory=dict)  # display/heading/…
+    spacing: dict[str, str] = Field(default_factory=dict)
+    rounded: dict[str, str] = Field(default_factory=dict)
+    elevation: dict[str, str] = Field(default_factory=dict)
+    components: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    rationale: str = ""
+    tokens_css: str = ""
+
+
+class Branding(BaseModel):
+    """The branding layer the Branding stage produces."""
+
+    design_system: DesignSystem | None = None
+    voice: str = ""
+    logo_asset: AssetRef | None = None
+    favicon_asset: AssetRef | None = None
+
+
+class DesignDirection(BaseModel):
+    """Visual direction gathered from the interview — references and mood."""
+
+    references: list[str] = Field(default_factory=list)  # URLs
+    layout_notes: str = ""
+    mood: str = ""
+
+
+class DesignBrief(BaseModel):
+    """The top-level baton threaded through the site-authoring crew.
+
+    The Designer stage fills goal/audience/sitemap/design_direction, Branding
+    fills ``branding.design_system``, and Frontend consumes copy + assets to
+    build. ``open_questions`` records what the interview did NOT resolve.
+    """
+
+    goal: str
+    audience: str = ""
+    engine: Literal["ripple", "svelte"] = "ripple"
+    pattern: Literal["landing", "dynamic"] = "landing"
+    sitemap: list[Section] = Field(default_factory=list)
+    design_direction: DesignDirection = Field(default_factory=DesignDirection)
+    branding: Branding = Field(default_factory=Branding)
+    copy: dict[str, Any] = Field(default_factory=dict)  # section_id -> copy blocks
+    asset_manifest: list[AssetRef] = Field(default_factory=list)
+    open_questions: list[str] = Field(default_factory=list)
+
+
+StageStatus = Literal["ok", "skipped", "error"]
+
+
+class StageResult(BaseModel):
+    """The outcome of one crew stage, wrapping the (possibly enriched) brief."""
+
+    stage: Literal["designer", "branding", "frontend"]
+    status: StageStatus
+    brief: DesignBrief | None = None
+    notes: str = ""
+    error: str = ""

--- a/tests/ee/sites_crew/__init__.py
+++ b/tests/ee/sites_crew/__init__.py
@@ -1,0 +1,3 @@
+# tests/ee/sites_crew/__init__.py — Test package for the sites_crew subsystem.
+# Created: 2026-07-06 (SC-1 / feat/sites-crew-brief) — marks tests/ee/sites_crew
+# as a package so pytest can collect the DesignBrief contract tests.

--- a/tests/ee/sites_crew/test_models.py
+++ b/tests/ee/sites_crew/test_models.py
@@ -1,0 +1,145 @@
+# tests/ee/sites_crew/test_models.py — locks the DesignBrief crew-baton contract.
+#
+# Created: 2026-07-06 (SC-1 / feat/sites-crew-brief) — covers a minimal brief,
+# a fully-populated brief with nested design system / color-scale aliases /
+# sections / assets, a JSON round-trip, the AssetRef url validator, and
+# StageResult carrying a brief.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites_crew.models import (
+    AssetRef,
+    Branding,
+    ColorScale,
+    DesignBrief,
+    DesignDirection,
+    DesignSystem,
+    Section,
+    StageResult,
+    Typography,
+)
+from pydantic import ValidationError
+
+
+def test_minimal_brief_needs_only_goal():
+    brief = DesignBrief(goal="Sell dentist appointments")
+    assert brief.goal == "Sell dentist appointments"
+    assert brief.engine == "ripple"
+    assert brief.pattern == "landing"
+    assert brief.sitemap == []
+    assert isinstance(brief.design_direction, DesignDirection)
+    assert isinstance(brief.branding, Branding)
+    assert brief.branding.design_system is None
+    assert brief.open_questions == []
+
+
+def _fully_populated_brief() -> DesignBrief:
+    design_system = DesignSystem(
+        name="Aurora",
+        colors={
+            "primary": ColorScale.model_validate({"50": "#eef", "500": "#3355ff", "900": "#001"}),
+            "neutral": ColorScale(s100="#f5f5f5", s900="#111111"),
+        },
+        typography={
+            "display": Typography(family="Inter", size="3rem", weight="700"),
+            "body": Typography(family="Inter", size="1rem", line_height="1.6"),
+        },
+        spacing={"md": "1rem", "lg": "2rem"},
+        rounded={"md": "8px"},
+        elevation={"card": "0 1px 3px rgba(0,0,0,.1)"},
+        components={"button": {"default": {"bg": "var(--primary-500)"}}},
+        rationale="Calm, clinical, trustworthy. Avoid neon.",
+        tokens_css=":root{--primary-500:#3355ff;}",
+    )
+    return DesignBrief(
+        goal="Book more cleanings",
+        audience="Local families",
+        engine="svelte",
+        pattern="landing",
+        sitemap=[
+            Section(id="hero", role="hero", heading="Brighter smiles"),
+            Section(id="pricing", role="pricing"),
+            Section(id="footer", role="footer"),
+        ],
+        design_direction=DesignDirection(
+            references=["https://example.com/inspo"],
+            layout_notes="Single column, big hero.",
+            mood="warm, clean",
+        ),
+        branding=Branding(
+            design_system=design_system,
+            voice="Friendly and reassuring",
+            logo_asset=AssetRef(url="https://cdn.example.com/logo.svg", kind="logo"),
+            favicon_asset=AssetRef(url="https://cdn.example.com/fav.ico", kind="favicon"),
+        ),
+        copy={"hero": {"headline": "Brighter smiles, closer than you think"}},
+        asset_manifest=[
+            AssetRef(
+                url="https://images.pexels.com/photo/1.jpg",
+                kind="image",
+                alt="smiling patient",
+                source="pexels",
+            ),
+        ],
+        open_questions=["What are the clinic hours?"],
+    )
+
+
+def test_fully_populated_brief_constructs():
+    brief = _fully_populated_brief()
+    assert brief.engine == "svelte"
+    assert len(brief.sitemap) == 3
+    assert brief.sitemap[0].role == "hero"
+    ds = brief.branding.design_system
+    assert ds is not None
+    # Color-scale aliases populate the python-named fields.
+    assert ds.colors["primary"].s50 == "#eef"
+    assert ds.colors["primary"].s500 == "#3355ff"
+    assert ds.colors["neutral"].s900 == "#111111"
+    assert ds.typography["display"].family == "Inter"
+    assert brief.asset_manifest[0].source == "pexels"
+
+
+def test_json_round_trip_reconstructs_equal_brief():
+    brief = _fully_populated_brief()
+    dumped = brief.model_dump(mode="json")
+    restored = DesignBrief.model_validate(dumped)
+    assert restored == brief
+
+
+def test_color_scale_alias_round_trips_by_alias():
+    scale = ColorScale.model_validate({"500": "#abc"})
+    dumped = scale.model_dump(by_alias=True, exclude_none=True)
+    assert dumped == {"500": "#abc"}
+    assert ColorScale.model_validate(dumped).s500 == "#abc"
+
+
+@pytest.mark.parametrize("bad_url", ["", "file:///etc/passwd", "/var/data/logo.png", "logo.png"])
+def test_asset_ref_rejects_non_http_url(bad_url):
+    with pytest.raises(ValidationError):
+        AssetRef(url=bad_url, kind="image")
+
+
+@pytest.mark.parametrize(
+    "good_url",
+    ["https://images.pexels.com/photo/1.jpg", "http://localhost:8000/blob/abc"],
+)
+def test_asset_ref_accepts_http_url(good_url):
+    asset = AssetRef(url=good_url, kind="image")
+    assert asset.url == good_url
+
+
+def test_stage_result_carries_brief():
+    brief = DesignBrief(goal="Ship a landing page")
+    result = StageResult(stage="designer", status="ok", brief=brief, notes="drafted sitemap")
+    assert result.stage == "designer"
+    assert result.status == "ok"
+    assert result.brief is not None
+    assert result.brief.goal == "Ship a landing page"
+
+
+def test_stage_result_error_has_no_brief():
+    result = StageResult(stage="frontend", status="error", error="build failed")
+    assert result.brief is None
+    assert result.error == "build failed"


### PR DESCRIPTION
## What ships

The `DesignBrief` — the data contract a multi-stage site-authoring crew (Designer → Branding → Frontend) passes between stages. Each stage reads the incoming brief, fills in its layer, and hands the same object forward. This is the first slice of that crew: pure models, no orchestration or agent wiring yet, so the shape is locked before anything is built on top of it.

New package `ee/pocketpaw_ee/sites_crew/`:

- `DesignBrief` — goal, audience, engine (ripple/svelte), pattern (landing/dynamic), sitemap, design direction, branding, copy, asset manifest, and the open questions the interview didn't resolve.
- `DesignSystem` — a DESIGN.md-style design layer: color scales (50–900), typography, spacing, component tokens, prose rationale, and a compiled `tokens_css` that both render engines read as one source of truth.
- `AssetRef` — a resolved asset that must be a real http(s) URL; a validator rejects local paths, `file://`, and empties so a downstream build can't emit a broken or host-leaking reference.
- `Section`, `Typography`, `ColorScale`, `Branding`, `DesignDirection`, and a `StageResult` wrapper for the runner.

## Why now

Everything else in the crew — the Designer interview, the Branding stage, the Frontend build — threads this object. Locking the contract first means the later slices can be built and reviewed against a stable shape instead of a moving target.

## Scope

- `ee/pocketpaw_ee/sites_crew/{__init__.py,models.py}` — the models.
- `tests/ee/sites_crew/test_models.py` — 12 tests: minimal brief, fully-populated brief, JSON round-trip, the AssetRef URL validator (accept/reject), color-scale alias round-trip, and StageResult.

## Testing

`uv run pytest tests/ee/sites_crew/test_models.py -q` → 12 passed. `ruff check` + `ruff format` clean on the new files.

One known warning: the `copy` field name shadows pydantic's deprecated `BaseModel.copy()`. It's harmless (pydantic v2 uses `model_copy()`) and the field name matches the design on purpose; flagging it rather than renaming.

## Out of scope

No orchestration, no MCP tools, no surface wiring — those are the following slices. This PR is only the contract.