### PR TITLE
fix(sites): stop re-publish 500ing on Windows (stale .svelte-kit EBUSY)

### DIFF
--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -8,6 +8,21 @@
 # behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-07-09 (fix/sites-svelte-kit-ebusy-windows): every RE-publish of a
+# site 500'd on Windows with SmokeGateFailed: "build failed (exit 1)". Root cause:
+# PERF-3 reuses a per-pocket build dir to cache node_modules, so the prior build's
+# ``.svelte-kit/cloudflare`` survives; adapter-cloudflare's ``adapt()`` starts by
+# ``rimraf``-ing that dir, and a lingering Windows handle (a just-exited workerd, or
+# real-time AV scanning the freshly written ``_worker.js``) makes the rmdir fail
+# ``EBUSY: resource busy or locked`` → build exits 1. The FIRST publish (fresh dir)
+# worked; every reuse hit the stale leftover. Fix: ``build_static`` now calls the new
+# ``_clear_stale_svelte_kit(project_dir)`` BEFORE spawning ``bun run build`` — it
+# wipes ``.svelte-kit`` (never node_modules) at a quiet moment, with a short retry +
+# workerd reap, so the adapter's own rimraf has nothing contended to remove. Also:
+# the non-zero-exit failure reason now carries the captured stderr TAIL (mirrors the
+# install path) so this class of failure is diagnosable from the log, not an opaque
+# "exit 1" (log-only — the client envelope keeps the static generator_failed message).
+#
 # Updated 2026-07-08 (DP0-1 — per-tenant D1 id plumbing for Dynamic Paw Sites
 # Phase 0): build()/_build_one() gained an optional ``d1_database_id: str = ""``
 # param that is ALWAYS written onto ``siteConfig.d1DatabaseId``. The paw-sites
@@ -214,6 +229,7 @@ import json
 import logging
 import os
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -458,6 +474,68 @@ def reap_build_workerd(project_dir: str) -> int:
     return len(victims)
 
 
+# The regenerable build-output dir a `bun run build` writes under a project. PERF-3
+# reuses a per-pocket build dir across publishes to cache node_modules, so this
+# dir survives between builds — and on Windows its leftover triggers the EBUSY
+# below. Wiping it before each build (never node_modules) is the fix.
+_SVELTE_KIT_DIRNAME = ".svelte-kit"
+# A lingering Windows handle on the prior build's output can take a beat to release
+# after that build's process returns; retry the wipe a few times with a short backoff.
+_SVELTE_KIT_CLEAR_ATTEMPTS = 4
+_SVELTE_KIT_CLEAR_BACKOFF_SEC = 0.25
+
+
+async def _clear_stale_svelte_kit(project_dir: str) -> None:
+    """Remove the reused build dir's ``.svelte-kit`` output BEFORE ``bun run build``.
+
+    PERF-3 reuses a per-pocket build dir (``build_home()/<pocket_id>/``) so
+    ``node_modules`` is cached across publishes. But ``adapter-cloudflare``'s
+    ``adapt()`` step begins by ``rimraf``-ing its own ``.svelte-kit/cloudflare``
+    output, and on Windows a lingering handle on the PRIOR build's output — a
+    just-exited workerd child, or a real-time AV scan of the freshly written
+    ``_worker.js`` — makes that ``rmdir`` fail ``EBUSY: resource busy or locked``.
+    The build then exits 1 → ``build_static`` returns ``(False, ...)`` →
+    ``SmokeGateFailed`` → ``sites.generator_failed``. The FIRST publish into a fresh
+    dir succeeds; every RE-publish hit the stale, momentarily-locked leftover — the
+    exact repro behind fix/sites-svelte-kit-ebusy-windows.
+
+    Wiping ``.svelte-kit`` HERE — at a quiet moment, before any build process opens a
+    handle under it — sidesteps the adapter's contended rimraf entirely (it then has
+    nothing to remove). ``.svelte-kit`` is pure regenerable output (``svelte-kit
+    sync`` + the build rebuild it); ``node_modules`` (the expensive install cache) is
+    left untouched, so PERF-3's install-skip still holds. Retries with a short backoff
+    because the lingering handle can take a beat to release after the prior build
+    returns; a best-effort ``reap_build_workerd`` between attempts kills a straggler
+    still holding it. If it ultimately can't be cleared, log and continue — the
+    adapter's own rimraf may still succeed, and either way the ``(False, <stderr
+    tail>)`` path now surfaces a clear reason instead of a bare ``exit 1``."""
+    target = Path(project_dir, _SVELTE_KIT_DIRNAME)
+    if not target.exists():
+        return
+    for attempt in range(_SVELTE_KIT_CLEAR_ATTEMPTS):
+        try:
+            shutil.rmtree(target)
+            return
+        except OSError as exc:
+            # EBUSY / PermissionError on a Windows locked handle (or a slow network
+            # unlink). On the last try, log and let the build proceed — the fix is
+            # best-effort and must never itself break a build.
+            if attempt == _SVELTE_KIT_CLEAR_ATTEMPTS - 1:
+                logger.warning(
+                    "sites: could not clear stale %s in %s after %d attempts: %s "
+                    "(build will fall back to the adapter's own cleanup)",
+                    _SVELTE_KIT_DIRNAME,
+                    project_dir,
+                    _SVELTE_KIT_CLEAR_ATTEMPTS,
+                    exc,
+                )
+                return
+            # A straggler workerd from the prior build may still hold the dir; reap it,
+            # back off, and retry the wipe.
+            reap_build_workerd(project_dir)
+            await asyncio.sleep(_SVELTE_KIT_CLEAR_BACKOFF_SEC * (attempt + 1))
+
+
 class SmokeGateFailed(RuntimeError):
     """Raised when the workerd smoke render fails — the site is not deployed."""
 
@@ -653,6 +731,11 @@ class _SubprocessRunner:
         #     (the live publish still gates + rolls back, so a broken edit can't go
         #     live) but still BUILDS so the served preview is fresh + anchored.
         timeout_s = _build_timeout_sec()
+        # Windows EBUSY guard: wipe the reused dir's stale .svelte-kit output before
+        # the build so adapter-cloudflare's own rimraf of .svelte-kit/cloudflare never
+        # races a lingering handle left by the PRIOR build (keeps node_modules). This
+        # is what made every RE-publish 500 on Windows. See _clear_stale_svelte_kit.
+        await _clear_stale_svelte_kit(project_dir)
         # start_new_session=True: own process group. This is the step that wedges —
         # adapter-cloudflare's workerd prerender can hang forever (upstream SvelteKit
         # bug). The group kill on timeout takes out the leaked workerd CHILD too, not
@@ -684,7 +767,12 @@ class _SubprocessRunner:
         reap_build_workerd(project_dir)
         haystack = stdout.decode() + "\n" + stderr.decode()
         if proc.returncode != 0:
-            return False, f"build failed (exit {proc.returncode})"
+            # Surface the captured stderr TAIL in the failure reason (mirrors the
+            # install path) so a build failure is diagnosable from the SmokeGateFailed
+            # log instead of an opaque "exit 1" — the whole reason this class of
+            # failure needed a manual repro to root-cause. Log-only: the client
+            # envelope keeps the static sites.generator_failed message.
+            return False, f"build failed (exit {proc.returncode}): {stderr.decode()[-800:]}"
         if gate:
             for marker in _WORKERD_SSR_MARKERS:
                 if marker in haystack:

--- a/tests/ee/sites/test_generator_client_svelte_kit_clear.py
+++ b/tests/ee/sites/test_generator_client_svelte_kit_clear.py
@@ -1,0 +1,137 @@
+# tests/ee/sites/test_generator_client_svelte_kit_clear.py
+# Created: 2026-07-09 (fix/sites-svelte-kit-ebusy-windows) — reproduce-first coverage
+# for the "every RE-publish 500s on Windows" bug.
+#
+# Root cause: PERF-3 reuses a per-pocket build dir to cache node_modules, so a prior
+# build's `.svelte-kit/cloudflare` survives into the next build. adapter-cloudflare's
+# adapt() begins by rimraf-ing that dir, and on Windows a lingering handle (a
+# just-exited workerd, or real-time AV scanning the freshly written `_worker.js`)
+# makes the rmdir fail `EBUSY: resource busy or locked` -> `bun run build` exits 1 ->
+# build_static returns (False, ...) -> SmokeGateFailed -> sites.generator_failed. The
+# FIRST publish into a fresh dir works; every reuse hit the stale leftover.
+#
+# Fix: build_static now wipes `.svelte-kit` (keeping node_modules) BEFORE spawning the
+# build, so the adapter's own rimraf has nothing contended to remove. These tests
+# exercise the REAL _SubprocessRunner but patch asyncio.create_subprocess_exec to a
+# fast exit-0 (or exit-1) child, so no bun/node/workerd is required. They assert:
+#   * the reused dir's stale `.svelte-kit` is GONE at the moment the build spawns,
+#   * `node_modules` (the install cache) is PRESERVED,
+#   * a non-zero build exit surfaces the stderr TAIL in the reason (the opacity fix).
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.sites.generator_client import _SubprocessRunner  # noqa: E402
+
+# A child that exits 0 immediately — stands in for a successful `bun run build`.
+_OK_ARGV = [sys.executable, "-c", "pass"]
+
+
+def _seed_reused_dir(project_dir) -> None:
+    """Make ``project_dir`` look like a REUSED PERF-3 build dir: a prior build's
+    ``.svelte-kit/cloudflare`` output (the leftover the adapter's rimraf trips on)
+    plus a populated ``node_modules`` (the expensive install cache that MUST survive)."""
+    stale = project_dir / ".svelte-kit" / "cloudflare"
+    stale.mkdir(parents=True)
+    (stale / "_worker.js").write_text("// stale output from a prior build")
+    nm = project_dir / "node_modules" / "svelte"
+    nm.mkdir(parents=True)
+    (nm / "package.json").write_text("{}")
+
+
+@pytest.mark.asyncio
+async def test_build_static_clears_stale_svelte_kit_before_spawning(tmp_path, monkeypatch):
+    """The fix: build_static wipes a reused dir's stale ``.svelte-kit`` BEFORE it
+    spawns ``bun run build`` — so adapter-cloudflare never has to rimraf a leftover
+    that a lingering Windows handle has locked (EBUSY). ``node_modules`` is preserved
+    so PERF-3's install cache still holds."""
+    _seed_reused_dir(tmp_path)
+    assert (tmp_path / ".svelte-kit").exists()  # precondition: the stale leftover is there
+
+    observed: dict[str, bool] = {}
+    real_exec = asyncio.create_subprocess_exec
+
+    async def _fake_exec(*_args, **kwargs):
+        # Capture the dir state at the exact moment the build would spawn.
+        observed["svelte_kit_present"] = (tmp_path / ".svelte-kit").exists()
+        observed["node_modules_present"] = (tmp_path / "node_modules").exists()
+        return await real_exec(
+            *_OK_ARGV,
+            stdout=kwargs.get("stdout", asyncio.subprocess.PIPE),
+            stderr=kwargs.get("stderr", asyncio.subprocess.PIPE),
+            cwd=kwargs.get("cwd"),
+            start_new_session=kwargs.get("start_new_session", False),
+        )
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    runner = _SubprocessRunner()
+
+    ok, msg = await asyncio.wait_for(runner.build_static(str(tmp_path), gate=True), timeout=10)
+
+    # The build ran cleanly (exit 0) once the contended leftover was cleared out of
+    # the way — this is the reproduced failure now passing.
+    assert ok is True, msg
+    # The core assertion: the stale .svelte-kit was gone BEFORE the build spawned, so
+    # the adapter's own rimraf had nothing locked to trip on.
+    assert observed["svelte_kit_present"] is False, (
+        "build_static spawned the build without first clearing the reused dir's stale "
+        ".svelte-kit — adapter-cloudflare's rimraf will hit EBUSY on Windows"
+    )
+    # ...and node_modules (the install cache) was NOT wiped.
+    assert observed["node_modules_present"] is True, "the install cache was wrongly cleared"
+    assert (tmp_path / "node_modules" / "svelte" / "package.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_build_static_noop_clear_when_no_svelte_kit(tmp_path, monkeypatch):
+    """A FRESH dir (no prior .svelte-kit — the first-ever publish, or the throwaway
+    tempfile dir) is unaffected: the clear is a no-op and the build still runs."""
+    real_exec = asyncio.create_subprocess_exec
+
+    async def _fake_exec(*_args, **kwargs):
+        return await real_exec(
+            *_OK_ARGV,
+            stdout=kwargs.get("stdout", asyncio.subprocess.PIPE),
+            stderr=kwargs.get("stderr", asyncio.subprocess.PIPE),
+            cwd=kwargs.get("cwd"),
+            start_new_session=kwargs.get("start_new_session", False),
+        )
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    runner = _SubprocessRunner()
+
+    ok, _msg = await asyncio.wait_for(runner.build_static(str(tmp_path), gate=False), timeout=10)
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_build_failure_reason_surfaces_stderr_tail(tmp_path, monkeypatch):
+    """The opacity fix: a non-zero build exit now carries the captured stderr TAIL in
+    the failure reason (mirrors the install path), so a future build failure is
+    diagnosable from the SmokeGateFailed log instead of an opaque ``exit 1`` — the
+    very reason this bug needed a hand repro to root-cause."""
+    marker = "PRERENDER_BOOM_a11y_or_ssr_detail"
+    fail_argv = [sys.executable, "-c", f"import sys; sys.stderr.write({marker!r}); sys.exit(1)"]
+    real_exec = asyncio.create_subprocess_exec
+
+    async def _fake_exec(*_args, **kwargs):
+        return await real_exec(
+            *fail_argv,
+            stdout=kwargs.get("stdout", asyncio.subprocess.PIPE),
+            stderr=kwargs.get("stderr", asyncio.subprocess.PIPE),
+            cwd=kwargs.get("cwd"),
+            start_new_session=kwargs.get("start_new_session", False),
+        )
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    runner = _SubprocessRunner()
+
+    ok, msg = await asyncio.wait_for(runner.build_static(str(tmp_path), gate=True), timeout=10)
+    assert ok is False
+    assert "exit 1" in msg
+    assert marker in msg, f"stderr tail not surfaced in failure reason: {msg!r}"


### PR DESCRIPTION
## What was broken

Re-publishing any Paw Site on Windows failed with a 500 (`sites.generator_failed`). The backend log showed `SmokeGateFailed: build failed (exit 1)` and nothing else — the real reason was swallowed, so it took a full local repro to find.

The first publish of a site worked; every publish after that failed. That split is the tell.

## Why

PERF-3 gives each pocket a persistent build dir (`build_home()/<pocket_id>/`) so `node_modules` stays cached across publishes. The side effect: the previous build's `.svelte-kit/cloudflare` output survives into the next build. adapter-cloudflare's `adapt()` step starts by `rimraf`-ing that directory, and on Windows a lingering handle on it — a just-exited workerd prerender child, or Defender/AV scanning the freshly written `_worker.js` — makes the `rmdir` fail with `EBUSY: resource busy or locked`. That aborts `bun run build` with exit 1.

Fresh dir → nothing to remove → works. Reused dir → stale locked leftover → fails. Which is exactly the first-publish-works, re-publish-fails pattern.

Reproduced deterministically against a real site's source: fresh `.svelte-kit` builds clean (exit 0); a reused dir fails EBUSY every time; `rm -rf .svelte-kit` then build is clean again.

## The fix

`build_static` now clears `.svelte-kit` before it spawns `bun run build` — at a quiet moment, before any build process opens a handle under that dir, so the adapter's own rimraf has nothing contended to remove. `node_modules` is left alone, so PERF-3's install-skip still holds. The wipe retries with a short backoff and reaps any straggler workerd, and it never fails the build if it somehow can't clear (the build's own cleanup is still there as a fallback).

Second change: the non-zero-exit path now includes the captured build stderr tail in the failure reason, the same way the `bun install` path already does. That's log-only — the client envelope keeps the static `sites.generator_failed` message — but it means the next build failure of this kind shows up in the log instead of a bare `exit 1`.

## Tests

`tests/ee/sites/test_generator_client_svelte_kit_clear.py`, reproduce-first: they fail on unmodified code (stale `.svelte-kit` still present when the build spawns; reason is a bare `exit 1`) and pass with the fix. A no-op case covers a fresh dir. The rest of the sites generator suite is unchanged (the timeout-file and smoke-at-publish failures on this host are pre-existing POSIX-only / `/tmp/site` fixture issues, confirmed identical with the fix stashed).

## Note for reviewers

Windows-specific behavior, so CI on Linux won't exercise the EBUSY path directly — the tests assert the contract (the dir is gone before the build spawns) rather than the OS lock itself.