### PR TITLE
Render a site build from a DesignBrief

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -47,10 +47,25 @@
 # Every other engine value (None / "ripple") keeps the existing ripple marketing
 # brain (`pocketpaw-create-paw-site` + create_landing_site) byte-for-byte. The
 # refine branch (keyed on `pocket_id`) is untouched by the toggle.
+# Updated: 2026-07-06 (feat/sites-crew-frontend-brief, SC-2) — added
+# `_frontend_preamble(meta, brief)`, the ADDITIVE brief-driven twin of
+# `_create_preamble`. It renders the Frontend stage's build instructions FROM a
+# structured `DesignBrief` (the crew's baton): it walks the ordered `sitemap`,
+# injects the matching `copy` blocks + real `asset_manifest` imagery, threads the
+# branding design-system tokens/voice, and ROUTES by `brief.engine` ("svelte" →
+# `create_svelte_site`; "ripple" → `create_landing_site` / the pocket specialist,
+# noting `create_dynamic_site` for `pattern="dynamic"`). It preserves the same
+# static-site (SSR) rules the create/refine preambles enforce. `build_preamble`'s
+# live create/refine dispatch is UNCHANGED — `_frontend_preamble` is exercised by
+# tests now and wired into the flow later by the orchestration slice (SC-9) behind
+# a flag (SC-11); it is exported in `__all__` so that slice can import it.
 
 from __future__ import annotations
 
+from typing import Any
+
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.sites_crew.models import DesignBrief
 
 
 async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
@@ -239,4 +254,175 @@ def _refine_preamble(meta: SurfaceMeta) -> str:
     )
 
 
-__all__ = ["build_preamble"]
+def _render_copy(block: Any) -> str:
+    """Flatten one section's copy block into an inline, LLM-readable string.
+
+    ``brief.copy[section_id]`` is free-form: usually a dict of copy fields
+    (``{"headline": ..., "subhead": ...}``), sometimes a plain string/list. Join
+    dict entries as ``key: value`` so the actual copy text lands in the preamble.
+    """
+    if isinstance(block, dict):
+        return "; ".join(f"{k}: {v}" for k, v in block.items())
+    if isinstance(block, (list, tuple)):
+        return "; ".join(str(item) for item in block)
+    return str(block)
+
+
+def _frontend_preamble(meta: SurfaceMeta, brief: DesignBrief) -> str:
+    """Render the Frontend stage's build instructions FROM a structured brief.
+
+    The crew's baton (``DesignBrief``) in → the build preamble out. This is the
+    additive, brief-driven twin of ``_create_preamble``: instead of orienting the
+    agent off a raw user message, it walks the brief's ordered ``sitemap``,
+    injects the matching ``copy`` blocks and ``asset_manifest`` imagery, threads
+    the branding design-system tokens/voice, and ROUTES by ``brief.engine``
+    (``"svelte"`` → ``create_svelte_site``; ``"ripple"`` → ``create_landing_site``
+    / the pocket specialist). It preserves the same static-site (SSR) rules the
+    create/refine preambles enforce so a brief-driven build can't reintroduce a
+    static-site trap.
+
+    NOTE: NOT wired into ``build_preamble`` — the live create/refine dispatch is
+    byte-for-byte unchanged. Exercised by tests now; the orchestration slice
+    (SC-9) wires it in behind a flag (SC-11).
+    """
+    route = meta.route_path or "/sites"
+    engine = brief.engine
+
+    # --- Ordered sitemap → build-in-order instructions, with copy injected. ---
+    section_lines: list[str] = []
+    for i, section in enumerate(brief.sitemap, start=1):
+        head = f"{i}. `{section.role}` section"
+        if section.heading:
+            head += f' — heading "{section.heading}"'
+        section_lines.append(head)
+        if section.notes:
+            section_lines.append(f"   - notes: {section.notes}")
+        copy_block = brief.copy.get(section.id)
+        if copy_block:
+            section_lines.append(f"   - copy: {_render_copy(copy_block)}")
+    sitemap_block = (
+        "\n".join(section_lines)
+        if section_lines
+        else "(the brief carries no explicit sitemap — build a standard "
+        "conversion funnel: nav → hero → services → proof → pricing → cta → "
+        "flat lead form → footer)"
+    )
+
+    # --- Real imagery from the asset manifest (never invent placeholder URLs). ---
+    if brief.asset_manifest:
+        asset_lines = "\n".join(
+            f"- {a.kind}: {a.url}" + (f' (alt: "{a.alt}")' if a.alt else "")
+            for a in brief.asset_manifest
+        )
+        assets_block = (
+            "Use these REAL asset URLs from the brief's manifest verbatim — never "
+            "invent placeholder image paths:\n" + asset_lines + "\n"
+        )
+    else:
+        assets_block = ""
+
+    # --- Design system + voice from the branding layer. ---
+    branding = brief.branding
+    design_block = ""
+    ds = branding.design_system
+    if ds is not None:
+        design_block += f"Theme the page with the brief's design system (`{ds.name}`). "
+        if ds.tokens_css:
+            design_block += (
+                "Apply its compiled `tokens_css` (CSS custom properties) as the "
+                "single source of truth for color, type, spacing, radius, and "
+                "elevation — never hard-code ad-hoc values. "
+            )
+        if ds.colors:
+            design_block += (
+                "Use its palette scales (the 50..900 steps per role color) for "
+                "every surface, text, and accent. "
+            )
+        if ds.rationale:
+            design_block += (
+                "Honor the design rationale — its mood, do's/don'ts, and "
+                f"anti-patterns: {ds.rationale} "
+            )
+    if branding.voice:
+        design_block += f'Match this brand voice throughout the copy: "{branding.voice}". '
+
+    # --- Route by engine. svelte → hand-written components; ripple → landing spec. ---
+    if engine == "svelte":
+        route_block = (
+            "BUILD ENGINE: svelte. Author this page as hand-written SvelteKit "
+            "components (the svelte track) — one component per section above, at "
+            "the premium design quality bar. There is NO rippleSpec and NO widget "
+            "catalog on this track: do not draft a rippleSpec, do not call the "
+            "pocket specialist. Assemble the components into the source map and "
+            "persist via `create_svelte_site` "
+            "(`mcp__pocketpaw_sites_manager__create_svelte_site`), which stamps "
+            'the source pocket `type="site"` + `pattern="landing"` + '
+            '`engine="svelte"`; then `mcp__pocketpaw_sites_manager__publish`. Do '
+            "NOT fall back to any ripple/landing create tool on this track."
+        )
+    else:
+        route_block = (
+            "BUILD ENGINE: ripple. Compose this page as a conversion-ordered "
+            "ripple landing spec via the pocket specialist / `create_landing_site` "
+            "(`mcp__pocketpaw_sites_manager__create_landing_site`), which stamps "
+            'the source pocket `type="site"` + `pattern="landing"`; then '
+            "`mcp__pocketpaw_sites_manager__publish` with the returned pocket_id."
+        )
+        if brief.pattern == "dynamic":
+            route_block += (
+                ' This brief is marked `pattern="dynamic"` (a live-data site): the '
+                "dynamic create path is `create_dynamic_site` "
+                "(`mcp__pocketpaw_sites_manager__create_dynamic_site`), but keep "
+                "the static landing build as the primary focus."
+            )
+
+    return (
+        f'<surface kind="sites" route="{route}" engine="{engine}" mode="frontend" />\n'
+        "<sites-orientation>\n"
+        "You are the FRONTEND stage of the site-authoring crew. Build a "
+        "publishable WEBSITE from the structured brief below — a real marketing "
+        "landing page that deploys as a standalone static page on the edge, NOT "
+        "an in-app pocket dashboard. It reads top to bottom as a conversion "
+        "funnel. Talk about it as a 'site' or 'page' — never a 'pocket'. The "
+        "pocket is only the source spec; it auto-publishes to a live URL. The "
+        "page renders STATICALLY (no JavaScript runs for the visitor), so every "
+        "section must work as plain HTML.\n"
+        "</sites-orientation>\n"
+        "<sites-brief>\n"
+        f"GOAL: {brief.goal}\n"
+        + (f"AUDIENCE: {brief.audience}\n" if brief.audience else "")
+        + "SITEMAP — build these sections IN THIS ORDER, using the copy provided:\n"
+        + sitemap_block
+        + "\n"
+        + assets_block
+        + (design_block + "\n" if design_block else "")
+        + "</sites-brief>\n"
+        "<sites-procedure>\n" + route_block + "\n"
+        "PRESERVE the landing structure and keep the static-site (SSR) rules "
+        "intact while you build:\n"
+        "1. Lead capture stays FLAT native `input`/`textarea`/"
+        '`button{type:"submit"}` with real field names (name, email, phone, '
+        "message) — NEVER the `form` or `newsletter` widget, which nests an "
+        "invalid `<form>` inside the site template's outer POST form and captures "
+        "zero leads.\n"
+        "2. `pricing-table` uses `tiers` (never `plans`/`columns`).\n"
+        "3. An FAQ is `heading` + `text` pairs — NEVER the `accordion` widget "
+        "(its panels only open with JS, so on a static site the answers never "
+        "expand).\n"
+        "4. Every CTA is an anchor `href` (or `tel:` / `mailto:`) — never an "
+        "`on_click` handler, which is a dead button with no client JS.\n"
+        "5. `hero` is the marketing Hero widget — never the dashboard `hero+grid` "
+        "(a page-header plus a KPI `stat` grid); no metric grid, no charts. This "
+        "is marketing, not analytics.\n"
+        "Any animation stays Tier-0 (CSS-only, static-safe) — `aurora`, "
+        "`marquee`, `border-beam`, `shimmer`, `text-effect`; never `reveal`, "
+        "`parallax`, or `spotlight` (they need client JS and hide content on a "
+        "static page).\n"
+        "After it publishes, relay any publish error — never claim a phantom "
+        "publish — and SHOW the live `url` plus a link to /sites. Keep talking "
+        "'site' / 'page', never 'pocket'.\n"
+        "</sites-procedure>"
+    )
+
+
+__all__ = ["build_preamble", "_frontend_preamble"]

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -36,12 +36,30 @@
 # svelte-engine create test with the strengthened preamble: the directive moved
 # from "prefer" to "this track is MANDATORY ... Use the skill", so the test now
 # pins "mandatory" instead of "prefer".
+# Updated: 2026-07-06 (feat/sites-crew-frontend-brief, SC-2) — added the
+# `_frontend_preamble(meta, brief)` tests: it renders the Frontend stage's build
+# instructions FROM a structured `DesignBrief` (the crew baton). The new tests pin
+# (1) sitemap roles/headings + copy injection from a hand-authored brief, (2)
+# engine ROUTING (svelte → create_svelte_site & not the ripple landing tool;
+# ripple → create_landing_site & not create_svelte_site), (3) the static-site
+# (SSR) rules language survives for a landing brief, and (4) that `build_preamble`
+# is UNCHANGED for the live create/refine paths (compared byte-for-byte against
+# calling `_create_preamble`/`_refine_preamble` directly), proving the new helper
+# is additive and not silently wired into the dispatch.
 
 from __future__ import annotations
 
 import pytest
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
 from pocketpaw_ee.cloud.surface.handlers import sites as sites_handler
+from pocketpaw_ee.sites_crew.models import (
+    AssetRef,
+    Branding,
+    ColorScale,
+    DesignBrief,
+    DesignSystem,
+    Section,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -276,3 +294,155 @@ async def test_engine_threads_through_meta_from_request() -> None:
 
     meta = _meta_from_request(SurfaceMetaRequest(engine="svelte", route_path="/sites"))
     assert meta.engine == "svelte"
+
+
+# --- Frontend-consumes-brief (`_frontend_preamble`) — the crew baton, end to end ---
+#
+# `_frontend_preamble(meta, brief)` renders the Frontend stage's build
+# instructions FROM a structured DesignBrief instead of a raw user message. These
+# tests prove the baton flows in and correct, engine-routed build instructions
+# flow out. `_frontend_preamble` is SYNC; the tests call it directly inside async
+# bodies (the module-level asyncio marker applies to every test here).
+
+
+def _landing_brief(engine: str = "ripple") -> DesignBrief:
+    """A hand-authored DesignBrief fixture for a dentist landing page."""
+    return DesignBrief(
+        goal="Book more new-patient appointments for a family dental clinic",
+        audience="Local families searching for a nearby dentist",
+        engine=engine,  # type: ignore[arg-type]
+        pattern="landing",
+        sitemap=[
+            Section(id="nav", role="nav", heading="BrightSmile Dental"),
+            Section(id="hero", role="hero", heading="A Brighter Smile Starts Here"),
+            Section(id="services", role="services", heading="Our Services"),
+            Section(id="pricing", role="pricing", heading="Simple, Honest Pricing"),
+            Section(id="lead", role="lead_form", heading="Book Your Visit"),
+            Section(id="footer", role="footer"),
+        ],
+        branding=Branding(
+            design_system=DesignSystem(
+                name="BrightSmile",
+                colors={"primary": ColorScale(s500="#0ea5e9")},  # type: ignore[call-arg]
+                rationale="Calm, clinical, trustworthy — avoid loud reds and clutter.",
+                tokens_css=":root{--color-primary:#0ea5e9;}",
+            ),
+            voice="Warm, reassuring, plain-spoken — no dental jargon.",
+        ),
+        copy={
+            "hero": {
+                "headline": "A Brighter Smile Starts Here",
+                "subhead": "Gentle, modern dentistry for the whole family.",
+            },
+            "services": {"body": "Cleanings, whitening, implants, and emergency care."},
+        },
+        asset_manifest=[
+            AssetRef(
+                url="https://images.pexels.com/photos/1/dentist.jpg",
+                kind="image",
+                alt="Smiling dentist with a patient",
+            ),
+        ],
+    )
+
+
+async def test_frontend_preamble_renders_sitemap_and_copy_from_brief() -> None:
+    """Given a hand-authored brief, the preamble is non-empty and carries the
+    section roles/headings from the sitemap AND the copy from `brief.copy`."""
+    brief = _landing_brief()
+    preamble = sites_handler._frontend_preamble(SurfaceMeta(route_path="/sites"), brief)
+
+    assert isinstance(preamble, str) and preamble.strip()
+    # Still the sites surface, framed as a site not a pocket.
+    assert '<surface kind="sites"' in preamble
+    assert "build a pocket" not in preamble.lower()
+
+    # Section roles + headings from the ordered sitemap are present.
+    assert "hero" in preamble
+    assert "services" in preamble
+    assert "A Brighter Smile Starts Here" in preamble
+    assert "Our Services" in preamble
+
+    # The copy blocks keyed by section id are injected verbatim.
+    assert "Gentle, modern dentistry for the whole family." in preamble
+    assert "Cleanings, whitening, implants, and emergency care." in preamble
+
+    # Sections are ordered: nav before hero before footer.
+    assert preamble.index("A Brighter Smile Starts Here") < preamble.index("Book Your Visit")
+
+    # The real asset URL from the manifest is used, not a placeholder.
+    assert "https://images.pexels.com/photos/1/dentist.jpg" in preamble
+
+    # Design system tokens + voice are threaded through.
+    assert "BrightSmile" in preamble
+    assert "tokens_css" in preamble
+    assert "avoid loud reds and clutter" in preamble
+    assert "no dental jargon" in preamble
+
+
+async def test_frontend_preamble_routes_svelte_to_create_svelte_site() -> None:
+    """engine="svelte" routes the build to `create_svelte_site` and must NOT
+    name the ripple landing tool."""
+    brief = _landing_brief(engine="svelte")
+    preamble = sites_handler._frontend_preamble(SurfaceMeta(route_path="/sites"), brief)
+
+    assert 'engine="svelte"' in preamble
+    assert "create_svelte_site" in preamble
+    # The ripple landing tool must be absent on the svelte track.
+    assert "create_landing_site" not in preamble
+
+
+async def test_frontend_preamble_routes_ripple_to_landing_tool() -> None:
+    """engine="ripple" routes the build to the ripple create path
+    (`create_landing_site`) and must NOT name `create_svelte_site`."""
+    brief = _landing_brief(engine="ripple")
+    preamble = sites_handler._frontend_preamble(SurfaceMeta(route_path="/sites"), brief)
+
+    assert 'engine="ripple"' in preamble
+    assert "create_landing_site" in preamble
+    # The svelte create tool must be absent on the ripple track.
+    assert "create_svelte_site" not in preamble
+
+
+async def test_frontend_preamble_preserves_ssr_rules_for_landing_brief() -> None:
+    """The static-site (SSR) rules language survives into the brief-driven
+    preamble — flat lead form (not form/newsletter), pricing-table tiers, and
+    anchor CTAs — so a brief-driven build can't reintroduce a static-site trap."""
+    brief = _landing_brief()
+    preamble = sites_handler._frontend_preamble(SurfaceMeta(route_path="/sites"), brief)
+    lower = preamble.lower()
+
+    # Rule 1 — flat native lead form, never the form/newsletter widget.
+    assert "flat" in lower
+    assert "newsletter" in lower
+    # Rule 2 — pricing-table uses tiers.
+    assert "tiers" in lower
+    # Rule 3 — FAQ never accordion.
+    assert "accordion" in lower
+    # Rule 4 — CTAs are anchor href, never on_click.
+    assert "href" in lower
+    assert "on_click" in lower
+    # Animation Tier-0 only.
+    assert "tier-0" in lower or "tier 0" in lower
+
+
+async def test_build_preamble_unchanged_for_create_path() -> None:
+    """`_frontend_preamble` is ADDITIVE — the live create dispatch is unchanged.
+    A create meta (no pocket_id) still returns exactly `_create_preamble`'s
+    output, proving the new helper is not silently wired into the flow."""
+    meta = SurfaceMeta(route_path="/sites")
+    live = await sites_handler.build_preamble(WORKSPACE, USER, meta)
+
+    assert live == sites_handler._create_preamble(meta)
+    # And it is NOT the brief-driven preamble.
+    assert 'mode="frontend"' not in live
+
+
+async def test_build_preamble_unchanged_for_refine_path() -> None:
+    """A refine meta (with pocket_id) still returns exactly `_refine_preamble`'s
+    output — the additive brief helper does not touch the refine dispatch."""
+    meta = SurfaceMeta(route_path="/sites/site-abc", pocket_id=REFINE_POCKET, site_id="site-abc")
+    live = await sites_handler.build_preamble(WORKSPACE, USER, meta)
+
+    assert live == sites_handler._refine_preamble(meta)
+    assert 'mode="frontend"' not in live


### PR DESCRIPTION
## What ships

`_frontend_preamble(meta, brief)` — the Frontend stage's instructions, rendered from a structured `DesignBrief` instead of a raw user message. It walks the brief's ordered sitemap, drops in the per-section copy and the real asset URLs from the manifest, threads the design system's tokens and voice, and routes to the right engine (svelte → `create_svelte_site`, ripple → the landing/pocket-specialist path). It carries the same static-site rules the existing create and refine preambles enforce — flat lead form, pricing tiers, anchor CTAs, marketing hero, CSS-only animation — so a brief-driven build can't reintroduce a static-site trap.

This proves the crew's baton end to end: a brief goes in, correct and complete build instructions come out.

## Why now

The `DesignBrief` contract landed in #1650; this is the first thing that consumes it. Locking the brief → build rendering now means the Designer and Branding stages have a real target to fill, and the orchestration slice has a ready function to call.

## Deliberately additive — no change to the live builder

`build_preamble`'s create/refine/chat dispatch is byte-for-byte unchanged. `_frontend_preamble` is exported for the later orchestration slice to wire in behind a flag; nothing routes through it yet. Two tests assert the existing paths still return the current create and refine preambles exactly, so this slice cannot regress the shipped builder.

## Stacked on #1650

Branches off `feat/sites-crew-brief` because it imports `DesignBrief`. Merge the base first with `--rebase`.

## Scope

- `ee/pocketpaw_ee/cloud/surface/handlers/sites.py` — the additive `_frontend_preamble`, exported in `__all__`.
- `tests/cloud/surface/test_sites_handler.py` — 6 new tests: sitemap + copy present, engine routing (svelte vs ripple, mutually exclusive), the SSR rules language, and the two unchanged-dispatch guards.

## Testing

`uv run pytest tests/cloud/surface/test_sites_handler.py -q` → 18 passed. `ruff check` + `ruff format` clean.

## Out of scope

No orchestration and no flag flip — wiring the crew to call this is the following slice.