### PR TITLE
feat(sites): skip the node build for html publishes

### DIFF
--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -8,6 +8,27 @@
 # behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-07-10 (HE-3 — html publish skips the Node build): build()/_build_one()
+# now branch the STAGE-2 payload AND the build chain on the engine's CAPABILITY, via
+# ``needs_node_build(engine)`` / ``is_source_engine(engine)`` from the canonical
+# engines.py (HE-2) — NOT by overloading ``smoke`` / ``static_build``. Overloading a
+# flag across this layer seam is exactly what caused the 2026-06-19 edit-overlay bug
+# (see that entry below); PRD Decision 6 guardrail #1 makes the new, third predicate
+# binding. Two additions, both html-only; ripple + svelte are byte-for-byte unchanged:
+#   * INPUT: html is a source-map engine, so it sends its raw {path: contents} static
+#     tree on ``input.source`` and OMITS ``rippleSpec`` (no binding split — dynamic
+#     html is a non-goal). The svelte ``if engine == "svelte"`` branch and the ripple
+#     ``else`` are untouched; html rides a new ``elif is_source_engine(engine)``.
+#   * BUILD: when ``needs_node_build(engine)`` is False (html), _build_one runs
+#     ``generate`` then RETURNS — skipping ``_rewrite_ripple_dep`` / ``_ripple_motion_dep``
+#     (an html site has no package.json), ``bun install``, ``bun run build``
+#     (build_static), AND the workerd SSR smoke gate. The workerd gate is replaced,
+#     for html only, by ``_html_static_smoke`` — a stdlib-only static check (parse the
+#     emitted index.html + resolve internal links) that raises the SAME
+#     ``SmokeGateFailed`` on a malformed/broken page, so the caller's rollback path is
+#     unchanged and a bad page never deploys. ripple + svelte (needs_node_build True)
+#     take the existing generate → install → build_static → gate chain unchanged.
+#
 # Updated 2026-07-09 (fix/sites-svelte-kit-ebusy-windows): every RE-publish of a
 # site 500'd on Windows with SmokeGateFailed: "build failed (exit 1)". Root cause:
 # PERF-3 reuses a per-pocket build dir to cache node_modules, so the prior build's
@@ -228,6 +249,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import signal
@@ -235,8 +257,12 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, Protocol
+from urllib.parse import unquote
+
+from pocketpaw_ee.sites.engines import is_source_engine, needs_node_build, static_output_rel
 
 logger = logging.getLogger(__name__)
 
@@ -538,6 +564,150 @@ async def _clear_stale_svelte_kit(project_dir: str) -> None:
 
 class SmokeGateFailed(RuntimeError):
     """Raised when the workerd smoke render fails — the site is not deployed."""
+
+
+# --------------------------------------------------------------------------- #
+# HE-3 — the html static smoke check (the html-path replacement for the workerd
+# SSR gate). ripple/svelte fail-gate a LIVE publish on a workerd SSR render (see
+# ``_WORKERD_SSR_MARKERS``); an html site has NO SSR and NO workerd, so that gate
+# is inapplicable — not skipped, replaced. This lightweight static check parses the
+# emitted index.html with the STDLIB parser (no new dependency) and confirms every
+# internal link / local asset ref resolves to a file in the output tree. It raises
+# the SAME ``SmokeGateFailed`` the workerd gate raises, so the publish caller's
+# existing rollback-on-SmokeGateFailed path is unchanged and a malformed page NEVER
+# reaches deploy (it fails closed). It is a clearly-named function, gated in
+# _build_one on the EXPLICIT ``needs_node_build(engine)`` predicate — never folded
+# into an overloaded ``smoke`` / ``static_build`` flag.
+# --------------------------------------------------------------------------- #
+
+_HTML_SMOKE_ENTRY = "index.html"
+
+# HTML void elements have no end tag: a ``</...>`` for one is never "unbalanced", and
+# one left "open" is not a structural error. Everything else pushes/pops the tag
+# stack in _HtmlSmokeParser. Matches HE-1's byte-preserving generator (unclosed
+# ``<br>`` is a valid authored input and must pass the smoke check).
+_HTML_VOID_ELEMENTS: frozenset[str] = frozenset(
+    {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr",
+    }
+)
+
+# A href/src value carrying a URL scheme (http:, https:, mailto:, tel:, data:,
+# javascript:, ...) is EXTERNAL / non-file and is never resolved to a local file.
+_URL_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*:")
+
+
+class _HtmlSmokeParser(HTMLParser):
+    """Collects href/src refs and detects gross structural malformation while
+    parsing the emitted ``index.html`` with the stdlib parser (no dependency).
+
+    * ``local_refs`` — every href/src attribute value seen (filtered to local files
+      by :func:`_local_ref_path` at check time).
+    * ``saw_element`` — whether ANY element start tag was seen; a file with none is
+      not a servable HTML document (a truncated/garbage input fails here).
+    * ``stray_end_tag`` — an end tag that closes no open element (an extra/unbalanced
+      ``</div>``): a genuine malformation a well-formed page never contains. Void and
+      explicitly self-closing tags never push, so they can't trigger a false
+      positive. This is the parse-side "malformed fails closed" teeth; the local-link
+      resolution check is the other.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.local_refs: list[str] = []
+        self.saw_element = False
+        self.stray_end_tag = False
+        self._open: list[str] = []
+
+    def _collect(self, attrs: list[tuple[str, str | None]]) -> None:
+        for name, value in attrs:
+            if name in ("href", "src") and value:
+                self.local_refs.append(value)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.saw_element = True
+        self._collect(attrs)
+        if tag not in _HTML_VOID_ELEMENTS:
+            self._open.append(tag)
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # An explicit self-closing tag (``<foo/>``) opens nothing.
+        self.saw_element = True
+        self._collect(attrs)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in _HTML_VOID_ELEMENTS:
+            return
+        if tag in self._open:
+            # Pop down to the matching open tag (tolerates optional-close nesting).
+            while self._open and self._open.pop() != tag:
+                continue
+        else:
+            self.stray_end_tag = True
+
+
+def _local_ref_path(ref: str) -> str | None:
+    """Return the local file path a href/src points at, or ``None`` when the ref is
+    not a local file we should verify.
+
+    ``None`` (skip) for: an in-page anchor (``#...``), a protocol-relative URL
+    (``//host``), any scheme-bearing URL (http/https/mailto/tel/data/javascript), an
+    empty value, or a same-document ``?query`` / ``#frag``. The query string and
+    fragment are stripped and the path is percent-decoded; a leading ``/``
+    (site-absolute) is resolved against the deploy root by the caller."""
+    value = ref.strip()
+    if not value or value.startswith("#"):
+        return None
+    if value.startswith("//"):  # protocol-relative → external
+        return None
+    if _URL_SCHEME_RE.match(value):  # http:, https:, mailto:, tel:, data:, ...
+        return None
+    path = value.split("#", 1)[0].split("?", 1)[0]
+    if not path:  # was a pure ?query / #frag → same document, nothing to resolve
+        return None
+    return unquote(path)
+
+
+def _html_static_smoke(static_dir: Path, *, entry: str = _HTML_SMOKE_ENTRY) -> None:
+    """The html-path smoke check (HE-3). Fails closed with ``SmokeGateFailed``.
+
+    Asserts the emitted static tree is coherent enough to serve: the entry
+    ``index.html`` exists and parses, contains at least one element, has no
+    unbalanced/stray end tag, and every internal link / local asset ref
+    (``href`` / ``src`` with a relative or site-absolute local path) resolves to a
+    file that exists under ``static_dir``. External refs (http/https/mailto/tel/data),
+    protocol-relative URLs, and in-page anchors are ignored. Any failure raises
+    ``SmokeGateFailed`` — the same class the workerd gate raises — so the caller's
+    rollback path is unchanged and a broken page never deploys."""
+    root = static_dir.resolve()
+    entry_path = root / entry
+    if not entry_path.is_file():
+        raise SmokeGateFailed(f"html smoke: no {entry} in the generated static tree ({root})")
+    markup = entry_path.read_text(encoding="utf-8", errors="replace")
+    parser = _HtmlSmokeParser()
+    try:
+        parser.feed(markup)
+        parser.close()
+    except Exception as exc:  # noqa: BLE001 — any parse error = an unservable page
+        raise SmokeGateFailed(f"html smoke: {entry} did not parse: {exc}") from exc
+    if not parser.saw_element:
+        raise SmokeGateFailed(f"html smoke: {entry} contains no HTML elements")
+    if parser.stray_end_tag:
+        raise SmokeGateFailed(f"html smoke: {entry} has an unbalanced/stray end tag")
+    for ref in parser.local_refs:
+        path = _local_ref_path(ref)
+        if path is None:
+            continue
+        target = (root / path.lstrip("/")).resolve()
+        try:
+            target.relative_to(root)
+        except ValueError:
+            raise SmokeGateFailed(
+                f"html smoke: link/asset escapes the site root: {ref!r}"
+            ) from None
+        if not target.exists():
+            raise SmokeGateFailed(f"html smoke: internal link/asset does not resolve: {ref!r}")
 
 
 @dataclass(frozen=True)
@@ -1049,10 +1219,38 @@ class GeneratorClient:
             files, bindings = _split_svelte_source(source)
             input_json["source"] = files
             input_json.update(bindings)
+        elif is_source_engine(engine):
+            # HE-3/HE-1: html is a source-map engine too — it sends its raw
+            # ``{path: contents}`` static tree on ``input.source`` and OMITS
+            # ``rippleSpec`` (a hand-authored html site has no rippleSpec). Unlike
+            # svelte there is NO binding split: dynamic (live-data) html is a
+            # non-goal, so an html source map carries only files. ripple (not a
+            # source engine) is untouched by this branch and still sends rippleSpec
+            # below, so its wire bytes — and svelte's — are unchanged.
+            input_json["source"] = source or {}
         else:
             input_json["rippleSpec"] = ripple_spec
         gen = await self._runner.generate(input_json, out_dir)
         project_dir = gen["projectDir"]
+        # HE-3: an html publish's last-mile output IS the authored source (HE-1 makes
+        # the generator emit a raw static tree), so there is NOTHING to install, no
+        # Vite/SvelteKit ``bun run build``, and no workerd SSR render. Skip all three
+        # and run the lightweight html static smoke instead. The skip is gated on the
+        # EXPLICIT ``needs_node_build(engine)`` predicate (engines.py, HE-2) — NEVER by
+        # overloading ``smoke`` / ``static_build``. Those two flags gate the workerd SSR
+        # fail-check and the ``bun run build`` step respectively; overloading either to
+        # ALSO mean "skip the node build" is the exact layer-seam flag conflation that
+        # caused the edit-overlay bug (this file's 2026-06-19 entry; PRD Decision 6,
+        # guardrail #1). ``needs_node_build`` is a THIRD, independent concept. Because
+        # this returns BEFORE ``_rewrite_ripple_dep`` / the install / ``build_static``
+        # below, NONE of them run on the html path — and neither ``_rewrite_ripple_dep``
+        # nor ``_ripple_motion_dep`` ever touch an html site (it has no package.json to
+        # rewrite). ripple + svelte (``needs_node_build`` True) fall through to the
+        # unchanged generate → install → build_static → gate chain.
+        if not needs_node_build(engine):
+            static_dir = Path(project_dir, static_output_rel(engine))
+            _html_static_smoke(static_dir)
+            return BuildResult(project_dir=project_dir, ripple_version=gen.get("rippleVersion"))
         # Make the generated project's deps resolvable BEFORE install (and before
         # the dep-hash is computed, so the rewrite is part of the fingerprint).
         # The template pins an unpublished @ripple-ui/svelte; the rewrite swaps it

--- a/tests/ee/sites/test_html_publish.py
+++ b/tests/ee/sites/test_html_publish.py
@@ -1,0 +1,345 @@
+# tests/ee/sites/test_html_publish.py
+# Created: 2026-07-10 (HE-3 — an html publish runs `generate` and nothing else).
+# Proves the html publish path in GeneratorClient.build()/_build_one():
+#   * html (needs_node_build == False) runs ONLY generate: `bun install`,
+#     build_static (`bun run build`), and the workerd SSR smoke gate are NEVER
+#     invoked. Asserted by spying on the fake runner's method calls — the same
+#     subprocess seam the existing generator_client tests fake — and by proving the
+#     ripple-dep rewrites (_rewrite_ripple_dep / _ripple_motion_dep) are never called
+#     on the html path (an html site has no package.json).
+#   * the html static-smoke check (_html_static_smoke) IS run and PASSES for good
+#     html, and FAILS CLOSED (raises SmokeGateFailed, does NOT return a BuildResult)
+#     for a malformed page or a broken internal link — so a bad page never reaches
+#     the deploy step.
+#   * REGRESSION: ripple + svelte (needs_node_build == True) still run
+#     generate -> install -> build_static/smoke exactly as before — the skip is
+#     gated on needs_node_build(engine), never on the smoke / static_build flags.
+#   * html's STAGE-2 payload carries its {path: contents} source map on
+#     `input.source` and OMITS rippleSpec (no binding split).
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.sites import generator_client as gc
+from pocketpaw_ee.sites.generator_client import (
+    BuildResult,
+    GeneratorClient,
+    SmokeGateFailed,
+    _html_static_smoke,
+)
+
+# asyncio_mode = "auto" (pyproject) drives the async tests; sync unit tests below
+# run as plain sync — so no module-level pytest.mark.asyncio (it would warn on them).
+
+_GOOD_HTML = (
+    "<!doctype html>\n"
+    "<html lang='en'>\n"
+    "<head>\n"
+    "  <meta charset='utf-8'>\n"
+    "  <title>Bright Smile</title>\n"
+    "  <link rel='stylesheet' href='style.css'>\n"
+    "</head>\n"
+    "<body>\n"
+    "  <header><a href='#top'>Top</a> <a href='https://example.com'>ext</a></header>\n"
+    "  <main><h1>Brighter Smiles</h1><img src='/assets/hero.png' alt='hero'><br></main>\n"
+    "  <footer><a href='mailto:hi@example.com'>Email</a></footer>\n"
+    "  <script src='app.js'></script>\n"
+    "</body>\n"
+    "</html>\n"
+)
+
+
+def _write_good_tree(root: Path) -> None:
+    """Materialize a coherent static tree: index.html + every local asset it refs."""
+    (root / "index.html").write_text(_GOOD_HTML, encoding="utf-8")
+    (root / "style.css").write_text(":root{--brand:#0A84FF}", encoding="utf-8")
+    (root / "app.js").write_text("console.log('hi')", encoding="utf-8")
+    assets = root / "assets"
+    assets.mkdir()
+    (assets / "hero.png").write_bytes(b"\x89PNG\r\n")
+
+
+class _SpyRunner:
+    """Fake runner recording which subprocess steps build() drove, and returning a
+    projectDir pointing at a real on-disk static tree so the html smoke can run.
+
+    Records ``calls`` so a test can assert install / build_static / smoke were (or
+    were NOT) invoked. Mirrors the real runner's full method set (generate, install,
+    build_static, smoke, install_inputs_hash) so the ripple/svelte regression runs
+    the modern build_static path, not the legacy smoke() fallback."""
+
+    def __init__(self, project_dir: str) -> None:
+        self._project_dir = project_dir
+        self.calls: list[str] = []
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.calls.append("generate")
+        return {"projectDir": self._project_dir, "engine": input_json.get("engine")}
+
+    def install_inputs_hash(self, project_dir: str) -> str:
+        # A stable hash: irrelevant on the html path (install is skipped entirely);
+        # on the ripple/svelte regression the first build always installs (no prior
+        # sentinel), which is what we assert.
+        return "h1"
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("install")
+        return True, "ok"
+
+    async def build_static(self, project_dir: str, *, gate: bool) -> tuple[bool, str]:
+        self.calls.append(f"build_static(gate={gate})")
+        return True, "ok"
+
+    async def smoke(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("smoke")
+        return True, "ok"
+
+
+class _CapturingSpyRunner(_SpyRunner):
+    """_SpyRunner that also captures the input_json handed to generate()."""
+
+    def __init__(self, project_dir: str) -> None:
+        super().__init__(project_dir)
+        self.input_json: dict | None = None
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.input_json = input_json
+        return await super().generate(input_json, out_dir)
+
+
+def _html_kwargs(source: dict[str, str]) -> dict:
+    return dict(
+        engine="html",
+        source=source,
+        ripple_spec=None,
+        theme={"primary": "#0A84FF"},
+        site_id="site_html",
+        title="Bright Smile",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The headline: an html publish runs generate + the html smoke, NOTHING else.
+# --------------------------------------------------------------------------- #
+
+
+async def test_html_publish_runs_only_generate_and_html_smoke(tmp_path, monkeypatch):
+    """HE-3 core: for engine='html' build() runs generate + the html static smoke and
+    SKIPS install, build_static, and the workerd smoke gate — asserted on the spy's
+    recorded calls (the subprocess seam)."""
+    _write_good_tree(tmp_path)
+
+    # Guard: if the html path ever reached the package.json rewrites, this explodes.
+    def _boom_rewrite(*a, **k):
+        raise AssertionError("_rewrite_ripple_dep must NEVER run on the html path")
+
+    def _boom_motion(*a, **k):
+        raise AssertionError("_ripple_motion_dep must NEVER run on the html path")
+
+    monkeypatch.setattr(gc, "_rewrite_ripple_dep", _boom_rewrite)
+    monkeypatch.setattr(gc, "_ripple_motion_dep", _boom_motion)
+
+    smoke_dirs: list[str] = []
+    real_smoke = gc._html_static_smoke
+
+    def _spy_smoke(static_dir: Path, **kw):
+        smoke_dirs.append(str(static_dir))
+        return real_smoke(static_dir, **kw)
+
+    monkeypatch.setattr(gc, "_html_static_smoke", _spy_smoke)
+
+    runner = _SpyRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    result = await client.build(**_html_kwargs({"index.html": _GOOD_HTML}))
+
+    # Only generate ran on the runner — no install / build_static / smoke.
+    assert runner.calls == ["generate"]
+    assert not any(c.startswith("install") for c in runner.calls)
+    assert not any(c.startswith("build_static") for c in runner.calls)
+    assert "smoke" not in runner.calls
+    # The html static smoke WAS invoked (and passed), against the project dir.
+    assert smoke_dirs == [str(tmp_path)]
+    assert isinstance(result, BuildResult)
+    assert result.project_dir == str(tmp_path)
+
+
+async def test_html_publish_sends_source_not_ripple_spec(tmp_path):
+    """html's STAGE-2 payload carries its {path: contents} map on input.source and
+    OMITS rippleSpec (no binding split — dynamic html is a non-goal)."""
+    _write_good_tree(tmp_path)
+    runner = _CapturingSpyRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    src = {"index.html": _GOOD_HTML, "style.css": ":root{}"}
+    await client.build(**_html_kwargs(src))
+
+    sent = runner.input_json
+    assert sent is not None
+    assert sent["engine"] == "html"
+    assert sent["source"] == src
+    assert "rippleSpec" not in sent
+    # No svelte binding split happened on the html source map.
+    for k in ("objects", "sources", "actions", "auth"):
+        assert k not in sent
+
+
+async def test_html_publish_malformed_fails_closed_before_deploy(tmp_path, monkeypatch):
+    """A malformed page (an unbalanced/stray end tag) FAILS the html smoke: build()
+    raises SmokeGateFailed and returns NO BuildResult, so it never reaches deploy.
+    The runner still only ran generate — the skip happened, the smoke bit."""
+    (tmp_path / "index.html").write_text(
+        "<html><body><div><h1>oops</h1></span></div></body></html>", encoding="utf-8"
+    )
+    runner = _SpyRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    with pytest.raises(SmokeGateFailed) as exc:
+        await client.build(**_html_kwargs({"index.html": "<html>...</html>"}))
+    assert "html smoke" in str(exc.value)
+    # Only generate ran — install/build_static/smoke were skipped, and the bad page
+    # was rejected before any deploy step.
+    assert runner.calls == ["generate"]
+
+
+async def test_html_publish_broken_internal_link_fails_closed(tmp_path):
+    """A broken internal link (href to a file that isn't in the output tree) FAILS
+    the html smoke, so a page with a dead local asset never deploys."""
+    (tmp_path / "index.html").write_text(
+        "<html><head><link rel='stylesheet' href='missing.css'></head>"
+        "<body><h1>hi</h1></body></html>",
+        encoding="utf-8",
+    )
+    runner = _SpyRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    with pytest.raises(SmokeGateFailed) as exc:
+        await client.build(**_html_kwargs({"index.html": "<html>...</html>"}))
+    assert "does not resolve" in str(exc.value)
+    assert runner.calls == ["generate"]
+
+
+# --------------------------------------------------------------------------- #
+# Regression: ripple + svelte still run the FULL build chain (unchanged).
+# --------------------------------------------------------------------------- #
+
+
+async def test_ripple_publish_still_runs_full_build_chain(tmp_path):
+    """needs_node_build('ripple') is True — the ripple path is UNCHANGED: generate ->
+    install -> build_static(gate=True). The html skip must not touch it."""
+    runner = _SpyRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    await client.build(
+        ripple_spec={"type": "container"},
+        theme={"primary": "#0A84FF"},
+        site_id="site_rp",
+        title="Dashboard",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_y",
+    )
+    assert runner.calls == ["generate", "install", "build_static(gate=True)"]
+
+
+async def test_svelte_publish_still_runs_full_build_chain(tmp_path):
+    """needs_node_build('svelte') is True — the svelte path is UNCHANGED: generate ->
+    install -> build_static(gate=True)."""
+    runner = _SpyRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    await client.build(
+        engine="svelte",
+        source={"src/routes/+page.svelte": "<h1>hi</h1>"},
+        ripple_spec=None,
+        theme={},
+        site_id="site_sv",
+        title="Tally",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+    )
+    assert runner.calls == ["generate", "install", "build_static(gate=True)"]
+
+
+async def test_html_skip_is_independent_of_smoke_and_static_build_flags(tmp_path):
+    """The skip is gated on needs_node_build(engine), NOT on smoke / static_build.
+    Even with the default flags (smoke=True, static_build=True) — the exact flags a
+    LIVE ripple/svelte publish uses — an html build still skips install/build_static.
+    This proves the flags were not overloaded to carry the skip."""
+    _write_good_tree(tmp_path)
+    runner = _SpyRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    await client.build(smoke=True, static_build=True, **_html_kwargs({"index.html": _GOOD_HTML}))
+    assert runner.calls == ["generate"]
+
+
+# --------------------------------------------------------------------------- #
+# _html_static_smoke unit coverage (the check in isolation).
+# --------------------------------------------------------------------------- #
+
+
+def test_html_smoke_passes_good_tree(tmp_path):
+    _write_good_tree(tmp_path)
+    _html_static_smoke(tmp_path)  # no raise
+
+
+def test_html_smoke_missing_index_fails(tmp_path):
+    with pytest.raises(SmokeGateFailed) as exc:
+        _html_static_smoke(tmp_path)
+    assert "no index.html" in str(exc.value)
+
+
+def test_html_smoke_no_elements_fails(tmp_path):
+    (tmp_path / "index.html").write_text("just plain text, no tags", encoding="utf-8")
+    with pytest.raises(SmokeGateFailed) as exc:
+        _html_static_smoke(tmp_path)
+    assert "no HTML elements" in str(exc.value)
+
+
+def test_html_smoke_stray_end_tag_fails(tmp_path):
+    (tmp_path / "index.html").write_text(
+        "<html><body><p>hi</p></div></body></html>", encoding="utf-8"
+    )
+    with pytest.raises(SmokeGateFailed) as exc:
+        _html_static_smoke(tmp_path)
+    assert "unbalanced" in str(exc.value)
+
+
+def test_html_smoke_broken_link_fails(tmp_path):
+    (tmp_path / "index.html").write_text(
+        "<html><body><img src='nope.png'></body></html>", encoding="utf-8"
+    )
+    with pytest.raises(SmokeGateFailed) as exc:
+        _html_static_smoke(tmp_path)
+    assert "does not resolve" in str(exc.value)
+
+
+def test_html_smoke_traversal_ref_fails(tmp_path):
+    (tmp_path / "index.html").write_text(
+        "<html><body><img src='../secret.png'></body></html>", encoding="utf-8"
+    )
+    with pytest.raises(SmokeGateFailed) as exc:
+        _html_static_smoke(tmp_path)
+    assert "escapes the site root" in str(exc.value)
+
+
+def test_html_smoke_ignores_external_and_anchor_refs(tmp_path):
+    (tmp_path / "index.html").write_text(
+        "<html><body>"
+        "<a href='https://example.com'>x</a>"
+        "<a href='mailto:hi@example.com'>m</a>"
+        "<a href='tel:+15551234'>t</a>"
+        "<a href='//cdn.example.com/x.js'>p</a>"
+        "<a href='#section'>a</a>"
+        "<a href='?q=1'>q</a>"
+        "<h1>ok</h1>"
+        "</body></html>",
+        encoding="utf-8",
+    )
+    _html_static_smoke(tmp_path)  # external / anchor / same-doc refs are not checked
+
+
+def test_html_smoke_site_absolute_and_query_refs_resolve(tmp_path):
+    (tmp_path / "index.html").write_text(
+        "<html><head><link rel='stylesheet' href='/style.css?v=2'></head>"
+        "<body><h1>hi</h1></body></html>",
+        encoding="utf-8",
+    )
+    (tmp_path / "style.css").write_text(":root{}", encoding="utf-8")
+    _html_static_smoke(tmp_path)  # /style.css resolves at root; ?v=2 is stripped


### PR DESCRIPTION
> **Stacked on #1689** (HE-2, `refactor/sites-engines-module`). Review that first — it adds the `needs_node_build` predicate this PR gates on. Base retargets to `dev` once #1689 merges.

## What ships

An html publish runs `generate` and nothing else. No `bun install`, no `vite build`, no workerd smoke render. This is the latency win the whole track was for — and structurally, it retires the six toolchain bug classes for the html path (no `.svelte-kit` lock, no `bunx`, no prerender, no ripple dep rewrite, no orphaned workerd).

## The one thing this PR is really about

The skip is gated on the explicit `needs_node_build(engine)` predicate from `engines.py`, **not** by overloading the existing `smoke` / `static_build` flags.

That distinction is the point. A prior production bug — the edit-overlay bug that recurred for days — was caused by one `smoke` flag meaning two things across a layer seam (it gated both the workerd check and the `vite build`). The team-soul guardrail from that incident is explicit: don't overload a flag across a layer boundary. So `needs_node_build` is a third, independent concept. The `smoke` / `static_build` signatures, defaults, and semantics are byte-for-byte unchanged and still flow only to the ripple/svelte chain.

The early return sits **before** `_rewrite_ripple_dep` and `install` in `_build_one`, so those plus `_ripple_motion_dep` are structurally unreachable on the html path — proven by a test that replaces both rewrite functions with raisers and watches the html build still succeed.

## The html smoke check

The workerd SSR gate doesn't apply to html. It's replaced, for html only, by `_html_static_smoke` — stdlib `html.parser`, no new dependency:

- `index.html` exists and parses, with ≥1 element (garbage/truncated fails)
- no stray end tags — void/self-closing tags and an authored unclosed `<br>` pass (matching HE-1's byte-preserving generator)
- every relative `href`/`src` resolves to a file in the output tree, with a traversal guard; external / anchor / `data:` refs are ignored

On failure it raises the **same `SmokeGateFailed`** the workerd gate raises, so the caller's existing rollback path is unchanged. A malformed page raises, returns no `BuildResult`, and the runner's recorded calls are `["generate"]` only — it never reaches deploy.

## Also in scope

The STAGE-2 input fork gained an `elif is_source_engine(engine)` branch so html sends its `{path: contents}` map on `input.source` and omits `rippleSpec`. Without this, html `generate` would receive no source and the track would be half-built. The svelte and ripple payloads are byte-identical.

## Verification

- 37 tests green. Spying the runner: html → `calls == ["generate"]`; ripple + svelte → `generate + install + build_static(gate=True)` unchanged, **even with `smoke=True, static_build=True`** (proving the flags weren't overloaded); malformed html → `SmokeGateFailed`, no deploy.
- **Zero regressions by stash-proof** over `tests/ee/sites`: identical failure set with and without the change. Those failures are the pre-existing `.svelte-kit` build-output environment limitation on this box (`sites.workers_no_build`), present on the base.
- `ruff` clean. One pre-existing `mypy` note (`psutil` stubs, untouched `reap_build_workerd`) proven pre-existing by stash.

## Reference

Tasks: `docs/design/drafts/2026-07-10-paw-sites-html-engine-tasks.md` (HE-3)