### PR TITLE
feat(sites): provision_site durable job for dynamic Paw Sites

### DIFF
--- a/ee/pocketpaw_ee/cloud/jobs/builtin/__init__.py
+++ b/ee/pocketpaw_ee/cloud/jobs/builtin/__init__.py
@@ -4,17 +4,21 @@
 # `init_realtime()`. Built-ins are registered into the process-wide registry
 # at mount time (the same lifecycle the outcomes-ledger / upload listeners
 # use). Adding a new built-in = add it to the list here.
+# Updated: 2026-07-09 (feat/dp0-provision-job, DP0-3) — registered the durable
+# ``provision_site`` job (create D1 → build → migrate → deploy → mark provisioned)
+# so DP0-4 can dispatch it from the dynamic-site publish path.
 
 """Built-in workspace jobs + their mount-time registration."""
 
 from __future__ import annotations
 
+from pocketpaw_ee.cloud.jobs.builtin.provision_site import ProvisionSiteJob
 from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
 from pocketpaw_ee.cloud.jobs.registry import register_job
 
 # The built-ins to register at mount time. Instantiated once; jobs are
 # stateless callables so a single instance is reused for every run.
-_BUILTINS = (ScoreApplicationsJob(),)
+_BUILTINS = (ScoreApplicationsJob(), ProvisionSiteJob())
 
 
 def register_builtins() -> None:

--- a/ee/pocketpaw_ee/cloud/jobs/builtin/provision_site.py
+++ b/ee/pocketpaw_ee/cloud/jobs/builtin/provision_site.py
@@ -1,0 +1,121 @@
+# ee/pocketpaw_ee/cloud/jobs/builtin/provision_site.py
+# Created: 2026-07-09 (feat/dp0-provision-job, DP0-3) — the durable job that takes a
+# Dynamic Paw Site from spec to live. A dynamic site can't reach a database until
+# this runs: it CREATES the per-tenant Cloudflare D1, BUILDS the site with the real
+# database id baked into the emitted wrangler.toml, APPLIES the D1 migration, DEPLOYS
+# the Worker with a D1 binding, and MARKS the Site doc provisioned.
+#
+# Each step is create-before-build ordered and idempotent/resumable:
+#   a. load the Site + the pocket's rippleSpec; fail-closed tenancy re-check (the
+#      worker already re-checks, this is defense-in-depth) — no dynamic site/spec
+#      fails cleanly.
+#   b. create_database GUARDED on Site.d1_database_id: reuse an already-stored id;
+#      else create it and persist the id IMMEDIATELY (status stays ``provisioning``)
+#      so a retry reuses the same D1 and never orphans a second one.
+#   c. build the site through the sites-service seam, passing the real d1 id.
+#   d. apply the D1 migration via the wrangler-migrate helper against the built
+#      project dir.
+#   e. put_worker with the D1 binding (same dynamic deploy as _deploy_site_doc).
+#   f. finalize the Site doc (provisioned + deployed + url); on ANY failure in b–f
+#      mark provision_status="failed" (the id already persisted) and re-raise so the
+#      worker marks the job failed and un-hangs the button.
+#   g. return a STATE-ONLY partial for the builder pocket's UI (the writeback path
+#      accepts only ``state``).
+#
+# The Beanie Site reads/writes funnel through ``sites.service`` seams (the
+# import-linter keeps this builtin off the Beanie doc); the build + deploy mechanics
+# reuse ``_deploy_site_doc``'s helpers rather than duplicating put_worker/build.
+
+"""Built-in ``provision_site`` job: stand up a Dynamic Paw Site's D1 data plane."""
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import d1_migrate
+from pocketpaw_ee.sites import service as sites_service
+
+
+class ProvisionError(RuntimeError):
+    """A clean, PII-free provision failure. The worker surfaces ``str(exc)`` into
+    broadcast state, so these messages are fixed, safe strings — never raw external
+    text or tenant data."""
+
+
+class ProvisionSiteJob:
+    """Provision a Dynamic Paw Site's D1 data plane and take it live.
+
+    Runs under the workspace service identity. Returns a STATE-ONLY partial spec —
+    the WORKER owns the ``<action>_status`` flag, so this returns only its domain
+    state (the provision outcome), never a status key."""
+
+    name = "provision_site"
+
+    async def __call__(
+        self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
+    ) -> dict:
+        # a. Fail-closed tenancy re-check (mirrors worker.py) — the Site-doc seams
+        # fetch by (workspace, pocket) and trust the workspace we hand them, so
+        # re-assert the pocket actually lives in this workspace BEFORE any create /
+        # build / deploy / write.
+        pocket_workspace = await pockets_service.get_pocket_workspace(pocket_id)
+        if pocket_workspace != workspace_id:
+            raise ProvisionError("tenancy mismatch: pocket is not in the job's workspace")
+
+        ripple_spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
+        if not ripple_spec:
+            raise ProvisionError("no rippleSpec for pocket — cannot provision a dynamic site")
+
+        site = await sites_service.load_provision_site(workspace_id, pocket_id)
+        if site is None:
+            raise ProvisionError("no Site doc to provision — publish the site first")
+
+        site_id = str(site.id)
+        cf = sites_service.provision_cf_client()
+
+        try:
+            # b. create_database GUARDED on the stored id. Reuse an existing D1;
+            # else create one and persist the id IMMEDIATELY (status stays
+            # ``provisioning``) so a retry reuses it — never orphan a second D1.
+            existing_id = (getattr(site, "d1_database_id", "") or "").strip()
+            if existing_id:
+                d1_database_id = existing_id
+            else:
+                d1_database_id = await cf.create_database(d1_migrate.database_name(site_id))
+                await sites_service.persist_provision_d1_id(site, d1_database_id)
+
+            # c. Build with the real d1 id baked into the emitted wrangler.toml.
+            project_dir, bundle = await sites_service.build_provision_bundle(
+                site=site,
+                ripple_spec=ripple_spec,
+                d1_database_id=d1_database_id,
+            )
+
+            # d. Apply the D1 migration against the built project (wrangler reads the
+            # baked-in database_id from the toml — no --database-id flag).
+            await d1_migrate.apply_migrations(site_id, project_dir)
+
+            # e. Deploy the Worker with its D1 binding (same as _deploy_site_doc's
+            # dynamic bind).
+            await cf.put_worker(
+                script_name=site_id,
+                bundle=bundle,
+                bindings=sites_service.provision_d1_bindings(d1_database_id),
+            )
+
+            # f. Mark the Site doc provisioned + live.
+            await sites_service.finalize_provisioned_site(
+                site, url=sites_service.provision_site_url(site_id)
+            )
+        except Exception:
+            # Any failure in b–f: mark failed (the d1 id, if created, is already
+            # persisted so a retry reuses it) and re-raise so the worker marks the
+            # job failed and writes the failed-state marker that un-hangs the button.
+            await sites_service.mark_provision_failed(site)
+            raise
+
+        # g. State-only partial for the builder pocket's UI (writeback accepts only
+        # ``state``; the worker stamps the generic ``<action>_status`` flag itself).
+        return {"state": {"provision_status": "done"}}
+
+
+__all__ = ["ProvisionSiteJob", "ProvisionError"]

--- a/ee/pocketpaw_ee/sites/d1_migrate.py
+++ b/ee/pocketpaw_ee/sites/d1_migrate.py
@@ -1,0 +1,150 @@
+# ee/pocketpaw_ee/sites/d1_migrate.py — apply a Dynamic Paw Site's D1 migration
+# with wrangler (DP0-3).
+#
+# Created: 2026-07-09 (feat/dp0-provision-job, DP0-3) — the wrangler-migrate step
+# of the durable ``provision_site`` job. After the generator emits a built dynamic
+# project (``wrangler.toml`` at the project root with the REAL ``database_id`` baked
+# in at build time via ``d1DatabaseId``, and ``migrations/0001_init.sql`` as a
+# sibling matching wrangler's default ``migrations_dir``), this runs
+# ``wrangler d1 migrations apply paw-site-<siteId> --remote`` against that project
+# so the per-tenant D1 gets its schema. NO file patching and NO ``--database-id``
+# flag: the toml + migrations layout is spike-confirmed to match wrangler's
+# defaults, and the id is already baked into the toml at build time.
+#
+# It mirrors ``workers_deploy.deploy_workers``' auth + subprocess style exactly —
+# ``_wrangler_argv()`` (PAW_CF_WRANGLER_CMD, default ``bunx wrangler@4.101.0``) and
+# the CF creds passed through the env (``CLOUDFLARE_API_TOKEN`` /
+# ``CLOUDFLARE_ACCOUNT_ID`` off ``os.environ``) — and wraps the subprocess in the
+# generator_client reap machinery (``start_new_session=True`` + a bounded
+# ``_communicate_bounded`` that SIGKILLs the whole process group on timeout) so a
+# wedged wrangler can't hang the jobs worker. A non-zero exit / missing toolchain /
+# timeout raises the sites ``Internal`` contract with the stderr tail, so the
+# provision job's failure path marks the site ``failed`` and re-raises cleanly.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shlex
+
+from pocketpaw_ee.cloud._core.errors import Internal
+from pocketpaw_ee.sites.generator_client import _BuildTimeout, _communicate_bounded
+from pocketpaw_ee.sites.workers_deploy import _sanitize
+
+logger = logging.getLogger(__name__)
+
+# The pinned wrangler invocation — same override seam as workers_deploy so the
+# deploy image can pin / swap the wrangler version without a code change
+# (PAW_CF_WRANGLER_CMD, ``shlex.split``, default ``bunx wrangler@4.101.0``).
+_DEFAULT_WRANGLER_CMD = "bunx wrangler@4.101.0"
+
+# The migrate subprocess timeout. A legit ``d1 migrations apply`` is seconds; the
+# bound is a safety net so a wedged wrangler (e.g. a hung network pull) can't hang
+# the jobs worker unbounded. Override with PAW_CF_MIGRATE_TIMEOUT_SEC (int seconds).
+_DEFAULT_MIGRATE_TIMEOUT_SEC = 120
+
+
+def _wrangler_argv() -> list[str]:
+    """The wrangler invocation, tokenised. Default ``bunx wrangler@4.101.0``.
+    Override with PAW_CF_WRANGLER_CMD to pin a version or point at a baked binary —
+    the SAME seam workers_deploy uses, so migrate + deploy share one wrangler pin."""
+    return shlex.split(os.environ.get("PAW_CF_WRANGLER_CMD", _DEFAULT_WRANGLER_CMD))
+
+
+def _cf_env() -> dict[str, str]:
+    """The subprocess env for wrangler: the full current env (so PATH / HOME / bun
+    caches resolve) plus whatever CF creds it already carries
+    (``CLOUDFLARE_API_TOKEN`` / ``CLOUDFLARE_ACCOUNT_ID``). Mirrors
+    ``workers_deploy._cf_env``; the creds are NEVER logged."""
+    return dict(os.environ)
+
+
+def _migrate_timeout_sec() -> int:
+    """The migrate subprocess timeout in seconds (PAW_CF_MIGRATE_TIMEOUT_SEC, int,
+    default 120). A malformed / empty value falls back to the default rather than
+    raising — the timeout is a safety net and must never itself break a migrate."""
+    raw = os.environ.get("PAW_CF_MIGRATE_TIMEOUT_SEC")
+    if raw is None:
+        return _DEFAULT_MIGRATE_TIMEOUT_SEC
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "sites: ignoring non-int PAW_CF_MIGRATE_TIMEOUT_SEC=%r, using default %ds",
+            raw,
+            _DEFAULT_MIGRATE_TIMEOUT_SEC,
+        )
+        return _DEFAULT_MIGRATE_TIMEOUT_SEC
+
+
+def database_name(site_id: str) -> str:
+    """The D1 ``database_name`` the generator bakes into the project's wrangler.toml:
+    ``paw-site-<siteId>``. Sanitized identically to the worker name (shared
+    ``workers_deploy._sanitize``) so a non-ObjectId id can't yield an invalid
+    identifier; a 24-hex ObjectId passes through unchanged. ``wrangler d1 migrations
+    apply`` addresses the database by THIS name (it resolves the id from the toml),
+    so it must match the emitted ``database_name`` exactly. The provision job also
+    creates the CF-side database under this name, so create + migrate agree."""
+    return f"paw-site-{_sanitize(site_id)}"
+
+
+async def apply_migrations(site_id: str, project_dir: str) -> None:
+    """Apply a dynamic site's D1 migration via wrangler (DP0-3).
+
+    Runs ``wrangler d1 migrations apply paw-site-<siteId> --remote`` with
+    ``cwd=project_dir`` (the built project carrying wrangler.toml + migrations/) and
+    the CF creds in the env. The real ``database_id`` is already baked into the toml
+    at build time (``d1DatabaseId``) and the migrations dir matches wrangler's
+    default, so no ``--database-id`` flag and no file patching are needed.
+
+    The subprocess runs in its own session (``start_new_session=True``) and is bounded
+    by ``_communicate_bounded`` (PAW_CF_MIGRATE_TIMEOUT_SEC), which SIGKILLs the whole
+    process group on timeout so a wedged wrangler can't hang the jobs worker. A
+    missing toolchain, a timeout, or a non-zero exit raises ``Internal`` (→ a clean
+    5xx envelope) with the stderr tail — the provision job maps that to
+    ``provision_status="failed"`` and re-raises."""
+    db_name = database_name(site_id)
+    argv = [*_wrangler_argv(), "d1", "migrations", "apply", db_name, "--remote"]
+    timeout = _migrate_timeout_sec()
+    logger.info("sites.migrate: applying D1 migrations for %s via %s", db_name, argv[:-4])
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=project_dir,
+            env=_cf_env(),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+    except FileNotFoundError as exc:
+        # wrangler / bunx not on PATH — a misconfigured deploy image.
+        raise Internal(
+            "sites.migrate_wrangler_missing",
+            "The wrangler toolchain is unavailable — a D1 migrate needs wrangler "
+            "reachable (bunx pulls it at publish time).",
+        ) from exc
+    try:
+        stdout_b, stderr_b = await _communicate_bounded(proc, timeout, "d1-migrate")
+    except _BuildTimeout as exc:
+        raise Internal(
+            "sites.migrate_timeout",
+            f"D1 migrate timed out after {timeout}s and was killed.",
+        ) from exc
+    stdout = stdout_b.decode(errors="replace")
+    stderr = stderr_b.decode(errors="replace")
+    if proc.returncode != 0:
+        tail = (stderr or stdout)[-800:]
+        logger.error(
+            "sites.migrate: wrangler d1 migrations apply failed (exit %s): %s",
+            proc.returncode,
+            tail,
+        )
+        raise Internal(
+            "sites.migrate_failed",
+            f"wrangler d1 migrations apply failed (exit {proc.returncode}): {tail}",
+        )
+    logger.info("sites.migrate: applied D1 migrations for %s", db_name)
+
+
+__all__ = ["apply_migrations", "database_name"]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1559,6 +1559,131 @@ async def _canonical_site_doc(workspace_id: str, pocket_id: str) -> _SiteDoc | N
     return next((d for d in docs if d.url), docs[0])
 
 
+# ---------------------------------------------------------------------------
+# DP0-3 — durable ``provision_site`` job seams.
+#
+# The provision job (ee/pocketpaw_ee/cloud/jobs/builtin/provision_site.py) takes a
+# dynamic site from spec to live: create D1 → build (with the real id baked in) →
+# apply migration → deploy the Worker → mark provisioned. The job orchestrates the
+# steps (migrate sits BETWEEN build and deploy), so these are granular seams — the
+# Site-doc Beanie reads/writes funnel through THIS module (the import-linter
+# boundary keeps the builtin job off the Beanie doc), and the build/deploy
+# mechanics reuse ``_deploy_site_doc``'s exact helpers rather than duplicating them.
+# ---------------------------------------------------------------------------
+
+
+def provision_cf_client() -> Any:
+    """The Cloudflare client the provision job uses (create_database / put_worker).
+
+    Thin public wrapper over ``_cf_client()`` so the builtin job builds the real CF
+    client the SAME way ``_deploy_site_doc`` does, and tests can monkeypatch this one
+    seam to inject a fake client without importing the client class."""
+    return _cf_client()
+
+
+def provision_d1_bindings(d1_database_id: str) -> list[dict]:
+    """The Worker D1 binding list a provisioned dynamic site deploys with — a single
+    ``{"type": "d1", "name": "DB", "id": <database_id>}`` (``_D1_BINDING_NAME``), the
+    exact shape ``_deploy_site_doc`` passes ``put_worker`` on the dynamic path."""
+    return [{"type": "d1", "name": _D1_BINDING_NAME, "id": d1_database_id}]
+
+
+def provision_site_url(site_id: str) -> str:
+    """The public URL a provisioned dynamic site resolves to — the per-site subdomain
+    ``https://<site_id>.<PAW_CF_SITES_DOMAIN>`` when the sites domain is configured,
+    else "" (the Worker is uploaded + reachable via the dispatch worker once the
+    operator sets the domain). Mirrors ``_deploy_site_doc``'s WfP URL logic."""
+    import os
+
+    domain = os.environ.get("PAW_CF_SITES_DOMAIN", "").strip()
+    return f"https://{site_id}.{domain}" if domain else ""
+
+
+async def load_provision_site(workspace_id: str, pocket_id: str) -> _SiteDoc | None:
+    """The canonical Site doc the provision job operates on, or None. Resolves the
+    ONE canonical doc for (workspace, pocket_id) (``_canonical_site_doc``), so a
+    pre-PERF-1 pocket with legacy dupes still provisions the live one."""
+    return await _canonical_site_doc(workspace_id, pocket_id)
+
+
+async def persist_provision_d1_id(site: _SiteDoc, d1_database_id: str) -> None:
+    """Persist a freshly-created D1 id on the Site doc IMMEDIATELY (DP0-3 contract).
+
+    ``provision_status`` stays ``provisioning`` — only ``d1_database_id`` is stamped
+    — so a retry of the job REUSES this D1 instead of creating (and orphaning) a
+    second one. Called right after ``cf.create_database`` succeeds, before build /
+    migrate / deploy."""
+    site.d1_database_id = d1_database_id
+    site.provision_status = "provisioning"
+    await site.save()
+
+
+async def finalize_provisioned_site(site: _SiteDoc, *, url: str) -> None:
+    """Mark a Site doc fully provisioned after migrate + deploy succeed (DP0-3):
+    ``provision_status="provisioned"``, ``deployed=True``, stamp the live URL +
+    ``deployed_at``. The last write of the durable job's happy path."""
+    site.provision_status = "provisioned"
+    site.deployed = True
+    site.deployed_at = datetime.now(UTC)
+    site.url = url
+    await site.save()
+
+
+async def mark_provision_failed(site: _SiteDoc) -> None:
+    """Mark a Site doc's provision as failed (DP0-3). The ``d1_database_id`` already
+    persisted (``persist_provision_d1_id``) is LEFT in place so a retry reuses that
+    D1 — only ``provision_status`` flips to ``failed``."""
+    site.provision_status = "failed"
+    await site.save()
+
+
+async def build_provision_bundle(
+    *,
+    site: _SiteDoc,
+    ripple_spec: dict[str, Any] | None,
+    d1_database_id: str,
+    generator: GeneratorClient | None = None,
+) -> tuple[str, bytes]:
+    """Build a dynamic site with its REAL D1 id baked in; return ``(project_dir,
+    bundle)`` (DP0-3).
+
+    Reuses ``_deploy_site_doc``'s exact build assembly: it derives the theme from
+    the rippleSpec, runs the SSR-gated build through ``_build_or_cloud_error`` (so a
+    broken build maps to a clean CloudError, never an opaque 500), and reads the
+    Worker bundle via ``_default_bundle_reader``. ``d1_database_id`` rides
+    ``siteConfig.d1DatabaseId`` so the generator threads it into the emitted
+    wrangler.toml ``database_id`` — this is what makes the later ``wrangler d1
+    migrations apply`` and the Worker's D1 binding target the right database. The
+    caller applies migrations against ``project_dir`` (which carries wrangler.toml +
+    migrations/) BEFORE deploying ``bundle``. ``generator`` is the test-injection
+    seam; None uses a real ``GeneratorClient``."""
+    gen = generator or GeneratorClient()
+    theme = (ripple_spec.get("theme") if isinstance(ripple_spec, dict) else {}) or {}
+    site_id = str(site.id)
+    build = await _build_or_cloud_error(
+        gen,
+        ripple_spec=ripple_spec,
+        theme=theme,
+        site_id=site_id,
+        title=site.name or "Untitled site",
+        capture_api_base=_capture_base(),
+        capture_signed_key=site.signed_key,
+        # A dynamic Paw Site is authored as a ripple site carrying live bindings
+        # (objects / sources / actions / auth) — the create-dynamic-site path.
+        engine="ripple",
+        source=None,
+        builder_origin=site.builder_origin or None,
+        # DP0-3: the REAL D1 uuid, baked into the emitted wrangler.toml.
+        d1_database_id=d1_database_id,
+        pocket_id=site.pocket_id,
+        # A live provision keeps the SSR fail-gate on — a broken site is rejected
+        # before it deploys (same as _deploy_site_doc).
+        smoke=True,
+    )
+    bundle = _default_bundle_reader(build.project_dir)
+    return build.project_dir, bundle
+
+
 async def add_domain(
     *,
     workspace_id: str,

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -508,6 +508,10 @@ source_modules = [
     "pocketpaw_ee.cloud.jobs.plugins",
     "pocketpaw_ee.cloud.jobs.worker",
     "pocketpaw_ee.cloud.jobs.builtin.score_applications",
+    # DP0-3 — the durable D1 provision job. Its Beanie Site reads/writes funnel
+    # through ``sites.service`` seams (it never imports the Site or WorkspaceJob
+    # doc directly).
+    "pocketpaw_ee.cloud.jobs.builtin.provision_site",
 ]
 forbidden_modules = ["pocketpaw_ee.cloud.models.workspace_job"]
 

--- a/tests/cloud/jobs/test_provision_site.py
+++ b/tests/cloud/jobs/test_provision_site.py
@@ -1,0 +1,259 @@
+# tests/cloud/jobs/test_provision_site.py
+# Created: 2026-07-09 (feat/dp0-provision-job, DP0-3) — integration coverage for the
+# durable ``provision_site`` job, mirroring the jobs tests' pytest-asyncio + mongo_db
+# conventions. Externals are mocked (CF client's create_database / put_worker, the
+# GeneratorClient build via the sites-service build seam, and the wrangler-migrate
+# helper); the REAL Site-doc seams + real pockets-service reads run against the
+# in-memory mongomock DB so the persistence contract is asserted for real.
+#
+# Pins the DP0-3 acceptance criteria:
+#   * guarded create is a NO-OP when Site.d1_database_id is already set (create_database
+#     not called, the stored id is reused for build + binding);
+#   * a mid-job failure (migrate raises) leaves provision_status == "failed" AND the
+#     freshly-created d1_database_id persisted — proving a retry reuses that D1 and
+#     never orphans a second one;
+#   * success writes provision_status="provisioned" + deployed=True to the Site doc
+#     and returns the state-only partial {"state": {"provision_status": "done"}};
+#   * the job is registered under the name "provision_site".
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud.jobs.builtin import register_builtins
+from pocketpaw_ee.cloud.jobs.builtin.provision_site import ProvisionSiteJob
+from pocketpaw_ee.cloud.jobs.registry import resolve_job
+from pocketpaw_ee.sites import d1_migrate
+from pocketpaw_ee.sites import service as sites_service
+
+WS = "ws-provision-1"
+OTHER_WS = "ws-provision-2"
+
+
+class _FakeCF:
+    """A stand-in Cloudflare client recording its create_database / put_worker calls.
+
+    ``create_database`` returns a fixed fresh uuid; ``put_worker`` records the bindings
+    so a test can assert the D1 id threaded into the deploy binding."""
+
+    def __init__(self, new_id: str = "d1-fresh-uuid-0001") -> None:
+        self.new_id = new_id
+        self.create_calls: list[str] = []
+        self.put_calls: list[dict[str, Any]] = []
+
+    async def create_database(self, name: str) -> str:
+        self.create_calls.append(name)
+        return self.new_id
+
+    async def put_worker(self, *, script_name: str, bundle: bytes, bindings: Any) -> bool:
+        self.put_calls.append({"script_name": script_name, "bundle": bundle, "bindings": bindings})
+        return True
+
+
+@pytest_asyncio.fixture
+async def seed(mongo_db: Any):
+    """Insert a real dynamic Pocket + its canonical Site doc, return a small context.
+
+    The Site is created at the STABLE per-(workspace, pocket) id (the same identity a
+    live publish upserts), in ``provision_status="provisioning"`` — the state the job
+    picks up. ``d1_database_id`` is caller-chosen so a test can exercise the guarded
+    (already-provisioned) branch or the fresh-create branch."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+    from pocketpaw_ee.cloud.models.site import Site
+
+    async def _seed(
+        *, workspace: str = WS, d1_database_id: str = ""
+    ) -> dict[str, Any]:
+        spec = {
+            "theme": {"mode": "light"},
+            "objects": [{"name": "entries", "fields": [{"name": "msg"}]}],
+            "sources": [{"name": "list_entries"}],
+            "actions": [{"name": "add_entry"}],
+        }
+        pocket = Pocket(workspace=workspace, name="Guestbook", owner="owner-1", rippleSpec=spec)
+        await pocket.insert()
+        pocket_id = str(pocket.id)
+
+        site = Site(
+            id=sites_service._live_object_id(workspace, pocket_id),
+            workspace=workspace,
+            pocket_id=pocket_id,
+            owner="owner-1",
+            name="Guestbook",
+            signed_key="site_key_test",
+            provision_status="provisioning",
+            d1_database_id=d1_database_id,
+        )
+        await site.insert()
+        return {"pocket_id": pocket_id, "site_id": str(site.id), "spec": spec}
+
+    return _seed
+
+
+def _install_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    cf: _FakeCF,
+    migrate_raises: Exception | None = None,
+) -> dict[str, list]:
+    """Monkeypatch the three externals — the CF client, the build seam, and the
+    wrangler-migrate helper — and return a record of the build-seam calls so a test
+    can assert the D1 id threaded into the build."""
+    build_calls: list[dict[str, Any]] = []
+    migrate_calls: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(sites_service, "provision_cf_client", lambda: cf)
+
+    async def _fake_build(*, site: Any, ripple_spec: Any, d1_database_id: str, **_kw: Any):
+        build_calls.append({"site_id": str(site.id), "d1_database_id": d1_database_id})
+        return "/fake/project/dir", b"worker-bundle-bytes"
+
+    monkeypatch.setattr(sites_service, "build_provision_bundle", _fake_build)
+
+    async def _fake_migrate(site_id: str, project_dir: str) -> None:
+        migrate_calls.append((site_id, project_dir))
+        if migrate_raises is not None:
+            raise migrate_raises
+
+    monkeypatch.setattr(d1_migrate, "apply_migrations", _fake_migrate)
+    return {"build": build_calls, "migrate": migrate_calls}
+
+
+# ---------------------------------------------------------------------------
+# Registration.
+# ---------------------------------------------------------------------------
+
+
+def test_provision_site_job_is_registered() -> None:
+    register_builtins()
+    job = resolve_job("provision_site")
+    assert isinstance(job, ProvisionSiteJob)
+    assert job.name == "provision_site"
+
+
+# ---------------------------------------------------------------------------
+# Guarded create is a no-op when the D1 id is already set.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_guarded_create_reuses_existing_d1(
+    seed: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pocketpaw_ee.cloud.models.site import Site
+
+    ctx = await seed(d1_database_id="already-provisioned-d1")
+    cf = _FakeCF()
+    rec = _install_fakes(monkeypatch, cf=cf)
+
+    result = await ProvisionSiteJob()(
+        workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-1", params={}
+    )
+
+    # create_database is NOT called — the stored id is reused everywhere.
+    assert cf.create_calls == []
+    assert rec["build"][0]["d1_database_id"] == "already-provisioned-d1"
+    assert cf.put_calls[0]["bindings"] == [
+        {"type": "d1", "name": "DB", "id": "already-provisioned-d1"}
+    ]
+
+    site = await Site.get(ctx["site_id"])
+    assert site is not None
+    assert site.provision_status == "provisioned"
+    assert site.deployed is True
+    assert site.d1_database_id == "already-provisioned-d1"
+    assert result == {"state": {"provision_status": "done"}}
+
+
+# ---------------------------------------------------------------------------
+# Mid-job failure (migrate raises) → failed, but the created D1 id is persisted.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migrate_failure_marks_failed_but_persists_d1(
+    seed: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pocketpaw_ee.cloud.models.site import Site
+
+    ctx = await seed(d1_database_id="")  # no prior D1 — the job creates one
+    cf = _FakeCF(new_id="d1-fresh-uuid-0001")
+    _install_fakes(monkeypatch, cf=cf, migrate_raises=RuntimeError("migrate blew up"))
+
+    with pytest.raises(RuntimeError, match="migrate blew up"):
+        await ProvisionSiteJob()(
+            workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-2", params={}
+        )
+
+    # The D1 was created under the paw-site-<siteId> name.
+    assert cf.create_calls == [d1_migrate.database_name(ctx["site_id"])]
+
+    site = await Site.get(ctx["site_id"])
+    assert site is not None
+    # Failed — but the id is persisted so a retry reuses it (no orphaned second D1).
+    assert site.provision_status == "failed"
+    assert site.d1_database_id == "d1-fresh-uuid-0001"
+    # The Worker was never deployed (failure was before put_worker).
+    assert cf.put_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Success → provisioned + deployed, state-only partial returned.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_marks_provisioned_and_deployed(
+    seed: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pocketpaw_ee.cloud.models.site import Site
+
+    ctx = await seed(d1_database_id="")
+    cf = _FakeCF(new_id="d1-fresh-uuid-0002")
+    rec = _install_fakes(monkeypatch, cf=cf)
+
+    result = await ProvisionSiteJob()(
+        workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-3", params={}
+    )
+
+    # Fresh create → build/migrate/deploy all keyed on the new id.
+    assert cf.create_calls == [d1_migrate.database_name(ctx["site_id"])]
+    assert rec["build"][0]["d1_database_id"] == "d1-fresh-uuid-0002"
+    assert rec["migrate"] == [(ctx["site_id"], "/fake/project/dir")]
+    assert cf.put_calls[0]["script_name"] == ctx["site_id"]
+    assert cf.put_calls[0]["bundle"] == b"worker-bundle-bytes"
+    assert cf.put_calls[0]["bindings"] == [
+        {"type": "d1", "name": "DB", "id": "d1-fresh-uuid-0002"}
+    ]
+
+    site = await Site.get(ctx["site_id"])
+    assert site is not None
+    assert site.provision_status == "provisioned"
+    assert site.deployed is True
+    assert site.d1_database_id == "d1-fresh-uuid-0002"
+    assert result == {"state": {"provision_status": "done"}}
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed tenancy re-check — a pocket in another workspace never provisions.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenancy_mismatch_fails_closed(
+    seed: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = await seed(workspace=OTHER_WS, d1_database_id="")
+    cf = _FakeCF()
+    _install_fakes(monkeypatch, cf=cf)
+
+    # The job runs for WS but the pocket lives in OTHER_WS → refuse before any work.
+    with pytest.raises(Exception, match="tenancy mismatch"):
+        await ProvisionSiteJob()(
+            workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-4", params={}
+        )
+
+    assert cf.create_calls == []
+    assert cf.put_calls == []


### PR DESCRIPTION
Stacked on #1670. Second slice of Dynamic Paw Sites Phase 0 — the job that actually stands up a dynamic site's data plane.

A published dynamic site has nowhere to read or write until something creates its D1 and runs the migration. This adds the durable `workspace-jobs` job that does the whole sequence, so it survives a partial failure and retries cleanly instead of blocking the publish request.

## The job

`provision_site` (a `JobCallable`, registered in `_BUILTINS`) runs, in order:

1. Fail-closed tenancy re-check, then load the Site doc + the pocket's rippleSpec.
2. **Create the D1, guarded on `Site.d1_database_id`** — if one's already stored, reuse it; otherwise create it and save the id right away (status stays `provisioning`). So a retry reuses that database instead of leaving a second one behind.
3. Build the site with the real id passed through (`siteConfig.d1DatabaseId`), which the generator bakes into the emitted `wrangler.toml`.
4. Apply the migration: `wrangler d1 migrations apply paw-site-<siteId> --remote` against the built project. No `--database-id` flag and no file patching — the id is already in the toml and the layout matches wrangler's default `migrations_dir` (confirmed by the DP0-2 spike).
5. Deploy the Worker with its `DB` D1 binding (same bind as the existing dynamic deploy path).
6. Mark the Site `provisioned` + `deployed`. On any failure in 2–6, flip to `failed` (the id stays saved) and re-raise so the worker un-hangs the button.

## Layering

The Beanie Site reads/writes go through new `sites.service` seams so the builtin stays off the ORM (import-linter enforces this — 28/28 contracts kept). The build + `put_worker` mechanics reuse `_deploy_site_doc`'s helpers rather than duplicating them. The wrangler subprocess reuses `workers_deploy`'s auth style and `generator_client`'s reap machinery, so a wedged wrangler can't hang the jobs worker.

## What it deliberately leaves alone

No publish-path changes — nothing dispatches this job yet. That wiring (the static/dynamic split in `_deploy_site_doc` + the single-flight guard) is the next PR in the stack. Dynamic-svelte provisioning is also out of scope; the build seam is `engine="ripple"` and can grow a param later.

## Tests

`uv run pytest tests/cloud/jobs/test_provision_site.py` → **5 passed**. Covers: guarded create is a no-op when the id exists; a mid-job failure leaves `provision_status="failed"` with the id still saved (no orphan on retry); success writes `provisioned` + `deployed`; tenancy mismatch fails before any create/deploy.

Base for `feat/dp0-publish-async` (DP0-4).