### PR TITLE
Add SMB seat/pocket/connector caps to the plan ladder

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -24,6 +24,13 @@ the subscription-cancel path when a workspace has no ``active`` subscription to
 cancel (only historical / already-cancelled rows, or never subscribed). 402 (the
 same money-error family as ``InsufficientCredits`` / ``QuotaExceeded``) so the
 client renders a "not subscribed" state rather than a 404-style missing resource.
+
+Changed 2026-07-08 (feat/billing-smb-caps): added ``PocketLimitError`` (402,
+``billing.pocket_limit``) and ``ConnectorLimitError`` (402,
+``billing.connector_limit``) — the pocket-create and connector-enable siblings of
+``SeatLimitError``. Same 402 money-adjacent family; distinct codes so the UI can
+prompt a plan upgrade. Both enforce at create/enable time only (never retroactive)
+and only when ``billing_enforced`` is on.
 """
 
 from __future__ import annotations
@@ -112,6 +119,34 @@ class SeatLimitError(CloudError):
         super().__init__(402, "billing.seat_limit", f"Seat limit of {seats} reached")
 
 
+class PocketLimitError(CloudError):
+    """Workspace hit its plan's pocket cap (402).
+
+    Sibling of ``SeatLimitError`` for the pocket-create seam: the workspace holds
+    its plan's ``max_pockets`` and a new create would exceed it. 402 (same
+    money-adjacent family) with a distinct ``billing.pocket_limit`` code so the UI
+    can prompt a plan upgrade. Enforced at CREATE time only — never removes an
+    existing pocket — and only when ``billing_enforced`` is on.
+    """
+
+    def __init__(self, limit: int) -> None:
+        super().__init__(402, "billing.pocket_limit", f"Pocket limit of {limit} reached")
+
+
+class ConnectorLimitError(CloudError):
+    """Workspace hit its plan's connector cap (402).
+
+    Sibling of ``SeatLimitError`` for the connector-enable seam: the workspace
+    already has its plan's ``max_connectors`` enabled and enabling another would
+    exceed it. 402 with a distinct ``billing.connector_limit`` code so the UI can
+    prompt a plan upgrade. Enforced at ENABLE time only — never disables an
+    already-enabled connector — and only when ``billing_enforced`` is on.
+    """
+
+    def __init__(self, limit: int) -> None:
+        super().__init__(402, "billing.connector_limit", f"Connector limit of {limit} reached")
+
+
 class InsufficientCredits(CloudError):
     """Credit wallet has too few credits for the requested debit (402)."""
 
@@ -194,11 +229,13 @@ __all__ = [
     "BadRequest",
     "CloudError",
     "ConflictError",
+    "ConnectorLimitError",
     "Forbidden",
     "InsufficientCredits",
     "Internal",
     "NoActiveSubscription",
     "NotFound",
+    "PocketLimitError",
     "PreconditionFailed",
     "QuotaExceeded",
     "RateLimited",

--- a/ee/pocketpaw_ee/cloud/billing/plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/plans.py
@@ -39,6 +39,18 @@
 #   the paid usage tiers; Free is an explicit trial cap (1000 — its 0 allotment can't
 #   derive it) and Enterprise is uncapped (None). The ``_build`` default for an
 #   unknown key FAILS CLOSED to the Free ceiling, never None/uncapped.
+# Updated 2026-07-08 (feat/billing-smb-caps) — ADDED three SMB resource ceilings the
+#   plan ladder now carries alongside ``monthly_ceiling``: ``max_seats`` (workspace
+#   members), ``max_pockets`` (pockets per workspace), and ``max_connectors``
+#   (enabled connectors per workspace). Each is a tunable dict (``_MAX_SEATS`` /
+#   ``_MAX_POCKETS`` / ``_MAX_CONNECTORS``) mirroring ``_CEILING`` in shape, surfaced
+#   on ``PlanTier`` as ``int | None`` (None = uncapped, Enterprise only). The values
+#   are GENEROUS PLACEHOLDERS — the real per-tier numbers are a captain pricing
+#   open-question; the machinery is tier-agnostic and these ceilings are roomy
+#   enough that an active tenant under them never notices, while still protecting
+#   the shared PEE box from runaway growth. Free ``max_seats`` is pinned at 5 (==
+#   the ``Workspace.seats`` default) so no existing workspace regresses. The
+#   ``_build`` default for an unknown key FAILS CLOSED to the Free value, never None.
 
 from __future__ import annotations
 
@@ -94,6 +106,51 @@ _CEILING: dict[str, int | None] = {
     "go": 2_250,
     "pro": 11_250,
     "pro_max": 45_000,
+    "enterprise": None,
+}
+
+# ---------------------------------------------------------------------------
+# Tunable constants — SMB resource ceilings per tier (feat/billing-smb-caps).
+# ---------------------------------------------------------------------------
+#
+# Three per-plan caps enforced at CREATE / INVITE / ENABLE time (never
+# retroactively): the max workspace SEATS, the max POCKETS a workspace may hold,
+# and the max ENABLED CONNECTORS. Same shape as ``_CEILING`` — an ``int`` ceiling,
+# or ``None`` for the one uncapped (Enterprise) tier. The ``_build`` default for an
+# unknown key FAILS CLOSED to the Free value (never None/uncapped).
+#
+# IMPORTANT: these are GENEROUS PLACEHOLDERS. The real per-tier numbers are a
+# captain pricing open-question; the enforcement machinery is deliberately
+# tier-agnostic so only these constants change when pricing lands. They are roomy
+# enough that an active tenant under the ceiling never notices, while still
+# protecting the shared PEE box from a single tenant's runaway growth.
+#
+# Free ``max_seats`` is pinned at 5 to EQUAL the ``Workspace.seats`` model default
+# — the seat gate enforces ``max(doc.seats, max_seats)`` so a free workspace sees
+# byte-for-byte the same limit it has today (no regression). The paid tiers step
+# up from there; Enterprise is uncapped (None) — negotiated contracts set their
+# own limits.
+_MAX_SEATS: dict[str, int | None] = {
+    "free": 5,
+    "go": 10,
+    "pro": 25,
+    "pro_max": 100,
+    "enterprise": None,
+}
+
+_MAX_POCKETS: dict[str, int | None] = {
+    "free": 200,
+    "go": 1_000,
+    "pro": 5_000,
+    "pro_max": 20_000,
+    "enterprise": None,
+}
+
+_MAX_CONNECTORS: dict[str, int | None] = {
+    "free": 50,
+    "go": 100,
+    "pro": 250,
+    "pro_max": 1_000,
     "enterprise": None,
 }
 
@@ -184,8 +241,13 @@ class PlanTier:
     per renewal — a BACK-OFFICE field, NOT the headline. ``monthly_ceiling`` is
     the per-plan monthly credit CAP (integer credits, or None = uncapped) that
     credit-quota enforcement caps spend against (allotment × 1.5 for paid tiers;
-    Free is the explicit 1000 trial cap; Enterprise is None). ``dodo_product_id``
-    is the recurring-product id, or None until BC-7 / config populates it.
+    Free is the explicit 1000 trial cap; Enterprise is None). ``max_seats`` /
+    ``max_pockets`` / ``max_connectors`` are the SMB resource ceilings enforced at
+    create/invite/enable time (integer, or None = uncapped for Enterprise);
+    Free's ``max_seats`` == the ``Workspace.seats`` default so no workspace
+    regresses. These are GENEROUS PLACEHOLDERS pending the captain's pricing call.
+    ``dodo_product_id`` is the recurring-product id, or None until BC-7 / config
+    populates it.
 
     The display + price fields are what the billing UI renders: ``display_name``
     ("Paw Pro"), ``usage_label`` (the ChatGPT/Claude-style "5x the usage" headline
@@ -197,6 +259,9 @@ class PlanTier:
     key: str
     monthly_credit_allotment: int
     monthly_ceiling: int | None
+    max_seats: int | None
+    max_pockets: int | None
+    max_connectors: int | None
     dodo_product_id: str | None
     features: frozenset[str]
     display_name: str
@@ -238,8 +303,10 @@ def _build(key: str) -> PlanTier:
     from ``_PLAN_DISPLAY`` (a missing row degrades to ``_DISPLAY_FALLBACK`` rather
     than NPE-ing). An unknown ``key`` yields an empty feature set and a 0
     allotment — but callers go through ``get_plan`` / ``list_plans``, which only
-    ever pass known keys. ``monthly_ceiling`` FAILS CLOSED: an unknown key defaults
-    to the Free ceiling (the trial cap), never None/uncapped.
+    ever pass known keys. ``monthly_ceiling`` and the three SMB caps
+    (``max_seats`` / ``max_pockets`` / ``max_connectors``) FAIL CLOSED: an unknown
+    key defaults to the Free value (the most restrictive tier), never
+    None/uncapped.
     """
     display = _PLAN_DISPLAY.get(key, _DISPLAY_FALLBACK)
     return PlanTier(
@@ -247,6 +314,11 @@ def _build(key: str) -> PlanTier:
         monthly_credit_allotment=_MONTHLY_CREDIT_ALLOTMENT.get(key, 0),
         # Fail closed: an unknown key caps at the Free ceiling, never uncapped.
         monthly_ceiling=_CEILING.get(key, _CEILING["free"]),
+        # Fail closed on every SMB cap too: an unknown key caps at the Free
+        # value (the most restrictive), never None/uncapped.
+        max_seats=_MAX_SEATS.get(key, _MAX_SEATS["free"]),
+        max_pockets=_MAX_POCKETS.get(key, _MAX_POCKETS["free"]),
+        max_connectors=_MAX_CONNECTORS.get(key, _MAX_CONNECTORS["free"]),
         dodo_product_id=_dodo_product_for(key),
         features=frozenset(PLAN_FEATURES.get(key, set())),
         display_name=str(display["display_name"]),

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -551,7 +551,9 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
 
     * ``subscription.active`` / ``subscription.renewed`` → grant the tier's
       monthly allotment ADDITIVELY (unused credits roll over) keyed on the
-      per-renewal ``event_id``; ``active`` ALSO upgrades ``Workspace.plan``.
+      per-renewal ``event_id``; ``active`` ALSO upgrades ``Workspace.plan`` and
+      resyncs the stored seat cap UP to the new plan (upgrade-only — a later
+      cancel reverts the plan but never strips seats).
     * ``subscription.cancelled`` → revert ``Workspace.plan`` to ``free`` WITHOUT
       clawing back any granted credits.
     * any other subscription.* delivery → acked, no action.
@@ -647,6 +649,31 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
     # subscription.active upgrades the entitlement to the subscribed tier.
     if event.type == _SUB_ACTIVE:
         await workspace_service.set_workspace_plan(event.workspace_id, tier.key)
+        # feat/billing-smb-caps: lift the stored seat cap to the new plan so an
+        # upgrade actually raises it. UPGRADE-ONLY (max(doc.seats, plan.max_seats))
+        # — a later cancel reverts the plan but never strips the seats. Best-effort:
+        # a resync hiccup must not fail the (already-applied) credit grant / plan
+        # move, and the seat gates also lift the ceiling live via the resolved plan.
+        try:
+            new_seats = await workspace_service.raise_seats_for_plan(
+                event.workspace_id, tier.key
+            )
+            if new_seats is not None:
+                logger.info(
+                    "billing.webhook: %s resynced seat cap to %d for workspace=%s plan=%s",
+                    event.type,
+                    new_seats,
+                    event.workspace_id,
+                    tier.key,
+                )
+        except Exception:
+            logger.exception(
+                "billing.webhook: seat-cap resync failed for workspace=%s plan=%s "
+                "(event_id=%s) — plan upgrade stands; seat gate still lifts live",
+                event.workspace_id,
+                tier.key,
+                event.event_id,
+            )
 
     # Track the subscription lifecycle (active for both active + renewed).
     await _upsert_subscription(event, status="active", plan_key=tier.key)

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -1,5 +1,13 @@
 # Connectors — workspace-scoped business logic.
 # Created: 2026-05-03 — PR-1 of Phase 1 connector consolidation.
+# Updated: 2026-07-08 (feat/billing-smb-caps) — added a per-plan CONNECTOR cap.
+#   ``enable_connector`` now raises ``ConnectorLimitError`` (402) when the workspace
+#   is already at/over its plan's ``max_connectors`` and the call would enable a NEW
+#   connector (a fresh row, or re-enabling a disabled one). The check
+#   (``_connector_cap_exceeded``) is GATED on ``billing_enforced`` (a no-op for OSS
+#   / self-host), never trips on an uncapped Enterprise plan, and is skipped for an
+#   idempotent re-enable of an already-enabled connector — enforcement is
+#   enable-time only, never retroactive.
 # Updated: 2026-06-07 (M3 connector→skill auto-authoring) — enable/disable of a
 #   POCKET-scoped connector now RE-DERIVES the pocket's surface_profile from ALL
 #   its enabled pocket-scoped connectors (``_rederive_pocket_surface_profile``)
@@ -71,7 +79,13 @@ from pathlib import Path
 from beanie.operators import And, Or
 
 from pocketpaw.connectors.protocol import ExecutionMode
-from pocketpaw_ee.cloud._core.errors import CloudError, Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.errors import (
+    CloudError,
+    ConnectorLimitError,
+    Forbidden,
+    NotFound,
+    ValidationError,
+)
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     ConnectorConfigUpdated,
@@ -437,12 +451,51 @@ async def get_connector(
     )
 
 
+async def _connector_cap_exceeded(workspace_id: str) -> tuple[bool, int, int | None]:
+    """Would enabling one MORE connector exceed this workspace's plan cap?
+
+    Returns ``(exceeded, enabled_count, limit)``. feat/billing-smb-caps. GATED on
+    ``billing_enforced``: OSS / self-host tenants (billing off) always get
+    ``(False, 0, None)`` — no cap, no extra DB read. When enforced, resolves the
+    workspace's plan ``max_connectors`` and counts its currently-ENABLED connector
+    rows. An uncapped plan (Enterprise, ``max_connectors=None``) never trips. The
+    caller only invokes this when it is about to enable a connector that isn't
+    already enabled, so ``enabled_count >= limit`` is precisely "this new one would
+    exceed" — an already-enabled connector re-enabled idempotently is never blocked
+    (never retroactive). Imports are lazy to keep this module off the config /
+    entitlements import graph at load.
+    """
+    from pocketpaw.config import get_settings
+
+    if not get_settings().billing_enforced:
+        return (False, 0, None)
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = await entitlements_service.resolve_entitlements(workspace_id)
+    limit = ent.max_connectors
+    if limit is None:
+        return (False, 0, None)
+    enabled_count = await _WCDoc.find(
+        _WCDoc.workspace == workspace_id,
+        _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+    ).count()
+    return (enabled_count >= limit, enabled_count, limit)
+
+
 async def enable_connector(
     workspace_id: str,
     name: str,
     body: EnableConnectorRequest,
 ) -> ConnectorResponse:
-    """Enable a connector for this workspace, creating the row if needed."""
+    """Enable a connector for this workspace, creating the row if needed.
+
+    feat/billing-smb-caps: raises ``ConnectorLimitError`` (402) when the workspace
+    is already at/over its plan's ``max_connectors`` and this call would enable a
+    NEW connector (a fresh row, or re-enabling a disabled one). A no-op unless
+    ``billing_enforced``; an idempotent re-enable of an already-enabled connector is
+    never blocked (create-time only, never retroactive).
+    """
     body = EnableConnectorRequest.model_validate(body)
     available = {a.name: a for a in _available_from_registry()}
     if name not in available:
@@ -454,6 +507,22 @@ async def enable_connector(
         raise ValidationError("connector.scope_missing_user", "scope=user requires user_id")
 
     doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+    # Cap check only when this call would turn a connector ON that isn't already on
+    # (a brand-new row, or re-enabling a disabled one). An idempotent re-enable of
+    # an already-enabled connector must NEVER be blocked — that would retroactively
+    # strip access. Checked BEFORE the write.
+    if doc is None or not doc.enabled:
+        exceeded, enabled_count, limit = await _connector_cap_exceeded(workspace_id)
+        if exceeded:
+            logger.info(
+                "connector enable blocked by plan cap: workspace=%s has %d enabled "
+                "(limit %s), name=%s",
+                workspace_id,
+                enabled_count,
+                limit,
+                name,
+            )
+            raise ConnectorLimitError(limit)  # type: ignore[arg-type]  # int when exceeded
     if doc is None:
         doc = _WCDoc(
             workspace=workspace_id,

--- a/ee/pocketpaw_ee/cloud/entitlements/domain.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/domain.py
@@ -15,6 +15,11 @@
 #   ``monthly_ceiling: int | None`` next to ``monthly_credit_allotment`` — the
 #   per-plan monthly credit CAP (None = uncapped) the resolver populates from the
 #   plan catalog and later quota chunks enforce against.
+# Updated 2026-07-08 (feat/billing-smb-caps): added ``max_seats`` / ``max_pockets``
+#   / ``max_connectors`` (all ``int | None``, None = uncapped) beside
+#   ``monthly_ceiling`` — the SMB resource ceilings the resolver populates from the
+#   plan catalog and the seat / pocket-create / connector-enable gates enforce
+#   against at create time. Fail-closed to the Free value on the fallback path.
 
 from __future__ import annotations
 
@@ -33,11 +38,18 @@ class Entitlements:
     per renewal for the tier. ``monthly_ceiling`` is the per-plan monthly credit
     CAP (integer credits, or None = uncapped) credit-quota enforcement caps spend
     against; a workspace with no/unknown plan resolves to the Free ceiling (the
-    fail-closed trial cap), never None/uncapped.
+    fail-closed trial cap), never None/uncapped. ``max_seats`` / ``max_pockets`` /
+    ``max_connectors`` are the SMB resource ceilings (integer, or None = uncapped
+    for Enterprise) the seat / pocket-create / connector-enable gates enforce at
+    create time; a no/unknown-plan workspace resolves to the Free values
+    (fail-closed), never None/uncapped.
     """
 
     workspace_id: str
     plan: str
     monthly_credit_allotment: int
     monthly_ceiling: int | None
+    max_seats: int | None
+    max_pockets: int | None
+    max_connectors: int | None
     features: frozenset[str] = field(default_factory=frozenset)

--- a/ee/pocketpaw_ee/cloud/entitlements/dto.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/dto.py
@@ -20,6 +20,11 @@
 #   INR/USD monthly+annual prices) so the billing UI can render ChatGPT/Claude-style
 #   "usage" wording instead of raw credits. ``monthly_credit_allotment`` stays as a
 #   back-office field; ``enterprise`` prices serialize as null ("talk to us").
+# Updated 2026-07-08 (feat/billing-smb-caps): both ``PlanTierResponse`` and
+#   ``EntitlementsResponse`` now carry the SMB resource caps ``max_seats`` /
+#   ``max_pockets`` / ``max_connectors`` (the enforced ceilings the plan ladder
+#   added), so the plan cards can render real per-tier limits and the settings UI
+#   can show a workspace's resolved caps. ``None`` == uncapped (Enterprise).
 
 from __future__ import annotations
 
@@ -53,6 +58,9 @@ class PlanTierResponse(BaseModel):
     price_inr_annual: int | None = None
     price_usd_monthly: int | None = None
     price_usd_annual: int | None = None
+    max_seats: int | None = None
+    max_pockets: int | None = None
+    max_connectors: int | None = None
 
 
 class PlanCatalogResponse(BaseModel):
@@ -71,6 +79,9 @@ class EntitlementsResponse(BaseModel):
     plan: str
     monthly_credit_allotment: int
     features: list[str] = Field(default_factory=list)
+    max_seats: int | None = None
+    max_pockets: int | None = None
+    max_connectors: int | None = None
 
 
 def plan_tier_to_dto(tier: PlanTier) -> PlanTierResponse:
@@ -87,6 +98,9 @@ def plan_tier_to_dto(tier: PlanTier) -> PlanTierResponse:
         price_inr_annual=tier.price_inr_annual,
         price_usd_monthly=tier.price_usd_monthly,
         price_usd_annual=tier.price_usd_annual,
+        max_seats=tier.max_seats,
+        max_pockets=tier.max_pockets,
+        max_connectors=tier.max_connectors,
     )
 
 
@@ -97,6 +111,9 @@ def entitlements_to_dto(ent: Entitlements) -> EntitlementsResponse:
         plan=ent.plan,
         monthly_credit_allotment=ent.monthly_credit_allotment,
         features=sorted(ent.features),
+        max_seats=ent.max_seats,
+        max_pockets=ent.max_pockets,
+        max_connectors=ent.max_connectors,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -27,6 +27,10 @@
 #   ``monthly_ceiling`` exactly as ``monthly_credit_allotment`` is. The defensive
 #   base-floor branch sets the Free trial ceiling (1000), so every path fails
 #   closed and no path leaves the cap uncapped.
+# Updated 2026-07-08 (feat/billing-smb-caps): ``Entitlements`` now also carries the
+#   three SMB caps (``max_seats`` / ``max_pockets`` / ``max_connectors``), populated
+#   from the resolved tier exactly as ``monthly_ceiling`` is. The defensive
+#   base-floor branch sets the Free values (5 / 200 / 50) so every path fails closed.
 
 from __future__ import annotations
 
@@ -70,6 +74,11 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
                 # Fail closed: the Free trial cap, never None/uncapped — even when
                 # the catalog itself is somehow missing the base tier.
                 monthly_ceiling=1_000,
+                # Fail closed on the SMB caps too: the Free values (max_seats == the
+                # Workspace.seats default so no workspace regresses), never uncapped.
+                max_seats=5,
+                max_pockets=200,
+                max_connectors=50,
                 features=frozenset(),
             )
 
@@ -78,5 +87,8 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
         plan=tier.key,
         monthly_credit_allotment=tier.monthly_credit_allotment,
         monthly_ceiling=tier.monthly_ceiling,
+        max_seats=tier.max_seats,
+        max_pockets=tier.max_pockets,
+        max_connectors=tier.max_connectors,
         features=tier.features,
     )

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -250,6 +250,16 @@ recompile is in play. The typed model is used INTERNALLY only — Beanie
 ``Pocket.rippleSpec`` and ``domain.Pocket.ripple_spec`` stay ``dict``, and
 every reader still receives a flat dict (executor dual-path readers deferred
 to a Phase 2 gated on PR #1472).
+Changes: 2026-07-08 (feat/billing-smb-caps) — added a per-plan POCKET cap. A new
+shared helper ``_pocket_cap_exceeded`` resolves the workspace's plan
+``max_pockets`` and counts its live pockets; it is GATED on ``billing_enforced``
+(a no-op for OSS / self-host) and never trips on an uncapped Enterprise plan.
+``create`` raises ``PocketLimitError`` (402) before any write when at/over the
+cap; ``create_from_ripple_spec`` (the agent auto-create path, which does NOT
+funnel through ``create``) returns ``None`` at/over the cap so the agent turn
+degrades gracefully. ``create_pocket_and_session`` funnels through ``create`` and
+is covered transitively. Enforcement is create-time only — an existing pocket is
+never removed.
 """
 
 from __future__ import annotations
@@ -267,6 +277,7 @@ from bson.errors import InvalidId
 from pydantic import ValidationError as PydanticValidationError
 
 from pocketpaw.bundled_templates.schema import RippleSpec
+from pocketpaw_ee.cloud._core.errors import PocketLimitError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     PocketCreated,
@@ -1395,6 +1406,37 @@ async def resolve_workspace_template_default_deny(workspace_id: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+async def _pocket_cap_exceeded(workspace_id: str) -> tuple[bool, int, int | None]:
+    """Would a new pocket exceed this workspace's plan cap? -> (exceeded, count, limit).
+
+    feat/billing-smb-caps. GATED on ``billing_enforced``: OSS / self-host tenants
+    (billing off) always get ``(False, 0, None)`` — no cap, no extra DB read — so a
+    self-hosted deployment behaves exactly as before. When enforced, resolves the
+    workspace's plan ``max_pockets`` and counts its live pockets. An uncapped plan
+    (Enterprise, ``max_pockets=None``) never trips. ``exceeded`` is ``count >=
+    limit`` — checked BEFORE the insert, so it blocks the create that WOULD push the
+    workspace over, never an existing pocket (create-time only, never retroactive).
+
+    Returns the tuple rather than raising so each caller responds in its native
+    shape: the HTTP ``create`` path raises ``PocketLimitError`` (402); the agent
+    auto-create path returns ``None``. Imports are lazy to keep this module off the
+    config / entitlements import graph at load.
+    """
+    from pocketpaw.config import get_settings
+
+    if not get_settings().billing_enforced:
+        return (False, 0, None)
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = await entitlements_service.resolve_entitlements(workspace_id)
+    limit = ent.max_pockets
+    if limit is None:
+        return (False, 0, None)
+    count = await _PocketDoc.find(_PocketDoc.workspace == workspace_id).count()
+    return (count >= limit, count, limit)
+
+
 async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> dict:
     """Create a pocket with optional agents, widgets, and rippleSpec.
 
@@ -1403,7 +1445,22 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     ``project.not_found`` otherwise. Pockets without a ``project_id``
     surface as "unassigned" in the Mission Control project picker, which
     is exactly the pre-projects-rollout shape.
+
+    feat/billing-smb-caps: raises ``PocketLimitError`` (402) BEFORE any write when
+    the workspace is at/over its plan's ``max_pockets`` — a no-op unless
+    ``billing_enforced``. Also covers ``create_pocket_and_session``, which funnels
+    through here.
     """
+    exceeded, count, limit = await _pocket_cap_exceeded(workspace_id)
+    if exceeded:
+        logger.info(
+            "pocket create blocked by plan cap: workspace=%s has %d pockets (limit %s)",
+            workspace_id,
+            count,
+            limit,
+        )
+        raise PocketLimitError(limit)  # type: ignore[arg-type]  # limit is int when exceeded
+
     from pocketpaw_ee.cloud.sessions import service as sessions_service
 
     normalized_spec = normalize_ripple_spec(body.ripple_spec) if body.ripple_spec else None
@@ -2153,8 +2210,25 @@ async def create_from_ripple_spec(
     ``pattern`` records the create-pocket layout pattern (``"landing"``
     for a marketing site). Optional; defaults to ``None`` so the
     pre-existing inline auto-create path is unchanged.
+
+    feat/billing-smb-caps: this path does NOT funnel through ``create``, so it
+    carries its OWN pocket-cap check. It returns ``None`` (not a 402) when at/over
+    the cap — consistent with the function's "return None on failure" contract, so
+    the agent turn degrades gracefully (no pocket attached) instead of surfacing a
+    raw 402 through the agent loop. A no-op unless ``billing_enforced``.
     """
     try:
+        exceeded, count, limit = await _pocket_cap_exceeded(workspace_id)
+        if exceeded:
+            logger.warning(
+                "Auto-create blocked by pocket cap: workspace=%s has %d pockets "
+                "(limit %s) — no pocket created",
+                workspace_id,
+                count,
+                limit,
+            )
+            return None
+
         normalized = normalize_ripple_spec(ripple_spec)
         if not normalized:
             return None

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -25,6 +25,11 @@ Public API:
   verified ``subscription.active`` upgrades to the subscribed tier and a
   ``subscription.cancelled`` reverts to ``free``. Returns True on a write,
   False when the workspace is missing/soft-deleted.
+- ``raise_seats_for_plan(workspace_id, plan_key)`` — UPGRADE-ONLY resync of
+  the stored ``Workspace.seats`` up to the new plan's ``max_seats`` (never
+  down). The subscription.active webhook calls it after set_workspace_plan so
+  an upgrade actually lifts the seat cap; a downgrade/cancel never strips
+  seats a workspace already has.
 
 Changes: added get_workspace_plan helper for plan-feature gate dep; added
 slug_reason() (format + reserved + uniqueness) backing the live
@@ -77,6 +82,16 @@ actor-role check an ADMIN could self-promote to owner or evict a sitting owner o
 approval. The guard lives in the service so every caller (admin tool, executor,
 route) inherits it; it mirrors the existing "an invite can never mint an owner"
 rule. The last-owner + cannot_demote/remove-doc-owner guards are unchanged.
+2026-07-08 (feat/billing-smb-caps): the three seat gates (create_invite,
+bulk_create_invites, accept_invite) now source their ceiling from the workspace's
+RESOLVED PLAN, not the flat ``doc.seats`` alone. ``_effective_seat_limit`` returns
+``max(doc.seats, plan.max_seats)`` (an uncapped Enterprise plan keeps the
+negotiated ``doc.seats``) so a plan upgrade lifts the cap while a workspace that
+already carries a higher custom seat count never regresses. Seat enforcement stays
+ALWAYS-ON (not behind ``billing_enforced``), unchanged from before; the Free
+``max_seats`` == the model default (5) means a free tenant sees the identical
+limit. ``raise_seats_for_plan`` (upgrade-only) keeps the stored ``doc.seats`` in
+step with the plan on a subscription.active.
 """
 
 from __future__ import annotations
@@ -1034,6 +1049,34 @@ async def _mint_invite_for_email(
     return _invite_to_domain(invite_doc, plaintext_token=plaintext)
 
 
+async def _effective_seat_limit(doc: _WorkspaceDoc) -> int:
+    """The seat ceiling to enforce for this workspace — plan-sourced.
+
+    Sources the limit from the workspace's RESOLVED PLAN (``max_seats``) rather
+    than the flat ``doc.seats`` alone, so a plan upgrade lifts the cap. Enforced
+    as ``max(doc.seats, plan.max_seats)`` so a workspace that already carries a
+    higher custom ``doc.seats`` — a seeded enterprise box, or a legacy
+    hand-bumped seat count — never regresses below what it has today. An uncapped
+    plan (Enterprise, ``max_seats=None``) imposes no plan ceiling: the workspace's
+    own ``doc.seats`` stands.
+
+    ALWAYS-ON (NOT gated on ``billing_enforced``), mirroring the pre-existing seat
+    gate. Because the Free ``max_seats`` equals the ``Workspace.seats`` model
+    default (5), a free tenant sees byte-for-byte the same limit it had before
+    this became plan-sourced — no regression.
+
+    The entitlements resolver is imported LAZILY to keep this module off the
+    resolver's import graph (the resolver itself imports this service lazily);
+    there is no static cycle.
+    """
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = await entitlements_service.resolve_entitlements(str(doc.id))
+    if ent.max_seats is None:
+        return doc.seats
+    return max(doc.seats, ent.max_seats)
+
+
 async def create_invite(
     ctx: RequestContext,
     workspace_id: str,
@@ -1044,8 +1087,9 @@ async def create_invite(
         raise NotFound("workspace", workspace_id)
 
     member_count = await _count_members(workspace_id)
-    if member_count >= doc.seats:
-        raise SeatLimitError(doc.seats)
+    seat_limit = await _effective_seat_limit(doc)
+    if member_count >= seat_limit:
+        raise SeatLimitError(seat_limit)
 
     invite = await _mint_invite_for_email(
         ctx, workspace_id, body.email, body.role, body.group_id, body.context
@@ -1110,8 +1154,9 @@ async def bulk_create_invites(
         raise NotFound("workspace", workspace_id)
 
     current_count = await _count_members(workspace_id)
-    if current_count + len(body.emails) > doc.seats:
-        raise SeatLimitError(doc.seats)
+    seat_limit = await _effective_seat_limit(doc)
+    if current_count + len(body.emails) > seat_limit:
+        raise SeatLimitError(seat_limit)
 
     created: list[Invite] = []
     skipped: list[dict] = []
@@ -1357,12 +1402,13 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
     already_member = await _get_member_role(invite.workspace_id, ctx.user_id) is not None
     if not already_member:
         member_count = await _count_members(invite.workspace_id)
-        if member_count >= ws_doc.seats:
+        seat_limit = await _effective_seat_limit(ws_doc)
+        if member_count >= seat_limit:
             await collection.update_one(
                 {"_id": claimed["_id"]},
                 {"$set": {"accepted": False, "accepted_at": None}},
             )
-            raise SeatLimitError(ws_doc.seats)
+            raise SeatLimitError(seat_limit)
         await _add_member(
             invite.workspace_id,
             ctx.user_id,
@@ -1721,6 +1767,45 @@ async def set_workspace_plan(workspace_id: str, plan: str) -> bool:
     return True
 
 
+async def raise_seats_for_plan(workspace_id: str, plan_key: str) -> int | None:
+    """Bump the stored ``Workspace.seats`` UP to the plan's ``max_seats`` (never down).
+
+    Called by the billing subscription webhook on a ``subscription.active`` upgrade,
+    right after ``set_workspace_plan``, so an upgrade actually lifts the stored seat
+    cap (the seat gates also lift it live via ``_effective_seat_limit``, but keeping
+    the persisted field in step means every direct ``doc.seats`` reader — dashboards,
+    "X of Y seats" — sees the new ceiling too).
+
+    UPGRADE-ONLY: writes ``max(doc.seats, plan.max_seats)`` so a downgrade / cancel
+    (which reverts the plan to ``free``) can NEVER strip seats a workspace already
+    has — a workspace on 100 seats that cancels to free keeps its 100. An uncapped
+    plan (Enterprise, ``max_seats=None``) leaves the negotiated ``doc.seats``
+    untouched. A same-or-lower target is a no-op write.
+
+    Returns the resulting seat count, or ``None`` when the plan is unknown/uncapped
+    or the workspace is missing / soft-deleted / malformed (the webhook logs-and-acks
+    rather than 500-ing on an unroutable event). The plan catalog is imported lazily
+    to keep this service off its import graph.
+    """
+    from pocketpaw_ee.cloud.billing import plans as plan_catalog
+
+    tier = plan_catalog.get_plan(plan_key)
+    if tier is None or tier.max_seats is None:
+        return None
+    try:
+        oid = PydanticObjectId(workspace_id)
+    except Exception:
+        return None
+    doc = await _WorkspaceDoc.get(oid)
+    if doc is None or doc.deleted_at is not None:
+        return None
+    new_seats = max(doc.seats, tier.max_seats)
+    if new_seats != doc.seats:
+        doc.seats = new_seats
+        await doc.save()
+    return new_seats
+
+
 # ---------------------------------------------------------------------------
 # Route Permissions
 # ---------------------------------------------------------------------------
@@ -1890,6 +1975,7 @@ __all__ = [
     "list_members",
     "list_peer_ids",
     "preview_invite",
+    "raise_seats_for_plan",
     "remove_member",
     "resend_invite",
     "revoke_invite",

--- a/tests/cloud/billing/test_plans.py
+++ b/tests/cloud/billing/test_plans.py
@@ -22,6 +22,14 @@
 #   each tier carries the approved ceiling (free=1000 explicit trial, go/pro/pro_max
 #   = allotment × 1.5, enterprise=None uncapped), and an unknown key built directly
 #   FAILS CLOSED to the Free ceiling (never None/uncapped).
+# Updated 2026-07-08 (feat/billing-smb-caps): added coverage for the three SMB
+#   resource caps (``max_seats`` / ``max_pockets`` / ``max_connectors``): every tier
+#   carries an int cap (Enterprise is None = uncapped), Free ``max_seats`` == the
+#   ``Workspace.seats`` default (5) so no workspace regresses, and an unknown key
+#   built directly FAILS CLOSED to the Free value on all three (never None/uncapped).
+#   The numbers under test are the GENEROUS PLACEHOLDERS pending the captain's
+#   pricing call — these tests lock the machinery (present on every tier, uncapped
+#   Enterprise, fail-closed default), not the exact figures.
 
 from __future__ import annotations
 
@@ -59,6 +67,30 @@ EXPECTED_USAGE_LABELS = {
     "pro": "5× the usage",
     "pro_max": "20× the usage",
     "enterprise": "Custom",
+}
+# The three SMB resource caps (feat/billing-smb-caps) — GENEROUS PLACEHOLDERS
+# pending the captain's pricing call. Enterprise is None (uncapped). Free
+# ``max_seats`` MUST equal the Workspace.seats default (5) so no workspace regresses.
+EXPECTED_MAX_SEATS: dict[str, int | None] = {
+    "free": 5,
+    "go": 10,
+    "pro": 25,
+    "pro_max": 100,
+    "enterprise": None,
+}
+EXPECTED_MAX_POCKETS: dict[str, int | None] = {
+    "free": 200,
+    "go": 1_000,
+    "pro": 5_000,
+    "pro_max": 20_000,
+    "enterprise": None,
+}
+EXPECTED_MAX_CONNECTORS: dict[str, int | None] = {
+    "free": 50,
+    "go": 100,
+    "pro": 250,
+    "pro_max": 1_000,
+    "enterprise": None,
 }
 
 
@@ -140,6 +172,71 @@ def test_build_unknown_key_fails_closed_to_free_ceiling():
     bogus = plans._build("definitely_not_a_tier")
     assert bogus.monthly_ceiling == EXPECTED_CEILINGS["free"]
     assert bogus.monthly_ceiling is not None
+
+
+# ---------------------------------------------------------------------------
+# SMB resource caps — max_seats / max_pockets / max_connectors.
+# ---------------------------------------------------------------------------
+
+
+def test_every_tier_carries_the_three_smb_caps():
+    """Each tier exposes max_seats / max_pockets / max_connectors (the machinery).
+
+    Locks that the caps are PRESENT on every tier with the placeholder values, not
+    that the figures are final — the captain's pricing call moves the numbers, not
+    the shape.
+    """
+    by_key = {p.key: p for p in plans.list_plans()}
+    for key in EXPECTED_ORDER:
+        assert by_key[key].max_seats == EXPECTED_MAX_SEATS[key], key
+        assert by_key[key].max_pockets == EXPECTED_MAX_POCKETS[key], key
+        assert by_key[key].max_connectors == EXPECTED_MAX_CONNECTORS[key], key
+
+
+def test_free_max_seats_is_at_least_the_workspace_default():
+    """Free max_seats MUST be >= the Workspace.seats model default (5) — no regression.
+
+    The seat gate enforces max(doc.seats, plan.max_seats); if Free's cap dropped
+    below 5 a default free workspace would be blocked below the seats it already
+    has. This is the CRITICAL non-regression invariant.
+    """
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    default_seats = Workspace.model_fields["seats"].default
+    assert default_seats == 5
+    assert plans.get_plan("free").max_seats is not None
+    assert plans.get_plan("free").max_seats >= default_seats
+
+
+def test_enterprise_smb_caps_are_uncapped():
+    """Enterprise is the one uncapped tier on every SMB cap (None, never a number)."""
+    ent = plans.get_plan("enterprise")
+    assert ent.max_seats is None
+    assert ent.max_pockets is None
+    assert ent.max_connectors is None
+
+
+def test_non_enterprise_smb_caps_are_positive_ints():
+    """Every non-Enterprise tier carries a concrete positive cap on all three."""
+    by_key = {p.key: p for p in plans.list_plans()}
+    for key in ("free", "go", "pro", "pro_max"):
+        for cap in (by_key[key].max_seats, by_key[key].max_pockets, by_key[key].max_connectors):
+            assert isinstance(cap, int) and cap > 0, key
+
+
+def test_build_unknown_key_fails_closed_to_free_smb_caps():
+    """An unknown key built directly caps at the Free values on all three — never None.
+
+    Same fail-closed floor the ceiling uses: a stray/typo'd key must NOT resolve to
+    an uncapped SMB cap.
+    """
+    bogus = plans._build("definitely_not_a_tier")
+    assert bogus.max_seats == EXPECTED_MAX_SEATS["free"]
+    assert bogus.max_pockets == EXPECTED_MAX_POCKETS["free"]
+    assert bogus.max_connectors == EXPECTED_MAX_CONNECTORS["free"]
+    assert bogus.max_seats is not None
+    assert bogus.max_pockets is not None
+    assert bogus.max_connectors is not None
 
 
 def test_list_plans_is_cheapest_first():

--- a/tests/cloud/connectors/test_connector_cap.py
+++ b/tests/cloud/connectors/test_connector_cap.py
@@ -1,0 +1,138 @@
+# tests/cloud/connectors/test_connector_cap.py
+# Created 2026-07-08 (feat/billing-smb-caps) — locks the per-plan CONNECTOR cap on
+# the enable seam. ``enable_connector`` raises ``ConnectorLimitError`` (402) when the
+# workspace already has its plan's ``max_connectors`` enabled and the call would
+# turn a NEW connector on (a fresh row, or re-enabling a disabled one). The cap
+# (``_connector_cap_exceeded``) is a no-op unless ``billing_enforced`` and never
+# trips on an uncapped Enterprise plan. An idempotent re-enable of an
+# already-enabled connector is NEVER blocked — enforcement is enable-time only,
+# never retroactive.
+#
+# The plan resolver is stubbed to a controlled ``max_connectors`` so the count/limit
+# logic is exercised against a small ceiling; the catalog-value + fail-closed
+# contract lives in test_plans.py / test_entitlements.py. ``billing_enforced`` is
+# toggled by pointing the config's ``get_settings`` at a flag stub. ``stripe`` /
+# ``gmail`` / ``github`` are YAML connectors shipped in repo /connectors, available
+# in every registry instance so tests need no catalog seeding.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ConnectorLimitError
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.dto import EnableConnectorRequest
+from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+from pocketpaw_ee.cloud.entitlements.domain import Entitlements
+
+import pocketpaw.config as ppconfig
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws_connector_cap"
+
+
+def _enforce(monkeypatch, *, on: bool) -> None:
+    """Point the config's ``get_settings`` (lazily imported inside the cap helper)
+    at a flag stub carrying the billing posture."""
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, dodo_plan_products=None),
+    )
+
+
+def _cap(monkeypatch, *, max_connectors: int | None) -> None:
+    """Stub the entitlements resolver to a controlled ``max_connectors`` ceiling."""
+    ent = Entitlements(
+        workspace_id=_WS,
+        plan="free",
+        monthly_credit_allotment=0,
+        monthly_ceiling=1_000,
+        max_seats=5,
+        max_pockets=200,
+        max_connectors=max_connectors,
+        features=frozenset(),
+    )
+    monkeypatch.setattr(entitlements_service, "resolve_entitlements", AsyncMock(return_value=ent))
+
+
+async def _enable(name: str):
+    return await connectors_service.enable_connector(
+        _WS, name, EnableConnectorRequest(scope="workspace")
+    )
+
+
+async def test_enable_raises_connector_limit_at_cap(monkeypatch) -> None:
+    """At/over the plan cap, enabling a NEW connector raises ConnectorLimitError."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_connectors=2)
+
+    await _enable("stripe")  # 1 enabled
+    await _enable("gmail")  # 2 enabled — at the cap
+
+    with pytest.raises(ConnectorLimitError) as exc:
+        await _enable("github")
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.connector_limit"
+
+
+async def test_enable_allows_below_cap(monkeypatch) -> None:
+    """Below the cap, enable proceeds normally."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_connectors=2)
+
+    resp = await _enable("stripe")
+    assert resp.enabled is True
+
+
+async def test_reenable_already_enabled_connector_is_never_blocked(monkeypatch) -> None:
+    """An idempotent re-enable of an already-enabled connector is NOT blocked, even
+    when the workspace sits exactly at the cap — the cap is create/enable-time only
+    and must never retroactively strip an existing connector."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_connectors=1)
+
+    await _enable("stripe")  # 1 enabled — at the cap
+
+    # Re-enabling the SAME already-enabled connector adds nothing, so it must pass.
+    resp = await _enable("stripe")
+    assert resp.enabled is True
+
+
+async def test_reenable_disabled_connector_is_capped(monkeypatch) -> None:
+    """Re-enabling a DISABLED connector counts as turning one on — blocked at cap."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_connectors=1)
+
+    await _enable("stripe")  # 1 enabled
+    await connectors_service.disable_connector(_WS, "stripe")  # 0 enabled
+    await _enable("gmail")  # 1 enabled — back at the cap
+
+    # stripe's row still exists but is disabled; re-enabling it would exceed the cap.
+    with pytest.raises(ConnectorLimitError):
+        await _enable("stripe")
+
+
+async def test_connector_cap_is_noop_when_billing_disabled(monkeypatch) -> None:
+    """With billing_enforced OFF, the cap never fires — even past the ceiling."""
+    _enforce(monkeypatch, on=False)
+    _cap(monkeypatch, max_connectors=1)
+
+    await _enable("stripe")
+    await _enable("gmail")
+    resp = await _enable("github")  # 3rd, well over the (ignored) cap
+    assert resp.enabled is True
+
+
+async def test_connector_cap_is_noop_when_uncapped(monkeypatch) -> None:
+    """An uncapped plan (Enterprise, max_connectors=None) never trips the cap."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_connectors=None)
+
+    await _enable("stripe")
+    await _enable("gmail")
+    resp = await _enable("github")
+    assert resp.enabled is True

--- a/tests/cloud/credits/test_billing_enforce_smoke.py
+++ b/tests/cloud/credits/test_billing_enforce_smoke.py
@@ -1,0 +1,182 @@
+# tests/cloud/credits/test_billing_enforce_smoke.py — LIVE flag-on smoke for the
+# billing-enforcement wave. Unlike the unit tests (which mock over_billing_limit),
+# this drives the REAL guard end-to-end: real credits.service.check_balance against
+# a REAL (empty / funded / negative) wallet in Beanie, with the REAL flag flipped
+# on via the guard's own get_settings. Only true infrastructure is stubbed (the
+# group lookup, the realtime emit, the run transport) — never the billing seam.
+#
+# Proves the money guarantee the wave claims:
+#   1. flag ON + empty wallet  -> the group/DM bridge (a NEW C1 seam) blocks with
+#      NO model call (neither the Haiku relevance pre-classifier nor the agent run).
+#   2. flag ON + funded wallet -> the bridge proceeds (no over-blocking).
+#   3. flag OFF + empty wallet -> proceeds (the default-off safety: nothing changes
+#      in prod until POCKETPAW_BILLING_ENFORCED is set).
+#   4. flag ON + negative wallet -> the WORKER/executor path (run_core's delegate)
+#      rejects with a terminal error frame — the balance-parity leg C1 added.
+#
+# Created 2026-07-08 (feat/billing-enforce-gate smoke, pre-Wave-2 gate).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _flag(on: bool):
+    """Patch the guard's own settings source so the REAL guard sees the flag."""
+    return patch(
+        "pocketpaw_ee.cloud.credits.guards.get_settings",
+        new=lambda: SimpleNamespace(billing_enforced=on),
+    )
+
+
+def _one_agent_group() -> SimpleNamespace:
+    return SimpleNamespace(
+        members=["u1"],
+        agents=[SimpleNamespace(agent_id="agent-a", respond_mode="smart")],
+    )
+
+
+async def test_smoke_bridge_blocks_empty_wallet_no_model_call(mongo_db):  # noqa: ARG001 — Beanie init
+    """flag ON + REAL empty wallet -> the group/DM bridge blocks with no model call."""
+    from pocketpaw_ee.cloud.credits import service as credits_service
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    # ws "ws-empty" has NO wallet -> real balance() is 0 -> check_balance raises.
+    assert await credits_service.balance("ws-empty") == 0
+
+    should_spy = AsyncMock(return_value=True)
+    run_spy = AsyncMock(return_value=None)
+    emit_spy = AsyncMock()
+
+    with (
+        _flag(True),
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=_one_agent_group()),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond", new=should_spy),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response", new=run_spy),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=emit_spy),
+    ):
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "g1",
+                "sender_id": "u1",
+                "content": "hey team",
+                "mentions": [],
+                "workspace_id": "ws-empty",
+            }
+        )
+
+    # No Haiku pre-classifier, no agent run — the real money guarantee.
+    should_spy.assert_not_awaited()
+    run_spy.assert_not_awaited()
+    # One terminal billing error emitted to the group.
+    assert emit_spy.await_count == 1
+    assert emit_spy.await_args_list[0].args[0].data["code"] == "credits.insufficient"
+
+
+async def test_smoke_bridge_proceeds_funded_wallet(mongo_db):  # noqa: ARG001 — Beanie init
+    """flag ON + REAL funded wallet -> the bridge proceeds (no over-blocking)."""
+    from pocketpaw_ee.cloud.credits import service as credits_service
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    await credits_service.grant("ws-funded", 500, cause="smoke.seed", idempotency_key="smoke-f1")
+    assert await credits_service.balance("ws-funded") == 500
+
+    should_spy = AsyncMock(return_value=False)  # returns False so no agent actually runs
+    run_spy = AsyncMock(return_value=None)
+
+    with (
+        _flag(True),
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=_one_agent_group()),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond", new=should_spy),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response", new=run_spy),
+    ):
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "g1",
+                "sender_id": "u1",
+                "content": "hey team",
+                "mentions": [],
+                "workspace_id": "ws-funded",
+            }
+        )
+
+    # The gate passed (real check_balance no-op + real check_quota under ceiling):
+    # respond-mode evaluation was reached, so the bridge did NOT over-block.
+    should_spy.assert_awaited()
+
+
+async def test_smoke_flag_off_empty_wallet_proceeds(mongo_db):  # noqa: ARG001 — Beanie init
+    """flag OFF + empty wallet -> proceeds. Default-off safety: inert until enabled."""
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    should_spy = AsyncMock(return_value=False)
+
+    with (
+        _flag(False),
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=_one_agent_group()),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond", new=should_spy),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response", new=AsyncMock()),
+    ):
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "g1",
+                "sender_id": "u1",
+                "content": "hey team",
+                "mentions": [],
+                "workspace_id": "ws-empty",  # empty wallet, but flag off
+            }
+        )
+
+    # Gate is a no-op with the flag off — the bridge proceeds past it.
+    should_spy.assert_awaited()
+
+
+async def test_smoke_worker_path_rejects_negative_wallet(mongo_db):  # noqa: ARG001 — Beanie init
+    """flag ON + REAL negative wallet -> the worker/executor guard rejects with a
+    terminal error frame (the balance-parity leg C1 added to the worker path)."""
+    from pocketpaw_ee.cloud.credits import guards
+    from pocketpaw_ee.cloud.credits import service as credits_service
+
+    # Drive the wallet negative through a real metered debit, like test_enforcement.
+    await credits_service.grant("ws-neg", 10, cause="smoke.seed", idempotency_key="smoke-n1")
+    await credits_service.debit(
+        "ws-neg", 25, cause="smoke.debit", idempotency_key="smoke-n2", allow_negative=True
+    )
+    assert await credits_service.balance("ws-neg") == -15
+
+    appended: list[tuple[str, dict]] = []
+
+    class _SpyTransport:
+        async def append_event(self, run_id: str, event: str, data: dict) -> None:  # noqa: ARG002
+            appended.append((event, data))
+
+        async def set_ttl(self, run_id: str, ttl: int) -> None:  # noqa: ARG002
+            return None
+
+    with (
+        _flag(True),
+        patch(
+            "pocketpaw_ee.cloud.chat.runs.service.mark_terminal",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        rejected = await guards.reject_if_over_billing(
+            "ws-neg", run_id="run-smoke", transport=_SpyTransport(), log_label="smoke"
+        )
+
+    assert rejected is True
+    assert appended and appended[0][0] == "error"
+    assert appended[0][1]["code"] == "credits.insufficient"

--- a/tests/cloud/entitlements/test_dto_caps.py
+++ b/tests/cloud/entitlements/test_dto_caps.py
@@ -1,0 +1,53 @@
+# tests/cloud/entitlements/test_dto_caps.py — the SMB caps (max_seats /
+# max_pockets / max_connectors) added to the plan ladder must reach the wire:
+# plan_tier_to_dto (GET /billing/plans) and entitlements_to_dto (GET /entitlements)
+# have to carry them, else the plan cards / settings UI cannot render real limits.
+# Created 2026-07-08 (feat/billing-smb-caps).
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.billing.plans import get_plan, list_plans
+from pocketpaw_ee.cloud.entitlements.domain import Entitlements
+from pocketpaw_ee.cloud.entitlements.dto import entitlements_to_dto, plan_tier_to_dto
+
+
+def test_plan_tier_dto_carries_caps() -> None:
+    """Every catalog row on the wire carries the three caps from its PlanTier."""
+    for tier in list_plans():
+        dto = plan_tier_to_dto(tier)
+        assert dto.max_seats == tier.max_seats
+        assert dto.max_pockets == tier.max_pockets
+        assert dto.max_connectors == tier.max_connectors
+
+
+def test_free_tier_dto_caps_are_concrete() -> None:
+    """Free (a capped tier) serializes concrete integer caps, not null."""
+    dto = plan_tier_to_dto(get_plan("free"))
+    assert isinstance(dto.max_seats, int)
+    assert isinstance(dto.max_pockets, int)
+    assert isinstance(dto.max_connectors, int)
+
+
+def test_enterprise_tier_dto_caps_are_null() -> None:
+    """Enterprise is uncapped — the caps serialize as null on the wire."""
+    dto = plan_tier_to_dto(get_plan("enterprise"))
+    assert dto.max_seats is None
+    assert dto.max_pockets is None
+    assert dto.max_connectors is None
+
+
+def test_entitlements_dto_carries_caps() -> None:
+    """A resolved entitlement carries its caps to the /entitlements response."""
+    ent = Entitlements(
+        workspace_id="ws-1",
+        plan="pro",
+        monthly_credit_allotment=1000,
+        monthly_ceiling=None,
+        features=frozenset(),
+        max_seats=25,
+        max_pockets=5000,
+        max_connectors=250,
+    )
+    dto = entitlements_to_dto(ent)
+    assert dto.max_seats == 25
+    assert dto.max_pockets == 5000
+    assert dto.max_connectors == 250

--- a/tests/cloud/entitlements/test_entitlements.py
+++ b/tests/cloud/entitlements/test_entitlements.py
@@ -25,6 +25,11 @@
 #   now also populates ``monthly_ceiling`` from the plan catalog — every known tier
 #   carries the catalog's ceiling (incl. enterprise=None uncapped), and an unknown
 #   / missing plan FAILS CLOSED to the Free ceiling (1000), never None/uncapped.
+# Updated 2026-07-08 (feat/billing-smb-caps): proves the resolver also surfaces the
+#   three SMB caps (``max_seats`` / ``max_pockets`` / ``max_connectors``) from the
+#   plan catalog for every known tier (incl. enterprise=None uncapped), and that an
+#   unknown / missing plan FAILS CLOSED to the Free values (5 / 200 / 50), never
+#   None/uncapped.
 
 from __future__ import annotations
 
@@ -95,6 +100,28 @@ async def test_every_known_plan_resolves_its_catalog_ceiling(patch_plan, plan):
         assert ent.monthly_ceiling is None  # the one uncapped tier
 
 
+@pytest.mark.parametrize("plan", ["free", "go", "pro", "pro_max", "enterprise"])
+async def test_every_known_plan_resolves_its_catalog_smb_caps(patch_plan, plan):
+    """The resolver mirrors the catalog's three SMB caps for every known tier."""
+    from pocketpaw_ee.cloud.billing import plans
+
+    patch_plan(plan)
+    ent = await entitlements.resolve_entitlements(WS)
+    tier = plans.get_plan(plan)
+    assert ent.max_seats == tier.max_seats
+    assert ent.max_pockets == tier.max_pockets
+    assert ent.max_connectors == tier.max_connectors
+    if plan == "enterprise":
+        # The one uncapped tier — all three surface as None.
+        assert ent.max_seats is None
+        assert ent.max_pockets is None
+        assert ent.max_connectors is None
+    else:
+        assert isinstance(ent.max_seats, int)
+        assert isinstance(ent.max_pockets, int)
+        assert isinstance(ent.max_connectors, int)
+
+
 # ---------------------------------------------------------------------------
 # Criterion (b) — no/unknown plan, or missing workspace, falls back to free.
 # ---------------------------------------------------------------------------
@@ -109,6 +136,20 @@ async def test_unknown_plan_falls_back_to_free(patch_plan):
     assert ent.monthly_credit_allotment == 0
     # FAIL-CLOSED: an unknown plan caps at the Free ceiling, never None/uncapped.
     assert ent.monthly_ceiling == 1_000
+    # FAIL-CLOSED on the SMB caps too: the Free values, never None/uncapped.
+    assert ent.max_seats == 5
+    assert ent.max_pockets == 200
+    assert ent.max_connectors == 50
+
+
+async def test_missing_workspace_falls_back_to_free_smb_caps(patch_plan):
+    """A missing workspace (get_workspace_plan -> None) fails closed on all SMB caps."""
+    patch_plan(None)
+    ent = await entitlements.resolve_entitlements(WS)
+    assert ent.plan == "free"
+    assert ent.max_seats == 5
+    assert ent.max_pockets == 200
+    assert ent.max_connectors == 50
 
 
 async def test_missing_workspace_falls_back_to_free(patch_plan):

--- a/tests/cloud/pockets/test_pocket_cap.py
+++ b/tests/cloud/pockets/test_pocket_cap.py
@@ -1,0 +1,150 @@
+# tests/cloud/pockets/test_pocket_cap.py
+# Created 2026-07-08 (feat/billing-smb-caps) — locks the per-plan POCKET cap on the
+# create seam. The cap (``_pocket_cap_exceeded``) resolves the workspace's plan
+# ``max_pockets`` and counts its live pockets; it is enforced at CREATE time only
+# (never removes an existing pocket) and is a no-op unless ``billing_enforced``.
+#
+# Two create seams are covered:
+#   * ``create`` — the HTTP path — RAISES ``PocketLimitError`` (402) at/over the cap.
+#   * ``create_from_ripple_spec`` — the agent auto-create path (does NOT funnel
+#     through ``create``) — returns ``None`` at/over the cap so the agent turn
+#     degrades gracefully instead of surfacing a raw 402 through the loop.
+#
+# The plan resolver is stubbed to a controlled ``max_pockets`` so the count/limit
+# logic is exercised against a small ceiling (no need to insert 200 real pockets);
+# the catalog-value + fail-closed contract itself lives in test_plans.py /
+# test_entitlements.py. ``billing_enforced`` is toggled by pointing the config's
+# ``get_settings`` at a flag stub — the same flag-mode lane the credit gate uses.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import PocketLimitError
+from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+from pocketpaw_ee.cloud.entitlements.domain import Entitlements
+from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+import pocketpaw.config as ppconfig
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws_pocket_cap"
+_USER = "user_pocket_cap"
+
+_RIPPLE_SPEC = {
+    "version": "1.0",
+    "state": {},
+    "ui": {"id": "n_root0001", "type": "flex", "props": {}, "children": []},
+}
+
+
+def _enforce(monkeypatch, *, on: bool) -> None:
+    """Point the config's ``get_settings`` (lazily imported inside the cap helper)
+    at a flag stub carrying the billing posture."""
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, dodo_plan_products=None),
+    )
+
+
+def _cap(monkeypatch, *, max_pockets: int | None) -> None:
+    """Stub the entitlements resolver to a controlled ``max_pockets`` ceiling."""
+    ent = Entitlements(
+        workspace_id=_WS,
+        plan="free",
+        monthly_credit_allotment=0,
+        monthly_ceiling=1_000,
+        max_seats=5,
+        max_pockets=max_pockets,
+        max_connectors=50,
+        features=frozenset(),
+    )
+    monkeypatch.setattr(entitlements_service, "resolve_entitlements", AsyncMock(return_value=ent))
+
+
+async def _seed_pockets(n: int) -> None:
+    for i in range(n):
+        await _PocketDoc(workspace=_WS, name=f"p{i}", owner=_USER).insert()
+
+
+# ---------------------------------------------------------------------------
+# create() — the HTTP path raises PocketLimitError.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_raises_pocket_limit_at_cap(monkeypatch) -> None:
+    """At/over the plan cap, create() raises PocketLimitError (402) — no write."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_pockets=2)
+    await _seed_pockets(2)  # already at the cap
+
+    with pytest.raises(PocketLimitError) as exc:
+        await pockets_service.create(_WS, _USER, CreatePocketRequest(name="over"))
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.pocket_limit"
+    # The blocked create did NOT persist a 3rd pocket.
+    assert await _PocketDoc.find(_PocketDoc.workspace == _WS).count() == 2
+
+
+async def test_create_allows_below_cap(monkeypatch) -> None:
+    """Below the cap, create() proceeds normally."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_pockets=2)
+    await _seed_pockets(1)  # one under the cap
+
+    wire = await pockets_service.create(_WS, _USER, CreatePocketRequest(name="ok"))
+    assert wire["_id"]
+    assert await _PocketDoc.find(_PocketDoc.workspace == _WS).count() == 2
+
+
+async def test_create_pocket_cap_is_noop_when_billing_disabled(monkeypatch) -> None:
+    """With billing_enforced OFF (OSS / self-host), the cap never fires — even well
+    over the ceiling."""
+    _enforce(monkeypatch, on=False)
+    _cap(monkeypatch, max_pockets=2)
+    await _seed_pockets(5)  # way over the (ignored) cap
+
+    wire = await pockets_service.create(_WS, _USER, CreatePocketRequest(name="ok"))
+    assert wire["_id"]
+
+
+async def test_create_pocket_cap_is_noop_when_uncapped(monkeypatch) -> None:
+    """An uncapped plan (Enterprise, max_pockets=None) never trips the cap."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_pockets=None)
+    await _seed_pockets(5)
+
+    wire = await pockets_service.create(_WS, _USER, CreatePocketRequest(name="ok"))
+    assert wire["_id"]
+
+
+# ---------------------------------------------------------------------------
+# create_from_ripple_spec() — the agent path returns None at the cap.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_from_ripple_spec_returns_none_at_cap(monkeypatch) -> None:
+    """The agent auto-create path degrades to None (not a 402) at/over the cap."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_pockets=2)
+    await _seed_pockets(2)
+
+    pocket_id = await pockets_service.create_from_ripple_spec(_WS, _USER, _RIPPLE_SPEC)
+    assert pocket_id is None
+    assert await _PocketDoc.find(_PocketDoc.workspace == _WS).count() == 2
+
+
+async def test_create_from_ripple_spec_succeeds_below_cap(monkeypatch) -> None:
+    """Below the cap, the agent auto-create path still creates the pocket."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_pockets=5)
+    await _seed_pockets(1)
+
+    pocket_id = await pockets_service.create_from_ripple_spec(_WS, _USER, _RIPPLE_SPEC)
+    assert pocket_id is not None

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -478,6 +478,98 @@ async def test_create_invite_seat_limit(owner, monkeypatch) -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# feat/billing-smb-caps — the seat gate is PLAN-SOURCED (max(doc.seats, plan cap)).
+# ---------------------------------------------------------------------------
+
+
+async def test_effective_seat_limit_is_max_of_doc_seats_and_plan(owner) -> None:
+    """The enforced ceiling is max(doc.seats, plan.max_seats) — plan lifts it, and a
+    custom-higher doc.seats never regresses."""
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WSDoc
+
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    doc = await _WSDoc.get(ws.id)
+
+    # Free plan (max_seats=5) == the default doc.seats=5: no change.
+    assert await workspace_service._effective_seat_limit(doc) == 5
+
+    # Upgrade the plan to pro (max_seats=25): the ceiling rises to 25.
+    doc.plan = "pro"
+    await doc.save()
+    assert await workspace_service._effective_seat_limit(doc) == 25
+
+    # A workspace whose custom doc.seats already exceeds the plan cap keeps the
+    # higher number — enforcement never strips seats it already has.
+    doc.plan = "free"
+    doc.seats = 40
+    await doc.save()
+    assert await workspace_service._effective_seat_limit(doc) == 40
+
+    # An uncapped plan (enterprise, max_seats=None) defers to doc.seats.
+    doc.plan = "enterprise"
+    doc.seats = 12
+    await doc.save()
+    assert await workspace_service._effective_seat_limit(doc) == 12
+
+
+async def test_create_invite_uses_plan_seat_limit_not_flat_seats(owner, monkeypatch) -> None:
+    """A workspace saturated at its flat doc.seats but on a higher-cap plan can still
+    invite — the gate sources the limit from the plan, not doc.seats alone."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WSDoc
+
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    # Move to pro (max_seats=25) while doc.seats stays the default 5.
+    doc = await _WSDoc.get(ws.id)
+    doc.plan = "pro"
+    await doc.save()
+
+    # Fill past the OLD flat limit of 5 (owner + 5 members = 6 > 5).
+    for i in range(5):
+        u = await _seed_user(email=f"seat{i}@x.c")
+        await workspace_service._add_member(ws.id, str(u.id), role="member")
+
+    # Under the flat-seats rule this would raise; under the plan cap (25) it succeeds.
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
+    )
+    assert invite.id
+
+
+async def test_raise_seats_for_plan_lifts_on_upgrade_only(owner) -> None:
+    """raise_seats_for_plan bumps doc.seats UP to the plan cap and never down."""
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WSDoc
+
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    # Default seats == 5. Upgrade to pro (25) lifts the stored cap.
+    new_seats = await workspace_service.raise_seats_for_plan(ws.id, "pro")
+    assert new_seats == 25
+    assert (await _WSDoc.get(ws.id)).seats == 25
+
+    # A "downgrade" to free (cap 5) must NOT strip the 25 seats it already has.
+    unchanged = await workspace_service.raise_seats_for_plan(ws.id, "free")
+    assert unchanged == 25
+    assert (await _WSDoc.get(ws.id)).seats == 25
+
+    # An uncapped plan (enterprise) is a no-op — returns None, leaves seats as-is.
+    ent_result = await workspace_service.raise_seats_for_plan(ws.id, "enterprise")
+    assert ent_result is None
+    assert (await _WSDoc.get(ws.id)).seats == 25
+
+    # An unknown plan key is a safe no-op (None), seats untouched.
+    assert await workspace_service.raise_seats_for_plan(ws.id, "bogus_tier") is None
+    assert (await _WSDoc.get(ws.id)).seats == 25
+
+
 async def test_create_invite_rejects_duplicate_pending(owner, monkeypatch) -> None:
     monkeypatch.setattr(
         "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop


### PR DESCRIPTION
Part 3 of 3 in the billing-enforcement stack, and the last backend criterion: real SMB resource caps so a plan can actually be sold. **Stacked on #1666** (base `feat/billing-cancel-downgrade`), so this diff is only the caps changes. Backend only; the PlanCards UI is a separate PR.

## What changed
Mirrors the existing `monthly_ceiling` precedent exactly:
- `plans.py` — `max_seats` / `max_pockets` / `max_connectors` on every `PlanTier`, from tunable dicts with the same fail-closed default for unknown keys.
- `entitlements` — the three caps surface on `Entitlements` and thread through `resolve_entitlements`, with defensive Free defaults.
- `_core/errors.py` — `PocketLimitError` (402 `billing.pocket_limit`) and `ConnectorLimitError` (402 `billing.connector_limit`), mirroring `SeatLimitError`.
- Enforcement, at create/invite/enable time only (never retroactive):
  - **Seats** — the three seat gates source the limit from the plan via `_effective_seat_limit = max(doc.seats, plan.max_seats)`, so an upgrade lifts the cap and a workspace with a higher custom seat count never regresses. `raise_seats_for_plan` on the `subscription.active` webhook resyncs the stored count up on an upgrade (upgrade-only, never strips).
  - **Pockets** — `PocketLimitError` at the ceiling in the create path; the ripple-spec agent path degrades to `None` at the cap (its failure contract) rather than throwing a raw 402 through the agent loop.
  - **Connectors** — `ConnectorLimitError` at the ceiling in `enable_connector`, but only when turning a connector on; an idempotent re-enable is never blocked.

## Two design choices
- Pocket + connector caps are **gated behind `billing_enforced`** (same as the credit gate), so OSS/self-host tenants are unaffected and pay no extra DB read. Seat enforcement stays always-on but is now plan-sourced.
- The cap **numbers are generous placeholders pending your pricing call** — the machinery is tier-agnostic and works with whatever ladder you land on. Free `max_seats` is pinned at 5 (the current `Workspace.seats` default), so no existing workspace regresses.

| tier | seats | pockets | connectors |
|---|---|---|---|
| free | 5 | 200 | 50 |
| go | 10 | 1,000 | 100 |
| pro | 25 | 5,000 | 250 |
| pro_max | 100 | 20,000 | 1,000 |
| enterprise | uncapped | uncapped | uncapped |

## Tests
- New `test_pocket_cap.py`, `test_connector_cap.py`, plus caps in `test_plans.py` / `test_entitlements.py` and seat tests in `test_service_v2.py`. 143 targeted pass: caps on every tier + fail-closed unknown key; seat limit sources from plan and an upgrade lifts it; pocket/connector caps raise at the ceiling, pass below, and no-op when billing is off.
- 152 billing+credits tests green across the full C1+C2+C3 stack. Both import-linter configs pass.
- Two `test_delete_preview_*` failures in `test_service_v2.py` are pre-existing: they fail identically on the base branch (verified by running them on the pre-C3 tip) and don't touch billing/cap code.

Top of the stack. Please review, but hold the merge — the whole stack lands together (merge the base with `--rebase`).