### PR TITLE
fix: add missing FileResponse import in auth router

### DIFF
--- a/ee/pocketpaw_ee/cloud/auth/router.py
+++ b/ee/pocketpaw_ee/cloud/auth/router.py
@@ -19,6 +19,7 @@ from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users.router.common import ErrorCode
 from pydantic import BaseModel
+from starlette.responses import FileResponse
 
 from pocketpaw.security.rate_limiter import mfa_challenge_limiter
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
@@ -538,8 +539,6 @@ async def get_avatar(
 
     has_thumb = w > 0 or h > 0
     if not has_thumb:
-        from fastapi.responses import FileResponse
-
         return FileResponse(path)
 
     # Resize the local avatar file on-the-fly with Pillow.
@@ -596,8 +595,6 @@ async def get_avatar(
         thumb_bytes = await asyncio.to_thread(_resize)
     except Exception:
         # Fall back to original on resize failure.
-        from fastapi.responses import FileResponse
-
         return FileResponse(path)
 
     # Write-through cache (atomic).


### PR DESCRIPTION
## Problem
The `get_avatar` endpoint was using `FileResponse` without a module-level import. Local `from fastapi.responses import FileResponse` imports inside the function body caused an `UnboundLocalError` when the resize code path was taken (the local import was skipped in that branch).

## Fix
- Added top-level `from starlette.responses import FileResponse` import
- Removed the two conditional local imports that were causing Python to treat `FileResponse` as an unbound local variable in the resize code path

## Testing
- `ruff check`: all checks passed
- `ruff format`: no changes needed
- Manual verification: avatar endpoint with resize params now returns 200 instead of 500