### PR TITLE
feat(fabric): shadow statements at the projection + cloud-mirror merge sites (FST-4)

### DIFF
--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -11,6 +11,17 @@
 #   pinned via the mapping's new optional type_id). Behavior note inherited
 #   from the canonical loop: a mapped field absent from a document projects as
 #   None (the mirror reflects the source) rather than being skipped.
+# Updated: 2026-07-10 (FST-4 — SHADOW mode at merge site 3) — the mirror now
+#   threads its TRUE provenance through ingest_records' new keyword params:
+#   writer_class="mirror" (a Firestore mirror is not a primary connector —
+#   the trust ladder ranks connector > mirror), source_document_uri = the
+#   full Firestore doc path (per-record, via the existing _DOC_PATH_KEY
+#   sentinel), and observed_at = the best available SOURCE time per doc
+#   (via the new _OBSERVED_AT_KEY sentinel — see _doc_observed_at for the
+#   per-field audit: cursor_field value first, snapshot update_time second,
+#   ingest-time default when neither parses). Only the shadow statements are
+#   affected; with fabric_source_truth_mode 'off' (default) the kwargs are
+#   inert and the mirror's writes are byte-for-byte unchanged.
 #
 # What this does
 # --------------
@@ -81,6 +92,10 @@ _SOURCE_CONNECTOR = "firestore"
 # extracts the source id from a record key, so we graft it on under a name no
 # real Firestore field would use (and which would be overwritten if one did).
 _DOC_PATH_KEY = "__firestore_doc_path__"
+# Sentinel record key carrying the per-doc SOURCE timestamp (FST-4) into the
+# OSS mapper's observed_at threading — same grafting trick as _DOC_PATH_KEY.
+# Holds a datetime or None (None → the statement defaults to ingest time).
+_OBSERVED_AT_KEY = "__fabric_observed_at__"
 
 # Per-collection page cap so one huge collection can't wedge a sweep tick.
 _MAX_DOCS_PER_RUN = 1000
@@ -416,6 +431,41 @@ def _doc_cursor(doc: dict[str, Any], cursor_field: str) -> str:
     return str(raw)
 
 
+def _doc_observed_at(doc: dict[str, Any], cursor_field: str) -> datetime | None:
+    """The best available SOURCE timestamp for one Firestore doc (FST-4).
+
+    Audit of what the worker actually knows per document (nothing else is on
+    the wire — the reader returns ``{path, data, update_time}`` only):
+
+    1. ``data[cursor_field]`` — the mapping's configured cursor field,
+       conventionally the document's own updated-at. The REAL source time
+       when present; may be a Firestore timestamp (google's
+       DatetimeWithNanoseconds subclasses datetime) or an RFC3339/ISO
+       string. Best choice when it parses.
+    2. ``update_time`` — the Firestore snapshot's server update time,
+       rendered RFC3339 by the reader. Not field-precise (any write to the
+       doc bumps it) but still a true source-side time; the fallback.
+    3. Neither parses → ``None``: the statement falls back to ingest time
+       (append_statement's observed_at default) — the honest floor, never a
+       fabricated timestamp.
+
+    There is NO per-field timestamp in Firestore, so one doc-level time
+    covers every property the doc updates.
+    """
+    data = doc.get("data") or {}
+    candidates = (data.get(cursor_field) if cursor_field else None, doc.get("update_time"))
+    for raw in candidates:
+        if raw is None or raw == "":
+            continue
+        if isinstance(raw, datetime):
+            return raw
+        try:
+            return datetime.fromisoformat(str(raw))
+        except ValueError:
+            continue
+    return None
+
+
 async def _mirror_docs(
     store: StoreLike,
     workspace_id: str,
@@ -442,13 +492,26 @@ async def _mirror_docs(
     otherwise — legacy NULL-workspace rows are globally visible),
     ``source_connector="firestore"``, and ``source_id`` = the full doc path.
     Returns the number of objects created + updated.
+
+    FST-4 (merge site 3): shadow-statement provenance rides the same call —
+    ``writer_class="mirror"`` (the mirror is not a primary connector), the
+    doc path doubles as the per-record ``source_document_uri`` (so each
+    statement's SourceRef names the exact Firestore collection/doc), and the
+    best available source time per doc (see ``_doc_observed_at``) becomes
+    ``observed_at``. All of it is inert when fabric_source_truth_mode is
+    'off'.
     """
     # Lazy import — keeps EE module import light and consistent with the other
     # OSS imports in this module (_default_store).
     from pocketpaw.connectors.fabric_ingest import FabricMapping, ingest_records
 
     records = [
-        {**(doc.get("data") or {}), _DOC_PATH_KEY: str(doc.get("path") or "")} for doc in docs
+        {
+            **(doc.get("data") or {}),
+            _DOC_PATH_KEY: str(doc.get("path") or ""),
+            _OBSERVED_AT_KEY: _doc_observed_at(doc, mapping.cursor_field),
+        }
+        for doc in docs
     ]
     oss_mapping = FabricMapping(
         type_name=mapping.object_type_id,  # label only; type_id pins the type
@@ -462,6 +525,9 @@ async def _mirror_docs(
         records,
         oss_mapping,
         workspace_id=workspace_id,
+        writer_class="mirror",
+        document_uri_field=_DOC_PATH_KEY,
+        observed_at_field=_OBSERVED_AT_KEY,
     )
     return summary.total
 

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -21,6 +21,27 @@
 #   site 1 therefore carry honest connector provenance end-to-end; in 'off'
 #   (default) the kwargs are inert and behavior is byte-for-byte. CREATE path
 #   untouched (FST-4's scope).
+# Updated: 2026-07-10 (FST-4 — SHADOW mode at merge site 3) — three OPTIONAL
+#   keyword-only params so the EE Firestore→Fabric mirror worker can thread
+#   its true provenance through this same loop (defaults keep every FST-3
+#   caller byte-identical):
+#     * ``writer_class`` (default "connector") — the mirror passes "mirror"
+#       (a Firestore mirror is not a primary connector; the trust ladder
+#       ranks connector > mirror);
+#     * ``document_uri_field`` — a record key whose value becomes the
+#       per-record ``source_document_uri`` (the mirror passes its doc-path
+#       sentinel, so each statement's SourceRef identifies the exact
+#       Firestore collection/doc);
+#     * ``observed_at_field`` — a record key holding a datetime that becomes
+#       the per-record ``observed_at`` (the mirror grafts the best available
+#       source time; non-datetime values are ignored → ingest-time default).
+#   CREATE-path decision (FST-4, settled): creates get NO statement hook.
+#   Promotion-time seeding already preserves the create-time claim — when a
+#   second source later updates a property, the seed statement is built from
+#   the current cache value with the OBJECT-level provenance (its
+#   source_connector) and touch-time observed_at, so the create-then-update
+#   flow yields both claims and a visible conflict without any create hook
+#   (proven by tests/test_fabric_shadow_create_path.py).
 # Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ensure_type() now
 #   threads ``workspace_id`` into both the get_type_by_name() resolve and the
 #   define_type() create, so the type catalog stays per-tenant: a connector
@@ -69,6 +90,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
 
 from pocketpaw.fabric.models import PropertyDef
@@ -179,6 +201,10 @@ async def ingest_records(
     mapping: FabricMapping,
     workspace_id: str | None = None,
     run_id: str | None = None,
+    *,
+    writer_class: str = "connector",
+    document_uri_field: str | None = None,
+    observed_at_field: str | None = None,
 ) -> IngestResult:
     """Map connector records into typed Fabric objects with provenance (idempotent).
 
@@ -194,6 +220,20 @@ async def ingest_records(
             shadow pass records for updated objects carries it, so statements
             from different sync runs of the same connector are distinguishable.
             ``None`` = "this connector, unattributed run".
+        writer_class: the writer class stamped on shadow statements from the
+            UPDATE path (FST-4). Default "connector" — byte-identical to
+            FST-3 for every real connector. The EE Firestore mirror passes
+            "mirror": a mirror is not a primary connector, and the trust
+            ladder ranks it below one.
+        document_uri_field: optional record key whose value becomes the
+            per-record ``source_document_uri`` (FST-4). Gives each statement's
+            SourceRef a document-precise identity (the mirror passes its
+            doc-path sentinel key). Empty/absent values → no document URI.
+        observed_at_field: optional record key holding a ``datetime`` that
+            becomes the per-record ``observed_at`` (FST-4) — when the SOURCE
+            says the value was true, not when we ingested it. Values that are
+            not datetimes are ignored (the statement then defaults to
+            ingest time).
 
     Returns:
         IngestResult with created / updated / skipped counts and the object ids.
@@ -205,12 +245,20 @@ async def ingest_records(
     cannot be deduplicated and would silently duplicate on every sync.
 
     FST-3: the UPDATE path passes full source-truth provenance
-    (``writer_class="connector"``, a ``connector_run`` SourceRef with this
-    connector + run_id) into ``store.update_object``, so when
-    ``fabric_source_truth_mode`` is shadow/enforce the statements recorded at
-    merge site 1 carry honest connector provenance. In mode 'off' the kwargs
-    are inert. The CREATE path is untouched (statement coverage for creates is
-    FST-4's scope).
+    (``writer_class`` + a ``connector_run`` SourceRef with this connector,
+    run_id, and optionally a per-record document URI + observed_at) into
+    ``store.update_object``, so when ``fabric_source_truth_mode`` is
+    shadow/enforce the statements recorded at merge site 1 carry honest
+    provenance. In mode 'off' the kwargs are inert.
+
+    CREATE path (FST-4 decision): creates append NO statements, by design.
+    A create doesn't merge — there is no prior claim to preserve and no
+    conflict to observe. The create-time claim is NOT lost: if a second
+    source later updates a tracked-able property, the FST-3 promotion gate
+    seeds a statement from the current cache value with the object's own
+    provenance (source_connector) and touch-time observed_at, so the
+    create-then-update flow surfaces both claims. Proven by
+    tests/test_fabric_shadow_create_path.py — do not add a create hook.
     """
     type_id = await ensure_type(store, mapping, workspace_id=workspace_id)
     result = IngestResult(type_name=mapping.type_name)
@@ -228,14 +276,29 @@ async def ingest_records(
             workspace_id=workspace_id,
         )
         if existing is not None:
+            # FST-4: per-record provenance. The document URI (when a field is
+            # declared) pins the SourceRef to the exact upstream document;
+            # observed_at (when a field is declared AND holds a datetime)
+            # carries the source's own timestamp instead of ingest time.
+            source_document_uri: str | None = None
+            if document_uri_field is not None:
+                raw_uri = record.get(document_uri_field)
+                source_document_uri = str(raw_uri) if raw_uri else None
+            observed_at: datetime | None = None
+            if observed_at_field is not None:
+                raw_observed = record.get(observed_at_field)
+                if isinstance(raw_observed, datetime):
+                    observed_at = raw_observed
             updated = await store.update_object(
                 existing.id,
                 properties,
                 workspace_id=workspace_id,
-                writer_class="connector",
+                writer_class=writer_class,
                 source_kind="connector_run",
                 source_connector=connector,
                 source_run_id=run_id,
+                source_document_uri=source_document_uri,
+                observed_at=observed_at,
             )
             result.updated += 1
             result.object_ids.append((updated or existing).id)

--- a/src/pocketpaw/fabric/journal_store.py
+++ b/src/pocketpaw/fabric/journal_store.py
@@ -18,11 +18,19 @@
 # projection applies the event immediately so the next read sees the change without
 # a full rebuild. On process start, bootstrap() replays from genesis to warm the
 # projection; operators who persist a cursor can skip ahead.
+#
+# Updated: 2026-07-10 (FST-4 — SHADOW mode at merge site 2) — optional
+# ``statement_store`` on the constructor wires the default projection to the
+# SQLite FabricStore's shadow machinery; update() drains the projection's
+# staged shadow observations after every live write (await flush_shadow()),
+# and the public flush_shadow() lets replay consumers drain after a sync
+# bootstrap(). Without a statement_store nothing changes — the flush is a
+# no-op and the projection never reads the mode flag.
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from soul_protocol.engine.journal import Journal
@@ -38,6 +46,11 @@ from pocketpaw.fabric.events import (
 )
 from pocketpaw.fabric.models import FabricObject, FabricQuery, FabricQueryResult
 from pocketpaw.fabric.projection import FabricProjection
+
+if TYPE_CHECKING:
+    # Typing only (FST-4) — the statement_store kwarg is forwarded to the
+    # projection; this module never touches the SQLite store at runtime.
+    from pocketpaw.fabric.store import FabricStore
 
 _SYSTEM_ACTOR_ID = "system:fabric"
 
@@ -65,9 +78,13 @@ class FabricJournalStore:
         *,
         projection: FabricProjection | None = None,
         default_actor: Actor | None = None,
+        statement_store: FabricStore | None = None,
     ) -> None:
+        # FST-4: ``statement_store`` wires the DEFAULT projection's shadow
+        # treatment (merge site 2). When the caller passes an explicit
+        # ``projection`` it owns that wiring itself and this kwarg is unused.
         self._journal = journal
-        self._projection = projection or FabricProjection()
+        self._projection = projection or FabricProjection(statement_store=statement_store)
         self._default_actor = default_actor or Actor(
             kind="system",
             id=_SYSTEM_ACTOR_ID,
@@ -80,9 +97,25 @@ class FabricJournalStore:
         """Warm the projection from the journal. Returns the number of
         events applied. Call once at process start; callers that persist
         a cursor can pass ``since_seq`` to skip already-applied events.
+
+        FST-4: with a statement_store-wired projection in shadow/enforce
+        mode, the replay STAGES shadow observations but cannot record them
+        (bootstrap is sync) — follow up with ``await flush_shadow()``.
+        Skipping the flush only delays it: the next live update() drains the
+        queue, and the store's event-id dedupe keeps any ordering honest.
         """
 
         return self._projection.rebuild(self._journal, since_seq=since_seq)
+
+    async def flush_shadow(self) -> int:
+        """Drain the projection's staged shadow observations (FST-4) —
+        the async companion to the sync :meth:`bootstrap`. Returns how many
+        journal events had their statements recorded. Safe to call anytime:
+        already-recorded events are deduped by id, an unwired projection
+        returns 0.
+        """
+
+        return await self._projection.flush_shadow()
 
     @property
     def projection(self) -> FabricProjection:
@@ -171,6 +204,10 @@ class FabricJournalStore:
         )
         self._journal.append(entry)
         self._projection.apply(entry)
+        # FST-4: drain the shadow observation this update may have staged so
+        # statements land as part of the write call, matching site 1's
+        # semantics. No statement_store wired (or mode off) → no-op.
+        await self._projection.flush_shadow()
         return self._lookup(object_id)
 
     async def archive(

--- a/src/pocketpaw/fabric/projection.py
+++ b/src/pocketpaw/fabric/projection.py
@@ -16,13 +16,32 @@
 #   - query(...): return a FabricQueryResult scoped to the caller
 # No persistence layer, no caching beyond the in-memory dict. Reopen a journal,
 # rebuild(), and you're back in sync — same guarantee as a good CQRS read model.
+#
+# Updated: 2026-07-10 (FST-4 — SHADOW mode at merge site 2) — the
+# ``merged = {**existing.obj.properties, **patch}`` fold in _apply_updated is
+# the journal-replay merge site. The projection writes IN MEMORY (it never
+# calls store.update_object), so it cannot thread provenance kwargs the way
+# site 1 does; instead, when an optional ``statement_store`` is wired and
+# ``fabric_source_truth_mode`` is shadow/enforce, _apply_updated STAGES a
+# shadow observation (pre-merge snapshot + patch + the event's identity,
+# actor, and ts) and the async ``flush_shadow()`` records it through
+# ``FabricStore.shadow_record_event_update`` — the SAME FST-3 machinery as
+# site 1, never a duplicate. apply() stays sync (staging is a list append);
+# the async boundary (FabricJournalStore.update, or an explicit flush after a
+# bootstrap replay) drains the queue. Provenance maps from the journal actor:
+# user → human/human_actor, agent → agent/agent_session (correlation_id, else
+# actor id), system/root → the store's derivation default. observed_at is the
+# event's ts, so a replayed event yields the same claims the live write did;
+# double-apply is deduped on the event id (see shadow_record_event_update).
+# Default construction (no statement_store) is byte-for-byte the prior
+# behavior — the mode flag is never even read.
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from soul_protocol.engine.journal import Journal
 from soul_protocol.spec.journal import EventEntry
@@ -35,6 +54,12 @@ from pocketpaw.fabric.events import (
 )
 from pocketpaw.fabric.models import FabricObject, FabricQuery, FabricQueryResult
 from pocketpaw.fabric.policy import filter_visible
+
+if TYPE_CHECKING:
+    # Import for typing only — the runtime dependency is lazy (see
+    # _apply_updated / flush_shadow) so a store-less projection never pays
+    # for the SQLite store stack.
+    from pocketpaw.fabric.store import FabricStore
 
 logger = logging.getLogger(__name__)
 
@@ -68,16 +93,72 @@ class _ProjectedObject:
         return payload
 
 
+@dataclass
+class _ShadowObservation:
+    """One staged shadow pass for a ``fabric.object.updated`` event (FST-4).
+
+    Captured synchronously in _apply_updated (which cannot await) and drained
+    by :meth:`FabricProjection.flush_shadow`. ``existing`` is the PRE-merge
+    FabricObject snapshot — _apply_updated rebinds ``row.obj`` to a fresh
+    model_copy, so the staged instance is never mutated afterwards.
+    """
+
+    event_id: str
+    existing: FabricObject
+    patch: dict[str, Any]
+    actor_kind: str
+    actor_id: str
+    correlation_id: str | None
+    ts: datetime
+
+
+def _journal_provenance(obs: _ShadowObservation) -> dict[str, str]:
+    """Map a journal event's actor onto site-1 provenance kwargs (FST-4).
+
+    - ``user`` actor → writer_class "human", a ``human_actor`` source carrying
+      the actor id;
+    - ``agent`` actor → writer_class "agent", an ``agent_session`` source
+      whose session identity is the event's correlation_id (the session/flow
+      per the journal spec), falling back to the actor id when the event
+      stands alone;
+    - ``system`` / ``root`` actors → NO kwargs: these are subsystem writes
+      (e.g. the journal store's default ``system:fabric``), i.e. exactly the
+      "unattributed" case, so the store's documented derivation default
+      applies (the object's own connector when it has one, else an
+      unattributed agent session).
+    """
+    if obs.actor_kind == "user":
+        return {
+            "writer_class": "human",
+            "source_kind": "human_actor",
+            "source_actor_id": obs.actor_id,
+        }
+    if obs.actor_kind == "agent":
+        return {
+            "writer_class": "agent",
+            "source_kind": "agent_session",
+            "source_session_id": obs.correlation_id or obs.actor_id,
+        }
+    return {}
+
+
 class FabricProjection:
     """Rebuilds and maintains a current-state view of Fabric objects from
     the org journal. One instance per process is the usual pattern; the
     projection is cheap to rebuild (O(events)) so operators can drop and
     rebuild at will if they suspect drift.
+
+    FST-4: pass ``statement_store`` to give the replay merge site the shadow
+    treatment — updates then stage observations (in shadow/enforce mode only)
+    that :meth:`flush_shadow` records through the store's FST-3 machinery.
+    Without it (the default) nothing changes: no staging, no mode read.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, statement_store: FabricStore | None = None) -> None:
         self._objects: dict[str, _ProjectedObject] = {}
         self._cursor: int = 0
+        self._statement_store = statement_store
+        self._pending_shadow: list[_ShadowObservation] = []
 
     # -- Build / rebuild ----------------------------------------------------
 
@@ -95,6 +176,11 @@ class FabricProjection:
         if since_seq == 0:
             self._objects.clear()
             self._cursor = 0
+            # A true reset also drops staged-but-unflushed shadow work: the
+            # replay will re-stage the same events, and the store's event-id
+            # dedupe makes a double-stage harmless anyway — this just keeps
+            # the queue from holding duplicates across back-to-back rebuilds.
+            self._pending_shadow.clear()
 
         applied = 0
         for entry in journal.replay_from(since_seq):
@@ -179,6 +265,32 @@ class FabricProjection:
             return
 
         patch = dict(payload.get("properties") or {})
+
+        # FST-4 (merge site 2): stage the shadow observation BEFORE the merge
+        # rebinds existing.obj, so the staged snapshot is the pre-update cache
+        # state (what the seed statement must preserve). Gate order matters:
+        # the statement_store check comes first so a store-less projection
+        # never reads the mode; in mode 'off' nothing is staged and the fold
+        # below is byte-for-byte the pre-FST-4 behavior. The import is lazy so
+        # tests can monkeypatch pocketpaw.fabric.store._source_truth_mode.
+        if self._statement_store is not None:
+            from pocketpaw.fabric.store import _source_truth_mode
+
+            if _source_truth_mode() != "off":
+                self._pending_shadow.append(
+                    _ShadowObservation(
+                        event_id=str(entry.id),
+                        existing=existing.obj,
+                        patch=dict(patch),
+                        actor_kind=entry.actor.kind,
+                        actor_id=entry.actor.id,
+                        correlation_id=(
+                            str(entry.correlation_id) if entry.correlation_id else None
+                        ),
+                        ts=_as_datetime(entry.ts),
+                    )
+                )
+
         merged = {**existing.obj.properties, **patch}
         existing.obj = existing.obj.model_copy(
             update={"properties": merged, "updated_at": _as_datetime(entry.ts)},
@@ -194,6 +306,49 @@ class FabricProjection:
             return
         existing.archived = True
         existing.last_seq = seq
+
+    # -- Shadow flush (FST-4) -------------------------------------------------
+
+    async def flush_shadow(self) -> int:
+        """Record every staged shadow observation through the statement
+        store's FST-3 machinery; returns how many events were recorded.
+
+        Called from the async boundary: FabricJournalStore.update() drains
+        after every live write, and replay consumers (bootstrap) call it
+        explicitly once the sync rebuild finishes. Replaying the same journal
+        twice cannot double-append — the store dedupes on the event id (see
+        FabricStore.shadow_record_event_update) — so a redundant flush is a
+        cheap no-op per already-recorded event.
+
+        Failure-shielded per observation, mirroring FST-3's shield at site 1:
+        a failing event logs a warning and is dropped; the projection state
+        and the remaining observations are unaffected.
+        """
+        if self._statement_store is None or not self._pending_shadow:
+            return 0
+        pending, self._pending_shadow = self._pending_shadow, []
+        recorded = 0
+        for obs in pending:
+            try:
+                done = await self._statement_store.shadow_record_event_update(
+                    obs.existing,
+                    obs.patch,
+                    event_id=obs.event_id,
+                    observed_at=obs.ts,
+                    **_journal_provenance(obs),
+                )
+            except Exception:
+                logger.warning(
+                    "fabric shadow: statement pass failed for event=%s object=%s"
+                    " — projection unaffected",
+                    obs.event_id,
+                    obs.existing.id,
+                    exc_info=True,
+                )
+                continue
+            if done:
+                recorded += 1
+        return recorded
 
     # -- Query --------------------------------------------------------------
 

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -192,6 +192,25 @@
 #   created_at/updated_at from the row (previously dropped — the model
 #   defaulted them to read-time now()), so the promotion backfill uses the
 #   TRUE last-touch time.
+# Updated: 2026-07-10 (FST-4 — SHADOW mode at merge sites 2 + 3) — two changes
+#   that let the remaining write paths ride the SAME shadow machinery instead
+#   of duplicating it:
+#   1. shadow_record_event_update(): a public, journal-event-keyed entry into
+#      the FST-3 shadow pass for the projection replay path (merge site 2 —
+#      fabric/projection.py stages observations, this method records them).
+#      Replay idempotence rides the NEW ``fabric_shadow_events`` table: the
+#      event id is claimed with INSERT OR IGNORE BEFORE the statement pass, so
+#      replaying the same journal N times (or two replayers racing) records a
+#      given event's statements AT MOST ONCE. Mode 'off' returns early — not
+#      even the marker row is written.
+#   2. _writer_family(): the second-distinct-source rule now compares writer
+#      FAMILIES, collapsing "connector" and "mirror" into one machine-sync
+#      family. Site 3 (the EE Firestore mirror) writes as writer_class
+#      "mirror" on objects whose baseline derives to "connector"; without the
+#      family rule every mirror self-refresh would look like a second source
+#      and promote every changed property, gutting the opt-in discipline. No
+#      behavior change for pre-FST-4 cohorts: "mirror" never reached this
+#      comparison before this slice.
 
 
 from __future__ import annotations
@@ -238,6 +257,26 @@ def _source_truth_mode() -> str:
     from pocketpaw.config import get_settings
 
     return get_settings().fabric_source_truth_mode
+
+
+def _writer_family(writer_class: str) -> str:
+    """Collapse writer classes into families for the second-distinct-source
+    comparison (FST-4).
+
+    "connector" and "mirror" are ONE machine-sync family: the EE Firestore
+    mirror (writer_class "mirror") refreshing an object whose baseline
+    derives to "connector" for the SAME connector is the object's owning
+    sync, not a second writer. Without this, every mirror self-refresh would
+    auto-promote every materially changed property — the opt-in discipline
+    ("single-source objects stay scalar/cheap") would be dead for mirrored
+    data. Every other class ("human", "agent", "inferred") is its own
+    family, so human-vs-connector and agent-vs-connector still count as
+    second sources exactly as FST-3 defined. NOTE: this only affects the
+    promotion GATE — the statement itself still records the true
+    writer_class ("mirror"), and the trust ladder still ranks connector >
+    mirror at resolve time.
+    """
+    return "sync" if writer_class in ("connector", "mirror") else writer_class
 
 
 # Hard cap on the working set during a multi-hop traversal. The per-hop query
@@ -344,6 +383,18 @@ CREATE TABLE IF NOT EXISTS fabric_statements (
     -- append; scoped reads see own rows + legacy NULL. Same ALTER-migration
     -- note as fabric_sources.workspace_id above.
     workspace_id TEXT
+);
+
+-- Journal-replay dedupe for the shadow pass (FST-4, merge site 2). One row per
+-- journal event whose update has been shadow-recorded. The event id (the
+-- journal EventEntry's UUID — stable across replays) is claimed with INSERT OR
+-- IGNORE BEFORE the statement pass runs, so replaying the same journal twice
+-- records a given event's statements at most once. No workspace column: event
+-- ids are globally unique, and the statements themselves carry workspace_id.
+CREATE TABLE IF NOT EXISTS fabric_shadow_events (
+    event_id TEXT PRIMARY KEY,
+    object_id TEXT,
+    recorded_at TEXT DEFAULT (datetime('now'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_objects_type ON fabric_objects(type_id);
@@ -1099,8 +1150,11 @@ class FabricStore:
         baseline is (``existing.source_connector``, its derived writer class —
         ``connector`` when a connector is stamped, else ``agent``). The
         incoming write is a SECOND source when its effective connector differs
-        from the baseline connector OR its effective writer class differs from
-        the baseline writer class. An unattributed write on a connector-owned
+        from the baseline connector OR its effective writer FAMILY differs
+        from the baseline writer family (FST-4: "connector" and "mirror" are
+        one machine-sync family — see :func:`_writer_family` — so the EE
+        mirror refreshing its own object is not a second source, while a
+        human or agent write still is). An unattributed write on a connector-owned
         object derives to that same connector, so it is NOT a second source —
         without provenance threading a second writer cannot be detected, which
         is exactly why ingest/API callers pass the kwargs.
@@ -1158,9 +1212,14 @@ class FabricStore:
         baseline_connector = existing.source_connector
         baseline_writer = "connector" if baseline_connector else "agent"
 
-        # --- Second-distinct-source rule ---
+        # --- Second-distinct-source rule (FST-4: compare writer FAMILIES,
+        # not raw classes, so a "mirror" write from the object's own
+        # connector is the owning sync refreshing itself, not a second
+        # source — see _writer_family) ---
         incoming_connector = connector if kind == "connector_run" else None
-        is_second_source = incoming_connector != baseline_connector or eff_writer != baseline_writer
+        is_second_source = incoming_connector != baseline_connector or _writer_family(
+            eff_writer
+        ) != _writer_family(baseline_writer)
 
         # Sources are upserted lazily so a fully scalar update (nothing tracked,
         # nothing promoted) writes NOTHING — not even a SourceRef row.
@@ -1232,6 +1291,77 @@ class FabricStore:
                 resolution.is_disputed,
                 resolution.unresolvable,
             )
+
+    async def shadow_record_event_update(
+        self,
+        existing: FabricObject,
+        incoming: dict[str, Any],
+        *,
+        event_id: str,
+        writer_class: str | None = None,
+        source_kind: str | None = None,
+        source_connector: str | None = None,
+        source_run_id: str | None = None,
+        source_document_uri: str | None = None,
+        source_actor_id: str | None = None,
+        source_session_id: str | None = None,
+        observed_at: datetime | None = None,
+        workspace_id: str | None = None,
+    ) -> bool:
+        """Journal-event-keyed entry into the FST-3 shadow pass (merge site 2).
+
+        The projection replay path (fabric/projection.py::_apply_updated)
+        merges in memory — it never goes through :meth:`update_object` — so it
+        stages observations and records them through THIS method, reusing
+        :meth:`_shadow_record_statements` verbatim (same promotion gate,
+        provenance derivation, divergence line) instead of duplicating it.
+
+        THE REPLAY-DEDUPE RULE: one shadow pass per journal event id. The
+        ``event_id`` (the journal EventEntry's UUID — stable across replays)
+        is claimed in ``fabric_shadow_events`` with INSERT OR IGNORE *before*
+        the statement pass; if the row already existed the event was recorded
+        by a previous replay (or a concurrent replayer won the race) and this
+        call returns ``False`` without writing anything. Claiming FIRST makes
+        the pass at-most-once: a failure after the claim drops that event's
+        shadow pass (consistent with FST-3's failure-shield, which also drops
+        a failed pass) rather than risking double-appended statements on
+        retry — "replaying the same journal twice never double-appends" is
+        the contract this method exists to keep.
+
+        Mode ``off`` returns ``False`` immediately — not even the marker row
+        is written (the off-mode byte-for-byte guarantee). Exceptions
+        propagate to the caller: the projection's flush shields per
+        observation, mirroring where FST-3 put the shield for site 1.
+
+        Returns ``True`` when the event's statements were recorded by this
+        call.
+        """
+        mode = _source_truth_mode()  # read ONCE per call; "off" writes NOTHING
+        if mode == "off":
+            return False
+        await self._ensure_schema()
+        async with self._conn() as db:
+            cur = await db.execute(
+                "INSERT OR IGNORE INTO fabric_shadow_events (event_id, object_id) VALUES (?, ?)",
+                (event_id, existing.id),
+            )
+            await db.commit()
+            if cur.rowcount == 0:
+                return False  # already recorded — replay/idempotency dedupe
+        await self._shadow_record_statements(
+            existing,
+            incoming,
+            writer_class=writer_class,
+            source_kind=source_kind,
+            source_connector=source_connector,
+            source_run_id=source_run_id,
+            source_document_uri=source_document_uri,
+            source_actor_id=source_actor_id,
+            source_session_id=source_session_id,
+            observed_at=observed_at,
+            workspace_id=workspace_id,
+        )
+        return True
 
     async def remove_object(self, obj_id: str) -> None:
         await self._ensure_schema()

--- a/tests/cloud/fabric_ingest/test_fabric_ingest_shadow.py
+++ b/tests/cloud/fabric_ingest/test_fabric_ingest_shadow.py
@@ -1,0 +1,305 @@
+# tests/cloud/fabric_ingest/test_fabric_ingest_shadow.py
+# Created: 2026-07-10 (FST-4 — SHADOW mode at merge site 3, the Firestore
+# mirror worker).
+#
+# Proves the EE Firestore→Fabric mirror threads TRUE provenance into the
+# shared shadow machinery via the canonical OSS ingest loop:
+#
+#   * a mirror re-sync of a TRACKED property lands a statement with
+#     writer_class="mirror" and a SourceRef naming the exact Firestore
+#     collection/doc (kind=connector_run, connector="firestore",
+#     document_uri=<doc path>), workspace-stamped,
+#   * observed_at is the best available SOURCE time: the doc's cursor_field
+#     value when it parses, the snapshot update_time as fallback — never
+#     fabricated (see service._doc_observed_at's audit),
+#   * a mirror self-refresh does NOT promote (writer-family rule): the
+#     mirror refreshing its own objects keeps them scalar/cheap,
+#   * mirror-create then agent-update yields BOTH claims (the ee variant of
+#     the FST-4 create-path proof),
+#   * mode=off — byte-for-byte: objects mirror exactly as before, zero
+#     statements/sources rows,
+#   * tenant scoping — statements + sources carry the workspace; a read
+#     scoped to another tenant sees none of them.
+#
+# Same harness as test_fabric_ingest_service.py: fake reader, real FabricStore
+# on tmp SQLite, config/state in the mongo_db fixture — no google creds.
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.fabric_ingest import service as ingest_service  # noqa: E402
+from pocketpaw_ee.cloud.models.fabric_ingest_state import (  # noqa: E402
+    FabricFieldMapping,
+    FabricIngestConfig,
+)
+
+from pocketpaw.fabric.models import PropertyDef  # noqa: E402
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------
+# Fakes + helpers (mirrors test_fabric_ingest_service.py).
+# --------------------------------------------------------------------------
+
+
+class FakeFirestoreReader:
+    def __init__(self, docs: list[dict] | None = None) -> None:
+        self._docs = docs or []
+
+    async def read_collection(self, collection, *, cursor_field, cursor, limit):  # noqa: ARG002
+        out = []
+        for d in self._docs:
+            val = (d.get("data") or {}).get(cursor_field)
+            if val is None or val == "":
+                val = d.get("update_time") or ""
+            if cursor and str(val) <= cursor:
+                continue
+            out.append(d)
+        return out[:limit]
+
+
+def _doc(path: str, **fields) -> dict:
+    update_time = fields.pop("_update_time", "2026-06-01T00:00:00Z")
+    return {"path": path, "data": dict(fields), "update_time": update_time}
+
+
+async def _make_store(tmp_path) -> FabricStore:
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type("Customer", [PropertyDef(name="name")])
+    return store
+
+
+async def _seed_config(workspace_id: str, mappings: list[FabricFieldMapping]) -> None:
+    cfg = FabricIngestConfig(workspace=workspace_id, enabled=True, mappings=mappings)
+    await cfg.insert()
+
+
+def _customer_mapping() -> FabricFieldMapping:
+    return FabricFieldMapping(
+        collection="customers",
+        object_type_id="ot-customer",
+        field_map={"display_name": "name", "tier": "tier"},
+        cursor_field="updated_at",
+    )
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _source_row(store: FabricStore, source_ref_id: str) -> dict:
+    con = sqlite3.connect(store._db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute("SELECT * FROM fabric_sources WHERE id = ?", (source_ref_id,)).fetchone()
+    finally:
+        con.close()
+    assert row is not None
+    return dict(row)
+
+
+def _table_count(store: FabricStore, table: str) -> int:
+    con = sqlite3.connect(store._db_path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        con.close()
+
+
+# --------------------------------------------------------------------------
+# Mirror provenance: writer_class="mirror" + firestore doc identity + times.
+# --------------------------------------------------------------------------
+
+
+async def test_mirror_resync_lands_mirror_statement_with_firestore_identity(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "shadow")
+
+    # Backfill mirrors the doc (CREATE — no statements, by the FST-4 ruling).
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", tier="gold", updated_at="2026-06-02T10:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj is not None
+    assert await store.get_statements(obj.id, "name", workspace_id=ws) == []
+
+    # An agent edit promotes "name" (seed from the firestore baseline + agent).
+    await store.update_object(
+        obj.id,
+        {"name": "Acme (agent edit)"},
+        workspace_id=ws,
+        writer_class="agent",
+        source_session_id="sess-1",
+    )
+    assert len(await store.get_statements(obj.id, "name", workspace_id=ws)) == 2
+
+    # Incremental re-sync with a newer doc version: the mirror UPDATE path.
+    reader2 = FakeFirestoreReader(
+        [
+            _doc(
+                "customers/c1",
+                display_name="Acme v2",
+                tier="gold",
+                updated_at="2026-06-05T10:00:00Z",
+            )
+        ]
+    )
+    result = await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+    assert result["status"] == "ok" and result["mode"] == "incremental"
+
+    stmts = await store.get_statements(obj.id, "name", workspace_id=ws)
+    assert len(stmts) == 3
+    mirror = next(s for s in stmts if s.writer_class == "mirror")
+    assert mirror.value == "Acme v2"
+    # observed_at = the doc's cursor_field time (the REAL source time).
+    assert mirror.observed_at == datetime.fromisoformat("2026-06-05T10:00:00Z")
+    src = _source_row(store, mirror.source_ref_id)
+    assert src["kind"] == "connector_run"
+    assert src["connector"] == "firestore"
+    assert src["document_uri"] == "customers/c1"  # the exact collection/doc
+    assert src["workspace_id"] == ws
+    assert mirror.workspace_id == ws
+
+    # The untracked "tier" property stayed scalar (opt-in discipline), and the
+    # cache is plain LWW.
+    assert await store.get_statements(obj.id, "tier", workspace_id=ws) == []
+    refreshed = await store.get_object(obj.id, workspace_id=ws)
+    assert refreshed is not None and refreshed.properties["name"] == "Acme v2"
+
+    # Tenant scoping: another workspace's scoped read sees NONE of it.
+    assert await store.get_statements(obj.id, "name", workspace_id="w-other") == []
+
+
+async def test_observed_at_falls_back_to_snapshot_update_time(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "shadow")
+
+    # Doc WITHOUT the cursor field: update_time is the best available time.
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", _update_time="2026-06-03T08:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    await store.update_object(obj.id, {"name": "Agent"}, workspace_id=ws, writer_class="agent")
+
+    reader2 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme v2", _update_time="2026-06-07T08:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+
+    stmts = await store.get_statements(obj.id, "name", workspace_id=ws)
+    mirror = next(s for s in stmts if s.writer_class == "mirror")
+    assert mirror.observed_at == datetime.fromisoformat("2026-06-07T08:00:00Z")
+
+
+# --------------------------------------------------------------------------
+# Writer-family rule at the worker level: self-refresh stays scalar.
+# --------------------------------------------------------------------------
+
+
+async def test_mirror_self_refresh_writes_no_statements(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "shadow")
+
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", updated_at="2026-06-02T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    # The same doc changes upstream; the mirror refreshes its OWN object.
+    reader2 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme Renamed", updated_at="2026-06-04T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj.properties["name"] == "Acme Renamed"  # LWW refresh intact
+    assert _table_count(store, "fabric_statements") == 0  # no promotion noise
+
+
+# --------------------------------------------------------------------------
+# The ee create-then-update proof: mirror creates, agent updates → conflict.
+# --------------------------------------------------------------------------
+
+
+async def test_mirror_create_then_agent_update_conflict_visible(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "shadow")
+
+    reader = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", updated_at="2026-06-02T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader, store=store)
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+
+    await store.update_object(
+        obj.id, {"name": "Acme Global"}, workspace_id=ws, writer_class="agent"
+    )
+
+    stmts = await store.get_statements(obj.id, "name", workspace_id=ws)
+    assert {s.value for s in stmts} == {"Acme", "Acme Global"}  # BOTH claims present
+
+
+# --------------------------------------------------------------------------
+# mode=off — the mirror is byte-for-byte untouched.
+# --------------------------------------------------------------------------
+
+
+async def test_mode_off_mirror_ingest_writes_no_statements(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "off")
+
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", updated_at="2026-06-02T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    reader2 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme v2", updated_at="2026-06-04T00:00:00Z")]
+    )
+    result = await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+
+    assert result["status"] == "ok"
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj.properties["name"] == "Acme v2"  # the mirror still mirrors
+    assert _table_count(store, "fabric_statements") == 0
+    assert _table_count(store, "fabric_sources") == 0

--- a/tests/test_fabric_shadow_create_path.py
+++ b/tests/test_fabric_shadow_create_path.py
@@ -1,0 +1,227 @@
+# tests/test_fabric_shadow_create_path.py
+# Created: 2026-07-10 (FST-4 — the CREATE-path decision + the mirror writer
+# family).
+#
+# FST-3 left ingest_records' CREATE path without a statement hook. FST-4's
+# ruling: creates need NO hook — promotion-time seeding already preserves the
+# create-time claim. This file is the PROOF that backs the decision:
+#
+#   * create-then-update — an object created by source A (via ingest_records,
+#     zero statements at create time even in shadow) then updated by source B
+#     yields BOTH claims: B's statement plus A's create-time value seeded with
+#     A's provenance and touch-time observed_at. The conflict is visible
+#     (disputed=True on the divergence line) — nothing was lost by skipping a
+#     create hook.
+#
+# Plus the FST-4 writer-family rule and per-record provenance threading:
+#
+#   * mirror self-refresh — writer_class="mirror" from the object's OWN
+#     connector is the owning sync, not a second source: no promotion, the
+#     opt-in discipline holds for mirrored data,
+#   * mirror on a FOREIGN connector's object — a real second source: promotes,
+#     and the statement records the true writer_class ("mirror"),
+#   * ingest_records' document_uri_field / observed_at_field — per-record
+#     SourceRef document identity and source-time observed_at; non-datetime
+#     observed values are ignored (ingest-time default).
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pocketpaw.connectors.fabric_ingest import FabricMapping, ingest_records
+from pocketpaw.fabric.store import FabricStore
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+async def _source(store: FabricStore, source_ref_id: str) -> dict[str, Any]:
+    import sqlite3
+
+    con = sqlite3.connect(store._db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute("SELECT * FROM fabric_sources WHERE id = ?", (source_ref_id,)).fetchone()
+    finally:
+        con.close()
+    assert row is not None
+    return dict(row)
+
+
+_MAPPING = FabricMapping(
+    type_name="Customer",
+    source_id_field="ext_id",
+    field_map={"name": "name", "arr": "arr"},
+)
+
+
+# ---------------------------------------------------------------------------
+# THE create-path proof: create by A, update by B → both claims, no hook needed
+# ---------------------------------------------------------------------------
+
+
+async def test_create_then_update_yields_both_claims_without_a_create_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    _set_mode(monkeypatch, "shadow")  # shadow from the very start — creates included
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # Source A (the crm connector) CREATES the object. Even in shadow mode the
+    # create path appends nothing — that is the documented decision under test.
+    res = await ingest_records(
+        store, "crm", [{"ext_id": "c-1", "name": "Acme", "arr": 120}], _MAPPING
+    )
+    assert res.created == 1
+    obj_id = res.object_ids[0]
+    assert await store.get_statements(obj_id, "arr") == []
+    assert _shadow_lines(caplog) == []
+
+    # Source B (an agent) UPDATES the property A created.
+    await store.update_object(
+        obj_id, {"arr": 250}, writer_class="agent", source_session_id="sess-b"
+    )
+
+    # BOTH claims are present: A's create-time value was seeded at promotion
+    # time with A's provenance — no create hook was needed to preserve it.
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 2
+    claim_a = next(s for s in stmts if s.writer_class == "connector")
+    claim_b = next(s for s in stmts if s.writer_class == "agent")
+    assert claim_a.value == 120  # the create-time claim, preserved
+    assert claim_b.value == 250
+    src_a = await _source(store, claim_a.source_ref_id)
+    assert src_a["kind"] == "connector_run" and src_a["connector"] == "crm"
+
+    # And the conflict is VISIBLE: one divergence line, disputed=True.
+    lines = _shadow_lines(caplog)
+    assert len(lines) == 1
+    assert re.search(r" disputed=True ", lines[0] + " ")
+    assert f"object={obj_id} property=arr" in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# The writer-family rule: mirror vs its own connector is NOT a second source
+# ---------------------------------------------------------------------------
+
+
+async def test_mirror_self_refresh_does_not_promote(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # The mirror creates, then re-syncs the SAME object with a changed value.
+    await ingest_records(
+        store, "firestore", [{"ext_id": "col/d1", "name": "Acme", "arr": 120}], _MAPPING
+    )
+    res = await ingest_records(
+        store,
+        "firestore",
+        [{"ext_id": "col/d1", "name": "Acme", "arr": 500}],
+        _MAPPING,
+        writer_class="mirror",
+    )
+    assert res.updated == 1
+    obj = await store.get_object_by_source("firestore", "col/d1")
+    assert obj is not None and obj.properties["arr"] == 500  # LWW refresh intact
+
+    # Same connector + machine-sync family → the owning sync, not a second
+    # source: no statements, no log line (the opt-in discipline holds).
+    assert await store.get_statements(obj.id, "arr") == []
+    assert _shadow_lines(caplog) == []
+
+
+async def test_mirror_write_on_foreign_object_is_a_second_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    _set_mode(monkeypatch, "shadow")
+
+    # Object owned by the crm connector; the firestore mirror writes it.
+    res = await ingest_records(
+        store, "crm", [{"ext_id": "c-9", "name": "Acme", "arr": 120}], _MAPPING
+    )
+    obj_id = res.object_ids[0]
+    await store.update_object(
+        obj_id,
+        {"arr": 300},
+        writer_class="mirror",
+        source_connector="firestore",
+        source_document_uri="customers/c-9",
+    )
+
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 2
+    mirror = next(s for s in stmts if s.writer_class == "mirror")  # true class recorded
+    src = await _source(store, mirror.source_ref_id)
+    assert src["connector"] == "firestore"
+    assert src["document_uri"] == "customers/c-9"
+
+
+# ---------------------------------------------------------------------------
+# ingest_records per-record provenance threading (document URI + observed_at)
+# ---------------------------------------------------------------------------
+
+
+async def test_ingest_records_threads_document_uri_and_observed_at(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    _set_mode(monkeypatch, "shadow")
+
+    res = await ingest_records(
+        store, "crm", [{"ext_id": "c-2", "name": "Acme", "arr": 120}], _MAPPING
+    )
+    obj_id = res.object_ids[0]
+    # Promote arr via a second source so subsequent writes append.
+    await store.update_object(obj_id, {"arr": 130}, writer_class="agent")
+    assert len(await store.get_statements(obj_id, "arr")) == 2
+
+    source_time = datetime(2030, 5, 1, 9, 30, 0)
+    record = {
+        "ext_id": "c-2",
+        "name": "Acme",
+        "arr": 200,
+        "__uri__": "crm://accounts/c-2",
+        "__obs__": source_time,
+    }
+    await ingest_records(
+        store,
+        "crm",
+        [record],
+        _MAPPING,
+        document_uri_field="__uri__",
+        observed_at_field="__obs__",
+    )
+
+    stmts = await store.get_statements(obj_id, "arr")
+    latest = next(s for s in stmts if s.value == 200)
+    assert latest.observed_at == source_time  # the SOURCE's time, not ingest time
+    src = await _source(store, latest.source_ref_id)
+    assert src["document_uri"] == "crm://accounts/c-2"
+
+    # A non-datetime observed value is ignored → ingest-time default (recent).
+    record2 = {"ext_id": "c-2", "name": "Acme", "arr": 210, "__obs__": "not-a-datetime"}
+    await ingest_records(store, "crm", [record2], _MAPPING, observed_at_field="__obs__")
+    newest = next(s for s in await store.get_statements(obj_id, "arr") if s.value == 210)
+    assert newest.observed_at != "not-a-datetime"
+    assert abs((datetime.now(newest.observed_at.tzinfo) - newest.observed_at).days) < 1

--- a/tests/test_fabric_shadow_site2.py
+++ b/tests/test_fabric_shadow_site2.py
@@ -1,0 +1,336 @@
+# tests/test_fabric_shadow_site2.py
+# Created: 2026-07-10 (FST-4 — SHADOW mode at merge site 2).
+#
+# Proves the journal-replay merge site (fabric/projection.py::_apply_updated,
+# the ``merged = {**existing.obj.properties, **patch}`` fold) emits shadow
+# statements through the SAME FST-3 store machinery as site 1, with
+# journal-derived provenance and replay idempotence:
+#
+#   * a live journal update by a ``user`` actor in shadow lands both claims
+#     (the promoted seed with the object's connector baseline + the human
+#     statement with a human_actor SourceRef) and the FST-8 divergence line;
+#     observed_at is the EVENT's ts (create ts for the seed, update ts for
+#     the incoming claim),
+#   * an ``agent`` actor maps to an agent_session SourceRef keyed on the
+#     event's correlation_id,
+#   * a ``system`` actor (the journal store default) passes NO provenance —
+#     the store's derivation default applies, so a system refresh of a
+#     connector-owned object is not a second source and stays scalar,
+#   * REPLAY DEDUPE — rebuilding/replaying the same journal (same store or a
+#     brand-new FabricJournalStore) never double-appends: statements are
+#     recorded at most once per journal event id (fabric_shadow_events),
+#   * REPLAY DETERMINISM — replaying a journal into a FRESH statement store
+#     produces the same claims (property, value, writer_class, observed_at)
+#     the live shadow pass produced,
+#   * mode=off — byte-for-byte: nothing staged, the statement verbs never
+#     touched, the mode read ONCE per update event; a store-LESS projection
+#     never even reads the mode flag.
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor
+
+from pocketpaw.fabric.events import ACTION_OBJECT_CREATED, ACTION_OBJECT_UPDATED
+from pocketpaw.fabric.journal_store import FabricJournalStore
+from pocketpaw.fabric.models import FabricObject
+from pocketpaw.fabric.store import FabricStore
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+def _table_count(db_path: Path, table: str) -> int:
+    """Rows in ``table`` — 0 when the table (or the whole DB) doesn't exist
+    yet, which is exactly what a byte-for-byte 'off' run leaves behind: the
+    store's schema is created lazily on first write, so an untouched
+    statement store never even materializes the tables."""
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        con.close()
+
+
+def _source_row(db_path: Path, source_ref_id: str) -> dict[str, Any]:
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute("SELECT * FROM fabric_sources WHERE id = ?", (source_ref_id,)).fetchone()
+    finally:
+        con.close()
+    assert row is not None, f"no fabric_sources row for {source_ref_id}"
+    return dict(row)
+
+
+def _events(journal, action: str) -> list:
+    return [e for e in journal.replay_from(0) if e.action == action]
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+def _crm_obj(**props: Any) -> FabricObject:
+    return FabricObject(
+        type_id="t1",
+        type_name="Customer",
+        properties=props or {"arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+
+
+def _human(actor_id: str = "user:alice") -> Actor:
+    return Actor(kind="user", id=actor_id, scope_context=[])
+
+
+# ---------------------------------------------------------------------------
+# Live journal update in shadow: journal-derived provenance + divergence line
+# ---------------------------------------------------------------------------
+
+
+async def test_journal_update_by_user_actor_records_both_claims(
+    tmp_path: Path,
+    journal,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    statement_db = tmp_path / "fabric.db"
+    statement_store = FabricStore(statement_db)
+    js = FabricJournalStore(journal, statement_store=statement_store)
+    js.bootstrap()
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+    await js.update(obj.id, {"arr": 150}, scope=["org"], actor=_human())
+
+    # The projection cache is plain LWW — shadow never touches it.
+    projected = await js.get(obj.id)
+    assert projected is not None and projected.properties["arr"] == 150
+
+    # Both claims exist: the promoted connector seed + the human statement.
+    stmts = await statement_store.get_statements(obj.id, "arr")
+    assert len(stmts) == 2
+    seed = next(s for s in stmts if s.writer_class == "connector")
+    human = next(s for s in stmts if s.writer_class == "human")
+
+    create_ts = _events(journal, ACTION_OBJECT_CREATED)[0].ts
+    update_ts = _events(journal, ACTION_OBJECT_UPDATED)[0].ts
+
+    # Seed: old cache value, object-level baseline, touch-time = create event ts.
+    assert seed.value == 120
+    assert seed.observed_at == create_ts
+    seed_src = _source_row(statement_db, seed.source_ref_id)
+    assert seed_src["kind"] == "connector_run"
+    assert seed_src["connector"] == "crm"
+
+    # Human claim: journal-derived provenance, observed_at = the update event ts.
+    assert human.value == 150
+    assert human.observed_at == update_ts
+    human_src = _source_row(statement_db, human.source_ref_id)
+    assert human_src["kind"] == "human_actor"
+    assert human_src["actor_id"] == "user:alice"
+
+    # ONE divergence line, exact FST-8 shape. Human outranks the connector
+    # seed on the ladder, so the resolver agrees with the LWW cache.
+    lines = _shadow_lines(caplog)
+    assert lines == [
+        f"fabric shadow: object={obj.id} property=arr lww=150 resolver=150"
+        " diverged=False disputed=True unresolvable=False"
+    ]
+
+
+async def test_agent_actor_maps_to_agent_session_via_correlation_id(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    statement_db = tmp_path / "fabric.db"
+    statement_store = FabricStore(statement_db)
+    js = FabricJournalStore(journal, statement_store=statement_store)
+    js.bootstrap()
+    _set_mode(monkeypatch, "shadow")
+
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+    correlation = uuid4()
+    await js.update(
+        obj.id,
+        {"arr": 175},
+        scope=["org"],
+        actor=Actor(kind="agent", id="did:soul:worker", scope_context=[]),
+        correlation_id=correlation,
+    )
+
+    stmts = await statement_store.get_statements(obj.id, "arr")
+    assert len(stmts) == 2
+    agent = next(s for s in stmts if s.writer_class == "agent")
+    src = _source_row(statement_db, agent.source_ref_id)
+    assert src["kind"] == "agent_session"
+    assert src["session_id"] == str(correlation)
+
+
+async def test_system_actor_uses_derivation_default_no_statements(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The journal store's default actor is system:fabric — an unattributed
+    subsystem write. The store's derivation default maps it to the object's
+    own connector, which is NOT a second source, so nothing is tracked."""
+    statement_db = tmp_path / "fabric.db"
+    statement_store = FabricStore(statement_db)
+    js = FabricJournalStore(journal, statement_store=statement_store)
+    js.bootstrap()
+    _set_mode(monkeypatch, "shadow")
+
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+    await js.update(obj.id, {"arr": 999}, scope=["org"])  # default system actor
+
+    assert _table_count(statement_db, "fabric_statements") == 0
+    assert _table_count(statement_db, "fabric_sources") == 0
+
+
+# ---------------------------------------------------------------------------
+# Replay dedupe: the same journal event never double-appends
+# ---------------------------------------------------------------------------
+
+
+async def test_rebuild_and_replay_never_double_append(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    statement_db = tmp_path / "fabric.db"
+    statement_store = FabricStore(statement_db)
+    js = FabricJournalStore(journal, statement_store=statement_store)
+    js.bootstrap()
+    _set_mode(monkeypatch, "shadow")
+
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+    await js.update(obj.id, {"arr": 150}, scope=["org"], actor=_human())
+    assert len(await statement_store.get_statements(obj.id, "arr")) == 2
+
+    # Rebuild the SAME store's projection from genesis: the update event is
+    # staged again, but its id is already claimed — flush records nothing.
+    js.bootstrap()
+    assert await js.flush_shadow() == 0
+    assert len(await statement_store.get_statements(obj.id, "arr")) == 2
+
+    # A brand-new FabricJournalStore over the same journal + statement store
+    # (a process restart): same outcome, still exactly two claims.
+    js2 = FabricJournalStore(journal, statement_store=statement_store)
+    js2.bootstrap()
+    assert await js2.flush_shadow() == 0
+    assert len(await statement_store.get_statements(obj.id, "arr")) == 2
+    assert _table_count(statement_db, "fabric_shadow_events") == 1
+
+
+# ---------------------------------------------------------------------------
+# Replay determinism: a replayed event produces the claims the live write did
+# ---------------------------------------------------------------------------
+
+
+async def test_replay_into_fresh_store_matches_live_statements(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    live_store = FabricStore(tmp_path / "live.db")
+    js = FabricJournalStore(journal, statement_store=live_store)
+    js.bootstrap()
+    _set_mode(monkeypatch, "shadow")
+
+    obj = await js.create(_crm_obj(arr=120, name="Acme"), scope=["org"])
+    await js.update(obj.id, {"arr": 150}, scope=["org"], actor=_human())
+    live = await live_store.get_statements(obj.id, "arr")
+    assert len(live) == 2
+
+    # Replay the same journal into a FRESH statement store (new machine, empty
+    # statements DB): bootstrap stages the update, flush records it.
+    replay_store = FabricStore(tmp_path / "replay.db")
+    js2 = FabricJournalStore(journal, statement_store=replay_store)
+    js2.bootstrap()
+    assert await js2.flush_shadow() == 1
+    replayed = await replay_store.get_statements(obj.id, "arr")
+
+    def _claims(stmts: list) -> set[tuple]:
+        return {(s.property, s.value, s.writer_class, s.observed_at) for s in stmts}
+
+    assert _claims(replayed) == _claims(live)
+
+
+# ---------------------------------------------------------------------------
+# mode=off — byte-for-byte at the projection site
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_off_stages_nothing_and_never_touches_statement_verbs(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    statement_db = tmp_path / "fabric.db"
+    statement_store = FabricStore(statement_db)
+    js = FabricJournalStore(journal, statement_store=statement_store)
+    js.bootstrap()
+
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+
+    mode_reads = {"count": 0}
+
+    def counting_off() -> str:
+        mode_reads["count"] += 1
+        return "off"
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", counting_off)
+
+    async def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("statements path touched in mode=off")
+
+    monkeypatch.setattr(statement_store, "get_statements", _boom)
+    monkeypatch.setattr(statement_store, "append_statement", _boom)
+    monkeypatch.setattr(statement_store, "upsert_source", _boom)
+    monkeypatch.setattr(statement_store, "shadow_record_event_update", _boom)
+
+    updated = await js.update(obj.id, {"arr": 150}, scope=["org"], actor=_human())
+
+    assert updated is not None and updated.properties["arr"] == 150  # LWW fold intact
+    assert mode_reads["count"] == 1  # read ONCE per update event, at stage time
+    assert await js.flush_shadow() == 0  # nothing was staged
+    assert _table_count(statement_db, "fabric_statements") == 0
+    assert _table_count(statement_db, "fabric_shadow_events") == 0  # not even the marker
+
+
+async def test_storeless_projection_never_reads_the_mode_flag(
+    journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default construction (no statement_store) must be byte-for-byte the
+    pre-FST-4 projection: the statement_store gate comes before the mode
+    read, so the flag is never consulted."""
+
+    def _explode() -> str:
+        raise AssertionError("mode flag read by a store-less projection")
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", _explode)
+
+    js = FabricJournalStore(journal)  # no statement_store
+    js.bootstrap()
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+    updated = await js.update(obj.id, {"arr": 150}, scope=["org"], actor=_human())
+    assert updated is not None and updated.properties["arr"] == 150
+    assert await js.flush_shadow() == 0


### PR DESCRIPTION
## What this does

Builds on #1692. Completes shadow coverage: all three Fabric merge sites now emit statements + divergence telemetry in shadow mode. After this slice, every write path — connector ingest, journal-replay projection, and the Firestore mirror — is observed; the mixed-trust cohabitation (discovery-inferred next to connector facts) is fully visible before anything enforces.

## The two hard problems, solved

- **Journal projection (site 2)** turned out to be a pure in-memory fold, not a store write — so it stages shadow observations (pre-merge snapshot + patch + event identity) and flushes them asynchronously through the same store machinery FST-3 built (no duplicated logic). Replay idempotence rides a new `fabric_shadow_events` claim table: the event id is claimed with INSERT OR IGNORE *before* the statement pass, making shadow recording at-most-once per journal event — replaying the same journal twice cannot double-append. A store-less projection (the default) never even reads the mode flag.
- **Mirror provenance (site 3)**: the ee worker now writes `writer_class="mirror"` with the exact Firestore doc path as the source identity, and threads real source timestamps (cursor field, else snapshot update_time, else honest ingest-time — never fabricated). The second-source promotion gate compares writer *families* (connector+mirror = one machine-sync family) so a mirror self-refresh can't force-promote every property; the ladder still ranks connector above mirror at resolve time.

## Create-path decision (documented, test-proven)

Creates get no statement hook: promotion-time seeding already preserves the create-time claim. Proven by create-then-update tests on both the OSS and mirror paths — both claims present, conflict visible.

## Verification

267 fabric tests (256 baseline + 11), 21 cloud fabric_ingest tests (incl. 5 new), replay-matches-live and double-replay-dedupe tests, FST-3 guard suite untouched and green, adjacent consumer sweep 43 passed. Ruff + import-linter clean.

Stacked on #1692. Next slice: enforce mode — the resolver takes ownership of the cache, plus the CHANGE/CORRECT verbs and the discovery-vs-connector proof.