### PR TITLE
Universalize the run-start credit gate across agent-run seams

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -53,6 +53,13 @@ Changes:
   model call — the no-overspend money guarantee). This is the universal cap that
   covers the worker/executor path; the chat HTTP route ALSO fast-rejects in
   ``agent_router`` so its synchronous caller gets a clean 402 with no DB trace.
+- 2026-07-08 (feat/billing-enforce-gate) — ``_reject_if_over_credit_quota`` now
+  delegates to the shared ``credits.guards.reject_if_over_billing`` so every
+  agent-run seam (this executor, the group/DM bridge, the /files agent ops, the
+  planner) blocks an over-budget tenant identically. The shared helper runs BOTH
+  credit assertions, so the worker/executor leg now ALSO rejects an empty wallet
+  (``check_balance``, 402 credits.insufficient) — previously it caught only the
+  monthly-ceiling case.
 - 2026-06-30 (feat/session-supervisor SS-5) — ``_drive_agent_loop`` now drives
   every supervised agent turn through the ``SessionSupervisor`` + the durable
   ``(workspace, session, agent) -> cli_session_id`` mapping (SS-3
@@ -1458,58 +1465,35 @@ async def _reject_if_over_jail_quota(spec: RunSpec, ctx: ScopeContext, transport
 
 
 async def _reject_if_over_credit_quota(spec: RunSpec, ctx: ScopeContext, transport: Any) -> bool:
-    """Universal monthly-CREDIT-QUOTA gate, enforced at RUN-START (chunk 3).
+    """Universal run-start BILLING gate on the worker/executor path.
 
-    The credit-spend sibling of ``_reject_if_over_jail_quota`` (ART-3): measure
-    the workspace's month-to-date spend against its effective monthly ceiling
-    ONCE here — before any model/agent work — and reject the run CLEANLY when it
-    has hit the cap, the SAME way the jail-quota reject does (a terminal ``error``
-    stream frame + a ``mark_terminal(failed)`` doc, then an early return — never
-    a model call). This is the universal gate: it covers EVERY run-start path
-    (the synchronous chat HTTP route also fast-rejects in ``agent_router`` so its
-    caller gets a clean 402 with no DB trace, but the worker/executor path only
-    passes through HERE, so this is the one that guarantees a queued/resumed run
-    can't spend past the ceiling).
+    The credit-spend sibling of ``_reject_if_over_jail_quota`` (ART-3): before any
+    model/agent work, reject the run CLEANLY when the workspace is over budget,
+    the SAME way the jail-quota reject does (a terminal ``error`` stream frame + a
+    ``mark_terminal(failed)`` doc, then an early return — never a model call).
+    This is the worker/executor leg of the universal gate: the synchronous chat
+    HTTP route fast-rejects in ``agent_router`` (a clean 402 with no DB trace),
+    but a queued/resumed run only passes through HERE.
 
-    Flag-gated: a no-op unless ``get_settings().billing_enforced`` is on (OSS /
-    self-host run no ledger). ``credits.service.check_quota`` is the pure,
-    flag-free assertion — it raises ``QuotaExceeded`` (402 ``credits.quota_exceeded``)
-    when month-to-date spend ``>=`` the effective ceiling, and is itself a no-op
-    for an uncapped (Enterprise) plan. We catch that exception here and translate
-    it into the clean terminal rejection. Returns ``True`` when the run was
-    rejected (the caller returns early), ``False`` to proceed. The credits package
-    is imported locally to keep it off this hot module's import graph (mirrors
-    the BC-4 chat-router gate).
+    Delegates to the shared ``credits.guards.reject_if_over_billing`` so every
+    agent-run seam blocks identically. That helper is flag-gated (a no-op unless
+    ``billing_enforced``) and runs BOTH credit assertions: ``check_balance``
+    (wallet <= 0 -> 402 credits.insufficient) AND ``check_quota`` (month-to-date
+    spend >= the effective monthly ceiling -> 402 credits.quota_exceeded, itself a
+    no-op for an uncapped Enterprise plan). Before this delegation the worker leg
+    caught only the quota case; it now rejects an empty wallet too. Returns
+    ``True`` when the run was rejected (the caller returns early), ``False`` to
+    proceed. ``ctx.workspace_id`` is validated non-empty upstream (the
+    ``scope.no_workspace`` guard).
     """
-    if not get_settings().billing_enforced:
-        return False
+    from pocketpaw_ee.cloud.credits import guards
 
-    from pocketpaw_ee.cloud._core.errors import QuotaExceeded
-    from pocketpaw_ee.cloud.credits import service as credits_service
-
-    try:
-        await credits_service.check_quota(ctx.workspace_id)
-        return False
-    except QuotaExceeded as exc:
-        quota_error = str(exc)
-        logger.warning(
-            "run %s rejected — monthly credit quota exceeded: %s", spec.run_id, quota_error
-        )
-        try:
-            await transport.append_event(
-                spec.run_id, "error", {"code": exc.code, "message": quota_error}
-            )
-        except Exception:
-            logger.debug("quota error frame append failed for %s", spec.run_id, exc_info=True)
-        try:
-            await run_service.mark_terminal(spec.run_id, status="failed", error=quota_error)
-        except Exception:
-            logger.exception("mark_terminal(failed) failed for over-quota run %s", spec.run_id)
-        try:
-            await transport.set_ttl(spec.run_id, _stream_ttl())
-        except Exception:
-            logger.debug("quota stream ttl set failed for %s", spec.run_id, exc_info=True)
-        return True
+    return await guards.reject_if_over_billing(
+        ctx.workspace_id,
+        run_id=spec.run_id,
+        transport=transport,
+        log_label=spec.run_id,
+    )
 
 
 async def execute_run(spec: RunSpec) -> None:

--- a/ee/pocketpaw_ee/cloud/credits/guards.py
+++ b/ee/pocketpaw_ee/cloud/credits/guards.py
@@ -1,0 +1,164 @@
+# ee/pocketpaw_ee/cloud/credits/guards.py — the shared, flag-gated run-start
+# BILLING gate, factored out of run_core so every agent-run entry seam blocks an
+# over-budget tenant the SAME way, with NO model call when rejected ("no model
+# call = no overspend").
+#
+# Three helpers, one core check, so each caller emits the terminal/error response
+# native to ITS transport (the callers are NOT identical):
+#
+#   * ``over_billing_limit(workspace)`` — the pure, reusable core. Flag-gated
+#     (a no-op returning None unless ``get_settings().billing_enforced``). Runs
+#     the SAME two assertions the chat chokepoint (chat/agent_router) runs, in the
+#     SAME order: ``check_balance`` (wallet <= 0 -> InsufficientCredits, 402
+#     credits.insufficient) FIRST, then ``check_quota`` (month-to-date spend >=
+#     the effective monthly ceiling -> QuotaExceeded, 402 credits.quota_exceeded).
+#     Returns the raised CloudError to REJECT, or None to PROCEED. It does NOT
+#     emit / raise itself — the caller decides how to respond. An uncapped
+#     (Enterprise, ceiling=None) plan is a no-op in ``check_quota`` by
+#     construction; an unknown plan fails CLOSED to the Free ceiling (the
+#     entitlements resolver). An empty workspace returns None (no wallet to
+#     attribute — the run-transport callers validate a non-empty workspace
+#     upstream; the event-bus callers can't gate a run they can't attribute).
+#
+#   * ``assert_within_billing(workspace)`` — for HTTP routes: RAISE the CloudError
+#     (402) so ``_core.http`` maps it to the wire. Place it BEFORE any local
+#     ``try/except Exception`` in the handler so the 402 isn't swallowed into a
+#     500.
+#
+#   * ``reject_if_over_billing(workspace, *, run_id, transport, log_label)`` — for
+#     the run/stream transport (run_core.execute_run): on rejection emit a clean
+#     terminal ``error`` stream frame, ``mark_terminal(failed)`` the run doc, and
+#     set the stream TTL, then return True so the caller early-returns BEFORE any
+#     model/agent work. Returns False to proceed. Each side effect is best-effort
+#     (a transient Redis/Mongo blip can't turn a clean reject into a crash),
+#     mirroring the jail-quota reject.
+#
+# The credits package is imported LOCALLY inside the core so this module stays off
+# the hot import graph; ``run_service`` is imported locally in the run-transport
+# helper to keep the credits layer from importing chat at module load.
+#
+# Created 2026-07-08 (feat/billing-enforce-gate): universalize the run-start
+# credit gate across every agent-run seam (chat was already gated; this adds the
+# group/DM auto-response bridge, the /files Library agent ops, and the planner
+# task executor). run_core's ``_reject_if_over_credit_quota`` now delegates here
+# and thereby ALSO gains the ``check_balance`` (wallet <= 0) leg it lacked — the
+# worker/executor path now rejects at an empty wallet, not only at the monthly
+# ceiling.
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from pocketpaw.config import get_settings  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.cloud._core.errors import CloudError
+
+logger = logging.getLogger(__name__)
+
+
+def _stream_ttl() -> int:
+    """Stream-doc TTL in seconds — mirrors ``run_core._stream_ttl`` so a rejected
+    run's error frame expires on the same schedule as a normal run's."""
+    return int(os.environ.get("POCKETPAW_CLOUD_RUN_STREAM_TTL", "3600"))
+
+
+async def over_billing_limit(workspace_id: str) -> CloudError | None:
+    """Return the billing rejection for ``workspace_id``, or None to proceed.
+
+    The pure, transport-agnostic core of the run-start billing gate. A no-op
+    (returns None) unless ``get_settings().billing_enforced`` is on — OSS /
+    self-host deployments run no credit ledger. When enforced, it runs the two
+    credit assertions in the SAME order as the chat chokepoint: ``check_balance``
+    (empty wallet) first, then ``check_quota`` (monthly ceiling). The FIRST that
+    trips is returned (an ``InsufficientCredits`` or ``QuotaExceeded``, both 402
+    CloudErrors); if both pass it returns None.
+
+    An uncapped plan (Enterprise, ``monthly_ceiling`` is None) never trips the
+    quota leg (``check_quota`` no-ops there). An empty ``workspace_id`` returns
+    None: there is no wallet to attribute, and the run-transport callers already
+    validate a non-empty workspace upstream. Only the two credit CloudErrors are
+    caught here — any other exception (a real infra failure) propagates, exactly
+    as the pre-existing run_core gate let it.
+    """
+    if not get_settings().billing_enforced:
+        return None
+    if not workspace_id:
+        return None
+
+    from pocketpaw_ee.cloud._core.errors import InsufficientCredits, QuotaExceeded
+    from pocketpaw_ee.cloud.credits import service as credits_service
+
+    try:
+        # Order mirrors chat/agent_router: the empty-wallet block is the primary
+        # money guarantee; the monthly-ceiling block sits beside it.
+        await credits_service.check_balance(workspace_id)
+        await credits_service.check_quota(workspace_id)
+    except (InsufficientCredits, QuotaExceeded) as exc:
+        return exc
+    return None
+
+
+async def assert_within_billing(workspace_id: str) -> None:
+    """Raise the billing rejection (402 CloudError) when over budget; else no-op.
+
+    For HTTP routes: the raised ``InsufficientCredits`` / ``QuotaExceeded`` is a
+    CloudError that ``_core.http`` maps to a 402 wire response. Call it BEFORE any
+    local ``try/except Exception`` in the handler so the 402 isn't swallowed into
+    a generic 500. Flag-gated and Enterprise-safe via ``over_billing_limit``.
+    """
+    exc = await over_billing_limit(workspace_id)
+    if exc is not None:
+        raise exc
+
+
+async def reject_if_over_billing(
+    workspace_id: str,
+    *,
+    run_id: str,
+    transport: Any,
+    log_label: str | None = None,
+) -> bool:
+    """Reject an over-budget run on the run/stream transport. Returns True if it did.
+
+    The run-transport variant (run_core.execute_run): when ``over_billing_limit``
+    trips, emit a terminal ``error`` stream frame, ``mark_terminal(failed)`` the
+    run doc, and set the stream TTL — the SAME clean shape the ART-3 jail-quota
+    reject uses — then return True so the caller early-returns BEFORE any model /
+    agent work (the no-overspend money guarantee). Returns False to proceed.
+
+    Every side effect is best-effort: a transient Redis / Mongo failure while
+    writing the rejection must not turn a clean 402-equivalent block into an
+    unhandled crash that takes the worker down.
+    """
+    exc = await over_billing_limit(workspace_id)
+    if exc is None:
+        return False
+
+    label = log_label or run_id
+    message = str(exc)
+    logger.warning("run %s rejected — billing gate: %s (%s)", label, message, exc.code)
+    try:
+        await transport.append_event(run_id, "error", {"code": exc.code, "message": message})
+    except Exception:
+        logger.debug("billing error frame append failed for %s", run_id, exc_info=True)
+    try:
+        from pocketpaw_ee.cloud.chat.runs import service as run_service
+
+        await run_service.mark_terminal(run_id, status="failed", error=message)
+    except Exception:
+        logger.exception("mark_terminal(failed) failed for over-billing run %s", run_id)
+    try:
+        await transport.set_ttl(run_id, _stream_ttl())
+    except Exception:
+        logger.debug("billing stream ttl set failed for %s", run_id, exc_info=True)
+    return True
+
+
+__all__ = [
+    "assert_within_billing",
+    "over_billing_limit",
+    "reject_if_over_billing",
+]

--- a/ee/pocketpaw_ee/cloud/file_versions/router.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/router.py
@@ -33,6 +33,12 @@
 #   ``current_workspace_id`` deps (dewani's #1193 signature) rather than the
 #   ``request_context`` the core write routes use — they run the agent, which
 #   needs the identity, not a RequestContext.
+# Updated: 2026-07-08 (feat/billing-enforce-gate) — the three *-edit routes
+#   (ai-edit / spreadsheet-edit / slides-edit) now run the shared run-start
+#   BILLING gate (``credits.guards.assert_within_billing``) as their FIRST
+#   statement, before the local try/except and before ``pool.run``. An over-budget
+#   tenant (empty wallet or over monthly ceiling) gets a clean 402 with no model
+#   call; flag-gated no-op unless ``billing_enforced``.
 """FileVersions router — file-version write + history API."""
 
 from __future__ import annotations
@@ -229,6 +235,14 @@ async def ai_edit_file(
     ``edit_document`` MCP tool can access them, and runs the workspace's default
     agent. Returns the final blocks array to the frontend.
     """
+    # Run-start BILLING gate — raise BEFORE the try/except below so an over-budget
+    # tenant gets a clean 402 (mapped by _core.http) instead of the generic 500
+    # this handler's ``except Exception`` would otherwise return, and BEFORE any
+    # model call via ``pool.run``. Flag-gated no-op unless ``billing_enforced``.
+    from pocketpaw_ee.cloud.credits.guards import assert_within_billing
+
+    await assert_within_billing(workspace_id)
+
     try:
         doc = json.loads(body.content) if body.content and body.content.strip() else {}
         blocks: list[dict] = doc.get("blocks", []) if isinstance(doc, dict) else []
@@ -368,6 +382,12 @@ async def spreadsheet_ai_edit(
     workspace_id: str = Depends(current_workspace_id),
 ) -> JSONResponse:
     """Run an AI agent to edit spreadsheet content. Returns the final snapshot."""
+    # Run-start BILLING gate — raise BEFORE the try/except (clean 402, not a 500)
+    # and BEFORE any model call. Flag-gated no-op unless ``billing_enforced``.
+    from pocketpaw_ee.cloud.credits.guards import assert_within_billing
+
+    await assert_within_billing(workspace_id)
+
     try:
         snapshot = json.loads(body.content) if body.content and body.content.strip() else {}
         if not isinstance(snapshot, dict):
@@ -514,6 +534,12 @@ async def slides_ai_edit(
     workspace_id: str = Depends(current_workspace_id),
 ) -> JSONResponse:
     """Run an AI agent to edit slides content. Returns the final deck."""
+    # Run-start BILLING gate — raise BEFORE the try/except (clean 402, not a 500)
+    # and BEFORE any model call. Flag-gated no-op unless ``billing_enforced``.
+    from pocketpaw_ee.cloud.credits.guards import assert_within_billing
+
+    await assert_within_billing(workspace_id)
+
     deck: dict = body.content if isinstance(body.content, dict) else {}
     deck = json.loads(json.dumps(deck))
 

--- a/ee/pocketpaw_ee/cloud/planner/service.py
+++ b/ee/pocketpaw_ee/cloud/planner/service.py
@@ -53,6 +53,12 @@
 #   the dependent-dispatch cascade still fires. A requeued or escalated
 #   attempt never saves its output file, uploads artifacts, or
 #   auto-completes.
+# Updated: 2026-07-08 (feat/billing-enforce-gate) — ``_execute_ready_plan_tasks``
+#   now runs the shared run-start BILLING gate
+#   (``credits.guards.over_billing_limit``) after it finds ready tasks and BEFORE
+#   the claim + ``pool.run`` batch, so an over-budget tenant makes NO model call
+#   on the planner path. Tasks stay ``proposed`` and execute on a later tick once
+#   budget frees. Flag-gated no-op unless ``billing_enforced``.
 """Planner entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -1243,6 +1249,27 @@ async def _execute_ready_plan_tasks(
         )
         return
     logger.info("_execute_ready_plan_tasks: %d ready task(s)", len(ready))
+
+    # Run-start BILLING gate — the planner is a background (non-HTTP) executor, so
+    # reject BEFORE claiming/running any task rather than starting work an
+    # over-budget tenant can't pay for. Gating here (after we know there is work,
+    # before the claim + ``pool.run`` batch) means NO model call fires while over
+    # budget; the tasks stay ``proposed`` and execute on a later tick once budget
+    # frees. Flag-gated no-op unless ``billing_enforced``; there is no user-facing
+    # stream on this path, so a warning log is the terminal signal.
+    from pocketpaw_ee.cloud.credits.guards import over_billing_limit
+
+    billing_reject = await over_billing_limit(workspace_id)
+    if billing_reject is not None:
+        logger.warning(
+            "_execute_ready_plan_tasks: workspace %s over billing limit (%s) — "
+            "skipping execution of %d ready task(s) for project %s",
+            workspace_id,
+            billing_reject.code,
+            len(ready),
+            project_id,
+        )
+        return
 
     from types import SimpleNamespace
 

--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -30,6 +30,13 @@ Updated 2026-06-28 (feat/aiam-agent-revoke, AW-4): ``_run_agent_response``
 catches ``AgentDisabled`` from ``pool.get`` explicitly and SKIPS the agent
 (returns None, no error to the channel) — a soft-disabled agent simply stops
 responding in groups/DMs until re-enabled.
+
+Updated 2026-07-08 (feat/billing-enforce-gate): ``_dispatch_agent_responses``
+now runs the shared run-start billing gate (``credits.guards.over_billing_limit``)
+ABOVE the respond-mode evaluation — before ``_smart_relevance_check``'s Haiku
+pre-classifier call and before ``pool.run`` — so an over-budget tenant triggers
+NO model call on the group/DM auto-response path. On rejection it emits one
+``agent.error`` to the group and returns.
 """
 
 from __future__ import annotations
@@ -43,6 +50,7 @@ from typing import Any
 
 from pocketpaw_ee.cloud.realtime.emit import emit
 from pocketpaw_ee.cloud.realtime.events import (
+    AgentError,
     AgentStreamChunk,
     AgentStreamEnd,
     AgentStreamStart,
@@ -116,6 +124,40 @@ async def _dispatch_agent_responses(data: dict) -> None:
         len(group.agents),
         [(a.agent_id, a.respond_mode) for a in group.agents],
     )
+
+    # Run-start BILLING gate — placed ABOVE the respond-mode evaluation so an
+    # over-budget tenant makes NO model call at all. Critically this sits before
+    # ``_should_agent_respond`` -> ``_smart_relevance_check``: that pre-classifier
+    # is itself a (cheap Haiku) model call, so gating only before ``pool.run``
+    # would still let an over-budget workspace spend on the relevance check. The
+    # shared guard is flag-gated (a no-op unless ``billing_enforced``) and runs
+    # both the empty-wallet and monthly-ceiling assertions; on rejection we emit a
+    # single terminal ``agent.error`` to the group (best-effort — no run_id /
+    # stream transport on this event-bus path) and return without dispatching any
+    # agent. An empty ``workspace_id`` is a no-op (no wallet to attribute).
+    from pocketpaw_ee.cloud.credits.guards import over_billing_limit
+
+    billing_reject = await over_billing_limit(workspace_id)
+    if billing_reject is not None:
+        logger.warning(
+            "Agent bridge: workspace %s over billing limit (%s) — skipping all agents in group %s",
+            workspace_id,
+            billing_reject.code,
+            group_id,
+        )
+        try:
+            await emit(
+                AgentError(
+                    data={
+                        "group_id": group_id,
+                        "code": billing_reject.code,
+                        "message": str(billing_reject),
+                    },
+                )
+            )
+        except Exception:
+            logger.debug("billing agent.error emit failed for group %s", group_id, exc_info=True)
+        return
 
     agents_to_run: list[str] = []
     for group_agent in group.agents:

--- a/tests/cloud/credits/test_guards.py
+++ b/tests/cloud/credits/test_guards.py
@@ -1,0 +1,242 @@
+# tests/cloud/credits/test_guards.py
+# Created 2026-07-08 (feat/billing-enforce-gate) — locks the shared run-start
+# BILLING gate (``credits.guards``) that every agent-run seam now funnels through.
+# These are GUARD-level tests: the seam under test is the guard, so they drive the
+# REAL ``check_balance`` / ``check_quota`` off real wallet + plan state (funded via
+# ``credits.grant``, spend back-dated into the ledger, plan set by inserting a real
+# ``Workspace``) rather than stubbing the credit assertions — over-mocking has hid
+# live billing bugs here before. The credit-math contract itself lives in
+# test_quota.py / test_enforcement.py; this locks the GUARD wiring:
+#   * ``over_billing_limit`` — flag OFF is a no-op (None) even at balance 0; flag
+#     ON returns InsufficientCredits at an empty wallet (the primary money leg,
+#     checked FIRST), QuotaExceeded when funded-but-over-the-monthly-ceiling, and
+#     None when funded + under the ceiling. An uncapped Enterprise plan
+#     (ceiling=None) is NEVER blocked by the quota leg. An empty workspace id is a
+#     no-op (no wallet to attribute).
+#   * ``assert_within_billing`` — raises the 402 CloudError over-limit (the HTTP
+#     shape), no-ops within limits.
+#   * ``reject_if_over_billing`` — the run-transport shape: on rejection emits a
+#     terminal ``error`` frame, marks the run failed, sets the stream TTL, returns
+#     True; flag OFF returns False with no side effects.
+# The flag is applied ON in the settings equivalent (``guards.get_settings`` stub
+# with ``billing_enforced=True``) — the flag-mode lane.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import InsufficientCredits, QuotaExceeded
+from pocketpaw_ee.cloud.credits import guards
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+from pocketpaw_ee.cloud.models.workspace import Workspace
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers (seeding style mirrors test_quota.py)
+# ---------------------------------------------------------------------------
+
+
+def _enforce(monkeypatch, *, on: bool) -> None:
+    """Point the guard's ``get_settings`` at a stub carrying the flag posture."""
+    monkeypatch.setattr(guards, "get_settings", lambda: SimpleNamespace(billing_enforced=on))
+
+
+async def _make_workspace(plan: str, *, slug: str) -> str:
+    """Insert a real Workspace so ``resolve_entitlements`` reads its plan."""
+    ws = Workspace(name="Tenant", slug=slug, owner="u-owner", plan=plan)
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _seed_spend(ws: str, amount: int, *, idem: str) -> None:
+    """Back-date an APPLIED compute_spend debit into the current month WITHOUT
+    moving the CreditBalance (raw insert) so a funded wallet can still be 'over
+    quota' — isolating the quota leg from the balance leg."""
+    n = datetime.now(UTC)
+    when = datetime(n.year, n.month, 15, 12, tzinfo=UTC)
+    entry = CreditLedgerEntry(
+        workspace=ws,
+        kind="spend",
+        amount_delta=-amount,
+        balance_after=0,
+        applied=True,
+        conditional=False,
+        cause="compute_spend",
+        ref={},
+        idempotency_key=idem,
+    )
+    await entry.insert()
+    await CreditLedgerEntry.get_pymongo_collection().update_one(
+        {"_id": entry.id}, {"$set": {"createdAt": when}}
+    )
+
+
+# ---------------------------------------------------------------------------
+# over_billing_limit
+# ---------------------------------------------------------------------------
+
+
+async def test_flag_off_is_noop_even_at_zero_balance(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=False)
+    # No wallet -> balance 0, but the flag is OFF: never gates.
+    assert await guards.over_billing_limit("ws-empty") is None
+
+
+async def test_enforced_empty_wallet_returns_insufficient(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    # No wallet -> balance 0 -> the balance leg (checked first) rejects.
+    exc = await guards.over_billing_limit("ws-empty")
+    assert isinstance(exc, InsufficientCredits)
+    assert exc.status_code == 402
+    assert exc.code == "credits.insufficient"
+
+
+async def test_enforced_funded_over_quota_returns_quota_exceeded(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    ws = await _make_workspace("free", slug="g-over")
+    # Fund the wallet so the balance leg passes, then spend up to the Free ceiling
+    # (1000) so the quota leg trips. The spend is raw-seeded so it does NOT reduce
+    # the funded balance — the wallet is genuinely funded AND over the monthly cap.
+    await credits.grant(ws, 5000, cause="test.seed", idempotency_key="fund-1")
+    await _seed_spend(ws, 1000, idem="spend-1")
+
+    exc = await guards.over_billing_limit(ws)
+    assert isinstance(exc, QuotaExceeded)
+    assert exc.status_code == 402
+    assert exc.code == "credits.quota_exceeded"
+
+
+async def test_enforced_funded_under_quota_returns_none(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    ws = await _make_workspace("free", slug="g-under")
+    await credits.grant(ws, 5000, cause="test.seed", idempotency_key="fund-2")
+    await _seed_spend(ws, 999, idem="spend-2")  # under the 1000 Free ceiling
+
+    assert await guards.over_billing_limit(ws) is None
+
+
+async def test_enforced_enterprise_uncapped_never_blocked(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    # Enterprise -> ceiling None. Funded wallet + huge spend must NOT block: the
+    # quota leg is a no-op on an uncapped plan (the guardrail).
+    ws = await _make_workspace("enterprise", slug="g-ent")
+    await credits.grant(ws, 5000, cause="test.seed", idempotency_key="fund-3")
+    await _seed_spend(ws, 1_000_000, idem="spend-3")
+
+    assert await guards.over_billing_limit(ws) is None
+
+
+async def test_enforced_empty_workspace_id_is_noop(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    # No workspace to attribute -> proceed (no wallet, no gate).
+    assert await guards.over_billing_limit("") is None
+
+
+# ---------------------------------------------------------------------------
+# assert_within_billing (the HTTP shape)
+# ---------------------------------------------------------------------------
+
+
+async def test_assert_raises_over_limit(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    with pytest.raises(InsufficientCredits) as exc:
+        await guards.assert_within_billing("ws-empty")
+    assert exc.value.status_code == 402
+
+
+async def test_assert_noop_within_limit(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    ws = await _make_workspace("free", slug="g-assert-ok")
+    await credits.grant(ws, 5000, cause="test.seed", idempotency_key="fund-4")
+    assert await guards.assert_within_billing(ws) is None
+
+
+async def test_assert_flag_off_never_raises(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=False)
+    # Empty wallet but flag OFF -> no raise.
+    assert await guards.assert_within_billing("ws-empty") is None
+
+
+# ---------------------------------------------------------------------------
+# reject_if_over_billing (the run/stream-transport shape)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTransport:
+    """Records the run-transport side effects the guard drives on a rejection."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict]] = []
+        self.ttls: list[tuple[str, int]] = []
+
+    async def append_event(self, run_id: str, event: str, data: dict) -> None:
+        self.events.append((run_id, event, data))
+
+    async def set_ttl(self, run_id: str, ttl: int) -> None:
+        self.ttls.append((run_id, ttl))
+
+
+async def test_reject_over_limit_emits_terminal_and_marks_failed(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    transport = _FakeTransport()
+
+    marked: list[dict] = []
+
+    async def _mark_terminal(run_id, *, status, error=None, **k):
+        marked.append({"run_id": run_id, "status": status, "error": error})
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.mark_terminal", _mark_terminal)
+
+    # Empty wallet -> the balance leg rejects.
+    rejected = await guards.reject_if_over_billing("ws-empty", run_id="run-1", transport=transport)
+
+    assert rejected is True
+    # A terminal ``error`` frame carrying the balance code went to the transport.
+    assert transport.events == [
+        ("run-1", "error", transport.events[0][2]),
+    ]
+    assert transport.events[0][2]["code"] == "credits.insufficient"
+    # The run was marked terminally failed, and the stream TTL was set.
+    assert marked == [
+        {"run_id": "run-1", "status": "failed", "error": transport.events[0][2]["message"]}
+    ]
+    assert transport.ttls and transport.ttls[0][0] == "run-1"
+
+
+async def test_reject_within_limit_returns_false_no_side_effects(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    ws = await _make_workspace("free", slug="g-reject-ok")
+    await credits.grant(ws, 5000, cause="test.seed", idempotency_key="fund-5")
+    transport = _FakeTransport()
+
+    async def _mark_terminal(run_id, *, status, error=None, **k):
+        raise AssertionError("mark_terminal must not run when within budget")
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.mark_terminal", _mark_terminal)
+
+    rejected = await guards.reject_if_over_billing(ws, run_id="run-2", transport=transport)
+
+    assert rejected is False
+    assert transport.events == []
+    assert transport.ttls == []
+
+
+async def test_reject_flag_off_returns_false(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=False)
+    transport = _FakeTransport()
+
+    async def _mark_terminal(run_id, *, status, error=None, **k):
+        raise AssertionError("mark_terminal must not run when the flag is OFF")
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.mark_terminal", _mark_terminal)
+
+    # Empty wallet but flag OFF -> no rejection, no side effects.
+    rejected = await guards.reject_if_over_billing("ws-empty", run_id="run-3", transport=transport)
+    assert rejected is False
+    assert transport.events == []
+    assert transport.ttls == []

--- a/tests/cloud/runs/test_run_core_credit_quota.py
+++ b/tests/cloud/runs/test_run_core_credit_quota.py
@@ -15,6 +15,17 @@
 # crash). ``check_quota`` is stubbed at the run_core seam (it is called via the
 # locally-imported ``credits_service`` module, patched on that module) so these
 # tests assert the WIRING, not the chunk-2 quota math (test_quota.py owns that).
+#
+# Changed 2026-07-08 (feat/billing-enforce-gate): run_core's
+# ``_reject_if_over_credit_quota`` now delegates to the shared
+# ``credits.guards.reject_if_over_billing``, so the worker/executor leg gained the
+# BALANCE assertion (``check_balance``, wallet <= 0) it lacked — it ran only
+# ``check_quota`` before. Two harness updates follow: (1) the ``billing_enforced``
+# flag is now read inside the guards module, so the flag stub is applied to
+# ``credits.guards.get_settings`` (not run_core's); (2) ``check_balance`` runs
+# BEFORE ``check_quota`` in the shared gate, so it is stubbed to a no-op by default
+# in ``_wire_common`` and the quota cases stay isolated. A new case locks the new
+# leg: enforced + empty wallet -> the same clean reject with no model call.
 
 from __future__ import annotations
 
@@ -101,12 +112,24 @@ def _wire_common(monkeypatch, transport, *, enforced: bool) -> dict[str, bool]:
         return False
 
     monkeypatch.setattr(run_core, "_reject_if_over_jail_quota", _no_jail_reject)
-    # Point the executor's flag at a stub carrying the desired posture.
+    # Point the flag at a stub carrying the desired posture. The billing flag is
+    # now read inside the shared guard, so patch THAT module's get_settings
+    # (run_core's is also patched for any of its own reads under the same stub).
     from types import SimpleNamespace
 
-    monkeypatch.setattr(
-        run_core, "get_settings", lambda: SimpleNamespace(billing_enforced=enforced)
-    )
+    from pocketpaw_ee.cloud.credits import guards
+
+    stub_settings = SimpleNamespace(billing_enforced=enforced)
+    monkeypatch.setattr(guards, "get_settings", lambda: stub_settings)
+    monkeypatch.setattr(run_core, "get_settings", lambda: stub_settings)
+
+    # The shared gate now runs check_balance BEFORE check_quota. Default it to a
+    # no-op so the quota-focused cases below stay isolated (the balance-reject
+    # case overrides it). Patched on the service module the guard imports.
+    async def _balance_ok(workspace_id):
+        return None
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.credits.service.check_balance", _balance_ok)
     return called
 
 
@@ -145,6 +168,53 @@ async def test_enforced_over_quota_rejects_and_does_not_call_model(monkeypatch):
     assert [e.event for e in events] == ["error"]
     assert events[0].data["code"] == "credits.quota_exceeded"
     # The run was marked terminally failed (and ONLY that — no completed mark).
+    assert mark_calls == [{"run_id": "r1", "status": "failed", "error": events[0].data["message"]}]
+
+
+# ---------------------------------------------------------------------------
+# 1b — enforced + EMPTY WALLET (balance <= 0) -> run rejected, model NOT called.
+#      Locks the new balance leg the worker/executor path gained by delegating to
+#      the shared guard (it previously caught only the quota case).
+# ---------------------------------------------------------------------------
+
+
+async def test_enforced_empty_wallet_rejects_and_does_not_call_model(monkeypatch):
+    from pocketpaw_ee.cloud._core.errors import InsufficientCredits
+
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+    called = _wire_common(monkeypatch, transport, enforced=True)
+
+    # check_balance raises FIRST (wallet <= 0) -> the gate rejects before quota.
+    async def _empty_wallet(workspace_id):
+        raise InsufficientCredits(1, 0)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.credits.service.check_balance", _empty_wallet)
+
+    # check_quota must never be reached — balance is the primary guard.
+    async def _quota_unreached(workspace_id):
+        raise AssertionError("check_quota must not run once check_balance rejects")
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.credits.service.check_quota", _quota_unreached)
+
+    mark_calls: list[dict[str, Any]] = []
+
+    async def _track_terminal(run_id, *, status, error=None, **k):
+        mark_calls.append({"run_id": run_id, "status": status, "error": error})
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.run_core.run_service.mark_terminal", _track_terminal
+    )
+
+    await run_core.execute_run(_spec())
+
+    # THE MONEY GUARANTEE: the agent loop (model) never ran.
+    assert called["agent_loop"] is False, "model must NOT be invoked on an empty-wallet block"
+
+    # A terminal ``error`` frame went to the stream with the balance code.
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    assert [e.event for e in events] == ["error"]
+    assert events[0].data["code"] == "credits.insufficient"
     assert mark_calls == [{"run_id": "r1", "status": "failed", "error": events[0].data["message"]}]
 
 

--- a/tests/cloud/shared/test_agent_bridge_billing.py
+++ b/tests/cloud/shared/test_agent_bridge_billing.py
@@ -1,0 +1,104 @@
+# tests/cloud/shared/test_agent_bridge_billing.py — proves the run-start billing
+# gate in agent_bridge._dispatch_agent_responses rejects an over-budget workspace
+# ABOVE the _smart_relevance_check Haiku pre-classifier (reached via
+# _should_agent_respond) AND above _run_agent_response/pool.run, so NO model call
+# fires on the group/DM auto-response path. This is the regression guard for the
+# money-leak correction: gating only before pool.run would still let an over-budget
+# tenant spend on the relevance pre-classifier.
+#
+# Created 2026-07-08 (feat/billing-enforce-gate).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_over_budget_before_any_model_call() -> None:
+    """Over-budget workspace: neither the Haiku pre-classifier
+    (_should_agent_respond) nor the agent run (_run_agent_response) is reached,
+    and exactly one terminal AgentError is emitted to the group."""
+    from pocketpaw_ee.cloud._core.errors import InsufficientCredits
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    group = SimpleNamespace(
+        members=["user-1"],
+        agents=[SimpleNamespace(agent_id="agent-a", respond_mode="smart")],
+    )
+    should_mock = AsyncMock(return_value=True)
+    run_mock = AsyncMock(return_value=None)
+    emit_mock = AsyncMock()
+
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=group),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.credits.guards.over_billing_limit",
+            new=AsyncMock(return_value=InsufficientCredits(requested=1, available=0)),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond", new=should_mock),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response", new=run_mock),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=emit_mock),
+    ):
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "group-over",
+                "sender_id": "user-1",
+                "content": "hello",
+                "mentions": [],
+                "workspace_id": "ws-over",
+            }
+        )
+
+    # The pre-classifier and the agent run must NOT be reached — no model call.
+    should_mock.assert_not_awaited()
+    run_mock.assert_not_awaited()
+    # Exactly one terminal AgentError emitted to the group.
+    assert emit_mock.await_count == 1
+    emitted = emit_mock.await_args_list[0].args[0]
+    assert emitted.data["code"] == "credits.insufficient"
+    assert emitted.data["group_id"] == "group-over"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_proceeds_when_within_budget() -> None:
+    """Within budget (guard returns None): normal dispatch proceeds and the agent
+    is run — the gate is a no-op when the workspace is funded."""
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    group = SimpleNamespace(
+        members=["user-1"],
+        agents=[SimpleNamespace(agent_id="agent-a", respond_mode="auto")],
+    )
+    run_mock = AsyncMock(return_value="ok")
+
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=group),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.credits.guards.over_billing_limit",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond",
+            new=AsyncMock(return_value=True),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response", new=run_mock),
+    ):
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "group-ok",
+                "sender_id": "user-1",
+                "content": "hello",
+                "mentions": [],
+                "workspace_id": "ws-ok",
+            }
+        )
+
+    run_mock.assert_awaited()


### PR DESCRIPTION
Part 1 of 3 in the billing-enforcement stack (the first-strike from the thesis-gap backlog). Criterion 1: make the run-start billing gate fire on every path that reaches an agent run, not just the sync chat route.

## What changed
- New shared guard `ee/pocketpaw_ee/cloud/credits/guards.py` factors the run-start check out of `run_core`, so every seam blocks an over-budget tenant the same way with no model call when rejected. Three entry points, one per transport: `over_billing_limit` (pure core), `assert_within_billing` (HTTP routes, raises 402), `reject_if_over_billing` (run/stream transport, terminal error frame).
- Wired into the three ungated `AgentPool.run` callers:
  - `agent_bridge` (Slack/WhatsApp/group/DM auto-response) — the gate sits **above** the `_smart_relevance_check` Haiku pre-classifier, so an over-budget workspace spends nothing, not even on the relevance check.
  - `file_versions` (ai-edit / spreadsheet-edit / slides-edit) — raises before the handler's try/except, so it returns a clean 402 instead of a swallowed 500.
  - `planner` — rejects after finding ready tasks, before the claim + run batch; tasks stay `proposed` and run on a later tick once budget frees.
- The worker/executor path (`_reject_if_over_credit_quota`) now delegates to the shared guard and gains the wallet-<=0 check it was missing (before, it only caught the monthly ceiling).

## Flag stays default-off
`billing_enforced` keeps its `default=False`. Enforcement turns on per deployment via `POCKETPAW_BILLING_ENFORCED=true`, which stays the instant kill-switch. OSS/self-host tenants run no ledger and are unaffected. Enterprise plans (uncapped) are a no-op; unknown plans fail closed to Free.

## Tests
- `test_guards.py` covers the shared guard across flag on/off, empty wallet, over-quota, enterprise no-op, and the best-effort side effects.
- `test_agent_bridge_billing.py` proves an over-budget workspace on the group/DM path reaches neither the pre-classifier nor the agent run, and emits one terminal error.
- `test_run_core_credit_quota.py` extended for the new wallet-<=0 worker rejection.
- Both import-linter configs pass, including the OSS->EE boundary the guard relies on. 35 tests green.

Fast-follow: HTTP-route (file_versions) and planner caller-level integration tests. The guard core and the group/DM path are covered here; those two are one-line wirings over the same tested guard.

Stacked: cancel/downgrade (part 2) and SMB caps (part 3) branch off this. Please review, but hold the merge, this is the base of a stack.