### PR TITLE
feat(fabric): statements + sources schema behind an inert mode flag (FST-1)

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,14 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-07-10 (FST-1 — Fabric source-truth schema): Added
+    ``fabric_source_truth_mode`` (Literal off|shadow|enforce, default 'off';
+    POCKETPAW_FABRIC_SOURCE_TRUTH_MODE) — the three-position rollout switch for
+    the Fabric source-truth chain, mirroring the ``litellm_spend_mode``
+    pattern. INERT in FST-1: no code path reads it yet; only the
+    fabric_statements/fabric_sources schema + append-only store CRUD exist.
+    'off' is byte-for-byte today's behavior (the flat properties dict is the
+    only read path); shadow/enforce semantics land in later FST slices.
   - 2026-07-02 (feat/judge-shadow-1168): Added the LLM-as-judge SHADOW settings
     (J-1, issue #1168) — ``deep_work_verify_judge_shadow_enabled`` (default
     False; when True AND deep_work_verify_loop_enabled is on, every completing
@@ -1912,6 +1920,25 @@ class Settings(BaseSettings):
             "resolved before flipping to 'live'. 1 credit == $0.01, so the default "
             "10 ≈ $0.10 of tolerated per-tenant-per-window drift (rounding noise). "
             "Set via POCKETPAW_LITELLM_RECONCILE_GAP_THRESHOLD_CREDITS."
+        ),
+    )
+    fabric_source_truth_mode: Literal["off", "shadow", "enforce"] = Field(
+        default="off",
+        description=(
+            "Rollout mode for the Fabric source-truth chain (FST). Three-position "
+            "switch, mirroring litellm_spend_mode:\n"
+            "  * 'off'     (default) — byte-for-byte today: nothing reads or writes "
+            "the fabric_statements / fabric_sources provenance tables; the flat "
+            "FabricObject.properties dict is the only read path.\n"
+            "  * 'shadow'  — RESERVED (semantics land in a later FST slice): "
+            "statement writes mirror alongside the flat properties dict, which "
+            "keeps serving every read.\n"
+            "  * 'enforce' — RESERVED (semantics land in a later FST slice): "
+            "resolved statements become authoritative for reads.\n"
+            "As of FST-1 the flag is INERT — no code path consumes it yet; only "
+            "the schema and append-only store CRUD exist. The flat properties "
+            "dict remains the primary read path in every mode. Set via "
+            "POCKETPAW_FABRIC_SOURCE_TRUTH_MODE."
         ),
     )
     site_pending_alert_hours: float = Field(

--- a/src/pocketpaw/fabric/models.py
+++ b/src/pocketpaw/fabric/models.py
@@ -28,6 +28,23 @@
 #   legacy/global type predating tenancy (or an OSS / single-tenant caller),
 #   which a scoped read still sees — exactly the NULL-as-legacy boundary the
 #   W4a object/link scoping already uses.
+# Updated: 2026-07-10 (FST-1 — Fabric source-truth schema) — added ``Statement``
+#   and ``SourceRef``: the provenance layer for the source-truth chain. A
+#   Statement records ONE observed (object, property, value) claim with full
+#   provenance (who wrote it — ``writer_class``; where it came from —
+#   ``source_ref_id``; bitemporal fields — observed/recorded/valid_from/
+#   valid_to) plus a curation rank. A SourceRef identifies WHERE a statement
+#   came from (a connector run, a document, a human actor, an agent session)
+#   and is deduplicated on that identity by ``FabricStore.upsert_source``.
+#   Both models carry ``workspace_id`` (W4a tenancy, same type/default as
+#   ObjectType.workspace_id: ``str | None = None``); on SourceRef it is PART
+#   of the dedup identity — the same source identity in two workspaces is two
+#   rows, so tenant data never rendezvouses on a shared SourceRef.
+#   ADDITIVE ONLY: nothing in the existing read path (FabricObject.properties,
+#   fabric_query, widgets, projections) consumes these yet — statements are
+#   inert until the ``fabric_source_truth_mode`` flag (default "off") gains
+#   shadow/enforce semantics in later slices. The flat properties dict remains
+#   the primary read path.
 
 from __future__ import annotations
 
@@ -105,6 +122,80 @@ class FabricLink(BaseModel):
     link_type: str  # "has_orders", "belongs_to", "purchased"
     properties: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime = Field(default_factory=datetime.now)
+
+
+class SourceRef(BaseModel):
+    """The identity of WHERE a :class:`Statement` came from (FST-1).
+
+    One row per distinct source identity: a connector run, a document, a
+    human actor, or an agent session. ``FabricStore.upsert_source`` dedups on
+    the identity tuple ``(kind, connector, run_id, document_uri, actor_id,
+    session_id, workspace_id)`` — calling it twice with the same identity
+    returns the same row, so statements from the same source share one
+    SourceRef. ``workspace_id`` IS part of the identity: the same source seen
+    from two workspaces is two rows (tenancy isolation beats dedup).
+
+    The identity fields are a union across the four kinds; only the ones
+    relevant to a given ``kind`` are expected to be set (e.g. a
+    ``connector_run`` carries ``connector`` + ``run_id``; a ``document``
+    carries ``document_uri``; a ``human_actor`` carries ``actor_id``; an
+    ``agent_session`` carries ``session_id``). Unset fields are ``None`` and
+    still participate in the identity (as "absent").
+    """
+
+    id: str = Field(default_factory=lambda: _gen_id("src"))
+    kind: Literal["connector_run", "document", "human_actor", "agent_session"]
+    connector: str | None = None
+    run_id: str | None = None
+    document_uri: str | None = None
+    actor_id: str | None = None
+    session_id: str | None = None
+    retrieved_at: datetime | None = None
+    # Tenancy (W4a semantics, carried on the model like ObjectType.workspace_id):
+    # the owning workspace. ``None`` = OSS / single-tenant caller. Unlike the
+    # other tables, this is PART OF THE DEDUP IDENTITY (see the docstring).
+    workspace_id: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
+class Statement(BaseModel):
+    """One observed (object, property, value) claim with provenance (FST-1).
+
+    Statements are APPEND-ONLY: the store exposes no update/delete verbs for
+    them (rank changes land in a later slice as new curation writes). Nothing
+    reads statements in production paths yet — the flat
+    ``FabricObject.properties`` dict remains the primary read path until the
+    ``fabric_source_truth_mode`` flag gains shadow/enforce semantics.
+
+    Bitemporal fields:
+
+    - ``observed_at`` — when the source says the value was true / was seen.
+    - ``recorded_at`` — when THIS store recorded the claim (stamped on write).
+    - ``valid_from`` / ``valid_to`` — the validity interval of the claim;
+      ``valid_to=None`` means "still valid as far as this statement knows".
+
+    ``rank`` is the curation knob resolvers will consume later:
+    ``preferred`` outranks ``normal`` outranks ``deprecated``; ``pinned``
+    marks a statement a human explicitly fixed in place.
+    """
+
+    id: str = Field(default_factory=lambda: _gen_id("stm"))
+    object_id: str
+    property: str
+    value: Any = None
+    source_ref_id: str
+    writer_class: Literal["human", "connector", "mirror", "agent", "inferred"]
+    observed_at: datetime = Field(default_factory=datetime.now)
+    recorded_at: datetime = Field(default_factory=datetime.now)
+    valid_from: datetime = Field(default_factory=datetime.now)
+    valid_to: datetime | None = None
+    rank: Literal["preferred", "normal", "deprecated"] = "normal"
+    rank_reason: str | None = None
+    pinned: bool = False
+    # Tenancy (W4a semantics): the owning workspace, stamped on append.
+    # ``None`` = OSS / single-tenant caller; a scoped read still sees NULL
+    # rows (own rows + legacy NULL — the standard W4a read scope).
+    workspace_id: str | None = None
 
 
 class PathHop(BaseModel):

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -143,12 +143,37 @@
 #   gets truncated instead of growing unbounded across 128+ cached tenants. The
 #   W4a in-row workspace_id WHERE-filter is UNCHANGED — physical file isolation
 #   is ADDITIVE defense-in-depth layered on top of it, never a replacement.
+# Updated: 2026-07-10 (FST-1 — Fabric source-truth schema) — two NEW tables,
+#   ``fabric_statements`` + ``fabric_sources``, with append-only CRUD:
+#   ``append_statement()`` / ``get_statements()`` / ``upsert_source()``. A
+#   statement is one observed (object, property, value) claim with provenance
+#   (writer_class, a SourceRef FK, bitemporal observed/recorded/valid_from/
+#   valid_to, a curation rank); a source row is deduplicated on its identity
+#   tuple (kind + connector/run_id/document_uri/actor_id/session_id +
+#   workspace_id) both by an upsert-time lookup and a DB-level expression
+#   UNIQUE index (race guard, NULLs normalized via IFNULL so absent fields
+#   dedup too). Both tables carry the W4a ``workspace_id`` (schema-freeze
+#   ruling): ``append_statement`` stamps it, ``get_statements`` applies the
+#   standard ``_workspace_scope`` read scope (own rows + legacy NULL), and on
+#   sources it is PART of the dedup identity — the same source identity in two
+#   workspaces is two rows (tenancy isolation beats dedup). The tables ride
+#   SCHEMA_SQL's CREATE TABLE IF NOT EXISTS, so the migration is idempotent on
+#   an existing fabric.db (brand-new tables; the W4a ALTER loop additionally
+#   covers them so a DB from an early FST-1 build without workspace_id is
+#   healed, and that build's identity index is dropped for the
+#   workspace-aware ``idx_sources_identity_ws``). Statements are APPEND-ONLY:
+#   no update/delete verbs (rank changes come later as curation writes). NO
+#   existing read or write path is touched — the flat
+#   ``fabric_objects.properties`` dict remains the primary read path; nothing
+#   writes statements in production until ``fabric_source_truth_mode``
+#   (default "off") gains shadow/enforce semantics in later slices.
 
 
 from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -162,6 +187,8 @@ from pocketpaw.fabric.models import (
     ObjectType,
     PathHop,
     PropertyDef,
+    SourceRef,
+    Statement,
 )
 
 logger = logging.getLogger(__name__)
@@ -220,11 +247,65 @@ CREATE TABLE IF NOT EXISTS fabric_links (
     created_at TEXT DEFAULT (datetime('now'))
 );
 
+-- Source-truth provenance (FST-1). Two NEW tables. On a pre-FST fabric.db
+-- this CREATE TABLE IF NOT EXISTS creates them whole; a DB created by an
+-- early FST-1 build (before the schema-freeze review added workspace_id) is
+-- healed by the same ALTER loop the W4a columns use (see _ensure_schema).
+-- Nothing in the existing read/write path touches them; they are inert until
+-- fabric_source_truth_mode gains shadow/enforce semantics in later slices.
+CREATE TABLE IF NOT EXISTS fabric_sources (
+    id TEXT PRIMARY KEY,
+    -- 'connector_run' | 'document' | 'human_actor' | 'agent_session'
+    kind TEXT NOT NULL,
+    -- Identity fields (union across kinds; NULL = absent, still part of the
+    -- dedup identity — see _SOURCES_IDENTITY_UNIQUE_INDEX_SQL).
+    connector TEXT,
+    run_id TEXT,
+    document_uri TEXT,
+    actor_id TEXT,
+    session_id TEXT,
+    retrieved_at TEXT,
+    -- Tenancy (W4a semantics): the owning workspace. NULL = OSS /
+    -- single-tenant caller. PART OF THE DEDUP IDENTITY — the same source
+    -- identity in two workspaces is two rows (tenancy isolation beats dedup).
+    -- On an early-FST-1 DB this column is added by the ALTER migration in
+    -- _ensure_schema, NOT here.
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS fabric_statements (
+    id TEXT PRIMARY KEY,
+    object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    property TEXT NOT NULL,
+    -- JSON-encoded value (any JSON type, incl. null).
+    value TEXT NOT NULL DEFAULT 'null',
+    source_ref_id TEXT NOT NULL REFERENCES fabric_sources(id),
+    -- 'human' | 'connector' | 'mirror' | 'agent' | 'inferred'
+    writer_class TEXT NOT NULL,
+    -- Bitemporal fields, ISO-8601 TEXT (same affinity as every other
+    -- timestamp column in this schema).
+    observed_at TEXT NOT NULL,
+    recorded_at TEXT NOT NULL,
+    valid_from TEXT NOT NULL,
+    valid_to TEXT,
+    -- Curation: 'preferred' | 'normal' | 'deprecated'; pinned = human-fixed.
+    rank TEXT NOT NULL DEFAULT 'normal',
+    rank_reason TEXT,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    -- Tenancy (W4a): same workspace semantics as fabric_objects. Stamped on
+    -- append; scoped reads see own rows + legacy NULL. Same ALTER-migration
+    -- note as fabric_sources.workspace_id above.
+    workspace_id TEXT
+);
+
 CREATE INDEX IF NOT EXISTS idx_objects_type ON fabric_objects(type_id);
 CREATE INDEX IF NOT EXISTS idx_objects_source ON fabric_objects(source_connector, source_id);
 CREATE INDEX IF NOT EXISTS idx_links_from ON fabric_links(from_object_id);
 CREATE INDEX IF NOT EXISTS idx_links_to ON fabric_links(to_object_id);
 CREATE INDEX IF NOT EXISTS idx_links_type ON fabric_links(link_type);
+CREATE INDEX IF NOT EXISTS idx_statements_object ON fabric_statements(object_id);
+CREATE INDEX IF NOT EXISTS idx_statements_object_property ON fabric_statements(object_id, property);
 """
 
 # Tenancy indexes are created AFTER the ALTER migration (see _ensure_schema),
@@ -240,6 +321,38 @@ _WORKSPACE_INDEX_SQL = (
     # list_types / stats reads. The UNIQUE (workspace_id, LOWER(name)) index is
     # created separately (_TYPE_NAME_UNIQUE_INDEX_SQL) after the de-dup pass.
     "CREATE INDEX IF NOT EXISTS idx_object_types_workspace ON fabric_object_types(workspace_id)",
+    # FST-1: same W4a pairing for the source-truth tables — the plain
+    # workspace index rides ALONGSIDE the (object_id, property) read index in
+    # SCHEMA_SQL, exactly like idx_objects_workspace pairs with
+    # idx_objects_type/idx_objects_source.
+    "CREATE INDEX IF NOT EXISTS idx_statements_workspace ON fabric_statements(workspace_id)",
+    "CREATE INDEX IF NOT EXISTS idx_sources_workspace ON fabric_sources(workspace_id)",
+)
+
+# Race guard for upsert_source: one row per source identity PER WORKSPACE.
+# Created AFTER the ALTER migration (same "no such column" hazard as
+# _WORKSPACE_INDEX_SQL: an early-FST-1 DB has the tables but not the
+# workspace_id column until the ALTER runs). SQLite treats NULLs as DISTINCT
+# in a UNIQUE index, so every nullable identity field — INCLUDING
+# workspace_id — is normalized through IFNULL(..., '') : two rows that both
+# omit run_id ARE the same identity, and two OSS (NULL-workspace) upserts of
+# the same source dedup to one row, while the same identity in two different
+# workspaces stays two rows (tenancy isolation beats dedup). upsert_source
+# does a lookup-first anyway; this index only closes the concurrent-insert
+# race the same way the type-name index does. The early-FST-1 index of the
+# same shape MINUS workspace_id is dropped first (it would collapse two
+# tenants' rows into one) — mirror of _OLD_GLOBAL_TYPE_NAME_INDEX.
+_OLD_SOURCES_IDENTITY_INDEX = "idx_sources_identity"
+_SOURCES_IDENTITY_UNIQUE_INDEX_SQL = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_sources_identity_ws ON fabric_sources("
+    " kind,"
+    " IFNULL(connector, ''),"
+    " IFNULL(run_id, ''),"
+    " IFNULL(document_uri, ''),"
+    " IFNULL(actor_id, ''),"
+    " IFNULL(session_id, ''),"
+    " IFNULL(workspace_id, '')"
+    ")"
 )
 
 # A UNIQUE index on (workspace_id, case-folded type name) closes a concurrent
@@ -382,15 +495,24 @@ class FabricStore:
             return
         async with aiosqlite.connect(self._db_path) as db:
             await db.executescript(SCHEMA_SQL)
-            # Additive migration (W4a + SZD-2): tenancy columns on a pre-existing
-            # DB. CREATE TABLE IF NOT EXISTS won't add a column to a table that
-            # already exists, so ALTER and swallow the duplicate-column error
-            # that fires on every subsequent boot — same pattern as the W2b
-            # instinct hash-chain / assignee migrations. Pre-existing rows keep
-            # NULL workspace_id (legacy/global; see the module header). SZD-2
-            # extends the same ALTER to fabric_object_types so the type catalog
-            # is per-tenant too.
-            for _tbl in ("fabric_objects", "fabric_links", "fabric_object_types"):
+            # Additive migration (W4a + SZD-2 + FST-1): tenancy columns on a
+            # pre-existing DB. CREATE TABLE IF NOT EXISTS won't add a column to
+            # a table that already exists, so ALTER and swallow the
+            # duplicate-column error that fires on every subsequent boot — same
+            # pattern as the W2b instinct hash-chain / assignee migrations.
+            # Pre-existing rows keep NULL workspace_id (legacy/global; see the
+            # module header). SZD-2 extends the same ALTER to
+            # fabric_object_types; FST-1 extends it to fabric_statements /
+            # fabric_sources (a no-op on any DB whose tables were created by
+            # this SCHEMA_SQL — it only heals a DB from an early FST-1 build
+            # that predates the schema-freeze workspace_id ruling).
+            for _tbl in (
+                "fabric_objects",
+                "fabric_links",
+                "fabric_object_types",
+                "fabric_statements",
+                "fabric_sources",
+            ):
                 try:
                     await db.execute(f"ALTER TABLE {_tbl} ADD COLUMN workspace_id TEXT")
                 except aiosqlite.OperationalError:
@@ -407,6 +529,15 @@ class FabricStore:
             # above). Doing this inside SCHEMA_SQL would fail on a pre-W4a DB.
             for _idx in _WORKSPACE_INDEX_SQL:
                 await db.execute(_idx)
+            # FST-1: the per-workspace source-identity UNIQUE index. Drop the
+            # early-FST-1 identity index (no workspace in its key — it would
+            # collapse two tenants' identical source identities into one row)
+            # before creating the workspace-aware replacement; both steps are
+            # no-ops on a fresh / already-migrated DB. Created here, after the
+            # ALTER, for the same "no such column" reason as
+            # _WORKSPACE_INDEX_SQL.
+            await db.execute(f"DROP INDEX IF EXISTS {_OLD_SOURCES_IDENTITY_INDEX}")
+            await db.execute(_SOURCES_IDENTITY_UNIQUE_INDEX_SQL)
             # SZD-2 backfill: attribute a NULL-workspace type to a tenant ONLY
             # when every object of that type unambiguously shares one workspace.
             # A type whose objects span tenants (or that has no objects, or whose
@@ -938,6 +1069,200 @@ class FabricStore:
             await db.execute("DELETE FROM fabric_links WHERE id = ?", (link_id,))
             await db.commit()
 
+    # --- Statements & Sources (FST-1 — source-truth provenance) ---
+
+    async def upsert_source(
+        self,
+        kind: str,
+        *,
+        connector: str | None = None,
+        run_id: str | None = None,
+        document_uri: str | None = None,
+        actor_id: str | None = None,
+        session_id: str | None = None,
+        retrieved_at: datetime | None = None,
+        workspace_id: str | None = None,
+    ) -> SourceRef:
+        """Return the SourceRef for this source identity, creating it if new.
+
+        Dedup key is the identity tuple ``(kind, connector, run_id,
+        document_uri, actor_id, session_id, workspace_id)`` — a second call
+        with the same identity returns the SAME row (``retrieved_at`` is
+        provenance metadata, not identity; an existing row is returned as-is,
+        never mutated). ``workspace_id`` IS part of the identity, unlike the
+        other fabric tables' W4a read-scope treatment: the same source seen
+        from two workspaces yields two rows, so tenant provenance never
+        rendezvouses on a shared row (tenancy isolation beats dedup);
+        ``None`` = the OSS / single-tenant identity. A concurrent
+        double-insert is closed by the ``idx_sources_identity_ws`` expression
+        UNIQUE index: the loser's INSERT raises and resolves to a re-read of
+        the winner's row.
+        """
+        identity_sql = (
+            "SELECT * FROM fabric_sources WHERE kind = ?"
+            " AND connector IS ? AND run_id IS ? AND document_uri IS ?"
+            " AND actor_id IS ? AND session_id IS ? AND workspace_id IS ?"
+        )
+        identity_params = (
+            kind,
+            connector,
+            run_id,
+            document_uri,
+            actor_id,
+            session_id,
+            workspace_id,
+        )
+        source = SourceRef(
+            kind=kind,  # type: ignore[arg-type]  # Literal validated by pydantic
+            connector=connector,
+            run_id=run_id,
+            document_uri=document_uri,
+            actor_id=actor_id,
+            session_id=session_id,
+            retrieved_at=retrieved_at,
+            workspace_id=workspace_id,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(identity_sql, identity_params) as cur:
+                row = await cur.fetchone()
+            if row:
+                return self._row_to_source(row)
+            try:
+                await db.execute(
+                    "INSERT INTO fabric_sources"
+                    " (id, kind, connector, run_id, document_uri, actor_id,"
+                    " session_id, retrieved_at, workspace_id)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        source.id,
+                        source.kind,
+                        connector,
+                        run_id,
+                        document_uri,
+                        actor_id,
+                        session_id,
+                        retrieved_at.isoformat() if retrieved_at else None,
+                        workspace_id,
+                    ),
+                )
+                await db.commit()
+            except aiosqlite.IntegrityError:
+                # Concurrent upsert won the race — return its row.
+                async with db.execute(identity_sql, identity_params) as cur:
+                    row = await cur.fetchone()
+                if row:
+                    return self._row_to_source(row)
+                raise
+        return source
+
+    async def append_statement(
+        self,
+        object_id: str,
+        property: str,
+        value: Any,
+        source_ref_id: str,
+        writer_class: str,
+        *,
+        observed_at: datetime | None = None,
+        valid_from: datetime | None = None,
+        valid_to: datetime | None = None,
+        rank: str = "normal",
+        rank_reason: str | None = None,
+        pinned: bool = False,
+        workspace_id: str | None = None,
+    ) -> Statement:
+        """Append ONE observed (object, property, value) claim with provenance.
+
+        APPEND-ONLY: statements are never updated or deleted (this store
+        exposes no verbs for either; rank changes land in a later slice as new
+        curation writes). ``recorded_at`` is stamped here; ``observed_at``
+        defaults to now (a live observation) and ``valid_from`` defaults to
+        ``observed_at``. ``value`` is JSON-encoded — any JSON-serializable
+        value round-trips, including ``None``. ``workspace_id`` stamps the
+        owning tenant on the row (W4a write semantics, same as
+        :meth:`create_object`); ``None`` = OSS / single-tenant caller.
+
+        Does NOT touch the object's flat ``properties`` dict — that dict
+        remains the primary read path; nothing consumes statements until
+        ``fabric_source_truth_mode`` gains shadow/enforce semantics.
+        """
+        stmt = Statement(
+            object_id=object_id,
+            property=property,
+            value=value,
+            source_ref_id=source_ref_id,
+            writer_class=writer_class,  # type: ignore[arg-type]  # Literal validated by pydantic
+            rank=rank,  # type: ignore[arg-type]  # Literal validated by pydantic
+            rank_reason=rank_reason,
+            pinned=pinned,
+            workspace_id=workspace_id,
+        )
+        if observed_at is not None:
+            stmt.observed_at = observed_at
+        stmt.valid_from = valid_from if valid_from is not None else stmt.observed_at
+        stmt.valid_to = valid_to
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO fabric_statements"
+                " (id, object_id, property, value, source_ref_id, writer_class,"
+                " observed_at, recorded_at, valid_from, valid_to, rank,"
+                " rank_reason, pinned, workspace_id)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    stmt.id,
+                    stmt.object_id,
+                    stmt.property,
+                    json.dumps(stmt.value),
+                    stmt.source_ref_id,
+                    stmt.writer_class,
+                    stmt.observed_at.isoformat(),
+                    stmt.recorded_at.isoformat(),
+                    stmt.valid_from.isoformat(),
+                    stmt.valid_to.isoformat() if stmt.valid_to else None,
+                    stmt.rank,
+                    stmt.rank_reason,
+                    1 if stmt.pinned else 0,
+                    workspace_id,
+                ),
+            )
+            await db.commit()
+        return stmt
+
+    async def get_statements(
+        self,
+        object_id: str,
+        property: str | None = None,
+        workspace_id: str | None = None,
+    ) -> list[Statement]:
+        """All statements for one object, optionally narrowed to one property.
+
+        Ordered by ``recorded_at`` (then id, for a stable order within the
+        same timestamp) — oldest first, so a resolver reading the full history
+        replays claims in the order the store learned them. ``workspace_id``
+        applies the standard W4a read scope (own rows + legacy NULL rows, via
+        ``_workspace_scope`` — same as :meth:`get_object`); ``None`` leaves
+        the read unscoped (OSS / single-tenant callers).
+        """
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "SELECT * FROM fabric_statements WHERE object_id = ?"
+        params: list[Any] = [object_id]
+        if property is not None:
+            sql += " AND property = ?"
+            params.append(property)
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        sql += " ORDER BY recorded_at, id"
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(sql, params) as cur:
+                rows = await cur.fetchall()
+        return [self._row_to_statement(r) for r in rows]
+
     async def get_linked_objects(
         self, obj_id: str, link_type: str | None = None, workspace_id: str | None = None
     ) -> list[FabricObject]:
@@ -1347,4 +1672,37 @@ class FabricStore:
             to_object_id=row["to_object_id"],
             link_type=row["link_type"],
             properties=json.loads(row["properties"]) if row["properties"] else {},
+        )
+
+    def _row_to_source(self, row: Any) -> SourceRef:
+        return SourceRef(
+            id=row["id"],
+            kind=row["kind"],
+            connector=row["connector"],
+            run_id=row["run_id"],
+            document_uri=row["document_uri"],
+            actor_id=row["actor_id"],
+            session_id=row["session_id"],
+            retrieved_at=(
+                datetime.fromisoformat(row["retrieved_at"]) if row["retrieved_at"] else None
+            ),
+            workspace_id=row["workspace_id"],
+        )
+
+    def _row_to_statement(self, row: Any) -> Statement:
+        return Statement(
+            id=row["id"],
+            object_id=row["object_id"],
+            property=row["property"],
+            value=json.loads(row["value"]) if row["value"] is not None else None,
+            source_ref_id=row["source_ref_id"],
+            writer_class=row["writer_class"],
+            observed_at=datetime.fromisoformat(row["observed_at"]),
+            recorded_at=datetime.fromisoformat(row["recorded_at"]),
+            valid_from=datetime.fromisoformat(row["valid_from"]),
+            valid_to=(datetime.fromisoformat(row["valid_to"]) if row["valid_to"] else None),
+            rank=row["rank"],
+            rank_reason=row["rank_reason"],
+            pinned=bool(row["pinned"]),
+            workspace_id=row["workspace_id"],
         )

--- a/tests/test_fabric_statements.py
+++ b/tests/test_fabric_statements.py
@@ -1,0 +1,442 @@
+# tests/test_fabric_statements.py
+# Created: 2026-07-10 (FST-1 — Fabric source-truth schema).
+# Updated: 2026-07-10 (FST-1 schema-freeze ruling — workspace_id tenancy) —
+#   both new tables carry the W4a workspace_id: added tests that the same
+#   source identity in two workspaces is TWO rows (workspace is part of the
+#   dedup identity), that get_statements applies the standard W4a read scope
+#   (own rows + legacy NULL), and that a DB from the early FST-1 build
+#   (tables without workspace_id, old idx_sources_identity index) is healed
+#   by the ALTER migration (column added, index swapped for
+#   idx_sources_identity_ws).
+#
+# Proves the FST-1 foundation the rest of the source-truth chain stacks on:
+#   * statement round-trip — append_statement / get_statements preserve every
+#     field (JSON value, writer_class, bitemporal datetimes, rank, pinned),
+#   * statements are append-only — the store exposes NO update/delete verbs,
+#   * source dedup — upsert_source returns the SAME row for the same identity
+#     tuple (kind + connector/run_id/document_uri/actor_id/session_id +
+#     workspace_id), including identities with absent (None) fields, and a
+#     DIFFERENT row for a different identity or a different workspace,
+#   * get_statements property filter narrows to one property; workspace_id
+#     scopes reads per W4a (own rows + legacy NULL),
+#   * migration idempotency — booting the store on a PRE-FST fabric.db (built
+#     from the old schema, no statements/sources tables) creates the new
+#     tables without touching existing data, and a second boot / second store
+#     is a no-op (no error, no duplicate tables/indexes),
+#   * the fabric_source_truth_mode flag exists, defaults to "off", rejects
+#     junk, and accepts the three documented positions.
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.fabric.store import FabricStore
+
+# The pre-FST-1 schema (fabric.db as it existed before this slice): the three
+# original tables + their indexes, WITHOUT fabric_statements / fabric_sources.
+# Inlined (rather than importing SCHEMA_SQL) so the fixture keeps simulating an
+# OLD database even as SCHEMA_SQL evolves.
+_PRE_FST_SCHEMA = """
+CREATE TABLE IF NOT EXISTS fabric_object_types (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    icon TEXT DEFAULT 'box',
+    color TEXT DEFAULT '#0A84FF',
+    properties_schema TEXT DEFAULT '[]',
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS fabric_objects (
+    id TEXT PRIMARY KEY,
+    type_id TEXT NOT NULL REFERENCES fabric_object_types(id),
+    type_name TEXT DEFAULT '',
+    properties TEXT NOT NULL DEFAULT '{}',
+    source_connector TEXT,
+    source_id TEXT,
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS fabric_links (
+    id TEXT PRIMARY KEY,
+    from_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    to_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    link_type TEXT NOT NULL,
+    properties TEXT DEFAULT '{}',
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_objects_type ON fabric_objects(type_id);
+CREATE INDEX IF NOT EXISTS idx_objects_source
+    ON fabric_objects(source_connector, source_id);
+"""
+
+
+async def _seeded_store(tmp_path: Path) -> tuple[FabricStore, str]:
+    """A store with one type + one object; returns (store, object_id)."""
+    store = FabricStore(tmp_path / "fabric.db")
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(obj_type.id, {"name": "Acme", "arr": 120})
+    return store, obj.id
+
+
+# ---------------------------------------------------------------------------
+# Statement round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_statement_round_trip(tmp_path: Path) -> None:
+    store, obj_id = await _seeded_store(tmp_path)
+    source = await store.upsert_source("connector_run", connector="gcalendar", run_id="run-1")
+    observed = datetime(2026, 7, 1, 12, 0, 0)
+    valid_to = datetime(2026, 12, 31, 23, 59, 59)
+
+    written = await store.append_statement(
+        obj_id,
+        "arr",
+        {"amount": 120, "currency": "USD"},
+        source.id,
+        "connector",
+        observed_at=observed,
+        valid_to=valid_to,
+        rank="preferred",
+        rank_reason="most recent sync",
+        pinned=True,
+    )
+
+    stmts = await store.get_statements(obj_id)
+    assert len(stmts) == 1
+    got = stmts[0]
+    assert got.id == written.id
+    assert got.object_id == obj_id
+    assert got.property == "arr"
+    assert got.value == {"amount": 120, "currency": "USD"}  # JSON round-trips
+    assert got.source_ref_id == source.id
+    assert got.writer_class == "connector"
+    assert got.observed_at == observed
+    assert got.valid_from == observed  # defaults to observed_at
+    assert got.valid_to == valid_to
+    assert got.recorded_at == written.recorded_at
+    assert got.rank == "preferred"
+    assert got.rank_reason == "most recent sync"
+    assert got.pinned is True
+
+
+@pytest.mark.asyncio
+async def test_statement_null_value_round_trips(tmp_path: Path) -> None:
+    store, obj_id = await _seeded_store(tmp_path)
+    source = await store.upsert_source("human_actor", actor_id="user-7")
+    await store.append_statement(obj_id, "churn_reason", None, source.id, "human")
+    stmts = await store.get_statements(obj_id, property="churn_reason")
+    assert len(stmts) == 1
+    assert stmts[0].value is None
+    assert stmts[0].writer_class == "human"
+
+
+@pytest.mark.asyncio
+async def test_get_statements_property_filter_and_order(tmp_path: Path) -> None:
+    store, obj_id = await _seeded_store(tmp_path)
+    source = await store.upsert_source("agent_session", session_id="sess-1")
+    first = await store.append_statement(obj_id, "arr", 120, source.id, "agent")
+    second = await store.append_statement(obj_id, "arr", 150, source.id, "agent")
+    await store.append_statement(obj_id, "name", "Acme Corp", source.id, "agent")
+
+    arr_stmts = await store.get_statements(obj_id, property="arr")
+    assert [s.value for s in arr_stmts] == [120, 150]  # oldest first (recorded_at)
+    assert [s.id for s in arr_stmts] == [first.id, second.id]  # insertion order
+    assert len(await store.get_statements(obj_id)) == 3
+    assert await store.get_statements(obj_id, property="missing") == []
+
+
+def test_statements_are_append_only() -> None:
+    """The store exposes NO update/delete verbs for statements in FST-1."""
+    verbs = [n for n in dir(FabricStore) if "statement" in n.lower()]
+    assert "append_statement" in verbs
+    assert "get_statements" in verbs
+    assert not any("update" in v or "delete" in v or "remove" in v for v in verbs)
+
+
+# ---------------------------------------------------------------------------
+# Source dedup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_source_dedups_on_identity(tmp_path: Path) -> None:
+    store, _ = await _seeded_store(tmp_path)
+    a = await store.upsert_source("connector_run", connector="stripe", run_id="run-9")
+    b = await store.upsert_source("connector_run", connector="stripe", run_id="run-9")
+    assert a.id == b.id  # same identity -> same row
+
+    c = await store.upsert_source("connector_run", connector="stripe", run_id="run-10")
+    assert c.id != a.id  # different identity -> new row
+
+    # Absent (None) identity fields dedup too.
+    d = await store.upsert_source("document", document_uri="s3://bucket/report.pdf")
+    e = await store.upsert_source("document", document_uri="s3://bucket/report.pdf")
+    assert d.id == e.id
+
+    # Same field values under a DIFFERENT kind is a different identity.
+    f = await store.upsert_source("human_actor", actor_id="u-1")
+    g = await store.upsert_source("agent_session", actor_id="u-1")
+    assert f.id != g.id
+
+
+@pytest.mark.asyncio
+async def test_upsert_source_returns_existing_row_unmutated(tmp_path: Path) -> None:
+    store, _ = await _seeded_store(tmp_path)
+    first_seen = datetime(2026, 7, 1, 8, 0, 0)
+    a = await store.upsert_source(
+        "connector_run", connector="gmail", run_id="r1", retrieved_at=first_seen
+    )
+    # retrieved_at is provenance metadata, NOT identity: a later call with a
+    # different retrieved_at still resolves to the original row, unchanged.
+    b = await store.upsert_source(
+        "connector_run",
+        connector="gmail",
+        run_id="r1",
+        retrieved_at=datetime(2026, 7, 2, 8, 0, 0),
+    )
+    assert b.id == a.id
+    assert b.retrieved_at == first_seen
+
+
+# ---------------------------------------------------------------------------
+# Workspace tenancy (schema-freeze ruling)
+# ---------------------------------------------------------------------------
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+@pytest.mark.asyncio
+async def test_same_source_identity_in_two_workspaces_is_two_rows(tmp_path: Path) -> None:
+    """workspace_id is PART of the source identity — isolation beats dedup."""
+    store, _ = await _seeded_store(tmp_path)
+    a = await store.upsert_source(
+        "connector_run", connector="stripe", run_id="run-1", workspace_id=WS_A
+    )
+    b = await store.upsert_source(
+        "connector_run", connector="stripe", run_id="run-1", workspace_id=WS_B
+    )
+    assert a.id != b.id  # two workspaces -> two rows
+    assert a.workspace_id == WS_A
+    assert b.workspace_id == WS_B
+
+    # Same identity within ONE workspace still dedups.
+    a2 = await store.upsert_source(
+        "connector_run", connector="stripe", run_id="run-1", workspace_id=WS_A
+    )
+    assert a2.id == a.id
+
+    # The OSS (None-workspace) identity is its own row, distinct from both.
+    none_ws = await store.upsert_source("connector_run", connector="stripe", run_id="run-1")
+    assert none_ws.id not in {a.id, b.id}
+    assert none_ws.workspace_id is None
+    # ... and still dedups against itself.
+    assert (await store.upsert_source("connector_run", connector="stripe", run_id="run-1")).id == (
+        none_ws.id
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_statements_scoped_by_workspace(tmp_path: Path) -> None:
+    """W4a read scope on statements: own rows + legacy NULL rows."""
+    store, obj_id = await _seeded_store(tmp_path)
+    src_a = await store.upsert_source("human_actor", actor_id="u-a", workspace_id=WS_A)
+    src_b = await store.upsert_source("human_actor", actor_id="u-b", workspace_id=WS_B)
+    src_legacy = await store.upsert_source("human_actor", actor_id="u-legacy")
+
+    stmt_a = await store.append_statement(obj_id, "arr", 100, src_a.id, "human", workspace_id=WS_A)
+    stmt_b = await store.append_statement(obj_id, "arr", 200, src_b.id, "human", workspace_id=WS_B)
+    stmt_legacy = await store.append_statement(obj_id, "arr", 300, src_legacy.id, "human")
+
+    assert stmt_a.workspace_id == WS_A  # stamped on the returned model too
+
+    # Scoped read: own rows + legacy NULL, never the other tenant's.
+    a_ids = {s.id for s in await store.get_statements(obj_id, workspace_id=WS_A)}
+    assert a_ids == {stmt_a.id, stmt_legacy.id}
+    b_ids = {s.id for s in await store.get_statements(obj_id, workspace_id=WS_B)}
+    assert b_ids == {stmt_b.id, stmt_legacy.id}
+
+    # Property filter and workspace scope compose.
+    a_arr = await store.get_statements(obj_id, property="arr", workspace_id=WS_A)
+    assert {s.value for s in a_arr} == {100, 300}
+
+    # Unscoped read (OSS / single-tenant) sees everything, workspace surfaced.
+    all_stmts = await store.get_statements(obj_id)
+    assert {s.id for s in all_stmts} == {stmt_a.id, stmt_b.id, stmt_legacy.id}
+    assert {s.workspace_id for s in all_stmts} == {WS_A, WS_B, None}
+
+
+# ---------------------------------------------------------------------------
+# Migration idempotency
+# ---------------------------------------------------------------------------
+
+
+def _table_names(db_path: Path) -> list[str]:
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall()
+    return [r[0] for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_migration_on_existing_pre_fst_db(tmp_path: Path) -> None:
+    """Booting on a PRE-FST fabric.db adds the new tables and keeps old data."""
+    db_path = tmp_path / "fabric.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(_PRE_FST_SCHEMA)
+        conn.execute("INSERT INTO fabric_object_types (id, name) VALUES ('ot-old', 'Lease')")
+        conn.execute(
+            "INSERT INTO fabric_objects (id, type_id, type_name, properties)"
+            " VALUES ('obj-old', 'ot-old', 'Lease', '{\"rent\": 900}')"
+        )
+        conn.commit()
+
+    store = FabricStore(db_path)
+    # First boot migrates; the new tables must appear.
+    obj = await store.get_object("obj-old")
+    assert obj is not None and obj.properties == {"rent": 900}
+    tables = _table_names(db_path)
+    assert "fabric_statements" in tables
+    assert "fabric_sources" in tables
+
+    # And the new tables are immediately usable against the OLD object.
+    src = await store.upsert_source("document", document_uri="doc:1")
+    await store.append_statement("obj-old", "rent", 900, src.id, "mirror")
+    assert (await store.get_statements("obj-old", property="rent"))[0].value == 900
+
+
+@pytest.mark.asyncio
+async def test_migration_idempotent_twice_no_dup_tables(tmp_path: Path) -> None:
+    """Migrating twice (two stores, plus a forced re-run) errors nowhere and
+    duplicates nothing."""
+    db_path = tmp_path / "fabric.db"
+
+    store1 = FabricStore(db_path)
+    await store1._ensure_schema()
+    tables_after_first = _table_names(db_path)
+
+    # A second store on the SAME file re-runs the full migration from scratch.
+    store2 = FabricStore(db_path)
+    await store2._ensure_schema()
+    # Force a third pass on store1 too (aclose resets the initialized latch).
+    await store1.aclose()
+    await store1._ensure_schema()
+
+    tables_after_third = _table_names(db_path)
+    assert tables_after_third == tables_after_first  # no new/dup tables
+    assert len(set(tables_after_third)) == len(tables_after_third)
+    assert tables_after_third.count("fabric_statements") == 1
+    assert tables_after_third.count("fabric_sources") == 1
+
+    # The workspace-aware source-identity unique index survived both re-runs
+    # exactly once, and the early-FST-1 (workspace-less) index name is absent.
+    with sqlite3.connect(db_path) as conn:
+        idx_ws = conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index'"
+            " AND name='idx_sources_identity_ws'"
+        ).fetchone()[0]
+        idx_old = conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_sources_identity'"
+        ).fetchone()[0]
+    assert idx_ws == 1
+    assert idx_old == 0
+
+
+@pytest.mark.asyncio
+async def test_migration_heals_early_fst1_db_without_workspace(tmp_path: Path) -> None:
+    """A DB from the early FST-1 build (statements/sources tables WITHOUT
+    workspace_id, plus the workspace-less identity index) is healed on boot:
+    the column is ALTERed in and the old index is swapped for
+    idx_sources_identity_ws."""
+    db_path = tmp_path / "fabric.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(_PRE_FST_SCHEMA)
+        conn.executescript(
+            """
+            CREATE TABLE fabric_sources (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                connector TEXT,
+                run_id TEXT,
+                document_uri TEXT,
+                actor_id TEXT,
+                session_id TEXT,
+                retrieved_at TEXT,
+                created_at TEXT DEFAULT (datetime('now'))
+            );
+            CREATE TABLE fabric_statements (
+                id TEXT PRIMARY KEY,
+                object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+                property TEXT NOT NULL,
+                value TEXT NOT NULL DEFAULT 'null',
+                source_ref_id TEXT NOT NULL REFERENCES fabric_sources(id),
+                writer_class TEXT NOT NULL,
+                observed_at TEXT NOT NULL,
+                recorded_at TEXT NOT NULL,
+                valid_from TEXT NOT NULL,
+                valid_to TEXT,
+                rank TEXT NOT NULL DEFAULT 'normal',
+                rank_reason TEXT,
+                pinned INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE UNIQUE INDEX idx_sources_identity ON fabric_sources(
+                kind, IFNULL(connector, ''), IFNULL(run_id, ''),
+                IFNULL(document_uri, ''), IFNULL(actor_id, ''),
+                IFNULL(session_id, '')
+            );
+            """
+        )
+        conn.commit()
+
+    store = FabricStore(db_path)
+    # Boot heals the schema and the workspace-aware surface works end to end.
+    src = await store.upsert_source("document", document_uri="doc:1", workspace_id=WS_A)
+    assert src.workspace_id == WS_A
+    with sqlite3.connect(db_path) as conn:
+        stmt_cols = {r[1] for r in conn.execute("PRAGMA table_info(fabric_statements)")}
+        src_cols = {r[1] for r in conn.execute("PRAGMA table_info(fabric_sources)")}
+        idx_names = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='fabric_sources'"
+            )
+        }
+    assert "workspace_id" in stmt_cols
+    assert "workspace_id" in src_cols
+    assert "idx_sources_identity_ws" in idx_names
+    assert "idx_sources_identity" not in idx_names
+
+
+# ---------------------------------------------------------------------------
+# Mode flag (inert in FST-1)
+# ---------------------------------------------------------------------------
+
+
+def test_mode_flag_defaults_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POCKETPAW_FABRIC_SOURCE_TRUTH_MODE", raising=False)
+    from pocketpaw.config import Settings
+
+    assert Settings().fabric_source_truth_mode == "off"
+
+
+def test_mode_flag_env_positions(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pocketpaw.config import Settings
+
+    for mode in ("off", "shadow", "enforce"):
+        monkeypatch.setenv("POCKETPAW_FABRIC_SOURCE_TRUTH_MODE", mode)
+        assert Settings().fabric_source_truth_mode == mode
+
+    monkeypatch.setenv("POCKETPAW_FABRIC_SOURCE_TRUTH_MODE", "sideways")
+    with pytest.raises(Exception):
+        Settings()


### PR DESCRIPTION
## What this does

Foundation slice of the Fabric source-truth chain. Adds two tables — `fabric_statements` (per-property value claims: value, source ref, writer class, observed/recorded/valid times, rank, pinned, workspace) and `fabric_sources` (normalized, deduplicated provenance: connector runs, documents, human actors, agent sessions) — plus append-only store CRUD and a `fabric_source_truth_mode` config flag (`off | shadow | enforce`, default `off`, fully inert: nothing reads it yet).

Zero behavior change: no merge site touched, nothing writes statements in production paths, all existing fabric tests pass untouched (205 vs the 192 baseline — the +13 are this slice's).

## The spike (settled before the schema froze)

One SQLite `FabricStore` serves both OSS and cloud — the cloud ingest worker writes through the OSS `ingest_records` -> `get_fabric_store()` chain (per-workspace db files under ISO-1, same schema); the ee `WorkspaceFabricRegistry` is an ontology *registry* (type declarations, separate db, never object data); the only Mongo touching fabric holds ingest cursors. So this schema lands once, no parity work.

## Design notes

- `workspace_id` on both tables from day one (W4a pattern: column + swallowed-ALTER healing + paired indexes; source dedup identity includes the workspace so two tenants never collapse onto one row; reads scope own-rows-plus-legacy-NULL via the existing `_workspace_scope` helper).
- Statements are append-only — no update/delete verbs; rank changes arrive with the resolver slices.
- Migration rides `CREATE TABLE IF NOT EXISTS` + the ALTER-healing loop; idempotency proven by a migrate-thrice test against a hand-built pre-existing db.

## Verification

13 new tests (round-trip, dedup incl. cross-workspace, W4a read scoping, migration healing, flag default/env) x3 clean runs; full fabric selection 205 passed; ruff clean; import-linter OSS/EE contract kept.

Part of the source-truth chain (design: docs/design/drafts in the workspace repo). Next slice stacks on this branch.