### PR TITLE
feat(fabric): enforce mode — resolver owns the cache, CHANGE/CORRECT verbs, the szd proof (FST-5)

### DIFF
--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -22,6 +22,18 @@
 #   ingest-time default when neither parses). Only the shadow statements are
 #   affected; with fabric_source_truth_mode 'off' (default) the kwargs are
 #   inert and the mirror's writes are byte-for-byte unchanged.
+# Updated: 2026-07-10 (FST-5 — ENFORCE at merge site 3, no code change) —
+#   enforce flows through this worker automatically because the update path
+#   delegates to store.update_object (via ingest_records): tracked properties
+#   land in the cache as the resolver's winner, untracked keep LWW. Ruling on
+#   the field-map collapse in _mirror_docs (two Firestore fields mapping to
+#   ONE property → the LAST mapping wins inside the dict comprehension): it
+#   STAYS as-is. The collapse happens BEFORE the store write and is
+#   WITHIN-SOURCE — one document from one source deciding which of its own
+#   fields feeds a property is a mapping-configuration concern, not a trust
+#   conflict between sources, so the source-truth chain has nothing to
+#   arbitrate there. Proven by
+#   tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py.
 #
 # What this does
 # --------------

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -42,6 +42,12 @@
 #   source_connector) and touch-time observed_at, so the create-then-update
 #   flow yields both claims and a visible conflict without any create hook
 #   (proven by tests/test_fabric_shadow_create_path.py).
+# Updated: 2026-07-10 (FST-5 — ENFORCE at merge site 3, no code change) — the
+#   re-ingest UPDATE path already goes through store.update_object with full
+#   provenance (FST-3/4 above), so enforce mode flows through this module
+#   AUTOMATICALLY: for a TRACKED property the store commits the resolver's
+#   winner instead of the blind LWW value; untracked properties keep LWW.
+#   Proven by tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py.
 # Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ensure_type() now
 #   threads ``workspace_id`` into both the get_type_by_name() resolve and the
 #   define_type() create, so the type catalog stays per-tenant: a connector

--- a/src/pocketpaw/fabric/projection.py
+++ b/src/pocketpaw/fabric/projection.py
@@ -35,6 +35,34 @@
 # double-apply is deduped on the event id (see shadow_record_event_update).
 # Default construction (no statement_store) is byte-for-byte the prior
 # behavior — the mode flag is never even read.
+#
+# Updated: 2026-07-10 (FST-5 — ENFORCE decision for merge site 2, READ THIS):
+# in enforce mode THE PROJECTION STAYS EVENT-FAITHFUL — it folds exactly what
+# the journal says (plain LWW merge), and enforce ownership of values applies
+# at the STORE CACHE layer only (fabric/store.py — the flat properties dict,
+# which is the primary read path per the FST constraints). Consequence: an
+# object served from this projection can show a journal-folded LWW value that
+# the resolver has overruled in the store cache. That divergence is KNOWN and
+# DELIBERATE, and it is exactly what the shadow machinery's divergence line
+# records per event — nobody has to discover it by accident. Why event-faithful
+# won over write-back (the rejected option (a) — flush_shadow() also rewriting
+# the projection's entry with the resolver's winner):
+#   1. The projection's core guarantee is "rebuild() from the journal and
+#      you're back in sync" — a deterministic CQRS fold of the journal alone.
+#      Write-back makes projection state a function of (journal + statements
+#      DB + flush timing); worse, shadow_record_event_update dedupes replayed
+#      events, so after a rebuild the flush records nothing and the write-back
+#      would NOT re-apply — live state and rebuilt state would silently
+#      disagree, breaking the one invariant this class exists to keep.
+#   2. The flat properties dict on the SQLite store is the read path the FST
+#      chain governs; the journal-store path keeps the journal itself as its
+#      system of record. Resolver-vs-journal disagreement there belongs to the
+#      statement layer (statements + divergence log), not to a mutated fold.
+#   3. The CHANGE/CORRECT verbs and FST-6's PIN/IGNORE executor act on the
+#      store layer — a curated value reaches journal consumers the same way
+#      every other correction does: as a new journal event.
+# Proven by tests/test_fabric_enforce_site2.py: the store cache holds the
+# resolved value while this projection's fold (event-faithfully) differs.
 
 from __future__ import annotations
 

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -211,6 +211,46 @@
 #      and promote every changed property, gutting the opt-in discipline. No
 #      behavior change for pre-FST-4 cohorts: "mirror" never reached this
 #      comparison before this slice.
+# Updated: 2026-07-10 (FST-5 — ENFORCE mode: the resolver owns the cache) —
+#   three changes; 'off' and 'shadow' are byte-for-byte the FST-3/4 behavior:
+#   1. update_object() in ENFORCE runs the statement pass BEFORE the cache
+#      commit and, for every TRACKED property (one that has statements after
+#      the pass — pre-tracked or just promoted), writes the RESOLVER'S WINNER
+#      into the flat properties dict instead of the blind LWW value.
+#      Untracked properties keep LWW (no statements → nothing to resolve).
+#      Write-once: the final dict is computed first, then committed in ONE
+#      UPDATE — never LWW-then-overwrite. The divergence line still logs with
+#      the same grep-stable shape; in enforce ``lww=`` is what LWW WOULD have
+#      kept and ``resolver=`` is what the cache now holds. A statement-pass
+#      failure in enforce falls back to plain LWW for that write (log + keep
+#      writing — the cache write must never break), mirroring FST-3's shield.
+#      _shadow_record_statements now RETURNS {property: Resolution} for the
+#      statement-producing properties so enforce reuses the pass's own
+#      resolutions instead of resolving twice; shadow ignores the return.
+#   2. change_property() / correct_property(): the curation verbs (the seams
+#      FST-6's PIN/IGNORE executor calls). CHANGE closes the current winner
+#      statement's valid_to and appends the new value as rank="preferred"
+#      (open validity); CORRECT marks the current winner deprecated with
+#      rank_reason and appends the corrected value as rank="normal". Both
+#      auto-promote an untracked property first (seed the current cache value
+#      with FST-3's baseline provenance + touch-time observed_at) so history
+#      is preserved, and both return the NEW Resolution. Cache behavior is
+#      mode-respecting: enforce writes the new resolver winner into the
+#      cache; shadow/off leave the cache alone (the verbs are statement-layer
+#      operations in every mode). These verbs are the ONLY two writes that
+#      touch existing statement rows — narrow curation UPDATEs on
+#      valid_to / rank+rank_reason only (the append-only doctrine's
+#      documented "later curation writes"); value and provenance columns are
+#      never rewritten.
+#   3. The FST-3 provenance derivation is factored into _derive_provenance()
+#      (byte-identical rules) so the verbs and the shadow pass share ONE
+#      definition instead of two drifting copies.
+#   Site-2 note (settled in fabric/projection.py): the PROJECTION stays
+#   event-faithful in enforce — it folds what the journal says; enforce
+#   ownership applies at THIS store's cache layer (the primary read path).
+#   Site-3 note: the EE mirror's update path goes through update_object, so
+#   enforce flows through automatically (proven in
+#   tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py).
 
 
 from __future__ import annotations
@@ -240,7 +280,7 @@ from pocketpaw.fabric.models import (
 # duplicating it here — one definition of "materially different" for the
 # whole source-truth chain. The name is module-private in resolver.py but
 # intra-package reuse is deliberate.
-from pocketpaw.fabric.resolver import _materially_different, resolve
+from pocketpaw.fabric.resolver import Resolution, _materially_different, resolve
 from pocketpaw.fabric.trust import default_trust_rules
 
 logger = logging.getLogger(__name__)
@@ -1059,21 +1099,64 @@ class FabricStore:
         FST-3 (source-truth shadow) — the new keyword-only kwargs are OPTIONAL
         provenance for the write (all default ``None``; every pre-FST-3 caller
         keeps working unchanged). They only matter when
-        ``fabric_source_truth_mode`` is ``shadow`` or ``enforce`` (enforce is
-        treated as shadow until FST-5): the write is then ALSO recorded as
-        statements per :meth:`_shadow_record_statements` (auto-promotion,
-        provenance derivation, divergence log — see its docstring for the exact
-        rules). The CACHE WRITE IS UNCHANGED in every mode: last-write-wins
-        merge into the flat properties dict, which remains the primary read
-        path. With mode ``off`` (the default) not a single new query or write
-        happens — the mode is read once per call and the whole shadow block is
-        skipped.
+        ``fabric_source_truth_mode`` is ``shadow`` or ``enforce``: the write is
+        then ALSO recorded as statements per
+        :meth:`_shadow_record_statements` (auto-promotion, provenance
+        derivation, divergence log — see its docstring for the exact rules).
+        With mode ``off`` (the default) not a single new query or write
+        happens — the mode is read once per call and the whole statement block
+        is skipped.
+
+        Cache semantics per mode (FST-5):
+
+        - ``off`` / ``shadow`` — UNCHANGED: last-write-wins merge into the
+          flat properties dict, which remains the primary read path. In
+          shadow the statement pass runs AFTER the cache commit and only
+          observes.
+        - ``enforce`` — the RESOLVER OWNS THE CACHE for tracked properties.
+          The statement pass runs FIRST; every property that has statements
+          after the pass (already tracked, or promoted by it) lands in the
+          cache as the resolver's winner instead of the blind LWW value.
+          Untracked properties keep LWW (no statements → nothing to
+          resolve). Write-once: the final dict is computed, then committed in
+          ONE UPDATE. A statement-pass failure falls back to plain LWW for
+          this write (warning logged) — the cache write must never break.
         """
         mode = _source_truth_mode()  # read ONCE per call; "off" skips everything
         existing = await self.get_object(obj_id, workspace_id=workspace_id)
         if not existing:
             return None
         merged = {**existing.properties, **properties}
+        if mode == "enforce":
+            # FST-5: statement pass BEFORE the commit so the resolver's winner
+            # for each tracked property can be folded into the ONE cache
+            # write. Failure-shielded like shadow: a broken pass degrades this
+            # write to plain LWW rather than blocking it.
+            try:
+                resolutions = await self._shadow_record_statements(
+                    existing,
+                    properties,
+                    writer_class=writer_class,
+                    source_kind=source_kind,
+                    source_connector=source_connector,
+                    source_run_id=source_run_id,
+                    source_document_uri=source_document_uri,
+                    source_actor_id=source_actor_id,
+                    source_session_id=source_session_id,
+                    observed_at=observed_at,
+                    workspace_id=workspace_id,
+                )
+            except Exception:
+                logger.warning(
+                    "fabric enforce: statement pass failed for object=%s"
+                    " — falling back to LWW for this write",
+                    obj_id,
+                    exc_info=True,
+                )
+                resolutions = {}
+            for prop, resolution in resolutions.items():
+                if resolution.winner_statement is not None:
+                    merged[prop] = resolution.value
         ws_cond, ws_params = _workspace_scope(workspace_id)
         sql = "UPDATE fabric_objects SET properties = ?, updated_at = datetime('now') WHERE id = ?"
         params: list[Any] = [json.dumps(merged), obj_id]
@@ -1084,10 +1167,10 @@ class FabricStore:
         async with self._conn() as db:
             await db.execute(sql, params)
             await db.commit()
-        if mode != "off":
-            # shadow | enforce (enforce == shadow until FST-5). Runs AFTER the
-            # cache write so the primary path's semantics and error behavior
-            # stay byte-identical; a shadow failure must never break the write.
+        if mode == "shadow":
+            # Shadow runs AFTER the cache write so the primary path's
+            # semantics and error behavior stay byte-identical (FST-3); a
+            # shadow failure must never break the write.
             try:
                 await self._shadow_record_statements(
                     existing,
@@ -1110,6 +1193,58 @@ class FabricStore:
                 )
         return await self.get_object(obj_id, workspace_id=workspace_id)
 
+    @staticmethod
+    def _derive_provenance(
+        existing: FabricObject,
+        *,
+        writer_class: str | None,
+        source_kind: str | None,
+        source_connector: str | None,
+        source_actor_id: str | None,
+        source_session_id: str | None,
+        source_document_uri: str | None,
+    ) -> tuple[str, str | None, str]:
+        """Effective ``(kind, connector, writer_class)`` of one write (FST-3).
+
+        The single definition of the provenance derivation rules, shared by
+        the statement pass and the FST-5 curation verbs (byte-identical to
+        the inline FST-3 logic this was factored from):
+
+        - kind, in order: explicit ``source_kind`` > ``source_connector`` →
+          ``connector_run`` > ``source_actor_id`` → ``human_actor`` >
+          ``source_session_id`` → ``agent_session`` > ``source_document_uri``
+          → ``document`` > the object's own ``source_connector`` →
+          ``connector_run`` for that connector > ``agent_session`` with no
+          identity (the honest default for unattributed writes).
+        - writer_class: explicit > ``connector`` for ``connector_run`` >
+          ``human`` for ``human_actor`` > ``agent`` for everything else.
+        """
+        kind = source_kind
+        connector = source_connector
+        if kind is None:
+            if connector is not None:
+                kind = "connector_run"
+            elif source_actor_id is not None:
+                kind = "human_actor"
+            elif source_session_id is not None:
+                kind = "agent_session"
+            elif source_document_uri is not None:
+                kind = "document"
+            elif existing.source_connector:
+                kind = "connector_run"
+                connector = existing.source_connector
+            else:
+                kind = "agent_session"
+        eff_writer = writer_class
+        if eff_writer is None:
+            if kind == "connector_run":
+                eff_writer = "connector"
+            elif kind == "human_actor":
+                eff_writer = "human"
+            else:
+                eff_writer = "agent"
+        return kind, connector, eff_writer
+
     async def _shadow_record_statements(
         self,
         existing: FabricObject,
@@ -1124,13 +1259,18 @@ class FabricStore:
         source_session_id: str | None,
         observed_at: datetime | None,
         workspace_id: str | None,
-    ) -> None:
-        """The FST-3 shadow pass: record an update's claims as statements.
+    ) -> dict[str, Resolution]:
+        """The FST-3 statement pass: record an update's claims as statements.
 
         Called from :meth:`update_object` (merge site 1) only when
-        ``fabric_source_truth_mode`` is shadow/enforce, AFTER the LWW cache
-        write. ``existing`` is the PRE-update snapshot (its properties and
+        ``fabric_source_truth_mode`` is shadow/enforce — AFTER the LWW cache
+        write in shadow, BEFORE the cache commit in enforce (FST-5, so the
+        caller can fold each Resolution into the one cache write).
+        ``existing`` is the PRE-update snapshot (its properties and
         ``updated_at`` are the old cache state).
+
+        Returns ``{property: Resolution}`` for every statement-producing
+        (tracked) property — the enforce path consumes it; shadow ignores it.
 
         Provenance derivation (when the caller passed no explicit kwargs):
 
@@ -1176,37 +1316,30 @@ class FabricStore:
            grep-stable, single line, values JSON-encoded so they can never
            wrap):
 
-           ``fabric shadow: object=<id> property=<p> lww=<cache-value>
+           ``fabric shadow: object=<id> property=<p> lww=<lww-value>
            resolver=<winner-value> diverged=<bool> disputed=<bool>
            unresolvable=<bool>``
 
-        The cache is NEVER touched here — shadow only observes.
+           The line's shape is mode-independent. In shadow ``lww`` is what
+           the cache holds and ``resolver`` is what it WOULD hold; in
+           enforce (FST-5) ``lww`` is what LWW would have kept and
+           ``resolver`` is what the cache now holds — ``diverged=True``
+           means the resolver overrode the incoming write.
+
+        The cache is NEVER touched here — the CALLER owns the cache write
+        (LWW in off/shadow; the returned resolutions in enforce).
         """
-        # --- Effective provenance of the incoming write ---
-        kind = source_kind
-        connector = source_connector
-        if kind is None:
-            if connector is not None:
-                kind = "connector_run"
-            elif source_actor_id is not None:
-                kind = "human_actor"
-            elif source_session_id is not None:
-                kind = "agent_session"
-            elif source_document_uri is not None:
-                kind = "document"
-            elif existing.source_connector:
-                kind = "connector_run"
-                connector = existing.source_connector
-            else:
-                kind = "agent_session"
-        eff_writer = writer_class
-        if eff_writer is None:
-            if kind == "connector_run":
-                eff_writer = "connector"
-            elif kind == "human_actor":
-                eff_writer = "human"
-            else:
-                eff_writer = "agent"
+        # --- Effective provenance of the incoming write (FST-3 rules,
+        # shared with the FST-5 curation verbs via _derive_provenance) ---
+        kind, connector, eff_writer = self._derive_provenance(
+            existing,
+            writer_class=writer_class,
+            source_kind=source_kind,
+            source_connector=source_connector,
+            source_actor_id=source_actor_id,
+            source_session_id=source_session_id,
+            source_document_uri=source_document_uri,
+        )
 
         # --- Object-level baseline (who owns the current cache value) ---
         baseline_connector = existing.source_connector
@@ -1225,6 +1358,7 @@ class FabricStore:
         # nothing promoted) writes NOTHING — not even a SourceRef row.
         incoming_source: SourceRef | None = None
         seed_source: SourceRef | None = None
+        resolutions: dict[str, Resolution] = {}
 
         for prop, value in incoming.items():
             stmts = await self.get_statements(existing.id, prop, workspace_id=workspace_id)
@@ -1279,7 +1413,10 @@ class FabricStore:
                 default_trust_rules(),
                 object_type=existing.type_name or None,
             )
-            # The LWW cache now holds the incoming value (last write wins).
+            # ``lww`` is the incoming value — what the cache holds in shadow
+            # and what LWW WOULD have kept in enforce (where the caller
+            # writes ``resolver`` into the cache instead). Same line either
+            # way: the FST-8 harness contract.
             logger.info(
                 "fabric shadow: object=%s property=%s lww=%s resolver=%s"
                 " diverged=%s disputed=%s unresolvable=%s",
@@ -1291,6 +1428,8 @@ class FabricStore:
                 resolution.is_disputed,
                 resolution.unresolvable,
             )
+            resolutions[prop] = resolution
+        return resolutions
 
     async def shadow_record_event_update(
         self,
@@ -1362,6 +1501,271 @@ class FabricStore:
             workspace_id=workspace_id,
         )
         return True
+
+    # --- Curation verbs (FST-5 — CHANGE / CORRECT) ---
+
+    async def change_property(
+        self,
+        object_id: str,
+        property: str,
+        new_value: Any,
+        *,
+        writer_class: str | None = None,
+        source_kind: str | None = None,
+        source_connector: str | None = None,
+        source_run_id: str | None = None,
+        source_document_uri: str | None = None,
+        source_actor_id: str | None = None,
+        source_session_id: str | None = None,
+        observed_at: datetime | None = None,
+        workspace_id: str | None = None,
+    ) -> Resolution:
+        """CHANGE one property's value as an explicit curation act (FST-5).
+
+        Semantics: close the CURRENT WINNER statement's validity
+        (``valid_to = now`` — it becomes superseded history, still auditable)
+        and append ``new_value`` as a ``rank="preferred"``, open-validity
+        statement carrying the caller's provenance (same optional kwargs and
+        derivation rules as :meth:`update_object` — callers SHOULD pass
+        provenance; unattributed calls inherit the object's baseline).
+
+        The property must be TRACKED. On an untracked property the verb
+        first PROMOTES it (seeds the current cache value with the object's
+        baseline provenance + touch-time ``observed_at``, exactly FST-3's
+        promotion seed) so the pre-change history is preserved, THEN applies.
+        A property absent from both statements and the cache has no prior
+        claim — the new statement is simply appended.
+
+        Returns the NEW :class:`Resolution` over the property's statements.
+        The new preferred statement wins within its writer tier; a
+        higher-tier statement or a pin still outranks it — the resolver owns
+        the outcome, by design. Cache behavior is mode-respecting: in
+        ``enforce`` the flat properties dict is updated to the new winner; in
+        ``shadow``/``off`` the cache is untouched (the verb is a
+        statement-layer operation in every mode).
+
+        This is one of the seams FST-6's PIN/IGNORE executor calls.
+        """
+        return await self._curate_property(
+            object_id,
+            property,
+            new_value,
+            verb="change",
+            reason=None,
+            writer_class=writer_class,
+            source_kind=source_kind,
+            source_connector=source_connector,
+            source_run_id=source_run_id,
+            source_document_uri=source_document_uri,
+            source_actor_id=source_actor_id,
+            source_session_id=source_session_id,
+            observed_at=observed_at,
+            workspace_id=workspace_id,
+        )
+
+    async def correct_property(
+        self,
+        object_id: str,
+        property: str,
+        new_value: Any,
+        *,
+        reason: str,
+        writer_class: str | None = None,
+        source_kind: str | None = None,
+        source_connector: str | None = None,
+        source_run_id: str | None = None,
+        source_document_uri: str | None = None,
+        source_actor_id: str | None = None,
+        source_session_id: str | None = None,
+        observed_at: datetime | None = None,
+        workspace_id: str | None = None,
+    ) -> Resolution:
+        """CORRECT one property's value: the current winner was WRONG (FST-5).
+
+        Semantics: mark the CURRENT WINNER statement ``rank="deprecated"``
+        with ``rank_reason=reason`` (a deprecated statement never wins, never
+        loses, never disputes — it is struck from resolution entirely, unlike
+        CHANGE's closed-but-candidate history) and append ``new_value`` as a
+        ``rank="normal"``, open-validity statement with the caller's
+        provenance.
+
+        Tracking, promotion, provenance derivation, the returned NEW
+        :class:`Resolution`, and the mode-respecting cache behavior (enforce
+        writes the new winner; shadow/off leave the cache alone) all match
+        :meth:`change_property` — see its docstring.
+
+        This is one of the seams FST-6's PIN/IGNORE executor calls.
+        """
+        return await self._curate_property(
+            object_id,
+            property,
+            new_value,
+            verb="correct",
+            reason=reason,
+            writer_class=writer_class,
+            source_kind=source_kind,
+            source_connector=source_connector,
+            source_run_id=source_run_id,
+            source_document_uri=source_document_uri,
+            source_actor_id=source_actor_id,
+            source_session_id=source_session_id,
+            observed_at=observed_at,
+            workspace_id=workspace_id,
+        )
+
+    async def _curate_property(
+        self,
+        object_id: str,
+        property: str,
+        new_value: Any,
+        *,
+        verb: str,
+        reason: str | None,
+        writer_class: str | None,
+        source_kind: str | None,
+        source_connector: str | None,
+        source_run_id: str | None,
+        source_document_uri: str | None,
+        source_actor_id: str | None,
+        source_session_id: str | None,
+        observed_at: datetime | None,
+        workspace_id: str | None,
+    ) -> Resolution:
+        """Shared core of :meth:`change_property` / :meth:`correct_property`.
+
+        ``verb`` is ``"change"`` (close the winner's validity, append
+        preferred) or ``"correct"`` (deprecate the winner with ``reason``,
+        append normal). Raises ``ValueError`` when the object doesn't exist
+        (or is outside the caller's workspace scope) — the FST-6 executor
+        needs a clean failure, not a silent no-op.
+        """
+        mode = _source_truth_mode()  # read ONCE; decides only the cache write
+        existing = await self.get_object(object_id, workspace_id=workspace_id)
+        if existing is None:
+            raise ValueError(f"fabric object not found: {object_id!r}")
+
+        stmts = await self.get_statements(object_id, property, workspace_id=workspace_id)
+        if not stmts and property in existing.properties:
+            # Auto-promotion (FST-3 seeding, unconditional here — the verb is
+            # explicit curation, so preserving the pre-verb claim IS the
+            # point): seed the current cache value with the object-level
+            # baseline provenance and touch-time observed_at.
+            baseline_connector = existing.source_connector
+            baseline_writer = "connector" if baseline_connector else "agent"
+            seed_source = await self.upsert_source(
+                "connector_run" if baseline_connector else "agent_session",
+                connector=baseline_connector,
+                workspace_id=workspace_id,
+            )
+            seed = await self.append_statement(
+                object_id,
+                property,
+                existing.properties[property],
+                seed_source.id,
+                baseline_writer,
+                observed_at=existing.updated_at or existing.created_at,
+                workspace_id=workspace_id,
+            )
+            stmts = [seed]
+
+        current = resolve(stmts, default_trust_rules(), object_type=existing.type_name or None)
+        winner = current.winner_statement
+        if winner is not None:
+            if verb == "change":
+                # Close the winner's validity — only if still open; a closed
+                # winner is already superseded history and its interval must
+                # not be rewritten.
+                if winner.valid_to is None:
+                    await self._close_statement_validity(winner.id, datetime.now())
+            else:
+                await self._deprecate_statement(winner.id, reason)
+
+        kind, connector, eff_writer = self._derive_provenance(
+            existing,
+            writer_class=writer_class,
+            source_kind=source_kind,
+            source_connector=source_connector,
+            source_actor_id=source_actor_id,
+            source_session_id=source_session_id,
+            source_document_uri=source_document_uri,
+        )
+        new_source = await self.upsert_source(
+            kind,
+            connector=connector,
+            run_id=source_run_id,
+            document_uri=source_document_uri,
+            actor_id=source_actor_id,
+            session_id=source_session_id,
+            workspace_id=workspace_id,
+        )
+        await self.append_statement(
+            object_id,
+            property,
+            new_value,
+            new_source.id,
+            eff_writer,
+            observed_at=observed_at,
+            rank="preferred" if verb == "change" else "normal",
+            workspace_id=workspace_id,
+        )
+
+        refreshed = await self.get_statements(object_id, property, workspace_id=workspace_id)
+        resolution = resolve(
+            refreshed, default_trust_rules(), object_type=existing.type_name or None
+        )
+
+        if mode == "enforce" and resolution.winner_statement is not None:
+            # The resolver owns the cache in enforce (FST-5): one targeted
+            # write of the property's new winner, merged onto the FRESH cache
+            # state so concurrent-property updates aren't clobbered.
+            fresh = await self.get_object(object_id, workspace_id=workspace_id)
+            base = fresh.properties if fresh is not None else existing.properties
+            merged = {**base, property: resolution.value}
+            ws_cond, ws_params = _workspace_scope(workspace_id)
+            sql = (
+                "UPDATE fabric_objects SET properties = ?,"
+                " updated_at = datetime('now') WHERE id = ?"
+            )
+            params: list[Any] = [json.dumps(merged), object_id]
+            if ws_cond:
+                sql += f" AND {ws_cond}"
+                params.extend(ws_params)
+            async with self._conn() as db:
+                await db.execute(sql, params)
+                await db.commit()
+
+        return resolution
+
+    async def _close_statement_validity(self, statement_id: str, closed_at: datetime) -> None:
+        """Set ``valid_to`` on one statement (the CHANGE verb's close).
+
+        One of the TWO narrow curation writes permitted on statement rows
+        (see the FST-5 module-header note) — the append-only doctrine's
+        documented "later curation writes". Value/provenance columns are
+        never rewritten.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE fabric_statements SET valid_to = ? WHERE id = ?",
+                (closed_at.isoformat(), statement_id),
+            )
+            await db.commit()
+
+    async def _deprecate_statement(self, statement_id: str, reason: str | None) -> None:
+        """Mark one statement ``rank="deprecated"`` (the CORRECT verb's strike).
+
+        The second of the TWO narrow curation writes permitted on statement
+        rows (see the FST-5 module-header note). ``rank_reason`` records why;
+        value/provenance columns are never rewritten.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE fabric_statements SET rank = 'deprecated', rank_reason = ? WHERE id = ?",
+                (reason, statement_id),
+            )
+            await db.commit()
 
     async def remove_object(self, obj_id: str) -> None:
         await self._ensure_schema()

--- a/tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py
+++ b/tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py
@@ -1,0 +1,184 @@
+# tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py
+# Created: 2026-07-10 (FST-5 — ENFORCE at merge site 3, the Firestore mirror).
+#
+# Site 3 needed NO code change for enforce: the mirror's update path delegates
+# to store.update_object (via the canonical OSS ingest loop), so the FST-5
+# enforce cache semantics flow through AUTOMATICALLY. This file is the proof:
+#
+#   * a mirror re-sync of a TRACKED property lands in the cache as the
+#     RESOLVER'S winner (the connector-tier baseline beats the mirror tier on
+#     the trust ladder), not the mirror's blind LWW value — while the mirror's
+#     claim is still recorded as a statement,
+#   * a mirror self-refresh of UNTRACKED properties keeps plain LWW even in
+#     enforce (writer-family rule: no promotion, nothing to resolve — the
+#     mirror still mirrors).
+#
+# Ruling documented in service.py's header: the within-source field-map
+# collapse in _mirror_docs (two Firestore fields mapping to one property →
+# last mapping wins) STAYS — it happens before the store write and is a
+# mapping-configuration concern within ONE source, not a trust conflict.
+#
+# Same harness as test_fabric_ingest_shadow.py: fake reader, real FabricStore
+# on tmp SQLite, config in the mongo_db fixture — no google creds.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.fabric_ingest import service as ingest_service  # noqa: E402
+from pocketpaw_ee.cloud.models.fabric_ingest_state import (  # noqa: E402
+    FabricFieldMapping,
+    FabricIngestConfig,
+)
+
+from pocketpaw.fabric.models import PropertyDef  # noqa: E402
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeFirestoreReader:
+    def __init__(self, docs: list[dict] | None = None) -> None:
+        self._docs = docs or []
+
+    async def read_collection(self, collection, *, cursor_field, cursor, limit):  # noqa: ARG002
+        out = []
+        for d in self._docs:
+            val = (d.get("data") or {}).get(cursor_field)
+            if val is None or val == "":
+                val = d.get("update_time") or ""
+            if cursor and str(val) <= cursor:
+                continue
+            out.append(d)
+        return out[:limit]
+
+
+def _doc(path: str, **fields) -> dict:
+    update_time = fields.pop("_update_time", "2026-06-01T00:00:00Z")
+    return {"path": path, "data": dict(fields), "update_time": update_time}
+
+
+async def _make_store(tmp_path) -> FabricStore:
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type("Customer", [PropertyDef(name="name")])
+    return store
+
+
+async def _seed_config(workspace_id: str, mappings: list[FabricFieldMapping]) -> None:
+    cfg = FabricIngestConfig(workspace=workspace_id, enabled=True, mappings=mappings)
+    await cfg.insert()
+
+
+def _customer_mapping() -> FabricFieldMapping:
+    return FabricFieldMapping(
+        collection="customers",
+        object_type_id="ot-customer",
+        field_map={"display_name": "name", "tier": "tier"},
+        cursor_field="updated_at",
+    )
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+# --------------------------------------------------------------------------
+# Enforce flows through the mirror's update path automatically.
+# --------------------------------------------------------------------------
+
+
+async def test_enforce_flows_through_mirror_resync_tracked_property(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "enforce")
+
+    # Backfill mirrors the doc (CREATE — no statements, the FST-4 ruling).
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", tier="gold", updated_at="2026-06-02T10:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj is not None
+
+    # An agent edit promotes "name". In enforce the store already resolves:
+    # the connector-tier baseline seed ("Acme") beats the agent claim, so the
+    # cache keeps "Acme".
+    await store.update_object(
+        obj.id,
+        {"name": "Acme (agent edit)"},
+        workspace_id=ws,
+        writer_class="agent",
+        source_session_id="sess-1",
+    )
+    tracked = await store.get_object(obj.id, workspace_id=ws)
+    assert tracked is not None and tracked.properties["name"] == "Acme"
+
+    # The mirror re-syncs a newer doc version THROUGH ingest_collection —
+    # merge site 3, no enforce-specific code anywhere in the worker.
+    reader2 = FakeFirestoreReader(
+        [
+            _doc(
+                "customers/c1",
+                display_name="Acme v2",
+                tier="gold",
+                updated_at="2026-06-05T10:00:00Z",
+            )
+        ]
+    )
+    result = await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+    assert result["status"] == "ok" and result["mode"] == "incremental"
+
+    # The mirror's claim IS recorded...
+    stmts = await store.get_statements(obj.id, "name", workspace_id=ws)
+    assert len(stmts) == 3
+    mirror = next(s for s in stmts if s.writer_class == "mirror")
+    assert mirror.value == "Acme v2"
+
+    # ...but the cache holds the RESOLVER'S winner (the connector-tier seed
+    # outranks mirror on the ladder), not the mirror's LWW value. Enforce
+    # flowed through store.update_object automatically.
+    refreshed = await store.get_object(obj.id, workspace_id=ws)
+    assert refreshed is not None and refreshed.properties["name"] == "Acme"
+
+
+async def test_enforce_untracked_mirror_refresh_keeps_lww(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    """A mirror self-refresh promotes nothing (writer-family rule), so its
+    untracked properties have no statements and enforce has nothing to
+    resolve: plain LWW — the mirror still mirrors, byte-for-byte."""
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "enforce")
+
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", tier="gold", updated_at="2026-06-02T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    reader2 = FakeFirestoreReader(
+        [
+            _doc(
+                "customers/c1",
+                display_name="Acme Renamed",
+                tier="silver",
+                updated_at="2026-06-04T00:00:00Z",
+            )
+        ]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj is not None
+    assert obj.properties["name"] == "Acme Renamed"  # LWW refresh intact
+    assert obj.properties["tier"] == "silver"
+    assert await store.get_statements(obj.id, "name", workspace_id=ws) == []

--- a/tests/test_fabric_change_correct.py
+++ b/tests/test_fabric_change_correct.py
@@ -1,0 +1,312 @@
+# tests/test_fabric_change_correct.py
+# Created: 2026-07-10 (FST-5 — the CHANGE / CORRECT curation verbs).
+#
+# Proves the two statement-layer curation verbs (the seams FST-6's PIN/IGNORE
+# executor calls):
+#
+#   * CHANGE — closes the current winner's validity (valid_to = now, it stays
+#     auditable history) and appends the new value as rank="preferred", open
+#     validity; returns the NEW Resolution,
+#   * CORRECT — marks the current winner rank="deprecated" with
+#     rank_reason=<reason> (struck from resolution entirely) and appends the
+#     corrected value as rank="normal"; returns the NEW Resolution,
+#   * both verbs auto-promote an UNTRACKED property first (seed the current
+#     cache value with the FST-3 baseline provenance + touch-time
+#     observed_at) so pre-verb history is preserved; a property absent from
+#     both statements and cache just appends,
+#   * mode-respecting cache: enforce writes the new resolver winner into the
+#     flat properties dict; shadow and off leave the cache alone (the verbs
+#     write statements in EVERY mode — they are statement-layer operations),
+#   * a missing / cross-tenant object raises ValueError (a clean seam
+#     failure), and statements/sources are workspace-stamped.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.store import FabricStore
+
+pytestmark = pytest.mark.asyncio
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+async def _crm_object(tmp_path: Path, **props: Any) -> tuple[FabricStore, str]:
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        props or {"name": "Acme", "arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+    return store, obj.id
+
+
+async def _tracked_arr(store: FabricStore, obj_id: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Track ``arr`` via the FST-3 promotion (agent write in shadow mode so
+    the cache stays LWW during setup): seed(connector, 120) + agent(150)."""
+    _set_mode(monkeypatch, "shadow")
+    await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-setup"
+    )
+    assert len(await store.get_statements(obj_id, "arr")) == 2
+
+
+# ---------------------------------------------------------------------------
+# CHANGE — close the winner, append preferred
+# ---------------------------------------------------------------------------
+
+
+async def test_change_closes_winner_and_appends_preferred(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.change_property(
+        obj_id, "arr", 200, writer_class="human", source_actor_id="user:alice"
+    )
+
+    # The NEW Resolution: the human-preferred statement wins.
+    assert resolution.value == 200
+    assert resolution.winner_statement is not None
+    assert resolution.winner_statement.rank == "preferred"
+    assert resolution.winner_statement.writer_class == "human"
+    assert resolution.winner_statement.valid_to is None  # open validity
+
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 3
+    # The prior winner (the connector-tier seed, value 120) is CLOSED — a
+    # superseded-history statement, still present for audit.
+    old_winner = next(s for s in stmts if s.value == 120)
+    assert old_winner.valid_to is not None
+    # The other loser (the agent 150) is untouched.
+    agent = next(s for s in stmts if s.value == 150)
+    assert agent.valid_to is None and agent.rank == "normal"
+
+    # Shadow: the cache is untouched by the verb (still the LWW setup value).
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150
+
+
+async def test_change_enforce_updates_cache_to_new_winner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    _set_mode(monkeypatch, "enforce")
+
+    resolution = await store.change_property(
+        obj_id, "arr", 200, writer_class="human", source_actor_id="user:alice"
+    )
+
+    assert resolution.value == 200
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 200  # resolver-owned cache
+
+
+# ---------------------------------------------------------------------------
+# CORRECT — deprecate the winner (with reason), append normal
+# ---------------------------------------------------------------------------
+
+
+async def test_correct_deprecates_winner_and_appends_normal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.correct_property(
+        obj_id,
+        "arr",
+        130,
+        reason="connector reported the pre-discount figure",
+        writer_class="human",
+        source_actor_id="user:alice",
+    )
+
+    # The corrected value wins (human tier; the old connector winner is
+    # struck entirely).
+    assert resolution.value == 130
+    assert resolution.winner_statement is not None
+    assert resolution.winner_statement.rank == "normal"
+    assert resolution.winner_statement.writer_class == "human"
+
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 3
+    deprecated = next(s for s in stmts if s.value == 120)
+    assert deprecated.rank == "deprecated"
+    assert deprecated.rank_reason == "connector reported the pre-discount figure"
+    # A deprecated statement never wins, loses, or disputes — it is not in
+    # the Resolution at all.
+    assert deprecated.id not in {s.id for s in resolution.losers}
+
+    # Shadow: cache untouched.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150
+
+
+async def test_correct_enforce_updates_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    _set_mode(monkeypatch, "enforce")
+
+    resolution = await store.correct_property(
+        obj_id,
+        "arr",
+        130,
+        reason="wrong unit",
+        writer_class="human",
+        source_actor_id="user:alice",
+    )
+
+    assert resolution.value == 130
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 130
+
+
+# ---------------------------------------------------------------------------
+# Untracked properties: promote-then-apply (history preserved)
+# ---------------------------------------------------------------------------
+
+
+async def test_change_on_untracked_property_promotes_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path, name="Acme")
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.change_property(
+        obj_id, "name", "Acme Corp", writer_class="human", source_actor_id="user:alice"
+    )
+
+    stmts = await store.get_statements(obj_id, "name")
+    assert len(stmts) == 2  # the promotion seed + the change
+    # The seed preserved the pre-change claim with the object's baseline
+    # provenance (connector-owned object → writer "connector") and was
+    # closed by the change (it WAS the current winner).
+    seed = next(s for s in stmts if s.value == "Acme")
+    assert seed.writer_class == "connector"
+    assert seed.valid_to is not None
+    assert resolution.value == "Acme Corp"
+
+
+async def test_correct_on_untracked_property_promotes_then_deprecates_seed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path, name="Acmee")
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.correct_property(
+        obj_id,
+        "name",
+        "Acme",
+        reason="typo in the source",
+        writer_class="human",
+        source_actor_id="user:alice",
+    )
+
+    stmts = await store.get_statements(obj_id, "name")
+    assert len(stmts) == 2
+    seed = next(s for s in stmts if s.value == "Acmee")
+    assert seed.rank == "deprecated" and seed.rank_reason == "typo in the source"
+    assert resolution.value == "Acme"
+    assert resolution.is_disputed is False  # the wrong claim is struck, not disputing
+
+
+async def test_verb_on_absent_property_appends_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A property with no statements AND no cache value has no prior claim —
+    nothing to seed, nothing to close; the verb just appends. In enforce the
+    cache gains the property (the new winner)."""
+    store, obj_id = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    resolution = await store.change_property(
+        obj_id, "tier", "gold", writer_class="human", source_actor_id="user:alice"
+    )
+
+    stmts = await store.get_statements(obj_id, "tier")
+    assert len(stmts) == 1 and stmts[0].rank == "preferred"
+    assert resolution.value == "gold"
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["tier"] == "gold"
+
+
+# ---------------------------------------------------------------------------
+# The verbs are statement-layer operations in EVERY mode; only enforce
+# touches the cache
+# ---------------------------------------------------------------------------
+
+
+async def test_change_in_off_mode_writes_statements_but_not_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "off")
+
+    resolution = await store.change_property(
+        obj_id, "arr", 200, writer_class="human", source_actor_id="user:alice"
+    )
+
+    assert resolution.value == 200
+    assert len(await store.get_statements(obj_id, "arr")) == 2  # seed + change
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120  # cache untouched (off)
+
+
+# ---------------------------------------------------------------------------
+# Failure + tenancy seams
+# ---------------------------------------------------------------------------
+
+
+async def test_verb_missing_object_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store, _ = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    with pytest.raises(ValueError, match="not found"):
+        await store.change_property("obj-nope", "arr", 1, writer_class="human")
+    with pytest.raises(ValueError, match="not found"):
+        await store.correct_property("obj-nope", "arr", 1, reason="x", writer_class="human")
+
+
+async def test_verbs_respect_workspace_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[], workspace_id="ws-a")
+    obj = await store.create_object(
+        obj_type.id,
+        {"arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+        workspace_id="ws-a",
+    )
+    _set_mode(monkeypatch, "enforce")
+
+    # Cross-tenant: the object is invisible to ws-b → clean ValueError.
+    with pytest.raises(ValueError, match="not found"):
+        await store.change_property(obj.id, "arr", 200, writer_class="human", workspace_id="ws-b")
+
+    # Own tenant: works, and statements are workspace-stamped.
+    resolution = await store.change_property(
+        obj.id, "arr", 200, writer_class="human", source_actor_id="u:a", workspace_id="ws-a"
+    )
+    assert resolution.value == 200
+    stmts = await store.get_statements(obj.id, "arr", workspace_id="ws-a")
+    assert len(stmts) == 2 and all(s.workspace_id == "ws-a" for s in stmts)
+    refreshed = await store.get_object(obj.id, workspace_id="ws-a")
+    assert refreshed is not None and refreshed.properties["arr"] == 200

--- a/tests/test_fabric_enforce_site1.py
+++ b/tests/test_fabric_enforce_site1.py
@@ -1,0 +1,358 @@
+# tests/test_fabric_enforce_site1.py
+# Created: 2026-07-10 (FST-5 — ENFORCE mode: the resolver owns the cache).
+#
+# Proves the enforce cache semantics at merge site 1 (store.update_object):
+#
+#   * a TRACKED property lands in the flat properties dict as the RESOLVER'S
+#     winner, not the blind LWW value; untracked properties keep LWW (they
+#     have no statements — nothing to resolve), including inside one mixed
+#     update,
+#   * the divergence line keeps its exact FST-8 shape; in enforce ``lww=`` is
+#     what LWW would have kept and ``resolver=`` is what the cache now holds,
+#   * a statement-pass failure degrades THAT write to plain LWW (warning
+#     logged) — the cache write never breaks,
+#   * when the incoming write IS the resolver's winner, enforce and LWW agree,
+#
+# plus THE SZD TEST (TestSzdProof — the payoff of the whole source-truth
+# chain) and the REVERSAL PROOF (enforce → off leaves a fully working store).
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.resolver import resolve
+from pocketpaw.fabric.store import FabricStore
+from pocketpaw.fabric.trust import default_trust_rules
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+DIVERGENCE_RE = re.compile(
+    r"^fabric shadow: object=\S+ property=\S+ lww=.+ resolver=.+"
+    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)$"
+)
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+def _table_count(db_path: Path, table: str) -> int:
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    finally:
+        con.close()
+
+
+async def _crm_object(tmp_path: Path, **props: Any) -> tuple[FabricStore, str, Path]:
+    """A store with one connector-owned object; returns (store, object_id, db_path)."""
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        props or {"name": "Acme", "arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+    return store, obj.id, db_path
+
+
+# ---------------------------------------------------------------------------
+# Tracked properties: the resolver's winner is what the cache receives
+# ---------------------------------------------------------------------------
+
+
+async def test_enforce_tracked_property_cache_gets_resolver_winner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    # Agent write (second source): promotes arr — seed(connector, 120) +
+    # agent(150). The connector-tier seed wins the ladder, so the cache gets
+    # 120, NOT the blind LWW 150.
+    updated = await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-1"
+    )
+
+    assert updated is not None
+    assert updated.properties["arr"] == 120  # resolver's winner, not LWW
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120
+    # Both claims exist regardless — the losing write is preserved as history.
+    stmts = await store.get_statements(obj_id, "arr")
+    assert {s.value for s in stmts} == {120, 150}
+
+
+async def test_enforce_untracked_properties_keep_lww(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    # Same source as the object's owner: no promotion, no statements — the
+    # property stays scalar and enforce has nothing to resolve → plain LWW.
+    updated = await store.update_object(
+        obj_id, {"arr": 999}, writer_class="connector", source_connector="crm"
+    )
+
+    assert updated is not None and updated.properties["arr"] == 999
+    assert _table_count(db_path, "fabric_statements") == 0
+
+
+async def test_enforce_mixed_update_tracked_resolved_untracked_lww(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path, name="Acme", arr=120, note="x")
+    _set_mode(monkeypatch, "enforce")
+
+    # One update carrying a promotable property (arr — materially different,
+    # second source) and a brand-new key (label — no prior claim, stays
+    # untracked): arr gets the resolver's winner, label gets LWW.
+    updated = await store.update_object(
+        obj_id,
+        {"arr": 150, "label": "vip"},
+        writer_class="agent",
+        source_session_id="sess-1",
+    )
+
+    assert updated is not None
+    assert updated.properties["arr"] == 120  # resolved (connector seed wins)
+    assert updated.properties["label"] == "vip"  # untracked → LWW
+    assert await store.get_statements(obj_id, "label") == []
+
+
+async def test_enforce_incoming_winner_lands_in_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the incoming write IS the resolver's winner (a human write beats
+    the connector seed), enforce agrees with LWW — same cache value, but now
+    it's the resolver's decision, not blind recency."""
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    updated = await store.update_object(
+        obj_id, {"arr": 175}, writer_class="human", source_actor_id="user:alice"
+    )
+
+    assert updated is not None and updated.properties["arr"] == 175
+    stmts = await store.get_statements(obj_id, "arr")
+    resolution = resolve(stmts, default_trust_rules(), object_type="Customer")
+    assert resolution.value == 175 and resolution.winner_statement is not None
+    assert resolution.winner_statement.writer_class == "human"
+
+
+# ---------------------------------------------------------------------------
+# The divergence line in enforce: lww=what LWW would have kept,
+# resolver=what the cache now holds
+# ---------------------------------------------------------------------------
+
+
+async def test_enforce_divergence_line_logs_lww_vs_written(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-1"
+    )
+
+    lines = _shadow_lines(caplog)
+    assert lines == [
+        f"fabric shadow: object={obj_id} property=arr lww=150 resolver=120"
+        " diverged=True disputed=True unresolvable=False"
+    ]
+    assert DIVERGENCE_RE.fullmatch(lines[0])
+    # And "resolver" really is what the cache holds now (enforce semantics).
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120
+
+
+# ---------------------------------------------------------------------------
+# Failure shield: a broken statement pass degrades to LWW, never blocks
+# ---------------------------------------------------------------------------
+
+
+async def test_enforce_statement_pass_failure_falls_back_to_lww(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, _ = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    async def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("simulated statement-pass failure")
+
+    monkeypatch.setattr(store, "append_statement", _explode)
+    caplog.set_level(logging.WARNING, logger=STORE_LOGGER)
+
+    updated = await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-1"
+    )
+
+    assert updated is not None and updated.properties["arr"] == 150  # LWW fallback
+    assert any(
+        "falling back to LWW" in r.getMessage() for r in caplog.records if r.name == STORE_LOGGER
+    )
+
+
+# ---------------------------------------------------------------------------
+# THE SZD TEST — the payoff of the whole source-truth chain
+# ---------------------------------------------------------------------------
+
+
+class TestSzdProof:
+    """THE SZD TEST: what the whole Fabric source-truth chain exists to prove.
+
+    Before FST, the flat properties dict was blind last-write-wins: a
+    discovery-INFERRED value written after a connector sync silently
+    overwrote the connector's FACT, and nothing recorded that it happened.
+    With ``fabric_source_truth_mode=enforce``:
+
+    * a discovery-inferred value can NO LONGER beat a connector fact in the
+      cache — the trust ladder (connector > inferred) decides, not recency;
+    * the inferred claim is NOT lost — it lands as a rank="normal" statement,
+      the conflict is flagged (``is_disputed=True``), and the divergence line
+      records exactly what LWW would have done and what enforce did instead;
+    * order doesn't matter — when the inferred value came FIRST (the object's
+      creator) and the connector fact arrives SECOND, the connector still
+      wins the cache.
+    """
+
+    async def test_inferred_value_cannot_beat_connector_fact(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A connector-written fact...
+        store, obj_id, db_path = await _crm_object(tmp_path, industry="fintech")
+        _set_mode(monkeypatch, "enforce")
+        caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+        # ...hit by a discovery-style inferred write with a different value.
+        updated = await store.update_object(
+            obj_id,
+            {"industry": "crypto"},
+            writer_class="inferred",
+            source_session_id="discovery-run-1",
+        )
+
+        # The cache STILL shows the connector fact.
+        assert updated is not None and updated.properties["industry"] == "fintech"
+        obj = await store.get_object(obj_id)
+        assert obj is not None and obj.properties["industry"] == "fintech"
+
+        # The inferred claim exists as a rank="normal" statement — recorded,
+        # not silently discarded.
+        stmts = await store.get_statements(obj_id, "industry")
+        inferred = next(s for s in stmts if s.writer_class == "inferred")
+        assert inferred.value == "crypto" and inferred.rank == "normal"
+
+        # The conflict is flagged.
+        resolution = resolve(stmts, default_trust_rules(), object_type="Customer")
+        assert resolution.value == "fintech"
+        assert resolution.is_disputed is True
+
+        # And the divergence line shows it: LWW would have kept "crypto",
+        # enforce wrote "fintech".
+        lines = _shadow_lines(caplog)
+        assert lines == [
+            f'fabric shadow: object={obj_id} property=industry lww="crypto"'
+            ' resolver="fintech" diverged=True disputed=True unresolvable=False'
+        ]
+
+    async def test_reversed_order_connector_fact_still_wins_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The inferred value comes FIRST: discovery CREATED the object (no
+        # source_connector — an unattributed creator, so the promotion seed
+        # derives the object-level agent baseline; connector outranks both
+        # agent and inferred, so the ordering below is decided by trust
+        # either way).
+        db_path = tmp_path / "fabric.db"
+        store = FabricStore(db_path)
+        obj_type = await store.define_type(name="Customer", properties=[])
+        obj = await store.create_object(obj_type.id, {"industry": "crypto"})
+        _set_mode(monkeypatch, "enforce")
+
+        # The connector fact arrives second.
+        updated = await store.update_object(
+            obj.id,
+            {"industry": "fintech"},
+            writer_class="connector",
+            source_connector="crm",
+            source_run_id="run-1",
+        )
+
+        # The connector wins the cache — enforce is order-independent.
+        assert updated is not None and updated.properties["industry"] == "fintech"
+
+        # Both claims exist: the seeded pre-connector value + the fact.
+        stmts = await store.get_statements(obj.id, "industry")
+        assert {s.value for s in stmts} == {"crypto", "fintech"}
+        resolution = resolve(stmts, default_trust_rules(), object_type="Customer")
+        assert resolution.winner_statement is not None
+        assert resolution.winner_statement.writer_class == "connector"
+
+
+# ---------------------------------------------------------------------------
+# REVERSAL PROOF — enforce → off leaves a fully working, plain-LWW store
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_flipped_back_to_off_after_enforce(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A store that ran enforce (statements on disk + a resolver-owned cache),
+    flipped back to 'off': every read works and serves the last-RESOLVED
+    values, subsequent writes are plain LWW with ZERO statement machinery,
+    and nothing errors."""
+    store, obj_id, db_path = await _crm_object(tmp_path, industry="fintech", arr=120)
+    _set_mode(monkeypatch, "enforce")
+
+    # Enforce run: the inferred write loses; the cache holds the resolved
+    # connector fact and two statements are on disk.
+    await store.update_object(
+        obj_id,
+        {"industry": "crypto"},
+        writer_class="inferred",
+        source_session_id="discovery-run-1",
+    )
+    assert _table_count(db_path, "fabric_statements") == 2
+
+    # --- Flip back to off ---
+    _set_mode(monkeypatch, "off")
+
+    # Reads work and serve the last-resolved values.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["industry"] == "fintech"
+
+    # Subsequent writes: pure LWW, no statement verb is ever touched.
+    async def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("statements path touched in mode=off")
+
+    monkeypatch.setattr(store, "get_statements", _boom)
+    monkeypatch.setattr(store, "append_statement", _boom)
+    monkeypatch.setattr(store, "upsert_source", _boom)
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    updated = await store.update_object(obj_id, {"industry": "web3", "arr": 500})
+    assert updated is not None
+    assert updated.properties["industry"] == "web3"  # LWW resumed
+    assert updated.properties["arr"] == 500
+    assert _table_count(db_path, "fabric_statements") == 2  # untouched history
+    assert _shadow_lines(caplog) == []

--- a/tests/test_fabric_enforce_site2.py
+++ b/tests/test_fabric_enforce_site2.py
@@ -1,0 +1,159 @@
+# tests/test_fabric_enforce_site2.py
+# Created: 2026-07-10 (FST-5 — the ENFORCE decision for merge site 2).
+#
+# Site 2 (the journal projection) stays EVENT-FAITHFUL in enforce — that is
+# the deliberate FST-5 ruling documented at the top of fabric/projection.py:
+# the projection folds exactly what the journal says (plain LWW), and enforce
+# ownership of values applies at the STORE CACHE layer (the flat properties
+# dict — the primary read path per the FST constraints). This file is the
+# proof that the ruling is honest, not an accident:
+#
+#   * the store cache holds the RESOLVED value while the projection's
+#     in-memory fold (event-faithfully) differs — and the divergence line was
+#     emitted, so the gap is recorded telemetry, not a silent surprise,
+#   * a projection rebuild in enforce reproduces the same event-faithful fold
+#     (deterministic from the journal alone) with no statement double-append,
+#     and the store cache still holds the resolved value.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor
+
+from pocketpaw.fabric.journal_store import FabricJournalStore
+from pocketpaw.fabric.models import FabricObject
+from pocketpaw.fabric.resolver import resolve
+from pocketpaw.fabric.store import FabricStore
+from pocketpaw.fabric.trust import default_trust_rules
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+async def _mirrored_setup(tmp_path: Path, journal) -> tuple[FabricStore, FabricJournalStore, str]:
+    """One connector-owned object living in BOTH read models: a row in the
+    SQLite store (the flat-properties cache) and a created event in the
+    journal (the projection's source), sharing one object id."""
+    store = FabricStore(tmp_path / "fabric.db")
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        {"industry": "fintech"},
+        source_connector="crm",
+        source_id="c-1",
+    )
+    js = FabricJournalStore(journal, statement_store=store)
+    js.bootstrap()
+    await js.create(
+        FabricObject(
+            id=obj.id,
+            type_id=obj_type.id,
+            type_name="Customer",
+            properties={"industry": "fintech"},
+            source_connector="crm",
+            source_id="c-1",
+        ),
+        scope=["org"],
+    )
+    return store, js, obj.id
+
+
+async def test_store_cache_holds_resolved_value_while_projection_fold_differs(
+    tmp_path: Path,
+    journal,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, js, obj_id = await _mirrored_setup(tmp_path, journal)
+    _set_mode(monkeypatch, "enforce")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # An agent writes a different value THROUGH THE JOURNAL (site 2).
+    await js.update(
+        obj_id,
+        {"industry": "crypto"},
+        scope=["org"],
+        actor=Actor(kind="agent", id="did:soul:discovery", scope_context=[]),
+    )
+
+    # The projection is event-faithful: its fold shows the journal's LWW.
+    projected = await js.get(obj_id)
+    assert projected is not None and projected.properties["industry"] == "crypto"
+
+    # The statements were recorded through the shared machinery, and the
+    # resolver's winner is the connector fact.
+    stmts = await store.get_statements(obj_id, "industry")
+    assert {s.value for s in stmts} == {"fintech", "crypto"}
+    resolution = resolve(stmts, default_trust_rules(), object_type="Customer")
+    assert resolution.value == "fintech" and resolution.is_disputed is True
+
+    # THE RULING'S PROOF: the store cache (the primary read path) holds the
+    # resolved value even though the projection's in-memory fold differs.
+    cached = await store.get_object(obj_id)
+    assert cached is not None and cached.properties["industry"] == "fintech"
+    assert cached.properties["industry"] != projected.properties["industry"]
+
+    # ...and a site-1 write on the same object keeps the cache resolver-owned:
+    # a second inferred claim still cannot displace the connector fact.
+    updated = await store.update_object(
+        obj_id,
+        {"industry": "web3"},
+        writer_class="inferred",
+        source_session_id="discovery-run-2",
+    )
+    assert updated is not None and updated.properties["industry"] == "fintech"
+
+    # The projection/resolver gap is RECORDED telemetry, not a silent hole:
+    # the journal update's own divergence line was emitted at flush time.
+    assert any(
+        f"object={obj_id} property=industry" in line and 'lww="crypto"' in line
+        for line in _shadow_lines(caplog)
+    )
+
+
+async def test_projection_rebuild_stays_event_faithful_in_enforce(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, js, obj_id = await _mirrored_setup(tmp_path, journal)
+    _set_mode(monkeypatch, "enforce")
+
+    await js.update(
+        obj_id,
+        {"industry": "crypto"},
+        scope=["org"],
+        actor=Actor(kind="agent", id="did:soul:discovery", scope_context=[]),
+    )
+    assert len(await store.get_statements(obj_id, "industry")) == 2
+
+    # Rebuild from the journal: the fold is deterministic from the journal
+    # ALONE (the event-faithful guarantee), the event-id dedupe prevents any
+    # statement double-append, and the store cache stays resolver-owned.
+    js.bootstrap()
+    assert await js.flush_shadow() == 0  # already recorded — deduped
+    projected = await js.get(obj_id)
+    assert projected is not None and projected.properties["industry"] == "crypto"
+    assert len(await store.get_statements(obj_id, "industry")) == 2
+    cached = await store.get_object(obj_id)
+    assert cached is not None and cached.properties["industry"] == "fintech"

--- a/tests/test_fabric_shadow_site1.py
+++ b/tests/test_fabric_shadow_site1.py
@@ -415,13 +415,19 @@ async def test_ingest_records_threads_provenance_through_update(
 
 
 # ---------------------------------------------------------------------------
-# enforce == shadow (until FST-5); shadow failures never break the write
+# enforce records statements like shadow; shadow failures never break the write
 # ---------------------------------------------------------------------------
 
 
-async def test_enforce_mode_behaves_as_shadow(
+async def test_enforce_mode_records_statements_like_shadow(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Enforce rides the SAME statement pass as shadow (seed + incoming both
+    land). FST-5 note: this test's pre-FST-5 form asserted "cache still LWW"
+    (enforce == shadow until FST-5); the resolver now owns the cache in
+    enforce, so the connector-tier seed (120) beats the agent write (150).
+    Full enforce cache semantics live in tests/test_fabric_enforce_site1.py.
+    """
     store, obj_id, db_path = await _crm_object(tmp_path)
     _set_mode(monkeypatch, "enforce")
 
@@ -429,7 +435,7 @@ async def test_enforce_mode_behaves_as_shadow(
 
     assert len(await store.get_statements(obj_id, "arr")) == 2
     obj = await store.get_object(obj_id)
-    assert obj is not None and obj.properties["arr"] == 150  # cache still LWW
+    assert obj is not None and obj.properties["arr"] == 120  # resolver-owned cache
 
 
 async def test_shadow_failure_never_breaks_cache_write(


### PR DESCRIPTION
## What this does

Builds on #1694. Enforce mode lands: for statement-tracked properties, the cache now holds the trust-ladder resolver's winner instead of whatever wrote last. Untracked properties keep LWW (nothing to resolve). The write is computed once (no LWW-then-overwrite), the divergence line keeps logging (in enforce it reads as what-LWW-would-have-kept vs what-was-written), and a resolver fault falls back to the LWW value with a warning — the primary write path can never break.

Two curation verbs land as store methods, both returning the new Resolution:
- `change_property` — the value changed in the world: closes the current winner's validity, appends the new value as preferred.
- `correct_property` — the old value was wrong: deprecates it with a machine-readable reason, appends the corrected value.

Both auto-promote untracked properties first, so history is preserved even on first-touch curation.

## The proof this chain exists for

`TestSzdProof`: a connector-written fact plus a discovery-inferred write of a different value, in enforce — the cache still shows the connector value, the inferred claim is retained as a normal-rank statement, the conflict is flagged. Reversed order (inferred creates, connector updates) — the connector still wins the cache. A machine-inferred value can no longer silently clobber a real fact.

Plus the reversal proof: a store that ran enforce, flipped back to off — reads serve the last-resolved values, LWW resumes, nothing errors.

## Judgment calls (flagged for review)

- **Projection stays event-faithful**: the journal fold remains a deterministic rebuild of the journal alone; enforce applies at the store cache (the primary read path). Writing resolver output back into the fold would silently diverge live-vs-rebuilt state (the replay dedupe means a rebuild's flush records nothing). Ruled, documented at the top of projection.py, and tested both ways.
- One shadow-guard test updated by necessity: it asserted the explicit "enforce == shadow until FST-5" placeholder — the exact behavior this slice replaces. Renamed with the cache assertion flipped; every other guard test is byte-for-byte untouched (diff: 1 file, +9/-3).
- Known gap, deliberately deferred to the freshness slice: a stale connector-tier value currently outranks a fresher mirror value (ladder-correct; freshness demotion is FST-7's scope).

## Verification

288 fabric tests (267 baseline + 21), all four shadow guard suites green, cloud fabric_ingest 23 green, ruff + import-linter clean.

Stacked on #1694. Next: un-rankable conflicts to the Instinct stewardship queue + PIN/IGNORE.