### PR TITLE
fix(sites): stop an unconfigured Cloudflare from wedging a dynamic site

### DIFF
--- a/ee/pocketpaw_ee/cloud/jobs/builtin/provision_site.py
+++ b/ee/pocketpaw_ee/cloud/jobs/builtin/provision_site.py
@@ -9,6 +9,14 @@
 #   a. load the Site + the pocket's rippleSpec; fail-closed tenancy re-check (the
 #      worker already re-checks, this is defense-in-depth) — no dynamic site/spec
 #      fails cleanly.
+#   Updated 2026-07-09 (fix/provision-cf-client-wedge) — building the CF client moved
+#   INSIDE the try. It reads the Cloudflare env and raises when unconfigured; raised
+#   outside the try it skipped ``mark_provision_failed`` and left the Site stuck in
+#   ``provision_status="provisioning"``, which the publish path's single-flight guard
+#   reads as "already in flight" — so every retry no-oped and the site could never be
+#   published again. Now an unconfigured Cloudflare fails the job cleanly and the site
+#   lands in ``failed``, which a re-publish resets and re-dispatches.
+#
 #   b. create_database GUARDED on Site.d1_database_id: reuse an already-stored id;
 #      else create it and persist the id IMMEDIATELY (status stays ``provisioning``)
 #      so a retry reuses the same D1 and never orphans a second one.
@@ -70,9 +78,15 @@ class ProvisionSiteJob:
             raise ProvisionError("no Site doc to provision — publish the site first")
 
         site_id = str(site.id)
-        cf = sites_service.provision_cf_client()
 
         try:
+            # Building the CF client READS the Cloudflare env and raises when it is
+            # unconfigured, so it belongs INSIDE the try: an escaping raise here would
+            # skip ``mark_provision_failed`` and strand the Site in ``provisioning``,
+            # where ``_provision_dynamic_site``'s single-flight guard no-ops every
+            # future publish (site permanently unpublishable).
+            cf = sites_service.provision_cf_client()
+
             # b. create_database GUARDED on the stored id. Reuse an existing D1;
             # else create one and persist the id IMMEDIATELY (status stays
             # ``provisioning``) so a retry reuses it — never orphan a second D1.

--- a/tests/cloud/jobs/test_provision_site.py
+++ b/tests/cloud/jobs/test_provision_site.py
@@ -257,3 +257,41 @@ async def test_tenancy_mismatch_fails_closed(
 
     assert cf.create_calls == []
     assert cf.put_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Building the CF client is itself a failure point — an unconfigured Cloudflare
+# must leave the Site doc "failed", never wedged in "provisioning".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cf_client_construction_failure_marks_failed(
+    seed: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``provision_cf_client()`` raises when Cloudflare env is missing.
+
+    That raise must mark the Site ``failed`` like any other provision failure. If it
+    escapes uncaught the doc stays ``provisioning``, and ``_provision_dynamic_site``'s
+    single-flight guard then makes EVERY future publish a silent no-op — the site is
+    permanently unpublishable with no way back short of a manual DB edit."""
+    from pocketpaw_ee.cloud.models.site import Site
+
+    ctx = await seed(d1_database_id="")
+
+    def _unconfigured() -> Any:
+        raise ValueError("sites.cloudflare_unconfigured: Cloudflare is not configured")
+
+    monkeypatch.setattr(sites_service, "provision_cf_client", _unconfigured)
+
+    with pytest.raises(ValueError, match="cloudflare_unconfigured"):
+        await ProvisionSiteJob()(
+            workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-5", params={}
+        )
+
+    site = await Site.get(ctx["site_id"])
+    assert site is not None
+    assert site.provision_status == "failed", (
+        "an unconfigured Cloudflare wedged the site in 'provisioning' — the "
+        "single-flight guard will no-op every retry"
+    )


### PR DESCRIPTION
## What happened

A dynamic site publish left the Site doc stuck in `provision_status="provisioning"` forever. Every subsequent publish was a silent no-op — the site could not be republished at all.

Seen in the wild: the `provision_site` job failed with `sites.cloudflare_unconfigured: Cloudflare is not configured`, and the Site doc never moved off `provisioning`.

## Why

`ProvisionSiteJob.__call__` built the Cloudflare client *before* its `try` block:

```python
cf = sites_service.provision_cf_client()   # reads CF env, raises if unconfigured
try:
    ...                                     # create D1 / build / migrate / deploy
except Exception:
    await sites_service.mark_provision_failed(site)
    raise
```

`provision_cf_client()` reads the Cloudflare env and raises when it's missing. Raised there, it bypassed `mark_provision_failed`, so the doc kept `provision_status="provisioning"`.

That state is exactly what `_provision_dynamic_site`'s single-flight guard treats as "a job is already in flight":

```python
if doc is not None and doc.provision_status == "provisioning":
    doc._provision_job_id = None
    return doc          # early return — no job dispatched
```

So the first failure wedged the site permanently. Only a manual DB edit could recover it.

## The fix

Move the client construction inside the `try`. It's a real failure point and belongs on the same path as create/build/migrate/deploy. The site now lands in `failed`, which a re-publish resets and re-dispatches.

## Testing

New regression test `test_cf_client_construction_failure_marks_failed` monkeypatches `provision_cf_client` to raise and asserts the doc reaches `failed`. It fails on the old code:

```
assert 'provisioning' == 'failed'
```

Full `tests/cloud/jobs/test_provision_site.py` suite passes (6 tests). Lint clean.

## Note for reviewers

This stops the wedge; it doesn't configure Cloudflare. Two related things worth a separate look:

1. The provision job always uses `provision_cf_client()` (the Workers-for-Platforms API path) regardless of `PAW_CF_DEPLOY_MODE`, so dynamic sites can't publish in `local` or `workers` mode.
2. `_cf_client()` requires `PAW_CF_ZONE_ID`, but `zone_id` is only used by `add_domain`'s custom-hostname calls — `create_database` and `put_worker` never read it. The guard blocks publish on a credential the publish path doesn't use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)