### PR TITLE
Thesis-gap remediation: billing, alerting, guardrails, ontology, transforms, analysis, evals, paw-bar (integration)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -65,6 +65,13 @@ svelte source via the apply-leaf-edit CLI and persist as a Branch draft, no
 rebuild — dynamic-source split + input-keyspace confinement) and GET
 /sites/by-pocket/{id}/native-artifact (serve the armed build's body_html + css
 for shadow render — per-GET arm-build cost, path-traversal-guarded CSS reader).
+
+Updated: 2026-07-11 (feat/real-pipeline-s1) — documented the Fabric — Transform
+Mappings section: GET/POST/DELETE /fabric/ingest/mappings (author the
+workspace's source→Fabric mappings, now with a "connector" source_kind that
+dispatches through the OSS FABRIC_INGESTORS registry — gcalendar first) and
+POST /fabric/ingest/run (run one mapping immediately; misconfiguration reports
+status="error" in the body, never a 5xx).
 -->
 
 # Cloud REST API Reference
@@ -1189,3 +1196,74 @@ Errors:
 | 404 | `pocket.not_found` | Unknown pocket id. |
 | 403 | `pocket.access_denied` | The caller lacks access to the pocket. |
 | 500 | `sites.generator_failed` | The arm build failed (missing toolchain, non-zero build, or smoke-gate failure). |
+
+## Fabric — Transform Mappings (source→Fabric ingest)
+
+The transform surface over the per-workspace `FabricIngestConfig`: which
+sources land as typed Fabric objects, and how. A mapping's `source_kind`
+picks the pipeline:
+
+- `"firestore"` (default) — the original reader path: mirror a Firestore
+  collection, keyed on the doc path, with a real high-water cursor.
+- `"connector"` — pull records through the OSS connector→Fabric ingestor
+  registry (`pocketpaw.connectors.fabric_ingest.FABRIC_INGESTORS`;
+  `gcalendar` is the first registered adopter). By convention `collection`
+  holds the connector name (it stays the routing key everywhere);
+  `connector_id` overrides it when they differ. The run resolves the
+  workspace's **enabled** `WorkspaceConnector` row and calls the ingestor
+  with that row's `user_id`, so a user-scoped connector reads with that
+  member's OAuth token bucket (`null` = the shared/workspace bucket).
+
+All routes are license + plan-feature `fabric` gated (business tier and up).
+Reads require `fabric.read`, mutations (author, delete, run-now) require
+`fabric.write`; the workspace is always the caller's active workspace — it
+never travels in a request body.
+
+### `GET /fabric/ingest/mappings`
+
+Returns `{"mappings": [...]}` — the caller's workspace's authored mappings
+(empty list when nothing is configured yet). Shown regardless of the config's
+`enabled` flag so a paused pipeline is still visible.
+
+### `POST /fabric/ingest/mappings`
+
+Author one mapping — create-or-replace, keyed on `collection` (201). Body:
+
+```json
+{
+  "collection": "gcalendar",
+  "object_type_id": "ot-calendar-event",
+  "source_kind": "connector",
+  "connector_id": null,
+  "field_map": {},
+  "cursor_field": "",
+  "link_rules": []
+}
+```
+
+A malformed mapping (blank `collection` / `object_type_id`, blank field-map
+entries) is rejected with 422 before anything is stored.
+
+### `DELETE /fabric/ingest/mappings?collection=<key>`
+
+Remove the mapping keyed on `collection` (204; 404 when it doesn't exist).
+The key rides a query param, not a path segment — Firestore collection paths
+can contain `/`.
+
+### `POST /fabric/ingest/run`
+
+Run one mapping's ingest immediately. Body: `{"collection": "<key>"}`.
+Returns the ingest result envelope:
+
+```json
+{
+  "workspace_id": "…", "source_id": "gcalendar", "status": "ok",
+  "mode": "backfill", "objects": 3, "cursor": "", "errors": []
+}
+```
+
+Misconfiguration — no mapping for the key, connector not connected or
+disabled, no ingestor registered under the connector id — reports
+`status: "error"` with the reason in `errors` (HTTP 200, matching the
+background sweep's never-raise, per-source isolation contract). Re-runs are
+idempotent: objects upsert by `(source_connector, source_id)`.

--- a/docs/getting-started/cli.mdx
+++ b/docs/getting-started/cli.mdx
@@ -273,3 +273,21 @@ pocketpaw update
 | `--workspace ID` | Workspace id (for `pocket reconcile`; or `POCKETPAW_WORKSPACE_ID`) |
 | `--user ID` | User id (for `pocket reconcile`; or `POCKETPAW_USER_ID`) |
 | `--version` | Show version |
+
+## The `paw` Command
+
+Alongside `pocketpaw`, the package installs `paw` — a companion CLI for the project-resident soul (`init`, `ask`, `chat`, `status`, `doctor`) plus remote reads against a running PocketPaw server:
+
+```bash
+# Ontology reads over HTTP (works against any running PocketPaw server)
+paw fabric stats                          # ontology counts for your workspace
+paw fabric types                          # object types you can see
+paw fabric query --type-name Customer     # run a Fabric query
+
+# Point it at a server + credential (flags or env)
+paw fabric stats --base-url https://cloud.example.com --api-key paw_xxxx
+export PAW_BASE_URL=https://cloud.example.com
+export PAW_API_KEY=paw_xxxx
+```
+
+The `--api-key` value is a bearer credential — a `paw_...` API key or a login JWT. Output is JSON, so the commands pipe cleanly into `jq`. For programmatic access from Python, the same route contracts are wrapped by `pocketpaw.paw.client.PawClient`.

--- a/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
@@ -38,19 +38,39 @@
 #     fabric_object_types table now carries a workspace_id; a NULL workspace_id
 #     is a legacy/global type visible to all — see FabricStore.list_types).
 #
-# Read-only: neither tool writes anything. FabricCreateTool is deliberately
-# NOT wrapped — ontology writes from the SDK backend should arrive as gated
-# proposals, not ambient writes.
+# Updated: 2026-07-11 (feat/paw-cli, C2) — the server is no longer read-only:
+# three ontology MODIFICATION tools joined the two reads, so an agent on this
+# backend can manage the ontology (link CRUD + type editing), mirroring the
+# HTTP surface the ontology-operator-ux wave shipped:
+#   * fabric_link_create — link two objects. Both endpoints must resolve in the
+#     caller's workspace (scoped get_object), and the workspace's DECLARED link
+#     schema is enforced through the router's own ``_enforce_link_type`` (one
+#     implementation, two surfaces) — same rules as POST /fabric/links.
+#   * fabric_link_delete — remove one link. ``FabricStore.unlink`` is unscoped,
+#     so the tool resolves the link through the scoped ``get_link`` first; a
+#     cross-tenant or unknown id refuses (mirrors DELETE /fabric/links/{id}).
+#   * fabric_type_update — rename/additive type editing via the store's
+#     versioned ``update_type`` + registry re-registration, mirroring
+#     PATCH /fabric/schema/types/{id}. That route is ADMIN-gated, so this tool
+#     RBAC-gates on ``fabric.admin`` (workspace_admin.py's check_workspace_action
+#     deny-envelope pattern) — a non-admin gets a structured denial, never a
+#     write. Destructive property removal stays deferred (store semantics).
+# The 2026-06-11 "writes arrive as gated proposals" posture is superseded for
+# the MEMBER-tier link writes: the HTTP routes already allow any member to
+# create/delete links directly (``fabric.write`` = MEMBER), so the MCP surface
+# now matches the REST surface instead of being stricter than it. Every write
+# is audited via record_tool_call.
 #
 # Security: query inputs are DATA — they are bound as SQL parameters by the
 # fabric store, never interpolated. The workspace id comes from the session's
-# ContextVars, never from the agent's args, so an agent cannot query another
-# tenant's rows. Result payloads are size-capped so a huge ontology can't blow
-# the model context.
+# ContextVars, never from the agent's args, so an agent cannot query or WRITE
+# another tenant's rows (writes stamp the resolved workspace; deletes resolve
+# through scoped reads). Result payloads are size-capped so a huge ontology
+# can't blow the model context.
 #
 # EE→OSS boundary: this module lives in pocketpaw_ee and imports only
 # ``pocketpaw`` (OSS) symbols at call time; core never imports this package.
-"""Agent-side MCP surface for read-only Fabric ontology access."""
+"""Agent-side MCP surface for Fabric ontology access (reads + gated writes)."""
 
 from __future__ import annotations
 
@@ -70,8 +90,17 @@ SERVER_NAME = "pocketpaw_fabric"
 # ``fabric_query`` / ``fabric_stats`` — keep the tool names stable.
 FABRIC_QUERY_TOOL_ID = f"mcp__{SERVER_NAME}__fabric_query"
 FABRIC_STATS_TOOL_ID = f"mcp__{SERVER_NAME}__fabric_stats"
+FABRIC_LINK_CREATE_TOOL_ID = f"mcp__{SERVER_NAME}__fabric_link_create"
+FABRIC_LINK_DELETE_TOOL_ID = f"mcp__{SERVER_NAME}__fabric_link_delete"
+FABRIC_TYPE_UPDATE_TOOL_ID = f"mcp__{SERVER_NAME}__fabric_type_update"
 
-FABRIC_TOOL_IDS = (FABRIC_QUERY_TOOL_ID, FABRIC_STATS_TOOL_ID)
+FABRIC_TOOL_IDS = (
+    FABRIC_QUERY_TOOL_ID,
+    FABRIC_STATS_TOOL_ID,
+    FABRIC_LINK_CREATE_TOOL_ID,
+    FABRIC_LINK_DELETE_TOOL_ID,
+    FABRIC_TYPE_UPDATE_TOOL_ID,
+)
 
 # Result-size caps. ``MAX_QUERY_LIMIT`` mirrors the registry tool's clamp
 # (``min(limit, 50)``); ``MAX_RESULT_BYTES`` bounds the serialized JSON body so
@@ -288,9 +317,309 @@ async def _fabric_stats_handler(args: dict) -> dict:
     )
 
 
+def _serialize_link(lnk: Any) -> dict[str, Any]:
+    """A JSON-friendly projection of a FabricLink."""
+    return {
+        "id": lnk.id,
+        "from_object_id": lnk.from_object_id,
+        "to_object_id": lnk.to_object_id,
+        "link_type": lnk.link_type,
+        "properties": dict(lnk.properties or {}),
+    }
+
+
+def _serialize_type(obj_type: Any) -> dict[str, Any]:
+    """A JSON-friendly projection of an ObjectType (schema surface fields)."""
+    return {
+        "id": obj_type.id,
+        "name": obj_type.name,
+        "version": getattr(obj_type, "version", 1),
+        "description": obj_type.description,
+        "properties": [
+            {"name": p.name, "type": p.type, "required": p.required}
+            for p in obj_type.properties
+        ],
+    }
+
+
+async def _load_user(user_id: str) -> Any | None:
+    """Load the User Beanie doc for ``user_id`` so ``check_workspace_action``
+    has the ``.workspaces`` membership list it reads. Returns ``None`` on a bad
+    id / missing user. Lazy imports keep the module's top-level import surface
+    minimal (mirrors workspace_admin.py)."""
+    from beanie import PydanticObjectId
+
+    from pocketpaw_ee.cloud.models.user import User as _UserDoc
+
+    try:
+        return await _UserDoc.get(PydanticObjectId(user_id))
+    except Exception:  # noqa: BLE001 — malformed id / no DB
+        return None
+
+
+async def _gate_admin(tool: str, workspace_id: str, user_id: str | None) -> dict | None:
+    """RBAC-gate an ADMIN-tier tool on ``fabric.admin``.
+
+    Mirrors workspace_admin.py's gate: the User doc is loaded so
+    ``check_workspace_action`` has the membership list, and a ``Forbidden`` is
+    CAUGHT and returned as a structured deny envelope (never raised) — the gate
+    itself audits the denial. Returns ``None`` on PASS, or a ready-to-return
+    response dict on any failure.
+    """
+    if not user_id:
+        return _error_response(f"{tool} could not resolve the calling user for the RBAC check.")
+
+    from pocketpaw_ee.guards.deps import check_workspace_action
+    from pocketpaw_ee.guards.rbac import Forbidden
+
+    user = await _load_user(user_id)
+    if user is None:
+        return _error_response(f"{tool} could not resolve the calling user for the RBAC check.")
+
+    try:
+        check_workspace_action(user, workspace_id, "fabric.admin")
+    except Forbidden as exc:
+        logger.info(
+            "%s denied: user=%s workspace=%s code=%s", tool, user_id, workspace_id, exc.code
+        )
+        return _success_response(
+            {
+                "ok": False,
+                "denied": True,
+                "code": exc.code,
+                "message": f"editing the ontology schema requires an admin role ({exc.code}).",
+            }
+        )
+    return None
+
+
+async def _fabric_link_create_handler(args: dict) -> dict:
+    """MCP handler for ``fabric__fabric_link_create``.
+
+    Links two objects in the caller's workspace. Both endpoints must resolve
+    through the SCOPED ``get_object`` (a cross-tenant / unknown id refuses),
+    and the workspace's declared link schema is enforced through the router's
+    own ``_enforce_link_type`` — identical rules to ``POST /fabric/links``.
+    """
+    workspace_id, _user_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "fabric_link_create requires workspace context (call from a cloud chat session)."
+        )
+
+    record_tool_call(
+        workspace_id=workspace_id,
+        user_id=_user_id,
+        tool_server="pocketpaw_fabric",
+        tool_name="_fabric_link_create",
+        status="ok",
+        ok=True,
+    )
+
+    args = coerce_json_object_args(args, ("properties",))
+    from_id = args.get("from_id")
+    to_id = args.get("to_id")
+    link_type = args.get("link_type")
+    properties = args.get("properties")
+
+    for field_name, value in (("from_id", from_id), ("to_id", to_id), ("link_type", link_type)):
+        if not value or not isinstance(value, str):
+            return _error_response(
+                f"fabric_link_create `{field_name}` is required and must be a string."
+            )
+    if properties is not None and not isinstance(properties, dict):
+        return _error_response("fabric_link_create `properties` must be a JSON object.")
+
+    store = _get_fabric_store()
+    if store is None:
+        return _error_response("Fabric is not available (enterprise feature).")
+
+    try:
+        for field_name, obj_id in (("from_id", from_id), ("to_id", to_id)):
+            obj = await store.get_object(obj_id, workspace_id=workspace_id)
+            if obj is None:
+                return _error_response(
+                    f"fabric_link_create `{field_name}` {obj_id!r} was not found in this "
+                    "workspace."
+                )
+
+        # One enforcement implementation, two surfaces: reuse the EE router's
+        # declared-link-schema check (no declarations -> no-op).
+        from pocketpaw_ee.cloud._core.errors import CloudError
+        from pocketpaw_ee.fabric.router import LinkRequest, _enforce_link_type
+
+        req = LinkRequest(
+            from_id=from_id, to_id=to_id, link_type=link_type, properties=properties or {}
+        )
+        try:
+            await _enforce_link_type(store, workspace_id, req)
+        except CloudError as exc:
+            return _error_response(exc.message)
+
+        lnk = await store.link(
+            from_id=from_id,
+            to_id=to_id,
+            link_type=link_type,
+            properties=properties or {},
+            workspace_id=workspace_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("fabric_link_create failed (link_type=%s)", link_type, exc_info=True)
+        return _error_response(f"could not create the link: {exc}")
+
+    return _success_response({"created": True, "link": _serialize_link(lnk)})
+
+
+async def _fabric_link_delete_handler(args: dict) -> dict:
+    """MCP handler for ``fabric__fabric_link_delete``.
+
+    Deletes one link. ``FabricStore.unlink`` is unscoped by design, so the
+    tenancy guard lives here: the link is resolved through the SCOPED
+    ``get_link`` first — a cross-tenant or unknown id refuses without leaking
+    whether it exists elsewhere. Mirrors ``DELETE /fabric/links/{id}``.
+    """
+    workspace_id, _user_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "fabric_link_delete requires workspace context (call from a cloud chat session)."
+        )
+
+    record_tool_call(
+        workspace_id=workspace_id,
+        user_id=_user_id,
+        tool_server="pocketpaw_fabric",
+        tool_name="_fabric_link_delete",
+        status="ok",
+        ok=True,
+    )
+
+    link_id = args.get("link_id")
+    if not link_id or not isinstance(link_id, str):
+        return _error_response("fabric_link_delete `link_id` is required and must be a string.")
+
+    store = _get_fabric_store()
+    if store is None:
+        return _error_response("Fabric is not available (enterprise feature).")
+
+    try:
+        link = await store.get_link(link_id, workspace_id=workspace_id)
+        if link is None:
+            return _error_response(f"link {link_id!r} was not found in this workspace.")
+        await store.unlink(link_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("fabric_link_delete failed (link_id=%s)", link_id, exc_info=True)
+        return _error_response(f"could not delete the link: {exc}")
+
+    return _success_response({"deleted": True, "link": _serialize_link(link)})
+
+
+async def _fabric_type_update_handler(args: dict) -> dict:
+    """MCP handler for ``fabric__fabric_type_update``.
+
+    Rename/additive type editing — versions the type and migrates existing
+    objects through the store's ``update_type`` (a property rename moves the
+    key; an added property with a default is backfilled; destructive removal
+    is deferred). Mirrors ``PATCH /fabric/schema/types/{id}`` including its
+    gate: that route is ADMIN-only, so this tool RBAC-checks ``fabric.admin``
+    and returns a structured denial for a non-admin. The registry is
+    re-registered after the write, exactly like the route handler.
+    """
+    workspace_id, _user_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "fabric_type_update requires workspace context (call from a cloud chat session)."
+        )
+
+    record_tool_call(
+        workspace_id=workspace_id,
+        user_id=_user_id,
+        tool_server="pocketpaw_fabric",
+        tool_name="_fabric_type_update",
+        status="ok",
+        ok=True,
+    )
+
+    denied = await _gate_admin("fabric_type_update", workspace_id, _user_id)
+    if denied is not None:
+        return denied
+
+    args = coerce_json_object_args(args, ("properties", "renames"))
+    type_name = args.get("type_name")
+    renames = args.get("renames")
+    properties = args.get("properties")
+    description = args.get("description")
+
+    if not type_name or not isinstance(type_name, str):
+        return _error_response("fabric_type_update `type_name` is required and must be a string.")
+    if renames is not None and not isinstance(renames, dict):
+        return _error_response(
+            "fabric_type_update `renames` must be a JSON object mapping "
+            "old property names to new ones."
+        )
+    if properties is not None and not isinstance(properties, list):
+        return _error_response(
+            "fabric_type_update `properties` must be an array of {name, type} objects."
+        )
+    if description is not None and not isinstance(description, str):
+        return _error_response("fabric_type_update `description` must be a string.")
+    if renames is None and properties is None and description is None:
+        return _error_response(
+            "fabric_type_update needs at least one change: `renames`, `properties`, "
+            "or `description`."
+        )
+
+    store = _get_fabric_store()
+    if store is None:
+        return _error_response("Fabric is not available (enterprise feature).")
+
+    try:
+        from pocketpaw.fabric.models import PropertyDef
+
+        prop_defs: list[Any] | None = None
+        if properties is not None:
+            prop_defs = []
+            for i, raw in enumerate(properties):
+                if not isinstance(raw, dict):
+                    return _error_response(
+                        f"fabric_type_update properties[{i}] must be a {{name, type}} object."
+                    )
+                try:
+                    prop_defs.append(PropertyDef(**raw))
+                except Exception as exc:  # pydantic ValidationError
+                    return _error_response(f"invalid property definition at index {i}: {exc}")
+
+        obj_type = await store.get_type_by_name(type_name, workspace_id=workspace_id)
+        if obj_type is None:
+            return _error_response(f"object type {type_name!r} was not found in this workspace.")
+
+        updated = await store.update_type(
+            obj_type.id,
+            properties=prop_defs,
+            renames=renames,
+            description=description,
+            workspace_id=workspace_id,
+        )
+        if updated is None:
+            return _error_response(f"object type {type_name!r} was not found in this workspace.")
+
+        # Registry re-registration, mirroring the route handler.
+        from pocketpaw_ee.fabric.storage import get_registry_store
+
+        reg = get_registry_store()
+        reg.register_entity_type(workspace_id, updated.name)
+        for prop in updated.properties:
+            reg.register_property(workspace_id, updated.name, prop.name, prop.type)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("fabric_type_update failed (type=%s)", type_name, exc_info=True)
+        return _error_response(f"could not update the type: {exc}")
+
+    return _success_response({"updated": True, "type": _serialize_type(updated)})
+
+
 def build_fabric_server() -> tuple[str, Any] | None:
-    """Build the in-process SDK MCP server for read-only Fabric access, or
-    return ``None`` if the Claude Agent SDK isn't installed.
+    """Build the in-process SDK MCP server for Fabric ontology access (two
+    reads + three modification tools), or return ``None`` if the Claude Agent
+    SDK isn't installed.
 
     Matches the shape returned by ``build_belt_server`` (``(name, server)`` or
     ``None``) so the backend's MCP registration loop treats it identically.
@@ -367,18 +696,142 @@ def build_fabric_server() -> tuple[str, Any] | None:
     async def fabric_stats(args):  # type: ignore[no-untyped-def]
         return await _fabric_stats_handler(args)
 
+    @tool(
+        "fabric_link_create",
+        (
+            "Create a LINK between two existing objects in the Fabric "
+            "ontology (e.g. connect an Order to its Customer). Both objects "
+            "must exist in the current workspace, and if the workspace has "
+            "declared link types the link must match one (type name + "
+            "endpoint object types), else it is refused with the reason. "
+            "Args: `from_id` (source object id), `to_id` (target object id), "
+            "`link_type` (relationship name, e.g. 'has_order'), `properties` "
+            "(optional JSON object of link metadata). Returns {created, "
+            "link:{id, from_object_id, to_object_id, link_type, properties}}. "
+            "An error means relay the reason."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "from_id": {
+                    "type": "string",
+                    "description": "Source object ID.",
+                },
+                "to_id": {
+                    "type": "string",
+                    "description": "Target object ID.",
+                },
+                "link_type": {
+                    "type": "string",
+                    "description": "Relationship type (e.g. 'has_order', 'belongs_to').",
+                },
+                "properties": {
+                    "type": "object",
+                    "description": "Optional metadata to store on the link.",
+                },
+            },
+            "required": ["from_id", "to_id", "link_type"],
+            "additionalProperties": False,
+        },
+    )
+    async def fabric_link_create(args):  # type: ignore[no-untyped-def]
+        return await _fabric_link_create_handler(args)
+
+    @tool(
+        "fabric_link_delete",
+        (
+            "Delete one LINK from the Fabric ontology by its link id (find "
+            "ids via fabric_query's linked_to traversal or the links list). "
+            "Only removes the relationship — the objects on both ends are "
+            "untouched. Scoped to the current workspace: a link id from "
+            "another workspace refuses. Args: `link_id`. Returns {deleted, "
+            "link}. An error means relay the reason."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "link_id": {
+                    "type": "string",
+                    "description": "ID of the link to delete.",
+                },
+            },
+            "required": ["link_id"],
+            "additionalProperties": False,
+        },
+    )
+    async def fabric_link_delete(args):  # type: ignore[no-untyped-def]
+        return await _fabric_link_delete_handler(args)
+
+    @tool(
+        "fabric_type_update",
+        (
+            "Edit an object TYPE's schema in the Fabric ontology — rename "
+            "properties and/or add new ones (rename + additive only; "
+            "removing a property never scrubs existing data). Requires an "
+            "ADMIN role in the workspace; non-admins get a structured "
+            "denial. The type's version is bumped and existing objects are "
+            "migrated (renamed keys move; an added property with a default "
+            "is backfilled). Args: `type_name` (which type to edit), "
+            "`renames` (JSON object mapping old property name -> new name), "
+            "`properties` (array of {name, type, required?, default?} — "
+            "REPLACES the declared schema, so include existing properties "
+            "you want to keep), `description` (new type description). At "
+            "least one change is required. Returns {updated, type:{id, "
+            "name, version, description, properties}}. An error means relay "
+            "the reason."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "type_name": {
+                    "type": "string",
+                    "description": "Name of the object type to edit (e.g. 'Customer').",
+                },
+                "renames": {
+                    "type": "object",
+                    "description": "Map of old property name -> new property name.",
+                },
+                "properties": {
+                    "type": "array",
+                    "description": (
+                        "Declared schema replacement: array of {name, type, "
+                        "required?, default?} objects. Include properties to keep."
+                    ),
+                    "items": {"type": "object"},
+                },
+                "description": {
+                    "type": "string",
+                    "description": "New human-readable description for the type.",
+                },
+            },
+            "required": ["type_name"],
+            "additionalProperties": False,
+        },
+    )
+    async def fabric_type_update(args):  # type: ignore[no-untyped-def]
+        return await _fabric_type_update_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[fabric_query, fabric_stats],
+        tools=[
+            fabric_query,
+            fabric_stats,
+            fabric_link_create,
+            fabric_link_delete,
+            fabric_type_update,
+        ],
     )
     return SERVER_NAME, server
 
 
 __all__ = [
+    "FABRIC_LINK_CREATE_TOOL_ID",
+    "FABRIC_LINK_DELETE_TOOL_ID",
     "FABRIC_QUERY_TOOL_ID",
     "FABRIC_STATS_TOOL_ID",
     "FABRIC_TOOL_IDS",
+    "FABRIC_TYPE_UPDATE_TOOL_ID",
     "SERVER_NAME",
     "build_fabric_server",
 ]

--- a/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
@@ -360,8 +360,7 @@ def _serialize_type(obj_type: Any) -> dict[str, Any]:
         "version": getattr(obj_type, "version", 1),
         "description": obj_type.description,
         "properties": [
-            {"name": p.name, "type": p.type, "required": p.required}
-            for p in obj_type.properties
+            {"name": p.name, "type": p.type, "required": p.required} for p in obj_type.properties
         ],
     }
 
@@ -463,8 +462,7 @@ async def _fabric_link_create_handler(args: dict) -> dict:
             obj = await store.get_object(obj_id, workspace_id=workspace_id)
             if obj is None:
                 return _error_response(
-                    f"fabric_link_create `{field_name}` {obj_id!r} was not found in this "
-                    "workspace."
+                    f"fabric_link_create `{field_name}` {obj_id!r} was not found in this workspace."
                 )
 
         # One enforcement implementation, two surfaces: reuse the EE router's

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,10 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-07-11 (feat/real-pipeline-s1) — Mounts the fabric_ingest
+    transform-surface router (``/fabric/ingest/mappings`` CRUD +
+    ``/fabric/ingest/run`` run-now) next to the fabric router under
+    ``/api/v1``. Same gates as fabric: license + plan feature at the router,
+    fabric.read/fabric.write per route.
 Modified: 2026-07-03 (feat/files-share-links, FL-12b) — Mounts two share-link
     routers: ``share_router`` (owner + license gated POST/DELETE
     /files/{id}/share) and ``public_share_router`` (intentionally
@@ -362,6 +367,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(pockets_journal_stream_router, prefix="/api/v1")
 
     from pocketpaw_ee.cloud.decisions.router import router as decisions_router
+    from pocketpaw_ee.cloud.fabric_ingest.router import router as fabric_ingest_router
     from pocketpaw_ee.cloud.instinct_approvals.router import router as instinct_approvals_router
     from pocketpaw_ee.cloud.kb.router import router as kb_router
     from pocketpaw_ee.cloud.leads.router import router as leads_router
@@ -596,6 +602,10 @@ def mount_cloud(app: FastAPI) -> None:
     # OSS core no longer mounts them. They ride along here, like paw_bar
     # above, instead of through the core's mount_v1_routers().
     app.include_router(fabric_router, prefix="/api/v1")
+    # Transform surface (feat/real-pipeline-s1): author/list/run-now the
+    # workspace's connector→Fabric ingest mappings. Rides next to fabric —
+    # same license + plan gates, fabric.read/write per route.
+    app.include_router(fabric_ingest_router, prefix="/api/v1")
     app.include_router(fleet_router, prefix="/api/v1")
     app.include_router(instinct_router, prefix="/api/v1")
 

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -249,6 +249,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.pockets.router import router as pockets_router
     from pocketpaw_ee.cloud.projects.router import router as projects_router
     from pocketpaw_ee.cloud.request_log.router import router as request_log_router
+    from pocketpaw_ee.cloud.rules.router import router as rules_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
     from pocketpaw_ee.cloud.skills.router import router as skills_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
@@ -297,6 +298,13 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(planner_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
     app.include_router(cycles_router, prefix="/api/v1")
+    # Governed Instinct rules (feat/instinct-guardrail-rules) — the UI-authored
+    # guardrail surface: create / list / archive a governed rule + the
+    # per-workspace authored-rule enforcement toggle (GET/PUT /rules/enforcement).
+    # Admin-gated (rules.manage); the enforcement it toggles is the shipped gate
+    # path in ee.cloud.pockets.instinct_dispatch — this router adds no new
+    # enforcement logic.
+    app.include_router(rules_router, prefix="/api/v1")
     # Foresight — RFC 08 scenario-run surface (POST /foresight/scenarios,
     # GET /foresight/runs[/{id}]). Mounted alongside cycles so the
     # Mission Control rail can launch / inspect simulation runs from the

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -226,6 +226,9 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.audit.router import router as audit_router
     from pocketpaw_ee.cloud.audit.router import workspace_router as audit_workspace_router
     from pocketpaw_ee.cloud.auth.router import router as auth_router
+    from pocketpaw_ee.cloud.automations_status.router import (
+        router as automations_status_router,
+    )
     from pocketpaw_ee.cloud.billing.router import router as billing_router
     from pocketpaw_ee.cloud.billing.webhooks import router as billing_webhooks_router
     from pocketpaw_ee.cloud.chat.router import router as chat_router
@@ -305,6 +308,7 @@ def mount_cloud(app: FastAPI) -> None:
     # path in ee.cloud.pockets.instinct_dispatch — this router adds no new
     # enforcement logic.
     app.include_router(rules_router, prefix="/api/v1")
+    app.include_router(automations_status_router, prefix="/api/v1")
     # Foresight — RFC 08 scenario-run surface (POST /foresight/scenarios,
     # GET /foresight/runs[/{id}]). Mounted alongside cycles so the
     # Mission Control rail can launch / inspect simulation runs from the

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -24,6 +24,13 @@ the subscription-cancel path when a workspace has no ``active`` subscription to
 cancel (only historical / already-cancelled rows, or never subscribed). 402 (the
 same money-error family as ``InsufficientCredits`` / ``QuotaExceeded``) so the
 client renders a "not subscribed" state rather than a 404-style missing resource.
+
+Changed 2026-07-08 (feat/billing-smb-caps): added ``PocketLimitError`` (402,
+``billing.pocket_limit``) and ``ConnectorLimitError`` (402,
+``billing.connector_limit``) — the pocket-create and connector-enable siblings of
+``SeatLimitError``. Same 402 money-adjacent family; distinct codes so the UI can
+prompt a plan upgrade. Both enforce at create/enable time only (never retroactive)
+and only when ``billing_enforced`` is on.
 """
 
 from __future__ import annotations
@@ -112,6 +119,34 @@ class SeatLimitError(CloudError):
         super().__init__(402, "billing.seat_limit", f"Seat limit of {seats} reached")
 
 
+class PocketLimitError(CloudError):
+    """Workspace hit its plan's pocket cap (402).
+
+    Sibling of ``SeatLimitError`` for the pocket-create seam: the workspace holds
+    its plan's ``max_pockets`` and a new create would exceed it. 402 (same
+    money-adjacent family) with a distinct ``billing.pocket_limit`` code so the UI
+    can prompt a plan upgrade. Enforced at CREATE time only — never removes an
+    existing pocket — and only when ``billing_enforced`` is on.
+    """
+
+    def __init__(self, limit: int) -> None:
+        super().__init__(402, "billing.pocket_limit", f"Pocket limit of {limit} reached")
+
+
+class ConnectorLimitError(CloudError):
+    """Workspace hit its plan's connector cap (402).
+
+    Sibling of ``SeatLimitError`` for the connector-enable seam: the workspace
+    already has its plan's ``max_connectors`` enabled and enabling another would
+    exceed it. 402 with a distinct ``billing.connector_limit`` code so the UI can
+    prompt a plan upgrade. Enforced at ENABLE time only — never disables an
+    already-enabled connector — and only when ``billing_enforced`` is on.
+    """
+
+    def __init__(self, limit: int) -> None:
+        super().__init__(402, "billing.connector_limit", f"Connector limit of {limit} reached")
+
+
 class InsufficientCredits(CloudError):
     """Credit wallet has too few credits for the requested debit (402)."""
 
@@ -194,11 +229,13 @@ __all__ = [
     "BadRequest",
     "CloudError",
     "ConflictError",
+    "ConnectorLimitError",
     "Forbidden",
     "InsufficientCredits",
     "Internal",
     "NoActiveSubscription",
     "NotFound",
+    "PocketLimitError",
     "PreconditionFailed",
     "QuotaExceeded",
     "RateLimited",

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -17,6 +17,13 @@ rather than a balance refill; it carries the effective `ceiling` and the
 FL-2 (file-version spine, port of dewani12's #1193) added
 ``PreconditionFailed`` (412) for stale ``If-Match`` optimistic-concurrency
 failures on the file-version write path.
+
+Changed 2026-07-08 (feat/billing-cancel-downgrade): added
+``NoActiveSubscription`` (402, ``billing.no_active_subscription``) — raised by
+the subscription-cancel path when a workspace has no ``active`` subscription to
+cancel (only historical / already-cancelled rows, or never subscribed). 402 (the
+same money-error family as ``InsufficientCredits`` / ``QuotaExceeded``) so the
+client renders a "not subscribed" state rather than a 404-style missing resource.
 """
 
 from __future__ import annotations
@@ -139,6 +146,24 @@ class QuotaExceeded(CloudError):
         )
 
 
+class NoActiveSubscription(CloudError):
+    """Workspace has no active recurring subscription to act on (402).
+
+    Raised by the cancel path when a workspace asks to cancel but has no ``active``
+    subscription row — only historical / already-cancelled rows, or it never
+    subscribed. 402 (the same family as ``InsufficientCredits`` / ``QuotaExceeded``,
+    "you can't do the money action right now") so the client prompts a
+    not-subscribed state rather than treating it as a 404-style missing resource.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            402,
+            "billing.no_active_subscription",
+            "No active subscription to cancel for this workspace",
+        )
+
+
 class RateLimited(CloudError):
     """Rate limit exceeded (429)."""
 
@@ -172,6 +197,7 @@ __all__ = [
     "Forbidden",
     "InsufficientCredits",
     "Internal",
+    "NoActiveSubscription",
     "NotFound",
     "PreconditionFailed",
     "QuotaExceeded",

--- a/ee/pocketpaw_ee/cloud/_core/temporal_scheduler.py
+++ b/ee/pocketpaw_ee/cloud/_core/temporal_scheduler.py
@@ -5,6 +5,10 @@
 # trigger, detects rising edges (false → true per-row predicate), and
 # dispatches the trigger's action via the Wave 3a gate when an edge
 # fires.
+# Updated: 2026-07-11 (feat/external-alerting-c2c3) — the per-pocket sweep now
+# honors the per-workspace automation opt-out
+# (``automations_status.service.filter_sweep_enabled_workspaces``): pockets in a
+# workspace that turned its background sweeps off are skipped. Fails OPEN.
 #
 # Design (mirrors ``cycles/scheduler.py`` and
 # ``pockets/refresh_scheduler.py``):
@@ -171,11 +175,29 @@ async def run_one_pass() -> int:
         logger.exception("temporal-scheduler: failed to list pockets")
         return 0
 
+    # Per-workspace opt-out (feat/external-alerting-c2c3): pre-compute the
+    # enabled-workspace set so a tenant that turned its background sweeps off is
+    # skipped. One deduped check per unique workspace; fails OPEN.
+    from pocketpaw_ee.cloud.automations_status.service import (
+        filter_sweep_enabled_workspaces,
+    )
+
+    enabled_ws = await filter_sweep_enabled_workspaces(
+        {ws for p in pockets if (ws := p.get("workspace_id"))}
+    )
+
     visited = 0
     for pocket in pockets:
         pocket_id = pocket.get("pocket_id")
         workspace_id = pocket.get("workspace_id")
         if not pocket_id or not workspace_id:
+            continue
+        if workspace_id not in enabled_ws:
+            logger.debug(
+                "temporal-scheduler: workspace=%s opted out — skipping pocket=%s",
+                workspace_id,
+                pocket_id,
+            )
             continue
         try:
             template, rows = await _resolve_pocket_template_and_rows(workspace_id, pocket_id)

--- a/ee/pocketpaw_ee/cloud/audit/service.py
+++ b/ee/pocketpaw_ee/cloud/audit/service.py
@@ -2,6 +2,11 @@
 # Created: 2026-05-17 — Read-only wrapper over pocketpaw.audit.store
 #   AuditStore.search_entries with mandatory workspace_id tenancy filter
 #   sourced from ctx.workspace_id. # no-event: read-only entity per Rule 9.
+# 2026-07-10 (compliance-starter): added ``purge_workspace_audit`` — the
+#   retention-enforcement seam. Deletes AuditEvent rows older than a cutoff
+#   for a single workspace (age- + tenant-scoped). Kept here because this
+#   module is the sole writer of the AuditEvent collection; the retention
+#   orchestrator in workspace.service calls it.
 from __future__ import annotations
 
 import json
@@ -209,6 +214,25 @@ async def record(
     _webhooks.schedule_delivery(doc)
 
 
+async def purge_workspace_audit(workspace_id: str, older_than: datetime) -> int:
+    """Delete audit rows older than ``older_than`` for ONE workspace.
+
+    The retention-enforcement seam (compliance-starter). Tenant-scoped by
+    ``workspace`` and age-scoped by ``at < older_than`` in a single Mongo
+    delete — a recent row, or another tenant's row of any age, is never
+    touched. Lives here because ``audit.service`` is the sole writer of the
+    ``AuditEvent`` collection (import-linter contract); the retention
+    orchestrator (``workspace.service.enforce_retention``) calls this rather
+    than reaching into the collection itself. Returns the deleted count.
+    """
+    result = await _AuditEventDoc.find(
+        {"workspace": workspace_id, "at": {"$lt": older_than}}
+    ).delete()
+    # motor/beanie DeleteResult exposes ``deleted_count``; guard for the
+    # mongomock shim which may return None on an empty match.
+    return int(getattr(result, "deleted_count", 0) or 0)
+
+
 async def list_events(workspace_id: str, query: AuditQueryRequest | dict) -> AuditPage:
     """Cursor-paginated audit-event list, newest first."""
     body = AuditQueryRequest.model_validate(query or {})
@@ -341,6 +365,7 @@ __all__ = [
     "agent_list_audit",
     "list_events",
     "list_events_response",
+    "purge_workspace_audit",
     "record",
     "stream_export_csv",
 ]

--- a/ee/pocketpaw_ee/cloud/automations_status/__init__.py
+++ b/ee/pocketpaw_ee/cloud/automations_status/__init__.py
@@ -1,0 +1,19 @@
+# automations_status — the workspace-scoped aggregate status entity for the
+# always-on automation surface (feat/external-alerting-c2c3, C3).
+#
+# Answers one question the merged-screen UI asks: "what automation is running for
+# this workspace, and is it on?" It aggregates four things behind a single read:
+#   1. OSS automation rules (threshold / data-change / schedule) from the OSS
+#      ``pocketpaw.automations.store`` — the box-local rule set.
+#   2. The OSS AutomationEvaluator status (running + interval).
+#   3. The cloud sweep REGISTRY — a constructed enumeration of every background
+#      sweep (cycles, decisions, member_ingest, fabric_ingest, temporal, refresh),
+#      the env flag that gates each, and whether that gate is currently on in this
+#      process. There is no queryable registry in the fleet today; this module
+#      CONSTRUCTS it from a static descriptor table kept next to the sweeps.
+#   4. The per-workspace enable state (``WorkspaceAutomationConfig``) — the
+#      opt-out the sweeps consult at their per-workspace fan-out.
+#
+# 4-file cloud entity: domain (frozen value objects) / dto (wire schemas) /
+# service (the sole Beanie writer + the sweep gate the schedulers import) /
+# router (thin HTTP surface, CloudError never HTTPException).

--- a/ee/pocketpaw_ee/cloud/automations_status/domain.py
+++ b/ee/pocketpaw_ee/cloud/automations_status/domain.py
@@ -1,0 +1,89 @@
+# domain.py — Frozen value objects for the automations-status entity.
+# Created: 2026-07-11 (feat/external-alerting-c2c3, C3) — the constructed cloud
+# sweep REGISTRY (there is no queryable registry in the fleet today) plus the
+# aggregate status view the workspace-scoped endpoint returns. Tenancy fields are
+# required at construction per ee/cloud Rule 3.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+# The kind of background automation a sweep performs. Informational only — the
+# UI groups the registry rows by this.
+SweepKind = Literal[
+    "snapshot",  # cycles daily snapshot
+    "decisions",  # decision-graph reconciler + abandon sweeper
+    "ingest",  # member_ingest / fabric_ingest data mirroring
+    "temporal",  # per-pocket temporal sweeps
+    "refresh",  # per-pocket interval source refresh
+]
+
+
+@dataclass(frozen=True)
+class SweepDescriptor:
+    """One row in the constructed cloud sweep registry.
+
+    ``key`` is a stable id; ``env_flag`` is the process env var that gates the
+    sweep's loop-spawn at app boot; ``env_flag_on`` is that flag's current value
+    in THIS process (resolved at read time). ``interval_env`` names the optional
+    override for the sweep's cadence, when it has one.
+    """
+
+    key: str
+    label: str
+    kind: SweepKind
+    env_flag: str
+    env_flag_on: bool
+    interval_env: str | None = None
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class RuleSummary:
+    """A compact view of one OSS automation rule for the status list."""
+
+    id: str
+    name: str
+    type: str
+    enabled: bool
+    pocket_id: str
+    fire_count: int
+
+
+@dataclass(frozen=True)
+class WorkspaceAutomationState:
+    """The per-workspace opt-out state (tenancy required)."""
+
+    workspace_id: str
+    sweeps_enabled: bool
+    automations_enabled: bool
+    configured: bool  # True once an admin has written an explicit doc
+
+
+@dataclass(frozen=True)
+class EvaluatorStatus:
+    """The OSS AutomationEvaluator's runtime state."""
+
+    running: bool
+    interval_seconds: int
+    autostart_enabled: bool
+
+
+@dataclass(frozen=True)
+class AutomationStatusView:
+    """The aggregate the workspace-scoped status endpoint returns.
+
+    Tenancy (``workspace_id``) is required at construction per cloud Rule 3.
+    ``scheduler_enabled`` is the master cloud-scheduler env gate's current value
+    in this process — the deployment-level "are background sweeps running at all"
+    switch that production sets. The per-workspace opt-out (``workspace_state``)
+    layers on top of it.
+    """
+
+    workspace_id: str
+    scheduler_enabled: bool
+    evaluator: EvaluatorStatus
+    workspace_state: WorkspaceAutomationState
+    sweeps: list[SweepDescriptor] = field(default_factory=list)
+    rules: list[RuleSummary] = field(default_factory=list)

--- a/ee/pocketpaw_ee/cloud/automations_status/dto.py
+++ b/ee/pocketpaw_ee/cloud/automations_status/dto.py
@@ -1,0 +1,77 @@
+# dto.py — Request / response wire schemas for the automations-status entity.
+# Created: 2026-07-11 (feat/external-alerting-c2c3, C3). Per cloud rule §4 the
+# request schema is distinct from the response schema. Tenancy is NEVER a body
+# field — it arrives as the service's explicit ``workspace_id`` from the auth
+# context. Responses are plain (snake_case) Pydantic models the merged-screen UI
+# reads; the domain value objects convert into these in the service.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class SetWorkspaceAutomationRequest(BaseModel):
+    """Body for ``PUT /automations/config`` → ``service.set_workspace_config``.
+
+    Both fields are optional so an admin can toggle one switch without touching
+    the other. ``None`` means "leave unchanged"; the service reads the current
+    doc, applies only the provided fields, and upserts. Tenancy is the service's
+    ``workspace_id`` parameter, never a field here.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    sweeps_enabled: bool | None = None
+    automations_enabled: bool | None = None
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class SweepDescriptorOut(BaseModel):
+    key: str
+    label: str
+    kind: str
+    env_flag: str
+    env_flag_on: bool
+    interval_env: str | None = None
+    description: str = ""
+
+
+class RuleSummaryOut(BaseModel):
+    id: str
+    name: str
+    type: str
+    enabled: bool
+    pocket_id: str
+    fire_count: int
+
+
+class WorkspaceAutomationStateOut(BaseModel):
+    workspace_id: str
+    sweeps_enabled: bool
+    automations_enabled: bool
+    configured: bool
+
+
+class EvaluatorStatusOut(BaseModel):
+    running: bool
+    interval_seconds: int
+    autostart_enabled: bool
+
+
+class AutomationStatusResponse(BaseModel):
+    """The aggregate the workspace-scoped status endpoint returns."""
+
+    workspace_id: str
+    scheduler_enabled: bool
+    evaluator: EvaluatorStatusOut
+    workspace_state: WorkspaceAutomationStateOut
+    sweeps: list[SweepDescriptorOut]
+    rules: list[RuleSummaryOut]

--- a/ee/pocketpaw_ee/cloud/automations_status/router.py
+++ b/ee/pocketpaw_ee/cloud/automations_status/router.py
@@ -1,0 +1,69 @@
+# router.py — FastAPI router for the automations-status entity (C3).
+# Created: 2026-07-11 (feat/external-alerting-c2c3) — the thin HTTP surface over
+# ``automations_status.service``. GET /automations/status returns the aggregate
+# (OSS rules + evaluator status + cloud sweep registry + per-workspace enable
+# state); PUT /automations/config flips the per-workspace opt-out.
+#
+# Discipline (ee/cloud 4-file rules): NO business logic and NO Beanie doc import
+# live here — the router only maps HTTP <-> service calls. Every route is
+# workspace-scoped (tenancy from the auth context, never a body/query). Errors
+# surface as ``CloudError`` via the global handler (never ``HTTPException``).
+# Mounted under ``/api/v1`` from ``ee/pocketpaw_ee/cloud/__init__.py``.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.deps import (
+    current_workspace_id,
+    require_action_any_workspace,
+)
+from pocketpaw_ee.cloud.automations_status import service as automations_status_service
+from pocketpaw_ee.cloud.automations_status.dto import (
+    AutomationStatusResponse,
+    SetWorkspaceAutomationRequest,
+    WorkspaceAutomationStateOut,
+)
+from pocketpaw_ee.cloud.license import require_license
+
+router = APIRouter(
+    prefix="/automations",
+    tags=["Automations"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.get(
+    "/status",
+    response_model=AutomationStatusResponse,
+    dependencies=[Depends(require_action_any_workspace("automations.read"))],
+)
+async def get_automation_status(
+    ctx: RequestContext = Depends(request_context),
+) -> AutomationStatusResponse:
+    """Aggregate automation status for the caller's active workspace."""
+    return await automations_status_service.agent_get_status(ctx)
+
+
+@router.put(
+    "/config",
+    response_model=WorkspaceAutomationStateOut,
+    dependencies=[Depends(require_action_any_workspace("automations.manage"))],
+)
+async def set_automation_config(
+    body: SetWorkspaceAutomationRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> WorkspaceAutomationStateOut:
+    """Upsert the per-workspace automation opt-out (sweeps / automations)."""
+    state = await automations_status_service.set_workspace_config(
+        workspace_id,
+        sweeps_enabled=body.sweeps_enabled,
+        automations_enabled=body.automations_enabled,
+    )
+    return WorkspaceAutomationStateOut(
+        workspace_id=state.workspace_id,
+        sweeps_enabled=state.sweeps_enabled,
+        automations_enabled=state.automations_enabled,
+        configured=state.configured,
+    )

--- a/ee/pocketpaw_ee/cloud/automations_status/service.py
+++ b/ee/pocketpaw_ee/cloud/automations_status/service.py
@@ -195,9 +195,7 @@ async def set_workspace_config(
         doc = WorkspaceAutomationConfig(
             workspace=workspace_id,
             sweeps_enabled=True if sweeps_enabled is None else sweeps_enabled,
-            automations_enabled=(
-                True if automations_enabled is None else automations_enabled
-            ),
+            automations_enabled=(True if automations_enabled is None else automations_enabled),
         )
         await doc.insert()
     else:
@@ -251,8 +249,7 @@ async def automations_enabled_for_workspace(workspace_id: str) -> bool:
         state = await get_workspace_config(workspace_id)
     except Exception:
         logger.warning(
-            "automations_status: automation-gate read failed for workspace=%s — "
-            "failing OPEN",
+            "automations_status: automation-gate read failed for workspace=%s — failing OPEN",
             workspace_id,
             exc_info=True,
         )

--- a/ee/pocketpaw_ee/cloud/automations_status/service.py
+++ b/ee/pocketpaw_ee/cloud/automations_status/service.py
@@ -1,0 +1,393 @@
+# service.py — automations-status business logic + the sole writer of
+# WorkspaceAutomationConfig + the per-workspace sweep GATE the schedulers import.
+# Created: 2026-07-11 (feat/external-alerting-c2c3, C3).
+#
+# This module owns three responsibilities:
+#   1. The per-workspace opt-out GATE — ``sweeps_enabled_for_workspace`` /
+#      ``automations_enabled_for_workspace``. Every cloud sweep consults this at
+#      its per-workspace fan-out so a tenant can turn its automation off. The gate
+#      FAILS OPEN (defaults to enabled) on a store read error: a transient Mongo
+#      hiccup must never silently disable the always-on fleet for every tenant.
+#   2. The config read / write over ``WorkspaceAutomationConfig`` (the sole Beanie
+#      writer — import-linter "AutomationsStatus"). ``get_workspace_config`` /
+#      ``set_workspace_config`` mirror the rules.service enforcement upsert.
+#   3. The aggregate ``agent_get_status`` the workspace-scoped router returns —
+#      OSS rules + evaluator status + the constructed cloud sweep registry + the
+#      per-workspace enable state. Tenancy is threaded from ``ctx.workspace_id``;
+#      every Beanie read is workspace-filtered. The OSS automation rules store is
+#      the box-local single-tenant store (per-tenant-dedicated-server topology),
+#      surfaced here as informational status.
+
+from __future__ import annotations
+
+import logging
+import os
+
+from pocketpaw.config import get_settings
+from pocketpaw_ee.cloud._core.context import RequestContext
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.automations_status.domain import (
+    AutomationStatusView,
+    EvaluatorStatus,
+    RuleSummary,
+    SweepDescriptor,
+    WorkspaceAutomationState,
+)
+from pocketpaw_ee.cloud.automations_status.dto import (
+    AutomationStatusResponse,
+    EvaluatorStatusOut,
+    RuleSummaryOut,
+    SweepDescriptorOut,
+    WorkspaceAutomationStateOut,
+)
+from pocketpaw_ee.cloud.models.workspace_automation_config import WorkspaceAutomationConfig
+
+logger = logging.getLogger(__name__)
+
+# The master cloud-scheduler env gate. Default OFF — production sets it to
+# "true" to run background sweeps (mirrors ``billing_enforced``: env-gated,
+# off in tests/dev so a pytest run never spawns a loop that outlives the test).
+# The per-workspace opt-out below layers on TOP of this deployment switch.
+_CLOUD_SCHEDULER_FLAG = "POCKETPAW_CLOUD_SCHEDULER_ENABLED"
+# The pocket-interval refresh sweep carries its own gate.
+_REFRESH_SCHEDULER_FLAG = "POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED"
+
+
+def _env_flag_on(name: str) -> bool:
+    return os.environ.get(name, "").lower() == "true"
+
+
+def scheduler_enabled() -> bool:
+    """True when the master cloud-scheduler env gate is on in THIS process."""
+    return _env_flag_on(_CLOUD_SCHEDULER_FLAG)
+
+
+# ---------------------------------------------------------------------------
+# Constructed cloud sweep REGISTRY.
+#
+# There is no queryable registry in the fleet today — each sweep is wired
+# independently in ``ee/pocketpaw_ee/cloud/__init__.py``. This static table is
+# the single place that enumerates them, kept in sync with the app-factory
+# wiring by the C4 touch-time rule (add a sweep → add a row here). The env-flag
+# on/off value is resolved at read time so the status reflects THIS process.
+# ---------------------------------------------------------------------------
+
+_SWEEP_TABLE: tuple[tuple[str, str, str, str, str | None, str], ...] = (
+    (
+        "cycles_snapshot",
+        "Cycle daily snapshot",
+        "snapshot",
+        _CLOUD_SCHEDULER_FLAG,
+        None,
+        "Once per UTC midnight, snapshots every active cycle in each active workspace.",
+    ),
+    (
+        "decisions_reconciler",
+        "Decision-graph reconciler + abandon sweeper",
+        "decisions",
+        _CLOUD_SCHEDULER_FLAG,
+        None,
+        "60s reconciler drains chain events the hot path missed; hourly sweeper "
+        "closes chains for parked Actions past the TTL.",
+    ),
+    (
+        "member_ingest",
+        "Member Gmail/Calendar ingest",
+        "ingest",
+        _CLOUD_SCHEDULER_FLAG,
+        "POCKETPAW_MEMBER_INGEST_INTERVAL_SECONDS",
+        "Backfills/incrementally syncs each consented member's Gmail + Calendar "
+        "into their private KB scope.",
+    ),
+    (
+        "fabric_ingest",
+        "Firestore → Fabric ingest",
+        "ingest",
+        _CLOUD_SCHEDULER_FLAG,
+        "POCKETPAW_FABRIC_INGEST_INTERVAL_SECONDS",
+        "Mirrors each workspace's configured Firestore collections into Fabric "
+        "objects (backfill then incremental).",
+    ),
+    (
+        "temporal_sweeps",
+        "Pocket temporal sweeps",
+        "temporal",
+        _CLOUD_SCHEDULER_FLAG,
+        None,
+        "Fires per-pocket temporal triggers across the workspace × pocket "
+        "cross-product for pockets that declare interval sources.",
+    ),
+    (
+        "pocket_refresh",
+        "Pocket interval-source refresh",
+        "refresh",
+        _REFRESH_SCHEDULER_FLAG,
+        None,
+        "Re-pulls each pocket's interval data sources on its declared cadence.",
+    ),
+)
+
+
+def build_sweep_registry() -> list[SweepDescriptor]:
+    """Return the constructed cloud sweep registry with live env-flag state."""
+    return [
+        SweepDescriptor(
+            key=key,
+            label=label,
+            kind=kind,  # type: ignore[arg-type]
+            env_flag=env_flag,
+            env_flag_on=_env_flag_on(env_flag),
+            interval_env=interval_env,
+            description=description,
+        )
+        for (key, label, kind, env_flag, interval_env, description) in _SWEEP_TABLE
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Per-workspace opt-out — config read / write + the sweep GATE.
+# ---------------------------------------------------------------------------
+
+
+async def get_workspace_config(workspace_id: str) -> WorkspaceAutomationState:
+    """Return the workspace's automation opt-out state.
+
+    Unconfigured workspaces default to fully enabled (the always-on posture);
+    ``configured`` is False until an admin has written an explicit doc. RAISES on
+    a store read error so the caller owns the failure decision (the aggregate
+    endpoint surfaces it; the sweep gate below catches it and fails OPEN).
+    """
+    doc = await WorkspaceAutomationConfig.find_one(
+        WorkspaceAutomationConfig.workspace == workspace_id,
+    )
+    if doc is None:
+        return WorkspaceAutomationState(
+            workspace_id=workspace_id,
+            sweeps_enabled=True,
+            automations_enabled=True,
+            configured=False,
+        )
+    return WorkspaceAutomationState(
+        workspace_id=workspace_id,
+        sweeps_enabled=doc.sweeps_enabled,
+        automations_enabled=doc.automations_enabled,
+        configured=True,
+    )
+
+
+async def set_workspace_config(
+    workspace_id: str,
+    *,
+    sweeps_enabled: bool | None,
+    automations_enabled: bool | None,
+) -> WorkspaceAutomationState:
+    """Upsert the workspace's automation opt-out, returning the new state.
+
+    ``None`` on a field leaves it unchanged. ``workspace`` is unique-indexed so
+    the find-then-insert/save upsert is O(1); a concurrent-insert race surfaces
+    as a DuplicateKeyError (admin-only write — treated as a 5xx, no retry loop,
+    mirroring ``rules.service.set_enforcement``).
+    """
+    doc = await WorkspaceAutomationConfig.find_one(
+        WorkspaceAutomationConfig.workspace == workspace_id,
+    )
+    if doc is None:
+        doc = WorkspaceAutomationConfig(
+            workspace=workspace_id,
+            sweeps_enabled=True if sweeps_enabled is None else sweeps_enabled,
+            automations_enabled=(
+                True if automations_enabled is None else automations_enabled
+            ),
+        )
+        await doc.insert()
+    else:
+        if sweeps_enabled is not None:
+            doc.sweeps_enabled = sweeps_enabled
+        if automations_enabled is not None:
+            doc.automations_enabled = automations_enabled
+        await doc.save()
+    return await get_workspace_config(workspace_id)
+
+
+async def sweeps_enabled_for_workspace(workspace_id: str) -> bool:
+    """The GATE every cloud sweep consults at its per-workspace fan-out.
+
+    Returns True (sweep this workspace) unless the workspace explicitly opted
+    out. FAILS OPEN: on a store read error it returns True and logs, so a
+    transient Mongo hiccup can never silently disable the always-on fleet for
+    every tenant. A workspace that deliberately turned sweeps off stays off.
+    """
+    try:
+        state = await get_workspace_config(workspace_id)
+    except Exception:
+        logger.warning(
+            "automations_status: sweep-gate read failed for workspace=%s — failing OPEN",
+            workspace_id,
+            exc_info=True,
+        )
+        return True
+    return state.sweeps_enabled
+
+
+async def filter_sweep_enabled_workspaces(workspace_ids: set[str]) -> set[str]:
+    """Return the subset of ``workspace_ids`` whose sweeps are enabled.
+
+    A single dedup pass for fan-outs that iterate MANY units (members, sources,
+    pockets) spanning few workspaces — each unique workspace is checked once
+    instead of once per unit. Fails OPEN per workspace (a read hiccup keeps that
+    tenant in the swept set), consistent with ``sweeps_enabled_for_workspace``.
+    """
+    enabled: set[str] = set()
+    for ws in workspace_ids:
+        if await sweeps_enabled_for_workspace(ws):
+            enabled.add(ws)
+    return enabled
+
+
+async def automations_enabled_for_workspace(workspace_id: str) -> bool:
+    """Narrower gate for the rule/alert automation surface. Fails OPEN like the
+    sweep gate — a read hiccup never silences alerts for the whole fleet."""
+    try:
+        state = await get_workspace_config(workspace_id)
+    except Exception:
+        logger.warning(
+            "automations_status: automation-gate read failed for workspace=%s — "
+            "failing OPEN",
+            workspace_id,
+            exc_info=True,
+        )
+        return True
+    return state.automations_enabled
+
+
+# ---------------------------------------------------------------------------
+# Aggregate status — the workspace-scoped read the merged-screen UI consumes.
+# ---------------------------------------------------------------------------
+
+
+def _evaluator_status() -> EvaluatorStatus:
+    """Snapshot the OSS AutomationEvaluator's runtime state.
+
+    Best-effort: if the OSS automations package is unavailable (a cloud-only
+    build without the evaluator wired) the status degrades to not-running rather
+    than raising.
+    """
+    autostart = bool(get_settings().automation_evaluator_autostart)
+    try:
+        from pocketpaw.automations.evaluator import get_evaluator
+
+        ev = get_evaluator()
+        return EvaluatorStatus(
+            running=ev.is_running,
+            interval_seconds=ev.interval,
+            autostart_enabled=autostart,
+        )
+    except Exception:
+        logger.debug("automations_status: OSS evaluator unavailable", exc_info=True)
+        return EvaluatorStatus(running=False, interval_seconds=0, autostart_enabled=autostart)
+
+
+def _oss_rule_summaries() -> list[RuleSummary]:
+    """Summarize the box-local OSS automation rules (informational).
+
+    The OSS automation store is the single-tenant box store (per-tenant-dedicated
+    -server topology); it has no workspace column, so this is a box-level read
+    surfaced in the workspace's status view rather than a tenant-filtered query.
+    Best-effort — a missing/broken store degrades to an empty list.
+    """
+    try:
+        from pocketpaw.automations.store import get_automation_store
+
+        rules = get_automation_store().list_rules()
+    except Exception:
+        logger.debug("automations_status: OSS rule store unavailable", exc_info=True)
+        return []
+    return [
+        RuleSummary(
+            id=r.id,
+            name=r.name,
+            type=str(r.type),
+            enabled=r.enabled,
+            pocket_id=r.pocket_id,
+            fire_count=r.fire_count,
+        )
+        for r in rules
+    ]
+
+
+async def agent_get_status(ctx: RequestContext) -> AutomationStatusResponse:
+    """Aggregate the workspace's automation status behind a single read.
+
+    Tenancy comes from ``ctx.workspace_id`` (never a body/query); a request
+    without an active workspace is a 400, not a silent global read.
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise ValidationError(
+            "automations_status.workspace_required",
+            "an active workspace is required to read automation status",
+        )
+
+    workspace_state = await get_workspace_config(workspace_id)
+    view = AutomationStatusView(
+        workspace_id=workspace_id,
+        scheduler_enabled=scheduler_enabled(),
+        evaluator=_evaluator_status(),
+        workspace_state=workspace_state,
+        sweeps=build_sweep_registry(),
+        rules=_oss_rule_summaries(),
+    )
+    return _view_to_response(view)
+
+
+def _view_to_response(view: AutomationStatusView) -> AutomationStatusResponse:
+    return AutomationStatusResponse(
+        workspace_id=view.workspace_id,
+        scheduler_enabled=view.scheduler_enabled,
+        evaluator=EvaluatorStatusOut(
+            running=view.evaluator.running,
+            interval_seconds=view.evaluator.interval_seconds,
+            autostart_enabled=view.evaluator.autostart_enabled,
+        ),
+        workspace_state=WorkspaceAutomationStateOut(
+            workspace_id=view.workspace_state.workspace_id,
+            sweeps_enabled=view.workspace_state.sweeps_enabled,
+            automations_enabled=view.workspace_state.automations_enabled,
+            configured=view.workspace_state.configured,
+        ),
+        sweeps=[
+            SweepDescriptorOut(
+                key=s.key,
+                label=s.label,
+                kind=s.kind,
+                env_flag=s.env_flag,
+                env_flag_on=s.env_flag_on,
+                interval_env=s.interval_env,
+                description=s.description,
+            )
+            for s in view.sweeps
+        ],
+        rules=[
+            RuleSummaryOut(
+                id=r.id,
+                name=r.name,
+                type=r.type,
+                enabled=r.enabled,
+                pocket_id=r.pocket_id,
+                fire_count=r.fire_count,
+            )
+            for r in view.rules
+        ],
+    )
+
+
+__all__ = [
+    "agent_get_status",
+    "automations_enabled_for_workspace",
+    "build_sweep_registry",
+    "filter_sweep_enabled_workspaces",
+    "get_workspace_config",
+    "scheduler_enabled",
+    "set_workspace_config",
+    "sweeps_enabled_for_workspace",
+]

--- a/ee/pocketpaw_ee/cloud/billing/dto.py
+++ b/ee/pocketpaw_ee/cloud/billing/dto.py
@@ -24,6 +24,10 @@
 #   LiteLLM proxy — the contract SHAPE is unchanged (the frontend is untouched), but
 #   ``UsageModelStats.tokens`` is 0 from this source (the ledger carries no per-entry
 #   token count). The credit + request figures are accurate.
+# Updated 2026-07-08 (feat/billing-cancel-downgrade): added
+#   ``CancelSubscriptionResponse`` for ``POST /billing/cancel`` (no request body —
+#   the caller's workspace is the scope). Tiny ack; the plan revert is not reflected
+#   here (it lands on the ``subscription.cancelled`` webhook).
 
 from __future__ import annotations
 
@@ -67,6 +71,17 @@ class CreateSubscriptionResponse(BaseModel):
     """Hosted recurring-checkout url the caller redirects the buyer to."""
 
     checkout_url: str
+
+
+class CancelSubscriptionResponse(BaseModel):
+    """Ack for ``POST /billing/cancel`` — the gateway was told to stop billing.
+
+    ``ok`` is True once the gateway cancel was requested. The plan revert
+    (``Workspace.plan`` -> free) is NOT reflected here — it lands reactively when
+    Dodo posts the verified ``subscription.cancelled`` webhook.
+    """
+
+    ok: bool = True
 
 
 class WebhookAck(BaseModel):

--- a/ee/pocketpaw_ee/cloud/billing/dto.py
+++ b/ee/pocketpaw_ee/cloud/billing/dto.py
@@ -24,6 +24,11 @@
 #   LiteLLM proxy — the contract SHAPE is unchanged (the frontend is untouched), but
 #   ``UsageModelStats.tokens`` is 0 from this source (the ledger carries no per-entry
 #   token count). The credit + request figures are accurate.
+# Updated 2026-07-11 (feat/llm-cost-attribution): ``UsageModelStats.tokens`` now
+#   carries REAL token volume — the metering path stamps ``total_tokens`` on each
+#   debit ref and the ledger read sums it. The contract SHAPE is still unchanged
+#   (the frontend is untouched). Also tightened the field descriptions so the spend
+#   figures read unambiguously as CREDITS (1 credit == $0.01), never USD.
 # Updated 2026-07-08 (feat/billing-cancel-downgrade): added
 #   ``CancelSubscriptionResponse`` for ``POST /billing/cancel`` (no request body —
 #   the caller's workspace is the scope). Tiny ack; the plan revert is not reflected
@@ -99,17 +104,23 @@ class WebhookAck(BaseModel):
 class UsageModelStats(BaseModel):
     """One model's usage within a single day.
 
-    ``credits`` is the day-and-model spend in integer credits straight off the
-    wallet's ledger (markup already applied at debit time, 1 credit == $0.01);
-    ``tokens`` is total tokens — currently 0 from the ledger source, which carries
-    no per-entry token count; ``requests`` is the count of charged ledger entries
-    for this model on this day. A model whose credit cost is 0 (sub-credit spend)
-    still appears — usage is real even when the credit cost rounds to 0.
+    ``credits`` is the day-and-model spend in integer CREDITS straight off the
+    wallet's ledger (markup already applied at debit time, 1 credit == $0.01 — this
+    is a credit figure, NOT a USD amount); ``tokens`` is the real total token volume
+    for this model (summed from each debit's ``ref.total_tokens``; a legacy debit
+    written before the ref carried tokens contributes 0); ``requests`` is the count
+    of charged ledger entries for this model on this day. A model whose credit cost
+    is 0 (sub-credit spend) still appears — usage is real even when the credit cost
+    rounds to 0.
     """
 
-    credits: int = Field(..., description="Spend for this model on this day, in credits.")
+    credits: int = Field(
+        ...,
+        description="Spend for this model on this day, in CREDITS (1 credit == $0.01; not USD).",
+    )
     tokens: int = Field(
-        ..., description="Total tokens for this model (0 from the ledger source — no token count)."
+        ...,
+        description="Total token volume for this model on this day (0 for pre-attribution debits).",
     )
     requests: int = Field(..., description="Charged request count for this model on this day.")
 
@@ -125,7 +136,9 @@ class UsageBucket(BaseModel):
     by_model: dict[str, UsageModelStats] = Field(
         default_factory=dict, description="Model id -> usage stats for this day."
     )
-    total_credits: int = Field(..., description="Sum of this day's per-model credits.")
+    total_credits: int = Field(
+        ..., description="Sum of this day's per-model spend, in CREDITS (not USD)."
+    )
 
 
 class WorkspaceUsageResponse(BaseModel):
@@ -135,10 +148,11 @@ class WorkspaceUsageResponse(BaseModel):
     to the last 30 days when the request omits them). ``models`` is the sorted
     distinct set of model ids seen across the whole range (so the frontend can build
     a stable legend / color map). ``buckets`` is one entry per day WITH usage, oldest
-    first. ``total_credits`` is the grand total over every bucket. The shape is kept
-    DAILY on purpose — the frontend aggregates to weekly / monthly and filters by
-    model client-side. A workspace with no spend in the window yields empty
-    ``models`` + ``buckets`` and ``total_credits`` 0 (HTTP 200).
+    first. ``total_credits`` is the grand total over every bucket, in CREDITS (1
+    credit == $0.01 — NOT USD). The shape is kept DAILY on purpose — the frontend
+    aggregates to weekly / monthly and filters by model client-side. A workspace
+    with no spend in the window yields empty ``models`` + ``buckets`` and
+    ``total_credits`` 0 (HTTP 200).
     """
 
     start_date: str

--- a/ee/pocketpaw_ee/cloud/billing/plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/plans.py
@@ -39,6 +39,18 @@
 #   the paid usage tiers; Free is an explicit trial cap (1000 — its 0 allotment can't
 #   derive it) and Enterprise is uncapped (None). The ``_build`` default for an
 #   unknown key FAILS CLOSED to the Free ceiling, never None/uncapped.
+# Updated 2026-07-08 (feat/billing-smb-caps) — ADDED three SMB resource ceilings the
+#   plan ladder now carries alongside ``monthly_ceiling``: ``max_seats`` (workspace
+#   members), ``max_pockets`` (pockets per workspace), and ``max_connectors``
+#   (enabled connectors per workspace). Each is a tunable dict (``_MAX_SEATS`` /
+#   ``_MAX_POCKETS`` / ``_MAX_CONNECTORS``) mirroring ``_CEILING`` in shape, surfaced
+#   on ``PlanTier`` as ``int | None`` (None = uncapped, Enterprise only). The values
+#   are GENEROUS PLACEHOLDERS — the real per-tier numbers are a captain pricing
+#   open-question; the machinery is tier-agnostic and these ceilings are roomy
+#   enough that an active tenant under them never notices, while still protecting
+#   the shared PEE box from runaway growth. Free ``max_seats`` is pinned at 5 (==
+#   the ``Workspace.seats`` default) so no existing workspace regresses. The
+#   ``_build`` default for an unknown key FAILS CLOSED to the Free value, never None.
 
 from __future__ import annotations
 
@@ -94,6 +106,51 @@ _CEILING: dict[str, int | None] = {
     "go": 2_250,
     "pro": 11_250,
     "pro_max": 45_000,
+    "enterprise": None,
+}
+
+# ---------------------------------------------------------------------------
+# Tunable constants — SMB resource ceilings per tier (feat/billing-smb-caps).
+# ---------------------------------------------------------------------------
+#
+# Three per-plan caps enforced at CREATE / INVITE / ENABLE time (never
+# retroactively): the max workspace SEATS, the max POCKETS a workspace may hold,
+# and the max ENABLED CONNECTORS. Same shape as ``_CEILING`` — an ``int`` ceiling,
+# or ``None`` for the one uncapped (Enterprise) tier. The ``_build`` default for an
+# unknown key FAILS CLOSED to the Free value (never None/uncapped).
+#
+# IMPORTANT: these are GENEROUS PLACEHOLDERS. The real per-tier numbers are a
+# captain pricing open-question; the enforcement machinery is deliberately
+# tier-agnostic so only these constants change when pricing lands. They are roomy
+# enough that an active tenant under the ceiling never notices, while still
+# protecting the shared PEE box from a single tenant's runaway growth.
+#
+# Free ``max_seats`` is pinned at 5 to EQUAL the ``Workspace.seats`` model default
+# — the seat gate enforces ``max(doc.seats, max_seats)`` so a free workspace sees
+# byte-for-byte the same limit it has today (no regression). The paid tiers step
+# up from there; Enterprise is uncapped (None) — negotiated contracts set their
+# own limits.
+_MAX_SEATS: dict[str, int | None] = {
+    "free": 5,
+    "go": 10,
+    "pro": 25,
+    "pro_max": 100,
+    "enterprise": None,
+}
+
+_MAX_POCKETS: dict[str, int | None] = {
+    "free": 200,
+    "go": 1_000,
+    "pro": 5_000,
+    "pro_max": 20_000,
+    "enterprise": None,
+}
+
+_MAX_CONNECTORS: dict[str, int | None] = {
+    "free": 50,
+    "go": 100,
+    "pro": 250,
+    "pro_max": 1_000,
     "enterprise": None,
 }
 
@@ -184,8 +241,13 @@ class PlanTier:
     per renewal — a BACK-OFFICE field, NOT the headline. ``monthly_ceiling`` is
     the per-plan monthly credit CAP (integer credits, or None = uncapped) that
     credit-quota enforcement caps spend against (allotment × 1.5 for paid tiers;
-    Free is the explicit 1000 trial cap; Enterprise is None). ``dodo_product_id``
-    is the recurring-product id, or None until BC-7 / config populates it.
+    Free is the explicit 1000 trial cap; Enterprise is None). ``max_seats`` /
+    ``max_pockets`` / ``max_connectors`` are the SMB resource ceilings enforced at
+    create/invite/enable time (integer, or None = uncapped for Enterprise);
+    Free's ``max_seats`` == the ``Workspace.seats`` default so no workspace
+    regresses. These are GENEROUS PLACEHOLDERS pending the captain's pricing call.
+    ``dodo_product_id`` is the recurring-product id, or None until BC-7 / config
+    populates it.
 
     The display + price fields are what the billing UI renders: ``display_name``
     ("Paw Pro"), ``usage_label`` (the ChatGPT/Claude-style "5x the usage" headline
@@ -197,6 +259,9 @@ class PlanTier:
     key: str
     monthly_credit_allotment: int
     monthly_ceiling: int | None
+    max_seats: int | None
+    max_pockets: int | None
+    max_connectors: int | None
     dodo_product_id: str | None
     features: frozenset[str]
     display_name: str
@@ -238,8 +303,10 @@ def _build(key: str) -> PlanTier:
     from ``_PLAN_DISPLAY`` (a missing row degrades to ``_DISPLAY_FALLBACK`` rather
     than NPE-ing). An unknown ``key`` yields an empty feature set and a 0
     allotment — but callers go through ``get_plan`` / ``list_plans``, which only
-    ever pass known keys. ``monthly_ceiling`` FAILS CLOSED: an unknown key defaults
-    to the Free ceiling (the trial cap), never None/uncapped.
+    ever pass known keys. ``monthly_ceiling`` and the three SMB caps
+    (``max_seats`` / ``max_pockets`` / ``max_connectors``) FAIL CLOSED: an unknown
+    key defaults to the Free value (the most restrictive tier), never
+    None/uncapped.
     """
     display = _PLAN_DISPLAY.get(key, _DISPLAY_FALLBACK)
     return PlanTier(
@@ -247,6 +314,11 @@ def _build(key: str) -> PlanTier:
         monthly_credit_allotment=_MONTHLY_CREDIT_ALLOTMENT.get(key, 0),
         # Fail closed: an unknown key caps at the Free ceiling, never uncapped.
         monthly_ceiling=_CEILING.get(key, _CEILING["free"]),
+        # Fail closed on every SMB cap too: an unknown key caps at the Free
+        # value (the most restrictive), never None/uncapped.
+        max_seats=_MAX_SEATS.get(key, _MAX_SEATS["free"]),
+        max_pockets=_MAX_POCKETS.get(key, _MAX_POCKETS["free"]),
+        max_connectors=_MAX_CONNECTORS.get(key, _MAX_CONNECTORS["free"]),
         dodo_product_id=_dodo_product_for(key),
         features=frozenset(PLAN_FEATURES.get(key, set())),
         display_name=str(display["display_name"]),

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -40,6 +40,12 @@
 #   every metering mode. The route surface is unchanged (same path, auth, and
 #   ``start_date`` / ``end_date`` query params) — only the docstring wording below
 #   is updated to reflect the source.
+# Updated 2026-07-08 (feat/billing-cancel-downgrade): added POST /billing/cancel —
+#   cancel the caller's workspace's ACTIVE recurring subscription (no body;
+#   workspace-scoped via ``current_workspace_id``, same auth as topup / subscribe).
+#   Thin adapter over ``billing_service.cancel``; the plan revert lands reactively on
+#   the ``subscription.cancelled`` webhook, and a workspace with no active
+#   subscription gets 402 ``billing.no_active_subscription``.
 
 from __future__ import annotations
 
@@ -50,6 +56,7 @@ from pocketpaw_ee.cloud.billing import service as billing_service
 from pocketpaw_ee.cloud.billing import site_plans as site_plan_catalog
 from pocketpaw_ee.cloud.billing import usage as usage_service
 from pocketpaw_ee.cloud.billing.dto import (
+    CancelSubscriptionResponse,
     CreateSubscriptionRequest,
     CreateSubscriptionResponse,
     CreateTopupRequest,
@@ -197,3 +204,19 @@ async def create_subscription(
         origin=_request_origin(request),
     )
     return CreateSubscriptionResponse(checkout_url=result["checkout_url"])
+
+
+@router.post("/cancel", response_model=CancelSubscriptionResponse)
+async def cancel_subscription(
+    workspace_id: str = Depends(current_workspace_id),
+) -> CancelSubscriptionResponse:
+    """Cancel the caller's workspace's ACTIVE recurring subscription. No body.
+
+    Tells the gateway to stop billing the workspace's active subscription. The plan
+    revert (``Workspace.plan`` -> free) is NOT applied here — it lands reactively
+    when Dodo posts the verified ``subscription.cancelled`` webhook (mirroring how
+    /subscribe defers the upgrade to ``subscription.active``). Returns 402
+    ``billing.no_active_subscription`` when the workspace has no active subscription.
+    """
+    result = await billing_service.cancel(workspace_id=workspace_id)
+    return CancelSubscriptionResponse(ok=result["ok"])

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -705,9 +705,7 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
         # a resync hiccup must not fail the (already-applied) credit grant / plan
         # move, and the seat gates also lift the ceiling live via the resolved plan.
         try:
-            new_seats = await workspace_service.raise_seats_for_plan(
-                event.workspace_id, tier.key
-            )
+            new_seats = await workspace_service.raise_seats_for_plan(event.workspace_id, tier.key)
             if new_seats is not None:
                 logger.info(
                     "billing.webhook: %s resynced seat cap to %d for workspace=%s plan=%s",

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -551,7 +551,9 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
 
     * ``subscription.active`` / ``subscription.renewed`` → grant the tier's
       monthly allotment ADDITIVELY (unused credits roll over) keyed on the
-      per-renewal ``event_id``; ``active`` ALSO upgrades ``Workspace.plan``.
+      per-renewal ``event_id``; ``active`` ALSO upgrades ``Workspace.plan`` and
+      resyncs the stored seat cap UP to the new plan (upgrade-only — a later
+      cancel reverts the plan but never strips seats).
     * ``subscription.cancelled`` → revert ``Workspace.plan`` to ``free`` WITHOUT
       clawing back any granted credits.
     * any other subscription.* delivery → acked, no action.
@@ -647,6 +649,31 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
     # subscription.active upgrades the entitlement to the subscribed tier.
     if event.type == _SUB_ACTIVE:
         await workspace_service.set_workspace_plan(event.workspace_id, tier.key)
+        # feat/billing-smb-caps: lift the stored seat cap to the new plan so an
+        # upgrade actually raises it. UPGRADE-ONLY (max(doc.seats, plan.max_seats))
+        # — a later cancel reverts the plan but never strips the seats. Best-effort:
+        # a resync hiccup must not fail the (already-applied) credit grant / plan
+        # move, and the seat gates also lift the ceiling live via the resolved plan.
+        try:
+            new_seats = await workspace_service.raise_seats_for_plan(
+                event.workspace_id, tier.key
+            )
+            if new_seats is not None:
+                logger.info(
+                    "billing.webhook: %s resynced seat cap to %d for workspace=%s plan=%s",
+                    event.type,
+                    new_seats,
+                    event.workspace_id,
+                    tier.key,
+                )
+        except Exception:
+            logger.exception(
+                "billing.webhook: seat-cap resync failed for workspace=%s plan=%s "
+                "(event_id=%s) — plan upgrade stands; seat gate still lifts live",
+                event.workspace_id,
+                tier.key,
+                event.event_id,
+            )
 
     # Track the subscription lifecycle (active for both active + renewed).
     await _upsert_subscription(event, status="active", plan_key=tier.key)

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -91,6 +91,16 @@
 #   the OLD subscription at the gateway (billing stops synchronously, so the two are
 #   never both billing). Webhook ``event_id`` idempotency is untouched. See the
 #   ``subscribe`` body for the native-``change_plan`` follow-up note.
+# Updated 2026-07-09 (fix/cancel-webhook-revert-guard): the ``subscription.cancelled``
+#   plan revert is no longer UNCONDITIONAL. Webhook delivery is unordered /
+#   at-least-once, so a ``cancelled(old_sub)`` retry can land AFTER ``active(new_sub)``
+#   during a plan switch and would previously downgrade a paying customer to free
+#   (nothing self-heals it — only ``subscription.active`` re-sets the plan). The
+#   handler now marks THIS sub cancelled first, then reverts to free ONLY when no
+#   OTHER active Subscription row still owns the workspace; a stale/out-of-order
+#   cancel is logged and skipped. Credits are still never clawed back. See the
+#   ``subscribe`` body for the STILL-OPEN downgrade lag-window (checkout→active
+#   webhook) that only the atomic Dodo ``change_plan`` closes.
 
 from __future__ import annotations
 
@@ -317,14 +327,32 @@ async def subscribe(
     # (BC-1's unique index), so a replayed active/renewed after a switch re-grants
     # nothing.
     #
-    # FOLLOW-UP (native change_plan): Dodo's SDK exposes an ATOMIC
+    # KNOWN LIMITATION — DOWNGRADE LAG WINDOW (not fixed here; needs change_plan).
+    # ``_active_subscription`` reads the LOCAL Subscription row, and only the
+    # ``subscription.active`` webhook writes ``status="active"``. Between checkout
+    # COMPLETION (buyer paid) and that ``active`` webhook LANDING, no local active
+    # row exists yet, so a fast SECOND switch in that window sees ``existing is None``,
+    # skips the cancel-then-create guard, and opens a SECOND parallel gateway
+    # subscription = double-charge — the exact defect this branch set out to fix.
+    #
+    # Why we do NOT close it by querying the gateway here: Dodo's
+    # ``subscriptions.list`` filters only by ``customer_id`` / ``product_id`` /
+    # ``status`` / dates — there is NO metadata filter, and we store no per-workspace
+    # Dodo ``customer_id`` (each ``create_subscription`` mints a fresh customer from
+    # the email). So "list THIS workspace's active subs at the gateway" would mean
+    # paging EVERY active subscription in the business and filtering client-side on
+    # ``metadata.workspace_id`` — fragile and unbounded. We deliberately do not add
+    # that under pressure.
+    #
+    # REAL FIX (follow-up): Dodo's SDK exposes an ATOMIC
     # ``subscriptions.change_plan`` (proration, no re-checkout, no drop-to-free
-    # window) that would remove the residual "buyer abandons the new checkout after
-    # the old is cancelled" gap. Wiring it is out of scope for this bug fix — it
-    # needs a new provider-port method, a ``subscription.plan_changed`` webhook
-    # handler (grant + plan + audit; the service acts on active/renewed/cancelled
-    # only today), and a /subscribe response-contract change (change_plan returns no
-    # checkout url). Tracked as a billing plan-change follow-up.
+    # window) that removes cancel-then-create ENTIRELY — no lag window, no second
+    # subscription, no "buyer abandons the new checkout after the old is cancelled"
+    # gap. Wiring it is a scoped change: a new provider-port method, a
+    # ``subscription.plan_changed`` webhook handler (grant + plan + audit; the
+    # service acts on active/renewed/cancelled only today), and a /subscribe
+    # response-contract change (change_plan returns no checkout url). Tracked as the
+    # billing plan-change follow-up; until it lands the lag window above remains.
     existing = await _active_subscription(workspace_id)
 
     checkout = await prov.create_subscription(
@@ -584,13 +612,35 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
         return {"ok": True, "granted": False}
 
     if event.type == _SUB_CANCELLED:
-        # Revert the entitlement to free. Do NOT claw back granted credits — the
-        # workspace keeps the rolled-over balance it already paid for.
-        ok = await workspace_service.set_workspace_plan(event.workspace_id, "free")
+        # Mark THIS subscription cancelled FIRST, then decide whether to revert the
+        # plan. Webhook delivery is unordered / at-least-once: during a plan switch a
+        # ``cancelled(old_sub)`` retry can land AFTER ``active(new_sub)``. Reverting
+        # to free UNCONDITIONALLY there would strand a paying customer on free
+        # entitlements — and nothing self-heals it (only subscription.active re-sets
+        # the plan; renewed does not). So flip this sub's row to cancelled, then ask
+        # whether any OTHER active subscription still owns the workspace:
+        #   * a newer active sub exists -> SKIP the revert (a stale cancel must not
+        #     downgrade the live plan);
+        #   * none -> revert to free (the normal cancel, and the common
+        #     cancel-then-active ordering still self-corrects because active arrives
+        #     later and re-sets the plan).
+        # Credits are NEVER clawed back either way.
         await _upsert_subscription(event, status="cancelled", plan_key="free")
+        still_active = await _active_subscription(event.workspace_id)
+        if still_active is not None:
+            logger.info(
+                "billing.webhook: subscription.cancelled for workspace=%s (event_id=%s) — "
+                "a newer active subscription=%s still owns the workspace; NOT reverting to "
+                "free (out-of-order/stale cancel)",
+                event.workspace_id,
+                event.event_id,
+                still_active.gateway_subscription_id,
+            )
+            return {"ok": True, "granted": False}
+        ok = await workspace_service.set_workspace_plan(event.workspace_id, "free")
         logger.info(
             "billing.webhook: subscription.cancelled for workspace=%s (event_id=%s) — "
-            "plan reverted to free=%s, credits NOT clawed back",
+            "no other active subscription; plan reverted to free=%s, credits NOT clawed back",
             event.workspace_id,
             event.event_id,
             ok,

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -76,6 +76,21 @@
 #   ``dodo_checkout_return_base`` config when no origin is present; omits the
 #   redirect entirely if both are absent. The webhook grant + idempotency are
 #   unchanged — they key on the event body's subscription_id + metadata + event_id.
+# Updated 2026-07-08 (feat/billing-cancel-downgrade): two money-management fixes.
+#   (A) ``cancel`` — wire the previously dead-coded provider ``cancel_subscription``
+#   end to end: load the workspace's ACTIVE Subscription row (the ``(workspace)``
+#   index is NON-unique, so select ``status == "active"`` specifically, never a
+#   naive first-match that could pick a stale cancelled row) and tell the gateway to
+#   stop billing it; 402 ``billing.no_active_subscription`` when there is none. The
+#   entitlement revert stays REACTIVE on the ``subscription.cancelled`` webhook — this
+#   only adds the initiation side (no duplicate plan-revert). (B) ``subscribe`` no
+#   longer double-subscribes: when a workspace ALREADY has an active subscription a
+#   plain ``create_subscription`` opened a SECOND parallel Dodo subscription (double
+#   billing). It now runs a GUARDED cancel-then-create — open the NEW checkout FIRST
+#   (a create failure leaves the current sub untouched, no coverage gap), THEN cancel
+#   the OLD subscription at the gateway (billing stops synchronously, so the two are
+#   never both billing). Webhook ``event_id`` idempotency is untouched. See the
+#   ``subscribe`` body for the native-``change_plan`` follow-up note.
 
 from __future__ import annotations
 
@@ -84,7 +99,7 @@ from datetime import UTC, datetime, timedelta
 
 from pymongo.errors import DuplicateKeyError
 
-from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud._core.errors import NoActiveSubscription, ValidationError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     BillingSubscriptionGranted,
@@ -211,6 +226,27 @@ def _checkout_return_urls(origin: str | None) -> tuple[str | None, str | None]:
     )
 
 
+async def _active_subscription(workspace_id: str) -> Subscription | None:
+    """The workspace's currently-ACTIVE gateway subscription, or None.
+
+    The ``Subscription`` ``(workspace)`` index is NON-UNIQUE — a workspace
+    accumulates historical rows over its lifetime (a prior tier it switched off, an
+    earlier subscription that was cancelled). So NEVER take a naive first-match:
+    filter on ``status == "active"`` and, if more than one somehow qualifies, take
+    the most-recent (``-createdAt``) for a deterministic pick. Returns None when the
+    workspace has no active subscription (only historical / cancelled rows, or never
+    subscribed).
+    """
+    return (
+        await Subscription.find(
+            Subscription.workspace == workspace_id,
+            Subscription.status == "active",
+        )
+        .sort("-createdAt")
+        .first_or_none()
+    )
+
+
 async def subscribe(
     workspace_id: str,
     user_id: str,
@@ -235,6 +271,11 @@ async def subscribe(
     back to after pay / cancel, so the buyer is NOT stranded on the gateway. When
     absent it falls back to the ``dodo_checkout_return_base`` config; if both are
     empty the redirect is simply omitted.
+
+    DOWNGRADE / SWITCH: if the workspace ALREADY has an active subscription this
+    does NOT open a second parallel one (which would double-bill). It runs a guarded
+    cancel-then-create — see the body — so a plan switch replaces the old
+    subscription instead of stacking on top of it.
     """
     # Rule 6 — validate at entry.
     if not workspace_id:
@@ -259,6 +300,33 @@ async def subscribe(
 
     return_url, cancel_url = _checkout_return_urls(origin)
     prov = provider or _default_provider()
+
+    # DOWNGRADE / SWITCH GUARD (fix double-subscribe). If the workspace ALREADY has
+    # an active gateway subscription, a plain create would open a SECOND parallel
+    # Dodo subscription and double-bill (the bug). Detect the active sub up front,
+    # then run a GUARDED cancel-then-create:
+    #   1. open the NEW checkout FIRST — if it raises we surface the error here and
+    #      the current subscription is untouched (no coverage gap, no orphaned
+    #      cancel; the tenant keeps billing the plan they had).
+    #   2. ONLY after the new checkout is open, cancel the OLD subscription at the
+    #      gateway. Dodo stops billing the old one synchronously, so the two are
+    #      never both billing; the plan mutations still land reactively on the
+    #      webhooks (the new ``subscription.active`` upgrades, the old
+    #      ``subscription.cancelled`` reverts) exactly as a fresh subscribe.
+    # Webhook idempotency is untouched — each grant still keys on its own event_id
+    # (BC-1's unique index), so a replayed active/renewed after a switch re-grants
+    # nothing.
+    #
+    # FOLLOW-UP (native change_plan): Dodo's SDK exposes an ATOMIC
+    # ``subscriptions.change_plan`` (proration, no re-checkout, no drop-to-free
+    # window) that would remove the residual "buyer abandons the new checkout after
+    # the old is cancelled" gap. Wiring it is out of scope for this bug fix — it
+    # needs a new provider-port method, a ``subscription.plan_changed`` webhook
+    # handler (grant + plan + audit; the service acts on active/renewed/cancelled
+    # only today), and a /subscribe response-contract change (change_plan returns no
+    # checkout url). Tracked as a billing plan-change follow-up.
+    existing = await _active_subscription(workspace_id)
+
     checkout = await prov.create_subscription(
         plan_key=plan_key,
         product_id=product_id,
@@ -268,7 +336,64 @@ async def subscribe(
         return_url=return_url,
         cancel_url=cancel_url,
     )
+
+    if existing is not None and existing.gateway_subscription_id:
+        # Cancel the prior subscription now that the new checkout is open. If THIS
+        # raises, the caller gets an error and the OLD sub keeps billing (never a
+        # silent double-charge); the just-opened checkout session simply expires
+        # unused (no new subscription exists until the buyer pays it).
+        await prov.cancel_subscription(existing.gateway_subscription_id)
+        logger.info(
+            "billing.subscribe: workspace=%s switching plans — opened new checkout "
+            "for plan=%s and cancelled prior subscription=%s",
+            workspace_id,
+            plan_key,
+            existing.gateway_subscription_id,
+        )
+
     return {"checkout_url": checkout.checkout_url}
+
+
+async def cancel(
+    workspace_id: str,
+    *,
+    provider: IPaymentsProvider | None = None,
+) -> dict:
+    """Cancel the workspace's ACTIVE recurring subscription at the gateway.
+
+    Loads the workspace's currently-active ``Subscription`` row and tells the
+    gateway to stop billing it (``provider.cancel_subscription``). Returns
+    ``{"ok": True}``.
+
+    The entitlement revert (``Workspace.plan`` -> free) and the Subscription-row
+    status flip are NOT done here — they land REACTIVELY on the verified
+    ``subscription.cancelled`` webhook (mirroring how ``subscribe`` defers the
+    upgrade to the ``subscription.active`` webhook; the webhook handler is the sole
+    writer of that plan mutation, so cancelling here would duplicate it).
+
+    Raises 402 ``billing.no_active_subscription`` when the workspace has no active
+    subscription — only historical / already-cancelled rows, or never subscribed.
+    """
+    # Rule 6 — validate at entry.
+    if not workspace_id:
+        raise ValidationError("billing.invalid_workspace", "workspace_id is required")
+
+    active = await _active_subscription(workspace_id)
+    if active is None or not active.gateway_subscription_id:
+        # An active row with a gateway id is required. A stale cancelled row or no
+        # subscription at all is a 402 (not a silent success, and not a naive
+        # first-match against a historical row).
+        raise NoActiveSubscription()
+
+    prov = provider or _default_provider()
+    await prov.cancel_subscription(active.gateway_subscription_id)
+    logger.info(
+        "billing.cancel: requested gateway cancel for workspace=%s subscription=%s "
+        "(plan revert lands reactively on the subscription.cancelled webhook)",
+        workspace_id,
+        active.gateway_subscription_id,
+    )
+    return {"ok": True}
 
 
 # ---------------------------------------------------------------------------
@@ -719,6 +844,7 @@ async def _upsert_subscription(event: SubscriptionEvent, *, status: str, plan_ke
 
 
 __all__ = [
+    "cancel",
     "create_topup",
     "handle_webhook",
     "subscribe",

--- a/ee/pocketpaw_ee/cloud/billing/usage.py
+++ b/ee/pocketpaw_ee/cloud/billing/usage.py
@@ -32,10 +32,13 @@
 #   * READ-ONLY: a pure read. It NEVER debits, NEVER touches the ledger or the
 #     balance, NEVER calls the cutover/metering path. It only reads + folds.
 #
-# TOKENS=0 (a deliberate limitation): the ledger ``ref`` does not carry a token
-# count, so per-model ``tokens`` is reported as 0. The credit + request figures are
-# accurate; a follow-up can add ``total_tokens`` to the debit ``ref`` and surface
-# it here. Do NOT try to recover tokens from elsewhere — they aren't on the wallet.
+# TOKENS: the metering path (``metering.service.bill_run``) now stamps the run's
+# real ``total_tokens`` onto the debit ``ref``, and ``spend_by_model`` sums it per
+# (day, model), so per-model ``tokens`` reflects real volume — no longer a
+# hardcoded 0. It is sourced from the wallet's own ledger like credits + requests
+# (NOT the blocked LiteLLM path). A debit written before the ref carried tokens
+# contributes 0, so historical days may under-report tokens while credits stay
+# exact; volume is accurate for every run billed after the change.
 #
 # UNKNOWN MODEL: a real charged debit whose ``ref.model`` is absent is bucketed
 # under the model id ``"unknown"`` so its credits STILL count toward the day + the
@@ -67,6 +70,12 @@
 # record-folding helpers); kept the date-range validator + clamp and the response
 # contract intact. tokens=0 is now intentional (the ledger ref carries no token
 # count).
+# Changed 2026-07-11 (feat/llm-cost-attribution): per-model ``tokens`` now carries
+# REAL volume — the metering path stamps ``total_tokens`` on the debit ref and
+# ``spend_by_model`` sums it, so this surfaces ``row.tokens`` instead of the former
+# hardcoded 0. Sourced from the wallet's own ledger (NOT the blocked LiteLLM path);
+# legacy debits without the ref field contribute 0. The response contract is
+# unchanged (the ``tokens`` field already existed) — only its value became real.
 
 from __future__ import annotations
 
@@ -151,10 +160,11 @@ async def get_workspace_usage(
     window defaults to the trailing 30 days. ``spend_reader`` is injectable for
     pure-unit tests (defaults to ``credits.service.spend_by_model``).
 
-    ``tokens`` is reported as 0 per model — the ledger ``ref`` does not carry a
-    token count (the credit + request figures are accurate). A workspace with no
-    spend in the window returns an empty contract (no models, no buckets, total 0)
-    at HTTP 200 — never an error.
+    ``tokens`` per model is the real volume the ledger now carries (the metering
+    path stamps ``total_tokens`` on each debit ref; a legacy debit without it reads
+    0). Credits are integer CREDITS (1 credit == $0.01 — NOT USD). A workspace with
+    no spend in the window returns an empty contract (no models, no buckets, total
+    0) at HTTP 200 — never an error.
     """
     # Rule 6 — validate at entry.
     if not workspace_id:
@@ -189,16 +199,17 @@ async def get_workspace_usage(
         models_seen.add(row.model)
         per_model = buckets.setdefault(row.day, {})
         existing = per_model.get(row.model)
-        # ``tokens=0`` intentionally — the ledger ref carries no token count
-        # (see the module header). Credits + requests come straight off the ledger.
+        # ``tokens`` is the real per-(day, model) volume the ledger now carries
+        # (summed from each debit's ``ref.total_tokens`` in ``spend_by_model``); a
+        # legacy row without it reads 0. Credits + requests come off the ledger too.
         if existing is None:
             per_model[row.model] = UsageModelStats(
-                credits=row.credits, tokens=0, requests=row.requests
+                credits=row.credits, tokens=row.tokens, requests=row.requests
             )
         else:
             per_model[row.model] = UsageModelStats(
                 credits=existing.credits + row.credits,
-                tokens=0,
+                tokens=existing.tokens + row.tokens,
                 requests=existing.requests + row.requests,
             )
 

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -53,6 +53,13 @@ Changes:
   model call — the no-overspend money guarantee). This is the universal cap that
   covers the worker/executor path; the chat HTTP route ALSO fast-rejects in
   ``agent_router`` so its synchronous caller gets a clean 402 with no DB trace.
+- 2026-07-08 (feat/billing-enforce-gate) — ``_reject_if_over_credit_quota`` now
+  delegates to the shared ``credits.guards.reject_if_over_billing`` so every
+  agent-run seam (this executor, the group/DM bridge, the /files agent ops, the
+  planner) blocks an over-budget tenant identically. The shared helper runs BOTH
+  credit assertions, so the worker/executor leg now ALSO rejects an empty wallet
+  (``check_balance``, 402 credits.insufficient) — previously it caught only the
+  monthly-ceiling case.
 - 2026-06-30 (feat/session-supervisor SS-5) — ``_drive_agent_loop`` now drives
   every supervised agent turn through the ``SessionSupervisor`` + the durable
   ``(workspace, session, agent) -> cli_session_id`` mapping (SS-3
@@ -1458,58 +1465,35 @@ async def _reject_if_over_jail_quota(spec: RunSpec, ctx: ScopeContext, transport
 
 
 async def _reject_if_over_credit_quota(spec: RunSpec, ctx: ScopeContext, transport: Any) -> bool:
-    """Universal monthly-CREDIT-QUOTA gate, enforced at RUN-START (chunk 3).
+    """Universal run-start BILLING gate on the worker/executor path.
 
-    The credit-spend sibling of ``_reject_if_over_jail_quota`` (ART-3): measure
-    the workspace's month-to-date spend against its effective monthly ceiling
-    ONCE here — before any model/agent work — and reject the run CLEANLY when it
-    has hit the cap, the SAME way the jail-quota reject does (a terminal ``error``
-    stream frame + a ``mark_terminal(failed)`` doc, then an early return — never
-    a model call). This is the universal gate: it covers EVERY run-start path
-    (the synchronous chat HTTP route also fast-rejects in ``agent_router`` so its
-    caller gets a clean 402 with no DB trace, but the worker/executor path only
-    passes through HERE, so this is the one that guarantees a queued/resumed run
-    can't spend past the ceiling).
+    The credit-spend sibling of ``_reject_if_over_jail_quota`` (ART-3): before any
+    model/agent work, reject the run CLEANLY when the workspace is over budget,
+    the SAME way the jail-quota reject does (a terminal ``error`` stream frame + a
+    ``mark_terminal(failed)`` doc, then an early return — never a model call).
+    This is the worker/executor leg of the universal gate: the synchronous chat
+    HTTP route fast-rejects in ``agent_router`` (a clean 402 with no DB trace),
+    but a queued/resumed run only passes through HERE.
 
-    Flag-gated: a no-op unless ``get_settings().billing_enforced`` is on (OSS /
-    self-host run no ledger). ``credits.service.check_quota`` is the pure,
-    flag-free assertion — it raises ``QuotaExceeded`` (402 ``credits.quota_exceeded``)
-    when month-to-date spend ``>=`` the effective ceiling, and is itself a no-op
-    for an uncapped (Enterprise) plan. We catch that exception here and translate
-    it into the clean terminal rejection. Returns ``True`` when the run was
-    rejected (the caller returns early), ``False`` to proceed. The credits package
-    is imported locally to keep it off this hot module's import graph (mirrors
-    the BC-4 chat-router gate).
+    Delegates to the shared ``credits.guards.reject_if_over_billing`` so every
+    agent-run seam blocks identically. That helper is flag-gated (a no-op unless
+    ``billing_enforced``) and runs BOTH credit assertions: ``check_balance``
+    (wallet <= 0 -> 402 credits.insufficient) AND ``check_quota`` (month-to-date
+    spend >= the effective monthly ceiling -> 402 credits.quota_exceeded, itself a
+    no-op for an uncapped Enterprise plan). Before this delegation the worker leg
+    caught only the quota case; it now rejects an empty wallet too. Returns
+    ``True`` when the run was rejected (the caller returns early), ``False`` to
+    proceed. ``ctx.workspace_id`` is validated non-empty upstream (the
+    ``scope.no_workspace`` guard).
     """
-    if not get_settings().billing_enforced:
-        return False
+    from pocketpaw_ee.cloud.credits import guards
 
-    from pocketpaw_ee.cloud._core.errors import QuotaExceeded
-    from pocketpaw_ee.cloud.credits import service as credits_service
-
-    try:
-        await credits_service.check_quota(ctx.workspace_id)
-        return False
-    except QuotaExceeded as exc:
-        quota_error = str(exc)
-        logger.warning(
-            "run %s rejected — monthly credit quota exceeded: %s", spec.run_id, quota_error
-        )
-        try:
-            await transport.append_event(
-                spec.run_id, "error", {"code": exc.code, "message": quota_error}
-            )
-        except Exception:
-            logger.debug("quota error frame append failed for %s", spec.run_id, exc_info=True)
-        try:
-            await run_service.mark_terminal(spec.run_id, status="failed", error=quota_error)
-        except Exception:
-            logger.exception("mark_terminal(failed) failed for over-quota run %s", spec.run_id)
-        try:
-            await transport.set_ttl(spec.run_id, _stream_ttl())
-        except Exception:
-            logger.debug("quota stream ttl set failed for %s", spec.run_id, exc_info=True)
-        return True
+    return await guards.reject_if_over_billing(
+        ctx.workspace_id,
+        run_id=spec.run_id,
+        transport=transport,
+        log_label=spec.run_id,
+    )
 
 
 async def execute_run(spec: RunSpec) -> None:

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -222,7 +222,6 @@ from pocketpaw.agents.pool import (  # type: ignore[import-untyped]
 from pocketpaw.agents.session_supervisor import (  # type: ignore[import-untyped]
     get_session_supervisor,
 )
-from pocketpaw.config import get_settings  # type: ignore[import-untyped]
 from pocketpaw_ee.cloud._core.realtime import xproc
 from pocketpaw_ee.cloud.agent_sessions import runtime_service
 from pocketpaw_ee.cloud.agent_sessions.store import MongoSessionStore

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -1,5 +1,13 @@
 # Connectors — workspace-scoped business logic.
 # Created: 2026-05-03 — PR-1 of Phase 1 connector consolidation.
+# Updated: 2026-07-08 (feat/billing-smb-caps) — added a per-plan CONNECTOR cap.
+#   ``enable_connector`` now raises ``ConnectorLimitError`` (402) when the workspace
+#   is already at/over its plan's ``max_connectors`` and the call would enable a NEW
+#   connector (a fresh row, or re-enabling a disabled one). The check
+#   (``_connector_cap_exceeded``) is GATED on ``billing_enforced`` (a no-op for OSS
+#   / self-host), never trips on an uncapped Enterprise plan, and is skipped for an
+#   idempotent re-enable of an already-enabled connector — enforcement is
+#   enable-time only, never retroactive.
 # Updated: 2026-06-07 (M3 connector→skill auto-authoring) — enable/disable of a
 #   POCKET-scoped connector now RE-DERIVES the pocket's surface_profile from ALL
 #   its enabled pocket-scoped connectors (``_rederive_pocket_surface_profile``)
@@ -71,7 +79,13 @@ from pathlib import Path
 from beanie.operators import And, Or
 
 from pocketpaw.connectors.protocol import ExecutionMode
-from pocketpaw_ee.cloud._core.errors import CloudError, Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.errors import (
+    CloudError,
+    ConnectorLimitError,
+    Forbidden,
+    NotFound,
+    ValidationError,
+)
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     ConnectorConfigUpdated,
@@ -437,12 +451,51 @@ async def get_connector(
     )
 
 
+async def _connector_cap_exceeded(workspace_id: str) -> tuple[bool, int, int | None]:
+    """Would enabling one MORE connector exceed this workspace's plan cap?
+
+    Returns ``(exceeded, enabled_count, limit)``. feat/billing-smb-caps. GATED on
+    ``billing_enforced``: OSS / self-host tenants (billing off) always get
+    ``(False, 0, None)`` — no cap, no extra DB read. When enforced, resolves the
+    workspace's plan ``max_connectors`` and counts its currently-ENABLED connector
+    rows. An uncapped plan (Enterprise, ``max_connectors=None``) never trips. The
+    caller only invokes this when it is about to enable a connector that isn't
+    already enabled, so ``enabled_count >= limit`` is precisely "this new one would
+    exceed" — an already-enabled connector re-enabled idempotently is never blocked
+    (never retroactive). Imports are lazy to keep this module off the config /
+    entitlements import graph at load.
+    """
+    from pocketpaw.config import get_settings
+
+    if not get_settings().billing_enforced:
+        return (False, 0, None)
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = await entitlements_service.resolve_entitlements(workspace_id)
+    limit = ent.max_connectors
+    if limit is None:
+        return (False, 0, None)
+    enabled_count = await _WCDoc.find(
+        _WCDoc.workspace == workspace_id,
+        _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+    ).count()
+    return (enabled_count >= limit, enabled_count, limit)
+
+
 async def enable_connector(
     workspace_id: str,
     name: str,
     body: EnableConnectorRequest,
 ) -> ConnectorResponse:
-    """Enable a connector for this workspace, creating the row if needed."""
+    """Enable a connector for this workspace, creating the row if needed.
+
+    feat/billing-smb-caps: raises ``ConnectorLimitError`` (402) when the workspace
+    is already at/over its plan's ``max_connectors`` and this call would enable a
+    NEW connector (a fresh row, or re-enabling a disabled one). A no-op unless
+    ``billing_enforced``; an idempotent re-enable of an already-enabled connector is
+    never blocked (create-time only, never retroactive).
+    """
     body = EnableConnectorRequest.model_validate(body)
     available = {a.name: a for a in _available_from_registry()}
     if name not in available:
@@ -454,6 +507,22 @@ async def enable_connector(
         raise ValidationError("connector.scope_missing_user", "scope=user requires user_id")
 
     doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+    # Cap check only when this call would turn a connector ON that isn't already on
+    # (a brand-new row, or re-enabling a disabled one). An idempotent re-enable of
+    # an already-enabled connector must NEVER be blocked — that would retroactively
+    # strip access. Checked BEFORE the write.
+    if doc is None or not doc.enabled:
+        exceeded, enabled_count, limit = await _connector_cap_exceeded(workspace_id)
+        if exceeded:
+            logger.info(
+                "connector enable blocked by plan cap: workspace=%s has %d enabled "
+                "(limit %s), name=%s",
+                workspace_id,
+                enabled_count,
+                limit,
+                name,
+            )
+            raise ConnectorLimitError(limit)  # type: ignore[arg-type]  # int when exceeded
     if doc is None:
         doc = _WCDoc(
             workspace=workspace_id,

--- a/ee/pocketpaw_ee/cloud/credits/domain.py
+++ b/ee/pocketpaw_ee/cloud/credits/domain.py
@@ -23,6 +23,11 @@
 # own ledger (the universal meter, mode-agnostic across compute_spend /
 # litellm_spend) instead of the LiteLLM proxy. Framework-free like the other
 # domain shapes — billing consumes this, never the Beanie doc.
+# Changed 2026-07-11 (feat/llm-cost-attribution): ``ModelSpendRow`` gained a
+# ``tokens`` field — the real per-(day, model) token volume summed from the debit
+# ``ref.total_tokens`` the metering path now records. Defaults to 0 so a legacy
+# entry (written before the ref carried tokens) contributes nothing rather than
+# breaking the read; the credits + requests figures are unaffected.
 
 from __future__ import annotations
 
@@ -56,15 +61,18 @@ class ModelSpendRow:
     proxy. ``day`` is ``YYYY-MM-DD`` (UTC, from the entry's ``createdAt`` date);
     ``model`` is the charged model id (``ref.model``, or ``"unknown"`` when the
     debit carried no model); ``credits`` is the POSITIVE credits debited for that
-    (day, model) over the window; ``requests`` is the number of ledger entries in
-    that group (a proxy for request count — the ledger ``ref`` does not carry a
-    token count, so tokens are not recoverable here).
+    (day, model) over the window (integer CREDITS, 1 credit == $0.01 — NOT USD);
+    ``requests`` is the number of ledger entries in that group (a proxy for request
+    count); ``tokens`` is the real total token volume for the group, summed from
+    each debit's ``ref.total_tokens`` (0 for legacy entries written before the ref
+    carried tokens — the credits + requests figures stay accurate regardless).
     """
 
     day: str
     model: str
     credits: int
     requests: int
+    tokens: int = 0
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/credits/guards.py
+++ b/ee/pocketpaw_ee/cloud/credits/guards.py
@@ -1,0 +1,164 @@
+# ee/pocketpaw_ee/cloud/credits/guards.py — the shared, flag-gated run-start
+# BILLING gate, factored out of run_core so every agent-run entry seam blocks an
+# over-budget tenant the SAME way, with NO model call when rejected ("no model
+# call = no overspend").
+#
+# Three helpers, one core check, so each caller emits the terminal/error response
+# native to ITS transport (the callers are NOT identical):
+#
+#   * ``over_billing_limit(workspace)`` — the pure, reusable core. Flag-gated
+#     (a no-op returning None unless ``get_settings().billing_enforced``). Runs
+#     the SAME two assertions the chat chokepoint (chat/agent_router) runs, in the
+#     SAME order: ``check_balance`` (wallet <= 0 -> InsufficientCredits, 402
+#     credits.insufficient) FIRST, then ``check_quota`` (month-to-date spend >=
+#     the effective monthly ceiling -> QuotaExceeded, 402 credits.quota_exceeded).
+#     Returns the raised CloudError to REJECT, or None to PROCEED. It does NOT
+#     emit / raise itself — the caller decides how to respond. An uncapped
+#     (Enterprise, ceiling=None) plan is a no-op in ``check_quota`` by
+#     construction; an unknown plan fails CLOSED to the Free ceiling (the
+#     entitlements resolver). An empty workspace returns None (no wallet to
+#     attribute — the run-transport callers validate a non-empty workspace
+#     upstream; the event-bus callers can't gate a run they can't attribute).
+#
+#   * ``assert_within_billing(workspace)`` — for HTTP routes: RAISE the CloudError
+#     (402) so ``_core.http`` maps it to the wire. Place it BEFORE any local
+#     ``try/except Exception`` in the handler so the 402 isn't swallowed into a
+#     500.
+#
+#   * ``reject_if_over_billing(workspace, *, run_id, transport, log_label)`` — for
+#     the run/stream transport (run_core.execute_run): on rejection emit a clean
+#     terminal ``error`` stream frame, ``mark_terminal(failed)`` the run doc, and
+#     set the stream TTL, then return True so the caller early-returns BEFORE any
+#     model/agent work. Returns False to proceed. Each side effect is best-effort
+#     (a transient Redis/Mongo blip can't turn a clean reject into a crash),
+#     mirroring the jail-quota reject.
+#
+# The credits package is imported LOCALLY inside the core so this module stays off
+# the hot import graph; ``run_service`` is imported locally in the run-transport
+# helper to keep the credits layer from importing chat at module load.
+#
+# Created 2026-07-08 (feat/billing-enforce-gate): universalize the run-start
+# credit gate across every agent-run seam (chat was already gated; this adds the
+# group/DM auto-response bridge, the /files Library agent ops, and the planner
+# task executor). run_core's ``_reject_if_over_credit_quota`` now delegates here
+# and thereby ALSO gains the ``check_balance`` (wallet <= 0) leg it lacked — the
+# worker/executor path now rejects at an empty wallet, not only at the monthly
+# ceiling.
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from pocketpaw.config import get_settings  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.cloud._core.errors import CloudError
+
+logger = logging.getLogger(__name__)
+
+
+def _stream_ttl() -> int:
+    """Stream-doc TTL in seconds — mirrors ``run_core._stream_ttl`` so a rejected
+    run's error frame expires on the same schedule as a normal run's."""
+    return int(os.environ.get("POCKETPAW_CLOUD_RUN_STREAM_TTL", "3600"))
+
+
+async def over_billing_limit(workspace_id: str) -> CloudError | None:
+    """Return the billing rejection for ``workspace_id``, or None to proceed.
+
+    The pure, transport-agnostic core of the run-start billing gate. A no-op
+    (returns None) unless ``get_settings().billing_enforced`` is on — OSS /
+    self-host deployments run no credit ledger. When enforced, it runs the two
+    credit assertions in the SAME order as the chat chokepoint: ``check_balance``
+    (empty wallet) first, then ``check_quota`` (monthly ceiling). The FIRST that
+    trips is returned (an ``InsufficientCredits`` or ``QuotaExceeded``, both 402
+    CloudErrors); if both pass it returns None.
+
+    An uncapped plan (Enterprise, ``monthly_ceiling`` is None) never trips the
+    quota leg (``check_quota`` no-ops there). An empty ``workspace_id`` returns
+    None: there is no wallet to attribute, and the run-transport callers already
+    validate a non-empty workspace upstream. Only the two credit CloudErrors are
+    caught here — any other exception (a real infra failure) propagates, exactly
+    as the pre-existing run_core gate let it.
+    """
+    if not get_settings().billing_enforced:
+        return None
+    if not workspace_id:
+        return None
+
+    from pocketpaw_ee.cloud._core.errors import InsufficientCredits, QuotaExceeded
+    from pocketpaw_ee.cloud.credits import service as credits_service
+
+    try:
+        # Order mirrors chat/agent_router: the empty-wallet block is the primary
+        # money guarantee; the monthly-ceiling block sits beside it.
+        await credits_service.check_balance(workspace_id)
+        await credits_service.check_quota(workspace_id)
+    except (InsufficientCredits, QuotaExceeded) as exc:
+        return exc
+    return None
+
+
+async def assert_within_billing(workspace_id: str) -> None:
+    """Raise the billing rejection (402 CloudError) when over budget; else no-op.
+
+    For HTTP routes: the raised ``InsufficientCredits`` / ``QuotaExceeded`` is a
+    CloudError that ``_core.http`` maps to a 402 wire response. Call it BEFORE any
+    local ``try/except Exception`` in the handler so the 402 isn't swallowed into
+    a generic 500. Flag-gated and Enterprise-safe via ``over_billing_limit``.
+    """
+    exc = await over_billing_limit(workspace_id)
+    if exc is not None:
+        raise exc
+
+
+async def reject_if_over_billing(
+    workspace_id: str,
+    *,
+    run_id: str,
+    transport: Any,
+    log_label: str | None = None,
+) -> bool:
+    """Reject an over-budget run on the run/stream transport. Returns True if it did.
+
+    The run-transport variant (run_core.execute_run): when ``over_billing_limit``
+    trips, emit a terminal ``error`` stream frame, ``mark_terminal(failed)`` the
+    run doc, and set the stream TTL — the SAME clean shape the ART-3 jail-quota
+    reject uses — then return True so the caller early-returns BEFORE any model /
+    agent work (the no-overspend money guarantee). Returns False to proceed.
+
+    Every side effect is best-effort: a transient Redis / Mongo failure while
+    writing the rejection must not turn a clean 402-equivalent block into an
+    unhandled crash that takes the worker down.
+    """
+    exc = await over_billing_limit(workspace_id)
+    if exc is None:
+        return False
+
+    label = log_label or run_id
+    message = str(exc)
+    logger.warning("run %s rejected — billing gate: %s (%s)", label, message, exc.code)
+    try:
+        await transport.append_event(run_id, "error", {"code": exc.code, "message": message})
+    except Exception:
+        logger.debug("billing error frame append failed for %s", run_id, exc_info=True)
+    try:
+        from pocketpaw_ee.cloud.chat.runs import service as run_service
+
+        await run_service.mark_terminal(run_id, status="failed", error=message)
+    except Exception:
+        logger.exception("mark_terminal(failed) failed for over-billing run %s", run_id)
+    try:
+        await transport.set_ttl(run_id, _stream_ttl())
+    except Exception:
+        logger.debug("billing stream ttl set failed for %s", run_id, exc_info=True)
+    return True
+
+
+__all__ = [
+    "assert_within_billing",
+    "over_billing_limit",
+    "reject_if_over_billing",
+]

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -130,6 +130,12 @@
 # must not read ``CreditLedgerEntry`` itself, so this owns the read (sibling to
 # ``sum_debits_by_cause``). It performs NO writes and changes NOTHING that is
 # charged — a pure re-source of the display.
+# Changed 2026-07-11 (feat/llm-cost-attribution): ``spend_by_model`` now sums each
+# debit's ``ref.total_tokens`` per (day, model) and returns it on the new
+# ``ModelSpendRow.tokens`` field, so the ledger-sourced usage graph surfaces real
+# token volume instead of a hardcoded 0. A legacy entry whose ref predates the
+# token stamp contributes 0 (the credits + requests figures are unchanged). Read
+# only — no new writes.
 # Changed 2026-06-30 (feat/billing-quota-enforcement, chunk 2): added the monthly
 # credit-QUOTA reads + assertion. ``month_to_date_spend`` sums this UTC calendar
 # month's APPLIED spend debits (compute_spend + litellm_spend, the same two
@@ -691,9 +697,10 @@ async def spend_by_model(
     charged spend with no model still counts toward the day so the chart
     reconciles with the wallet); ``credits`` is the POSITIVE amount debited (a
     stray positive delta is clamped out, like ``sum_debits_by_cause``). ``requests``
-    is the COUNT of entries in the (day, model) group — the ledger ``ref`` does not
-    carry a token count, so tokens are not recoverable here (a follow-up could add
-    ``total_tokens`` to the debit ``ref``).
+    is the COUNT of entries in the (day, model) group. ``tokens`` is the real total
+    token volume for the group, summed from each entry's ``ref.total_tokens`` (the
+    metering path now records it — a legacy entry without it contributes 0, so the
+    figure reflects real volume going forward without breaking historical reads).
 
     EE entity-isolation: billing must not read ``CreditLedgerEntry`` directly, so
     this owns the read (sibling to ``sum_debits_by_cause``). It performs NO writes.
@@ -714,7 +721,8 @@ async def spend_by_model(
     # credits and count entries. A stray positive ``amount_delta`` under a spend
     # cause (there should be none — spend is debit-only) is skipped so a bad row
     # can't make a group read as a refund.
-    grouped: dict[tuple[str, str], list[int]] = {}  # (day, model) -> [credits, requests]
+    # (day, model) -> [credits, requests, tokens]
+    grouped: dict[tuple[str, str], list[int]] = {}
     for e in entries:
         delta = int(e.amount_delta)
         if delta >= 0:
@@ -725,13 +733,20 @@ async def spend_by_model(
         day = created.date().isoformat()
         ref = e.ref or {}
         model = ref.get("model") or "unknown"
-        bucket = grouped.setdefault((day, model), [0, 0])
+        # ``total_tokens`` is the real per-run volume the metering path stamps on
+        # the ref; a legacy entry without it (or a non-int) reads 0.
+        try:
+            tokens = int(ref.get("total_tokens") or 0)
+        except (TypeError, ValueError):
+            tokens = 0
+        bucket = grouped.setdefault((day, model), [0, 0, 0])
         bucket[0] += -delta  # positive credits debited
         bucket[1] += 1  # one more request in this group
+        bucket[2] += tokens if tokens > 0 else 0  # real token volume
 
     return [
-        ModelSpendRow(day=day, model=model, credits=credits, requests=requests)
-        for (day, model), (credits, requests) in grouped.items()
+        ModelSpendRow(day=day, model=model, credits=credits, requests=requests, tokens=tokens)
+        for (day, model), (credits, requests, tokens) in grouped.items()
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/cycles/scheduler.py
+++ b/ee/pocketpaw_ee/cloud/cycles/scheduler.py
@@ -5,6 +5,10 @@
 #   CronJob, Celery beat, OS cron) leave the flag unset and dispatch
 #   ``snapshot_all_active`` from their platform scheduler — same callable,
 #   same idempotency.
+# Updated: 2026-07-11 (feat/external-alerting-c2c3) — the per-workspace pass now
+#   consults the automation opt-out (``sweeps_enabled_for_workspace``): a tenant
+#   that turned its background sweeps off is skipped. The gate fails OPEN, so a
+#   config-read hiccup keeps the always-on default.
 """In-process daily snapshot scheduler.
 
 For each active cycle in each active workspace, calls
@@ -33,6 +37,7 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi import FastAPI
 
+from pocketpaw_ee.cloud.automations_status.service import sweeps_enabled_for_workspace
 from pocketpaw_ee.cloud.cycles import service as cycles_service
 from pocketpaw_ee.cloud.cycles.snapshot_job import snapshot_all_active
 
@@ -79,6 +84,12 @@ async def _run_scheduler_loop() -> None:
             continue
 
         for ws in workspaces:
+            # Per-workspace opt-out (feat/external-alerting-c2c3): a tenant that
+            # turned its background sweeps off is skipped here. The gate fails
+            # OPEN, so a config-read hiccup keeps the always-on default.
+            if not await sweeps_enabled_for_workspace(ws):
+                logger.debug("cycle.scheduler: workspace=%s opted out — skipping", ws)
+                continue
             try:
                 count = await snapshot_all_active(ws)
                 logger.info("cycle.scheduler: workspace=%s snapshotted=%d", ws, count)

--- a/ee/pocketpaw_ee/cloud/entitlements/domain.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/domain.py
@@ -15,6 +15,11 @@
 #   ``monthly_ceiling: int | None`` next to ``monthly_credit_allotment`` — the
 #   per-plan monthly credit CAP (None = uncapped) the resolver populates from the
 #   plan catalog and later quota chunks enforce against.
+# Updated 2026-07-08 (feat/billing-smb-caps): added ``max_seats`` / ``max_pockets``
+#   / ``max_connectors`` (all ``int | None``, None = uncapped) beside
+#   ``monthly_ceiling`` — the SMB resource ceilings the resolver populates from the
+#   plan catalog and the seat / pocket-create / connector-enable gates enforce
+#   against at create time. Fail-closed to the Free value on the fallback path.
 
 from __future__ import annotations
 
@@ -33,11 +38,18 @@ class Entitlements:
     per renewal for the tier. ``monthly_ceiling`` is the per-plan monthly credit
     CAP (integer credits, or None = uncapped) credit-quota enforcement caps spend
     against; a workspace with no/unknown plan resolves to the Free ceiling (the
-    fail-closed trial cap), never None/uncapped.
+    fail-closed trial cap), never None/uncapped. ``max_seats`` / ``max_pockets`` /
+    ``max_connectors`` are the SMB resource ceilings (integer, or None = uncapped
+    for Enterprise) the seat / pocket-create / connector-enable gates enforce at
+    create time; a no/unknown-plan workspace resolves to the Free values
+    (fail-closed), never None/uncapped.
     """
 
     workspace_id: str
     plan: str
     monthly_credit_allotment: int
     monthly_ceiling: int | None
+    max_seats: int | None
+    max_pockets: int | None
+    max_connectors: int | None
     features: frozenset[str] = field(default_factory=frozenset)

--- a/ee/pocketpaw_ee/cloud/entitlements/dto.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/dto.py
@@ -20,6 +20,11 @@
 #   INR/USD monthly+annual prices) so the billing UI can render ChatGPT/Claude-style
 #   "usage" wording instead of raw credits. ``monthly_credit_allotment`` stays as a
 #   back-office field; ``enterprise`` prices serialize as null ("talk to us").
+# Updated 2026-07-08 (feat/billing-smb-caps): both ``PlanTierResponse`` and
+#   ``EntitlementsResponse`` now carry the SMB resource caps ``max_seats`` /
+#   ``max_pockets`` / ``max_connectors`` (the enforced ceilings the plan ladder
+#   added), so the plan cards can render real per-tier limits and the settings UI
+#   can show a workspace's resolved caps. ``None`` == uncapped (Enterprise).
 
 from __future__ import annotations
 
@@ -53,6 +58,9 @@ class PlanTierResponse(BaseModel):
     price_inr_annual: int | None = None
     price_usd_monthly: int | None = None
     price_usd_annual: int | None = None
+    max_seats: int | None = None
+    max_pockets: int | None = None
+    max_connectors: int | None = None
 
 
 class PlanCatalogResponse(BaseModel):
@@ -71,6 +79,9 @@ class EntitlementsResponse(BaseModel):
     plan: str
     monthly_credit_allotment: int
     features: list[str] = Field(default_factory=list)
+    max_seats: int | None = None
+    max_pockets: int | None = None
+    max_connectors: int | None = None
 
 
 def plan_tier_to_dto(tier: PlanTier) -> PlanTierResponse:
@@ -87,6 +98,9 @@ def plan_tier_to_dto(tier: PlanTier) -> PlanTierResponse:
         price_inr_annual=tier.price_inr_annual,
         price_usd_monthly=tier.price_usd_monthly,
         price_usd_annual=tier.price_usd_annual,
+        max_seats=tier.max_seats,
+        max_pockets=tier.max_pockets,
+        max_connectors=tier.max_connectors,
     )
 
 
@@ -97,6 +111,9 @@ def entitlements_to_dto(ent: Entitlements) -> EntitlementsResponse:
         plan=ent.plan,
         monthly_credit_allotment=ent.monthly_credit_allotment,
         features=sorted(ent.features),
+        max_seats=ent.max_seats,
+        max_pockets=ent.max_pockets,
+        max_connectors=ent.max_connectors,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -27,6 +27,10 @@
 #   ``monthly_ceiling`` exactly as ``monthly_credit_allotment`` is. The defensive
 #   base-floor branch sets the Free trial ceiling (1000), so every path fails
 #   closed and no path leaves the cap uncapped.
+# Updated 2026-07-08 (feat/billing-smb-caps): ``Entitlements`` now also carries the
+#   three SMB caps (``max_seats`` / ``max_pockets`` / ``max_connectors``), populated
+#   from the resolved tier exactly as ``monthly_ceiling`` is. The defensive
+#   base-floor branch sets the Free values (5 / 200 / 50) so every path fails closed.
 
 from __future__ import annotations
 
@@ -70,6 +74,11 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
                 # Fail closed: the Free trial cap, never None/uncapped — even when
                 # the catalog itself is somehow missing the base tier.
                 monthly_ceiling=1_000,
+                # Fail closed on the SMB caps too: the Free values (max_seats == the
+                # Workspace.seats default so no workspace regresses), never uncapped.
+                max_seats=5,
+                max_pockets=200,
+                max_connectors=50,
                 features=frozenset(),
             )
 
@@ -78,5 +87,8 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
         plan=tier.key,
         monthly_credit_allotment=tier.monthly_credit_allotment,
         monthly_ceiling=tier.monthly_ceiling,
+        max_seats=tier.max_seats,
+        max_pockets=tier.max_pockets,
+        max_connectors=tier.max_connectors,
         features=tier.features,
     )

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/__init__.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/__init__.py
@@ -1,26 +1,43 @@
-# fabric_ingest — Generic Firestore→Fabric ingestion worker.
+# fabric_ingest — Generic source→Fabric ingestion worker (Firestore + connectors).
 # Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+# Updated: 2026-07-11 (feat/real-pipeline-s1) — the transform surface. Mappings
+#   now carry a ``source_kind`` ("firestore" | "connector"): connector mappings
+#   dispatch through the OSS ``FABRIC_INGESTORS`` registry with the workspace's
+#   own WorkspaceConnector binding (per-user token via ``wc.user_id``). New
+#   ``router.py`` exposes author/list/delete + run-now over the mappings
+#   (mounted at /api/v1/fabric/ingest/*), backed by new service helpers
+#   (``list_mappings`` / ``upsert_mapping`` / ``delete_mapping``).
 # Updated: 2026-06-11 (rebase onto dev) — the upsert path now delegates to the
 #   canonical OSS connector→Fabric mapper (pocketpaw.connectors.fabric_ingest,
 #   landed in the Calendar ingestion PR #1418) instead of a private loop.
-"""Continuously mirror selected Firestore collections into Fabric objects.
+"""Continuously mirror selected sources into Fabric objects.
 
-Fully generic: the per-deployment mapping (which collections, which Fabric
+Fully generic: the per-deployment mapping (which sources, which Fabric
 object types, field maps, cursor fields, link rules) lives in a per-workspace
 ``FabricIngestConfig`` document. NOTHING domain-specific lives in this package.
+Two source kinds per mapping: ``"firestore"`` (the original reader path) and
+``"connector"`` (records pulled through the OSS connector→Fabric ingestor
+registry — gcalendar first).
 
 Pieces
 ------
-* ``service.ingest_collection`` — mirror ONE Firestore collection into Fabric
-  objects for one workspace. Reads the mapping from the workspace's config and
-  upserts each document through the canonical OSS connector→Fabric mapper
-  (``pocketpaw.connectors.fabric_ingest.ingest_records`` — the same loop the
-  Calendar connector ingestion uses), keyed on the doc's source path so a
-  re-run updates rather than duplicates. Every object is stamped with
-  ``workspace_id`` + ``source_connector="firestore"`` + ``source_id`` (the full
-  doc path); the worker advances a REAL high-water cursor taken from document
-  data and applies any link rules. Backfill on first run, incremental
-  thereafter.
+* ``router`` — the transform surface: ``GET/POST/DELETE
+  /fabric/ingest/mappings`` (author the workspace's mappings) and
+  ``POST /fabric/ingest/run`` (run one mapping now). Same gates as the fabric
+  router: license + plan feature ``fabric``, ``fabric.read``/``fabric.write``
+  per route, workspace from ``current_workspace_id``.
+* ``service.ingest_collection`` — mirror ONE source into Fabric objects for
+  one workspace. Reads the mapping from the workspace's config; a firestore
+  mapping upserts each document through the canonical OSS connector→Fabric
+  mapper (``pocketpaw.connectors.fabric_ingest.ingest_records`` — the same
+  loop the Calendar connector ingestion uses), keyed on the doc's source path
+  so a re-run updates rather than duplicates; a connector mapping resolves the
+  workspace's enabled ``WorkspaceConnector`` row and calls the registered
+  ingestor with that row's ``user_id`` (misconfiguration is an error result,
+  never a raise). Every object is stamped with ``workspace_id`` +
+  ``source_connector`` + ``source_id``; the firestore path advances a REAL
+  high-water cursor taken from document data and applies any link rules.
+  Backfill on first run, incremental thereafter.
 * ``service.run_ingest_sweep`` — fan ``ingest_collection`` out across every
   configured (workspace, collection) pair under a bounded concurrency cap;
   per-collection failures are isolated.

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/dto.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/dto.py
@@ -1,5 +1,12 @@
 # dto.py — Request/validation schemas for the Firestore→Fabric ingest worker.
 # Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+# Updated: 2026-07-11 (feat/real-pipeline-s1) — FieldMappingSpec mirrors the
+#   model's new additive source discriminator (``source_kind`` +
+#   ``connector_id``) so connector-source mappings validate at entry like
+#   firestore ones. Also added the transform-surface DTOs the new
+#   ``fabric_ingest/router.py`` uses: ``MappingUpsertRequest`` (author a
+#   mapping), ``MappingsListResponse`` / ``MappingResponse`` (read side),
+#   ``RunNowRequest`` / ``RunNowResponse`` (run-now dispatch result).
 #
 # Per cloud rule §4 (request/response split) and §6 (validate at entry): the
 # service functions re-parse their inputs through these even when called by
@@ -10,6 +17,8 @@
 # mirroring nothing or crashing mid-sweep.
 
 from __future__ import annotations
+
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -73,6 +82,12 @@ class FieldMappingSpec(BaseModel):
     field_map: dict[str, str] = Field(default_factory=dict)
     cursor_field: str = ""
     link_rules: list[LinkRuleSpec] = Field(default_factory=list)
+    # Source discriminator (feat/real-pipeline-s1) — mirrors the model field.
+    # "connector" mappings pull records through the OSS ingestor registry;
+    # ``connector_id`` defaults to ``collection`` when unset (the collection
+    # holds the connector name for connector mappings by convention).
+    source_kind: Literal["firestore", "connector"] = "firestore"
+    connector_id: str | None = None
 
     @field_validator("collection", "object_type_id")
     @classmethod
@@ -109,3 +124,60 @@ class IngestConfigRequest(BaseModel):
         if not v.strip():
             raise ValueError("workspace_id must not be blank")
         return v
+
+
+# ---------------------------------------------------------------------------
+# Transform-surface DTOs (feat/real-pipeline-s1) — the fabric_ingest router's
+# request/response split (cloud rule §4). The workspace never travels in the
+# body; the router injects the caller's active workspace (cloud rule §7).
+# ---------------------------------------------------------------------------
+
+
+class MappingUpsertRequest(FieldMappingSpec):
+    """Author one mapping (create-or-replace, keyed on ``collection``).
+
+    Same validated shape as ``FieldMappingSpec`` — subclassed so the router's
+    request type names its intent while the service keeps one validation
+    source of truth.
+    """
+
+
+class MappingResponse(FieldMappingSpec):
+    """One mapping as read back from the workspace's config."""
+
+
+class MappingsListResponse(BaseModel):
+    """The workspace's authored mappings."""
+
+    mappings: list[MappingResponse] = Field(default_factory=list)
+
+
+class RunNowRequest(BaseModel):
+    """Trigger one mapping's ingest immediately. ``collection`` is the
+    routing key (the connector name for connector mappings)."""
+
+    collection: str = Field(min_length=1)
+
+    @field_validator("collection")
+    @classmethod
+    def _not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("collection must not be blank")
+        return v
+
+
+class RunNowResponse(BaseModel):
+    """The result dict of ``ingest_collection``, typed for the wire.
+
+    ``status`` is ``"ok"`` or ``"error"`` — a misconfigured mapping (missing
+    connector, unregistered ingestor, no mapping) reports here rather than as
+    an HTTP 5xx, matching the sweep's never-raise contract.
+    """
+
+    workspace_id: str
+    source_id: str
+    status: str
+    mode: str
+    objects: int
+    cursor: str
+    errors: list[Any] = Field(default_factory=list)

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/router.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/router.py
@@ -1,0 +1,124 @@
+# ee/cloud/fabric_ingest/router.py — the connector→Fabric transform surface.
+# Created: 2026-07-11 (feat/real-pipeline-s1) — author/list/delete the
+#   workspace's FabricIngestConfig mappings + a run-now endpoint that fires
+#   one mapping's ingest immediately (firestore OR connector source; the
+#   gcalendar connector is the first real connector adopter).
+#
+# RBAC copies ee/fabric/router.py exactly: router-level ``require_license`` +
+# ``require_plan_feature("fabric")`` (the whole surface is business-tier+),
+# then per-route ``require_action_any_workspace`` — reads need ``fabric.read``
+# (MEMBER), every mutation (author, delete, run-now) needs ``fabric.write``
+# (MEMBER; a caller outside the workspace 403s). Tenancy: every handler takes
+# the caller's active workspace via ``current_workspace_id`` and threads it
+# into the service — the workspace NEVER travels in a request body, so a
+# caller can only ever author/run its own tenant's mappings (cloud rule §7).
+#
+# The router is thin (cloud chokepoint rule): all FabricIngestConfig reads and
+# writes live in service.py (``list_mappings`` / ``upsert_mapping`` /
+# ``delete_mapping`` / ``ingest_collection``); DTOs live in dto.py. No prefix
+# on the router — ee/cloud/__init__.py mounts it under ``/api/v1`` like the
+# fabric router.
+#
+# Run-now semantics: ``ingest_collection`` never raises for a misconfigured
+# mapping — a missing mapping, an unconnected/disabled connector, or an
+# unregistered ingestor all come back as ``status="error"`` in the result
+# body (HTTP 200), matching the sweep's per-collection isolation contract.
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Query
+
+from pocketpaw_ee.cloud._core.deps import current_workspace_id, require_plan_feature
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.fabric_ingest import service
+from pocketpaw_ee.cloud.fabric_ingest.dto import (
+    MappingResponse,
+    MappingsListResponse,
+    MappingUpsertRequest,
+    RunNowRequest,
+    RunNowResponse,
+)
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import require_action_any_workspace
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    tags=["Fabric Ingest"],
+    dependencies=[Depends(require_license), Depends(require_plan_feature("fabric"))],
+)
+
+
+@router.get(
+    "/fabric/ingest/mappings",
+    response_model=MappingsListResponse,
+    dependencies=[Depends(require_action_any_workspace("fabric.read"))],
+)
+async def list_mappings(
+    workspace_id: str = Depends(current_workspace_id),
+) -> MappingsListResponse:
+    """List the caller's workspace's authored transform mappings."""
+    mappings = await service.list_mappings(workspace_id)
+    return MappingsListResponse(
+        mappings=[MappingResponse.model_validate(m) for m in mappings]
+    )
+
+
+@router.post(
+    "/fabric/ingest/mappings",
+    response_model=MappingResponse,
+    status_code=201,
+    dependencies=[Depends(require_action_any_workspace("fabric.write"))],
+)
+async def upsert_mapping(
+    req: MappingUpsertRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> MappingResponse:
+    """Author one mapping (create-or-replace, keyed on ``collection``).
+
+    For a connector-source mapping set ``source_kind="connector"`` and keep
+    ``collection`` = the connector name (``connector_id`` defaults to it).
+    """
+    stored = await service.upsert_mapping(workspace_id, req.model_dump())
+    return MappingResponse.model_validate(stored)
+
+
+@router.delete(
+    "/fabric/ingest/mappings",
+    status_code=204,
+    dependencies=[Depends(require_action_any_workspace("fabric.write"))],
+)
+async def delete_mapping(
+    collection: str = Query(..., min_length=1, description="The mapping's routing key"),
+    workspace_id: str = Depends(current_workspace_id),
+) -> None:
+    """Remove the mapping keyed on ``collection`` (404 when it doesn't exist).
+
+    ``collection`` rides a query param, not a path segment — Firestore
+    collection paths can contain ``/``.
+    """
+    removed = await service.delete_mapping(workspace_id, collection)
+    if not removed:
+        raise NotFound("fabric_ingest.mapping_not_found", "No such mapping")
+
+
+@router.post(
+    "/fabric/ingest/run",
+    response_model=RunNowResponse,
+    dependencies=[Depends(require_action_any_workspace("fabric.write"))],
+)
+async def run_now(
+    req: RunNowRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> RunNowResponse:
+    """Run one mapping's ingest immediately for the caller's workspace.
+
+    Returns the ingest result envelope; a misconfigured mapping (no mapping,
+    connector not connected, ingestor unregistered) reports ``status="error"``
+    in the body rather than an HTTP 5xx — the same never-raise contract the
+    background sweep relies on.
+    """
+    result = await service.ingest_collection(workspace_id, req.collection)
+    return RunNowResponse.model_validate(result)

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/router.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/router.py
@@ -61,9 +61,7 @@ async def list_mappings(
 ) -> MappingsListResponse:
     """List the caller's workspace's authored transform mappings."""
     mappings = await service.list_mappings(workspace_id)
-    return MappingsListResponse(
-        mappings=[MappingResponse.model_validate(m) for m in mappings]
-    )
+    return MappingsListResponse(mappings=[MappingResponse.model_validate(m) for m in mappings])
 
 
 @router.post(

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -1,5 +1,20 @@
 # service.py — Generic Firestore→Fabric ingestion worker.
 # Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+# Updated: 2026-07-11 (feat/real-pipeline-s1) — connector-source dispatch. The
+#   run path now branches on ``mapping.source_kind``: "firestore" rides the
+#   existing reader path UNCHANGED; "connector" routes through the new
+#   ``_ingest_from_connector`` — resolve the workspace's enabled
+#   ``WorkspaceConnector`` row (missing/disabled → error result, never raise),
+#   look the ingestor up in the OSS ``FABRIC_INGESTORS`` registry
+#   (lazy-imported; unregistered → error result), then
+#   ``await ingestor(store, workspace_id=..., user_id=wc.user_id)`` so a
+#   user-scoped connector reads with THAT member's OAuth token bucket (None =
+#   the shared/workspace bucket — the member_ingest seam). State bookkeeping +
+#   FabricIngestCompleted emit are reused verbatim; the cursor is untouched on
+#   connector runs (the ingestor owns its own read window). Also added the
+#   mapping-authoring service surface for the new router: ``list_mappings`` /
+#   ``upsert_mapping`` / ``delete_mapping`` (service.py stays the only reader
+#   of FabricIngestConfig — cloud rule §2).
 # Updated: 2026-07-11 (feat/external-alerting-c2c3) — ``run_ingest_sweep`` now
 #   filters sources by the per-workspace automation opt-out
 #   (``automations_status.service.filter_sweep_enabled_workspaces``): a tenant
@@ -187,35 +202,52 @@ async def ingest_collection(
     errors: list[str] = []
     objects = 0
     new_cursor = state.cursor
+    source_kind = getattr(mapping, "source_kind", "firestore")
 
-    if reader is None:
+    # Only the firestore path needs a reader — a connector run's ingestor owns
+    # its own read (and constructing the default reader pulls google creds).
+    if reader is None and source_kind != "connector":
         reader = _default_reader()
 
     try:
-        # Backfill reads from an empty cursor (everything); incremental reads
-        # only documents past the stored high-water mark.
-        lower_bound = "" if mode == "backfill" else state.cursor
-        docs = await reader.read_collection(
-            mapping.collection,
-            cursor_field=mapping.cursor_field,
-            cursor=lower_bound,
-            limit=_MAX_DOCS_PER_RUN,
-        )
-        # Advance the high-water mark to the MAX cursor value we actually saw
-        # across docs with a usable identity — a real watermark from document
-        # data, never run wall-clock. Persisted only on a clean run (below).
-        for doc in docs:
-            if not str(doc.get("path") or ""):
-                continue  # no stable identity — the mapper skips it too
-            doc_cursor = _doc_cursor(doc, mapping.cursor_field)
-            if doc_cursor and doc_cursor > new_cursor:
-                new_cursor = doc_cursor
-        # Upsert through the canonical OSS connector→Fabric loop.
-        objects = await _mirror_docs(store, workspace_id, docs, mapping)
-        # Link rules run after all objects exist so a link can target a
-        # document mirrored earlier in the same batch.
-        if mapping.link_rules:
-            await _apply_link_rules(store, workspace_id, docs, mapping)
+        if source_kind == "connector":
+            # Connector-source dispatch (feat/real-pipeline-s1): pull records
+            # through the OSS ingestor registry with the workspace's own
+            # connector binding. Misconfiguration (connector not connected,
+            # ingestor not registered) is an error RESULT, never a raise —
+            # same contract as a missing mapping above. The cursor is left
+            # untouched: the ingestor owns its own read window and the
+            # upsert-by-(source_connector, source_id) loop keeps re-runs
+            # idempotent.
+            objects, connector_error = await _ingest_from_connector(store, workspace_id, mapping)
+            if connector_error:
+                errors.append(f"{source_id}: {connector_error}")
+        else:
+            # Backfill reads from an empty cursor (everything); incremental
+            # reads only documents past the stored high-water mark.
+            lower_bound = "" if mode == "backfill" else state.cursor
+            docs = await reader.read_collection(
+                mapping.collection,
+                cursor_field=mapping.cursor_field,
+                cursor=lower_bound,
+                limit=_MAX_DOCS_PER_RUN,
+            )
+            # Advance the high-water mark to the MAX cursor value we actually
+            # saw across docs with a usable identity — a real watermark from
+            # document data, never run wall-clock. Persisted only on a clean
+            # run (below).
+            for doc in docs:
+                if not str(doc.get("path") or ""):
+                    continue  # no stable identity — the mapper skips it too
+                doc_cursor = _doc_cursor(doc, mapping.cursor_field)
+                if doc_cursor and doc_cursor > new_cursor:
+                    new_cursor = doc_cursor
+            # Upsert through the canonical OSS connector→Fabric loop.
+            objects = await _mirror_docs(store, workspace_id, docs, mapping)
+            # Link rules run after all objects exist so a link can target a
+            # document mirrored earlier in the same batch.
+            if mapping.link_rules:
+                await _apply_link_rules(store, workspace_id, docs, mapping)
     except Exception as exc:  # noqa: BLE001 — isolate this collection so one bad
         # source never crashes the sweep or the other collections.
         logger.warning(
@@ -521,6 +553,127 @@ async def _apply_link_rules(
             )
 
 
+async def _ingest_from_connector(
+    store: StoreLike,
+    workspace_id: str,
+    mapping: Any,
+) -> tuple[int, str]:
+    """Run one connector-source mapping through the OSS ingestor registry.
+
+    Returns ``(objects_ingested, error)`` — ``error`` is ``""`` on success.
+    The two misconfiguration cases report as an error string (never raise):
+
+    1. the workspace has no ENABLED ``WorkspaceConnector`` row for the
+       connector — not connected, or the operator disabled it (tenant filter
+       on the read, cloud rule §7);
+    2. no ingestor is registered under the connector id in the OSS
+       ``FABRIC_INGESTORS`` registry.
+
+    On success the ingestor is called with the mapping's tenant-scoped store
+    and the connector row's ``user_id`` — a user-scoped connector (VIP
+    onboarding) reads with THAT member's OAuth token bucket; ``None`` means
+    the shared/workspace bucket (the member_ingest seam, proven at
+    member_ingest/service.py's WorkspaceConnector lookup). A genuine ingestor
+    failure (API error, expired token) propagates to ``ingest_collection``'s
+    per-collection isolation and lands as an error result there.
+    """
+    # service-to-model read of another entity's doc — same minimal correct
+    # path member_ingest/service.py takes (flagged there for a future
+    # ``connectors.service.list_user_connectors`` extraction).
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    connector_id = getattr(mapping, "connector_id", None) or mapping.collection
+    wc = await WorkspaceConnector.find_one(
+        WorkspaceConnector.workspace == workspace_id,  # tenant filter
+        WorkspaceConnector.name == connector_id,
+        WorkspaceConnector.enabled == True,  # noqa: E712 — Beanie needs ==, not `is`
+    )
+    if wc is None:
+        return 0, f"connector {connector_id!r} is not connected/enabled for this workspace"
+
+    # Lazy import — EE reaches into the OSS registry, never the reverse.
+    from pocketpaw.connectors.fabric_ingest import get_fabric_ingestor
+
+    ingestor = get_fabric_ingestor(connector_id)
+    if ingestor is None:
+        return 0, f"no fabric ingestor registered for connector {connector_id!r}"
+
+    result = await ingestor(store, workspace_id=workspace_id, user_id=wc.user_id)
+    return result.total, ""
+
+
+# --------------------------------------------------------------------------
+# Mapping authoring (the transform surface's service layer)
+# --------------------------------------------------------------------------
+
+
+async def list_mappings(workspace_id: str) -> list[dict[str, Any]]:
+    """Return the workspace's authored mappings (empty list when no config).
+
+    Tenant filter on the read (cloud rule §7). Reads the config row regardless
+    of its ``enabled`` flag — authoring must show what's configured even while
+    the sweep is paused.
+    """
+    from pocketpaw_ee.cloud.models.fabric_ingest_state import FabricIngestConfig
+
+    cfg = await FabricIngestConfig.find_one(FabricIngestConfig.workspace == workspace_id)
+    if cfg is None:
+        return []
+    return [m.model_dump() for m in cfg.mappings]
+
+
+async def upsert_mapping(workspace_id: str, spec: dict[str, Any]) -> dict[str, Any]:
+    """Create-or-replace one mapping, keyed on ``collection``.
+
+    ``spec`` is validated through the DTO at entry (cloud rule §6) so a
+    malformed mapping never lands in the stored config. Creates the
+    workspace's config row on first authoring. Returns the stored mapping.
+    """
+    from pocketpaw_ee.cloud.fabric_ingest.dto import FieldMappingSpec
+    from pocketpaw_ee.cloud.models.fabric_ingest_state import (
+        FabricFieldMapping,
+        FabricIngestConfig,
+    )
+
+    validated = FieldMappingSpec.model_validate(spec)
+    mapping = FabricFieldMapping.model_validate(validated.model_dump())
+
+    cfg = await FabricIngestConfig.find_one(FabricIngestConfig.workspace == workspace_id)
+    if cfg is None:
+        cfg = FabricIngestConfig(workspace=workspace_id, mappings=[mapping])
+        await cfg.insert()
+        return mapping.model_dump()
+
+    replaced = False
+    mappings: list[FabricFieldMapping] = []
+    for existing in cfg.mappings:
+        if existing.collection == mapping.collection:
+            mappings.append(mapping)
+            replaced = True
+        else:
+            mappings.append(existing)
+    if not replaced:
+        mappings.append(mapping)
+    cfg.mappings = mappings
+    await cfg.save()  # no-event: config authoring, surfaced via the router
+    return mapping.model_dump()
+
+
+async def delete_mapping(workspace_id: str, collection: str) -> bool:
+    """Remove the mapping keyed on ``collection``. Returns True if removed."""
+    from pocketpaw_ee.cloud.models.fabric_ingest_state import FabricIngestConfig
+
+    cfg = await FabricIngestConfig.find_one(FabricIngestConfig.workspace == workspace_id)
+    if cfg is None:
+        return False
+    kept = [m for m in cfg.mappings if m.collection != collection]
+    if len(kept) == len(cfg.mappings):
+        return False
+    cfg.mappings = kept
+    await cfg.save()  # no-event: config authoring, surfaced via the router
+    return True
+
+
 # --------------------------------------------------------------------------
 # Default reader + store (lazy — keep google + OSS imports out of unit tests)
 # --------------------------------------------------------------------------
@@ -552,7 +705,10 @@ def _default_reader() -> FirestoreReader:
 
 __all__ = [
     "FirestoreReader",
+    "delete_mapping",
     "ingest_collection",
     "list_ingest_sources",
+    "list_mappings",
     "run_ingest_sweep",
+    "upsert_mapping",
 ]

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -1,5 +1,9 @@
 # service.py — Generic Firestore→Fabric ingestion worker.
 # Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+# Updated: 2026-07-11 (feat/external-alerting-c2c3) — ``run_ingest_sweep`` now
+#   filters sources by the per-workspace automation opt-out
+#   (``automations_status.service.filter_sweep_enabled_workspaces``): a tenant
+#   that turned its background sweeps off is skipped. Fails OPEN.
 # Updated: 2026-06-11 (rebase onto dev) — the per-document upsert now delegates
 #   to the OSS connector→Fabric mapper (pocketpaw.connectors.fabric_ingest
 #   .ingest_records, landed on dev in the Calendar ingestion PR #1418) instead
@@ -302,6 +306,18 @@ async def run_ingest_sweep(
     fn = ingest_fn or ingest_collection
 
     sources = await list_ingest_sources(workspace_id=workspace_id)
+    if not sources:
+        return {"sources": 0, "ok": 0, "errors": 0}
+
+    # Per-workspace opt-out (feat/external-alerting-c2c3): drop sources whose
+    # workspace turned its background sweeps off. One deduped check per unique
+    # workspace; fails OPEN so a config-read hiccup keeps the always-on default.
+    from pocketpaw_ee.cloud.automations_status.service import (
+        filter_sweep_enabled_workspaces,
+    )
+
+    enabled_ws = await filter_sweep_enabled_workspaces({s["workspace_id"] for s in sources})
+    sources = [s for s in sources if s["workspace_id"] in enabled_ws]
     if not sources:
         return {"sources": 0, "ok": 0, "errors": 0}
 

--- a/ee/pocketpaw_ee/cloud/file_versions/router.py
+++ b/ee/pocketpaw_ee/cloud/file_versions/router.py
@@ -33,6 +33,12 @@
 #   ``current_workspace_id`` deps (dewani's #1193 signature) rather than the
 #   ``request_context`` the core write routes use — they run the agent, which
 #   needs the identity, not a RequestContext.
+# Updated: 2026-07-08 (feat/billing-enforce-gate) — the three *-edit routes
+#   (ai-edit / spreadsheet-edit / slides-edit) now run the shared run-start
+#   BILLING gate (``credits.guards.assert_within_billing``) as their FIRST
+#   statement, before the local try/except and before ``pool.run``. An over-budget
+#   tenant (empty wallet or over monthly ceiling) gets a clean 402 with no model
+#   call; flag-gated no-op unless ``billing_enforced``.
 """FileVersions router — file-version write + history API."""
 
 from __future__ import annotations
@@ -229,6 +235,14 @@ async def ai_edit_file(
     ``edit_document`` MCP tool can access them, and runs the workspace's default
     agent. Returns the final blocks array to the frontend.
     """
+    # Run-start BILLING gate — raise BEFORE the try/except below so an over-budget
+    # tenant gets a clean 402 (mapped by _core.http) instead of the generic 500
+    # this handler's ``except Exception`` would otherwise return, and BEFORE any
+    # model call via ``pool.run``. Flag-gated no-op unless ``billing_enforced``.
+    from pocketpaw_ee.cloud.credits.guards import assert_within_billing
+
+    await assert_within_billing(workspace_id)
+
     try:
         doc = json.loads(body.content) if body.content and body.content.strip() else {}
         blocks: list[dict] = doc.get("blocks", []) if isinstance(doc, dict) else []
@@ -368,6 +382,12 @@ async def spreadsheet_ai_edit(
     workspace_id: str = Depends(current_workspace_id),
 ) -> JSONResponse:
     """Run an AI agent to edit spreadsheet content. Returns the final snapshot."""
+    # Run-start BILLING gate — raise BEFORE the try/except (clean 402, not a 500)
+    # and BEFORE any model call. Flag-gated no-op unless ``billing_enforced``.
+    from pocketpaw_ee.cloud.credits.guards import assert_within_billing
+
+    await assert_within_billing(workspace_id)
+
     try:
         snapshot = json.loads(body.content) if body.content and body.content.strip() else {}
         if not isinstance(snapshot, dict):
@@ -514,6 +534,12 @@ async def slides_ai_edit(
     workspace_id: str = Depends(current_workspace_id),
 ) -> JSONResponse:
     """Run an AI agent to edit slides content. Returns the final deck."""
+    # Run-start BILLING gate — raise BEFORE the try/except (clean 402, not a 500)
+    # and BEFORE any model call. Flag-gated no-op unless ``billing_enforced``.
+    from pocketpaw_ee.cloud.credits.guards import assert_within_billing
+
+    await assert_within_billing(workspace_id)
+
     deck: dict = body.content if isinstance(body.content, dict) else {}
     deck = json.loads(json.dumps(deck))
 

--- a/ee/pocketpaw_ee/cloud/member_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/member_ingest/service.py
@@ -1,5 +1,9 @@
 # service.py — Per-user Gmail/Calendar → private-KB ingest worker (Phase B).
 # Created: 2026-06-08 — VIP Onboarding Phase B (per-user ingest worker).
+# Updated: 2026-07-11 (feat/external-alerting-c2c3) — ``run_ingest_sweep`` now
+#   filters members by the per-workspace automation opt-out
+#   (``automations_status.service.filter_sweep_enabled_workspaces``): a tenant
+#   that turned its background sweeps off is skipped. Fails OPEN.
 #
 # What this does
 # --------------
@@ -315,6 +319,18 @@ async def run_ingest_sweep(
     fn = ingest_fn or ingest_member
 
     members = await list_connected_members(workspace_id=workspace_id)
+    if not members:
+        return {"members": 0, "ok": 0, "errors": 0}
+
+    # Per-workspace opt-out (feat/external-alerting-c2c3): drop members whose
+    # workspace turned its background sweeps off. One deduped check per unique
+    # workspace; fails OPEN so a config-read hiccup keeps the always-on default.
+    from pocketpaw_ee.cloud.automations_status.service import (
+        filter_sweep_enabled_workspaces,
+    )
+
+    enabled_ws = await filter_sweep_enabled_workspaces({m["workspace_id"] for m in members})
+    members = [m for m in members if m["workspace_id"] in enabled_ws]
     if not members:
         return {"members": 0, "ok": 0, "errors": 0}
 

--- a/ee/pocketpaw_ee/cloud/metering/service.py
+++ b/ee/pocketpaw_ee/cloud/metering/service.py
@@ -46,6 +46,14 @@
 # Updated 2026-06-24 (B3 review fix): ``bill_run`` no longer does
 # ``run_doc.billed=True; run_doc.save()`` directly (a foreign cross-entity write).
 # It now delegates the flag write to ``chat.runs.service.mark_billed(run_id)``.
+# Updated 2026-07-11 (feat/llm-cost-attribution): ``bill_run`` now records the run's
+# ``total_tokens`` on the debit ``ref`` (alongside cost/source/model). The token
+# volume is a REAL per-run figure the backend reports onto ``ChatRunDoc.usage`` in
+# every metering mode (it is NOT the blocked LiteLLM SpendLogs path), so persisting
+# it lets the ledger-sourced usage graph surface real token volume instead of a
+# hardcoded 0 — the follow-up the usage-graph module header named. Purely additive
+# ledger metadata: no change to the debited amount, the idempotency key, or the
+# exactly-once guard; legacy entries with no ``ref.total_tokens`` simply read 0.
 
 from __future__ import annotations
 
@@ -72,6 +80,27 @@ def _int(value: Any) -> int:
     except (TypeError, ValueError):
         return 0
     return n if n > 0 else 0
+
+
+def _total_tokens(usage: dict[str, Any] | None) -> int:
+    """Total tokens a run consumed, from its ``usage`` dict.
+
+    This is the REAL per-run token volume the backend reports onto
+    ``ChatRunDoc.usage`` (via the ``token_usage`` event) in EVERY metering mode —
+    NOT the blocked LiteLLM SpendLogs path. Prefers an explicit ``total_tokens``
+    the backend supplied; otherwise sums the components (input + output + cached —
+    cached_input are real tokens, so they count, matching the runtime
+    usage_tracker's own total). Returns 0 for empty / malformed usage.
+    """
+    usage = usage or {}
+    explicit = _int(usage.get("total_tokens"))
+    if explicit > 0:
+        return explicit
+    return (
+        _int(usage.get("input_tokens"))
+        + _int(usage.get("output_tokens"))
+        + _int(usage.get("cached_input_tokens"))
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +199,10 @@ async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) ->
     card = rate_card if rate_card is not None else load_rate_card()
     cost = resolve_cost(run_doc.usage)
     credits = card.to_credits(cost.cost_usd)
+    # Real per-run token volume (see ``_total_tokens``) — stamped on the debit ref
+    # so the ledger-sourced usage graph can surface it. Mode-agnostic; never the
+    # blocked LiteLLM path.
+    tokens = _total_tokens(run_doc.usage)
 
     workspace = run_doc.workspace
     run_id = run_doc.run_id
@@ -185,6 +218,7 @@ async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) ->
                 "cost_usd": cost.cost_usd,
                 "cost_source": cost.source,
                 "model": cost.model,
+                "total_tokens": tokens,
             },
             allow_negative=True,
         )

--- a/ee/pocketpaw_ee/cloud/mission_control/dto.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/dto.py
@@ -444,6 +444,15 @@ class AnalyticsResponse(BaseModel):
     per_day: list[AnalyticsDayDTO]
     by_agent: list[AnalyticsAgentDTO]
     by_pocket: list[AnalyticsPocketDTO]
+    # Outcome-verdict rollup (evals slice). ``solved_rate`` = solved / checkable
+    # (checkable = solved + partial + not_solved; ``unknown`` reported separately
+    # so low criteria coverage stays visible). None = no checkable verdicts in
+    # the window — the UI renders an em dash, never a fake 0% or 100%.
+    solved_rate: float | None = None  # 0-100
+    solved_count: int = 0
+    partial_count: int = 0
+    not_solved_count: int = 0
+    unknown_count: int = 0
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -1913,6 +1913,22 @@ async def agent_analytics(ctx: RequestContext, window: str = "7d") -> AnalyticsR
         for pid, count in sorted(pocket_map.items(), key=lambda x: -x[1])
     ]
 
+    # Outcome-verdict rollup (evals slice): bucket Task.verify["verdict"]["status"]
+    # (OutcomeStatus: solved/partial/not_solved/unknown; verify == {} when the
+    # verify loop is off or the task predates it → no verdict). solved_rate is
+    # solved / CHECKABLE (unknown excluded and reported separately, so low
+    # criteria coverage is visible instead of hiding inside a fake 100%);
+    # None = no checkable verdicts in the window (UI renders "—", not "0%").
+    verdict_counts = {"solved": 0, "partial": 0, "not_solved": 0, "unknown": 0}
+    for d in docs:
+        status = ((d.verify or {}).get("verdict") or {}).get("status")
+        if status in verdict_counts:
+            verdict_counts[status] += 1
+    checkable = (
+        verdict_counts["solved"] + verdict_counts["partial"] + verdict_counts["not_solved"]
+    )
+    solved_rate = round(verdict_counts["solved"] / checkable * 100, 1) if checkable else None
+
     return AnalyticsResponse(
         shipped=total_shipped,
         approval_rate=approval_rate,
@@ -1922,6 +1938,11 @@ async def agent_analytics(ctx: RequestContext, window: str = "7d") -> AnalyticsR
         per_day=per_day,
         by_agent=by_agent,
         by_pocket=by_pocket,
+        solved_rate=solved_rate,
+        solved_count=verdict_counts["solved"],
+        partial_count=verdict_counts["partial"],
+        not_solved_count=verdict_counts["not_solved"],
+        unknown_count=verdict_counts["unknown"],
     )
 
 

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -1924,9 +1924,7 @@ async def agent_analytics(ctx: RequestContext, window: str = "7d") -> AnalyticsR
         status = ((d.verify or {}).get("verdict") or {}).get("status")
         if status in verdict_counts:
             verdict_counts[status] += 1
-    checkable = (
-        verdict_counts["solved"] + verdict_counts["partial"] + verdict_counts["not_solved"]
-    )
+    checkable = verdict_counts["solved"] + verdict_counts["partial"] + verdict_counts["not_solved"]
     solved_rate = round(verdict_counts["solved"] / checkable * 100, 1) if checkable else None
 
     return AnalyticsResponse(

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -84,6 +84,12 @@ Updated: 2026-06-20 (feat/szd-slice2-discovery, S2-R1) — added ``InstinctRuleD
 the imports, ``__all__``, and ``get_all_documents()`` so the ``instinct_rules``
 collection is wired into ``init_beanie`` and the ``beanie_test_db`` fixture. Only
 ``ee.cloud.rules.service`` imports the doc class directly (import-linter "Rules").
+Updated: 2026-07-09 (feat/instinct-guardrail-rules) — added
+``InstinctWorkspaceConfig`` (the per-workspace tri-state override on the global
+``instinct_enforce_discovered_rules`` flag) to the imports, ``__all__``, and
+``get_all_documents()`` so the ``instinct_workspace_configs`` collection is wired
+into ``init_beanie``. Only ``ee.cloud.rules.service`` writes it (import-linter
+"Rules").
 """
 
 from __future__ import annotations
@@ -125,6 +131,7 @@ from pocketpaw_ee.cloud.models.foresight_workspace_scenario import (
 from pocketpaw_ee.cloud.models.group import Group, GroupAgent
 from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval
 from pocketpaw_ee.cloud.models.instinct_rule import InstinctRuleDoc
+from pocketpaw_ee.cloud.models.instinct_workspace_config import InstinctWorkspaceConfig
 from pocketpaw_ee.cloud.models.invite import Invite
 from pocketpaw_ee.cloud.models.lead import Lead, LeadSource
 from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
@@ -273,6 +280,7 @@ __all__ = [
     "GroupAgent",
     "InstinctApproval",
     "InstinctRuleDoc",
+    "InstinctWorkspaceConfig",
     "Invite",
     "Lead",
     "LeadSource",
@@ -375,6 +383,9 @@ def get_all_documents():
         # Discovered governed rules (SZD slice-2). Only ``ee.cloud.rules.service``
         # writes it.
         InstinctRuleDoc,
+        # Per-workspace Instinct enforcement override (feat/instinct-guardrail-rules).
+        # Only ``ee.cloud.rules.service`` writes it.
+        InstinctWorkspaceConfig,
         Message,
         ReadState,
         RequestLog,

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,12 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-08 (feat/external-alerting-delivery) — added
+``NotificationDeliveryConfig`` (the per-workspace external-delivery config: Slack
+incoming-webhook + generic HTTPS webhook + enabled switch + per-kind routing) to
+the imports, ``__all__``, and ``get_all_documents()`` so the
+``notification_delivery_configs`` collection is wired into ``init_beanie``. Only
+``ee.cloud.notifications`` (service writes, delivery reads) imports the doc class
+directly (import-linter "Notifications" contract).
 Updated: 2026-07-03 (feat/files-share-links FL-12b) — added ``ShareLink`` (the
 public, token-gated file share-link doc) to the lazy uploads loader,
 ``get_all_documents()`` and ``__all__`` so the ``file_share_links`` collection
@@ -137,6 +144,7 @@ from pocketpaw_ee.cloud.models.meeting import (
 from pocketpaw_ee.cloud.models.member_ingest_state import MemberIngestState
 from pocketpaw_ee.cloud.models.message import Attachment, Mention, Message, Reaction
 from pocketpaw_ee.cloud.models.notification import Notification, NotificationSource
+from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
 from pocketpaw_ee.cloud.models.payment import Payment
 from pocketpaw_ee.cloud.models.planner import PlanSession, PlanSessionAgentGap
 from pocketpaw_ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
@@ -285,6 +293,7 @@ __all__ = [
     "Mention",
     "Message",
     "Notification",
+    "NotificationDeliveryConfig",
     "NotificationSource",
     "OAuthAccount",
     "Payment",
@@ -343,6 +352,9 @@ def get_all_documents():
         AgentSessionRuntimeDoc,
         Comment,
         Notification,
+        # Per-workspace external-delivery config (Slack + generic webhook).
+        # Only ``ee.cloud.notifications`` service/delivery import it.
+        NotificationDeliveryConfig,
         FileObj,
         FileUpload,
         FileFolder,

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -97,6 +97,11 @@ Updated: 2026-07-09 (feat/instinct-guardrail-rules) — added
 ``get_all_documents()`` so the ``instinct_workspace_configs`` collection is wired
 into ``init_beanie``. Only ``ee.cloud.rules.service`` writes it (import-linter
 "Rules").
+Updated: 2026-07-11 (feat/external-alerting-c2c3) — added
+``WorkspaceAutomationConfig`` (the per-workspace opt-out for the always-on
+background sweeps) to the imports, ``__all__``, and ``get_all_documents()`` so the
+``workspace_automation_configs`` collection is wired into ``init_beanie``. Only
+``ee.cloud.automations_status.service`` writes it (import-linter "AutomationsStatus").
 """
 
 from __future__ import annotations
@@ -174,6 +179,7 @@ from pocketpaw_ee.cloud.models.temporal_sweep_state import TemporalSweepStateDoc
 from pocketpaw_ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from pocketpaw_ee.cloud.models.vapid_keypair import VapidKeypair
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
+from pocketpaw_ee.cloud.models.workspace_automation_config import WorkspaceAutomationConfig
 from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
 
 # Lazy import to avoid circular imports
@@ -289,6 +295,7 @@ __all__ = [
     "InstinctApproval",
     "InstinctRuleDoc",
     "InstinctWorkspaceConfig",
+    "WorkspaceAutomationConfig",
     "Invite",
     "Lead",
     "LeadSource",
@@ -398,6 +405,9 @@ def get_all_documents():
         # Per-workspace Instinct enforcement override (feat/instinct-guardrail-rules).
         # Only ``ee.cloud.rules.service`` writes it.
         InstinctWorkspaceConfig,
+        # Per-workspace automation opt-out (feat/external-alerting-c2c3). Only
+        # ``ee.cloud.automations_status.service`` writes it.
+        WorkspaceAutomationConfig,
         Message,
         ReadState,
         RequestLog,

--- a/ee/pocketpaw_ee/cloud/models/fabric_ingest_state.py
+++ b/ee/pocketpaw_ee/cloud/models/fabric_ingest_state.py
@@ -1,5 +1,14 @@
 # FabricIngestState + FabricIngestConfig Beanie documents — Firestore→Fabric ingest.
 # Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+# Updated: 2026-07-11 (feat/real-pipeline-s1) — FabricFieldMapping gains an
+#   additive, back-compat source discriminator: ``source_kind``
+#   ("firestore" | "connector", default "firestore") and an optional
+#   ``connector_id``. A "connector" mapping routes the run through the OSS
+#   connector→Fabric ingestor registry instead of the Firestore reader.
+#   ``collection`` stays the routing key for BOTH kinds (for connector
+#   mappings it holds the connector name), so list_ingest_sources and
+#   _load_mapping keep keying on ``mapping.collection`` unchanged;
+#   ``connector_id`` defaults to ``collection`` when unset.
 #
 # Two collections back the generic ingestion worker:
 #
@@ -29,6 +38,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from beanie import Indexed
 from pydantic import BaseModel, Field
@@ -53,6 +63,15 @@ class FabricFieldMapping(BaseModel):
       snapshot's ``update_time``.
     * ``link_rules`` — optional relationship rules; each links the mirrored
       object to another object resolved by the value of ``via_field``.
+    * ``source_kind`` — where records come from: ``"firestore"`` (the default,
+      the original reader path — back-compat: every stored mapping without the
+      field parses as firestore) or ``"connector"`` (records pulled through
+      the OSS connector→Fabric ingestor registry).
+    * ``connector_id`` — for ``source_kind="connector"``: the registry key of
+      the ingesting connector (e.g. ``"gcalendar"``). ``None`` defaults to
+      ``collection``, which by convention HOLDS the connector name for
+      connector mappings so the (workspace, collection) routing key stays the
+      single source-id everywhere (sweep enumeration, state rows, run-now).
     """
 
     collection: str = Field(min_length=1)
@@ -60,6 +79,8 @@ class FabricFieldMapping(BaseModel):
     field_map: dict[str, str] = Field(default_factory=dict)
     cursor_field: str = ""
     link_rules: list[FabricLinkRule] = Field(default_factory=list)
+    source_kind: Literal["firestore", "connector"] = "firestore"
+    connector_id: str | None = None
 
 
 class FabricLinkRule(BaseModel):

--- a/ee/pocketpaw_ee/cloud/models/instinct_workspace_config.py
+++ b/ee/pocketpaw_ee/cloud/models/instinct_workspace_config.py
@@ -1,0 +1,60 @@
+# ee/pocketpaw_ee/cloud/models/instinct_workspace_config.py
+# Created: 2026-07-09 (feat/instinct-guardrail-rules) — Per-workspace Instinct
+# enforcement configuration. v1 ships ONE field — ``enforce_discovered_rules``,
+# a TRI-STATE override on the global ``settings.instinct_enforce_discovered_rules``
+# flag so a workspace admin can turn authored-rule enforcement ON (or OFF) for a
+# SINGLE tenant without a code change / redeploy:
+#   - ``True``  → enforcement ON for this workspace regardless of the global flag.
+#   - ``False`` → enforcement OFF for this workspace regardless of the global flag.
+#   - ``None``  → no override; inherit the global settings flag.
+# The live gate (``ee.cloud.pockets.instinct_dispatch``) resolves the effective
+# value as ``override if override is not None else global_flag``.
+#
+# Why a per-workspace Mongo doc (mirrors ForesightWorkspaceConfig / BeltWorkspaceConfig):
+# the toggle must survive restarts and be settable at runtime by an admin, and the
+# deployment topology is per-tenant-dedicated-server, so a workspace-keyed doc is the
+# tenant-sane home. One row per workspace; ``workspace`` is indexed unique so the
+# read/upsert path stays O(1). The shape is extension-additive — future instinct
+# knobs layer on as new optional fields with safe defaults.
+#
+# Only ``ee.cloud.rules.service`` reads/writes this module (same single-importer
+# discipline as ForesightWorkspaceConfig, enforced by the "Rules" import-linter
+# contract in ee/pyproject.toml).
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class InstinctWorkspaceConfig(TimestampedDocument):
+    """Per-workspace Instinct enforcement configuration override.
+
+    Fields:
+      - ``workspace`` — tenancy key. Indexed unique so ``find_one`` / upsert
+        stays O(1).
+      - ``enforce_discovered_rules`` — TRI-STATE override on the global
+        ``settings.instinct_enforce_discovered_rules`` flag. ``True`` forces
+        authored-rule enforcement ON for this workspace, ``False`` forces it
+        OFF, and ``None`` (the default) means "no override — inherit the global
+        flag". Stored as ``bool | None`` exactly like
+        ``ForesightWorkspaceConfig.threshold_override`` models a per-workspace
+        inherit-vs-override knob.
+      - ``createdAt`` / ``updatedAt`` — inherited from
+        :class:`TimestampedDocument`. ``updatedAt`` doubles as the
+        "when did the admin last touch this" timestamp the GET response exposes.
+
+    The shape is extension-additive; new optional fields with safe defaults
+    won't break callers reading the v1 wire dict.
+    """
+
+    workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
+    enforce_discovered_rules: bool | None = Field(default=None)
+
+    class Settings:
+        name = "instinct_workspace_configs"
+        # ``workspace`` already has a unique single-field index from the
+        # ``Indexed(..., unique=True)`` annotation; the upsert path uses it
+        # directly. No composite indexes needed in v1.

--- a/ee/pocketpaw_ee/cloud/models/notification_delivery.py
+++ b/ee/pocketpaw_ee/cloud/models/notification_delivery.py
@@ -1,0 +1,62 @@
+# ee/pocketpaw_ee/cloud/models/notification_delivery.py
+# Created: 2026-07-08 (feat/external-alerting-delivery) — Per-workspace external
+# notification delivery configuration. Backs Criterion 1 of external alerting:
+# a cloud notification (today WebSocket-only / in-app) can now ALSO fan out to a
+# Slack incoming-webhook and/or a generic HTTPS webhook. One row per workspace;
+# the ``workspace`` key is Indexed unique so the read/upsert path stays O(1)
+# (mirrors BeltWorkspaceConfig / ForesightWorkspaceConfig).
+#
+# Only ``ee.cloud.notifications.service`` WRITES this doc (upsert via the PUT
+# /notifications/delivery-config route) and only ``ee.cloud.notifications``
+# (service + delivery) READS it — same single-owner discipline the other
+# per-workspace config docs use, pinned by the import-linter "Notifications"
+# contract (router/dto/domain may never import this module).
+#
+# Routing: ``routes`` maps a notification kind -> the sink names it should reach
+# ("slack", "webhook"). The default (empty ``routes`` OR a kind absent from it)
+# is deliver-to-every-configured-sink when ``enabled`` is True. A present entry
+# NARROWS delivery of that kind to the named sinks. The shape is
+# extension-additive: a third sink ("email" via the gmail connector) layers on
+# as a new optional URL field + a new sink name with safe defaults.
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class NotificationDeliveryConfig(TimestampedDocument):
+    """Per-workspace external-delivery config for notifications.
+
+    Fields:
+      - ``workspace`` — tenancy key. Indexed unique so ``find_one`` / upsert
+        stays O(1).
+      - ``slack_webhook_url`` — a Slack *incoming webhook* URL
+        (``https://hooks.slack.com/services/...``). ``None`` disables the Slack
+        sink. POSTed as ``{"text": ...}`` (Slack's incoming-webhook shape).
+      - ``webhook_url`` — a generic HTTPS endpoint. ``None`` disables the generic
+        sink. Receives the full notification payload as JSON.
+      - ``enabled`` — master switch. When ``False`` no external delivery happens
+        regardless of the URLs (a workspace can save URLs but keep them dark).
+      - ``routes`` — optional per-kind narrowing (see module docstring). Default
+        empty => deliver every kind to every configured sink.
+      - ``createdAt`` / ``updatedAt`` — inherited from
+        :class:`TimestampedDocument`.
+
+    The shape is extension-additive; new optional fields with safe defaults won't
+    break callers reading the v1 config.
+    """
+
+    workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
+    slack_webhook_url: str | None = None
+    webhook_url: str | None = None
+    enabled: bool = False
+    routes: dict[str, list[str]] = Field(default_factory=dict)
+
+    class Settings:
+        name = "notification_delivery_configs"
+        # ``workspace`` already carries a unique single-field index from the
+        # ``Indexed(..., unique=True)`` annotation; the upsert path uses it
+        # directly. No composite indexes needed in v1.

--- a/ee/pocketpaw_ee/cloud/models/workspace.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace.py
@@ -62,7 +62,9 @@ class WorkspaceSettings(BaseModel):
     @classmethod
     def _validate_retention_days(cls, v: int | None) -> int | None:
         if v is not None and v < 1:
-            raise ValueError("retention_days must be a positive number of days, or null to keep forever")
+            raise ValueError(
+                "retention_days must be a positive number of days, or null to keep forever"
+            )
         return v
 
 

--- a/ee/pocketpaw_ee/cloud/models/workspace.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace.py
@@ -1,5 +1,14 @@
 """Workspace document — one per deployment/org.
 
+2026-07-10 (compliance-starter): ``WorkspaceSettings.retention_days`` is no
+longer decorative. Added a field validator so a persisted value is always
+``None`` (keep forever) or a POSITIVE day count — 0 / negative are rejected
+at construction, closing both the dedicated retention endpoint and the
+general ``update()`` settings-merge path. The setting is read/written through
+``workspace.service.get_retention`` / ``set_retention`` and enforced by
+``workspace.service.enforce_retention`` (purges audit rows older than the
+cutoff). Nothing else on this document changed.
+
 2026-06-28 (AW-7 template gate deny-on-no-match): added
 ``Workspace.instinct_template_default_deny`` — the PER-WORKSPACE override for
 the TEMPLATE-level deny-by-default. ``None`` (the default) means "use the
@@ -35,7 +44,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from beanie import Indexed
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
@@ -43,7 +52,18 @@ from pocketpaw_ee.cloud.models.base import TimestampedDocument
 class WorkspaceSettings(BaseModel):
     default_agent: str | None = None  # Agent ID
     allow_invites: bool = True
-    retention_days: int | None = None  # None = keep forever
+    # Compliance retention policy: None = keep forever; otherwise a POSITIVE
+    # number of days after which audit records are purged (enforced by
+    # ``workspace.service.enforce_retention``). Zero / negative is rejected so
+    # a bad value can never silently disable retention or wipe everything.
+    retention_days: int | None = None
+
+    @field_validator("retention_days")
+    @classmethod
+    def _validate_retention_days(cls, v: int | None) -> int | None:
+        if v is not None and v < 1:
+            raise ValueError("retention_days must be a positive number of days, or null to keep forever")
+        return v
 
 
 class Branding(BaseModel):

--- a/ee/pocketpaw_ee/cloud/models/workspace_automation_config.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace_automation_config.py
@@ -1,0 +1,66 @@
+# ee/pocketpaw_ee/cloud/models/workspace_automation_config.py
+# Created: 2026-07-11 (feat/external-alerting-c2c3) — Per-workspace automation
+# opt-out. The always-on cloud sweeps (cycles, decisions, member_ingest,
+# fabric_ingest, temporal, refresh) run for EVERY active workspace by default;
+# this doc lets a single tenant turn its background automation OFF without a
+# code change / redeploy:
+#   - ``sweeps_enabled``      — master switch for ALL background sweeps for the
+#     workspace. False makes every sweep skip this tenant at its per-workspace
+#     fan-out point.
+#   - ``automations_enabled`` — narrower switch reserved for the rule/alert
+#     automation surface specifically (evaluator-driven rules); kept separate so
+#     an admin can silence alerts without stopping data-mirroring sweeps.
+# Both default TRUE so an unconfigured workspace keeps the always-on behavior;
+# the row only exists once an admin has opted out (and survives a re-enable so
+# ``updatedAt`` stays audit-relevant).
+#
+# Why a per-workspace Mongo doc (mirrors InstinctWorkspaceConfig /
+# ForesightWorkspaceConfig / BeltWorkspaceConfig): the toggle must survive
+# restarts and be settable at runtime by an admin, and the deployment topology
+# is per-tenant-dedicated-server, so a workspace-keyed doc is the tenant-sane
+# home. One row per workspace; ``workspace`` is indexed unique so the
+# read/upsert path stays O(1). The shape is extension-additive — future
+# per-workspace automation knobs layer on as new optional fields with safe
+# defaults.
+#
+# Only ``ee.cloud.automations_status.service`` reads/writes this module (same
+# single-importer discipline as InstinctWorkspaceConfig, enforced by the
+# "AutomationsStatus" import-linter contract in ee/pyproject.toml).
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class WorkspaceAutomationConfig(TimestampedDocument):
+    """Per-workspace opt-out for the always-on background automation sweeps.
+
+    Fields:
+      - ``workspace`` — tenancy key. Indexed unique so ``find_one`` / upsert
+        stays O(1).
+      - ``sweeps_enabled`` — master switch for ALL background sweeps for this
+        workspace. ``True`` (default) keeps the always-on behavior; ``False``
+        makes every sweep skip this tenant at its per-workspace fan-out.
+      - ``automations_enabled`` — narrower switch for the rule/alert automation
+        surface. ``True`` (default); ``False`` silences alert automations while
+        leaving other sweeps (data mirroring, snapshots) untouched.
+      - ``createdAt`` / ``updatedAt`` — inherited from
+        :class:`TimestampedDocument`. ``updatedAt`` doubles as the "when did the
+        admin last touch this" timestamp the status response exposes.
+
+    The shape is extension-additive; new optional fields with safe defaults
+    won't break callers reading the v1 wire dict.
+    """
+
+    workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
+    sweeps_enabled: bool = Field(default=True)
+    automations_enabled: bool = Field(default=True)
+
+    class Settings:
+        name = "workspace_automation_configs"
+        # ``workspace`` already has a unique single-field index from the
+        # ``Indexed(..., unique=True)`` annotation; the upsert path uses it
+        # directly. No composite indexes needed in v1.

--- a/ee/pocketpaw_ee/cloud/notifications/delivery.py
+++ b/ee/pocketpaw_ee/cloud/notifications/delivery.py
@@ -216,8 +216,8 @@ async def _post_one(
 ) -> None:
     """POST the notification to one sink. Raises on failure — the caller
     swallows it per-sink so one dead sink never blocks the others."""
-    payload = _slack_payload(notification) if sink_name == SINK_SLACK else _generic_payload(
-        notification
+    payload = (
+        _slack_payload(notification) if sink_name == SINK_SLACK else _generic_payload(notification)
     )
     resp = await client.post(url, json=payload, timeout=_DELIVERY_TIMEOUT_SECONDS)
     # 2xx is success; anything else is logged but not retried in v1.

--- a/ee/pocketpaw_ee/cloud/notifications/delivery.py
+++ b/ee/pocketpaw_ee/cloud/notifications/delivery.py
@@ -1,0 +1,203 @@
+# ee/pocketpaw_ee/cloud/notifications/delivery.py
+# Created: 2026-07-08 (feat/external-alerting-delivery) — external fan-out for
+# cloud notifications (Criterion 1: get alerts OUT of the app). Every cloud
+# notification funnels through ``notifications.service.create`` (tasks, meetings,
+# mentions all call it); this module POSTs that notification to the workspace's
+# configured Slack incoming-webhook and/or generic HTTPS webhook.
+#
+# Contract with the caller: ``_deliver_external`` is FIRE-AND-FORGET / NEVER-RAISE
+# (modeled on ``_core/realtime/emit.py`` and ``audit/webhooks.deliver``). It is
+# awaited inline right after the ``emit(NotificationNew(...))`` in ``create``, so
+# a dead/slow/malicious webhook must NOT be able to roll back the notification
+# insert or bubble an exception out of ``create``. Every network call is wrapped
+# and every URL is bounded by a short timeout so a hung endpoint can't stall the
+# insert response. A per-workspace kill switch (``enabled``) and per-kind routing
+# live on ``NotificationDeliveryConfig``.
+#
+# SSRF: the webhook URLs are workspace-admin-supplied, so a POST from the server
+# to an arbitrary URL is an SSRF vector. ``is_safe_webhook_url`` requires https://
+# and rejects literal private/loopback IPs and known-internal hostnames. It runs
+# at write time (the PUT route rejects a bad URL up front) AND here at delivery
+# time (defense-in-depth against a stored value that later became unsafe). Full
+# DNS-resolution hardening (like ``audit.webhooks._validate_url_safety``) is a
+# follow-up; this is the baseline.
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import httpx
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.cloud.notifications.domain import Notification
+
+logger = logging.getLogger(__name__)
+
+# Bounded so a hung endpoint can't stall the notification insert response.
+_DELIVERY_TIMEOUT_SECONDS = 5.0
+
+# Sink names. Kept as constants so ``routes`` values and future sinks stay
+# consistent. A third sink ("email") layers on here + a new URL field.
+SINK_SLACK = "slack"
+SINK_WEBHOOK = "webhook"
+
+# Hostnames that point at internal infrastructure on common cloud platforms /
+# dev boxes. Rejected even before any IP check (mirrors audit.webhooks).
+_FORBIDDEN_HOSTNAMES = frozenset(
+    {
+        "localhost",
+        "ip6-localhost",
+        "ip6-loopback",
+        "metadata",
+        "metadata.google.internal",
+        "metadata.goog",
+        "instance-data",
+    }
+)
+
+
+def _ip_is_unsafe(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def is_safe_webhook_url(url: str | None) -> bool:
+    """True when ``url`` is a plausible-safe external https webhook target.
+
+    Baseline SSRF guard for workspace-admin-supplied URLs: requires https://,
+    a hostname, a non-forbidden hostname, and — when the host is a literal IP —
+    a public address. A hostname that resolves to a private IP is NOT caught
+    here (no DNS lookup in the hot path); that DNS-resolution hardening is a
+    follow-up. ``None`` / empty is "no sink", which is safe (returns False).
+    """
+    if not url:
+        return False
+    if not url.startswith("https://"):
+        return False
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    hostname = (parsed.hostname or "").lower()
+    if not hostname or hostname in _FORBIDDEN_HOSTNAMES:
+        return False
+    try:
+        literal_ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        literal_ip = None
+    if literal_ip is not None and _ip_is_unsafe(literal_ip):
+        return False
+    return True
+
+
+def _slack_payload(notification: Notification) -> dict:
+    """Slack incoming-webhook shape. Slack renders ``text`` as the message body;
+    we lead with the title and append the body when present."""
+    text = notification.title
+    if notification.body:
+        text = f"{text}\n{notification.body}"
+    return {"text": text}
+
+
+def _generic_payload(notification: Notification) -> dict:
+    """Full notification payload for a generic consumer. Field names mirror the
+    domain object so a receiver can key off ``kind`` / ``workspace_id``."""
+    return {
+        "id": notification.id,
+        "workspace_id": notification.workspace_id,
+        "recipient_id": notification.recipient_id,
+        "actor_id": notification.actor_id,
+        "kind": notification.kind,
+        "title": notification.title,
+        "body": notification.body,
+    }
+
+
+async def _load_config(workspace_id: str):
+    """Load the workspace's delivery config, or ``None`` when unset.
+
+    Best-effort: a missing doc (the common case) or a read failure returns
+    ``None`` so a Mongo hiccup can never take down ``create``. Imported inside
+    the function to keep the module-import graph light (same lazy-import style
+    the belt service uses for its config doc)."""
+    from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
+
+    return await NotificationDeliveryConfig.find_one(
+        NotificationDeliveryConfig.workspace == workspace_id
+    )
+
+
+def _resolve_sinks(config, kind: str) -> list[tuple[str, str]]:
+    """Return the ``(sink_name, url)`` pairs to deliver ``kind`` to.
+
+    A sink is eligible when its URL is set AND passes the safety check. Routing:
+    if ``config.routes`` has an entry for ``kind``, only the named sinks are
+    used; otherwise every configured+safe sink is used (deliver-all default).
+    """
+    available: dict[str, str] = {}
+    if is_safe_webhook_url(config.slack_webhook_url):
+        available[SINK_SLACK] = config.slack_webhook_url
+    if is_safe_webhook_url(config.webhook_url):
+        available[SINK_WEBHOOK] = config.webhook_url
+
+    allowed = config.routes.get(kind) if config.routes else None
+    if allowed is not None:
+        return [(name, url) for name, url in available.items() if name in allowed]
+    return list(available.items())
+
+
+async def _post_one(
+    client: httpx.AsyncClient,
+    sink_name: str,
+    url: str,
+    notification: Notification,
+) -> None:
+    """POST the notification to one sink. Raises on failure — the caller
+    swallows it per-sink so one dead sink never blocks the others."""
+    payload = _slack_payload(notification) if sink_name == SINK_SLACK else _generic_payload(
+        notification
+    )
+    resp = await client.post(url, json=payload, timeout=_DELIVERY_TIMEOUT_SECONDS)
+    # 2xx is success; anything else is logged but not retried in v1.
+    if not (200 <= resp.status_code < 300):
+        logger.warning(
+            "notification external delivery: %s returned http %s", sink_name, resp.status_code
+        )
+
+
+async def _deliver_external(notification: Notification) -> None:
+    """Fan a freshly-created notification out to the workspace's external sinks.
+
+    NEVER raises — every failure mode (no config, disabled, unsafe URL, dead
+    endpoint, Mongo hiccup) is swallowed so the notification insert + realtime
+    emit that preceded this call can never be rolled back by a delivery problem.
+    """
+    try:
+        config = await _load_config(notification.workspace_id)
+        if config is None or not config.enabled:
+            return
+        sinks = _resolve_sinks(config, notification.kind)
+        if not sinks:
+            return
+        async with httpx.AsyncClient() as client:
+            for sink_name, url in sinks:
+                try:
+                    await _post_one(client, sink_name, url, notification)
+                except Exception:
+                    logger.warning(
+                        "notification external delivery to %s failed", sink_name, exc_info=True
+                    )
+    except Exception:
+        logger.warning("notification external delivery fan-out crashed", exc_info=True)
+
+
+__all__ = ["_deliver_external", "is_safe_webhook_url"]

--- a/ee/pocketpaw_ee/cloud/notifications/delivery.py
+++ b/ee/pocketpaw_ee/cloud/notifications/delivery.py
@@ -21,11 +21,22 @@
 # time (defense-in-depth against a stored value that later became unsafe). Full
 # DNS-resolution hardening (like ``audit.webhooks._validate_url_safety``) is a
 # follow-up; this is the baseline.
+#
+# Updated 2026-07-09 (fix/ssrf-encoding-bypass): close the alternate-ENCODING
+# bypass. The old guard only ran ``ipaddress.ip_address(hostname)`` and treated a
+# parse FAILURE as "not an IP" — but that raises on encoded forms (decimal
+# ``2852039166`` == 169.254.169.254 metadata, ``0x7f000001`` / ``017700000001`` /
+# ``127.1`` == 127.0.0.1), so the guard returned True while ``getaddrinfo`` / httpx
+# still resolved them to metadata / loopback. ``_host_as_literal_ip`` now normalizes
+# the host (strict literal -> ``int(host, 0)`` -> ``socket.inet_aton``) before the
+# unsafe-IP check. DNS-name-resolution hardening (a host that RESOLVES to a private
+# IP) remains the documented follow-up — this needs no DNS control to exploit.
 
 from __future__ import annotations
 
 import ipaddress
 import logging
+import socket
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -70,6 +81,47 @@ def _ip_is_unsafe(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     )
 
 
+def _host_as_literal_ip(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Interpret ``hostname`` as an IP the way the OS resolver / httpx would, or None.
+
+    ``ipaddress.ip_address`` only accepts the strict dotted-quad (and IPv6) form,
+    so it MISSES the alternate encodings an SSRF payload uses — a decimal integer
+    (``2852039166`` == 169.254.169.254 cloud metadata), a hex/octal integer
+    (``0x7f000001`` / ``017700000001`` == 127.0.0.1), or a short-dotted form
+    (``127.1``). ``getaddrinfo`` / httpx DO resolve those to the loopback / metadata
+    address, so the guard must normalize them before deciding. We try, in order:
+
+      1. the strict literal (also the ONLY IPv6 path);
+      2. a bare integer via ``int(host, 0)`` (decimal / ``0x`` hex / ``0o`` octal);
+      3. ``socket.inet_aton`` — the liberal C parser ``getaddrinfo`` shares, which
+         covers ``a`` / ``a.b`` / ``a.b.c`` / ``a.b.c.d`` with decimal, leading-zero
+         octal, or ``0x`` hex parts (this is what catches ``127.1`` and the bare
+         leading-zero octal ``017700000001`` that ``int(host, 0)`` rejects).
+
+    Returns None for a genuine DNS hostname (``hooks.slack.com``) so it stays allowed;
+    hostnames that RESOLVE to a private IP are still not caught here (no DNS lookup in
+    the hot path) — that is the documented follow-up. This only closes the alternate-
+    ENCODING bypass, which needs no DNS control.
+    """
+    # 1. Strict literal (dotted-quad IPv4 or any IPv6).
+    try:
+        return ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    # 2. Bare integer form: decimal / 0x-hex / 0o-octal. ``int(host, 0)`` rejects a
+    #    bare leading-zero octal (e.g. "017700000001"); step 3 covers that.
+    try:
+        return ipaddress.IPv4Address(int(hostname, 0))
+    except (ValueError, OverflowError):
+        pass
+    # 3. inet_aton — liberal short-dotted / leading-zero-octal / hex parsing.
+    try:
+        packed = socket.inet_aton(hostname)
+    except OSError:
+        return None
+    return ipaddress.IPv4Address(packed)
+
+
 def is_safe_webhook_url(url: str | None) -> bool:
     """True when ``url`` is a plausible-safe external https webhook target.
 
@@ -90,10 +142,11 @@ def is_safe_webhook_url(url: str | None) -> bool:
     hostname = (parsed.hostname or "").lower()
     if not hostname or hostname in _FORBIDDEN_HOSTNAMES:
         return False
-    try:
-        literal_ip = ipaddress.ip_address(hostname)
-    except ValueError:
-        literal_ip = None
+    # Normalize the host to the IP the OS resolver would use BEFORE deciding — this
+    # catches the alternate-encoding SSRF bypasses (decimal/hex/octal integer,
+    # short-dotted) that a naive ``ipaddress.ip_address`` parse silently lets
+    # through while ``getaddrinfo`` / httpx resolve them to metadata / loopback.
+    literal_ip = _host_as_literal_ip(hostname)
     if literal_ip is not None and _ip_is_unsafe(literal_ip):
         return False
     return True

--- a/ee/pocketpaw_ee/cloud/notifications/router.py
+++ b/ee/pocketpaw_ee/cloud/notifications/router.py
@@ -4,17 +4,45 @@ Thin: parses requests, delegates to ``ee.cloud.notifications.service``,
 returns ``NotificationOut`` DTOs at the boundary. FastAPI serializes to
 JSON. The wire shape matches the legacy ``_to_wire`` output byte-for-byte
 (verified by ``tests/cloud/notifications/test_router_golden.py``).
+
+Updated: 2026-07-08 (feat/external-alerting-delivery) — added the
+external-delivery config surface: ``GET`` / ``PUT /notifications/delivery-config``
+(workspace-scoped, ``notifications.manage`` = ADMIN) so a workspace admin can
+paste a Slack incoming-webhook / generic HTTPS webhook URL. The router never
+touches the Beanie doc — it delegates to the service (sole writer).
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.deps import (
+    current_workspace_id,
+    require_action_any_workspace,
+)
 from pocketpaw_ee.cloud.notifications import service as notifications_service
 from pocketpaw_ee.cloud.notifications.dto import NotificationOut, notification_to_dto
 
 router = APIRouter(prefix="/notifications", tags=["Notifications"])
+
+
+class DeliveryConfigRequest(BaseModel):
+    """Body for ``PUT /notifications/delivery-config``.
+
+    Full replacement of the workspace's external-delivery config. An empty /
+    omitted URL clears that sink. ``enabled`` is the master switch. ``routes``
+    optionally narrows a notification kind to specific sinks (``"slack"`` /
+    ``"webhook"``); the default (empty) delivers every kind to every configured
+    sink. URLs are validated (https + public host) by the service; a bad URL
+    yields a ``notifications.invalid_webhook_url`` error.
+    """
+
+    slack_webhook_url: str | None = Field(default=None)
+    webhook_url: str | None = Field(default=None)
+    enabled: bool = Field(default=False)
+    routes: dict[str, list[str]] = Field(default_factory=dict)
 
 
 @router.get("", response_model=list[NotificationOut])
@@ -74,3 +102,46 @@ async def delete_notification(
 
         raise HTTPException(status_code=404, detail="Notification not found")
     return {"status": "deleted"}
+
+
+# ---------------------------------------------------------------------------
+# External-delivery config (Criterion 1: get alerts OUT of the app).
+# Workspace-scoped, ADMIN-gated (``notifications.manage``): the config controls
+# where the server POSTs on every notification, so it extends the workspace's
+# egress surface — same tier as connector.manage / belt.manage.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/delivery-config")
+async def get_delivery_config(
+    _user=Depends(require_action_any_workspace("notifications.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict:
+    """Return the workspace's external-delivery config, or an empty default when
+    unset (so the settings form always has a shape to render)."""
+    config = await notifications_service.get_delivery_config(workspace_id)
+    if config is None:
+        return {
+            "workspace_id": workspace_id,
+            "slack_webhook_url": None,
+            "webhook_url": None,
+            "enabled": False,
+            "routes": {},
+        }
+    return config
+
+
+@router.put("/delivery-config")
+async def put_delivery_config(
+    body: DeliveryConfigRequest,
+    _user=Depends(require_action_any_workspace("notifications.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict:
+    """Upsert the workspace's external-delivery config. ADMIN-only."""
+    return await notifications_service.set_delivery_config(
+        workspace_id,
+        slack_webhook_url=body.slack_webhook_url,
+        webhook_url=body.webhook_url,
+        enabled=body.enabled,
+        routes=body.routes,
+    )

--- a/ee/pocketpaw_ee/cloud/notifications/service.py
+++ b/ee/pocketpaw_ee/cloud/notifications/service.py
@@ -1,5 +1,14 @@
 """Notification service — CRUD + realtime fan-out.
 
+Updated: 2026-07-08 (feat/external-alerting-delivery) — ``create`` now also
+fans the new notification OUT of the app: right after the in-app realtime
+``emit(NotificationNew(...))`` it awaits ``delivery._deliver_external(created)``,
+which POSTs to the workspace's configured Slack incoming-webhook and/or generic
+HTTPS webhook. That call is never-raise, so a dead sink can't roll back the
+insert. Added ``get_delivery_config`` / ``set_delivery_config`` — this service is
+the SOLE writer of the ``NotificationDeliveryConfig`` doc (upsert), fronted by
+the PUT /notifications/delivery-config route.
+
 Sole owner of writes to the ``Notification`` Beanie document. Writes are
 inline; there is no separate repository layer. Tests use the shared
 ``mongo_db`` fixture (mongomock-motor) instead of injecting a Protocol
@@ -7,11 +16,13 @@ fake.
 
 Public API is module-level ``async def`` functions:
 
-- ``create(...)`` — insert a notification, emit ``NotificationNew``
+- ``create(...)`` — insert a notification, emit ``NotificationNew``, fan out
 - ``list_for_user(user_id)`` — list domain ``Notification`` objects
 - ``list_for_user_dicts(user_id)`` — list of legacy wire-format dicts
 - ``mark_read(notification_id, user_id)`` — flip the read flag, emit
 - ``clear_all(user_id)`` — bulk mark unread → read for a user, emit
+- ``get_delivery_config(workspace_id)`` — read the external-delivery config
+- ``set_delivery_config(workspace_id, ...)`` — upsert the external-delivery config
 
 Cross-module fan-out callers (``chat/message_service.py``,
 ``workspace/service.py``) call ``notifications_service.create(...)``
@@ -33,6 +44,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 )
 from pocketpaw_ee.cloud.models.notification import Notification as _NotificationDoc
 from pocketpaw_ee.cloud.models.notification import NotificationSource as _NotificationSourceDoc
+from pocketpaw_ee.cloud.notifications.delivery import _deliver_external, is_safe_webhook_url
 from pocketpaw_ee.cloud.notifications.domain import Notification, NotificationSource
 from pocketpaw_ee.cloud.notifications.dto import notification_to_dto
 
@@ -115,6 +127,9 @@ async def create(
     await doc.insert()
     created = _to_domain(doc)
     await emit(NotificationNew(data=notification_to_dto(created).model_dump()))
+    # External fan-out (Slack / generic webhook). Never-raise: a dead sink must
+    # not roll back the insert or the emit above. See notifications/delivery.py.
+    await _deliver_external(created)
     return created
 
 
@@ -175,14 +190,89 @@ async def delete_notification(notification_id: str, user_id: str) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# External-delivery config — this service is the SOLE writer of the
+# NotificationDeliveryConfig doc (import-linter "Notifications" contract).
+# ---------------------------------------------------------------------------
+
+
+def _config_to_dict(doc) -> dict:
+    """Wire shape for the delivery config. Returns the workspace's own config,
+    so the URLs are returned as-stored (the admin who set them may see them)."""
+    return {
+        "workspace_id": doc.workspace,
+        "slack_webhook_url": doc.slack_webhook_url,
+        "webhook_url": doc.webhook_url,
+        "enabled": doc.enabled,
+        "routes": dict(doc.routes or {}),
+    }
+
+
+async def get_delivery_config(workspace_id: str) -> dict | None:
+    """Return the workspace's external-delivery config as a wire dict, or
+    ``None`` when unset."""
+    from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
+
+    doc = await NotificationDeliveryConfig.find_one(
+        NotificationDeliveryConfig.workspace == workspace_id
+    )
+    return _config_to_dict(doc) if doc is not None else None
+
+
+async def set_delivery_config(
+    workspace_id: str,
+    *,
+    slack_webhook_url: str | None = None,
+    webhook_url: str | None = None,
+    enabled: bool = False,
+    routes: dict[str, list[str]] | None = None,
+) -> dict:
+    """Upsert the workspace's external-delivery config and return the wire dict.
+
+    A non-empty URL that fails the SSRF safety check is rejected up front with a
+    ``Forbidden`` so a bad value never reaches storage (and later the delivery
+    hot path). Empty / ``None`` clears that sink. This is the only write path to
+    ``NotificationDeliveryConfig``.
+    """
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
+
+    slack = (slack_webhook_url or "").strip() or None
+    generic = (webhook_url or "").strip() or None
+    if slack is not None and not is_safe_webhook_url(slack):
+        raise Forbidden(
+            "notifications.invalid_webhook_url",
+            "Slack webhook URL must be an https:// URL to a public host.",
+        )
+    if generic is not None and not is_safe_webhook_url(generic):
+        raise Forbidden(
+            "notifications.invalid_webhook_url",
+            "Webhook URL must be an https:// URL to a public host.",
+        )
+
+    doc = await NotificationDeliveryConfig.find_one(
+        NotificationDeliveryConfig.workspace == workspace_id
+    )
+    if doc is None:
+        doc = NotificationDeliveryConfig(workspace=workspace_id)
+    doc.slack_webhook_url = slack
+    doc.webhook_url = generic
+    doc.enabled = enabled
+    doc.routes = dict(routes or {})
+    await doc.save()
+    return _config_to_dict(doc)
+
+
 __all__ = [
     "Notification",
     "NotificationSource",
     "count_unread",
     "create",
     "delete_notification",
+    "get_delivery_config",
     "list_for_user",
     "list_for_user_dicts",
     "mark_read",
     "clear_all",
+    "set_delivery_config",
 ]

--- a/ee/pocketpaw_ee/cloud/planner/service.py
+++ b/ee/pocketpaw_ee/cloud/planner/service.py
@@ -53,6 +53,12 @@
 #   the dependent-dispatch cascade still fires. A requeued or escalated
 #   attempt never saves its output file, uploads artifacts, or
 #   auto-completes.
+# Updated: 2026-07-08 (feat/billing-enforce-gate) — ``_execute_ready_plan_tasks``
+#   now runs the shared run-start BILLING gate
+#   (``credits.guards.over_billing_limit``) after it finds ready tasks and BEFORE
+#   the claim + ``pool.run`` batch, so an over-budget tenant makes NO model call
+#   on the planner path. Tasks stay ``proposed`` and execute on a later tick once
+#   budget frees. Flag-gated no-op unless ``billing_enforced``.
 """Planner entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -1243,6 +1249,27 @@ async def _execute_ready_plan_tasks(
         )
         return
     logger.info("_execute_ready_plan_tasks: %d ready task(s)", len(ready))
+
+    # Run-start BILLING gate — the planner is a background (non-HTTP) executor, so
+    # reject BEFORE claiming/running any task rather than starting work an
+    # over-budget tenant can't pay for. Gating here (after we know there is work,
+    # before the claim + ``pool.run`` batch) means NO model call fires while over
+    # budget; the tasks stay ``proposed`` and execute on a later tick once budget
+    # frees. Flag-gated no-op unless ``billing_enforced``; there is no user-facing
+    # stream on this path, so a warning log is the terminal signal.
+    from pocketpaw_ee.cloud.credits.guards import over_billing_limit
+
+    billing_reject = await over_billing_limit(workspace_id)
+    if billing_reject is not None:
+        logger.warning(
+            "_execute_ready_plan_tasks: workspace %s over billing limit (%s) — "
+            "skipping execution of %d ready task(s) for project %s",
+            workspace_id,
+            billing_reject.code,
+            len(ready),
+            project_id,
+        )
+        return
 
     from types import SimpleNamespace
 

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
@@ -30,6 +30,18 @@
 # fail-open in the user's mental model. The audit write is wrapped so an audit
 # failure can never break the gate (mirrors `_audit_triage_decision`).
 #
+# Updated: 2026-07-09 (feat/instinct-guardrail-rules — per-workspace enforcement)
+# — the `gate_action` enforcement decision is now resolved PER WORKSPACE via
+# `_enforcement_enabled(workspace_id)` instead of reading the global
+# `instinct_enforce_discovered_rules` flag directly. Resolution: a workspace's
+# `InstinctWorkspaceConfig` override (rules.service.get_enforcement_override)
+# wins when set (True/False), else the call falls back to the global flag. The
+# override read is FAIL-OPEN — a config/store read error yields "no enforcement"
+# (False), logs a WARNING, and never blocks the gate — preserving the same
+# fail-open rail `_load_discovered_instinct_rules` already applies to the
+# `get_active_rules` read. So one tenant can flip enforcement without a code
+# change, and a DB hiccup can never turn into a hard failure.
+#
 # Updated: 2026-06-30 (integration/szd-finish, B1 — gate DoS fix) — the
 # discovered-rule CEL probe in `_load_discovered_instinct_rules` now catches ANY
 # exception, not just `CelEvaluationError`. `evaluate_cel` calls
@@ -142,7 +154,7 @@ from pocketpaw_ee.cloud.pockets.instinct_triage import (
     TriageProposal,
     classify_lane,
 )
-from pocketpaw_ee.cloud.rules.service import get_active_rules
+from pocketpaw_ee.cloud.rules.service import get_active_rules, get_enforcement_override
 
 logger = logging.getLogger(__name__)
 
@@ -390,6 +402,35 @@ async def _find_existing_pending_id(
     return None
 
 
+async def _enforcement_enabled(workspace_id: str) -> bool:
+    """Resolve whether authored-rule enforcement is ON for ``workspace_id``.
+
+    The per-workspace ``InstinctWorkspaceConfig`` override wins when set
+    (``True``/``False``); otherwise the call falls back to the global
+    ``instinct_enforce_discovered_rules`` settings flag. The global read stays
+    HERE (not in the service) so the existing gate tests that flip the flag by
+    monkeypatching ``instinct_dispatch.get_settings`` keep working.
+
+    FAIL-OPEN: a config/store read error yields ``False`` (no enforcement), logs
+    a WARNING, and NEVER raises — a DB hiccup must never turn into a blocked gate
+    (the same rail ``_load_discovered_instinct_rules`` applies to the
+    ``get_active_rules`` read). Enforcement can only ever ADD a block/escalation,
+    so "no enforcement" is the safe direction when the override is unreadable.
+    """
+    global_flag = bool(get_settings().instinct_enforce_discovered_rules)
+    try:
+        override = await get_enforcement_override(workspace_id)
+    except Exception:  # noqa: BLE001 — fail-OPEN: a config read hiccup never blocks
+        logger.warning(
+            "discovered-rule enforcement: enforcement-config read failed for "
+            "workspace=%s — defaulting to NO enforcement (fail-open)",
+            workspace_id,
+            exc_info=True,
+        )
+        return False
+    return override if override is not None else global_flag
+
+
 async def _load_discovered_instinct_rules(
     *,
     workspace_id: str,
@@ -609,11 +650,15 @@ async def gate_action(
     level = _coerce_approval_level(approval_level)
 
     # F6 — merge approved workspace-discovered rules into the template before
-    # the (unchanged) composer call. DEFAULT-OFF: when the flag is off,
-    # `get_active_rules` is never called and `effective_template is template`,
-    # so the entire discovered branch is dead code on the default path.
+    # the (unchanged) composer call. Enforcement is resolved PER WORKSPACE
+    # (`_enforcement_enabled`): the workspace's `InstinctWorkspaceConfig` override
+    # wins, else the global `instinct_enforce_discovered_rules` flag. When
+    # enforcement is off, `get_active_rules` is never called and
+    # `effective_template is template`, so the discovered branch stays dead code
+    # on the off path. The resolver is fail-open — a config read error yields
+    # "no enforcement", never a block.
     effective_template = template
-    if get_settings().instinct_enforce_discovered_rules:
+    if await _enforcement_enabled(workspace_id):
         # Pin a stable `now` shared by the guarded probe and the composer so a
         # time-sensitive CEL `when` evaluates identically in both.
         if now is None:

--- a/ee/pocketpaw_ee/cloud/pockets/refresh_scheduler.py
+++ b/ee/pocketpaw_ee/cloud/pockets/refresh_scheduler.py
@@ -198,15 +198,35 @@ async def run_one_pass() -> int:
         logger.exception("refresh-scheduler: failed to list interval-source pockets")
         return 0
 
+    # Per-workspace opt-out (feat/external-alerting-c2c3): pockets in a workspace
+    # that turned its background sweeps off are skipped. One deduped check per
+    # unique workspace; fails OPEN so a config-read hiccup keeps the default.
+    from pocketpaw_ee.cloud.automations_status.service import (
+        filter_sweep_enabled_workspaces,
+    )
+
+    enabled_ws = await filter_sweep_enabled_workspaces(
+        {ws for p in pockets if (ws := p.get("workspace_id"))}
+    )
+
+    visited = 0
     for pocket in pockets:
+        if pocket.get("workspace_id") not in enabled_ws:
+            logger.debug(
+                "refresh-scheduler: workspace=%s opted out — skipping pocket %s",
+                pocket.get("workspace_id"),
+                pocket.get("pocket_id"),
+            )
+            continue
         try:
             await _refresh_one_pocket(pocket)
+            visited += 1
         except Exception:
             logger.exception(
                 "refresh-scheduler: pass failed for pocket %s",
                 pocket.get("pocket_id"),
             )
-    return len(pockets)
+    return visited
 
 
 async def _loop() -> None:

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -250,6 +250,16 @@ recompile is in play. The typed model is used INTERNALLY only — Beanie
 ``Pocket.rippleSpec`` and ``domain.Pocket.ripple_spec`` stay ``dict``, and
 every reader still receives a flat dict (executor dual-path readers deferred
 to a Phase 2 gated on PR #1472).
+Changes: 2026-07-08 (feat/billing-smb-caps) — added a per-plan POCKET cap. A new
+shared helper ``_pocket_cap_exceeded`` resolves the workspace's plan
+``max_pockets`` and counts its live pockets; it is GATED on ``billing_enforced``
+(a no-op for OSS / self-host) and never trips on an uncapped Enterprise plan.
+``create`` raises ``PocketLimitError`` (402) before any write when at/over the
+cap; ``create_from_ripple_spec`` (the agent auto-create path, which does NOT
+funnel through ``create``) returns ``None`` at/over the cap so the agent turn
+degrades gracefully. ``create_pocket_and_session`` funnels through ``create`` and
+is covered transitively. Enforcement is create-time only — an existing pocket is
+never removed.
 """
 
 from __future__ import annotations
@@ -267,6 +277,7 @@ from bson.errors import InvalidId
 from pydantic import ValidationError as PydanticValidationError
 
 from pocketpaw.bundled_templates.schema import RippleSpec
+from pocketpaw_ee.cloud._core.errors import PocketLimitError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     PocketCreated,
@@ -1395,6 +1406,37 @@ async def resolve_workspace_template_default_deny(workspace_id: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+async def _pocket_cap_exceeded(workspace_id: str) -> tuple[bool, int, int | None]:
+    """Would a new pocket exceed this workspace's plan cap? -> (exceeded, count, limit).
+
+    feat/billing-smb-caps. GATED on ``billing_enforced``: OSS / self-host tenants
+    (billing off) always get ``(False, 0, None)`` — no cap, no extra DB read — so a
+    self-hosted deployment behaves exactly as before. When enforced, resolves the
+    workspace's plan ``max_pockets`` and counts its live pockets. An uncapped plan
+    (Enterprise, ``max_pockets=None``) never trips. ``exceeded`` is ``count >=
+    limit`` — checked BEFORE the insert, so it blocks the create that WOULD push the
+    workspace over, never an existing pocket (create-time only, never retroactive).
+
+    Returns the tuple rather than raising so each caller responds in its native
+    shape: the HTTP ``create`` path raises ``PocketLimitError`` (402); the agent
+    auto-create path returns ``None``. Imports are lazy to keep this module off the
+    config / entitlements import graph at load.
+    """
+    from pocketpaw.config import get_settings
+
+    if not get_settings().billing_enforced:
+        return (False, 0, None)
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = await entitlements_service.resolve_entitlements(workspace_id)
+    limit = ent.max_pockets
+    if limit is None:
+        return (False, 0, None)
+    count = await _PocketDoc.find(_PocketDoc.workspace == workspace_id).count()
+    return (count >= limit, count, limit)
+
+
 async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> dict:
     """Create a pocket with optional agents, widgets, and rippleSpec.
 
@@ -1403,7 +1445,22 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     ``project.not_found`` otherwise. Pockets without a ``project_id``
     surface as "unassigned" in the Mission Control project picker, which
     is exactly the pre-projects-rollout shape.
+
+    feat/billing-smb-caps: raises ``PocketLimitError`` (402) BEFORE any write when
+    the workspace is at/over its plan's ``max_pockets`` — a no-op unless
+    ``billing_enforced``. Also covers ``create_pocket_and_session``, which funnels
+    through here.
     """
+    exceeded, count, limit = await _pocket_cap_exceeded(workspace_id)
+    if exceeded:
+        logger.info(
+            "pocket create blocked by plan cap: workspace=%s has %d pockets (limit %s)",
+            workspace_id,
+            count,
+            limit,
+        )
+        raise PocketLimitError(limit)  # type: ignore[arg-type]  # limit is int when exceeded
+
     from pocketpaw_ee.cloud.sessions import service as sessions_service
 
     normalized_spec = normalize_ripple_spec(body.ripple_spec) if body.ripple_spec else None
@@ -2153,8 +2210,25 @@ async def create_from_ripple_spec(
     ``pattern`` records the create-pocket layout pattern (``"landing"``
     for a marketing site). Optional; defaults to ``None`` so the
     pre-existing inline auto-create path is unchanged.
+
+    feat/billing-smb-caps: this path does NOT funnel through ``create``, so it
+    carries its OWN pocket-cap check. It returns ``None`` (not a 402) when at/over
+    the cap — consistent with the function's "return None on failure" contract, so
+    the agent turn degrades gracefully (no pocket attached) instead of surfacing a
+    raw 402 through the agent loop. A no-op unless ``billing_enforced``.
     """
     try:
+        exceeded, count, limit = await _pocket_cap_exceeded(workspace_id)
+        if exceeded:
+            logger.warning(
+                "Auto-create blocked by pocket cap: workspace=%s has %d pockets "
+                "(limit %s) — no pocket created",
+                workspace_id,
+                count,
+                limit,
+            )
+            return None
+
         normalized = normalize_ripple_spec(ripple_spec)
         if not normalized:
             return None

--- a/ee/pocketpaw_ee/cloud/rules/__init__.py
+++ b/ee/pocketpaw_ee/cloud/rules/__init__.py
@@ -1,22 +1,42 @@
-# Cloud rules entity — re-exports for the gate executor + read seam.
+# Cloud rules entity — re-exports for the gate executor, read seam, and HTTP router.
 # Created: 2026-06-20 (S2-R1 / feat/szd-slice2-discovery). The discovered-rules
 # entity: the persistence + read API for governed Instinct rules mined from
-# workspace exhaust and approved through the gate. No HTTP router this slice
-# (rules are born only via the S2-R3 ``_instinct_rule`` executor; see the
-# ``no-router`` note in service.py). Re-exports the service entry points so the
-# executor + the slice-3 dispatcher import from the package root.
+# workspace exhaust and approved through the gate.
+#
+# Updated: 2026-07-09 (feat/instinct-guardrail-rules). A UI-authored governed rule
+# is now manageable over HTTP: the entity gains a thin ``router`` (create / list /
+# archive + the per-workspace enforcement toggle) over the shipped service, plus the
+# enforcement DTOs. The original "no HTTP router this slice" note is retired.
+# Re-exports the service entry points + DTOs so consumers import from the package root.
 
 from __future__ import annotations
 
 from pocketpaw_ee.cloud.rules.domain import Rule
-from pocketpaw_ee.cloud.rules.dto import CreateRuleRequest, RuleResponse
-from pocketpaw_ee.cloud.rules.service import archive_rule, create_rule, get_active_rules
+from pocketpaw_ee.cloud.rules.dto import (
+    CreateRuleRequest,
+    EnforcementResponse,
+    RuleResponse,
+    SetEnforcementRequest,
+)
+from pocketpaw_ee.cloud.rules.service import (
+    archive_rule,
+    create_rule,
+    get_active_rules,
+    get_enforcement,
+    get_enforcement_override,
+    set_enforcement,
+)
 
 __all__ = [
     "CreateRuleRequest",
+    "EnforcementResponse",
     "Rule",
     "RuleResponse",
+    "SetEnforcementRequest",
     "archive_rule",
     "create_rule",
     "get_active_rules",
+    "get_enforcement",
+    "get_enforcement_override",
+    "set_enforcement",
 ]

--- a/ee/pocketpaw_ee/cloud/rules/dto.py
+++ b/ee/pocketpaw_ee/cloud/rules/dto.py
@@ -7,6 +7,11 @@
 # ``rules.service.create_rule``: the editable ``RuleDraft`` plus ``owner_user_id``
 # (the approver). Tenancy is NOT in this DTO — it arrives as the service's explicit
 # ``workspace_id`` parameter, and the service asserts it matches ``draft.scope``.
+#
+# Updated: 2026-07-09 (feat/instinct-guardrail-rules) — added the per-workspace
+# enforcement-toggle DTOs (``SetEnforcementRequest`` / ``EnforcementResponse``)
+# the new ``rules.router`` PUT/GET ``/rules/enforcement`` endpoints use to read
+# and set the tri-state override on the global enforcement flag.
 
 from __future__ import annotations
 
@@ -34,6 +39,20 @@ class CreateRuleRequest(BaseModel):
 
     draft: RuleDraft
     owner_user_id: str
+
+
+class SetEnforcementRequest(BaseModel):
+    """Body for ``PUT /rules/enforcement`` → ``rules.service.set_enforcement``.
+
+    ``enabled`` is the TRI-STATE per-workspace override on the global
+    ``instinct_enforce_discovered_rules`` flag: ``True`` forces authored-rule
+    enforcement ON for this workspace, ``False`` forces it OFF, and ``None``
+    (the default) clears the override so the workspace inherits the global flag.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -71,4 +90,28 @@ class RuleResponse(BaseModel):
     updated_at: datetime | None = None
 
 
-__all__ = ["CreateRuleRequest", "RuleResponse", "RuleScopeResponse"]
+class EnforcementResponse(BaseModel):
+    """Wire shape for a workspace's authored-rule enforcement state.
+
+    ``enforce_discovered_rules`` is the EFFECTIVE value the live gate uses
+    (``override`` when set, else ``global_default``). ``override`` exposes the
+    raw tri-state per-workspace value (``None`` = inheriting) and
+    ``global_default`` the current global flag, so the admin UI can show both
+    "your setting" and "what the workspace inherits".
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: str
+    enforce_discovered_rules: bool
+    override: bool | None = None
+    global_default: bool
+
+
+__all__ = [
+    "CreateRuleRequest",
+    "EnforcementResponse",
+    "RuleResponse",
+    "RuleScopeResponse",
+    "SetEnforcementRequest",
+]

--- a/ee/pocketpaw_ee/cloud/rules/router.py
+++ b/ee/pocketpaw_ee/cloud/rules/router.py
@@ -1,0 +1,119 @@
+# router.py — FastAPI router for the Rules entity (governed Instinct rules).
+# Created: 2026-07-09 (feat/instinct-guardrail-rules) — the thin HTTP surface over
+# the shipped ``rules.service``. A UI-authored governed rule ("writes over $500 need
+# approval") is created / listed / archived here, and the per-workspace authored-rule
+# ENFORCEMENT toggle is read / set here. Every route is workspace-scoped (tenancy from
+# the auth context, never a body/query) and admin-gated behind ``rules.manage``.
+#
+# Discipline (ee/cloud 4-file rules): NO enforcement logic and NO Beanie doc import
+# live here — the router only maps HTTP <-> service calls. Errors surface as
+# ``CloudError`` via the global handler (never ``HTTPException``). Mounted under
+# ``/api/v1`` from ``ee/pocketpaw_ee/cloud/__init__.py``.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.rules import service as rules_service
+from pocketpaw_ee.cloud.rules.dto import (
+    CreateRuleRequest,
+    EnforcementResponse,
+    RuleResponse,
+    SetEnforcementRequest,
+)
+
+router = APIRouter(
+    prefix="/rules",
+    tags=["Rules"],
+    dependencies=[Depends(require_license)],
+)
+
+
+# ---------------------------------------------------------------------------
+# Governed-rule CRUD (thin wrappers over rules.service).
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "",
+    response_model=RuleResponse,
+    dependencies=[Depends(require_action_any_workspace("rules.manage"))],
+)
+async def create_rule(
+    body: CreateRuleRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Create a governed rule for the caller's workspace.
+
+    The service asserts ``body.draft.scope.workspace_id`` matches the caller's
+    workspace, so an edited draft can never persist into another tenant.
+    """
+    return await rules_service.create_rule(workspace_id, user_id, body)
+
+
+@router.get(
+    "",
+    response_model=list[RuleResponse],
+    dependencies=[Depends(require_action_any_workspace("rules.manage"))],
+)
+async def list_rules(
+    workspace_id: str = Depends(current_workspace_id),
+) -> list[dict]:
+    """List the ACTIVE governed rules for the caller's workspace (tenant-filtered;
+    archived rows excluded)."""
+    return await rules_service.get_active_rules(workspace_id)
+
+
+# ---------------------------------------------------------------------------
+# Per-workspace enforcement toggle. Declared BEFORE the ``/{rule_id}/archive``
+# route so ``/enforcement`` is never captured as a rule id.
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/enforcement",
+    response_model=EnforcementResponse,
+    dependencies=[Depends(require_action_any_workspace("rules.manage"))],
+)
+async def get_enforcement(
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict:
+    """Read the caller workspace's effective authored-rule enforcement state."""
+    return await rules_service.get_enforcement(workspace_id)
+
+
+@router.put(
+    "/enforcement",
+    response_model=EnforcementResponse,
+    dependencies=[Depends(require_action_any_workspace("rules.manage"))],
+)
+async def set_enforcement(
+    body: SetEnforcementRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Set (or clear, with ``enabled=null``) the caller workspace's tri-state
+    enforcement override on the global flag."""
+    return await rules_service.set_enforcement(workspace_id, user_id, body.enabled)
+
+
+@router.post(
+    "/{rule_id}/archive",
+    response_model=RuleResponse,
+    dependencies=[Depends(require_action_any_workspace("rules.manage"))],
+)
+async def archive_rule(
+    rule_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Archive (retire) a governed rule. Tenant-scoped — a caller can only
+    archive a rule in their own workspace; an unknown id 404s via CloudError."""
+    return await rules_service.archive_rule(workspace_id, user_id, rule_id)

--- a/ee/pocketpaw_ee/cloud/rules/service.py
+++ b/ee/pocketpaw_ee/cloud/rules/service.py
@@ -1,26 +1,37 @@
-# Rules — service (the sole owner of InstinctRuleDoc writes).
+# Rules — service (the sole owner of InstinctRuleDoc + InstinctWorkspaceConfig writes).
 # Created: 2026-06-20 (S2-R1 / feat/szd-slice2-discovery). The R3 ``_instinct_rule``
 # gate executor calls ``create_rule`` at approve time; ``get_active_rules`` is the
 # slice-2 read seam (slice-3 wires it into live gate dispatch). Follows the ee/cloud
 # 4-file rules: module-level ``async def``, validate-at-entry, tenant filter on every
 # read, emit on every write, errors via CloudError.
 #
-# no-router: rules have NO direct HTTP surface this slice. A rule is born ONLY by
-#   approving an ``_instinct_rule`` gate proposal (S2-R3 executor → this service);
-#   it is never POSTed by a client. The read seam ``get_active_rules`` is consumed
-#   in-process by the (slice-3) gate dispatcher, not over HTTP. A read router can be
-#   added later if a workspace rule-list endpoint is needed; omitted by design now.
+# Updated: 2026-07-09 (feat/instinct-guardrail-rules). The rules entity now HAS a thin
+# HTTP router (``rules/router.py``) over ``create_rule`` / ``get_active_rules`` /
+# ``archive_rule`` so a UI-authored governed rule is manageable over HTTP (the
+# original "no-router" note is retired). This module also gains the per-workspace
+# ENFORCEMENT toggle: ``get_enforcement_override`` (the fail-open resolver seam the
+# live gate consults), ``get_enforcement`` (read) and ``set_enforcement`` (upsert)
+# over the ``InstinctWorkspaceConfig`` doc — a tri-state override on the global
+# ``instinct_enforce_discovered_rules`` flag so one tenant can flip enforcement
+# without a code change. The gate's fail-OPEN-on-read-error rail is unchanged.
 
 from __future__ import annotations
 
 from typing import Any
 
+from pocketpaw.config import get_settings
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import RuleArchived, RuleCreated
 from pocketpaw_ee.cloud.models.instinct_rule import InstinctRuleDoc
+from pocketpaw_ee.cloud.models.instinct_workspace_config import InstinctWorkspaceConfig
 from pocketpaw_ee.cloud.rules.domain import Rule
-from pocketpaw_ee.cloud.rules.dto import CreateRuleRequest, RuleResponse, RuleScopeResponse
+from pocketpaw_ee.cloud.rules.dto import (
+    CreateRuleRequest,
+    EnforcementResponse,
+    RuleResponse,
+    RuleScopeResponse,
+)
 
 # ---------------------------------------------------------------------------
 # Private mapping helpers — Beanie doc ↔ domain ↔ wire dict
@@ -164,4 +175,76 @@ def _as_object_id(rule_id: str) -> Any:
         raise ValidationError("rule.invalid_id", f"invalid rule id: {rule_id}") from exc
 
 
-__all__ = ["archive_rule", "create_rule", "get_active_rules"]
+# ---------------------------------------------------------------------------
+# Per-workspace enforcement toggle — the tri-state override on the global
+# ``instinct_enforce_discovered_rules`` flag, over ``InstinctWorkspaceConfig``.
+# ---------------------------------------------------------------------------
+
+
+async def get_enforcement_override(workspace_id: str) -> bool | None:
+    """Return the workspace's raw enforcement override, or ``None`` if unset.
+
+    ``True``/``False`` is an explicit per-workspace override; ``None`` means the
+    workspace has no override and inherits the global flag. This is the pure read
+    seam the live gate consults — it RAISES on a store read error so the CALLER
+    owns the fail-OPEN decision (the gate must never turn a read hiccup into a
+    block; see ``instinct_dispatch._enforcement_enabled``).
+    """
+    doc = await InstinctWorkspaceConfig.find_one(
+        InstinctWorkspaceConfig.workspace == workspace_id,
+    )
+    return None if doc is None else doc.enforce_discovered_rules
+
+
+async def get_enforcement(workspace_id: str) -> dict:
+    """Return the workspace's effective enforcement state as a wire dict.
+
+    ``enforce_discovered_rules`` is the EFFECTIVE value (``override`` when set,
+    else the global flag); ``override`` is the raw tri-state; ``global_default``
+    is the current global flag. Read-only — never writes a doc.
+    """
+    override = await get_enforcement_override(workspace_id)
+    global_default = bool(get_settings().instinct_enforce_discovered_rules)
+    return EnforcementResponse(
+        workspace_id=workspace_id,
+        enforce_discovered_rules=override if override is not None else global_default,
+        override=override,
+        global_default=global_default,
+    ).model_dump(mode="json")
+
+
+async def set_enforcement(workspace_id: str, user_id: str, enabled: bool | None) -> dict:
+    """Upsert the workspace's enforcement override, returning the effective state.
+
+    ``enabled=True`` forces enforcement ON, ``False`` forces it OFF, and ``None``
+    clears the override (the workspace re-inherits the global flag). The doc
+    itself survives a reset — a "previously overridden, now cleared" workspace
+    keeps an audit-relevant ``updatedAt``. ``workspace`` is unique-indexed, so
+    the find-then-insert/save upsert is O(1); a concurrent-insert race would
+    surface as a DuplicateKeyError (admin-only write path — treated as a 5xx, no
+    retry loop, mirroring ``foresight.service.set_threshold``).
+    """
+    doc = await InstinctWorkspaceConfig.find_one(
+        InstinctWorkspaceConfig.workspace == workspace_id,
+    )
+    if doc is None:
+        doc = InstinctWorkspaceConfig(
+            workspace=workspace_id,
+            enforce_discovered_rules=enabled,
+        )
+        await doc.insert()
+    else:
+        doc.enforce_discovered_rules = enabled
+        await doc.save()
+
+    return await get_enforcement(workspace_id)
+
+
+__all__ = [
+    "archive_rule",
+    "create_rule",
+    "get_active_rules",
+    "get_enforcement",
+    "get_enforcement_override",
+    "set_enforcement",
+]

--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -30,6 +30,13 @@ Updated 2026-06-28 (feat/aiam-agent-revoke, AW-4): ``_run_agent_response``
 catches ``AgentDisabled`` from ``pool.get`` explicitly and SKIPS the agent
 (returns None, no error to the channel) — a soft-disabled agent simply stops
 responding in groups/DMs until re-enabled.
+
+Updated 2026-07-08 (feat/billing-enforce-gate): ``_dispatch_agent_responses``
+now runs the shared run-start billing gate (``credits.guards.over_billing_limit``)
+ABOVE the respond-mode evaluation — before ``_smart_relevance_check``'s Haiku
+pre-classifier call and before ``pool.run`` — so an over-budget tenant triggers
+NO model call on the group/DM auto-response path. On rejection it emits one
+``agent.error`` to the group and returns.
 """
 
 from __future__ import annotations
@@ -43,6 +50,7 @@ from typing import Any
 
 from pocketpaw_ee.cloud.realtime.emit import emit
 from pocketpaw_ee.cloud.realtime.events import (
+    AgentError,
     AgentStreamChunk,
     AgentStreamEnd,
     AgentStreamStart,
@@ -116,6 +124,40 @@ async def _dispatch_agent_responses(data: dict) -> None:
         len(group.agents),
         [(a.agent_id, a.respond_mode) for a in group.agents],
     )
+
+    # Run-start BILLING gate — placed ABOVE the respond-mode evaluation so an
+    # over-budget tenant makes NO model call at all. Critically this sits before
+    # ``_should_agent_respond`` -> ``_smart_relevance_check``: that pre-classifier
+    # is itself a (cheap Haiku) model call, so gating only before ``pool.run``
+    # would still let an over-budget workspace spend on the relevance check. The
+    # shared guard is flag-gated (a no-op unless ``billing_enforced``) and runs
+    # both the empty-wallet and monthly-ceiling assertions; on rejection we emit a
+    # single terminal ``agent.error`` to the group (best-effort — no run_id /
+    # stream transport on this event-bus path) and return without dispatching any
+    # agent. An empty ``workspace_id`` is a no-op (no wallet to attribute).
+    from pocketpaw_ee.cloud.credits.guards import over_billing_limit
+
+    billing_reject = await over_billing_limit(workspace_id)
+    if billing_reject is not None:
+        logger.warning(
+            "Agent bridge: workspace %s over billing limit (%s) — skipping all agents in group %s",
+            workspace_id,
+            billing_reject.code,
+            group_id,
+        )
+        try:
+            await emit(
+                AgentError(
+                    data={
+                        "group_id": group_id,
+                        "code": billing_reject.code,
+                        "message": str(billing_reject),
+                    },
+                )
+            )
+        except Exception:
+            logger.debug("billing agent.error emit failed for group %s", group_id, exc_info=True)
+        return
 
     agents_to_run: list[str] = []
     for group_agent in group.agents:

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -17,6 +17,9 @@ and the ``Branding`` -> ``BrandingOut`` mapping in ``workspace_to_dto``.
 2026-06-19 (feat/instinct-gate-integration, security-review FIX 1): added
 ``SetApprovalLevelRequest`` — the closed-enum body for the OWNER-only route
 that activates the layered Instinct gate's triager for a workspace.
+2026-07-10 (compliance-starter): added ``SetRetentionRequest`` (positive-or-
+null ``retention_days``, ``extra="forbid"``) + ``RetentionOut`` for the
+dedicated per-workspace data-retention endpoint.
 """
 
 from __future__ import annotations
@@ -130,6 +133,31 @@ class SetApprovalLevelRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     level: Literal["ASK", "TRIAGE", "TRUSTED"]
+
+
+class SetRetentionRequest(BaseModel):
+    """PUT /workspaces/{id}/retention request (compliance-starter).
+
+    The dedicated, no-clobber writer for the per-workspace data-retention
+    policy. ``retention_days`` is ``None`` to keep records forever, or a
+    POSITIVE day count (``ge=1``) after which audit records are purged. A 0 /
+    negative value is a 422 at the route boundary; ``extra="forbid"`` rejects
+    stray fields so this can never smuggle another settings key onto the
+    document.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    retention_days: int | None = Field(default=None, ge=1)
+
+
+class RetentionOut(BaseModel):
+    """GET/PUT /workspaces/{id}/retention response — the current policy.
+
+    ``retention_days`` is ``None`` when the workspace keeps records forever.
+    """
+
+    retention_days: int | None = None
 
 
 class BulkInviteRequest(BaseModel):
@@ -493,9 +521,11 @@ __all__ = [
     "InviteOut",
     "InvitePreviewResponse",
     "MemberOut",
+    "RetentionOut",
     "RoutePermissionsOut",
     "SetMemberConnectorPermissionsRequest",
     "SetMemberRoutePermissionsRequest",
+    "SetRetentionRequest",
     "SlugAvailabilityOut",
     "UpdateDomainRequest",
     "UpdateMemberRoleRequest",

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -9,6 +9,10 @@ entities; the router maps to DTOs at the boundary.
 (``instinct.activate``) switch that activates the layered Instinct gate's
 triager for a workspace. Kept off the general PATCH route because a non-ASK
 level enables auto-approval of agent WRITE actions workspace-wide.
+2026-07-10 (compliance-starter): added ``GET`` + ``PUT
+/{workspace_id}/retention`` — read (member) / set (admin, ``workspace.update``)
+the per-workspace data-retention policy. The PUT writes only ``retention_days``
+without clobbering sibling settings.
 """
 
 from __future__ import annotations
@@ -44,10 +48,12 @@ from pocketpaw_ee.cloud.workspace.dto import (
     InviteOut,
     InvitePreviewResponse,
     MemberOut,
+    RetentionOut,
     RoutePermissionsOut,
     SetApprovalLevelRequest,
     SetMemberConnectorPermissionsRequest,
     SetMemberRoutePermissionsRequest,
+    SetRetentionRequest,
     SlugAvailabilityOut,
     UpdateDomainRequest,
     UpdateMemberRoleRequest,
@@ -177,6 +183,46 @@ async def delete_preview(
     seeing the preview implies you're the one who could pull the trigger.
     """
     return await workspace_service.get_delete_preview(workspace_id)
+
+
+# ---------------------------------------------------------------------------
+# Data retention (compliance-starter)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{workspace_id}/retention", response_model=RetentionOut)
+async def get_retention(
+    workspace_id: str,
+    ctx: RequestContext = Depends(request_context),
+    user: User = Depends(require_membership),
+) -> RetentionOut:
+    """Read the workspace's data-retention policy.
+
+    ``retention_days`` is ``None`` when the workspace keeps records forever.
+    Any member may read the policy (it's config, not data); setting it is
+    admin-gated on the PUT below.
+    """
+    days = await workspace_service.get_retention(ctx, workspace_id)
+    return RetentionOut(retention_days=days)
+
+
+@router.put("/{workspace_id}/retention", response_model=RetentionOut)
+async def set_retention(
+    workspace_id: str,
+    body: SetRetentionRequest,
+    ctx: RequestContext = Depends(request_context),
+    user: User = Depends(require_action("workspace.update")),
+) -> RetentionOut:
+    """Set the workspace's data-retention policy (admin — ``workspace.update``).
+
+    Writes ONLY ``settings.retention_days`` — sibling settings are preserved
+    (the service merges rather than full-replaces). ``retention_days`` null =
+    keep forever; a positive value is the age after which
+    ``enforce_retention`` purges audit records. Emits a ``workspace.retention_set``
+    audit row.
+    """
+    await workspace_service.set_retention(ctx, workspace_id, body.retention_days)
+    return RetentionOut(retention_days=body.retention_days)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -25,6 +25,11 @@ Public API:
   verified ``subscription.active`` upgrades to the subscribed tier and a
   ``subscription.cancelled`` reverts to ``free``. Returns True on a write,
   False when the workspace is missing/soft-deleted.
+- ``raise_seats_for_plan(workspace_id, plan_key)`` — UPGRADE-ONLY resync of
+  the stored ``Workspace.seats`` up to the new plan's ``max_seats`` (never
+  down). The subscription.active webhook calls it after set_workspace_plan so
+  an upgrade actually lifts the seat cap; a downgrade/cancel never strips
+  seats a workspace already has.
 
 Changes: added get_workspace_plan helper for plan-feature gate dep; added
 slug_reason() (format + reserved + uniqueness) backing the live
@@ -77,6 +82,16 @@ actor-role check an ADMIN could self-promote to owner or evict a sitting owner o
 approval. The guard lives in the service so every caller (admin tool, executor,
 route) inherits it; it mirrors the existing "an invite can never mint an owner"
 rule. The last-owner + cannot_demote/remove-doc-owner guards are unchanged.
+2026-07-08 (feat/billing-smb-caps): the three seat gates (create_invite,
+bulk_create_invites, accept_invite) now source their ceiling from the workspace's
+RESOLVED PLAN, not the flat ``doc.seats`` alone. ``_effective_seat_limit`` returns
+``max(doc.seats, plan.max_seats)`` (an uncapped Enterprise plan keeps the
+negotiated ``doc.seats``) so a plan upgrade lifts the cap while a workspace that
+already carries a higher custom seat count never regresses. Seat enforcement stays
+ALWAYS-ON (not behind ``billing_enforced``), unchanged from before; the Free
+``max_seats`` == the model default (5) means a free tenant sees the identical
+limit. ``raise_seats_for_plan`` (upgrade-only) keeps the stored ``doc.seats`` in
+step with the plan on a subscription.active.
 """
 
 from __future__ import annotations
@@ -1034,6 +1049,34 @@ async def _mint_invite_for_email(
     return _invite_to_domain(invite_doc, plaintext_token=plaintext)
 
 
+async def _effective_seat_limit(doc: _WorkspaceDoc) -> int:
+    """The seat ceiling to enforce for this workspace — plan-sourced.
+
+    Sources the limit from the workspace's RESOLVED PLAN (``max_seats``) rather
+    than the flat ``doc.seats`` alone, so a plan upgrade lifts the cap. Enforced
+    as ``max(doc.seats, plan.max_seats)`` so a workspace that already carries a
+    higher custom ``doc.seats`` — a seeded enterprise box, or a legacy
+    hand-bumped seat count — never regresses below what it has today. An uncapped
+    plan (Enterprise, ``max_seats=None``) imposes no plan ceiling: the workspace's
+    own ``doc.seats`` stands.
+
+    ALWAYS-ON (NOT gated on ``billing_enforced``), mirroring the pre-existing seat
+    gate. Because the Free ``max_seats`` equals the ``Workspace.seats`` model
+    default (5), a free tenant sees byte-for-byte the same limit it had before
+    this became plan-sourced — no regression.
+
+    The entitlements resolver is imported LAZILY to keep this module off the
+    resolver's import graph (the resolver itself imports this service lazily);
+    there is no static cycle.
+    """
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = await entitlements_service.resolve_entitlements(str(doc.id))
+    if ent.max_seats is None:
+        return doc.seats
+    return max(doc.seats, ent.max_seats)
+
+
 async def create_invite(
     ctx: RequestContext,
     workspace_id: str,
@@ -1044,8 +1087,9 @@ async def create_invite(
         raise NotFound("workspace", workspace_id)
 
     member_count = await _count_members(workspace_id)
-    if member_count >= doc.seats:
-        raise SeatLimitError(doc.seats)
+    seat_limit = await _effective_seat_limit(doc)
+    if member_count >= seat_limit:
+        raise SeatLimitError(seat_limit)
 
     invite = await _mint_invite_for_email(
         ctx, workspace_id, body.email, body.role, body.group_id, body.context
@@ -1110,8 +1154,9 @@ async def bulk_create_invites(
         raise NotFound("workspace", workspace_id)
 
     current_count = await _count_members(workspace_id)
-    if current_count + len(body.emails) > doc.seats:
-        raise SeatLimitError(doc.seats)
+    seat_limit = await _effective_seat_limit(doc)
+    if current_count + len(body.emails) > seat_limit:
+        raise SeatLimitError(seat_limit)
 
     created: list[Invite] = []
     skipped: list[dict] = []
@@ -1357,12 +1402,13 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
     already_member = await _get_member_role(invite.workspace_id, ctx.user_id) is not None
     if not already_member:
         member_count = await _count_members(invite.workspace_id)
-        if member_count >= ws_doc.seats:
+        seat_limit = await _effective_seat_limit(ws_doc)
+        if member_count >= seat_limit:
             await collection.update_one(
                 {"_id": claimed["_id"]},
                 {"$set": {"accepted": False, "accepted_at": None}},
             )
-            raise SeatLimitError(ws_doc.seats)
+            raise SeatLimitError(seat_limit)
         await _add_member(
             invite.workspace_id,
             ctx.user_id,
@@ -1721,6 +1767,45 @@ async def set_workspace_plan(workspace_id: str, plan: str) -> bool:
     return True
 
 
+async def raise_seats_for_plan(workspace_id: str, plan_key: str) -> int | None:
+    """Bump the stored ``Workspace.seats`` UP to the plan's ``max_seats`` (never down).
+
+    Called by the billing subscription webhook on a ``subscription.active`` upgrade,
+    right after ``set_workspace_plan``, so an upgrade actually lifts the stored seat
+    cap (the seat gates also lift it live via ``_effective_seat_limit``, but keeping
+    the persisted field in step means every direct ``doc.seats`` reader — dashboards,
+    "X of Y seats" — sees the new ceiling too).
+
+    UPGRADE-ONLY: writes ``max(doc.seats, plan.max_seats)`` so a downgrade / cancel
+    (which reverts the plan to ``free``) can NEVER strip seats a workspace already
+    has — a workspace on 100 seats that cancels to free keeps its 100. An uncapped
+    plan (Enterprise, ``max_seats=None``) leaves the negotiated ``doc.seats``
+    untouched. A same-or-lower target is a no-op write.
+
+    Returns the resulting seat count, or ``None`` when the plan is unknown/uncapped
+    or the workspace is missing / soft-deleted / malformed (the webhook logs-and-acks
+    rather than 500-ing on an unroutable event). The plan catalog is imported lazily
+    to keep this service off its import graph.
+    """
+    from pocketpaw_ee.cloud.billing import plans as plan_catalog
+
+    tier = plan_catalog.get_plan(plan_key)
+    if tier is None or tier.max_seats is None:
+        return None
+    try:
+        oid = PydanticObjectId(workspace_id)
+    except Exception:
+        return None
+    doc = await _WorkspaceDoc.get(oid)
+    if doc is None or doc.deleted_at is not None:
+        return None
+    new_seats = max(doc.seats, tier.max_seats)
+    if new_seats != doc.seats:
+        doc.seats = new_seats
+        await doc.save()
+    return new_seats
+
+
 # ---------------------------------------------------------------------------
 # Route Permissions
 # ---------------------------------------------------------------------------
@@ -1890,6 +1975,7 @@ __all__ = [
     "list_members",
     "list_peer_ids",
     "preview_invite",
+    "raise_seats_for_plan",
     "remove_member",
     "resend_invite",
     "revoke_invite",

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -82,6 +82,15 @@ actor-role check an ADMIN could self-promote to owner or evict a sitting owner o
 approval. The guard lives in the service so every caller (admin tool, executor,
 route) inherits it; it mirrors the existing "an invite can never mint an owner"
 rule. The last-owner + cannot_demote/remove-doc-owner guards are unchanged.
+2026-07-10 (compliance-starter): retention setting is now real. update()'s
+settings write MERGES via ``_merge_settings`` instead of the destructive
+``WorkspaceSettings(**body.settings)`` full-replace (a partial patch no longer
+wipes sibling settings — recon-flagged bug). Added ``get_retention`` /
+``set_retention`` (the clean, no-clobber compliance read/write for
+``settings.retention_days``, owner/admin-gated at the route) and
+``enforce_retention`` (again-callable purge of audit rows older than the
+policy cutoff; delegates the delete to ``audit.service.purge_workspace_audit``
+so the AuditEvent-write contract stays in the audit module).
 2026-07-08 (feat/billing-smb-caps): the three seat gates (create_invite,
 bulk_create_invites, accept_invite) now source their ceiling from the workspace's
 RESOLVED PLAN, not the flat ``doc.seats`` alone. ``_effective_seat_limit`` returns
@@ -102,6 +111,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from beanie import PydanticObjectId
+from pydantic import ValidationError as PydanticValidationError
 from pymongo.errors import DuplicateKeyError
 
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
@@ -476,7 +486,7 @@ async def update(
     if body.name is not None:
         doc.name = body.name
     if body.settings is not None:
-        doc.settings = WorkspaceSettings(**body.settings)
+        doc.settings = _merge_settings(doc.settings, body.settings)
     if body.branding is not None:
         await _apply_branding_patch(doc, workspace_id, body.branding)
     await doc.save()
@@ -495,6 +505,125 @@ async def update(
 
     count = await _count_members(workspace_id)
     return _workspace_to_domain(doc, member_count=count)
+
+
+def _merge_settings(current: WorkspaceSettings, patch: dict) -> WorkspaceSettings:
+    """MERGE a partial settings dict onto the existing settings.
+
+    The old code did ``WorkspaceSettings(**body.settings)`` — a destructive
+    FULL-REPLACE that silently reset every field the caller didn't send (a
+    ``{"retention_days": 30}`` patch wiped ``default_agent`` and
+    ``allow_invites`` back to their defaults). Mirrors ``_apply_branding_patch``:
+    dump the current settings, overlay only the keys the patch carries, and
+    re-validate through the model (so ``retention_days`` bounds are enforced
+    on this path too). A bad value raises ``ValidationError`` (422) rather than
+    persisting junk.
+    """
+    merged = current.model_dump()
+    merged.update(patch)
+    try:
+        return WorkspaceSettings(**merged)
+    except PydanticValidationError as exc:
+        raise ValidationError("workspace.invalid_settings", str(exc)) from exc
+
+
+async def get_retention(ctx: RequestContext, workspace_id: str) -> int | None:
+    """Read a workspace's data-retention policy (``retention_days``).
+
+    ``None`` means "keep forever". Membership is enforced at the route layer;
+    this is a plain read of the workspace document the service owns.
+    """
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        raise NotFound("workspace", workspace_id)
+    return doc.settings.retention_days
+
+
+async def set_retention(
+    ctx: RequestContext,
+    workspace_id: str,
+    retention_days: int | None,
+) -> Workspace:
+    """Set a workspace's data-retention policy without clobbering siblings.
+
+    Writes ONLY ``settings.retention_days`` — the other settings fields are
+    carried through the merge untouched. ``retention_days`` is re-validated
+    through ``WorkspaceSettings`` (positive-or-null) so a direct service
+    caller gets the same guarantee the route DTO enforces. ``None`` clears the
+    policy (keep forever). Emits a workspace audit row so the compliance
+    change is attributable.
+    """
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        raise NotFound("workspace", workspace_id)
+
+    old = doc.settings.retention_days
+    doc.settings = _merge_settings(doc.settings, {"retention_days": retention_days})
+    await doc.save()
+
+    await audit_service.record(
+        workspace_id,
+        ctx.user_id,
+        "workspace.retention_set",
+        target_type="workspace",
+        target_id=workspace_id,
+        metadata={"old_retention_days": old, "new_retention_days": retention_days},
+    )
+
+    count = await _count_members(workspace_id)
+    return _workspace_to_domain(doc, member_count=count)
+
+
+async def enforce_retention(workspace_id: str) -> dict:
+    """Purge records older than the workspace's ``retention_days`` policy.
+
+    Idempotent / again-callable: it deletes everything older than
+    ``now - retention_days`` for THIS workspace, so running it twice is safe
+    and running it late just catches up. A ``None`` policy (keep forever) is a
+    no-op. The audit-event store is the retention target — it is the durable,
+    workspace-scoped compliance record store (the decision journal is a
+    projection rebuilt from the immutable journal, so purging it would not
+    stick; the soul journal itself is the event source-of-truth and is out of
+    scope for a per-workspace age purge). Notifications + journal purge are
+    tracked as a FOLLOW-UP.
+
+    FOLLOW-UP (scheduler wiring): nothing calls this on a cadence yet. It is
+    intentionally a pure, side-effect-scoped function so a periodic sweep can
+    iterate workspaces with a non-null ``retention_days`` and call it — the
+    natural home is a cloud background loop registered at ``mount_cloud`` /
+    the temporal scheduler (``ee/pocketpaw_ee/cloud/temporal_sweeps``). Until
+    that lands, an admin can trigger a purge by re-saving the retention policy
+    and calling this from an ops shell.
+    """
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        raise NotFound("workspace", workspace_id)
+
+    retention_days = doc.settings.retention_days
+    if retention_days is None:
+        return {
+            "workspace_id": workspace_id,
+            "retention_days": None,
+            "audit_deleted": 0,
+            "skipped": "no_retention_policy",
+        }
+
+    cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+    audit_deleted = await audit_service.purge_workspace_audit(workspace_id, cutoff)
+
+    logger.info(
+        "retention: purged %d audit rows older than %s for workspace %s (retention_days=%d)",
+        audit_deleted,
+        cutoff.isoformat(),
+        workspace_id,
+        retention_days,
+    )
+    return {
+        "workspace_id": workspace_id,
+        "retention_days": retention_days,
+        "cutoff": cutoff.isoformat(),
+        "audit_deleted": audit_deleted,
+    }
 
 
 def _audit_approval_level_change(

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -94,6 +94,12 @@ from or weaken them. It returns ``None`` for the legacy (no-workspace) path, lea
 the OSS factory's shared singleton in place. This activates the entry-point end to
 end and gives EE the single hook to later swap in a cloud-backed store without
 touching core.
+
+Updated: 2026-07-11 (feat/paw-cli, C2) — ``CloudFabricMcpProvider`` is no longer
+read-only: the ``pocketpaw_fabric`` server grew three ontology modification
+tools (``fabric_link_create`` / ``fabric_link_delete`` at MEMBER tier,
+``fabric_type_update`` RBAC-gated on ``fabric.admin``), mirroring the REST
+routes. ``tool_ids()`` picks them up automatically via ``FABRIC_TOOL_IDS``.
 """
 
 from __future__ import annotations
@@ -971,14 +977,17 @@ class CloudWorkspaceAdminMcpProvider:
 
 
 class CloudFabricMcpProvider:
-    """`pocketpaw.mcp_servers` — read-only Fabric ontology access in-process
-    server (``pocketpaw_fabric``). Hosts ``fabric_query`` + ``fabric_stats``.
+    """`pocketpaw.mcp_servers` — Fabric ontology access in-process server
+    (``pocketpaw_fabric``). Hosts the reads ``fabric_query`` + ``fabric_stats``
+    and, since feat/paw-cli C2, the modification tools ``fabric_link_create``
+    / ``fabric_link_delete`` (MEMBER tier — mirroring the fabric.write REST
+    routes) and ``fabric_type_update`` (RBAC-gated on ``fabric.admin``,
+    mirroring the ADMIN schema routes).
 
     On the claude_agent_sdk backend, registry tools (BaseTool) never reach the
     agent — only MCP servers do — so this server is the cloud chat agent's only
-    path to the Fabric ontology. Both tools are READ-ONLY and workspace-scoped
-    via the chat ContextVars; ontology writes from this backend should arrive
-    as gated proposals, never ambient writes.
+    path to the Fabric ontology. All tools are workspace-scoped via the chat
+    ContextVars and every write is audited via record_tool_call.
 
     Ambient (NOT in ``OPT_IN_MCP_SERVERS``) — surfaces scope access via their
     profile allowlist, the same regime the sibling belt / external-actions /

--- a/ee/pocketpaw_ee/fabric/router.py
+++ b/ee/pocketpaw_ee/fabric/router.py
@@ -75,6 +75,14 @@
 #   (``fabric.write``), completing link CRUD over HTTP. The delete resolves the
 #   link through the store's new scoped ``get_link`` first — a cross-tenant or
 #   unknown id 404s (no existence leak), because ``unlink`` itself is unscoped.
+# Updated: 2026-07-11 (self-serve-analysis S1) — ``POST /fabric/query`` now
+#   surfaces the store's flag-gated aggregation path: a query carrying
+#   ``group_by``/``aggregate`` returns ``aggregates`` ({key, value} rows) plus
+#   ``steps`` (the {title, detail, status} QueryPlanStep reasoning trace) via
+#   the extended FabricQueryResult response model; with POCKETPAW_FABRIC_ANALYST
+#   off the store's FabricAnalystDisabledError maps to 422
+#   ``fabric.analyst_disabled``. Plain queries are unchanged on the wire
+#   (aggregates/steps serialize as null).
 
 from __future__ import annotations
 
@@ -85,6 +93,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from pocketpaw.fabric.models import (
+    FabricAnalystDisabledError,
     FabricLink,
     FabricObject,
     FabricQuery,
@@ -373,8 +382,21 @@ async def query_fabric(
     q: FabricQuery,
     workspace_id: str = Depends(current_workspace_id),
 ):
-    """Run an arbitrary FabricQuery, scoped to the caller's workspace (W4a)."""
-    return await _store(workspace_id).query(q, workspace_id=workspace_id)
+    """Run an arbitrary FabricQuery, scoped to the caller's workspace (W4a).
+
+    Self-serve-analysis S1: a query carrying ``group_by``/``aggregate`` runs the
+    flag-gated aggregation path and the response additionally carries
+    ``aggregates`` ({key, value} rows) and ``steps`` — the reasoning trace in
+    the exact ``{title, detail, status}`` QueryPlanStep wire shape ripple's
+    ReasoningTrace consumes. With POCKETPAW_FABRIC_ANALYST off the store
+    rejects the aggregation fail-loud and this handler maps it to 422
+    ``fabric.analyst_disabled``. Plain queries are byte-compatible with the
+    pre-S1 response (aggregates/steps null).
+    """
+    try:
+        return await _store(workspace_id).query(q, workspace_id=workspace_id)
+    except FabricAnalystDisabledError as exc:
+        raise ValidationError("fabric.analyst_disabled", str(exc)) from exc
 
 
 @router.post(

--- a/ee/pocketpaw_ee/fabric/router.py
+++ b/ee/pocketpaw_ee/fabric/router.py
@@ -52,6 +52,25 @@
 #   ``workspace_id`` filter args are UNCHANGED — physical file isolation is
 #   additive defense-in-depth, kept alongside the in-row WHERE-filter, not a
 #   replacement for it.
+# Updated: 2026-07-10 (ontology-operator-ux) — makes the ontology operable by a
+#   non-engineer. Three additions:
+#     1. A new ADMIN-gated schema-authoring surface under ``/fabric/schema`` —
+#        ``POST /fabric/schema/types`` (create a typed object type),
+#        ``POST /fabric/schema/types/{id}/properties`` (add a property, additive),
+#        ``PATCH /fabric/schema/types/{id}`` (version + rename/additive migrate),
+#        ``POST /fabric/schema/link-types`` (declare a link type), and
+#        ``GET /fabric/schema`` (list object types + their properties + link types
+#        for the UI). The write routes are gated on the new ``fabric.admin`` action
+#        (ADMIN); the list is ``fabric.read`` so any member can render the browser.
+#        The schema WRITES call ``WorkspaceFabricStore.register_*`` directly IN the
+#        handler — the injected FabricRegistry Protocol is read-only, so registry
+#        authoring must run here, never through it.
+#     2. Write-time LINK enforcement in ``create_link``: when the workspace has
+#        declared any link types, a new link must name a declared type AND match
+#        its declared (from_type -> to_type) endpoints, else 422. No declarations
+#        -> no enforcement (backward compatible).
+#     3. ``create_object`` now surfaces the OSS store's ``FabricTypeError`` (a
+#        declared-property type clash) as a 422 instead of a 500.
 
 from __future__ import annotations
 
@@ -66,14 +85,17 @@ from pocketpaw.fabric.models import (
     FabricObject,
     FabricQuery,
     FabricQueryResult,
+    FabricTypeError,
     ObjectType,
     PropertyDef,
 )
 from pocketpaw.fabric.store import FabricStore
 from pocketpaw.stores import get_fabric_store
 from pocketpaw_ee.cloud._core.deps import current_workspace_id, require_plan_feature
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import require_action_any_workspace
+from pocketpaw_ee.fabric.storage import WorkspaceFabricStore, get_registry_store
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +143,65 @@ class LinkRequest(BaseModel):
     to_id: str
     link_type: str
     properties: dict[str, Any] = {}
+
+
+# --- Schema-authoring surface (ontology-operator-ux) ---
+
+
+class SchemaTypeRequest(BaseModel):
+    """Create an object type with typed properties (the operator 'create a type')."""
+
+    name: str
+    properties: list[PropertyDef] = []
+    description: str = ""
+    icon: str = "box"
+    color: str = "#0A84FF"
+
+
+class AddPropertyRequest(BaseModel):
+    """Add one property to an existing object type (additive schema change)."""
+
+    property: PropertyDef
+
+
+class UpdateTypeRequest(BaseModel):
+    """Version + non-destructively migrate a type (rename and/or additive).
+
+    ``renames`` maps ``old_property_name -> new_property_name`` (the key is moved
+    on every existing object). ``properties`` replaces the declared schema (a
+    property dropped from it is deferred — its orphaned key is left on existing
+    objects, never scrubbed). All fields optional; an empty body still bumps the
+    version.
+    """
+
+    properties: list[PropertyDef] | None = None
+    renames: dict[str, str] | None = None
+    description: str | None = None
+    icon: str | None = None
+    color: str | None = None
+
+
+class LinkTypeRequest(BaseModel):
+    """Declare a directed link type between two object types."""
+
+    name: str
+    from_type: str
+    to_type: str
+
+
+class LinkTypeDef(BaseModel):
+    """A declared link type as rendered in the schema list."""
+
+    name: str
+    from_type: str
+    to_type: str
+
+
+class SchemaResponse(BaseModel):
+    """The current ontology schema: object types (with properties) + link types."""
+
+    object_types: list[ObjectType]
+    link_types: list[LinkTypeDef]
 
 
 # ---------------------------------------------------------------------------
@@ -240,14 +321,23 @@ async def create_object(
     req: CreateObjectRequest,
     workspace_id: str = Depends(current_workspace_id),
 ):
-    """Create an object stamped with the caller's active workspace (W4a)."""
-    return await _store(workspace_id).create_object(
-        type_id=req.type_id,
-        properties=req.properties,
-        source_connector=req.source_connector,
-        source_id=req.source_id,
-        workspace_id=workspace_id,
-    )
+    """Create an object stamped with the caller's active workspace (W4a).
+
+    Write-time type enforcement (ontology-operator-ux): the OSS store validates
+    the property bag against the type's declared schema and raises
+    ``FabricTypeError`` on a clash. Surface that as a 422 (a well-formed request
+    that fails a field rule) rather than letting it bubble to a 500.
+    """
+    try:
+        return await _store(workspace_id).create_object(
+            type_id=req.type_id,
+            properties=req.properties,
+            source_connector=req.source_connector,
+            source_id=req.source_id,
+            workspace_id=workspace_id,
+        )
+    except FabricTypeError as exc:
+        raise ValidationError("fabric.property_type_mismatch", str(exc)) from exc
 
 
 @router.get(
@@ -292,8 +382,16 @@ async def create_link(
     req: LinkRequest,
     workspace_id: str = Depends(current_workspace_id),
 ):
-    """Create a link stamped with the caller's active workspace (W4a)."""
-    return await _store(workspace_id).link(
+    """Create a link stamped with the caller's active workspace (W4a).
+
+    Write-time LINK enforcement (ontology-operator-ux): if the workspace has
+    declared any link types, the new link must name a declared type AND match its
+    declared ``from_type -> to_type`` endpoints, else 422. A workspace with no
+    declared link types is unaffected (backward compatible).
+    """
+    store = _store(workspace_id)
+    await _enforce_link_type(store, workspace_id, req)
+    return await store.link(
         from_id=req.from_id,
         to_id=req.to_id,
         link_type=req.link_type,
@@ -316,3 +414,182 @@ async def fabric_stats(workspace_id: str = Depends(current_workspace_id)):
     leaked another tenant's experimental type names into chat.
     """
     return await _store(workspace_id).stats(workspace_id=workspace_id)
+
+
+# ---------------------------------------------------------------------------
+# Schema-authoring surface (ontology-operator-ux)
+#
+# ADMIN-gated (``fabric.admin``) writes that let a non-engineer author the
+# ontology: create a typed object type, add a property, version + migrate a
+# type, and declare a link type. The registry-write methods
+# (``register_entity_type`` / ``register_property`` / ``register_link``) live on
+# the concrete ``WorkspaceFabricStore`` and are called DIRECTLY here — the
+# injected ``FabricRegistry`` Protocol is read-only, so authoring must run in the
+# handler, never through it. Object types + their declared properties + versions
+# live in the OSS ``FabricStore`` (the source of truth for write-time property
+# enforcement and versioning); link types live in the EE registry store. The
+# schema list stitches both.
+# ---------------------------------------------------------------------------
+
+
+def _registry() -> WorkspaceFabricStore:
+    """The workspace-registry store (single file under the OSS data dir)."""
+    return get_registry_store()
+
+
+async def _enforce_link_type(
+    store: FabricStore, workspace_id: str, req: LinkRequest
+) -> None:
+    """Reject a link that violates the workspace's declared link schema.
+
+    No-op when the workspace has declared no link types (backward compatible).
+    Otherwise the link's ``link_type`` must be a declared name AND the from/to
+    objects' TYPE NAMES must match one declared ``(from_type -> to_type)`` pair
+    for that name. Endpoint types are resolved from the objects themselves
+    (workspace-scoped), so a link to a cross-tenant / unknown object cannot
+    satisfy a declaration.
+    """
+    declared = _registry().list_links(workspace_id)
+    if not declared:
+        return
+    names = {d["name"] for d in declared}
+    if req.link_type not in names:
+        raise ValidationError(
+            "fabric.link_type_unregistered",
+            f"link type {req.link_type!r} is not defined in this workspace's ontology",
+        )
+    from_obj = await store.get_object(req.from_id, workspace_id=workspace_id)
+    to_obj = await store.get_object(req.to_id, workspace_id=workspace_id)
+    from_type = from_obj.type_name if from_obj else None
+    to_type = to_obj.type_name if to_obj else None
+    if not any(
+        d["name"] == req.link_type and d["from_type"] == from_type and d["to_type"] == to_type
+        for d in declared
+    ):
+        expected = [
+            f"{d['from_type']} -> {d['to_type']}" for d in declared if d["name"] == req.link_type
+        ]
+        raise ValidationError(
+            "fabric.link_type_mismatch",
+            f"link {req.link_type!r} expects {expected} but got "
+            f"{from_type!r} -> {to_type!r}",
+        )
+
+
+@router.get(
+    "/fabric/schema",
+    response_model=SchemaResponse,
+    dependencies=[Depends(require_action_any_workspace("fabric.read"))],
+)
+async def get_schema(workspace_id: str = Depends(current_workspace_id)) -> SchemaResponse:
+    """Render the workspace's current ontology schema for the operator UI.
+
+    Object types (with their declared, typed properties and schema version) come
+    from the OSS store; link types come from the EE registry. Both are scoped to
+    the caller's workspace.
+    """
+    object_types = await _store(workspace_id).list_types(workspace_id=workspace_id)
+    link_types = [LinkTypeDef(**d) for d in _registry().list_links(workspace_id)]
+    return SchemaResponse(object_types=object_types, link_types=link_types)
+
+
+@router.post(
+    "/fabric/schema/types",
+    response_model=ObjectType,
+    status_code=201,
+    dependencies=[Depends(require_action_any_workspace("fabric.admin"))],
+)
+async def create_schema_type(
+    req: SchemaTypeRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ObjectType:
+    """Create a typed object type + register it in the workspace registry (ADMIN)."""
+    obj_type = await _store(workspace_id).define_type(
+        name=req.name,
+        properties=req.properties,
+        description=req.description,
+        icon=req.icon,
+        color=req.color,
+        workspace_id=workspace_id,
+    )
+    reg = _registry()
+    reg.register_entity_type(workspace_id, obj_type.name)
+    for prop in req.properties:
+        reg.register_property(workspace_id, obj_type.name, prop.name, prop.type)
+    return obj_type
+
+
+@router.post(
+    "/fabric/schema/types/{type_id}/properties",
+    response_model=ObjectType,
+    dependencies=[Depends(require_action_any_workspace("fabric.admin"))],
+)
+async def add_schema_property(
+    type_id: str,
+    req: AddPropertyRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ObjectType:
+    """Add one property to a type (additive; bumps the type version) (ADMIN)."""
+    store = _store(workspace_id)
+    existing = await store.get_type(type_id, workspace_id=workspace_id)
+    if existing is None:
+        raise NotFound("object type", type_id)
+    if any(p.name == req.property.name for p in existing.properties):
+        raise ValidationError(
+            "fabric.property_exists",
+            f"property {req.property.name!r} is already declared on {existing.name!r}",
+        )
+    updated = await store.update_type(
+        type_id,
+        properties=[*existing.properties, req.property],
+        workspace_id=workspace_id,
+    )
+    reg = _registry()
+    reg.register_entity_type(workspace_id, existing.name)
+    reg.register_property(workspace_id, existing.name, req.property.name, req.property.type)
+    # update_type returned the type; None is impossible here (existing resolved).
+    return updated  # type: ignore[return-value]
+
+
+@router.patch(
+    "/fabric/schema/types/{type_id}",
+    response_model=ObjectType,
+    dependencies=[Depends(require_action_any_workspace("fabric.admin"))],
+)
+async def update_schema_type(
+    type_id: str,
+    req: UpdateTypeRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ObjectType:
+    """Version + non-destructively migrate a type (rename / additive) (ADMIN)."""
+    updated = await _store(workspace_id).update_type(
+        type_id,
+        properties=req.properties,
+        renames=req.renames,
+        description=req.description,
+        icon=req.icon,
+        color=req.color,
+        workspace_id=workspace_id,
+    )
+    if updated is None:
+        raise NotFound("object type", type_id)
+    reg = _registry()
+    reg.register_entity_type(workspace_id, updated.name)
+    for prop in updated.properties:
+        reg.register_property(workspace_id, updated.name, prop.name, prop.type)
+    return updated
+
+
+@router.post(
+    "/fabric/schema/link-types",
+    response_model=LinkTypeDef,
+    status_code=201,
+    dependencies=[Depends(require_action_any_workspace("fabric.admin"))],
+)
+async def create_link_type(
+    req: LinkTypeRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> LinkTypeDef:
+    """Declare a directed link type in the workspace registry (ADMIN)."""
+    _registry().register_link(workspace_id, req.name, req.from_type, req.to_type)
+    return LinkTypeDef(name=req.name, from_type=req.from_type, to_type=req.to_type)

--- a/ee/pocketpaw_ee/fabric/router.py
+++ b/ee/pocketpaw_ee/fabric/router.py
@@ -486,9 +486,7 @@ def _registry() -> WorkspaceFabricStore:
     return get_registry_store()
 
 
-async def _enforce_link_type(
-    store: FabricStore, workspace_id: str, req: LinkRequest
-) -> None:
+async def _enforce_link_type(store: FabricStore, workspace_id: str, req: LinkRequest) -> None:
     """Reject a link that violates the workspace's declared link schema.
 
     No-op when the workspace has declared no link types (backward compatible).
@@ -520,8 +518,7 @@ async def _enforce_link_type(
         ]
         raise ValidationError(
             "fabric.link_type_mismatch",
-            f"link {req.link_type!r} expects {expected} but got "
-            f"{from_type!r} -> {to_type!r}",
+            f"link {req.link_type!r} expects {expected} but got {from_type!r} -> {to_type!r}",
         )
 
 

--- a/ee/pocketpaw_ee/fabric/router.py
+++ b/ee/pocketpaw_ee/fabric/router.py
@@ -71,6 +71,10 @@
 #        -> no enforcement (backward compatible).
 #     3. ``create_object`` now surfaces the OSS store's ``FabricTypeError`` (a
 #        declared-property type clash) as a 422 instead of a 500.
+# Updated: 2026-07-11 (feat/paw-cli, C2) — added ``DELETE /fabric/links/{id}``
+#   (``fabric.write``), completing link CRUD over HTTP. The delete resolves the
+#   link through the store's new scoped ``get_link`` first — a cross-tenant or
+#   unknown id 404s (no existence leak), because ``unlink`` itself is unscoped.
 
 from __future__ import annotations
 
@@ -398,6 +402,29 @@ async def create_link(
         properties=req.properties,
         workspace_id=workspace_id,
     )
+
+
+@router.delete(
+    "/fabric/links/{link_id}",
+    status_code=204,
+    dependencies=[Depends(require_action_any_workspace("fabric.write"))],
+)
+async def delete_link(
+    link_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+) -> None:
+    """Delete one link, scoped to the caller's workspace (feat/paw-cli, C2).
+
+    ``FabricStore.unlink`` is unscoped by design (OSS single-tenant callers),
+    so the tenancy guard lives HERE: the link is resolved through the scoped
+    ``get_link`` first, and a cross-tenant or unknown id gets a 404 — never a
+    cross-workspace delete, and no existence leak for other tenants' ids.
+    """
+    store = _store(workspace_id)
+    link = await store.get_link(link_id, workspace_id=workspace_id)
+    if link is None:
+        raise HTTPException(404, "Link not found")
+    await store.unlink(link_id)
 
 
 @router.get(

--- a/ee/pocketpaw_ee/fabric/storage.py
+++ b/ee/pocketpaw_ee/fabric/storage.py
@@ -12,6 +12,13 @@
 # ``list_entity_links()``: enumerate the declared links touching one
 # entity type (either end), so the atlas Fabric introspector can
 # describe a workspace's live schema. Read-only, additive.
+# Updated: 2026-07-10 (ontology-operator-ux) — two additions for the
+# operator schema surface: ``list_links(workspace_id)`` enumerates ALL
+# declared link types in a workspace (name + from/to type), used by the
+# GET /fabric/schema list endpoint and by write-time LINK enforcement in
+# the router; and ``get_registry_store()`` builds a WorkspaceFabricStore
+# under the OSS data dir (``pocketpaw.stores._DATA_DIR``) so it inherits
+# the same test isolation the OSS Fabric store already gets. Both additive.
 """SQLite-backed workspace-scoped Fabric registry store.
 
 The store is the write-side of the concrete ``FabricRegistry``
@@ -291,8 +298,46 @@ class WorkspaceFabricStore:
                 {"name": row[0], "from_type": row[1], "to_type": row[2]} for row in cur.fetchall()
             ]
 
+    def list_links(self, workspace_id: str) -> list[dict[str, str]]:
+        """Every declared link type in ``workspace_id`` as ``{"name",
+        "from_type", "to_type"}`` dicts (ontology-operator-ux).
+
+        Unlike :meth:`list_entity_links` (which filters to one entity), this
+        returns the WHOLE link schema for the workspace — what the operator's
+        GET /fabric/schema list endpoint renders, and what write-time link
+        enforcement in the router checks a new link against. Ordered by
+        (name, from_type, to_type) for stable callers.
+        """
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT name, from_type, to_type FROM fabric_registry_links "
+                "WHERE workspace = ? ORDER BY name, from_type, to_type",
+                (workspace_id,),
+            )
+            return [
+                {"name": row[0], "from_type": row[1], "to_type": row[2]} for row in cur.fetchall()
+            ]
+
+
+def get_registry_store() -> WorkspaceFabricStore:
+    """Return the workspace-registry store under the OSS data dir (ontology-operator-ux).
+
+    The registry is a SINGLE SQLite file with a ``workspace`` column (not a
+    per-workspace file), living beside the OSS Fabric data at
+    ``<pocketpaw.stores._DATA_DIR>/fabric_registry.db``. Reading ``_DATA_DIR`` at
+    call time (rather than binding ``DEFAULT_DB_PATH`` once) means a test that
+    repoints ``stores._DATA_DIR`` at a tmp dir isolates the registry too — the
+    same isolation the OSS Fabric store already inherits from the factory. In
+    production ``_DATA_DIR`` is ``~/.pocketpaw``, so the path equals the module
+    default.
+    """
+    from pocketpaw import stores  # local import: OSS core, avoids an import cycle
+
+    return WorkspaceFabricStore(stores._DATA_DIR / "fabric_registry.db")
+
 
 __all__ = [
     "DEFAULT_DB_PATH",
     "WorkspaceFabricStore",
+    "get_registry_store",
 ]

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -196,6 +196,14 @@ ACTIONS: dict[str, ActionRule] = {
     # tier (mirrors workspace.delete / billing.manage): a mere admin must not
     # be able to disable the human-in-the-loop for everyone.
     "instinct.activate": ActionRule(WorkspaceRole.OWNER, "workspace.insufficient_role"),
+    # Governed rules — the UI-authored guardrail surface (ee.cloud.rules.router:
+    # create / list / archive a rule + the per-workspace enforcement toggle).
+    # ADMIN, mirroring the other governance write surfaces (instinct.approve /
+    # audit.read): authoring a rule and flipping enforcement change workspace-wide
+    # governance and can only ADD blocks/escalations (never relax the template
+    # floor), so an admin bar — not the OWNER-only bar reserved for
+    # instinct.activate (which turns OFF the human-in-the-loop) — is correct.
+    "rules.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Connector — workspace-level connector lifecycle.
     # execute is MEMBER so any team member can run actions against enabled connectors.
     # manage (enable/disable/config) is ADMIN because it changes workspace-wide state

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -175,12 +175,17 @@ ACTIONS: dict[str, ActionRule] = {
     # authenticated caller could install into any workspace
     # (docs/plans/cluster-D-reality.md#106-112, P0 fix 2026-04-19).
     "fleet.install": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
-    # Fabric — ontology read/write.
-    # Both tiers are MEMBER so any workspace member can query and author objects.
-    # Type/schema management intentionally stays MEMBER for now; tighten to ADMIN
-    # once a Fabric admin tier is validated with clients.
+    # Fabric — ontology read/write + schema authoring.
+    # read/write are MEMBER so any workspace member can query objects and author
+    # object DATA (create/update objects, add links). SCHEMA authoring — defining
+    # object types, adding typed properties, declaring link types, and versioning
+    # a type (ontology-operator-ux, the /fabric/schema surface) — is the more
+    # privileged "operator" tier and is ADMIN: changing the ontology reshapes
+    # write-time enforcement for the whole workspace, so it sits above the member
+    # data tier (mirrors connector.manage / rules.manage / skills.manage).
     "fabric.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
     "fabric.write": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
+    "fabric.admin": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Instinct — human-in-the-loop decision pipeline.
     # Propose and read are MEMBER (agents and analysts can propose + view actions).
     # Approve/reject and audit are ADMIN — governance actions with downstream

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -237,6 +237,13 @@ ACTIONS: dict[str, ActionRule] = {
     # diffs), mirroring connector.manage / skills.manage.
     "belt.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
     "belt.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Notifications external-delivery config (ee.cloud.notifications.router,
+    # feat/external-alerting-delivery). ADMIN because the config sets where the
+    # server POSTs on EVERY notification (a Slack / generic webhook URL) — it
+    # extends the workspace's egress surface, mirroring connector.manage /
+    # belt.manage. There is no separate read action: the config is admin-only to
+    # view too (it holds the webhook URLs), so GET reuses ``notifications.manage``.
+    "notifications.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Security — the shield control-plane proxy (ee.cloud.security.router,
     # SEC-5). OWNER-only, the most restrictive workspace tier (mirrors
     # workspace.delete / billing.manage / instinct.activate). shield fronts the

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -3,6 +3,12 @@
 # machine-readable `code` emitted on denial. Tests iterate ACTIONS to
 # guarantee every guarded operation is covered.
 #
+# Updated: 2026-07-11 (feat/external-alerting-c2c3) — registered
+# ``automations.read`` (MEMBER) and ``automations.manage`` (ADMIN) for the
+# always-on automation status surface (ee.cloud.automations_status.router): view
+# the sweep registry / rules / per-workspace enable state, and flip the
+# per-workspace opt-out.
+#
 # Updated: 2026-04-19 (fix/fleet-install-auth-guard) — registered
 # ``fleet.install`` at ``WorkspaceRole.ADMIN`` with deny code
 # ``workspace.insufficient_role``. This lets the fleet router call
@@ -209,6 +215,13 @@ ACTIONS: dict[str, ActionRule] = {
     # floor), so an admin bar — not the OWNER-only bar reserved for
     # instinct.activate (which turns OFF the human-in-the-loop) — is correct.
     "rules.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Automations status — the always-on automation surface (external-alerting C3).
+    # read is MEMBER (any team member can view which sweeps/rules are running and
+    # the per-workspace enable state). manage is ADMIN because flipping the
+    # per-workspace opt-out turns the always-on background sweeps ON/OFF for the
+    # whole workspace (mirrors rules.manage / connector.manage).
+    "automations.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
+    "automations.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Connector — workspace-level connector lifecycle.
     # execute is MEMBER so any team member can run actions against enabled connectors.
     # manage (enable/disable/config) is ADMIN because it changes workspace-wide state

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,7 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-11 (W4a spec revisions) — POST /paw-bar/widgets/{id}/spec/
+#   rollback (admin + owner-token, workspace-scoped like update_spec) restores
+#   the latest archived spec revision; 409 when no revision exists.
 # Updated: 2026-07-11 (W4a tenancy seam) — (1) Admin CRUD (create / list /
 #   update-spec / rotate-token / delete) now threads the caller's active
 #   workspace via Depends(current_workspace_id): create stamps the row, the
@@ -256,6 +259,34 @@ async def update_spec(
     if updated is None:
         raise HTTPException(404, "Widget not found")
     return PawBarWidgetPublic.from_widget(updated)
+
+
+@router.post(
+    "/paw-bar/widgets/{widget_id}/spec/rollback",
+    response_model=PawBarWidgetPublic,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def rollback_spec(
+    widget_id: str,
+    x_paw_bar_token: str | None = Header(default=None, alias="X-Paw-Bar-Token"),
+    workspace_id: str = Depends(current_workspace_id),
+) -> PawBarWidgetPublic:
+    """Restore the latest archived spec revision (W4a).
+
+    Every ``update_spec`` archives the prior spec as a monotonic revision;
+    this endpoint restores the most recent one. The restore is itself an
+    update that archives the current spec, so a rollback is reversible.
+    Auth mirrors ``update_spec``: admin session + per-widget owner token,
+    with the lookup workspace-scoped (cross-tenant id → 404).
+    """
+    widget = await _store().get_widget(widget_id, workspace_id=workspace_id)
+    if widget is None:
+        raise HTTPException(404, "Widget not found")
+    _require_owner_token(widget, x_paw_bar_token)
+    restored = await _store().rollback_spec(widget_id, workspace_id=workspace_id)
+    if restored is None:
+        raise HTTPException(409, "No spec revision to roll back to")
+    return PawBarWidgetPublic.from_widget(restored)
 
 
 @router.post(

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,13 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-11 (W4a tenancy seam) — (1) Admin CRUD (create / list /
+#   update-spec / rotate-token / delete) now threads the caller's active
+#   workspace via Depends(current_workspace_id): create stamps the row, the
+#   rest scope lookups + mutations so a cross-tenant widget id 404s and never
+#   mutates. (2) Public-path fix (the cross-tenant Fabric leak): ingest stays
+#   token-only but derives the tenant from the widget ROW —
+#   _apply_event_mapping now calls get_fabric_store(workspace_id=
+#   widget.workspace_id or None) instead of the bare shared store; legacy
+#   unstamped rows ('' → None) keep the old single-tenant behavior.
 # Updated: 2026-07-08 — Renamed widget "Paw Print" → "Paw Bar" (routes /paw-print→/paw-bar,
 #   header X-Paw-Print-Token→X-Paw-Bar-Token, tag PawPrint→PawBar, source_connector
 #   "paw_print"→"paw_bar"). Hard-rename — widget has zero deployments. The separate
@@ -570,13 +579,14 @@ async def _apply_event_mapping(widget: PawBarWidget, event: PawBarEvent) -> str 
     except ImportError:
         return None
 
-    # ISO note: paw-bar's tenant key is the widget OWNER, a logical, possibly
-    # colon-qualified string (``user:maya``) — NOT a physical-store-path
-    # workspace id (a ``:`` fails the path-traversal allowlist). The Fabric
-    # write is scoped by the object's ``source_*`` provenance + the store's own
-    # in-row guard, not by a per-owner store file, so this keeps the BARE store
-    # rather than threading the owner into the factory (which would ValueError).
-    fabric = get_fabric_store()
+    # W4a tenancy — the public ingest path is token-only (no session), so the
+    # tenant is derived from the widget ROW: the workspace_id stamped at
+    # create time by the admin route. That is a REAL workspace id (unlike the
+    # logical, possibly colon-qualified ``owner`` — ``user:maya`` — which fails
+    # the store factory's path allowlist and must never be used as a store
+    # key). ``or None`` preserves legacy/single-tenant behavior: an unstamped
+    # ('' ) row keeps writing to the shared default store exactly as before.
+    fabric = get_fabric_store(workspace_id=widget.workspace_id or None)
     if fabric is None:
         return None
 

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -47,6 +47,8 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
+
 from pocketpaw.api.deps import require_scope
 from pocketpaw.paw_bar.models import (
     MAX_PAYLOAD_BYTES,
@@ -169,10 +171,16 @@ class EventsListResponse(BaseModel):
     status_code=201,
     dependencies=[Depends(require_scope("admin"))],
 )
-async def create_widget(req: CreateWidgetRequest) -> PawBarWidget:
+async def create_widget(
+    req: CreateWidgetRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> PawBarWidget:
+    # W4a — the row is stamped with the caller's ACTIVE workspace, never a
+    # client-supplied value: tenancy is derived server-side from the session.
     widget = PawBarWidget(
         pocket_id=req.pocket_id,
         owner=req.owner,
+        workspace_id=workspace_id,
         name=req.name,
         spec=req.spec,
         allowed_domains=req.allowed_domains,
@@ -192,8 +200,11 @@ async def list_widgets(
     pocket_id: str | None = Query(None),
     owner: str | None = Query(None),
     limit: int = Query(100, ge=1, le=500),
+    workspace_id: str = Depends(current_workspace_id),
 ) -> WidgetListResponse:
-    widgets = await _store().list_widgets(pocket_id=pocket_id, owner=owner, limit=limit)
+    widgets = await _store().list_widgets(
+        pocket_id=pocket_id, owner=owner, limit=limit, workspace_id=workspace_id
+    )
     # Project to the token-free model — a list payload must never carry the
     # per-widget access_token (W0b).
     public = [PawBarWidgetPublic.from_widget(w) for w in widgets]
@@ -224,12 +235,15 @@ async def update_spec(
     widget_id: str,
     spec: PawBarSpec,
     x_paw_bar_token: str | None = Header(default=None, alias="X-Paw-Bar-Token"),
+    workspace_id: str = Depends(current_workspace_id),
 ) -> PawBarWidgetPublic:
-    widget = await _store().get_widget(widget_id)
+    # W4a — the lookup is workspace-scoped: another tenant's widget id resolves
+    # to None → 404, before the token even gets compared. Never mutates.
+    widget = await _store().get_widget(widget_id, workspace_id=workspace_id)
     if widget is None:
         raise HTTPException(404, "Widget not found")
     _require_owner_token(widget, x_paw_bar_token)
-    updated = await _store().update_spec(widget_id, spec)
+    updated = await _store().update_spec(widget_id, spec, workspace_id=workspace_id)
     if updated is None:
         raise HTTPException(404, "Widget not found")
     return PawBarWidgetPublic.from_widget(updated)
@@ -243,16 +257,18 @@ async def update_spec(
 async def rotate_token(
     widget_id: str,
     x_paw_bar_token: str | None = Header(default=None, alias="X-Paw-Bar-Token"),
+    workspace_id: str = Depends(current_workspace_id),
 ) -> PawBarWidget:
     # Returns the FULL widget (with the new access_token) on purpose: this is
     # the explicit, authenticated reveal path so the owner can capture the
     # rotated secret. Still requires the old token AND an admin dashboard
-    # session (W0b).
-    widget = await _store().get_widget(widget_id)
+    # session (W0b). W4a — lookup + rotate are workspace-scoped (cross-tenant
+    # id → 404, nothing rotates).
+    widget = await _store().get_widget(widget_id, workspace_id=workspace_id)
     if widget is None:
         raise HTTPException(404, "Widget not found")
     _require_owner_token(widget, x_paw_bar_token)
-    rotated = await _store().rotate_token(widget_id)
+    rotated = await _store().rotate_token(widget_id, workspace_id=workspace_id)
     if rotated is None:
         raise HTTPException(404, "Widget not found")
     return rotated
@@ -266,12 +282,15 @@ async def rotate_token(
 async def delete_widget(
     widget_id: str,
     x_paw_bar_token: str | None = Header(default=None, alias="X-Paw-Bar-Token"),
+    workspace_id: str = Depends(current_workspace_id),
 ) -> None:
-    widget = await _store().get_widget(widget_id)
+    # W4a — scoped lookup + scoped DELETE: a cross-tenant widget id 404s and
+    # the row is never touched.
+    widget = await _store().get_widget(widget_id, workspace_id=workspace_id)
     if widget is None:
         raise HTTPException(404, "Widget not found")
     _require_owner_token(widget, x_paw_bar_token)
-    await _store().delete_widget(widget_id)
+    await _store().delete_widget(widget_id, workspace_id=workspace_id)
 
 
 @router.get("/paw-bar/widgets/{widget_id}/events", response_model=EventsListResponse)

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -59,8 +59,6 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from pocketpaw_ee.cloud._core.deps import current_workspace_id
-
 from pocketpaw.api.deps import require_scope
 from pocketpaw.paw_bar.models import (
     MAX_PAYLOAD_BYTES,
@@ -70,6 +68,7 @@ from pocketpaw.paw_bar.models import (
     PawBarWidget,
     PawBarWidgetPublic,
 )
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
 
 logger = logging.getLogger(__name__)
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -461,6 +461,21 @@ forbidden_modules = [
 ]
 
 [[tool.importlinter.contracts]]
+name = "AutomationsStatus — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    # feat/external-alerting-c2c3 (C3) — only ``automations_status.service`` owns
+    # the WorkspaceAutomationConfig Beanie writes; dto/domain/router go through it.
+    # The router is thin — it maps HTTP to service calls and must not import a
+    # Beanie doc directly.
+    "pocketpaw_ee.cloud.automations_status.dto",
+    "pocketpaw_ee.cloud.automations_status.domain",
+    "pocketpaw_ee.cloud.automations_status.router",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.workspace_automation_config"]
+
+[[tool.importlinter.contracts]]
 name = "Notifications — Beanie writes only from service.py"
 type = "forbidden"
 allow_indirect_imports = "true"

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -448,12 +448,17 @@ type = "forbidden"
 allow_indirect_imports = "true"
 source_modules = [
     # Discovered governed rules (SZD slice-2). Only ``rules.service`` owns the
-    # InstinctRuleDoc Beanie write; dto/domain go through it. No router this slice
-    # (rules are born via the _instinct_rule gate executor, not over HTTP).
+    # InstinctRuleDoc / InstinctWorkspaceConfig Beanie writes; dto/domain/router
+    # go through it. The router (feat/instinct-guardrail-rules) is thin — it maps
+    # HTTP to service calls and must not import a Beanie doc directly.
     "pocketpaw_ee.cloud.rules.dto",
     "pocketpaw_ee.cloud.rules.domain",
+    "pocketpaw_ee.cloud.rules.router",
 ]
-forbidden_modules = ["pocketpaw_ee.cloud.models.instinct_rule"]
+forbidden_modules = [
+    "pocketpaw_ee.cloud.models.instinct_rule",
+    "pocketpaw_ee.cloud.models.instinct_workspace_config",
+]
 
 [[tool.importlinter.contracts]]
 name = "Notifications — Beanie writes only from service.py"

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -464,7 +464,13 @@ source_modules = [
     "pocketpaw_ee.cloud.notifications.dto",
     "pocketpaw_ee.cloud.notifications.domain",
 ]
-forbidden_modules = ["pocketpaw_ee.cloud.models.notification"]
+# The external-delivery config doc (feat/external-alerting-delivery) is written
+# only by ``notifications.service`` and read by ``notifications.delivery`` — the
+# router/dto/domain façade must never touch either Beanie doc directly.
+forbidden_modules = [
+    "pocketpaw_ee.cloud.models.notification",
+    "pocketpaw_ee.cloud.models.notification_delivery",
+]
 
 [[tool.importlinter.contracts]]
 name = "FileVersions — Beanie writes only from service.py"

--- a/ee/uv.lock
+++ b/ee/uv.lock
@@ -3370,7 +3370,7 @@ requires-dist = [
     { name = "pocketpaw", specifier = "~=0.4.16" },
     { name = "pwdlib", extras = ["argon2"], specifier = ">=0.2.0" },
     { name = "py-vapid", specifier = ">=1.9.0" },
-    { name = "pymupdf", marker = "extra == 'extraction'", specifier = ">=1.24.0" },
+    { name = "pymupdf", marker = "extra == 'extraction'", specifier = ">=1.24.0,<2.0" },
     { name = "pyotp", specifier = ">=2.9.0" },
     { name = "pypdf", marker = "extra == 'extraction'" },
     { name = "pytesseract", marker = "extra == 'extraction'", specifier = ">=0.3.10" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -366,6 +366,7 @@ dev = [
 
 [project.scripts]
 pocketpaw = "pocketpaw.__main__:main"
+paw = "pocketpaw.paw.cli:main"
 
 # --- Extension-point providers (OSS-EE split) ---
 # Core (`pocketpaw`) discovers optional providers via importlib entry-points

--- a/src/pocketpaw/alert_manager.py
+++ b/src/pocketpaw/alert_manager.py
@@ -362,6 +362,12 @@ class AlertManager:
             "details": details or {},
             "timestamp": timestamp,
         }
+        # FOLLOW-UP (external alerting): this OSS alert path is in-app only (local
+        # store + bus). The cloud external fan-out (Slack / generic webhook) lives
+        # in ee.cloud.notifications.delivery, but OSS core MUST NOT import EE
+        # (import-linter "OSS core may not import from EE"). Routing these alerts
+        # to external sinks needs a bus-indirection the EE layer subscribes (or an
+        # OSS-side sink impl), not a direct import — tracked as a separate slice.
         # Store locally
         self._store.append({**alert_data, "_unread": True})
         logger.info("Alert [%s/%s]: %s", severity, alert_type, message)

--- a/src/pocketpaw/automations/evaluator.py
+++ b/src/pocketpaw/automations/evaluator.py
@@ -172,6 +172,12 @@ class AutomationEvaluator:
     async def _notify(self, rule: Rule) -> None:
         """Send notification only (no action proposal or execution)."""
         # TODO: Integrate with notification system (WebSocket, email, etc.)
+        # FOLLOW-UP (external alerting): the cloud external fan-out (Slack /
+        # generic webhook) lives in ee.cloud.notifications.delivery, but OSS core
+        # MUST NOT import EE (import-linter "OSS core may not import from EE").
+        # Reaching external sinks from here needs a structurally-different path —
+        # an event-bus indirection the EE layer subscribes, or an OSS-side sink
+        # impl — not a direct import. Tracked as a separate slice.
         logger.info("Notification for rule %s: %s fired", rule.name, rule.description)
 
 

--- a/src/pocketpaw/automations/evaluator.py
+++ b/src/pocketpaw/automations/evaluator.py
@@ -2,6 +2,13 @@
 # Created: 2026-03-30 — Periodic loop checks threshold/data_change conditions,
 #   fires rules through the Instinct pipeline (propose) or directly via daemon.
 #   Singleton via get_evaluator(). Start/stop endpoints wired in router.
+# Updated: 2026-07-11 (feat/external-alerting-c2c3) — replaced the
+#   ``_evaluate_threshold`` ``return False`` stub with a REAL Fabric query: the
+#   rule's (object_type, property, operator, value) becomes a FabricQuery with a
+#   comparison filter, run against the OSS FabricStore; the rule fires when at
+#   least one object crosses the threshold. Operator strings ("less_than",
+#   "greater_than", "equals", …) map to the store's whitelisted filter operators.
+#   OSS-only — no EE import (the store is resolved via pocketpaw.stores).
 
 """
 evaluator.py — Background evaluation engine for automation rules.
@@ -22,6 +29,49 @@ from pocketpaw.automations.models import ExecutionMode, Rule, RuleType, UpdateRu
 from pocketpaw.automations.store import get_automation_store
 
 logger = logging.getLogger(__name__)
+
+# Rule operator strings -> FabricStore whitelisted filter operators
+# (see fabric.store._FILTER_OPERATORS). Anything not in this map is a
+# non-comparable rule (e.g. "changed" is handled by the data_change path)
+# and never fires from the threshold branch.
+_OPERATOR_MAP: dict[str, str] = {
+    "less_than": "lt",
+    "lt": "lt",
+    "<": "lt",
+    "less_or_equal": "lte",
+    "less_than_or_equal": "lte",
+    "lte": "lte",
+    "<=": "lte",
+    "greater_than": "gt",
+    "gt": "gt",
+    ">": "gt",
+    "greater_or_equal": "gte",
+    "greater_than_or_equal": "gte",
+    "gte": "gte",
+    ">=": "gte",
+    "equals": "eq",
+    "equal": "eq",
+    "eq": "eq",
+    "==": "eq",
+    "not_equals": "ne",
+    "ne": "ne",
+    "!=": "ne",
+}
+
+
+def _coerce_value(raw: str) -> object:
+    """Coerce a rule's string threshold value to int/float when it looks numeric.
+
+    Fabric comparison filters CAST the stored property to REAL, so a numeric
+    threshold must be bound as a number, not the string ``"10"``. Non-numeric
+    values (an equality against a status string) pass through unchanged.
+    """
+    try:
+        if "." in raw or "e" in raw.lower():
+            return float(raw)
+        return int(raw)
+    except (ValueError, AttributeError):
+        return raw
 
 
 class AutomationEvaluator:
@@ -87,7 +137,15 @@ class AutomationEvaluator:
                 await self._fire_rule(rule)
 
     async def _evaluate_threshold(self, rule: Rule) -> bool:
-        """Check if a threshold condition is met by querying Fabric."""
+        """Check if a threshold condition is met by querying Fabric.
+
+        Builds a :class:`~pocketpaw.fabric.models.FabricQuery` from the rule's
+        ``(object_type, property, operator, value)`` and runs it against the OSS
+        FabricStore. The rule FIRES when at least one object matches — e.g.
+        "Product.stock less_than 10" fires the moment any Product's stock drops
+        under 10. A malformed / non-comparable rule (missing fields, an operator
+        with no comparison mapping) never fires and is logged at debug.
+        """
         try:
             logger.debug(
                 "Evaluating threshold: %s.%s %s %s",
@@ -97,16 +155,53 @@ class AutomationEvaluator:
                 rule.value,
             )
 
-            # Update last_evaluated timestamp
+            # Update last_evaluated timestamp regardless of outcome so the UI can
+            # show the rule is being actively checked.
             store = get_automation_store()
             store.update_rule(
                 rule.id,
                 UpdateRuleRequest(last_evaluated=datetime.now(UTC)),
             )
 
-            # TODO: Real Fabric query when ontology store is wired.
-            # For now, return False (never fires without real data).
-            return False
+            if not (rule.object_type and rule.property and rule.operator and rule.value):
+                logger.debug("Rule %s has an incomplete threshold condition — skipping", rule.id)
+                return False
+
+            fabric_op = _OPERATOR_MAP.get(rule.operator.strip().lower())
+            if fabric_op is None:
+                logger.debug(
+                    "Rule %s operator %r has no comparison mapping — skipping",
+                    rule.id,
+                    rule.operator,
+                )
+                return False
+
+            # Lazy import: keep the automations package importable without the
+            # Fabric stack at module load, and avoid a heavy startup-time import.
+            from pocketpaw.fabric.models import FabricQuery
+            from pocketpaw.stores import get_fabric_store
+
+            query = FabricQuery(
+                type_name=rule.object_type,
+                filters={rule.property: {fabric_op: _coerce_value(rule.value)}},
+                limit=1,
+            )
+            # OSS is single-tenant: the store resolves the default workspace and
+            # an unscoped read is correct here (the cloud sweep path applies
+            # per-workspace scoping separately).
+            result = await get_fabric_store().query(query)
+            fired = result.total > 0
+            if fired:
+                logger.info(
+                    "Threshold met for rule %s: %s.%s %s %s (%d matching object(s))",
+                    rule.id,
+                    rule.object_type,
+                    rule.property,
+                    rule.operator,
+                    rule.value,
+                    result.total,
+                )
+            return fired
         except Exception as e:
             logger.debug("Threshold evaluation failed for rule %s: %s", rule.id, e)
             return False

--- a/src/pocketpaw/bundled_templates/schema.py
+++ b/src/pocketpaw/bundled_templates/schema.py
@@ -38,6 +38,13 @@
 # and every reader still receives a flat dict (executor dual-path readers are
 # deferred to a #1472-gated Phase 2). All compile_template passthrough keys are
 # explicit typed fields so no ``.get("agents")`` reader silently breaks.
+# Modified: 2026-07-11 (feat/guardrail-c2-composer, instinct-guardrail-ux
+# Criterion 2) — added ``LlmStep`` + ``LlmStepPipeline``: the typed spec for
+# the fixed 3-step LLM pipeline composer (extract → classify → recommend).
+# A validator enforces the fixed order, 1-3 steps, each kind at most once,
+# and that every ``input_from`` reference resolves to "input" or an EARLIER
+# step. The executor lives in ``bundled_templates.step_composer``; the agent
+# invokes it via ``tools.builtin.step_pipeline_tool``.
 """Pydantic v2 model for the RFC 03 v2 Pocket Template Schema.
 
 This module is the **schema chokepoint** — every bundled template, every
@@ -299,6 +306,63 @@ class AgentDef(BaseModel):
     tools: list[str] = Field(default_factory=list)
     skill_refs: list[str] = Field(default_factory=list)
     soul_snippet: str | None = None
+
+
+_LLM_STEP_ORDER: tuple[str, ...] = ("extract", "classify", "recommend")
+
+
+class LlmStep(BaseModel):
+    """One step of the fixed 3-step LLM pipeline (extract → classify → recommend).
+
+    ``instruction`` is the human-authored prompt for the step. ``input_from``
+    names where the step's input comes from: ``"input"`` (the pipeline's initial
+    input) or an EARLIER step's kind; ``None`` = the previous step's output
+    (or the initial input for the first step). ``fields`` (extract only) names
+    the fields to pull; ``labels`` (classify only) is the closed label set.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    step: Literal["extract", "classify", "recommend"]
+    instruction: str
+    input_from: str | None = None
+    fields: list[str] | None = None
+    labels: list[str] | None = None
+
+
+class LlmStepPipeline(BaseModel):
+    """The fixed-order LLM pipeline a non-technical author composes.
+
+    Deterministic Python owns structure and sequencing (the ``start_flow``
+    discipline); the model is invoked once per step by the executor
+    (``bundled_templates.step_composer``). The validator enforces: 1-3 steps,
+    each kind at most once, the canonical order preserved, and every
+    ``input_from`` resolving to ``"input"`` or an earlier step's kind.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    steps: list[LlmStep]
+
+    @model_validator(mode="after")
+    def _fixed_order(self) -> LlmStepPipeline:
+        if not 1 <= len(self.steps) <= 3:
+            raise ValueError("pipeline.steps must contain 1-3 steps")
+        kinds = [s.step for s in self.steps]
+        if len(set(kinds)) != len(kinds):
+            raise ValueError("pipeline.steps must not repeat a step kind")
+        order = [_LLM_STEP_ORDER.index(k) for k in kinds]
+        if order != sorted(order):
+            raise ValueError("pipeline.steps must follow extract -> classify -> recommend order")
+        seen: set[str] = {"input"}
+        for s in self.steps:
+            if s.input_from is not None and s.input_from not in seen:
+                raise ValueError(
+                    f"steps[{kinds.index(s.step)}].input_from={s.input_from!r} must be"
+                    " 'input' or an earlier step's kind"
+                )
+            seen.add(s.step)
+        return self
 
 
 class TriggerDef(BaseModel):

--- a/src/pocketpaw/bundled_templates/step_composer.py
+++ b/src/pocketpaw/bundled_templates/step_composer.py
@@ -1,0 +1,118 @@
+# pocketpaw/bundled_templates/step_composer.py — the fixed 3-step LLM pipeline
+# executor (instinct-guardrail-ux Criterion 2).
+#
+# Created: 2026-07-11 (feat/guardrail-c2-composer).
+#
+# The ``start_flow`` discipline applied to an LLM-in-the-loop pipeline:
+# deterministic Python owns the STRUCTURE and SEQUENCING (which step runs,
+# what feeds what); the model is invoked exactly once per step through an
+# INJECTED ``agent_runner`` callable. This module never instantiates an LLM
+# client — the caller resolves the backend (this deployment may run the
+# Claude Code agent backend with no ANTHROPIC_API_KEY, so any direct client
+# here would be a bug, not a missing key).
+#
+# Leniency contract: a step's weird model reply degrades to raw text (the
+# pipeline keeps going and the transcript shows what happened); a MALFORMED
+# PIPELINE raises (the ``LlmStepPipeline`` validator owns most of that).
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pocketpaw.bundled_templates.schema import LlmStep, LlmStepPipeline
+
+logger = logging.getLogger(__name__)
+
+AgentRunner = Callable[[str], Awaitable[str]]
+
+
+def _step_prompt(step: LlmStep, step_input: str) -> str:
+    """Build the one typed prompt for a step (instruction + typed ask + input)."""
+    if step.step == "extract":
+        fields = ", ".join(step.fields or []) or "the relevant fields"
+        ask = (
+            f"Extract these fields as a flat JSON object: {fields}. "
+            "Reply with ONLY the JSON object."
+        )
+    elif step.step == "classify":
+        labels = ", ".join(step.labels or []) or "an appropriate label"
+        ask = f"Classify the input as exactly ONE of: {labels}. Reply with ONLY the label."
+    else:  # recommend
+        ask = "Recommend the next action, concisely."
+    return f"{step.instruction}\n\n{ask}\n\nInput:\n{step_input}"
+
+
+def _parse_output(step: LlmStep, reply: str) -> Any:
+    """Parse a step's reply into its typed output — leniently, never raising.
+
+    extract → a dict of the named fields when the reply parses as JSON (a
+    fenced JSON block is unwrapped), else the raw text. classify → the matching
+    label (case-insensitive) when one of ``labels`` appears, else the trimmed
+    raw reply. recommend → free text.
+    """
+    text = reply.strip()
+    if step.step == "extract":
+        candidate = text
+        if candidate.startswith("```"):
+            candidate = candidate.strip("`")
+            candidate = candidate.split("\n", 1)[1] if "\n" in candidate else candidate
+            candidate = candidate.rsplit("```", 1)[0] if "```" in candidate else candidate
+        try:
+            parsed = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            return text
+        if isinstance(parsed, dict) and step.fields:
+            return {k: parsed.get(k) for k in step.fields}
+        return parsed if isinstance(parsed, dict) else text
+    if step.step == "classify":
+        lowered = text.lower()
+        for label in step.labels or []:
+            if label.lower() == lowered or label.lower() in lowered:
+                return label
+        return text
+    return text
+
+
+def _as_text(value: Any) -> str:
+    """Render a prior step's typed output as the next step's text input."""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+async def run_step_pipeline(
+    pipeline: LlmStepPipeline,
+    initial_input: str,
+    agent_runner: AgentRunner,
+) -> dict[str, Any]:
+    """Run the pipeline sequentially with typed handoff between steps.
+
+    Each step's input resolves from ``input_from`` ("input" = the initial
+    input; a kind name = that earlier step's output; None = the previous
+    step's output, or the initial input for the first step). Returns
+    ``{"steps": [{step, input, output}, ...], "result": <final output>}``.
+    """
+    outputs: dict[str, Any] = {"input": initial_input}
+    transcript: list[dict[str, Any]] = []
+    previous: Any = initial_input
+
+    for step in pipeline.steps:
+        source = step.input_from if step.input_from is not None else None
+        step_input = _as_text(outputs[source]) if source is not None else _as_text(previous)
+        reply = await agent_runner(_step_prompt(step, step_input))
+        output = _parse_output(step, reply)
+        outputs[step.step] = output
+        previous = output
+        transcript.append({"step": step.step, "input": step_input, "output": output})
+        logger.debug("step_composer: %s -> %.120r", step.step, output)
+
+    return {"steps": transcript, "result": previous}
+
+
+__all__ = ["AgentRunner", "run_step_pipeline"]

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,12 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-07-11 (self-serve-analysis S1): Added ``fabric_analyst`` (default False,
+    env POCKETPAW_FABRIC_ANALYST) — gates the Fabric transparent-analysis read
+    engine (SQL GROUP BY aggregation + reasoning steps on FabricStore.query /
+    POST /fabric/query). Off (default): an aggregation query is rejected
+    fail-loud with FabricAnalystDisabledError -> HTTP 422
+    fabric.analyst_disabled; plain queries are unaffected either way.
   - 2026-07-11 (feat/external-alerting-c2c3): Added ``automation_evaluator_autostart``
     (default True, env POCKETPAW_AUTOMATION_EVALUATOR_AUTOSTART) — the OSS
     always-on automation switch. When on (default), the background
@@ -1842,6 +1848,23 @@ class Settings(BaseSettings):
             "killed. Default False so OSS / self-host deployments (which run no "
             "credit ledger) are unaffected; the cloud / subscription (PEE) "
             "deployments turn it on via POCKETPAW_BILLING_ENFORCED."
+        ),
+    )
+
+    # Self-serve analysis (S1 — transparent-analysis read engine). Gates the
+    # Fabric aggregation surface (FabricQuery.group_by/aggregate) end-to-end at
+    # the store, so neither the EE /fabric/query route nor agent-tool callers
+    # can aggregate while the feature is dark.
+    fabric_analyst: bool = Field(
+        default=False,
+        description=(
+            "Enable the Fabric self-serve-analysis read engine (S1): SQL "
+            "GROUP BY aggregation + human-readable reasoning steps on "
+            "FabricStore.query / POST /fabric/query. When False (the default) a "
+            "query carrying group_by/aggregate is rejected with a clear "
+            "FabricAnalystDisabledError (HTTP 422, code fabric.analyst_disabled) "
+            "— fail-loud, never silent degrade; plain queries are unaffected "
+            "either way. Set via POCKETPAW_FABRIC_ANALYST."
         ),
     )
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,12 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-07-11 (feat/external-alerting-c2c3): Added ``automation_evaluator_autostart``
+    (default True, env POCKETPAW_AUTOMATION_EVALUATOR_AUTOSTART) — the OSS
+    always-on automation switch. When on (default), the background
+    AutomationEvaluator starts at dashboard boot so threshold rules fire without
+    a manual POST /automations/evaluator/start. A new default-ON flag is safe: a
+    fresh install with no enabled rules just sleeps.
   - 2026-07-02 (feat/judge-shadow-1168): Added the LLM-as-judge SHADOW settings
     (J-1, issue #1168) — ``deep_work_verify_judge_shadow_enabled`` (default
     False; when True AND deep_work_verify_loop_enabled is on, every completing
@@ -1706,6 +1712,17 @@ class Settings(BaseSettings):
             "the live gate. Off by default — the template-rule path is unchanged "
             "and the whole discovered branch is dead code on the default path. "
             "Set via POCKETPAW_INSTINCT_ENFORCE_DISCOVERED_RULES."
+        ),
+    )
+    automation_evaluator_autostart: bool = Field(
+        default=True,
+        description=(
+            "When true (the default), the background AutomationEvaluator starts at "
+            "dashboard boot so threshold/data-change rules fire without a manual "
+            "POST /automations/evaluator/start. This is the OSS always-on automation "
+            "switch — a new flag defaulting ON is safe because a fresh install with no "
+            "enabled rules does nothing but sleep. Set POCKETPAW_AUTOMATION_EVALUATOR_"
+            "AUTOSTART=false to keep the evaluator dormant until started via the router."
         ),
     )
 

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -12,6 +12,15 @@
 #   existing ObjectType by id (the EE Firestore→Fabric worker's per-workspace
 #   mapping) ride this same canonical upsert loop instead of hand-rolling a
 #   parallel one. Additive; name-based callers are unchanged.
+# Updated: 2026-07-11 (feat/real-pipeline-s1) — added the connector→Fabric
+#   INGESTOR REGISTRY: ``IngestorFn`` (the ``(store, *, workspace_id, user_id)
+#   -> IngestResult`` contract), the ``FABRIC_INGESTORS`` dict, and
+#   ``get_fabric_ingestor()`` which lazily seeds the built-ins (gcalendar's
+#   existing ``ingest_to_fabric``) on first lookup. The seed is LAZY because
+#   adapters/gcalendar.py imports FabricMapping/ingest_records from THIS
+#   module — an eager top-level import back into the adapter would be
+#   circular. Registry lives OSS; the EE fabric_ingest service lazy-imports
+#   it (no OSS→EE edge).
 # Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ensure_type() now
 #   threads ``workspace_id`` into both the get_type_by_name() resolve and the
 #   define_type() create, so the type catalog stays per-tenant: a connector
@@ -58,7 +67,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -68,6 +77,41 @@ from pocketpaw.fabric.store import FabricStore
 # A field projection value is either a record key (str) or a callable that
 # derives the value from the whole record (for normalization / joins).
 FieldSource = str | Callable[[Mapping[str, Any]], Any]
+
+# The connector→Fabric ingestor contract: pull this connector's records and
+# land them as typed Fabric objects in ``store``, scoped to ``workspace_id``
+# and reading with ``user_id``'s per-user OAuth token bucket (``None`` = the
+# shared/workspace bucket). Concretely ``(store, *, workspace_id, user_id)
+# -> IngestResult`` — extra keyword defaults (e.g. gcalendar's ``days_ahead``)
+# are allowed but callers pass only the contract kwargs.
+IngestorFn = Callable[..., Awaitable["IngestResult"]]
+
+# Registry of connector-name → ingestor. Built-ins are seeded LAZILY by
+# ``get_fabric_ingestor`` (adapters import FabricMapping/ingest_records from
+# this module, so an eager import back into an adapter would be circular).
+# Third-party/OSS callers may register additional ingestors directly.
+FABRIC_INGESTORS: dict[str, IngestorFn] = {}
+
+
+def _seed_builtin_ingestors() -> None:
+    """Populate ``FABRIC_INGESTORS`` with the built-in adapters (idempotent).
+
+    ``setdefault`` so a test double or an explicit registration installed
+    before the first lookup is never clobbered.
+    """
+    from pocketpaw.connectors.adapters.gcalendar import GoogleCalendarConnector
+
+    FABRIC_INGESTORS.setdefault("gcalendar", GoogleCalendarConnector().ingest_to_fabric)
+
+
+def get_fabric_ingestor(connector_id: str) -> IngestorFn | None:
+    """Resolve the registered ingestor for ``connector_id`` (or ``None``).
+
+    Seeds the built-ins on first use — the one lookup path callers (the EE
+    fabric_ingest dispatch) should go through instead of reading the dict raw.
+    """
+    _seed_builtin_ingestors()
+    return FABRIC_INGESTORS.get(connector_id)
 
 
 @dataclass(frozen=True)

--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -7,6 +7,11 @@ Extracted from dashboard.py — contains:
 - ``shutdown_event()`` — tears down all services
 
 Changes:
+- 2026-07-11 (feat/external-alerting-c2c3): ``startup_event`` now autostarts the
+  ``AutomationEvaluator`` (background threshold/data-change rule loop) when
+  ``settings.automation_evaluator_autostart`` is true (the default) — the OSS
+  always-on automation switch. Same best-effort + ``_register_lifecycle``
+  shutdown pattern as AlertManager, so a clean shutdown cancels the loop.
 - 2026-05-22: ``startup_event`` also mirrors the built-in pocket
   templates into ``~/.pocketpaw/templates/`` via the
   ``bundled_templates`` installer — same best-effort, catch-and-log
@@ -332,6 +337,24 @@ async def startup_event(
         logger.info("AlertManager started")
     except Exception as e:
         logger.warning("Failed to start AlertManager: %s", e)
+
+    # Start the AutomationEvaluator (background loop that fires threshold /
+    # data-change automation rules). Default-ON via
+    # ``automation_evaluator_autostart`` so external-alerting automations run
+    # without a manual POST /automations/evaluator/start — the OSS always-on
+    # switch. Same best-effort, register-shutdown pattern as AlertManager so a
+    # clean shutdown cancels the loop (mirrors the alert_manager lifecycle). A
+    # fresh install with no enabled rules just sleeps, so the default is safe.
+    if settings.automation_evaluator_autostart:
+        try:
+            from pocketpaw.automations.evaluator import get_evaluator
+
+            evaluator = get_evaluator()
+            evaluator.start()
+            _register_lifecycle("automation_evaluator", shutdown=evaluator.stop)
+            logger.info("AutomationEvaluator started")
+        except Exception as e:
+            logger.warning("Failed to start AutomationEvaluator: %s", e)
 
     # Start ChannelHealthStore (connects/disconnects uptime tracking)
     try:

--- a/src/pocketpaw/fabric/models.py
+++ b/src/pocketpaw/fabric/models.py
@@ -28,6 +28,18 @@
 #   legacy/global type predating tenancy (or an OSS / single-tenant caller),
 #   which a scoped read still sees — exactly the NULL-as-legacy boundary the
 #   W4a object/link scoping already uses.
+# Updated: 2026-07-10 (ontology-operator-ux) — two additions that make the Fabric
+#   ontology operable by a non-engineer:
+#     1. ObjectType gains a ``version`` int (starts at 1). ``FabricStore.update_type``
+#        bumps it when the operator renames a property or adds one, so the schema
+#        carries a monotonic version the UI can surface. Additive ALTER migration on
+#        a pre-existing DB (see the store); a pre-version row reads back as 1.
+#     2. ``FabricTypeError`` (a ``ValueError`` subclass) — raised by the store's
+#        write-time property validation when a provided property value clashes with
+#        its declared ``PropertyDef.type`` / ``enum_values``. Framework-agnostic on
+#        purpose: the EE router maps it to a 422, agent-tool callers (which already
+#        catch ValueError) degrade to a readable message, and the OSS store never
+#        imports FastAPI.
 
 from __future__ import annotations
 
@@ -43,6 +55,19 @@ from pydantic import BaseModel, Field, field_validator
 # practice (the audit's hardest case is two); anything deeper is almost
 # certainly a mistake and is rejected up front with a clear error.
 MAX_HOPS = 5
+
+
+class FabricTypeError(ValueError):
+    """A write-time property value clashes with its declared type (ontology-operator-ux).
+
+    Raised by :func:`pocketpaw.fabric.store.validate_object_properties` when a
+    provided property value does not satisfy the ``PropertyDef`` declared for it
+    on the object's ``ObjectType`` (wrong scalar kind, or a value outside a
+    declared ``enum_values`` set). A ``ValueError`` subclass so the OSS store can
+    stay framework-agnostic: the EE Fabric router catches it and returns HTTP 422,
+    while agent-tool / connector callers that already guard ``ValueError`` fall
+    back to a readable message instead of a 500.
+    """
 
 
 def _gen_id(prefix: str) -> str:
@@ -79,6 +104,10 @@ class ObjectType(BaseModel):
     # legacy/global type written before per-type tenancy or by an OSS /
     # single-tenant caller; a scoped read still sees it (own rows + NULL).
     workspace_id: str | None = None
+    # Schema version (ontology-operator-ux). Starts at 1 on define_type and is
+    # bumped by FabricStore.update_type on a non-destructive schema change (a
+    # property rename or an additive add). A pre-version DB row reads back as 1.
+    version: int = 1
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
 

--- a/src/pocketpaw/fabric/models.py
+++ b/src/pocketpaw/fabric/models.py
@@ -40,13 +40,32 @@
 #        purpose: the EE router maps it to a 422, agent-tool callers (which already
 #        catch ValueError) degrade to a readable message, and the OSS store never
 #        imports FastAPI.
+# Updated: 2026-07-11 (self-serve-analysis S1) — transparent-analysis read engine,
+#   additive and flag-gated (POCKETPAW_FABRIC_ANALYST):
+#     1. FabricQuery gains optional aggregation fields: ``group_by`` (a property
+#        key to group on), ``aggregate`` (count/sum/avg/min/max, defaults to
+#        "count" when only group_by is set), ``aggregate_field`` (the numeric
+#        property sum/avg/min/max read), ``ranges`` (RangeBucket numeric buckets
+#        for the group key), and ``sort`` (order of the aggregate output). A
+#        model validator normalizes/rejects inconsistent combinations (aggregate
+#        without group_by, sum without aggregate_field, ranges/sort without
+#        group_by, aggregation combined with ``path``).
+#     2. ``QueryPlanStep {title, detail?, status?}`` — one human-readable
+#        reasoning step of an aggregation run; the shape ripple's ReasoningTrace
+#        consumes (never {label, count}).
+#     3. FabricQueryResult gains ``aggregates`` (list of {key, value} group rows)
+#        and ``steps`` (list[QueryPlanStep]); both default None so plain-query
+#        responses are unchanged.
+#     4. ``FabricAnalystDisabledError`` (a ``ValueError`` subclass) — raised by
+#        the store when an aggregation query arrives while the
+#        POCKETPAW_FABRIC_ANALYST flag is off; the EE router maps it to 422.
 
 from __future__ import annotations
 
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Cap on path depth (number of hops) for a multi-hop FabricQuery. A path is
 # resolved iteratively, one DB round-trip per hop, with no cycle de-duplication
@@ -67,6 +86,22 @@ class FabricTypeError(ValueError):
     stay framework-agnostic: the EE Fabric router catches it and returns HTTP 422,
     while agent-tool / connector callers that already guard ``ValueError`` fall
     back to a readable message instead of a 500.
+    """
+
+
+class FabricAnalystDisabledError(ValueError):
+    """An aggregation query arrived while the analyst flag is off (self-serve-analysis S1).
+
+    Raised by :meth:`pocketpaw.fabric.store.FabricStore.query` when a
+    ``FabricQuery`` carries ``group_by`` / ``aggregate`` but the
+    ``POCKETPAW_FABRIC_ANALYST`` settings flag is False (the default). The
+    contract is FAIL-LOUD, not silent-degrade: the aggregation fields are
+    accepted by the model (so the wire schema is stable and discoverable) and
+    the STORE rejects the run with this error, which the EE Fabric router maps
+    to HTTP 422 (code ``fabric.analyst_disabled``). A ``ValueError`` subclass so
+    the OSS store stays framework-agnostic and agent-tool callers that already
+    guard ``ValueError`` degrade to a readable message. Plain (non-aggregation)
+    queries are never affected by the flag.
     """
 
 
@@ -165,6 +200,63 @@ class PathHop(BaseModel):
     direction: Literal["out", "in", "any"] = "out"
 
 
+class QueryPlanStep(BaseModel):
+    """One human-readable reasoning step of an analysis run (self-serve-analysis S1).
+
+    The transparent-analysis contract consumed by ripple's ReasoningTrace widget:
+    exactly ``{title, detail?, status?}``. ``title`` is the short human sentence
+    ("Grouped by category"), ``detail`` an optional elaboration ("4 groups from
+    128 objects"), ``status`` an optional lifecycle marker — the read engine
+    emits "done" for completed steps; "thinking" is reserved for streaming
+    surfaces that render in-progress steps.
+    """
+
+    title: str
+    detail: str | None = None
+    status: Literal["thinking", "done"] | None = None
+
+
+class RangeBucket(BaseModel):
+    """One numeric bucket for a range-grouped aggregation (self-serve-analysis S1).
+
+    Buckets the ``FabricQuery.group_by`` property by value: an object falls into
+    the bucket when ``min <= value < max`` (min inclusive, max exclusive; either
+    bound may be omitted for an open-ended bucket, but not both). ``label`` is
+    the group key reported in the aggregate output; when omitted it is derived
+    from the bounds ("100-500", "<100", ">=500"). Objects matching no bucket
+    (including non-numeric / missing values) are dropped from the aggregation.
+    """
+
+    label: str | None = None
+    min: float | None = None
+    max: float | None = None
+
+    @model_validator(mode="after")
+    def _require_a_bound(self) -> RangeBucket:
+        if self.min is None and self.max is None:
+            raise ValueError("a range bucket needs at least one of min/max")
+        return self
+
+    def resolved_label(self) -> str:
+        """The group key this bucket reports — explicit label or derived bounds."""
+        if self.label:
+            return self.label
+        if self.min is None:
+            return f"<{self.max:g}"
+        if self.max is None:
+            return f">={self.min:g}"
+        return f"{self.min:g}-{self.max:g}"
+
+
+# Aggregation functions the analyst read engine supports. ``count`` counts
+# matching objects per group; the rest fold a numeric property
+# (``aggregate_field``) per group.
+AggregateFn = Literal["count", "sum", "avg", "min", "max"]
+
+# Sort orders for the aggregate output rows.
+AggregateSort = Literal["value_desc", "value_asc", "key_asc", "key_desc"]
+
+
 class FabricQuery(BaseModel):
     """Query parameters for finding objects.
 
@@ -181,6 +273,18 @@ class FabricQuery(BaseModel):
     ``FabricStore.query`` for the traversal contract. ``path`` and the legacy
     single-hop ``link_type`` are mutually exclusive (``path`` wins when both are
     present, and ``link_type`` is ignored — the per-hop ``link_type`` governs).
+
+    Aggregation (self-serve-analysis S1, additive, flag-gated on
+    POCKETPAW_FABRIC_ANALYST): set ``group_by`` (and optionally ``aggregate`` —
+    it defaults to "count") to fold the workspace-scoped, filtered result set
+    into per-group aggregate rows instead of object rows. ``aggregate_field``
+    names the numeric property sum/avg/min/max read; ``ranges`` buckets a
+    numeric group key; ``sort`` orders the aggregate rows (default: value
+    descending). Aggregation composes with ``type_name``/``type_id``/``filters``
+    /``linked_to`` but NOT with ``path`` (rejected — slice 1 aggregates the flat
+    WHERE path only). Scope-then-aggregate: the workspace scope and filters are
+    applied BEFORE grouping, so a cross-workspace object can never leak into a
+    group total.
     """
 
     type_name: str | None = None
@@ -189,6 +293,11 @@ class FabricQuery(BaseModel):
     linked_to: str | None = None
     link_type: str | None = None
     path: list[PathHop] = Field(default_factory=list)
+    group_by: str | None = None
+    aggregate: AggregateFn | None = None
+    aggregate_field: str | None = None
+    ranges: list[RangeBucket] | None = None
+    sort: AggregateSort | None = None
     limit: int = 50
     offset: int = 0
 
@@ -210,10 +319,57 @@ class FabricQuery(BaseModel):
             )
         return value
 
+    @model_validator(mode="after")
+    def _normalize_aggregation(self) -> FabricQuery:
+        """Normalize + validate the aggregation field combination (S1).
+
+        - ``group_by`` alone implies ``aggregate="count"`` (the forgiving
+          default a self-serve caller expects).
+        - ``aggregate`` / ``aggregate_field`` / ``ranges`` / ``sort`` without
+          ``group_by`` is inconsistent -> rejected with a readable error.
+        - sum/avg/min/max fold a numeric property, so they REQUIRE
+          ``aggregate_field``; ``count`` counts rows and must not carry one.
+        - Aggregation over a ``path`` traversal is out of scope for slice 1 ->
+          rejected (the flat WHERE path is the only aggregation surface).
+        - ``group_by`` / ``aggregate_field`` must be plain identifier property
+          names (alnum + underscore), mirroring the filter-key rule, so the
+          error surfaces at the model boundary instead of deep in the store.
+        """
+        if self.group_by is not None and self.aggregate is None:
+            self.aggregate = "count"
+        if self.group_by is None:
+            for name in ("aggregate", "aggregate_field", "ranges", "sort"):
+                if getattr(self, name) is not None:
+                    raise ValueError(f"{name} requires group_by to be set")
+            return self
+        if self.path:
+            raise ValueError(
+                "aggregation (group_by/aggregate) cannot be combined with a "
+                "path traversal; aggregate the flat filtered set instead"
+            )
+        for label, name in (("group_by", self.group_by), ("aggregate_field", self.aggregate_field)):
+            if name is not None and (not name or not all(c.isalnum() or c == "_" for c in name)):
+                raise ValueError(f"Invalid {label} property name: {name!r}")
+        if self.aggregate == "count":
+            if self.aggregate_field is not None:
+                raise ValueError('aggregate="count" does not take an aggregate_field')
+        elif self.aggregate_field is None:
+            raise ValueError(f'aggregate="{self.aggregate}" requires an aggregate_field')
+        return self
+
 
 class FabricQueryResult(BaseModel):
-    """Result of a fabric query."""
+    """Result of a fabric query.
+
+    Aggregation queries (self-serve-analysis S1) return ``objects=[]`` and
+    populate ``aggregates`` — one ``{"key": <group>, "value": <aggregate>}``
+    row per group — plus ``steps``, the human-readable reasoning trace
+    (:class:`QueryPlanStep`). Both fields default to ``None`` so plain-query
+    results are byte-compatible with the pre-S1 shape.
+    """
 
     objects: list[FabricObject]
     total: int
     links: list[FabricLink] = Field(default_factory=list)
+    aggregates: list[dict[str, Any]] | None = None
+    steps: list[QueryPlanStep] | None = None

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -143,6 +143,31 @@
 #   gets truncated instead of growing unbounded across 128+ cached tenants. The
 #   W4a in-row workspace_id WHERE-filter is UNCHANGED — physical file isolation
 #   is ADDITIVE defense-in-depth layered on top of it, never a replacement.
+# Updated: 2026-07-10 (ontology-operator-ux) — makes the ontology operable by a
+#   non-engineer, in three additive pieces:
+#     1. WRITE-TIME TYPE ENFORCEMENT. ``validate_object_properties()`` checks a
+#        provided property bag against the type's declared ``PropertyDef``s and
+#        raises ``FabricTypeError`` on a clash. ``create_object`` and
+#        ``update_object`` now call it (create validates the full bag; update
+#        validates only the provided delta). Enforcement is DECLARED-ONLY and
+#        LENIENT by design so it never breaks live connector / agent ingest: only
+#        declared properties are checked, a ``None`` / absent value is skipped
+#        (``required`` is NOT enforced at write time), unknown keys pass through,
+#        an empty schema is a no-op, and scalar checks accept the JSON-string form
+#        of a number/bool/date (a connector often ships "42"). A genuinely wrong
+#        value — "not-a-number" for a ``number`` field, a value outside a declared
+#        ``enum`` — is rejected.
+#     2. SCHEMA VERSIONING + NON-DESTRUCTIVE MIGRATION. ``fabric_object_types``
+#        gains a ``version INTEGER DEFAULT 1`` column (additive ALTER, swallow the
+#        duplicate-column error like the W4a/SZD-2 tenancy columns). ``update_type``
+#        bumps the version and migrates existing objects for a property RENAME (the
+#        key is moved on every object of the type) and an ADDITIVE add (a new
+#        property carrying a default is backfilled onto objects that lack it).
+#        DESTRUCTIVE removal is DEFERRED: a property dropped from the schema leaves
+#        its now-orphaned key untouched on existing objects (documented behaviour,
+#        asserted in tests).
+#     3. Both are OSS-side and framework-agnostic; ``FabricTypeError`` lives in
+#        models so the EE router (422) and OSS callers (ValueError) both consume it.
 
 
 from __future__ import annotations
@@ -159,6 +184,7 @@ from pocketpaw.fabric.models import (
     FabricObject,
     FabricQuery,
     FabricQueryResult,
+    FabricTypeError,
     ObjectType,
     PathHop,
     PropertyDef,
@@ -190,6 +216,10 @@ CREATE TABLE IF NOT EXISTS fabric_object_types (
     -- a scoped read still sees it (own rows + NULL). On a pre-SZD-2 DB this
     -- column is added by the ALTER migration in _ensure_schema, NOT here.
     workspace_id TEXT,
+    -- Schema version (ontology-operator-ux). 1 on define_type; bumped by
+    -- update_type on a non-destructive change (rename / additive add). On a
+    -- pre-version DB this column is added by the ALTER migration, NOT here.
+    version INTEGER DEFAULT 1,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -370,6 +400,103 @@ def _build_filter_conditions(filters: dict[str, Any]) -> tuple[list[str], list[A
     return conditions, params
 
 
+def _looks_numeric(value: Any) -> bool:
+    """True if ``value`` is a real number or a string that parses as one.
+
+    A connector routinely ships a number as a string ("42", "3.14"), so a
+    tolerant check keeps write-time enforcement from breaking live ingest while
+    still rejecting genuine garbage ("not-a-number"). ``bool`` is excluded — it
+    is an ``int`` subclass in Python but is never a valid ``number`` value.
+    """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, str):
+        try:
+            float(value.strip())
+            return True
+        except ValueError:
+            return False
+    return False
+
+
+def _property_value_ok(prop: PropertyDef, value: Any) -> bool:
+    """Return True if ``value`` satisfies ``prop``'s declared type (lenient).
+
+    Enforcement is deliberately tolerant so it never breaks live connector /
+    agent writes (see the module header). Rules per declared ``type``:
+
+    - ``number`` — a real number OR a numeric string (``_looks_numeric``).
+    - ``boolean`` — a ``bool``, ``0`` / ``1``, or a common truthy/falsy string.
+    - ``date`` — a string or a number (an ISO string or an epoch); a
+      ``dict`` / ``list`` / bare ``bool`` is rejected.
+    - ``enum`` — membership in ``enum_values`` (compared directly and as a
+      string) when that set is declared; no constraint when it is empty.
+    - ``string`` / anything unknown — any non-``None`` scalar-or-not is accepted
+      (string fields stay lenient; the meaningful checks are the ones above).
+
+    ``None`` is handled by the caller (skipped — absence is not a type clash).
+    """
+    declared = (prop.type or "string").strip().lower()
+    if declared == "number":
+        return _looks_numeric(value)
+    if declared == "boolean":
+        if isinstance(value, bool):
+            return True
+        if isinstance(value, int) and value in (0, 1):
+            return True
+        return isinstance(value, str) and value.strip().lower() in {
+            "true",
+            "false",
+            "1",
+            "0",
+            "yes",
+            "no",
+        }
+    if declared == "date":
+        return isinstance(value, str) or (
+            isinstance(value, (int, float)) and not isinstance(value, bool)
+        )
+    if declared == "enum":
+        allowed = prop.enum_values or []
+        if not allowed:
+            return True
+        return value in allowed or str(value) in {str(a) for a in allowed}
+    # string / unknown declared type -> no strict constraint.
+    return True
+
+
+def validate_object_properties(obj_type: ObjectType | None, properties: dict[str, Any]) -> None:
+    """Enforce a property bag against a type's declared schema (ontology-operator-ux).
+
+    Raises :class:`FabricTypeError` on the FIRST declared property whose provided
+    value clashes with its ``PropertyDef.type`` / ``enum_values``. Declared-only
+    and lenient by design (see the module header and :func:`_property_value_ok`):
+
+    - ``obj_type is None`` or a type with NO declared properties -> no-op (every
+      pre-schema type and every ``properties=[]`` type keeps working unchanged).
+    - only keys that are BOTH declared AND present with a non-``None`` value are
+      checked; ``required`` is NOT enforced at write time, and unknown extra keys
+      pass through (the schema is open / additive).
+    """
+    if obj_type is None or not obj_type.properties:
+        return
+    declared = {p.name: p for p in obj_type.properties}
+    for key, value in properties.items():
+        prop = declared.get(key)
+        if prop is None or value is None:
+            continue
+        if not _property_value_ok(prop, value):
+            expected = prop.type
+            if prop.type == "enum" and prop.enum_values:
+                expected = f"enum{list(prop.enum_values)}"
+            raise FabricTypeError(
+                f"property {key!r} expected type {expected!r} "
+                f"but got {value!r} ({type(value).__name__})"
+            )
+
+
 class FabricStore:
     """Async SQLite store for Fabric ontology data."""
 
@@ -395,6 +522,16 @@ class FabricStore:
                     await db.execute(f"ALTER TABLE {_tbl} ADD COLUMN workspace_id TEXT")
                 except aiosqlite.OperationalError:
                     pass
+            # Additive migration (ontology-operator-ux): the schema-version column
+            # on a pre-existing fabric_object_types. Same swallow-the-duplicate
+            # pattern as the tenancy columns above — a pre-version row defaults to
+            # 1, matching the ObjectType model default.
+            try:
+                await db.execute(
+                    "ALTER TABLE fabric_object_types ADD COLUMN version INTEGER DEFAULT 1"
+                )
+            except aiosqlite.OperationalError:
+                pass
             # SZD-2: drop the pre-SZD-2 GLOBAL unique index on LOWER(name) if it
             # exists. It enforced one type name per WHOLE DB; under per-workspace
             # tenancy two tenants must be able to use the same name, so it would
@@ -593,8 +730,9 @@ class FabricStore:
         async with self._conn() as db:
             await db.execute(
                 "INSERT INTO fabric_object_types"
-                " (id, name, description, icon, color, properties_schema, workspace_id)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                " (id, name, description, icon, color, properties_schema,"
+                " workspace_id, version)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     obj_type.id,
                     obj_type.name,
@@ -603,6 +741,7 @@ class FabricStore:
                     obj_type.color,
                     json.dumps([p.model_dump() for p in properties]),
                     workspace_id,
+                    obj_type.version,
                 ),
             )
             await db.commit()
@@ -706,6 +845,116 @@ class FabricStore:
             await db.execute("DELETE FROM fabric_object_types WHERE id = ?", (type_id,))
             await db.commit()
 
+    async def update_type(
+        self,
+        type_id: str,
+        *,
+        properties: list[PropertyDef] | None = None,
+        renames: dict[str, str] | None = None,
+        description: str | None = None,
+        icon: str | None = None,
+        color: str | None = None,
+        workspace_id: str | None = None,
+    ) -> ObjectType | None:
+        """Version + non-destructively migrate an object type (ontology-operator-ux).
+
+        The operator's "edit the schema" path. Bumps ``version`` and migrates the
+        type's existing objects for the two SAFE change kinds:
+
+        - **rename** — ``renames`` maps ``old_property_name -> new_property_name``.
+          The key is moved on the type's schema AND on every existing object of
+          the type (value preserved), so no object is orphaned by the rename.
+        - **additive add** — a ``PropertyDef`` present in the new ``properties``
+          that the type did not declare before. If it carries a non-``None``
+          ``default``, that default is backfilled onto every existing object that
+          lacks the key; otherwise the property is simply declared (existing
+          objects gain it lazily on their next write).
+
+        **Destructive removal is DEFERRED.** If ``properties`` omits a property the
+        type previously declared (and it is not the source of a rename), the
+        declaration is dropped but the now-orphaned key is LEFT UNTOUCHED on
+        existing objects — no data is scrubbed. This is the documented, intentional
+        behaviour for this build (a later task adds an explicit, opt-in purge).
+
+        Returns the updated :class:`ObjectType`, or ``None`` if ``type_id`` does
+        not resolve within ``workspace_id`` (a cross-tenant / unknown id). Passing
+        neither ``properties`` nor ``renames`` still bumps the version and applies
+        any metadata (``description`` / ``icon`` / ``color``) change.
+        """
+        existing = await self.get_type(type_id, workspace_id=workspace_id)
+        if existing is None:
+            return None
+        renames = {k: v for k, v in (renames or {}).items() if k != v}
+
+        # Resolve the NEW schema. Start from the caller's list (or keep the old
+        # one), then fold in renames so a rename is reflected even when the caller
+        # passes an unchanged property list.
+        new_props = list(properties) if properties is not None else list(existing.properties)
+        if renames:
+            for prop in new_props:
+                if prop.name in renames:
+                    prop.name = renames[prop.name]
+
+        old_names = {p.name for p in existing.properties}
+        # Additive properties carrying a default -> backfill onto existing objects.
+        additive_defaults = {
+            p.name: p.default
+            for p in new_props
+            if p.name not in old_names and p.name not in renames.values() and p.default is not None
+        }
+
+        new_version = (existing.version or 1) + 1
+        schema_json = json.dumps([p.model_dump() for p in new_props])
+        new_description = description if description is not None else existing.description
+        new_icon = icon if icon is not None else existing.icon
+        new_color = color if color is not None else existing.color
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            # 1. Migrate existing objects (rename keys + additive default backfill).
+            if renames or additive_defaults:
+                async with db.execute(
+                    "SELECT id, properties FROM fabric_objects WHERE type_id = ?",
+                    (type_id,),
+                ) as cur:
+                    rows = await cur.fetchall()
+                for row in rows:
+                    props = json.loads(row["properties"]) if row["properties"] else {}
+                    changed = False
+                    for old_name, new_name in renames.items():
+                        if old_name in props:
+                            props[new_name] = props.pop(old_name)
+                            changed = True
+                    for name, default in additive_defaults.items():
+                        if name not in props:
+                            props[name] = default
+                            changed = True
+                    if changed:
+                        await db.execute(
+                            "UPDATE fabric_objects SET properties = ?,"
+                            " updated_at = datetime('now') WHERE id = ?",
+                            (json.dumps(props), row["id"]),
+                        )
+            # 2. Persist the new schema + bumped version on the type row.
+            await db.execute(
+                "UPDATE fabric_object_types SET properties_schema = ?, version = ?,"
+                " description = ?, icon = ?, color = ?, updated_at = datetime('now')"
+                " WHERE id = ?",
+                (schema_json, new_version, new_description, new_icon, new_color, type_id),
+            )
+            await db.commit()
+        return ObjectType(
+            id=existing.id,
+            name=existing.name,
+            description=new_description,
+            icon=new_icon,
+            color=new_color,
+            properties=new_props,
+            workspace_id=existing.workspace_id,
+            version=new_version,
+        )
+
     # --- Objects ---
 
     async def create_object(
@@ -717,6 +966,11 @@ class FabricStore:
         workspace_id: str | None = None,
     ) -> FabricObject:
         obj_type = await self.get_type(type_id)
+        # Write-time type enforcement (ontology-operator-ux): reject a property
+        # whose value clashes with its declared PropertyDef. Declared-only and
+        # lenient (see validate_object_properties) so pre-schema / empty-schema
+        # types and live connector ingest are unaffected.
+        validate_object_properties(obj_type, properties)
         obj = FabricObject(
             type_id=type_id,
             type_name=obj_type.name if obj_type else "",
@@ -821,6 +1075,11 @@ class FabricStore:
         existing = await self.get_object(obj_id, workspace_id=workspace_id)
         if not existing:
             return None
+        # Write-time type enforcement (ontology-operator-ux): validate the PROVIDED
+        # delta against the type's declared schema. Only the incoming keys are
+        # checked (a merge-update touches only those); the type is loaded unscoped
+        # because the object read above already carries the tenancy guard.
+        validate_object_properties(await self.get_type(existing.type_id), properties)
         merged = {**existing.properties, **properties}
         ws_cond, ws_params = _workspace_scope(workspace_id)
         sql = "UPDATE fabric_objects SET properties = ?, updated_at = datetime('now') WHERE id = ?"
@@ -1320,6 +1579,9 @@ class FabricStore:
         # column (defensive — current callers all SELECT *).
         keys = row.keys() if hasattr(row, "keys") else ()
         workspace_id = row["workspace_id"] if "workspace_id" in keys else None
+        # version may be absent on a projection that predates the column; a NULL
+        # (pre-migration row) reads back as the model default of 1.
+        version = row["version"] if "version" in keys and row["version"] is not None else 1
         return ObjectType(
             id=row["id"],
             name=row["name"],
@@ -1328,6 +1590,7 @@ class FabricStore:
             color=row["color"] or "#0A84FF",
             properties=[PropertyDef(**p) for p in props_raw],
             workspace_id=workspace_id,
+            version=version,
         )
 
     def _row_to_object(self, row: Any) -> FabricObject:

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -168,6 +168,12 @@
 #        asserted in tests).
 #     3. Both are OSS-side and framework-agnostic; ``FabricTypeError`` lives in
 #        models so the EE router (422) and OSS callers (ValueError) both consume it.
+# Updated: 2026-07-11 (feat/paw-cli, C2) — added ``get_link(link_id,
+#   workspace_id=None)``, a scoped single-link read mirroring ``get_object``.
+#   It exists as the tenancy guard for deletes: ``unlink`` is deliberately
+#   unscoped, so multi-tenant callers (the EE DELETE /fabric/links route and
+#   the fabric MCP link-delete tool) resolve the link through this scoped read
+#   first and refuse a cross-tenant id.
 
 
 from __future__ import annotations
@@ -1190,6 +1196,29 @@ class FabricStore:
                 links = [self._row_to_link(row) async for row in cur]
 
         return links, total
+
+    async def get_link(self, link_id: str, workspace_id: str | None = None) -> FabricLink | None:
+        """Fetch one link by id, optionally scoped to ``workspace_id`` (W4a).
+
+        The scoped read is the tenancy guard for deletes: :meth:`unlink` is
+        deliberately unscoped (single-tenant OSS callers), so a multi-tenant
+        caller (the EE router / MCP tools) resolves the link THROUGH this scoped
+        read first — a cross-tenant ``link_id`` returns ``None`` (legacy
+        NULL-workspace links stay visible, matching :meth:`list_links`).
+        """
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "SELECT * FROM fabric_links WHERE id = ?"
+        params: list[Any] = [link_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(sql, params) as cur:
+                row = await cur.fetchone()
+        return self._row_to_link(row) if row else None
 
     async def unlink(self, link_id: str) -> None:
         await self._ensure_schema()

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -174,6 +174,20 @@
 #   unscoped, so multi-tenant callers (the EE DELETE /fabric/links route and
 #   the fabric MCP link-delete tool) resolve the link through this scoped read
 #   first and refuse a cross-tenant id.
+# Updated: 2026-07-11 (self-serve-analysis S1) — transparent-analysis read engine
+#   on ``query``: when a FabricQuery carries ``group_by``/``aggregate`` (and the
+#   POCKETPAW_FABRIC_ANALYST flag is ON — otherwise FabricAnalystDisabledError,
+#   fail-loud), the query runs as a SQL GROUP BY over the ALREADY workspace-scoped
+#   + filtered set (scope-then-aggregate: the same WHERE the plain path builds,
+#   extracted into ``_flat_query_conditions``, is applied BEFORE grouping so a
+#   cross-workspace object can never enter a group total). Supports
+#   count/sum/avg/min/max (numeric folds CAST to REAL like the numeric filters),
+#   optional RangeBucket bucketing of a numeric group key (a fully-parameterized
+#   CASE chain), and value/key sort. The result carries ``aggregates``
+#   ({key, value} rows, paginated by limit/offset) plus human-readable ``steps``
+#   (QueryPlanStep — the ReasoningTrace contract). Plain queries are untouched
+#   (same SQL, no steps); aggregation composes with filters/linked_to but not
+#   ``path`` (rejected at the model).
 
 
 from __future__ import annotations
@@ -186,6 +200,7 @@ from typing import Any
 import aiosqlite
 
 from pocketpaw.fabric.models import (
+    FabricAnalystDisabledError,
     FabricLink,
     FabricObject,
     FabricQuery,
@@ -194,6 +209,7 @@ from pocketpaw.fabric.models import (
     ObjectType,
     PathHop,
     PropertyDef,
+    QueryPlanStep,
 )
 
 logger = logging.getLogger(__name__)
@@ -404,6 +420,197 @@ def _build_filter_conditions(filters: dict[str, Any]) -> tuple[list[str], list[A
                 conditions.append(f"json_extract(o.properties, ?) {sql_op} ?")
                 params.extend([path, value])
     return conditions, params
+
+
+def _flat_query_conditions(q: FabricQuery, workspace_id: str | None) -> tuple[list[str], list[Any]]:
+    """Build the flat (non-path) WHERE fragments + params for a FabricQuery.
+
+    Extracted from ``FabricStore.query`` (self-serve-analysis S1) so the plain
+    fetch path and the aggregation path share ONE condition builder — the
+    scope-then-aggregate invariant holds by construction, not by parallel
+    maintenance. Covers type constraint, single-hop ``linked_to``/``link_type``,
+    property filters (``_build_filter_conditions``), and the W4a tenancy scope
+    (``_workspace_scope``). Every value is a bound ``?`` parameter.
+    """
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if q.type_id:
+        conditions.append("o.type_id = ?")
+        params.append(q.type_id)
+    elif q.type_name:
+        conditions.append("LOWER(o.type_name) = LOWER(?)")
+        params.append(q.type_name)
+
+    if q.linked_to:
+        if q.link_type:
+            link_cond = (
+                "o.id IN ("
+                "SELECT to_object_id FROM fabric_links"
+                " WHERE from_object_id = ? AND link_type = ? "
+                "UNION "
+                "SELECT from_object_id FROM fabric_links"
+                " WHERE to_object_id = ? AND link_type = ?"
+                ")"
+            )
+            conditions.append(link_cond)
+            params.extend([q.linked_to, q.link_type, q.linked_to, q.link_type])
+        else:
+            link_cond = (
+                "o.id IN ("
+                "SELECT to_object_id FROM fabric_links WHERE from_object_id = ? "
+                "UNION "
+                "SELECT from_object_id FROM fabric_links WHERE to_object_id = ?"
+                ")"
+            )
+            conditions.append(link_cond)
+            params.extend([q.linked_to, q.linked_to])
+
+    # Property filters against the JSON properties bag. Kept as a localized
+    # block (see _build_filter_conditions) so concurrent work on this method
+    # — e.g. workspace_id scoping — merges without touching this logic.
+    if q.filters:
+        filter_conditions, filter_params = _build_filter_conditions(q.filters)
+        conditions.extend(filter_conditions)
+        params.extend(filter_params)
+
+    # Tenancy scope (W4a) — an ADDITIONAL condition ANDed alongside the W0d
+    # property filters above, never a replacement for them. Restricts the
+    # result set to the caller's workspace plus legacy NULL-workspace rows.
+    ws_cond, ws_params = _workspace_scope(workspace_id, column="o.workspace_id")
+    if ws_cond:
+        conditions.append(ws_cond)
+        params.extend(ws_params)
+
+    return conditions, params
+
+
+# Aggregate function whitelist (self-serve-analysis S1): FabricQuery.aggregate
+# -> the SQL function name. Mirrors _FILTER_OPS — user input selects FROM this
+# fixed map and never reaches the SQL text itself.
+_AGG_FN_SQL: dict[str, str] = {
+    "sum": "SUM",
+    "avg": "AVG",
+    "min": "MIN",
+    "max": "MAX",
+}
+
+# Sort whitelist for the aggregate output rows. ``val``/``grp`` are the fixed
+# SELECT aliases; the default (sort=None) is value descending — "biggest group
+# first", the order an analyst reads.
+_AGG_SORT_SQL: dict[str, str] = {
+    "value_desc": "val DESC",
+    "value_asc": "val ASC",
+    "key_asc": "grp ASC",
+    "key_desc": "grp DESC",
+}
+
+
+def _group_key_expr(q: FabricQuery) -> tuple[str, list[Any]]:
+    """SQL expression + bound params for the GROUP BY key (S1).
+
+    Plain grouping extracts the raw JSON property value. With ``q.ranges`` the
+    numeric value (CAST to REAL, same affinity rule as numeric filters) is
+    bucketed by a CASE chain — bounds AND labels are bound ``?`` params, and a
+    value matching no bucket (or a missing property, which CASTs to NULL) falls
+    to ELSE NULL and is dropped by the caller's HAVING.
+    """
+    path = f"$.{q.group_by}"
+    if not q.ranges:
+        return "json_extract(o.properties, ?)", [path]
+
+    cast = "CAST(json_extract(o.properties, ?) AS REAL)"
+    whens: list[str] = []
+    params: list[Any] = []
+    for bucket in q.ranges:
+        conds: list[str] = []
+        # A NULL property must never match an open-ended bucket by accident:
+        # NULL comparisons yield NULL (not-matched) in SQLite, so the bound
+        # checks alone are safe — no explicit IS NOT NULL needed.
+        if bucket.min is not None:
+            conds.append(f"{cast} >= ?")
+            params.extend([path, bucket.min])
+        if bucket.max is not None:
+            conds.append(f"{cast} < ?")
+            params.extend([path, bucket.max])
+        whens.append(f"WHEN {' AND '.join(conds)} THEN ?")
+        params.append(bucket.resolved_label())
+    return f"CASE {' '.join(whens)} ELSE NULL END", params
+
+
+def _aggregate_expr(q: FabricQuery) -> tuple[str, list[Any]]:
+    """SQL expression + bound params for the aggregate value (S1).
+
+    ``count`` counts the rows in each group; the numeric folds read
+    ``aggregate_field`` CAST to REAL so "sum of price" adds numbers even when a
+    connector stored them as JSON strings (the same affinity rule the numeric
+    filter operators use). The function name comes from ``_AGG_FN_SQL``.
+    """
+    if q.aggregate == "count":
+        return "COUNT(*)", []
+    fn = _AGG_FN_SQL[q.aggregate or ""]
+    return f"{fn}(CAST(json_extract(o.properties, ?) AS REAL))", [f"$.{q.aggregate_field}"]
+
+
+def _describe_filters(filters: dict[str, Any]) -> str:
+    """Human-readable one-line summary of a FabricQuery.filters bag (S1 steps)."""
+    parts: list[str] = []
+    for key, raw_val in filters.items():
+        if isinstance(raw_val, dict):
+            for op, value in raw_val.items():
+                parts.append(f"{key} {op} {value}")
+        else:
+            parts.append(f"{key} = {raw_val}")
+    return " and ".join(parts)
+
+
+def _build_plan_steps(q: FabricQuery, *, total: int, group_count: int) -> list[QueryPlanStep]:
+    """The human-readable reasoning trace for an aggregation run (S1).
+
+    Emits the ``{title, detail?, status?}`` QueryPlanStep contract ripple's
+    ReasoningTrace consumes: what was filtered/scanned (with the matched-object
+    count), how it was grouped (property or range buckets), and what was
+    computed. Every step is ``status="done"`` — the read engine reports a
+    finished run; "thinking" is for streaming surfaces.
+    """
+    type_label = q.type_name or q.type_id or "objects"
+    steps: list[QueryPlanStep] = []
+    if q.filters:
+        steps.append(
+            QueryPlanStep(
+                title=f"Filtered {type_label} where {_describe_filters(q.filters)}",
+                detail=f"{total} matching objects",
+                status="done",
+            )
+        )
+    else:
+        steps.append(
+            QueryPlanStep(
+                title=f"Scanned {type_label}",
+                detail=f"{total} objects",
+                status="done",
+            )
+        )
+    groups_label = f"{group_count} group{'s' if group_count != 1 else ''}"
+    grouped_detail = (
+        f"{len(q.ranges)} value range{'s' if len(q.ranges) != 1 else ''}"
+        if q.ranges
+        else groups_label
+    )
+    steps.append(
+        QueryPlanStep(title=f"Grouped by {q.group_by}", detail=grouped_detail, status="done")
+    )
+    computed = f"Computed {q.aggregate}"
+    if q.aggregate_field:
+        computed += f" of {q.aggregate_field}"
+    steps.append(
+        QueryPlanStep(
+            title=computed,
+            detail=f"{groups_label} from {total} objects",
+            status="done",
+        )
+    )
+    return steps
 
 
 def _looks_numeric(value: Any) -> bool:
@@ -1310,57 +1517,13 @@ class FabricStore:
         await self._ensure_schema()
         if q.path:
             return await self._query_path(q, workspace_id)
+        if q.group_by:
+            # Self-serve-analysis S1: aggregation runs over the SAME flat
+            # scoped+filtered WHERE the plain path builds (scope-then-aggregate).
+            # Flag-gated inside — a dark feature rejects fail-loud.
+            return await self._query_aggregate(q, workspace_id)
 
-        conditions: list[str] = []
-        params: list[Any] = []
-
-        if q.type_id:
-            conditions.append("o.type_id = ?")
-            params.append(q.type_id)
-        elif q.type_name:
-            conditions.append("LOWER(o.type_name) = LOWER(?)")
-            params.append(q.type_name)
-
-        if q.linked_to:
-            if q.link_type:
-                link_cond = (
-                    "o.id IN ("
-                    "SELECT to_object_id FROM fabric_links"
-                    " WHERE from_object_id = ? AND link_type = ? "
-                    "UNION "
-                    "SELECT from_object_id FROM fabric_links"
-                    " WHERE to_object_id = ? AND link_type = ?"
-                    ")"
-                )
-                conditions.append(link_cond)
-                params.extend([q.linked_to, q.link_type, q.linked_to, q.link_type])
-            else:
-                link_cond = (
-                    "o.id IN ("
-                    "SELECT to_object_id FROM fabric_links WHERE from_object_id = ? "
-                    "UNION "
-                    "SELECT from_object_id FROM fabric_links WHERE to_object_id = ?"
-                    ")"
-                )
-                conditions.append(link_cond)
-                params.extend([q.linked_to, q.linked_to])
-
-        # Property filters against the JSON properties bag. Kept as a localized
-        # block (see _build_filter_conditions) so concurrent work on this method
-        # — e.g. workspace_id scoping — merges without touching this logic.
-        if q.filters:
-            filter_conditions, filter_params = _build_filter_conditions(q.filters)
-            conditions.extend(filter_conditions)
-            params.extend(filter_params)
-
-        # Tenancy scope (W4a) — an ADDITIONAL condition ANDed alongside the W0d
-        # property filters above, never a replacement for them. Restricts the
-        # result set to the caller's workspace plus legacy NULL-workspace rows.
-        ws_cond, ws_params = _workspace_scope(workspace_id, column="o.workspace_id")
-        if ws_cond:
-            conditions.append(ws_cond)
-            params.extend(ws_params)
-
+        conditions, params = _flat_query_conditions(q, workspace_id)
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
 
         await self._ensure_schema()
@@ -1382,6 +1545,76 @@ class FabricStore:
                 objects = [self._row_to_object(row) async for row in cur]
 
         return FabricQueryResult(objects=objects, total=total)
+
+    async def _query_aggregate(self, q: FabricQuery, workspace_id: str | None) -> FabricQueryResult:
+        """Run a flag-gated SQL GROUP BY aggregation (self-serve-analysis S1).
+
+        Contract:
+
+        - GATE: requires the ``fabric_analyst`` settings flag
+          (POCKETPAW_FABRIC_ANALYST). Off -> :class:`FabricAnalystDisabledError`
+          (fail-loud; the EE router maps it to 422 ``fabric.analyst_disabled``).
+        - SCOPE-THEN-AGGREGATE: the WHERE is built by the same
+          ``_flat_query_conditions`` the plain path uses — tenancy scope (W4a)
+          and property filters constrain the row set BEFORE grouping, so a
+          cross-workspace object can never be counted into a group.
+        - GROUPING: plain ``group_by`` groups on the raw JSON property value;
+          with ``q.ranges`` a fully-parameterized CASE chain buckets the
+          numeric value (min inclusive, max exclusive; labels are bound
+          params). Rows whose group key resolves to NULL (missing property, or
+          a value outside every bucket) are dropped via HAVING.
+        - AGGREGATE: ``count`` = COUNT(*); sum/avg/min/max fold
+          ``aggregate_field`` CAST to REAL (same numeric affinity rule as the
+          numeric filter operators). Function names come from a fixed internal
+          map — user input never reaches the SQL text; property names ride as
+          bound ``$.name`` json_extract path params.
+        - OUTPUT: ``aggregates`` = one ``{"key", "value"}`` dict per group,
+          ordered by ``q.sort`` (default: value descending) and paginated by
+          ``limit``/``offset``; ``objects`` is empty (this is an analysis read,
+          not a fetch); ``total`` = scoped+filtered object count; ``steps`` =
+          the human-readable reasoning trace (:class:`QueryPlanStep`).
+        """
+        from pocketpaw.config import get_settings
+
+        if not get_settings().fabric_analyst:
+            raise FabricAnalystDisabledError(
+                "Fabric self-serve analysis is disabled: aggregation queries "
+                "(group_by/aggregate) require the POCKETPAW_FABRIC_ANALYST "
+                "flag. Plain queries remain available."
+            )
+
+        # The model validator guarantees: group_by set, aggregate normalized
+        # (count default), aggregate_field present iff sum/avg/min/max, no path.
+        assert q.group_by is not None and q.aggregate is not None
+
+        conditions, params = _flat_query_conditions(q, workspace_id)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        group_expr, group_params = _group_key_expr(q)
+        agg_expr, agg_params = _aggregate_expr(q)
+        order_sql = _AGG_SORT_SQL[q.sort or "value_desc"]
+
+        sql = (
+            f"SELECT {group_expr} AS grp, {agg_expr} AS val"
+            f" FROM fabric_objects o {where}"
+            " GROUP BY grp HAVING grp IS NOT NULL"
+            f" ORDER BY {order_sql} LIMIT ? OFFSET ?"
+        )
+
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                f"SELECT COUNT(*) as cnt FROM fabric_objects o {where}", params
+            ) as cur:
+                row = await cur.fetchone()
+                total = row["cnt"] if row else 0
+            async with db.execute(
+                sql, [*group_params, *agg_params, *params, q.limit, q.offset]
+            ) as cur:
+                aggregates = [{"key": r["grp"], "value": r["val"]} async for r in cur]
+
+        steps = _build_plan_steps(q, total=total, group_count=len(aggregates))
+        return FabricQueryResult(objects=[], total=total, aggregates=aggregates, steps=steps)
 
     async def _query_path(self, q: FabricQuery, workspace_id: str | None) -> FabricQueryResult:
         """Walk ``q.path`` server-side and return the terminal-hop objects.

--- a/src/pocketpaw/paw/cli.py
+++ b/src/pocketpaw/paw/cli.py
@@ -1,7 +1,12 @@
 # Paw CLI — Click-based universal entry point for PocketPaw with soul-protocol.
 # Created: 2026-03-02
 # Updated: 2026-03-02 — Fixed _print() call without args in doctor command.
-# Commands: init, ask, chat, serve, status, doctor, os, channels.
+# Updated: 2026-07-11 (feat/paw-cli, C1) — the CLI is now a real console script
+#   (`paw` in [project.scripts]) and grew a `paw fabric` remote group (stats,
+#   types, query) that talks HTTP to a running PocketPaw server through the new
+#   thin PawClient (paw/client.py) — base URL / API key from --base-url /
+#   --api-key or PAW_BASE_URL / PAW_API_KEY.
+# Commands: init, ask, chat, serve, status, doctor, os, channels, fabric.
 
 from __future__ import annotations
 
@@ -554,6 +559,103 @@ def channels(telegram: bool, slack: bool, discord: bool) -> None:
         _print("Install channel extras: pip install pocketpaw[telegram,discord,slack]", style="dim")
     except KeyboardInterrupt:
         _print("Channels stopped.", style="dim")
+
+
+# ---------------------------------------------------------------------------
+# paw fabric — remote ontology reads over HTTP (C1)
+# ---------------------------------------------------------------------------
+
+_BASE_URL_OPT = click.option(
+    "--base-url",
+    envvar="PAW_BASE_URL",
+    default="http://127.0.0.1:8888",
+    show_default=True,
+    help="PocketPaw server origin (env: PAW_BASE_URL).",
+)
+_API_KEY_OPT = click.option(
+    "--api-key",
+    envvar="PAW_API_KEY",
+    default=None,
+    help="Bearer credential — a paw_... API key or JWT (env: PAW_API_KEY).",
+)
+
+
+def _make_client(base_url: str, api_key: str | None):
+    """Build the PawClient for the remote commands. One seam — tests stub it."""
+    from pocketpaw.paw.client import PawClient
+
+    return PawClient(base_url, api_key)
+
+
+def _echo_json(payload) -> None:
+    """Render an API payload as pretty JSON (scripting-friendly)."""
+    import json
+
+    click.echo(json.dumps(payload, indent=2, default=str))
+
+
+@main.group()
+def fabric() -> None:
+    """Read the Fabric ontology on a running PocketPaw server."""
+
+
+@fabric.command(name="stats")
+@_BASE_URL_OPT
+@_API_KEY_OPT
+def fabric_stats(base_url: str, api_key: str | None) -> None:
+    """Show ontology counts for your workspace."""
+    _fabric_call(base_url, api_key, lambda c: c.fabric_stats())
+
+
+@fabric.command(name="types")
+@_BASE_URL_OPT
+@_API_KEY_OPT
+def fabric_types(base_url: str, api_key: str | None) -> None:
+    """List the object types visible to your workspace."""
+    _fabric_call(base_url, api_key, lambda c: c.list_types())
+
+
+@fabric.command(name="query")
+@click.option("--type-name", "-t", default=None, help="Object type to search.")
+@click.option("--linked-to", default=None, help="Find objects linked to this object id.")
+@click.option("--link-type", default=None, help="Filter links by type.")
+@click.option("--limit", default=20, show_default=True, type=int, help="Max results.")
+@_BASE_URL_OPT
+@_API_KEY_OPT
+def fabric_query(
+    type_name: str | None,
+    linked_to: str | None,
+    link_type: str | None,
+    limit: int,
+    base_url: str,
+    api_key: str | None,
+) -> None:
+    """Run a Fabric query and print the matching objects as JSON."""
+    _fabric_call(
+        base_url,
+        api_key,
+        lambda c: c.query(
+            type_name=type_name, linked_to=linked_to, link_type=link_type, limit=limit
+        ),
+    )
+
+
+def _fabric_call(base_url: str, api_key: str | None, fn) -> None:
+    """Run one client call with uniform connection/API error handling."""
+    from pocketpaw.paw.client import PawAPIError
+
+    client = _make_client(base_url, api_key)
+    try:
+        _echo_json(fn(client))
+    except PawAPIError as e:
+        _print(f"API error: {e}", style="red")
+        raise SystemExit(1)
+    except Exception as e:  # httpx.ConnectError etc. — no server at base_url
+        _print(f"Could not reach {base_url}: {e}", style="red")
+        _print("Is a PocketPaw server running? Try: pocketpaw serve", style="dim")
+        raise SystemExit(1)
+    finally:
+        client.close()
 
 
 if __name__ == "__main__":

--- a/src/pocketpaw/paw/client.py
+++ b/src/pocketpaw/paw/client.py
@@ -1,0 +1,257 @@
+# paw/client.py — PawClient, a thin synchronous httpx client for the PocketPaw
+# cloud REST API (paw-cli C1 — the external programmatic surface).
+# Created: 2026-07-11 (feat/paw-cli) — wraps the EXISTING /api/v1/fabric route
+# contracts only (ee/pocketpaw_ee/fabric/router.py); no invented endpoints.
+# Auth is a bearer token (a `paw_...` API key or a login JWT — both ride the
+# same Authorization header). A custom httpx transport can be injected so tests
+# and embedders stub the wire without patching.
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8888"
+DEFAULT_TIMEOUT = 30.0
+
+_API_PREFIX = "/api/v1"
+
+
+class PawAPIError(Exception):
+    """A non-2xx response from the PocketPaw API.
+
+    Carries ``status_code`` and the response ``detail`` (the FastAPI error
+    body's ``detail`` field when present, else the raw text) so callers and
+    the CLI can render the server's actual reason.
+    """
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"HTTP {status_code}: {detail}")
+
+
+class PawClient:
+    """Thin synchronous client for the PocketPaw cloud REST API.
+
+    Mirrors the existing router contracts (fabric ontology today) — each
+    method maps 1:1 onto a mounted ``/api/v1`` route and returns the decoded
+    JSON body. Workspace scoping is server-side (the token's active
+    workspace); the client never sends a workspace id.
+
+    Args:
+        base_url: server origin, e.g. ``https://cloud.example.com``.
+        api_key: bearer credential (``paw_...`` API key or JWT). Optional so
+            unauthenticated endpoints (``/openapi.json``) still work.
+        timeout: per-request timeout in seconds.
+        transport: optional ``httpx.BaseTransport`` for tests/embedders
+            (e.g. ``httpx.MockTransport``).
+    """
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        api_key: str | None = None,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        self._client = httpx.Client(
+            base_url=base_url.rstrip("/"),
+            headers=headers,
+            timeout=timeout,
+            transport=transport,
+        )
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> PawClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- plumbing -----------------------------------------------------------
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> Any:
+        """Issue one request against the API prefix and decode the JSON body.
+
+        Raises :class:`PawAPIError` on any non-2xx status, with the FastAPI
+        ``detail`` extracted when the body is JSON.
+        """
+        resp = self._client.request(method, f"{_API_PREFIX}{path}", **kwargs)
+        if resp.is_error:
+            try:
+                detail = resp.json().get("detail", resp.text)
+            except Exception:  # noqa: BLE001 — non-JSON error body
+                detail = resp.text
+            raise PawAPIError(resp.status_code, str(detail))
+        if resp.status_code == 204 or not resp.content:
+            return None
+        return resp.json()
+
+    # -- meta ----------------------------------------------------------------
+
+    def openapi(self) -> dict[str, Any]:
+        """Fetch the live OpenAPI schema (unauthenticated; contract anchor)."""
+        resp = self._client.get("/openapi.json")
+        if resp.is_error:
+            raise PawAPIError(resp.status_code, resp.text)
+        return resp.json()
+
+    # -- fabric: reads --------------------------------------------------------
+
+    def fabric_stats(self) -> dict[str, Any]:
+        """GET /fabric/stats — ontology counts for the token's workspace."""
+        return self._request("GET", "/fabric/stats")
+
+    def list_types(self) -> list[dict[str, Any]]:
+        """GET /fabric/types — object types visible to the workspace."""
+        return self._request("GET", "/fabric/types")
+
+    def get_schema(self) -> dict[str, Any]:
+        """GET /fabric/schema — object types + declared link types."""
+        return self._request("GET", "/fabric/schema")
+
+    def list_objects(
+        self,
+        *,
+        type_id: str | None = None,
+        type_name: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """GET /fabric/objects — paged object listing with type filters."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if type_id:
+            params["type_id"] = type_id
+        if type_name:
+            params["type_name"] = type_name
+        return self._request("GET", "/fabric/objects", params=params)
+
+    def get_object(self, obj_id: str) -> dict[str, Any]:
+        """GET /fabric/objects/{id} — one object (404 -> PawAPIError)."""
+        return self._request("GET", f"/fabric/objects/{obj_id}")
+
+    def query(
+        self,
+        *,
+        type_name: str | None = None,
+        linked_to: str | None = None,
+        link_type: str | None = None,
+        filters: dict[str, Any] | None = None,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        """POST /fabric/query — run a FabricQuery (same body the router takes)."""
+        body: dict[str, Any] = {"limit": limit}
+        if type_name:
+            body["type_name"] = type_name
+        if linked_to:
+            body["linked_to"] = linked_to
+        if link_type:
+            body["link_type"] = link_type
+        if filters:
+            body["filters"] = filters
+        return self._request("POST", "/fabric/query", json=body)
+
+    def list_links(
+        self,
+        *,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        link_type: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """GET /fabric/links — paged link listing with endpoint/type filters."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if from_id:
+            params["from_id"] = from_id
+        if to_id:
+            params["to_id"] = to_id
+        if link_type:
+            params["link_type"] = link_type
+        return self._request("GET", "/fabric/links", params=params)
+
+    # -- fabric: writes -------------------------------------------------------
+
+    def create_object(
+        self,
+        type_id: str,
+        properties: dict[str, Any] | None = None,
+        *,
+        source_connector: str | None = None,
+        source_id: str | None = None,
+    ) -> dict[str, Any]:
+        """POST /fabric/objects — create one object of an existing type."""
+        return self._request(
+            "POST",
+            "/fabric/objects",
+            json={
+                "type_id": type_id,
+                "properties": properties or {},
+                "source_connector": source_connector,
+                "source_id": source_id,
+            },
+        )
+
+    def create_link(
+        self,
+        from_id: str,
+        to_id: str,
+        link_type: str,
+        properties: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """POST /fabric/links — link two objects."""
+        return self._request(
+            "POST",
+            "/fabric/links",
+            json={
+                "from_id": from_id,
+                "to_id": to_id,
+                "link_type": link_type,
+                "properties": properties or {},
+            },
+        )
+
+    def delete_link(self, link_id: str) -> None:
+        """DELETE /fabric/links/{id} — remove one link (workspace-scoped)."""
+        self._request("DELETE", f"/fabric/links/{link_id}")
+
+    def update_type(
+        self,
+        type_id: str,
+        *,
+        properties: list[dict[str, Any]] | None = None,
+        renames: dict[str, str] | None = None,
+        description: str | None = None,
+        icon: str | None = None,
+        color: str | None = None,
+    ) -> dict[str, Any]:
+        """PATCH /fabric/schema/types/{id} — version + migrate a type (ADMIN).
+
+        Rename and additive changes only — a dropped property is deferred
+        server-side (its orphaned key stays on existing objects).
+        """
+        body: dict[str, Any] = {}
+        if properties is not None:
+            body["properties"] = properties
+        if renames is not None:
+            body["renames"] = renames
+        if description is not None:
+            body["description"] = description
+        if icon is not None:
+            body["icon"] = icon
+        if color is not None:
+            body["color"] = color
+        return self._request("PATCH", f"/fabric/schema/types/{type_id}", json=body)
+
+
+__all__ = ["DEFAULT_BASE_URL", "PawAPIError", "PawClient"]

--- a/src/pocketpaw/paw_bar/models.py
+++ b/src/pocketpaw/paw_bar/models.py
@@ -1,4 +1,7 @@
 # ee/paw_bar/models.py — Pydantic models for the Paw Bar widget layer.
+# Updated: 2026-07-11 (W4a tenancy seam) — PawBarWidget + PawBarWidgetPublic
+#   gain `workspace_id: str = ""` (in-row tenancy, same model as DecisionStatus).
+#   Empty string = legacy/single-tenant row; the store's scoped reads match it.
 # Updated: 2026-07-08 — Renamed widget "Paw Print" → "Paw Bar" (PawPrint*→PawBar* models).
 #   The separate one-word audit feed (past-tense record) is a DIFFERENT feature, untouched.
 # Created: 2026-04-13 (Move 3 PR-A) — Minimal, secure-by-design render vocabulary
@@ -146,6 +149,9 @@ class PawBarWidget(BaseModel):
     id: str = Field(default_factory=lambda: _gen_id("pp"))
     pocket_id: str
     owner: str
+    # W4a in-row tenancy — the owning workspace. Empty string means a
+    # legacy/single-tenant row (matched by every scoped read, like decisions).
+    workspace_id: str = ""
     name: str = ""
     spec: PawBarSpec
     allowed_domains: list[str] = Field(default_factory=list)
@@ -192,6 +198,7 @@ class PawBarWidgetPublic(BaseModel):
     id: str
     pocket_id: str
     owner: str
+    workspace_id: str = ""
     name: str = ""
     spec: PawBarSpec
     allowed_domains: list[str] = Field(default_factory=list)

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -1,4 +1,9 @@
 # ee/paw_bar/store.py — Async SQLite store for Paw Bar widgets and events.
+# Updated: 2026-07-11 (W4a spec revisions) — new paw_bar_spec_revisions table:
+#   update_spec archives the PRIOR spec with a monotonic per-widget revision
+#   number (same transaction as the update); latest_spec_revision reads the
+#   newest one; rollback_spec restores it via update_spec (so the rollback is
+#   itself archived + reversible) and honors the same workspace scoping.
 # Updated: 2026-07-11 (W4a tenancy seam) — paw_bar_widgets gains an in-row
 #   workspace_id column + index and a _widget_workspace_scope helper (verbatim
 #   clone of _decision_workspace_scope: legacy ''/NULL rows always match, None
@@ -90,6 +95,17 @@ CREATE TABLE IF NOT EXISTS paw_bar_decisions (
     updated_at TEXT DEFAULT (datetime('now'))
 );
 
+-- W4a spec revisions: every update_spec archives the PRIOR spec here with a
+-- monotonic per-widget revision number; rollback restores the latest one
+-- (itself an update that archives the current spec).
+CREATE TABLE IF NOT EXISTS paw_bar_spec_revisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    widget_id TEXT NOT NULL,
+    revision INTEGER NOT NULL,
+    spec TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_pocket ON paw_bar_widgets(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_owner ON paw_bar_widgets(owner);
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_workspace ON paw_bar_widgets(workspace_id);
@@ -101,6 +117,8 @@ CREATE INDEX IF NOT EXISTS idx_pp_decisions_customer
     ON paw_bar_decisions(widget_id, customer_ref, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_pp_decisions_action
     ON paw_bar_decisions(instinct_action_id);
+CREATE INDEX IF NOT EXISTS idx_pp_spec_revisions_widget
+    ON paw_bar_spec_revisions(widget_id, revision DESC);
 """
 
 
@@ -244,9 +262,55 @@ class PawBarStore:
             params.extend(ws_params)
         await self._ensure_schema()
         async with self._conn() as db:
+            # Archive the PRIOR spec (monotonic per-widget revision) in the
+            # same transaction as the update, so every update_spec leaves a
+            # rollback point behind.
+            async with db.execute(
+                "SELECT COALESCE(MAX(revision), 0) FROM paw_bar_spec_revisions WHERE widget_id = ?",
+                (widget_id,),
+            ) as cur:
+                row = await cur.fetchone()
+                next_revision = (row[0] if row else 0) + 1
+            await db.execute(
+                "INSERT INTO paw_bar_spec_revisions (widget_id, revision, spec) VALUES (?, ?, ?)",
+                (widget_id, next_revision, existing.spec.model_dump_json()),
+            )
             await db.execute(sql, params)
             await db.commit()
         return await self.get_widget(widget_id, workspace_id=workspace_id)
+
+    async def latest_spec_revision(self, widget_id: str) -> tuple[int, PawBarSpec] | None:
+        """Return the most recent archived spec revision, or None when none exist."""
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(
+                "SELECT revision, spec FROM paw_bar_spec_revisions"
+                " WHERE widget_id = ? ORDER BY revision DESC LIMIT 1",
+                (widget_id,),
+            ) as cur:
+                row = await cur.fetchone()
+                if row is None:
+                    return None
+                return row[0], PawBarSpec.model_validate_json(row[1])
+
+    async def rollback_spec(
+        self, widget_id: str, workspace_id: str | None = None
+    ) -> PawBarWidget | None:
+        """Restore the latest archived spec revision (W4a).
+
+        The restore is itself an ``update_spec`` — the CURRENT spec is archived
+        as a new revision before being replaced, so a rollback is always
+        auditable and itself reversible. Returns ``None`` when the widget does
+        not exist in the caller's workspace scope OR when no revision exists.
+        """
+        widget = await self.get_widget(widget_id, workspace_id=workspace_id)
+        if widget is None:
+            return None
+        latest = await self.latest_spec_revision(widget_id)
+        if latest is None:
+            return None
+        _, archived_spec = latest
+        return await self.update_spec(widget_id, archived_spec, workspace_id=workspace_id)
 
     async def rotate_token(
         self, widget_id: str, workspace_id: str | None = None

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -1,4 +1,11 @@
 # ee/paw_bar/store.py — Async SQLite store for Paw Bar widgets and events.
+# Updated: 2026-07-11 (W4a tenancy seam) — paw_bar_widgets gains an in-row
+#   workspace_id column + index and a _widget_workspace_scope helper (verbatim
+#   clone of _decision_workspace_scope: legacy ''/NULL rows always match, None
+#   means unscoped). get/list/update_spec/rotate_token/delete_widget take an
+#   optional workspace_id and scope both reads and mutations to that tenant —
+#   another tenant's widget id resolves to None / mutates nothing. Hard schema
+#   change, no migration: the widget has zero deployments.
 # Updated: 2026-07-08 — Renamed widget "Paw Print" → "Paw Bar" (PawBarStore, tables
 #   paw_print_*→paw_bar_*, db paw_print.db→paw_bar.db). Hard-rename — widget has zero
 #   deployments, so no persisted rows to migrate. The separate one-word audit feed
@@ -45,6 +52,7 @@ CREATE TABLE IF NOT EXISTS paw_bar_widgets (
     id TEXT PRIMARY KEY,
     pocket_id TEXT NOT NULL,
     owner TEXT NOT NULL,
+    workspace_id TEXT DEFAULT '',
     name TEXT DEFAULT '',
     spec TEXT NOT NULL,
     allowed_domains TEXT DEFAULT '[]',
@@ -84,6 +92,7 @@ CREATE TABLE IF NOT EXISTS paw_bar_decisions (
 
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_pocket ON paw_bar_widgets(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_owner ON paw_bar_widgets(owner);
+CREATE INDEX IF NOT EXISTS idx_pp_widgets_workspace ON paw_bar_widgets(workspace_id);
 CREATE INDEX IF NOT EXISTS idx_pp_events_widget_ts
     ON paw_bar_events(widget_id, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_pp_events_customer
@@ -103,6 +112,21 @@ def _decision_workspace_scope(workspace_id: str | None) -> tuple[str | None, lis
     SQL NULL when no workspace was set, so a legacy/global row is matched on
     ``= ''`` as well as ``IS NULL``. Returns ``(None, [])`` when ``workspace_id``
     is ``None`` — no scoping, fully backward-compatible.
+    """
+    if workspace_id is None:
+        return None, []
+    return "(workspace_id = ? OR workspace_id = '' OR workspace_id IS NULL)", [workspace_id]
+
+
+def _widget_workspace_scope(workspace_id: str | None) -> tuple[str | None, list[Any]]:
+    """Build the tenancy WHERE fragment + bound params for a scoped widget read.
+
+    Verbatim clone of :func:`_decision_workspace_scope` for the widgets table
+    (W4a — in-row tenancy). Widget rows store ``workspace_id`` as an EMPTY
+    STRING (the model default) rather than SQL NULL when no workspace was set,
+    so a legacy/global row is matched on ``= ''`` as well as ``IS NULL``.
+    Returns ``(None, [])`` when ``workspace_id`` is ``None`` — no scoping,
+    fully backward-compatible.
     """
     if workspace_id is None:
         return None, []
@@ -134,14 +158,15 @@ class PawBarStore:
         async with self._conn() as db:
             await db.execute(
                 "INSERT INTO paw_bar_widgets"
-                " (id, pocket_id, owner, name, spec, allowed_domains,"
+                " (id, pocket_id, owner, workspace_id, name, spec, allowed_domains,"
                 " access_token, rate_limit_per_min, per_customer_limit_per_min,"
                 " event_mapping, created_at, updated_at)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     widget.id,
                     widget.pocket_id,
                     widget.owner,
+                    widget.workspace_id,
                     widget.name,
                     widget.spec.model_dump_json(),
                     json.dumps(widget.allowed_domains),
@@ -158,19 +183,28 @@ class PawBarStore:
             await db.commit()
         return widget
 
-    async def get_widget(self, widget_id: str) -> PawBarWidget | None:
+    async def get_widget(
+        self, widget_id: str, workspace_id: str | None = None
+    ) -> PawBarWidget | None:
+        ws_cond, ws_params = _widget_workspace_scope(workspace_id)
+        sql = "SELECT * FROM paw_bar_widgets WHERE id = ?"
+        params: list[Any] = [widget_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT * FROM paw_bar_widgets WHERE id = ?",
-                (widget_id,),
-            ) as cur:
+            async with db.execute(sql, params) as cur:
                 row = await cur.fetchone()
                 return self._row_to_widget(row) if row else None
 
     async def list_widgets(
-        self, pocket_id: str | None = None, owner: str | None = None, limit: int = 100
+        self,
+        pocket_id: str | None = None,
+        owner: str | None = None,
+        limit: int = 100,
+        workspace_id: str | None = None,
     ) -> list[PawBarWidget]:
         conditions: list[str] = []
         params: list[Any] = []
@@ -180,6 +214,10 @@ class PawBarStore:
         if owner:
             conditions.append("owner = ?")
             params.append(owner)
+        ws_cond, ws_params = _widget_workspace_scope(workspace_id)
+        if ws_cond:
+            conditions.append(ws_cond)
+            params.extend(ws_params)
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         params.append(limit)
 
@@ -192,40 +230,53 @@ class PawBarStore:
             ) as cur:
                 return [self._row_to_widget(row) async for row in cur]
 
-    async def update_spec(self, widget_id: str, spec: PawBarSpec) -> PawBarWidget | None:
-        existing = await self.get_widget(widget_id)
+    async def update_spec(
+        self, widget_id: str, spec: PawBarSpec, workspace_id: str | None = None
+    ) -> PawBarWidget | None:
+        existing = await self.get_widget(widget_id, workspace_id=workspace_id)
         if existing is None:
             return None
+        ws_cond, ws_params = _widget_workspace_scope(workspace_id)
+        sql = "UPDATE paw_bar_widgets SET spec = ?, updated_at = ? WHERE id = ?"
+        params: list[Any] = [spec.model_dump_json(), datetime.now().isoformat(), widget_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
         await self._ensure_schema()
         async with self._conn() as db:
-            await db.execute(
-                "UPDATE paw_bar_widgets SET spec = ?, updated_at = ? WHERE id = ?",
-                (spec.model_dump_json(), datetime.now().isoformat(), widget_id),
-            )
+            await db.execute(sql, params)
             await db.commit()
-        return await self.get_widget(widget_id)
+        return await self.get_widget(widget_id, workspace_id=workspace_id)
 
-    async def rotate_token(self, widget_id: str) -> PawBarWidget | None:
-        existing = await self.get_widget(widget_id)
+    async def rotate_token(
+        self, widget_id: str, workspace_id: str | None = None
+    ) -> PawBarWidget | None:
+        existing = await self.get_widget(widget_id, workspace_id=workspace_id)
         if existing is None:
             return None
         new_token = _gen_token()
+        ws_cond, ws_params = _widget_workspace_scope(workspace_id)
+        sql = "UPDATE paw_bar_widgets SET access_token = ?, updated_at = ? WHERE id = ?"
+        params: list[Any] = [new_token, datetime.now().isoformat(), widget_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
         await self._ensure_schema()
         async with self._conn() as db:
-            await db.execute(
-                "UPDATE paw_bar_widgets SET access_token = ?, updated_at = ? WHERE id = ?",
-                (new_token, datetime.now().isoformat(), widget_id),
-            )
+            await db.execute(sql, params)
             await db.commit()
-        return await self.get_widget(widget_id)
+        return await self.get_widget(widget_id, workspace_id=workspace_id)
 
-    async def delete_widget(self, widget_id: str) -> bool:
+    async def delete_widget(self, widget_id: str, workspace_id: str | None = None) -> bool:
+        ws_cond, ws_params = _widget_workspace_scope(workspace_id)
+        sql = "DELETE FROM paw_bar_widgets WHERE id = ?"
+        params: list[Any] = [widget_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
         await self._ensure_schema()
         async with self._conn() as db:
-            cur = await db.execute(
-                "DELETE FROM paw_bar_widgets WHERE id = ?",
-                (widget_id,),
-            )
+            cur = await db.execute(sql, params)
             await db.commit()
             return (cur.rowcount or 0) > 0
 
@@ -445,6 +496,7 @@ class PawBarStore:
             id=row["id"],
             pocket_id=row["pocket_id"],
             owner=row["owner"],
+            workspace_id=row["workspace_id"] or "",
             name=row["name"] or "",
             spec=spec,
             allowed_domains=raw_domains,

--- a/src/pocketpaw/tools/builtin/__init__.py
+++ b/src/pocketpaw/tools/builtin/__init__.py
@@ -100,6 +100,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "AddWidgetTool": (".pocket", "AddWidgetTool"),
     "RemoveWidgetTool": (".pocket", "RemoveWidgetTool"),
     "StartFlowTool": (".flow_tool", "StartFlowTool"),
+    "StepPipelineTool": (".step_pipeline_tool", "StepPipelineTool"),
     "DiscordCLITool": (".discord", "DiscordCLITool"),
     "ConnectorListTool": (".connector_tools", "ConnectorListTool"),
     "ConnectorConnectTool": (".connector_tools", "ConnectorConnectTool"),

--- a/src/pocketpaw/tools/builtin/step_pipeline_tool.py
+++ b/src/pocketpaw/tools/builtin/step_pipeline_tool.py
@@ -1,0 +1,101 @@
+# pocketpaw/tools/builtin/step_pipeline_tool.py — `run_step_pipeline` builtin
+# (instinct-guardrail-ux Criterion 2).
+#
+# Created: 2026-07-11 (feat/guardrail-c2-composer).
+#
+# The tool wrapper over ``bundled_templates.step_composer``: an agent (or an
+# action) invokes it with a fixed-order pipeline spec (extract → classify →
+# recommend) + an input string; deterministic Python sequences the steps and
+# the model is called once per step through an INJECTED runner.
+#
+# Runner resolution (the risky seam, kept honest): no builtin currently
+# invokes the model mid-tool, so this tool does NOT construct an LLM client.
+# The hosting layer that registers the tool passes ``agent_runner=`` (an async
+# ``(prompt) -> str``); without one the tool returns a clear
+# "requires an agent backend" error instead of guessing at credentials —
+# this deployment may run the Claude Code backend with no ANTHROPIC_API_KEY.
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import ValidationError
+
+from pocketpaw.bundled_templates.schema import LlmStepPipeline
+from pocketpaw.bundled_templates.step_composer import AgentRunner, run_step_pipeline
+from pocketpaw.tools.protocol import BaseTool
+
+_NO_RUNNER_ERROR = (
+    "run_step_pipeline requires an agent backend: the hosting layer did not "
+    "provide an agent_runner, so no model call can be made. Register the tool "
+    "with agent_runner=<async (prompt) -> str> to enable it."
+)
+
+
+class StepPipelineTool(BaseTool):
+    """Run a fixed 3-step LLM pipeline (extract → classify → recommend)."""
+
+    def __init__(self, agent_runner: AgentRunner | None = None) -> None:
+        self._agent_runner = agent_runner
+
+    @property
+    def name(self) -> str:
+        return "run_step_pipeline"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Run a small fixed-order LLM pipeline over an input text: "
+            "extract (pull named fields) -> classify (pick one label) -> "
+            "recommend (suggest the next action). Steps are optional but must "
+            "keep that order, each at most once. Deterministic code sequences "
+            "the steps; each step is one model call. Returns a JSON transcript "
+            "{steps: [{step, input, output}], result}."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "pipeline": {
+                    "type": "object",
+                    "description": (
+                        "The pipeline spec: {steps: [{step: extract|classify|"
+                        "recommend, instruction, input_from?, fields?, labels?}]}"
+                        " — 1-3 steps in the fixed order, each kind at most once."
+                    ),
+                },
+                "input": {
+                    "type": "string",
+                    "description": "The input text the pipeline runs over.",
+                },
+            },
+            "required": ["pipeline", "input"],
+        }
+
+    async def execute(
+        self,
+        pipeline: dict[str, Any] | str | None = None,
+        input: str = "",  # noqa: A002 — tool-schema param name
+        **_: Any,
+    ) -> str:
+        if self._agent_runner is None:
+            return json.dumps({"error": _NO_RUNNER_ERROR})
+        if isinstance(pipeline, str):
+            try:
+                pipeline = json.loads(pipeline)
+            except (json.JSONDecodeError, ValueError):
+                return json.dumps({"error": "pipeline must be a JSON object"})
+        try:
+            spec = LlmStepPipeline.model_validate(pipeline or {})
+        except ValidationError as exc:
+            # Surface the validator's precise message so the model can fix the
+            # spec and retry (the flow_tool forgiving-author loop).
+            return json.dumps({"error": f"invalid pipeline: {exc.errors()[0]['msg']}"})
+        result = await run_step_pipeline(spec, input, self._agent_runner)
+        return json.dumps(result, ensure_ascii=False)
+
+
+__all__ = ["StepPipelineTool"]

--- a/tests/cloud/billing/test_plans.py
+++ b/tests/cloud/billing/test_plans.py
@@ -22,6 +22,14 @@
 #   each tier carries the approved ceiling (free=1000 explicit trial, go/pro/pro_max
 #   = allotment × 1.5, enterprise=None uncapped), and an unknown key built directly
 #   FAILS CLOSED to the Free ceiling (never None/uncapped).
+# Updated 2026-07-08 (feat/billing-smb-caps): added coverage for the three SMB
+#   resource caps (``max_seats`` / ``max_pockets`` / ``max_connectors``): every tier
+#   carries an int cap (Enterprise is None = uncapped), Free ``max_seats`` == the
+#   ``Workspace.seats`` default (5) so no workspace regresses, and an unknown key
+#   built directly FAILS CLOSED to the Free value on all three (never None/uncapped).
+#   The numbers under test are the GENEROUS PLACEHOLDERS pending the captain's
+#   pricing call — these tests lock the machinery (present on every tier, uncapped
+#   Enterprise, fail-closed default), not the exact figures.
 
 from __future__ import annotations
 
@@ -59,6 +67,30 @@ EXPECTED_USAGE_LABELS = {
     "pro": "5× the usage",
     "pro_max": "20× the usage",
     "enterprise": "Custom",
+}
+# The three SMB resource caps (feat/billing-smb-caps) — GENEROUS PLACEHOLDERS
+# pending the captain's pricing call. Enterprise is None (uncapped). Free
+# ``max_seats`` MUST equal the Workspace.seats default (5) so no workspace regresses.
+EXPECTED_MAX_SEATS: dict[str, int | None] = {
+    "free": 5,
+    "go": 10,
+    "pro": 25,
+    "pro_max": 100,
+    "enterprise": None,
+}
+EXPECTED_MAX_POCKETS: dict[str, int | None] = {
+    "free": 200,
+    "go": 1_000,
+    "pro": 5_000,
+    "pro_max": 20_000,
+    "enterprise": None,
+}
+EXPECTED_MAX_CONNECTORS: dict[str, int | None] = {
+    "free": 50,
+    "go": 100,
+    "pro": 250,
+    "pro_max": 1_000,
+    "enterprise": None,
 }
 
 
@@ -140,6 +172,71 @@ def test_build_unknown_key_fails_closed_to_free_ceiling():
     bogus = plans._build("definitely_not_a_tier")
     assert bogus.monthly_ceiling == EXPECTED_CEILINGS["free"]
     assert bogus.monthly_ceiling is not None
+
+
+# ---------------------------------------------------------------------------
+# SMB resource caps — max_seats / max_pockets / max_connectors.
+# ---------------------------------------------------------------------------
+
+
+def test_every_tier_carries_the_three_smb_caps():
+    """Each tier exposes max_seats / max_pockets / max_connectors (the machinery).
+
+    Locks that the caps are PRESENT on every tier with the placeholder values, not
+    that the figures are final — the captain's pricing call moves the numbers, not
+    the shape.
+    """
+    by_key = {p.key: p for p in plans.list_plans()}
+    for key in EXPECTED_ORDER:
+        assert by_key[key].max_seats == EXPECTED_MAX_SEATS[key], key
+        assert by_key[key].max_pockets == EXPECTED_MAX_POCKETS[key], key
+        assert by_key[key].max_connectors == EXPECTED_MAX_CONNECTORS[key], key
+
+
+def test_free_max_seats_is_at_least_the_workspace_default():
+    """Free max_seats MUST be >= the Workspace.seats model default (5) — no regression.
+
+    The seat gate enforces max(doc.seats, plan.max_seats); if Free's cap dropped
+    below 5 a default free workspace would be blocked below the seats it already
+    has. This is the CRITICAL non-regression invariant.
+    """
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    default_seats = Workspace.model_fields["seats"].default
+    assert default_seats == 5
+    assert plans.get_plan("free").max_seats is not None
+    assert plans.get_plan("free").max_seats >= default_seats
+
+
+def test_enterprise_smb_caps_are_uncapped():
+    """Enterprise is the one uncapped tier on every SMB cap (None, never a number)."""
+    ent = plans.get_plan("enterprise")
+    assert ent.max_seats is None
+    assert ent.max_pockets is None
+    assert ent.max_connectors is None
+
+
+def test_non_enterprise_smb_caps_are_positive_ints():
+    """Every non-Enterprise tier carries a concrete positive cap on all three."""
+    by_key = {p.key: p for p in plans.list_plans()}
+    for key in ("free", "go", "pro", "pro_max"):
+        for cap in (by_key[key].max_seats, by_key[key].max_pockets, by_key[key].max_connectors):
+            assert isinstance(cap, int) and cap > 0, key
+
+
+def test_build_unknown_key_fails_closed_to_free_smb_caps():
+    """An unknown key built directly caps at the Free values on all three — never None.
+
+    Same fail-closed floor the ceiling uses: a stray/typo'd key must NOT resolve to
+    an uncapped SMB cap.
+    """
+    bogus = plans._build("definitely_not_a_tier")
+    assert bogus.max_seats == EXPECTED_MAX_SEATS["free"]
+    assert bogus.max_pockets == EXPECTED_MAX_POCKETS["free"]
+    assert bogus.max_connectors == EXPECTED_MAX_CONNECTORS["free"]
+    assert bogus.max_seats is not None
+    assert bogus.max_pockets is not None
+    assert bogus.max_connectors is not None
 
 
 def test_list_plans_is_cheapest_first():

--- a/tests/cloud/billing/test_subscriptions.py
+++ b/tests/cloud/billing/test_subscriptions.py
@@ -875,3 +875,77 @@ async def test_switch_then_new_active_webhook_is_idempotent(
     )
     assert second == {"ok": True, "granted": False}
     assert await credits.balance(ws) == before + go_allotment
+
+
+# ---------------------------------------------------------------------------
+# fix/cancel-webhook-revert-guard — the subscription.cancelled plan revert must
+# NOT be unconditional. Under unordered / at-least-once delivery a
+# ``cancelled(old_sub)`` retry can land AFTER ``active(new_sub)`` during a plan
+# switch; reverting to free there strands a paying customer on free entitlements
+# (nothing self-heals it — only subscription.active re-sets the plan). The fix
+# marks THIS sub cancelled first, then reverts to free ONLY when no OTHER active
+# subscription still owns the workspace.
+# ---------------------------------------------------------------------------
+
+
+async def test_cancelled_does_not_revert_when_newer_active_sub_exists(mongo_db):
+    """Reordered delivery: active(new) already landed (workspace on pro, a NEW active
+    Subscription row owns it) when a stale cancelled(old) retry arrives. The plan
+    must STAY pro — the stale cancel must not downgrade the live subscription."""
+    ws = await _make_workspace(plan="pro")
+    # The newer subscription's active row already owns the workspace (as if its
+    # subscription.active landed first in the reordered delivery).
+    await _seed_subscription(ws, subscription_id="sub_new_active", status="active", plan_key="pro")
+    assert (await entitlements.resolve_entitlements(ws)).plan == "pro"
+
+    # A stale cancelled retry for a DIFFERENT (older) subscription lands now.
+    cancel_body = _subscription_body(
+        event_type="subscription.cancelled", workspace_id=ws, subscription_id="sub_old_cancelled"
+    )
+    result = await billing.handle_webhook(
+        payload=cancel_body.encode(),
+        headers=_sign(cancel_body, msg_id="evt_stale_cancel"),
+        provider=_provider(),
+    )
+
+    assert result == {"ok": True, "granted": False}
+    # The plan is NOT reverted to free — the newer active sub still owns the workspace.
+    assert (await entitlements.resolve_entitlements(ws)).plan == "pro"
+    # The newer subscription's row is untouched (still active).
+    still = await Subscription.find_one(
+        Subscription.gateway == "dodo",
+        Subscription.gateway_subscription_id == "sub_new_active",
+    )
+    assert still is not None
+    assert still.status == "active"
+
+
+async def test_cancelled_reverts_to_free_when_no_other_active_sub(mongo_db):
+    """The normal cancel: the ONLY subscription is the one being cancelled, so no
+    other active sub remains — the plan reverts to free (credits untouched)."""
+    ws = await _make_workspace(plan="pro")
+    await _seed_subscription(ws, subscription_id=SUB_ID, status="active", plan_key="pro")
+    # Give the wallet a balance to prove cancellation never claws it back.
+    await credits.grant(workspace=ws, amount=500, cause="seed", idempotency_key="seed_cancel")
+    assert await credits.balance(ws) == 500
+
+    cancel_body = _subscription_body(
+        event_type="subscription.cancelled", workspace_id=ws, subscription_id=SUB_ID
+    )
+    result = await billing.handle_webhook(
+        payload=cancel_body.encode(),
+        headers=_sign(cancel_body, msg_id="evt_solo_cancel"),
+        provider=_provider(),
+    )
+
+    assert result == {"ok": True, "granted": False}
+    # No other active sub -> plan reverts to free.
+    assert (await entitlements.resolve_entitlements(ws)).plan == "free"
+    # Credits preserved (no clawback).
+    assert await credits.balance(ws) == 500
+    # The cancelled subscription's row reflects the cancelled status.
+    sub = await Subscription.find_one(
+        Subscription.gateway == "dodo", Subscription.gateway_subscription_id == SUB_ID
+    )
+    assert sub is not None
+    assert sub.status == "cancelled"

--- a/tests/cloud/billing/test_subscriptions.py
+++ b/tests/cloud/billing/test_subscriptions.py
@@ -40,6 +40,16 @@
 #   is returned to the app after paying), omit return_url when no base is available,
 #   and the service must thread an ``origin`` into the return_url. Rewired the
 #   existing criterion-1 mock from subscriptions.create to checkout_sessions.create.
+# Updated 2026-07-08 (feat/billing-cancel-downgrade): added the two money-management
+#   bug-fix tests. (A) CANCEL — ``billing.cancel`` calls the provider's
+#   cancel_subscription with the ACTIVE sub id (proven at the SDK edge:
+#   subscriptions.update(<id>, status="cancelled")), 402s
+#   ``billing.no_active_subscription`` when there is none, and NEVER selects a stale
+#   cancelled historical row; plus POST /billing/cancel route wiring (200 + 402). (B)
+#   DOWNGRADE — ``subscribe`` on a workspace with an active sub does cancel-then-create
+#   (opens exactly one new checkout AND cancels the old sub id), does NOT cancel when
+#   there's no active sub (or only a cancelled row), and stays event_id-idempotent on
+#   the new subscription's active-webhook replay.
 
 from __future__ import annotations
 
@@ -604,3 +614,264 @@ async def test_empty_subscription_id_does_not_corrupt_cross_tenant(mongo_db):
     # trail is never replaced by workspace B's.
     subs = await Subscription.find().to_list()
     assert subs == []
+
+
+# ---------------------------------------------------------------------------
+# feat/billing-cancel-downgrade — two money-management bug fixes.
+#
+# Fixtures / helpers here spy at the SDK-client EDGE (a REAL DodoProvider with a
+# mocked ``AsyncDodoPayments``), so the tests exercise the real provider paths:
+#   * cancel  -> DodoProvider.cancel_subscription -> subscriptions.update(<id>,
+#     status="cancelled")
+#   * switch  -> DodoProvider.create_subscription -> checkout_sessions.create
+#     AND DodoProvider.cancel_subscription -> subscriptions.update
+# ---------------------------------------------------------------------------
+
+import pytest_asyncio  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+
+async def _seed_subscription(
+    workspace_id: str, *, subscription_id: str, status: str, plan_key: str = "pro"
+) -> Subscription:
+    """Insert a Subscription row directly (bypassing the webhook) to set up the
+    active / cancelled fixtures the cancel + switch paths select against."""
+    doc = Subscription(
+        workspace=workspace_id,
+        gateway="dodo",
+        gateway_subscription_id=subscription_id,
+        plan_key=plan_key,
+        product_id="prod_pro_recurring",
+        status=status,
+    )
+    await doc.insert()
+    return doc
+
+
+def _fake_switch_client(monkeypatch) -> MagicMock:
+    """SDK client mock for the cancel / plan-switch paths.
+
+    Exposes BOTH ``checkout_sessions.create`` (the new checkout) and
+    ``subscriptions.update`` (how the provider cancels — a status PATCH). A
+    regression back to ``subscriptions.create`` (the stranded path) still fails
+    loudly via the AssertionError side effect.
+    """
+    fake_session = MagicMock()
+    fake_session.session_id = SESSION_ID
+    fake_session.checkout_url = SESSION_CHECKOUT_URL
+
+    fake_client = MagicMock()
+    fake_client.checkout_sessions.create = AsyncMock(return_value=fake_session)
+    fake_client.subscriptions.update = AsyncMock(return_value=MagicMock())
+    fake_client.subscriptions.create = AsyncMock(
+        side_effect=AssertionError("must use checkout_sessions.create, not subscriptions.create")
+    )
+
+    import pocketpaw_ee.cloud.billing.providers.dodo as dodo_mod
+
+    monkeypatch.setattr(dodo_mod, "AsyncDodoPayments", MagicMock(return_value=fake_client))
+    return fake_client
+
+
+# ---- (A) cancel() -------------------------------------------------------- #
+
+
+async def test_cancel_calls_provider_with_active_subscription_id(mongo_db, monkeypatch):
+    """cancel() loads the ACTIVE sub and tells the gateway to stop billing IT."""
+    ws = await _make_workspace(plan="pro")
+    await _seed_subscription(ws, subscription_id=SUB_ID, status="active")
+    fake_client = _fake_switch_client(monkeypatch)
+
+    result = await billing.cancel(workspace_id=ws, provider=_provider())
+
+    assert result == {"ok": True}
+    # The real provider path cancels via the status PATCH on the ACTIVE sub id.
+    fake_client.subscriptions.update.assert_awaited_once_with(SUB_ID, status="cancelled")
+
+
+async def test_cancel_without_active_subscription_raises_402(mongo_db, monkeypatch):
+    """No subscription at all -> 402 billing.no_active_subscription, gateway untouched."""
+    ws = await _make_workspace(plan="free")
+    fake_client = _fake_switch_client(monkeypatch)
+    from pocketpaw_ee.cloud._core.errors import NoActiveSubscription
+
+    with pytest.raises(NoActiveSubscription) as exc:
+        await billing.cancel(workspace_id=ws, provider=_provider())
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.no_active_subscription"
+    fake_client.subscriptions.update.assert_not_called()
+
+
+async def test_cancel_ignores_stale_cancelled_row(mongo_db, monkeypatch):
+    """A historical CANCELLED row must NOT be selected — cancel targets the ACTIVE
+    row's id (the (workspace) index is non-unique, so a naive first-match is wrong)."""
+    ws = await _make_workspace(plan="pro")
+    await _seed_subscription(ws, subscription_id="sub_old_cancelled", status="cancelled")
+    await _seed_subscription(ws, subscription_id="sub_current_active", status="active")
+    fake_client = _fake_switch_client(monkeypatch)
+
+    await billing.cancel(workspace_id=ws, provider=_provider())
+
+    fake_client.subscriptions.update.assert_awaited_once_with(
+        "sub_current_active", status="cancelled"
+    )
+
+
+async def test_cancel_with_only_cancelled_row_raises_402(mongo_db, monkeypatch):
+    """Only a stale cancelled row exists -> 402 (a naive first-match would wrongly
+    'cancel' the dead row; the status filter prevents that)."""
+    ws = await _make_workspace(plan="free")
+    await _seed_subscription(ws, subscription_id="sub_dead", status="cancelled")
+    fake_client = _fake_switch_client(monkeypatch)
+    from pocketpaw_ee.cloud._core.errors import NoActiveSubscription
+
+    with pytest.raises(NoActiveSubscription):
+        await billing.cancel(workspace_id=ws, provider=_provider())
+    fake_client.subscriptions.update.assert_not_called()
+
+
+# ---- (A) cancel() route wiring (httpx AsyncClient) ----------------------- #
+
+
+@pytest_asyncio.fixture
+async def billing_app_client() -> AsyncClient:
+    """A FastAPI app with ONLY the billing router mounted + auth/license overridden,
+    scoped to workspace ``w1`` — so the POST /billing/cancel wiring is exercised
+    without a real JWT / license (mirrors the shared cloud_app_client fixture)."""
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.billing.router import router as billing_router
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(billing_router)
+    app.dependency_overrides[current_user_id] = lambda: "u1"
+    app.dependency_overrides[current_workspace_id] = lambda: "w1"
+    app.dependency_overrides[require_license] = lambda: None
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+async def test_cancel_route_cancels_active_subscription(mongo_db, billing_app_client, monkeypatch):
+    """POST /billing/cancel -> 200 {ok: true} and the gateway sub is cancelled."""
+    await _seed_subscription("w1", subscription_id=SUB_ID, status="active")
+    fake_client = _fake_switch_client(monkeypatch)
+    # The route uses the DEFAULT provider — point it at the test provider whose SDK
+    # client is mocked (no real Dodo settings / network needed).
+    monkeypatch.setattr(billing, "_default_provider", lambda: _provider())
+
+    resp = await billing_app_client.post("/billing/cancel")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    fake_client.subscriptions.update.assert_awaited_once_with(SUB_ID, status="cancelled")
+
+
+async def test_cancel_route_402_when_no_active_subscription(
+    mongo_db, billing_app_client, monkeypatch
+):
+    """POST /billing/cancel with no active sub -> 402 billing.no_active_subscription."""
+    monkeypatch.setattr(billing, "_default_provider", lambda: _provider())
+
+    resp = await billing_app_client.post("/billing/cancel")
+
+    assert resp.status_code == 402
+    assert resp.json()["error"]["code"] == "billing.no_active_subscription"
+
+
+# ---- (B) subscribe() switch guard --------------------------------------- #
+
+
+async def test_subscribe_with_active_sub_cancels_old_then_creates_new(
+    mongo_db, monkeypatch, patch_plan_products
+):
+    """A switch (workspace already has an active sub) opens exactly ONE new checkout
+    AND cancels the OLD subscription — never the blind double-create."""
+    ws = await _make_workspace(plan="pro")
+    await _seed_subscription(ws, subscription_id=SUB_ID, status="active", plan_key="pro")
+    fake_client = _fake_switch_client(monkeypatch)
+
+    result = await billing.subscribe(
+        workspace_id=ws, user_id="u1", plan_key="go", provider=_provider()
+    )
+    assert result == {"checkout_url": SESSION_CHECKOUT_URL}
+
+    # Exactly one NEW checkout was opened (no second parallel subscribe)...
+    fake_client.checkout_sessions.create.assert_awaited_once()
+    # ...and the OLD subscription was cancelled at the gateway. The pre-fix blind
+    # path (create WITHOUT cancel) would leave subscriptions.update un-called.
+    fake_client.subscriptions.update.assert_awaited_once_with(SUB_ID, status="cancelled")
+
+
+async def test_subscribe_without_active_sub_does_not_cancel(
+    mongo_db, monkeypatch, patch_plan_products
+):
+    """A fresh subscribe (no active sub) opens the checkout and cancels NOTHING."""
+    ws = await _make_workspace(plan="free")
+    fake_client = _fake_switch_client(monkeypatch)
+
+    await billing.subscribe(workspace_id=ws, user_id="u1", plan_key="pro", provider=_provider())
+
+    fake_client.checkout_sessions.create.assert_awaited_once()
+    fake_client.subscriptions.update.assert_not_called()
+
+
+async def test_subscribe_ignores_cancelled_row_and_does_not_cancel(
+    mongo_db, monkeypatch, patch_plan_products
+):
+    """A stale CANCELLED row is not 'active' — subscribe treats the workspace as
+    having no active sub and cancels nothing (no spurious gateway call)."""
+    ws = await _make_workspace(plan="free")
+    await _seed_subscription(ws, subscription_id="sub_dead", status="cancelled")
+    fake_client = _fake_switch_client(monkeypatch)
+
+    await billing.subscribe(workspace_id=ws, user_id="u1", plan_key="pro", provider=_provider())
+
+    fake_client.checkout_sessions.create.assert_awaited_once()
+    fake_client.subscriptions.update.assert_not_called()
+
+
+async def test_switch_then_new_active_webhook_is_idempotent(
+    mongo_db, monkeypatch, patch_plan_products
+):
+    """After a switch, the NEW subscription's active webhook grants exactly once — a
+    replay (same event_id) is a no-op, so the switch never breaks BC-1 replay-safety."""
+    ws = await _make_workspace(plan="pro")
+    await _seed_subscription(ws, subscription_id=SUB_ID, status="active", plan_key="pro")
+    _fake_switch_client(monkeypatch)
+
+    # Switch to go — opens a new checkout + cancels the old sub.
+    await billing.subscribe(workspace_id=ws, user_id="u1", plan_key="go", provider=_provider())
+
+    go_allotment = plans.get_plan("go").monthly_credit_allotment
+    assert go_allotment > 0
+    before = await credits.balance(ws)
+
+    # The NEW subscription's active webhook lands (fresh gateway sub id + event id).
+    body = _subscription_body(
+        event_type="subscription.active",
+        workspace_id=ws,
+        plan_key="go",
+        product_id="prod_go_recurring",
+        subscription_id="sub_new_go",
+    )
+    first = await billing.handle_webhook(
+        payload=body.encode(),
+        headers=_sign(body, msg_id="evt_switch_go_active"),
+        provider=_provider(),
+    )
+    assert first == {"ok": True, "granted": True}
+    assert await credits.balance(ws) == before + go_allotment
+
+    # Replay the SAME active event id — a no-op (BC-1 unique index); balance flat.
+    second = await billing.handle_webhook(
+        payload=body.encode(),
+        headers=_sign(body, msg_id="evt_switch_go_active"),  # SAME id
+        provider=_provider(),
+    )
+    assert second == {"ok": True, "granted": False}
+    assert await credits.balance(ws) == before + go_allotment

--- a/tests/cloud/billing/test_usage_ledger_source.py
+++ b/tests/cloud/billing/test_usage_ledger_source.py
@@ -17,6 +17,10 @@
 # Created 2026-06-29 (fix/billing-usage-ledger-source): RED anchor for
 # re-sourcing get_workspace_usage from the credit ledger instead of the LiteLLM
 # proxy daily-activity.
+# Updated 2026-07-11 (feat/llm-cost-attribution): ``_seed_spend`` gained a
+# ``tokens`` param (stamps ``ref.total_tokens``) and a case proves the usage graph
+# surfaces REAL per-model token volume end-to-end (token-bearing debits summed, a
+# legacy debit adding 0) instead of the former hardcoded 0.
 
 from __future__ import annotations
 
@@ -39,14 +43,19 @@ async def _seed_spend(
     credits: int,
     idem: str,
     cause: str = "compute_spend",
+    tokens: int | None = None,
 ) -> None:
     """Insert one APPLIED debit ledger entry stamped on a controlled date.
 
     Mirrors what ``metering.service.bill_run`` writes: a negative ``amount_delta``
-    under ``cause`` with the run's ``model`` in ``ref``. Inserts first (the Insert
-    event forces createdAt=now), then back-dates ``createdAt`` via the raw
-    collection so the (day, model) bucketing can be asserted.
+    under ``cause`` with the run's ``model`` (and ``total_tokens`` when given) in
+    ``ref``. Inserts first (the Insert event forces createdAt=now), then back-dates
+    ``createdAt`` via the raw collection so the (day, model) bucketing can be
+    asserted.
     """
+    ref: dict = {"model": model}
+    if tokens is not None:
+        ref["total_tokens"] = tokens
     entry = CreditLedgerEntry(
         workspace=ws,
         kind="spend",
@@ -55,7 +64,7 @@ async def _seed_spend(
         applied=True,
         conditional=False,
         cause=cause,
-        ref={"model": model},
+        ref=ref,
         idempotency_key=idem,
     )
     await entry.insert()
@@ -114,6 +123,25 @@ async def test_usage_includes_litellm_spend_cause_after_cutover(mongo_db):
 
     assert result.models == [SONNET]
     assert result.total_credits == 20  # 8 (compute_spend) + 12 (litellm_spend)
+
+
+async def test_usage_surfaces_real_token_volume(mongo_db):
+    """Per-model ``tokens`` reflects the real volume the ledger now carries (summed
+    from each debit's ``ref.total_tokens``), no longer a hardcoded 0."""
+    assert await provisioning.get_tenant_key(WS) is None
+
+    # Two token-bearing runs for the same (day, model) + one legacy run (no
+    # total_tokens) whose credits still count but adds 0 tokens.
+    await _seed_spend(WS, day=(2026, 6, 1), model=SONNET, credits=10, idem="run:r1", tokens=1500)
+    await _seed_spend(WS, day=(2026, 6, 1), model=SONNET, credits=5, idem="run:r2", tokens=500)
+    await _seed_spend(WS, day=(2026, 6, 1), model=SONNET, credits=2, idem="run:r3")  # legacy
+
+    result = await usage.get_workspace_usage(WS, start_date="2026-06-01", end_date="2026-06-01")
+
+    stats = result.buckets[0].by_model[SONNET]
+    assert stats.tokens == 2000  # 1500 + 500 + 0 (legacy)
+    assert stats.credits == 17  # 10 + 5 + 2 — credits unaffected by tokens
+    assert stats.requests == 3
 
 
 async def test_usage_excludes_non_spend_causes(mongo_db):

--- a/tests/cloud/connectors/test_connector_cap.py
+++ b/tests/cloud/connectors/test_connector_cap.py
@@ -1,0 +1,138 @@
+# tests/cloud/connectors/test_connector_cap.py
+# Created 2026-07-08 (feat/billing-smb-caps) — locks the per-plan CONNECTOR cap on
+# the enable seam. ``enable_connector`` raises ``ConnectorLimitError`` (402) when the
+# workspace already has its plan's ``max_connectors`` enabled and the call would
+# turn a NEW connector on (a fresh row, or re-enabling a disabled one). The cap
+# (``_connector_cap_exceeded``) is a no-op unless ``billing_enforced`` and never
+# trips on an uncapped Enterprise plan. An idempotent re-enable of an
+# already-enabled connector is NEVER blocked — enforcement is enable-time only,
+# never retroactive.
+#
+# The plan resolver is stubbed to a controlled ``max_connectors`` so the count/limit
+# logic is exercised against a small ceiling; the catalog-value + fail-closed
+# contract lives in test_plans.py / test_entitlements.py. ``billing_enforced`` is
+# toggled by pointing the config's ``get_settings`` at a flag stub. ``stripe`` /
+# ``gmail`` / ``github`` are YAML connectors shipped in repo /connectors, available
+# in every registry instance so tests need no catalog seeding.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ConnectorLimitError
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.dto import EnableConnectorRequest
+from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+from pocketpaw_ee.cloud.entitlements.domain import Entitlements
+
+import pocketpaw.config as ppconfig
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws_connector_cap"
+
+
+def _enforce(monkeypatch, *, on: bool) -> None:
+    """Point the config's ``get_settings`` (lazily imported inside the cap helper)
+    at a flag stub carrying the billing posture."""
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, dodo_plan_products=None),
+    )
+
+
+def _cap(monkeypatch, *, max_connectors: int | None) -> None:
+    """Stub the entitlements resolver to a controlled ``max_connectors`` ceiling."""
+    ent = Entitlements(
+        workspace_id=_WS,
+        plan="free",
+        monthly_credit_allotment=0,
+        monthly_ceiling=1_000,
+        max_seats=5,
+        max_pockets=200,
+        max_connectors=max_connectors,
+        features=frozenset(),
+    )
+    monkeypatch.setattr(entitlements_service, "resolve_entitlements", AsyncMock(return_value=ent))
+
+
+async def _enable(name: str):
+    return await connectors_service.enable_connector(
+        _WS, name, EnableConnectorRequest(scope="workspace")
+    )
+
+
+async def test_enable_raises_connector_limit_at_cap(monkeypatch) -> None:
+    """At/over the plan cap, enabling a NEW connector raises ConnectorLimitError."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_connectors=2)
+
+    await _enable("stripe")  # 1 enabled
+    await _enable("gmail")  # 2 enabled — at the cap
+
+    with pytest.raises(ConnectorLimitError) as exc:
+        await _enable("github")
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.connector_limit"
+
+
+async def test_enable_allows_below_cap(monkeypatch) -> None:
+    """Below the cap, enable proceeds normally."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_connectors=2)
+
+    resp = await _enable("stripe")
+    assert resp.enabled is True
+
+
+async def test_reenable_already_enabled_connector_is_never_blocked(monkeypatch) -> None:
+    """An idempotent re-enable of an already-enabled connector is NOT blocked, even
+    when the workspace sits exactly at the cap — the cap is create/enable-time only
+    and must never retroactively strip an existing connector."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_connectors=1)
+
+    await _enable("stripe")  # 1 enabled — at the cap
+
+    # Re-enabling the SAME already-enabled connector adds nothing, so it must pass.
+    resp = await _enable("stripe")
+    assert resp.enabled is True
+
+
+async def test_reenable_disabled_connector_is_capped(monkeypatch) -> None:
+    """Re-enabling a DISABLED connector counts as turning one on — blocked at cap."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_connectors=1)
+
+    await _enable("stripe")  # 1 enabled
+    await connectors_service.disable_connector(_WS, "stripe")  # 0 enabled
+    await _enable("gmail")  # 1 enabled — back at the cap
+
+    # stripe's row still exists but is disabled; re-enabling it would exceed the cap.
+    with pytest.raises(ConnectorLimitError):
+        await _enable("stripe")
+
+
+async def test_connector_cap_is_noop_when_billing_disabled(monkeypatch) -> None:
+    """With billing_enforced OFF, the cap never fires — even past the ceiling."""
+    _enforce(monkeypatch, on=False)
+    _cap(monkeypatch, max_connectors=1)
+
+    await _enable("stripe")
+    await _enable("gmail")
+    resp = await _enable("github")  # 3rd, well over the (ignored) cap
+    assert resp.enabled is True
+
+
+async def test_connector_cap_is_noop_when_uncapped(monkeypatch) -> None:
+    """An uncapped plan (Enterprise, max_connectors=None) never trips the cap."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_connectors=None)
+
+    await _enable("stripe")
+    await _enable("gmail")
+    resp = await _enable("github")
+    assert resp.enabled is True

--- a/tests/cloud/credits/test_billing_enforce_smoke.py
+++ b/tests/cloud/credits/test_billing_enforce_smoke.py
@@ -1,0 +1,182 @@
+# tests/cloud/credits/test_billing_enforce_smoke.py — LIVE flag-on smoke for the
+# billing-enforcement wave. Unlike the unit tests (which mock over_billing_limit),
+# this drives the REAL guard end-to-end: real credits.service.check_balance against
+# a REAL (empty / funded / negative) wallet in Beanie, with the REAL flag flipped
+# on via the guard's own get_settings. Only true infrastructure is stubbed (the
+# group lookup, the realtime emit, the run transport) — never the billing seam.
+#
+# Proves the money guarantee the wave claims:
+#   1. flag ON + empty wallet  -> the group/DM bridge (a NEW C1 seam) blocks with
+#      NO model call (neither the Haiku relevance pre-classifier nor the agent run).
+#   2. flag ON + funded wallet -> the bridge proceeds (no over-blocking).
+#   3. flag OFF + empty wallet -> proceeds (the default-off safety: nothing changes
+#      in prod until POCKETPAW_BILLING_ENFORCED is set).
+#   4. flag ON + negative wallet -> the WORKER/executor path (run_core's delegate)
+#      rejects with a terminal error frame — the balance-parity leg C1 added.
+#
+# Created 2026-07-08 (feat/billing-enforce-gate smoke, pre-Wave-2 gate).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _flag(on: bool):
+    """Patch the guard's own settings source so the REAL guard sees the flag."""
+    return patch(
+        "pocketpaw_ee.cloud.credits.guards.get_settings",
+        new=lambda: SimpleNamespace(billing_enforced=on),
+    )
+
+
+def _one_agent_group() -> SimpleNamespace:
+    return SimpleNamespace(
+        members=["u1"],
+        agents=[SimpleNamespace(agent_id="agent-a", respond_mode="smart")],
+    )
+
+
+async def test_smoke_bridge_blocks_empty_wallet_no_model_call(mongo_db):  # noqa: ARG001 — Beanie init
+    """flag ON + REAL empty wallet -> the group/DM bridge blocks with no model call."""
+    from pocketpaw_ee.cloud.credits import service as credits_service
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    # ws "ws-empty" has NO wallet -> real balance() is 0 -> check_balance raises.
+    assert await credits_service.balance("ws-empty") == 0
+
+    should_spy = AsyncMock(return_value=True)
+    run_spy = AsyncMock(return_value=None)
+    emit_spy = AsyncMock()
+
+    with (
+        _flag(True),
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=_one_agent_group()),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond", new=should_spy),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response", new=run_spy),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=emit_spy),
+    ):
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "g1",
+                "sender_id": "u1",
+                "content": "hey team",
+                "mentions": [],
+                "workspace_id": "ws-empty",
+            }
+        )
+
+    # No Haiku pre-classifier, no agent run — the real money guarantee.
+    should_spy.assert_not_awaited()
+    run_spy.assert_not_awaited()
+    # One terminal billing error emitted to the group.
+    assert emit_spy.await_count == 1
+    assert emit_spy.await_args_list[0].args[0].data["code"] == "credits.insufficient"
+
+
+async def test_smoke_bridge_proceeds_funded_wallet(mongo_db):  # noqa: ARG001 — Beanie init
+    """flag ON + REAL funded wallet -> the bridge proceeds (no over-blocking)."""
+    from pocketpaw_ee.cloud.credits import service as credits_service
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    await credits_service.grant("ws-funded", 500, cause="smoke.seed", idempotency_key="smoke-f1")
+    assert await credits_service.balance("ws-funded") == 500
+
+    should_spy = AsyncMock(return_value=False)  # returns False so no agent actually runs
+    run_spy = AsyncMock(return_value=None)
+
+    with (
+        _flag(True),
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=_one_agent_group()),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond", new=should_spy),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response", new=run_spy),
+    ):
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "g1",
+                "sender_id": "u1",
+                "content": "hey team",
+                "mentions": [],
+                "workspace_id": "ws-funded",
+            }
+        )
+
+    # The gate passed (real check_balance no-op + real check_quota under ceiling):
+    # respond-mode evaluation was reached, so the bridge did NOT over-block.
+    should_spy.assert_awaited()
+
+
+async def test_smoke_flag_off_empty_wallet_proceeds(mongo_db):  # noqa: ARG001 — Beanie init
+    """flag OFF + empty wallet -> proceeds. Default-off safety: inert until enabled."""
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    should_spy = AsyncMock(return_value=False)
+
+    with (
+        _flag(False),
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=_one_agent_group()),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond", new=should_spy),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response", new=AsyncMock()),
+    ):
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "g1",
+                "sender_id": "u1",
+                "content": "hey team",
+                "mentions": [],
+                "workspace_id": "ws-empty",  # empty wallet, but flag off
+            }
+        )
+
+    # Gate is a no-op with the flag off — the bridge proceeds past it.
+    should_spy.assert_awaited()
+
+
+async def test_smoke_worker_path_rejects_negative_wallet(mongo_db):  # noqa: ARG001 — Beanie init
+    """flag ON + REAL negative wallet -> the worker/executor guard rejects with a
+    terminal error frame (the balance-parity leg C1 added to the worker path)."""
+    from pocketpaw_ee.cloud.credits import guards
+    from pocketpaw_ee.cloud.credits import service as credits_service
+
+    # Drive the wallet negative through a real metered debit, like test_enforcement.
+    await credits_service.grant("ws-neg", 10, cause="smoke.seed", idempotency_key="smoke-n1")
+    await credits_service.debit(
+        "ws-neg", 25, cause="smoke.debit", idempotency_key="smoke-n2", allow_negative=True
+    )
+    assert await credits_service.balance("ws-neg") == -15
+
+    appended: list[tuple[str, dict]] = []
+
+    class _SpyTransport:
+        async def append_event(self, run_id: str, event: str, data: dict) -> None:  # noqa: ARG002
+            appended.append((event, data))
+
+        async def set_ttl(self, run_id: str, ttl: int) -> None:  # noqa: ARG002
+            return None
+
+    with (
+        _flag(True),
+        patch(
+            "pocketpaw_ee.cloud.chat.runs.service.mark_terminal",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        rejected = await guards.reject_if_over_billing(
+            "ws-neg", run_id="run-smoke", transport=_SpyTransport(), log_label="smoke"
+        )
+
+    assert rejected is True
+    assert appended and appended[0][0] == "error"
+    assert appended[0][1]["code"] == "credits.insufficient"

--- a/tests/cloud/credits/test_guards.py
+++ b/tests/cloud/credits/test_guards.py
@@ -1,0 +1,242 @@
+# tests/cloud/credits/test_guards.py
+# Created 2026-07-08 (feat/billing-enforce-gate) — locks the shared run-start
+# BILLING gate (``credits.guards``) that every agent-run seam now funnels through.
+# These are GUARD-level tests: the seam under test is the guard, so they drive the
+# REAL ``check_balance`` / ``check_quota`` off real wallet + plan state (funded via
+# ``credits.grant``, spend back-dated into the ledger, plan set by inserting a real
+# ``Workspace``) rather than stubbing the credit assertions — over-mocking has hid
+# live billing bugs here before. The credit-math contract itself lives in
+# test_quota.py / test_enforcement.py; this locks the GUARD wiring:
+#   * ``over_billing_limit`` — flag OFF is a no-op (None) even at balance 0; flag
+#     ON returns InsufficientCredits at an empty wallet (the primary money leg,
+#     checked FIRST), QuotaExceeded when funded-but-over-the-monthly-ceiling, and
+#     None when funded + under the ceiling. An uncapped Enterprise plan
+#     (ceiling=None) is NEVER blocked by the quota leg. An empty workspace id is a
+#     no-op (no wallet to attribute).
+#   * ``assert_within_billing`` — raises the 402 CloudError over-limit (the HTTP
+#     shape), no-ops within limits.
+#   * ``reject_if_over_billing`` — the run-transport shape: on rejection emits a
+#     terminal ``error`` frame, marks the run failed, sets the stream TTL, returns
+#     True; flag OFF returns False with no side effects.
+# The flag is applied ON in the settings equivalent (``guards.get_settings`` stub
+# with ``billing_enforced=True``) — the flag-mode lane.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import InsufficientCredits, QuotaExceeded
+from pocketpaw_ee.cloud.credits import guards
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+from pocketpaw_ee.cloud.models.workspace import Workspace
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers (seeding style mirrors test_quota.py)
+# ---------------------------------------------------------------------------
+
+
+def _enforce(monkeypatch, *, on: bool) -> None:
+    """Point the guard's ``get_settings`` at a stub carrying the flag posture."""
+    monkeypatch.setattr(guards, "get_settings", lambda: SimpleNamespace(billing_enforced=on))
+
+
+async def _make_workspace(plan: str, *, slug: str) -> str:
+    """Insert a real Workspace so ``resolve_entitlements`` reads its plan."""
+    ws = Workspace(name="Tenant", slug=slug, owner="u-owner", plan=plan)
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _seed_spend(ws: str, amount: int, *, idem: str) -> None:
+    """Back-date an APPLIED compute_spend debit into the current month WITHOUT
+    moving the CreditBalance (raw insert) so a funded wallet can still be 'over
+    quota' — isolating the quota leg from the balance leg."""
+    n = datetime.now(UTC)
+    when = datetime(n.year, n.month, 15, 12, tzinfo=UTC)
+    entry = CreditLedgerEntry(
+        workspace=ws,
+        kind="spend",
+        amount_delta=-amount,
+        balance_after=0,
+        applied=True,
+        conditional=False,
+        cause="compute_spend",
+        ref={},
+        idempotency_key=idem,
+    )
+    await entry.insert()
+    await CreditLedgerEntry.get_pymongo_collection().update_one(
+        {"_id": entry.id}, {"$set": {"createdAt": when}}
+    )
+
+
+# ---------------------------------------------------------------------------
+# over_billing_limit
+# ---------------------------------------------------------------------------
+
+
+async def test_flag_off_is_noop_even_at_zero_balance(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=False)
+    # No wallet -> balance 0, but the flag is OFF: never gates.
+    assert await guards.over_billing_limit("ws-empty") is None
+
+
+async def test_enforced_empty_wallet_returns_insufficient(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    # No wallet -> balance 0 -> the balance leg (checked first) rejects.
+    exc = await guards.over_billing_limit("ws-empty")
+    assert isinstance(exc, InsufficientCredits)
+    assert exc.status_code == 402
+    assert exc.code == "credits.insufficient"
+
+
+async def test_enforced_funded_over_quota_returns_quota_exceeded(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    ws = await _make_workspace("free", slug="g-over")
+    # Fund the wallet so the balance leg passes, then spend up to the Free ceiling
+    # (1000) so the quota leg trips. The spend is raw-seeded so it does NOT reduce
+    # the funded balance — the wallet is genuinely funded AND over the monthly cap.
+    await credits.grant(ws, 5000, cause="test.seed", idempotency_key="fund-1")
+    await _seed_spend(ws, 1000, idem="spend-1")
+
+    exc = await guards.over_billing_limit(ws)
+    assert isinstance(exc, QuotaExceeded)
+    assert exc.status_code == 402
+    assert exc.code == "credits.quota_exceeded"
+
+
+async def test_enforced_funded_under_quota_returns_none(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    ws = await _make_workspace("free", slug="g-under")
+    await credits.grant(ws, 5000, cause="test.seed", idempotency_key="fund-2")
+    await _seed_spend(ws, 999, idem="spend-2")  # under the 1000 Free ceiling
+
+    assert await guards.over_billing_limit(ws) is None
+
+
+async def test_enforced_enterprise_uncapped_never_blocked(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    # Enterprise -> ceiling None. Funded wallet + huge spend must NOT block: the
+    # quota leg is a no-op on an uncapped plan (the guardrail).
+    ws = await _make_workspace("enterprise", slug="g-ent")
+    await credits.grant(ws, 5000, cause="test.seed", idempotency_key="fund-3")
+    await _seed_spend(ws, 1_000_000, idem="spend-3")
+
+    assert await guards.over_billing_limit(ws) is None
+
+
+async def test_enforced_empty_workspace_id_is_noop(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    # No workspace to attribute -> proceed (no wallet, no gate).
+    assert await guards.over_billing_limit("") is None
+
+
+# ---------------------------------------------------------------------------
+# assert_within_billing (the HTTP shape)
+# ---------------------------------------------------------------------------
+
+
+async def test_assert_raises_over_limit(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    with pytest.raises(InsufficientCredits) as exc:
+        await guards.assert_within_billing("ws-empty")
+    assert exc.value.status_code == 402
+
+
+async def test_assert_noop_within_limit(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    ws = await _make_workspace("free", slug="g-assert-ok")
+    await credits.grant(ws, 5000, cause="test.seed", idempotency_key="fund-4")
+    assert await guards.assert_within_billing(ws) is None
+
+
+async def test_assert_flag_off_never_raises(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=False)
+    # Empty wallet but flag OFF -> no raise.
+    assert await guards.assert_within_billing("ws-empty") is None
+
+
+# ---------------------------------------------------------------------------
+# reject_if_over_billing (the run/stream-transport shape)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTransport:
+    """Records the run-transport side effects the guard drives on a rejection."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict]] = []
+        self.ttls: list[tuple[str, int]] = []
+
+    async def append_event(self, run_id: str, event: str, data: dict) -> None:
+        self.events.append((run_id, event, data))
+
+    async def set_ttl(self, run_id: str, ttl: int) -> None:
+        self.ttls.append((run_id, ttl))
+
+
+async def test_reject_over_limit_emits_terminal_and_marks_failed(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    transport = _FakeTransport()
+
+    marked: list[dict] = []
+
+    async def _mark_terminal(run_id, *, status, error=None, **k):
+        marked.append({"run_id": run_id, "status": status, "error": error})
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.mark_terminal", _mark_terminal)
+
+    # Empty wallet -> the balance leg rejects.
+    rejected = await guards.reject_if_over_billing("ws-empty", run_id="run-1", transport=transport)
+
+    assert rejected is True
+    # A terminal ``error`` frame carrying the balance code went to the transport.
+    assert transport.events == [
+        ("run-1", "error", transport.events[0][2]),
+    ]
+    assert transport.events[0][2]["code"] == "credits.insufficient"
+    # The run was marked terminally failed, and the stream TTL was set.
+    assert marked == [
+        {"run_id": "run-1", "status": "failed", "error": transport.events[0][2]["message"]}
+    ]
+    assert transport.ttls and transport.ttls[0][0] == "run-1"
+
+
+async def test_reject_within_limit_returns_false_no_side_effects(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=True)
+    ws = await _make_workspace("free", slug="g-reject-ok")
+    await credits.grant(ws, 5000, cause="test.seed", idempotency_key="fund-5")
+    transport = _FakeTransport()
+
+    async def _mark_terminal(run_id, *, status, error=None, **k):
+        raise AssertionError("mark_terminal must not run when within budget")
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.mark_terminal", _mark_terminal)
+
+    rejected = await guards.reject_if_over_billing(ws, run_id="run-2", transport=transport)
+
+    assert rejected is False
+    assert transport.events == []
+    assert transport.ttls == []
+
+
+async def test_reject_flag_off_returns_false(mongo_db, monkeypatch):  # noqa: ARG001
+    _enforce(monkeypatch, on=False)
+    transport = _FakeTransport()
+
+    async def _mark_terminal(run_id, *, status, error=None, **k):
+        raise AssertionError("mark_terminal must not run when the flag is OFF")
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.mark_terminal", _mark_terminal)
+
+    # Empty wallet but flag OFF -> no rejection, no side effects.
+    rejected = await guards.reject_if_over_billing("ws-empty", run_id="run-3", transport=transport)
+    assert rejected is False
+    assert transport.events == []
+    assert transport.ttls == []

--- a/tests/cloud/credits/test_spend_by_model.py
+++ b/tests/cloud/credits/test_spend_by_model.py
@@ -21,6 +21,10 @@
 #
 # Created 2026-06-29 (fix/billing-usage-ledger-source): new test module — unit
 # coverage for the ledger read that re-sources the billing usage graph.
+# Updated 2026-07-11 (feat/llm-cost-attribution): ``_seed`` gained a ``tokens``
+# param (stamps ``ref.total_tokens``) and two cases cover the new token sum —
+# real per-group volume across token-bearing debits + a legacy debit adding 0,
+# and an all-legacy group reporting tokens=0.
 
 from __future__ import annotations
 
@@ -44,10 +48,17 @@ async def _seed(
     applied: bool = True,
     idem: str,
     ws: str = WS,
+    tokens: int | None = None,
 ) -> None:
     """Insert one ledger entry stamped at ``when`` (back-dated via the raw
-    collection so the window boundaries can be asserted)."""
+    collection so the window boundaries can be asserted).
+
+    When ``tokens`` is given it is stamped on the ref as ``total_tokens`` (the real
+    volume the metering path records); omitting it models a legacy debit whose ref
+    predates token attribution (contributes 0 to the group's token sum)."""
     ref = {"model": model} if model is not None else {}
+    if tokens is not None:
+        ref["total_tokens"] = tokens
     entry = CreditLedgerEntry(
         workspace=ws,
         kind="spend",
@@ -215,6 +226,60 @@ async def test_missing_ref_model_buckets_unknown(mongo_db):
     assert len(rows) == 1
     assert rows[0].model == "unknown"
     assert rows[0].credits == 15
+
+
+async def test_sums_total_tokens_per_group(mongo_db):
+    # Two token-bearing debits + one legacy debit (no total_tokens) in one group:
+    # the group's tokens is the sum of the real figures, the legacy one adds 0.
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
+        amount_delta=-4,
+        model=SONNET,
+        idem="t1",
+        tokens=1000,
+    )
+    await _seed(
+        when=datetime(2026, 6, 1, 18, 0, tzinfo=UTC),
+        amount_delta=-6,
+        model=SONNET,
+        idem="t2",
+        tokens=500,
+    )
+    await _seed(
+        when=datetime(2026, 6, 1, 20, 0, tzinfo=UTC),
+        amount_delta=-2,
+        model=SONNET,
+        idem="t3",  # legacy: no total_tokens on the ref
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+    by = _by_key(rows)
+
+    row = by[("2026-06-01", SONNET)]
+    assert row.tokens == 1500  # 1000 + 500 + 0 (legacy)
+    assert row.requests == 3
+    assert row.credits == 12  # 4 + 6 + 2 — unaffected by tokens
+
+
+async def test_tokens_default_zero_when_no_ref_tokens(mongo_db):
+    # A group made entirely of legacy debits reports tokens=0 (credits still real).
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC), amount_delta=-7, model=GPT, idem="legacy"
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+
+    assert len(rows) == 1
+    assert rows[0].tokens == 0
+    assert rows[0].credits == 7
 
 
 async def test_is_tenant_scoped(mongo_db):

--- a/tests/cloud/entitlements/test_dto_caps.py
+++ b/tests/cloud/entitlements/test_dto_caps.py
@@ -1,0 +1,53 @@
+# tests/cloud/entitlements/test_dto_caps.py — the SMB caps (max_seats /
+# max_pockets / max_connectors) added to the plan ladder must reach the wire:
+# plan_tier_to_dto (GET /billing/plans) and entitlements_to_dto (GET /entitlements)
+# have to carry them, else the plan cards / settings UI cannot render real limits.
+# Created 2026-07-08 (feat/billing-smb-caps).
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.billing.plans import get_plan, list_plans
+from pocketpaw_ee.cloud.entitlements.domain import Entitlements
+from pocketpaw_ee.cloud.entitlements.dto import entitlements_to_dto, plan_tier_to_dto
+
+
+def test_plan_tier_dto_carries_caps() -> None:
+    """Every catalog row on the wire carries the three caps from its PlanTier."""
+    for tier in list_plans():
+        dto = plan_tier_to_dto(tier)
+        assert dto.max_seats == tier.max_seats
+        assert dto.max_pockets == tier.max_pockets
+        assert dto.max_connectors == tier.max_connectors
+
+
+def test_free_tier_dto_caps_are_concrete() -> None:
+    """Free (a capped tier) serializes concrete integer caps, not null."""
+    dto = plan_tier_to_dto(get_plan("free"))
+    assert isinstance(dto.max_seats, int)
+    assert isinstance(dto.max_pockets, int)
+    assert isinstance(dto.max_connectors, int)
+
+
+def test_enterprise_tier_dto_caps_are_null() -> None:
+    """Enterprise is uncapped — the caps serialize as null on the wire."""
+    dto = plan_tier_to_dto(get_plan("enterprise"))
+    assert dto.max_seats is None
+    assert dto.max_pockets is None
+    assert dto.max_connectors is None
+
+
+def test_entitlements_dto_carries_caps() -> None:
+    """A resolved entitlement carries its caps to the /entitlements response."""
+    ent = Entitlements(
+        workspace_id="ws-1",
+        plan="pro",
+        monthly_credit_allotment=1000,
+        monthly_ceiling=None,
+        features=frozenset(),
+        max_seats=25,
+        max_pockets=5000,
+        max_connectors=250,
+    )
+    dto = entitlements_to_dto(ent)
+    assert dto.max_seats == 25
+    assert dto.max_pockets == 5000
+    assert dto.max_connectors == 250

--- a/tests/cloud/entitlements/test_entitlements.py
+++ b/tests/cloud/entitlements/test_entitlements.py
@@ -25,6 +25,11 @@
 #   now also populates ``monthly_ceiling`` from the plan catalog — every known tier
 #   carries the catalog's ceiling (incl. enterprise=None uncapped), and an unknown
 #   / missing plan FAILS CLOSED to the Free ceiling (1000), never None/uncapped.
+# Updated 2026-07-08 (feat/billing-smb-caps): proves the resolver also surfaces the
+#   three SMB caps (``max_seats`` / ``max_pockets`` / ``max_connectors``) from the
+#   plan catalog for every known tier (incl. enterprise=None uncapped), and that an
+#   unknown / missing plan FAILS CLOSED to the Free values (5 / 200 / 50), never
+#   None/uncapped.
 
 from __future__ import annotations
 
@@ -95,6 +100,28 @@ async def test_every_known_plan_resolves_its_catalog_ceiling(patch_plan, plan):
         assert ent.monthly_ceiling is None  # the one uncapped tier
 
 
+@pytest.mark.parametrize("plan", ["free", "go", "pro", "pro_max", "enterprise"])
+async def test_every_known_plan_resolves_its_catalog_smb_caps(patch_plan, plan):
+    """The resolver mirrors the catalog's three SMB caps for every known tier."""
+    from pocketpaw_ee.cloud.billing import plans
+
+    patch_plan(plan)
+    ent = await entitlements.resolve_entitlements(WS)
+    tier = plans.get_plan(plan)
+    assert ent.max_seats == tier.max_seats
+    assert ent.max_pockets == tier.max_pockets
+    assert ent.max_connectors == tier.max_connectors
+    if plan == "enterprise":
+        # The one uncapped tier — all three surface as None.
+        assert ent.max_seats is None
+        assert ent.max_pockets is None
+        assert ent.max_connectors is None
+    else:
+        assert isinstance(ent.max_seats, int)
+        assert isinstance(ent.max_pockets, int)
+        assert isinstance(ent.max_connectors, int)
+
+
 # ---------------------------------------------------------------------------
 # Criterion (b) — no/unknown plan, or missing workspace, falls back to free.
 # ---------------------------------------------------------------------------
@@ -109,6 +136,20 @@ async def test_unknown_plan_falls_back_to_free(patch_plan):
     assert ent.monthly_credit_allotment == 0
     # FAIL-CLOSED: an unknown plan caps at the Free ceiling, never None/uncapped.
     assert ent.monthly_ceiling == 1_000
+    # FAIL-CLOSED on the SMB caps too: the Free values, never None/uncapped.
+    assert ent.max_seats == 5
+    assert ent.max_pockets == 200
+    assert ent.max_connectors == 50
+
+
+async def test_missing_workspace_falls_back_to_free_smb_caps(patch_plan):
+    """A missing workspace (get_workspace_plan -> None) fails closed on all SMB caps."""
+    patch_plan(None)
+    ent = await entitlements.resolve_entitlements(WS)
+    assert ent.plan == "free"
+    assert ent.max_seats == 5
+    assert ent.max_pockets == 200
+    assert ent.max_connectors == 50
 
 
 async def test_missing_workspace_falls_back_to_free(patch_plan):

--- a/tests/cloud/fabric_ingest/test_fabric_ingest_connector_dispatch.py
+++ b/tests/cloud/fabric_ingest/test_fabric_ingest_connector_dispatch.py
@@ -1,0 +1,269 @@
+# tests/cloud/fabric_ingest/test_fabric_ingest_connector_dispatch.py
+# Created: 2026-07-11 (feat/real-pipeline-s1) — connector-source dispatch.
+#
+# Pins the transform surface's dispatch contract:
+#
+#   1. model back-compat — a stored mapping WITHOUT the new fields parses as
+#      source_kind="firestore", connector_id=None (existing configs are
+#      untouched by the migration-free additive change).
+#   2. happy path — a "connector" mapping resolves the workspace's ENABLED
+#      WorkspaceConnector row and calls the registered ingestor with the
+#      tenant store, workspace_id, and the row's user_id (the per-user OAuth
+#      token seam); the run reports ok + objects, state bookkeeping advances.
+#   3. user_id=None (workspace-scoped connector) → the shared bucket is used.
+#   4. missing / DISABLED connector → error RESULT, never a raise; the
+#      ingestor is not called.
+#   5. unregistered connector id → error result, never a raise.
+#   6. tenancy — workspace A's run never resolves workspace B's connector row.
+#   7. the ingestor raising → error result (per-collection isolation holds).
+#
+# The registry is spied via monkeypatch.setitem on FABRIC_INGESTORS (the lazy
+# builtin seed uses setdefault, so a pre-installed spy is never clobbered).
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.fabric_ingest import service as ingest_service  # noqa: E402
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector  # noqa: E402
+from pocketpaw_ee.cloud.models.fabric_ingest_state import (  # noqa: E402
+    FabricFieldMapping,
+    FabricIngestConfig,
+    FabricIngestState,
+)
+
+import pocketpaw.connectors.fabric_ingest as oss_fabric_ingest  # noqa: E402
+from pocketpaw.connectors.fabric_ingest import IngestResult  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+class FakeStore:
+    """Dispatch tests never touch Fabric — the spy ingestor absorbs the store."""
+
+
+class SpyIngestor:
+    """Records every call; returns a canned IngestResult (or raises)."""
+
+    def __init__(self, result: IngestResult | None = None, exc: Exception | None = None):
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+        self.result = result or IngestResult(type_name="CalendarEvent", created=2, updated=1)
+        self.exc = exc
+
+    async def __call__(self, store: Any, **kwargs: Any) -> IngestResult:
+        self.calls.append((store, kwargs))
+        if self.exc is not None:
+            raise self.exc
+        return self.result
+
+
+def _connector_mapping(name: str = "gcalendar", **overrides: Any) -> FabricFieldMapping:
+    kwargs: dict[str, Any] = {
+        "collection": name,
+        "object_type_id": "ot-calendar-event",
+        "source_kind": "connector",
+    }
+    kwargs.update(overrides)
+    return FabricFieldMapping(**kwargs)
+
+
+async def _seed_config(workspace_id: str, mappings: list[FabricFieldMapping]) -> None:
+    await FabricIngestConfig(workspace=workspace_id, enabled=True, mappings=mappings).insert()
+
+
+async def _seed_connector(
+    workspace_id: str,
+    name: str = "gcalendar",
+    *,
+    enabled: bool = True,
+    user_id: str | None = None,
+) -> None:
+    await WorkspaceConnector(
+        workspace=workspace_id,
+        name=name,
+        enabled=enabled,
+        scope="user" if user_id else "workspace",
+        user_id=user_id,
+    ).insert()
+
+
+# --------------------------------------------------------------------------
+# 1 — model back-compat: existing configs parse as firestore.
+# --------------------------------------------------------------------------
+
+
+async def test_mapping_without_new_fields_defaults_to_firestore():
+    """A raw stored mapping dict from BEFORE this change parses unchanged."""
+    m = FabricFieldMapping.model_validate(
+        {
+            "collection": "customers",
+            "object_type_id": "ot-customer",
+            "field_map": {"display_name": "name"},
+            "cursor_field": "updated_at",
+        }
+    )
+    assert m.source_kind == "firestore"
+    assert m.connector_id is None
+
+
+# --------------------------------------------------------------------------
+# 2/3 — happy path: WorkspaceConnector resolved, ingestor called with the seam.
+# --------------------------------------------------------------------------
+
+
+async def test_connector_mapping_dispatches_with_per_user_token(mongo_db, monkeypatch):  # noqa: ARG001
+    ws = "w1"
+    await _seed_config(ws, [_connector_mapping()])
+    await _seed_connector(ws, user_id="u42")
+
+    spy = SpyIngestor()
+    monkeypatch.setitem(oss_fabric_ingest.FABRIC_INGESTORS, "gcalendar", spy)
+    store = FakeStore()
+
+    result = await ingest_service.ingest_collection(ws, "gcalendar", store=store)
+
+    assert result["status"] == "ok", result
+    assert result["objects"] == 3  # created=2 + updated=1
+    assert result["errors"] == []
+    # The seam: tenant store + workspace + the CONNECTOR ROW's user token.
+    assert len(spy.calls) == 1
+    called_store, kwargs = spy.calls[0]
+    assert called_store is store
+    assert kwargs == {"workspace_id": ws, "user_id": "u42"}
+    # State bookkeeping reused verbatim.
+    state = await FabricIngestState.find_one(
+        FabricIngestState.workspace == ws, FabricIngestState.source_id == "gcalendar"
+    )
+    assert state is not None
+    assert state.status == "ok"
+    assert state.backfill_done is True
+    assert state.objects_ingested == 3
+    assert state.cursor == ""  # connector runs never touch the firestore cursor
+
+
+async def test_workspace_scoped_connector_uses_shared_bucket(mongo_db, monkeypatch):  # noqa: ARG001
+    ws = "w1"
+    await _seed_config(ws, [_connector_mapping()])
+    await _seed_connector(ws, user_id=None)  # workspace scope — no per-user token
+
+    spy = SpyIngestor()
+    monkeypatch.setitem(oss_fabric_ingest.FABRIC_INGESTORS, "gcalendar", spy)
+
+    result = await ingest_service.ingest_collection(ws, "gcalendar", store=FakeStore())
+
+    assert result["status"] == "ok", result
+    assert spy.calls[0][1]["user_id"] is None
+
+
+async def test_connector_id_overrides_collection_as_registry_key(mongo_db, monkeypatch):  # noqa: ARG001
+    """An explicit connector_id wins over the collection routing key."""
+    ws = "w1"
+    await _seed_config(ws, [_connector_mapping("cal-main", connector_id="gcalendar")])
+    await _seed_connector(ws, name="gcalendar", user_id="u7")
+
+    spy = SpyIngestor()
+    monkeypatch.setitem(oss_fabric_ingest.FABRIC_INGESTORS, "gcalendar", spy)
+
+    result = await ingest_service.ingest_collection(ws, "cal-main", store=FakeStore())
+
+    assert result["status"] == "ok", result
+    assert spy.calls[0][1] == {"workspace_id": ws, "user_id": "u7"}
+
+
+# --------------------------------------------------------------------------
+# 4/5 — misconfiguration: error results, never raises, ingestor untouched.
+# --------------------------------------------------------------------------
+
+
+async def test_missing_connector_is_error_result_not_raise(mongo_db, monkeypatch):  # noqa: ARG001
+    ws = "w1"
+    await _seed_config(ws, [_connector_mapping()])
+    # No WorkspaceConnector row at all.
+
+    spy = SpyIngestor()
+    monkeypatch.setitem(oss_fabric_ingest.FABRIC_INGESTORS, "gcalendar", spy)
+
+    result = await ingest_service.ingest_collection(ws, "gcalendar", store=FakeStore())
+
+    assert result["status"] == "error"
+    assert result["objects"] == 0
+    assert any("not connected/enabled" in e for e in result["errors"]), result["errors"]
+    assert spy.calls == []
+
+
+async def test_disabled_connector_is_error_result(mongo_db, monkeypatch):  # noqa: ARG001
+    ws = "w1"
+    await _seed_config(ws, [_connector_mapping()])
+    await _seed_connector(ws, enabled=False, user_id="u42")
+
+    spy = SpyIngestor()
+    monkeypatch.setitem(oss_fabric_ingest.FABRIC_INGESTORS, "gcalendar", spy)
+
+    result = await ingest_service.ingest_collection(ws, "gcalendar", store=FakeStore())
+
+    assert result["status"] == "error"
+    assert any("not connected/enabled" in e for e in result["errors"])
+    assert spy.calls == []
+
+
+async def test_unregistered_connector_is_error_result(mongo_db):  # noqa: ARG001
+    ws = "w1"
+    await _seed_config(ws, [_connector_mapping("no-such-connector")])
+    await _seed_connector(ws, name="no-such-connector")
+
+    result = await ingest_service.ingest_collection(ws, "no-such-connector", store=FakeStore())
+
+    assert result["status"] == "error"
+    assert any("no fabric ingestor registered" in e for e in result["errors"]), result["errors"]
+
+
+# --------------------------------------------------------------------------
+# 6 — tenancy: another workspace's connector row never satisfies the lookup.
+# --------------------------------------------------------------------------
+
+
+async def test_other_tenants_connector_row_is_not_resolved(mongo_db, monkeypatch):  # noqa: ARG001
+    await _seed_config("w1", [_connector_mapping()])
+    await _seed_connector("w-OTHER", user_id="intruder")  # only the OTHER tenant connected
+
+    spy = SpyIngestor()
+    monkeypatch.setitem(oss_fabric_ingest.FABRIC_INGESTORS, "gcalendar", spy)
+
+    result = await ingest_service.ingest_collection("w1", "gcalendar", store=FakeStore())
+
+    assert result["status"] == "error"
+    assert spy.calls == []
+
+
+# --------------------------------------------------------------------------
+# 7 — a genuine ingestor failure lands as an error result (isolation holds).
+# --------------------------------------------------------------------------
+
+
+async def test_ingestor_exception_is_error_result(mongo_db, monkeypatch):  # noqa: ARG001
+    ws = "w1"
+    await _seed_config(ws, [_connector_mapping()])
+    await _seed_connector(ws, user_id="u42")
+
+    spy = SpyIngestor(exc=RuntimeError("token expired"))
+    monkeypatch.setitem(oss_fabric_ingest.FABRIC_INGESTORS, "gcalendar", spy)
+
+    result = await ingest_service.ingest_collection(ws, "gcalendar", store=FakeStore())
+
+    assert result["status"] == "error"
+    assert any("token expired" in e for e in result["errors"])
+    state = await FabricIngestState.find_one(
+        FabricIngestState.workspace == ws, FabricIngestState.source_id == "gcalendar"
+    )
+    assert state is not None
+    assert state.status == "error"
+    assert state.backfill_done is False  # a failed first run retries the full read

--- a/tests/cloud/fabric_ingest/test_fabric_ingest_router.py
+++ b/tests/cloud/fabric_ingest/test_fabric_ingest_router.py
@@ -1,0 +1,233 @@
+# tests/cloud/fabric_ingest/test_fabric_ingest_router.py
+# Created: 2026-07-11 (feat/real-pipeline-s1) — the transform-surface router.
+#
+# Pins the HTTP contract of /fabric/ingest/*:
+#
+#   1. CRUD — POST authors a mapping (201), GET lists it, POST again with the
+#      same collection REPLACES (no duplicate), DELETE removes it (204) and a
+#      second DELETE 404s.
+#   2. validation — a malformed mapping (blank object_type_id) 422s at entry.
+#   3. tenancy — GET only ever returns the CALLER's workspace's mappings even
+#      when another tenant has its own config; POST writes only to the
+#      caller's config row.
+#   4. RBAC — a caller who is not a member of their active workspace 403s on
+#      every route (fabric.read gates the GET, fabric.write gates the rest).
+#   5. run-now — POST /fabric/ingest/run dispatches the mapping through the
+#      service (connector mapping → spied registry ingestor, 200 + status ok);
+#      an unknown collection reports status="error" in the body (never a 5xx).
+#
+# Harness matches tests/cloud/test_fabric_objects_gate.py: the real router on
+# a bare FastAPI app with require_license / current_active_user /
+# current_workspace_id overridden and get_workspace_plan patched to
+# enterprise, over mongomock Beanie (mongo_db).
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.fabric_ingest.router import router  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector  # noqa: E402
+from pocketpaw_ee.cloud.models.fabric_ingest_state import (  # noqa: E402
+    FabricFieldMapping,
+    FabricIngestConfig,
+)
+
+import pocketpaw.connectors.fabric_ingest as oss_fabric_ingest  # noqa: E402
+from pocketpaw.connectors.fabric_ingest import IngestResult  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------
+# Harness (same shape as test_fabric_objects_gate.py)
+# --------------------------------------------------------------------------
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "u1", workspace_id: str = "w1", member: bool = True) -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        # member=False models a caller whose active workspace they do NOT
+        # belong to — require_action_any_workspace must 403 them.
+        self.workspaces = [_FakeMembership(workspace=workspace_id)] if member else []
+
+
+def _make_client(user: _FakeUser, monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _mapping_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "collection": "gcalendar",
+        "object_type_id": "ot-calendar-event",
+        "source_kind": "connector",
+    }
+    body.update(overrides)
+    return body
+
+
+# --------------------------------------------------------------------------
+# 1 — CRUD round-trip
+# --------------------------------------------------------------------------
+
+
+async def test_crud_roundtrip(mongo_db, monkeypatch):  # noqa: ARG001
+    client = _make_client(_FakeUser(), monkeypatch)
+
+    # Author.
+    resp = client.post("/fabric/ingest/mappings", json=_mapping_body())
+    assert resp.status_code == 201, resp.text
+    created = resp.json()
+    assert created["collection"] == "gcalendar"
+    assert created["source_kind"] == "connector"
+
+    # List.
+    resp = client.get("/fabric/ingest/mappings")
+    assert resp.status_code == 200, resp.text
+    assert [m["collection"] for m in resp.json()["mappings"]] == ["gcalendar"]
+
+    # Upsert (same collection) REPLACES, never duplicates.
+    resp = client.post("/fabric/ingest/mappings", json=_mapping_body(object_type_id="ot-updated"))
+    assert resp.status_code == 201, resp.text
+    mappings = client.get("/fabric/ingest/mappings").json()["mappings"]
+    assert len(mappings) == 1
+    assert mappings[0]["object_type_id"] == "ot-updated"
+
+    # Delete.
+    resp = client.delete("/fabric/ingest/mappings", params={"collection": "gcalendar"})
+    assert resp.status_code == 204, resp.text
+    assert client.get("/fabric/ingest/mappings").json()["mappings"] == []
+
+    # Second delete 404s.
+    resp = client.delete("/fabric/ingest/mappings", params={"collection": "gcalendar"})
+    assert resp.status_code == 404, resp.text
+
+
+async def test_malformed_mapping_422s(mongo_db, monkeypatch):  # noqa: ARG001
+    client = _make_client(_FakeUser(), monkeypatch)
+    resp = client.post("/fabric/ingest/mappings", json=_mapping_body(object_type_id=""))
+    assert resp.status_code == 422, resp.text
+
+
+# --------------------------------------------------------------------------
+# 3 — tenancy: caller only sees / writes its own workspace's config
+# --------------------------------------------------------------------------
+
+
+async def test_list_is_tenant_filtered(mongo_db, monkeypatch):  # noqa: ARG001
+    await FabricIngestConfig(
+        workspace="w-OTHER",
+        mappings=[FabricFieldMapping(collection="secret", object_type_id="ot-x")],
+    ).insert()
+
+    client = _make_client(_FakeUser(workspace_id="w1"), monkeypatch)
+    assert client.get("/fabric/ingest/mappings").json()["mappings"] == []
+
+    client.post("/fabric/ingest/mappings", json=_mapping_body())
+    # w1's write landed in w1's config row, not w-OTHER's.
+    other = await FabricIngestConfig.find_one(FabricIngestConfig.workspace == "w-OTHER")
+    assert [m.collection for m in other.mappings] == ["secret"]
+    mine = await FabricIngestConfig.find_one(FabricIngestConfig.workspace == "w1")
+    assert [m.collection for m in mine.mappings] == ["gcalendar"]
+
+
+# --------------------------------------------------------------------------
+# 4 — RBAC: non-member of the active workspace 403s on every route
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs"),
+    [
+        ("get", "/fabric/ingest/mappings", {}),
+        ("post", "/fabric/ingest/mappings", {"json": _mapping_body()}),
+        ("delete", "/fabric/ingest/mappings", {"params": {"collection": "gcalendar"}}),
+        ("post", "/fabric/ingest/run", {"json": {"collection": "gcalendar"}}),
+    ],
+)
+async def test_non_member_403s(mongo_db, monkeypatch, method, path, kwargs):  # noqa: ARG001
+    client = _make_client(_FakeUser(member=False), monkeypatch)
+    resp = getattr(client, method)(path, **kwargs)
+    assert resp.status_code == 403, f"{method} {path} -> {resp.status_code}: {resp.text}"
+
+
+# --------------------------------------------------------------------------
+# 5 — run-now
+# --------------------------------------------------------------------------
+
+
+class SpyIngestor:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, store: Any, **kwargs: Any) -> IngestResult:  # noqa: ARG002
+        self.calls.append(kwargs)
+        return IngestResult(type_name="CalendarEvent", created=2)
+
+
+async def test_run_now_dispatches_connector_mapping(mongo_db, monkeypatch, tmp_path):  # noqa: ARG001
+    ws = "w1"
+    await FabricIngestConfig(
+        workspace=ws,
+        mappings=[
+            FabricFieldMapping(
+                collection="gcalendar", object_type_id="ot-cal", source_kind="connector"
+            )
+        ],
+    ).insert()
+    await WorkspaceConnector(
+        workspace=ws, name="gcalendar", enabled=True, scope="user", user_id="u42"
+    ).insert()
+
+    spy = SpyIngestor()
+    monkeypatch.setitem(oss_fabric_ingest.FABRIC_INGESTORS, "gcalendar", spy)
+    # Keep the default tenant store off the real home dir.
+    from pocketpaw.fabric.store import FabricStore
+
+    fs = FabricStore(tmp_path / "fabric_run_now.db")
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda *a, workspace_id=None, **k: fs)
+
+    client = _make_client(_FakeUser(workspace_id=ws), monkeypatch)
+    resp = client.post("/fabric/ingest/run", json={"collection": "gcalendar"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok", body
+    assert body["objects"] == 2
+    assert body["workspace_id"] == ws
+    assert spy.calls == [{"workspace_id": ws, "user_id": "u42"}]
+
+
+async def test_run_now_unknown_collection_reports_error_body(mongo_db, monkeypatch):  # noqa: ARG001
+    client = _make_client(_FakeUser(), monkeypatch)
+    resp = client.post("/fabric/ingest/run", json={"collection": "never-configured"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["objects"] == 0

--- a/tests/cloud/jobs/test_provision_site.py
+++ b/tests/cloud/jobs/test_provision_site.py
@@ -323,9 +323,7 @@ async def test_workers_mode_deploys_via_wrangler_not_put_worker(
 
     monkeypatch.setattr(workers_deploy_mod, "deploy_workers", _fake_deploy)
 
-    await ProvisionSiteJob()(
-        workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-6", params={}
-    )
+    await ProvisionSiteJob()(workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-6", params={})
 
     # Deployed through wrangler with the D1 bound — and never through the WfP upload.
     assert len(calls) == 1
@@ -340,18 +338,14 @@ async def test_workers_mode_deploys_via_wrangler_not_put_worker(
 
 
 @pytest.mark.asyncio
-async def test_wfp_mode_still_uses_put_worker(
-    seed: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_wfp_mode_still_uses_put_worker(seed: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression guard: ``wfp`` mode keeps the pre-existing dispatch-namespace upload."""
     ctx = await seed(d1_database_id="d1-existing-0008")
     cf = _FakeCF()
     _install_fakes(monkeypatch, cf=cf)
     monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "wfp")
 
-    await ProvisionSiteJob()(
-        workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-7", params={}
-    )
+    await ProvisionSiteJob()(workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-7", params={})
 
     assert len(cf.put_calls) == 1
     assert cf.put_calls[0]["bindings"] == [{"type": "d1", "name": "DB", "id": "d1-existing-0008"}]

--- a/tests/cloud/metering/test_compute_meter.py
+++ b/tests/cloud/metering/test_compute_meter.py
@@ -25,6 +25,10 @@
 # depends on ambient settings.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-3): new test module.
+# Updated 2026-07-11 (feat/llm-cost-attribution): added two token-attribution
+# cases — ``bill_run`` stamps the run's real ``total_tokens`` on the debit ref
+# (summed from input + output + cached when no explicit total is given, and the
+# explicit backend-supplied total wins when present).
 
 from __future__ import annotations
 
@@ -277,3 +281,57 @@ async def test_sweep_covers_terminal_states_and_skips_active(mongo_db):
     for rid in ("run-queued", "run-running"):
         doc = await ChatRunDoc.find_one(ChatRunDoc.run_id == rid)
         assert doc is not None and doc.billed is False
+
+
+# ---------------------------------------------------------------------------
+# Token attribution — bill_run stamps the run's real total_tokens on the debit
+# ref so the ledger-sourced usage graph can surface real volume (not a hardcoded
+# 0). The token counts ride ChatRunDoc.usage in every mode — NOT the LiteLLM path.
+# ---------------------------------------------------------------------------
+
+
+async def test_bill_run_stamps_total_tokens_on_ref(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    run = await _make_run(
+        run_id="run-tok",
+        usage={
+            "total_cost_usd": 0.04,
+            "model": "claude-sonnet-4-20250514",
+            "input_tokens": 1200,
+            "output_tokens": 300,
+            "cached_input_tokens": 100,
+        },
+    )
+
+    await metering.bill_run(run, rate_card=RATE)
+
+    spend = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "run:run-tok",
+    ).to_list()
+    assert len(spend) == 1
+    # input + output + cached = 1200 + 300 + 100.
+    assert spend[0].ref.get("total_tokens") == 1600
+
+
+async def test_bill_run_prefers_explicit_total_tokens(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    run = await _make_run(
+        run_id="run-tt",
+        usage={
+            "total_cost_usd": 0.04,
+            "model": "claude-sonnet-4-20250514",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 999,  # backend supplied an explicit total — trust it
+        },
+    )
+
+    await metering.bill_run(run, rate_card=RATE)
+
+    spend = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "run:run-tt",
+    ).to_list()
+    assert len(spend) == 1
+    assert spend[0].ref.get("total_tokens") == 999

--- a/tests/cloud/notifications/test_delivery.py
+++ b/tests/cloud/notifications/test_delivery.py
@@ -1,0 +1,241 @@
+# tests/cloud/notifications/test_delivery.py
+# Created: 2026-07-08 (feat/external-alerting-delivery) — proves the external
+# fan-out (Slack + generic webhook) that ``notifications.service.create`` now
+# performs. Tests drive the REAL ``create`` path with a stubbed httpx transport
+# (spy on the POST, don't mock the seam under test) so the whole seam is
+# exercised end-to-end: config load -> routing -> httpx POST -> per-sink payload.
+# Fire-and-forget is proven directly: a sink whose transport RAISES does not
+# propagate out of ``create`` and the notification still inserts + still emits.
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud._core.realtime.events import NotificationNew
+from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
+from pocketpaw_ee.cloud.notifications import delivery as delivery_mod
+from pocketpaw_ee.cloud.notifications import service as notifications_service
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+SLACK_URL = "https://hooks.slack.com/services/T000/B000/xxx"
+WEBHOOK_URL = "https://alerts.example.com/ingest"
+
+
+class _Recorder:
+    """Records every httpx request routed through the stubbed transport and
+    returns a caller-supplied response (or raises to simulate a dead sink)."""
+
+    def __init__(self, responder=None) -> None:
+        self.requests: list[tuple[str, dict | None]] = []
+        # Default responder: 200 OK.
+        self._responder = responder or (lambda req: httpx.Response(200))
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else None
+        self.requests.append((str(request.url), body))
+        return self._responder(request)
+
+    def urls(self) -> list[str]:
+        return [u for u, _ in self.requests]
+
+
+def _install_transport(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None:
+    """Patch ``httpx.AsyncClient`` so delivery's real client code runs but the
+    network is served by an in-memory ``MockTransport``. This is a SPY, not a
+    mock of the seam under test: real request encoding + real ``.post`` execute.
+    """
+    real_async_client = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(recorder.handler)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+
+async def _set_config(**kwargs) -> None:
+    """Persist a delivery config for workspace ``w1`` via the sole writer."""
+    defaults: dict = {
+        "slack_webhook_url": SLACK_URL,
+        "webhook_url": WEBHOOK_URL,
+        "enabled": True,
+        "routes": {},
+    }
+    defaults.update(kwargs)
+    await notifications_service.set_delivery_config("w1", **defaults)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through service.create — the real seam.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_fans_out_to_both_sinks(monkeypatch, recording_bus) -> None:
+    rec = _Recorder()
+    _install_transport(monkeypatch, rec)
+    await _set_config()
+
+    out = await notifications_service.create(
+        workspace_id="w1", recipient="u2", kind="mention", title="Hi", body="you were mentioned"
+    )
+
+    # Both sinks POSTed.
+    assert set(rec.urls()) == {SLACK_URL, WEBHOOK_URL}
+    payloads = {u: b for u, b in rec.requests}
+    # Slack incoming-webhook shape: {"text": ...} carrying title + body.
+    assert payloads[SLACK_URL] == {"text": "Hi\nyou were mentioned"}
+    # Generic webhook: full notification payload.
+    generic = payloads[WEBHOOK_URL]
+    assert generic["kind"] == "mention"
+    assert generic["workspace_id"] == "w1"
+    assert generic["recipient_id"] == "u2"
+    assert generic["title"] == "Hi"
+
+    # The insert + realtime emit still happened.
+    assert out.id
+    assert len(await notifications_service.list_for_user("u2")) == 1
+    assert any(isinstance(e, NotificationNew) for e in recording_bus.events)
+
+
+async def test_dead_sink_never_breaks_create(monkeypatch, recording_bus) -> None:
+    """A sink whose transport RAISES must not propagate out of create; the
+    notification still inserts and still emits (fire-and-forget)."""
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    rec = _Recorder(responder=responder)
+    _install_transport(monkeypatch, rec)
+    await _set_config()
+
+    # Must not raise even though every sink's POST blows up.
+    out = await notifications_service.create(
+        workspace_id="w1", recipient="u2", kind="mention", title="Hi"
+    )
+
+    # Delivery was attempted (both sinks tried) ...
+    assert set(rec.urls()) == {SLACK_URL, WEBHOOK_URL}
+    # ... but the insert + emit survived the dead sinks.
+    assert out.id
+    assert len(await notifications_service.list_for_user("u2")) == 1
+    assert any(isinstance(e, NotificationNew) for e in recording_bus.events)
+
+
+async def test_no_config_means_no_delivery(monkeypatch) -> None:
+    rec = _Recorder()
+    _install_transport(monkeypatch, rec)
+    # No config saved for w1.
+    out = await notifications_service.create(
+        workspace_id="w1", recipient="u2", kind="mention", title="Hi"
+    )
+    assert out.id
+    assert rec.requests == []
+
+
+async def test_disabled_config_means_no_delivery(monkeypatch) -> None:
+    rec = _Recorder()
+    _install_transport(monkeypatch, rec)
+    await _set_config(enabled=False)
+    await notifications_service.create(
+        workspace_id="w1", recipient="u2", kind="mention", title="Hi"
+    )
+    assert rec.requests == []
+
+
+async def test_routes_narrow_kind_to_named_sink(monkeypatch) -> None:
+    rec = _Recorder()
+    _install_transport(monkeypatch, rec)
+    # 'mention' routes to slack only; other kinds still deliver-all.
+    await _set_config(routes={"mention": ["slack"]})
+
+    await notifications_service.create(workspace_id="w1", recipient="u2", kind="mention", title="M")
+    assert rec.urls() == [SLACK_URL]
+
+    rec.requests.clear()
+    await notifications_service.create(
+        workspace_id="w1", recipient="u2", kind="task_assigned", title="T"
+    )
+    assert set(rec.urls()) == {SLACK_URL, WEBHOOK_URL}
+
+
+async def test_delivery_scoped_per_workspace(monkeypatch) -> None:
+    """A notification in a workspace with no config does not use another
+    workspace's sinks."""
+    rec = _Recorder()
+    _install_transport(monkeypatch, rec)
+    await _set_config()  # config for w1 only
+
+    await notifications_service.create(
+        workspace_id="w2", recipient="u2", kind="mention", title="Hi"
+    )
+    assert rec.requests == []
+
+
+# ---------------------------------------------------------------------------
+# set_delivery_config — the sole write path.
+# ---------------------------------------------------------------------------
+
+
+async def test_set_config_upserts_one_row_per_workspace() -> None:
+    await notifications_service.set_delivery_config("w1", slack_webhook_url=SLACK_URL, enabled=True)
+    await notifications_service.set_delivery_config("w1", webhook_url=WEBHOOK_URL, enabled=False)
+    # Upsert, not duplicate insert: exactly one row for the workspace.
+    count = await NotificationDeliveryConfig.find(
+        NotificationDeliveryConfig.workspace == "w1"
+    ).count()
+    assert count == 1
+
+    current = await notifications_service.get_delivery_config("w1")
+    assert current is not None
+    assert current["webhook_url"] == WEBHOOK_URL
+    assert current["slack_webhook_url"] is None  # replaced by the second upsert
+    assert current["enabled"] is False
+
+
+async def test_set_config_rejects_unsafe_url_and_stores_nothing() -> None:
+    with pytest.raises(Forbidden):
+        await notifications_service.set_delivery_config(
+            "w1", webhook_url="http://169.254.169.254/latest/meta-data", enabled=True
+        )
+    # Rejected before any write.
+    assert await notifications_service.get_delivery_config("w1") is None
+
+
+async def test_set_config_empty_string_clears_sink() -> None:
+    await notifications_service.set_delivery_config(
+        "w1", slack_webhook_url=SLACK_URL, webhook_url=WEBHOOK_URL, enabled=True
+    )
+    await notifications_service.set_delivery_config(
+        "w1", slack_webhook_url="", webhook_url=WEBHOOK_URL, enabled=True
+    )
+    current = await notifications_service.get_delivery_config("w1")
+    assert current["slack_webhook_url"] is None
+    assert current["webhook_url"] == WEBHOOK_URL
+
+
+# ---------------------------------------------------------------------------
+# is_safe_webhook_url — SSRF baseline.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,safe",
+    [
+        ("https://hooks.slack.com/services/x", True),
+        ("https://alerts.example.com/ingest", True),
+        ("http://alerts.example.com/ingest", False),  # not https
+        ("https://localhost/x", False),  # forbidden hostname
+        ("https://127.0.0.1/x", False),  # loopback literal IP
+        ("https://169.254.169.254/x", False),  # link-local (cloud metadata)
+        ("https://10.0.0.5/x", False),  # private literal IP
+        ("https://metadata.google.internal/x", False),  # forbidden hostname
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_safe_webhook_url(url, safe) -> None:
+    assert delivery_mod.is_safe_webhook_url(url) is safe

--- a/tests/cloud/notifications/test_delivery.py
+++ b/tests/cloud/notifications/test_delivery.py
@@ -239,3 +239,30 @@ async def test_set_config_empty_string_clears_sink() -> None:
 )
 def test_is_safe_webhook_url(url, safe) -> None:
     assert delivery_mod.is_safe_webhook_url(url) is safe
+
+
+# ---------------------------------------------------------------------------
+# SSRF encoding-bypass regression — the old guard only ran
+# ``ipaddress.ip_address(hostname)`` and treated its ValueError as "not an IP",
+# so alternate-encoding hosts (decimal / hex / octal integer, short-dotted)
+# sailed through as safe while getaddrinfo / httpx resolve them to metadata /
+# loopback. Each of these MUST now be rejected; a normal https host stays safe.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://2852039166/",  # decimal int == 169.254.169.254 (cloud metadata)
+        "https://2130706433/",  # decimal int == 127.0.0.1
+        "https://0x7f000001/",  # hex int == 127.0.0.1
+        "https://127.1/",  # short-dotted == 127.0.0.1
+        "https://017700000001/",  # leading-zero octal int == 127.0.0.1
+    ],
+)
+def test_is_safe_webhook_url_rejects_encoded_ssrf(url) -> None:
+    assert delivery_mod.is_safe_webhook_url(url) is False
+
+
+def test_is_safe_webhook_url_allows_normal_https_host() -> None:
+    assert delivery_mod.is_safe_webhook_url("https://hooks.slack.com/services/T0/B0/xxx") is True

--- a/tests/cloud/pockets/test_pocket_cap.py
+++ b/tests/cloud/pockets/test_pocket_cap.py
@@ -1,0 +1,150 @@
+# tests/cloud/pockets/test_pocket_cap.py
+# Created 2026-07-08 (feat/billing-smb-caps) — locks the per-plan POCKET cap on the
+# create seam. The cap (``_pocket_cap_exceeded``) resolves the workspace's plan
+# ``max_pockets`` and counts its live pockets; it is enforced at CREATE time only
+# (never removes an existing pocket) and is a no-op unless ``billing_enforced``.
+#
+# Two create seams are covered:
+#   * ``create`` — the HTTP path — RAISES ``PocketLimitError`` (402) at/over the cap.
+#   * ``create_from_ripple_spec`` — the agent auto-create path (does NOT funnel
+#     through ``create``) — returns ``None`` at/over the cap so the agent turn
+#     degrades gracefully instead of surfacing a raw 402 through the loop.
+#
+# The plan resolver is stubbed to a controlled ``max_pockets`` so the count/limit
+# logic is exercised against a small ceiling (no need to insert 200 real pockets);
+# the catalog-value + fail-closed contract itself lives in test_plans.py /
+# test_entitlements.py. ``billing_enforced`` is toggled by pointing the config's
+# ``get_settings`` at a flag stub — the same flag-mode lane the credit gate uses.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import PocketLimitError
+from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+from pocketpaw_ee.cloud.entitlements.domain import Entitlements
+from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+import pocketpaw.config as ppconfig
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws_pocket_cap"
+_USER = "user_pocket_cap"
+
+_RIPPLE_SPEC = {
+    "version": "1.0",
+    "state": {},
+    "ui": {"id": "n_root0001", "type": "flex", "props": {}, "children": []},
+}
+
+
+def _enforce(monkeypatch, *, on: bool) -> None:
+    """Point the config's ``get_settings`` (lazily imported inside the cap helper)
+    at a flag stub carrying the billing posture."""
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, dodo_plan_products=None),
+    )
+
+
+def _cap(monkeypatch, *, max_pockets: int | None) -> None:
+    """Stub the entitlements resolver to a controlled ``max_pockets`` ceiling."""
+    ent = Entitlements(
+        workspace_id=_WS,
+        plan="free",
+        monthly_credit_allotment=0,
+        monthly_ceiling=1_000,
+        max_seats=5,
+        max_pockets=max_pockets,
+        max_connectors=50,
+        features=frozenset(),
+    )
+    monkeypatch.setattr(entitlements_service, "resolve_entitlements", AsyncMock(return_value=ent))
+
+
+async def _seed_pockets(n: int) -> None:
+    for i in range(n):
+        await _PocketDoc(workspace=_WS, name=f"p{i}", owner=_USER).insert()
+
+
+# ---------------------------------------------------------------------------
+# create() — the HTTP path raises PocketLimitError.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_raises_pocket_limit_at_cap(monkeypatch) -> None:
+    """At/over the plan cap, create() raises PocketLimitError (402) — no write."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_pockets=2)
+    await _seed_pockets(2)  # already at the cap
+
+    with pytest.raises(PocketLimitError) as exc:
+        await pockets_service.create(_WS, _USER, CreatePocketRequest(name="over"))
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.pocket_limit"
+    # The blocked create did NOT persist a 3rd pocket.
+    assert await _PocketDoc.find(_PocketDoc.workspace == _WS).count() == 2
+
+
+async def test_create_allows_below_cap(monkeypatch) -> None:
+    """Below the cap, create() proceeds normally."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_pockets=2)
+    await _seed_pockets(1)  # one under the cap
+
+    wire = await pockets_service.create(_WS, _USER, CreatePocketRequest(name="ok"))
+    assert wire["_id"]
+    assert await _PocketDoc.find(_PocketDoc.workspace == _WS).count() == 2
+
+
+async def test_create_pocket_cap_is_noop_when_billing_disabled(monkeypatch) -> None:
+    """With billing_enforced OFF (OSS / self-host), the cap never fires — even well
+    over the ceiling."""
+    _enforce(monkeypatch, on=False)
+    _cap(monkeypatch, max_pockets=2)
+    await _seed_pockets(5)  # way over the (ignored) cap
+
+    wire = await pockets_service.create(_WS, _USER, CreatePocketRequest(name="ok"))
+    assert wire["_id"]
+
+
+async def test_create_pocket_cap_is_noop_when_uncapped(monkeypatch) -> None:
+    """An uncapped plan (Enterprise, max_pockets=None) never trips the cap."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_pockets=None)
+    await _seed_pockets(5)
+
+    wire = await pockets_service.create(_WS, _USER, CreatePocketRequest(name="ok"))
+    assert wire["_id"]
+
+
+# ---------------------------------------------------------------------------
+# create_from_ripple_spec() — the agent path returns None at the cap.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_from_ripple_spec_returns_none_at_cap(monkeypatch) -> None:
+    """The agent auto-create path degrades to None (not a 402) at/over the cap."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_pockets=2)
+    await _seed_pockets(2)
+
+    pocket_id = await pockets_service.create_from_ripple_spec(_WS, _USER, _RIPPLE_SPEC)
+    assert pocket_id is None
+    assert await _PocketDoc.find(_PocketDoc.workspace == _WS).count() == 2
+
+
+async def test_create_from_ripple_spec_succeeds_below_cap(monkeypatch) -> None:
+    """Below the cap, the agent auto-create path still creates the pocket."""
+    _enforce(monkeypatch, on=True)
+    _cap(monkeypatch, max_pockets=5)
+    await _seed_pockets(1)
+
+    pocket_id = await pockets_service.create_from_ripple_spec(_WS, _USER, _RIPPLE_SPEC)
+    assert pocket_id is not None

--- a/tests/cloud/runs/test_run_core_credit_quota.py
+++ b/tests/cloud/runs/test_run_core_credit_quota.py
@@ -113,15 +113,14 @@ def _wire_common(monkeypatch, transport, *, enforced: bool) -> dict[str, bool]:
 
     monkeypatch.setattr(run_core, "_reject_if_over_jail_quota", _no_jail_reject)
     # Point the flag at a stub carrying the desired posture. The billing flag is
-    # now read inside the shared guard, so patch THAT module's get_settings
-    # (run_core's is also patched for any of its own reads under the same stub).
+    # read inside the shared guard, so patch THAT module's get_settings —
+    # run_core no longer imports it (the orphaned import was dropped).
     from types import SimpleNamespace
 
     from pocketpaw_ee.cloud.credits import guards
 
     stub_settings = SimpleNamespace(billing_enforced=enforced)
     monkeypatch.setattr(guards, "get_settings", lambda: stub_settings)
-    monkeypatch.setattr(run_core, "get_settings", lambda: stub_settings)
 
     # The shared gate now runs check_balance BEFORE check_quota. Default it to a
     # no-op so the quota-focused cases below stay isolated (the balance-reject

--- a/tests/cloud/runs/test_run_core_credit_quota.py
+++ b/tests/cloud/runs/test_run_core_credit_quota.py
@@ -15,6 +15,17 @@
 # crash). ``check_quota`` is stubbed at the run_core seam (it is called via the
 # locally-imported ``credits_service`` module, patched on that module) so these
 # tests assert the WIRING, not the chunk-2 quota math (test_quota.py owns that).
+#
+# Changed 2026-07-08 (feat/billing-enforce-gate): run_core's
+# ``_reject_if_over_credit_quota`` now delegates to the shared
+# ``credits.guards.reject_if_over_billing``, so the worker/executor leg gained the
+# BALANCE assertion (``check_balance``, wallet <= 0) it lacked — it ran only
+# ``check_quota`` before. Two harness updates follow: (1) the ``billing_enforced``
+# flag is now read inside the guards module, so the flag stub is applied to
+# ``credits.guards.get_settings`` (not run_core's); (2) ``check_balance`` runs
+# BEFORE ``check_quota`` in the shared gate, so it is stubbed to a no-op by default
+# in ``_wire_common`` and the quota cases stay isolated. A new case locks the new
+# leg: enforced + empty wallet -> the same clean reject with no model call.
 
 from __future__ import annotations
 
@@ -101,12 +112,24 @@ def _wire_common(monkeypatch, transport, *, enforced: bool) -> dict[str, bool]:
         return False
 
     monkeypatch.setattr(run_core, "_reject_if_over_jail_quota", _no_jail_reject)
-    # Point the executor's flag at a stub carrying the desired posture.
+    # Point the flag at a stub carrying the desired posture. The billing flag is
+    # now read inside the shared guard, so patch THAT module's get_settings
+    # (run_core's is also patched for any of its own reads under the same stub).
     from types import SimpleNamespace
 
-    monkeypatch.setattr(
-        run_core, "get_settings", lambda: SimpleNamespace(billing_enforced=enforced)
-    )
+    from pocketpaw_ee.cloud.credits import guards
+
+    stub_settings = SimpleNamespace(billing_enforced=enforced)
+    monkeypatch.setattr(guards, "get_settings", lambda: stub_settings)
+    monkeypatch.setattr(run_core, "get_settings", lambda: stub_settings)
+
+    # The shared gate now runs check_balance BEFORE check_quota. Default it to a
+    # no-op so the quota-focused cases below stay isolated (the balance-reject
+    # case overrides it). Patched on the service module the guard imports.
+    async def _balance_ok(workspace_id):
+        return None
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.credits.service.check_balance", _balance_ok)
     return called
 
 
@@ -145,6 +168,53 @@ async def test_enforced_over_quota_rejects_and_does_not_call_model(monkeypatch):
     assert [e.event for e in events] == ["error"]
     assert events[0].data["code"] == "credits.quota_exceeded"
     # The run was marked terminally failed (and ONLY that — no completed mark).
+    assert mark_calls == [{"run_id": "r1", "status": "failed", "error": events[0].data["message"]}]
+
+
+# ---------------------------------------------------------------------------
+# 1b — enforced + EMPTY WALLET (balance <= 0) -> run rejected, model NOT called.
+#      Locks the new balance leg the worker/executor path gained by delegating to
+#      the shared guard (it previously caught only the quota case).
+# ---------------------------------------------------------------------------
+
+
+async def test_enforced_empty_wallet_rejects_and_does_not_call_model(monkeypatch):
+    from pocketpaw_ee.cloud._core.errors import InsufficientCredits
+
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+    called = _wire_common(monkeypatch, transport, enforced=True)
+
+    # check_balance raises FIRST (wallet <= 0) -> the gate rejects before quota.
+    async def _empty_wallet(workspace_id):
+        raise InsufficientCredits(1, 0)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.credits.service.check_balance", _empty_wallet)
+
+    # check_quota must never be reached — balance is the primary guard.
+    async def _quota_unreached(workspace_id):
+        raise AssertionError("check_quota must not run once check_balance rejects")
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.credits.service.check_quota", _quota_unreached)
+
+    mark_calls: list[dict[str, Any]] = []
+
+    async def _track_terminal(run_id, *, status, error=None, **k):
+        mark_calls.append({"run_id": run_id, "status": status, "error": error})
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.run_core.run_service.mark_terminal", _track_terminal
+    )
+
+    await run_core.execute_run(_spec())
+
+    # THE MONEY GUARANTEE: the agent loop (model) never ran.
+    assert called["agent_loop"] is False, "model must NOT be invoked on an empty-wallet block"
+
+    # A terminal ``error`` frame went to the stream with the balance code.
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    assert [e.event for e in events] == ["error"]
+    assert events[0].data["code"] == "credits.insufficient"
     assert mark_calls == [{"run_id": "r1", "status": "failed", "error": events[0].data["message"]}]
 
 

--- a/tests/cloud/shared/test_agent_bridge_billing.py
+++ b/tests/cloud/shared/test_agent_bridge_billing.py
@@ -1,0 +1,104 @@
+# tests/cloud/shared/test_agent_bridge_billing.py — proves the run-start billing
+# gate in agent_bridge._dispatch_agent_responses rejects an over-budget workspace
+# ABOVE the _smart_relevance_check Haiku pre-classifier (reached via
+# _should_agent_respond) AND above _run_agent_response/pool.run, so NO model call
+# fires on the group/DM auto-response path. This is the regression guard for the
+# money-leak correction: gating only before pool.run would still let an over-budget
+# tenant spend on the relevance pre-classifier.
+#
+# Created 2026-07-08 (feat/billing-enforce-gate).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_over_budget_before_any_model_call() -> None:
+    """Over-budget workspace: neither the Haiku pre-classifier
+    (_should_agent_respond) nor the agent run (_run_agent_response) is reached,
+    and exactly one terminal AgentError is emitted to the group."""
+    from pocketpaw_ee.cloud._core.errors import InsufficientCredits
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    group = SimpleNamespace(
+        members=["user-1"],
+        agents=[SimpleNamespace(agent_id="agent-a", respond_mode="smart")],
+    )
+    should_mock = AsyncMock(return_value=True)
+    run_mock = AsyncMock(return_value=None)
+    emit_mock = AsyncMock()
+
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=group),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.credits.guards.over_billing_limit",
+            new=AsyncMock(return_value=InsufficientCredits(requested=1, available=0)),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond", new=should_mock),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response", new=run_mock),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=emit_mock),
+    ):
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "group-over",
+                "sender_id": "user-1",
+                "content": "hello",
+                "mentions": [],
+                "workspace_id": "ws-over",
+            }
+        )
+
+    # The pre-classifier and the agent run must NOT be reached — no model call.
+    should_mock.assert_not_awaited()
+    run_mock.assert_not_awaited()
+    # Exactly one terminal AgentError emitted to the group.
+    assert emit_mock.await_count == 1
+    emitted = emit_mock.await_args_list[0].args[0]
+    assert emitted.data["code"] == "credits.insufficient"
+    assert emitted.data["group_id"] == "group-over"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_proceeds_when_within_budget() -> None:
+    """Within budget (guard returns None): normal dispatch proceeds and the agent
+    is run — the gate is a no-op when the workspace is funded."""
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    group = SimpleNamespace(
+        members=["user-1"],
+        agents=[SimpleNamespace(agent_id="agent-a", respond_mode="auto")],
+    )
+    run_mock = AsyncMock(return_value="ok")
+
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.group_service.get_for_dispatch",
+            new=AsyncMock(return_value=group),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.credits.guards.over_billing_limit",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.shared.agent_bridge._should_agent_respond",
+            new=AsyncMock(return_value=True),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge._run_agent_response", new=run_mock),
+    ):
+        await agent_bridge._dispatch_agent_responses(
+            {
+                "group_id": "group-ok",
+                "sender_id": "user-1",
+                "content": "hello",
+                "mentions": [],
+                "workspace_id": "ws-ok",
+            }
+        )
+
+    run_mock.assert_awaited()

--- a/tests/cloud/test_automations_status.py
+++ b/tests/cloud/test_automations_status.py
@@ -1,0 +1,111 @@
+# tests/cloud/test_automations_status.py — external-alerting C2/C3: the
+# per-workspace automation opt-out (WorkspaceAutomationConfig +
+# sweeps_enabled_for_workspace / filter_sweep_enabled_workspaces), the
+# constructed sweep registry, the OSS evaluator autostart flag, and the
+# _evaluate_threshold real-Fabric-query replacement of the return-False stub.
+# Created: 2026-07-11 (feat/external-alerting-c2c3).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# NOTE: the suite runs pytest-asyncio in AUTO mode — async tests need no marks.
+
+# ---------------------------------------------------------------------------
+# Per-workspace opt-out (service layer, real Beanie docs via mongo_db)
+# ---------------------------------------------------------------------------
+
+
+async def test_sweeps_enabled_defaults_true_without_config(mongo_db):  # noqa: ARG001
+    from pocketpaw_ee.cloud.automations_status import service
+
+    assert await service.sweeps_enabled_for_workspace("ws-unconfigured") is True
+
+
+async def test_opt_out_round_trip_and_filter(mongo_db):  # noqa: ARG001
+    from pocketpaw_ee.cloud.automations_status import service
+
+    # Opt one workspace out; leave another untouched.
+    await service.set_workspace_config("ws-off", sweeps_enabled=False, automations_enabled=True)
+    assert await service.sweeps_enabled_for_workspace("ws-off") is False
+    assert await service.sweeps_enabled_for_workspace("ws-on") is True
+
+    # The shared fan-out filter drops ONLY the opted-out tenant.
+    kept = await service.filter_sweep_enabled_workspaces({"ws-off", "ws-on"})
+    assert kept == {"ws-on"}
+
+    # Re-enable restores the always-on default behavior.
+    await service.set_workspace_config("ws-off", sweeps_enabled=True, automations_enabled=True)
+    assert await service.sweeps_enabled_for_workspace("ws-off") is True
+
+
+async def test_automations_enabled_is_independent_of_sweeps(mongo_db):  # noqa: ARG001
+    from pocketpaw_ee.cloud.automations_status import service
+
+    await service.set_workspace_config("ws-mix", sweeps_enabled=True, automations_enabled=False)
+    assert await service.sweeps_enabled_for_workspace("ws-mix") is True
+    assert await service.automations_enabled_for_workspace("ws-mix") is False
+
+
+# ---------------------------------------------------------------------------
+# The constructed sweep registry (no queryable registry existed before)
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_registry_enumerates_the_fleet():
+    from pocketpaw_ee.cloud.automations_status.service import build_sweep_registry
+
+    registry = build_sweep_registry()
+    names = {d.key for d in registry}
+    # The fleet the opt-out must cover — each descriptor carries its gate flag.
+    for expected in ("cycles", "member_ingest", "fabric_ingest", "temporal", "refresh"):
+        assert any(expected in n for n in names), f"missing sweep descriptor: {expected}"
+    assert all(d.env_flag for d in registry)
+
+
+# ---------------------------------------------------------------------------
+# OSS evaluator — autostart flag + the real threshold query
+# ---------------------------------------------------------------------------
+
+
+def test_evaluator_autostart_flag_defaults_on():
+    from pocketpaw.config import Settings
+
+    assert Settings().automation_evaluator_autostart is True
+
+
+def _threshold_rule(**over) -> SimpleNamespace:
+    base = dict(
+        id="rule-1",
+        object_type="Product",
+        property="stock",
+        operator="less_than",
+        value="10",
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+async def _run_threshold(rule, total: int) -> bool:
+    from pocketpaw.automations.evaluator import AutomationEvaluator
+
+    fabric = MagicMock()
+    fabric.query = AsyncMock(return_value=SimpleNamespace(total=total))
+    with (
+        patch("pocketpaw.automations.evaluator.get_automation_store", return_value=MagicMock()),
+        patch("pocketpaw.stores.get_fabric_store", return_value=fabric),
+    ):
+        return await AutomationEvaluator()._evaluate_threshold(rule)
+
+
+async def test_threshold_fires_on_matching_object():
+    assert await _run_threshold(_threshold_rule(), total=1) is True
+
+
+async def test_threshold_quiet_when_nothing_matches():
+    assert await _run_threshold(_threshold_rule(), total=0) is False
+
+
+async def test_threshold_skips_unmapped_operator():
+    # An operator with no comparison mapping must never fire (and never query).
+    assert await _run_threshold(_threshold_rule(operator="resembles"), total=5) is False

--- a/tests/cloud/test_fabric_mcp.py
+++ b/tests/cloud/test_fabric_mcp.py
@@ -18,10 +18,24 @@
 #   * error relaying: bad input types refuse cleanly; a store failure returns a
 #     plain relayable error; missing identity refuses.
 #
+# Updated: 2026-07-11 (feat/paw-cli, C2) — the server grew three ontology
+# MODIFICATION tools; this file now also pins:
+#   * the extended tool-id contract (5 ids).
+#   * fabric_link_create — creates a workspace-stamped link; refuses a
+#     cross-tenant endpoint id; enforces the workspace's DECLARED link schema
+#     through the router's own _enforce_link_type.
+#   * fabric_link_delete — deletes through the scoped get_link guard; a
+#     cross-tenant link id refuses and the row survives.
+#   * fabric_type_update — RBAC-gated on fabric.admin (deny envelope for a
+#     non-admin, never a write); renames migrate existing objects and bump the
+#     type version; refuses an empty change set.
+#
 # `pocketpaw_ee` is import-skipped on an OSS-only install. The handlers read
 # identity through ee.cloud.chat.agent_service ContextVars (set in-test via
 # attach_agent_identity) and the store through pocketpaw.stores.get_fabric_store
 # (patched to a tmp-file store so nothing touches ~/.pocketpaw/fabric.db).
+# The registry (declared link types / schema re-registration) is patched to a
+# tmp-file WorkspaceFabricStore at BOTH import sites (router + storage).
 
 from __future__ import annotations
 
@@ -113,9 +127,15 @@ def test_tool_id_contract_pin() -> None:
     assert fabric_mcp.SERVER_NAME == "pocketpaw_fabric"
     assert fabric_mcp.FABRIC_QUERY_TOOL_ID == "mcp__pocketpaw_fabric__fabric_query"
     assert fabric_mcp.FABRIC_STATS_TOOL_ID == "mcp__pocketpaw_fabric__fabric_stats"
+    assert fabric_mcp.FABRIC_LINK_CREATE_TOOL_ID == "mcp__pocketpaw_fabric__fabric_link_create"
+    assert fabric_mcp.FABRIC_LINK_DELETE_TOOL_ID == "mcp__pocketpaw_fabric__fabric_link_delete"
+    assert fabric_mcp.FABRIC_TYPE_UPDATE_TOOL_ID == "mcp__pocketpaw_fabric__fabric_type_update"
     assert fabric_mcp.FABRIC_TOOL_IDS == (
         "mcp__pocketpaw_fabric__fabric_query",
         "mcp__pocketpaw_fabric__fabric_stats",
+        "mcp__pocketpaw_fabric__fabric_link_create",
+        "mcp__pocketpaw_fabric__fabric_link_delete",
+        "mcp__pocketpaw_fabric__fabric_type_update",
     )
 
 
@@ -308,3 +328,245 @@ async def test_store_error_is_relayed(store, monkeypatch):
         res = await fabric_mcp._fabric_query_handler({"type_name": "Customer"})
     assert res.get("is_error") is True
     assert "fabric db is locked" in res["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# C2 modification tools — fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry(tmp_path: Path, monkeypatch):
+    """Isolated workspace-registry store, patched at BOTH call sites: the
+    router's module-level import (used by _enforce_link_type) and the storage
+    factory (used by the type-update handler's re-registration)."""
+    from pocketpaw_ee.fabric.storage import WorkspaceFabricStore
+
+    reg = WorkspaceFabricStore(tmp_path / "fabric_registry_test.db")
+    monkeypatch.setattr("pocketpaw_ee.fabric.router.get_registry_store", lambda: reg)
+    monkeypatch.setattr("pocketpaw_ee.fabric.storage.get_registry_store", lambda: reg)
+    return reg
+
+
+@pytest.fixture
+def admin_ok(monkeypatch):
+    """Make the fabric.admin RBAC gate PASS: a resolvable user + a no-op check."""
+
+    async def _fake_load_user(user_id):
+        return object()
+
+    monkeypatch.setattr(fabric_mcp, "_load_user", _fake_load_user)
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action", lambda user, ws, action: None
+    )
+
+
+async def _seed_link(store: FabricStore, workspace: str = "w1"):
+    """Two Customer objects + one link between them in ``workspace``.
+    Returns (from_id, to_id, link_id)."""
+    obj_type = await store.define_type(name=f"Cust-{workspace}", properties=[])
+    a = await store.create_object(obj_type.id, {"name": "A"}, workspace_id=workspace)
+    b = await store.create_object(obj_type.id, {"name": "B"}, workspace_id=workspace)
+    lnk = await store.link(a.id, b.id, "knows", workspace_id=workspace)
+    return a.id, b.id, lnk.id
+
+
+# ---------------------------------------------------------------------------
+# fabric_link_create
+# ---------------------------------------------------------------------------
+
+
+async def test_link_create_stamps_workspace(store, registry):
+    """A created link lands workspace-stamped — visible to w1, not to w2."""
+    w1_ids = await _seed_customers(store)
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_link_create_handler(
+            {"from_id": w1_ids[0], "to_id": w1_ids[1], "link_type": "competes_with"}
+        )
+
+    body = await _result_body(res)
+    assert body["created"] is True
+    assert body["link"]["from_object_id"] == w1_ids[0]
+    assert body["link"]["link_type"] == "competes_with"
+
+    links_w1, total_w1 = await store.list_links(workspace_id="w1")
+    assert total_w1 == 1
+    _, total_w2 = await store.list_links(workspace_id="w2")
+    assert total_w2 == 0
+
+
+async def test_link_create_refuses_cross_tenant_endpoint(store, registry):
+    """An endpoint id belonging to another workspace refuses — no link written."""
+    await _seed_customers(store)
+    # The w2 object (scoped read from w1 must not resolve it).
+    w2_objs = await store.query(
+        __import__("pocketpaw.fabric.models", fromlist=["FabricQuery"]).FabricQuery(),
+        workspace_id="w2",
+    )
+    w2_id = w2_objs.objects[0].id
+    w1_ids = await _seed_customers(store)
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_link_create_handler(
+            {"from_id": w1_ids[0], "to_id": w2_id, "link_type": "knows"}
+        )
+
+    assert res.get("is_error") is True
+    assert "not found in this workspace" in res["content"][0]["text"]
+    _, total = await store.list_links(workspace_id="w1")
+    assert total == 0
+
+
+async def test_link_create_enforces_declared_schema(store, registry):
+    """With a declared link schema, an unregistered link type refuses — the
+    router's own enforcement runs behind the MCP tool."""
+    w1_ids = await _seed_customers(store)
+    registry.register_link("w1", "has_order", "Customer", "Order")
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_link_create_handler(
+            {"from_id": w1_ids[0], "to_id": w1_ids[1], "link_type": "made_up_type"}
+        )
+
+    assert res.get("is_error") is True
+    assert "made_up_type" in res["content"][0]["text"]
+    _, total = await store.list_links(workspace_id="w1")
+    assert total == 0
+
+
+@pytest.mark.parametrize("missing", ["from_id", "to_id", "link_type"])
+async def test_link_create_requires_fields(store, registry, missing):
+    args = {"from_id": "a", "to_id": "b", "link_type": "knows"}
+    del args[missing]
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_link_create_handler(args)
+    assert res.get("is_error") is True
+    assert f"`{missing}`" in res["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# fabric_link_delete
+# ---------------------------------------------------------------------------
+
+
+async def test_link_delete_removes_own_link(store):
+    _, _, link_id = await _seed_link(store, workspace="w1")
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_link_delete_handler({"link_id": link_id})
+
+    body = await _result_body(res)
+    assert body["deleted"] is True
+    assert body["link"]["id"] == link_id
+    _, total = await store.list_links(workspace_id="w1")
+    assert total == 0
+
+
+async def test_link_delete_refuses_cross_tenant_link(store):
+    """Another tenant's link id refuses, and the row SURVIVES."""
+    _, _, w2_link_id = await _seed_link(store, workspace="w2")
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_link_delete_handler({"link_id": w2_link_id})
+
+    assert res.get("is_error") is True
+    assert "not found in this workspace" in res["content"][0]["text"]
+    _, total = await store.list_links(workspace_id="w2")
+    assert total == 1
+
+
+async def test_link_delete_requires_link_id(store):
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_link_delete_handler({})
+    assert res.get("is_error") is True
+    assert "`link_id`" in res["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# fabric_type_update
+# ---------------------------------------------------------------------------
+
+
+async def test_type_update_renames_and_bumps_version(store, registry, admin_ok):
+    """A rename migrates existing objects and bumps the type version."""
+    from pocketpaw.fabric.models import PropertyDef
+
+    obj_type = await store.define_type(
+        name="Customer",
+        properties=[PropertyDef(name="name", type="string")],
+        workspace_id="w1",
+    )
+    obj = await store.create_object(obj_type.id, {"name": "Acme"}, workspace_id="w1")
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_type_update_handler(
+            {"type_name": "Customer", "renames": {"name": "full_name"}}
+        )
+
+    body = await _result_body(res)
+    assert body["updated"] is True
+    assert body["type"]["version"] == 2
+
+    migrated = await store.get_object(obj.id, workspace_id="w1")
+    assert migrated.properties.get("full_name") == "Acme"
+    assert "name" not in migrated.properties
+
+
+async def test_type_update_denied_for_non_admin(store, registry, monkeypatch):
+    """A non-admin gets a structured deny envelope and NO write happens."""
+    from pocketpaw_ee.guards.rbac import Forbidden
+
+    async def _fake_load_user(user_id):
+        return object()
+
+    def _deny(user, ws, action):
+        raise Forbidden("workspace.insufficient_role", "admin required")
+
+    monkeypatch.setattr(fabric_mcp, "_load_user", _fake_load_user)
+    monkeypatch.setattr("pocketpaw_ee.guards.deps.check_workspace_action", _deny)
+
+    obj_type = await store.define_type(name="Customer", properties=[], workspace_id="w1")
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_type_update_handler(
+            {"type_name": "Customer", "description": "hacked"}
+        )
+
+    body = await _result_body(res)
+    assert body["denied"] is True
+    assert body["ok"] is False
+    unchanged = await store.get_type(obj_type.id, workspace_id="w1")
+    assert unchanged.description != "hacked"
+
+
+async def test_type_update_requires_a_change(store, registry, admin_ok):
+    await store.define_type(name="Customer", properties=[], workspace_id="w1")
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_type_update_handler({"type_name": "Customer"})
+    assert res.get("is_error") is True
+    assert "at least one change" in res["content"][0]["text"]
+
+
+async def test_type_update_unknown_type_refuses(store, registry, admin_ok):
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_type_update_handler(
+            {"type_name": "Ghost", "description": "x"}
+        )
+    assert res.get("is_error") is True
+    assert "Ghost" in res["content"][0]["text"]
+
+
+@pytest.mark.parametrize(
+    "handler,args",
+    [
+        (fabric_mcp._fabric_link_create_handler, {"from_id": "a", "to_id": "b", "link_type": "t"}),
+        (fabric_mcp._fabric_link_delete_handler, {"link_id": "x"}),
+        (fabric_mcp._fabric_type_update_handler, {"type_name": "Customer", "description": "d"}),
+    ],
+)
+async def test_write_tools_require_identity(store, handler, args):
+    """Called without workspace ContextVars → an explicit error, no write."""
+    res = await handler(args)
+    assert res.get("is_error") is True
+    assert "workspace context" in res["content"][0]["text"]

--- a/tests/cloud/test_fabric_ontology_operator.py
+++ b/tests/cloud/test_fabric_ontology_operator.py
@@ -502,9 +502,7 @@ class TestLinkDelete:
         again = member_client.delete(f"/api/v1/fabric/links/{lnk['id']}")
         assert again.status_code == 404
 
-    def test_cross_tenant_link_404s_and_survives(
-        self, member_client: TestClient
-    ) -> None:
+    def test_cross_tenant_link_404s_and_survives(self, member_client: TestClient) -> None:
         # A link stamped with ANOTHER workspace inside the same store file must
         # 404 (no existence leak) and must NOT be deleted — the in-row scope
         # guard, independent of the physical per-workspace file split.

--- a/tests/cloud/test_fabric_ontology_operator.py
+++ b/tests/cloud/test_fabric_ontology_operator.py
@@ -1,0 +1,466 @@
+# test_fabric_ontology_operator.py — the ontology-operator-ux backend.
+# Created: 2026-07-10 (feat/ontology-operator-ux) — covers the three backend
+# criteria that make the Fabric ontology operable by a non-engineer:
+#   1. AUTHORING endpoints (/fabric/schema/*): create a typed object type, add a
+#      property, declare a link type, and the GET /fabric/schema list reflects
+#      them. Tenant-scoped and ADMIN-gated (fabric.admin) — a member is denied
+#      (403) and an unauthenticated caller gets 401.
+#   2. WRITE-TIME TYPE ENFORCEMENT: a wrong-typed property is rejected (422 over
+#      HTTP, FabricTypeError at the store) and a valid one accepted; a link that
+#      violates the declared link schema (unknown type, or wrong endpoints) is
+#      rejected, a matching one accepted.
+#   3. SCHEMA VERSIONING: update_type bumps the version, a property rename
+#      migrates existing objects, an additive property with a default is
+#      backfilled, and a property dropped from the schema leaves its orphaned key
+#      on existing objects (the documented deferred-removal behaviour).
+#
+# The store-level tests drive the real FabricStore against a tmp SQLite file; the
+# HTTP tests wire the real EE router + real RBAC (fabric.read/write/admin) with an
+# isolated per-workspace store, spying on behaviour rather than mocking the seam
+# under test.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pocketpaw_ee.fabric.router as fabric_router_module
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.auth import current_active_user
+from pocketpaw_ee.cloud.license import require_license
+
+from pocketpaw.fabric.models import FabricTypeError, PropertyDef
+from pocketpaw.fabric.store import FabricStore
+
+# ---------------------------------------------------------------------------
+# Store-level: write-time type enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> FabricStore:
+    return FabricStore(tmp_path / "test.db")
+
+
+class TestWriteTimeTypeEnforcement:
+    @pytest.mark.asyncio
+    async def test_rejects_wrong_typed_property_on_create(self, store: FabricStore) -> None:
+        t = await store.define_type(
+            name="Customer",
+            properties=[
+                PropertyDef(name="name", type="string"),
+                PropertyDef(name="revenue", type="number"),
+            ],
+        )
+        with pytest.raises(FabricTypeError):
+            await store.create_object(t.id, {"name": "Acme", "revenue": "not-a-number"})
+
+    @pytest.mark.asyncio
+    async def test_accepts_valid_typed_property_on_create(self, store: FabricStore) -> None:
+        t = await store.define_type(
+            name="Customer",
+            properties=[
+                PropertyDef(name="name", type="string"),
+                PropertyDef(name="revenue", type="number"),
+            ],
+        )
+        obj = await store.create_object(t.id, {"name": "Acme", "revenue": 75000})
+        assert obj.properties["revenue"] == 75000
+
+    @pytest.mark.asyncio
+    async def test_numeric_string_is_coerced_ok(self, store: FabricStore) -> None:
+        # A connector often ships a number as a string; enforcement must stay
+        # lenient enough not to reject "75000" for a number field.
+        t = await store.define_type(
+            name="Customer", properties=[PropertyDef(name="revenue", type="number")]
+        )
+        obj = await store.create_object(t.id, {"revenue": "75000"})
+        assert obj.properties["revenue"] == "75000"
+
+    @pytest.mark.asyncio
+    async def test_enum_membership_enforced(self, store: FabricStore) -> None:
+        t = await store.define_type(
+            name="Deal",
+            properties=[
+                PropertyDef(name="stage", type="enum", enum_values=["open", "won", "lost"]),
+            ],
+        )
+        with pytest.raises(FabricTypeError):
+            await store.create_object(t.id, {"stage": "banana"})
+        ok = await store.create_object(t.id, {"stage": "won"})
+        assert ok.properties["stage"] == "won"
+
+    @pytest.mark.asyncio
+    async def test_undeclared_property_passes_through(self, store: FabricStore) -> None:
+        # The schema is open/additive: an extra key that the type does not declare
+        # is not a type clash and must be allowed.
+        t = await store.define_type(
+            name="Customer", properties=[PropertyDef(name="name", type="string")]
+        )
+        obj = await store.create_object(t.id, {"name": "Acme", "note": {"any": "shape"}})
+        assert obj.properties["note"] == {"any": "shape"}
+
+    @pytest.mark.asyncio
+    async def test_empty_schema_is_no_op(self, store: FabricStore) -> None:
+        # A type with no declared properties enforces nothing (backward compat).
+        t = await store.define_type(name="Freeform", properties=[])
+        obj = await store.create_object(t.id, {"whatever": 123})
+        assert obj.properties["whatever"] == 123
+
+    @pytest.mark.asyncio
+    async def test_update_validates_provided_delta(self, store: FabricStore) -> None:
+        t = await store.define_type(
+            name="Customer", properties=[PropertyDef(name="revenue", type="number")]
+        )
+        obj = await store.create_object(t.id, {"revenue": 100})
+        with pytest.raises(FabricTypeError):
+            await store.update_object(obj.id, {"revenue": "still-not-a-number"})
+        # A valid update goes through.
+        updated = await store.update_object(obj.id, {"revenue": 200})
+        assert updated is not None
+        assert updated.properties["revenue"] == 200
+
+
+# ---------------------------------------------------------------------------
+# Store-level: schema versioning + non-destructive migration
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersioning:
+    @pytest.mark.asyncio
+    async def test_new_type_starts_at_version_one(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Customer", properties=[])
+        assert t.version == 1
+        fetched = await store.get_type(t.id)
+        assert fetched is not None
+        assert fetched.version == 1
+
+    @pytest.mark.asyncio
+    async def test_update_bumps_version(self, store: FabricStore) -> None:
+        t = await store.define_type(
+            name="Customer", properties=[PropertyDef(name="name", type="string")]
+        )
+        updated = await store.update_type(
+            t.id, properties=[PropertyDef(name="name", type="string")]
+        )
+        assert updated is not None
+        assert updated.version == 2
+        assert (await store.get_type(t.id)).version == 2  # persisted
+
+    @pytest.mark.asyncio
+    async def test_rename_migrates_existing_objects(self, store: FabricStore) -> None:
+        t = await store.define_type(
+            name="Customer", properties=[PropertyDef(name="revenue", type="number")]
+        )
+        obj = await store.create_object(t.id, {"revenue": 500})
+        updated = await store.update_type(
+            t.id,
+            properties=[PropertyDef(name="annual_revenue", type="number")],
+            renames={"revenue": "annual_revenue"},
+        )
+        assert updated is not None
+        assert updated.version == 2
+        assert [p.name for p in updated.properties] == ["annual_revenue"]
+        # The existing object's key was moved, value preserved.
+        migrated = await store.get_object(obj.id)
+        assert migrated is not None
+        assert "revenue" not in migrated.properties
+        assert migrated.properties["annual_revenue"] == 500
+
+    @pytest.mark.asyncio
+    async def test_additive_property_with_default_is_backfilled(self, store: FabricStore) -> None:
+        t = await store.define_type(
+            name="Customer", properties=[PropertyDef(name="name", type="string")]
+        )
+        obj = await store.create_object(t.id, {"name": "Acme"})
+        updated = await store.update_type(
+            t.id,
+            properties=[
+                PropertyDef(name="name", type="string"),
+                PropertyDef(name="tier", type="string", default="standard"),
+            ],
+        )
+        assert updated is not None
+        assert updated.version == 2
+        migrated = await store.get_object(obj.id)
+        assert migrated is not None
+        assert migrated.properties["tier"] == "standard"  # backfilled onto the old object
+
+    @pytest.mark.asyncio
+    async def test_dropped_property_leaves_orphaned_key(self, store: FabricStore) -> None:
+        # DEFERRED destructive removal: dropping a property from the schema does
+        # NOT scrub the key from existing objects — it is left orphaned. This is
+        # the documented behaviour asserted here so a future purge is a
+        # deliberate, separate change.
+        t = await store.define_type(
+            name="Customer",
+            properties=[
+                PropertyDef(name="name", type="string"),
+                PropertyDef(name="legacy_code", type="string"),
+            ],
+        )
+        obj = await store.create_object(t.id, {"name": "Acme", "legacy_code": "XYZ"})
+        updated = await store.update_type(
+            t.id, properties=[PropertyDef(name="name", type="string")]
+        )
+        assert updated is not None
+        assert [p.name for p in updated.properties] == ["name"]  # declaration dropped
+        orphaned = await store.get_object(obj.id)
+        assert orphaned is not None
+        assert orphaned.properties["legacy_code"] == "XYZ"  # data survives, orphaned
+
+    @pytest.mark.asyncio
+    async def test_update_unknown_type_returns_none(self, store: FabricStore) -> None:
+        assert await store.update_type("ot-nope", properties=[]) is None
+
+    @pytest.mark.asyncio
+    async def test_update_type_workspace_scoped(self, store: FabricStore) -> None:
+        # A type owned by ws-b cannot be updated from a ws-a-scoped call.
+        b_type = await store.define_type(name="Secret", properties=[], workspace_id="ws-b")
+        assert await store.update_type(b_type.id, properties=[], workspace_id="ws-a") is None
+        # Its owner can.
+        updated = await store.update_type(b_type.id, properties=[], workspace_id="ws-b")
+        assert updated is not None
+        assert updated.version == 2
+
+
+# ---------------------------------------------------------------------------
+# HTTP: authoring endpoints, admin gate, and write-time enforcement over the wire
+# ---------------------------------------------------------------------------
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str) -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, role: str, workspace_id: str = "ws-test") -> None:
+        self.id = f"user-{role}"
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role=role)]
+
+
+def _build_client(tmp_path: Path, monkeypatch, *, role: str | None) -> TestClient:
+    """An isolated app with the real fabric router + real RBAC.
+
+    ``role`` sets the fake user's workspace role (``admin`` / ``member``). When
+    ``role`` is ``None`` no auth override is installed, so an unauthenticated
+    request hits the real fastapi-users dependency and gets a 401.
+    """
+    import pocketpaw.stores as stores
+
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    stores.reset_store_caches()
+
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(fabric_router_module.router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+    if role is not None:
+        user = _FakeUser(role=role)
+        app.dependency_overrides[current_active_user] = lambda: user
+        app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.fixture
+def admin_client(tmp_path: Path, monkeypatch) -> TestClient:
+    return _build_client(tmp_path, monkeypatch, role="admin")
+
+
+@pytest.fixture
+def member_client(tmp_path: Path, monkeypatch) -> TestClient:
+    return _build_client(tmp_path, monkeypatch, role="member")
+
+
+class TestAuthoringEndpoints:
+    def test_create_type_add_property_and_schema_reflects_them(
+        self, admin_client: TestClient
+    ) -> None:
+        # Create a typed object type.
+        resp = admin_client.post(
+            "/api/v1/fabric/schema/types",
+            json={
+                "name": "Customer",
+                "properties": [{"name": "name", "type": "string"}],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        type_id = resp.json()["id"]
+        assert resp.json()["version"] == 1
+
+        # Add a property (additive) — bumps the version.
+        add = admin_client.post(
+            f"/api/v1/fabric/schema/types/{type_id}/properties",
+            json={"property": {"name": "revenue", "type": "number"}},
+        )
+        assert add.status_code == 200, add.text
+        assert add.json()["version"] == 2
+        assert {p["name"] for p in add.json()["properties"]} == {"name", "revenue"}
+
+        # Declare a link type.
+        link = admin_client.post(
+            "/api/v1/fabric/schema/link-types",
+            json={"name": "has_order", "from_type": "Customer", "to_type": "Order"},
+        )
+        assert link.status_code == 201, link.text
+
+        # The schema list reflects the object type (with properties) + link type.
+        schema = admin_client.get("/api/v1/fabric/schema")
+        assert schema.status_code == 200, schema.text
+        body = schema.json()
+        names = {t["name"] for t in body["object_types"]}
+        assert "Customer" in names
+        customer = next(t for t in body["object_types"] if t["name"] == "Customer")
+        assert {p["name"] for p in customer["properties"]} == {"name", "revenue"}
+        assert body["link_types"] == [
+            {"name": "has_order", "from_type": "Customer", "to_type": "Order"}
+        ]
+
+    def test_add_duplicate_property_rejected(self, admin_client: TestClient) -> None:
+        t = admin_client.post(
+            "/api/v1/fabric/schema/types",
+            json={"name": "Customer", "properties": [{"name": "name", "type": "string"}]},
+        ).json()
+        dup = admin_client.post(
+            f"/api/v1/fabric/schema/types/{t['id']}/properties",
+            json={"property": {"name": "name", "type": "string"}},
+        )
+        assert dup.status_code == 422
+
+    def test_patch_type_rename_versions_over_http(self, admin_client: TestClient) -> None:
+        t = admin_client.post(
+            "/api/v1/fabric/schema/types",
+            json={"name": "Customer", "properties": [{"name": "revenue", "type": "number"}]},
+        ).json()
+        patch = admin_client.patch(
+            f"/api/v1/fabric/schema/types/{t['id']}",
+            json={
+                "properties": [{"name": "annual_revenue", "type": "number"}],
+                "renames": {"revenue": "annual_revenue"},
+            },
+        )
+        assert patch.status_code == 200, patch.text
+        assert patch.json()["version"] == 2
+        assert [p["name"] for p in patch.json()["properties"]] == ["annual_revenue"]
+
+
+class TestAdminGate:
+    def test_member_denied_on_authoring(self, member_client: TestClient) -> None:
+        resp = member_client.post(
+            "/api/v1/fabric/schema/types",
+            json={"name": "Customer", "properties": []},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_member_denied_on_link_type(self, member_client: TestClient) -> None:
+        resp = member_client.post(
+            "/api/v1/fabric/schema/link-types",
+            json={"name": "has_order", "from_type": "Customer", "to_type": "Order"},
+        )
+        assert resp.status_code == 403
+
+    def test_member_can_read_schema(self, member_client: TestClient) -> None:
+        # The schema LIST is fabric.read — a member can render the browser.
+        resp = member_client.get("/api/v1/fabric/schema")
+        assert resp.status_code == 200
+
+    def test_unauthenticated_denied(self, tmp_path: Path, monkeypatch) -> None:
+        anon = _build_client(tmp_path, monkeypatch, role=None)
+        resp = anon.post(
+            "/api/v1/fabric/schema/types",
+            json={"name": "Customer", "properties": []},
+        )
+        assert resp.status_code == 401
+
+
+class TestWriteTimeEnforcementOverHTTP:
+    def test_object_wrong_typed_property_rejected(self, admin_client: TestClient) -> None:
+        t = admin_client.post(
+            "/api/v1/fabric/schema/types",
+            json={"name": "Customer", "properties": [{"name": "revenue", "type": "number"}]},
+        ).json()
+        bad = admin_client.post(
+            "/api/v1/fabric/objects",
+            json={"type_id": t["id"], "properties": {"revenue": "not-a-number"}},
+        )
+        assert bad.status_code == 422, bad.text
+        assert bad.json()["error"]["code"] == "fabric.property_type_mismatch"
+
+        ok = admin_client.post(
+            "/api/v1/fabric/objects",
+            json={"type_id": t["id"], "properties": {"revenue": 42}},
+        )
+        assert ok.status_code == 201, ok.text
+
+    def test_link_enforced_against_declared_schema(self, admin_client: TestClient) -> None:
+        # Author two types + a link type Customer --has_order--> Order.
+        cust = admin_client.post(
+            "/api/v1/fabric/schema/types", json={"name": "Customer", "properties": []}
+        ).json()
+        order = admin_client.post(
+            "/api/v1/fabric/schema/types", json={"name": "Order", "properties": []}
+        ).json()
+        admin_client.post(
+            "/api/v1/fabric/schema/link-types",
+            json={"name": "has_order", "from_type": "Customer", "to_type": "Order"},
+        )
+
+        c = admin_client.post(
+            "/api/v1/fabric/objects", json={"type_id": cust["id"], "properties": {}}
+        ).json()
+        o = admin_client.post(
+            "/api/v1/fabric/objects", json={"type_id": order["id"], "properties": {}}
+        ).json()
+
+        # A valid link (Customer -> Order via has_order) is accepted.
+        good = admin_client.post(
+            "/api/v1/fabric/links",
+            json={"from_id": c["id"], "to_id": o["id"], "link_type": "has_order"},
+        )
+        assert good.status_code == 201, good.text
+
+        # An unregistered link type is rejected.
+        unknown = admin_client.post(
+            "/api/v1/fabric/links",
+            json={"from_id": c["id"], "to_id": o["id"], "link_type": "invented"},
+        )
+        assert unknown.status_code == 422
+        assert unknown.json()["error"]["code"] == "fabric.link_type_unregistered"
+
+        # A declared type used with the WRONG endpoints (Order -> Customer) is
+        # rejected — the declaration is directional.
+        wrong = admin_client.post(
+            "/api/v1/fabric/links",
+            json={"from_id": o["id"], "to_id": c["id"], "link_type": "has_order"},
+        )
+        assert wrong.status_code == 422
+        assert wrong.json()["error"]["code"] == "fabric.link_type_mismatch"
+
+    def test_links_unenforced_when_no_link_schema(self, admin_client: TestClient) -> None:
+        # A workspace that declared no link types keeps the pre-enforcement
+        # behaviour: any link_type is accepted (backward compatible).
+        t = admin_client.post(
+            "/api/v1/fabric/schema/types", json={"name": "Node", "properties": []}
+        ).json()
+        a = admin_client.post(
+            "/api/v1/fabric/objects", json={"type_id": t["id"], "properties": {}}
+        ).json()
+        b = admin_client.post(
+            "/api/v1/fabric/objects", json={"type_id": t["id"], "properties": {}}
+        ).json()
+        resp = admin_client.post(
+            "/api/v1/fabric/links",
+            json={"from_id": a["id"], "to_id": b["id"], "link_type": "anything_goes"},
+        )
+        assert resp.status_code == 201, resp.text

--- a/tests/cloud/test_fabric_ontology_operator.py
+++ b/tests/cloud/test_fabric_ontology_operator.py
@@ -13,6 +13,10 @@
 #      migrates existing objects, an additive property with a default is
 #      backfilled, and a property dropped from the schema leaves its orphaned key
 #      on existing objects (the documented deferred-removal behaviour).
+# Updated: 2026-07-11 (feat/paw-cli, C2) — added DELETE /fabric/links/{id}
+#      coverage: a member deletes their own link (204, then 404 on the gone id),
+#      and a link stamped with another workspace 404s AND survives (the in-row
+#      scope guard behind the scoped get_link).
 #
 # The store-level tests drive the real FabricStore against a tmp SQLite file; the
 # HTTP tests wire the real EE router + real RBAC (fabric.read/write/admin) with an
@@ -464,3 +468,63 @@ class TestWriteTimeEnforcementOverHTTP:
             json={"from_id": a["id"], "to_id": b["id"], "link_type": "anything_goes"},
         )
         assert resp.status_code == 201, resp.text
+
+
+# ---------------------------------------------------------------------------
+# HTTP: DELETE /fabric/links/{id} (feat/paw-cli, C2 — link CRUD completion)
+# ---------------------------------------------------------------------------
+
+
+class TestLinkDelete:
+    def test_member_deletes_own_link_then_404(self, member_client: TestClient) -> None:
+        # Members hold fabric.write — the same tier that creates links.
+        t = member_client.post(
+            "/api/v1/fabric/types", json={"name": "Node", "properties": []}
+        ).json()
+        a = member_client.post(
+            "/api/v1/fabric/objects", json={"type_id": t["id"], "properties": {}}
+        ).json()
+        b = member_client.post(
+            "/api/v1/fabric/objects", json={"type_id": t["id"], "properties": {}}
+        ).json()
+        lnk = member_client.post(
+            "/api/v1/fabric/links",
+            json={"from_id": a["id"], "to_id": b["id"], "link_type": "knows"},
+        ).json()
+
+        resp = member_client.delete(f"/api/v1/fabric/links/{lnk['id']}")
+        assert resp.status_code == 204, resp.text
+
+        listing = member_client.get("/api/v1/fabric/links")
+        assert listing.json()["total"] == 0
+
+        # Idempotence boundary: the id is gone now — 404, not a second delete.
+        again = member_client.delete(f"/api/v1/fabric/links/{lnk['id']}")
+        assert again.status_code == 404
+
+    def test_cross_tenant_link_404s_and_survives(
+        self, member_client: TestClient
+    ) -> None:
+        # A link stamped with ANOTHER workspace inside the same store file must
+        # 404 (no existence leak) and must NOT be deleted — the in-row scope
+        # guard, independent of the physical per-workspace file split.
+        import asyncio
+
+        import pocketpaw.stores as stores
+
+        store = stores.get_fabric_store(workspace_id="ws-test")
+
+        async def _seed() -> str:
+            t = await store.define_type(name="Alien", properties=[], workspace_id="other-ws")
+            a = await store.create_object(t.id, {}, workspace_id="other-ws")
+            b = await store.create_object(t.id, {}, workspace_id="other-ws")
+            lnk = await store.link(a.id, b.id, "knows", workspace_id="other-ws")
+            return lnk.id
+
+        link_id = asyncio.run(_seed())
+
+        resp = member_client.delete(f"/api/v1/fabric/links/{link_id}")
+        assert resp.status_code == 404
+
+        survived = asyncio.run(store.get_link(link_id))  # unscoped read
+        assert survived is not None

--- a/tests/cloud/test_fabric_self_serve_analysis.py
+++ b/tests/cloud/test_fabric_self_serve_analysis.py
@@ -1,0 +1,415 @@
+# test_fabric_self_serve_analysis.py — self-serve-analysis Slice 1 (read engine).
+# Created: 2026-07-11 (feat/self-serve-analysis-s1) — covers the flag-gated SQL
+# aggregation + reasoning-steps path on FabricStore.query / POST /fabric/query:
+#   1. FLAG GATE: POCKETPAW_FABRIC_ANALYST off (the default) -> an aggregation
+#      query raises FabricAnalystDisabledError at the store and 422
+#      fabric.analyst_disabled over HTTP; plain queries pass either way.
+#   2. CORRECTNESS: group-by count and sum/avg/min/max fold the right numbers;
+#      numeric folds CAST to REAL (JSON-string numbers still add up).
+#   3. SCOPE-THEN-AGGREGATE: a cross-workspace object is NEVER counted into a
+#      group total (the W4a scope applies BEFORE grouping).
+#   4. RANGES: RangeBucket bucketing (explicit + derived labels, min-inclusive /
+#      max-exclusive, out-of-bucket and missing values dropped).
+#   5. BACK-COMPAT: plain queries return objects exactly as before with
+#      aggregates/steps None (null on the wire).
+#   6. WIRE CONTRACT: steps serialize as exactly {title, detail, status} — the
+#      QueryPlanStep shape ripple's ReasoningTrace consumes, never {label, count}.
+#   7. MODEL VALIDATION: inconsistent aggregation field combinations are
+#      rejected at the FabricQuery boundary; group_by alone defaults to count.
+#
+# Store tests drive the real FabricStore against a tmp SQLite file; the HTTP
+# tests wire the real EE router + real RBAC with an isolated per-workspace
+# store (same harness as test_fabric_ontology_operator).
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pocketpaw_ee.fabric.router as fabric_router_module
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.auth import current_active_user
+from pocketpaw_ee.cloud.license import require_license
+
+from pocketpaw.config import get_settings
+from pocketpaw.fabric.models import (
+    FabricAnalystDisabledError,
+    FabricQuery,
+    RangeBucket,
+)
+from pocketpaw.fabric.store import FabricStore
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_settings(monkeypatch: pytest.MonkeyPatch):
+    """Every test starts and ends with a pristine settings cache (flag off)."""
+    monkeypatch.delenv("POCKETPAW_FABRIC_ANALYST", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def analyst_on(monkeypatch: pytest.MonkeyPatch):
+    """Turn the POCKETPAW_FABRIC_ANALYST flag ON for one test."""
+    monkeypatch.setenv("POCKETPAW_FABRIC_ANALYST", "true")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> FabricStore:
+    return FabricStore(tmp_path / "analysis.db")
+
+
+async def _seed_products(store: FabricStore) -> None:
+    """Products across two workspaces.
+
+    WS_A: 4 products — categories a/a/b plus one with NO category;
+    WS_B: 1 product in category b (the cross-tenant canary).
+    """
+    t = await store.define_type(name="Product", properties=[])
+    rows = [
+        ({"category": "a", "stock": 5, "price": 10}, WS_A),
+        ({"category": "a", "stock": 3, "price": "20"}, WS_A),  # JSON-string number
+        ({"category": "b", "stock": 50, "price": 30}, WS_A),
+        ({"stock": 1, "price": 5}, WS_A),  # no category
+        ({"category": "b", "stock": 2, "price": 1000}, WS_B),
+    ]
+    for props, ws in rows:
+        await store.create_object(t.id, props, workspace_id=ws)
+
+
+# ---------------------------------------------------------------------------
+# Flag gate
+# ---------------------------------------------------------------------------
+
+
+class TestFlagGate:
+    @pytest.mark.asyncio
+    async def test_flag_off_rejects_aggregation(self, store: FabricStore) -> None:
+        await _seed_products(store)
+        with pytest.raises(FabricAnalystDisabledError, match="POCKETPAW_FABRIC_ANALYST"):
+            await store.query(FabricQuery(type_name="Product", group_by="category"))
+
+    @pytest.mark.asyncio
+    async def test_flag_off_plain_query_unaffected(self, store: FabricStore) -> None:
+        await _seed_products(store)
+        result = await store.query(FabricQuery(type_name="Product"), workspace_id=WS_A)
+        assert result.total == 4
+        assert len(result.objects) == 4
+
+    @pytest.mark.asyncio
+    async def test_flag_on_allows_aggregation(self, analyst_on, store: FabricStore) -> None:
+        await _seed_products(store)
+        result = await store.query(
+            FabricQuery(type_name="Product", group_by="category"), workspace_id=WS_A
+        )
+        assert result.aggregates is not None
+
+
+# ---------------------------------------------------------------------------
+# Aggregation correctness (flag on)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("analyst_on")
+class TestAggregationCorrectness:
+    @pytest.mark.asyncio
+    async def test_group_by_count(self, store: FabricStore) -> None:
+        await _seed_products(store)
+        result = await store.query(
+            FabricQuery(type_name="Product", group_by="category"), workspace_id=WS_A
+        )
+        assert result.objects == []  # analysis read, not a fetch
+        assert result.total == 4  # scoped+filtered rows, incl. the no-category one
+        assert {r["key"]: r["value"] for r in result.aggregates} == {"a": 2, "b": 1}
+
+    @pytest.mark.asyncio
+    async def test_group_by_sum_casts_string_numbers(self, store: FabricStore) -> None:
+        await _seed_products(store)
+        result = await store.query(
+            FabricQuery(
+                type_name="Product",
+                group_by="category",
+                aggregate="sum",
+                aggregate_field="price",
+            ),
+            workspace_id=WS_A,
+        )
+        # "20" (a JSON-string number) still adds: a = 10 + 20, b = 30.
+        assert {r["key"]: r["value"] for r in result.aggregates} == {"a": 30.0, "b": 30.0}
+
+    @pytest.mark.asyncio
+    async def test_avg_min_max(self, store: FabricStore) -> None:
+        await _seed_products(store)
+        for fn, expected_a in [("avg", 15.0), ("min", 10.0), ("max", 20.0)]:
+            result = await store.query(
+                FabricQuery(
+                    type_name="Product",
+                    group_by="category",
+                    aggregate=fn,
+                    aggregate_field="price",
+                ),
+                workspace_id=WS_A,
+            )
+            by_key = {r["key"]: r["value"] for r in result.aggregates}
+            assert by_key["a"] == expected_a, fn
+
+    @pytest.mark.asyncio
+    async def test_filters_apply_before_grouping(self, store: FabricStore) -> None:
+        await _seed_products(store)
+        result = await store.query(
+            FabricQuery(
+                type_name="Product",
+                filters={"stock": {"<": 10}},
+                group_by="category",
+            ),
+            workspace_id=WS_A,
+        )
+        # stock<10 in WS_A: the two category-a products + the no-category one.
+        assert result.total == 3
+        assert {r["key"]: r["value"] for r in result.aggregates} == {"a": 2}
+
+    @pytest.mark.asyncio
+    async def test_sort_orders(self, store: FabricStore) -> None:
+        await _seed_products(store)
+
+        async def keys(sort: str | None) -> list:
+            result = await store.query(
+                FabricQuery(type_name="Product", group_by="category", sort=sort),
+                workspace_id=WS_A,
+            )
+            return [r["key"] for r in result.aggregates]
+
+        assert await keys(None) == ["a", "b"]  # default: value desc
+        assert await keys("value_asc") == ["b", "a"]
+        assert await keys("key_asc") == ["a", "b"]
+        assert await keys("key_desc") == ["b", "a"]
+
+    @pytest.mark.asyncio
+    async def test_scope_then_aggregate_cross_workspace_never_counted(
+        self, store: FabricStore
+    ) -> None:
+        await _seed_products(store)
+        # WS_B holds a category-b product priced 1000. Neither its count nor its
+        # price may leak into WS_A's aggregates.
+        count = await store.query(
+            FabricQuery(type_name="Product", group_by="category"), workspace_id=WS_A
+        )
+        assert {r["key"]: r["value"] for r in count.aggregates} == {"a": 2, "b": 1}
+        total = await store.query(
+            FabricQuery(
+                type_name="Product",
+                group_by="category",
+                aggregate="sum",
+                aggregate_field="price",
+            ),
+            workspace_id=WS_A,
+        )
+        assert {r["key"]: r["value"] for r in total.aggregates}["b"] == 30.0
+
+    @pytest.mark.asyncio
+    async def test_ranges_bucketing(self, store: FabricStore) -> None:
+        await _seed_products(store)
+        result = await store.query(
+            FabricQuery(
+                type_name="Product",
+                group_by="stock",
+                ranges=[
+                    RangeBucket(min=0, max=10),  # derived label "0-10"
+                    RangeBucket(min=10, max=40, label="mid"),
+                    RangeBucket(min=40, label="lots"),  # open-ended
+                ],
+            ),
+            workspace_id=WS_A,
+        )
+        by_key = {r["key"]: r["value"] for r in result.aggregates}
+        # WS_A stocks: 5, 3, 50, 1 -> three in 0-10, none in mid, one in lots.
+        assert by_key == {"0-10": 3, "lots": 1}
+
+    @pytest.mark.asyncio
+    async def test_ranges_min_inclusive_max_exclusive(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Reading", properties=[])
+        for v in (10, 20):
+            await store.create_object(t.id, {"value": v})
+        result = await store.query(
+            FabricQuery(
+                type_name="Reading",
+                group_by="value",
+                ranges=[RangeBucket(min=10, max=20, label="low")],
+            ),
+        )
+        # 10 falls in [10, 20); 20 does not.
+        assert [(r["key"], r["value"]) for r in result.aggregates] == [("low", 1)]
+
+    @pytest.mark.asyncio
+    async def test_steps_narrate_the_run(self, store: FabricStore) -> None:
+        await _seed_products(store)
+        result = await store.query(
+            FabricQuery(
+                type_name="Product",
+                filters={"stock": {"<": 10}},
+                group_by="category",
+            ),
+            workspace_id=WS_A,
+        )
+        assert result.steps is not None
+        titles = [s.title for s in result.steps]
+        assert titles == [
+            "Filtered Product where stock < 10",
+            "Grouped by category",
+            "Computed count",
+        ]
+        assert all(s.status == "done" for s in result.steps)
+        assert result.steps[0].detail == "3 matching objects"
+
+    @pytest.mark.asyncio
+    async def test_plain_query_unchanged_with_flag_on(self, store: FabricStore) -> None:
+        await _seed_products(store)
+        result = await store.query(FabricQuery(type_name="Product"), workspace_id=WS_A)
+        assert len(result.objects) == 4
+        assert result.total == 4
+        assert result.aggregates is None
+        assert result.steps is None
+
+
+# ---------------------------------------------------------------------------
+# FabricQuery model validation
+# ---------------------------------------------------------------------------
+
+
+class TestQueryModelValidation:
+    def test_group_by_alone_defaults_to_count(self) -> None:
+        q = FabricQuery(group_by="category")
+        assert q.aggregate == "count"
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"aggregate": "count"},  # aggregate without group_by
+            {"aggregate_field": "price"},
+            {"sort": "value_desc"},
+            {"ranges": [{"min": 0, "max": 1}]},
+            {"group_by": "x", "aggregate": "sum"},  # sum without aggregate_field
+            {"group_by": "x", "aggregate": "count", "aggregate_field": "y"},
+            {"group_by": "bad name"},  # non-identifier property
+            {"group_by": "x", "path": [{"link_type": "t"}]},  # no path aggregation
+        ],
+    )
+    def test_inconsistent_combinations_rejected(self, kwargs: dict) -> None:
+        with pytest.raises(ValueError):
+            FabricQuery(**kwargs)
+
+    def test_range_bucket_needs_a_bound(self) -> None:
+        with pytest.raises(ValueError):
+            RangeBucket(label="empty")
+
+
+# ---------------------------------------------------------------------------
+# HTTP contract on POST /fabric/query
+# ---------------------------------------------------------------------------
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str) -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, role: str, workspace_id: str = "ws-test") -> None:
+        self.id = f"user-{role}"
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role=role)]
+
+
+@pytest.fixture
+def member_client(tmp_path: Path, monkeypatch) -> TestClient:
+    """The real fabric router + real RBAC over an isolated per-workspace store."""
+    import pocketpaw.stores as stores
+
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    stores.reset_store_caches()
+
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(fabric_router_module.router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+    user = _FakeUser(role="member")
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app, raise_server_exceptions=True)
+
+
+async def _seed_http_store(tmp_path_ignored, workspace_id: str = "ws-test") -> None:
+    import pocketpaw.stores as stores
+
+    store = stores.get_fabric_store(workspace_id=workspace_id)
+    t = await store.define_type(name="Product", properties=[])
+    for props in ({"category": "a", "stock": 5}, {"category": "b", "stock": 3}):
+        await store.create_object(t.id, props, workspace_id=workspace_id)
+
+
+class TestHttpContract:
+    def test_steps_serialize_title_detail_status(
+        self, analyst_on, member_client: TestClient, tmp_path: Path
+    ) -> None:
+        import asyncio
+
+        asyncio.run(_seed_http_store(tmp_path))
+        resp = member_client.post(
+            "/api/v1/fabric/query",
+            json={"type_name": "Product", "group_by": "category"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["objects"] == []
+        assert {r["key"]: r["value"] for r in body["aggregates"]} == {"a": 1, "b": 1}
+        assert body["steps"], "aggregation must narrate its steps"
+        for step in body["steps"]:
+            # The exact QueryPlanStep wire shape ripple's ReasoningTrace
+            # consumes: {title, detail, status} — never {label, count}.
+            assert set(step.keys()) == {"title", "detail", "status"}
+            assert isinstance(step["title"], str) and step["title"]
+            assert step["status"] == "done"
+
+    def test_flag_off_maps_to_422_analyst_disabled(
+        self, member_client: TestClient, tmp_path: Path
+    ) -> None:
+        import asyncio
+
+        asyncio.run(_seed_http_store(tmp_path))
+        resp = member_client.post(
+            "/api/v1/fabric/query",
+            json={"type_name": "Product", "group_by": "category"},
+        )
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["error"]["code"] == "fabric.analyst_disabled"
+
+    def test_plain_query_wire_shape_unchanged(
+        self, member_client: TestClient, tmp_path: Path
+    ) -> None:
+        import asyncio
+
+        asyncio.run(_seed_http_store(tmp_path))
+        resp = member_client.post("/api/v1/fabric/query", json={"type_name": "Product"})
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total"] == 2
+        assert len(body["objects"]) == 2
+        # Additive fields serialize as null on a plain query.
+        assert body["aggregates"] is None
+        assert body["steps"] is None

--- a/tests/cloud/test_mission_control_analytics_verdicts.py
+++ b/tests/cloud/test_mission_control_analytics_verdicts.py
@@ -1,0 +1,80 @@
+# tests/cloud/test_mission_control_analytics_verdicts.py — the evals slice:
+# agent_analytics buckets Task.verify["verdict"]["status"] into solved/partial/
+# not_solved/unknown, computes solved_rate over CHECKABLE verdicts only
+# (unknown excluded, reported separately), returns None when nothing is
+# checkable (UI renders an em dash, never a fake 0%/100%), and stays
+# tenant-isolated. Created: 2026-07-11 (feat/evals-solved-rate).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from pocketpaw_ee.cloud.mission_control import service as mc_service
+from pocketpaw_ee.cloud.models.task import Task as TaskDoc
+from pocketpaw_ee.cloud.models.task import TaskAssignee as TaskAssigneeDoc
+
+_WS = "ws-verdicts"
+
+# NOTE: the suite runs pytest-asyncio in AUTO mode — async tests need no marks.
+
+
+async def _task(workspace_id: str, verdict_status: str | None) -> None:
+    doc = TaskDoc(
+        workspace_id=workspace_id,
+        creator_id="u1",
+        title="t",
+        summary="s",
+        assignee=TaskAssigneeDoc(kind="agent", id="a1", name="Bot"),
+        assignee_id="a1",
+        assignee_kind="agent",
+        status="done",
+        verify={"verdict": {"status": verdict_status}} if verdict_status else {},
+    )
+    await doc.insert()
+
+
+def _ctx(workspace_id: str = _WS) -> SimpleNamespace:
+    return SimpleNamespace(workspace_id=workspace_id, user_id="u1")
+
+
+def _no_pockets():
+    return patch.object(mc_service.pockets_service, "list_pockets", new=AsyncMock(return_value=[]))
+
+
+async def test_solved_rate_excludes_unknown(mongo_db):  # noqa: ARG001 — Beanie init
+    # 2 solved, 1 partial, 1 not_solved (checkable=4) + 2 unknown-ish (one
+    # explicit unknown, one verify=={} from a loop-off task).
+    for status in ("solved", "solved", "partial", "not_solved", "unknown", None):
+        await _task(_WS, status)
+
+    with _no_pockets():
+        res = await mc_service.agent_analytics(_ctx(), window="7d")
+
+    assert res.solved_count == 2
+    assert res.partial_count == 1
+    assert res.not_solved_count == 1
+    assert res.unknown_count == 1  # verify=={} carries no verdict at all
+    assert res.solved_rate == 50.0  # 2 / (2+1+1), unknown excluded
+
+
+async def test_solved_rate_none_when_nothing_checkable(mongo_db):  # noqa: ARG001
+    await _task(_WS, "unknown")
+    await _task(_WS, None)
+
+    with _no_pockets():
+        res = await mc_service.agent_analytics(_ctx(), window="7d")
+
+    assert res.solved_rate is None
+    assert res.unknown_count == 1
+
+
+async def test_verdicts_are_tenant_isolated(mongo_db):  # noqa: ARG001
+    await _task(_WS, "solved")
+    await _task("ws-other", "not_solved")  # must never leak into _WS's rollup
+
+    with _no_pockets():
+        res = await mc_service.agent_analytics(_ctx(), window="7d")
+
+    assert res.solved_count == 1
+    assert res.not_solved_count == 0
+    assert res.solved_rate == 100.0

--- a/tests/cloud/test_paw_bar_backend.py
+++ b/tests/cloud/test_paw_bar_backend.py
@@ -1,6 +1,12 @@
 # tests/cloud/test_paw_bar_backend.py — PR-A: Paw Bar models + store.
 # Created: 2026-04-13 — Covers validation caps, domain normalization, token
 # rotation, event persistence, and the rate-limit primitives used by PR-B.
+# Updated: 2026-07-11 (W4a tenancy seam) — Added TestWorkspaceScoping (two-
+# tenant isolation on get/list/update/rotate/delete + legacy ''-row matching),
+# TestSpecRevisions (archive-on-update, rollback round-trip, workspace-scoped
+# rollback), and TestScopedFabricWrite (the leak fix: _apply_event_mapping
+# threads the widget row's workspace_id into get_fabric_store; '' → None keeps
+# the single-tenant default store).
 
 from __future__ import annotations
 
@@ -297,3 +303,212 @@ class TestEventStore:
             now=now,
         )
         assert allowed is False
+
+
+# ---------------------------------------------------------------------------
+# W4a — in-row workspace scoping (two-tenant isolation)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceScoping:
+    @pytest.mark.asyncio
+    async def test_get_widget_is_workspace_scoped(self, store: PawBarStore) -> None:
+        widget = await store.create_widget(_widget(workspace_id="w1"))
+        assert await store.get_widget(widget.id, workspace_id="w1") is not None
+        assert await store.get_widget(widget.id, workspace_id="w2") is None
+        # None ⇒ unscoped (backward-compatible internal reads).
+        assert await store.get_widget(widget.id) is not None
+
+    @pytest.mark.asyncio
+    async def test_legacy_empty_workspace_row_matches_any_scope(self, store: PawBarStore) -> None:
+        widget = await store.create_widget(_widget())  # workspace_id defaults to ""
+        assert await store.get_widget(widget.id, workspace_id="w1") is not None
+        assert await store.get_widget(widget.id, workspace_id="w2") is not None
+
+    @pytest.mark.asyncio
+    async def test_list_widgets_is_workspace_scoped(self, store: PawBarStore) -> None:
+        await store.create_widget(_widget(workspace_id="w1", owner="user:maya"))
+        await store.create_widget(_widget(workspace_id="w2", owner="user:priya"))
+        legacy = await store.create_widget(_widget(owner="user:legacy"))  # ""
+
+        w1 = await store.list_widgets(workspace_id="w1")
+        assert {w.owner for w in w1} == {"user:maya", "user:legacy"}
+        w2 = await store.list_widgets(workspace_id="w2")
+        assert {w.owner for w in w2} == {"user:priya", "user:legacy"}
+        unscoped = await store.list_widgets()
+        assert len(unscoped) == 3
+        assert legacy.workspace_id == ""
+
+    @pytest.mark.asyncio
+    async def test_update_spec_cross_tenant_returns_none_and_never_mutates(
+        self, store: PawBarStore
+    ) -> None:
+        widget = await store.create_widget(_widget(workspace_id="w1"))
+        new_spec = PawBarSpec(
+            widget_id=widget.id,
+            pocket_id=widget.pocket_id,
+            blocks=[PawBarBlock(type="text", content="hijacked")],
+        )
+        assert await store.update_spec(widget.id, new_spec, workspace_id="w2") is None
+        untouched = await store.get_widget(widget.id)
+        assert untouched is not None
+        assert untouched.spec.blocks[0].content == "Today's menu"
+
+    @pytest.mark.asyncio
+    async def test_rotate_token_cross_tenant_returns_none_and_never_mutates(
+        self, store: PawBarStore
+    ) -> None:
+        widget = await store.create_widget(_widget(workspace_id="w1"))
+        assert await store.rotate_token(widget.id, workspace_id="w2") is None
+        unchanged = await store.get_widget(widget.id)
+        assert unchanged is not None
+        assert unchanged.access_token == widget.access_token
+
+    @pytest.mark.asyncio
+    async def test_delete_widget_cross_tenant_is_a_noop(self, store: PawBarStore) -> None:
+        widget = await store.create_widget(_widget(workspace_id="w1"))
+        assert await store.delete_widget(widget.id, workspace_id="w2") is False
+        assert await store.get_widget(widget.id) is not None
+        # Same-tenant delete still works.
+        assert await store.delete_widget(widget.id, workspace_id="w1") is True
+
+
+# ---------------------------------------------------------------------------
+# W4a — spec revisions + rollback
+# ---------------------------------------------------------------------------
+
+
+class TestSpecRevisions:
+    @pytest.mark.asyncio
+    async def test_update_archives_prior_spec_and_rollback_restores_it(
+        self, store: PawBarStore
+    ) -> None:
+        widget = await store.create_widget(_widget())
+        new_spec = PawBarSpec(
+            widget_id=widget.id,
+            pocket_id=widget.pocket_id,
+            blocks=[PawBarBlock(type="text", content="Closed today")],
+        )
+        await store.update_spec(widget.id, new_spec)
+
+        latest = await store.latest_spec_revision(widget.id)
+        assert latest is not None
+        revision, archived = latest
+        assert revision == 1
+        assert archived.blocks[0].content == "Today's menu"
+
+        restored = await store.rollback_spec(widget.id)
+        assert restored is not None
+        assert restored.spec.blocks[0].content == "Today's menu"
+
+        # The rollback itself archived the replaced spec (monotonic revision),
+        # so rolling back again restores "Closed today" — always reversible.
+        latest2 = await store.latest_spec_revision(widget.id)
+        assert latest2 is not None
+        assert latest2[0] == 2
+        again = await store.rollback_spec(widget.id)
+        assert again is not None
+        assert again.spec.blocks[0].content == "Closed today"
+
+    @pytest.mark.asyncio
+    async def test_rollback_without_revisions_returns_none(self, store: PawBarStore) -> None:
+        widget = await store.create_widget(_widget())
+        assert await store.rollback_spec(widget.id) is None
+
+    @pytest.mark.asyncio
+    async def test_rollback_is_workspace_scoped(self, store: PawBarStore) -> None:
+        widget = await store.create_widget(_widget(workspace_id="w1"))
+        new_spec = PawBarSpec(
+            widget_id=widget.id,
+            pocket_id=widget.pocket_id,
+            blocks=[PawBarBlock(type="text", content="v2")],
+        )
+        await store.update_spec(widget.id, new_spec, workspace_id="w1")
+        assert await store.rollback_spec(widget.id, workspace_id="w2") is None
+        current = await store.get_widget(widget.id)
+        assert current is not None
+        assert current.spec.blocks[0].content == "v2"
+
+
+# ---------------------------------------------------------------------------
+# W4a — the public-path Fabric write is scoped to the widget's workspace
+# ---------------------------------------------------------------------------
+
+
+class _StubFabricObject:
+    """Kwarg-eating FabricObject stand-in for the seam tests below."""
+
+    def __init__(self, **kwargs: object) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class TestScopedFabricWrite:
+    @pytest.mark.asyncio
+    async def test_apply_event_mapping_threads_the_widget_workspace(self, monkeypatch) -> None:
+        """The cross-tenant leak fix: get_fabric_store must receive the OWNER's
+        workspace_id (from the widget row), not be called bare."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        import pocketpaw_ee.api as ee_api
+        from pocketpaw_ee.paw_bar import router as ppr
+
+        captured: dict[str, object] = {}
+        created_obj = MagicMock()
+        created_obj.id = "obj_scoped_1"
+        fabric = MagicMock()
+        fabric.create_object = AsyncMock(return_value=created_obj)
+
+        def spy_get_fabric_store(*, workspace_id: str | None = None):
+            captured["workspace_id"] = workspace_id
+            return fabric
+
+        monkeypatch.setattr(ee_api, "get_fabric_store", spy_get_fabric_store)
+        # NOTE: the real FabricObject requires type_id (the router only passes
+        # type_name — a pre-existing gap, unrelated to W4a); stub it so this
+        # test isolates the tenancy seam.
+        monkeypatch.setattr("pocketpaw.fabric.models.FabricObject", _StubFabricObject)
+
+        widget = _widget(workspace_id="w-owner")
+        event = PawBarEvent(
+            widget_id=widget.id,
+            type="order_click",
+            payload={"item": "oat_latte"},
+            customer_ref="cust_a",
+        )
+        obj_id = await ppr._apply_event_mapping(widget, event)
+        assert obj_id == "obj_scoped_1"
+        assert captured["workspace_id"] == "w-owner"
+
+    @pytest.mark.asyncio
+    async def test_legacy_widget_keeps_the_default_store(self, monkeypatch) -> None:
+        """An unstamped ('' workspace) widget passes None — single-tenant
+        behavior is unchanged."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        import pocketpaw_ee.api as ee_api
+        from pocketpaw_ee.paw_bar import router as ppr
+
+        captured: dict[str, object] = {"workspace_id": "sentinel"}
+        created_obj = MagicMock()
+        created_obj.id = "obj_default_1"
+        fabric = MagicMock()
+        fabric.create_object = AsyncMock(return_value=created_obj)
+
+        def spy_get_fabric_store(*, workspace_id: str | None = None):
+            captured["workspace_id"] = workspace_id
+            return fabric
+
+        monkeypatch.setattr(ee_api, "get_fabric_store", spy_get_fabric_store)
+        monkeypatch.setattr("pocketpaw.fabric.models.FabricObject", _StubFabricObject)
+
+        widget = _widget()  # workspace_id defaults to ""
+        event = PawBarEvent(
+            widget_id=widget.id,
+            type="order_click",
+            payload={"item": "oat_latte"},
+            customer_ref="cust_a",
+        )
+        obj_id = await ppr._apply_event_mapping(widget, event)
+        assert obj_id == "obj_default_1"
+        assert captured["workspace_id"] is None

--- a/tests/cloud/test_paw_bar_decision_loop.py
+++ b/tests/cloud/test_paw_bar_decision_loop.py
@@ -84,6 +84,11 @@ def client(stores, monkeypatch):
     pp_store, _ = stores
     app = FastAPI()
     app.include_router(router)
+    # W4a — the admin CRUD routes resolve the caller's workspace via the cloud
+    # session dep; pin it for the bare test app (same as tests/cloud/conftest.py).
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+
+    app.dependency_overrides[current_workspace_id] = lambda: "w-test"
     monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda *a, **k: pp_store)
     return TestClient(app)
 
@@ -289,9 +294,7 @@ class TestRobustness:
             raise RuntimeError("instinct store down")
 
         monkeypatch.setattr("pocketpaw.stores.get_instinct_store", _boom)
-        result = await propose_customer_decision(
-            widget=widget, event=event, paw_bar_store=pp_store
-        )
+        result = await propose_customer_decision(widget=widget, event=event, paw_bar_store=pp_store)
         assert result is None
 
     async def test_deliver_no_parked_row_is_noop(self, stores) -> None:

--- a/tests/cloud/test_paw_bar_ingest.py
+++ b/tests/cloud/test_paw_bar_ingest.py
@@ -62,10 +62,24 @@ def _widget_payload(**overrides: Any) -> dict[str, Any]:
     return payload
 
 
+def _override_workspace(app: FastAPI, workspace_id: str = "w-test") -> None:
+    """Pin current_workspace_id for a bare test app (W4a).
+
+    The admin CRUD routes resolve the caller's active workspace through the
+    cloud session dep; these router-level tests mount the router on a bare
+    FastAPI app with no auth stack, so the dep is overridden the same way
+    tests/cloud/conftest.py does for other cloud routers.
+    """
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+
+
 @pytest.fixture
 def app_with_store(tmp_path: Path):
     app = FastAPI()
     app.include_router(router)
+    _override_workspace(app)
     store = PawBarStore(tmp_path / "paw_bar_router.db")
     with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
         yield app, store
@@ -445,6 +459,7 @@ def _build_authed_app(store: PawBarStore, **state_kwargs):
         return await call_next(request)
 
     app.include_router(router)
+    _override_workspace(app)
     return app
 
 

--- a/tests/cloud/test_paw_bar_ingest.py
+++ b/tests/cloud/test_paw_bar_ingest.py
@@ -13,6 +13,10 @@
 # the list and read responses must NOT contain access_token. Note the
 # existing CRUD tests above run under the conftest's _TESTING_FULL_ACCESS
 # bypass, so they exercise the post-auth route logic without a real session.
+# Updated: 2026-07-11 (W4a tenancy seam) — Test apps now pin the cloud
+# current_workspace_id dep via _override_workspace (the admin CRUD routes
+# thread it); added workspace-stamp-on-create + spec rollback endpoint tests
+# (round-trip, 409 when no revision, owner-token required).
 
 from __future__ import annotations
 
@@ -150,6 +154,42 @@ class TestWidgetCRUDEndpoints:
             headers={"X-Paw-Bar-Token": created["access_token"]},
         )
         assert authed.status_code == 200
+
+    def test_created_widget_is_stamped_with_caller_workspace(self, client: TestClient) -> None:
+        # W4a — the admin route stamps the session workspace (the fixture pins
+        # current_workspace_id to "w-test"); the row's tenancy is server-derived.
+        created = client.post("/paw-bar/widgets", json=_widget_payload()).json()
+        assert created["workspace_id"] == "w-test"
+
+    def test_spec_rollback_round_trip(self, client: TestClient) -> None:
+        # W4a spec revisions — update archives the prior spec; rollback restores it.
+        created = client.post("/paw-bar/widgets", json=_widget_payload()).json()
+        token = {"X-Paw-Bar-Token": created["access_token"]}
+
+        new_spec = _spec(widget_id=created["id"]).model_dump()
+        new_spec["blocks"] = [{"type": "text", "content": "Closed today"}]
+        updated = client.patch(
+            f"/paw-bar/widgets/{created['id']}/spec", json=new_spec, headers=token
+        )
+        assert updated.status_code == 200
+        assert updated.json()["spec"]["blocks"][0]["content"] == "Closed today"
+
+        rolled = client.post(f"/paw-bar/widgets/{created['id']}/spec/rollback", headers=token)
+        assert rolled.status_code == 200
+        assert rolled.json()["spec"]["blocks"][0]["content"] == "Hi from Brew & Co"
+
+    def test_spec_rollback_without_revisions_is_409(self, client: TestClient) -> None:
+        created = client.post("/paw-bar/widgets", json=_widget_payload()).json()
+        res = client.post(
+            f"/paw-bar/widgets/{created['id']}/spec/rollback",
+            headers={"X-Paw-Bar-Token": created["access_token"]},
+        )
+        assert res.status_code == 409
+
+    def test_spec_rollback_requires_owner_token(self, client: TestClient) -> None:
+        created = client.post("/paw-bar/widgets", json=_widget_payload()).json()
+        res = client.post(f"/paw-bar/widgets/{created['id']}/spec/rollback")
+        assert res.status_code == 401
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_rules_router.py
+++ b/tests/cloud/test_rules_router.py
@@ -1,0 +1,251 @@
+# test_rules_router.py — HTTP-layer tests for ee/cloud/rules/router.py.
+# Created: 2026-07-09 (feat/instinct-guardrail-rules) — smokes the thin
+# /api/v1/rules surface over the shipped rules.service: create persists an active
+# InstinctRuleDoc, list is tenant-filtered (a workspace sees only its own active
+# rules), archive flips a rule to archived (and it drops out of the list), the
+# service's cross-tenant-scope guard surfaces as a 400, the enforcement GET/PUT
+# round-trips, and the auth/permission seams (401 unauth, 403 without rules.manage).
+#
+# The router calls the REAL service against the mongomock-backed ``mongo_db``
+# fixture (Beanie), so these are true persistence smokes, not Protocol fakes.
+# Auth: ``current_active_user`` is overridden to a SimpleNamespace user and RBAC's
+# ``check_workspace_action`` is patched on the consumer module (mirrors
+# test_audit_router.py).
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from beanie import PydanticObjectId
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.auth import current_active_user
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.models.instinct_rule import InstinctRuleDoc
+from pocketpaw_ee.cloud.rules.router import router as rules_router
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _fake_user(user_id: str = "u1", workspace_id: str | None = "w1") -> SimpleNamespace:
+    """User stand-in shaped like ``ee.cloud.models.user.User`` — only the
+    attributes the rules-router auth chain reads (``id``, ``active_workspace``,
+    ``workspaces``)."""
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role="admin")] if workspace_id else [],
+    )
+
+
+def _build_app(
+    workspace_id: str | None = "w1",
+    user_id: str = "u1",
+    *,
+    skip_auth_override: bool = False,
+    permission_denier: bool = False,
+    monkeypatch=None,
+) -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(rules_router)
+    app.dependency_overrides[require_license] = lambda: None
+
+    if not skip_auth_override:
+        user = _fake_user(user_id=user_id, workspace_id=workspace_id)
+
+        async def _fake_user_dep():
+            return user
+
+        app.dependency_overrides[current_active_user] = _fake_user_dep
+
+        if monkeypatch is not None:
+            from pocketpaw_ee.cloud._core import deps as core_deps
+            from pocketpaw_ee.guards.rbac import Forbidden as GuardForbidden
+
+            if permission_denier:
+
+                def _deny(*_a, **_k):
+                    raise GuardForbidden(
+                        code="workspace.insufficient_role",
+                        detail="no rules.manage",
+                    )
+
+                monkeypatch.setattr(core_deps, "check_workspace_action", _deny)
+            else:
+                monkeypatch.setattr(core_deps, "check_workspace_action", lambda *a, **k: None)
+
+    return app
+
+
+def _create_body(workspace_id: str = "w1", *, name: str = "big-write approval") -> dict:
+    """A valid ``CreateRuleRequest`` JSON body — a governed rule that escalates
+    writes over $500, scoped to ``workspace_id``."""
+    return {
+        "draft": {
+            "name": name,
+            "description": "writes over $500 need approval",
+            "when": "value > 500",
+            "action": "require_approval",
+            "scope": {"workspace_id": workspace_id},
+            "confidence": 0.9,
+            "provenance": ["ui-authored"],
+        },
+        "owner_user_id": "u1",
+    }
+
+
+@pytest_asyncio.fixture
+async def w1_client(monkeypatch) -> AsyncClient:
+    app = _build_app(workspace_id="w1", monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(monkeypatch) -> AsyncClient:
+    app = _build_app(workspace_id="w2", monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Create → persist
+# ---------------------------------------------------------------------------
+
+
+async def test_create_persists_active_rule(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/rules", json=_create_body("w1"))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "active"
+    assert body["when"] == "value > 500"
+    assert body["workspace_id"] == "w1"
+    assert body["id"]
+
+    # It persists as an active InstinctRuleDoc.
+    doc = await InstinctRuleDoc.find_one(InstinctRuleDoc.id == PydanticObjectId(body["id"]))
+    assert doc is not None
+    assert doc.status == "active"
+    assert doc.workspace == "w1"
+
+
+async def test_list_returns_active_rules_for_workspace(w1_client: AsyncClient) -> None:
+    await w1_client.post("/rules", json=_create_body("w1", name="rule-a"))
+    r = await w1_client.get("/rules")
+    assert r.status_code == 200, r.text
+    names = {row["name"] for row in r.json()}
+    assert names == {"rule-a"}
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_list_is_tenant_isolated(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    """A rule created in w1 is invisible to w2's list, and vice-versa."""
+    await w1_client.post("/rules", json=_create_body("w1", name="w1-secret"))
+    await w2_client.post("/rules", json=_create_body("w2", name="w2-secret"))
+
+    r1 = await w1_client.get("/rules")
+    r2 = await w2_client.get("/rules")
+    assert {row["name"] for row in r1.json()} == {"w1-secret"}
+    assert {row["name"] for row in r2.json()} == {"w2-secret"}
+
+
+async def test_create_rejects_cross_tenant_scope(w1_client: AsyncClient) -> None:
+    """A w1 caller cannot persist a rule scoped to w2 — the service's tenancy
+    assertion surfaces as a 400 CloudError, never a silent cross-tenant write."""
+    r = await w1_client.post("/rules", json=_create_body("w2"))
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "rule.workspace_mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Archive
+# ---------------------------------------------------------------------------
+
+
+async def test_archive_flips_rule_and_drops_from_list(w1_client: AsyncClient) -> None:
+    created = (await w1_client.post("/rules", json=_create_body("w1"))).json()
+    rule_id = created["id"]
+
+    r = await w1_client.post(f"/rules/{rule_id}/archive")
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "archived"
+
+    listed = (await w1_client.get("/rules")).json()
+    assert all(row["id"] != rule_id for row in listed)
+
+
+async def test_archive_cannot_reach_across_tenant(
+    w1_client: AsyncClient, w2_client: AsyncClient
+) -> None:
+    """w2 cannot archive a rule that lives in w1 — the tenant-scoped lookup
+    misses and returns a 400 not-found CloudError."""
+    created = (await w1_client.post("/rules", json=_create_body("w1"))).json()
+    r = await w2_client.post(f"/rules/{created['id']}/archive")
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "rule.not_found"
+
+
+# ---------------------------------------------------------------------------
+# Enforcement toggle round-trip
+# ---------------------------------------------------------------------------
+
+
+async def test_enforcement_get_defaults_and_put_sets_override(w1_client: AsyncClient) -> None:
+    # Fresh workspace → no override, effective == global default (False).
+    g = await w1_client.get("/rules/enforcement")
+    assert g.status_code == 200, g.text
+    assert g.json() == {
+        "workspace_id": "w1",
+        "enforce_discovered_rules": False,
+        "override": None,
+        "global_default": False,
+    }
+
+    # PUT enabled=true → override wins, effective True even though global is False.
+    p = await w1_client.put("/rules/enforcement", json={"enabled": True})
+    assert p.status_code == 200, p.text
+    assert p.json()["override"] is True
+    assert p.json()["enforce_discovered_rules"] is True
+
+    # Clear the override (null) → back to inheriting the global default.
+    c = await w1_client.put("/rules/enforcement", json={"enabled": None})
+    assert c.status_code == 200, c.text
+    assert c.json()["override"] is None
+    assert c.json()["enforce_discovered_rules"] is False
+
+
+# ---------------------------------------------------------------------------
+# Auth / permission seams
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_auth_returns_401() -> None:
+    app = _build_app(workspace_id="w1", skip_auth_override=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        r = await client.get("/rules")
+        assert r.status_code == 401
+
+
+async def test_missing_rules_manage_permission_returns_403(monkeypatch) -> None:
+    app = _build_app(workspace_id="w1", permission_denier=True, monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        r = await client.get("/rules")
+        assert r.status_code == 403, r.text
+        assert r.json()["error"]["code"] == "workspace.insufficient_role"
+
+
+# Silence ruff unused-import nudge on fixture-composition helpers.
+_unused: tuple[Any, ...] = ()

--- a/tests/cloud/test_workspace_enforcement.py
+++ b/tests/cloud/test_workspace_enforcement.py
@@ -1,0 +1,245 @@
+# test_workspace_enforcement.py — per-workspace authored-rule enforcement toggle.
+# Created: 2026-07-09 (feat/instinct-guardrail-rules) — pins the PER-WORKSPACE
+# resolution of Instinct enforcement at the live gate:
+#   * A workspace override set True enforces authored rules even when the GLOBAL
+#     ``instinct_enforce_discovered_rules`` flag is OFF.
+#   * With NO override, the workspace inherits the global flag (OFF → inert,
+#     ON → enforced) — the pre-existing default is preserved.
+#   * A workspace override set False turns enforcement OFF even when the global
+#     flag is ON.
+#   * CRITICAL fail-OPEN: an enforcement-config read error yields NO enforcement
+#     (the gate proceeds on the template floor, a WARNING is logged, no raise) —
+#     a DB hiccup never blocks the gate.
+#
+# Harness mirrors test_discovered_rule_enforcement.py: it targets
+# ``instinct_dispatch.gate_action`` with a stubbed ``get_active_rules`` and the
+# REAL ``resolve_instinct`` composer. The per-workspace override is written
+# through the real ``rules.service.set_enforcement`` against the mongomock
+# ``mongo_db`` fixture; the global flag is flipped by monkeypatching
+# ``instinct_dispatch.get_settings``.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.pockets import instinct_dispatch
+from pocketpaw_ee.cloud.rules import service as rules_service
+
+from pocketpaw.bundled_templates import PocketTemplate
+from pocketpaw.config import get_settings
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+FROZEN_NOW = datetime(2026, 7, 9, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (minimal, copied from test_discovered_rule_enforcement.py)
+# ---------------------------------------------------------------------------
+
+
+def _template(action_name: str = "do_thing") -> PocketTemplate:
+    raw: dict = {
+        "schema_version": "2",
+        "name": "test-template",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "test fixture",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [{"field": "value", "widget": "number"}],
+        },
+        "actions": [
+            {
+                "name": action_name,
+                "label": "Do Thing",
+                "kind": "single-row",
+                "instinct_policy": "auto",
+            }
+        ],
+    }
+    return PocketTemplate.model_validate(raw)
+
+
+def _block_rule() -> dict:
+    return {
+        "id": "rule-1",
+        "workspace_id": "w1",
+        "owner_user_id": "u1",
+        "name": "discovered block",
+        "description": None,
+        "when": "value > 100",
+        "action": "block",
+        "status": "active",
+        "scope": {"workspace_id": "w1", "pocket_id": None, "object_type": None},
+        "confidence": 0.9,
+        "provenance": ["discovery"],
+        "created_at": None,
+        "updated_at": None,
+    }
+
+
+def _set_global(monkeypatch, *, enabled: bool) -> None:
+    """Flip the GLOBAL ``instinct_enforce_discovered_rules`` flag the gate reads."""
+    settings = get_settings()
+    object.__setattr__(settings, "instinct_enforce_discovered_rules", enabled)
+    monkeypatch.setattr(instinct_dispatch, "get_settings", lambda: settings)
+
+
+def _stub_active_rules(monkeypatch, rows: list[dict]) -> None:
+    async def _fake(workspace_id: str) -> list[dict]:  # noqa: ARG001
+        return list(rows)
+
+    monkeypatch.setattr(instinct_dispatch, "get_active_rules", _fake)
+
+
+async def _gate(template: PocketTemplate, *, row_context: dict[str, Any], workspace_id: str = "w1"):
+    return await instinct_dispatch.gate_action(
+        workspace_id=workspace_id,
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context=row_context,
+        workspace_context=None,
+        now=FROZEN_NOW,
+    )
+
+
+# ===========================================================================
+# Per-workspace override turns enforcement ON when the global flag is OFF.
+# ===========================================================================
+
+
+async def test_workspace_override_on_enforces_when_global_off(monkeypatch) -> None:
+    _set_global(monkeypatch, enabled=False)  # global OFF
+    await rules_service.set_enforcement("w1", "u1", True)  # per-workspace ON
+    _stub_active_rules(monkeypatch, [_block_rule()])
+
+    result = await _gate(_template(), row_context={"value": 999})
+
+    assert result.next_step == "blocked"
+    assert result.decision.verdict == "BLOCK"
+
+
+async def test_other_workspace_not_affected_by_w1_override(monkeypatch) -> None:
+    """Turning enforcement on for w1 leaves w2 (no override, global OFF) inert."""
+    _set_global(monkeypatch, enabled=False)
+    await rules_service.set_enforcement("w1", "u1", True)
+
+    called = {"n": 0}
+
+    async def _boom(workspace_id: str) -> list[dict]:  # noqa: ARG001
+        called["n"] += 1
+        raise AssertionError("get_active_rules must not be called for an un-enforced workspace")
+
+    monkeypatch.setattr(instinct_dispatch, "get_active_rules", _boom)
+
+    # w2 has no override and the global flag is OFF → no enforcement.
+    result = await _gate(_template(), row_context={"value": 999}, workspace_id="w2")
+
+    assert called["n"] == 0
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "EXECUTE"
+
+
+# ===========================================================================
+# No override → inherit the global flag (default preserved).
+# ===========================================================================
+
+
+async def test_no_override_global_off_is_inert(monkeypatch) -> None:
+    _set_global(monkeypatch, enabled=False)
+
+    called = {"n": 0}
+
+    async def _boom(workspace_id: str) -> list[dict]:  # noqa: ARG001
+        called["n"] += 1
+        raise AssertionError("get_active_rules must not be called when enforcement is off")
+
+    monkeypatch.setattr(instinct_dispatch, "get_active_rules", _boom)
+
+    result = await _gate(_template(), row_context={"value": 999})
+
+    assert called["n"] == 0
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "EXECUTE"
+
+
+async def test_no_override_global_on_enforces(monkeypatch) -> None:
+    _set_global(monkeypatch, enabled=True)  # global ON, no per-workspace override
+    _stub_active_rules(monkeypatch, [_block_rule()])
+
+    result = await _gate(_template(), row_context={"value": 999})
+
+    assert result.next_step == "blocked"
+    assert result.decision.verdict == "BLOCK"
+
+
+async def test_workspace_override_off_beats_global_on(monkeypatch) -> None:
+    """A workspace can opt OUT even when the global flag is ON."""
+    _set_global(monkeypatch, enabled=True)
+    await rules_service.set_enforcement("w1", "u1", False)  # force OFF for w1
+    _stub_active_rules(monkeypatch, [_block_rule()])
+
+    result = await _gate(_template(), row_context={"value": 999})
+
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "EXECUTE"
+
+
+# ===========================================================================
+# CRITICAL — fail-OPEN: a config read error never blocks the gate.
+# ===========================================================================
+
+
+async def test_enforcement_config_read_error_fails_open(monkeypatch, caplog) -> None:
+    """If the per-workspace override read raises, enforcement resolves to OFF
+    (no enforcement), the gate proceeds on the template floor, a WARNING is
+    logged, and NOTHING is raised — even with the global flag ON."""
+    _set_global(monkeypatch, enabled=True)
+
+    async def _raise(workspace_id: str) -> Any:  # noqa: ARG001
+        raise RuntimeError("mongo is down")
+
+    monkeypatch.setattr(instinct_dispatch, "get_enforcement_override", _raise)
+
+    async def _boom(workspace_id: str) -> list[dict]:  # noqa: ARG001
+        raise AssertionError("get_active_rules must not be called when the config read fails open")
+
+    monkeypatch.setattr(instinct_dispatch, "get_active_rules", _boom)
+
+    with caplog.at_level("WARNING"):
+        result = await _gate(_template(), row_context={"value": 999})
+
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "EXECUTE"
+    assert any("enforcement" in r.message.lower() for r in caplog.records)
+
+
+# ===========================================================================
+# Unit — the _enforcement_enabled resolver in isolation.
+# ===========================================================================
+
+
+async def test_enforcement_enabled_resolution_matrix(monkeypatch) -> None:
+    # override True → True regardless of global
+    _set_global(monkeypatch, enabled=False)
+    await rules_service.set_enforcement("w1", "u1", True)
+    assert await instinct_dispatch._enforcement_enabled("w1") is True
+
+    # override False → False regardless of global
+    _set_global(monkeypatch, enabled=True)
+    await rules_service.set_enforcement("w1", "u1", False)
+    assert await instinct_dispatch._enforcement_enabled("w1") is False
+
+    # no override → inherit global (True here, distinct workspace)
+    _set_global(monkeypatch, enabled=True)
+    assert await instinct_dispatch._enforcement_enabled("w-none") is True
+
+    _set_global(monkeypatch, enabled=False)
+    assert await instinct_dispatch._enforcement_enabled("w-none") is False

--- a/tests/cloud/workspace/test_retention.py
+++ b/tests/cloud/workspace/test_retention.py
@@ -1,0 +1,232 @@
+# tests/cloud/workspace/test_retention.py — Tests for the per-workspace data
+# retention setting + enforcement (compliance-starter).
+# Created: 2026-07-10 — covers:
+#   * retention_days round-trips through the dedicated get/set path AND the
+#     general update() settings merge WITHOUT clobbering sibling settings
+#     (regression guard for the destructive full-replace recon flagged).
+#   * WorkspaceSettings rejects a non-positive retention_days.
+#   * enforce_retention() purges ONLY audit rows older than the cutoff for
+#     the RIGHT workspace, and is a no-op when retention is unset.
+#   * purge_workspace_audit() is age- + tenant-scoped.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.audit import service as audit_service
+from pocketpaw_ee.cloud.models.audit_event import AuditEvent as _AuditEventDoc
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+from pocketpaw_ee.cloud.models.workspace import WorkspaceSettings
+from pocketpaw_ee.cloud.workspace import service as workspace_service
+from pocketpaw_ee.cloud.workspace.dto import (
+    CreateWorkspaceRequest,
+    UpdateWorkspaceRequest,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+@pytest.fixture(autouse=True)
+def _resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stub the realtime resolver so ``get_resolver()`` doesn't explode
+    (the real one needs ``init_realtime()`` which unit tests don't run)."""
+    mock = MagicMock()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.get_resolver", lambda: mock)
+    return mock
+
+
+def _ctx(user_id: str, workspace_id: str | None = None) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_user(email: str = "owner@x.c") -> _UserDoc:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="U",
+        workspaces=[],
+    )
+    await doc.insert()
+    return doc
+
+
+async def _create_ws(owner: _UserDoc):
+    return await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+
+
+# ---------------------------------------------------------------------------
+# retention_days round-trips + no sibling clobber
+# ---------------------------------------------------------------------------
+
+
+async def test_set_retention_round_trips() -> None:
+    owner = await _seed_user()
+    ws = await _create_ws(owner)
+
+    assert await workspace_service.get_retention(_ctx(str(owner.id)), ws.id) is None
+
+    await workspace_service.set_retention(_ctx(str(owner.id)), ws.id, 30)
+    assert await workspace_service.get_retention(_ctx(str(owner.id)), ws.id) == 30
+
+    # None clears the policy (keep forever).
+    await workspace_service.set_retention(_ctx(str(owner.id)), ws.id, None)
+    assert await workspace_service.get_retention(_ctx(str(owner.id)), ws.id) is None
+
+
+async def test_set_retention_does_not_clobber_sibling_settings() -> None:
+    owner = await _seed_user()
+    ws = await _create_ws(owner)
+
+    # Seed sibling settings via the general update path.
+    await workspace_service.update(
+        _ctx(str(owner.id)),
+        ws.id,
+        UpdateWorkspaceRequest(settings={"default_agent": "agent-1", "allow_invites": False}),
+    )
+    # Now set retention through the dedicated path.
+    await workspace_service.set_retention(_ctx(str(owner.id)), ws.id, 45)
+
+    doc = await _WorkspaceDoc.get(ws.id)
+    assert doc.settings.retention_days == 45
+    assert doc.settings.default_agent == "agent-1"  # sibling preserved
+    assert doc.settings.allow_invites is False  # sibling preserved
+
+
+async def test_update_settings_merges_and_does_not_clobber() -> None:
+    """The general PATCH settings path must MERGE, not full-replace.
+
+    Regression guard for the destructive ``doc.settings =
+    WorkspaceSettings(**body.settings)`` the recon flagged.
+    """
+    owner = await _seed_user()
+    ws = await _create_ws(owner)
+
+    await workspace_service.update(
+        _ctx(str(owner.id)),
+        ws.id,
+        UpdateWorkspaceRequest(settings={"default_agent": "agent-1"}),
+    )
+    # A partial settings patch that only carries retention_days must NOT
+    # wipe default_agent.
+    await workspace_service.update(
+        _ctx(str(owner.id)),
+        ws.id,
+        UpdateWorkspaceRequest(settings={"retention_days": 30}),
+    )
+
+    doc = await _WorkspaceDoc.get(ws.id)
+    assert doc.settings.retention_days == 30
+    assert doc.settings.default_agent == "agent-1"  # NOT clobbered
+
+
+def test_workspace_settings_rejects_non_positive_retention() -> None:
+    with pytest.raises(Exception):
+        WorkspaceSettings(retention_days=0)
+    with pytest.raises(Exception):
+        WorkspaceSettings(retention_days=-5)
+    # None and positive are fine.
+    assert WorkspaceSettings(retention_days=None).retention_days is None
+    assert WorkspaceSettings(retention_days=1).retention_days == 1
+
+
+async def test_set_retention_rejects_non_positive() -> None:
+    owner = await _seed_user()
+    ws = await _create_ws(owner)
+    with pytest.raises(ValidationError):
+        await workspace_service.set_retention(_ctx(str(owner.id)), ws.id, 0)
+
+
+# ---------------------------------------------------------------------------
+# Enforcement — purge_workspace_audit + enforce_retention
+# ---------------------------------------------------------------------------
+
+
+async def _seed_audit(
+    workspace_id: str, *, at: datetime, action: str = "workspace.updated"
+) -> None:
+    doc = _AuditEventDoc(
+        workspace=workspace_id,
+        actor_id="u1",
+        action=action,
+        target_type="workspace",
+        target_id=workspace_id,
+        metadata={},
+        at=at,
+    )
+    await doc.insert()
+
+
+# NOTE ON AGES: the AuditEvent model carries a 365-day TTL index. Real Mongo
+# expires TTL rows via a lazy background reaper (never on insert), so a
+# 400-day row is insertable and the retention purge (e.g. 30 days) deletes it.
+# mongomock, however, applies the TTL at query time — a >365-day seed row just
+# vanishes, masking the purge. So the "old" seed rows below sit comfortably
+# UNDER 365 days but OVER the retention cutoff, which exercises the purge
+# cleanly in-memory. Assertions are tz-agnostic (mongomock stores ``at`` naive)
+# — we tag rows by ``action`` rather than compare mixed-tz datetimes.
+
+
+async def test_purge_workspace_audit_deletes_only_old_and_right_tenant() -> None:
+    now = datetime.now(UTC)
+    old = now - timedelta(days=100)
+    recent = now - timedelta(days=1)
+
+    await _seed_audit("ws-A", at=old, action="old.row")
+    await _seed_audit("ws-A", at=recent, action="recent.row")
+    await _seed_audit("ws-B", at=old, action="old.row")  # other tenant — must survive
+
+    cutoff = now - timedelta(days=30)
+    deleted = await audit_service.purge_workspace_audit("ws-A", cutoff)
+
+    assert deleted == 1
+    remaining_a = await _AuditEventDoc.find({"workspace": "ws-A"}).to_list()
+    assert [r.action for r in remaining_a] == ["recent.row"]  # only the old row went
+    # Other tenant's old row untouched despite the same age.
+    remaining_b = await _AuditEventDoc.find({"workspace": "ws-B"}).to_list()
+    assert len(remaining_b) == 1
+
+
+async def test_enforce_retention_purges_old_audit() -> None:
+    owner = await _seed_user()
+    ws = await _create_ws(owner)
+    now = datetime.now(UTC)
+
+    await _seed_audit(ws.id, at=now - timedelta(days=100), action="old.row")
+    await _seed_audit(ws.id, at=now - timedelta(days=5), action="recent.row")
+
+    await workspace_service.set_retention(_ctx(str(owner.id)), ws.id, 30)
+    result = await workspace_service.enforce_retention(ws.id)
+
+    assert result["audit_deleted"] == 1
+    actions = [r.action for r in await _AuditEventDoc.find({"workspace": ws.id}).to_list()]
+    assert "old.row" not in actions  # the 100-day row was purged
+    assert "recent.row" in actions  # the 5-day row survived
+
+
+async def test_enforce_retention_noop_when_unset() -> None:
+    owner = await _seed_user()
+    ws = await _create_ws(owner)
+    now = datetime.now(UTC)
+    await _seed_audit(ws.id, at=now - timedelta(days=100), action="old.row")
+
+    result = await workspace_service.enforce_retention(ws.id)
+    assert result["audit_deleted"] == 0
+    assert result.get("skipped") == "no_retention_policy"
+    # The old row is untouched because retention is unset (keep forever).
+    actions = [r.action for r in await _AuditEventDoc.find({"workspace": ws.id}).to_list()]
+    assert "old.row" in actions

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -478,6 +478,98 @@ async def test_create_invite_seat_limit(owner, monkeypatch) -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# feat/billing-smb-caps — the seat gate is PLAN-SOURCED (max(doc.seats, plan cap)).
+# ---------------------------------------------------------------------------
+
+
+async def test_effective_seat_limit_is_max_of_doc_seats_and_plan(owner) -> None:
+    """The enforced ceiling is max(doc.seats, plan.max_seats) — plan lifts it, and a
+    custom-higher doc.seats never regresses."""
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WSDoc
+
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    doc = await _WSDoc.get(ws.id)
+
+    # Free plan (max_seats=5) == the default doc.seats=5: no change.
+    assert await workspace_service._effective_seat_limit(doc) == 5
+
+    # Upgrade the plan to pro (max_seats=25): the ceiling rises to 25.
+    doc.plan = "pro"
+    await doc.save()
+    assert await workspace_service._effective_seat_limit(doc) == 25
+
+    # A workspace whose custom doc.seats already exceeds the plan cap keeps the
+    # higher number — enforcement never strips seats it already has.
+    doc.plan = "free"
+    doc.seats = 40
+    await doc.save()
+    assert await workspace_service._effective_seat_limit(doc) == 40
+
+    # An uncapped plan (enterprise, max_seats=None) defers to doc.seats.
+    doc.plan = "enterprise"
+    doc.seats = 12
+    await doc.save()
+    assert await workspace_service._effective_seat_limit(doc) == 12
+
+
+async def test_create_invite_uses_plan_seat_limit_not_flat_seats(owner, monkeypatch) -> None:
+    """A workspace saturated at its flat doc.seats but on a higher-cap plan can still
+    invite — the gate sources the limit from the plan, not doc.seats alone."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WSDoc
+
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    # Move to pro (max_seats=25) while doc.seats stays the default 5.
+    doc = await _WSDoc.get(ws.id)
+    doc.plan = "pro"
+    await doc.save()
+
+    # Fill past the OLD flat limit of 5 (owner + 5 members = 6 > 5).
+    for i in range(5):
+        u = await _seed_user(email=f"seat{i}@x.c")
+        await workspace_service._add_member(ws.id, str(u.id), role="member")
+
+    # Under the flat-seats rule this would raise; under the plan cap (25) it succeeds.
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
+    )
+    assert invite.id
+
+
+async def test_raise_seats_for_plan_lifts_on_upgrade_only(owner) -> None:
+    """raise_seats_for_plan bumps doc.seats UP to the plan cap and never down."""
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WSDoc
+
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    # Default seats == 5. Upgrade to pro (25) lifts the stored cap.
+    new_seats = await workspace_service.raise_seats_for_plan(ws.id, "pro")
+    assert new_seats == 25
+    assert (await _WSDoc.get(ws.id)).seats == 25
+
+    # A "downgrade" to free (cap 5) must NOT strip the 25 seats it already has.
+    unchanged = await workspace_service.raise_seats_for_plan(ws.id, "free")
+    assert unchanged == 25
+    assert (await _WSDoc.get(ws.id)).seats == 25
+
+    # An uncapped plan (enterprise) is a no-op — returns None, leaves seats as-is.
+    ent_result = await workspace_service.raise_seats_for_plan(ws.id, "enterprise")
+    assert ent_result is None
+    assert (await _WSDoc.get(ws.id)).seats == 25
+
+    # An unknown plan key is a safe no-op (None), seats untouched.
+    assert await workspace_service.raise_seats_for_plan(ws.id, "bogus_tier") is None
+    assert (await _WSDoc.get(ws.id)).seats == 25
+
+
 async def test_create_invite_rejects_duplicate_pending(owner, monkeypatch) -> None:
     monkeypatch.setattr(
         "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop

--- a/tests/test_paw_cli_entrypoint.py
+++ b/tests/test_paw_cli_entrypoint.py
@@ -1,0 +1,113 @@
+# tests/test_paw_cli_entrypoint.py — the `paw` console script + the remote
+# `paw fabric` read commands (paw-cli C1).
+# Created: 2026-07-11 (feat/paw-cli).
+# What this pins:
+#   * the `paw` entry point is declared and resolves to pocketpaw.paw.cli:main
+#     (importlib.metadata — the same lookup pip/uv use to generate the script).
+#   * `paw fabric stats` / `paw fabric query` execute end-to-end against a
+#     stubbed httpx transport (the REAL PawClient runs; only the wire is faked)
+#     and print the server's JSON.
+#   * connection failures exit non-zero with a readable hint, not a traceback.
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+
+import httpx
+from click.testing import CliRunner
+
+import pocketpaw.paw.cli as paw_cli
+from pocketpaw.paw.client import PawClient
+
+# ---------------------------------------------------------------------------
+# Entry-point contract
+# ---------------------------------------------------------------------------
+
+
+def test_paw_console_script_declared_and_resolves():
+    """The installed dist declares `paw` and it loads to the Click group."""
+    eps = importlib.metadata.entry_points(group="console_scripts", name="paw")
+    matches = [ep for ep in eps if ep.value == "pocketpaw.paw.cli:main"]
+    assert matches, "console script `paw` missing or mis-declared in [project.scripts]"
+    assert matches[0].load() is paw_cli.main
+
+
+def test_paw_help_lists_fabric_group():
+    runner = CliRunner()
+    result = runner.invoke(paw_cli.main, ["--help"])
+    assert result.exit_code == 0
+    assert "fabric" in result.output
+
+
+# ---------------------------------------------------------------------------
+# paw fabric — reads over a stubbed transport
+# ---------------------------------------------------------------------------
+
+
+def _stub_client_factory(handler):
+    """A _make_client replacement returning a PawClient on a MockTransport."""
+
+    def factory(base_url: str, api_key: str | None) -> PawClient:
+        return PawClient(base_url, api_key, transport=httpx.MockTransport(handler))
+
+    return factory
+
+
+def test_fabric_stats_prints_server_json(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/fabric/stats"
+        return httpx.Response(200, json={"types": 3, "objects": 42, "links": 7})
+
+    monkeypatch.setattr(paw_cli, "_make_client", _stub_client_factory(handler))
+    runner = CliRunner()
+    result = runner.invoke(paw_cli.main, ["fabric", "stats"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"types": 3, "objects": 42, "links": 7}
+
+
+def test_fabric_query_sends_options_and_prints_objects(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["type_name"] == "Customer"
+        assert body["limit"] == 5
+        return httpx.Response(
+            200,
+            json={"objects": [{"id": "o1", "type_name": "Customer"}], "total": 1},
+        )
+
+    monkeypatch.setattr(paw_cli, "_make_client", _stub_client_factory(handler))
+    runner = CliRunner()
+    result = runner.invoke(
+        paw_cli.main,
+        ["fabric", "query", "--type-name", "Customer", "--limit", "5"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["total"] == 1
+
+
+def test_fabric_api_error_exits_nonzero(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"detail": "Enterprise license required"})
+
+    monkeypatch.setattr(paw_cli, "_make_client", _stub_client_factory(handler))
+    runner = CliRunner()
+    result = runner.invoke(paw_cli.main, ["fabric", "types"])
+
+    assert result.exit_code == 1
+    assert "Enterprise license required" in result.output
+
+
+def test_fabric_connection_error_exits_with_hint(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(paw_cli, "_make_client", _stub_client_factory(handler))
+    runner = CliRunner()
+    result = runner.invoke(paw_cli.main, ["fabric", "stats"])
+
+    assert result.exit_code == 1
+    assert "Could not reach" in result.output

--- a/tests/test_paw_client.py
+++ b/tests/test_paw_client.py
@@ -1,0 +1,186 @@
+# tests/test_paw_client.py — PawClient, the thin httpx client for the cloud
+# REST API (paw-cli C1).
+# Created: 2026-07-11 (feat/paw-cli).
+# What this pins, all against httpx.MockTransport (no live server, no mocking
+# of the seam under test — the real client code runs down to the transport):
+#   * requests hit the exact /api/v1 fabric route contracts (path, method,
+#     params, JSON body) the EE router mounts.
+#   * the api_key rides as an Authorization: Bearer header; absent when unset.
+#   * non-2xx responses raise PawAPIError carrying the FastAPI `detail`.
+#   * delete_link returns None on an empty body.
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from pocketpaw.paw.client import PawAPIError, PawClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_client(handler) -> PawClient:
+    """PawClient wired to a MockTransport handler."""
+    return PawClient(
+        "http://testserver",
+        api_key="paw_test_key",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def capture(response_json, status_code: int = 200):
+    """Return (requests_list, handler) — the handler records every request."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(status_code, json=response_json)
+
+    return seen, handler
+
+
+# ---------------------------------------------------------------------------
+# Route contracts
+# ---------------------------------------------------------------------------
+
+
+def test_fabric_stats_hits_route_with_bearer():
+    seen, handler = capture({"types": 1, "objects": 2, "links": 0})
+    with make_client(handler) as client:
+        body = client.fabric_stats()
+
+    assert body == {"types": 1, "objects": 2, "links": 0}
+    req = seen[0]
+    assert req.method == "GET"
+    assert req.url.path == "/api/v1/fabric/stats"
+    assert req.headers["Authorization"] == "Bearer paw_test_key"
+
+
+def test_no_api_key_sends_no_auth_header():
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=[])
+
+    with PawClient("http://testserver", transport=httpx.MockTransport(handler)) as client:
+        client.list_types()
+
+    assert "Authorization" not in seen[0].headers
+
+
+def test_list_types_route():
+    seen, handler = capture([{"name": "Customer"}])
+    with make_client(handler) as client:
+        assert client.list_types() == [{"name": "Customer"}]
+    assert seen[0].url.path == "/api/v1/fabric/types"
+
+
+def test_query_posts_fabric_query_body():
+    seen, handler = capture({"objects": [], "total": 0})
+    with make_client(handler) as client:
+        client.query(type_name="Customer", filters={"status": "active"}, limit=5)
+
+    req = seen[0]
+    assert req.method == "POST"
+    assert req.url.path == "/api/v1/fabric/query"
+    body = json.loads(req.content)
+    assert body == {"limit": 5, "type_name": "Customer", "filters": {"status": "active"}}
+
+
+def test_list_objects_passes_filter_params():
+    seen, handler = capture({"objects": [], "total": 0})
+    with make_client(handler) as client:
+        client.list_objects(type_name="Order", limit=10, offset=20)
+
+    params = dict(seen[0].url.params)
+    assert params == {"type_name": "Order", "limit": "10", "offset": "20"}
+
+
+def test_list_links_passes_endpoint_filters():
+    seen, handler = capture({"links": [], "total": 0})
+    with make_client(handler) as client:
+        client.list_links(from_id="a", link_type="has_order")
+
+    req = seen[0]
+    assert req.url.path == "/api/v1/fabric/links"
+    params = dict(req.url.params)
+    assert params["from_id"] == "a"
+    assert params["link_type"] == "has_order"
+    assert "to_id" not in params
+
+
+def test_create_object_posts_body():
+    seen, handler = capture({"id": "obj-1"}, status_code=201)
+    with make_client(handler) as client:
+        client.create_object("type-1", {"name": "Acme"})
+
+    body = json.loads(seen[0].content)
+    assert body["type_id"] == "type-1"
+    assert body["properties"] == {"name": "Acme"}
+
+
+def test_create_link_posts_body():
+    seen, handler = capture({"id": "lnk-1"}, status_code=201)
+    with make_client(handler) as client:
+        client.create_link("a", "b", "has_order")
+
+    req = seen[0]
+    assert req.url.path == "/api/v1/fabric/links"
+    body = json.loads(req.content)
+    assert body == {"from_id": "a", "to_id": "b", "link_type": "has_order", "properties": {}}
+
+
+def test_delete_link_hits_route_and_returns_none():
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(204)
+
+    with make_client(handler) as client:
+        assert client.delete_link("lnk-1") is None
+
+    req = seen[0]
+    assert req.method == "DELETE"
+    assert req.url.path == "/api/v1/fabric/links/lnk-1"
+
+
+def test_update_type_patches_schema_route():
+    seen, handler = capture({"id": "type-1", "version": 2})
+    with make_client(handler) as client:
+        client.update_type("type-1", renames={"old": "new"})
+
+    req = seen[0]
+    assert req.method == "PATCH"
+    assert req.url.path == "/api/v1/fabric/schema/types/type-1"
+    assert json.loads(req.content) == {"renames": {"old": "new"}}
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+def test_error_response_raises_with_detail():
+    _, handler = capture({"detail": "Object not found"}, status_code=404)
+    with make_client(handler) as client, pytest.raises(PawAPIError) as exc_info:
+        client.get_object("missing")
+
+    assert exc_info.value.status_code == 404
+    assert "Object not found" in exc_info.value.detail
+
+
+def test_non_json_error_body_is_relayed():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="bad gateway")
+
+    with make_client(handler) as client, pytest.raises(PawAPIError) as exc_info:
+        client.fabric_stats()
+
+    assert exc_info.value.status_code == 502
+    assert "bad gateway" in exc_info.value.detail

--- a/tests/test_step_composer.py
+++ b/tests/test_step_composer.py
@@ -1,0 +1,152 @@
+# tests/test_step_composer.py — instinct-guardrail-ux Criterion 2: the fixed
+# 3-step LLM pipeline (schema validator, executor typed handoff + lenient
+# parsing, tool wrapper registration + no-backend error). No real model calls —
+# the runner is always a scripted fake.
+# Created: 2026-07-11 (feat/guardrail-c2-composer).
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from pocketpaw.bundled_templates.schema import LlmStepPipeline
+from pocketpaw.bundled_templates.step_composer import run_step_pipeline
+from pocketpaw.tools.builtin.step_pipeline_tool import StepPipelineTool
+
+# NOTE: the suite runs pytest-asyncio in AUTO mode — async tests need no marks.
+
+
+def _pipeline(*kinds: str, **extras) -> dict:
+    steps = []
+    for k in kinds:
+        step: dict = {"step": k, "instruction": f"do {k}"}
+        step.update(extras.get(k, {}))
+        steps.append(step)
+    return {"steps": steps}
+
+
+# ---------------------------------------------------------------------------
+# Validator: fixed order, no dups, 1-3 steps, input_from resolution
+# ---------------------------------------------------------------------------
+
+
+def test_validator_accepts_canonical_order():
+    p = LlmStepPipeline.model_validate(
+        _pipeline("extract", "classify", "recommend", extract={"fields": ["amount"]})
+    )
+    assert [s.step for s in p.steps] == ["extract", "classify", "recommend"]
+
+
+def test_validator_rejects_wrong_order_and_dups():
+    with pytest.raises(ValidationError, match="order"):
+        LlmStepPipeline.model_validate(_pipeline("classify", "extract"))
+    with pytest.raises(ValidationError, match="repeat"):
+        LlmStepPipeline.model_validate(_pipeline("extract", "extract"))
+    with pytest.raises(ValidationError, match="1-3"):
+        LlmStepPipeline.model_validate({"steps": []})
+
+
+def test_validator_rejects_forward_input_from():
+    bad = _pipeline("extract", "recommend")
+    bad["steps"][0]["input_from"] = "recommend"  # forward reference
+    with pytest.raises(ValidationError, match="input_from"):
+        LlmStepPipeline.model_validate(bad)
+
+
+# ---------------------------------------------------------------------------
+# Executor: typed handoff + lenient parsing
+# ---------------------------------------------------------------------------
+
+
+def _scripted_runner(replies: list[str]):
+    calls: list[str] = []
+
+    async def run(prompt: str) -> str:
+        calls.append(prompt)
+        return replies[len(calls) - 1]
+
+    run.calls = calls  # type: ignore[attr-defined]
+    return run
+
+
+async def test_executor_typed_handoff():
+    """extract's JSON fields feed classify; classify's label feeds recommend."""
+    pipeline = LlmStepPipeline.model_validate(
+        _pipeline(
+            "extract",
+            "classify",
+            "recommend",
+            extract={"fields": ["amount", "vendor"]},
+            classify={"labels": ["approve", "review"]},
+        )
+    )
+    runner = _scripted_runner(
+        ['{"amount": 900, "vendor": "Acme"}', "REVIEW", "Escalate to a human."]
+    )
+    result = await run_step_pipeline(pipeline, "Invoice from Acme for $900", runner)
+
+    assert result["result"] == "Escalate to a human."
+    assert [s["step"] for s in result["steps"]] == ["extract", "classify", "recommend"]
+    # extract parsed to the named fields
+    assert result["steps"][0]["output"] == {"amount": 900, "vendor": "Acme"}
+    # classify received extract's output as its input (typed handoff)
+    assert "Acme" in result["steps"][1]["input"]
+    # classify's reply matched the closed label set case-insensitively
+    assert result["steps"][1]["output"] == "review"
+    # recommend received the label
+    assert result["steps"][2]["input"] == "review"
+
+
+async def test_executor_lenient_on_weird_replies():
+    """A non-JSON extract reply and an off-label classify reply degrade to text."""
+    pipeline = LlmStepPipeline.model_validate(
+        _pipeline("extract", "classify", extract={"fields": ["x"]}, classify={"labels": ["a"]})
+    )
+    runner = _scripted_runner(["not json at all", "something else entirely"])
+    result = await run_step_pipeline(pipeline, "input", runner)
+    assert result["steps"][0]["output"] == "not json at all"
+    assert result["result"] == "something else entirely"
+
+
+async def test_executor_input_from_initial_input():
+    """input_from='input' rewires a later step back to the pipeline input."""
+    pipeline = LlmStepPipeline.model_validate(
+        {
+            "steps": [
+                {"step": "extract", "instruction": "pull", "fields": ["a"]},
+                {"step": "recommend", "instruction": "advise", "input_from": "input"},
+            ]
+        }
+    )
+    runner = _scripted_runner(['{"a": 1}', "ok"])
+    await run_step_pipeline(pipeline, "THE-ORIGINAL", runner)
+    assert "THE-ORIGINAL" in runner.calls[1]  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Tool wrapper: registration + no-backend error + happy path
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registered_in_builtin_map():
+    import pocketpaw.tools.builtin as builtin
+
+    tool_cls = getattr(builtin, "StepPipelineTool")
+    assert tool_cls is StepPipelineTool
+
+
+async def test_tool_without_runner_returns_clear_error():
+    out = json.loads(await StepPipelineTool().execute(pipeline=_pipeline("recommend"), input="x"))
+    assert "requires an agent backend" in out["error"]
+
+
+async def test_tool_happy_path_and_invalid_spec():
+    async def runner(prompt: str) -> str:
+        return "fine"
+
+    tool = StepPipelineTool(agent_runner=runner)
+    ok = json.loads(await tool.execute(pipeline=_pipeline("recommend"), input="x"))
+    assert ok["result"] == "fine"
+    bad = json.loads(await tool.execute(pipeline=_pipeline("extract", "extract"), input="x"))
+    assert "invalid pipeline" in bad["error"]


### PR DESCRIPTION
The single merge unit for the thesis-gap remediation arc — every buildable backend item from the 13-gap backlog, reviewed, fully tested, and live-smoked on this branch. Supersedes #1665, #1666, #1668, #1669, #1673 (close those).

## What's in it
- **Billing enforcement** (the sell-gate): universal run-start credit gate on every agent-run seam (incl. above the Haiku pre-classifier on the group/DM bridge), worker wallet parity, subscription cancel + downgrade fixes, SMB seat/pocket/connector caps on the ladder + wire DTOs. Flag stays default-off (`POCKETPAW_BILLING_ENFORCED` enables per deployment). Includes the review fixes: the cancel-webhook plan-revert guard and the SSRF encoding bypass (`127.1`, `0x7f000001`, decimal metadata IPs — all rejected, verified empirically).
- **External alerting, complete**: Slack + webhook fan-out from the notification chokepoint (never-raise, SSRF-guarded), OSS evaluator autostart (default-on flag) with a real Fabric threshold query replacing the return-False stub, per-workspace automation opt-out honored at every sweep fan-out, and the aggregate `automations_status` endpoint (constructed sweep registry).
- **Instinct guardrails**: governed-rules authoring router over the shipped rules service + per-workspace enforcement toggle (fail-open preserved), and the 3-step LLM composer (extract→classify→recommend; deterministic sequencing, injected runner, no LLM client constructed).
- **Compliance starter**: per-workspace `retention_days` made real (no-clobber settings merge, again-callable audit purge); the audit CSV export already existed and is untouched.
- **Ontology operator backend**: `/fabric/schema/*` authoring routes (admin-gated), write-time type enforcement (lenient — live ingest unaffected, proven), non-destructive schema versioning with rename/additive migration.
- **LLM cost**: real token counts stamped onto debit refs and surfaced on the usage graph; credits-vs-USD clarified. (The claimed enumeration bug was investigated and is NOT real — no change.)
- **paw CLI**: the `paw` console script shipped (thin httpx client over the fabric routes) + 3 ontology-modification MCP tools + a tenancy-guarded link-delete route.
- **Connector→Fabric transforms**: mapping CRUD + run-now dispatch with the per-tenant token seam (`WorkspaceConnector.user_id`), gcalendar as the first registered ingestor (lazy-seeded registry, OSS-pure).
- **Self-serve analysis engine**: flag-gated (`POCKETPAW_FABRIC_ANALYST`) SQL GROUP BY aggregation on the Fabric query path with reasoning steps (`{title, detail, status}`), scope-then-aggregate proven.
- **Mission-control evals**: outcome-verdict rollup (`solved_rate` over checkable verdicts, unknown reported separately).
- **Paw Bar tenancy**: in-row workspace scoping on widgets, the cross-tenant Fabric-write leak closed (`get_fabric_store(workspace_id=owner)`), spec revisions + rollback.

## Verification
- Full suite on this branch: **7922 passed**; the 20 fails are in 4 files (codex-cli backend, headless subprocess, mem0, context-budget) that fail identically on plain `origin/dev` and none of which are in this branch's 110-file diff.
- Both import-linter configs green throughout (OSS↛EE held; 29 EE contracts incl. two new ones).
- Live smoke on this branch: every new route mounted + auth-gated (zero 404s), caps served on `GET /billing/plans`, flag-on billing enforcement blocks a real empty wallet with no model call.

## Parked captain decisions (documented in code, not built blind)
Cap price numbers · Dodo `change_plan` (closes the downgrade lag window) · verify-loop enablement (populates the solved-rate tile) · Paw Bar host/DNS/TLS · SNCTM embed paste.

Companion PRs: paw-enterprise #575 (UI), paw-workspace `feat/tenant-deploy-slice1` (stacks on #54), paw-print-widget `feat/paw-bar-reconcile`.