### PR TITLE
feat(fabric): shadow statements + divergence log at the update_object merge site (FST-3)

### DIFF
--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -12,6 +12,15 @@
 #   existing ObjectType by id (the EE Firestore→Fabric worker's per-workspace
 #   mapping) ride this same canonical upsert loop instead of hand-rolling a
 #   parallel one. Additive; name-based callers are unchanged.
+# Updated: 2026-07-10 (FST-3 — SHADOW mode at merge site 1) — ingest_records
+#   now threads source-truth provenance into the UPDATE path: update_object is
+#   called with writer_class="connector", source_kind="connector_run",
+#   source_connector=<this connector>, and the new optional ``run_id`` param
+#   (default None — every existing caller unchanged) as source_run_id. When
+#   fabric_source_truth_mode is shadow/enforce, statements recorded at merge
+#   site 1 therefore carry honest connector provenance end-to-end; in 'off'
+#   (default) the kwargs are inert and behavior is byte-for-byte. CREATE path
+#   untouched (FST-4's scope).
 # Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ensure_type() now
 #   threads ``workspace_id`` into both the get_type_by_name() resolve and the
 #   define_type() create, so the type catalog stays per-tenant: a connector
@@ -169,6 +178,7 @@ async def ingest_records(
     records: Iterable[Mapping[str, Any]],
     mapping: FabricMapping,
     workspace_id: str | None = None,
+    run_id: str | None = None,
 ) -> IngestResult:
     """Map connector records into typed Fabric objects with provenance (idempotent).
 
@@ -180,6 +190,10 @@ async def ingest_records(
         workspace_id: W4a tenancy scope; threaded into both the dedup read and
             the create write so an ingest stays inside its tenant. ``None`` for
             single-tenant / OSS callers.
+        run_id: optional sync-run identity (FST-3). When set, the SourceRef the
+            shadow pass records for updated objects carries it, so statements
+            from different sync runs of the same connector are distinguishable.
+            ``None`` = "this connector, unattributed run".
 
     Returns:
         IngestResult with created / updated / skipped counts and the object ids.
@@ -189,6 +203,14 @@ async def ingest_records(
     store's merge-update); a new source_id CREATES one with provenance. Records
     lacking a usable source_id are skipped (counted) — without a stable key they
     cannot be deduplicated and would silently duplicate on every sync.
+
+    FST-3: the UPDATE path passes full source-truth provenance
+    (``writer_class="connector"``, a ``connector_run`` SourceRef with this
+    connector + run_id) into ``store.update_object``, so when
+    ``fabric_source_truth_mode`` is shadow/enforce the statements recorded at
+    merge site 1 carry honest connector provenance. In mode 'off' the kwargs
+    are inert. The CREATE path is untouched (statement coverage for creates is
+    FST-4's scope).
     """
     type_id = await ensure_type(store, mapping, workspace_id=workspace_id)
     result = IngestResult(type_name=mapping.type_name)
@@ -206,7 +228,15 @@ async def ingest_records(
             workspace_id=workspace_id,
         )
         if existing is not None:
-            updated = await store.update_object(existing.id, properties, workspace_id=workspace_id)
+            updated = await store.update_object(
+                existing.id,
+                properties,
+                workspace_id=workspace_id,
+                writer_class="connector",
+                source_kind="connector_run",
+                source_connector=connector,
+                source_run_id=run_id,
+            )
             result.updated += 1
             result.object_ids.append((updated or existing).id)
         else:

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -167,6 +167,31 @@
 #   ``fabric_objects.properties`` dict remains the primary read path; nothing
 #   writes statements in production until ``fabric_source_truth_mode``
 #   (default "off") gains shadow/enforce semantics in later slices.
+# Updated: 2026-07-10 (FST-3 — SHADOW mode at merge site 1) — update_object()
+#   now records statements when ``fabric_source_truth_mode`` is shadow/enforce
+#   (enforce == shadow until FST-5). The mode is read ONCE per call; 'off'
+#   (default) is byte-for-byte the prior behavior — zero new queries/writes.
+#   The LWW cache write is UNCHANGED in every mode. New OPTIONAL keyword-only
+#   provenance kwargs on update_object (writer_class, source_kind,
+#   source_connector, source_run_id, source_document_uri, source_actor_id,
+#   source_session_id, observed_at — all default None, every existing caller
+#   keeps working); connectors/fabric_ingest.py threads its connector context
+#   through them. The shadow pass (_shadow_record_statements) implements: the
+#   opt-in discipline (untracked single-source properties write NO
+#   statements), auto-promotion (an untracked property hit by a SECOND
+#   distinct source with a materially different value seeds a statement from
+#   the current cache value with object-level provenance + touch-time
+#   observed_at backfill), provenance derivation for unattributed writes
+#   (object's source_connector → writer_class "connector", else "agent"),
+#   FST-2 resolution over the property's statements, and ONE grep-stable
+#   divergence log line per statement-producing property ("fabric shadow:
+#   object=... property=... lww=... resolver=... diverged=... disputed=...
+#   unresolvable=..." — the FST-8 harness contract). Shadow runs AFTER the
+#   cache commit and is exception-shielded: a shadow failure logs a warning,
+#   never breaks the primary write. Supporting fix: _row_to_object now parses
+#   created_at/updated_at from the row (previously dropped — the model
+#   defaulted them to read-time now()), so the promotion backfill uses the
+#   TRUE last-touch time.
 
 
 from __future__ import annotations
@@ -191,7 +216,29 @@ from pocketpaw.fabric.models import (
     Statement,
 )
 
+# FST-3: the shadow pass reuses the resolver's material-difference rule
+# (strings compared stripped, everything else plain ==) rather than
+# duplicating it here — one definition of "materially different" for the
+# whole source-truth chain. The name is module-private in resolver.py but
+# intra-package reuse is deliberate.
+from pocketpaw.fabric.resolver import _materially_different, resolve
+from pocketpaw.fabric.trust import default_trust_rules
+
 logger = logging.getLogger(__name__)
+
+
+def _source_truth_mode() -> str:
+    """The fabric_source_truth_mode setting: 'off' | 'shadow' | 'enforce'.
+
+    Read lazily (import inside the function) so importing the store never
+    pulls the full config module, and so tests can monkeypatch either this
+    helper or ``pocketpaw.config.get_settings``. Callers read it ONCE per
+    operation — 'off' must stay byte-for-byte free of new queries/writes.
+    """
+    from pocketpaw.config import get_settings
+
+    return get_settings().fabric_source_truth_mode
+
 
 # Hard cap on the working set during a multi-hop traversal. The per-hop query
 # binds one ``?`` per frontier id in a ``WHERE l.<col> IN (?, ?, …)`` list; left
@@ -938,6 +985,15 @@ class FabricStore:
         obj_id: str,
         properties: dict[str, Any],
         workspace_id: str | None = None,
+        *,
+        writer_class: str | None = None,
+        source_kind: str | None = None,
+        source_connector: str | None = None,
+        source_run_id: str | None = None,
+        source_document_uri: str | None = None,
+        source_actor_id: str | None = None,
+        source_session_id: str | None = None,
+        observed_at: datetime | None = None,
     ) -> FabricObject | None:
         """Merge-update one object's properties, optionally scoped to a tenant (W4a).
 
@@ -948,7 +1004,21 @@ class FabricStore:
         and the UPDATE. A cross-tenant ``obj_id`` returns ``None`` and writes
         nothing. ``None`` leaves the update unscoped (OSS / agent-tool callers),
         exactly as before.
+
+        FST-3 (source-truth shadow) — the new keyword-only kwargs are OPTIONAL
+        provenance for the write (all default ``None``; every pre-FST-3 caller
+        keeps working unchanged). They only matter when
+        ``fabric_source_truth_mode`` is ``shadow`` or ``enforce`` (enforce is
+        treated as shadow until FST-5): the write is then ALSO recorded as
+        statements per :meth:`_shadow_record_statements` (auto-promotion,
+        provenance derivation, divergence log — see its docstring for the exact
+        rules). The CACHE WRITE IS UNCHANGED in every mode: last-write-wins
+        merge into the flat properties dict, which remains the primary read
+        path. With mode ``off`` (the default) not a single new query or write
+        happens — the mode is read once per call and the whole shadow block is
+        skipped.
         """
+        mode = _source_truth_mode()  # read ONCE per call; "off" skips everything
         existing = await self.get_object(obj_id, workspace_id=workspace_id)
         if not existing:
             return None
@@ -963,7 +1033,205 @@ class FabricStore:
         async with self._conn() as db:
             await db.execute(sql, params)
             await db.commit()
+        if mode != "off":
+            # shadow | enforce (enforce == shadow until FST-5). Runs AFTER the
+            # cache write so the primary path's semantics and error behavior
+            # stay byte-identical; a shadow failure must never break the write.
+            try:
+                await self._shadow_record_statements(
+                    existing,
+                    properties,
+                    writer_class=writer_class,
+                    source_kind=source_kind,
+                    source_connector=source_connector,
+                    source_run_id=source_run_id,
+                    source_document_uri=source_document_uri,
+                    source_actor_id=source_actor_id,
+                    source_session_id=source_session_id,
+                    observed_at=observed_at,
+                    workspace_id=workspace_id,
+                )
+            except Exception:
+                logger.warning(
+                    "fabric shadow: statement pass failed for object=%s — cache write unaffected",
+                    obj_id,
+                    exc_info=True,
+                )
         return await self.get_object(obj_id, workspace_id=workspace_id)
+
+    async def _shadow_record_statements(
+        self,
+        existing: FabricObject,
+        incoming: dict[str, Any],
+        *,
+        writer_class: str | None,
+        source_kind: str | None,
+        source_connector: str | None,
+        source_run_id: str | None,
+        source_document_uri: str | None,
+        source_actor_id: str | None,
+        source_session_id: str | None,
+        observed_at: datetime | None,
+        workspace_id: str | None,
+    ) -> None:
+        """The FST-3 shadow pass: record an update's claims as statements.
+
+        Called from :meth:`update_object` (merge site 1) only when
+        ``fabric_source_truth_mode`` is shadow/enforce, AFTER the LWW cache
+        write. ``existing`` is the PRE-update snapshot (its properties and
+        ``updated_at`` are the old cache state).
+
+        Provenance derivation (when the caller passed no explicit kwargs):
+
+        - source kind, in order: explicit ``source_kind`` > ``source_connector``
+          → ``connector_run`` > ``source_actor_id`` → ``human_actor`` >
+          ``source_session_id`` → ``agent_session`` > ``source_document_uri``
+          → ``document`` > the object's own ``source_connector`` →
+          ``connector_run`` for that connector (the historical main caller of
+          update_object is the connector re-sync refreshing its own object) >
+          ``agent_session`` with no identity (the honest default for
+          unattributed legacy writes).
+        - writer_class: explicit > ``connector`` when the effective kind is
+          ``connector_run`` > ``human`` for ``human_actor`` > ``agent`` for
+          everything else.
+
+        Second-distinct-source rule (drives auto-promotion): the object-level
+        baseline is (``existing.source_connector``, its derived writer class —
+        ``connector`` when a connector is stamped, else ``agent``). The
+        incoming write is a SECOND source when its effective connector differs
+        from the baseline connector OR its effective writer class differs from
+        the baseline writer class. An unattributed write on a connector-owned
+        object derives to that same connector, so it is NOT a second source —
+        without provenance threading a second writer cannot be detected, which
+        is exactly why ingest/API callers pass the kwargs.
+
+        Per incoming property:
+
+        1. already tracked (has statements) → append the incoming statement.
+        2. untracked → PROMOTE only when (second distinct source) AND (the
+           property exists in the current cache — a brand-new key has no prior
+           claim to preserve) AND (the values materially differ): seed a
+           statement from the current cache value with the object-level
+           baseline provenance and touch-time backfill
+           (``observed_at = existing.updated_at or created_at`` — the best
+           available approximation of when the cache value was written), then
+           append the incoming statement. Otherwise the property stays
+           scalar/cheap: NO statements, NO log line (the opt-in discipline).
+        3. resolve the property's statements via the FST-2 trust ladder and
+           log ONE structured divergence line (the FST-8 harness contract —
+           grep-stable, single line, values JSON-encoded so they can never
+           wrap):
+
+           ``fabric shadow: object=<id> property=<p> lww=<cache-value>
+           resolver=<winner-value> diverged=<bool> disputed=<bool>
+           unresolvable=<bool>``
+
+        The cache is NEVER touched here — shadow only observes.
+        """
+        # --- Effective provenance of the incoming write ---
+        kind = source_kind
+        connector = source_connector
+        if kind is None:
+            if connector is not None:
+                kind = "connector_run"
+            elif source_actor_id is not None:
+                kind = "human_actor"
+            elif source_session_id is not None:
+                kind = "agent_session"
+            elif source_document_uri is not None:
+                kind = "document"
+            elif existing.source_connector:
+                kind = "connector_run"
+                connector = existing.source_connector
+            else:
+                kind = "agent_session"
+        eff_writer = writer_class
+        if eff_writer is None:
+            if kind == "connector_run":
+                eff_writer = "connector"
+            elif kind == "human_actor":
+                eff_writer = "human"
+            else:
+                eff_writer = "agent"
+
+        # --- Object-level baseline (who owns the current cache value) ---
+        baseline_connector = existing.source_connector
+        baseline_writer = "connector" if baseline_connector else "agent"
+
+        # --- Second-distinct-source rule ---
+        incoming_connector = connector if kind == "connector_run" else None
+        is_second_source = incoming_connector != baseline_connector or eff_writer != baseline_writer
+
+        # Sources are upserted lazily so a fully scalar update (nothing tracked,
+        # nothing promoted) writes NOTHING — not even a SourceRef row.
+        incoming_source: SourceRef | None = None
+        seed_source: SourceRef | None = None
+
+        for prop, value in incoming.items():
+            stmts = await self.get_statements(existing.id, prop, workspace_id=workspace_id)
+            if not stmts:
+                # Untracked property — promotion gate.
+                if not is_second_source:
+                    continue
+                if prop not in existing.properties:
+                    continue  # brand-new key: no prior claim to preserve
+                old_value = existing.properties[prop]
+                if not _materially_different(old_value, value):
+                    continue
+                if seed_source is None:
+                    seed_source = await self.upsert_source(
+                        "connector_run" if baseline_connector else "agent_session",
+                        connector=baseline_connector,
+                        workspace_id=workspace_id,
+                    )
+                seed = await self.append_statement(
+                    existing.id,
+                    prop,
+                    old_value,
+                    seed_source.id,
+                    baseline_writer,
+                    observed_at=existing.updated_at or existing.created_at,
+                    workspace_id=workspace_id,
+                )
+                stmts = [seed]
+            if incoming_source is None:
+                incoming_source = await self.upsert_source(
+                    kind,
+                    connector=connector,
+                    run_id=source_run_id,
+                    document_uri=source_document_uri,
+                    actor_id=source_actor_id,
+                    session_id=source_session_id,
+                    workspace_id=workspace_id,
+                )
+            stmts.append(
+                await self.append_statement(
+                    existing.id,
+                    prop,
+                    value,
+                    incoming_source.id,
+                    eff_writer,
+                    observed_at=observed_at,
+                    workspace_id=workspace_id,
+                )
+            )
+            resolution = resolve(
+                stmts,
+                default_trust_rules(),
+                object_type=existing.type_name or None,
+            )
+            # The LWW cache now holds the incoming value (last write wins).
+            logger.info(
+                "fabric shadow: object=%s property=%s lww=%s resolver=%s"
+                " diverged=%s disputed=%s unresolvable=%s",
+                existing.id,
+                prop,
+                json.dumps(value, default=str),
+                json.dumps(resolution.value, default=str),
+                _materially_different(value, resolution.value),
+                resolution.is_disputed,
+                resolution.unresolvable,
+            )
 
     async def remove_object(self, obj_id: str) -> None:
         await self._ensure_schema()
@@ -1656,6 +1924,17 @@ class FabricStore:
         )
 
     def _row_to_object(self, row: Any) -> FabricObject:
+        # FST-3: created_at/updated_at now come from the ROW (they were
+        # silently dropped before, so the model defaulted them to read-time
+        # ``now()``). The shadow pass needs the TRUE last-touch time for the
+        # auto-promotion backfill (observed_at of the seeded statement).
+        # SQLite's datetime('now') stamps are naive UTC "YYYY-MM-DD HH:MM:SS"
+        # strings; fromisoformat parses them as-is. Defensive: a NULL falls
+        # back to the model default rather than crashing the read.
+        timestamps: dict[str, Any] = {}
+        for ts_field in ("created_at", "updated_at"):
+            if ts_field in row.keys() and row[ts_field]:
+                timestamps[ts_field] = datetime.fromisoformat(row[ts_field])
         return FabricObject(
             id=row["id"],
             type_id=row["type_id"],
@@ -1663,6 +1942,7 @@ class FabricStore:
             properties=json.loads(row["properties"]) if row["properties"] else {},
             source_connector=row["source_connector"],
             source_id=row["source_id"],
+            **timestamps,
         )
 
     def _row_to_link(self, row: Any) -> FabricLink:

--- a/tests/test_fabric_shadow_site1.py
+++ b/tests/test_fabric_shadow_site1.py
@@ -1,0 +1,481 @@
+# tests/test_fabric_shadow_site1.py
+# Created: 2026-07-10 (FST-3 — SHADOW mode at merge site 1).
+#
+# Proves the first real source-truth data flow: store.update_object records
+# statements when fabric_source_truth_mode is shadow/enforce, while the LWW
+# cache write stays byte-for-byte unchanged in every mode.
+#
+#   * two writers (different sources) on one property in shadow — both
+#     statements exist, the divergence line is logged with correct
+#     diverged/disputed/unresolvable values, the cache still shows the LWW
+#     value,
+#   * single-source / same-source / immaterial-difference / brand-new-key
+#     properties — zero statements, zero log lines (the opt-in discipline),
+#   * mode=off — byte-for-byte: the mode is read ONCE and no statement verb
+#     (get_statements / append_statement / upsert_source) is ever touched,
+#     asserted via instance spies + direct table counts,
+#   * auto-promotion — the seed statement carries the OLD cache value, the
+#     object-level provenance (source_connector -> writer_class "connector",
+#     a connector_run SourceRef), and touch-time observed_at backfill (the
+#     object's TRUE pre-update updated_at from the DB row),
+#   * ingest_records provenance threading — the re-sync UPDATE path produces a
+#     statement with writer_class="connector" and a SourceRef carrying the
+#     connector name + run_id,
+#   * the divergence log line is grep-stable and single-line (FST-8's harness
+#     contract), enforce behaves as shadow (until FST-5), a shadow failure
+#     never breaks the cache write, and statements/sources are stamped with
+#     the caller's workspace_id.
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from pocketpaw.connectors.fabric_ingest import FabricMapping, ingest_records
+from pocketpaw.fabric.store import FabricStore, _source_truth_mode
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+# The FST-8 harness contract: one line, grep-stable, values JSON-encoded.
+DIVERGENCE_RE = re.compile(
+    r"^fabric shadow: object=\S+ property=\S+ lww=.+ resolver=.+"
+    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)$"
+)
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """The divergence lines (excludes the failure-shield warning)."""
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+def _table_count(db_path: Path, table: str) -> int:
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    finally:
+        con.close()
+
+
+def _db_object_timestamps(db_path: Path, obj_id: str) -> tuple[str, str]:
+    con = sqlite3.connect(db_path)
+    try:
+        row = con.execute(
+            "SELECT created_at, updated_at FROM fabric_objects WHERE id = ?", (obj_id,)
+        ).fetchone()
+    finally:
+        con.close()
+    return row[0], row[1]
+
+
+def _source_row(db_path: Path, source_ref_id: str) -> dict[str, Any]:
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute("SELECT * FROM fabric_sources WHERE id = ?", (source_ref_id,)).fetchone()
+    finally:
+        con.close()
+    assert row is not None, f"no fabric_sources row for {source_ref_id}"
+    return dict(row)
+
+
+async def _crm_object(tmp_path: Path, **props: Any) -> tuple[FabricStore, str, Path]:
+    """A store with one connector-owned object; returns (store, object_id, db_path)."""
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        props or {"name": "Acme", "arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+    return store, obj.id, db_path
+
+
+# ---------------------------------------------------------------------------
+# The settings wiring
+# ---------------------------------------------------------------------------
+
+
+def test_mode_helper_reads_settings_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    import pocketpaw.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "get_settings",
+        lambda force_reload=False: SimpleNamespace(fabric_source_truth_mode="shadow"),
+    )
+    assert _source_truth_mode() == "shadow"
+
+
+# ---------------------------------------------------------------------------
+# (c) mode=off — byte-for-byte, mode read once, statements path untouched
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_off_never_touches_statements_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+
+    mode_reads = {"count": 0}
+
+    def counting_off() -> str:
+        mode_reads["count"] += 1
+        return "off"
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", counting_off)
+
+    async def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("statements path touched in mode=off")
+
+    monkeypatch.setattr(store, "get_statements", _boom)
+    monkeypatch.setattr(store, "append_statement", _boom)
+    monkeypatch.setattr(store, "upsert_source", _boom)
+
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+    updated = await store.update_object(obj_id, {"arr": 150}, writer_class="agent")
+
+    assert updated is not None
+    assert updated.properties == {"name": "Acme", "arr": 150}  # LWW merge intact
+    assert mode_reads["count"] == 1  # mode read ONCE per update_object call
+    assert _table_count(db_path, "fabric_statements") == 0
+    assert _table_count(db_path, "fabric_sources") == 0
+    assert _shadow_lines(caplog) == []
+
+
+# ---------------------------------------------------------------------------
+# (a) + (d) two writers, promotion seed, divergence log, cache unchanged
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_two_writers_promotes_logs_and_keeps_lww_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _, pre_updated_at = _db_object_timestamps(db_path, obj_id)
+
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # Second distinct source: an agent session, vs the object's crm connector.
+    await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-1"
+    )
+
+    # Cache: EXACTLY the LWW value, shadow never changes it.
+    obj = await store.get_object(obj_id)
+    assert obj is not None
+    assert obj.properties["arr"] == 150
+
+    # Both statements exist: the promoted seed + the incoming write.
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 2
+    seed = next(s for s in stmts if s.writer_class == "connector")
+    incoming = next(s for s in stmts if s.writer_class == "agent")
+
+    # (d) the seed carries the OLD cache value, object-level provenance, and
+    # touch-time backfill = the object's TRUE pre-update updated_at.
+    assert seed.value == 120
+    assert seed.observed_at == datetime.fromisoformat(pre_updated_at)
+    seed_src = _source_row(db_path, seed.source_ref_id)
+    assert seed_src["kind"] == "connector_run"
+    assert seed_src["connector"] == "crm"
+    assert seed_src["run_id"] is None
+
+    # The incoming statement carries the caller's provenance.
+    assert incoming.value == 150
+    in_src = _source_row(db_path, incoming.source_ref_id)
+    assert in_src["kind"] == "agent_session"
+    assert in_src["session_id"] == "sess-1"
+
+    # ONE divergence line, exact FST-8 shape. The connector-tier seed (120)
+    # outranks the agent write on the trust ladder, so the resolver diverges
+    # from the LWW cache (150), and the open agent loser disputes.
+    lines = _shadow_lines(caplog)
+    assert lines == [
+        f"fabric shadow: object={obj_id} property=arr lww=150 resolver=120"
+        " diverged=True disputed=True unresolvable=False"
+    ]
+    assert DIVERGENCE_RE.fullmatch(lines[0])
+    assert "\n" not in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# (b) the opt-in discipline: untracked single-source properties stay scalar
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_same_connector_resync_writes_no_statements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # Same source as the object's owner: crm refreshing its own object.
+    await store.update_object(
+        obj_id, {"arr": 999}, writer_class="connector", source_connector="crm"
+    )
+
+    assert _table_count(db_path, "fabric_statements") == 0
+    assert _table_count(db_path, "fabric_sources") == 0
+    assert _shadow_lines(caplog) == []
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 999
+
+
+async def test_shadow_unattributed_write_derives_to_owner_no_statements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No provenance kwargs on a connector-owned object derives to that same
+    connector (the honest default — the historical caller IS the re-sync), so
+    it is NOT a second distinct source and nothing is tracked."""
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    await store.update_object(obj_id, {"arr": 500})
+
+    assert _table_count(db_path, "fabric_statements") == 0
+    assert _shadow_lines(caplog) == []
+
+
+async def test_shadow_agent_object_agent_write_no_statements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unattributed object (no source_connector) written by an agent: the
+    baseline writer class is 'agent' and so is the incoming — same source."""
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Note", properties=[])
+    obj = await store.create_object(obj_type.id, {"body": "draft"})
+    _set_mode(monkeypatch, "shadow")
+
+    await store.update_object(obj.id, {"body": "final"}, writer_class="agent")
+
+    assert _table_count(db_path, "fabric_statements") == 0
+
+
+async def test_shadow_promotion_requires_material_difference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+
+    # Same value from a second source — nothing to dispute, no promotion.
+    await store.update_object(obj_id, {"arr": 120}, writer_class="agent")
+    # Whitespace-only string difference is immaterial by the resolver's rule.
+    await store.update_object(obj_id, {"name": "  Acme  "}, writer_class="agent")
+
+    assert _table_count(db_path, "fabric_statements") == 0
+
+
+async def test_shadow_new_key_from_second_source_not_promoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A brand-new property has no prior cache claim to preserve — it stays
+    untracked even when written by a second distinct source."""
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    await store.update_object(obj_id, {"tier": "gold"}, writer_class="agent")
+
+    assert _table_count(db_path, "fabric_statements") == 0
+    assert _shadow_lines(caplog) == []
+
+
+# ---------------------------------------------------------------------------
+# Tracked properties append on EVERY write; mixed updates log per-statement
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_tracked_property_appends_and_reconverges(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # Promote via an agent write (2 statements: seed 120 + agent 150).
+    await store.update_object(obj_id, {"arr": 150}, writer_class="agent")
+    caplog.clear()
+
+    # Now the owning connector writes again — tracked, so it appends even from
+    # the same source. Far-future observed_at keeps the recency leg (and the
+    # 24h un-rankable epsilon) deterministic regardless of run date/timezone.
+    await store.update_object(
+        obj_id,
+        {"arr": 200},
+        writer_class="connector",
+        source_connector="crm",
+        source_run_id="run-9",
+        observed_at=datetime(2030, 1, 1, 12, 0, 0),
+    )
+
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 3
+    lines = _shadow_lines(caplog)
+    # The fresh connector write wins the ladder → resolver agrees with LWW.
+    assert lines == [
+        f"fabric shadow: object={obj_id} property=arr lww=200 resolver=200"
+        " diverged=False disputed=True unresolvable=False"
+    ]
+
+
+async def test_shadow_mixed_update_logs_only_statement_properties(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path, name="Acme", arr=120, note="x")
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # Track arr via promotion.
+    await store.update_object(obj_id, {"arr": 150}, writer_class="agent")
+    caplog.clear()
+
+    # Same-source update touching a tracked (arr) and an untracked (note)
+    # property: arr appends + logs, note stays scalar — one line total.
+    await store.update_object(
+        obj_id,
+        {"arr": 170, "note": "z"},
+        writer_class="connector",
+        source_connector="crm",
+    )
+
+    assert len(await store.get_statements(obj_id, "arr")) == 3
+    assert await store.get_statements(obj_id, "note") == []
+    lines = _shadow_lines(caplog)
+    assert len(lines) == 1 and "property=arr" in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# (e) ingest_records threads connector provenance end-to-end
+# ---------------------------------------------------------------------------
+
+
+async def test_ingest_records_threads_provenance_through_update(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    _set_mode(monkeypatch, "shadow")
+    mapping = FabricMapping(
+        type_name="CalendarEvent",
+        source_id_field="event_id",
+        field_map={"title": "title"},
+    )
+
+    # CREATE path — no statements at site 1 (creates are FST-4's scope).
+    res1 = await ingest_records(store, "gcal", [{"event_id": "e1", "title": "Standup"}], mapping)
+    assert res1.created == 1
+    obj_id = res1.object_ids[0]
+    assert await store.get_statements(obj_id, "title") == []
+
+    # An agent edit promotes the property (seed "Standup" + agent value).
+    await store.update_object(
+        obj_id, {"title": "Standup (moved)"}, writer_class="agent", source_session_id="s-9"
+    )
+    assert len(await store.get_statements(obj_id, "title")) == 2
+
+    # Re-sync: the UPDATE path passes connector provenance + run identity.
+    res2 = await ingest_records(
+        store, "gcal", [{"event_id": "e1", "title": "Standup v2"}], mapping, run_id="run-7"
+    )
+    assert res2.updated == 1
+
+    stmts = await store.get_statements(obj_id, "title")
+    assert len(stmts) == 3
+    ingest_stmt = next(s for s in stmts if s.value == "Standup v2")
+    assert ingest_stmt.writer_class == "connector"
+    src = _source_row(db_path, ingest_stmt.source_ref_id)
+    assert src["kind"] == "connector_run"
+    assert src["connector"] == "gcal"
+    assert src["run_id"] == "run-7"
+
+    # Cache is still plain LWW.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["title"] == "Standup v2"
+
+
+# ---------------------------------------------------------------------------
+# enforce == shadow (until FST-5); shadow failures never break the write
+# ---------------------------------------------------------------------------
+
+
+async def test_enforce_mode_behaves_as_shadow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    await store.update_object(obj_id, {"arr": 150}, writer_class="agent")
+
+    assert len(await store.get_statements(obj_id, "arr")) == 2
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150  # cache still LWW
+
+
+async def test_shadow_failure_never_breaks_cache_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, _ = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+
+    async def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("simulated shadow failure")
+
+    monkeypatch.setattr(store, "append_statement", _explode)
+    caplog.set_level(logging.WARNING, logger=STORE_LOGGER)
+
+    updated = await store.update_object(obj_id, {"arr": 150}, writer_class="agent")
+
+    assert updated is not None and updated.properties["arr"] == 150
+    assert any(
+        "statement pass failed" in r.getMessage() for r in caplog.records if r.name == STORE_LOGGER
+    )
+
+
+# ---------------------------------------------------------------------------
+# Workspace stamping (W4a semantics carried into the shadow pass)
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_statements_and_sources_stamped_with_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[], workspace_id="ws-a")
+    obj = await store.create_object(
+        obj_type.id,
+        {"arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+        workspace_id="ws-a",
+    )
+    _set_mode(monkeypatch, "shadow")
+
+    await store.update_object(obj.id, {"arr": 150}, workspace_id="ws-a", writer_class="agent")
+
+    stmts = await store.get_statements(obj.id, "arr", workspace_id="ws-a")
+    assert len(stmts) == 2
+    assert all(s.workspace_id == "ws-a" for s in stmts)
+    for s in stmts:
+        assert _source_row(db_path, s.source_ref_id)["workspace_id"] == "ws-a"


### PR DESCRIPTION
## What this does

Builds on #1691. First real data flow of the source-truth chain: in shadow (or enforce) mode, `store.update_object` records per-property statements alongside the unchanged LWW cache write. Multi-source properties auto-promote (the old cache value is seeded as a statement with the object's own provenance and true touch-time), the incoming write lands as a statement with threaded provenance, and one grep-stable divergence line per property reports where the resolver's answer differs from what LWW kept:

```
fabric shadow: object=<id> property=<p> lww=<json> resolver=<json> diverged=<bool> disputed=<bool> unresolvable=<bool>
```

Mode off (the default) reads the flag once and does nothing else — no new queries, no writes (spy-tested). The cache write is byte-identical in every mode; the shadow pass runs after the cache commit and is exception-shielded, so a statement-table fault can never break the primary write path.

## Design notes

- `update_object` gains optional keyword-only provenance kwargs (writer class, source identity, observed_at) — every existing caller works unchanged; absent provenance derives honestly (connector-owned objects -> connector; unattributed legacy writes -> agent session). `ingest_records`, the canonical production writer, now threads its connector + run identity through on the UPDATE path.
- Auto-promotion is the opt-in lever: single-source properties stay scalar and write nothing (not even a source row); only a genuinely second source with a materially different value starts statement tracking.
- Rider fix: `_row_to_object` now returns the true DB created/updated timestamps instead of read-time defaults (needed for touch-time seeding; adjacent projection/retrieval/widget suites verified green).

## Verification

14 new e2e tests (two-source divergence, single-source stays scalar, off-mode spy, promotion seeding, ingest provenance threading, enforce==shadow for now, failure shield, workspace stamping, log grep-stability); fabric selection 256 passed (242 baseline + 14); adjacent selections 220 passed; ruff + import-linter clean.

Stacked on #1691. Next slice mirrors this at the remaining two merge sites (projection + cloud ingest).