### PR TITLE
Per-send model override on the cloud agent chat endpoint

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -264,6 +264,10 @@ async def post_agent_chat(
         # request's ctx and is dropped when the run is submitted.
         surface=body.surface,
         surface_meta=body.surface_meta or {},
+        # CS-13 — carry the per-send model override to the executor. Validated on
+        # the request body; ``None`` for every older client leaves model selection
+        # to the backend.
+        model_override=body.model,
     )
     # create_run is idempotent on (workspace, client_message_id) — when a doc
     # already exists, re-use its run_id so the executor + SSE stream both

--- a/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
@@ -42,6 +42,15 @@
 #   ``*-context`` routes on the file_versions router (which still use the inline
 #   ``pool.run`` path) and the registered ``EditDocumentTool`` family (which edit
 #   a Library file by id and write a revertable version).
+# Changes: 2026-07-08 (CS-13, feat/per-send-model-override) — added the optional
+#   ``model`` field: a per-send model override id chosen by the client's composer
+#   picker for THIS turn only. Validated (``max_length=100`` + a strict character
+#   pattern) because it lands in a subprocess launch arg downstream; a bad value
+#   fails as a 422 rather than reaching the shell. ``None`` (the default / what
+#   every older client sends) leaves model selection entirely to the backend's
+#   existing smart-routing / ``claude_sdk_model`` logic — behavior byte-identical.
+#   It rides ``RunSpec.model_override`` → ``ScopeContext`` → ``AgentPool.run`` to
+#   the Claude SDK backend, where it wins over ALL other model sources.
 """Request and SSE-event payload schemas for the enterprise agent chat endpoint.
 
 The endpoint lives at ``POST /cloud/chat/{scope}/{scope_id}/agent`` and streams
@@ -117,6 +126,18 @@ class CloudAgentChatRequest(BaseModel):
     spreadsheet_snapshot: dict[str, Any] | None = None
     # reveal.js deck JSON from an open slides editor.
     slides_data: dict[str, Any] | None = None
+    # CS-13 — per-send model override. The composer's model picker stamps the
+    # model id to run THIS turn on (e.g. ``claude-haiku-4-5-20251001``); it is
+    # the user's explicit choice for this one send and takes precedence over the
+    # backend's smart-routing / ``claude_sdk_model`` selection. ``None`` (the
+    # default, and what every older client sends) leaves model selection to the
+    # backend, byte-identical to today. Validated at the edge — ``max_length``
+    # plus a strict pattern (letters, digits, ``. _ : / -``) — because the value
+    # is threaded into the Claude CLI subprocess launch options downstream; the
+    # pattern rejects whitespace and shell metacharacters, so a hostile or
+    # malformed id fails as a 422 instead of reaching the process spawn. The
+    # pattern's ``+`` also rejects the empty string.
+    model: str | None = Field(default=None, max_length=100, pattern=r"^[A-Za-z0-9._:/-]+$")
 
     @field_validator("intent")
     @classmethod

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -493,6 +493,13 @@ class ScopeContext:
     # array as "this pocket is an empty shell"). ``None`` when the chat
     # isn't anchored to a pocket — no block, behavior unchanged.
     pocket_summary: dict[str, Any] | None = None
+    # CS-13 — the per-send model override the client's composer picker chose for
+    # THIS turn. ``execute_run`` copies it off ``RunSpec.model_override`` onto the
+    # ctx it rebuilds; ``_drive_agent_loop`` forwards it into ``AgentPool.run`` only
+    # when set, where the Claude SDK backend makes it win over smart-routing /
+    # ``claude_sdk_model``. ``None`` (older clients / no picker) leaves the backend's
+    # own selection untouched — byte-identical to today.
+    model_override: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/chat/runs/domain.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/domain.py
@@ -9,7 +9,15 @@ hint was dropped at the boundary and the whole SurfaceProfile gate (tool-deny,
 ripple-block omission, preamble, create-svelte-site skill) silently no-oped on
 the real ``/agent`` path. Both default to the legacy shape (``None`` / ``{}``),
 which the resolver turns into a GENERIC context with an empty deny — so
-non-/sites and older clients are unchanged."""
+non-/sites and older clients are unchanged.
+
+Changes: 2026-07-08 (CS-13, feat/per-send-model-override) — ``RunSpec`` grows
+``model_override``: the optional per-send model id from ``CloudAgentChatRequest.model``.
+Same boundary reason as ``surface`` — the HTTP handler has the value but submits a
+``RunSpec`` to the executor, so without carrying it the executor's rebuilt ctx would
+never see the client's model choice. ``None`` (the default / older clients) leaves the
+backend's own model selection untouched, byte-identical to today. It's a bare ``str``,
+so it survives the pickle round-trip like every other field."""
 
 from __future__ import annotations
 
@@ -43,3 +51,8 @@ class RunSpec(BaseModel):
     # legacy path (GENERIC context, empty deny).
     surface: str | None = None
     surface_meta: dict[str, Any] = Field(default_factory=dict)
+    # Per-send model override (CS-13), mirrored from ``CloudAgentChatRequest.model``.
+    # The executor rebuilds its own ctx from this spec, so the client's model choice
+    # must ride the spec to survive the submit. ``None`` = backend picks the model
+    # (the legacy path). Validated at the HTTP edge before it ever reaches here.
+    model_override: str | None = None

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,12 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-07-08 (CS-13, feat/per-send-model-override) — ``execute_run`` copies
+  ``spec.model_override`` onto the rebuilt ``ctx`` and ``_drive_agent_loop``
+  forwards it into ``pool.run`` as ``model_override`` ONLY when set (the same
+  withhold-when-empty idiom as the surface kwargs). It reaches the Claude SDK
+  backend, where it wins over smart-routing / ``claude_sdk_model``. ``None``
+  (older clients / no picker) is byte-identical to today.
 - 2026-06-28 (feat/aiam-agent-revoke, AW-4) — ``_drive_agent_loop`` catches
   ``AgentDisabled`` from ``pool.get`` explicitly and yields a clean
   ``agent.unavailable`` error instead of letting it fall through to the generic
@@ -1077,6 +1083,13 @@ async def _drive_agent_loop(
         # narrower signature safe.
         if surface_skills:
             run_kwargs["skill_names"] = surface_skills
+        # CS-13 — per-send model override. Same withhold-when-empty idiom as the
+        # kwargs above: only the Claude SDK backend accepts ``model_override``
+        # (the 7 other backends keep the narrower signature), so it is forwarded
+        # ONLY when the client actually chose a model for this turn. ``None`` =
+        # legacy path, byte-identical to today.
+        if ctx.model_override:
+            run_kwargs["model_override"] = ctx.model_override
         # --- Supervised native-resume wiring (feat/session-supervisor SS-5) -----
         # Flag-gated (default OFF). When ON, route this turn through the
         # SessionSupervisor: recover any prior native ``cli_session_id`` from the
@@ -1547,6 +1560,11 @@ async def execute_run(spec: RunSpec) -> None:
             "Could not resolve a workspace for this run's scope",
         )
     ctx.intent = spec.intent
+    # CS-13 — carry the per-send model override onto the rebuilt ctx. Like
+    # ``intent``, the executor builds a fresh ctx from the spec, so the client's
+    # model choice reaches ``_drive_agent_loop`` only via this copy. ``None`` (older
+    # clients) leaves the backend's own model selection untouched.
+    ctx.model_override = spec.model_override
 
     # Mirror agent_router._ensure_scope_session so _drive_agent_loop's
     # title-gen guard (`if not history and ctx.session_id`) actually fires

--- a/src/pocketpaw/agents/backend.py
+++ b/src/pocketpaw/agents/backend.py
@@ -3,6 +3,14 @@
 Every agent backend (Claude SDK, OpenAI Agents, Gemini CLI, OpenCode CLI)
 must expose a ``info()`` staticmethod and an async ``run()`` generator.
 
+Updated: 2026-07-08 (CS-13, feat/per-send-model-override) — the shared ``run``
+signature grows an optional ``model_override: str | None = None`` keyword: the
+client's per-send model choice. It rides the same withhold-when-empty contract as
+``deny_mcp_tool_ids`` / ``skill_names`` — ``AgentPool.run`` forwards it ONLY when
+non-None, so the 7 backends that keep the narrower signature are unaffected. Only
+the Claude SDK backend acts on it (it wins over smart-routing / ``claude_sdk_model``
+in ``_build_options``). ``None`` = the unchanged legacy path.
+
 Updated: 2026-06-30 (feat/warm-reuse WH-1) — adds the ``LeasedClient`` dataclass:
 a connected, CALLER-owned warm ``ClaudeSDKClient`` plus the backend cache key it
 was connected under. The ``SessionSupervisor`` (WH-2/WH-3) owns a per-(workspace,
@@ -182,6 +190,12 @@ class AgentBackend(Protocol):
         deny_mcp_tool_ids: frozenset[str] = frozenset(),
         allow_sdk_tools: frozenset[str] = frozenset(),
         skill_names: frozenset[str] = frozenset(),
+        # CS-13 — optional per-send model override. Rides the withhold-when-empty
+        # contract: ``AgentPool.run`` forwards it ONLY when non-None, so backends
+        # that keep the narrower signature never receive it. Backends that DO
+        # accept it (the Claude SDK backend) let it win over their own model
+        # selection; any other backend that grows the kwarg may simply ignore it.
+        model_override: str | None = None,
     ) -> AsyncIterator[AgentEvent]: ...
 
     async def stop(self) -> None: ...

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,14 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-07-08 (CS-13, feat/per-send-model-override) — ``run`` /
+  ``_build_options`` grow an optional ``model_override: str | None = None``
+  keyword. When set, it is applied as the LAST word in the model-selection block,
+  so it wins over the non-anthropic ``llm.model``, smart-routing's complexity pick,
+  and the configured ``claude_sdk_model`` — it is the user's explicit per-send
+  choice from the composer's model picker. Because ``_client_cache_key`` already
+  folds ``model`` in, an override that differs from the warm client's model MISSES
+  the cache and gets a fresh subprocess (no stale-model reuse). ``None`` (the
+  default, and all ``prewarm`` ever passes) is byte-identical to the prior path.
 Updated: 2026-07-02 (feat/atlas-fabric AT-7) — the ``pocketpaw_atlas`` server
   additionally gets a per-run live Fabric introspector (``atlas/fabric.py``)
   when — and only when — the tenant scope is a real ``ws:<id>`` (not the OSS
@@ -1525,6 +1534,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         skill_names: frozenset[str],
         stderr_sink: list[str],
         session_handle: SessionHandle | None = None,
+        model_override: str | None = None,
     ) -> _BuiltOptions:
         """Assemble the ``ClaudeAgentOptions`` a turn (or a prewarm) will run on.
 
@@ -1989,6 +1999,19 @@ class ClaudeSDKBackend(BaseAgentBackend):
             elif self.settings.claude_sdk_model:
                 options_kwargs["model"] = self.settings.claude_sdk_model
 
+        # CS-13 — per-send model override. Applied LAST so it wins over ALL of the
+        # above: the non-anthropic ``llm.model``, smart-routing's complexity pick,
+        # and the configured ``claude_sdk_model``. It is the user's explicit choice
+        # for THIS one turn (the composer's model picker), so nothing overrides it.
+        # Already validated at the HTTP edge (``CloudAgentChatRequest.model`` —
+        # ``max_length`` + a strict character pattern) before it ever reaches this
+        # subprocess launch arg. Because ``_client_cache_key`` folds ``model`` in, a
+        # turn carrying a different model naturally MISSES the warm client and gets a
+        # fresh subprocess — no stale-model reuse. ``None`` (the default, and the
+        # only value ``prewarm`` ever passes) leaves the selection above untouched.
+        if model_override:
+            options_kwargs["model"] = model_override
+
         # Capture stderr for better error diagnostics
         def _on_stderr(line: str) -> None:
             stderr_sink.append(line)
@@ -2280,6 +2303,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         session_handle: SessionHandle | None = None,
         warm_client: LeasedClient | None = None,
         on_client_built: Callable[[Any, str, Callable], None] | None = None,
+        model_override: str | None = None,
     ) -> AsyncIterator[AgentEvent]:
         """Process a message through Claude Agent SDK with streaming.
 
@@ -2445,6 +2469,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 allow_mcp_tool_ids=allow_mcp_tool_ids,
                 skill_names=skill_names,
                 session_handle=session_handle,
+                model_override=model_override,
                 stderr_sink=_stderr_lines,
             )
             options = _built.options

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -3,6 +3,12 @@
 Each cloud Agent gets its own AgentBackend + SoulManager + memory namespace.
 Instances are cached and evicted when idle (default 5 minutes).
 
+Updated: 2026-07-08 (CS-13, feat/per-send-model-override) — ``run`` accepts an
+  optional ``model_override: str | None`` (the client's per-send model choice) and
+  forwards it to the backend's ``run`` ONLY when non-None (the same
+  withhold-when-empty idiom as ``deny_mcp_tool_ids`` / ``skill_names``). Only the
+  Claude SDK backend consumes it, where it wins over smart-routing /
+  ``claude_sdk_model``. ``None`` = the unchanged legacy path.
 Updated: 2026-05-21 — ``_build`` now translates an agent's ``config.tools``
   entries that name an opt-in in-process MCP server (see
   ``pocketpaw.tools.policy.OPT_IN_MCP_SERVERS``) into a per-agent
@@ -453,6 +459,7 @@ class AgentPool:
         session_handle: SessionHandle | None = None,
         warm_client: LeasedClient | None = None,
         on_client_built: Callable[[Any, str, Callable], None] | None = None,
+        model_override: str | None = None,
     ) -> AsyncIterator[Any]:
         """Run an agent on a message. Yields AgentEvent stream.
 
@@ -504,6 +511,12 @@ class AgentPool:
         non-Claude backends keep their narrower signature and only the Claude SDK
         backend acts on them. Both unset (the default) = the unchanged legacy
         warm-client path.
+
+        ``model_override`` (CS-13) is the client's per-send model choice. It rides
+        the SAME withhold-when-empty contract as the kwargs above — forwarded to the
+        backend's ``run`` ONLY when set, so the 6 non-Claude backends keep their
+        narrower signature and only the Claude SDK backend acts on it (where it wins
+        over smart-routing / ``claude_sdk_model``). ``None`` = the unchanged path.
         """
         instance = await self.get(agent_id)
         instance.last_active = datetime.now(UTC)
@@ -595,6 +608,13 @@ class AgentPool:
                 run_kwargs["warm_client"] = warm_client
             if on_client_built is not None:
                 run_kwargs["on_client_built"] = on_client_built
+            # Per-send model override (CS-13). Same withhold-when-empty rule as
+            # the kwargs above: only the Claude SDK backend accepts
+            # ``model_override``; the other backends keep the narrower signature,
+            # so the override is forwarded ONLY when the client chose a model for
+            # this turn. None = legacy path, unchanged for every existing run.
+            if model_override is not None:
+                run_kwargs["model_override"] = model_override
             async for event in instance.backend.run(message, **run_kwargs):
                 instance.last_active = datetime.now(UTC)
                 yield event

--- a/tests/cloud/runs/test_run_domain.py
+++ b/tests/cloud/runs/test_run_domain.py
@@ -54,6 +54,50 @@ def test_run_spec_roundtrips_surface_fields():
     assert restored.surface_meta == {"engine": "svelte"}
 
 
+def test_run_spec_roundtrips_model_override():
+    """CS-13 — the per-send model override must ride the spec across the arq
+    pickle boundary so the executor can copy it onto its rebuilt ctx."""
+    spec = RunSpec(
+        run_id="r1",
+        workspace_id="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c1",
+        user_message_id="m1",
+        content="hello",
+        history=[],
+        intent=None,
+        model_override="claude-haiku-4-5-20251001",
+    )
+    restored = RunSpec.model_validate(spec.model_dump())
+    assert restored == spec
+    assert restored.model_override == "claude-haiku-4-5-20251001"
+
+
+def test_run_spec_model_override_defaults_to_none():
+    """Older callers get ``model_override=None`` — the backend picks the model."""
+    spec = RunSpec(
+        run_id="r1",
+        workspace_id="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c1",
+        user_message_id="m1",
+        content="hello",
+        history=[],
+        intent=None,
+    )
+    assert spec.model_override is None
+
+
 def test_run_spec_surface_fields_default_to_legacy():
     """Older callers that don't set surface fields get the legacy shape:
     ``surface=None`` + empty ``surface_meta`` (the resolver then yields a

--- a/tests/cloud/test_agent_chat_schemas.py
+++ b/tests/cloud/test_agent_chat_schemas.py
@@ -62,6 +62,47 @@ def test_intent_rejects_unknown_values(value):
         CloudAgentChatRequest(content="hi", intent=value)
 
 
+def test_model_defaults_to_none():
+    """CS-13 — no model picker means no override; the backend picks the model."""
+    req = CloudAgentChatRequest(content="hi")
+    assert req.model is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "claude-haiku-4-5-20251001",
+        "claude-opus-4-8",
+        "anthropic:claude-sonnet-4-6",
+        "anthropic/claude-sonnet-4-6",
+        "gpt-5.2",
+        "ollama:llama3.2",
+    ],
+)
+def test_model_accepts_valid_ids(value):
+    """CS-13 — real model ids (letters, digits, ``. _ : / -``) validate."""
+    req = CloudAgentChatRequest(content="hi", model=value)
+    assert req.model == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "claude haiku",  # whitespace
+        "claude;rm -rf /",  # shell metacharacters
+        "model$(whoami)",  # command substitution
+        "model|cat",  # pipe
+        "",  # empty string
+        "m" * 101,  # over max_length
+    ],
+)
+def test_model_rejects_hostile_or_malformed_ids(value):
+    """CS-13 — the field lands in a subprocess launch arg, so whitespace, shell
+    metacharacters, the empty string, and >100 chars must 422 at the edge."""
+    with pytest.raises(ValidationError):
+        CloudAgentChatRequest(content="hi", model=value)
+
+
 def test_event_names_cover_spec():
     expected = {
         "message.persisted",
@@ -75,6 +116,7 @@ def test_event_names_cover_spec():
         "pocket_mutation",
         "pocket_execution",
         "ask_user_question",
+        "token_usage",
         "stream_end",
         "error",
     }

--- a/tests/test_agent_pool_entity_profile_runtime.py
+++ b/tests/test_agent_pool_entity_profile_runtime.py
@@ -8,6 +8,9 @@
 #     wrapper). Net = override + instructions + knowledge.
 #   * ``skill_names`` — forwarded to the backend's ``run`` ONLY when non-empty
 #     (withhold-when-empty, so the 6 non-Claude backends keep their signature).
+# Updated: 2026-07-08 (CS-13, feat/per-send-model-override) — adds coverage for
+#   ``model_override`` forwarding: reaches the backend verbatim when the client
+#   picked a model, WITHHELD when None (the same withhold-when-empty contract).
 
 from __future__ import annotations
 
@@ -181,3 +184,24 @@ async def test_no_skill_refs_no_skill_names_withheld(monkeypatch):
     inst = _instance_with(backend)  # no skill_refs, no caller skill_names
     await _run_with_instance(monkeypatch, inst)
     assert "skill_names" not in backend.last_kwargs
+
+
+# ---------------------------------------------------------------------------
+# CS-13 — model_override forwarding (withhold-when-empty)
+# ---------------------------------------------------------------------------
+
+
+async def test_model_override_forwarded_when_set(monkeypatch):
+    """A per-send model choice reaches the backend's ``run`` verbatim so the
+    Claude SDK backend can make it win over its own model selection."""
+    backend = await _run_with(monkeypatch, model_override="claude-haiku-4-5-20251001")
+    assert backend.last_kwargs.get("model_override") == "claude-haiku-4-5-20251001"
+
+
+async def test_model_override_withheld_when_none(monkeypatch):
+    """No picker (None) must be WITHHELD so the 6 non-Claude backends keep their
+    narrower signature — the same contract as skill_names / deny_mcp_tool_ids."""
+    backend = await _run_with(monkeypatch)
+    assert "model_override" not in backend.last_kwargs, (
+        "None model_override must be withheld so non-Claude backends keep their signature"
+    )

--- a/tests/test_claude_sdk_model_override.py
+++ b/tests/test_claude_sdk_model_override.py
@@ -1,0 +1,148 @@
+# tests/test_claude_sdk_model_override.py
+# Created: 2026-07-08 (CS-13, feat/per-send-model-override) — pins the backend
+# half of the per-send model picker. ``ClaudeSDKBackend._build_options`` grows an
+# optional ``model_override`` that, when set, is applied as the LAST word in the
+# model-selection block, so it wins over ALL of: smart-routing's complexity pick,
+# the configured ``claude_sdk_model``, and the auto-select default. These tests
+# drive ``_build_options`` directly (the seam the token-usage event and the warm
+# cache key both read ``options_kwargs["model"]`` from) under the fake-SDK harness
+# reused from tests/test_claude_sdk_prewarm.py, and assert:
+#   1. an override lands on ``options_kwargs["model"]`` verbatim;
+#   2. the override WINS over a configured ``claude_sdk_model``;
+#   3. the override WINS over smart-routing;
+#   4. ``None`` (older clients / no picker) leaves selection byte-identical to
+#      today (auto-select → no model set; or the configured model untouched).
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pocketpaw.agents.claude_sdk import ClaudeAgentSDK, ClaudeSDKBackend
+from pocketpaw.agents.model_router import ModelSelection, TaskComplexity
+
+_LLM_CLIENT = "pocketpaw.llm.client.resolve_llm_client"
+_MODEL_ROUTER = "pocketpaw.agents.model_router.ModelRouter"
+
+
+class _Options:
+    """Real-enough options object: reads ``model`` / ``allowed_tools`` /
+    ``system_prompt`` / ``plugins`` the way ``_build_options`` sets them."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.model = kwargs.get("model", "")
+        self.allowed_tools = kwargs.get("allowed_tools", [])
+        self.system_prompt = kwargs.get("system_prompt", "")
+        self.plugins = kwargs.get("plugins", [])
+
+
+def _make_settings(**overrides):
+    defaults = {
+        "agent_backend": "claude_agent_sdk",
+        "tool_profile": "full",
+        "tools_allow": [],
+        "tools_deny": [],
+        "smart_routing_enabled": False,
+        "claude_sdk_provider": "anthropic",
+        "claude_sdk_model": None,
+        "claude_sdk_max_turns": None,
+        "sdk_load_bundled_skills": False,
+        "anthropic_api_key": "sk-test-key",
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _make_sdk(settings=None):
+    s = settings or _make_settings()
+    with patch.object(ClaudeSDKBackend, "_initialize"):
+        sdk = ClaudeAgentSDK(s)
+    sdk._sdk_available = True
+    sdk._cli_available = True
+    sdk._ClaudeAgentOptions = _Options
+    sdk._HookMatcher = MagicMock()
+    sdk._StreamEvent = None
+    return sdk
+
+
+async def _build(sdk, *, message="hello", model_override=None):
+    """Drive ``_build_options`` to completion under the standard LLM/router/MCP
+    patches and return the raw ``options_kwargs`` the turn will launch with."""
+    selection = ModelSelection(
+        complexity=TaskComplexity.MODERATE,
+        model="claude-sonnet-4-5-20250929",
+        reason="test",
+    )
+    with patch(_LLM_CLIENT) as mock_resolve:
+        mock_llm = MagicMock()
+        mock_llm.is_ollama = False
+        mock_llm.is_openai_compatible = False
+        mock_llm.is_gemini = False
+        mock_llm.is_litellm = False
+        mock_llm.is_openrouter = False
+        mock_llm.to_sdk_env.return_value = {"ANTHROPIC_API_KEY": "sk-test"}
+        mock_resolve.return_value = mock_llm
+        with (
+            patch(_MODEL_ROUTER) as MockRouter,
+            patch.object(ClaudeSDKBackend, "_get_mcp_servers", return_value={}),
+        ):
+            MockRouter.return_value.classify.return_value = selection
+            built = await sdk._build_options(
+                message,
+                system_prompt="identity",
+                history=None,
+                session_key="s1",
+                deny_mcp_tool_ids=frozenset(),
+                allow_sdk_tools=frozenset(),
+                allow_mcp_tool_ids=None,
+                skill_names=frozenset(),
+                stderr_sink=[],
+                model_override=model_override,
+            )
+    return built.options_kwargs
+
+
+@pytest.mark.asyncio
+async def test_override_sets_options_model_verbatim():
+    """A per-send override lands on ``options_kwargs['model']`` byte-for-byte."""
+    sdk = _make_sdk()
+    kwargs = await _build(sdk, model_override="claude-haiku-4-5-20251001")
+    assert kwargs["model"] == "claude-haiku-4-5-20251001"
+
+
+@pytest.mark.asyncio
+async def test_override_wins_over_claude_sdk_model_setting():
+    """The override beats a configured ``claude_sdk_model`` — it's the user's
+    explicit choice for this one turn."""
+    sdk = _make_sdk(_make_settings(claude_sdk_model="claude-opus-4-8"))
+    # Sanity: without an override the configured model is what would be used.
+    baseline = await _build(sdk, model_override=None)
+    assert baseline["model"] == "claude-opus-4-8"
+    # With an override, it wins.
+    kwargs = await _build(sdk, model_override="claude-haiku-4-5-20251001")
+    assert kwargs["model"] == "claude-haiku-4-5-20251001"
+
+
+@pytest.mark.asyncio
+async def test_override_wins_over_smart_routing():
+    """The override beats smart-routing's complexity-based pick."""
+    sdk = _make_sdk(_make_settings(smart_routing_enabled=True))
+    # Sanity: routing alone would pick the router's model.
+    baseline = await _build(sdk, model_override=None)
+    assert baseline["model"] == "claude-sonnet-4-5-20250929"
+    # The override supersedes it.
+    kwargs = await _build(sdk, model_override="claude-haiku-4-5-20251001")
+    assert kwargs["model"] == "claude-haiku-4-5-20251001"
+
+
+@pytest.mark.asyncio
+async def test_no_override_is_byte_identical_auto_select():
+    """``None`` (older clients) leaves auto-select untouched — no model set."""
+    sdk = _make_sdk()  # smart routing off, claude_sdk_model None → auto-select
+    kwargs = await _build(sdk, model_override=None)
+    assert "model" not in kwargs, "auto-select must not stamp a model when no override"


### PR DESCRIPTION
Backend half of the composer model picker (frontend lands in paw-enterprise separately; pair rule — this merges first).

The chat request body gains an optional `model` field: the id runs THAT turn only, winning over smart routing and the claude_sdk_model setting; omitted means byte-identical behavior to today. Validated (charset + length) since it ends up as a subprocess argument. Plumbed CloudAgentChatRequest → RunSpec → ScopeContext → AgentPool.run → the Claude SDK options build. The AgentBackend protocol grows one optional kwarg, forwarded only when set — the other seven backends keep their signatures and simply ignore it.

A nice property for free: the warm-client cache key already folds the model in, so an override naturally gets a fresh subprocess instead of stale-model reuse.

Tests: request validation accept/reject, RunSpec carry-through, override-wins-over-settings at the options seam, pool forwarding — plus claude_sdk/pool/router regression suites green. One pre-existing red fixed in passing: the SSE event-name spec test was missing token_usage.