### PR TITLE
feat(sites): split dynamic-site publish into an async provision job

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -94,6 +94,15 @@
 # D1 instead of orphaning a second one; status advances to ``provisioned`` only
 # after migrate + deploy succeed, and to ``failed`` on error. Defaults ``"none"`` so
 # every static site and every pre-DP0 row reads "not provisioning" — no migration.
+#
+# Updated 2026-07-09 (DP0-4 — publish async split + single-flight): added
+# ``_provision_job_id`` — a TRANSIENT pydantic PrivateAttr (NOT persisted to Mongo),
+# mirroring ``_checkout_url``. A DYNAMIC-site publish no longer deploys inline; it
+# ensures the Site doc in ``provision_status="provisioning"`` and enqueues the
+# durable ``provision_site`` job, stashing the enqueued job id here so the router
+# can surface it on ``SiteResponse.provision_job_id``. None for a static publish and
+# for any DB-loaded doc (the PrivateAttr defaults to None). Private so it never
+# round-trips through the DB.
 
 from __future__ import annotations
 
@@ -169,6 +178,11 @@ class Site(TimestampedDocument):
     # publish. The publish path stashes it here so the router can surface it on
     # ``SiteResponse.checkout_url``; a PrivateAttr so it never serializes to Mongo.
     _checkout_url: str | None = PrivateAttr(default=None)
+    # DP0-4: TRANSIENT (NOT persisted) id of the durable ``provision_site`` job a
+    # DYNAMIC-site publish enqueued. The publish path stashes it here so the router
+    # can surface it on ``SiteResponse.provision_job_id``; a PrivateAttr so it never
+    # serializes to Mongo. None for a static publish and any DB-loaded doc.
+    _provision_job_id: str | None = PrivateAttr(default=None)
     # PERF-2: a non-destructive tombstone for duplicate Site docs the pre-PERF-1
     # per-publish ObjectId minting left behind. The dedupe migration keeps ONE
     # canonical doc per (workspace, pocket_id) active and sets this True on the

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -94,6 +94,13 @@
 # already-rendered {uid, op} edits and the endpoint returns one verdict per edit.
 # ``op`` rides as an open dict — its {kind:setText|setProp,...} shape is validated
 # downstream by the paw-sites apply-leaf-edit CLI, not at this DTO boundary.
+# Updated 2026-07-09 (DP0-4 — publish async split): ``SiteResponse`` gains
+# ``provision_status`` (none | provisioning | provisioned | failed) and
+# ``provision_job_id``. A DYNAMIC-site publish no longer deploys inline — it enqueues
+# the durable ``provision_site`` job and returns immediately with
+# ``provision_status="provisioning"`` / ``deployed=False`` and the enqueued job id;
+# the site goes live only when the job finalizes. Both default to "none" / None so a
+# static publish and every non-publish response stay backward-compatible.
 # Updated 2026-07-01 (NE-5b — native-artifact endpoint): added NativeArtifactResponse
 # ({pocket_id, body_html, css}) — the response of GET
 # /sites/by-pocket/{pocket_id}/native-artifact. ``body_html`` is the armed svelte
@@ -153,6 +160,16 @@ class SiteResponse(BaseModel):
     # the ``subscription.active`` webhook confirms payment. None for a free/base
     # publish (which deploys immediately) and for any non-publish response.
     checkout_url: str | None = None
+    # DP0-4: where a dynamic site sits in the durable D1 provision job
+    # (none | provisioning | provisioned | failed). A DYNAMIC-site publish does NOT
+    # deploy inline — it enqueues the ``provision_site`` job and returns immediately
+    # with ``provision_status="provisioning"`` (``deployed=False``); the site goes
+    # live only when the job finalizes. "none" for a static site (deploys inline).
+    provision_status: str = "none"
+    # DP0-4: the id of the ``provision_site`` job a dynamic publish enqueued, so the
+    # caller can poll the job. None for a static publish, and None on a single-flight
+    # no-op (a second publish while already provisioning does not enqueue a job).
+    provision_job_id: str | None = None
 
 
 class SitePreviewResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,22 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-09 (DP0-4 — publish async split + single-flight): ``_deploy_site_doc``
+# now FORKS on ``_is_dynamic`` BEFORE any build. A DYNAMIC site no longer builds /
+# deploys inline — it returns early into the new ``_provision_dynamic_site`` helper,
+# which ensures the canonical Site doc in ``provision_status="provisioning"``
+# (``deployed=False``, ``url=""``) and enqueues the durable ``provision_site`` job via
+# ``jobs.service.dispatch_job`` (``params={}``). SINGLE-FLIGHT: a re-publish while the
+# site is already ``provisioning`` does NOT enqueue a second job (a double-publish is a
+# no-op). The enqueued job id rides the returned doc on the transient
+# ``_provision_job_id`` PrivateAttr, which ``_to_response`` surfaces on
+# ``SiteResponse.provision_job_id`` alongside ``provision_status``. The STATIC path is
+# byte-for-byte the pre-DP0-4 inline build → deploy → upsert (regression guarantee).
+# Both publish entry points reach it through ``_deploy_site_doc`` (the free ``publish``
+# and the charge-first ``activate_site``), so both get the async behaviour; the return
+# is still a plain ``_SiteDoc`` so their post-processing (plan stamp / sub-active) is
+# unchanged.
+#
 # Updated 2026-07-02 (harden native-editing endpoints): (1) ``get_native_artifact``
 # now routes its arm build through ``_build_or_cloud_error`` (like the publish paths)
 # so a missing-toolchain / non-zero build / SmokeGateFailed becomes a clean
@@ -1009,6 +1025,11 @@ def _to_response(doc: _SiteDoc, pattern: str = "") -> SiteResponse:
         # for a free/live publish and for any list/status read (those docs are
         # loaded from Mongo, where the PrivateAttr defaults to None).
         checkout_url=getattr(doc, "_checkout_url", None),
+        # DP0-4: the dynamic-site provision state (persisted) + the id of the job a
+        # dynamic publish just enqueued (transient ``_provision_job_id`` PrivateAttr,
+        # None for a static publish / any DB-loaded doc / a single-flight no-op).
+        provision_status=getattr(doc, "provision_status", "none"),
+        provision_job_id=getattr(doc, "_provision_job_id", None),
     )
 
 
@@ -1308,7 +1329,29 @@ async def _deploy_site_doc(
     ``workers_deploy`` is the test-injection seam for the workers-mode deployer
     (mirrors ``local_deploy``/``cloudflare``); ``None`` uses the real
     ``workers_deploy.deploy_workers``.
+
+    DP0-4 — DYNAMIC split: a DYNAMIC site (``pattern == "dynamic"`` / a spec carrying
+    live bindings) is NOT built or deployed inline here. Its per-tenant D1 data plane
+    must be stood up by the durable ``provision_site`` job (create D1 → build with the
+    real id → migrate → deploy), so this returns EARLY into ``_provision_dynamic_site``
+    — which ensures the canonical Site doc in ``provision_status="provisioning"`` and
+    enqueues the job (single-flight: a re-publish while already provisioning does NOT
+    enqueue a second job). Only the STATIC path below runs the inline build → deploy →
+    upsert (byte-for-byte the pre-DP0-4 behaviour, the regression guarantee).
     """
+    # DP0-4: fork BEFORE any build. A dynamic site defers to the provision job; only
+    # a static site takes the inline build/deploy/upsert path unchanged below.
+    if _is_dynamic(pattern, ripple_spec):
+        return await _provision_dynamic_site(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            site_id=site_id,
+            signed_key=signed_key,
+            site_name=site_name,
+            builder_origin=builder_origin,
+        )
+
     gen = generator or GeneratorClient()
     # DEP-3: map a generator/install/smoke failure (missing toolchain, non-zero
     # build, SSR fail-gate) to a clean CloudError (sites.generator_failed → 5xx)
@@ -1476,6 +1519,105 @@ async def _deploy_site_doc(
         if is_dynamic:
             doc.d1_database_id = d1_database_id
         await doc.save()
+    return doc
+
+
+async def _provision_dynamic_site(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    site_id: str,
+    signed_key: str,
+    site_name: str,
+    builder_origin: str | None,
+) -> _SiteDoc:
+    """DP0-4 — the DYNAMIC half of ``_deploy_site_doc``: stand the site up
+    ASYNCHRONOUSLY via the durable ``provision_site`` job instead of deploying inline.
+
+    A dynamic site is backed by a per-tenant Cloudflare D1 that must be created,
+    migrated, and bound BEFORE the Worker can serve — work the ``provision_site`` job
+    owns (create D1 → build with the real id → migrate → deploy → mark provisioned).
+    So rather than build/deploy here, this:
+
+      1. ENSURES the ONE canonical Site doc for ``(workspace, pocket_id)`` exists in
+         ``provision_status="provisioning"`` (``deployed=False``, ``url=""`` — the job
+         flips those on finalize), mirroring the fields the static upsert seeds on a
+         first publish (script_name / owner / signed_key / capture defaults).
+      2. SINGLE-FLIGHT: if the doc is ALREADY ``provisioning``, it does NOT enqueue a
+         second job — a double-publish is a no-op that returns the in-progress
+         provisioning response (without a fresh job id).
+      3. DISPATCHES the ``provision_site`` job (``params={}`` — the job re-reads the
+         pocket's spec itself; ``validate_job_params({})`` passes with no schema).
+
+    Returns the Site doc in ``provisioning`` state, carrying the enqueued job id on the
+    transient ``_provision_job_id`` PrivateAttr so ``_to_response`` surfaces it. Both
+    publish entry points (the free ``publish`` and the charge-first ``activate_site``)
+    reach this through ``_deploy_site_doc``, so both get the async behaviour; each does
+    its own post-processing on the returned doc (plan stamp / sub-active), which is a
+    plain ``_SiteDoc`` exactly as before — only ``deployed``/``provision_status`` differ.
+    """
+    oid = ObjectId(site_id)
+    doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+
+    # SINGLE-FLIGHT: a publish while the site is already provisioning must not enqueue
+    # a second job — return the in-progress provisioning response as a no-op. (We do
+    # not resolve the in-flight job id here; the caller can poll the site's status.)
+    if doc is not None and doc.provision_status == "provisioning":
+        doc._provision_job_id = None
+        return doc
+
+    # Ensure the canonical doc exists in ``provisioning`` state. leave ``deployed`` /
+    # ``url`` for the job to finalize; seed the same identity/capture fields the static
+    # upsert seeds so the site is coherent while it provisions.
+    if doc is None:
+        doc = _SiteDoc(
+            id=oid,
+            workspace=workspace_id,
+            pocket_id=pocket_id,
+            owner=user_id,
+            name=site_name,
+            script_name=site_id,
+            deployed=False,
+            url="",
+            signed_key=signed_key,
+            provision_status="provisioning",
+            builder_origin=builder_origin or "",
+            allowed_origins=_default_allowed_origins(),
+            event_mapping=_DEFAULT_EVENT_MAPPING,
+        )
+        await doc.insert()
+    else:
+        # Re-publish of a not-currently-provisioning dynamic site (e.g. a failed /
+        # provisioned one re-run): reset to ``provisioning`` and refresh the identity
+        # fields. Preserve the stored ``signed_key`` (the capture endpoint verifies
+        # against it) and any connected domain / allowlist. Clear any captured
+        # pending-deploy inputs — the charge-first webhook has already handed off to
+        # the job, so the snapshot is no longer needed.
+        doc.pocket_id = pocket_id
+        doc.owner = user_id
+        doc.name = site_name
+        doc.script_name = site_id
+        doc.deployed = False
+        doc.url = ""
+        doc.provision_status = "provisioning"
+        doc.pending_deploy_inputs = {}
+        await doc.save()
+
+    # DISPATCH the durable provision job. Lazy import keeps the sites service free of
+    # an eager jobs/arq import at module load (mirrors the billing/pockets lazy
+    # imports). ``params={}`` — the job re-reads the pocket spec; no params needed.
+    from pocketpaw_ee.cloud.jobs import service as jobs_service
+
+    result = await jobs_service.dispatch_job(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        action="provision_site",
+        job_name="provision_site",
+        params={},
+        triggered_by=user_id,
+    )
+    doc._provision_job_id = result.get("job_id")
     return doc
 
 

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -57,6 +57,16 @@
 # domain UNSET the CF path leaves url="" without crashing (the worker is still
 # uploaded — the deploy succeeded — it just has no public URL until the operator
 # sets the domain + deploys the dispatch worker).
+# Updated 2026-07-09 (DP0-4 — publish async split + single-flight): the DS-2
+# inline-dynamic-deploy tests are superseded — a dynamic publish no longer deploys
+# inline. New coverage: a dynamic publish enqueues the ``provision_site`` job once +
+# returns provision_status="provisioning"/deployed=False with the job id (via a
+# ``_RecordingDispatch`` stand-in for ``jobs.service.dispatch_job``, so no arq/Redis);
+# a second dynamic publish while provisioning is a single-flight no-op (no second
+# job); publish_pocket threads pattern="dynamic" through to the same enqueue; and a
+# dynamic publish enqueues regardless of PAW_CF_DEPLOY_MODE=workers (it returns before
+# the static deploy-mode fork). The STATIC publish tests are unchanged (regression
+# guarantee: static still deploys inline + passes no bindings).
 from __future__ import annotations
 
 import pytest
@@ -1085,31 +1095,71 @@ async def test_preview_pocket_falls_back_to_current_content_when_no_draft(beanie
 
 
 # ---------------------------------------------------------------------------
-# DS-2 — a DYNAMIC site (Pocket.pattern == "dynamic") is backed by a per-tenant
-# Cloudflare D1. Its deployed Worker therefore needs a D1 binding so the SSR
-# remote functions can reach that DB. publish() passes the d1 binding(s) to
-# put_worker ONLY when the site is dynamic; a static (landing/None) publish
-# passes NO bindings (the single-module path stays byte-for-byte unchanged).
+# DP0-4 — a DYNAMIC site (Pocket.pattern == "dynamic" / a spec carrying live
+# bindings) is backed by a per-tenant Cloudflare D1 that must be created, migrated,
+# and bound BEFORE the Worker can serve. So a dynamic publish no longer builds /
+# deploys inline — it ensures the Site doc in provision_status="provisioning" and
+# ENQUEUES the durable ``provision_site`` job (single-flight: a re-publish while
+# already provisioning does not enqueue a second job). A STATIC (landing/None)
+# publish is unchanged — it deploys inline and passes NO d1 bindings.
+#
+# These tests supersede the DS-2 inline-dynamic-deploy tests (the inline dynamic
+# deploy path was removed in DP0-4). ``_patch_dispatch`` swaps
+# ``jobs.service.dispatch_job`` for a recorder so no arq/Redis is touched.
 # ---------------------------------------------------------------------------
 
 
+class _RecordingDispatch:
+    """A stand-in for ``jobs.service.dispatch_job`` — records every call and
+    returns the same ``{ok, code, job_id}`` envelope the real dispatch returns,
+    so no arq pool / Redis is needed."""
+
+    def __init__(self, job_id: str = "job_123") -> None:
+        self.calls: list[dict] = []
+        self._job_id = job_id
+
+    async def __call__(
+        self, *, workspace_id, pocket_id, action, job_name, params, triggered_by
+    ) -> dict:
+        self.calls.append(
+            {
+                "workspace_id": workspace_id,
+                "pocket_id": pocket_id,
+                "action": action,
+                "job_name": job_name,
+                "params": params,
+                "triggered_by": triggered_by,
+            }
+        )
+        return {"ok": True, "code": "job_enqueued", "job_id": self._job_id}
+
+
+def _patch_dispatch(monkeypatch, job_id: str = "job_123") -> _RecordingDispatch:
+    rec = _RecordingDispatch(job_id=job_id)
+    monkeypatch.setattr("pocketpaw_ee.cloud.jobs.service.dispatch_job", rec)
+    return rec
+
+
+_DYNAMIC_SPEC = {
+    "type": "container",
+    "objects": [{"name": "signups", "fields": {"email": "text"}}],
+    "sources": [{"name": "all", "kind": "data", "object": "signups", "refresh": "pocket_open"}],
+}
+
+
 @pytest.mark.asyncio
-async def test_dynamic_publish_passes_d1_binding_to_put_worker(beanie_test_db):
-    """A pattern="dynamic" publish hands put_worker a d1 binding carrying the
-    binding name + the site's D1 database id, and persists that id on the Site
-    doc so a re-publish reuses it (and DS-3 can read the site's D1)."""
+async def test_dynamic_publish_enqueues_provision_job(beanie_test_db, monkeypatch):
+    """A dynamic publish does NOT deploy inline: it upserts the Site doc in
+    provision_status="provisioning" (deployed=False), enqueues ``provision_site``
+    exactly once, and returns the provisioning response carrying the job id."""
+    dispatch = _patch_dispatch(monkeypatch, job_id="job_abc")
     gen, cf = _FakeGenerator(), _FakeCF()
+
     site = await sites_service.publish(
         workspace_id="ws1",
         user_id="u1",
         pocket_id="pk_dyn",
-        ripple_spec={
-            "type": "container",
-            "objects": [{"name": "signups", "fields": {"email": "text"}}],
-            "sources": [
-                {"name": "all", "kind": "data", "object": "signups", "refresh": "pocket_open"}
-            ],
-        },
+        ripple_spec=_DYNAMIC_SPEC,
         theme={"primary": "#0A84FF"},
         name="Guestbook",
         pattern="dynamic",
@@ -1117,33 +1167,38 @@ async def test_dynamic_publish_passes_d1_binding_to_put_worker(beanie_test_db):
         _cloudflare=cf,
         _bundle_reader=lambda d: b"export default {}",
     )
-    assert site.deployed is True
-    # put_worker received exactly one call carrying a non-empty bindings list.
-    assert len(cf.put_bindings) == 1
-    bindings = cf.put_bindings[0]
-    assert bindings, "dynamic publish must pass bindings to put_worker"
-    d1 = [b for b in bindings if b.get("type") == "d1"]
-    assert len(d1) == 1
-    assert d1[0]["name"] == "DB"
-    assert d1[0]["id"], "d1 binding must carry the database id"
-    # The id is persisted on the Site doc (re-publish reuse + DS-3 read).
-    assert site.d1_database_id == d1[0]["id"]
+
+    # No inline deploy — the Worker is stood up by the job, not here.
+    assert site.deployed is False
+    assert site.provision_status == "provisioning"
+    assert cf.put_calls == [], "a dynamic publish must not deploy inline"
+    # Enqueued the provision job exactly once, with the right name + empty params.
+    assert len(dispatch.calls) == 1
+    call = dispatch.calls[0]
+    assert call["job_name"] == "provision_site"
+    assert call["pocket_id"] == "pk_dyn"
+    assert call["workspace_id"] == "ws1"
+    assert call["params"] == {}
+    # The provisioning response carries the enqueued job id (transient PrivateAttr,
+    # surfaced on SiteResponse).
+    assert site._provision_job_id == "job_abc"
+    resp = sites_service._to_response(site)
+    assert resp.provision_status == "provisioning"
+    assert resp.provision_job_id == "job_abc"
+    assert resp.deployed is False
 
 
 @pytest.mark.asyncio
-async def test_dynamic_publish_reuses_persisted_d1_id_on_republish(beanie_test_db):
-    """Re-publishing a dynamic pocket keeps the SAME D1 id (the binding target
-    must be stable across deploys — the data lives behind that id)."""
+async def test_dynamic_publish_single_flight(beanie_test_db, monkeypatch):
+    """A SECOND dynamic publish while the site is already provisioning is a no-op:
+    it does NOT enqueue a second job (single-flight guard)."""
+    dispatch = _patch_dispatch(monkeypatch)
     gen, cf = _FakeGenerator(), _FakeCF()
     kw = dict(
         workspace_id="ws1",
         user_id="u1",
         pocket_id="pk_dyn2",
-        ripple_spec={
-            "type": "container",
-            "objects": [{"name": "rows", "fields": {"x": "text"}}],
-            "actions": [{"name": "add", "object": "rows", "op": "insert"}],
-        },
+        ripple_spec=_DYNAMIC_SPEC,
         theme={"primary": "#000"},
         name="Board",
         pattern="dynamic",
@@ -1151,10 +1206,17 @@ async def test_dynamic_publish_reuses_persisted_d1_id_on_republish(beanie_test_d
         _cloudflare=cf,
         _bundle_reader=lambda d: b"export default {}",
     )
+
     first = await sites_service.publish(**kw)
     second = await sites_service.publish(**kw)
-    assert first.d1_database_id
-    assert first.d1_database_id == second.d1_database_id
+
+    # Exactly ONE job across both publishes — the second is a single-flight no-op.
+    assert len(dispatch.calls) == 1
+    assert first.provision_status == "provisioning"
+    assert second.provision_status == "provisioning"
+    # The single-flight no-op returns the in-progress response without a fresh job id.
+    assert second._provision_job_id is None
+    assert cf.put_calls == []
 
 
 @pytest.mark.asyncio
@@ -1180,11 +1242,14 @@ async def test_static_publish_passes_no_bindings(beanie_test_db):
 
 
 @pytest.mark.asyncio
-async def test_publish_pocket_threads_dynamic_pattern(beanie_test_db):
-    """publish_pocket reads pattern off the pocket wire dict and forwards it, so a
-    dynamic pocket published via the shared path gets the d1 binding."""
+async def test_publish_pocket_dynamic_enqueues_provision_job(beanie_test_db, monkeypatch):
+    """publish_pocket reads pattern="dynamic" off the pocket wire dict and forwards
+    it, so a dynamic pocket published via the shared path enqueues the provision job
+    (once) and returns provisioning — the charge-first + plan-stamp post-processing
+    leaves the provision state intact."""
     from unittest.mock import AsyncMock, patch
 
+    dispatch = _patch_dispatch(monkeypatch, job_id="job_pp")
     gen, cf = _FakeGenerator(), _FakeCF()
     wire = {
         "name": "Live Guestbook",
@@ -1208,9 +1273,14 @@ async def test_publish_pocket_threads_dynamic_pattern(beanie_test_db):
             _bundle_reader=lambda d: b"export default {}",
         )
 
-    assert site.d1_database_id
-    d1 = [b for b in (cf.put_bindings[0] or []) if b.get("type") == "d1"]
-    assert len(d1) == 1
+    assert len(dispatch.calls) == 1
+    assert dispatch.calls[0]["job_name"] == "provision_site"
+    assert site.provision_status == "provisioning"
+    assert site.deployed is False
+    # The plan-stamp post-processing (publish_pocket → _apply_site_plan) preserves the
+    # transient job id, so the router still surfaces it.
+    assert site._provision_job_id == "job_pp"
+    assert cf.put_calls == []
 
 
 # ── workers deploy mode (PAW_CF_DEPLOY_MODE=workers) ──────────────────────────
@@ -1255,12 +1325,12 @@ async def test_workers_mode_routes_static_publish_to_workers_deployer(beanie_tes
 
 
 @pytest.mark.asyncio
-async def test_workers_mode_dynamic_site_raises_validation_error(beanie_test_db, monkeypatch):
-    """A DYNAMIC site in workers mode is rejected with a clean ValidationError
-    (Phase 2 needs a per-tenant D1) rather than deploying a broken site. The
-    injected workers deployer must NOT be called."""
-    from pocketpaw_ee.cloud._core.errors import ValidationError
-
+async def test_workers_mode_dynamic_site_enqueues_not_deploys(beanie_test_db, monkeypatch):
+    """DP0-4: a DYNAMIC site enqueues the provision job REGARDLESS of the static
+    deploy-mode selection — it returns provisioning BEFORE the deploy-mode fork, so
+    PAW_CF_DEPLOY_MODE=workers is irrelevant: no ValidationError, no workers deploy,
+    no inline deploy. (The provision job always stands the D1 site up via WfP.)"""
+    dispatch = _patch_dispatch(monkeypatch)
     monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "workers")
     monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
 
@@ -1268,24 +1338,25 @@ async def test_workers_mode_dynamic_site_raises_validation_error(beanie_test_db,
         raise AssertionError("a dynamic site must not reach the workers deployer")
 
     gen = _FakeGenerator()
-    with pytest.raises(ValidationError) as exc:
-        await sites_service.publish(
-            workspace_id="ws1",
-            user_id="u1",
-            pocket_id="pk_w_dyn",
-            ripple_spec={
-                "type": "container",
-                "objects": [{"name": "rows", "fields": {"x": "text"}}],
-                "actions": [{"name": "add", "object": "rows", "op": "insert"}],
-            },
-            theme={},
-            name="Dynamic in Workers",
-            pattern="dynamic",
-            _generator=gen,
-            _bundle_reader=lambda d: b"unused",
-            _workers_deploy=must_not_run,
-        )
-    assert "workers" in str(exc.value).lower()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_w_dyn",
+        ripple_spec={
+            "type": "container",
+            "objects": [{"name": "rows", "fields": {"x": "text"}}],
+            "actions": [{"name": "add", "object": "rows", "op": "insert"}],
+        },
+        theme={},
+        name="Dynamic in Workers",
+        pattern="dynamic",
+        _generator=gen,
+        _bundle_reader=lambda d: b"unused",
+        _workers_deploy=must_not_run,
+    )
+    assert site.provision_status == "provisioning"
+    assert site.deployed is False
+    assert len(dispatch.calls) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Stacked on #1675. Third slice of Dynamic Paw Sites Phase 0 — the wiring that makes the provision job actually fire when someone publishes a dynamic site.

Until now nothing dispatched the `provision_site` job. This forks the publish path so a dynamic site provisions asynchronously while a static site behaves exactly as before.

## The split

`_deploy_site_doc` now forks on `_is_dynamic` before it builds anything:

- **Static** — falls straight through to the existing inline build → deploy → upsert. Byte-for-byte unchanged; that's the regression guarantee.
- **Dynamic** — returns early into a new `_provision_dynamic_site` helper, which:
  1. Ensures the one canonical Site doc exists in `provision_status="provisioning"` (`deployed=False`, `url=""` — the job flips those on finalize), seeding the same fields the static upsert seeds on a first publish.
  2. Single-flights: if the site is already `provisioning`, it does **not** enqueue a second job — a double-publish is a no-op.
  3. Dispatches `provision_site` via `jobs.service.dispatch_job` (`params={}` — the job re-reads the pocket spec itself).

Both entry points reach this through `_deploy_site_doc`, so the free `publish` and the charge-first `activate_site` webhook both get the async behavior. The enqueued job id rides a transient PrivateAttr and surfaces on `SiteResponse.provision_status` / `provision_job_id` so the builder can poll.

## Tests

`uv run pytest tests/ee/sites/test_service.py tests/cloud/jobs/test_provision_site.py` → **49 passed**. Covers: static publish unchanged; dynamic publish upserts `provisioning` and enqueues exactly one `provision_site` job; single-flight no-op on re-publish while provisioning. `dispatch_job` is mocked, so no Redis/arq needed. Import-linter: 28/28 contracts kept.

Heads up: `tests/ee/sites/test_generator_client_timeout.py` has 4 failures on Windows (subprocess process-group kill). They're pre-existing and unrelated — confirmed by running them on the base branch without this diff; they fail identically. Not touched here.

Base for `feat/dp0-deploy-shims` (DP0-5) and the DP0-6 e2e smoke.