### PR TITLE
fix(sites): make bunx wrangler launchable on Windows (workers deploy + D1 migrate)

### DIFF
--- a/ee/pocketpaw_ee/sites/_wrangler.py
+++ b/ee/pocketpaw_ee/sites/_wrangler.py
@@ -1,0 +1,52 @@
+# ee/pocketpaw_ee/sites/_wrangler.py — the shared wrangler-invocation resolver for
+# the sites workers-deploy + D1-migrate paths.
+#
+# Created 2026-07-09 (fix/sites-wrangler-bunx-windows): both workers_deploy.py and
+# d1_migrate.py resolved PAW_CF_WRANGLER_CMD (default `bunx wrangler@4.101.0`) with a
+# bare `shlex.split`. On Windows that default is unlaunchable: create_subprocess_exec
+# (CreateProcess) resolves a bare `bun` to bun.exe, but a bare `bunx` to the
+# NON-EXISTENT bunx.exe — bunx ships only as `.cmd` / `.ps1` shims, which can't be
+# launched without a shell — so it raised FileNotFoundError and every workers-mode
+# deploy 500'd with `sites.workers_wrangler_missing` (and the D1 migrate hit the same
+# wall). This centralizes the tokenization + a Windows `bunx`->`bun x` rewrite so BOTH
+# paths share one Windows-safe resolver instead of duplicating the broken default.
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+
+# The pinned wrangler invocation. Default `bunx wrangler@4.101.0` (pulls + runs the
+# pinned wrangler at publish time — needs network). Override with PAW_CF_WRANGLER_CMD
+# to pin a different version or point at a baked binary, e.g.
+# `/opt/node_modules/.bin/wrangler`. Mirrors PAW_SITES_GEN_CMD's override seam.
+_DEFAULT_WRANGLER_CMD = "bunx wrangler@4.101.0"
+
+# argv[0] basenames that mean "run bunx". create_subprocess_exec can't launch any of
+# them on Windows (there is no bunx.exe), so they get rewritten to `bun x`.
+_BUNX_NAMES = frozenset({"bunx", "bunx.cmd", "bunx.exe", "bunx.ps1"})
+
+
+def wrangler_argv() -> list[str]:
+    """The wrangler invocation, tokenised and made directly launchable by
+    ``create_subprocess_exec`` (no shell). Reads PAW_CF_WRANGLER_CMD (default
+    ``bunx wrangler@4.101.0``) — the SAME override seam workers_deploy + d1_migrate
+    share, so a deploy image pins one wrangler version for both.
+
+    Windows fix: a leading ``bunx`` is rewritten to ``bun x``.
+    ``create_subprocess_exec`` (CreateProcess) resolves a bare ``bun`` to ``bun.exe``
+    but a bare ``bunx`` to the non-existent ``bunx.exe`` (bunx is only ``.cmd`` /
+    ``.ps1`` shims on Windows, unlaunchable without a shell) → FileNotFoundError →
+    ``sites.workers_wrangler_missing``. ``bun x`` is the exact equivalent of ``bunx``
+    and ``bun`` resolves cleanly. An absolute ``.../bunx`` keeps its directory (the
+    sibling ``bun`` is used). No-op on POSIX (a real ``bunx`` exists) and no-op when
+    PAW_CF_WRANGLER_CMD was overridden to something that isn't bunx."""
+    argv = shlex.split(os.environ.get("PAW_CF_WRANGLER_CMD", _DEFAULT_WRANGLER_CMD))
+    if sys.platform != "win32" or not argv:
+        return argv
+    head = argv[0]
+    if os.path.basename(head).lower() in _BUNX_NAMES:
+        base_dir = os.path.dirname(head)
+        bun = os.path.join(base_dir, "bun") if base_dir else "bun"
+        return [bun, "x", *argv[1:]]
+    return argv

--- a/ee/pocketpaw_ee/sites/d1_migrate.py
+++ b/ee/pocketpaw_ee/sites/d1_migrate.py
@@ -26,30 +26,23 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import shlex
 
 from pocketpaw_ee.cloud._core.errors import Internal
+from pocketpaw_ee.sites._wrangler import wrangler_argv as _wrangler_argv
 from pocketpaw_ee.sites.generator_client import _BuildTimeout, _communicate_bounded
 from pocketpaw_ee.sites.workers_deploy import _sanitize
 
 logger = logging.getLogger(__name__)
 
-# The pinned wrangler invocation — same override seam as workers_deploy so the
-# deploy image can pin / swap the wrangler version without a code change
-# (PAW_CF_WRANGLER_CMD, ``shlex.split``, default ``bunx wrangler@4.101.0``).
-_DEFAULT_WRANGLER_CMD = "bunx wrangler@4.101.0"
+# The wrangler invocation (PAW_CF_WRANGLER_CMD, default `bunx wrangler@4.101.0`) is
+# resolved by the shared, Windows-safe helper (imported above as _wrangler_argv) — the
+# SAME seam workers_deploy uses, so migrate + deploy share one wrangler pin and one
+# `bunx`->`bun x` Windows rewrite. See _wrangler.py.
 
 # The migrate subprocess timeout. A legit ``d1 migrations apply`` is seconds; the
 # bound is a safety net so a wedged wrangler (e.g. a hung network pull) can't hang
 # the jobs worker unbounded. Override with PAW_CF_MIGRATE_TIMEOUT_SEC (int seconds).
 _DEFAULT_MIGRATE_TIMEOUT_SEC = 120
-
-
-def _wrangler_argv() -> list[str]:
-    """The wrangler invocation, tokenised. Default ``bunx wrangler@4.101.0``.
-    Override with PAW_CF_WRANGLER_CMD to pin a version or point at a baked binary —
-    the SAME seam workers_deploy uses, so migrate + deploy share one wrangler pin."""
-    return shlex.split(os.environ.get("PAW_CF_WRANGLER_CMD", _DEFAULT_WRANGLER_CMD))
 
 
 def _cf_env() -> dict[str, str]:

--- a/ee/pocketpaw_ee/sites/workers_deploy.py
+++ b/ee/pocketpaw_ee/sites/workers_deploy.py
@@ -53,10 +53,10 @@ import json
 import logging
 import os
 import re
-import shlex
 from pathlib import Path
 
 from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
+from pocketpaw_ee.sites._wrangler import wrangler_argv as _wrangler_argv
 
 logger = logging.getLogger(__name__)
 
@@ -79,18 +79,10 @@ _ASSETSIGNORE_LINES = ("_worker.js", "_routes.json", "_headers")
 _WORKER_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
 # The pinned wrangler invocation. Overridable (and ``shlex.split``) via
-# PAW_CF_WRANGLER_CMD — mirrors generator_client._gen_cmd_argv's PAW_SITES_GEN_CMD
-# so the deploy image can pin / swap the wrangler version without a code change.
-_DEFAULT_WRANGLER_CMD = "bunx wrangler@4.101.0"
-
-
-def _wrangler_argv() -> list[str]:
-    """The wrangler invocation, tokenised. Default ``bunx wrangler@4.101.0`` (pulls
-    + runs the pinned wrangler at publish time — needs network). Override with
-    PAW_CF_WRANGLER_CMD to pin a different version or point at a baked binary, e.g.
-    ``/opt/node_modules/.bin/wrangler``. Mirrors PAW_SITES_GEN_CMD's override seam.
-    """
-    return shlex.split(os.environ.get("PAW_CF_WRANGLER_CMD", _DEFAULT_WRANGLER_CMD))
+# The wrangler invocation (PAW_CF_WRANGLER_CMD, default `bunx wrangler@4.101.0`) is
+# resolved by the shared, Windows-safe helper (imported at top as _wrangler_argv) so
+# deploy + D1-migrate share one seam. See _wrangler.py for the `bunx`->`bun x` rewrite
+# that keeps it launchable on Windows.
 
 
 def _sanitize(raw: str) -> str:

--- a/tests/ee/sites/test_workers_deploy.py
+++ b/tests/ee/sites/test_workers_deploy.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -135,7 +136,14 @@ async def test_deploy_invokes_wrangler_with_deploy_in_project_dir(tmp_path, monk
 
     await workers_deploy.deploy_workers("507f1f77bcf86cd799439011", project)
 
-    assert captured["argv"] == ["bunx", "wrangler@4.101.0", "deploy"]
+    # On Windows the shared resolver rewrites `bunx` -> `bun x` (there is no bunx.exe
+    # for create_subprocess_exec to launch); POSIX keeps the real `bunx`.
+    expected = (
+        ["bun", "x", "wrangler@4.101.0", "deploy"]
+        if sys.platform == "win32"
+        else ["bunx", "wrangler@4.101.0", "deploy"]
+    )
+    assert captured["argv"] == expected
     assert captured["cwd"] == project
     # The CF creds wrangler reads itself ride through the env (full os.environ).
     assert captured["env"] is not None

--- a/tests/ee/sites/test_wrangler_argv.py
+++ b/tests/ee/sites/test_wrangler_argv.py
@@ -1,0 +1,64 @@
+# tests/ee/sites/test_wrangler_argv.py
+# Created: 2026-07-09 (fix/sites-wrangler-bunx-windows) — reproduce-first coverage for
+# the "workers-mode deploy 500s on Windows with sites.workers_wrangler_missing" bug.
+#
+# Root cause: the default PAW_CF_WRANGLER_CMD is `bunx wrangler@4.101.0`, and the
+# deploy / D1-migrate paths launch it with asyncio.create_subprocess_exec (CreateProcess
+# on Windows). CreateProcess resolves a bare `bun` to bun.exe but a bare `bunx` to the
+# NON-EXISTENT bunx.exe (bunx ships only as .cmd/.ps1 shims on Windows) -> FileNotFoundError
+# -> sites.workers_wrangler_missing. Fix: the shared wrangler_argv() rewrites a leading
+# `bunx` to `bun x` on Windows only. These tests patch sys.platform so both branches are
+# exercised deterministically on any host.
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.sites import _wrangler  # noqa: E402
+
+
+def test_bunx_rewritten_to_bun_x_on_windows(monkeypatch):
+    """The bug repro: on Windows the default `bunx ...` must become `bun x ...` so
+    create_subprocess_exec can actually launch it (bun.exe exists, bunx.exe does not)."""
+    monkeypatch.setattr(_wrangler.sys, "platform", "win32")
+    monkeypatch.delenv("PAW_CF_WRANGLER_CMD", raising=False)  # exercise the default
+
+    assert _wrangler.wrangler_argv() == ["bun", "x", "wrangler@4.101.0"]
+
+
+def test_bunx_left_alone_on_posix(monkeypatch):
+    """POSIX has a real `bunx` on PATH — the rewrite is a no-op there."""
+    monkeypatch.setattr(_wrangler.sys, "platform", "linux")
+    monkeypatch.delenv("PAW_CF_WRANGLER_CMD", raising=False)
+
+    assert _wrangler.wrangler_argv() == ["bunx", "wrangler@4.101.0"]
+
+
+def test_absolute_bunx_keeps_its_directory_on_windows(monkeypatch):
+    """An absolute `.../bunx` override still resolves to the sibling `bun` (+ `x`), so
+    the directory the operator pinned is preserved — not collapsed to a bare `bun`."""
+    monkeypatch.setattr(_wrangler.sys, "platform", "win32")
+    monkeypatch.setenv("PAW_CF_WRANGLER_CMD", "C:/tools/npm/bunx wrangler@4.101.0")
+
+    argv = _wrangler.wrangler_argv()
+    # os.path.join on Windows uses backslash; compare on the normalized parts.
+    assert argv[0].replace("\\", "/") == "C:/tools/npm/bun"
+    assert argv[1:] == ["x", "wrangler@4.101.0"]
+
+
+def test_non_bunx_override_is_untouched_on_windows(monkeypatch):
+    """A pinned absolute wrangler binary (not bunx) is launched as-is — no rewrite."""
+    monkeypatch.setattr(_wrangler.sys, "platform", "win32")
+    monkeypatch.setenv("PAW_CF_WRANGLER_CMD", "C:/opt/node_modules/.bin/wrangler.exe")
+
+    assert _wrangler.wrangler_argv() == ["C:/opt/node_modules/.bin/wrangler.exe"]
+
+
+def test_bun_exe_x_override_is_untouched(monkeypatch):
+    """The explicit `bun.exe x wrangler` form (what a .env pin would use) already
+    launches on Windows — it must pass through unchanged."""
+    monkeypatch.setattr(_wrangler.sys, "platform", "win32")
+    monkeypatch.setenv("PAW_CF_WRANGLER_CMD", "C:/npm/bun.exe x wrangler@4.101.0")
+
+    assert _wrangler.wrangler_argv() == ["C:/npm/bun.exe", "x", "wrangler@4.101.0"]


### PR DESCRIPTION
Stacked on #1679 (base is `fix/sites-svelte-kit-ebusy-windows`, not `dev`). #1679 gets the build past the smoke gate; this gets the deploy step past the toolchain check. Rebase onto `dev` once #1679 merges.

## What was broken

With `PAW_CF_DEPLOY_MODE=workers`, publishing 500'd with `sites.workers_wrangler_missing`. D1 migrations for dynamic sites hit the same wall.

## Why

The deploy and migrate paths launch the default `bunx wrangler@4.101.0` with `create_subprocess_exec`, which is `CreateProcess` on Windows. `CreateProcess` resolves a bare `bun` to `bun.exe` — which is why `bun install` and `bun run build` worked — but resolves a bare `bunx` to `bunx.exe`, and that doesn't exist. On Windows `bunx` ships only as `.cmd` and `.ps1` shims, which can't be launched without a shell, so the exec raised `FileNotFoundError` and the service mapped it to `workers_wrangler_missing`.

## The fix

Both files had the same `shlex.split(PAW_CF_WRANGLER_CMD or default)`. I pulled that into a shared `_wrangler.wrangler_argv()` so deploy and migrate share one seam, and added a Windows-only rewrite: a leading `bunx` becomes `bun x`. That's the exact equivalent, and `bun` resolves to `bun.exe` cleanly. An absolute `.../bunx` keeps its directory (uses the sibling `bun`); a non-bunx override (a pinned wrangler binary) is launched untouched. On POSIX it's a no-op — a real `bunx` is on PATH there.

No `.env` pin needed anymore — the default works on Windows out of the box.

## Tests

`test_wrangler_argv.py` patches `sys.platform` so both the Windows rewrite and the POSIX no-op run deterministically on any host, plus the absolute-path and non-bunx-override cases. The existing workers-deploy argv assertion is now platform-aware. Full run: 24 passed across the wrangler / workers-deploy / migrate tests.

## Note for reviewers

Windows-specific, so Linux CI exercises the POSIX no-op branch, not the rewrite — the `win32` branch is covered by the `sys.platform` patch in the unit test rather than the real OS.