### PR TITLE
test(sites): d1_migrate tests + dynamic-site smoke/cleanup runbooks (DP0-6)

### DIFF
--- a/docs/runbooks/2026-07-09-dynamic-sites-orphan-d1-cleanup.md
+++ b/docs/runbooks/2026-07-09-dynamic-sites-orphan-d1-cleanup.md
@@ -1,0 +1,70 @@
+<!-- Runbook: clean up orphaned per-tenant D1 databases left by failed dynamic-site
+     provisions (Phase 0). Created 2026-07-09 (DP0-6). Phase 0 ships this MANUAL
+     procedure; an automated reaper is a Phase 1 follow-up. -->
+
+# Runbook — Dynamic Paw Sites: orphaned D1 cleanup
+
+## Why orphans happen
+
+The `provision_site` job persists a new D1's id on the Site doc **immediately** after
+`create_database`, before migrate/deploy. That is deliberate: if the job fails later and
+**retries**, it reuses that same D1 instead of creating a second one. The trade-off is that a
+D1 whose site is then abandoned (deleted, never retried, or the pocket removed) leaves a real,
+billable Cloudflare database behind.
+
+Phase 0 handles this **manually** (this runbook). An automated reaper is deferred to Phase 1.
+
+## Find orphans
+
+An orphan = a `paw-site-<id>` D1 on the Cloudflare account with no live/`provisioned` Site
+backing it. Cross-reference two lists:
+
+1. **Cloudflare side** — every D1 named `paw-site-*`:
+   ```
+   wrangler d1 list        # or the D1 dashboard; note each database_name + uuid
+   ```
+2. **Control-plane side** — the Site docs and their state. In Mongo:
+   ```
+   // sites where provisioning never completed
+   db.sites.find(
+     { provision_status: { $in: ["failed", "provisioning"] } },
+     { _id: 1, workspace: 1, pocket_id: 1, d1_database_id: 1, provision_status: 1 }
+   )
+   // and sites that were archived/deleted but still carry a d1_database_id
+   db.sites.find({ archived: true, d1_database_id: { $ne: "" } },
+                 { _id: 1, d1_database_id: 1 })
+   ```
+
+A `paw-site-<id>` D1 whose `<id>` has **no** matching Site doc, or whose Site is `failed` /
+archived and will not be retried, is a cleanup candidate.
+
+## Before deleting — confirm it's truly dead
+
+- The D1 name is `paw-site-<site_id>`; look up that `site_id` in `db.sites`.
+- If the Site is `provisioning` and **recent**, it may be an in-flight job — do NOT delete; wait
+  for the job to finish or fail.
+- If the Site is `provisioned`/live, its D1 is **in use** — never delete.
+- Only delete when the Site is `failed`/archived/absent AND you do not intend to retry the
+  publish (a retry would recreate the schema in the same D1, so deleting forces a fresh create).
+
+## Delete
+
+```
+wrangler d1 delete paw-site-<site_id>          # irreversible — data is gone
+```
+
+Then clear the stale pointer so a future publish provisions fresh (optional, if the Site doc
+is being kept):
+```
+db.sites.updateOne(
+  { _id: ObjectId("<site_id>") },
+  { $set: { d1_database_id: "", provision_status: "none" } }
+)
+```
+
+## Notes
+
+- D1 delete is **destructive and irreversible** — double-check the `site_id` maps to a dead
+  site before running it.
+- Keep a short log of what was deleted (site_id, uuid, date, reason) until the automated reaper
+  lands, so a mistaken delete is traceable.

--- a/docs/runbooks/2026-07-09-dynamic-sites-real-cf-smoke.md
+++ b/docs/runbooks/2026-07-09-dynamic-sites-real-cf-smoke.md
@@ -1,0 +1,104 @@
+<!-- Runbook: real-Cloudflare end-to-end smoke for Dynamic Paw Sites (Phase 0).
+     Created 2026-07-09 (DP0-6). This is the moment-of-truth proof — provision a
+     real per-tenant D1, migrate it, deploy, and confirm live read+write. It needs a
+     real Cloudflare account + a runnable wrangler, so it is NOT part of CI. -->
+
+# Runbook — Dynamic Paw Sites: real-Cloudflare end-to-end smoke
+
+**Goal:** publish one no-auth guestbook dynamic site and prove the whole runtime chain
+works against a real Cloudflare account — a per-tenant D1 is *created*, the migration is
+*applied*, the Worker *deploys*, and the live URL both *lists* entries (read) and *accepts*
+a new entry (write).
+
+This is the binary success metric for Phase 0. The code chain is merged to `dev`
+(#1670 create_database + provision_status, #1675 provision_site job, #1677 publish split,
+#1681 baked wrangler); this runbook is what turns "code-complete" into "proven".
+
+---
+
+## 1. Operational-readiness checklist (all must be true)
+
+A dynamic publish will silently sit in `provisioning` or fail unless every row holds:
+
+| # | Requirement | How to satisfy / check |
+|---|-------------|------------------------|
+| 1 | **Deploy mode = `wfp`** | `PAW_CF_DEPLOY_MODE=wfp`. Free `workers` mode rejects dynamic (`sites.workers_dynamic_unsupported`). |
+| 2 | **Workers-for-Platforms dispatch namespace + dispatch worker** | Follow `docs/runbooks/2026-06-26-cloudflare-sites-dispatch-setup.md`. `PAW_CF_DISPATCH_NAMESPACE` set (default `paw-sites`). |
+| 3 | **HTTP-API creds** (create D1 + deploy Worker) | `PAW_CF_ACCOUNT_ID`, `PAW_CF_API_TOKEN`. Token needs **D1:Edit** (create databases) + **Workers Scripts:Edit** + the dispatch-namespace perms. |
+| 4 | **wrangler creds** (migrate subprocess) | `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` (the standard wrangler env names; the same D1-capable token is fine). Set both pairs. |
+| 5 | **wrangler on the box** | The enterprise image bakes it (#1681) and sets `PAW_CF_WRANGLER_CMD=wrangler`. On a non-baked host, install wrangler and point `PAW_CF_WRANGLER_CMD` at it. Verify: `wrangler --version` runs. |
+| 6 | **Generator toolchain** | Already baked: `paw-sites-gen`, `bun`, the `@ripple-ui/svelte` tarball (`PAW_SITES_RIPPLE_DEP`). Verify: `paw-sites-gen --help` runs. |
+| 7 | **arq worker running** | The `provision_site` job runs on the shared chat/jobs arq worker (`arq pocketpaw_ee.cloud.chat.runs.worker.WorkerSettings`). If it isn't running, the site enqueues and never provisions. Needs `POCKETPAW_REDIS_URL`. |
+| 8 | **Sites domain (for a live URL)** | `PAW_CF_SITES_DOMAIN` so the provisioned site resolves at `https://<site_id>.<domain>`. |
+
+> Quick pre-flight on the box:
+> ```
+> wrangler --version && paw-sites-gen --help >/dev/null && echo "toolchain OK"
+> env | grep -E 'PAW_CF_|CLOUDFLARE_|POCKETPAW_REDIS_URL|PAW_SITES_' | sort
+> ```
+
+---
+
+## 2. Build the guestbook dynamic site
+
+Author a minimal no-auth guestbook (one object, one read source, one insert action). Either
+via the `pocketpaw-create-dynamic-site` skill in chat ("a public guestbook people can sign"),
+or directly with a rippleSpec carrying:
+
+```jsonc
+{
+  "ui": { /* a list bound to {guestbook} + the sign form is auto-rendered */ },
+  "objects": [{ "name": "entries",
+    "fields": { "id": "text", "visitor": "text", "message": "text", "created_at": "timestamp" },
+    "primaryKey": "id" }],
+  "sources": [{ "name": "guestbook", "kind": "data", "object": "entries",
+    "orderBy": "created_at", "refresh": "pocket_open" }],
+  "actions": [{ "name": "sign", "object": "entries", "op": "insert" }]
+}
+```
+
+Confirm the pocket is stamped `type="site"`, `pattern="dynamic"`.
+
+## 3. Publish and watch the provision job
+
+Publish the site (chat "publish this", or the publish endpoint). A **dynamic** publish returns
+immediately with `{ "code": "provisioning", "job_id": ... }` — it does NOT block. Then watch:
+
+- **Job status:** `GET /workspaces/{workspace_id}/jobs/{job_id}` → `queued → running → done | failed`.
+- **Site status:** the Site doc's `provision_status`: `none → provisioning → provisioned` (or `failed`).
+
+On success the Site flips to `provisioned` + `deployed=True` with a live `url`.
+
+## 4. Verify the runtime chain (the actual proof)
+
+1. **D1 exists** — in the Cloudflare dashboard (or `wrangler d1 list`), a database named
+   `paw-site-<site_id>` is present, and the Site doc's `d1_database_id` is a real CF uuid (not
+   a hash-shaped placeholder).
+2. **Migration applied** — `wrangler d1 execute paw-site-<site_id> --remote --command "SELECT name FROM sqlite_master WHERE type='table'"` lists `entries` (+ a `d1_migrations` ledger row).
+3. **Read** — open the live `url`; the guestbook list renders server-side (empty first).
+4. **Write** — submit the sign form; the page reflects the new row after the single-flight
+   refresh. Re-query D1 to confirm the row landed.
+
+If all four hold, **Phase 0 is proven.**
+
+---
+
+## 5. Troubleshooting map (symptom → cause → fix)
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Publish returns `sites.workers_dynamic_unsupported` | deploy mode is `workers`, not `wfp` | set `PAW_CF_DEPLOY_MODE=wfp` (checklist #1) |
+| Site stuck in `provisioning` forever, job stays `queued` | arq worker not running | start the arq worker; check `POCKETPAW_REDIS_URL` (checklist #7) |
+| Job `failed`, `provision_status="failed"`, no `d1_database_id` | `create_database` 403/401 | token lacks **D1:Edit** — fix `PAW_CF_API_TOKEN` scope (checklist #3) |
+| Job `failed` **with** `d1_database_id` set, error `sites.migrate_*` | wrangler missing / bad creds / D1 not reachable | `sites.migrate_wrangler_missing` → checklist #5; else check `CLOUDFLARE_*` creds (#4). Retrying reuses the same D1 (no orphan). |
+| Migrate error "no such database" | D1 create + migrate name mismatch, or WfP-vs-account D1 region | confirm the D1 is `paw-site-<site_id>` on the same account the token addresses |
+| Read renders but write 500s | remote-fn/D1 write perms or schema drift | check the Worker logs; confirm the `entries` table matches the emitted `0001_init.sql` |
+| Deploy step fails (`put_worker`) | dispatch namespace / Workers perms | checklist #2/#3; re-run the dispatch-setup runbook |
+
+## 6. After the smoke
+
+- A failed provision that created a D1 leaves it behind (the retry reuses it, but an abandoned
+  site does not). Clean stray databases with
+  `docs/runbooks/2026-07-09-dynamic-sites-orphan-d1-cleanup.md`.
+- Record what broke + the fix here or in a follow-up — the first real run always surfaces
+  real-world quirks the mocked unit tests can't (exact wrangler behavior, D1 API timing).

--- a/tests/ee/sites/test_d1_migrate.py
+++ b/tests/ee/sites/test_d1_migrate.py
@@ -1,0 +1,119 @@
+# tests/ee/sites/test_d1_migrate.py — unit tests for the DP0-3 wrangler-migrate
+# helper (ee/pocketpaw_ee/sites/d1_migrate.py). Created 2026-07-09 (DP0-6). Mocks
+# asyncio.create_subprocess_exec (mirroring test_workers_deploy) so the tests run
+# with NO real wrangler: they assert the exact command shape
+# (`wrangler d1 migrations apply paw-site-<id> --remote`), the cwd, the sanitized
+# database name, and the three fail-closed Internal contracts (non-zero exit,
+# missing toolchain, timeout). The LIVE wrangler-apply against a real/miniflare D1
+# is out of scope here — it lives in the real-CF smoke runbook (gated on wrangler
+# being installed), not in the hermetic unit suite.
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pocketpaw_ee.cloud._core.errors import Internal
+from pocketpaw_ee.sites import d1_migrate
+from pocketpaw_ee.sites.generator_client import _BuildTimeout
+
+
+class _FakeProc:
+    """Minimal asyncio subprocess stand-in: returns (returncode, stdout, stderr)
+    from communicate(). Mirrors the fake in test_workers_deploy."""
+
+    def __init__(self, returncode: int, stdout: bytes, stderr: bytes) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+
+def _patch_subprocess(monkeypatch, proc: _FakeProc) -> dict:
+    """Patch d1_migrate's create_subprocess_exec to return ``proc`` and capture the
+    argv + kwargs of the call."""
+    captured: dict = {}
+
+    async def _fake_exec(*argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr(d1_migrate.asyncio, "create_subprocess_exec", _fake_exec)
+    return captured
+
+
+def test_database_name_is_paw_site_prefixed_and_sanitized() -> None:
+    # A 24-hex ObjectId passes through unchanged.
+    oid = "0123456789abcdef01234567"
+    assert d1_migrate.database_name(oid) == f"paw-site-{oid}"
+
+
+@pytest.mark.asyncio
+async def test_apply_migrations_runs_the_expected_wrangler_command(tmp_path, monkeypatch):
+    monkeypatch.setenv("PAW_CF_WRANGLER_CMD", "bunx wrangler@4.101.0")
+    captured = _patch_subprocess(monkeypatch, _FakeProc(0, b"Migrations applied\n", b""))
+
+    site_id = "0123456789abcdef01234567"
+    await d1_migrate.apply_migrations(site_id, str(tmp_path))
+
+    argv = captured["argv"]
+    # ...wrangler... d1 migrations apply paw-site-<id> --remote
+    assert argv[-5:] == ["d1", "migrations", "apply", f"paw-site-{site_id}", "--remote"]
+    assert argv[:2] == ["bunx", "wrangler@4.101.0"]
+    assert captured["kwargs"]["cwd"] == str(tmp_path)
+    # runs in its own session so a wedged wrangler's whole group can be killed
+    assert captured["kwargs"]["start_new_session"] is True
+
+
+@pytest.mark.asyncio
+async def test_apply_migrations_raises_on_nonzero_exit(tmp_path, monkeypatch):
+    _patch_subprocess(monkeypatch, _FakeProc(1, b"", b"D1_ERROR: no such database\n"))
+
+    with pytest.raises(Internal) as exc:
+        await d1_migrate.apply_migrations("0123456789abcdef01234567", str(tmp_path))
+    assert exc.value.code == "sites.migrate_failed"
+    # the stderr tail is surfaced for debugging
+    assert "no such database" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_apply_migrations_raises_when_wrangler_missing(tmp_path, monkeypatch):
+    async def _boom(*argv, **kwargs):
+        raise FileNotFoundError("wrangler")
+
+    monkeypatch.setattr(d1_migrate.asyncio, "create_subprocess_exec", _boom)
+
+    with pytest.raises(Internal) as exc:
+        await d1_migrate.apply_migrations("0123456789abcdef01234567", str(tmp_path))
+    assert exc.value.code == "sites.migrate_wrangler_missing"
+
+
+@pytest.mark.asyncio
+async def test_apply_migrations_raises_on_timeout(tmp_path, monkeypatch):
+    # A proc whose communicate never returns; a tiny timeout forces the bounded
+    # wait to fire, which _communicate_bounded converts to _BuildTimeout → Internal.
+    class _HangProc:
+        returncode = None
+
+        async def communicate(self):
+            await asyncio.sleep(10)
+            return b"", b""
+
+    async def _fake_exec(*argv, **kwargs):
+        return _HangProc()
+
+    monkeypatch.setattr(d1_migrate.asyncio, "create_subprocess_exec", _fake_exec)
+    # _communicate_bounded kills the process group on timeout; make that a no-op so
+    # the test doesn't try to signal a fake pid.
+    monkeypatch.setattr(d1_migrate, "_communicate_bounded", _raising_timeout)
+
+    with pytest.raises(Internal) as exc:
+        await d1_migrate.apply_migrations("0123456789abcdef01234567", str(tmp_path))
+    assert exc.value.code == "sites.migrate_timeout"
+
+
+async def _raising_timeout(proc, timeout_s, label):
+    raise _BuildTimeout(label, timeout_s)


### PR DESCRIPTION
Part of Dynamic Paw Sites Phase 0 — the prep so the real end-to-end run can happen in staging.

## What's here

- **`d1_migrate` unit tests** (`tests/ee/sites/test_d1_migrate.py`, 5 tests, no real wrangler). They mock the subprocess and assert the migrate helper runs exactly `wrangler d1 migrations apply paw-site-<id> --remote` in the built project dir, sanitizes the db name, and fails closed with the right `Internal` codes for a non-zero exit, a missing wrangler binary, and a timeout.
- **Real-CF smoke runbook** (`docs/runbooks/2026-07-09-dynamic-sites-real-cf-smoke.md`) — the operational-readiness checklist (deploy mode, dispatch namespace, both cred pairs, baked wrangler, the arq worker, sites domain) plus step-by-step: build a guestbook → publish → watch the provision job → verify D1 created + migrated + live read + live write, with a symptom→cause→fix troubleshooting table.
- **Orphan-D1 cleanup runbook** — find + safely delete `paw-site-*` D1s left by failed provisions (Phase 0 is manual; an automated reaper is Phase 1).

## Why the live path isn't tested in CI

The provision chain's migrate step needs a runnable wrangler + a real (or miniflare) D1, which isn't available in CI or the dev session. So the hermetic suite covers the command contract and error handling; the actual "guestbook provisions + reads + writes" proof lives in the smoke runbook, to be run against a staging Cloudflare account. That's the last, deliberately-gated step of Phase 0.

## Tests

`uv run pytest tests/ee/sites/test_d1_migrate.py` → **5 passed**.