### PR TITLE
Turn a custom brand color into a full palette scale

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/palette.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/palette.py
@@ -31,7 +31,15 @@
 # lightest→darkest). Fail-soft: an empty/non-http url, a download/HTTP error, or
 # bytes PIL can't open all return an ``_error_response`` and never raise into the
 # agent.
-"""Agent-side MCP surface for reference-image palette extraction (full scales)."""
+#
+# Updated: 2026-07-06 (feat/sites-crew-scale-from-color, SC-7c) — added a SECOND
+# tool ``scale_from_color`` for the custom-color path: it exposes the pure
+# ``scale_from_base`` helper directly, turning ONE brand hex the user supplied
+# into a full 50–900 scale (no image needed) so a user can override a design
+# system's palette from an exact color. Same fail-soft contract — a malformed hex
+# returns an ``_error_response``. Tool id namespaces as
+# ``mcp__pocketpaw_palette__scale_from_color``.
+"""Agent-side MCP surface for palette derivation (image extraction + custom hex)."""
 
 from __future__ import annotations
 
@@ -47,8 +55,9 @@ logger = logging.getLogger(__name__)
 SERVER_NAME = "pocketpaw_palette"
 # Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
 EXTRACT_PALETTE_TOOL_ID = f"mcp__{SERVER_NAME}__extract_palette"
+SCALE_FROM_COLOR_TOOL_ID = f"mcp__{SERVER_NAME}__scale_from_color"
 
-PALETTE_TOOL_IDS = (EXTRACT_PALETTE_TOOL_ID,)
+PALETTE_TOOL_IDS = (EXTRACT_PALETTE_TOOL_ID, SCALE_FROM_COLOR_TOOL_ID)
 
 # Bound the image download so a slow/hanging host can't stall a site build.
 _TIMEOUT_SECONDS = 10.0
@@ -286,6 +295,31 @@ async def _extract_handler(args: dict) -> dict:
     return _success_response({"ok": True, "palette": palette})
 
 
+async def _scale_from_color_handler(args: dict) -> dict:
+    """MCP handler for ``palette__scale_from_color``.
+
+    The custom-color path: turn a single brand hex the user supplied into a full
+    50–900 scale (the same deterministic ladder ``extract_palette`` applies to
+    image-derived colors), so a user can override a design system's palette from
+    an exact color rather than a reference image. Optional ``role`` just labels
+    the returned scale (default ``"primary"``). Fail-soft: an empty or malformed
+    hex returns an ``_error_response`` and never raises into the agent.
+    """
+    raw = args.get("hex")
+    if not isinstance(raw, str) or not raw.strip():
+        return _error_response("scale_from_color requires a non-empty `hex` color.")
+    role = args.get("role")
+    role = role.strip() if isinstance(role, str) and role.strip() else "primary"
+
+    try:
+        scale = scale_from_base(raw)
+    except Exception as exc:  # noqa: BLE001 — malformed hex → soft error, never raise
+        logger.warning("palette: scale_from_color got an invalid hex %r", raw)
+        return _error_response(f"scale_from_color failed: invalid hex color {raw!r} ({exc}).")
+
+    return _success_response({"ok": True, "role": role, "scale": scale})
+
+
 def build_palette_server() -> tuple[str, Any] | None:
     """Build the in-process SDK MCP server for palette extraction, or return
     ``None`` if the Claude Agent SDK isn't installed. Matches the ``(name,
@@ -330,16 +364,52 @@ def build_palette_server() -> tuple[str, Any] | None:
     async def extract_palette_tool(args):  # type: ignore[no-untyped-def]
         return await _extract_handler(args)
 
+    @tool(
+        "scale_from_color",
+        (
+            "Expand ONE custom brand color into a full 50–900 tint/shade scale. "
+            "Use when the user gives an exact color (e.g. 'make the primary "
+            "#6B21A8' or 'match my brand navy') and you need real design tokens "
+            "for it — this is the custom-color path, complementary to "
+            "extract_palette (which derives colors from an image). Args: `hex` "
+            "(required — a #RRGGBB or #RGB color) and optional `role` (a label "
+            "like 'primary'/'accent', default 'primary'). Returns {ok, role, "
+            "scale:{'50':'#..', ..., '900':'#..'}} — 50 lightest, 500 the given "
+            "color, 900 darkest. Wire the scale into the design tokens (500 for "
+            "buttons, 50/100 for surfaces, 900 for text). An error means the hex "
+            "was malformed — ask the user for a valid color, do not retry blindly."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "hex": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The base color as #RRGGBB (or #RGB shorthand).",
+                },
+                "role": {
+                    "type": "string",
+                    "description": "Optional label for the scale (e.g. 'primary', 'accent').",
+                },
+            },
+            "required": ["hex"],
+            "additionalProperties": False,
+        },
+    )
+    async def scale_from_color_tool(args):  # type: ignore[no-untyped-def]
+        return await _scale_from_color_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[extract_palette_tool],
+        tools=[extract_palette_tool, scale_from_color_tool],
     )
     return SERVER_NAME, server
 
 
 __all__ = [
     "EXTRACT_PALETTE_TOOL_ID",
+    "SCALE_FROM_COLOR_TOOL_ID",
     "PALETTE_TOOL_IDS",
     "SERVER_NAME",
     "scale_from_base",

--- a/tests/ee/agent/test_palette_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_palette_mcp_server/test_mcp_tool.py
@@ -90,7 +90,11 @@ class TestPaletteMcpServerRegistration:
         # The tool id must use the exact ``mcp__<server>__<tool>`` form so the
         # Claude Code allowlist machinery matches it.
         assert palette_mcp.EXTRACT_PALETTE_TOOL_ID == "mcp__pocketpaw_palette__extract_palette"
-        assert palette_mcp.PALETTE_TOOL_IDS == (palette_mcp.EXTRACT_PALETTE_TOOL_ID,)
+        # SC-7c added the custom-color tool; the allowlist now carries both ids.
+        assert palette_mcp.PALETTE_TOOL_IDS == (
+            palette_mcp.EXTRACT_PALETTE_TOOL_ID,
+            palette_mcp.SCALE_FROM_COLOR_TOOL_ID,
+        )
 
     def test_extension_provider_advertises_tool_id(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk
@@ -273,3 +277,57 @@ class TestExtractPaletteHandler:
 
         assert out.get("is_error") is True
         assert "palette extraction failed" in out["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# scale_from_color — the custom-color path (SC-7c): a single brand hex → scale.
+# Pure math, no network.
+# ---------------------------------------------------------------------------
+
+_STEPS = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900"]
+
+
+async def test_scale_from_color_valid_hex_full_scale() -> None:
+    """A valid hex returns a full 50–900 scale under the default 'primary' role."""
+    env = await palette_mcp._scale_from_color_handler({"hex": "#6B21A8"})
+    assert "is_error" not in env
+    body = _decode_payload(env)
+    assert body["ok"] is True
+    assert body["role"] == "primary"
+    assert list(body["scale"].keys()) == _STEPS
+    assert all(v.startswith("#") and len(v) == 7 for v in body["scale"].values())
+
+
+async def test_scale_from_color_custom_role_label() -> None:
+    """An explicit role is echoed back on the scale."""
+    body = _decode_payload(
+        await palette_mcp._scale_from_color_handler({"hex": "#0A84FF", "role": "accent"})
+    )
+    assert body["role"] == "accent"
+    assert body["scale"]["500"].startswith("#")
+
+
+async def test_scale_from_color_shorthand_hex() -> None:
+    """#RGB shorthand is accepted (mirrors scale_from_base)."""
+    body = _decode_payload(await palette_mcp._scale_from_color_handler({"hex": "#f30"}))
+    assert body["ok"] is True
+    assert len(body["scale"]) == 10
+
+
+async def test_scale_from_color_bad_hex_soft_error() -> None:
+    """A malformed hex fails soft — an error envelope, never a raise."""
+    env = await palette_mcp._scale_from_color_handler({"hex": "not-a-color"})
+    assert env["is_error"] is True
+
+
+async def test_scale_from_color_missing_hex_soft_error() -> None:
+    """Empty/missing hex returns an error envelope."""
+    assert (await palette_mcp._scale_from_color_handler({}))["is_error"] is True
+    assert (await palette_mcp._scale_from_color_handler({"hex": "  "}))["is_error"] is True
+
+
+def test_scale_from_color_tool_id_published() -> None:
+    """The new tool id namespaces correctly and joins the allowlist tuple."""
+    assert palette_mcp.SCALE_FROM_COLOR_TOOL_ID == "mcp__pocketpaw_palette__scale_from_color"
+    assert palette_mcp.SCALE_FROM_COLOR_TOOL_ID in palette_mcp.PALETTE_TOOL_IDS
+    assert len(palette_mcp.PALETTE_TOOL_IDS) == 2


### PR DESCRIPTION
## What ships

A second tool on the palette server, `scale_from_color`: give it one brand hex and it returns a full 50–900 tint/shade scale (50 lightest, 500 the color you gave, 900 darkest). It complements `extract_palette`, which derives colors from a reference image — this is the path for when the user already knows the exact color.

This is the "custom colors" path directly. A user can say "make the primary `#6B21A8`" and the crew gets real design tokens for it — a full scale with light tints for surfaces and dark shades for text — instead of a single flat value. It's the override primitive behind editing a bundled design system's palette.

## Why now

Answers a concrete gap: the design-system library ships coherent presets, but customization needs a way to swap in an exact color and still get a usable scale. The scale math already existed as an internal helper; this exposes it as a callable tool.

## Stacked on #1653

Branches off `feat/sites-crew-design-systems` because it also touches the palette module in the same stack. Merge the chain base-first with `--rebase`.

## Scope

- `ee/pocketpaw_ee/agent/mcp_servers/palette.py` — the `scale_from_color` tool (input `hex`, optional `role`), `SCALE_FROM_COLOR_TOOL_ID` added to the allowlist tuple. Fail-soft: a malformed hex returns an error, never raises.
- `tests/ee/agent/test_palette_mcp_server/test_mcp_tool.py` — 6 new tests (valid hex → full scale, custom role label, shorthand hex, bad hex and missing hex going soft, tool-id publication); the existing registration test updated for two tool ids.

## Testing

`uv run pytest tests/ee/agent/test_palette_mcp_server/ -q` → 23 passed. `ruff check` + `ruff format` clean.

## Out of scope

No crew wiring — consuming this in the Branding stage to override a design system's palette is later crew work.