### PR TITLE
feat(verify): three-position verify_mode adds a shadow rung to the rollout ladder

### DIFF
--- a/ee/pocketpaw_ee/cloud/planner/service.py
+++ b/ee/pocketpaw_ee/cloud/planner/service.py
@@ -29,6 +29,21 @@
 #   ``preconditions`` from each OSS TaskSpec onto the cloud Task it
 #   creates, so completion-time verification (pocketpaw#1162) can read
 #   machine-checkable criteria off the materialized Task.
+# Updated: 2026-07-10 (feat/verify-mode-shadow) — three-position
+#   ``verify_mode`` at the cloud terminal: ``_run_one`` now resolves
+#   ``effective_cloud_plan_verify_mode()`` ONCE (off | shadow | enforce;
+#   the legacy ``cloud_plan_verify_loop_enabled`` bool resolves to ENFORCE
+#   for back-compat) and passes it to ``_verify_plan_task_outcome``. off ⇒
+#   byte-for-byte today's default. shadow ⇒ the verdict is stamped on
+#   ``Task.verify['verdict']`` plus ``verify['mode']='shadow'`` and
+#   ``verify['would_have']=<done|requeued|escalated>`` (what enforce WOULD
+#   have decided, computed READ-ONLY — no requeue_count bump, no feedback
+#   growth, no status change) with a ``verify shadow mode: would_have=...``
+#   log line; the helper returns "done" so every DONE side-effect (output
+#   file, artifact upload, auto-complete) runs exactly as today. enforce ⇒
+#   the prior flag-on behaviour, unchanged. The rejected-attempt feedback
+#   block in the run instructions renders ONLY in enforce — shadow must not
+#   alter the run itself.
 # Updated: 2026-07-02 (feat/svl-5-cloud-verify) — Self-Verifying Loop at
 #   the CLOUD planner terminal (SVL-5), behind
 #   ``cloud_plan_verify_loop_enabled`` (default False ⇒ byte-for-byte
@@ -1281,6 +1296,11 @@ async def _execute_ready_plan_tasks(
 
     # Run all concurrently
     async def _run_one(tid, aid, d):
+        # Resolve the three-position verify mode ONCE per run (off | shadow
+        # | enforce — the legacy cloud_plan_verify_loop_enabled bool resolves
+        # to 'enforce' via effective_cloud_plan_verify_mode()). Everything
+        # verify-related below keys off this single resolution.
+        verify_mode = get_settings().effective_cloud_plan_verify_mode()
         instr = "You are executing a task from a project plan.\\n\\n"
         instr += "## Task: " + d.title + "\\n\\n"
         instr += d.summary + "\\n\\n"
@@ -1293,9 +1313,12 @@ async def _execute_ready_plan_tasks(
         # first — so the re-dispatched agent sees exactly what to fix
         # rather than a bare "try again". Mirrors the OSS executor's
         # ``_build_task_prompt`` "Why the last attempt was rejected"
-        # block. Flag-gated so a disabled loop renders today's
-        # instructions byte-for-byte even if old feedback is on the doc.
-        if get_settings().cloud_plan_verify_loop_enabled:
+        # block. ENFORCE-only: off renders today's instructions
+        # byte-for-byte even if old feedback is on the doc, and shadow
+        # must be observe-only — it never writes feedback itself, and
+        # rendering leftovers from a prior enforce phase would change the
+        # run in a mode that promises zero behavioural delta.
+        if verify_mode == "enforce":
             feedback = (getattr(d, "verify", None) or {}).get("feedback") or []
             if feedback:
                 instr += "\\n## Why the last attempt was rejected\\n"
@@ -1339,20 +1362,23 @@ async def _execute_ready_plan_tasks(
 
             # SVL-5 (Self-Verifying Loop, cloud planner terminal): judge
             # the run's output against the Task's success_criteria BEFORE
-            # any DONE side-effect fires. "done" = SOLVED / UNKNOWN (or
-            # flag off) — fall through to today's completion path
-            # untouched. "requeued" / "escalated" = the verify helper
-            # already moved the task (back to ``proposed`` / to
-            # ``failed``) and stamped why; a rejected attempt must NOT
-            # save its output file, upload artifacts, or auto-complete —
-            # returning here is what enforces that invariant.
+            # any DONE side-effect fires. "done" = SOLVED / UNKNOWN, mode
+            # off, or SHADOW mode (which stamps the verdict + would_have
+            # and always passes through) — fall through to today's
+            # completion path untouched. "requeued" / "escalated"
+            # (enforce only) = the verify helper already moved the task
+            # (back to ``proposed`` / to ``failed``) and stamped why; a
+            # rejected attempt must NOT save its output file, upload
+            # artifacts, or auto-complete — returning here is what
+            # enforces that invariant.
             resolution = "done"
-            if get_settings().cloud_plan_verify_loop_enabled:
+            if verify_mode != "off":
                 resolution = await _verify_plan_task_outcome(
                     workspace_id=workspace_id,
                     project_id=project_id,
                     task_id=tid,
                     full_output=full_output,
+                    mode=verify_mode,
                 )
             if resolution != "done":
                 return resolution
@@ -1501,14 +1527,29 @@ async def _verify_plan_task_outcome(
     project_id: str,
     task_id: str,
     full_output: str,
+    mode: str = "enforce",
 ) -> str:
     """SVL-5 verify hook — judge a finished plan-task run before completion.
 
-    Called from ``_run_one`` only when ``cloud_plan_verify_loop_enabled``
-    is on, after the agent run produced ``full_output`` and BEFORE any
-    DONE side-effect. The verifier is the OSS
-    ``DeterministicVerdictProvider`` — external to the agent that
-    produced the output. Returns the resolution the caller must honour:
+    Called from ``_run_one`` only when the resolved
+    ``effective_cloud_plan_verify_mode()`` is non-'off', after the agent
+    run produced ``full_output`` and BEFORE any DONE side-effect. The
+    verifier is the OSS ``DeterministicVerdictProvider`` — external to the
+    agent that produced the output.
+
+    ``mode`` is the caller's resolved verify mode:
+
+      - ``"shadow"`` — observe-only rollout rung. The verdict is stamped
+        on ``verify['verdict']`` together with ``verify['mode']='shadow'``
+        and ``verify['would_have']=<done|requeued|escalated>`` (what
+        enforce WOULD have decided, computed READ-ONLY — no
+        ``requeue_count`` bump, no ``feedback`` growth, no status change),
+        a ``verify shadow mode: would_have=...`` line is logged, and the
+        helper ALWAYS returns ``"done"`` so every DONE side-effect runs
+        exactly as today.
+      - ``"enforce"`` — the full loop below.
+
+    Returns the resolution the caller must honour:
 
       - ``"done"`` — SOLVED / UNKNOWN (or the task doc vanished): a
         passing or uncheckable result is NEVER requeued or mutated. The
@@ -1558,6 +1599,16 @@ async def _verify_plan_task_outcome(
 
     if verdict.status not in (OutcomeStatus.PARTIAL, OutcomeStatus.NOT_SOLVED):
         # SOLVED / UNKNOWN — stamp the verdict and pass through.
+        if mode == "shadow":
+            # Shadow telemetry covers every completion, not just the
+            # failing ones: enforce would have passed this through too.
+            verify_state["mode"] = "shadow"
+            verify_state["would_have"] = "done"
+            logger.info(
+                "verify shadow mode: would_have=done verdict=%s task=%s",
+                verdict.status.value,
+                task_id,
+            )
         doc.verify = verify_state
         await doc.save()
         # no-event: the TaskResolved emitted by _auto_complete_task
@@ -1581,6 +1632,36 @@ async def _verify_plan_task_outcome(
         current = frozenset(cr.criterion for cr in unmet)
         prev = frozenset(item["criterion"] for item in prior_feedback[-1].get("unmet_criteria", []))
         no_progress = current == prev or len(current) >= len(prev)
+
+    if mode == "shadow":
+        # SHADOW: record what enforce WOULD have decided (no-progress vs
+        # budget vs requeue — computed read-only above) WITHOUT mutating
+        # anything the loop acts through: no status change, no
+        # requeue_count bump, no feedback growth. Returning "done" lets
+        # every DONE side-effect run exactly as today — the would_have
+        # stamp + log line are the rollout telemetry a tenant reads
+        # before daring enforce.
+        if no_progress:
+            would_have = "escalated"
+            would_reason = "no_progress"
+        elif n < max_requeues:
+            would_have = "requeued"
+            would_reason = ""
+        else:
+            would_have = "escalated"
+            would_reason = "budget_exhausted"
+        verify_state["mode"] = "shadow"
+        verify_state["would_have"] = would_have
+        doc.verify = verify_state
+        await doc.save()
+        logger.info(
+            "verify shadow mode: would_have=%s%s verdict=%s task=%s",
+            would_have,
+            f" reason={would_reason}" if would_reason else "",
+            verdict.status.value,
+            task_id,
+        )
+        return "done"
 
     if not no_progress and n < max_requeues:
         # REQUEUE: append this attempt's rejections to the CUMULATIVE

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,21 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-07-10 (feat/verify-mode-shadow): Added the three-position verify
+    rollout modes — ``deep_work_verify_mode`` and ``cloud_plan_verify_mode``
+    (Literal off|shadow|enforce, default 'off'; env
+    POCKETPAW_DEEP_WORK_VERIFY_MODE / POCKETPAW_CLOUD_PLAN_VERIFY_MODE) —
+    superseding the boolean kill-switches so a real tenant can run a SAFE
+    observe-only SHADOW phase (verdict + judge stamps + a
+    ``would_have=<done|requeued|escalated>`` telemetry line; task status
+    NEVER touched) before anyone risks ENFORCE. Resolved by
+    ``effective_deep_work_verify_mode()`` /
+    ``effective_cloud_plan_verify_mode()`` (mirrors
+    ``effective_spend_mode()``): a non-'off' mode wins outright; mode 'off'
+    + legacy bool True resolves to 'enforce' — NOT shadow — because the
+    bools' SHIPPED meaning is the full acting loop, and mapping them to
+    shadow would silently strip requeue/escalate from any deployment that
+    already set them. The legacy bools stay for back-compat.
   - 2026-07-02 (feat/judge-shadow-1168): Added the LLM-as-judge SHADOW settings
     (J-1, issue #1168) — ``deep_work_verify_judge_shadow_enabled`` (default
     False; when True AND deep_work_verify_loop_enabled is on, every completing
@@ -575,15 +590,45 @@ class Settings(BaseSettings):
     deep_work_verify_loop_enabled: bool = Field(
         default=False,
         description=(
-            "Kill-switch for the deep_work Self-Verifying Loop. When False "
-            "(default) deep_work tasks complete exactly as before — no outcome "
-            "verification, byte-for-byte today's behaviour. When True, every "
-            "task that completes successfully has its result checked against "
-            "the success_criteria captured at intake and the resulting "
-            "OutcomeVerdict is stamped on the task's metadata "
-            "(``verify_verdict``) and logged. The verdict is observe-only in "
-            "this slice (SVL-1): the task's status is NOT changed by the "
-            "verification — that is the requeue slice (SVL-2)."
+            "LEGACY back-compat bool for the deep_work Self-Verifying Loop — "
+            "superseded by the three-position "
+            "POCKETPAW_DEEP_WORK_VERIFY_MODE switch. Kept so an existing "
+            "deployment that set this bool keeps the behaviour it shipped "
+            "with: when the new mode is left at its 'off' default and this "
+            "bool is True, ``effective_deep_work_verify_mode()`` resolves to "
+            "'enforce' (the FULL acting loop — verify, requeue, escalate), "
+            "NOT 'shadow' — the bool's shipped meaning IS enforce, and "
+            "mapping it to shadow would silently weaken a deploy that "
+            "already relies on requeue/escalate. Ignored once the mode is "
+            "set to any non-'off' value. Set via "
+            "POCKETPAW_DEEP_WORK_VERIFY_LOOP_ENABLED."
+        ),
+    )
+    deep_work_verify_mode: Literal["off", "shadow", "enforce"] = Field(
+        default="off",
+        description=(
+            "Three-position rollout switch for the deep_work Self-Verifying "
+            "Loop (OSS Mission Control executor terminal). Supersedes the "
+            "deep_work_verify_loop_enabled bool so a tenant can run a SAFE "
+            "observe-only phase before verification is allowed to touch "
+            "task status:\n"
+            "  * 'off'     (default) — no verification; tasks complete "
+            "byte-for-byte as today.\n"
+            "  * 'shadow'  — the safe rollout rung. The deterministic "
+            "verdict is computed and stamped (``verify_verdict``, plus a "
+            "``verify_mode='shadow'`` marker and "
+            "``verify_would_have=<done|requeued|escalated>`` — what enforce "
+            "WOULD have decided), and the judge shadow still runs when its "
+            "flag is on; but the task ALWAYS completes DONE — no requeue, "
+            "no escalation, no ``verify_requeue_count``, no "
+            "``verify_feedback`` growth. Pure telemetry.\n"
+            "  * 'enforce' — the full loop: PARTIAL / NOT_SOLVED requeues "
+            "with feedback (bounded by deep_work_verify_max_requeues) then "
+            "escalates to BLOCKED — exactly the legacy bool's behaviour.\n"
+            "Precedence (``effective_deep_work_verify_mode()``): a non-'off' "
+            "mode wins outright; mode 'off' + legacy bool True resolves to "
+            "'enforce'; otherwise 'off'. Set via "
+            "POCKETPAW_DEEP_WORK_VERIFY_MODE."
         ),
     )
     deep_work_verify_max_requeues: int = Field(
@@ -645,18 +690,47 @@ class Settings(BaseSettings):
     cloud_plan_verify_loop_enabled: bool = Field(
         default=False,
         description=(
-            "Kill-switch for the Self-Verifying Loop at the CLOUD planner "
-            "terminal (ee/cloud plan-task execution — the paw-enterprise "
-            "product path). When False (default) plan tasks auto-complete "
-            "exactly as before — no outcome verification, byte-for-byte "
-            "today's behaviour. When True, every plan task that finishes its "
-            "agent run has its output checked against the cloud Task's "
-            "success_criteria and the OutcomeVerdict is stamped on the task "
-            "(``verify.verdict``). SOLVED / UNKNOWN complete exactly as "
-            "today; PARTIAL / NOT_SOLVED is requeued with the unmet criteria "
-            "fed back to the next attempt, bounded by "
-            "cloud_plan_verify_max_requeues, then failed with a stamped "
-            "``verify.escalation_reason``."
+            "LEGACY back-compat bool for the Self-Verifying Loop at the "
+            "CLOUD planner terminal — superseded by the three-position "
+            "POCKETPAW_CLOUD_PLAN_VERIFY_MODE switch. Kept so an existing "
+            "deployment that set this bool keeps the behaviour it shipped "
+            "with: when the new mode is left at its 'off' default and this "
+            "bool is True, ``effective_cloud_plan_verify_mode()`` resolves "
+            "to 'enforce' (the FULL acting loop — verify, requeue, "
+            "escalate), NOT 'shadow' — the bool's shipped meaning IS "
+            "enforce, and mapping it to shadow would silently weaken a "
+            "deploy that already relies on requeue/escalate. Ignored once "
+            "the mode is set to any non-'off' value. Set via "
+            "POCKETPAW_CLOUD_PLAN_VERIFY_LOOP_ENABLED."
+        ),
+    )
+    cloud_plan_verify_mode: Literal["off", "shadow", "enforce"] = Field(
+        default="off",
+        description=(
+            "Three-position rollout switch for the Self-Verifying Loop at "
+            "the CLOUD planner terminal (ee/cloud plan-task execution — the "
+            "paw-enterprise product path). Supersedes the "
+            "cloud_plan_verify_loop_enabled bool so a real tenant can run a "
+            "SAFE observe-only phase before verification is allowed to "
+            "touch task status:\n"
+            "  * 'off'     (default) — no verification; plan tasks "
+            "auto-complete byte-for-byte as today.\n"
+            "  * 'shadow'  — the safe rollout rung. The deterministic "
+            "verdict is computed and stamped on the task's ``verify`` dict "
+            "(``verify.verdict``, plus ``verify.mode='shadow'`` and "
+            "``verify.would_have=<done|requeued|escalated>`` — what enforce "
+            "WOULD have decided); the task ALWAYS completes done with every "
+            "DONE side-effect intact — no requeue, no escalation, no "
+            "``verify.requeue_count``, no ``verify.feedback`` growth. Pure "
+            "telemetry.\n"
+            "  * 'enforce' — the full loop: PARTIAL / NOT_SOLVED requeues "
+            "with feedback (bounded by cloud_plan_verify_max_requeues) then "
+            "fails with ``verify.escalation_reason`` — exactly the legacy "
+            "bool's behaviour.\n"
+            "Precedence (``effective_cloud_plan_verify_mode()``): a "
+            "non-'off' mode wins outright; mode 'off' + legacy bool True "
+            "resolves to 'enforce'; otherwise 'off'. Set via "
+            "POCKETPAW_CLOUD_PLAN_VERIFY_MODE."
         ),
     )
     cloud_plan_verify_max_requeues: int = Field(
@@ -2274,6 +2348,54 @@ class Settings(BaseSettings):
             return self.litellm_spend_mode
         if self.litellm_spend_ingest_enabled:
             return "shadow"
+        return "off"
+
+    def effective_deep_work_verify_mode(self) -> Literal["off", "shadow", "enforce"]:
+        """Resolve the deep_work verify-loop mode, honouring the legacy bool.
+
+        Mirrors the ``effective_spend_mode()`` shape: the three-position
+        ``deep_work_verify_mode`` switch supersedes the
+        ``deep_work_verify_loop_enabled`` bool. Resolution, in order:
+
+          1. An EXPLICIT ``POCKETPAW_DEEP_WORK_VERIFY_MODE`` (any non-'off'
+             value) wins outright — ``shadow`` and ``enforce`` are taken as
+             set.
+          2. Mode unset / 'off' + the legacy bool True → ``enforce``.
+          3. Mode unset / 'off' + the legacy bool False/unset → ``off``.
+
+        WHY the legacy bool maps to ``enforce`` and never ``shadow`` (the
+        DELIBERATE opposite of the spend-mode precedent): the verify bool's
+        SHIPPED meaning is the full acting loop — requeue on PARTIAL /
+        NOT_SOLVED, escalate to BLOCKED on budget / no-progress. A
+        deployment that set the bool opted into that enforcement; resolving
+        it to 'shadow' would silently strip requeue/escalate from that
+        deployment on upgrade — a behaviour downgrade with no operator
+        decision. (The spend bool mapped to the safe MIDDLE position
+        because 'live' moves money and the bool's legacy path had no
+        periodic caller; here the bool's legacy behaviour IS the strong
+        position, so back-compat preserves it.)
+        """
+        if self.deep_work_verify_mode != "off":
+            return self.deep_work_verify_mode
+        if self.deep_work_verify_loop_enabled:
+            return "enforce"
+        return "off"
+
+    def effective_cloud_plan_verify_mode(self) -> Literal["off", "shadow", "enforce"]:
+        """Resolve the CLOUD planner verify-loop mode, honouring the legacy bool.
+
+        Identical shape to ``effective_deep_work_verify_mode()`` at the
+        ee/cloud planner terminal: an explicit non-'off'
+        ``POCKETPAW_CLOUD_PLAN_VERIFY_MODE`` wins outright; mode 'off' +
+        legacy ``cloud_plan_verify_loop_enabled`` True → ``enforce`` (NOT
+        shadow — the bool's shipped meaning is the acting loop, see the
+        deep_work resolver's docstring for the full rationale); otherwise
+        ``off``.
+        """
+        if self.cloud_plan_verify_mode != "off":
+            return self.cloud_plan_verify_mode
+        if self.cloud_plan_verify_loop_enabled:
+            return "enforce"
         return "off"
 
     def save(self) -> None:

--- a/src/pocketpaw/mission_control/executor.py
+++ b/src/pocketpaw/mission_control/executor.py
@@ -1,6 +1,20 @@
 """Mission Control Task Executor.
 
 Created: 2026-02-05
+Updated: 2026-07-10 — three-position ``verify_mode`` (feat/verify-mode-shadow):
+  the completion block now resolves ``effective_deep_work_verify_mode()``
+  ONCE (off | shadow | enforce; the legacy
+  ``deep_work_verify_loop_enabled`` bool resolves to ENFORCE for
+  back-compat). ``off`` skips the whole block — byte-for-byte today's
+  default. ``shadow`` is the new rollout rung: the deterministic verdict is
+  computed and stamped (``verify_verdict``), the judge shadow still runs
+  when its flag is on, and what enforce WOULD have decided is computed
+  READ-ONLY and recorded as ``verify_would_have=<done|requeued|escalated>``
+  plus a ``verify_mode='shadow'`` marker and a ``verify shadow mode:
+  would_have=...`` log line — but status/should_retry are NEVER touched, no
+  ``verify_requeue_count`` bump, no ``verify_feedback`` growth: the task
+  completes DONE with the deliverable + side-effects intact. ``enforce`` is
+  exactly the prior flag-on behaviour (SVL-1/2/3 + J-1 below, unchanged).
 Updated: 2026-07-02 — LLM-as-judge SHADOW stamp (J-1, #1168): inside the
   existing ``deep_work_verify_loop_enabled`` block, AFTER the deterministic
   verdict is computed and stamped, when ``deep_work_verify_judge_shadow_enabled``
@@ -322,15 +336,24 @@ class MCTaskExecutor:
             if final_status == "completed":
                 new_task_status = TaskStatus.DONE
 
-                # Self-Verifying Loop: when the loop is enabled, check the
-                # completed task's result against the success_criteria captured
-                # at intake and STAMP the verdict on the task — the "verify"
-                # half (SVL-1). SVL-2 then ACTS on the verdict: a result that
-                # does NOT meet its criteria is requeued with the specific unmet
-                # criteria fed back, up to a budget, then escalated to BLOCKED.
-                # When the flag is off this whole block is skipped and behaviour
-                # is byte-for-byte unchanged.
-                if get_settings().deep_work_verify_loop_enabled and task_fresh:
+                # Self-Verifying Loop: resolve the three-position mode ONCE
+                # (off | shadow | enforce — the legacy bool resolves to
+                # 'enforce' via effective_deep_work_verify_mode()).
+                #   off     → this whole block is skipped; byte-for-byte
+                #             today's default behaviour.
+                #   shadow  → the rollout rung: compute + STAMP the verdict
+                #             (SVL-1) and run the judge shadow if its flag is
+                #             on, then compute READ-ONLY what enforce WOULD
+                #             have done and record it as would_have telemetry
+                #             — but NEVER touch status/should_retry, counters,
+                #             or feedback: the task falls through to normal
+                #             DONE with deliverable + side-effects intact.
+                #   enforce → the full loop, exactly the prior flag-on
+                #             behaviour: SVL-2 ACTS on the verdict (requeue
+                #             with feedback, bounded by the budget, then
+                #             escalate to BLOCKED; SVL-3 no-progress guard).
+                verify_mode = get_settings().effective_deep_work_verify_mode()
+                if verify_mode != "off" and task_fresh:
                     success_criteria = task_fresh.metadata.get("success_criteria", [])
                     verdict = DeterministicVerdictProvider().verify(
                         task_fresh.output, success_criteria
@@ -375,9 +398,11 @@ class MCTaskExecutor:
                     # SVL-2: act on the verdict. SOLVED / UNKNOWN pass through
                     # as DONE — a passing (or uncheckable) result is NEVER
                     # requeued or mutated. PARTIAL / NOT_SOLVED means the output
-                    # missed at least one captured criterion: requeue the task
-                    # with the unmet criteria fed back, bounded by
-                    # deep_work_verify_max_requeues, then escalate to BLOCKED.
+                    # missed at least one captured criterion: in ENFORCE mode,
+                    # requeue the task with the unmet criteria fed back, bounded
+                    # by deep_work_verify_max_requeues, then escalate to
+                    # BLOCKED; in SHADOW mode only record what enforce would
+                    # have done.
                     if verdict.status in (
                         OutcomeStatus.PARTIAL,
                         OutcomeStatus.NOT_SOLVED,
@@ -410,7 +435,35 @@ class MCTaskExecutor:
                             )
                             no_progress = current == prev or len(current) >= len(prev)
 
-                        if no_progress:
+                        if verify_mode == "shadow":
+                            # SHADOW: record what enforce WOULD have decided
+                            # (no-progress vs budget vs requeue — computed
+                            # read-only above) WITHOUT mutating anything the
+                            # loop acts through: no status change, no
+                            # should_retry, no verify_requeue_count bump, no
+                            # verify_feedback growth. The task falls through
+                            # to normal DONE; the would_have stamp + log line
+                            # are the rollout telemetry a tenant reads before
+                            # daring enforce.
+                            if no_progress:
+                                would_have = "escalated"
+                                would_reason = "no_progress"
+                            elif n < max_requeues:
+                                would_have = "requeued"
+                                would_reason = ""
+                            else:
+                                would_have = "escalated"
+                                would_reason = "budget_exhausted"
+                            task_fresh.metadata["verify_mode"] = "shadow"
+                            task_fresh.metadata["verify_would_have"] = would_have
+                            logger.info(
+                                "verify shadow mode: would_have=%s%s verdict=%s task=%s",
+                                would_have,
+                                f" reason={would_reason}" if would_reason else "",
+                                verdict.status.value,
+                                task_id,
+                            )
+                        elif no_progress:
                             # Same/non-shrinking unmet set: stuck. Escalate to
                             # the SAME BLOCKED status + cascade branch as a
                             # budget exhaustion, distinguished only by the
@@ -469,6 +522,18 @@ class MCTaskExecutor:
                                 verdict.status,
                                 n,
                             )
+                    elif verify_mode == "shadow":
+                        # SHADOW + SOLVED/UNKNOWN: enforce would have passed it
+                        # through as DONE too — stamp would_have=done so the
+                        # shadow telemetry covers every completion, not just
+                        # the failing ones.
+                        task_fresh.metadata["verify_mode"] = "shadow"
+                        task_fresh.metadata["verify_would_have"] = "done"
+                        logger.info(
+                            "verify shadow mode: would_have=done verdict=%s task=%s",
+                            verdict.status.value,
+                            task_id,
+                        )
             elif final_status in ("error", "timeout") and task_fresh:
                 # Check if we should retry
                 if task_fresh.retry_count < task_fresh.max_retries:

--- a/tests/cloud/test_planner_verify_loop.py
+++ b/tests/cloud/test_planner_verify_loop.py
@@ -1,3 +1,12 @@
+# Updated: 2026-07-10 (feat/verify-mode-shadow) — three-position
+#   ``cloud_plan_verify_mode``: added shadow-mode tests (a failing task
+#   still lands ``done`` with the output-file/artifact side-effects intact,
+#   ``verify.verdict`` + ``verify.mode='shadow'`` + ``verify.would_have``
+#   stamped, NO ``requeue_count`` / ``feedback`` written; SOLVED stamps
+#   would_have=done) and a mode='enforce'-without-the-bool test. The
+#   pre-existing tests set ONLY the legacy bool (``enabled=True``), so their
+#   continued passing IS the back-compat proof that the bool still resolves
+#   to enforce through ``effective_cloud_plan_verify_mode()``.
 # Created: 2026-07-02 (feat/svl-5-cloud-verify) — SVL-5: the Self-Verifying
 #   Loop at the CLOUD planner terminal. Drives the real
 #   ``_execute_ready_plan_tasks`` → ``_run_one`` → ``_verify_plan_task_outcome``
@@ -66,11 +75,14 @@ class _FakePool:
         return _gen()
 
 
-def _settings(enabled: bool, max_requeues: int = 2):
-    """A Settings copy with the SVL-5 flag and requeue budget forced."""
+def _settings(enabled: bool, max_requeues: int = 2, mode: str = "off"):
+    """A Settings copy with the legacy bool, the three-position mode, and
+    the requeue budget forced. ``mode`` defaults to 'off' so the legacy
+    tests exercise the bool→enforce back-compat resolution."""
     return get_settings().model_copy(
         update={
             "cloud_plan_verify_loop_enabled": enabled,
+            "cloud_plan_verify_mode": mode,
             "cloud_plan_verify_max_requeues": max_requeues,
         }
     )
@@ -93,7 +105,7 @@ async def _make_plan_task(criteria: list[str]) -> str:
     return str(doc.id)
 
 
-async def _drive(pool: _FakePool, *, enabled: bool, max_requeues: int = 2):
+async def _drive(pool: _FakePool, *, enabled: bool, max_requeues: int = 2, mode: str = "off"):
     """Run the real dispatch path with the pool, settings, and DONE
     side-effects (output-file save + artifact scan) patched. Returns the
     two side-effect mocks so tests assert fired / not-fired."""
@@ -103,7 +115,7 @@ async def _drive(pool: _FakePool, *, enabled: bool, max_requeues: int = 2):
         patch("pocketpaw.agents.pool.get_agent_pool", return_value=pool),
         patch(
             "pocketpaw.config.get_settings",
-            return_value=_settings(enabled, max_requeues),
+            return_value=_settings(enabled, max_requeues, mode),
         ),
         patch.object(planner_service, "_save_task_output_file", save_mock),
         patch.object(planner_service, "_scan_and_upload_agent_files", scan_mock),
@@ -275,3 +287,81 @@ async def test_flag_off_no_verdict_no_requeue(recording_bus) -> None:
     assert save_mock.await_count == 1
     assert scan_mock.await_count == 1
     assert len(_resolved_done_events(recording_bus)) == 1
+
+
+# ---------------------------------------------------------------------------
+# verify_mode: the three-position rollout switch (off | shadow | enforce)
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_failing_task_completes_with_would_have_stamped(recording_bus) -> None:
+    """The shadow rung: a FAILING output still lands ``done`` after ONE run
+    — no requeue, no escalation — with every DONE side-effect intact, the
+    verdict + would_have + shadow marker stamped on ``verify``, and no
+    ``requeue_count`` / ``feedback`` ever written."""
+
+    tid = await _make_plan_task([_C_ALPHA])
+    pool = _FakePool(["This mentions bravo."])  # fails the alpha criterion
+
+    save_mock, scan_mock = await _drive(pool, enabled=False, mode="shadow")
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 1  # shadow never re-dispatches
+    assert doc.status == "done"
+    assert doc.verify["verdict"]["status"] == "not_solved"
+    assert doc.verify["mode"] == "shadow"
+    assert doc.verify["would_have"] == "requeued"
+    # NO enforce-side state was written.
+    assert "requeue_count" not in doc.verify
+    assert "feedback" not in doc.verify
+    assert "escalation_reason" not in doc.verify
+    # DONE side-effects fired exactly as a normal completion.
+    assert save_mock.await_count == 1
+    assert scan_mock.await_count == 1
+    assert len(_resolved_done_events(recording_bus)) == 1
+
+
+async def test_shadow_solved_stamps_would_have_done(recording_bus) -> None:
+    """SOLVED under shadow: would_have=done — the telemetry covers every
+    completion, and the task completes exactly as today."""
+
+    tid = await _make_plan_task([_C_ALPHA])
+    pool = _FakePool(["The summary mentions alpha clearly."])
+
+    save_mock, _ = await _drive(pool, enabled=False, mode="shadow")
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 1
+    assert doc.status == "done"
+    assert doc.verify["verdict"]["status"] == "solved"
+    assert doc.verify["mode"] == "shadow"
+    assert doc.verify["would_have"] == "done"
+    assert save_mock.await_count == 1
+    assert len(_resolved_done_events(recording_bus)) == 1
+
+
+async def test_mode_enforce_without_bool_drives_the_loop(recording_bus) -> None:
+    """mode='enforce' alone (legacy bool off) drives exactly the flag-on
+    behaviour — identical failing set twice escalates no_progress, no DONE
+    side-effect fires. The new switch fully supersedes the bool."""
+
+    tid = await _make_plan_task([_C_ALPHA])
+    pool = _FakePool(
+        [
+            "This mentions bravo.",  # unmet: alpha
+            "Still mentions bravo.",  # unmet: alpha — identical set
+        ]
+    )
+
+    save_mock, scan_mock = await _drive(pool, enabled=False, mode="enforce", max_requeues=2)
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 2
+    assert doc.status == "failed"
+    assert doc.verify["escalation_reason"] == "no_progress"
+    assert doc.verify["requeue_count"] == 1
+    assert "mode" not in doc.verify  # the shadow marker is shadow-only
+    assert "would_have" not in doc.verify
+    assert save_mock.await_count == 0
+    assert scan_mock.await_count == 0
+    assert _resolved_done_events(recording_bus) == []

--- a/tests/test_deep_work_e2e.py
+++ b/tests/test_deep_work_e2e.py
@@ -1,5 +1,15 @@
 # End-to-end tests for the Deep Work interactive intake mode (issue #1161).
 # Created: 2026-05-21 (feat/deep-work-intake)
+# Updated: 2026-07-10 (feat/verify-mode-shadow) — added TestVerifyShadowMode:
+#   the three-position ``deep_work_verify_mode`` rollout switch. shadow: a
+#   FAILING task still lands DONE with its deliverable saved, the verdict +
+#   ``verify_would_have`` + ``verify_mode='shadow'`` stamped, and NO
+#   ``verify_requeue_count`` / ``verify_feedback`` written; the judge shadow
+#   keeps working under shadow mode. mode='enforce' alone (bool off) drives
+#   the full requeue loop; the legacy bool alone still ENFORCES
+#   (back-compat — it must never silently weaken to shadow); mode='off'
+#   stays byte-for-byte inert. The pre-existing TestVerify* classes set only
+#   the legacy bool, so their continued passing is the enforce==today proof.
 # Updated: 2026-07-02 (feat/judge-shadow-1168) — added TestJudgeShadow (J-1,
 #   #1168): with BOTH flags on, a deterministic FAIL + judge PASS still
 #   requeues the task (the judge NEVER rescues a failing result), the judge
@@ -1322,3 +1332,218 @@ class TestJudgeShadow:
         assert done.metadata["verify_judge_verdict"]["status"] == "solved"
         assert "verify judge shadow: deterministic=solved judge=solved" in caplog.text
         assert "agree=True" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# verify_mode: the three-position rollout switch (off | shadow | enforce)
+# ---------------------------------------------------------------------------
+
+
+def _settings_with_verify_mode(
+    mode: str,
+    *,
+    legacy_bool: bool = False,
+    max_requeues: int = 2,
+    judge_enabled: bool = False,
+):
+    """A Settings copy with the three-position mode + the legacy bool forced."""
+    return get_settings().model_copy(
+        update={
+            "deep_work_verify_mode": mode,
+            "deep_work_verify_loop_enabled": legacy_bool,
+            "deep_work_verify_max_requeues": max_requeues,
+            "deep_work_verify_judge_shadow_enabled": judge_enabled,
+        }
+    )
+
+
+class TestVerifyShadowMode:
+    """The shadow rung: verdicts + would_have telemetry are stamped but task
+    status is NEVER touched — a failing task still completes DONE with its
+    deliverable intact. The legacy bool alone still means ENFORCE."""
+
+    async def _make_agent_and_task(self):
+        from pocketpaw.mission_control import get_mission_control_manager
+
+        manager = get_mission_control_manager()
+        agent = await manager.create_agent(
+            name="FinanceBot",
+            role="Finance Assistant",
+            description="Chases overdue invoices",
+            backend="claude_agent_sdk",
+        )
+        task = await manager.create_task(
+            title="Pull the list of overdue invoices",
+            description="Query accounting for invoices 30+ days overdue",
+            priority=TaskPriority.HIGH,
+        )
+        task.metadata["success_criteria"] = list(_SUCCESS_CRITERIA)
+        await manager.save_task(task)
+        await manager.assign_task(task.id, [agent.id])
+        return manager, agent, task
+
+    async def _run_once(self, executor, task_id, agent_id, mock_router, settings):
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=mock_router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=settings,
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            return await executor.execute_task(task_id, agent_id)
+
+    @pytest.mark.asyncio
+    async def test_shadow_failing_task_lands_done_with_would_have(self, svl_singletons, caplog):
+        """The heart of the rollout rung: a FAILING task in shadow mode still
+        completes DONE with the deliverable saved, carries the verdict +
+        would_have + shadow marker, and grows NO requeue counter / feedback
+        — status and should_retry are never touched."""
+        from pocketpaw.mission_control import ActivityType
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("shadow")
+        router = _svl_failing_router()  # output fails BOTH criteria
+
+        with caplog.at_level(logging.INFO, logger="pocketpaw.mission_control.executor"):
+            result = await self._run_once(executor, task.id, agent.id, router, settings)
+        assert result["status"] == "completed"
+
+        done = await manager.get_task(task.id)
+        # The task landed DONE despite failing verify — shadow never acts.
+        assert done.status == TaskStatus.DONE
+        assert done.output == _FAILING_OUTPUT
+        # Verdict + shadow telemetry stamped.
+        assert done.metadata["verify_verdict"]["status"] == "not_solved"
+        assert done.metadata["verify_mode"] == "shadow"
+        assert done.metadata["verify_would_have"] == "requeued"
+        # NO enforce-side state was written.
+        assert "verify_requeue_count" not in done.metadata
+        assert "verify_feedback" not in done.metadata
+        assert "verify_escalation_reason" not in done.metadata
+        # The would_have telemetry line fired.
+        assert "verify shadow mode: would_have=requeued" in caplog.text
+
+        # DONE side-effects ran exactly as a normal completion: the
+        # completion activity logged and the output saved as a deliverable.
+        feed = await manager.get_activity_feed(limit=100)
+        completed = [
+            a for a in feed if a.task_id == task.id and a.type == ActivityType.TASK_COMPLETED
+        ]
+        assert completed, "shadow mode must not suppress the TASK_COMPLETED activity"
+        docs = await manager.get_task_documents(task.id)
+        assert docs, "shadow mode must not suppress the deliverable save"
+
+    @pytest.mark.asyncio
+    async def test_shadow_solved_task_stamps_would_have_done(self, svl_singletons):
+        """SOLVED under shadow: would_have=done — telemetry covers every
+        completion, not just the failing ones."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("shadow")
+        router = _svl_mock_router()  # passing output
+
+        await self._run_once(executor, task.id, agent.id, router, settings)
+
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert done.metadata["verify_verdict"]["status"] == "solved"
+        assert done.metadata["verify_mode"] == "shadow"
+        assert done.metadata["verify_would_have"] == "done"
+        assert "verify_requeue_count" not in done.metadata
+
+    @pytest.mark.asyncio
+    async def test_shadow_keeps_the_judge_shadow_running(self, svl_singletons):
+        """The judge shadow works as-is under shadow mode: its verdict is
+        stamped while the task still completes DONE."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("shadow", judge_enabled=True)
+
+        fake_llm = _FakeJudgeLlm(response=_JUDGE_ALL_MET)
+        judge_cls = MagicMock(return_value=LlmJudgeVerdictProvider(llm=fake_llm))
+        router = _svl_failing_router()
+
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=settings,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.LlmJudgeVerdictProvider",
+                judge_cls,
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            await executor.execute_task(task.id, agent.id)
+
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE  # shadow never requeues
+        assert done.metadata["verify_verdict"]["status"] == "not_solved"
+        assert done.metadata["verify_judge_verdict"]["status"] == "solved"
+        assert len(fake_llm.prompts) == 1
+
+    @pytest.mark.asyncio
+    async def test_legacy_bool_alone_still_enforces(self, svl_singletons):
+        """BACK-COMPAT: mode left at 'off' + the legacy bool True must run the
+        FULL loop (the bool's shipped meaning) — a failing task requeues, it
+        does not silently complete in shadow."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("off", legacy_bool=True)
+        router = _svl_failing_router()
+
+        await self._run_once(executor, task.id, agent.id, router, settings)
+
+        reloaded = await manager.get_task(task.id)
+        assert reloaded.status == TaskStatus.ASSIGNED, (
+            "legacy bool True must keep enforcing — never weaken to shadow"
+        )
+        assert reloaded.metadata["verify_requeue_count"] == 1
+        assert "verify_mode" not in reloaded.metadata
+        assert "verify_would_have" not in reloaded.metadata
+
+    @pytest.mark.asyncio
+    async def test_mode_enforce_without_bool_drives_the_loop(self, svl_singletons):
+        """mode='enforce' alone (legacy bool off) drives exactly today's
+        flag-on behaviour — the new switch fully supersedes the bool."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("enforce", legacy_bool=False)
+        router = _svl_failing_router()
+
+        await self._run_once(executor, task.id, agent.id, router, settings)
+
+        reloaded = await manager.get_task(task.id)
+        assert reloaded.status == TaskStatus.ASSIGNED
+        assert reloaded.metadata["verify_requeue_count"] == 1
+        assert len(reloaded.metadata["verify_feedback"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_mode_off_default_is_byte_for_byte_inert(self, svl_singletons):
+        """mode='off' + bool False (the shipped default): no verdict, no
+        shadow stamps, no requeue — exactly today's default path."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("off", legacy_bool=False)
+        router = _svl_failing_router()
+
+        result = await self._run_once(executor, task.id, agent.id, router, settings)
+        assert result["status"] == "completed"
+
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert "verify_verdict" not in done.metadata
+        assert "verify_mode" not in done.metadata
+        assert "verify_would_have" not in done.metadata
+        assert "verify_requeue_count" not in done.metadata

--- a/tests/test_verify_mode.py
+++ b/tests/test_verify_mode.py
@@ -1,0 +1,83 @@
+# Created: 2026-07-10 (feat/verify-mode-shadow) — resolver-precedence unit
+#   tests for the three-position Self-Verifying-Loop rollout switches:
+#   ``effective_deep_work_verify_mode()`` (OSS executor terminal) and
+#   ``effective_cloud_plan_verify_mode()`` (ee/cloud planner terminal).
+#   Both mirror the ``effective_spend_mode()`` resolution shape — a
+#   non-'off' mode wins outright — EXCEPT the legacy bool maps to
+#   'enforce' (its shipped meaning), never to shadow: mapping it to the
+#   middle position would silently strip requeue/escalate from a deploy
+#   that already set the bool.
+"""Precedence tests for the verify_mode resolvers (off | shadow | enforce)."""
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.config import Settings
+
+# Every test passes BOTH the mode and the legacy bool explicitly so a local
+# config.json / env can never skew the resolution under test.
+
+
+class TestDeepWorkVerifyModeResolver:
+    """effective_deep_work_verify_mode() — OSS Mission Control terminal."""
+
+    def test_field_default_is_off(self):
+        assert Settings.model_fields["deep_work_verify_mode"].default == "off"
+
+    def test_off_plus_bool_false_resolves_off(self):
+        s = Settings(deep_work_verify_mode="off", deep_work_verify_loop_enabled=False)
+        assert s.effective_deep_work_verify_mode() == "off"
+
+    def test_legacy_bool_true_resolves_enforce_not_shadow(self):
+        # BACK-COMPAT SAFETY: the bool's shipped meaning IS the acting loop.
+        # Resolving it to 'shadow' would silently weaken any deployment that
+        # already set it — so the bool maps to 'enforce', never the middle.
+        s = Settings(deep_work_verify_mode="off", deep_work_verify_loop_enabled=True)
+        assert s.effective_deep_work_verify_mode() == "enforce"
+
+    def test_explicit_shadow_wins_over_legacy_bool(self):
+        s = Settings(deep_work_verify_mode="shadow", deep_work_verify_loop_enabled=True)
+        assert s.effective_deep_work_verify_mode() == "shadow"
+
+    def test_explicit_enforce_resolves_without_bool(self):
+        s = Settings(deep_work_verify_mode="enforce", deep_work_verify_loop_enabled=False)
+        assert s.effective_deep_work_verify_mode() == "enforce"
+
+    def test_invalid_mode_rejected(self):
+        with pytest.raises(Exception):
+            Settings(deep_work_verify_mode="on")
+
+
+class TestCloudPlanVerifyModeResolver:
+    """effective_cloud_plan_verify_mode() — ee/cloud planner terminal."""
+
+    def test_field_default_is_off(self):
+        assert Settings.model_fields["cloud_plan_verify_mode"].default == "off"
+
+    def test_off_plus_bool_false_resolves_off(self):
+        s = Settings(cloud_plan_verify_mode="off", cloud_plan_verify_loop_enabled=False)
+        assert s.effective_cloud_plan_verify_mode() == "off"
+
+    def test_legacy_bool_true_resolves_enforce_not_shadow(self):
+        s = Settings(cloud_plan_verify_mode="off", cloud_plan_verify_loop_enabled=True)
+        assert s.effective_cloud_plan_verify_mode() == "enforce"
+
+    def test_explicit_shadow_wins_over_legacy_bool(self):
+        s = Settings(cloud_plan_verify_mode="shadow", cloud_plan_verify_loop_enabled=True)
+        assert s.effective_cloud_plan_verify_mode() == "shadow"
+
+    def test_explicit_enforce_resolves_without_bool(self):
+        s = Settings(cloud_plan_verify_mode="enforce", cloud_plan_verify_loop_enabled=False)
+        assert s.effective_cloud_plan_verify_mode() == "enforce"
+
+    def test_terminals_resolve_independently(self):
+        # One terminal in shadow must not drag the other along.
+        s = Settings(
+            deep_work_verify_mode="shadow",
+            deep_work_verify_loop_enabled=False,
+            cloud_plan_verify_mode="off",
+            cloud_plan_verify_loop_enabled=True,
+        )
+        assert s.effective_deep_work_verify_mode() == "shadow"
+        assert s.effective_cloud_plan_verify_mode() == "enforce"


### PR DESCRIPTION
## What this does

The Self-Verifying Loop's flags were booleans: off, or full enforce (requeues + escalations) — a cliff no real tenant wants to jump. This adds `deep_work_verify_mode` and `cloud_plan_verify_mode` (`off | shadow | enforce`, default `off`) on both terminals.

**Shadow** stamps the verdict (and the judge shadow, when enabled) plus a `verify_would_have` field recording what enforce would have decided (requeued / escalated + reason), logs one telemetry line per task — and never touches status, retry counters, or feedback. The task completes exactly as today. A tenant reads the would-have telemetry before daring enforce.

## Why

Nothing real runs the loop yet because the only ON position acts immediately, and the smoke found the deterministic check over-escalates on real planner-authored criteria. Shadow lets real workloads (not just the synthetic farm) accrue verdicts and judge-agreement data risk-free — the calibration distribution that actually matters — while making the feature demonstrable on real work.

## Design notes

- Resolver precedence mirrors `litellm_spend_mode`: an explicit non-off mode wins; otherwise the legacy bool maps to **enforce** — deliberately the opposite of the spend precedent's shadow mapping, because the bool's shipped meaning IS the acting loop; mapping it to shadow would silently strip requeue/escalate from any deploy that already set it. Documented in the resolvers, Field descriptions, and changelog.
- In shadow, the cloud "why the last attempt was rejected" instruction block does not render (observe-only means zero behavioral delta on the run); it renders in enforce as before.
- Honest telemetry caveat: shadow never grows counters/feedback, so `would_have` is per-attempt, not a full enforce trajectory simulation — a pure-shadow tenant sees `would_have=requeued` for every failing task.

## Verification

128 passed across the verify suites + the new `tests/test_verify_mode.py` (12 resolver-precedence units) + `TestVerifyShadowMode` (6 e2e: failing task lands DONE with deliverable intact and no counters; judge-under-shadow; legacy-bool-enforces; off inert). All pre-existing verify tests pass unchanged — the enforce==today and back-compat proof. Ruff clean.

## Out of scope

Actually flipping shadow on for any tenant (ops decision), the judge calibration harness, and the Fabric source-truth work (separate lane).