### PR TITLE
feat(sites): D1 provisioning foundation for dynamic Paw Sites

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -85,6 +85,15 @@
 #     the publish path stashes the Dodo checkout link on so the router can surface
 #     it on ``SiteResponse.checkout_url`` for a paid publish. None for a free
 #     publish. Private so it never round-trips through the DB.
+#
+# Updated 2026-07-08 (DP0-1 — Dynamic Paw Sites Phase 0 provisioning state): added
+# ``provision_status`` (none | provisioning | provisioned | failed) alongside
+# ``d1_database_id``. It tracks where a dynamic site is in the durable D1 provision
+# job. The contract the job upholds: it persists ``d1_database_id`` IMMEDIATELY
+# after the D1 is created (status still ``provisioning``) so a retry reuses the same
+# D1 instead of orphaning a second one; status advances to ``provisioned`` only
+# after migrate + deploy succeed, and to ``failed`` on error. Defaults ``"none"`` so
+# every static site and every pre-DP0 row reads "not provisioning" — no migration.
 
 from __future__ import annotations
 
@@ -129,6 +138,13 @@ class Site(TimestampedDocument):
     # Stable across re-publishes (publish reuses the stored value) so the D1
     # binding target — and the data behind it — never moves under a live site.
     d1_database_id: str = ""
+    # DP0-1: where a dynamic site sits in the durable D1 provision job
+    # (none | provisioning | provisioned | failed). Contract: the job persists
+    # ``d1_database_id`` IMMEDIATELY after the D1 is created (status still
+    # ``provisioning``) so a retry REUSES the same D1 instead of orphaning a second
+    # one; status becomes ``provisioned`` only after migrate + deploy succeed, and
+    # ``failed`` on error. Defaults "none" for static sites and pre-DP0 rows.
+    provision_status: str = "none"
     # BC-9: per-site annual plan (the Webflow model — each published site has its
     # OWN recurring annual plan on a tier, distinct from the workspace plan).
     # ``plan_tier`` is the site-plan catalog key (basic | pro | business — see

--- a/ee/pocketpaw_ee/sites/cloudflare_client.py
+++ b/ee/pocketpaw_ee/sites/cloudflare_client.py
@@ -1,9 +1,12 @@
 # ee/pocketpaw_ee/sites/cloudflare_client.py — async Cloudflare API client for
-# the Sites control plane. Three surfaces:
+# the Sites control plane. Four surfaces:
 #   * Workers for Platforms — PUT a user Worker into our dispatch namespace
 #     (one synchronous call per site; live on 200; no per-account script cap).
 #   * Cloudflare for SaaS — create a custom hostname, return the single CNAME
 #     the client pastes, poll validation + TLS status.
+#   * D1 provisioning (DP0-1) — create a per-tenant D1 database and return its
+#     real uuid, so a Dynamic Paw Site's data plane can be stood up; see
+#     create_database.
 #   * D1 (DS-3) — query a dynamic site's per-tenant D1 over the HTTP API so the
 #     control plane can READ its data (the operator data-view); see query_d1.
 # httpx-based; account id + token come from settings (env), not per-tenant rows
@@ -13,6 +16,16 @@
 # header — never logged, never written to disk. All errors fail closed (raise
 # ValidationError), so a failed CF call never silently reports success.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.2).
+#
+# Updated 2026-07-08 (DP0-1 — D1 provisioning for Dynamic Paw Sites Phase 0):
+# added create_database(). It POSTs to the Cloudflare D1 create endpoint
+# (POST /accounts/{acct}/d1/database) with a ``{"name": <name>}`` body and returns
+# the new database's real uuid (``result.uuid`` in the envelope). It mirrors the
+# existing client style exactly: the CF token in the in-memory Authorization header
+# only, and fail-closed via the shared ``_unwrap`` (a non-2xx or success:false
+# raises ValidationError). This is the FIRST step of the durable provision job: the
+# returned uuid is persisted immediately so a retry reuses the same D1 instead of
+# orphaning a second one.
 #
 # Updated 2026-06-20 (DS-3 — control-plane read of a dynamic site's D1): added
 # query_d1(). It POSTs to the Cloudflare D1 query endpoint
@@ -248,6 +261,24 @@ class CloudflareClient:
             resp = await client.get(url)
         result = self._unwrap(resp)
         return _map_status(result.get("status", ""), (result.get("ssl") or {}).get("status", ""))
+
+    async def create_database(self, name: str) -> str:
+        """Create a Cloudflare D1 database and return its real uuid (DP0-1).
+
+        POSTs to the D1 create endpoint (POST /accounts/{acct}/d1/database) with a
+        ``{"name": <name>}`` body. Cloudflare returns the new database in the
+        standard envelope; the D1 uuid is at ``result.uuid``. This returns that
+        uuid string — the id every later step (migrate, the Worker's D1 binding,
+        the generated wrangler.toml ``database_id``) keys on.
+
+        Fail-closed: a non-2xx or a ``success: false`` envelope raises
+        ValidationError via ``_unwrap``, so a failed create never silently returns
+        an empty/garbage id."""
+        url = f"{_CF_API}/accounts/{self._account_id}/d1/database"
+        async with self._client() as client:
+            resp = await client.post(url, json={"name": name})
+        result = self._unwrap(resp)
+        return result["uuid"]
 
     async def query_d1(
         self, *, database_id: str, sql: str, params: list | None = None

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -8,6 +8,17 @@
 # behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-07-08 (DP0-1 — per-tenant D1 id plumbing for Dynamic Paw Sites
+# Phase 0): build()/_build_one() gained an optional ``d1_database_id: str = ""``
+# param that is ALWAYS written onto ``siteConfig.d1DatabaseId``. The paw-sites
+# generator already threads ``siteConfig.d1DatabaseId`` into the emitted
+# wrangler.toml ``database_id``, but this bridge never populated it, so today every
+# generated wrangler.toml ships ``database_id = ""``. This adds ONLY the
+# pass-through: a caller CAN now supply the per-tenant D1 id and it lands in
+# ``siteConfig.d1DatabaseId`` (default "" → the prior empty value, so a static site
+# is byte-unchanged). Wiring the real id from the provision job at the caller
+# (service.py) is a LATER task (DP0-3/DP0-4) — not done here.
+#
 # Updated 2026-07-09 (fix/sites-gen-windows-process-kill): ``_kill_process_group``
 # was POSIX-only — it unconditionally called ``os.killpg(os.getpgid(pid), SIGKILL)``,
 # neither of which exists on Windows. On a Windows host a build TIMEOUT therefore
@@ -787,6 +798,7 @@ class GeneratorClient:
         engine: str = "ripple",
         source: dict[str, Any] | None = None,
         builder_origin: str | None = None,
+        d1_database_id: str = "",
         pocket_id: str | None = None,
         smoke: bool = True,
         static_build: bool = True,
@@ -820,6 +832,13 @@ class GeneratorClient:
         is OMITTED from the payload when ``None`` so a normal (non-editable)
         publish keeps the exact prior wire bytes and the generator does not inject
         the bridge.
+
+        ``d1_database_id`` (DP0-1) is the per-tenant Cloudflare D1 id a DYNAMIC
+        site's data plane is bound to. It ALWAYS rides ``siteConfig.d1DatabaseId``
+        (default "" for a static site); the paw-sites generator threads that value
+        into the emitted wrangler.toml ``database_id`` so the deployed Worker binds
+        the right D1. This is only the pass-through — the real id is supplied by the
+        provision job at the caller in a later task (DP0-3/DP0-4).
 
         ``pocket_id`` (PERF-3) builds into a STABLE per-pocket working dir under
         build_home() (``<build_home>/<pocket_id>/``) so node_modules persists and
@@ -857,6 +876,7 @@ class GeneratorClient:
                 engine=engine,
                 source=source,
                 builder_origin=builder_origin,
+                d1_database_id=d1_database_id,
                 pocket_id=None,
                 smoke=smoke,
                 static_build=static_build,
@@ -872,6 +892,7 @@ class GeneratorClient:
                 engine=engine,
                 source=source,
                 builder_origin=builder_origin,
+                d1_database_id=d1_database_id,
                 pocket_id=pocket_id,
                 smoke=smoke,
                 static_build=static_build,
@@ -889,6 +910,7 @@ class GeneratorClient:
         engine: str,
         source: dict[str, Any] | None,
         builder_origin: str | None,
+        d1_database_id: str,
         pocket_id: str | None,
         smoke: bool,
         static_build: bool = True,
@@ -909,6 +931,12 @@ class GeneratorClient:
             "title": title,
             "captureApiBase": capture_api_base,
             "captureSignedKey": capture_signed_key,
+            # DP0-1: the per-tenant D1 id the generator threads into the emitted
+            # wrangler.toml ``database_id``. ALWAYS present (default "" for a static
+            # site — the prior empty value), so a caller CAN bind a dynamic site's
+            # data plane by supplying it. The real id comes from the provision job
+            # at the caller in a later task (DP0-3/DP0-4).
+            "d1DatabaseId": d1_database_id,
         }
         # SE-2b: only present when the site is being published as editable, so a
         # non-editable publish's payload is byte-identical to before this change.

--- a/tests/ee/sites/test_cloudflare_client.py
+++ b/tests/ee/sites/test_cloudflare_client.py
@@ -14,6 +14,10 @@
 # bindings + compatibility_date, plus the module file part) so a dynamic site's
 # deployed Worker reaches its per-tenant D1. When omitted it keeps the exact
 # single-module upload (static sites unchanged) — both paths are asserted here.
+# Updated 2026-07-08 (DP0-1 — D1 provisioning): added coverage for
+# create_database(): a successful create returns the uuid at ``result.uuid``, and
+# a Cloudflare error envelope (success:false or non-2xx) fails closed by raising
+# ValidationError with code ``sites.cloudflare_error``.
 from __future__ import annotations
 
 import json
@@ -211,3 +215,61 @@ async def test_non_2xx_raises():
     client = _client(handler)
     with pytest.raises(Exception):
         await client.put_worker(script_name="x", bundle=b"")
+
+
+@pytest.mark.asyncio
+async def test_create_database_returns_uuid_and_posts_name():
+    """DP0-1: create_database POSTs {"name": <name>} to the D1 create endpoint and
+    returns the new database's uuid from ``result.uuid``."""
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["method"] = request.method
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"success": True, "result": {"uuid": "d1_uuid_xyz", "name": "site-db"}},
+        )
+
+    client = _client(handler)
+    db_id = await client.create_database("site-db")
+    assert db_id == "d1_uuid_xyz"
+    assert seen["method"] == "POST"
+    assert seen["url"].endswith("/accounts/acct_1/d1/database")
+    assert seen["body"] == {"name": "site-db"}
+    # sanity: a real ValidationError type is importable (used by the fail path below).
+    assert ValidationError is not None
+
+
+@pytest.mark.asyncio
+async def test_create_database_error_envelope_raises_cloudflare_error():
+    """A Cloudflare error envelope (success:false) fails closed: create_database
+    raises ValidationError with code ``sites.cloudflare_error``."""
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"success": False, "errors": [{"message": "d1 quota exceeded"}]}
+        )
+
+    client = _client(handler)
+    with pytest.raises(ValidationError) as exc:
+        await client.create_database("site-db")
+    assert exc.value.code == "sites.cloudflare_error"
+
+
+@pytest.mark.asyncio
+async def test_create_database_non_2xx_raises_cloudflare_error():
+    """A non-2xx response fails closed with the same ``sites.cloudflare_error`` code."""
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"success": False, "errors": [{"message": "boom"}]})
+
+    client = _client(handler)
+    with pytest.raises(ValidationError) as exc:
+        await client.create_database("site-db")
+    assert exc.value.code == "sites.cloudflare_error"

--- a/tests/ee/sites/test_generator_client_svelte.py
+++ b/tests/ee/sites/test_generator_client_svelte.py
@@ -27,6 +27,12 @@
 # tracks, which masked it. This test pins the REAL svelte output shape so the
 # regression can't return.
 #
+# Updated 2026-07-08 (DP0-1 — per-tenant D1 id plumbing): build() now ALWAYS
+# threads an optional ``d1_database_id`` onto ``siteConfig.d1DatabaseId`` (default
+# "" for a static site), which the paw-sites generator bakes into the emitted
+# wrangler.toml ``database_id``. Two tests pin it: a supplied id lands on
+# ``siteConfig.d1DatabaseId``, and an omitted one defaults to "".
+#
 # Updated 2026-06-21 (feat/dsv-5-svelte-dynamic-brain): DSV-5 — a DYNAMIC svelte
 # pocket carries its live-data bindings (objects/sources/actions/auth) as SIBLING
 # keys on the same ``source`` envelope as the files. build() must SPLIT the
@@ -170,6 +176,50 @@ async def test_builder_origin_is_threaded_into_site_config() -> None:
     sent = runner.input_json
     assert sent is not None
     assert sent["siteConfig"]["builderOrigin"] == "https://app.paw.example"
+
+
+@pytest.mark.asyncio
+async def test_d1_database_id_is_threaded_into_site_config() -> None:
+    """DP0-1: build(d1_database_id=...) puts it on siteConfig.d1DatabaseId so the
+    paw-sites generator threads it into the emitted wrangler.toml database_id."""
+    runner = _CapturingRunner()
+    client = GeneratorClient(_runner=runner)
+    await client.build(
+        engine="svelte",
+        source=_SOURCE_MAP,
+        ripple_spec=None,
+        theme={},
+        site_id="site_sv",
+        title="Guestbook",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+        d1_database_id="abc123",
+    )
+    sent = runner.input_json
+    assert sent is not None
+    assert sent["siteConfig"]["d1DatabaseId"] == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_d1_database_id_defaults_to_empty_when_omitted() -> None:
+    """A static site (no d1_database_id) still carries the key, defaulting to "" —
+    the prior empty value the generator bakes into wrangler.toml database_id."""
+    runner = _CapturingRunner()
+    client = GeneratorClient(_runner=runner)
+    await client.build(
+        engine="svelte",
+        source=_SOURCE_MAP,
+        ripple_spec=None,
+        theme={},
+        site_id="site_sv",
+        title="Tally",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+        # d1_database_id omitted
+    )
+    sent = runner.input_json
+    assert sent is not None
+    assert sent["siteConfig"]["d1DatabaseId"] == ""
 
 
 @pytest.mark.asyncio

--- a/tests/ee/sites/test_site_provision_status.py
+++ b/tests/ee/sites/test_site_provision_status.py
@@ -1,0 +1,44 @@
+# tests/ee/sites/test_site_provision_status.py — pins the DP0-1 provisioning-state
+# field on the Site document.
+# Created: 2026-07-08 (feat/dp0-create-database, DP0-1) — a lightweight
+# pydantic-level round-trip: ``provision_status`` defaults to "none" (so static
+# sites and pre-DP0 rows read "not provisioning"), and a set value persists through
+# a model_dump/re-parse cycle. Documents the value set none | provisioning |
+# provisioned | failed. No DB is needed — instantiating the Beanie document is a
+# pure pydantic construction here.
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.models.site import Site
+
+
+def _site(**overrides) -> Site:
+    base = dict(workspace="ws1", pocket_id="pk1", owner="u1")
+    base.update(overrides)
+    return Site(**base)
+
+
+def test_provision_status_defaults_to_none() -> None:
+    """A fresh Site (static or pre-DP0) reads provision_status == "none"."""
+    assert _site().provision_status == "none"
+
+
+def test_provision_status_persists_a_set_value() -> None:
+    """A provisioning-state value round-trips through model_dump/re-parse."""
+    site = _site(provision_status="provisioning", d1_database_id="d1_uuid_xyz")
+    assert site.provision_status == "provisioning"
+    # The DP0-1 contract pairing: the D1 id is set the instant the D1 is created,
+    # while status is still "provisioning" (so a retry reuses the same D1).
+    assert site.d1_database_id == "d1_uuid_xyz"
+    dumped = site.model_dump()
+    assert dumped["provision_status"] == "provisioning"
+    reparsed = Site(
+        **{k: dumped[k] for k in ("workspace", "pocket_id", "owner")},
+        provision_status=dumped["provision_status"],
+    )
+    assert reparsed.provision_status == "provisioning"
+
+
+def test_provision_status_accepts_documented_states() -> None:
+    """The documented value set is none | provisioning | provisioned | failed."""
+    for state in ("none", "provisioning", "provisioned", "failed"):
+        assert _site(provision_status=state).provision_status == state


### PR DESCRIPTION
First slice of Dynamic Paw Sites Phase 0 — the foundation the provision job stacks on. Right now a published dynamic site can't actually reach a database: the D1 is never created and the generated `wrangler.toml` ships an empty `database_id`. This PR lays the three pieces that fix lets us fix that, without changing any publish behavior yet.

## What's here

- **`CloudflareClient.create_database`** — creates a per-tenant D1 and returns its real uuid. Same shape as the existing `query_d1`/`put_worker` methods, and fail-closed through the shared `_unwrap`, so a bad Cloudflare response can't hand back a garbage id.
- **`Site.provision_status`** (`none` / `provisioning` / `provisioned` / `failed`) — tracks where a dynamic site is in the provision job. The contract it documents: the id is saved the moment the D1 is created (status still `provisioning`), so if the job retries it reuses that D1 instead of leaving a second one behind.
- **`generator_client` plumbing** — `build()` now takes an optional `d1_database_id` and threads it onto `siteConfig.d1DatabaseId`, which the generator bakes into the emitted `wrangler.toml`. That value shipped empty before this change.

## What it deliberately leaves alone

No publish-path branching, no deploy changes, no provision job. `d1_database_id` is a pass-through today (default `""`); the real id gets supplied by the provision job in the next PR of the stack. Static sites are unaffected beyond gaining an empty `d1DatabaseId` key on the generate payload.

## Tests

`uv run pytest tests/ee/sites/test_cloudflare_client.py tests/ee/sites/test_generator_client_svelte.py tests/ee/sites/test_site_provision_status.py` → **25 passed**. Covers create_database success plus two error envelopes, the provision_status default/persist/valid-states, and the d1DatabaseId threading (set and default-empty).

Part of the Phase 0 stack. Base for `feat/dp0-provision-job`.