### PR TITLE
Governed-rules router + per-workspace enforcement toggle

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -249,6 +249,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.pockets.router import router as pockets_router
     from pocketpaw_ee.cloud.projects.router import router as projects_router
     from pocketpaw_ee.cloud.request_log.router import router as request_log_router
+    from pocketpaw_ee.cloud.rules.router import router as rules_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
     from pocketpaw_ee.cloud.skills.router import router as skills_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
@@ -297,6 +298,13 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(planner_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
     app.include_router(cycles_router, prefix="/api/v1")
+    # Governed Instinct rules (feat/instinct-guardrail-rules) — the UI-authored
+    # guardrail surface: create / list / archive a governed rule + the
+    # per-workspace authored-rule enforcement toggle (GET/PUT /rules/enforcement).
+    # Admin-gated (rules.manage); the enforcement it toggles is the shipped gate
+    # path in ee.cloud.pockets.instinct_dispatch — this router adds no new
+    # enforcement logic.
+    app.include_router(rules_router, prefix="/api/v1")
     # Foresight — RFC 08 scenario-run surface (POST /foresight/scenarios,
     # GET /foresight/runs[/{id}]). Mounted alongside cycles so the
     # Mission Control rail can launch / inspect simulation runs from the

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -84,6 +84,12 @@ Updated: 2026-06-20 (feat/szd-slice2-discovery, S2-R1) — added ``InstinctRuleD
 the imports, ``__all__``, and ``get_all_documents()`` so the ``instinct_rules``
 collection is wired into ``init_beanie`` and the ``beanie_test_db`` fixture. Only
 ``ee.cloud.rules.service`` imports the doc class directly (import-linter "Rules").
+Updated: 2026-07-09 (feat/instinct-guardrail-rules) — added
+``InstinctWorkspaceConfig`` (the per-workspace tri-state override on the global
+``instinct_enforce_discovered_rules`` flag) to the imports, ``__all__``, and
+``get_all_documents()`` so the ``instinct_workspace_configs`` collection is wired
+into ``init_beanie``. Only ``ee.cloud.rules.service`` writes it (import-linter
+"Rules").
 """
 
 from __future__ import annotations
@@ -125,6 +131,7 @@ from pocketpaw_ee.cloud.models.foresight_workspace_scenario import (
 from pocketpaw_ee.cloud.models.group import Group, GroupAgent
 from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval
 from pocketpaw_ee.cloud.models.instinct_rule import InstinctRuleDoc
+from pocketpaw_ee.cloud.models.instinct_workspace_config import InstinctWorkspaceConfig
 from pocketpaw_ee.cloud.models.invite import Invite
 from pocketpaw_ee.cloud.models.lead import Lead, LeadSource
 from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
@@ -273,6 +280,7 @@ __all__ = [
     "GroupAgent",
     "InstinctApproval",
     "InstinctRuleDoc",
+    "InstinctWorkspaceConfig",
     "Invite",
     "Lead",
     "LeadSource",
@@ -375,6 +383,9 @@ def get_all_documents():
         # Discovered governed rules (SZD slice-2). Only ``ee.cloud.rules.service``
         # writes it.
         InstinctRuleDoc,
+        # Per-workspace Instinct enforcement override (feat/instinct-guardrail-rules).
+        # Only ``ee.cloud.rules.service`` writes it.
+        InstinctWorkspaceConfig,
         Message,
         ReadState,
         RequestLog,

--- a/ee/pocketpaw_ee/cloud/models/instinct_workspace_config.py
+++ b/ee/pocketpaw_ee/cloud/models/instinct_workspace_config.py
@@ -1,0 +1,60 @@
+# ee/pocketpaw_ee/cloud/models/instinct_workspace_config.py
+# Created: 2026-07-09 (feat/instinct-guardrail-rules) — Per-workspace Instinct
+# enforcement configuration. v1 ships ONE field — ``enforce_discovered_rules``,
+# a TRI-STATE override on the global ``settings.instinct_enforce_discovered_rules``
+# flag so a workspace admin can turn authored-rule enforcement ON (or OFF) for a
+# SINGLE tenant without a code change / redeploy:
+#   - ``True``  → enforcement ON for this workspace regardless of the global flag.
+#   - ``False`` → enforcement OFF for this workspace regardless of the global flag.
+#   - ``None``  → no override; inherit the global settings flag.
+# The live gate (``ee.cloud.pockets.instinct_dispatch``) resolves the effective
+# value as ``override if override is not None else global_flag``.
+#
+# Why a per-workspace Mongo doc (mirrors ForesightWorkspaceConfig / BeltWorkspaceConfig):
+# the toggle must survive restarts and be settable at runtime by an admin, and the
+# deployment topology is per-tenant-dedicated-server, so a workspace-keyed doc is the
+# tenant-sane home. One row per workspace; ``workspace`` is indexed unique so the
+# read/upsert path stays O(1). The shape is extension-additive — future instinct
+# knobs layer on as new optional fields with safe defaults.
+#
+# Only ``ee.cloud.rules.service`` reads/writes this module (same single-importer
+# discipline as ForesightWorkspaceConfig, enforced by the "Rules" import-linter
+# contract in ee/pyproject.toml).
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class InstinctWorkspaceConfig(TimestampedDocument):
+    """Per-workspace Instinct enforcement configuration override.
+
+    Fields:
+      - ``workspace`` — tenancy key. Indexed unique so ``find_one`` / upsert
+        stays O(1).
+      - ``enforce_discovered_rules`` — TRI-STATE override on the global
+        ``settings.instinct_enforce_discovered_rules`` flag. ``True`` forces
+        authored-rule enforcement ON for this workspace, ``False`` forces it
+        OFF, and ``None`` (the default) means "no override — inherit the global
+        flag". Stored as ``bool | None`` exactly like
+        ``ForesightWorkspaceConfig.threshold_override`` models a per-workspace
+        inherit-vs-override knob.
+      - ``createdAt`` / ``updatedAt`` — inherited from
+        :class:`TimestampedDocument`. ``updatedAt`` doubles as the
+        "when did the admin last touch this" timestamp the GET response exposes.
+
+    The shape is extension-additive; new optional fields with safe defaults
+    won't break callers reading the v1 wire dict.
+    """
+
+    workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
+    enforce_discovered_rules: bool | None = Field(default=None)
+
+    class Settings:
+        name = "instinct_workspace_configs"
+        # ``workspace`` already has a unique single-field index from the
+        # ``Indexed(..., unique=True)`` annotation; the upsert path uses it
+        # directly. No composite indexes needed in v1.

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
@@ -30,6 +30,18 @@
 # fail-open in the user's mental model. The audit write is wrapped so an audit
 # failure can never break the gate (mirrors `_audit_triage_decision`).
 #
+# Updated: 2026-07-09 (feat/instinct-guardrail-rules — per-workspace enforcement)
+# — the `gate_action` enforcement decision is now resolved PER WORKSPACE via
+# `_enforcement_enabled(workspace_id)` instead of reading the global
+# `instinct_enforce_discovered_rules` flag directly. Resolution: a workspace's
+# `InstinctWorkspaceConfig` override (rules.service.get_enforcement_override)
+# wins when set (True/False), else the call falls back to the global flag. The
+# override read is FAIL-OPEN — a config/store read error yields "no enforcement"
+# (False), logs a WARNING, and never blocks the gate — preserving the same
+# fail-open rail `_load_discovered_instinct_rules` already applies to the
+# `get_active_rules` read. So one tenant can flip enforcement without a code
+# change, and a DB hiccup can never turn into a hard failure.
+#
 # Updated: 2026-06-30 (integration/szd-finish, B1 — gate DoS fix) — the
 # discovered-rule CEL probe in `_load_discovered_instinct_rules` now catches ANY
 # exception, not just `CelEvaluationError`. `evaluate_cel` calls
@@ -142,7 +154,7 @@ from pocketpaw_ee.cloud.pockets.instinct_triage import (
     TriageProposal,
     classify_lane,
 )
-from pocketpaw_ee.cloud.rules.service import get_active_rules
+from pocketpaw_ee.cloud.rules.service import get_active_rules, get_enforcement_override
 
 logger = logging.getLogger(__name__)
 
@@ -390,6 +402,35 @@ async def _find_existing_pending_id(
     return None
 
 
+async def _enforcement_enabled(workspace_id: str) -> bool:
+    """Resolve whether authored-rule enforcement is ON for ``workspace_id``.
+
+    The per-workspace ``InstinctWorkspaceConfig`` override wins when set
+    (``True``/``False``); otherwise the call falls back to the global
+    ``instinct_enforce_discovered_rules`` settings flag. The global read stays
+    HERE (not in the service) so the existing gate tests that flip the flag by
+    monkeypatching ``instinct_dispatch.get_settings`` keep working.
+
+    FAIL-OPEN: a config/store read error yields ``False`` (no enforcement), logs
+    a WARNING, and NEVER raises — a DB hiccup must never turn into a blocked gate
+    (the same rail ``_load_discovered_instinct_rules`` applies to the
+    ``get_active_rules`` read). Enforcement can only ever ADD a block/escalation,
+    so "no enforcement" is the safe direction when the override is unreadable.
+    """
+    global_flag = bool(get_settings().instinct_enforce_discovered_rules)
+    try:
+        override = await get_enforcement_override(workspace_id)
+    except Exception:  # noqa: BLE001 — fail-OPEN: a config read hiccup never blocks
+        logger.warning(
+            "discovered-rule enforcement: enforcement-config read failed for "
+            "workspace=%s — defaulting to NO enforcement (fail-open)",
+            workspace_id,
+            exc_info=True,
+        )
+        return False
+    return override if override is not None else global_flag
+
+
 async def _load_discovered_instinct_rules(
     *,
     workspace_id: str,
@@ -609,11 +650,15 @@ async def gate_action(
     level = _coerce_approval_level(approval_level)
 
     # F6 — merge approved workspace-discovered rules into the template before
-    # the (unchanged) composer call. DEFAULT-OFF: when the flag is off,
-    # `get_active_rules` is never called and `effective_template is template`,
-    # so the entire discovered branch is dead code on the default path.
+    # the (unchanged) composer call. Enforcement is resolved PER WORKSPACE
+    # (`_enforcement_enabled`): the workspace's `InstinctWorkspaceConfig` override
+    # wins, else the global `instinct_enforce_discovered_rules` flag. When
+    # enforcement is off, `get_active_rules` is never called and
+    # `effective_template is template`, so the discovered branch stays dead code
+    # on the off path. The resolver is fail-open — a config read error yields
+    # "no enforcement", never a block.
     effective_template = template
-    if get_settings().instinct_enforce_discovered_rules:
+    if await _enforcement_enabled(workspace_id):
         # Pin a stable `now` shared by the guarded probe and the composer so a
         # time-sensitive CEL `when` evaluates identically in both.
         if now is None:

--- a/ee/pocketpaw_ee/cloud/rules/__init__.py
+++ b/ee/pocketpaw_ee/cloud/rules/__init__.py
@@ -1,22 +1,42 @@
-# Cloud rules entity — re-exports for the gate executor + read seam.
+# Cloud rules entity — re-exports for the gate executor, read seam, and HTTP router.
 # Created: 2026-06-20 (S2-R1 / feat/szd-slice2-discovery). The discovered-rules
 # entity: the persistence + read API for governed Instinct rules mined from
-# workspace exhaust and approved through the gate. No HTTP router this slice
-# (rules are born only via the S2-R3 ``_instinct_rule`` executor; see the
-# ``no-router`` note in service.py). Re-exports the service entry points so the
-# executor + the slice-3 dispatcher import from the package root.
+# workspace exhaust and approved through the gate.
+#
+# Updated: 2026-07-09 (feat/instinct-guardrail-rules). A UI-authored governed rule
+# is now manageable over HTTP: the entity gains a thin ``router`` (create / list /
+# archive + the per-workspace enforcement toggle) over the shipped service, plus the
+# enforcement DTOs. The original "no HTTP router this slice" note is retired.
+# Re-exports the service entry points + DTOs so consumers import from the package root.
 
 from __future__ import annotations
 
 from pocketpaw_ee.cloud.rules.domain import Rule
-from pocketpaw_ee.cloud.rules.dto import CreateRuleRequest, RuleResponse
-from pocketpaw_ee.cloud.rules.service import archive_rule, create_rule, get_active_rules
+from pocketpaw_ee.cloud.rules.dto import (
+    CreateRuleRequest,
+    EnforcementResponse,
+    RuleResponse,
+    SetEnforcementRequest,
+)
+from pocketpaw_ee.cloud.rules.service import (
+    archive_rule,
+    create_rule,
+    get_active_rules,
+    get_enforcement,
+    get_enforcement_override,
+    set_enforcement,
+)
 
 __all__ = [
     "CreateRuleRequest",
+    "EnforcementResponse",
     "Rule",
     "RuleResponse",
+    "SetEnforcementRequest",
     "archive_rule",
     "create_rule",
     "get_active_rules",
+    "get_enforcement",
+    "get_enforcement_override",
+    "set_enforcement",
 ]

--- a/ee/pocketpaw_ee/cloud/rules/dto.py
+++ b/ee/pocketpaw_ee/cloud/rules/dto.py
@@ -7,6 +7,11 @@
 # ``rules.service.create_rule``: the editable ``RuleDraft`` plus ``owner_user_id``
 # (the approver). Tenancy is NOT in this DTO — it arrives as the service's explicit
 # ``workspace_id`` parameter, and the service asserts it matches ``draft.scope``.
+#
+# Updated: 2026-07-09 (feat/instinct-guardrail-rules) — added the per-workspace
+# enforcement-toggle DTOs (``SetEnforcementRequest`` / ``EnforcementResponse``)
+# the new ``rules.router`` PUT/GET ``/rules/enforcement`` endpoints use to read
+# and set the tri-state override on the global enforcement flag.
 
 from __future__ import annotations
 
@@ -34,6 +39,20 @@ class CreateRuleRequest(BaseModel):
 
     draft: RuleDraft
     owner_user_id: str
+
+
+class SetEnforcementRequest(BaseModel):
+    """Body for ``PUT /rules/enforcement`` → ``rules.service.set_enforcement``.
+
+    ``enabled`` is the TRI-STATE per-workspace override on the global
+    ``instinct_enforce_discovered_rules`` flag: ``True`` forces authored-rule
+    enforcement ON for this workspace, ``False`` forces it OFF, and ``None``
+    (the default) clears the override so the workspace inherits the global flag.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -71,4 +90,28 @@ class RuleResponse(BaseModel):
     updated_at: datetime | None = None
 
 
-__all__ = ["CreateRuleRequest", "RuleResponse", "RuleScopeResponse"]
+class EnforcementResponse(BaseModel):
+    """Wire shape for a workspace's authored-rule enforcement state.
+
+    ``enforce_discovered_rules`` is the EFFECTIVE value the live gate uses
+    (``override`` when set, else ``global_default``). ``override`` exposes the
+    raw tri-state per-workspace value (``None`` = inheriting) and
+    ``global_default`` the current global flag, so the admin UI can show both
+    "your setting" and "what the workspace inherits".
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: str
+    enforce_discovered_rules: bool
+    override: bool | None = None
+    global_default: bool
+
+
+__all__ = [
+    "CreateRuleRequest",
+    "EnforcementResponse",
+    "RuleResponse",
+    "RuleScopeResponse",
+    "SetEnforcementRequest",
+]

--- a/ee/pocketpaw_ee/cloud/rules/router.py
+++ b/ee/pocketpaw_ee/cloud/rules/router.py
@@ -1,0 +1,119 @@
+# router.py — FastAPI router for the Rules entity (governed Instinct rules).
+# Created: 2026-07-09 (feat/instinct-guardrail-rules) — the thin HTTP surface over
+# the shipped ``rules.service``. A UI-authored governed rule ("writes over $500 need
+# approval") is created / listed / archived here, and the per-workspace authored-rule
+# ENFORCEMENT toggle is read / set here. Every route is workspace-scoped (tenancy from
+# the auth context, never a body/query) and admin-gated behind ``rules.manage``.
+#
+# Discipline (ee/cloud 4-file rules): NO enforcement logic and NO Beanie doc import
+# live here — the router only maps HTTP <-> service calls. Errors surface as
+# ``CloudError`` via the global handler (never ``HTTPException``). Mounted under
+# ``/api/v1`` from ``ee/pocketpaw_ee/cloud/__init__.py``.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.rules import service as rules_service
+from pocketpaw_ee.cloud.rules.dto import (
+    CreateRuleRequest,
+    EnforcementResponse,
+    RuleResponse,
+    SetEnforcementRequest,
+)
+
+router = APIRouter(
+    prefix="/rules",
+    tags=["Rules"],
+    dependencies=[Depends(require_license)],
+)
+
+
+# ---------------------------------------------------------------------------
+# Governed-rule CRUD (thin wrappers over rules.service).
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "",
+    response_model=RuleResponse,
+    dependencies=[Depends(require_action_any_workspace("rules.manage"))],
+)
+async def create_rule(
+    body: CreateRuleRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Create a governed rule for the caller's workspace.
+
+    The service asserts ``body.draft.scope.workspace_id`` matches the caller's
+    workspace, so an edited draft can never persist into another tenant.
+    """
+    return await rules_service.create_rule(workspace_id, user_id, body)
+
+
+@router.get(
+    "",
+    response_model=list[RuleResponse],
+    dependencies=[Depends(require_action_any_workspace("rules.manage"))],
+)
+async def list_rules(
+    workspace_id: str = Depends(current_workspace_id),
+) -> list[dict]:
+    """List the ACTIVE governed rules for the caller's workspace (tenant-filtered;
+    archived rows excluded)."""
+    return await rules_service.get_active_rules(workspace_id)
+
+
+# ---------------------------------------------------------------------------
+# Per-workspace enforcement toggle. Declared BEFORE the ``/{rule_id}/archive``
+# route so ``/enforcement`` is never captured as a rule id.
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/enforcement",
+    response_model=EnforcementResponse,
+    dependencies=[Depends(require_action_any_workspace("rules.manage"))],
+)
+async def get_enforcement(
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict:
+    """Read the caller workspace's effective authored-rule enforcement state."""
+    return await rules_service.get_enforcement(workspace_id)
+
+
+@router.put(
+    "/enforcement",
+    response_model=EnforcementResponse,
+    dependencies=[Depends(require_action_any_workspace("rules.manage"))],
+)
+async def set_enforcement(
+    body: SetEnforcementRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Set (or clear, with ``enabled=null``) the caller workspace's tri-state
+    enforcement override on the global flag."""
+    return await rules_service.set_enforcement(workspace_id, user_id, body.enabled)
+
+
+@router.post(
+    "/{rule_id}/archive",
+    response_model=RuleResponse,
+    dependencies=[Depends(require_action_any_workspace("rules.manage"))],
+)
+async def archive_rule(
+    rule_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Archive (retire) a governed rule. Tenant-scoped — a caller can only
+    archive a rule in their own workspace; an unknown id 404s via CloudError."""
+    return await rules_service.archive_rule(workspace_id, user_id, rule_id)

--- a/ee/pocketpaw_ee/cloud/rules/service.py
+++ b/ee/pocketpaw_ee/cloud/rules/service.py
@@ -1,26 +1,37 @@
-# Rules — service (the sole owner of InstinctRuleDoc writes).
+# Rules — service (the sole owner of InstinctRuleDoc + InstinctWorkspaceConfig writes).
 # Created: 2026-06-20 (S2-R1 / feat/szd-slice2-discovery). The R3 ``_instinct_rule``
 # gate executor calls ``create_rule`` at approve time; ``get_active_rules`` is the
 # slice-2 read seam (slice-3 wires it into live gate dispatch). Follows the ee/cloud
 # 4-file rules: module-level ``async def``, validate-at-entry, tenant filter on every
 # read, emit on every write, errors via CloudError.
 #
-# no-router: rules have NO direct HTTP surface this slice. A rule is born ONLY by
-#   approving an ``_instinct_rule`` gate proposal (S2-R3 executor → this service);
-#   it is never POSTed by a client. The read seam ``get_active_rules`` is consumed
-#   in-process by the (slice-3) gate dispatcher, not over HTTP. A read router can be
-#   added later if a workspace rule-list endpoint is needed; omitted by design now.
+# Updated: 2026-07-09 (feat/instinct-guardrail-rules). The rules entity now HAS a thin
+# HTTP router (``rules/router.py``) over ``create_rule`` / ``get_active_rules`` /
+# ``archive_rule`` so a UI-authored governed rule is manageable over HTTP (the
+# original "no-router" note is retired). This module also gains the per-workspace
+# ENFORCEMENT toggle: ``get_enforcement_override`` (the fail-open resolver seam the
+# live gate consults), ``get_enforcement`` (read) and ``set_enforcement`` (upsert)
+# over the ``InstinctWorkspaceConfig`` doc — a tri-state override on the global
+# ``instinct_enforce_discovered_rules`` flag so one tenant can flip enforcement
+# without a code change. The gate's fail-OPEN-on-read-error rail is unchanged.
 
 from __future__ import annotations
 
 from typing import Any
 
+from pocketpaw.config import get_settings
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import RuleArchived, RuleCreated
 from pocketpaw_ee.cloud.models.instinct_rule import InstinctRuleDoc
+from pocketpaw_ee.cloud.models.instinct_workspace_config import InstinctWorkspaceConfig
 from pocketpaw_ee.cloud.rules.domain import Rule
-from pocketpaw_ee.cloud.rules.dto import CreateRuleRequest, RuleResponse, RuleScopeResponse
+from pocketpaw_ee.cloud.rules.dto import (
+    CreateRuleRequest,
+    EnforcementResponse,
+    RuleResponse,
+    RuleScopeResponse,
+)
 
 # ---------------------------------------------------------------------------
 # Private mapping helpers — Beanie doc ↔ domain ↔ wire dict
@@ -164,4 +175,76 @@ def _as_object_id(rule_id: str) -> Any:
         raise ValidationError("rule.invalid_id", f"invalid rule id: {rule_id}") from exc
 
 
-__all__ = ["archive_rule", "create_rule", "get_active_rules"]
+# ---------------------------------------------------------------------------
+# Per-workspace enforcement toggle — the tri-state override on the global
+# ``instinct_enforce_discovered_rules`` flag, over ``InstinctWorkspaceConfig``.
+# ---------------------------------------------------------------------------
+
+
+async def get_enforcement_override(workspace_id: str) -> bool | None:
+    """Return the workspace's raw enforcement override, or ``None`` if unset.
+
+    ``True``/``False`` is an explicit per-workspace override; ``None`` means the
+    workspace has no override and inherits the global flag. This is the pure read
+    seam the live gate consults — it RAISES on a store read error so the CALLER
+    owns the fail-OPEN decision (the gate must never turn a read hiccup into a
+    block; see ``instinct_dispatch._enforcement_enabled``).
+    """
+    doc = await InstinctWorkspaceConfig.find_one(
+        InstinctWorkspaceConfig.workspace == workspace_id,
+    )
+    return None if doc is None else doc.enforce_discovered_rules
+
+
+async def get_enforcement(workspace_id: str) -> dict:
+    """Return the workspace's effective enforcement state as a wire dict.
+
+    ``enforce_discovered_rules`` is the EFFECTIVE value (``override`` when set,
+    else the global flag); ``override`` is the raw tri-state; ``global_default``
+    is the current global flag. Read-only — never writes a doc.
+    """
+    override = await get_enforcement_override(workspace_id)
+    global_default = bool(get_settings().instinct_enforce_discovered_rules)
+    return EnforcementResponse(
+        workspace_id=workspace_id,
+        enforce_discovered_rules=override if override is not None else global_default,
+        override=override,
+        global_default=global_default,
+    ).model_dump(mode="json")
+
+
+async def set_enforcement(workspace_id: str, user_id: str, enabled: bool | None) -> dict:
+    """Upsert the workspace's enforcement override, returning the effective state.
+
+    ``enabled=True`` forces enforcement ON, ``False`` forces it OFF, and ``None``
+    clears the override (the workspace re-inherits the global flag). The doc
+    itself survives a reset — a "previously overridden, now cleared" workspace
+    keeps an audit-relevant ``updatedAt``. ``workspace`` is unique-indexed, so
+    the find-then-insert/save upsert is O(1); a concurrent-insert race would
+    surface as a DuplicateKeyError (admin-only write path — treated as a 5xx, no
+    retry loop, mirroring ``foresight.service.set_threshold``).
+    """
+    doc = await InstinctWorkspaceConfig.find_one(
+        InstinctWorkspaceConfig.workspace == workspace_id,
+    )
+    if doc is None:
+        doc = InstinctWorkspaceConfig(
+            workspace=workspace_id,
+            enforce_discovered_rules=enabled,
+        )
+        await doc.insert()
+    else:
+        doc.enforce_discovered_rules = enabled
+        await doc.save()
+
+    return await get_enforcement(workspace_id)
+
+
+__all__ = [
+    "archive_rule",
+    "create_rule",
+    "get_active_rules",
+    "get_enforcement",
+    "get_enforcement_override",
+    "set_enforcement",
+]

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -196,6 +196,14 @@ ACTIONS: dict[str, ActionRule] = {
     # tier (mirrors workspace.delete / billing.manage): a mere admin must not
     # be able to disable the human-in-the-loop for everyone.
     "instinct.activate": ActionRule(WorkspaceRole.OWNER, "workspace.insufficient_role"),
+    # Governed rules — the UI-authored guardrail surface (ee.cloud.rules.router:
+    # create / list / archive a rule + the per-workspace enforcement toggle).
+    # ADMIN, mirroring the other governance write surfaces (instinct.approve /
+    # audit.read): authoring a rule and flipping enforcement change workspace-wide
+    # governance and can only ADD blocks/escalations (never relax the template
+    # floor), so an admin bar — not the OWNER-only bar reserved for
+    # instinct.activate (which turns OFF the human-in-the-loop) — is correct.
+    "rules.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Connector — workspace-level connector lifecycle.
     # execute is MEMBER so any team member can run actions against enabled connectors.
     # manage (enable/disable/config) is ADMIN because it changes workspace-wide state

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -448,12 +448,17 @@ type = "forbidden"
 allow_indirect_imports = "true"
 source_modules = [
     # Discovered governed rules (SZD slice-2). Only ``rules.service`` owns the
-    # InstinctRuleDoc Beanie write; dto/domain go through it. No router this slice
-    # (rules are born via the _instinct_rule gate executor, not over HTTP).
+    # InstinctRuleDoc / InstinctWorkspaceConfig Beanie writes; dto/domain/router
+    # go through it. The router (feat/instinct-guardrail-rules) is thin — it maps
+    # HTTP to service calls and must not import a Beanie doc directly.
     "pocketpaw_ee.cloud.rules.dto",
     "pocketpaw_ee.cloud.rules.domain",
+    "pocketpaw_ee.cloud.rules.router",
 ]
-forbidden_modules = ["pocketpaw_ee.cloud.models.instinct_rule"]
+forbidden_modules = [
+    "pocketpaw_ee.cloud.models.instinct_rule",
+    "pocketpaw_ee.cloud.models.instinct_workspace_config",
+]
 
 [[tool.importlinter.contracts]]
 name = "Notifications — Beanie writes only from service.py"

--- a/tests/cloud/test_rules_router.py
+++ b/tests/cloud/test_rules_router.py
@@ -1,0 +1,251 @@
+# test_rules_router.py — HTTP-layer tests for ee/cloud/rules/router.py.
+# Created: 2026-07-09 (feat/instinct-guardrail-rules) — smokes the thin
+# /api/v1/rules surface over the shipped rules.service: create persists an active
+# InstinctRuleDoc, list is tenant-filtered (a workspace sees only its own active
+# rules), archive flips a rule to archived (and it drops out of the list), the
+# service's cross-tenant-scope guard surfaces as a 400, the enforcement GET/PUT
+# round-trips, and the auth/permission seams (401 unauth, 403 without rules.manage).
+#
+# The router calls the REAL service against the mongomock-backed ``mongo_db``
+# fixture (Beanie), so these are true persistence smokes, not Protocol fakes.
+# Auth: ``current_active_user`` is overridden to a SimpleNamespace user and RBAC's
+# ``check_workspace_action`` is patched on the consumer module (mirrors
+# test_audit_router.py).
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from beanie import PydanticObjectId
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.auth import current_active_user
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.models.instinct_rule import InstinctRuleDoc
+from pocketpaw_ee.cloud.rules.router import router as rules_router
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _fake_user(user_id: str = "u1", workspace_id: str | None = "w1") -> SimpleNamespace:
+    """User stand-in shaped like ``ee.cloud.models.user.User`` — only the
+    attributes the rules-router auth chain reads (``id``, ``active_workspace``,
+    ``workspaces``)."""
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role="admin")] if workspace_id else [],
+    )
+
+
+def _build_app(
+    workspace_id: str | None = "w1",
+    user_id: str = "u1",
+    *,
+    skip_auth_override: bool = False,
+    permission_denier: bool = False,
+    monkeypatch=None,
+) -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(rules_router)
+    app.dependency_overrides[require_license] = lambda: None
+
+    if not skip_auth_override:
+        user = _fake_user(user_id=user_id, workspace_id=workspace_id)
+
+        async def _fake_user_dep():
+            return user
+
+        app.dependency_overrides[current_active_user] = _fake_user_dep
+
+        if monkeypatch is not None:
+            from pocketpaw_ee.cloud._core import deps as core_deps
+            from pocketpaw_ee.guards.rbac import Forbidden as GuardForbidden
+
+            if permission_denier:
+
+                def _deny(*_a, **_k):
+                    raise GuardForbidden(
+                        code="workspace.insufficient_role",
+                        detail="no rules.manage",
+                    )
+
+                monkeypatch.setattr(core_deps, "check_workspace_action", _deny)
+            else:
+                monkeypatch.setattr(core_deps, "check_workspace_action", lambda *a, **k: None)
+
+    return app
+
+
+def _create_body(workspace_id: str = "w1", *, name: str = "big-write approval") -> dict:
+    """A valid ``CreateRuleRequest`` JSON body — a governed rule that escalates
+    writes over $500, scoped to ``workspace_id``."""
+    return {
+        "draft": {
+            "name": name,
+            "description": "writes over $500 need approval",
+            "when": "value > 500",
+            "action": "require_approval",
+            "scope": {"workspace_id": workspace_id},
+            "confidence": 0.9,
+            "provenance": ["ui-authored"],
+        },
+        "owner_user_id": "u1",
+    }
+
+
+@pytest_asyncio.fixture
+async def w1_client(monkeypatch) -> AsyncClient:
+    app = _build_app(workspace_id="w1", monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(monkeypatch) -> AsyncClient:
+    app = _build_app(workspace_id="w2", monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Create → persist
+# ---------------------------------------------------------------------------
+
+
+async def test_create_persists_active_rule(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/rules", json=_create_body("w1"))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "active"
+    assert body["when"] == "value > 500"
+    assert body["workspace_id"] == "w1"
+    assert body["id"]
+
+    # It persists as an active InstinctRuleDoc.
+    doc = await InstinctRuleDoc.find_one(InstinctRuleDoc.id == PydanticObjectId(body["id"]))
+    assert doc is not None
+    assert doc.status == "active"
+    assert doc.workspace == "w1"
+
+
+async def test_list_returns_active_rules_for_workspace(w1_client: AsyncClient) -> None:
+    await w1_client.post("/rules", json=_create_body("w1", name="rule-a"))
+    r = await w1_client.get("/rules")
+    assert r.status_code == 200, r.text
+    names = {row["name"] for row in r.json()}
+    assert names == {"rule-a"}
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_list_is_tenant_isolated(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    """A rule created in w1 is invisible to w2's list, and vice-versa."""
+    await w1_client.post("/rules", json=_create_body("w1", name="w1-secret"))
+    await w2_client.post("/rules", json=_create_body("w2", name="w2-secret"))
+
+    r1 = await w1_client.get("/rules")
+    r2 = await w2_client.get("/rules")
+    assert {row["name"] for row in r1.json()} == {"w1-secret"}
+    assert {row["name"] for row in r2.json()} == {"w2-secret"}
+
+
+async def test_create_rejects_cross_tenant_scope(w1_client: AsyncClient) -> None:
+    """A w1 caller cannot persist a rule scoped to w2 — the service's tenancy
+    assertion surfaces as a 400 CloudError, never a silent cross-tenant write."""
+    r = await w1_client.post("/rules", json=_create_body("w2"))
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "rule.workspace_mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Archive
+# ---------------------------------------------------------------------------
+
+
+async def test_archive_flips_rule_and_drops_from_list(w1_client: AsyncClient) -> None:
+    created = (await w1_client.post("/rules", json=_create_body("w1"))).json()
+    rule_id = created["id"]
+
+    r = await w1_client.post(f"/rules/{rule_id}/archive")
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "archived"
+
+    listed = (await w1_client.get("/rules")).json()
+    assert all(row["id"] != rule_id for row in listed)
+
+
+async def test_archive_cannot_reach_across_tenant(
+    w1_client: AsyncClient, w2_client: AsyncClient
+) -> None:
+    """w2 cannot archive a rule that lives in w1 — the tenant-scoped lookup
+    misses and returns a 400 not-found CloudError."""
+    created = (await w1_client.post("/rules", json=_create_body("w1"))).json()
+    r = await w2_client.post(f"/rules/{created['id']}/archive")
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "rule.not_found"
+
+
+# ---------------------------------------------------------------------------
+# Enforcement toggle round-trip
+# ---------------------------------------------------------------------------
+
+
+async def test_enforcement_get_defaults_and_put_sets_override(w1_client: AsyncClient) -> None:
+    # Fresh workspace → no override, effective == global default (False).
+    g = await w1_client.get("/rules/enforcement")
+    assert g.status_code == 200, g.text
+    assert g.json() == {
+        "workspace_id": "w1",
+        "enforce_discovered_rules": False,
+        "override": None,
+        "global_default": False,
+    }
+
+    # PUT enabled=true → override wins, effective True even though global is False.
+    p = await w1_client.put("/rules/enforcement", json={"enabled": True})
+    assert p.status_code == 200, p.text
+    assert p.json()["override"] is True
+    assert p.json()["enforce_discovered_rules"] is True
+
+    # Clear the override (null) → back to inheriting the global default.
+    c = await w1_client.put("/rules/enforcement", json={"enabled": None})
+    assert c.status_code == 200, c.text
+    assert c.json()["override"] is None
+    assert c.json()["enforce_discovered_rules"] is False
+
+
+# ---------------------------------------------------------------------------
+# Auth / permission seams
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_auth_returns_401() -> None:
+    app = _build_app(workspace_id="w1", skip_auth_override=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        r = await client.get("/rules")
+        assert r.status_code == 401
+
+
+async def test_missing_rules_manage_permission_returns_403(monkeypatch) -> None:
+    app = _build_app(workspace_id="w1", permission_denier=True, monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        r = await client.get("/rules")
+        assert r.status_code == 403, r.text
+        assert r.json()["error"]["code"] == "workspace.insufficient_role"
+
+
+# Silence ruff unused-import nudge on fixture-composition helpers.
+_unused: tuple[Any, ...] = ()

--- a/tests/cloud/test_workspace_enforcement.py
+++ b/tests/cloud/test_workspace_enforcement.py
@@ -1,0 +1,245 @@
+# test_workspace_enforcement.py — per-workspace authored-rule enforcement toggle.
+# Created: 2026-07-09 (feat/instinct-guardrail-rules) — pins the PER-WORKSPACE
+# resolution of Instinct enforcement at the live gate:
+#   * A workspace override set True enforces authored rules even when the GLOBAL
+#     ``instinct_enforce_discovered_rules`` flag is OFF.
+#   * With NO override, the workspace inherits the global flag (OFF → inert,
+#     ON → enforced) — the pre-existing default is preserved.
+#   * A workspace override set False turns enforcement OFF even when the global
+#     flag is ON.
+#   * CRITICAL fail-OPEN: an enforcement-config read error yields NO enforcement
+#     (the gate proceeds on the template floor, a WARNING is logged, no raise) —
+#     a DB hiccup never blocks the gate.
+#
+# Harness mirrors test_discovered_rule_enforcement.py: it targets
+# ``instinct_dispatch.gate_action`` with a stubbed ``get_active_rules`` and the
+# REAL ``resolve_instinct`` composer. The per-workspace override is written
+# through the real ``rules.service.set_enforcement`` against the mongomock
+# ``mongo_db`` fixture; the global flag is flipped by monkeypatching
+# ``instinct_dispatch.get_settings``.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.pockets import instinct_dispatch
+from pocketpaw_ee.cloud.rules import service as rules_service
+
+from pocketpaw.bundled_templates import PocketTemplate
+from pocketpaw.config import get_settings
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+FROZEN_NOW = datetime(2026, 7, 9, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (minimal, copied from test_discovered_rule_enforcement.py)
+# ---------------------------------------------------------------------------
+
+
+def _template(action_name: str = "do_thing") -> PocketTemplate:
+    raw: dict = {
+        "schema_version": "2",
+        "name": "test-template",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "test fixture",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [{"field": "value", "widget": "number"}],
+        },
+        "actions": [
+            {
+                "name": action_name,
+                "label": "Do Thing",
+                "kind": "single-row",
+                "instinct_policy": "auto",
+            }
+        ],
+    }
+    return PocketTemplate.model_validate(raw)
+
+
+def _block_rule() -> dict:
+    return {
+        "id": "rule-1",
+        "workspace_id": "w1",
+        "owner_user_id": "u1",
+        "name": "discovered block",
+        "description": None,
+        "when": "value > 100",
+        "action": "block",
+        "status": "active",
+        "scope": {"workspace_id": "w1", "pocket_id": None, "object_type": None},
+        "confidence": 0.9,
+        "provenance": ["discovery"],
+        "created_at": None,
+        "updated_at": None,
+    }
+
+
+def _set_global(monkeypatch, *, enabled: bool) -> None:
+    """Flip the GLOBAL ``instinct_enforce_discovered_rules`` flag the gate reads."""
+    settings = get_settings()
+    object.__setattr__(settings, "instinct_enforce_discovered_rules", enabled)
+    monkeypatch.setattr(instinct_dispatch, "get_settings", lambda: settings)
+
+
+def _stub_active_rules(monkeypatch, rows: list[dict]) -> None:
+    async def _fake(workspace_id: str) -> list[dict]:  # noqa: ARG001
+        return list(rows)
+
+    monkeypatch.setattr(instinct_dispatch, "get_active_rules", _fake)
+
+
+async def _gate(template: PocketTemplate, *, row_context: dict[str, Any], workspace_id: str = "w1"):
+    return await instinct_dispatch.gate_action(
+        workspace_id=workspace_id,
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context=row_context,
+        workspace_context=None,
+        now=FROZEN_NOW,
+    )
+
+
+# ===========================================================================
+# Per-workspace override turns enforcement ON when the global flag is OFF.
+# ===========================================================================
+
+
+async def test_workspace_override_on_enforces_when_global_off(monkeypatch) -> None:
+    _set_global(monkeypatch, enabled=False)  # global OFF
+    await rules_service.set_enforcement("w1", "u1", True)  # per-workspace ON
+    _stub_active_rules(monkeypatch, [_block_rule()])
+
+    result = await _gate(_template(), row_context={"value": 999})
+
+    assert result.next_step == "blocked"
+    assert result.decision.verdict == "BLOCK"
+
+
+async def test_other_workspace_not_affected_by_w1_override(monkeypatch) -> None:
+    """Turning enforcement on for w1 leaves w2 (no override, global OFF) inert."""
+    _set_global(monkeypatch, enabled=False)
+    await rules_service.set_enforcement("w1", "u1", True)
+
+    called = {"n": 0}
+
+    async def _boom(workspace_id: str) -> list[dict]:  # noqa: ARG001
+        called["n"] += 1
+        raise AssertionError("get_active_rules must not be called for an un-enforced workspace")
+
+    monkeypatch.setattr(instinct_dispatch, "get_active_rules", _boom)
+
+    # w2 has no override and the global flag is OFF → no enforcement.
+    result = await _gate(_template(), row_context={"value": 999}, workspace_id="w2")
+
+    assert called["n"] == 0
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "EXECUTE"
+
+
+# ===========================================================================
+# No override → inherit the global flag (default preserved).
+# ===========================================================================
+
+
+async def test_no_override_global_off_is_inert(monkeypatch) -> None:
+    _set_global(monkeypatch, enabled=False)
+
+    called = {"n": 0}
+
+    async def _boom(workspace_id: str) -> list[dict]:  # noqa: ARG001
+        called["n"] += 1
+        raise AssertionError("get_active_rules must not be called when enforcement is off")
+
+    monkeypatch.setattr(instinct_dispatch, "get_active_rules", _boom)
+
+    result = await _gate(_template(), row_context={"value": 999})
+
+    assert called["n"] == 0
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "EXECUTE"
+
+
+async def test_no_override_global_on_enforces(monkeypatch) -> None:
+    _set_global(monkeypatch, enabled=True)  # global ON, no per-workspace override
+    _stub_active_rules(monkeypatch, [_block_rule()])
+
+    result = await _gate(_template(), row_context={"value": 999})
+
+    assert result.next_step == "blocked"
+    assert result.decision.verdict == "BLOCK"
+
+
+async def test_workspace_override_off_beats_global_on(monkeypatch) -> None:
+    """A workspace can opt OUT even when the global flag is ON."""
+    _set_global(monkeypatch, enabled=True)
+    await rules_service.set_enforcement("w1", "u1", False)  # force OFF for w1
+    _stub_active_rules(monkeypatch, [_block_rule()])
+
+    result = await _gate(_template(), row_context={"value": 999})
+
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "EXECUTE"
+
+
+# ===========================================================================
+# CRITICAL — fail-OPEN: a config read error never blocks the gate.
+# ===========================================================================
+
+
+async def test_enforcement_config_read_error_fails_open(monkeypatch, caplog) -> None:
+    """If the per-workspace override read raises, enforcement resolves to OFF
+    (no enforcement), the gate proceeds on the template floor, a WARNING is
+    logged, and NOTHING is raised — even with the global flag ON."""
+    _set_global(monkeypatch, enabled=True)
+
+    async def _raise(workspace_id: str) -> Any:  # noqa: ARG001
+        raise RuntimeError("mongo is down")
+
+    monkeypatch.setattr(instinct_dispatch, "get_enforcement_override", _raise)
+
+    async def _boom(workspace_id: str) -> list[dict]:  # noqa: ARG001
+        raise AssertionError("get_active_rules must not be called when the config read fails open")
+
+    monkeypatch.setattr(instinct_dispatch, "get_active_rules", _boom)
+
+    with caplog.at_level("WARNING"):
+        result = await _gate(_template(), row_context={"value": 999})
+
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "EXECUTE"
+    assert any("enforcement" in r.message.lower() for r in caplog.records)
+
+
+# ===========================================================================
+# Unit — the _enforcement_enabled resolver in isolation.
+# ===========================================================================
+
+
+async def test_enforcement_enabled_resolution_matrix(monkeypatch) -> None:
+    # override True → True regardless of global
+    _set_global(monkeypatch, enabled=False)
+    await rules_service.set_enforcement("w1", "u1", True)
+    assert await instinct_dispatch._enforcement_enabled("w1") is True
+
+    # override False → False regardless of global
+    _set_global(monkeypatch, enabled=True)
+    await rules_service.set_enforcement("w1", "u1", False)
+    assert await instinct_dispatch._enforcement_enabled("w1") is False
+
+    # no override → inherit global (True here, distinct workspace)
+    _set_global(monkeypatch, enabled=True)
+    assert await instinct_dispatch._enforcement_enabled("w-none") is True
+
+    _set_global(monkeypatch, enabled=False)
+    assert await instinct_dispatch._enforcement_enabled("w-none") is False


### PR DESCRIPTION
The API and per-tenant switch behind the guardrail authoring UI (instinct-guardrail-ux C1 backend). The enforcement engine already ships and is tested — a UI-authored active rule already flows through `resolve_instinct` — so this is the thin HTTP surface over `rules.service` plus a per-workspace enforcement flip, with no new gate logic.

## What changed
- New `rules/router.py` — thin, workspace-scoped, admin-gated (`rules.manage`) endpoints over the shipped service:
  - `POST /rules` create · `GET /rules` list-active · `POST /rules/{id}/archive`
  - `GET` / `PUT /rules/enforcement` — the per-workspace enforcement toggle (declared before `/{id}` so `/enforcement` is not captured as a rule id). Mounted in `cloud/__init__.py`.
- Per-workspace enforcement: `instinct_enforce_discovered_rules` was a single global flag. A new `InstinctWorkspaceConfig` override lets an admin turn authored-rule enforcement on for one tenant without a code change. `instinct_dispatch` now resolves via `_enforcement_enabled(workspace_id)` — the tri-state override (true/false) wins, else the global flag.
- The override read is **fail-open**: a config/DB read error yields no enforcement, logs, and never blocks the gate — the same rail the existing rule-load uses. Enforcement can only ever add a block, so "no enforcement" is the safe direction when the override is unreadable.

## Deliberately deferred
- The frontend `GuardrailsPanel` (object/property/operator → CEL authoring) is the next slice.
- The 3-step LLM composer (Criterion 2) is a later, separate slice.

## Tests
- `test_rules_router.py` + `test_workspace_enforcement.py` (16 new): create/list/archive with tenant isolation + auth; the per-workspace override enforces when the global flag is off, falls back to the global default, and fails open on a read error. 30 pass across these plus the existing discovered-rule enforcement test (no regression). Both import-linter configs green (including OSS-cannot-import-EE); ruff clean.

Please review; hold the merge.