### PR TITLE
Let the site agent actually use the authoring toolbelt

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -195,15 +195,35 @@ def _load_mcp_tool_ids() -> _McpToolIds:
 
     logger = logging.getLogger(__name__)
     try:
+        from pocketpaw_ee.agent.mcp_servers.design_systems import DESIGN_SYSTEM_TOOL_IDS
         from pocketpaw_ee.agent.mcp_servers.foresight import FORESIGHT_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.icons import ICON_TOOL_IDS
         from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
         from pocketpaw_ee.agent.mcp_servers.media import MEDIA_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.palette import PALETTE_TOOL_IDS
         from pocketpaw_ee.agent.mcp_servers.sites import SITES_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.stock_images import STOCK_TOOL_IDS
+
+        # /sites scopes to the sites-manager tools PLUS the authoring TOOLBELT the
+        # crew (and the create-svelte-site skill) needs on-surface: stock photos,
+        # icons, palette derivation, and the design-system library. These live on
+        # ambient in-process servers, but the per-surface allow-list is a hard
+        # whitelist (claude_sdk `allow_mcp_tool_ids`), so an id absent here is
+        # FILTERED OUT on /sites — the tool would be silently unreachable. Named
+        # here so authoring can actually call them. MEDIA (image/video gen) stays
+        # scoped to /studio, not added here (site imagery leans on stock first).
+        sites_allow = (
+            frozenset(SITES_TOOL_IDS)
+            | frozenset(STOCK_TOOL_IDS)
+            | frozenset(ICON_TOOL_IDS)
+            | frozenset(PALETTE_TOOL_IDS)
+            | frozenset(DESIGN_SYSTEM_TOOL_IDS)
+        )
 
         return _McpToolIds(
             loaded=True,
             foresight_allow=frozenset(FORESIGHT_TOOL_IDS),
-            sites_allow=frozenset(SITES_TOOL_IDS),
+            sites_allow=sites_allow,
             # /studio scopes to the media-generation tools (image + video).
             # Crossed over from the EE mcp-server module as a plain
             # frozenset[str] — never an imported pocketpaw_ee symbol leaks into

--- a/tests/cloud/surface/test_surface_registry.py
+++ b/tests/cloud/surface/test_surface_registry.py
@@ -102,3 +102,78 @@ def test_sites_refine_keeps_ripple_and_wins_over_engine():
         profile = resolve_profile(SurfaceKind.SITES, meta)
         assert profile.ripple_mode == "on", f"refine {meta!r} must keep ripple"
         assert profile.deny_mcp_tool_ids == frozenset(), f"refine {meta!r} must deny nothing"
+
+
+# ---------------------------------------------------------------------------
+# Sites authoring TOOLBELT allow-list (feat/sites-crew-toolbelt-allow) — the
+# crew (and the create-svelte-site skill) must be able to CALL stock / icons /
+# palette / design-system tools on /sites. The per-surface allow-list is a hard
+# whitelist enforced by claude_sdk, so an id absent from sites_allow is silently
+# filtered out. These tests pin that the toolbelt ids ARE permitted AND survive
+# the real SDK filter predicate.
+# ---------------------------------------------------------------------------
+
+from pocketpaw_ee.agent.mcp_servers.design_systems import DESIGN_SYSTEM_TOOL_IDS  # noqa: E402
+from pocketpaw_ee.agent.mcp_servers.icons import ICON_TOOL_IDS  # noqa: E402
+from pocketpaw_ee.agent.mcp_servers.palette import PALETTE_TOOL_IDS  # noqa: E402
+from pocketpaw_ee.agent.mcp_servers.sites import SITES_TOOL_IDS  # noqa: E402
+from pocketpaw_ee.agent.mcp_servers.stock_images import STOCK_TOOL_IDS  # noqa: E402
+
+_TOOLBELT_IDS = (
+    frozenset(STOCK_TOOL_IDS)
+    | frozenset(ICON_TOOL_IDS)
+    | frozenset(PALETTE_TOOL_IDS)
+    | frozenset(DESIGN_SYSTEM_TOOL_IDS)
+)
+
+
+def _sites_create_metas():
+    """The two /sites CREATE modes (ripple + svelte) — both need the toolbelt."""
+    return (SurfaceMeta(), SurfaceMeta(engine="ripple"), SurfaceMeta(engine="svelte"))
+
+
+def test_sites_allowlist_includes_authoring_toolbelt():
+    """Every /sites create+refine mode permits the sites-manager tools AND the
+    full authoring toolbelt (stock / icons / palette / design-systems)."""
+    metas = (*_sites_create_metas(), SurfaceMeta(pocket_id="pkt_1"))
+    for meta in metas:
+        profile = resolve_profile(SurfaceKind.SITES, meta)
+        allow = profile.allow_mcp_tool_ids
+        assert allow is not None, f"{meta!r}: /sites must impose a (non-None) allow-list"
+        assert frozenset(SITES_TOOL_IDS) <= allow, f"{meta!r}: sites-manager tools missing"
+        assert _TOOLBELT_IDS <= allow, (
+            f"{meta!r}: authoring toolbelt missing {_TOOLBELT_IDS - allow}"
+        )
+
+
+def test_toolbelt_survives_the_real_sdk_allowlist_filter():
+    """Simulate claude_sdk's ACTUAL allow-list filter with the /sites allow set:
+    every toolbelt id must survive, while an unrelated MCP id (a foresight tool)
+    is filtered out. This proves the tools are genuinely callable on /sites, not
+    merely present in a set."""
+    from pocketpaw.agents.claude_sdk import (
+        ALWAYS_ALLOWED_MCP_SERVERS,
+        POCKET_CREATION_GRANT,
+        _mcp_server_of,
+    )
+    from pocketpaw.agents.sdk_mcp_atlas import ATLAS_TOOL_IDS
+    from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
+
+    allow = resolve_profile(SurfaceKind.SITES, SurfaceMeta()).allow_mcp_tool_ids
+    assert allow is not None
+    grant = allow | POCKET_CREATION_GRANT | frozenset(WIDGET_TOOL_IDS) | frozenset(ATLAS_TOOL_IDS)
+
+    def _survives(t: str) -> bool:
+        # Mirrors claude_sdk.py's filter predicate exactly.
+        return (
+            not t.startswith("mcp__")
+            or t in grant
+            or _mcp_server_of(t) in ALWAYS_ALLOWED_MCP_SERVERS
+        )
+
+    for tool_id in _TOOLBELT_IDS:
+        assert _survives(tool_id), f"{tool_id} would be filtered out on /sites"
+
+    # Control: an unrelated MCP id NOT granted to /sites is filtered out — proves
+    # the allow-list is real, not a no-op that keeps everything.
+    assert not _survives("mcp__pocketpaw_foresight__save_scenario")


### PR DESCRIPTION
## What ships

The `/sites` surface scopes which MCP tools the agent may call to a hard whitelist. Until now that list was only the sites-manager tools (publish, create, edit), so the ambient asset servers — stock photos, icons, palette extraction, and the design-system library — were **silently filtered out**. The agent could not call them on `/sites` even though they were loaded.

This unions those tool ids into the sites allow-list so the authoring flow can actually reach them. It also closes a latent gap: the shipped stock-photo tool, added for the Svelte-track site skill, wasn't reachable on `/sites` for the same reason.

`media` (image/video generation) is deliberately left scoped to `/studio` — site imagery leans on stock first, and generated logo/favicon work belongs to the later Branding stage.

## Why now

This is the load-bearing wiring for the authoring crew. Without it, a crew flow that asks the agent to "retrieve a design system" or "extract a palette" would have those calls quietly dropped — the kind of failure that only shows up during manual testing.

## Stacked on #1654

Branches off `feat/sites-crew-scale-from-color` because it imports the tool-id constants from the icons/palette/design-systems servers. Merge the chain base-first with `--rebase`.

## Scope

- `ee/pocketpaw_ee/cloud/surface/surface_registry.py` — `_load_mcp_tool_ids()` now builds `sites_allow` as the sites-manager tools unioned with stock + icons + palette + design-systems.
- `tests/cloud/surface/test_surface_registry.py` — two tests: every create/refine mode permits the toolbelt, and a simulation of the actual claude_sdk filter predicate proving each toolbelt id survives on `/sites` while an unrelated tool id is correctly filtered out.

## Testing

`uv run pytest tests/cloud/surface/ tests/cloud/test_surface_profile.py -q` → 88 passed. `ruff` clean. Only `sites_allow` changed.

## Out of scope

No preamble or crew-flow changes — this only makes the tools reachable.