### PR TITLE
Add subscription cancel and stop downgrade double-subscribing

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -17,6 +17,13 @@ rather than a balance refill; it carries the effective `ceiling` and the
 FL-2 (file-version spine, port of dewani12's #1193) added
 ``PreconditionFailed`` (412) for stale ``If-Match`` optimistic-concurrency
 failures on the file-version write path.
+
+Changed 2026-07-08 (feat/billing-cancel-downgrade): added
+``NoActiveSubscription`` (402, ``billing.no_active_subscription``) — raised by
+the subscription-cancel path when a workspace has no ``active`` subscription to
+cancel (only historical / already-cancelled rows, or never subscribed). 402 (the
+same money-error family as ``InsufficientCredits`` / ``QuotaExceeded``) so the
+client renders a "not subscribed" state rather than a 404-style missing resource.
 """
 
 from __future__ import annotations
@@ -139,6 +146,24 @@ class QuotaExceeded(CloudError):
         )
 
 
+class NoActiveSubscription(CloudError):
+    """Workspace has no active recurring subscription to act on (402).
+
+    Raised by the cancel path when a workspace asks to cancel but has no ``active``
+    subscription row — only historical / already-cancelled rows, or it never
+    subscribed. 402 (the same family as ``InsufficientCredits`` / ``QuotaExceeded``,
+    "you can't do the money action right now") so the client prompts a
+    not-subscribed state rather than treating it as a 404-style missing resource.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            402,
+            "billing.no_active_subscription",
+            "No active subscription to cancel for this workspace",
+        )
+
+
 class RateLimited(CloudError):
     """Rate limit exceeded (429)."""
 
@@ -172,6 +197,7 @@ __all__ = [
     "Forbidden",
     "InsufficientCredits",
     "Internal",
+    "NoActiveSubscription",
     "NotFound",
     "PreconditionFailed",
     "QuotaExceeded",

--- a/ee/pocketpaw_ee/cloud/billing/dto.py
+++ b/ee/pocketpaw_ee/cloud/billing/dto.py
@@ -24,6 +24,10 @@
 #   LiteLLM proxy — the contract SHAPE is unchanged (the frontend is untouched), but
 #   ``UsageModelStats.tokens`` is 0 from this source (the ledger carries no per-entry
 #   token count). The credit + request figures are accurate.
+# Updated 2026-07-08 (feat/billing-cancel-downgrade): added
+#   ``CancelSubscriptionResponse`` for ``POST /billing/cancel`` (no request body —
+#   the caller's workspace is the scope). Tiny ack; the plan revert is not reflected
+#   here (it lands on the ``subscription.cancelled`` webhook).
 
 from __future__ import annotations
 
@@ -67,6 +71,17 @@ class CreateSubscriptionResponse(BaseModel):
     """Hosted recurring-checkout url the caller redirects the buyer to."""
 
     checkout_url: str
+
+
+class CancelSubscriptionResponse(BaseModel):
+    """Ack for ``POST /billing/cancel`` — the gateway was told to stop billing.
+
+    ``ok`` is True once the gateway cancel was requested. The plan revert
+    (``Workspace.plan`` -> free) is NOT reflected here — it lands reactively when
+    Dodo posts the verified ``subscription.cancelled`` webhook.
+    """
+
+    ok: bool = True
 
 
 class WebhookAck(BaseModel):

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -40,6 +40,12 @@
 #   every metering mode. The route surface is unchanged (same path, auth, and
 #   ``start_date`` / ``end_date`` query params) — only the docstring wording below
 #   is updated to reflect the source.
+# Updated 2026-07-08 (feat/billing-cancel-downgrade): added POST /billing/cancel —
+#   cancel the caller's workspace's ACTIVE recurring subscription (no body;
+#   workspace-scoped via ``current_workspace_id``, same auth as topup / subscribe).
+#   Thin adapter over ``billing_service.cancel``; the plan revert lands reactively on
+#   the ``subscription.cancelled`` webhook, and a workspace with no active
+#   subscription gets 402 ``billing.no_active_subscription``.
 
 from __future__ import annotations
 
@@ -50,6 +56,7 @@ from pocketpaw_ee.cloud.billing import service as billing_service
 from pocketpaw_ee.cloud.billing import site_plans as site_plan_catalog
 from pocketpaw_ee.cloud.billing import usage as usage_service
 from pocketpaw_ee.cloud.billing.dto import (
+    CancelSubscriptionResponse,
     CreateSubscriptionRequest,
     CreateSubscriptionResponse,
     CreateTopupRequest,
@@ -197,3 +204,19 @@ async def create_subscription(
         origin=_request_origin(request),
     )
     return CreateSubscriptionResponse(checkout_url=result["checkout_url"])
+
+
+@router.post("/cancel", response_model=CancelSubscriptionResponse)
+async def cancel_subscription(
+    workspace_id: str = Depends(current_workspace_id),
+) -> CancelSubscriptionResponse:
+    """Cancel the caller's workspace's ACTIVE recurring subscription. No body.
+
+    Tells the gateway to stop billing the workspace's active subscription. The plan
+    revert (``Workspace.plan`` -> free) is NOT applied here — it lands reactively
+    when Dodo posts the verified ``subscription.cancelled`` webhook (mirroring how
+    /subscribe defers the upgrade to ``subscription.active``). Returns 402
+    ``billing.no_active_subscription`` when the workspace has no active subscription.
+    """
+    result = await billing_service.cancel(workspace_id=workspace_id)
+    return CancelSubscriptionResponse(ok=result["ok"])

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -76,6 +76,21 @@
 #   ``dodo_checkout_return_base`` config when no origin is present; omits the
 #   redirect entirely if both are absent. The webhook grant + idempotency are
 #   unchanged — they key on the event body's subscription_id + metadata + event_id.
+# Updated 2026-07-08 (feat/billing-cancel-downgrade): two money-management fixes.
+#   (A) ``cancel`` — wire the previously dead-coded provider ``cancel_subscription``
+#   end to end: load the workspace's ACTIVE Subscription row (the ``(workspace)``
+#   index is NON-unique, so select ``status == "active"`` specifically, never a
+#   naive first-match that could pick a stale cancelled row) and tell the gateway to
+#   stop billing it; 402 ``billing.no_active_subscription`` when there is none. The
+#   entitlement revert stays REACTIVE on the ``subscription.cancelled`` webhook — this
+#   only adds the initiation side (no duplicate plan-revert). (B) ``subscribe`` no
+#   longer double-subscribes: when a workspace ALREADY has an active subscription a
+#   plain ``create_subscription`` opened a SECOND parallel Dodo subscription (double
+#   billing). It now runs a GUARDED cancel-then-create — open the NEW checkout FIRST
+#   (a create failure leaves the current sub untouched, no coverage gap), THEN cancel
+#   the OLD subscription at the gateway (billing stops synchronously, so the two are
+#   never both billing). Webhook ``event_id`` idempotency is untouched. See the
+#   ``subscribe`` body for the native-``change_plan`` follow-up note.
 
 from __future__ import annotations
 
@@ -84,7 +99,7 @@ from datetime import UTC, datetime, timedelta
 
 from pymongo.errors import DuplicateKeyError
 
-from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud._core.errors import NoActiveSubscription, ValidationError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     BillingSubscriptionGranted,
@@ -211,6 +226,27 @@ def _checkout_return_urls(origin: str | None) -> tuple[str | None, str | None]:
     )
 
 
+async def _active_subscription(workspace_id: str) -> Subscription | None:
+    """The workspace's currently-ACTIVE gateway subscription, or None.
+
+    The ``Subscription`` ``(workspace)`` index is NON-UNIQUE — a workspace
+    accumulates historical rows over its lifetime (a prior tier it switched off, an
+    earlier subscription that was cancelled). So NEVER take a naive first-match:
+    filter on ``status == "active"`` and, if more than one somehow qualifies, take
+    the most-recent (``-createdAt``) for a deterministic pick. Returns None when the
+    workspace has no active subscription (only historical / cancelled rows, or never
+    subscribed).
+    """
+    return (
+        await Subscription.find(
+            Subscription.workspace == workspace_id,
+            Subscription.status == "active",
+        )
+        .sort("-createdAt")
+        .first_or_none()
+    )
+
+
 async def subscribe(
     workspace_id: str,
     user_id: str,
@@ -235,6 +271,11 @@ async def subscribe(
     back to after pay / cancel, so the buyer is NOT stranded on the gateway. When
     absent it falls back to the ``dodo_checkout_return_base`` config; if both are
     empty the redirect is simply omitted.
+
+    DOWNGRADE / SWITCH: if the workspace ALREADY has an active subscription this
+    does NOT open a second parallel one (which would double-bill). It runs a guarded
+    cancel-then-create — see the body — so a plan switch replaces the old
+    subscription instead of stacking on top of it.
     """
     # Rule 6 — validate at entry.
     if not workspace_id:
@@ -259,6 +300,33 @@ async def subscribe(
 
     return_url, cancel_url = _checkout_return_urls(origin)
     prov = provider or _default_provider()
+
+    # DOWNGRADE / SWITCH GUARD (fix double-subscribe). If the workspace ALREADY has
+    # an active gateway subscription, a plain create would open a SECOND parallel
+    # Dodo subscription and double-bill (the bug). Detect the active sub up front,
+    # then run a GUARDED cancel-then-create:
+    #   1. open the NEW checkout FIRST — if it raises we surface the error here and
+    #      the current subscription is untouched (no coverage gap, no orphaned
+    #      cancel; the tenant keeps billing the plan they had).
+    #   2. ONLY after the new checkout is open, cancel the OLD subscription at the
+    #      gateway. Dodo stops billing the old one synchronously, so the two are
+    #      never both billing; the plan mutations still land reactively on the
+    #      webhooks (the new ``subscription.active`` upgrades, the old
+    #      ``subscription.cancelled`` reverts) exactly as a fresh subscribe.
+    # Webhook idempotency is untouched — each grant still keys on its own event_id
+    # (BC-1's unique index), so a replayed active/renewed after a switch re-grants
+    # nothing.
+    #
+    # FOLLOW-UP (native change_plan): Dodo's SDK exposes an ATOMIC
+    # ``subscriptions.change_plan`` (proration, no re-checkout, no drop-to-free
+    # window) that would remove the residual "buyer abandons the new checkout after
+    # the old is cancelled" gap. Wiring it is out of scope for this bug fix — it
+    # needs a new provider-port method, a ``subscription.plan_changed`` webhook
+    # handler (grant + plan + audit; the service acts on active/renewed/cancelled
+    # only today), and a /subscribe response-contract change (change_plan returns no
+    # checkout url). Tracked as a billing plan-change follow-up.
+    existing = await _active_subscription(workspace_id)
+
     checkout = await prov.create_subscription(
         plan_key=plan_key,
         product_id=product_id,
@@ -268,7 +336,64 @@ async def subscribe(
         return_url=return_url,
         cancel_url=cancel_url,
     )
+
+    if existing is not None and existing.gateway_subscription_id:
+        # Cancel the prior subscription now that the new checkout is open. If THIS
+        # raises, the caller gets an error and the OLD sub keeps billing (never a
+        # silent double-charge); the just-opened checkout session simply expires
+        # unused (no new subscription exists until the buyer pays it).
+        await prov.cancel_subscription(existing.gateway_subscription_id)
+        logger.info(
+            "billing.subscribe: workspace=%s switching plans — opened new checkout "
+            "for plan=%s and cancelled prior subscription=%s",
+            workspace_id,
+            plan_key,
+            existing.gateway_subscription_id,
+        )
+
     return {"checkout_url": checkout.checkout_url}
+
+
+async def cancel(
+    workspace_id: str,
+    *,
+    provider: IPaymentsProvider | None = None,
+) -> dict:
+    """Cancel the workspace's ACTIVE recurring subscription at the gateway.
+
+    Loads the workspace's currently-active ``Subscription`` row and tells the
+    gateway to stop billing it (``provider.cancel_subscription``). Returns
+    ``{"ok": True}``.
+
+    The entitlement revert (``Workspace.plan`` -> free) and the Subscription-row
+    status flip are NOT done here — they land REACTIVELY on the verified
+    ``subscription.cancelled`` webhook (mirroring how ``subscribe`` defers the
+    upgrade to the ``subscription.active`` webhook; the webhook handler is the sole
+    writer of that plan mutation, so cancelling here would duplicate it).
+
+    Raises 402 ``billing.no_active_subscription`` when the workspace has no active
+    subscription — only historical / already-cancelled rows, or never subscribed.
+    """
+    # Rule 6 — validate at entry.
+    if not workspace_id:
+        raise ValidationError("billing.invalid_workspace", "workspace_id is required")
+
+    active = await _active_subscription(workspace_id)
+    if active is None or not active.gateway_subscription_id:
+        # An active row with a gateway id is required. A stale cancelled row or no
+        # subscription at all is a 402 (not a silent success, and not a naive
+        # first-match against a historical row).
+        raise NoActiveSubscription()
+
+    prov = provider or _default_provider()
+    await prov.cancel_subscription(active.gateway_subscription_id)
+    logger.info(
+        "billing.cancel: requested gateway cancel for workspace=%s subscription=%s "
+        "(plan revert lands reactively on the subscription.cancelled webhook)",
+        workspace_id,
+        active.gateway_subscription_id,
+    )
+    return {"ok": True}
 
 
 # ---------------------------------------------------------------------------
@@ -719,6 +844,7 @@ async def _upsert_subscription(event: SubscriptionEvent, *, status: str, plan_ke
 
 
 __all__ = [
+    "cancel",
     "create_topup",
     "handle_webhook",
     "subscribe",

--- a/tests/cloud/billing/test_subscriptions.py
+++ b/tests/cloud/billing/test_subscriptions.py
@@ -40,6 +40,16 @@
 #   is returned to the app after paying), omit return_url when no base is available,
 #   and the service must thread an ``origin`` into the return_url. Rewired the
 #   existing criterion-1 mock from subscriptions.create to checkout_sessions.create.
+# Updated 2026-07-08 (feat/billing-cancel-downgrade): added the two money-management
+#   bug-fix tests. (A) CANCEL — ``billing.cancel`` calls the provider's
+#   cancel_subscription with the ACTIVE sub id (proven at the SDK edge:
+#   subscriptions.update(<id>, status="cancelled")), 402s
+#   ``billing.no_active_subscription`` when there is none, and NEVER selects a stale
+#   cancelled historical row; plus POST /billing/cancel route wiring (200 + 402). (B)
+#   DOWNGRADE — ``subscribe`` on a workspace with an active sub does cancel-then-create
+#   (opens exactly one new checkout AND cancels the old sub id), does NOT cancel when
+#   there's no active sub (or only a cancelled row), and stays event_id-idempotent on
+#   the new subscription's active-webhook replay.
 
 from __future__ import annotations
 
@@ -604,3 +614,264 @@ async def test_empty_subscription_id_does_not_corrupt_cross_tenant(mongo_db):
     # trail is never replaced by workspace B's.
     subs = await Subscription.find().to_list()
     assert subs == []
+
+
+# ---------------------------------------------------------------------------
+# feat/billing-cancel-downgrade — two money-management bug fixes.
+#
+# Fixtures / helpers here spy at the SDK-client EDGE (a REAL DodoProvider with a
+# mocked ``AsyncDodoPayments``), so the tests exercise the real provider paths:
+#   * cancel  -> DodoProvider.cancel_subscription -> subscriptions.update(<id>,
+#     status="cancelled")
+#   * switch  -> DodoProvider.create_subscription -> checkout_sessions.create
+#     AND DodoProvider.cancel_subscription -> subscriptions.update
+# ---------------------------------------------------------------------------
+
+import pytest_asyncio  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+
+async def _seed_subscription(
+    workspace_id: str, *, subscription_id: str, status: str, plan_key: str = "pro"
+) -> Subscription:
+    """Insert a Subscription row directly (bypassing the webhook) to set up the
+    active / cancelled fixtures the cancel + switch paths select against."""
+    doc = Subscription(
+        workspace=workspace_id,
+        gateway="dodo",
+        gateway_subscription_id=subscription_id,
+        plan_key=plan_key,
+        product_id="prod_pro_recurring",
+        status=status,
+    )
+    await doc.insert()
+    return doc
+
+
+def _fake_switch_client(monkeypatch) -> MagicMock:
+    """SDK client mock for the cancel / plan-switch paths.
+
+    Exposes BOTH ``checkout_sessions.create`` (the new checkout) and
+    ``subscriptions.update`` (how the provider cancels — a status PATCH). A
+    regression back to ``subscriptions.create`` (the stranded path) still fails
+    loudly via the AssertionError side effect.
+    """
+    fake_session = MagicMock()
+    fake_session.session_id = SESSION_ID
+    fake_session.checkout_url = SESSION_CHECKOUT_URL
+
+    fake_client = MagicMock()
+    fake_client.checkout_sessions.create = AsyncMock(return_value=fake_session)
+    fake_client.subscriptions.update = AsyncMock(return_value=MagicMock())
+    fake_client.subscriptions.create = AsyncMock(
+        side_effect=AssertionError("must use checkout_sessions.create, not subscriptions.create")
+    )
+
+    import pocketpaw_ee.cloud.billing.providers.dodo as dodo_mod
+
+    monkeypatch.setattr(dodo_mod, "AsyncDodoPayments", MagicMock(return_value=fake_client))
+    return fake_client
+
+
+# ---- (A) cancel() -------------------------------------------------------- #
+
+
+async def test_cancel_calls_provider_with_active_subscription_id(mongo_db, monkeypatch):
+    """cancel() loads the ACTIVE sub and tells the gateway to stop billing IT."""
+    ws = await _make_workspace(plan="pro")
+    await _seed_subscription(ws, subscription_id=SUB_ID, status="active")
+    fake_client = _fake_switch_client(monkeypatch)
+
+    result = await billing.cancel(workspace_id=ws, provider=_provider())
+
+    assert result == {"ok": True}
+    # The real provider path cancels via the status PATCH on the ACTIVE sub id.
+    fake_client.subscriptions.update.assert_awaited_once_with(SUB_ID, status="cancelled")
+
+
+async def test_cancel_without_active_subscription_raises_402(mongo_db, monkeypatch):
+    """No subscription at all -> 402 billing.no_active_subscription, gateway untouched."""
+    ws = await _make_workspace(plan="free")
+    fake_client = _fake_switch_client(monkeypatch)
+    from pocketpaw_ee.cloud._core.errors import NoActiveSubscription
+
+    with pytest.raises(NoActiveSubscription) as exc:
+        await billing.cancel(workspace_id=ws, provider=_provider())
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.no_active_subscription"
+    fake_client.subscriptions.update.assert_not_called()
+
+
+async def test_cancel_ignores_stale_cancelled_row(mongo_db, monkeypatch):
+    """A historical CANCELLED row must NOT be selected — cancel targets the ACTIVE
+    row's id (the (workspace) index is non-unique, so a naive first-match is wrong)."""
+    ws = await _make_workspace(plan="pro")
+    await _seed_subscription(ws, subscription_id="sub_old_cancelled", status="cancelled")
+    await _seed_subscription(ws, subscription_id="sub_current_active", status="active")
+    fake_client = _fake_switch_client(monkeypatch)
+
+    await billing.cancel(workspace_id=ws, provider=_provider())
+
+    fake_client.subscriptions.update.assert_awaited_once_with(
+        "sub_current_active", status="cancelled"
+    )
+
+
+async def test_cancel_with_only_cancelled_row_raises_402(mongo_db, monkeypatch):
+    """Only a stale cancelled row exists -> 402 (a naive first-match would wrongly
+    'cancel' the dead row; the status filter prevents that)."""
+    ws = await _make_workspace(plan="free")
+    await _seed_subscription(ws, subscription_id="sub_dead", status="cancelled")
+    fake_client = _fake_switch_client(monkeypatch)
+    from pocketpaw_ee.cloud._core.errors import NoActiveSubscription
+
+    with pytest.raises(NoActiveSubscription):
+        await billing.cancel(workspace_id=ws, provider=_provider())
+    fake_client.subscriptions.update.assert_not_called()
+
+
+# ---- (A) cancel() route wiring (httpx AsyncClient) ----------------------- #
+
+
+@pytest_asyncio.fixture
+async def billing_app_client() -> AsyncClient:
+    """A FastAPI app with ONLY the billing router mounted + auth/license overridden,
+    scoped to workspace ``w1`` — so the POST /billing/cancel wiring is exercised
+    without a real JWT / license (mirrors the shared cloud_app_client fixture)."""
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.billing.router import router as billing_router
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(billing_router)
+    app.dependency_overrides[current_user_id] = lambda: "u1"
+    app.dependency_overrides[current_workspace_id] = lambda: "w1"
+    app.dependency_overrides[require_license] = lambda: None
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+async def test_cancel_route_cancels_active_subscription(mongo_db, billing_app_client, monkeypatch):
+    """POST /billing/cancel -> 200 {ok: true} and the gateway sub is cancelled."""
+    await _seed_subscription("w1", subscription_id=SUB_ID, status="active")
+    fake_client = _fake_switch_client(monkeypatch)
+    # The route uses the DEFAULT provider — point it at the test provider whose SDK
+    # client is mocked (no real Dodo settings / network needed).
+    monkeypatch.setattr(billing, "_default_provider", lambda: _provider())
+
+    resp = await billing_app_client.post("/billing/cancel")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    fake_client.subscriptions.update.assert_awaited_once_with(SUB_ID, status="cancelled")
+
+
+async def test_cancel_route_402_when_no_active_subscription(
+    mongo_db, billing_app_client, monkeypatch
+):
+    """POST /billing/cancel with no active sub -> 402 billing.no_active_subscription."""
+    monkeypatch.setattr(billing, "_default_provider", lambda: _provider())
+
+    resp = await billing_app_client.post("/billing/cancel")
+
+    assert resp.status_code == 402
+    assert resp.json()["error"]["code"] == "billing.no_active_subscription"
+
+
+# ---- (B) subscribe() switch guard --------------------------------------- #
+
+
+async def test_subscribe_with_active_sub_cancels_old_then_creates_new(
+    mongo_db, monkeypatch, patch_plan_products
+):
+    """A switch (workspace already has an active sub) opens exactly ONE new checkout
+    AND cancels the OLD subscription — never the blind double-create."""
+    ws = await _make_workspace(plan="pro")
+    await _seed_subscription(ws, subscription_id=SUB_ID, status="active", plan_key="pro")
+    fake_client = _fake_switch_client(monkeypatch)
+
+    result = await billing.subscribe(
+        workspace_id=ws, user_id="u1", plan_key="go", provider=_provider()
+    )
+    assert result == {"checkout_url": SESSION_CHECKOUT_URL}
+
+    # Exactly one NEW checkout was opened (no second parallel subscribe)...
+    fake_client.checkout_sessions.create.assert_awaited_once()
+    # ...and the OLD subscription was cancelled at the gateway. The pre-fix blind
+    # path (create WITHOUT cancel) would leave subscriptions.update un-called.
+    fake_client.subscriptions.update.assert_awaited_once_with(SUB_ID, status="cancelled")
+
+
+async def test_subscribe_without_active_sub_does_not_cancel(
+    mongo_db, monkeypatch, patch_plan_products
+):
+    """A fresh subscribe (no active sub) opens the checkout and cancels NOTHING."""
+    ws = await _make_workspace(plan="free")
+    fake_client = _fake_switch_client(monkeypatch)
+
+    await billing.subscribe(workspace_id=ws, user_id="u1", plan_key="pro", provider=_provider())
+
+    fake_client.checkout_sessions.create.assert_awaited_once()
+    fake_client.subscriptions.update.assert_not_called()
+
+
+async def test_subscribe_ignores_cancelled_row_and_does_not_cancel(
+    mongo_db, monkeypatch, patch_plan_products
+):
+    """A stale CANCELLED row is not 'active' — subscribe treats the workspace as
+    having no active sub and cancels nothing (no spurious gateway call)."""
+    ws = await _make_workspace(plan="free")
+    await _seed_subscription(ws, subscription_id="sub_dead", status="cancelled")
+    fake_client = _fake_switch_client(monkeypatch)
+
+    await billing.subscribe(workspace_id=ws, user_id="u1", plan_key="pro", provider=_provider())
+
+    fake_client.checkout_sessions.create.assert_awaited_once()
+    fake_client.subscriptions.update.assert_not_called()
+
+
+async def test_switch_then_new_active_webhook_is_idempotent(
+    mongo_db, monkeypatch, patch_plan_products
+):
+    """After a switch, the NEW subscription's active webhook grants exactly once — a
+    replay (same event_id) is a no-op, so the switch never breaks BC-1 replay-safety."""
+    ws = await _make_workspace(plan="pro")
+    await _seed_subscription(ws, subscription_id=SUB_ID, status="active", plan_key="pro")
+    _fake_switch_client(monkeypatch)
+
+    # Switch to go — opens a new checkout + cancels the old sub.
+    await billing.subscribe(workspace_id=ws, user_id="u1", plan_key="go", provider=_provider())
+
+    go_allotment = plans.get_plan("go").monthly_credit_allotment
+    assert go_allotment > 0
+    before = await credits.balance(ws)
+
+    # The NEW subscription's active webhook lands (fresh gateway sub id + event id).
+    body = _subscription_body(
+        event_type="subscription.active",
+        workspace_id=ws,
+        plan_key="go",
+        product_id="prod_go_recurring",
+        subscription_id="sub_new_go",
+    )
+    first = await billing.handle_webhook(
+        payload=body.encode(),
+        headers=_sign(body, msg_id="evt_switch_go_active"),
+        provider=_provider(),
+    )
+    assert first == {"ok": True, "granted": True}
+    assert await credits.balance(ws) == before + go_allotment
+
+    # Replay the SAME active event id — a no-op (BC-1 unique index); balance flat.
+    second = await billing.handle_webhook(
+        payload=body.encode(),
+        headers=_sign(body, msg_id="evt_switch_go_active"),  # SAME id
+        provider=_provider(),
+    )
+    assert second == {"ok": True, "granted": False}
+    assert await credits.balance(ws) == before + go_allotment


### PR DESCRIPTION
Part 2 of 3 in the billing-enforcement stack. Two money-management bug fixes. **Stacked on #1665** (base is `feat/billing-enforce-gate`, so this diff is only the cancel/downgrade changes). Backend only; the cancel UI is a separate PR.

## (A) Subscription cancel was dead-coded
The provider `cancel_subscription` existed with no callers, no route, no service. Wired end to end:
- `POST /billing/cancel` (workspace-scoped, no body) -> `billing.service.cancel()`.
- `cancel()` loads the workspace's **active** subscription. The `(workspace)` index is non-unique (a workspace keeps historical/cancelled rows), so it filters on `status == "active"` rather than a naive first-match, and returns 402 `billing.no_active_subscription` when there's none.
- The plan revert (`Workspace.plan -> free`) stays reactive on the `subscription.cancelled` webhook. Cancel only adds the initiation side, no duplicate revert.

## (B) Downgrade/switch no longer double-subscribes
`subscribe()` called `create_subscription` unconditionally, so switching plans opened a second parallel Dodo subscription and double-billed. Now, when a workspace already has an active subscription, it runs a guarded cancel-then-create: open the new checkout first (a create failure leaves the current sub untouched), then cancel the old one at the gateway. `event_id` webhook idempotency is unchanged.

## One decision for you
The cancel-old-immediately ordering has a residual gap: if the buyer abandons the new checkout after the old sub is cancelled, they're temporarily reverted to free. It's the lesser evil versus the double-billing bug and is inherent to the checkout-session model. Dodo's SDK exposes an atomic `change_plan` (proration, no re-checkout, no drop-to-free window) that closes the gap cleanly, but wiring it needs a new provider-port method, a `subscription.plan_changed` webhook handler, and a `/subscribe` response-contract change, which is out of scope for a bug fix and tracked as a follow-up in the code. Your call on whether to schedule it.

## Tests
- `test_subscriptions.py` (+11, 24 total): cancel targets the active sub id, 402s on none / only-stale-rows, ignores cancelled rows; switch cancels the old sub and opens exactly one new checkout; a fresh subscribe cancels nothing; the switch stays webhook-idempotent. Tests spy at the SDK-client edge (real DodoProvider, mocked client).
- 147 billing+credits tests green (C1 included, no regression). Both import-linter configs pass.

Hold the merge, this is the stacked base of the caps PR (part 3).