### PR TITLE
refactor(sites): canonical engine-capability module (engines.py)

### DIFF
--- a/ee/pocketpaw_ee/sites/audit.py
+++ b/ee/pocketpaw_ee/sites/audit.py
@@ -20,12 +20,21 @@
 # The judgment tier (copy quality / SEO wording via a small LLM pass) is DEFERRED
 # — see the TODO near the bottom. The deterministic checks stand alone and must
 # never depend on or be gated by a live model.
+#
+# Updated 2026-07-10 (HE-2 — canonical engine module): the "does this engine carry a
+# hand-written {path: contents} markup map?" checks (the source-map document scan,
+# the markup-shape a11y pass, the heading-structure pass) now route through
+# ``is_source_engine(engine)`` instead of ``== "svelte"``. These are markup-engine
+# capabilities, not svelte-brand facts — the ripple branch (a flattened rippleSpec
+# blob) is unchanged. Pure refactor, zero behaviour change for ripple/svelte.
 
 from __future__ import annotations
 
 import re
 from dataclasses import asdict, dataclass, field
 from typing import Any
+
+from pocketpaw_ee.sites.engines import is_source_engine
 
 
 # ── Finding model ──────────────────────────────────────────────────────────────
@@ -67,7 +76,7 @@ def _documents(engine: str, content: Any) -> list[tuple[str, str]]:
       text-level checks (links, copy) can still scan. Markup-shape checks (img
       alt, h1 count) are svelte-only — a ripple site has no hand-written markup.
     """
-    if engine == "svelte" and isinstance(content, dict):
+    if is_source_engine(engine) and isinstance(content, dict):
         docs: list[tuple[str, str]] = []
         for path, body in content.items():
             if isinstance(path, str) and path.lower().endswith(_SCANNABLE_EXT):
@@ -429,14 +438,15 @@ def audit_pocket_site(*, engine: str, content: Any) -> list[dict[str, Any]]:
     counter: dict[str, int] = {}
     findings: list[Finding] = []
 
-    # Per-document checks (markup-shape a11y + links).
+    # Per-document checks (markup-shape a11y + links). a11y only applies to engines
+    # with hand-written markup (source-map engines); a ripple site has none.
     for file, html in docs:
-        if engine == "svelte":
+        if is_source_engine(engine):
             findings.extend(_check_a11y(file, html, counter))
         findings.extend(_check_links(file, html, counter))
 
-    # Page-wide checks (heading structure is svelte-only; SEO spans the shell).
-    if engine == "svelte":
+    # Page-wide checks (heading structure needs hand-written markup; SEO spans the shell).
+    if is_source_engine(engine):
         findings.extend(_check_h1(docs, counter))
     findings.extend(_check_seo(docs, counter))
 

--- a/ee/pocketpaw_ee/sites/engines.py
+++ b/ee/pocketpaw_ee/sites/engines.py
@@ -1,0 +1,122 @@
+# Canonical engine-capability module for Paw Sites.
+#
+# Created 2026-07-10 (HE-2): the single source of truth for "what can this site
+# engine do", replacing scattered ``== "svelte"`` / ``!= "svelte"`` string-equality
+# checks across the sites + cloud/surface code. Workspace-charter principle: one
+# canonical reference module beats phased propagation.
+"""Engine capability predicates for Paw Sites.
+
+Three site-generation engines are modeled:
+
+* ``"ripple"`` — the DEFAULT. The pocket's authored content is a ``rippleSpec`` (a
+  widget tree). Publishing runs a per-site Node build (``bun install`` + Vite +
+  a workerd smoke render) and emits ``.svelte-kit/cloudflare``.
+* ``"svelte"`` — the pocket's content is a ``{path: contents}`` source map of
+  hand-written SvelteKit files. Publishing runs the SAME per-site Node build and
+  emits ``.svelte-kit/cloudflare``.
+* ``"html"`` — the pocket's content is a ``{path: contents}`` source map of raw
+  HTML/CSS/JS. Publishing runs NO Node build; the generator emits a plain static
+  directory. *Not yet wired* into the publish / deploy / authoring paths
+  (HE-1/3/4/6) — this module already KNOWS about it (that is the point) so the rest
+  of the codebase can branch on a capability instead of a string as html lands, but
+  no behaviour changes for html today.
+
+The four predicates split the engine question into orthogonal capabilities:
+
+* :func:`is_source_engine` — is the content a ``{path: contents}`` source map
+  (svelte, html) or a rippleSpec (ripple)?
+* :func:`content_key` — which pocket-dict key holds the authored content
+  (``"source"`` vs ``"rippleSpec"``)?
+* :func:`needs_node_build` — does publishing run a per-site Node build (ripple,
+  svelte) or not (html)?
+* :func:`static_output_rel` — where, relative to the generated project dir, do the
+  deployable static assets land?
+
+Unknown-engine policy — **fall back to ripple, never raise.** The codebase reads
+``pocket.get("engine") or "ripple"`` in roughly a dozen places: an empty or missing
+engine has ALWAYS meant ripple, and these predicates sit on hot read/publish paths
+where raising would turn a bad-data pocket into a 500 instead of degrading to the
+historical default. So both an empty/``None`` engine AND an unknown non-empty string
+(a typo, or a future engine a given build predates) normalize to ``"ripple"``.
+Ripple is the safe fallback precisely because it is the LEAST-capable shape — a
+rippleSpec behind a full Node build — so an unknown engine treated as ripple never
+skips a build or an editing guard it should have run. Callers that need strict
+validation should validate the engine string at their own entry point.
+"""
+
+from __future__ import annotations
+
+_DEFAULT_ENGINE = "ripple"
+
+# Engines whose pocket content is a {path: contents} source map (as opposed to a
+# rippleSpec). The one place the "source map vs rippleSpec" fact is encoded.
+_SOURCE_MAP_ENGINES: frozenset[str] = frozenset({"svelte", "html"})
+
+# Engines that require a per-site Node build (bun install + Vite/SvelteKit build +
+# workerd smoke render) before deploy. Note html is source-map-backed yet needs NO
+# build — "source map" and "node build" are deliberately distinct capabilities.
+_NODE_BUILD_ENGINES: frozenset[str] = frozenset({"ripple", "svelte"})
+
+# Per-engine deployable static-output dir, relative to the generated project dir.
+# ripple/svelte emit the SvelteKit Cloudflare adapter output (``_CF_OUTPUT_REL`` in
+# ``sites/workers_deploy.py`` today); html has no build, so the project dir itself
+# IS the static root (``"."``) — the emitted ``index.html`` is the deploy root and
+# the served artifact stays byte-identical to the authored source (HE-1/HE-4).
+_STATIC_OUTPUT_REL: dict[str, str] = {
+    "ripple": ".svelte-kit/cloudflare",
+    "svelte": ".svelte-kit/cloudflare",
+    "html": ".",
+}
+
+
+def normalize_engine(engine: str | None) -> str:
+    """Normalize a pocket's raw engine value to a known engine string.
+
+    Empty / ``None`` / unknown → ``"ripple"`` (see the module docstring for why we
+    fall back rather than raise). A known engine passes through unchanged. Every
+    other predicate in this module routes through here, so the fallback policy lives
+    in exactly one place.
+    """
+    if engine in _SOURCE_MAP_ENGINES or engine == _DEFAULT_ENGINE:
+        return engine  # type: ignore[return-value]  # narrowed to a known non-None str
+    return _DEFAULT_ENGINE
+
+
+def is_source_engine(engine: str | None) -> bool:
+    """True when the engine's content is a ``{path: contents}`` source map.
+
+    ``"svelte"`` and ``"html"`` are source engines; ``"ripple"`` is not (its content
+    is a rippleSpec). Accepts ``str | None`` because most call sites pass
+    ``pocket.get("engine")`` directly.
+    """
+    return normalize_engine(engine) in _SOURCE_MAP_ENGINES
+
+
+def content_key(engine: str | None) -> str:
+    """The pocket-dict key holding this engine's authored content.
+
+    ``"source"`` for a source-map engine (svelte, html); ``"rippleSpec"`` for ripple.
+    """
+    return "source" if is_source_engine(engine) else "rippleSpec"
+
+
+def needs_node_build(engine: str | None) -> bool:
+    """True when publishing this engine runs a per-site Node build.
+
+    ``"ripple"`` and ``"svelte"`` run ``bun install`` + a Vite/SvelteKit build + a
+    workerd smoke render. ``"html"`` does not — the generator emits a plain static
+    dir with no build step.
+    """
+    return normalize_engine(engine) in _NODE_BUILD_ENGINES
+
+
+def static_output_rel(engine: str | None) -> str:
+    """The deployable static-output dir, RELATIVE to the generated project dir.
+
+    * ripple / svelte → ``".svelte-kit/cloudflare"`` (the SvelteKit Cloudflare
+      adapter output).
+    * html → ``"."`` — the generator writes the static site directly into the
+      project dir (a plain ``{path: contents}`` tree, no framework build subdir), so
+      the project dir IS the static root.
+    """
+    return _STATIC_OUTPUT_REL[normalize_engine(engine)]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,19 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-10 (HE-2 — canonical engine module): the engine content-selection
+# checks now route through ``sites.engines`` predicates instead of inline
+# ``== "svelte"`` string equality. ``is_source_engine(engine)`` replaces the
+# "source vs rippleSpec" content switch (publish/activate promote, preview/audit
+# fallback, dynamic-envelope), and ``content_key(engine)`` replaces the literal
+# ``"source" | "rippleSpec"`` key pick. PURE refactor, zero behaviour change for the
+# existing ripple/svelte engines. The three svelte NATIVE-EDITING guards
+# (``apply_leaf_edits`` ~2595, native shadow-render ~2697, ``edit_svelte_component``
+# ~2823) deliberately KEEP the ``!= "svelte"`` literal — their bodies are svelte-only
+# (component-path splice, ``.svelte-kit/cloudflare`` read, DSV-5 source split), so
+# guard and body must widen together; HE-9 widens ``apply_leaf_edits`` when the html
+# editing lane lands.
+#
 # Updated 2026-07-09 (DP0-4 — publish async split + single-flight): ``_deploy_site_doc``
 # now FORKS on ``_is_dynamic`` BEFORE any build. A DYNAMIC site no longer builds /
 # deploys inline — it returns early into the new ``_provision_dynamic_site`` helper,
@@ -533,6 +546,7 @@ from pocketpaw_ee.sites.dto import (
     SiteResponse,
     SiteStatusResponse,
 )
+from pocketpaw_ee.sites.engines import content_key, is_source_engine
 from pocketpaw_ee.sites.generator_client import GeneratorClient
 
 logger = logging.getLogger(__name__)
@@ -1259,7 +1273,7 @@ async def publish(
     # not-live while the published tag stands). The snapshot for the promote is the
     # engine's content: the rippleSpec for a ripple site, the {path: contents}
     # source map for a svelte site.
-    version_content: dict[str, Any] = (source if engine == "svelte" else ripple_spec) or {}
+    version_content: dict[str, Any] = (source if is_source_engine(engine) else ripple_spec) or {}
     await _promote_pocket_draft_to_published(
         pocket_id=pocket_id,
         workspace_id=workspace_id,
@@ -2435,7 +2449,9 @@ async def activate_site(
     # record, mirroring the live publish path (best-effort; versioning never gates
     # the deploy/activation).
     version_content: dict[str, Any] = (
-        inputs.get("source") if (inputs.get("engine") == "svelte") else inputs.get("ripple_spec")
+        inputs.get("source")
+        if is_source_engine(inputs.get("engine"))
+        else inputs.get("ripple_spec")
     ) or {}
     await _promote_pocket_draft_to_published(
         pocket_id=pocket_id,
@@ -2592,6 +2608,10 @@ async def apply_leaf_edits(
     # The pockets service's PUBLIC get raises NotFound / Forbidden itself (entity
     # isolation) — a missing / cross-tenant pocket surfaces as 404 / 403.
     pocket = await pockets_service.get(pocket_id, user_id)
+    # KEPT svelte-specific (not is_source_engine): the body below runs the DSV-5
+    # ``_split_svelte_source`` split and the SvelteKit leaf-edit CLI, both svelte-only.
+    # HE-9 widens THIS guard to html (via is_source_engine) in the same change that
+    # teaches the CLI the html editing lane, so guard and body widen together.
     if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(pocket.get("source"), dict):
         raise ValidationError(
             "pocket.not_svelte_site",
@@ -2694,6 +2714,9 @@ async def get_native_artifact(
     # The pockets service's PUBLIC get raises NotFound / Forbidden itself (entity
     # isolation) — a missing / cross-tenant pocket surfaces as 404 / 403.
     pocket = await pockets_service.get(pocket_id, user_id)
+    # KEPT svelte-specific (not is_source_engine): this shadow-renders the SvelteKit
+    # ARMED build by reading ``.svelte-kit/cloudflare/index.html``. An html site's
+    # served artifact IS its source, so it never uses this SvelteKit render path.
     if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(pocket.get("source"), dict):
         raise ValidationError(
             "pocket.not_svelte_site",
@@ -2820,6 +2843,9 @@ async def edit_svelte_component(
         # A missing component path is a NotFound (same contract as the full-rewrite
         # path, where set_svelte_source_file raises it) — not a silent create.
         pocket = await pockets_service.get(pocket_id, user_id)
+        # KEPT svelte-specific (not is_source_engine): edits a single named SvelteKit
+        # component by ``component_path`` and persists via ``set_svelte_source_file``.
+        # html has no per-component model — it edits by uid splice (HE-9), not here.
         if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(
             pocket.get("source"), dict
         ):
@@ -2978,7 +3004,7 @@ async def _ensure_pocket_draft(*, workspace_id: str, user_id: str, pocket_id: st
             return
         pocket = await pockets_service.get(pocket_id, user_id)
         engine = pocket.get("engine") or "ripple"
-        if engine == "svelte":
+        if is_source_engine(engine):
             content = pocket.get("source") if isinstance(pocket.get("source"), dict) else {}
         else:
             content = pocket.get("rippleSpec") if isinstance(pocket.get("rippleSpec"), dict) else {}
@@ -3033,7 +3059,7 @@ async def preview_pocket(
 
     # The pocket's CURRENT content for the engine — the fallback when the Branch
     # primitive has no draft row for this pocket yet.
-    if engine == "svelte":
+    if is_source_engine(engine):
         source = pocket.get("source")
         current = source if isinstance(source, dict) else None
     else:
@@ -3142,7 +3168,7 @@ async def audit_pocket(
 
     # The pocket's CURRENT content for the engine — the fallback when the Branch
     # primitive has no draft row for this pocket yet (mirrors preview_pocket).
-    if engine == "svelte":
+    if is_source_engine(engine):
         source = pocket.get("source")
         current: dict[str, Any] | None = source if isinstance(source, dict) else None
     else:
@@ -3205,7 +3231,7 @@ def _dynamic_content_envelope(pocket: dict[str, Any]) -> dict[str, Any]:
     engine-agnostic ``_is_dynamic`` / ``_dynamic_objects`` helpers can read the
     bindings off it without caring which engine produced it."""
     engine = pocket.get("engine") or "ripple"
-    key = "source" if engine == "svelte" else "rippleSpec"
+    key = content_key(engine)
     content = pocket.get(key)
     return content if isinstance(content, dict) else {}
 

--- a/tests/ee/sites/test_engines.py
+++ b/tests/ee/sites/test_engines.py
@@ -1,0 +1,94 @@
+# tests/ee/sites/test_engines.py — unit tests for the canonical engine-capability
+# module (ee/pocketpaw_ee/sites/engines.py).
+#
+# Created 2026-07-10 (HE-2). Covers all three modeled engines (ripple / svelte /
+# html) plus the empty / missing / unknown-engine fallback contract that the
+# scattered ``pocket.get("engine") or "ripple"`` call sites relied on.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites import engines
+
+
+class TestIsSourceEngine:
+    def test_svelte_is_source(self) -> None:
+        assert engines.is_source_engine("svelte") is True
+
+    def test_html_is_source(self) -> None:
+        assert engines.is_source_engine("html") is True
+
+    def test_ripple_is_not_source(self) -> None:
+        assert engines.is_source_engine("ripple") is False
+
+    @pytest.mark.parametrize("value", [None, "", "  ", "nope", "SVELTE"])
+    def test_empty_missing_unknown_default_to_ripple_semantics(self, value: str | None) -> None:
+        # Empty / missing / unknown (incl. wrong case) → treated as ripple → not a
+        # source engine. Preserves the historical ``engine or "ripple"`` behaviour.
+        assert engines.is_source_engine(value) is False
+
+
+class TestContentKey:
+    def test_svelte_reads_source(self) -> None:
+        assert engines.content_key("svelte") == "source"
+
+    def test_html_reads_source(self) -> None:
+        assert engines.content_key("html") == "source"
+
+    def test_ripple_reads_ripplespec(self) -> None:
+        assert engines.content_key("ripple") == "rippleSpec"
+
+    @pytest.mark.parametrize("value", [None, "", "unknown"])
+    def test_default_reads_ripplespec(self, value: str | None) -> None:
+        assert engines.content_key(value) == "rippleSpec"
+
+
+class TestNeedsNodeBuild:
+    def test_ripple_needs_build(self) -> None:
+        assert engines.needs_node_build("ripple") is True
+
+    def test_svelte_needs_build(self) -> None:
+        assert engines.needs_node_build("svelte") is True
+
+    def test_html_skips_build(self) -> None:
+        assert engines.needs_node_build("html") is False
+
+    @pytest.mark.parametrize("value", [None, "", "unknown"])
+    def test_default_needs_build(self, value: str | None) -> None:
+        # Unknown → ripple → runs the full build (the safe, least-capable default).
+        assert engines.needs_node_build(value) is True
+
+
+class TestStaticOutputRel:
+    def test_ripple_output(self) -> None:
+        assert engines.static_output_rel("ripple") == ".svelte-kit/cloudflare"
+
+    def test_svelte_output(self) -> None:
+        assert engines.static_output_rel("svelte") == ".svelte-kit/cloudflare"
+
+    def test_html_output_is_project_root(self) -> None:
+        assert engines.static_output_rel("html") == "."
+
+    @pytest.mark.parametrize("value", [None, "", "unknown"])
+    def test_default_output_matches_ripple(self, value: str | None) -> None:
+        assert engines.static_output_rel(value) == ".svelte-kit/cloudflare"
+
+
+class TestNormalizeEngine:
+    @pytest.mark.parametrize("value", ["ripple", "svelte", "html"])
+    def test_known_engines_pass_through(self, value: str) -> None:
+        assert engines.normalize_engine(value) == value
+
+    @pytest.mark.parametrize("value", [None, "", "  ", "nope", "Svelte", "RIPPLE"])
+    def test_empty_missing_unknown_fall_back_to_ripple(self, value: str | None) -> None:
+        assert engines.normalize_engine(value) == "ripple"
+
+
+def test_source_and_build_are_distinct_capabilities() -> None:
+    # The whole point of the module: html is source-map-backed but needs NO build.
+    # Guard against a future refactor collapsing the two into one flag.
+    assert engines.is_source_engine("html") is True
+    assert engines.needs_node_build("html") is False
+    # ... while svelte is both source-map-backed AND build-requiring.
+    assert engines.is_source_engine("svelte") is True
+    assert engines.needs_node_build("svelte") is True


### PR DESCRIPTION
## What ships

One module — `ee/pocketpaw_ee/sites/engines.py` — that answers every "what can this engine do" question in one place, replacing scattered `== "svelte"` string checks across the sites package. Pure refactor, zero behaviour change.

## Why

The sites package had 16 executable `== "svelte"` / `!= "svelte"` checks. Most of them don't actually ask "is this svelte" — they ask "is this engine backed by a `{path: contents}` source map?" or "which field holds the content?" That difference is about to matter: html is a third source-map engine, and a literal `== "svelte"` silently excludes html from paths it belongs in. Encoding the fact once, now, is cheaper than chasing the same distinction through a dozen sites later.

This is the workspace charter's "one canonical reference module beats phased propagation" principle.

## The module

| Predicate | Meaning |
|---|---|
| `is_source_engine` | svelte + html carry a `{path: contents}` map; ripple carries a rippleSpec |
| `content_key` | `"source"` vs `"rippleSpec"` |
| `needs_node_build` | ripple/svelte run bun + vite + workerd; html does not |
| `static_output_rel` | `.svelte-kit/cloudflare` vs `.` for html |
| `normalize_engine` | empty / `None` / unknown → `"ripple"` |

## What migrated, what stayed

**Migrated (9)** — every genuinely content-selection / source-map / markup-scan check: `service.py` content + draft/preview/audit fallback + the content-key pick; `audit.py` markup/a11y/heading scans.

**Kept as `"svelte"` literals (7)** — because the *bodies* are svelte-specific, not source-generic: `apply_leaf_edits` and `edit_svelte_component` (DSV-5 `_split_svelte_source` and the per-component SvelteKit edit path — HE-9 widens guard and body together), the native shadow-render guard (a `.svelte-kit` render path html never uses), `set_svelte_source_file`, the DSV-5 binding split, and the create-svelte skill routing. Each carries an inline reason. Migrating a guard without its body would admit html into a svelte-only code path — worse than leaving the literal.

`apply_edits()` is already engine-agnostic and was not touched.

## Unknown-engine behaviour

`normalize_engine` falls back to `"ripple"`, never raises. The codebase has always read `pocket.get("engine") or "ripple"`; these predicates sit on hot read/publish paths where raising would turn a bad-data pocket into a 500; and ripple is the least-capable shape, so an unknown engine treated as ripple never *skips* a build or an editing guard it should have run.

## Verification

- 36 new tests in `test_engines.py`, covering all three engines plus the empty/missing/unknown default. Green.
- `ruff` and `mypy` clean on the touched files.
- **Zero regressions, proven by stash.** `tests/ee/sites/test_{service,audit,engine_field}` fail an *identical* set (30) with and without this change. Those failures pre-exist on `dev` — they're the known `.svelte-kit` build-output environment limitation on this box (`sites.workers_no_build`), not caused here.

## Reference

Tasks: `docs/design/drafts/2026-07-10-paw-sites-html-engine-tasks.md` (HE-2)