### PR TITLE
Add a guided two-phase crew flow for building sites

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -47,6 +47,20 @@
 # Every other engine value (None / "ripple") keeps the existing ripple marketing
 # brain (`pocketpaw-create-paw-site` + create_landing_site) byte-for-byte. The
 # refine branch (keyed on `pocket_id`) is untouched by the toggle.
+# Updated: 2026-07-06 (feat/sites-crew-create-flow, SC-crew) — the CREATE branch
+# now optionally runs a guided two-phase authoring-crew flow behind the
+# `settings.sites_crew_enabled` flag (default OFF). When the flag is ON, a create
+# meta returns `_crew_create_preamble`: PHASE 1 assesses the request's clarity
+# and interviews the user (one round of 3–5 questions) when it is vague, with a
+# "just build it" escape hatch; PHASE 2 retrieves a design system
+# (`mcp__pocketpaw_design_systems__*`), pulls real assets (stock/icons/palette
+# MCP tools), states a one-line brief, and BUILDS via the same engine skill the
+# single-shot path uses (`pocketpaw-create-svelte-site` on svelte,
+# `pocketpaw-create-paw-site` on ripple) — the skill still owns the SSR page
+# assembly, the crew preamble only feeds it the design system, sections, copy,
+# and assets. When the flag is OFF, the create branch returns
+# `_create_preamble(meta)` byte-for-byte (no behaviour change). The refine/chat
+# branches (keyed on `pocket_id`) are untouched.
 
 from __future__ import annotations
 
@@ -66,7 +80,24 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     """
     if meta.pocket_id:
         return _refine_preamble(meta)
+    if _crew_enabled():
+        return _crew_create_preamble(meta)
     return _create_preamble(meta)
+
+
+def _crew_enabled() -> bool:
+    """Read the ``sites_crew_enabled`` flag (default OFF).
+
+    Isolated so a config-import failure can never break the create path — a
+    bad read falls back to the shipped single-shot builder, not a 5xx. Mirrors
+    the ``get_settings()`` access pattern in ``handlers/foresight.py``.
+    """
+    try:
+        from pocketpaw.config import get_settings
+
+        return bool(getattr(get_settings(), "sites_crew_enabled", False))
+    except Exception:
+        return False
 
 
 def _create_preamble(meta: SurfaceMeta) -> str:
@@ -180,6 +211,145 @@ def _svelte_create_preamble(meta: SurfaceMeta) -> str:
     )
 
 
+def _crew_create_preamble(meta: SurfaceMeta) -> str:
+    """The /sites create preamble on the guided authoring-crew flow.
+
+    Gated behind ``settings.sites_crew_enabled`` (default OFF). Same visible
+    behaviour as a design agent that asks questions and then builds, realized
+    as ONE agent running two staged phases behind the proven build pipeline:
+
+    * **Phase 1** — a clarity gate. Assess whether the request already covers
+      the design dimensions; if it does, restate and proceed; if it is vague,
+      ask ONE round of 3–5 high-value questions and stop (always with a "just
+      build it" escape hatch).
+    * **Phase 2** — retrieve/adapt a design system, gather real assets, state a
+      one-line brief, then BUILD via the SAME engine skill the single-shot path
+      uses. The skill owns the SSR page assembly + rules; the crew preamble only
+      feeds it the chosen design system, sections, copy, and assets.
+
+    The BUILD step forks on ``meta.engine`` exactly like ``_create_preamble``:
+    ``"svelte"`` → the ``pocketpaw-create-svelte-site`` skill +
+    ``create_svelte_site``; anything else → the ``pocketpaw-create-paw-site``
+    skill + the ripple create/publish path.
+    """
+    route = meta.route_path or "/sites"
+    is_svelte = meta.engine == "svelte"
+    engine_attr = ' engine="svelte"' if is_svelte else ""
+    engine_note = (
+        " On this track the page is authored as hand-written SvelteKit "
+        "components and PRERENDERED to static HTML (no JavaScript runs for the "
+        "visitor on first paint)."
+        if is_svelte
+        else " The page is rendered STATICALLY (no JavaScript runs for the visitor)."
+    )
+    if is_svelte:
+        build_step = (
+            "BUILD via the `pocketpaw-create-svelte-site` skill — invoke it by "
+            "intent (no slash command). It is the Svelte-track authoring brain: "
+            "YOU write the premium hand-written SvelteKit components (Hero, "
+            "Pricing, Faq, …) at the design quality bar, THEME them with the "
+            "chosen design system's tokens + your asset URLs, and it persists "
+            'the source pocket `type="site"` + `pattern="landing"` + '
+            '`engine="svelte"` and publishes it. There is NO rippleSpec and NO '
+            "widget catalog on this track. If the skill is unavailable, author "
+            "the source map yourself and call "
+            "`mcp__pocketpaw_sites_manager__create_svelte_site` then "
+            "`mcp__pocketpaw_sites_manager__publish`. The skill owns the "
+            "component assembly and the resting-state SSR rule — defer to it "
+            "for those; your job is to hand it the design system, sections, "
+            "copy, and real assets."
+        )
+    else:
+        build_step = (
+            "BUILD via the `pocketpaw-create-paw-site` skill — invoke it by "
+            "intent (no slash command). It is the marketing brain: it composes "
+            'the page by conversion role, stamps the source pocket `type="site"` '
+            '+ `pattern="landing"`, and publishes it. THEME the page with the '
+            "chosen design system's tokens + your asset URLs. If the skill is "
+            "unavailable, fall back to "
+            "`mcp__pocketpaw_pocket_specialist__create` (build the "
+            "conversion-ordered landing spec) then "
+            "`mcp__pocketpaw_sites_manager__publish`. The skill owns the page "
+            "assembly and the static-site (SSR) rules — defer to it for those; "
+            "your job is to hand it the design system, sections, copy, and real "
+            "assets."
+        )
+    return (
+        f'<surface kind="sites" route="{route}"{engine_attr} mode="crew" />\n'
+        "<sites-orientation>\n"
+        "The user is on the SITES surface, building a publishable WEBSITE that "
+        "deploys as a standalone static page on the edge — not an in-app pocket "
+        "dashboard. It renders as a real marketing landing page read top to "
+        "bottom as a conversion funnel: nav, hero, services, social proof, "
+        "pricing, a call-to-action, a lead-capture form, footer. Talk about it "
+        "as a 'site' or 'page' — never a 'pocket'. The pocket is only the "
+        f"source spec; it auto-publishes to a live URL.{engine_note} You are "
+        "the AUTHORING CREW: rather than building blindly from one line, you "
+        "run a guided two-phase flow — first make sure you understand the "
+        "request, then design and build a coherent, on-brand site.\n"
+        "</sites-orientation>\n"
+        "<sites-procedure>\n"
+        "Run TWO phases. Do not skip Phase 1, and do not start building until "
+        "Phase 1 is resolved.\n"
+        "\n"
+        "PHASE 1 — CLARITY GATE + INTERVIEW.\n"
+        "Assess the user's request across these dimensions: (a) the purpose / "
+        "goal of the site, (b) the business and its audience, (c) the key "
+        "sections they want, (d) brand — colors, vibe, any existing logo or "
+        "brand assets, (e) voice / tone.\n"
+        "- IF the request ALREADY covers most of these dimensions (a detailed "
+        "prompt) → do NOT interrogate. Briefly restate the plan in one or two "
+        "lines and proceed straight to Phase 2.\n"
+        "- IF the request is VAGUE (e.g. 'make me a site for my cafe') → ask "
+        "3–5 SHORT, high-value questions in ONE message covering the biggest "
+        "gaps: what the site should achieve, the vibe or brands they admire, "
+        "the must-have sections, and any brand colors. THEN STOP and wait for "
+        "the reply — do not build yet. Always offer an out: end with '…or say "
+        "\"just build it\" and I'll pick sensible defaults.' NEVER ask more "
+        "than ONE round of questions; if the user already gave detail, or "
+        "replies, or says 'just build it', move on to Phase 2 immediately.\n"
+        "\n"
+        "PHASE 2 — DESIGN + BUILD.\n"
+        "1. PICK A LOOK. Call "
+        "`mcp__pocketpaw_design_systems__list_design_systems` to see the "
+        "library, choose the best fit by industry + aesthetic, then "
+        "`mcp__pocketpaw_design_systems__get_design_system` with its slug to "
+        "load the DESIGN.md + tokens.css. THEME the site with those tokens — "
+        "colors, type scale, spacing, component styles — and honor the "
+        "system's rationale and anti-patterns.\n"
+        "2. CUSTOM COLORS. If the user gave a brand color, call "
+        "`mcp__pocketpaw_palette__scale_from_color` with the hex to get a full "
+        "scale and OVERRIDE the design system's primary with it. If they gave "
+        "a logo or reference-image URL, call "
+        "`mcp__pocketpaw_palette__extract_palette` on it and key the palette "
+        "off that.\n"
+        "3. REAL ASSETS. Use `mcp__pocketpaw_stock__search_stock_images` for "
+        "hero and section photography and `mcp__pocketpaw_icons__search_icons` "
+        "for feature icons. Wire the REAL returned URLs into the page — never "
+        "leave placeholders or invent image paths.\n"
+        "4. BRIEF. State a one-line brief back so the user sees the plan — e.g. "
+        "'Building a [design-system vibe] site for [business] with sections "
+        "[…], palette [primary].' Then build.\n"
+        f"5. {build_step}\n"
+        "6. PUBLISH and SHOW the live `url` plus a link to /sites where the "
+        "user manages their sites.\n"
+        "\n"
+        "ROBUSTNESS (this flow must never stall or disappoint in real use):\n"
+        "- If ANY tool errors (design-system, stock, palette, or icons), do "
+        "NOT retry blindly or stall. Proceed with sensible defaults — a "
+        "reasonable built-in look, generic-but-tasteful section imagery — and "
+        "briefly note what you fell back on. A tool failure must NEVER block "
+        "the build.\n"
+        "- ONE round of questions maximum. If the user already gave detail or "
+        "says 'just build it', skip straight to Phase 2 with sensible "
+        "defaults.\n"
+        "- Never claim a publish that didn't happen — relay the real publish "
+        "error and show the real `url`. No phantom URLs.\n"
+        "- Keep the 'site' / 'page' vocabulary throughout; never say 'pocket'.\n"
+        "</sites-procedure>"
+    )
+
+
 def _refine_preamble(meta: SurfaceMeta) -> str:
     """The /sites/[siteId] refine preamble — edit an EXISTING published site.
 
@@ -239,4 +409,4 @@ def _refine_preamble(meta: SurfaceMeta) -> str:
     )
 
 
-__all__ = ["build_preamble"]
+__all__ = ["build_preamble", "_crew_create_preamble"]

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -147,6 +147,10 @@ Changes:
   - 2026-05-22: Added ``pocket_router_enabled`` (kill-switch) and
     ``pocket_router_min_confidence`` (cheap-tier confidence floor) for
     the pocket execution router (Increment 3).
+  - 2026-07-06: Added ``sites_crew_enabled`` — when true, the /sites
+    CREATE surface runs the guided authoring-crew flow (clarity gate →
+    interview → design-system + assets → build) instead of the single-shot
+    create preamble; default off (feat/sites-crew-create-flow, SC-crew).
   - 2026-05-22: Added ``auto_install_bundled_templates`` — toggles the
     boot-time mirror of built-in pocket templates into
     ``~/.pocketpaw/templates/`` (feat/bundled-templates, Increment 2a).
@@ -686,6 +690,24 @@ class Settings(BaseSettings):
             "Idempotent — SHA-256 hash compare per file. Set ``false`` to "
             "freeze a manually-customized copy. Best-effort: pocket creation "
             "still works via the MCP tool surface even when no skill loads."
+        ),
+    )
+    sites_crew_enabled: bool = Field(
+        default=False,
+        description=(
+            "When true, the /sites CREATE surface runs the guided "
+            "authoring-crew flow instead of the single-shot create preamble. "
+            "The crew flow stages two phases behind the same proven build "
+            "pipeline: (1) a clarity gate that interviews the user when the "
+            "request is vague (purpose, business/audience, sections, brand, "
+            "voice), then (2) retrieves and adapts a design system, gathers "
+            "real assets (stock photography, icons, palette scales), states a "
+            "short brief back, and builds a coherent site via the same engine "
+            "skill (`pocketpaw-create-svelte-site` on the svelte track, "
+            "`pocketpaw-create-paw-site` on the ripple track). Env "
+            "``POCKETPAW_SITES_CREW_ENABLED``. Default off so it can never "
+            "regress the shipped single-shot builder; the refine/chat "
+            "branches are untouched by this flag."
         ),
     )
     sdk_load_bundled_skills: bool = Field(

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -36,8 +36,20 @@
 # svelte-engine create test with the strengthened preamble: the directive moved
 # from "prefer" to "this track is MANDATORY ... Use the skill", so the test now
 # pins "mandatory" instead of "prefer".
+# Updated: 2026-07-06 (feat/sites-crew-create-flow, SC-crew) — the CREATE branch
+# now optionally runs a guided two-phase authoring-crew flow behind the
+# `settings.sites_crew_enabled` flag (default OFF). The crew tests at the bottom
+# pin: (1) flag OFF → the create branch is BYTE-FOR-BYTE `_create_preamble` for
+# both ripple and svelte metas, and refine is untouched; (2) flag ON → a create
+# meta returns the crew preamble carrying the two-phase structure (interview +
+# build), the design-system / stock / palette MCP tool ids, the "just build it"
+# escape hatch, and the correct engine skill (`pocketpaw-create-svelte-site` on
+# the svelte track, `pocketpaw-create-paw-site` otherwise). The flag is toggled
+# via monkeypatch of `pocketpaw.config.get_settings` (not process env).
 
 from __future__ import annotations
+
+from types import SimpleNamespace
 
 import pytest
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
@@ -276,3 +288,148 @@ async def test_engine_threads_through_meta_from_request() -> None:
 
     meta = _meta_from_request(SurfaceMetaRequest(engine="svelte", route_path="/sites"))
     assert meta.engine == "svelte"
+
+
+# --- Authoring-crew create flow (behind settings.sites_crew_enabled) ---
+#
+# Default OFF: the create branch returns `_create_preamble(meta)` byte-for-byte.
+# Flag ON: a create meta returns the guided two-phase crew preamble. The flag is
+# toggled by monkeypatching `pocketpaw.config.get_settings` (the `_crew_enabled`
+# helper imports it lazily), never via leaking process env.
+
+
+def _set_crew_flag(monkeypatch: pytest.MonkeyPatch, enabled: bool) -> None:
+    """Toggle `sites_crew_enabled` by patching `config.get_settings`."""
+    from pocketpaw import config
+
+    fake = SimpleNamespace(sites_crew_enabled=enabled)
+    monkeypatch.setattr(config, "get_settings", lambda *a, **k: fake)
+
+
+async def test_crew_flag_off_is_byte_identical_ripple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag OFF → a ripple create meta returns `_create_preamble` byte-for-byte."""
+    _set_crew_flag(monkeypatch, False)
+    meta = SurfaceMeta(route_path="/sites")
+    out = await sites_handler.build_preamble(WORKSPACE, USER, meta)
+    assert out == sites_handler._create_preamble(meta)
+    assert 'mode="crew"' not in out
+
+
+async def test_crew_flag_off_is_byte_identical_svelte(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag OFF → a svelte create meta returns `_create_preamble` byte-for-byte."""
+    _set_crew_flag(monkeypatch, False)
+    meta = SurfaceMeta(route_path="/sites", engine="svelte")
+    out = await sites_handler.build_preamble(WORKSPACE, USER, meta)
+    assert out == sites_handler._create_preamble(meta)
+    assert 'mode="crew"' not in out
+
+
+async def test_crew_flag_off_default_settings_still_single_shot() -> None:
+    """With no monkeypatch (real settings, flag defaults False) the create branch
+    is the shipped single-shot builder — the flag can't regress by default."""
+    meta = SurfaceMeta(route_path="/sites")
+    out = await sites_handler.build_preamble(WORKSPACE, USER, meta)
+    assert out == sites_handler._create_preamble(meta)
+
+
+async def test_crew_flag_on_returns_two_phase_ripple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag ON → a ripple create meta returns the crew preamble with BOTH phases:
+    an interview/questions instruction AND a build instruction."""
+    _set_crew_flag(monkeypatch, True)
+    out = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
+    lower = out.lower()
+
+    # Still the sites surface, tagged as the crew flow.
+    assert '<surface kind="sites"' in out
+    assert 'mode="crew"' in out
+    # Two-phase structure: a clarity/interview front AND a build back.
+    assert "phase 1" in lower
+    assert "phase 2" in lower
+    assert "question" in lower  # the interview instruction
+    assert "build" in lower
+
+
+async def test_crew_flag_on_names_design_and_asset_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The crew preamble names the design-system, stock, and custom-color tool
+    ids so the agent themes the site and wires real assets."""
+    _set_crew_flag(monkeypatch, True)
+    out = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
+
+    assert "mcp__pocketpaw_design_systems__list_design_systems" in out
+    assert "mcp__pocketpaw_design_systems__get_design_system" in out
+    assert "mcp__pocketpaw_stock__search_stock_images" in out
+    # Custom-color path: brand hex → full scale.
+    assert "mcp__pocketpaw_palette__scale_from_color" in out
+
+
+async def test_crew_flag_on_has_just_build_it_escape_hatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The interview must always offer the 'just build it' out and cap at one
+    round of questions so the flow never traps the user."""
+    _set_crew_flag(monkeypatch, True)
+    out = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
+    lower = out.lower()
+
+    assert "just build it" in lower
+    # One round of questions maximum — the anti-interrogation guard.
+    assert "one round" in lower or "never ask more than one" in lower
+
+
+async def test_crew_flag_on_ripple_uses_ripple_skill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On the ripple (default) engine the crew BUILD step uses the ripple
+    marketing skill, not the svelte one."""
+    _set_crew_flag(monkeypatch, True)
+    out = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
+
+    assert "pocketpaw-create-paw-site" in out
+    assert "create-svelte-site" not in out
+    assert 'engine="svelte"' not in out
+
+
+async def test_crew_flag_on_svelte_uses_svelte_skill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On the svelte engine the crew BUILD step uses the svelte authoring skill
+    and stamps engine="svelte" — still a crew preamble with the design tools."""
+    _set_crew_flag(monkeypatch, True)
+    out = await sites_handler.build_preamble(
+        WORKSPACE, USER, SurfaceMeta(route_path="/sites", engine="svelte")
+    )
+    lower = out.lower()
+
+    assert 'mode="crew"' in out
+    assert 'engine="svelte"' in out
+    assert "pocketpaw-create-svelte-site" in out
+    # Same design-system + interview machinery on both engines.
+    assert "mcp__pocketpaw_design_systems__list_design_systems" in out
+    assert "phase 1" in lower
+    # The svelte build step names its create/publish fallback tools.
+    assert "mcp__pocketpaw_sites_manager__create_svelte_site" in out
+
+
+async def test_crew_flag_on_leaves_refine_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The flag only governs the CREATE branch — a refine meta (pocket_id set)
+    still returns the refine preamble, never the crew flow."""
+    _set_crew_flag(monkeypatch, True)
+    out = await sites_handler.build_preamble(
+        WORKSPACE,
+        USER,
+        SurfaceMeta(route_path="/sites/site-abc", pocket_id=REFINE_POCKET, site_id="site-abc"),
+    )
+
+    assert 'mode="refine"' in out
+    assert 'mode="crew"' not in out
+    assert "phase 1" not in out.lower()


### PR DESCRIPTION
## What ships

A flagged authoring-crew flow for the `/sites` create surface. Instead of the single agent building straight from one line, it runs two phases — the same shape as a design agent that interviews you and then hands off to a builder, realized as one agent running staged phases on the proven build pipeline.

**Phase 1 — clarity gate + interview.** The agent checks whether the request covers the design dimensions (purpose, business/audience, sections, brand/colors, voice). A detailed prompt gets a one-line restate and proceeds; a vague one ("make me a site for my cafe") gets 3–5 short questions in a single message, then waits — always with a "just build it" escape hatch, and never more than one round.

**Phase 2 — design + build.** Pick a design system from the library, theme with its tokens, override with the user's brand color if given, pull real stock photos and icons, state a one-line brief back, then build via the existing engine skill (svelte or ripple) and publish. The skill still owns page assembly and the static-site rules; the crew feeds it the chosen system, sections, copy, and assets.

Robustness is written into the preamble: a tool failure falls back to sensible defaults and never blocks the build, questions are capped at one round, and no publish is ever claimed that didn't happen.

## Behind a flag, off by default

`POCKETPAW_SITES_CREW_ENABLED` (default false). With it off, the create path returns the existing preamble byte-for-byte — refine and chat are untouched — so this cannot regress the shipped builder. Flip it on to try the crew.

## Requires #1656

The crew tells the agent to call the design-system, stock, palette, and icon tools; #1656 makes those reachable on `/sites`. Merge the chain base-first with `--rebase`.

## Scope

- `src/pocketpaw/config.py` — the `sites_crew_enabled` setting.
- `ee/pocketpaw_ee/cloud/surface/handlers/sites.py` — `_crew_create_preamble` and a fail-safe `_crew_enabled()` gate (a config-read failure falls back to the single-shot builder, never a 5xx).
- `tests/cloud/surface/test_sites_handler.py` — 9 tests: flag-off byte-for-byte identical (both engines), flag-on two-phase structure, the exact tool ids, the engine skill routing, and the escape hatch.

## Testing

`uv run pytest tests/cloud/surface/test_sites_handler.py -q` → 21 passed. `ruff` clean.

## How to try it

Set `POCKETPAW_SITES_CREW_ENABLED=1`, restart the backend, open `/sites`, and describe a site vaguely — it should ask a few questions, then build a themed page from a design system with real imagery.

## Out of scope

No multi-process orchestration and no rail changes — this is the single-agent staged flow. Separate Designer/Branding processes with isolation are a later hardening that doesn't change the experience.