### PR TITLE
refactor(atlas): rename the Instinct decision feed /paw-print to /decisions

### DIFF
--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -168,7 +168,7 @@ in its `surface` field:
 | `surface:pockets` | `/pockets` | pocket list + live canvas detail |
 | `surface:sites` | `/sites` | published-sites gallery, create→publish flow |
 | `surface:belt` | `/belt` | develop-station console: runs + diff viewer |
-| `surface:paw-print` | `/paw-print` | org-wide decision feed (Instinct corrections) |
+| `surface:decisions` | `/decisions` | org-wide decision feed (Instinct corrections) |
 | `surface:decisions-graph` | `/decisions-graph` | visual query layer over decision history |
 | `surface:mission-control` | `/mission-control` | operator work feed (cycles, analytics) |
 | `surface:agents` | `/agents` | agent list + per-agent editor |
@@ -187,7 +187,7 @@ in its `surface` field:
 
 Primitives with a natural home route cross-link it in their own `surface`
 field so `atlas_describe` answers include where to see the result:
-`primitive:pocket` → `/pockets`, `primitive:instinct` → `/paw-print`,
+`primitive:pocket` → `/pockets`, `primitive:instinct` → `/decisions`,
 `primitive:connector` → `/settings/workspace/integrations`,
 `primitive:sites` → `/sites`, `primitive:belt` → `/belt`. (There is no
 dedicated billing route in the client today; plan info lives on

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -17,6 +17,10 @@ and the ``Branding`` -> ``BrandingOut`` mapping in ``workspace_to_dto``.
 2026-06-19 (feat/instinct-gate-integration, security-review FIX 1): added
 ``SetApprovalLevelRequest`` — the closed-enum body for the OWNER-only route
 that activates the layered Instinct gate's triager for a workspace.
+2026-07-08 (chore/decisions-feed-rename): renamed the Instinct decision-feed
+route key in ``VALID_ROUTES`` to ``decisions`` — mirrors the atlas surface
+``surface:decisions`` (route ``/decisions``), the org-wide feed of recent
+Instinct corrections (sibling to ``/decisions-graph``).
 """
 
 from __future__ import annotations
@@ -329,7 +333,7 @@ class SetMemberRoutePermissionsRequest(BaseModel):
             "foresight",
             "sites",
             "belt",
-            "paw-print",
+            "decisions",
             "audit",
             "settings",
         }

--- a/src/pocketpaw/atlas/authored/primitives.json
+++ b/src/pocketpaw/atlas/authored/primitives.json
@@ -33,7 +33,7 @@
       "gist": "the governance gate — agents PROPOSE actions and a human approves, rejects, or edits each one at the gate",
       "narrative": "Instinct is the governance primitive: agents PROPOSE actions instead of executing them, and humans approve, reject, or edit each proposal at a gate. Every decision captures a reasoning trace. It is becoming a multi-lane triage router (auto / optimistic / escalate / dry-run + a trust ledger), with ASK as the default lane. Reach for it whenever an agent action needs governance — approvals, human review of agent writes, gated side effects. It pairs with Branch (which builds propose→review→merge on top of the gate) and Belt (where the human mans the Instinct gate on proposed diffs). NOT a biology term — Instinct is the approval pipeline.",
       "how": "Instinct action store + gate APIs; agents emit proposals, humans resolve them at the gate",
-      "surface": "/paw-print",
+      "surface": "/decisions",
       "requires": [],
       "keywords": [
         "approve",

--- a/src/pocketpaw/atlas/authored/surfaces.json
+++ b/src/pocketpaw/atlas/authored/surfaces.json
@@ -111,13 +111,13 @@
       ]
     },
     {
-      "id": "surface:paw-print",
+      "id": "surface:decisions",
       "kind": "surface",
-      "name": "Paw Print",
+      "name": "Decisions",
       "summary": "Org-wide decision feed: recent Instinct corrections across the workspace's pockets, with diff viewers.",
-      "narrative": "Paw Print is the org-wide decision feed — recent Instinct corrections across the workspace, each rendered through a diff viewer. Point a user here to review what decisions agents and humans have been making. It is the decision-feed home of the Instinct primitive; the historical query layer is /decisions-graph.",
+      "narrative": "Decisions is the org-wide decision feed — recent Instinct corrections across the workspace, each rendered through a diff viewer. Point a user here to review what decisions agents and humans have been making. It is the decision-feed home of the Instinct primitive; the historical query layer is /decisions-graph.",
       "how": "",
-      "surface": "/paw-print",
+      "surface": "/decisions",
       "requires": [
         "primitive:instinct"
       ],
@@ -136,7 +136,7 @@
       "kind": "surface",
       "name": "Decision Graph",
       "summary": "Visual query layer over the historical Decision projection: trace a decision's graph by id, depth, and mode.",
-      "narrative": "Decision Graph lets an operator query the historical Decision projection visually — deep-linkable by decision id, depth, and mode. Point a user here to trace WHY a decision happened and what it connects to; for the live feed of recent decisions use /paw-print instead.",
+      "narrative": "Decision Graph lets an operator query the historical Decision projection visually — deep-linkable by decision id, depth, and mode. Point a user here to trace WHY a decision happened and what it connects to; for the live feed of recent decisions use /decisions instead.",
       "how": "",
       "surface": "/decisions-graph",
       "requires": [

--- a/src/pocketpaw/atlas/data/atlas.json
+++ b/src/pocketpaw/atlas/data/atlas.json
@@ -1405,7 +1405,7 @@
       "narrative": "Instinct is the governance primitive: agents PROPOSE actions instead of executing them, and humans approve, reject, or edit each proposal at a gate. Every decision captures a reasoning trace. It is becoming a multi-lane triage router (auto / optimistic / escalate / dry-run + a trust ledger), with ASK as the default lane. Reach for it whenever an agent action needs governance — approvals, human review of agent writes, gated side effects. It pairs with Branch (which builds propose→review→merge on top of the gate) and Belt (where the human mans the Instinct gate on proposed diffs). NOT a biology term — Instinct is the approval pipeline.",
       "requires": [],
       "summary": "The decision pipeline: agents PROPOSE actions, humans approve/reject/edit at a gate; captures reasoning traces.",
-      "surface": "/paw-print"
+      "surface": "/decisions"
     },
     {
       "gist": "the 'app' primitive — one workspace container for agents, data, tools, connectors, and Instinct rules",
@@ -2003,6 +2003,28 @@
     {
       "gist": "",
       "how": "",
+      "id": "surface:decisions",
+      "keywords": [
+        "decisions",
+        "corrections",
+        "feed",
+        "governance",
+        "what happened",
+        "instinct",
+        "review decisions"
+      ],
+      "kind": "surface",
+      "name": "Decisions",
+      "narrative": "Decisions is the org-wide decision feed — recent Instinct corrections across the workspace, each rendered through a diff viewer. Point a user here to review what decisions agents and humans have been making. It is the decision-feed home of the Instinct primitive; the historical query layer is /decisions-graph.",
+      "requires": [
+        "primitive:instinct"
+      ],
+      "summary": "Org-wide decision feed: recent Instinct corrections across the workspace's pockets, with diff viewers.",
+      "surface": "/decisions"
+    },
+    {
+      "gist": "",
+      "how": "",
       "id": "surface:decisions-graph",
       "keywords": [
         "decision graph",
@@ -2015,7 +2037,7 @@
       ],
       "kind": "surface",
       "name": "Decision Graph",
-      "narrative": "Decision Graph lets an operator query the historical Decision projection visually — deep-linkable by decision id, depth, and mode. Point a user here to trace WHY a decision happened and what it connects to; for the live feed of recent decisions use /paw-print instead.",
+      "narrative": "Decision Graph lets an operator query the historical Decision projection visually — deep-linkable by decision id, depth, and mode. Point a user here to trace WHY a decision happened and what it connects to; for the live feed of recent decisions use /decisions instead.",
       "requires": [
         "primitive:instinct"
       ],
@@ -2168,28 +2190,6 @@
       "requires": [],
       "summary": "Operator + approvals surface at /deep-work: unified work feed with cycles, plan, activity, and analytics tabs, plus the approvals tray, filterable by project.",
       "surface": "/deep-work"
-    },
-    {
-      "gist": "",
-      "how": "",
-      "id": "surface:paw-print",
-      "keywords": [
-        "decisions",
-        "corrections",
-        "feed",
-        "governance",
-        "what happened",
-        "instinct",
-        "review decisions"
-      ],
-      "kind": "surface",
-      "name": "Paw Print",
-      "narrative": "Paw Print is the org-wide decision feed — recent Instinct corrections across the workspace, each rendered through a diff viewer. Point a user here to review what decisions agents and humans have been making. It is the decision-feed home of the Instinct primitive; the historical query layer is /decisions-graph.",
-      "requires": [
-        "primitive:instinct"
-      ],
-      "summary": "Org-wide decision feed: recent Instinct corrections across the workspace's pockets, with diff viewers.",
-      "surface": "/paw-print"
     },
     {
       "gist": "",

--- a/tests/atlas/test_store.py
+++ b/tests/atlas/test_store.py
@@ -66,7 +66,7 @@ EXPECTED_SURFACE_IDS = {
     "surface:pockets",
     "surface:sites",
     "surface:belt",
-    "surface:paw-print",
+    "surface:decisions",
     "surface:decisions-graph",
     "surface:mission-control",
     "surface:agents",
@@ -90,7 +90,7 @@ EXPECTED_SURFACE_IDS = {
 # cross-links, so atlas_describe answers include where to see the result).
 EXPECTED_PRIMITIVE_SURFACES = {
     "primitive:pocket": "/pockets",
-    "primitive:instinct": "/paw-print",
+    "primitive:instinct": "/decisions",
     "primitive:connector": "/settings/workspace/integrations",
     "primitive:sites": "/sites",
     "primitive:belt": "/belt",


### PR DESCRIPTION
Renames the Instinct org-wide decision feed surface from `/paw-print` to `/decisions` in the atlas and route registry. This is the follow-up to the Paw Bar rename: the feed is a third thing, distinct from both the Paw Bar widget and the one-word Pawprints completed-work feed. It is the live feed of recent Instinct corrections, and its sibling is the existing Decision Graph (`/decisions-graph`).

"Decisions" was chosen over reusing `/pawprints` because that name already belongs to the completed-work audit family (`/belt/pawprints`, the Mission Control done section). The atlas already frames this surface as the Instinct decision feed paired with Decision Graph, so the name follows the existing structure.

Pairs with the paw-enterprise PR that renames the live route to `/decisions`. They should land together so the atlas surface path and the live route stay in lockstep.

## What changed
- `atlas/authored/surfaces.json`: the `surface:paw-print` surface becomes `surface:decisions`: id, name "Decisions", path `/decisions`, its narrative, and the Decision Graph cross-reference that pointed at `/paw-print`.
- `atlas/authored/primitives.json`: the Instinct primitive's home surface path.
- `ee/pocketpaw_ee/cloud/workspace/dto.py`: the `VALID_ROUTES` entry `paw-print` becomes `decisions` (the distinct `decisions-graph` entry is untouched).
- `atlas/data/atlas.json`: rebuilt from the authored files with `pocketpaw atlas build` (not hand-edited).
- `tests/atlas/test_store.py`: two expectation sets hardcoded the old surface id and path; updated to the new canonical names so the atlas suite stays green.

## Verification
- `pocketpaw atlas build --check` reports the artifact is up to date (authored matches compiled).
- Zero `paw-print` matches across the atlas tree and `dto.py`.
- `239 passed` on the atlas/surface/dto test selection; `58 passed` on the atlas store/compile/widgets suites.

## Not in this PR
The live `/decisions` frontend route is in paw-enterprise (its own PR). The atlas check only proves authored matches compiled, not that the route exists, so the two PRs are a lockstep pair.
