### PR TITLE
fix(sites): kill build subprocess tree on Windows instead of crashing

### DIFF
--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -8,6 +8,16 @@
 # behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-07-09 (fix/sites-gen-windows-process-kill): ``_kill_process_group``
+# was POSIX-only — it unconditionally called ``os.killpg(os.getpgid(pid), SIGKILL)``,
+# neither of which exists on Windows. On a Windows host a build TIMEOUT therefore
+# crashed inside ``_communicate_bounded``'s timeout handler with ``AttributeError:
+# module 'os' has no attribute 'killpg'``, masking the real ``_BuildTimeout`` and
+# escaping ``publish_pocket`` as an unhandled 500. ``_kill_process_group`` now
+# branches on ``sys.platform``: POSIX keeps the process-group SIGKILL; Windows calls
+# the new ``_kill_process_tree_windows`` (``taskkill /F /T`` to reap the leaked
+# workerd child TREE, best-effort ``proc.kill()`` fallback if taskkill is missing).
+#
 # Updated 2026-07-02 (harden apply_leaf_edits temp-file cleanup): ``apply_leaf_edits``
 # now assigns ``input_path = fh.name`` BEFORE ``json.dump`` inside the ``with`` and
 # wraps creation + write + exec in ONE guarded try/finally, so a serialization
@@ -194,6 +204,8 @@ import logging
 import os
 import shlex
 import signal
+import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -244,19 +256,49 @@ class _BuildTimeout(RuntimeError):
         super().__init__(f"{label} timed out after {timeout_s}s")
 
 
-def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
-    """SIGKILL the entire process GROUP of a launched subprocess so leaked workerd
-    CHILDREN die too, not just the parent.
+def _kill_process_tree_windows(proc: asyncio.subprocess.Process) -> None:
+    """Windows has no ``setsid`` process groups, so kill the whole child TREE with
+    ``taskkill /F /T`` — ``/T`` recurses into children, reaping the leaked workerd
+    child the bun parent never cleans up (the POSIX ``killpg`` equivalent). If
+    ``taskkill`` is missing or blocked, degrade to a best-effort parent kill so the
+    exception never escapes the timeout handler."""
+    pid = proc.pid
+    try:
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(pid)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=10,
+        )
+    except Exception:
+        # taskkill unavailable / blocked / timed out — best-effort parent kill.
+        with contextlib.suppress(Exception):
+            proc.kill()
 
-    The build subprocesses are launched with ``start_new_session=True``, so each is
-    its own process-group leader (pgid == pid). ``adapter-cloudflare``'s prerender
-    boots a workerd child that the bun parent never reaps; killing only the parent
-    would leave that child wedged. ``os.killpg(os.getpgid(pid), SIGKILL)`` takes out
-    the whole group. Guards ``ProcessLookupError`` (the proc/group already exited)
-    and ``PermissionError`` (can't signal — nothing we can do) so a best-effort kill
-    never raises into the build path."""
+
+def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
+    """Kill a launched build subprocess AND its leaked children so a wedged workerd
+    prerender dies too, not just the parent.
+
+    ``adapter-cloudflare``'s prerender boots a workerd child that the bun parent
+    never reaps; killing only the parent would leave that child wedged. The
+    mechanism is platform-specific:
+
+    * **POSIX** — the subprocesses are launched with ``start_new_session=True``, so
+      each leads its own process group (pgid == pid); ``os.killpg(os.getpgid(pid),
+      SIGKILL)`` takes out the whole group. Guards ``ProcessLookupError`` (already
+      exited) and ``PermissionError`` (can't signal) so the best-effort kill never
+      raises into the build path.
+    * **Windows** — ``start_new_session`` is a no-op, and ``os.killpg`` /
+      ``os.getpgid`` don't exist at all (referencing them raised ``AttributeError``
+      inside the timeout handler, masking ``_BuildTimeout`` and escaping publish as
+      an unhandled 500). Use ``taskkill /F /T`` to kill the child tree instead."""
     pid = proc.pid
     if pid is None:
+        return
+    if sys.platform == "win32":
+        _kill_process_tree_windows(proc)
         return
     try:
         os.killpg(os.getpgid(pid), signal.SIGKILL)

--- a/tests/cloud/test_paw_bar_decision_loop.py
+++ b/tests/cloud/test_paw_bar_decision_loop.py
@@ -289,9 +289,7 @@ class TestRobustness:
             raise RuntimeError("instinct store down")
 
         monkeypatch.setattr("pocketpaw.stores.get_instinct_store", _boom)
-        result = await propose_customer_decision(
-            widget=widget, event=event, paw_bar_store=pp_store
-        )
+        result = await propose_customer_decision(widget=widget, event=event, paw_bar_store=pp_store)
         assert result is None
 
     async def test_deliver_no_parked_row_is_noop(self, stores) -> None:

--- a/tests/ee/sites/test_generator_client.py
+++ b/tests/ee/sites/test_generator_client.py
@@ -12,16 +12,28 @@
 # proves a failed install fails the gate closed (no smoke, no deploy). The dep
 # rewrite + gen-cmd resolution are covered by direct helper tests so the env knobs
 # are pinned without spawning bun/node.
+# Updated 2026-07-09 (fix/sites-gen-windows-process-kill): added tests for the
+# build-timeout kill path on Windows. The old _kill_process_group unconditionally
+# called os.killpg/os.getpgid (POSIX-only), so on a Windows host a build TIMEOUT
+# crashed with AttributeError inside the timeout handler — masking _BuildTimeout
+# and escaping publish_pocket as an unhandled 500. These tests simulate win32
+# (deleting the POSIX os attrs so any reference explodes) and assert the killer
+# uses taskkill /T for the child tree instead, and that _communicate_bounded still
+# raises _BuildTimeout end-to-end. A linux-branch test guards the POSIX path.
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
 import pytest
+from pocketpaw_ee.sites import generator_client as gc
 from pocketpaw_ee.sites.generator_client import (
     GeneratorClient,
     SmokeGateFailed,
+    _BuildTimeout,
+    _communicate_bounded,
     _gen_cmd_argv,
+    _kill_process_group,
     _rewrite_ripple_dep,
     _ripple_dep_source,
     _ripple_motion_dep,
@@ -187,3 +199,114 @@ def test_gen_cmd_and_ripple_dep_env_knobs(monkeypatch):
     assert _ripple_motion_dep() == "^12.40.0"
     monkeypatch.setenv("PAW_SITES_MOTION_DEP", "^12.41.0")
     assert _ripple_motion_dep() == "^12.41.0"
+
+
+# --- build-timeout kill path: cross-platform (fix/sites-gen-windows-process-kill) ---
+
+
+class _FakeProc:
+    """Minimal stand-in for asyncio.subprocess.Process: a pid plus the sync
+    kill()/terminate() and async wait() the kill path touches."""
+
+    def __init__(self, pid: int | None = 4242) -> None:
+        self.pid = pid
+        self.returncode: int | None = None
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+
+    def terminate(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        self.returncode = -9
+        return -9
+
+
+def _simulate_windows(monkeypatch) -> None:
+    """Pretend we're on Windows AND remove the POSIX-only os attrs, so any code
+    that still reaches for os.killpg/os.getpgid explodes exactly as it does on a
+    real Windows host (that AttributeError is the bug under test)."""
+    monkeypatch.setattr(gc.sys, "platform", "win32", raising=False)
+    monkeypatch.delattr(gc.os, "killpg", raising=False)
+    monkeypatch.delattr(gc.os, "getpgid", raising=False)
+
+
+def test_kill_process_group_on_windows_uses_taskkill_not_killpg(monkeypatch):
+    """On Windows there are no setsid process groups; the killer must fall back to
+    `taskkill /F /T` (which reaps the leaked workerd child tree) and must NOT touch
+    os.killpg — the AttributeError that crashed publish on a Windows host."""
+    _simulate_windows(monkeypatch)
+    ran: list[list[str]] = []
+
+    def _fake_run(argv, **kwargs):
+        ran.append(argv)
+
+        class _Completed:
+            returncode = 0
+
+        return _Completed()
+
+    monkeypatch.setattr(gc.subprocess, "run", _fake_run)
+
+    # Must not raise AttributeError (the pre-fix crash).
+    _kill_process_group(_FakeProc(pid=4242))
+
+    assert len(ran) == 1, "taskkill should be invoked exactly once"
+    argv = ran[0]
+    assert argv[0] == "taskkill"
+    assert "/T" in argv and "/F" in argv, "must kill the whole child tree, forcibly"
+    assert "4242" in argv, "must target the launched proc's pid"
+
+
+def test_kill_process_group_windows_taskkill_missing_falls_back_to_kill(monkeypatch):
+    """If taskkill is unavailable/blocked, degrade to a best-effort parent kill
+    rather than letting the exception escape the timeout handler."""
+    _simulate_windows(monkeypatch)
+
+    def _boom(*a, **k):
+        raise FileNotFoundError("taskkill not found")
+
+    monkeypatch.setattr(gc.subprocess, "run", _boom)
+    proc = _FakeProc(pid=4242)
+
+    _kill_process_group(proc)  # must not raise
+
+    assert proc.killed is True
+
+
+def test_kill_process_group_on_posix_uses_killpg(monkeypatch):
+    """Guard the Unix path: on POSIX we still SIGKILL the process GROUP so the
+    leaked workerd child dies with the bun parent."""
+    monkeypatch.setattr(gc.sys, "platform", "linux", raising=False)
+    # signal.SIGKILL doesn't exist on a Windows dev host, so inject it — this keeps
+    # the POSIX-branch assertion runnable regardless of where the suite executes.
+    monkeypatch.setattr(gc.signal, "SIGKILL", 9, raising=False)
+    calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(gc.os, "getpgid", lambda pid: pid, raising=False)
+    monkeypatch.setattr(gc.os, "killpg", lambda pgid, sig: calls.append((pgid, sig)), raising=False)
+
+    _kill_process_group(_FakeProc(pid=4242))
+
+    assert calls == [(4242, 9)]
+
+
+@pytest.mark.asyncio
+async def test_communicate_bounded_timeout_raises_buildtimeout_on_windows(monkeypatch):
+    """End-to-end reproduction of the crash from the field log: a build subprocess
+    that hangs past the timeout, on a Windows host, must surface _BuildTimeout — the
+    step's real failure contract — NOT an AttributeError from the kill path."""
+    _simulate_windows(monkeypatch)
+    monkeypatch.setattr(gc.subprocess, "run", lambda *a, **k: None)
+
+    class _HangingProc(_FakeProc):
+        async def communicate(self):
+            import asyncio
+
+            await asyncio.sleep(3600)  # never returns within the timeout
+
+    with pytest.raises(_BuildTimeout) as excinfo:
+        await _communicate_bounded(_HangingProc(pid=4242), timeout_s=0.05, label="bun install")
+
+    assert excinfo.value.label == "bun install"


### PR DESCRIPTION
## What broke

A Windows dev box hit an unhandled 500 while publishing a pocket as a site. The backend log pointed at the build-timeout cleanup path:

```
AttributeError: module 'os' has no attribute 'killpg'
  at ee/pocketpaw_ee/sites/generator_client.py:262 in _kill_process_group
```

Two things happened in sequence. First, a `bun install` smoke gate timed out (the expected failure, and `_communicate_bounded` caught it correctly). Then the cleanup that was supposed to kill the wedged process crashed, because it reached for `os.killpg(os.getpgid(pid), signal.SIGKILL)` — and `os.killpg`, `os.getpgid`, and `signal.SIGKILL` are all POSIX-only. On Windows that `AttributeError` replaced the real `_BuildTimeout`, so instead of a clean "build timed out, site stays view-only" the whole `publish_pocket` call fell over with a 500.

The process-group design assumes `start_new_session=True` gives each subprocess its own killable group. That holds on POSIX; on Windows `start_new_session` is a no-op and there's no `killpg` to call.

## The fix

`_kill_process_group` now branches on `sys.platform`:

- **POSIX** keeps the existing group SIGKILL, so a leaked workerd child still dies with the bun parent.
- **Windows** uses `taskkill /F /T` to kill the child tree (the `/T` is what reaps the workerd child), and falls back to a best-effort `proc.kill()` if `taskkill` isn't available.

Either way the timeout handler now surfaces `_BuildTimeout`, which callers already map to their normal failure contract (the FE degrades to view-only instead of 500ing).

## Tests

Followed the write-the-failing-test-first rule. Four new tests in `test_generator_client.py`, all host-agnostic (they simulate `win32` by patching `sys.platform` and deleting the POSIX `os` attrs, so a stray reference explodes the same way it does on a real Windows host):

- Windows kill path calls `taskkill /F /T` against the right pid and never touches `os.killpg`
- Windows fallback to `proc.kill()` when `taskkill` is missing
- POSIX path still SIGKILLs the process group
- `_communicate_bounded` on a hung proc raises `_BuildTimeout`, not `AttributeError` — the end-to-end repro of the field crash

`uv run pytest tests/ee/sites/test_generator_client.py` → 10 passed. Ruff clean. The other pre-existing failures in `tests/ee/sites/` (Cloudflare deploy config) reproduce on `dev` and are untouched by this change.

Internal-only change to the sites generator's subprocess handling; no API or doc surface to update.
