### PR TITLE
feat(sites): surface each site's engine on the gallery wire (SR-9)

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -1659,6 +1659,41 @@ async def patterns_for_pockets(workspace_id: str, pocket_ids: list[str]) -> dict
     return {str(row["_id"]): row.get("pattern") for row in rows}
 
 
+async def engines_for_pockets(workspace_id: str, pocket_ids: list[str]) -> dict[str, str | None]:
+    """Map each given ``pocket_id`` to its ``Pocket.engine`` in ONE query.
+
+    The sibling of ``patterns_for_pockets`` (DS-1a): the sites service surfaces a
+    published site's authoring ``engine`` ("svelte" | "ripple") on its list/status
+    responses (SR-9) so the gallery can badge each card's engine WITHOUT a second
+    per-site fetch. The engine lives on the source Pocket, not the Site, so this is
+    the cross-entity read — the Pocket read stays here (the sole owner of Pocket
+    reads, entity isolation), exactly like the pattern resolution.
+
+    ONE ``$in`` query projected to ``_id`` + ``engine`` only, tenant-scoped on
+    ``workspace`` (a pocket in another workspace is not returned even if its id is
+    passed). Keyed by the wire-string ``pocket_id``; a doc that predates the
+    ``engine`` field is absent from its projection and reads ``None`` (the caller
+    defaults it to ""), and an id with no matching pocket (deleted / cross-tenant /
+    malformed) is simply absent from the map. Malformed ids that cannot cast to an
+    ObjectId are skipped; an empty list is a no-op (empty map)."""
+    if not pocket_ids:
+        return {}
+    oids: list[PydanticObjectId] = []
+    for pid in pocket_ids:
+        try:
+            oids.append(PydanticObjectId(pid))
+        except (InvalidId, TypeError, ValueError):
+            continue
+    if not oids:
+        return {}
+    collection = _PocketDoc.get_pymongo_collection()
+    rows = await collection.find(
+        {"workspace": workspace_id, "_id": {"$in": oids}},
+        {"_id": 1, "engine": 1},
+    ).to_list(length=None)
+    return {str(row["_id"]): row.get("engine") for row in rows}
+
+
 async def get(pocket_id: str, user_id: str) -> dict:
     """Get a single pocket. Access check: owner, team member, shared_with,
     or workspace-visible.

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -101,6 +101,10 @@
 # ``paw-edit-manifest`` script); ``css`` is the built stylesheet(s) concatenated into
 # one string. The native editor injects both into a shadow root to render the site
 # natively instead of framing an iframe.
+# Updated 2026-07-09 (SR-9 — surface each site's ENGINE): ``SiteResponse`` and
+# ``SiteStatusResponse`` gain ``engine`` ("svelte" | "ripple"; "" when unresolved) —
+# the sibling of DS-1a's ``pattern``, resolved from the source Pocket.engine so the
+# gallery can badge each card's engine (Custom vs Ripple) without a per-site fetch.
 
 from __future__ import annotations
 
@@ -147,6 +151,12 @@ class SiteResponse(BaseModel):
     # the pocket has no pattern or could not be resolved. Lets the frontend badge
     # dynamic sites in the gallery without a second fetch.
     pattern: str = ""
+    # SR-9: the source pocket's authoring engine ("svelte" | "ripple"), resolved
+    # from Pocket.engine (it lives on the pocket, not the Site) — the sibling of
+    # ``pattern`` above. Lets the gallery badge each card's engine (Custom vs
+    # Ripple) without a second per-site fetch. "" when the pocket predates the
+    # engine field or could not be resolved (the card shows no engine badge).
+    engine: str = ""
     # charge-first: the Dodo annual-checkout link for a PAID-tier publish. A paid
     # publish creates the site as PENDING (deployed=False) and returns this link
     # the caller redirects the buyer to; the site deploys + goes live only after
@@ -206,6 +216,10 @@ class SiteStatusResponse(BaseModel):
     # the list response carries, so a by-pocket status read can badge a dynamic
     # site too.
     pattern: str = ""
+    # SR-9: the source pocket's authoring engine ("svelte" | "ripple"), resolved
+    # from Pocket.engine — the same field the list response carries, so a by-pocket
+    # status read can badge the engine too. "" when unresolved / pre-engine row.
+    engine: str = ""
 
 
 class SiteVersionResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -212,6 +212,15 @@
 # gained an optional ``pattern`` arg; both DTOs default it to "" (empty-safe for a
 # pocket with no pattern or a missing/cross-tenant pocket).
 #
+# Updated 2026-07-09 (SR-9 — surface each site's ENGINE): the sibling of DS-1a.
+# list_for_workspace() and pocket_status() now also carry the source pocket's
+# authoring ``engine`` ("svelte" | "ripple") so the gallery can badge each card's
+# engine (Custom vs Ripple) without a per-site fetch. Resolved via the new
+# pockets_service.engines_for_pockets (one projected $in read, tenant-scoped),
+# mirroring patterns_for_pockets. _to_response gained an optional ``engine`` arg;
+# both DTOs default it to "" (empty-safe for a pocket that predates the engine
+# field or a missing/cross-tenant pocket).
+#
 # Updated 2026-06-19 (P2b-backend — "Last Deployed" + revert endpoint): publish()
 # now stamps the Site doc's ``deployed_at`` (UTC) ONLY when a non-preview deploy
 # succeeds (when ``deployed`` flips True) — the true "last shipped" marker, not a
@@ -984,7 +993,7 @@ async def _promote_pocket_draft_to_published(
         )
 
 
-def _to_response(doc: _SiteDoc, pattern: str = "") -> SiteResponse:
+def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResponse:
     deployed_at = getattr(doc, "deployed_at", None)
     return SiteResponse(
         id=str(doc.id),
@@ -1004,6 +1013,10 @@ def _to_response(doc: _SiteDoc, pattern: str = "") -> SiteResponse:
         # ...), resolved by the caller from Pocket.pattern (it lives on the pocket,
         # not the Site). "" when unset / unresolved so the gallery is empty-safe.
         pattern=pattern,
+        # SR-9: the source pocket's authoring engine ("svelte" | "ripple"),
+        # resolved by the caller from Pocket.engine (sibling of pattern above). ""
+        # when unresolved, so the gallery's engine badge is empty-safe.
+        engine=engine,
         # charge-first: the Dodo checkout link a PAID-tier publish returns, read
         # from the transient ``_checkout_url`` PrivateAttr (never persisted). None
         # for a free/live publish and for any list/status read (those docs are
@@ -3181,13 +3194,16 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
     # no deployed site or the doc predates the field (a pre-P2b row).
     deployed_at = getattr(doc, "deployed_at", None) if doc is not None else None
 
-    # DS-1a: resolve the source pocket's authoring pattern so a by-pocket status
-    # read can badge a dynamic site too. ONE read, tenant-scoped; "" when the
-    # pocket has no pattern or could not be resolved (empty-safe).
+    # DS-1a/SR-9: resolve the source pocket's authoring pattern + engine so a
+    # by-pocket status read can badge a dynamic site AND its engine too. Each is
+    # ONE read, tenant-scoped; "" when the pocket has no value or could not be
+    # resolved (empty-safe).
     from pocketpaw_ee.cloud.pockets import service as pockets_service
 
     patterns = await pockets_service.patterns_for_pockets(workspace_id, [pocket_id])
     pattern = patterns.get(pocket_id) or ""
+    engines = await pockets_service.engines_for_pockets(workspace_id, [pocket_id])
+    engine = engines.get(pocket_id) or ""
 
     return SiteStatusResponse(
         pocket_id=pocket_id,
@@ -3201,6 +3217,7 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
         url=(doc.url or None) if doc is not None else None,
         deployed_at=deployed_at.isoformat() if deployed_at is not None else None,
         pattern=pattern,
+        engine=engine,
     )
 
 
@@ -3353,15 +3370,24 @@ async def list_for_workspace(workspace_id: str) -> list[SiteResponse]:
         -_SiteDoc.createdAt
     )  # type: ignore[operator]
     docs = [doc async for doc in cursor]
-    # ONE cross-entity read for every card's pattern (no per-site fetch). The
-    # Pocket read stays in the pockets service (entity isolation) — this service
-    # never imports the Pocket model.
+    # ONE cross-entity read per field for every card's pattern + engine (no
+    # per-site fetch). The Pocket reads stay in the pockets service (entity
+    # isolation) — this service never imports the Pocket model. SR-9 adds the
+    # engine resolution alongside DS-1a's pattern; each is a single projected
+    # $in query keyed on the listed pockets.
     from pocketpaw_ee.cloud.pockets import service as pockets_service
 
-    patterns = await pockets_service.patterns_for_pockets(
-        workspace_id, [doc.pocket_id for doc in docs]
-    )
-    return [_to_response(doc, patterns.get(doc.pocket_id) or "") for doc in docs]
+    pocket_ids = [doc.pocket_id for doc in docs]
+    patterns = await pockets_service.patterns_for_pockets(workspace_id, pocket_ids)
+    engines = await pockets_service.engines_for_pockets(workspace_id, pocket_ids)
+    return [
+        _to_response(
+            doc,
+            patterns.get(doc.pocket_id) or "",
+            engines.get(doc.pocket_id) or "",
+        )
+        for doc in docs
+    ]
 
 
 async def site_pocket_ids(workspace_id: str) -> set[str]:

--- a/tests/ee/sites/test_engine_field.py
+++ b/tests/ee/sites/test_engine_field.py
@@ -1,0 +1,163 @@
+# tests/ee/sites/test_engine_field.py — SR-9: a published site surfaces its
+# SOURCE pocket's authoring ``engine`` ("svelte" | "ripple") on the sites-list
+# (list_for_workspace) and the by-pocket status (pocket_status) responses, so the
+# gallery can badge each card's engine (Custom vs Ripple) without a second fetch.
+#
+# The engine lives on Pocket.engine, not the Site, so the service resolves it via
+# pockets_service.engines_for_pockets — the sibling of DS-1a's patterns_for_pockets
+# (see test_pattern_field.py, which this mirrors). These tests seed a REAL Pocket
+# doc (so its ObjectId can be matched), publish a Site whose pocket_id == that doc's
+# id, and assert the response carries the pocket's engine. Empty-safe cases
+# (missing pocket) read "".
+#
+# Created: 2026-07-09 (feat/sites-engine-field, SR-9).
+from __future__ import annotations
+
+import pytest
+from bson import ObjectId
+from pocketpaw_ee.sites import service as sites_service
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakeCF:
+    def __init__(self):
+        self.put_calls = []
+
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        self.put_calls.append(script_name)
+        return True
+
+
+async def _seed_pocket(*, workspace_id: str, owner: str, name: str, engine: str) -> str:
+    """Insert a real Pocket doc with the given engine and return its id (the
+    wire-string ObjectId). Returns the id so the published Site's ``pocket_id`` can
+    point at it — the engine resolution matches on the Pocket's ``_id``."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(
+        workspace=workspace_id,
+        name=name,
+        owner=owner,
+        type="site",
+        engine=engine,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _publish_for_pocket(*, workspace_id: str, pocket_id: str) -> None:
+    """Publish a site for an existing pocket. ``name`` is passed explicitly so
+    publish does not try to read the pocket through the full access path."""
+    await sites_service.publish(
+        workspace_id=workspace_id,
+        user_id="u1",
+        pocket_id=pocket_id,
+        ripple_spec={"type": "container"},
+        theme={},
+        name="x",
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_for_workspace_surfaces_svelte_engine(beanie_test_db):
+    """A site published from a pocket with engine="svelte" lists with
+    engine == "svelte"."""
+    pocket_id = await _seed_pocket(
+        workspace_id="ws1", owner="u1", name="Custom Site", engine="svelte"
+    )
+    await _publish_for_pocket(workspace_id="ws1", pocket_id=pocket_id)
+
+    sites = await sites_service.list_for_workspace("ws1")
+
+    assert len(sites) == 1
+    assert sites[0].pocket_id == pocket_id
+    assert sites[0].engine == "svelte"
+
+
+@pytest.mark.asyncio
+async def test_list_for_workspace_distinguishes_engines(beanie_test_db):
+    """A svelte and a ripple site in the same workspace each surface their own
+    source pocket's engine — the field is per-card, resolved from the pocket."""
+    svelte = await _seed_pocket(workspace_id="ws1", owner="u1", name="Custom", engine="svelte")
+    ripple = await _seed_pocket(workspace_id="ws1", owner="u1", name="Marketing", engine="ripple")
+    await _publish_for_pocket(workspace_id="ws1", pocket_id=svelte)
+    await _publish_for_pocket(workspace_id="ws1", pocket_id=ripple)
+
+    by_pocket = {s.pocket_id: s.engine for s in await sites_service.list_for_workspace("ws1")}
+
+    assert by_pocket[svelte] == "svelte"
+    assert by_pocket[ripple] == "ripple"
+
+
+@pytest.mark.asyncio
+async def test_list_for_workspace_empty_safe_when_pocket_missing(beanie_test_db):
+    """A site whose source pocket no longer exists (deleted, or a non-ObjectId
+    pocket_id) reads "" for engine rather than crashing the list."""
+    await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="not-an-objectid",  # cannot resolve to a Pocket doc
+        ripple_spec={"type": "container"},
+        theme={},
+        name="x",
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+
+    sites = await sites_service.list_for_workspace("ws1")
+
+    assert len(sites) == 1
+    assert sites[0].engine == ""
+
+
+@pytest.mark.asyncio
+async def test_pocket_status_surfaces_engine(beanie_test_db):
+    """The by-pocket status read carries the source pocket's engine too, so a
+    builder/gallery status fetch can badge the engine."""
+    pocket_id = await _seed_pocket(workspace_id="ws1", owner="u1", name="Custom", engine="svelte")
+    await _publish_for_pocket(workspace_id="ws1", pocket_id=pocket_id)
+
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id=pocket_id)
+
+    assert res.engine == "svelte"
+
+
+@pytest.mark.asyncio
+async def test_pocket_status_engine_is_tenant_scoped(beanie_test_db):
+    """A pocket's engine does not leak across workspaces: a foreign workspace's
+    status read for the same pocket id reads "" (the batch read is workspace-
+    scoped)."""
+    pocket_id = await _seed_pocket(
+        workspace_id="ws_owner", owner="u1", name="Private", engine="svelte"
+    )
+    await _publish_for_pocket(workspace_id="ws_owner", pocket_id=pocket_id)
+
+    res = await sites_service.pocket_status(workspace_id="ws_intruder", pocket_id=pocket_id)
+
+    assert res.engine == ""
+
+
+@pytest.mark.asyncio
+async def test_engines_for_pockets_batch_read(beanie_test_db):
+    """The pockets-service helper returns a {pocket_id: engine} map in one read,
+    tenant-scoped, with missing/cross-tenant ids simply absent."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    a = await _seed_pocket(workspace_id="ws1", owner="u1", name="A", engine="svelte")
+    b = await _seed_pocket(workspace_id="ws1", owner="u1", name="B", engine="ripple")
+    other = await _seed_pocket(workspace_id="ws2", owner="u1", name="C", engine="svelte")
+    missing = str(ObjectId())
+
+    out = await pockets_service.engines_for_pockets("ws1", [a, b, other, missing, "garbage"])
+
+    assert out == {a: "svelte", b: "ripple"}


### PR DESCRIPTION
## What

The Sites gallery is about to badge each card by its authoring engine — Custom (Svelte) vs Ripple — so an operator can tell at a glance how a site was built. The list wire didn't carry that signal, so this adds it.

The engine lives on the source `Pocket.engine`, not the `Site`. This resolves it exactly the way DS-1a resolved `pattern`:

- New `pockets_service.engines_for_pockets(workspace_id, pocket_ids)` — one projected, tenant-scoped `$in` read, sibling to `patterns_for_pockets`.
- `list_for_workspace` and `pocket_status` attach the resolved engine per card.
- `SiteResponse` and `SiteStatusResponse` gain an `engine` field.

`engine` defaults to `""`, so a pocket that predates the field, or one that can't be resolved (deleted / cross-tenant / malformed id), stays empty-safe and the card simply shows no engine badge.

## Why this shape

The pattern precedent (DS-1a) already established that gallery badges read a backend-resolved field off the source pocket in one batch read — no per-card fetch, no N+1. Engine is the same problem, so it gets the same solution rather than a new one.

## Tests

`tests/ee/sites/test_engine_field.py` mirrors `test_pattern_field.py`: svelte and ripple sites each surface their own engine, the batch read is tenant-scoped, a missing pocket reads `""`, and the by-pocket status carries it too.

Full sites suite green (309 passed). The frontend badge + create-entry work lands separately in paw-enterprise.

> Note for local runs: `tests/ee/sites` publish tests assume `PAW_CF_DEPLOY_MODE` is unset (as in CI). A local `.env` that pins it to `workers` routes the stubbed publish down the real workers-deploy path and fails unrelated assertions — run these with the var cleared.