### PR TITLE
fix(pockets): let the catalog gate fail closed when the widget manifest is unreachable

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -340,6 +340,7 @@ from pocketpaw_ee.cloud.pockets.id_resolve import AmbiguousId, resolve_id
 from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
 from pocketpaw_ee.cloud.ripple_validator import (
     ActionWiringViolationError,
+    CatalogUnavailableError,
     CatalogViolationError,
     MissingRequiredPropError,
     find_unreferenced_state_keys,
@@ -922,14 +923,26 @@ async def _gate_catalog(
     (human / import path) logs a structured warning per violation and does
     not block. Either way, an embed-bearing spec is audit-logged.
 
-    Best-effort: when the widget manifest can't be fetched the gate is
-    skipped (same posture as the manifest-drift validator).
+    When the widget manifest can't be fetched the gate can't verify the spec.
+    Posture is controlled by ``ripple_catalog_gate_require_manifest``:
+
+    * default (``False``) — best-effort skip, same as the manifest-drift
+      validator (preserves current behavior; the manifest URL defaults to the
+      local ripple dev server, often down in dev).
+    * ``True`` — the strict (agent) path FAILS CLOSED, raising
+      :class:`CatalogUnavailableError` rather than persisting an unverifiable
+      spec. The logged (human/import) path still skips — it never blocks.
     """
     if not isinstance(spec, dict):
         return
     _audit_embed_ingest(spec, actor=actor, workspace_id=workspace_id, pocket_id=pocket_id)
     allowed_types = await _catalog_allowed_types()
     if allowed_types is None:
+        if strict:
+            from pocketpaw.config import get_settings
+
+            if get_settings().ripple_catalog_gate_require_manifest:
+                raise CatalogUnavailableError()
         return
     embed_hosts = _embed_allowed_hosts()
     if strict:

--- a/ee/pocketpaw_ee/cloud/ripple_validator.py
+++ b/ee/pocketpaw_ee/cloud/ripple_validator.py
@@ -23,6 +23,12 @@ new token / method added to the resolver should be added here too — the
 two files together are the contract.
 
 Changes:
+  - 2026-07-09 (RCR-3b, catalog gate fail-closed): added
+    ``CatalogUnavailableError`` (subclasses ``CatalogViolationError`` so
+    existing strict-path handlers block it) for the fail-closed posture in
+    ``pockets/service._gate_catalog`` when the manifest can't be fetched and
+    ``ripple_catalog_gate_require_manifest`` is enabled. The shared formatters
+    render a synthetic ``{"unavailable": True}`` violation as a clear message.
   - 2026-06-19 (feat/typed-ripplespec-phase2): DUAL-PATH READER. Every public
     spec reader (``validate_ripple_spec`` + ``_logged`` / ``_strict``,
     ``validate_against_catalog_*``, ``validate_action_wiring_*``,
@@ -423,7 +429,12 @@ class CatalogViolationError(Exception):
     def _format(violations: list[dict[str, Any]]) -> str:
         lines = [f"{len(violations)} catalog violation(s) in rippleSpec:"]
         for v in violations[:20]:  # cap the message length
-            if "reason" in v:
+            if v.get("unavailable"):
+                lines.append(
+                    f"  - [catalog_unavailable] {v['path']}: widget manifest "
+                    "could not be fetched — spec could not be verified"
+                )
+            elif "reason" in v:
                 lines.append(f"  - [embed] {v['path']}: {v['reason']}\n      url: {v.get('url')!r}")
             else:
                 hint = f" — did you mean '{v['suggestion']}'?" if v.get("suggestion") else ""
@@ -431,6 +442,23 @@ class CatalogViolationError(Exception):
         if len(violations) > 20:
             lines.append(f"  - …and {len(violations) - 20} more")
         return "\n".join(lines)
+
+
+class CatalogUnavailableError(CatalogViolationError):
+    """Raised on the STRICT (agent-generation) path when the widget-catalog
+    manifest can't be fetched and ``ripple_catalog_gate_require_manifest`` is
+    enabled — the spec can't be verified against the catalog, so it is
+    rejected rather than persisted (fail-closed).
+
+    Subclasses :class:`CatalogViolationError` so every existing strict-path
+    handler (which already catches ``CatalogViolationError``) blocks the write
+    with no new wiring. The distinct type lets operators tell "manifest down"
+    from "bad widget type" in telemetry, and carries a single synthetic
+    ``unavailable`` violation so the shared formatters render a clear message.
+    """
+
+    def __init__(self) -> None:
+        super().__init__([{"path": "ui", "unavailable": True}])
 
 
 def _collect_catalog_violations(
@@ -459,7 +487,12 @@ def format_violations_for_agent(violations: list[dict[str, Any]]) -> str:
         return ""
     lines = ["The rippleSpec was rejected — it contains nodes outside the widget catalog:"]
     for v in violations[:10]:
-        if "reason" in v:
+        if v.get("unavailable"):
+            lines.append(
+                f"  • {v['path']}: the widget catalog is temporarily unavailable, "
+                "so this spec could not be verified. Try again shortly."
+            )
+        elif "reason" in v:
             lines.append(f"  • {v['path']}: embed url rejected — {v['reason']}")
         else:
             hint = f" Use '{v['suggestion']}' instead." if v.get("suggestion") else ""
@@ -979,6 +1012,7 @@ def find_unreferenced_state_keys(spec: RippleSpec | dict[str, Any] | None) -> li
 
 __all__ = [
     "ActionWiringViolationError",
+    "CatalogUnavailableError",
     "CatalogViolationError",
     "ExpressionWarning",
     "MissingRequiredPropError",

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -2125,6 +2125,19 @@ class Settings(BaseSettings):
         default=86400,
         description="TTL in seconds for cached Ripple manifest (default: 24h)",
     )
+    ripple_catalog_gate_require_manifest: bool = Field(
+        default=False,
+        description=(
+            "When True, the strict (agent-generation) catalog gate FAILS CLOSED "
+            "if the Ripple widget manifest can't be fetched — an unverifiable "
+            "spec is rejected instead of persisted. Defaults False (best-effort "
+            "skip, preserving current behavior) because ripple_manifest_url "
+            "defaults to the local ripple dev server, which is often down in "
+            "dev; enable it on cloud/prod where the manifest URL points at a "
+            "reliable CDN. Set via "
+            "POCKETPAW_RIPPLE_CATALOG_GATE_REQUIRE_MANIFEST."
+        ),
+    )
     ripple_embed_allowed_hosts: list[str] = Field(
         default_factory=lambda: [
             "youtube-nocookie.com",

--- a/tests/cloud/test_pocket_catalog_gate.py
+++ b/tests/cloud/test_pocket_catalog_gate.py
@@ -13,7 +13,10 @@ import pytest
 pytest.importorskip("pocketpaw_ee")
 
 from pocketpaw_ee.cloud.pockets import service as pockets_service  # noqa: E402
-from pocketpaw_ee.cloud.ripple_validator import CatalogViolationError  # noqa: E402
+from pocketpaw_ee.cloud.ripple_validator import (  # noqa: E402
+    CatalogUnavailableError,
+    CatalogViolationError,
+)
 
 from pocketpaw.security.audit import get_audit_logger  # noqa: E402
 
@@ -153,4 +156,76 @@ async def test_gate_catalog_audits_embed_even_when_manifest_unavailable(
         deregister()
 
     # The embed audit fires regardless of whether the manifest was reachable.
+    assert any(e.get("action") == "pocket.embed_ingest" for e in captured)
+
+
+def _require_manifest_on(monkeypatch) -> None:
+    """Flip ripple_catalog_gate_require_manifest=True by stubbing get_settings
+    (it is lru_cached, so patch the accessor, not an env var)."""
+
+    class _S:
+        ripple_catalog_gate_require_manifest = True
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+
+async def test_gate_catalog_fails_closed_when_required_and_manifest_unavailable(
+    monkeypatch,
+) -> None:
+    """Flag ON + strict + no manifest → FAIL CLOSED: raise instead of skip,
+    so an unverifiable agent-generated spec is never persisted."""
+
+    async def _no_manifest() -> None:
+        return None
+
+    monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _no_manifest)
+    _require_manifest_on(monkeypatch)
+
+    spec = {"ui": {"type": "ghost-widget", "props": {}}}
+    with pytest.raises(CatalogUnavailableError):
+        await pockets_service._gate_catalog(spec, strict=True, actor="u1", workspace_id="w1")
+
+
+async def test_gate_catalog_logged_still_skips_when_required_and_manifest_unavailable(
+    monkeypatch,
+) -> None:
+    """Flag ON but strict=False (human/import path) → still a no-op. The
+    logged path never blocks; fail-closed is strict-only."""
+
+    async def _no_manifest() -> None:
+        return None
+
+    monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _no_manifest)
+    _require_manifest_on(monkeypatch)
+
+    spec = {"ui": {"type": "ghost-widget", "props": {}}}
+    # Must NOT raise — logged mode is best-effort regardless of the flag.
+    await pockets_service._gate_catalog(spec, strict=False, actor="u1", workspace_id="w1")
+
+
+async def test_gate_catalog_fail_closed_still_audits_embed(monkeypatch) -> None:
+    """Even when failing closed, the embed-ingest audit (which runs before the
+    gate) still fires — the fail-closed raise doesn't swallow the audit."""
+
+    async def _no_manifest() -> None:
+        return None
+
+    monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _no_manifest)
+    _require_manifest_on(monkeypatch)
+
+    captured, deregister = _capture_audit()
+    try:
+        spec = {
+            "ui": {
+                "type": "embed",
+                "props": {"mode": "url", "url": "https://www.figma.com/file/x"},
+            }
+        }
+        with pytest.raises(CatalogUnavailableError):
+            await pockets_service._gate_catalog(
+                spec, strict=True, actor="u1", workspace_id="w1", pocket_id="p9"
+            )
+    finally:
+        deregister()
+
     assert any(e.get("action") == "pocket.embed_ingest" for e in captured)


### PR DESCRIPTION
## The gap

The strict catalog gate — the one on the agent-generation path — verifies a generated rippleSpec against the widget manifest before it's persisted. But when the manifest can't be fetched (network hiccup, or the local ripple dev server is down), `_gate_catalog` returned early and skipped verification entirely. So the one moment we couldn't check a spec was the moment we let it through unchecked. That's fail-open on a security boundary.

Part of the ripple consumer-readiness arc (B7). Targets the `integration/ripple-consumer-readiness` branch, not `dev`.

## The change

An opt-in fail-closed posture, behind a new setting:

- `ripple_catalog_gate_require_manifest` (default **false**). When true, the **strict** path raises `CatalogUnavailableError` when the manifest can't be resolved, instead of skipping. The **logged** (human/import) path still never blocks — fail-closed is strict-only.
- `CatalogUnavailableError` subclasses `CatalogViolationError`, so every existing strict-path handler already catches and blocks it with no new wiring. Keeping it a distinct type means operators can tell "manifest was down" apart from "the spec used a bad widget type" in telemetry. The shared formatters render it as a clear message (log: `[catalog_unavailable] ui: widget manifest could not be fetched`; agent: `the widget catalog is temporarily unavailable, so this spec could not be verified`).

## Why it defaults off (please confirm the rollout)

The manifest URL defaults to `http://localhost:5174/manifest.json` — the local ripple dev server, which is usually not running in dev. If this shipped fail-closed by default, every dev environment without that server up would start rejecting agent pocket creation. That's the same shape as the guard that turned dev red and got reverted before (#1570).

So the mechanism ships **off**. The intended rollout: flip `POCKETPAW_RIPPLE_CATALOG_GATE_REQUIRE_MANIFEST=true` on cloud/prod once `ripple_manifest_url` points at a reliable CDN (which happens after ripple publishes to npm). Flagging it here so you can confirm that's the posture you want before it ships enabled anywhere.

## Verification

- `tests/cloud/test_pocket_catalog_gate.py` — 3 new tests: strict + flag on + no manifest → raises; logged + flag on + no manifest → still skips; the embed-ingest audit still fires before the fail-closed raise. 36 pass in the file.
- 61 more tests pass across the related strict-path gate + validator suites (`test_pocket_widget_spec_gate`, `test_pocket_edit_action_gate`, `test_ripple_required_props_gate`, `test_ripple_validator_action_wiring`, `test_ripple_catalog`) — default-off behavior is unchanged.
- `ruff check` clean on all four changed files. Default confirmed `False` at runtime.
