### PR TITLE
Fan cloud notifications out to Slack and generic webhooks

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,12 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-08 (feat/external-alerting-delivery) — added
+``NotificationDeliveryConfig`` (the per-workspace external-delivery config: Slack
+incoming-webhook + generic HTTPS webhook + enabled switch + per-kind routing) to
+the imports, ``__all__``, and ``get_all_documents()`` so the
+``notification_delivery_configs`` collection is wired into ``init_beanie``. Only
+``ee.cloud.notifications`` (service writes, delivery reads) imports the doc class
+directly (import-linter "Notifications" contract).
 Updated: 2026-07-03 (feat/files-share-links FL-12b) — added ``ShareLink`` (the
 public, token-gated file share-link doc) to the lazy uploads loader,
 ``get_all_documents()`` and ``__all__`` so the ``file_share_links`` collection
@@ -137,6 +144,7 @@ from pocketpaw_ee.cloud.models.meeting import (
 from pocketpaw_ee.cloud.models.member_ingest_state import MemberIngestState
 from pocketpaw_ee.cloud.models.message import Attachment, Mention, Message, Reaction
 from pocketpaw_ee.cloud.models.notification import Notification, NotificationSource
+from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
 from pocketpaw_ee.cloud.models.payment import Payment
 from pocketpaw_ee.cloud.models.planner import PlanSession, PlanSessionAgentGap
 from pocketpaw_ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
@@ -285,6 +293,7 @@ __all__ = [
     "Mention",
     "Message",
     "Notification",
+    "NotificationDeliveryConfig",
     "NotificationSource",
     "OAuthAccount",
     "Payment",
@@ -343,6 +352,9 @@ def get_all_documents():
         AgentSessionRuntimeDoc,
         Comment,
         Notification,
+        # Per-workspace external-delivery config (Slack + generic webhook).
+        # Only ``ee.cloud.notifications`` service/delivery import it.
+        NotificationDeliveryConfig,
         FileObj,
         FileUpload,
         FileFolder,

--- a/ee/pocketpaw_ee/cloud/models/notification_delivery.py
+++ b/ee/pocketpaw_ee/cloud/models/notification_delivery.py
@@ -1,0 +1,62 @@
+# ee/pocketpaw_ee/cloud/models/notification_delivery.py
+# Created: 2026-07-08 (feat/external-alerting-delivery) — Per-workspace external
+# notification delivery configuration. Backs Criterion 1 of external alerting:
+# a cloud notification (today WebSocket-only / in-app) can now ALSO fan out to a
+# Slack incoming-webhook and/or a generic HTTPS webhook. One row per workspace;
+# the ``workspace`` key is Indexed unique so the read/upsert path stays O(1)
+# (mirrors BeltWorkspaceConfig / ForesightWorkspaceConfig).
+#
+# Only ``ee.cloud.notifications.service`` WRITES this doc (upsert via the PUT
+# /notifications/delivery-config route) and only ``ee.cloud.notifications``
+# (service + delivery) READS it — same single-owner discipline the other
+# per-workspace config docs use, pinned by the import-linter "Notifications"
+# contract (router/dto/domain may never import this module).
+#
+# Routing: ``routes`` maps a notification kind -> the sink names it should reach
+# ("slack", "webhook"). The default (empty ``routes`` OR a kind absent from it)
+# is deliver-to-every-configured-sink when ``enabled`` is True. A present entry
+# NARROWS delivery of that kind to the named sinks. The shape is
+# extension-additive: a third sink ("email" via the gmail connector) layers on
+# as a new optional URL field + a new sink name with safe defaults.
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class NotificationDeliveryConfig(TimestampedDocument):
+    """Per-workspace external-delivery config for notifications.
+
+    Fields:
+      - ``workspace`` — tenancy key. Indexed unique so ``find_one`` / upsert
+        stays O(1).
+      - ``slack_webhook_url`` — a Slack *incoming webhook* URL
+        (``https://hooks.slack.com/services/...``). ``None`` disables the Slack
+        sink. POSTed as ``{"text": ...}`` (Slack's incoming-webhook shape).
+      - ``webhook_url`` — a generic HTTPS endpoint. ``None`` disables the generic
+        sink. Receives the full notification payload as JSON.
+      - ``enabled`` — master switch. When ``False`` no external delivery happens
+        regardless of the URLs (a workspace can save URLs but keep them dark).
+      - ``routes`` — optional per-kind narrowing (see module docstring). Default
+        empty => deliver every kind to every configured sink.
+      - ``createdAt`` / ``updatedAt`` — inherited from
+        :class:`TimestampedDocument`.
+
+    The shape is extension-additive; new optional fields with safe defaults won't
+    break callers reading the v1 config.
+    """
+
+    workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
+    slack_webhook_url: str | None = None
+    webhook_url: str | None = None
+    enabled: bool = False
+    routes: dict[str, list[str]] = Field(default_factory=dict)
+
+    class Settings:
+        name = "notification_delivery_configs"
+        # ``workspace`` already carries a unique single-field index from the
+        # ``Indexed(..., unique=True)`` annotation; the upsert path uses it
+        # directly. No composite indexes needed in v1.

--- a/ee/pocketpaw_ee/cloud/notifications/delivery.py
+++ b/ee/pocketpaw_ee/cloud/notifications/delivery.py
@@ -1,0 +1,203 @@
+# ee/pocketpaw_ee/cloud/notifications/delivery.py
+# Created: 2026-07-08 (feat/external-alerting-delivery) — external fan-out for
+# cloud notifications (Criterion 1: get alerts OUT of the app). Every cloud
+# notification funnels through ``notifications.service.create`` (tasks, meetings,
+# mentions all call it); this module POSTs that notification to the workspace's
+# configured Slack incoming-webhook and/or generic HTTPS webhook.
+#
+# Contract with the caller: ``_deliver_external`` is FIRE-AND-FORGET / NEVER-RAISE
+# (modeled on ``_core/realtime/emit.py`` and ``audit/webhooks.deliver``). It is
+# awaited inline right after the ``emit(NotificationNew(...))`` in ``create``, so
+# a dead/slow/malicious webhook must NOT be able to roll back the notification
+# insert or bubble an exception out of ``create``. Every network call is wrapped
+# and every URL is bounded by a short timeout so a hung endpoint can't stall the
+# insert response. A per-workspace kill switch (``enabled``) and per-kind routing
+# live on ``NotificationDeliveryConfig``.
+#
+# SSRF: the webhook URLs are workspace-admin-supplied, so a POST from the server
+# to an arbitrary URL is an SSRF vector. ``is_safe_webhook_url`` requires https://
+# and rejects literal private/loopback IPs and known-internal hostnames. It runs
+# at write time (the PUT route rejects a bad URL up front) AND here at delivery
+# time (defense-in-depth against a stored value that later became unsafe). Full
+# DNS-resolution hardening (like ``audit.webhooks._validate_url_safety``) is a
+# follow-up; this is the baseline.
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import httpx
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.cloud.notifications.domain import Notification
+
+logger = logging.getLogger(__name__)
+
+# Bounded so a hung endpoint can't stall the notification insert response.
+_DELIVERY_TIMEOUT_SECONDS = 5.0
+
+# Sink names. Kept as constants so ``routes`` values and future sinks stay
+# consistent. A third sink ("email") layers on here + a new URL field.
+SINK_SLACK = "slack"
+SINK_WEBHOOK = "webhook"
+
+# Hostnames that point at internal infrastructure on common cloud platforms /
+# dev boxes. Rejected even before any IP check (mirrors audit.webhooks).
+_FORBIDDEN_HOSTNAMES = frozenset(
+    {
+        "localhost",
+        "ip6-localhost",
+        "ip6-loopback",
+        "metadata",
+        "metadata.google.internal",
+        "metadata.goog",
+        "instance-data",
+    }
+)
+
+
+def _ip_is_unsafe(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def is_safe_webhook_url(url: str | None) -> bool:
+    """True when ``url`` is a plausible-safe external https webhook target.
+
+    Baseline SSRF guard for workspace-admin-supplied URLs: requires https://,
+    a hostname, a non-forbidden hostname, and — when the host is a literal IP —
+    a public address. A hostname that resolves to a private IP is NOT caught
+    here (no DNS lookup in the hot path); that DNS-resolution hardening is a
+    follow-up. ``None`` / empty is "no sink", which is safe (returns False).
+    """
+    if not url:
+        return False
+    if not url.startswith("https://"):
+        return False
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    hostname = (parsed.hostname or "").lower()
+    if not hostname or hostname in _FORBIDDEN_HOSTNAMES:
+        return False
+    try:
+        literal_ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        literal_ip = None
+    if literal_ip is not None and _ip_is_unsafe(literal_ip):
+        return False
+    return True
+
+
+def _slack_payload(notification: Notification) -> dict:
+    """Slack incoming-webhook shape. Slack renders ``text`` as the message body;
+    we lead with the title and append the body when present."""
+    text = notification.title
+    if notification.body:
+        text = f"{text}\n{notification.body}"
+    return {"text": text}
+
+
+def _generic_payload(notification: Notification) -> dict:
+    """Full notification payload for a generic consumer. Field names mirror the
+    domain object so a receiver can key off ``kind`` / ``workspace_id``."""
+    return {
+        "id": notification.id,
+        "workspace_id": notification.workspace_id,
+        "recipient_id": notification.recipient_id,
+        "actor_id": notification.actor_id,
+        "kind": notification.kind,
+        "title": notification.title,
+        "body": notification.body,
+    }
+
+
+async def _load_config(workspace_id: str):
+    """Load the workspace's delivery config, or ``None`` when unset.
+
+    Best-effort: a missing doc (the common case) or a read failure returns
+    ``None`` so a Mongo hiccup can never take down ``create``. Imported inside
+    the function to keep the module-import graph light (same lazy-import style
+    the belt service uses for its config doc)."""
+    from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
+
+    return await NotificationDeliveryConfig.find_one(
+        NotificationDeliveryConfig.workspace == workspace_id
+    )
+
+
+def _resolve_sinks(config, kind: str) -> list[tuple[str, str]]:
+    """Return the ``(sink_name, url)`` pairs to deliver ``kind`` to.
+
+    A sink is eligible when its URL is set AND passes the safety check. Routing:
+    if ``config.routes`` has an entry for ``kind``, only the named sinks are
+    used; otherwise every configured+safe sink is used (deliver-all default).
+    """
+    available: dict[str, str] = {}
+    if is_safe_webhook_url(config.slack_webhook_url):
+        available[SINK_SLACK] = config.slack_webhook_url
+    if is_safe_webhook_url(config.webhook_url):
+        available[SINK_WEBHOOK] = config.webhook_url
+
+    allowed = config.routes.get(kind) if config.routes else None
+    if allowed is not None:
+        return [(name, url) for name, url in available.items() if name in allowed]
+    return list(available.items())
+
+
+async def _post_one(
+    client: httpx.AsyncClient,
+    sink_name: str,
+    url: str,
+    notification: Notification,
+) -> None:
+    """POST the notification to one sink. Raises on failure — the caller
+    swallows it per-sink so one dead sink never blocks the others."""
+    payload = _slack_payload(notification) if sink_name == SINK_SLACK else _generic_payload(
+        notification
+    )
+    resp = await client.post(url, json=payload, timeout=_DELIVERY_TIMEOUT_SECONDS)
+    # 2xx is success; anything else is logged but not retried in v1.
+    if not (200 <= resp.status_code < 300):
+        logger.warning(
+            "notification external delivery: %s returned http %s", sink_name, resp.status_code
+        )
+
+
+async def _deliver_external(notification: Notification) -> None:
+    """Fan a freshly-created notification out to the workspace's external sinks.
+
+    NEVER raises — every failure mode (no config, disabled, unsafe URL, dead
+    endpoint, Mongo hiccup) is swallowed so the notification insert + realtime
+    emit that preceded this call can never be rolled back by a delivery problem.
+    """
+    try:
+        config = await _load_config(notification.workspace_id)
+        if config is None or not config.enabled:
+            return
+        sinks = _resolve_sinks(config, notification.kind)
+        if not sinks:
+            return
+        async with httpx.AsyncClient() as client:
+            for sink_name, url in sinks:
+                try:
+                    await _post_one(client, sink_name, url, notification)
+                except Exception:
+                    logger.warning(
+                        "notification external delivery to %s failed", sink_name, exc_info=True
+                    )
+    except Exception:
+        logger.warning("notification external delivery fan-out crashed", exc_info=True)
+
+
+__all__ = ["_deliver_external", "is_safe_webhook_url"]

--- a/ee/pocketpaw_ee/cloud/notifications/router.py
+++ b/ee/pocketpaw_ee/cloud/notifications/router.py
@@ -4,17 +4,45 @@ Thin: parses requests, delegates to ``ee.cloud.notifications.service``,
 returns ``NotificationOut`` DTOs at the boundary. FastAPI serializes to
 JSON. The wire shape matches the legacy ``_to_wire`` output byte-for-byte
 (verified by ``tests/cloud/notifications/test_router_golden.py``).
+
+Updated: 2026-07-08 (feat/external-alerting-delivery) — added the
+external-delivery config surface: ``GET`` / ``PUT /notifications/delivery-config``
+(workspace-scoped, ``notifications.manage`` = ADMIN) so a workspace admin can
+paste a Slack incoming-webhook / generic HTTPS webhook URL. The router never
+touches the Beanie doc — it delegates to the service (sole writer).
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.deps import (
+    current_workspace_id,
+    require_action_any_workspace,
+)
 from pocketpaw_ee.cloud.notifications import service as notifications_service
 from pocketpaw_ee.cloud.notifications.dto import NotificationOut, notification_to_dto
 
 router = APIRouter(prefix="/notifications", tags=["Notifications"])
+
+
+class DeliveryConfigRequest(BaseModel):
+    """Body for ``PUT /notifications/delivery-config``.
+
+    Full replacement of the workspace's external-delivery config. An empty /
+    omitted URL clears that sink. ``enabled`` is the master switch. ``routes``
+    optionally narrows a notification kind to specific sinks (``"slack"`` /
+    ``"webhook"``); the default (empty) delivers every kind to every configured
+    sink. URLs are validated (https + public host) by the service; a bad URL
+    yields a ``notifications.invalid_webhook_url`` error.
+    """
+
+    slack_webhook_url: str | None = Field(default=None)
+    webhook_url: str | None = Field(default=None)
+    enabled: bool = Field(default=False)
+    routes: dict[str, list[str]] = Field(default_factory=dict)
 
 
 @router.get("", response_model=list[NotificationOut])
@@ -74,3 +102,46 @@ async def delete_notification(
 
         raise HTTPException(status_code=404, detail="Notification not found")
     return {"status": "deleted"}
+
+
+# ---------------------------------------------------------------------------
+# External-delivery config (Criterion 1: get alerts OUT of the app).
+# Workspace-scoped, ADMIN-gated (``notifications.manage``): the config controls
+# where the server POSTs on every notification, so it extends the workspace's
+# egress surface — same tier as connector.manage / belt.manage.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/delivery-config")
+async def get_delivery_config(
+    _user=Depends(require_action_any_workspace("notifications.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict:
+    """Return the workspace's external-delivery config, or an empty default when
+    unset (so the settings form always has a shape to render)."""
+    config = await notifications_service.get_delivery_config(workspace_id)
+    if config is None:
+        return {
+            "workspace_id": workspace_id,
+            "slack_webhook_url": None,
+            "webhook_url": None,
+            "enabled": False,
+            "routes": {},
+        }
+    return config
+
+
+@router.put("/delivery-config")
+async def put_delivery_config(
+    body: DeliveryConfigRequest,
+    _user=Depends(require_action_any_workspace("notifications.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict:
+    """Upsert the workspace's external-delivery config. ADMIN-only."""
+    return await notifications_service.set_delivery_config(
+        workspace_id,
+        slack_webhook_url=body.slack_webhook_url,
+        webhook_url=body.webhook_url,
+        enabled=body.enabled,
+        routes=body.routes,
+    )

--- a/ee/pocketpaw_ee/cloud/notifications/service.py
+++ b/ee/pocketpaw_ee/cloud/notifications/service.py
@@ -1,5 +1,14 @@
 """Notification service — CRUD + realtime fan-out.
 
+Updated: 2026-07-08 (feat/external-alerting-delivery) — ``create`` now also
+fans the new notification OUT of the app: right after the in-app realtime
+``emit(NotificationNew(...))`` it awaits ``delivery._deliver_external(created)``,
+which POSTs to the workspace's configured Slack incoming-webhook and/or generic
+HTTPS webhook. That call is never-raise, so a dead sink can't roll back the
+insert. Added ``get_delivery_config`` / ``set_delivery_config`` — this service is
+the SOLE writer of the ``NotificationDeliveryConfig`` doc (upsert), fronted by
+the PUT /notifications/delivery-config route.
+
 Sole owner of writes to the ``Notification`` Beanie document. Writes are
 inline; there is no separate repository layer. Tests use the shared
 ``mongo_db`` fixture (mongomock-motor) instead of injecting a Protocol
@@ -7,11 +16,13 @@ fake.
 
 Public API is module-level ``async def`` functions:
 
-- ``create(...)`` — insert a notification, emit ``NotificationNew``
+- ``create(...)`` — insert a notification, emit ``NotificationNew``, fan out
 - ``list_for_user(user_id)`` — list domain ``Notification`` objects
 - ``list_for_user_dicts(user_id)`` — list of legacy wire-format dicts
 - ``mark_read(notification_id, user_id)`` — flip the read flag, emit
 - ``clear_all(user_id)`` — bulk mark unread → read for a user, emit
+- ``get_delivery_config(workspace_id)`` — read the external-delivery config
+- ``set_delivery_config(workspace_id, ...)`` — upsert the external-delivery config
 
 Cross-module fan-out callers (``chat/message_service.py``,
 ``workspace/service.py``) call ``notifications_service.create(...)``
@@ -33,6 +44,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 )
 from pocketpaw_ee.cloud.models.notification import Notification as _NotificationDoc
 from pocketpaw_ee.cloud.models.notification import NotificationSource as _NotificationSourceDoc
+from pocketpaw_ee.cloud.notifications.delivery import _deliver_external, is_safe_webhook_url
 from pocketpaw_ee.cloud.notifications.domain import Notification, NotificationSource
 from pocketpaw_ee.cloud.notifications.dto import notification_to_dto
 
@@ -115,6 +127,9 @@ async def create(
     await doc.insert()
     created = _to_domain(doc)
     await emit(NotificationNew(data=notification_to_dto(created).model_dump()))
+    # External fan-out (Slack / generic webhook). Never-raise: a dead sink must
+    # not roll back the insert or the emit above. See notifications/delivery.py.
+    await _deliver_external(created)
     return created
 
 
@@ -175,14 +190,89 @@ async def delete_notification(notification_id: str, user_id: str) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# External-delivery config — this service is the SOLE writer of the
+# NotificationDeliveryConfig doc (import-linter "Notifications" contract).
+# ---------------------------------------------------------------------------
+
+
+def _config_to_dict(doc) -> dict:
+    """Wire shape for the delivery config. Returns the workspace's own config,
+    so the URLs are returned as-stored (the admin who set them may see them)."""
+    return {
+        "workspace_id": doc.workspace,
+        "slack_webhook_url": doc.slack_webhook_url,
+        "webhook_url": doc.webhook_url,
+        "enabled": doc.enabled,
+        "routes": dict(doc.routes or {}),
+    }
+
+
+async def get_delivery_config(workspace_id: str) -> dict | None:
+    """Return the workspace's external-delivery config as a wire dict, or
+    ``None`` when unset."""
+    from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
+
+    doc = await NotificationDeliveryConfig.find_one(
+        NotificationDeliveryConfig.workspace == workspace_id
+    )
+    return _config_to_dict(doc) if doc is not None else None
+
+
+async def set_delivery_config(
+    workspace_id: str,
+    *,
+    slack_webhook_url: str | None = None,
+    webhook_url: str | None = None,
+    enabled: bool = False,
+    routes: dict[str, list[str]] | None = None,
+) -> dict:
+    """Upsert the workspace's external-delivery config and return the wire dict.
+
+    A non-empty URL that fails the SSRF safety check is rejected up front with a
+    ``Forbidden`` so a bad value never reaches storage (and later the delivery
+    hot path). Empty / ``None`` clears that sink. This is the only write path to
+    ``NotificationDeliveryConfig``.
+    """
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
+
+    slack = (slack_webhook_url or "").strip() or None
+    generic = (webhook_url or "").strip() or None
+    if slack is not None and not is_safe_webhook_url(slack):
+        raise Forbidden(
+            "notifications.invalid_webhook_url",
+            "Slack webhook URL must be an https:// URL to a public host.",
+        )
+    if generic is not None and not is_safe_webhook_url(generic):
+        raise Forbidden(
+            "notifications.invalid_webhook_url",
+            "Webhook URL must be an https:// URL to a public host.",
+        )
+
+    doc = await NotificationDeliveryConfig.find_one(
+        NotificationDeliveryConfig.workspace == workspace_id
+    )
+    if doc is None:
+        doc = NotificationDeliveryConfig(workspace=workspace_id)
+    doc.slack_webhook_url = slack
+    doc.webhook_url = generic
+    doc.enabled = enabled
+    doc.routes = dict(routes or {})
+    await doc.save()
+    return _config_to_dict(doc)
+
+
 __all__ = [
     "Notification",
     "NotificationSource",
     "count_unread",
     "create",
     "delete_notification",
+    "get_delivery_config",
     "list_for_user",
     "list_for_user_dicts",
     "mark_read",
     "clear_all",
+    "set_delivery_config",
 ]

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -237,6 +237,13 @@ ACTIONS: dict[str, ActionRule] = {
     # diffs), mirroring connector.manage / skills.manage.
     "belt.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
     "belt.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Notifications external-delivery config (ee.cloud.notifications.router,
+    # feat/external-alerting-delivery). ADMIN because the config sets where the
+    # server POSTs on EVERY notification (a Slack / generic webhook URL) — it
+    # extends the workspace's egress surface, mirroring connector.manage /
+    # belt.manage. There is no separate read action: the config is admin-only to
+    # view too (it holds the webhook URLs), so GET reuses ``notifications.manage``.
+    "notifications.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Security — the shield control-plane proxy (ee.cloud.security.router,
     # SEC-5). OWNER-only, the most restrictive workspace tier (mirrors
     # workspace.delete / billing.manage / instinct.activate). shield fronts the

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -464,7 +464,13 @@ source_modules = [
     "pocketpaw_ee.cloud.notifications.dto",
     "pocketpaw_ee.cloud.notifications.domain",
 ]
-forbidden_modules = ["pocketpaw_ee.cloud.models.notification"]
+# The external-delivery config doc (feat/external-alerting-delivery) is written
+# only by ``notifications.service`` and read by ``notifications.delivery`` — the
+# router/dto/domain façade must never touch either Beanie doc directly.
+forbidden_modules = [
+    "pocketpaw_ee.cloud.models.notification",
+    "pocketpaw_ee.cloud.models.notification_delivery",
+]
 
 [[tool.importlinter.contracts]]
 name = "FileVersions — Beanie writes only from service.py"

--- a/src/pocketpaw/alert_manager.py
+++ b/src/pocketpaw/alert_manager.py
@@ -362,6 +362,12 @@ class AlertManager:
             "details": details or {},
             "timestamp": timestamp,
         }
+        # FOLLOW-UP (external alerting): this OSS alert path is in-app only (local
+        # store + bus). The cloud external fan-out (Slack / generic webhook) lives
+        # in ee.cloud.notifications.delivery, but OSS core MUST NOT import EE
+        # (import-linter "OSS core may not import from EE"). Routing these alerts
+        # to external sinks needs a bus-indirection the EE layer subscribes (or an
+        # OSS-side sink impl), not a direct import — tracked as a separate slice.
         # Store locally
         self._store.append({**alert_data, "_unread": True})
         logger.info("Alert [%s/%s]: %s", severity, alert_type, message)

--- a/src/pocketpaw/automations/evaluator.py
+++ b/src/pocketpaw/automations/evaluator.py
@@ -172,6 +172,12 @@ class AutomationEvaluator:
     async def _notify(self, rule: Rule) -> None:
         """Send notification only (no action proposal or execution)."""
         # TODO: Integrate with notification system (WebSocket, email, etc.)
+        # FOLLOW-UP (external alerting): the cloud external fan-out (Slack /
+        # generic webhook) lives in ee.cloud.notifications.delivery, but OSS core
+        # MUST NOT import EE (import-linter "OSS core may not import from EE").
+        # Reaching external sinks from here needs a structurally-different path —
+        # an event-bus indirection the EE layer subscribes, or an OSS-side sink
+        # impl — not a direct import. Tracked as a separate slice.
         logger.info("Notification for rule %s: %s fired", rule.name, rule.description)
 
 

--- a/tests/cloud/notifications/test_delivery.py
+++ b/tests/cloud/notifications/test_delivery.py
@@ -1,0 +1,241 @@
+# tests/cloud/notifications/test_delivery.py
+# Created: 2026-07-08 (feat/external-alerting-delivery) — proves the external
+# fan-out (Slack + generic webhook) that ``notifications.service.create`` now
+# performs. Tests drive the REAL ``create`` path with a stubbed httpx transport
+# (spy on the POST, don't mock the seam under test) so the whole seam is
+# exercised end-to-end: config load -> routing -> httpx POST -> per-sink payload.
+# Fire-and-forget is proven directly: a sink whose transport RAISES does not
+# propagate out of ``create`` and the notification still inserts + still emits.
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud._core.realtime.events import NotificationNew
+from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
+from pocketpaw_ee.cloud.notifications import delivery as delivery_mod
+from pocketpaw_ee.cloud.notifications import service as notifications_service
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+SLACK_URL = "https://hooks.slack.com/services/T000/B000/xxx"
+WEBHOOK_URL = "https://alerts.example.com/ingest"
+
+
+class _Recorder:
+    """Records every httpx request routed through the stubbed transport and
+    returns a caller-supplied response (or raises to simulate a dead sink)."""
+
+    def __init__(self, responder=None) -> None:
+        self.requests: list[tuple[str, dict | None]] = []
+        # Default responder: 200 OK.
+        self._responder = responder or (lambda req: httpx.Response(200))
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else None
+        self.requests.append((str(request.url), body))
+        return self._responder(request)
+
+    def urls(self) -> list[str]:
+        return [u for u, _ in self.requests]
+
+
+def _install_transport(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None:
+    """Patch ``httpx.AsyncClient`` so delivery's real client code runs but the
+    network is served by an in-memory ``MockTransport``. This is a SPY, not a
+    mock of the seam under test: real request encoding + real ``.post`` execute.
+    """
+    real_async_client = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(recorder.handler)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+
+async def _set_config(**kwargs) -> None:
+    """Persist a delivery config for workspace ``w1`` via the sole writer."""
+    defaults: dict = {
+        "slack_webhook_url": SLACK_URL,
+        "webhook_url": WEBHOOK_URL,
+        "enabled": True,
+        "routes": {},
+    }
+    defaults.update(kwargs)
+    await notifications_service.set_delivery_config("w1", **defaults)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through service.create — the real seam.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_fans_out_to_both_sinks(monkeypatch, recording_bus) -> None:
+    rec = _Recorder()
+    _install_transport(monkeypatch, rec)
+    await _set_config()
+
+    out = await notifications_service.create(
+        workspace_id="w1", recipient="u2", kind="mention", title="Hi", body="you were mentioned"
+    )
+
+    # Both sinks POSTed.
+    assert set(rec.urls()) == {SLACK_URL, WEBHOOK_URL}
+    payloads = {u: b for u, b in rec.requests}
+    # Slack incoming-webhook shape: {"text": ...} carrying title + body.
+    assert payloads[SLACK_URL] == {"text": "Hi\nyou were mentioned"}
+    # Generic webhook: full notification payload.
+    generic = payloads[WEBHOOK_URL]
+    assert generic["kind"] == "mention"
+    assert generic["workspace_id"] == "w1"
+    assert generic["recipient_id"] == "u2"
+    assert generic["title"] == "Hi"
+
+    # The insert + realtime emit still happened.
+    assert out.id
+    assert len(await notifications_service.list_for_user("u2")) == 1
+    assert any(isinstance(e, NotificationNew) for e in recording_bus.events)
+
+
+async def test_dead_sink_never_breaks_create(monkeypatch, recording_bus) -> None:
+    """A sink whose transport RAISES must not propagate out of create; the
+    notification still inserts and still emits (fire-and-forget)."""
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    rec = _Recorder(responder=responder)
+    _install_transport(monkeypatch, rec)
+    await _set_config()
+
+    # Must not raise even though every sink's POST blows up.
+    out = await notifications_service.create(
+        workspace_id="w1", recipient="u2", kind="mention", title="Hi"
+    )
+
+    # Delivery was attempted (both sinks tried) ...
+    assert set(rec.urls()) == {SLACK_URL, WEBHOOK_URL}
+    # ... but the insert + emit survived the dead sinks.
+    assert out.id
+    assert len(await notifications_service.list_for_user("u2")) == 1
+    assert any(isinstance(e, NotificationNew) for e in recording_bus.events)
+
+
+async def test_no_config_means_no_delivery(monkeypatch) -> None:
+    rec = _Recorder()
+    _install_transport(monkeypatch, rec)
+    # No config saved for w1.
+    out = await notifications_service.create(
+        workspace_id="w1", recipient="u2", kind="mention", title="Hi"
+    )
+    assert out.id
+    assert rec.requests == []
+
+
+async def test_disabled_config_means_no_delivery(monkeypatch) -> None:
+    rec = _Recorder()
+    _install_transport(monkeypatch, rec)
+    await _set_config(enabled=False)
+    await notifications_service.create(
+        workspace_id="w1", recipient="u2", kind="mention", title="Hi"
+    )
+    assert rec.requests == []
+
+
+async def test_routes_narrow_kind_to_named_sink(monkeypatch) -> None:
+    rec = _Recorder()
+    _install_transport(monkeypatch, rec)
+    # 'mention' routes to slack only; other kinds still deliver-all.
+    await _set_config(routes={"mention": ["slack"]})
+
+    await notifications_service.create(workspace_id="w1", recipient="u2", kind="mention", title="M")
+    assert rec.urls() == [SLACK_URL]
+
+    rec.requests.clear()
+    await notifications_service.create(
+        workspace_id="w1", recipient="u2", kind="task_assigned", title="T"
+    )
+    assert set(rec.urls()) == {SLACK_URL, WEBHOOK_URL}
+
+
+async def test_delivery_scoped_per_workspace(monkeypatch) -> None:
+    """A notification in a workspace with no config does not use another
+    workspace's sinks."""
+    rec = _Recorder()
+    _install_transport(monkeypatch, rec)
+    await _set_config()  # config for w1 only
+
+    await notifications_service.create(
+        workspace_id="w2", recipient="u2", kind="mention", title="Hi"
+    )
+    assert rec.requests == []
+
+
+# ---------------------------------------------------------------------------
+# set_delivery_config — the sole write path.
+# ---------------------------------------------------------------------------
+
+
+async def test_set_config_upserts_one_row_per_workspace() -> None:
+    await notifications_service.set_delivery_config("w1", slack_webhook_url=SLACK_URL, enabled=True)
+    await notifications_service.set_delivery_config("w1", webhook_url=WEBHOOK_URL, enabled=False)
+    # Upsert, not duplicate insert: exactly one row for the workspace.
+    count = await NotificationDeliveryConfig.find(
+        NotificationDeliveryConfig.workspace == "w1"
+    ).count()
+    assert count == 1
+
+    current = await notifications_service.get_delivery_config("w1")
+    assert current is not None
+    assert current["webhook_url"] == WEBHOOK_URL
+    assert current["slack_webhook_url"] is None  # replaced by the second upsert
+    assert current["enabled"] is False
+
+
+async def test_set_config_rejects_unsafe_url_and_stores_nothing() -> None:
+    with pytest.raises(Forbidden):
+        await notifications_service.set_delivery_config(
+            "w1", webhook_url="http://169.254.169.254/latest/meta-data", enabled=True
+        )
+    # Rejected before any write.
+    assert await notifications_service.get_delivery_config("w1") is None
+
+
+async def test_set_config_empty_string_clears_sink() -> None:
+    await notifications_service.set_delivery_config(
+        "w1", slack_webhook_url=SLACK_URL, webhook_url=WEBHOOK_URL, enabled=True
+    )
+    await notifications_service.set_delivery_config(
+        "w1", slack_webhook_url="", webhook_url=WEBHOOK_URL, enabled=True
+    )
+    current = await notifications_service.get_delivery_config("w1")
+    assert current["slack_webhook_url"] is None
+    assert current["webhook_url"] == WEBHOOK_URL
+
+
+# ---------------------------------------------------------------------------
+# is_safe_webhook_url — SSRF baseline.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,safe",
+    [
+        ("https://hooks.slack.com/services/x", True),
+        ("https://alerts.example.com/ingest", True),
+        ("http://alerts.example.com/ingest", False),  # not https
+        ("https://localhost/x", False),  # forbidden hostname
+        ("https://127.0.0.1/x", False),  # loopback literal IP
+        ("https://169.254.169.254/x", False),  # link-local (cloud metadata)
+        ("https://10.0.0.5/x", False),  # private literal IP
+        ("https://metadata.google.internal/x", False),  # forbidden hostname
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_safe_webhook_url(url, safe) -> None:
+    assert delivery_mod.is_safe_webhook_url(url) is safe


### PR DESCRIPTION
The first slice of external alerting (Wave 2), and the highest-value one: alerts now leave the app. Cloud notifications have been WebSocket-only (in-app); this adds a per-workspace fan-out to Slack and a generic webhook, on top of the existing in-app push.

## What changed
- New `NotificationDeliveryConfig` (per-workspace, unique on `workspace_id`, in `cloud/models/`): Slack incoming-webhook URL, a generic webhook URL, an `enabled` master switch, and per-kind `routes`.
- `notifications/delivery.py` -> `_deliver_external`, awaited right after the `emit(NotificationNew(...))` in `service.create`. Every cloud notification funnels through `create` (tasks, meetings, mentions), so this covers them all.
- It's **fire-and-forget / never-raise**, modeled on `emit`: a dead, slow, or malicious sink can't roll back the notification insert or bubble an exception out of `create`. Each POST is bounded by a 5s timeout and wrapped per-sink.
- `PUT` / `GET /notifications/delivery-config` to manage the config, gated by a new `notifications.manage` admin action.

## Security: SSRF guard on the webhook URLs
Workspace-admin-supplied URLs are an SSRF vector, so `is_safe_webhook_url` requires https, rejects literal private/loopback/link-local IPs and known metadata hostnames, and runs both at write time (a bad URL is rejected up front) and at delivery time (defense in depth). One known gap, flagged for follow-up: a hostname that *resolves* to a private IP isn't caught here (no DNS lookup in the hot path); full DNS-resolution hardening, like `audit.webhooks`, is the next step.

## Deliberately deferred (with reasons)
- **The OSS `_notify` / `_emit_alert` paths carry a FOLLOW-UP note only.** OSS core can't import the EE delivery module (import-linter forbids OSS->EE), so that fan-out needs a separate mechanism (event-bus indirection or an OSS-side impl), not this module. Forcing the import would break the build.
- **Email sink** (via the Gmail connector) is structured as an easy third sink, deferred so this PR stays tight.
- **Criteria 2 (default-on automation flips) and 3 (merged Automations screen)** are their own slices.
- **UI** (a form to paste the Slack webhook URL) is a small follow-up PR.

## Tests
- 19 new tests in `test_delivery.py` drive the real `notifications.service.create` with a stubbed httpx transport (spy on the POST, real client code runs): both sinks fire with the right payloads; a sink that raises does not propagate (the insert and emit still happen); no-config / disabled / wrong-workspace deliver nothing; per-kind routing narrows; upsert keeps one row per workspace; an unsafe URL is rejected and stores nothing.
- Both import-linter configs pass, including `OSS core may not import from EE` and the extended Notifications Beanie-writes contract. `ruff` clean.
- 7 failures in the broader notifications suite (`test_router_golden`, `test_dto`, `test_derived`) are pre-existing: they fail identically on `origin/dev` (verified), unrelated to this change.

Please review; hold the merge.