### PR TITLE
feat(sites): deploy dynamic sites to workers.dev without Workers for Platforms

### DIFF
--- a/ee/pocketpaw_ee/cloud/jobs/builtin/provision_site.py
+++ b/ee/pocketpaw_ee/cloud/jobs/builtin/provision_site.py
@@ -17,6 +17,14 @@
 #   published again. Now an unconfigured Cloudflare fails the job cleanly and the site
 #   lands in ``failed``, which a re-publish resets and re-dispatches.
 #
+#   Updated 2026-07-09 (feat/dynamic-workers-deploy) — step (e) now deploys through
+#   ``sites_service.provision_deploy``, which honours PAW_CF_DEPLOY_MODE, instead of
+#   calling ``cf.put_worker`` directly. put_worker ONLY uploads into a
+#   Workers-for-Platforms dispatch namespace — a paid add-on — so on an account
+#   without WfP every dynamic publish died on ``Cloudflare API 403`` (CF 10121) no
+#   matter what deploy mode was configured. ``workers`` mode now deploys the same
+#   built worker to the free workers.dev tier with the D1 bound as ``DB``.
+#
 #   b. create_database GUARDED on Site.d1_database_id: reuse an already-stored id;
 #      else create it and persist the id IMMEDIATELY (status stays ``provisioning``)
 #      so a retry reuses the same D1 and never orphans a second one.
@@ -108,18 +116,21 @@ class ProvisionSiteJob:
             # baked-in database_id from the toml — no --database-id flag).
             await d1_migrate.apply_migrations(site_id, project_dir)
 
-            # e. Deploy the Worker with its D1 binding (same as _deploy_site_doc's
-            # dynamic bind).
-            await cf.put_worker(
-                script_name=site_id,
+            # e. Deploy the Worker with its D1 binding, to whichever target
+            # PAW_CF_DEPLOY_MODE names. ``workers`` mode binds the D1 through
+            # wrangler on the free tier; ``wfp`` keeps the dispatch-namespace
+            # put_worker. The seam owns the choice AND returns the live URL, since
+            # the two targets resolve URLs differently.
+            url = await sites_service.provision_deploy(
+                site_id=site_id,
+                project_dir=project_dir,
                 bundle=bundle,
-                bindings=sites_service.provision_d1_bindings(d1_database_id),
+                d1_database_id=d1_database_id,
+                cloudflare=cf,
             )
 
             # f. Mark the Site doc provisioned + live.
-            await sites_service.finalize_provisioned_site(
-                site, url=sites_service.provision_site_url(site_id)
-            )
+            await sites_service.finalize_provisioned_site(site, url=url)
         except Exception:
             # Any failure in b–f: mark failed (the d1 id, if created, is already
             # persisted so a retry reuses it) and re-raise so the worker marks the

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1757,6 +1757,53 @@ def provision_d1_bindings(d1_database_id: str) -> list[dict]:
     return [{"type": "d1", "name": _D1_BINDING_NAME, "id": d1_database_id}]
 
 
+async def provision_deploy(
+    *,
+    site_id: str,
+    project_dir: str,
+    bundle: bytes,
+    d1_database_id: str,
+    cloudflare: Any = None,
+) -> str:
+    """Deploy a PROVISIONED dynamic site to whichever target ``_deploy_mode()`` names,
+    and return its public URL. The one seam the provision job deploys through.
+
+    Before this existed the job always called ``cf.put_worker``, which only uploads
+    into a Workers-for-Platforms dispatch namespace. WfP is a PAID add-on, so an
+    account without it got a bare ``Cloudflare API 403`` (CF error 10121) and NO
+    dynamic site could ever publish — regardless of PAW_CF_DEPLOY_MODE, which the job
+    never consulted. Honouring the mode here gives dynamic sites the same free
+    workers.dev target static sites already use:
+
+      * ``workers`` → ``workers_deploy.deploy_workers`` with the D1 bound as ``DB``.
+        Free tier, no dispatch namespace. Returns the real workers.dev URL.
+      * ``wfp`` / UNSET → the pre-existing ``put_worker`` upload (unchanged), whose
+        URL comes from ``provision_site_url``.
+
+    ``local`` is not a dynamic target (nothing serves the D1 binding locally), so it
+    degrades to ``workers`` rather than deploying a site that cannot reach its own
+    database."""
+    mode = _deploy_mode()
+    if mode == "local":
+        logger.info("sites.provision: local mode has no dynamic target — using workers mode")
+        mode = "workers"
+
+    if mode == "workers":
+        from pocketpaw_ee.sites import workers_deploy as workers_deploy_mod
+
+        return await workers_deploy_mod.deploy_workers(
+            site_id, project_dir, d1_database_id=d1_database_id
+        )
+
+    cf = cloudflare or _cf_client()
+    await cf.put_worker(
+        script_name=site_id,
+        bundle=bundle,
+        bindings=provision_d1_bindings(d1_database_id),
+    )
+    return provision_site_url(site_id)
+
+
 def provision_site_url(site_id: str) -> str:
     """The public URL a provisioned dynamic site resolves to — the per-site subdomain
     ``https://<site_id>.<PAW_CF_SITES_DOMAIN>`` when the sites domain is configured,

--- a/ee/pocketpaw_ee/sites/workers_deploy.py
+++ b/ee/pocketpaw_ee/sites/workers_deploy.py
@@ -98,6 +98,16 @@ def _sanitize(raw: str) -> str:
     return s or "site"
 
 
+# The D1 binding name a dynamic site's remote functions read (``platform.env.DB``).
+# Must match the WfP path's binding so the SAME built worker runs on either target.
+_D1_BINDING_NAME = "DB"
+
+# We write our own config, but a DYNAMIC project dir ALSO carries the generator's
+# wrangler.toml (name + d1 + queue producers, aimed at the WfP upload). Two configs
+# in one dir is ambiguous, so every wrangler invocation names ours explicitly.
+_CONFIG_FILENAME = "wrangler.jsonc"
+
+
 def _worker_name(site_id: str) -> str:
     """The worker / workers.dev subdomain name for a site: ``paw-site-<site_id>``,
     sanitized so it always matches ``^[a-z0-9][a-z0-9-]*$`` (CF rejects underscores
@@ -106,16 +116,26 @@ def _worker_name(site_id: str) -> str:
     return f"paw-site-{_sanitize(site_id)}"
 
 
-def _wrangler_jsonc(name: str) -> str:
-    """The clean STATIC-site wrangler config (the proven recipe). ``main`` points at
-    the worker entry adapter-cloudflare emits INSIDE the asset dir, and
-    ``assets.directory`` points at that SAME dir (the ``.assetsignore`` we write
-    keeps wrangler from uploading the worker entry as an asset). ``workers_dev:
+def _wrangler_jsonc(name: str, d1_database_id: str | None = None) -> str:
+    """The clean wrangler config for a workers.dev deploy (the proven recipe).
+    ``main`` points at the worker entry adapter-cloudflare emits INSIDE the asset
+    dir, and ``assets.directory`` points at that SAME dir (the ``.assetsignore`` we
+    write keeps wrangler from uploading the worker entry as an asset). ``workers_dev:
     true`` publishes to the free ``<name>.<subdomain>.workers.dev`` URL;
-    ``nodejs_compat`` is what the SvelteKit worker needs at runtime. Deliberately
-    minimal — NO D1 / Queue bindings (those are the dynamic-site Phase-2 path, and
-    the generator's own wrangler.toml that carries them is NOT reused here)."""
-    config = {
+    ``nodejs_compat`` is what the SvelteKit worker needs at runtime.
+
+    ``d1_database_id`` (DYNAMIC sites) adds the single ``DB`` D1 binding — the same
+    binding WfP's ``put_worker`` passes — so a dynamic site's remote functions reach
+    their per-tenant database on the FREE tier, with no dispatch namespace.
+
+    Deliberately still NO Queue bindings. The generator's own wrangler.toml declares
+    ``LEADS_QUEUE`` / ``WRITEBACK_QUEUE`` producers, but Cloudflare Queues is a paid
+    feature and those queues are not created on this path — declaring a producer for
+    a nonexistent queue fails the deploy outright. Both consumers already degrade
+    gracefully on a missing binding (``api/submit`` forwards straight to the capture
+    API; ``writeback.ts`` warns and skips), so omitting them costs durability
+    buffering, never a dropped lead."""
+    config: dict[str, object] = {
         "name": name,
         "main": f"{_CF_OUTPUT_REL}/_worker.js",
         "compatibility_date": "2024-09-23",
@@ -123,6 +143,10 @@ def _wrangler_jsonc(name: str) -> str:
         "workers_dev": True,
         "assets": {"binding": "ASSETS", "directory": _CF_OUTPUT_REL},
     }
+    if d1_database_id:
+        config["d1_databases"] = [
+            {"binding": _D1_BINDING_NAME, "database_name": name, "database_id": d1_database_id}
+        ]
     return json.dumps(config, indent=2) + "\n"
 
 
@@ -151,11 +175,12 @@ def _parse_deploy_url(stdout: str, *, name: str) -> str:
     return ""
 
 
-def _write_deploy_files(project_dir: str, name: str) -> None:
+def _write_deploy_files(project_dir: str, name: str, d1_database_id: str | None = None) -> None:
     """Write the two files the recipe needs into the project: the REQUIRED
     ``.svelte-kit/cloudflare/.assetsignore`` (exact three lines) and the clean
-    static ``wrangler.jsonc`` at the project root. Both are overwritten on a
-    re-publish so a stale config can never linger."""
+    ``wrangler.jsonc`` at the project root. Both are overwritten on a re-publish so
+    a stale config can never linger. ``d1_database_id`` adds the dynamic site's D1
+    binding to the emitted config."""
     out_dir = Path(project_dir, _CF_OUTPUT_REL)
     if not out_dir.is_dir():
         # The static output must exist before this runs — generator.build() emits it.
@@ -165,7 +190,7 @@ def _write_deploy_files(project_dir: str, name: str) -> None:
             "The static build output is missing — the site must be built before a workers deploy.",
         )
     (out_dir / ".assetsignore").write_text("\n".join(_ASSETSIGNORE_LINES) + "\n")
-    Path(project_dir, "wrangler.jsonc").write_text(_wrangler_jsonc(name))
+    Path(project_dir, _CONFIG_FILENAME).write_text(_wrangler_jsonc(name, d1_database_id))
 
 
 def _cf_env() -> dict[str, str]:
@@ -176,8 +201,10 @@ def _cf_env() -> dict[str, str]:
     return dict(os.environ)
 
 
-async def deploy_workers(site_id: str, project_dir: str) -> str:
-    """Deploy a STATIC Paw Site as a regular Worker on the free workers.dev tier.
+async def deploy_workers(
+    site_id: str, project_dir: str, *, d1_database_id: str | None = None
+) -> str:
+    """Deploy a Paw Site as a regular Worker on the free workers.dev tier.
 
     Writes the proven recipe files (``.assetsignore`` + ``wrangler.jsonc``) into the
     already-built project, then runs ``wrangler deploy`` (PAW_CF_WRANGLER_CMD, default
@@ -185,24 +212,28 @@ async def deploy_workers(site_id: str, project_dir: str) -> str:
     ``https://<name>.<subdomain>.workers.dev`` URL (parsed from wrangler's stdout,
     falling back to constructing it from PAW_CF_WORKERS_SUBDOMAIN).
 
+    ``d1_database_id`` (DYNAMIC sites) binds the site's per-tenant D1 as ``DB``, so a
+    dynamic site can serve its live data WITHOUT a Workers-for-Platforms dispatch
+    namespace (a paid add-on). The D1 must already exist and be migrated — the
+    provision job does both before calling this.
+
     The project MUST already carry the generator's ``.svelte-kit/cloudflare/``
     static output (generator.build() emits it before this is called). On a non-zero
     wrangler exit this raises ``Internal`` with the stderr tail so the failure
-    surfaces as a clean 5xx envelope, not an opaque crash.
-
-    NOTE: dynamic-site rejection is the CALLER's job (the service deploy-mode
-    selector knows the pattern). This function deploys whatever static output it is
-    given — it does not re-classify the site."""
+    surfaces as a clean 5xx envelope, not an opaque crash."""
     name = _worker_name(site_id)
     if not _WORKER_NAME_RE.match(name):  # defensive — _worker_name always sanitizes
         raise ValidationError(
             "sites.workers_bad_name",
             f"Computed an invalid worker name from site id {site_id!r}.",
         )
-    _write_deploy_files(project_dir, name)
+    _write_deploy_files(project_dir, name, d1_database_id)
 
-    argv = [*_wrangler_argv(), "deploy"]
-    logger.info("sites.workers: deploying %s via %s", name, argv[:-1])
+    # ``--config`` is REQUIRED, not cosmetic: a dynamic project dir also holds the
+    # generator's wrangler.toml (whose queue producers reference queues that do not
+    # exist on this path), and wrangler must not pick it up.
+    argv = [*_wrangler_argv(), "deploy", "--config", _CONFIG_FILENAME]
+    logger.info("sites.workers: deploying %s (d1=%s) via %s", name, bool(d1_database_id), argv)
     try:
         proc = await asyncio.create_subprocess_exec(
             *argv,

--- a/tests/cloud/jobs/test_provision_site.py
+++ b/tests/cloud/jobs/test_provision_site.py
@@ -289,3 +289,69 @@ async def test_cf_client_construction_failure_marks_failed(
         "an unconfigured Cloudflare wedged the site in 'provisioning' — the "
         "single-flight guard will no-op every retry"
     )
+
+
+# ---------------------------------------------------------------------------
+# Deploy target follows PAW_CF_DEPLOY_MODE — a dynamic site must not require the
+# paid Workers-for-Platforms dispatch namespace.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workers_mode_deploys_via_wrangler_not_put_worker(
+    seed: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In ``workers`` mode the job deploys to the free workers.dev tier.
+
+    ``put_worker`` uploads ONLY into a WfP dispatch namespace (a paid add-on), which
+    403s with CF error 10121 on an account without it. The job must instead hand the
+    built project to ``deploy_workers`` with the D1 id, and store the workers.dev URL
+    it returns."""
+    from pocketpaw_ee.cloud.models.site import Site
+    from pocketpaw_ee.sites import workers_deploy as workers_deploy_mod
+
+    ctx = await seed(d1_database_id="d1-existing-0007")
+    cf = _FakeCF()
+    _install_fakes(monkeypatch, cf=cf)
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "workers")
+
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_deploy(site_id: str, project_dir: str, *, d1_database_id: str | None = None):
+        calls.append({"site_id": site_id, "d1": d1_database_id, "dir": project_dir})
+        return "https://paw-site-x.acct.workers.dev"
+
+    monkeypatch.setattr(workers_deploy_mod, "deploy_workers", _fake_deploy)
+
+    await ProvisionSiteJob()(
+        workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-6", params={}
+    )
+
+    # Deployed through wrangler with the D1 bound — and never through the WfP upload.
+    assert len(calls) == 1
+    assert calls[0]["d1"] == "d1-existing-0007"
+    assert cf.put_calls == [], "workers mode must not touch the WfP dispatch namespace"
+
+    site = await Site.get(ctx["site_id"])
+    assert site is not None
+    assert site.provision_status == "provisioned"
+    assert site.deployed is True
+    assert site.url == "https://paw-site-x.acct.workers.dev"
+
+
+@pytest.mark.asyncio
+async def test_wfp_mode_still_uses_put_worker(
+    seed: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression guard: ``wfp`` mode keeps the pre-existing dispatch-namespace upload."""
+    ctx = await seed(d1_database_id="d1-existing-0008")
+    cf = _FakeCF()
+    _install_fakes(monkeypatch, cf=cf)
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "wfp")
+
+    await ProvisionSiteJob()(
+        workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-7", params={}
+    )
+
+    assert len(cf.put_calls) == 1
+    assert cf.put_calls[0]["bindings"] == [{"type": "d1", "name": "DB", "id": "d1-existing-0008"}]

--- a/tests/ee/sites/test_workers_deploy.py
+++ b/tests/ee/sites/test_workers_deploy.py
@@ -122,8 +122,54 @@ async def test_deploy_writes_assetsignore_and_wrangler_jsonc(tmp_path, monkeypat
     assert cfg["compatibility_flags"] == ["nodejs_compat"]
     assert cfg["compatibility_date"] == "2024-09-23"
     assert cfg["assets"] == {"binding": "ASSETS", "directory": ".svelte-kit/cloudflare"}
+    # A STATIC site binds no database.
+    assert "d1_databases" not in cfg
 
     assert url == "https://paw-site-507f1f77bcf86cd799439011.acct.workers.dev"
+
+
+# ── dynamic sites: the D1 binding on the free workers.dev tier ───────────────
+
+
+@pytest.mark.asyncio
+async def test_dynamic_deploy_binds_d1_in_wrangler_jsonc(tmp_path, monkeypatch):
+    """A dynamic site must reach its per-tenant D1 WITHOUT Workers-for-Platforms.
+
+    WfP (``put_worker``'s dispatch namespace) is a paid add-on; an account without it
+    gets CF error 10121 / HTTP 403. Binding the D1 in the workers-mode config is what
+    lets the same built worker serve live data on the free tier."""
+    project = _build_project(tmp_path)
+    site_id = "507f1f77bcf86cd799439011"
+    proc = _FakeProc(0, b"https://paw-site-507f1f77bcf86cd799439011.acct.workers.dev\n", b"")
+    _patch_subprocess(monkeypatch, proc)
+
+    await workers_deploy.deploy_workers(site_id, project, d1_database_id="d1-uuid-0001")
+
+    cfg = json.loads(Path(project, "wrangler.jsonc").read_text())
+    assert cfg["d1_databases"] == [
+        {
+            "binding": "DB",
+            "database_name": f"paw-site-{site_id}",
+            "database_id": "d1-uuid-0001",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dynamic_deploy_declares_no_queue_producers(tmp_path, monkeypatch):
+    """Cloudflare Queues is paid and these queues are never created on this path.
+
+    Declaring a producer for a nonexistent queue fails ``wrangler deploy`` outright,
+    so the emitted config must carry none. Both site-side consumers already degrade
+    gracefully on a missing binding."""
+    project = _build_project(tmp_path)
+    proc = _FakeProc(0, b"https://x.y.workers.dev\n", b"")
+    _patch_subprocess(monkeypatch, proc)
+
+    await workers_deploy.deploy_workers("507f1f77bcf86cd799439011", project, d1_database_id="d1-1")
+
+    cfg = json.loads(Path(project, "wrangler.jsonc").read_text())
+    assert "queues" not in cfg
 
 
 @pytest.mark.asyncio
@@ -138,10 +184,12 @@ async def test_deploy_invokes_wrangler_with_deploy_in_project_dir(tmp_path, monk
 
     # On Windows the shared resolver rewrites `bunx` -> `bun x` (there is no bunx.exe
     # for create_subprocess_exec to launch); POSIX keeps the real `bunx`.
+    # ``--config wrangler.jsonc`` is always passed: a DYNAMIC project dir also holds
+    # the generator's wrangler.toml, and wrangler must not resolve that one.
     expected = (
-        ["bun", "x", "wrangler@4.101.0", "deploy"]
+        ["bun", "x", "wrangler@4.101.0", "deploy", "--config", "wrangler.jsonc"]
         if sys.platform == "win32"
-        else ["bunx", "wrangler@4.101.0", "deploy"]
+        else ["bunx", "wrangler@4.101.0", "deploy", "--config", "wrangler.jsonc"]
     )
     assert captured["argv"] == expected
     assert captured["cwd"] == project


### PR DESCRIPTION
Stacked on #1683 (base: `fix/provision-cf-client-wedge`).

## The problem

A dynamic Paw Site could not be published on any Cloudflare account without the **Workers for Platforms** add-on. Publishing died with:

```
sites.cloudflare_error: Cloudflare API 403
```

Confirmed against a real account — the dispatch-namespace API answers:

```
10121  You do not have access to dispatch namespaces. You can purchase it
       within the Cloudflare dashboard ... workers-for-platforms
```

`ProvisionSiteJob` called `cf.put_worker()` unconditionally, and `put_worker` only ever uploads to `/accounts/{id}/workers/dispatch/namespaces/{ns}/scripts/{name}`. It never consulted `PAW_CF_DEPLOY_MODE`. Meanwhile `workers` mode rejected dynamic sites outright (`sites.workers_dynamic_unsupported`, marked "Phase 2") and `local` mode never ran for them.

Net: WfP was a hard requirement for any site with a database, and no env var could change that.

## The change

Deploy through a new `sites_service.provision_deploy` seam that honours the deploy mode:

- **`workers`** → `workers_deploy.deploy_workers` with the site's per-tenant D1 bound as `DB`. Free tier, no dispatch namespace, real workers.dev URL.
- **`wfp` / unset** → the existing `put_worker` upload, unchanged.
- **`local`** → degrades to `workers` (nothing serves a D1 binding locally, so deploying there would produce a site that can't reach its own database).

The seam also returns the URL, since the two targets resolve URLs differently.

Everything needed for the free path already existed: the D1 is created and migrated before deploy, and adapter-cloudflare emits `_worker.js` + static assets. Only the binding was missing.

## Two details worth review

**`--config wrangler.jsonc` is now always passed.** A dynamic project dir carries *both* our emitted `wrangler.jsonc` and the generator's `wrangler.toml` (aimed at the WfP bundle upload). Leaving it ambiguous invites wrangler to resolve the wrong one.

**No Queue producers in the emitted config.** The generator's toml declares `LEADS_QUEUE` and `WRITEBACK_QUEUE` producers. Queues is a paid feature, and these queues are never created on this path — a producer bound to a nonexistent queue fails `wrangler deploy` outright. Both consumers already handle a missing binding: `api/submit` forwards straight to the capture API, and `writeback.ts` warns and skips. So this costs edge durability buffering, never a dropped lead. If we later want Queues on the free-ish tier, creating them in the provision job is the follow-up.

## Testing

Four new tests, all passing:

- `test_dynamic_deploy_binds_d1_in_wrangler_jsonc` — the D1 binding lands in the emitted config
- `test_dynamic_deploy_declares_no_queue_producers` — no producers emitted
- `test_workers_mode_deploys_via_wrangler_not_put_worker` — job uses wrangler, `put_worker` untouched, workers.dev URL stored on the doc
- `test_wfp_mode_still_uses_put_worker` — regression guard for the paid path

`tests/cloud/jobs/` fully green. `tests/ee/sites/` shows the same 15 pre-existing failures before and after this change (they come from `PAW_CF_DEPLOY_MODE` leaking out of a local `.env` into local-mode tests — unrelated, worth a separate fix). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)