### PR TITLE
feat(fabric): un-rankable conflicts to the Instinct stewardship queue + PIN/IGNORE (FST-6)

### DIFF
--- a/ee/pocketpaw_ee/cloud/fabric_conflicts/__init__.py
+++ b/ee/pocketpaw_ee/cloud/fabric_conflicts/__init__.py
@@ -1,0 +1,40 @@
+# ee/cloud/fabric_conflicts/__init__.py — the conflict-stewardship Instinct
+# proposal type (a peer of ``_instinct_rule`` / ``_fabric_objects`` /
+# ``_pocket_create`` / ``_pocket_write`` / ``_code_change`` /
+# ``_external_action`` / ``_belt_plan`` / ``_artifact_change`` /
+# ``_admin_action``).
+# Created: 2026-07-10 (FST-6 — the conflict lifecycle) — the hybrid conflict UX:
+#   the source-truth resolver auto-resolves every conflict it can RANK; the
+#   un-rankable残り (``Resolution.unresolvable=True``) is swept into ONE Instinct
+#   proposal per conflicted property for a human steward to arbitrate. Approve
+#   (optionally editing the choice) → the executor PINs the chosen statement via
+#   the canonical OSS steward verb (``FabricStore.pin_statement``); reject → the
+#   policy's provisional winner stands, no statement change (router owns the
+#   reject-close). Precedent mirrored: ``instinct_rule_proposals`` (one proposal
+#   per subject, propose stages / executor fires on approve).
+#
+# Re-exports the propose + sweep helpers, the apply-on-approve executor, and the
+# blob constants so callers (the ingest sweep, the instinct router) import from
+# the package root, mirroring the instinct-rule gate.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.fabric_conflicts.executor import execute_approved_fabric_conflict
+from pocketpaw_ee.cloud.fabric_conflicts.propose import (
+    FABRIC_CONFLICT_KIND,
+    FABRIC_CONFLICT_PARAM_KEY,
+    FABRIC_CONFLICT_SCHEMA,
+    STEWARDSHIP_QUEUE_WARN_THRESHOLD,
+    propose_fabric_conflict,
+    sweep_conflicts_to_proposals,
+)
+
+__all__ = [
+    "FABRIC_CONFLICT_KIND",
+    "FABRIC_CONFLICT_PARAM_KEY",
+    "FABRIC_CONFLICT_SCHEMA",
+    "STEWARDSHIP_QUEUE_WARN_THRESHOLD",
+    "execute_approved_fabric_conflict",
+    "propose_fabric_conflict",
+    "sweep_conflicts_to_proposals",
+]

--- a/ee/pocketpaw_ee/cloud/fabric_conflicts/executor.py
+++ b/ee/pocketpaw_ee/cloud/fabric_conflicts/executor.py
@@ -1,0 +1,366 @@
+# ee/cloud/fabric_conflicts/executor.py — apply an approved conflict-stewardship choice.
+# Created: 2026-07-10 (FST-6 — the conflict lifecycle: _fabric_conflict proposal type).
+#
+# What this module does (the apply-on-approve half of the conflict gate): the
+# propose helper (``fabric_conflicts.propose``) stages an un-rankable Fabric
+# conflict as an Instinct Action carrying a ``_fabric_conflict`` blob. After a
+# human approves it (optionally editing ``resolution.chosen_statement_id`` to a
+# rival via the approve-with-edits path), the ee instinct router fires
+# ``execute_approved_fabric_conflict`` here — exactly mirroring the
+# instinct-rule gate (the PRECEDENT MIRRORED; see propose.py). This function:
+#
+#   1. Reads the ``_fabric_conflict`` blob. Missing blob → return (no chain was
+#      opened for it). Schema mismatch → mark_failed + close, return.
+#   2. Tenancy guard — an empty ``workspace_id`` → mark_failed + close (a pin
+#      with no tenant to scope it is a tenancy hole). Subject guard — missing
+#      ``object_id`` / ``property`` → mark_failed + close.
+#   3. Idempotency guard — a terminal Action (executed/failed) or a blob
+#      already carrying an ``outcome`` is NOT re-run: re-approve / retry never
+#      double-pins.
+#   4. Choice validation at the entry to the write path — the (possibly
+#      edited) ``resolution.chosen_statement_id`` MUST be one of the blob's
+#      staged ``choices``; anything else fails CLEANLY (an edit cannot smuggle
+#      an arbitrary statement id in). Belt-and-braces: the OSS verb re-checks
+#      that the statement belongs to exactly this (object, property) within
+#      the workspace scope.
+#   5. THE CHOICE → VERB MAPPING: **PIN the chosen statement** via the
+#      canonical OSS steward verb ``FabricStore.pin_statement`` (workspace-
+#      scoped store, ISO-1). PIN is the durable "this one wins" — the
+#      resolver's pinned short-circuit settles today's rivals AND future ones,
+#      and the losers stay auditable (IGNORE-the-rival would strike history
+#      and only settle today's conflict). In enforce the verb also writes the
+#      new winner into the flat cache; in shadow the pin lands on the
+#      statement layer only — exactly the steward-verb contract.
+#      REJECT never reaches this module: the router owns the reject-close and
+#      the policy's provisional winner simply stands (no statement change).
+#   6. Back-writes the outcome ``{status, pinned_statement_id, value,
+#      executed_at}`` onto the blob, marks the Action executed/failed, and
+#      closes the Decision-Graph chain exactly once.
+#
+# EXACTLY-ONE-TERMINAL discipline: on APPROVE the EXECUTOR owns the
+# ``decision.completed`` close — the router does NOT emit it. On REJECT the
+# ROUTER owns the close and the executor never runs. Every terminal path goes
+# through the single ``_fail`` chokepoint or the one success emit at the end.
+#
+# Never raises — a failure here must not break the approve response. The
+# router wraps the call too; this is belt-and-braces.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.fabric_conflicts.propose import (
+    FABRIC_CONFLICT_PARAM_KEY,
+    FABRIC_CONFLICT_SCHEMA,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_uuid(raw: Any) -> UUID | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be."""
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+async def _persist_outcome(
+    *,
+    store: Any,
+    action_id: str,
+    status: str,
+    summary: dict[str, Any],
+    executed_at: str,
+) -> None:
+    """Back-write the pin outcome onto the persisted ``_fabric_conflict`` blob.
+
+    Direct SQL update — the same pattern the instinct-rule executor uses. The
+    blob's ``outcome`` carries the pinned statement id + value so a reader
+    (audit, the idempotency guard, a "disputed facts" view) sees the result
+    structurally. Best-effort: a write failure leaves the free-text
+    ``mark_executed`` / ``mark_failed`` outcome as the record.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(FABRIC_CONFLICT_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["outcome"] = {"status": status, "executed_at": executed_at, **summary}
+        params[FABRIC_CONFLICT_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — back-write is best-effort
+        logger.warning(
+            "fabric_conflict: failed to persist outcome onto action %s — the "
+            "structured outcome is unavailable (free-text outcome still recorded)",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: UUID | None,
+    summary: str | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for a conflict stewardship.
+
+    Mirrors ``instinct_rule_proposals.executor._emit_chain_close`` — the
+    executor owns the close on the approve path. Returns early when
+    ``correlation_id`` is None (no chain to close). Best-effort.
+    """
+    if correlation_id is None:
+        return
+
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if summary:
+        payload["summary"] = summary
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "fabric_conflict decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+def _already_executed(action: Any, blob: dict[str, Any]) -> bool:
+    """Idempotency guard — True when this stewardship choice already ran.
+
+    Two signals, either sufficient: the blob carries an ``outcome`` (a prior
+    run back-wrote it), or the Action is already terminal (executed/failed).
+    A PIN is idempotent at the store layer, but re-running would still emit a
+    duplicate chain terminal — so the guard mirrors the precedent exactly.
+    """
+    if isinstance(blob.get("outcome"), dict):
+        return True
+    status = getattr(action, "status", None)
+    status_value = getattr(status, "value", status)
+    return str(status_value) in ("executed", "failed")
+
+
+async def execute_approved_fabric_conflict(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """PIN the statement a freshly-approved stewardship Action chose.
+
+    Called best-effort from the instinct router's ``approve_action`` /
+    ``bulk_approve_actions`` after ``store.approve()`` succeeds — the same
+    hook shape the instinct-rule executor uses. ``human_event_id`` threads
+    the router's ``human.corrected`` event id into the terminal
+    ``decision.completed`` causation. Never raises.
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(FABRIC_CONFLICT_PARAM_KEY)
+    if not isinstance(blob, dict):
+        # Not a conflict-stewardship Action — no chain was opened for it here.
+        logger.warning("approved action %s carries no _fabric_conflict blob", action.id)
+        return
+
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    object_id = str(blob.get("object_id") or "")
+    property_name = str(blob.get("property") or "")
+    approver = str(getattr(action, "approved_by", "") or "") or "steward"
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str) -> None:
+        """Mark the Action failed AND close the chain with one terminal — the
+        single failure-path chokepoint (never both fail and double-fire)."""
+        await store.mark_failed(action.id, reason)
+        await _persist_outcome(
+            store=store,
+            action_id=str(action.id),
+            status="failed",
+            summary={"reason": reason},
+            executed_at=datetime.now(UTC).isoformat(),
+        )
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=approver,
+            causation_id=causation,
+            summary=reason,
+        )
+
+    # Schema guard — a stale blob from an incompatible build fails loud rather
+    # than pinning a misinterpreted statement.
+    if blob.get("schema") != FABRIC_CONFLICT_SCHEMA:
+        await _fail(
+            "fabric-conflict schema mismatch — the blob is from an incompatible "
+            "build and cannot be executed",
+            error_class="SchemaMismatch",
+        )
+        return
+
+    # Tenancy — a pin with no workspace to scope it is a tenancy hole.
+    if not workspace_id:
+        await _fail(
+            "fabric-conflict blob carries no workspace_id — cannot scope the pin",
+            error_class="MissingWorkspace",
+        )
+        return
+    if not object_id or not property_name:
+        await _fail(
+            "fabric-conflict blob carries no object_id/property — nothing to pin",
+            error_class="MalformedBlob",
+        )
+        return
+
+    # Idempotency — never re-run on a re-invocation (bulk re-approve, retry).
+    if _already_executed(action, blob):
+        logger.info(
+            "fabric_conflict: action %s already executed (idempotency guard) — skipping the pin",
+            action.id,
+        )
+        return
+
+    # The human's (possibly edited) choice — validated against the STAGED
+    # choices so an edit can never smuggle in an arbitrary statement id.
+    resolution_spec = blob.get("resolution")
+    chosen = ""
+    if isinstance(resolution_spec, dict):
+        chosen = str(resolution_spec.get("chosen_statement_id") or "")
+    if not chosen:
+        await _fail(
+            "fabric-conflict blob carries no resolution.chosen_statement_id",
+            error_class="MalformedBlob",
+        )
+        return
+    staged_ids = {
+        str(c.get("statement_id") or "") for c in (blob.get("choices") or []) if isinstance(c, dict)
+    }
+    if chosen not in staged_ids:
+        await _fail(
+            f"chosen statement {chosen!r} is not one of the staged choices — "
+            "refusing to pin an unstaged statement",
+            error_class="InvalidChoice",
+        )
+        return
+
+    # THE VERB: pin the chosen statement through the canonical OSS steward
+    # verb on the workspace-scoped store. Any failure (statement vanished, was
+    # deprecated by a CORRECT in the meantime, store error) is a failed
+    # outcome — NEVER re-raised into the router.
+    try:
+        from pocketpaw.stores import get_fabric_store
+
+        fabric = get_fabric_store(workspace_id=workspace_id or None)
+        resolution = await fabric.pin_statement(
+            object_id, property_name, chosen, workspace_id=workspace_id
+        )
+    except Exception as exc:  # noqa: BLE001 — never let the pin break approve
+        logger.warning(
+            "fabric_conflict: pin crashed for action %s (workspace=%s)",
+            action.id,
+            workspace_id,
+            exc_info=True,
+        )
+        await _fail(f"pin failed: {exc}", error_class=type(exc).__name__)
+        return
+
+    summary = {
+        "pinned_statement_id": chosen,
+        "object_id": object_id,
+        "property": property_name,
+        "value": resolution.value,
+    }
+
+    # Success — mark executed, back-write the structured outcome, close the
+    # chain. This is the ONLY terminal on the happy path.
+    await store.mark_executed(
+        action.id,
+        f"pinned statement {chosen} as the winner for {property_name!r} (object {object_id})",
+    )
+    await _persist_outcome(
+        store=store,
+        action_id=str(action.id),
+        status="executed",
+        summary=summary,
+        executed_at=datetime.now(UTC).isoformat(),
+    )
+    _emit_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=approver,
+        causation_id=causation,
+        summary=f"pinned statement {chosen} for {property_name!r} on {object_id}",
+    )
+    logger.info(
+        "fabric_conflict: executed action %s → pinned %s on (%s, %r) (ok)",
+        action.id,
+        chosen,
+        object_id,
+        property_name,
+    )
+
+
+__all__ = ["execute_approved_fabric_conflict"]

--- a/ee/pocketpaw_ee/cloud/fabric_conflicts/propose.py
+++ b/ee/pocketpaw_ee/cloud/fabric_conflicts/propose.py
@@ -1,0 +1,582 @@
+# ee/cloud/fabric_conflicts/propose.py — stage an un-rankable Fabric conflict for a steward.
+# Created: 2026-07-10 (FST-6 — the conflict lifecycle: _fabric_conflict proposal type).
+#
+# What this module does (the propose half of the conflict-stewardship gate): the
+# source-truth chain's resolver (FST-2) auto-resolves every conflict it can RANK;
+# the残り — same-tier, same-rank, both-open, materially-different, within-epsilon
+# conflicts (``Resolution.unresolvable=True``) — cannot be ordered by policy and
+# need a human. This module turns each such open conflict (recomputed from
+# statements by ``pocketpaw.fabric.conflicts.detect_open_conflicts`` — no
+# conflicts table) into ONE Instinct ``Action`` carrying a ``_fabric_conflict``
+# blob (schema 1) under ``Action.parameters``. A human arbitrates it in The Tray:
+# approve (optionally editing the choice) → the apply-on-approve executor
+# (``fabric_conflicts.executor.execute_approved_fabric_conflict``) PINs the
+# chosen statement via the canonical OSS steward verb
+# ``FabricStore.pin_statement``; reject → the policy's provisional winner stands,
+# NO statement changes (the router owns the reject-close). This module does NOT
+# write Fabric — it only gates.
+#
+# PRECEDENT MIRRORED: ``instinct_rule_proposals`` (propose.py stages one proposal
+# per subject, executor.py fires on approve, the router owns reject-close) — the
+# closest shape: one SUBJECT (here one conflicted property) per proposal, an
+# editable sub-dict the human may adjust before approving, tenancy pinned on
+# SEPARATE top-level blob fields. The blob sits alongside ``_instinct_rule``,
+# ``_fabric_objects``, ``_pocket_create``, ``_pocket_write``, ``_code_change``,
+# ``_external_action``, ``_belt_plan``, ``_artifact_change``, ``_admin_action``;
+# the router + executor dispatch on the ``_fabric_conflict`` parameters key.
+#
+# Schema 1 — the blob carries:
+#   * ``schema`` / ``kind`` — version + discriminator;
+#   * ``workspace_id`` — the originating tenant, a SEPARATE top-level field (NOT
+#     inside the editable ``resolution``) so an edit can never move the proposal
+#     to another workspace. The executor's tenancy gate reads it here; the PIN is
+#     executed against this workspace's Fabric store.
+#   * ``object_id`` / ``property`` — the conflict subject. Top-level (immutable
+#     via edits); together with ``workspace_id`` they form the DEDUPE KEY
+#     ``(workspace_id, object_id, property)`` — the sweep guarantees at most ONE
+#     open proposal per key.
+#   * ``object_type`` — display context for the Tray.
+#   * ``choices`` — the competing statements (the policy's provisional winner
+#     first, then the un-rankable rivals), each with value + provenance
+#     (writer_class, rank, observed_at/recorded_at, and the SourceRef fields —
+#     enough for a human to decide). Read-only context.
+#   * ``policy_winner_statement_id`` — what policy provisionally picked (what
+#     "reject" keeps).
+#   * ``conflict_signature`` — sorted competing statement ids. Reject-memory: a
+#     rejected proposal for the same key with the SAME signature blocks
+#     re-filing (the human already said "keep the policy winner" for exactly
+#     this conflict); a new rival observation changes the signature and the
+#     conflict is re-staged.
+#   * ``resolution`` — the ONE editable sub-dict:
+#     ``{"chosen_statement_id": <id>}``, defaulting to the policy winner. The
+#     human either approves as-is (endorse policy's pick — now durable) or edits
+#     the choice to a rival via the approve-with-edits path
+#     (``ApproveRequest.parameters``) before approving. The executor validates
+#     the chosen id against ``choices`` — an edit cannot smuggle in an arbitrary
+#     statement.
+#   * ``summary`` — a human-readable one-liner for the gate UI;
+#   * ``correlation_id`` / ``proposed_event_id`` — the Decision-Graph chain ids
+#     (``agent.proposed`` opens the chain; the router's approve/reject paths and
+#     the executor close the SAME chain).
+#
+# APPROVE-CHOICE → VERB MAPPING (settled here, per the FST-6 design): approving
+# with choice A **PINs A's statement** — the durable "this one wins". PIN beats
+# IGNORE-the-rival because (a) the resolver's pinned short-circuit also settles
+# FUTURE rival observations, not just today's, and (b) the losing statements
+# stay intact for audit instead of being struck. IGNORE remains available as a
+# direct OSS steward verb for genuinely bogus claims.
+#
+# SWEEP WIRING (the lightest honest trigger): ``sweep_conflicts_to_proposals``
+# is invoked at the tail of ``fabric_ingest.service.run_ingest_sweep`` for each
+# workspace the ingest touched — conflicts are born at merge sites, so
+# after-ingest is the natural beat, AND that sweep already runs every 5 minutes
+# under ``FabricIngestScheduler`` (the established cloud periodic pattern), so
+# the same hook is the periodic sweep too. No new scheduler class. Best-effort,
+# exception-shielded, mode-gated (off → zero reads).
+#
+# Mode gate: the lifecycle runs in shadow AND enforce — a queued conflict in
+# shadow is observation with a human answer (the PIN lands on the statement
+# layer; only the cache write is enforce-only, exactly the verbs' contract).
+# Off → nothing (no scans, no proposals).
+#
+# Volume guard (the PRD queue-volume metric): after each sweep the number of
+# OPEN stewardship proposals for the workspace is counted; past
+# ``STEWARDSHIP_QUEUE_WARN_THRESHOLD`` (5) a grep-stable warning line is logged
+# — conflicts outpacing steward review is a rules/trust-ladder problem, not
+# something to silently queue.
+#
+# Security:
+#   * NO Fabric mutation here — the conflict is staged as DATA; the PIN only
+#     lands after a human approves.
+#   * Tenancy + subject are SEPARATE top-level blob fields (NOT in the editable
+#     ``resolution``); the router's ``_assert_fabric_conflict_workspace`` gates
+#     all four approve/reject paths (asymmetric tenant scope is no tenant scope
+#     — pocketpaw#1183 / #1250) and the executor re-validates.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# The Instinct Action kind discriminator for a conflict-stewardship proposal.
+# The router + executor dispatch on the presence of the parameters key below;
+# the blob also carries ``kind="fabric_conflict"`` for readers that introspect it.
+FABRIC_CONFLICT_KIND = "fabric_conflict"
+
+# The parameters key under which the conflict blob rides — peer of
+# ``_instinct_rule`` / ``_fabric_objects`` / ``_pocket_create`` et al.
+FABRIC_CONFLICT_PARAM_KEY = "_fabric_conflict"
+
+# Schema version stamped on the ``_fabric_conflict`` blob. Bump when the blob
+# shape changes so a stale pending Action approved after a deploy fails loud
+# instead of pinning a misinterpreted statement. Starts at 1 — first version.
+FABRIC_CONFLICT_SCHEMA = 1
+
+# The PRD queue-volume metric: past this many OPEN stewardship proposals in one
+# workspace, the sweep logs a warning — un-rankable conflicts are outpacing
+# steward review.
+STEWARDSHIP_QUEUE_WARN_THRESHOLD = 5
+
+
+def _source_truth_mode() -> str:
+    """The fabric_source_truth_mode setting, read through the OSS chokepoint.
+
+    Late import + late call so a test monkeypatch of
+    ``pocketpaw.fabric.store._source_truth_mode`` (the suite-wide seam every
+    FST test uses) is observed here too — ONE definition of the mode read.
+    """
+    from pocketpaw.fabric import store as fabric_store_mod
+
+    return fabric_store_mod._source_truth_mode()
+
+
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    workspace_id: str,
+    user_id: str,
+    object_type: str,
+    property: str,
+    choice_count: int,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for a conflict proposal.
+
+    Mirrors ``instinct_rule_proposals.propose._emit_agent_proposed``: the
+    proposing caller is the actor (``kind="agent"``); a conflict isn't bound
+    to a pocket — its tenancy is the workspace — so ``pocket_id`` on the chain
+    carries the workspace id (matching the Action's ``pocket_id``).
+
+    Returns the emitted event id (back-written onto the blob for the
+    ``human.corrected`` causation chain) or ``None`` when the emit raised —
+    best-effort per RFC 09; the Slice 4 reconciler picks up orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = f"arbitrate {choice_count} competing values for {object_type or 'object'}.{property}"
+    payload: dict[str, Any] = {
+        # Fields the projection's ``_fold_proposed`` consumes.
+        "intent": intent,
+        "action": "fabric_conflict",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        # Richer fields for the explain narrator.
+        "proposal_kind": "fabric_conflict",
+        "proposal": {
+            "object_type": object_type,
+            "property": property,
+            "choice_count": choice_count,
+        },
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "fabric_conflict agent.proposed emit failed for correlation_id=%s "
+            "(action_id=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Back-write ``correlation_id`` + ``proposed_event_id`` onto the persisted
+    Action's ``parameters._fabric_conflict`` blob after ``agent.proposed`` fired.
+
+    Direct SQL update — the same pattern the instinct-rule gate's
+    ``_persist_chain_ids`` uses. Best-effort: a write failure leaves
+    ``proposed_event_id`` None and the eventual ``human.corrected`` emits
+    without a causation_id (the chain still folds).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(FABRIC_CONFLICT_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[FABRIC_CONFLICT_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "fabric_conflict: failed to persist chain ids onto action %s — the "
+            "chain's human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _short(value: Any, limit: int = 60) -> str:
+    """A compact display form of a statement value for titles/summaries."""
+    text = repr(value)
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+async def _statement_choice(fabric: Any, stmt: Any, workspace_id: str) -> dict[str, Any]:
+    """One entry of the blob's ``choices`` list: value + full provenance.
+
+    Enough for a human to decide: WHO wrote it (writer_class), WHEN the
+    source says it was true (observed_at), when we learned it (recorded_at),
+    and WHERE it came from (the SourceRef identity fields). The source lookup
+    is best-effort — a missing SourceRef (pruned, out of scope) degrades to
+    ``source: None`` rather than blocking the proposal.
+    """
+    source_payload: dict[str, Any] | None = None
+    try:
+        source = await fabric.get_source(stmt.source_ref_id, workspace_id=workspace_id or None)
+    except Exception:  # noqa: BLE001 — provenance display is best-effort
+        source = None
+    if source is not None:
+        source_payload = {
+            "kind": source.kind,
+            "connector": source.connector,
+            "run_id": source.run_id,
+            "document_uri": source.document_uri,
+            "actor_id": source.actor_id,
+            "session_id": source.session_id,
+        }
+    return {
+        "statement_id": stmt.id,
+        "value": stmt.value,
+        "writer_class": stmt.writer_class,
+        "rank": stmt.rank,
+        "pinned": stmt.pinned,
+        "observed_at": stmt.observed_at.isoformat(),
+        "recorded_at": stmt.recorded_at.isoformat(),
+        "source": source_payload,
+    }
+
+
+async def propose_fabric_conflict(
+    *,
+    workspace_id: str,
+    conflict: Any,
+    requested_by: str = "fabric_steward",
+    summary: str | None = None,
+    correlation_id: str | None = None,
+    assignee: str | None = None,
+    fabric_store: Any | None = None,
+) -> str:
+    """Build + store an Instinct ``Action`` for ONE un-rankable conflict.
+
+    ``conflict`` is a ``pocketpaw.fabric.conflicts.ConflictRecord`` (winner +
+    rivals). Files an Action carrying the ``_fabric_conflict`` blob (schema 1)
+    and opens the Decision-Graph chain. Returns the proposed Action id. NO
+    Fabric mutation happens here — the choice is staged as DATA and the PIN
+    only lands after a human approves.
+
+    Callers normally reach this through :func:`sweep_conflicts_to_proposals`
+    (which dedupes); calling it directly bypasses the one-open-per-key
+    guarantee.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_fabric_store, get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("propose_fabric_conflict requires a non-empty workspace_id")
+    if conflict.winner is None or not conflict.rivals:
+        raise ValueError("propose_fabric_conflict requires a conflict with a winner and rivals")
+
+    fabric = fabric_store or get_fabric_store(workspace_id=workspace_id or None)
+
+    competing = [conflict.winner, *conflict.rivals]
+    choices = [await _statement_choice(fabric, s, workspace_id) for s in competing]
+
+    corr = correlation_id or str(uuid4())
+
+    values_text = " vs ".join(_short(c["value"]) for c in choices)
+    subject = f"{conflict.object_type or 'object'}.{conflict.property}"
+    human_summary = summary or (
+        f"Policy cannot rank {len(choices)} competing values for {subject}"
+        f" ({values_text}). Approve to make the selected value the durable"
+        f" winner (PIN); reject to keep the policy winner."
+    )
+
+    blob: dict[str, Any] = {
+        "kind": FABRIC_CONFLICT_KIND,
+        "schema": FABRIC_CONFLICT_SCHEMA,
+        # Tenancy + subject are SEPARATE top-level fields (NOT in the editable
+        # ``resolution``) so an edit can never re-scope or re-target the pin.
+        "workspace_id": workspace_id,
+        "object_id": conflict.object_id,
+        "property": conflict.property,
+        "object_type": conflict.object_type or "",
+        # Read-only decision context.
+        "choices": choices,
+        "policy_winner_statement_id": conflict.winner.id,
+        "conflict_signature": list(conflict.signature),
+        # The ONE editable sub-dict — the human's choice (defaults to the
+        # policy winner; approving unedited endorses policy's pick durably).
+        "resolution": {"chosen_statement_id": conflict.winner.id},
+        "summary": human_summary,
+        # RFC 09 chain-correlation fields (schema 1 carries them from the start).
+        "correlation_id": corr,
+        "proposed_event_id": None,
+    }
+
+    title = f"Disputed fact — {subject} has {len(choices)} competing values"
+    recommendation = f"Pick the value that should win. {human_summary}"
+    trigger = ActionTrigger(
+        type="agent",
+        source=requested_by or "fabric_conflicts",
+        reason="un-rankable Fabric conflict requires a steward decision",
+    )
+
+    # ISO: scope the store to the caller's workspace (validated non-empty
+    # above) — this propose path has no ``current_workspace`` ContextVar set.
+    store = get_instinct_store(workspace_id=workspace_id or None)
+    action_obj = await store.propose(
+        # ``pocket_id`` carries the workspace — a conflict isn't bound to a
+        # pocket (mirrors the instinct-rule gate); the workspace also rides on
+        # the blob (the executor's tenancy gate reads it there).
+        pocket_id=workspace_id,
+        title=title,
+        description=recommendation,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.WORKFLOW,
+        priority=ActionPriority.MEDIUM,
+        parameters={FABRIC_CONFLICT_PARAM_KEY: blob},
+        assignee=assignee or None,
+        workspace_id=workspace_id,
+    )
+
+    logger.info(
+        "fabric_conflict: proposed stewardship for %s (object=%s, %d choices) → "
+        "Instinct action %s (workspace=%s, correlation_id=%s)",
+        subject,
+        conflict.object_id,
+        len(choices),
+        action_obj.id,
+        workspace_id,
+        corr,
+    )
+
+    # Open the Decision-Graph chain now that the Action is stored. Best-effort:
+    # a Decision-Graph wiring failure must NOT fail the propose.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=UUID(corr),
+        action_id=action_obj.id,
+        workspace_id=workspace_id,
+        user_id=requested_by,
+        object_type=conflict.object_type or "",
+        property=conflict.property,
+        choice_count=len(choices),
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action_obj.id,
+            correlation_id=corr,
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    return action_obj.id
+
+
+def _conflict_blob(action: Any) -> dict[str, Any] | None:
+    """The ``_fabric_conflict`` blob on an Action, or ``None``."""
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get(FABRIC_CONFLICT_PARAM_KEY)
+    return blob if isinstance(blob, dict) else None
+
+
+def _blob_dedupe_key(blob: dict[str, Any]) -> tuple[str, str, str]:
+    """The proposal's dedupe key off the blob's top-level subject fields."""
+    return (
+        str(blob.get("workspace_id") or ""),
+        str(blob.get("object_id") or ""),
+        str(blob.get("property") or ""),
+    )
+
+
+async def sweep_conflicts_to_proposals(
+    workspace_id: str,
+    *,
+    requested_by: str = "fabric_steward",
+    assignee: str | None = None,
+    fabric_store: Any | None = None,
+) -> list[str]:
+    """Turn one workspace's open un-rankable conflicts into Instinct proposals.
+
+    The sweep half of the FST-6 lifecycle (see the module header for the
+    wiring: post-ingest hook + the 5-minute ingest scheduler beat). Steps:
+
+    1. Mode gate — ``fabric_source_truth_mode`` off → return [] with ZERO
+       reads. Shadow and enforce both sweep (a queued conflict in shadow is
+       observation with a human answer).
+    2. Recompute the open conflicts from statements
+       (``detect_open_conflicts`` — no persisted conflict state).
+    3. Dedupe — ONE open proposal per ``(workspace_id, object_id, property)``:
+       a key with a PENDING ``_fabric_conflict`` Action is skipped, so
+       re-sweeps never duplicate while one is open (the instinct-rule
+       precedent's one-proposal-per-subject discipline). Additionally,
+       reject-memory: a key whose most recent REJECTED proposal carries the
+       SAME ``conflict_signature`` is skipped — the human already answered
+       "keep the policy winner" for exactly this conflict; a new rival
+       observation changes the signature and re-stages it.
+    4. File a proposal per remaining conflict (isolated — one failure never
+       blocks the rest).
+    5. Volume guard — warn past :data:`STEWARDSHIP_QUEUE_WARN_THRESHOLD` open
+       stewardship proposals for the workspace.
+
+    Returns the NEWLY filed Action ids.
+    """
+    from pocketpaw.fabric.conflicts import detect_open_conflicts
+    from pocketpaw.instinct.models import ActionStatus
+    from pocketpaw.stores import get_fabric_store, get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("sweep_conflicts_to_proposals requires a non-empty workspace_id")
+
+    mode = _source_truth_mode()  # read ONCE per sweep
+    if mode not in ("shadow", "enforce"):
+        return []
+
+    fabric = fabric_store or get_fabric_store(workspace_id=workspace_id or None)
+    conflicts = await detect_open_conflicts(fabric, workspace_id=workspace_id)
+
+    store = get_instinct_store(workspace_id=workspace_id or None)
+
+    # Open (PENDING) stewardship proposals → the one-open-per-key guarantee.
+    open_keys: set[tuple[str, str, str]] = set()
+    try:
+        pending = await store.list_actions(
+            pocket_id=workspace_id,
+            status=ActionStatus.PENDING,
+            workspace_id=workspace_id,
+            limit=500,
+        )
+    except Exception:  # noqa: BLE001 — a failed listing must not crash the sweep
+        logger.warning(
+            "fabric_conflict: failed to list open proposals for workspace %s — "
+            "skipping this sweep rather than risking duplicates",
+            workspace_id,
+            exc_info=True,
+        )
+        return []
+    for action in pending:
+        blob = _conflict_blob(action)
+        if blob is not None:
+            open_keys.add(_blob_dedupe_key(blob))
+
+    # Reject-memory: (key, signature) pairs a human already dismissed.
+    rejected_signatures: set[tuple[tuple[str, str, str], tuple[str, ...]]] = set()
+    try:
+        rejected = await store.list_actions(
+            pocket_id=workspace_id,
+            status=ActionStatus.REJECTED,
+            workspace_id=workspace_id,
+            limit=500,
+        )
+    except Exception:  # noqa: BLE001 — reject-memory is best-effort
+        rejected = []
+    for action in rejected:
+        blob = _conflict_blob(action)
+        if blob is not None:
+            signature = tuple(str(s) for s in blob.get("conflict_signature") or [])
+            rejected_signatures.add((_blob_dedupe_key(blob), signature))
+
+    filed: list[str] = []
+    for conflict in conflicts:
+        key = (workspace_id, conflict.object_id, conflict.property)
+        if key in open_keys:
+            continue  # one open proposal per key — re-sweeps never duplicate
+        if (key, tuple(conflict.signature)) in rejected_signatures:
+            continue  # the human already kept the policy winner for THIS conflict
+        try:
+            action_id = await propose_fabric_conflict(
+                workspace_id=workspace_id,
+                conflict=conflict,
+                requested_by=requested_by,
+                assignee=assignee,
+                fabric_store=fabric,
+            )
+        except Exception:  # noqa: BLE001 — one bad conflict never blocks the rest
+            logger.warning(
+                "fabric_conflict: failed to file a proposal for %s.%s (object=%s, ws=%s)",
+                conflict.object_type or "object",
+                conflict.property,
+                conflict.object_id,
+                workspace_id,
+                exc_info=True,
+            )
+            continue
+        filed.append(action_id)
+        open_keys.add(key)
+
+    # Volume guard — the PRD queue-volume metric. ``open_keys`` now holds the
+    # pre-existing open proposals plus everything just filed.
+    open_count = len(open_keys)
+    if open_count > STEWARDSHIP_QUEUE_WARN_THRESHOLD:
+        logger.warning(
+            "fabric_conflict: stewardship queue for workspace %s has %d open "
+            "proposal(s) (threshold %d) — un-rankable conflicts are outpacing "
+            "steward review; consider a trust-rule override for the noisy "
+            "properties",
+            workspace_id,
+            open_count,
+            STEWARDSHIP_QUEUE_WARN_THRESHOLD,
+        )
+
+    if filed:
+        logger.info(
+            "fabric_conflict: sweep filed %d stewardship proposal(s) for workspace %s",
+            len(filed),
+            workspace_id,
+        )
+    return filed
+
+
+__all__ = [
+    "FABRIC_CONFLICT_KIND",
+    "FABRIC_CONFLICT_PARAM_KEY",
+    "FABRIC_CONFLICT_SCHEMA",
+    "STEWARDSHIP_QUEUE_WARN_THRESHOLD",
+    "propose_fabric_conflict",
+    "sweep_conflicts_to_proposals",
+]

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -34,6 +34,17 @@
 #   conflict between sources, so the source-truth chain has nothing to
 #   arbitrate there. Proven by
 #   tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py.
+# Updated: 2026-07-10 (FST-6 — the conflict lifecycle: post-ingest stewardship
+#   sweep) — run_ingest_sweep now ends with a best-effort per-workspace call to
+#   fabric_conflicts.sweep_conflicts_to_proposals: every workspace the ingest
+#   touched gets its open un-rankable conflicts staged as Instinct stewardship
+#   proposals. THIS is the FST-6 sweep wiring (the lightest honest trigger):
+#   conflicts are born at the merge sites this worker drives, so after-ingest
+#   is the natural beat — and because FabricIngestScheduler already ticks
+#   run_ingest_sweep every 5 minutes, the same hook doubles as the periodic
+#   sweep with no new scheduler class. Exception-shielded (a conflict-sweep
+#   failure never fails the ingest summary) and mode-gated inside the sweep
+#   itself (fabric_source_truth_mode 'off' → zero reads, zero proposals).
 #
 # What this does
 # --------------
@@ -364,6 +375,32 @@ async def run_ingest_sweep(
         errors,
         workspace_id or "ALL",
     )
+
+    # FST-6 — after the ingest batches land, stage each touched workspace's
+    # un-rankable conflicts as Instinct stewardship proposals. Best-effort per
+    # workspace (a conflict-sweep failure never fails the ingest summary);
+    # mode-gated inside the sweep (off → zero reads); lazy import so the
+    # ingest worker carries no module-top dependency on the gate package.
+    for ws in sorted({s["workspace_id"] for s in sources}):
+        try:
+            from pocketpaw_ee.cloud.fabric_conflicts import sweep_conflicts_to_proposals
+
+            filed = await sweep_conflicts_to_proposals(ws)
+            if filed:
+                logger.info(
+                    "fabric_ingest: post-ingest conflict sweep filed %d stewardship "
+                    "proposal(s) for workspace %s",
+                    len(filed),
+                    ws,
+                )
+        except Exception:  # noqa: BLE001 — the conflict sweep is best-effort
+            logger.warning(
+                "fabric_ingest: post-ingest conflict sweep failed for workspace %s "
+                "(non-fatal)",
+                ws,
+                exc_info=True,
+            )
+
     return {"sources": len(sources), "ok": ok, "errors": errors}
 
 

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,26 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-07-10 (FST-6 — _fabric_conflict proposal type) — wired the
+#   conflict-stewardship gate kind into the FOUR-path dispatch.
+#   ``_fabric_conflict_blob`` + ``_assert_fabric_conflict_workspace`` are the
+#   peers of the existing blob accessors + tenancy guards. The blob
+#   (``Action.parameters._fabric_conflict``) carries the un-rankable Fabric
+#   conflict's subject (top-level ``workspace_id`` / ``object_id`` /
+#   ``property`` — immutable), the read-only ``choices`` (competing values +
+#   provenance), and the ONE editable sub-dict
+#   ``resolution.chosen_statement_id`` (defaults to the policy winner; the
+#   approve-with-edits path may re-point it at a staged rival). On APPROVE the
+#   router emits ``human.corrected`` then fires
+#   ``fabric_conflicts.executor.execute_approved_fabric_conflict`` (which
+#   validates the choice against the staged set and PINs it via the OSS
+#   steward verb ``FabricStore.pin_statement`` on the workspace-scoped store,
+#   and OWNS the chain close). On REJECT the router emits ``human.corrected``
+#   + ``decision.completed(rejected)`` itself (the executor never runs — NO
+#   statement changes; the policy's provisional winner stands). The
+#   ``_assert_fabric_conflict_workspace`` 403 runs in ALL FOUR locations
+#   (approve / bulk-approve / reject / bulk-reject) BEFORE any mutation. Same
+#   exactly-one-terminal discipline as the instinct-rule gate (the precedent
+#   this kind mirrors); the other 9 kinds are unchanged.
 # Updated: 2026-07-03 (feat/workspace-admin-tools, WA-2 — _admin_action proposal
 #   type) — added the 8th gated proposal kind: a gated workspace-admin write.
 #   ``_admin_action_blob`` + ``_assert_admin_action_workspace`` are the peers of
@@ -974,6 +995,47 @@ def _assert_instinct_rule_workspace(action: Any, current_workspace: str) -> None
         )
 
 
+def _fabric_conflict_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_fabric_conflict`` blob on an Action, or ``None``.
+
+    The blob is the conflict-stewardship payload ``ee.cloud.fabric_conflicts.
+    propose`` stores under ``Action.parameters._fabric_conflict`` (FST-6): the
+    un-rankable conflict's subject (``workspace_id`` / ``object_id`` /
+    ``property`` as SEPARATE top-level fields), the read-only ``choices``, and
+    the editable ``resolution.chosen_statement_id``. A peer gated proposal
+    kind — the approve path dispatches the apply-on-approve executor (which
+    PINs the chosen statement) on its presence, exactly as it dispatches the
+    instinct-rule executor on ``_instinct_rule``. Anything that is not a dict
+    is treated as "no fabric conflict".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_fabric_conflict")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_fabric_conflict_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting a conflict stewardship from another workspace.
+
+    Mirror of ``_assert_instinct_rule_workspace`` for the ``_fabric_conflict``
+    blob (FST-6). Approving pins a statement in the tenant's Fabric, so the
+    cross-workspace gate is mandatory on BOTH the approve and reject side
+    (asymmetric tenant scope is no tenant scope — pocketpaw#1183 / #1250).
+    Tenancy lives on the blob's top-level ``workspace_id`` (NEVER inside the
+    editable ``resolution``). A non-conflict Action (no blob) is unaffected.
+    """
+    blob = _fabric_conflict_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This fabric conflict belongs to a different workspace",
+        )
+
+
 def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
     """Reject approving a parked pocket write from another workspace.
 
@@ -1353,6 +1415,7 @@ async def bulk_approve_actions(
             _assert_fabric_objects_workspace(action, workspace_id)
             _assert_pocket_create_workspace(action, workspace_id)
             _assert_instinct_rule_workspace(action, workspace_id)
+            _assert_fabric_conflict_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
             _assert_admin_action_workspace(action, workspace_id)
@@ -1541,6 +1604,40 @@ async def bulk_approve_actions(
                 )
             continue
 
+        # FST-6 — a bulk-approved ``_fabric_conflict`` Action PINs its chosen
+        # statement (the staged default — bulk-approve has no edit surface, so
+        # disposition is always ``accepted`` and the choice is the policy
+        # winner). Mirrors the instinct-rule branch above: per-item
+        # ``human.corrected(accepted)``, the ``agent.proposed`` event id as
+        # causation, then the executor (which owns the chain close). Matched
+        # BEFORE the pocket-write fallthrough and ``continue``d so the kinds
+        # never cross.
+        fabric_conflict_blob = _fabric_conflict_blob(action)
+        if fabric_conflict_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=fabric_conflict_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(fabric_conflict_blob),
+            )
+            try:
+                from pocketpaw_ee.cloud.fabric_conflicts import (
+                    executor as fabric_conflict_executor,
+                )
+
+                await fabric_conflict_executor.execute_approved_fabric_conflict(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve fabric-conflict execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
         # MANDATES — a bulk-approved ``_belt_plan`` Action fires the plan
         # executor, exactly like the single-approve hook (disposition is always
         # ``accepted`` — bulk-approve has no edit surface). The executor owns
@@ -1708,6 +1805,7 @@ async def bulk_reject_actions(
             _assert_fabric_objects_workspace(action, workspace_id)
             _assert_pocket_create_workspace(action, workspace_id)
             _assert_instinct_rule_workspace(action, workspace_id)
+            _assert_fabric_conflict_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
             _assert_admin_action_workspace(action, workspace_id)
@@ -1874,6 +1972,32 @@ async def bulk_reject_actions(
             )
             continue
 
+        # FST-6 — a bulk-rejected ``_fabric_conflict`` Action closes its chain
+        # HERE (the executor never runs on reject — the router owns the close).
+        # NO statement changes: the policy's provisional winner stands. Mirrors
+        # the instinct-rule reject branch. Matched AFTER the earlier kinds and
+        # ``continue``d so the kinds never cross.
+        fabric_conflict_blob = _fabric_conflict_blob(action)
+        if fabric_conflict_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=fabric_conflict_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(fabric_conflict_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=fabric_conflict_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            continue
+
         # MANDATES — a bulk-rejected ``_belt_plan`` Action closes its chain
         # here (the plan executor never runs on reject), mirroring the
         # code-change branch above.
@@ -2014,6 +2138,11 @@ async def approve_action(
     # top-level fields, not a pocket. Approving it creates an active governed rule
     # in the tenant's workspace, so the cross-workspace gate is mandatory here.
     _assert_instinct_rule_workspace(before, workspace_id)
+    # FST-6 — same tenancy gate for a conflict-stewardship Action — its
+    # ``_fabric_conflict`` blob carries the workspace on a SEPARATE top-level
+    # field. Approving it PINs a statement in the tenant's Fabric, so the
+    # cross-workspace gate is mandatory here.
+    _assert_fabric_conflict_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -2306,6 +2435,38 @@ async def approve_action(
         except Exception:
             logger.exception("instinct-rule execution after approval failed (non-fatal)")
 
+    # FST-6 — when the approved Action carries a ``_fabric_conflict`` blob,
+    # PIN the chosen statement via the OSS steward verb (workspace-scoped
+    # Fabric store). Same best-effort, lazy-import, never-break-the-approve-
+    # response shape as the instinct-rule hook above; the executor records
+    # success / failure on the Action itself. The router owns the
+    # ``human.corrected`` emit (disposition ``edited`` when the approver
+    # adjusted the choice via the edit surface); the EXECUTOR owns the chain
+    # CLOSE — no ``decision.completed`` here, no double terminal.
+    fabric_conflict_blob = _fabric_conflict_blob(approved)
+    if fabric_conflict_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=fabric_conflict_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(fabric_conflict_blob),
+        )
+        try:
+            from pocketpaw_ee.cloud.fabric_conflicts import (
+                executor as fabric_conflict_executor,
+            )
+
+            await fabric_conflict_executor.execute_approved_fabric_conflict(
+                approved, human_event_id=human_event_id
+            )
+        except Exception:
+            logger.exception("fabric-conflict execution after approval failed (non-fatal)")
+
     # MANDATES — when the approved Action carries a ``_belt_plan`` blob (the
     # mandate foreman's shift plan), dispatch the plan executor. Same shape as
     # the code-change hook: the router owns the ``human.corrected`` emit, the
@@ -2489,6 +2650,11 @@ async def reject_action(
     # asymmetric tenant scope is no tenant scope: a cross-workspace reject must
     # 403 before any mutation, exactly like the approve side.
     _assert_instinct_rule_workspace(before, workspace_id)
+    # FST-6 — same tenancy gate for a conflict-stewardship Action on the REJECT
+    # side. Asymmetric tenant scope is no tenant scope: a cross-workspace reject
+    # (which would dismiss another tenant's conflict) must 403 before any
+    # mutation, exactly like the approve side.
+    _assert_fabric_conflict_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -2663,6 +2829,32 @@ async def reject_action(
         )
         _emit_decision_completed_rejected(
             blob=instinct_rule_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
+        )
+
+    # FST-6 — a rejected ``_fabric_conflict`` Action closes its chain HERE
+    # (the executor never runs on reject — the router owns the close,
+    # mirroring the instinct-rule reject path). NO statement changes: the
+    # policy's provisional winner simply stands, and the sweep's
+    # reject-memory (the blob's ``conflict_signature``) keeps the same
+    # conflict from being re-staged until it materially changes.
+    fabric_conflict_blob = _fabric_conflict_blob(action)
+    if fabric_conflict_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=fabric_conflict_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(fabric_conflict_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=fabric_conflict_blob,
             action=action,
             user_id=rejector_id,
             workspace_id=workspace_id,

--- a/src/pocketpaw/fabric/__init__.py
+++ b/src/pocketpaw/fabric/__init__.py
@@ -8,7 +8,12 @@
 # The legacy SQLite FabricStore still ships here for types + links; object lifecycle
 # + scope-filtered queries are the journal path. See ee/fabric/journal_store.py for
 # the rationale (Wave 3 / Org Architecture RFC, Phase 3; supersedes #938).
+# Updated: 2026-07-10 (FST-6 — conflict lifecycle) — exported the open-conflict
+# surface (ConflictRecord, detect_open_conflicts): the un-rankable残り the trust
+# ladder cannot order, recomputed from statements (no conflicts table). The EE
+# stewardship sweep and a future "disputed facts" view read it from here.
 
+from pocketpaw.fabric.conflicts import ConflictRecord, detect_open_conflicts
 from pocketpaw.fabric.events import (
     ACTION_OBJECT_ARCHIVED,
     ACTION_OBJECT_CREATED,
@@ -40,6 +45,9 @@ from pocketpaw.fabric.store import FabricStore
 __all__ = [
     # Legacy SQLite store — still the home for types + links.
     "FabricStore",
+    # Open-conflict surface (FST-6) — recomputed from statements.
+    "ConflictRecord",
+    "detect_open_conflicts",
     # Journal-backed object lifecycle (Wave 3).
     "FabricJournalStore",
     "FabricProjection",

--- a/src/pocketpaw/fabric/conflicts.py
+++ b/src/pocketpaw/fabric/conflicts.py
@@ -1,0 +1,172 @@
+# fabric/conflicts.py — the open-conflict surface for the lifecycle slice (FST-6).
+# Created: 2026-07-10 (feat/fst-6-stewardship) — recompute, don't persist.
+#
+# ``detect_open_conflicts(store)`` scans the tracked properties (only objects
+# WITH statements, via ``FabricStore.list_statement_keys``) and returns a
+# :class:`ConflictRecord` for every property whose CURRENT resolution is
+# ``unresolvable=True`` — the un-rankable残り the trust ladder cannot order
+# (same tier, same rank, both open validity, materially different values,
+# observed within the recency epsilon). Policy auto-resolves everything it CAN
+# rank; only these records ever reach a human.
+#
+# Design choices:
+#   * NO conflicts table. A conflict is recomputed from statements via the
+#     FST-2 resolver on every scan — the statements ARE the state, so a
+#     conflict "closes" the moment a steward verb (PIN/IGNORE), a curation
+#     verb (CHANGE/CORRECT), or a new higher-tier observation changes the
+#     resolution. Nothing to invalidate, nothing to drift.
+#   * ``rivals`` carries exactly the statements that TRIGGERED the
+#     un-rankable flag (the resolver's own condition, re-applied here via the
+#     resolver's private helpers — intra-package reuse, the same deliberate
+#     pattern store.py uses for ``_materially_different``). Lower-tier /
+#     closed / same-value losers are policy-ranked history, not choices a
+#     human needs to arbitrate.
+#   * The dedupe key is ``(workspace_id, object_id, property)`` — the EE
+#     stewardship glue uses it to guarantee ONE open Instinct proposal per
+#     conflicted property across re-sweeps. ``workspace_id`` on the record is
+#     the CALLER'S scope (the tenancy the proposal will be filed under), not
+#     any individual statement's stamp — legacy NULL-stamped statements are
+#     visible inside a workspace scope and must dedupe under it.
+#
+# Pure read path: this module never writes. The steward verbs that ANSWER a
+# conflict live on the store (pin/unpin/ignore, FST-6) next to their FST-5
+# siblings (change/correct).
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from pocketpaw.fabric.models import FabricObject, Statement
+from pocketpaw.fabric.resolver import _materially_different, _tier, resolve
+from pocketpaw.fabric.trust import TrustRules, default_trust_rules
+
+if TYPE_CHECKING:
+    from pocketpaw.fabric.store import FabricStore
+
+
+class ConflictRecord(BaseModel):
+    """One un-rankable conflict: a property the trust ladder cannot order.
+
+    ``winner`` is the resolver's PROVISIONAL winner (reads never block —
+    FST-2 always returns one); ``rivals`` are the open-validity, same-tier,
+    same-rank, materially-different, within-epsilon contenders that made the
+    resolution un-rankable. Together they are the CHOICES a steward
+    arbitrates between. ``workspace_id`` is the detection scope (see the
+    module header), part of the dedupe key.
+    """
+
+    object_id: str
+    object_type: str = ""  # the object's type_name; "" when unknown
+    property: str
+    workspace_id: str | None = None
+    winner: Statement
+    rivals: list[Statement] = Field(default_factory=list)
+
+    @property
+    def dedupe_key(self) -> tuple[str | None, str, str]:
+        """``(workspace_id, object_id, property)`` — one open proposal per key.
+
+        The EE stewardship sweep compares these tuples against the open
+        Instinct proposals' blobs so re-sweeps never file a duplicate while
+        one is open.
+        """
+        return (self.workspace_id, self.object_id, self.property)
+
+    @property
+    def signature(self) -> list[str]:
+        """Sorted ids of the competing statements (winner + rivals).
+
+        Two scans of the SAME unresolved conflict produce the same
+        signature; a new rival observation (or a steward/curation verb)
+        changes it. The EE sweep uses it as reject-memory: a human's
+        explicit "keep the policy winner" (reject) stands until the conflict
+        materially changes shape.
+        """
+        return sorted([self.winner.id] + [r.id for r in self.rivals])
+
+
+def _unrankable_rivals(
+    winner: Statement,
+    losers: list[Statement],
+    rules: TrustRules,
+    object_type: str | None,
+) -> list[Statement]:
+    """The losers that triggered ``unresolvable`` — the resolver's own
+    condition (same tier, same rank, both open validity, materially
+    different, observed within the recency epsilon), re-applied to name the
+    contenders. Preserves the losers' best-to-worst order."""
+    ladder = rules.ladder_for(object_type, winner.property)
+    top_tier = _tier(winner.writer_class, ladder)
+    epsilon = rules.recency_epsilon_seconds
+    return [
+        s
+        for s in losers
+        if _tier(s.writer_class, ladder) == top_tier
+        and s.rank == winner.rank
+        and s.valid_to is None
+        and _materially_different(s.value, winner.value)
+        and abs((winner.observed_at - s.observed_at).total_seconds()) <= epsilon
+    ]
+
+
+async def detect_open_conflicts(
+    store: FabricStore,
+    *,
+    workspace_id: str | None = None,
+    object_id: str | None = None,
+    rules: TrustRules | None = None,
+) -> list[ConflictRecord]:
+    """Scan tracked properties and return the currently un-rankable conflicts.
+
+    Recomputes from statements via :func:`resolve` — no persisted conflict
+    state (see the module header). Only (object, property) pairs that HAVE
+    statements are visited, so the scan is cheap relative to the fabric.
+    Disputes the ladder CAN rank (``is_disputed`` without ``unresolvable``)
+    are excluded by design: policy already answered them. Pinned properties
+    never appear (a pin is authoritative — the pinned path is never
+    un-rankable).
+
+    ``workspace_id`` applies the standard W4a read scope to every underlying
+    read and stamps the returned records (the dedupe-key tenancy);
+    ``object_id`` narrows the scan to one object; ``rules`` overrides the
+    trust rules (default: :func:`default_trust_rules`, the same set the
+    store's shadow/enforce paths resolve with). Deterministic order:
+    ``(object_id, property)``.
+    """
+    effective_rules = rules if rules is not None else default_trust_rules()
+    keys = await store.list_statement_keys(workspace_id=workspace_id, object_id=object_id)
+
+    records: list[ConflictRecord] = []
+    object_cache: dict[str, FabricObject | None] = {}
+    for obj_id, prop in keys:
+        if obj_id not in object_cache:
+            object_cache[obj_id] = await store.get_object(obj_id, workspace_id=workspace_id)
+        obj = object_cache[obj_id]
+        if obj is None:
+            # Statements for an object outside the caller's scope (or a
+            # deleted object) are not this scope's conflict to arbitrate.
+            continue
+
+        object_type = obj.type_name or ""
+        statements = await store.get_statements(obj_id, prop, workspace_id=workspace_id)
+        resolution = resolve(statements, effective_rules, object_type=object_type or None)
+        if not resolution.unresolvable or resolution.winner_statement is None:
+            continue
+        winner = resolution.winner_statement
+        rivals = _unrankable_rivals(winner, resolution.losers, effective_rules, object_type or None)
+        records.append(
+            ConflictRecord(
+                object_id=obj_id,
+                object_type=object_type,
+                property=prop,
+                workspace_id=workspace_id,
+                winner=winner,
+                rivals=rivals,
+            )
+        )
+    return records
+
+
+__all__ = ["ConflictRecord", "detect_open_conflicts"]

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -251,6 +251,38 @@
 #   Site-3 note: the EE mirror's update path goes through update_object, so
 #   enforce flows through automatically (proven in
 #   tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py).
+# Updated: 2026-07-10 (FST-6 — the conflict lifecycle: PIN / IGNORE steward
+#   verbs) — four changes; 'off' and 'shadow' cache behavior is untouched:
+#   1. pin_statement() / unpin_statement() / ignore_statement(): the steward
+#      verbs (siblings of change/correct — the operations FST-6's Instinct
+#      stewardship executor calls). PIN sets ``pinned=True`` on ONE existing,
+#      non-deprecated statement (the resolver's pinned short-circuit then
+#      makes it win outright — the durable "this one wins"); UNPIN retracts
+#      the flag; IGNORE deprecates the statement with rank_reason=<reason>
+#      (struck from resolution entirely — the steward's "this claim is
+#      bogus"). All three return the NEW Resolution and are mode-respecting
+#      on the cache exactly like CHANGE/CORRECT (enforce writes the new
+#      resolver winner; shadow/off leave the cache alone). PIN does NOT
+#      auto-unpin other pins: two pins on one property is a curation conflict
+#      the resolver deliberately flags as disputed. No auto-promotion here —
+#      the verbs target an EXISTING statement id, so an untracked property
+#      (no statements) has nothing to pin/ignore.
+#   2. The FST-5 "ONLY two writes" doctrine widens to THREE narrow curation
+#      UPDATEs on statement rows: valid_to (CHANGE), rank+rank_reason
+#      (CORRECT / IGNORE), and now pinned (PIN/UNPIN via
+#      _set_statement_pinned). Value and provenance columns are still never
+#      rewritten.
+#   3. list_statement_keys() + get_source(): two small read helpers.
+#      list_statement_keys returns the DISTINCT (object_id, property) pairs
+#      that HAVE statements (W4a-scoped) — the cheap scan surface
+#      fabric/conflicts.py recomputes open conflicts from (only objects WITH
+#      statements are ever visited; the statements ARE the conflict state, no
+#      conflicts table). get_source reads one SourceRef by id so the EE
+#      stewardship proposal can show a human WHERE each competing value came
+#      from.
+#   4. The enforce cache write is factored into _write_winner_to_cache()
+#      (byte-identical behavior) so _curate_property and the steward verbs
+#      share ONE definition of "the resolver owns the cache".
 
 
 from __future__ import annotations
@@ -1714,27 +1746,209 @@ class FabricStore:
             refreshed, default_trust_rules(), object_type=existing.type_name or None
         )
 
-        if mode == "enforce" and resolution.winner_statement is not None:
-            # The resolver owns the cache in enforce (FST-5): one targeted
-            # write of the property's new winner, merged onto the FRESH cache
-            # state so concurrent-property updates aren't clobbered.
-            fresh = await self.get_object(object_id, workspace_id=workspace_id)
-            base = fresh.properties if fresh is not None else existing.properties
-            merged = {**base, property: resolution.value}
-            ws_cond, ws_params = _workspace_scope(workspace_id)
-            sql = (
-                "UPDATE fabric_objects SET properties = ?,"
-                " updated_at = datetime('now') WHERE id = ?"
+        if mode == "enforce":
+            await self._write_winner_to_cache(
+                object_id, property, resolution, workspace_id=workspace_id, existing=existing
             )
-            params: list[Any] = [json.dumps(merged), object_id]
-            if ws_cond:
-                sql += f" AND {ws_cond}"
-                params.extend(ws_params)
-            async with self._conn() as db:
-                await db.execute(sql, params)
-                await db.commit()
 
         return resolution
+
+    async def _write_winner_to_cache(
+        self,
+        object_id: str,
+        property: str,
+        resolution: Resolution,
+        *,
+        workspace_id: str | None,
+        existing: FabricObject,
+    ) -> None:
+        """Write one property's resolver winner into the flat cache (enforce).
+
+        The resolver owns the cache in enforce (FST-5): one targeted write of
+        the property's new winner, merged onto the FRESH cache state so
+        concurrent-property updates aren't clobbered. A Resolution with no
+        winner (e.g. every statement deprecated) writes NOTHING — the cache
+        keeps its last value rather than losing the key. Shared by the
+        curation verbs (CHANGE/CORRECT) and the steward verbs
+        (PIN/UNPIN/IGNORE); callers gate on mode — this helper never reads it.
+        """
+        if resolution.winner_statement is None:
+            return
+        fresh = await self.get_object(object_id, workspace_id=workspace_id)
+        base = fresh.properties if fresh is not None else existing.properties
+        merged = {**base, property: resolution.value}
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "UPDATE fabric_objects SET properties = ?, updated_at = datetime('now') WHERE id = ?"
+        params: list[Any] = [json.dumps(merged), object_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        async with self._conn() as db:
+            await db.execute(sql, params)
+            await db.commit()
+
+    async def pin_statement(
+        self,
+        object_id: str,
+        property: str,
+        statement_id: str,
+        *,
+        workspace_id: str | None = None,
+    ) -> Resolution:
+        """PIN one statement: the durable steward "this one wins" (FST-6).
+
+        Sets ``pinned=True`` on the identified statement. The resolver's
+        pinned short-circuit (FST-2) then makes it win outright — above every
+        ladder tier, immune to newer rival observations — which is why the
+        conflict-lifecycle executor maps an approved stewardship choice to
+        PIN rather than IGNORE-the-rival: a pin also settles FUTURE rivals,
+        and the losing statements stay intact for audit.
+
+        The statement must exist for exactly this ``(object_id, property)``
+        (within the caller's workspace scope) and must be non-deprecated —
+        a deprecated statement never reaches resolution, so pinning it would
+        be a silent no-op lie; both violations raise ``ValueError``. Pinning
+        an already-pinned statement is idempotent. PIN does NOT auto-unpin
+        other pins: multiple pins are a curation conflict the resolver
+        deliberately surfaces as ``is_disputed``.
+
+        Returns the NEW :class:`Resolution`. Cache behavior is
+        mode-respecting like the FST-5 verbs: enforce writes the new resolver
+        winner into the flat properties dict; shadow/off leave the cache
+        alone.
+        """
+        return await self._steward_statement(
+            object_id, property, statement_id, verb="pin", reason=None, workspace_id=workspace_id
+        )
+
+    async def unpin_statement(
+        self,
+        object_id: str,
+        property: str,
+        statement_id: str,
+        *,
+        workspace_id: str | None = None,
+    ) -> Resolution:
+        """UNPIN one statement: retract a steward pin (FST-6).
+
+        Sets ``pinned=False``; resolution falls back to the trust ladder.
+        The statement must exist for exactly this ``(object_id, property)``
+        (ValueError otherwise). Unpinning a statement that isn't pinned is
+        idempotent, and rank is not checked — retracting a flag is always a
+        safe act. Returns the NEW :class:`Resolution`; cache behavior is
+        mode-respecting (see :meth:`pin_statement`).
+        """
+        return await self._steward_statement(
+            object_id, property, statement_id, verb="unpin", reason=None, workspace_id=workspace_id
+        )
+
+    async def ignore_statement(
+        self,
+        object_id: str,
+        property: str,
+        statement_id: str,
+        *,
+        reason: str = "steward_ignored",
+        workspace_id: str | None = None,
+    ) -> Resolution:
+        """IGNORE one statement: the steward's "this claim is bogus" (FST-6).
+
+        Deprecates the identified statement with ``rank_reason=reason`` —
+        the same narrow curation write CORRECT applies to a wrong winner,
+        but aimed at ANY statement (typically a losing rival) and without
+        appending a replacement value. A deprecated statement never wins,
+        never loses, never disputes: it is struck from resolution entirely
+        while remaining in the table for audit.
+
+        The statement must exist for exactly this ``(object_id, property)``
+        (within the caller's workspace scope) — ValueError otherwise.
+        Ignoring an already-deprecated statement just refreshes the reason.
+        Returns the NEW :class:`Resolution`; cache behavior is
+        mode-respecting (see :meth:`pin_statement`). Note: deprecating the
+        ONLY live statement leaves a winner-less Resolution and the cache
+        untouched — reads never lose a value to a steward strike.
+        """
+        return await self._steward_statement(
+            object_id,
+            property,
+            statement_id,
+            verb="ignore",
+            reason=reason,
+            workspace_id=workspace_id,
+        )
+
+    async def _steward_statement(
+        self,
+        object_id: str,
+        property: str,
+        statement_id: str,
+        *,
+        verb: str,
+        reason: str | None,
+        workspace_id: str | None,
+    ) -> Resolution:
+        """Shared core of :meth:`pin_statement` / :meth:`unpin_statement` /
+        :meth:`ignore_statement`.
+
+        Unlike ``_curate_property`` there is NO auto-promotion: the steward
+        verbs target an EXISTING statement id, and an untracked property has
+        no statements to target. Raises ``ValueError`` when the object or the
+        statement doesn't exist (or is outside the caller's workspace scope),
+        or when PIN targets a deprecated statement — the FST-6 executor needs
+        clean failures, not silent no-ops.
+        """
+        mode = _source_truth_mode()  # read ONCE; decides only the cache write
+        existing = await self.get_object(object_id, workspace_id=workspace_id)
+        if existing is None:
+            raise ValueError(f"fabric object not found: {object_id!r}")
+
+        stmts = await self.get_statements(object_id, property, workspace_id=workspace_id)
+        target = next((s for s in stmts if s.id == statement_id), None)
+        if target is None:
+            raise ValueError(
+                f"statement {statement_id!r} not found for"
+                f" ({object_id!r}, {property!r}) in the caller's workspace scope"
+            )
+
+        if verb == "pin":
+            if target.rank == "deprecated":
+                raise ValueError(
+                    f"cannot pin deprecated statement {statement_id!r} — a deprecated"
+                    " statement never reaches resolution; un-ignore it via a new"
+                    " curation write first"
+                )
+            await self._set_statement_pinned(statement_id, True)
+        elif verb == "unpin":
+            await self._set_statement_pinned(statement_id, False)
+        else:  # ignore
+            await self._deprecate_statement(statement_id, reason)
+
+        refreshed = await self.get_statements(object_id, property, workspace_id=workspace_id)
+        resolution = resolve(
+            refreshed, default_trust_rules(), object_type=existing.type_name or None
+        )
+
+        if mode == "enforce":
+            await self._write_winner_to_cache(
+                object_id, property, resolution, workspace_id=workspace_id, existing=existing
+            )
+
+        return resolution
+
+    async def _set_statement_pinned(self, statement_id: str, pinned: bool) -> None:
+        """Set the ``pinned`` flag on one statement (the PIN/UNPIN verbs).
+
+        The THIRD narrow curation write permitted on statement rows (see the
+        FST-6 module-header note; valid_to and rank/rank_reason are the other
+        two). Value/provenance columns are never rewritten.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE fabric_statements SET pinned = ? WHERE id = ?",
+                (1 if pinned else 0, statement_id),
+            )
+            await db.commit()
 
     async def _close_statement_validity(self, statement_id: str, closed_at: datetime) -> None:
         """Set ``valid_to`` on one statement (the CHANGE verb's close).
@@ -2064,6 +2278,64 @@ class FabricStore:
             async with db.execute(sql, params) as cur:
                 rows = await cur.fetchall()
         return [self._row_to_statement(r) for r in rows]
+
+    async def list_statement_keys(
+        self,
+        *,
+        workspace_id: str | None = None,
+        object_id: str | None = None,
+    ) -> list[tuple[str, str]]:
+        """DISTINCT ``(object_id, property)`` pairs that HAVE statements (FST-6).
+
+        The cheap scan surface the conflict lifecycle recomputes open
+        conflicts from: only objects WITH statements (the opted-in / promoted
+        minority) are ever visited, so the scan cost tracks the tracked set,
+        not the whole fabric. ``workspace_id`` applies the standard W4a read
+        scope (own rows + legacy NULL); ``object_id`` narrows to one object.
+        Ordered by ``(object_id, property)`` for a deterministic walk.
+        """
+        conditions: list[str] = []
+        params: list[Any] = []
+        if object_id is not None:
+            conditions.append("object_id = ?")
+            params.append(object_id)
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        if ws_cond:
+            conditions.append(ws_cond)
+            params.extend(ws_params)
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        sql = (
+            "SELECT DISTINCT object_id, property FROM fabric_statements"
+            f"{where} ORDER BY object_id, property"
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(sql, params) as cur:
+                rows = await cur.fetchall()
+        return [(str(r[0]), str(r[1])) for r in rows]
+
+    async def get_source(
+        self, source_ref_id: str, workspace_id: str | None = None
+    ) -> SourceRef | None:
+        """Read one SourceRef by id (FST-6).
+
+        The provenance lookup behind the stewardship proposal payload: a
+        human arbitrating a conflict sees WHERE each competing value came
+        from (connector run / document / actor / session). ``workspace_id``
+        applies the standard W4a read scope (own rows + legacy NULL).
+        """
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "SELECT * FROM fabric_sources WHERE id = ?"
+        params: list[Any] = [source_ref_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(sql, params) as cur:
+                row = await cur.fetchone()
+        return self._row_to_source(row) if row else None
 
     async def get_linked_objects(
         self, obj_id: str, link_type: str | None = None, workspace_id: str | None = None

--- a/tests/cloud/fabric_conflicts/__init__.py
+++ b/tests/cloud/fabric_conflicts/__init__.py
@@ -1,0 +1,1 @@
+# tests/cloud/fabric_conflicts/__init__.py — FST-6 conflict-stewardship gate tests.

--- a/tests/cloud/fabric_conflicts/test_fabric_conflict_gate.py
+++ b/tests/cloud/fabric_conflicts/test_fabric_conflict_gate.py
@@ -1,0 +1,461 @@
+# tests/cloud/fabric_conflicts/test_fabric_conflict_gate.py
+# Created: 2026-07-10 (FST-6 — the _fabric_conflict stewardship gate).
+#
+# Covers the sweep + propose + apply-on-approve executor for the conflict
+# lifecycle: un-rankable Fabric conflicts become Instinct stewardship
+# proposals a human arbitrates; approve PINs the chosen statement, reject
+# keeps the policy winner. Clones the discipline of
+# ``tests/ee/test_instinct_rule_propose.py`` (the precedent module — isolated
+# stores via the lazy ``pocketpaw.stores`` seams). Asserts:
+#
+#   * an un-rankable conflict yields exactly ONE proposal with the EXACT blob
+#     shape (tenancy + subject as SEPARATE top-level fields, editable
+#     ``resolution`` defaulting to the policy winner, choices with provenance);
+#   * re-sweep files NO duplicate while one is open (one open proposal per
+#     ``(workspace_id, object_id, property)`` dedupe key);
+#   * mode off → the sweep is inert (shadow AND enforce both sweep);
+#   * approve (default choice) → the executor PINs the policy winner and the
+#     cache reflects it in enforce; the answered conflict stops re-sweeping;
+#   * approve with an EDITED choice → the rival gets pinned instead;
+#   * reject → NO statement changes (the policy winner stands) and the
+#     reject-memory (conflict_signature) stops the same conflict from
+#     re-staging until a new rival changes its shape;
+#   * the volume guard warns past 5 open stewardship proposals;
+#   * tenant scoping: another workspace's sweep never sees the conflict;
+#   * schema mismatch / unstaged choice → terminal FAILED, NO pin;
+#   * idempotent re-execute → no double run, exactly ONE chain close.
+#
+# Run with:
+#   uv run pytest tests/cloud/fabric_conflicts/ -q
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.fabric_conflicts import (  # noqa: E402
+    FABRIC_CONFLICT_KIND,
+    FABRIC_CONFLICT_PARAM_KEY,
+    FABRIC_CONFLICT_SCHEMA,
+    STEWARDSHIP_QUEUE_WARN_THRESHOLD,
+    execute_approved_fabric_conflict,
+    sweep_conflicts_to_proposals,
+)
+
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+WS = "w1"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — isolated Fabric + Instinct stores via the lazy store seams,
+# cloned from the instinct-rule precedent tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    monkeypatch.setenv("AUTH_SECRET", "fabric-conflict-gate-test-secret")
+
+
+@pytest.fixture
+def fabric(tmp_path: Path, monkeypatch) -> FabricStore:
+    st = FabricStore(tmp_path / "fabric_conflict_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda *a, **k: st)
+    return st
+
+
+@pytest.fixture
+def instinct(tmp_path: Path, monkeypatch) -> InstinctStore:
+    st = InstinctStore(tmp_path / "instinct_conflict_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    return st
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    """The suite-wide FST mode seam — the gate reads it through the OSS
+    chokepoint (late-bound), so this patch governs sweep + verbs alike."""
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+async def _conflicted_object(
+    fabric: FabricStore,
+    *,
+    workspace_id: str = WS,
+    properties: tuple[str, ...] = ("arr",),
+) -> tuple[str, dict[str, tuple[str, str]]]:
+    """One Customer whose ``properties`` each carry an un-rankable pair:
+    two connector-tier, normal-rank, open, materially different statements
+    observed within the epsilon. Returns (object_id, {property:
+    (winner_stmt_id, rival_stmt_id)}) — the newer observation (value 120)
+    provisionally wins over the rival (value 200)."""
+    obj_type = await fabric.define_type(name="Customer", properties=[])
+    obj = await fabric.create_object(
+        obj_type.id, {p: 0 for p in properties}, source_connector="crm", source_id="c-1"
+    )
+    now = datetime.now()
+    src_a = await fabric.upsert_source(
+        "connector_run", connector="crm", run_id="r1", workspace_id=workspace_id
+    )
+    src_b = await fabric.upsert_source(
+        "connector_run", connector="billing", run_id="r9", workspace_id=workspace_id
+    )
+    pairs: dict[str, tuple[str, str]] = {}
+    for prop in properties:
+        rival = await fabric.append_statement(
+            obj.id,
+            prop,
+            200,
+            src_b.id,
+            "connector",
+            observed_at=now - timedelta(hours=1),
+            workspace_id=workspace_id,
+        )
+        winner = await fabric.append_statement(
+            obj.id, prop, 120, src_a.id, "connector", observed_at=now, workspace_id=workspace_id
+        )
+        pairs[prop] = (winner.id, rival.id)
+    return obj.id, pairs
+
+
+async def _pending_conflict_actions(instinct: InstinctStore, workspace_id: str = WS) -> list[Any]:
+    actions = await instinct.list_actions(
+        pocket_id=workspace_id,
+        status=ActionStatus.PENDING,
+        workspace_id=workspace_id,
+        limit=500,
+    )
+    return [a for a in actions if FABRIC_CONFLICT_PARAM_KEY in (a.parameters or {})]
+
+
+# ---------------------------------------------------------------------------
+# Sweep: exactly ONE proposal, exact blob shape.
+# ---------------------------------------------------------------------------
+
+
+async def test_sweep_files_exactly_one_proposal_with_exact_blob_shape(
+    fabric, instinct, monkeypatch
+):
+    obj_id, pairs = await _conflicted_object(fabric)
+    winner_id, rival_id = pairs["arr"]
+    _set_mode(monkeypatch, "shadow")
+
+    filed = await sweep_conflicts_to_proposals(WS)
+
+    assert len(filed) == 1
+    action = await instinct.get_action(filed[0])
+    assert action.status == ActionStatus.PENDING
+    assert str(action.pocket_id) == WS  # workspace anchoring
+
+    blob = action.parameters[FABRIC_CONFLICT_PARAM_KEY]
+
+    # EXACT key set — no stray keys.
+    assert set(blob.keys()) == {
+        "kind",
+        "schema",
+        "workspace_id",
+        "object_id",
+        "property",
+        "object_type",
+        "choices",
+        "policy_winner_statement_id",
+        "conflict_signature",
+        "resolution",
+        "summary",
+        "correlation_id",
+        "proposed_event_id",
+    }
+    assert blob["kind"] == FABRIC_CONFLICT_KIND == "fabric_conflict"
+    assert blob["schema"] == FABRIC_CONFLICT_SCHEMA == 1
+
+    # Tenancy + subject ride as SEPARATE top-level fields — NOT inside the
+    # editable ``resolution`` (so an edit can't re-scope or re-target the pin).
+    assert blob["workspace_id"] == WS
+    assert blob["object_id"] == obj_id
+    assert blob["property"] == "arr"
+    assert blob["object_type"] == "Customer"
+    assert set(blob["resolution"].keys()) == {"chosen_statement_id"}
+
+    # The editable choice defaults to the policy's provisional winner.
+    assert blob["resolution"]["chosen_statement_id"] == winner_id
+    assert blob["policy_winner_statement_id"] == winner_id
+    assert blob["conflict_signature"] == sorted([winner_id, rival_id])
+
+    # Choices: the winner first, then the rival — each with value +
+    # provenance (writer_class, observed_at, and the SourceRef identity).
+    assert [c["statement_id"] for c in blob["choices"]] == [winner_id, rival_id]
+    by_id = {c["statement_id"]: c for c in blob["choices"]}
+    assert by_id[winner_id]["value"] == 120
+    assert by_id[rival_id]["value"] == 200
+    assert by_id[winner_id]["writer_class"] == "connector"
+    assert by_id[winner_id]["source"]["connector"] == "crm"
+    assert by_id[rival_id]["source"]["connector"] == "billing"
+    assert by_id[winner_id]["observed_at"]
+
+    # Chain fields: correlation minted at propose; proposed_event_id is the
+    # best-effort back-write (present either way).
+    assert blob["correlation_id"]
+    assert "proposed_event_id" in blob
+
+
+async def test_resweep_does_not_duplicate_while_open(fabric, instinct, monkeypatch):
+    await _conflicted_object(fabric)
+    _set_mode(monkeypatch, "shadow")
+
+    first = await sweep_conflicts_to_proposals(WS)
+    second = await sweep_conflicts_to_proposals(WS)
+
+    assert len(first) == 1
+    assert second == []  # one open proposal per dedupe key
+    assert len(await _pending_conflict_actions(instinct)) == 1
+
+
+@pytest.mark.parametrize("mode", ["off", "shadow", "enforce"])
+async def test_mode_gate(fabric, instinct, monkeypatch, mode):
+    """Off → inert (zero proposals). Shadow AND enforce both sweep — a
+    queued conflict in shadow is observation with a human answer."""
+    await _conflicted_object(fabric)
+    _set_mode(monkeypatch, mode)
+
+    filed = await sweep_conflicts_to_proposals(WS)
+
+    if mode == "off":
+        assert filed == []
+        assert await _pending_conflict_actions(instinct) == []
+    else:
+        assert len(filed) == 1
+
+
+# ---------------------------------------------------------------------------
+# Approve — the choice → PIN mapping.
+# ---------------------------------------------------------------------------
+
+
+async def test_approve_default_choice_pins_policy_winner_and_enforce_cache(
+    fabric, instinct, monkeypatch
+):
+    obj_id, pairs = await _conflicted_object(fabric)
+    winner_id, _ = pairs["arr"]
+    _set_mode(monkeypatch, "enforce")
+
+    filed = await sweep_conflicts_to_proposals(WS)
+    approved = await instinct.approve(filed[0], approver="steward-1")
+    await execute_approved_fabric_conflict(approved)
+
+    final = await instinct.get_action(filed[0])
+    assert final.status == ActionStatus.EXECUTED, final.error
+
+    # The policy winner is now PINNED — the durable "this one wins".
+    stmts = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+    pinned = [s for s in stmts if s.pinned]
+    assert [s.id for s in pinned] == [winner_id]
+
+    # Enforce: the cache reflects the pinned winner.
+    obj = await fabric.get_object(obj_id, workspace_id=WS)
+    assert obj is not None and obj.properties["arr"] == 120
+
+    # The structured outcome was back-written onto the blob.
+    outcome = final.parameters[FABRIC_CONFLICT_PARAM_KEY]["outcome"]
+    assert outcome["status"] == "executed"
+    assert outcome["pinned_statement_id"] == winner_id
+    assert outcome["value"] == 120
+
+    # The answered conflict is CLOSED — a re-sweep stages nothing (the
+    # pinned path is never un-rankable).
+    assert await sweep_conflicts_to_proposals(WS) == []
+
+
+async def test_approve_with_edited_choice_pins_the_rival(fabric, instinct, monkeypatch):
+    obj_id, pairs = await _conflicted_object(fabric)
+    _, rival_id = pairs["arr"]
+    _set_mode(monkeypatch, "enforce")
+
+    filed = await sweep_conflicts_to_proposals(WS)
+    approved = await instinct.approve(filed[0], approver="steward-1")
+    # Simulate the approve-with-edits path (ApproveRequest.parameters): the
+    # human re-points the editable choice at the staged rival. Same in-memory
+    # mutation pattern the instinct-rule precedent tests use.
+    approved.parameters[FABRIC_CONFLICT_PARAM_KEY]["resolution"] = {"chosen_statement_id": rival_id}
+    await execute_approved_fabric_conflict(approved)
+
+    final = await instinct.get_action(filed[0])
+    assert final.status == ActionStatus.EXECUTED, final.error
+
+    stmts = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+    pinned = [s for s in stmts if s.pinned]
+    assert [s.id for s in pinned] == [rival_id]
+
+    # Enforce: the cache flips to the human's chosen value.
+    obj = await fabric.get_object(obj_id, workspace_id=WS)
+    assert obj is not None and obj.properties["arr"] == 200
+
+
+# ---------------------------------------------------------------------------
+# Reject — the policy winner stands; reject-memory stops the nag.
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_keeps_policy_winner_and_resweep_respects_reject_memory(
+    fabric, instinct, monkeypatch
+):
+    obj_id, pairs = await _conflicted_object(fabric)
+    _set_mode(monkeypatch, "shadow")
+
+    filed = await sweep_conflicts_to_proposals(WS)
+    before = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+
+    await instinct.reject(filed[0], reason="policy pick is fine", rejector="steward-1")
+    # The executor NEVER runs on reject (router owns the close): no pins, no
+    # deprecations, no validity changes — the policy winner simply stands.
+    after = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+    assert [(s.id, s.pinned, s.rank, s.valid_to) for s in after] == [
+        (s.id, s.pinned, s.rank, s.valid_to) for s in before
+    ]
+
+    # Reject-memory: the SAME conflict (same signature) is not re-staged —
+    # the human already answered "keep the policy winner".
+    assert await sweep_conflicts_to_proposals(WS) == []
+
+    # A NEW rival changes the conflict's signature → it re-stages.
+    src = await fabric.upsert_source(
+        "connector_run", connector="erp", run_id="r22", workspace_id=WS
+    )
+    await fabric.append_statement(
+        obj_id, "arr", 300, src.id, "connector", observed_at=datetime.now(), workspace_id=WS
+    )
+    refiled = await sweep_conflicts_to_proposals(WS)
+    assert len(refiled) == 1
+    blob = (await instinct.get_action(refiled[0])).parameters[FABRIC_CONFLICT_PARAM_KEY]
+    assert len(blob["choices"]) == 3  # the reshaped conflict carries all three
+
+
+# ---------------------------------------------------------------------------
+# Volume guard — the PRD queue-volume metric.
+# ---------------------------------------------------------------------------
+
+
+async def test_volume_guard_warns_past_threshold(fabric, instinct, monkeypatch, caplog):
+    properties = tuple(f"kpi_{i}" for i in range(STEWARDSHIP_QUEUE_WARN_THRESHOLD + 1))
+    await _conflicted_object(fabric, properties=properties)
+    _set_mode(monkeypatch, "shadow")
+
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.fabric_conflicts.propose"):
+        filed = await sweep_conflicts_to_proposals(WS)
+
+    assert len(filed) == STEWARDSHIP_QUEUE_WARN_THRESHOLD + 1
+    warnings = [r for r in caplog.records if "stewardship queue" in r.getMessage()]
+    assert len(warnings) == 1
+    assert f"has {STEWARDSHIP_QUEUE_WARN_THRESHOLD + 1} open" in warnings[0].getMessage()
+
+
+async def test_volume_guard_quiet_at_threshold(fabric, instinct, monkeypatch, caplog):
+    properties = tuple(f"kpi_{i}" for i in range(STEWARDSHIP_QUEUE_WARN_THRESHOLD))
+    await _conflicted_object(fabric, properties=properties)
+    _set_mode(monkeypatch, "shadow")
+
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.fabric_conflicts.propose"):
+        filed = await sweep_conflicts_to_proposals(WS)
+
+    assert len(filed) == STEWARDSHIP_QUEUE_WARN_THRESHOLD
+    assert [r for r in caplog.records if "stewardship queue" in r.getMessage()] == []
+
+
+# ---------------------------------------------------------------------------
+# Tenancy — another workspace never sees the conflict.
+# ---------------------------------------------------------------------------
+
+
+async def test_tenant_scoping_respected(fabric, instinct, monkeypatch):
+    await _conflicted_object(fabric, workspace_id="w1")
+    _set_mode(monkeypatch, "shadow")
+
+    # w2's sweep: the W4a scope hides w1's statements — nothing to stage.
+    assert await sweep_conflicts_to_proposals("w2") == []
+    assert await _pending_conflict_actions(instinct, "w2") == []
+
+    # w1's own sweep stages it, stamped with w1's tenancy.
+    filed = await sweep_conflicts_to_proposals("w1")
+    assert len(filed) == 1
+    blob = (await instinct.get_action(filed[0])).parameters[FABRIC_CONFLICT_PARAM_KEY]
+    assert blob["workspace_id"] == "w1"
+
+
+# ---------------------------------------------------------------------------
+# Executor guards — fail clean, never pin on a bad blob.
+# ---------------------------------------------------------------------------
+
+
+async def test_schema_mismatch_fails_terminal_no_pin(fabric, instinct, monkeypatch):
+    obj_id, _ = await _conflicted_object(fabric)
+    _set_mode(monkeypatch, "shadow")
+    filed = await sweep_conflicts_to_proposals(WS)
+
+    approved = await instinct.approve(filed[0], approver="steward-1")
+    approved.parameters[FABRIC_CONFLICT_PARAM_KEY]["schema"] = 2
+    await execute_approved_fabric_conflict(approved)
+
+    final = await instinct.get_action(filed[0])
+    assert final.status == ActionStatus.FAILED, final.error
+    assert "schema mismatch" in (final.error or "").lower()
+    stmts = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+    assert not any(s.pinned for s in stmts)
+
+
+async def test_unstaged_choice_fails_terminal_no_pin(fabric, instinct, monkeypatch):
+    """An edit cannot smuggle in an arbitrary statement id — the executor
+    validates the chosen id against the STAGED choices."""
+    obj_id, _ = await _conflicted_object(fabric)
+    _set_mode(monkeypatch, "shadow")
+    filed = await sweep_conflicts_to_proposals(WS)
+
+    approved = await instinct.approve(filed[0], approver="steward-1")
+    approved.parameters[FABRIC_CONFLICT_PARAM_KEY]["resolution"] = {
+        "chosen_statement_id": "stm-evil"
+    }
+    await execute_approved_fabric_conflict(approved)
+
+    final = await instinct.get_action(filed[0])
+    assert final.status == ActionStatus.FAILED, final.error
+    assert "staged choices" in (final.error or "")
+    stmts = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+    assert not any(s.pinned for s in stmts)
+
+
+async def test_idempotent_reexecute_single_chain_close(fabric, instinct, monkeypatch):
+    calls: list[dict[str, Any]] = []
+
+    from pocketpaw_ee.cloud.fabric_conflicts import executor as conflict_executor
+
+    real_close = conflict_executor._emit_chain_close
+
+    def _spy(**kwargs: Any) -> None:
+        calls.append(kwargs)
+        return real_close(**kwargs)
+
+    monkeypatch.setattr(conflict_executor, "_emit_chain_close", _spy)
+
+    await _conflicted_object(fabric)
+    _set_mode(monkeypatch, "shadow")
+    filed = await sweep_conflicts_to_proposals(WS)
+
+    approved = await instinct.approve(filed[0], approver="steward-1")
+    await execute_approved_fabric_conflict(approved)
+    # Re-invoke on the now-terminal Action — must NOT re-pin or re-close.
+    again = await instinct.get_action(filed[0])
+    await execute_approved_fabric_conflict(again)
+
+    final = await instinct.get_action(filed[0])
+    assert final.status == ActionStatus.EXECUTED, final.error
+    assert len(calls) == 1
+    assert calls[0]["passed"] is True
+    assert calls[0]["action_outcome"] == "landed"

--- a/tests/test_fabric_conflicts.py
+++ b/tests/test_fabric_conflicts.py
@@ -1,0 +1,228 @@
+# tests/test_fabric_conflicts.py
+# Created: 2026-07-10 (FST-6 — the open-conflict surface).
+#
+# Proves ``detect_open_conflicts`` (fabric/conflicts.py) — the recompute-from-
+# statements scan the EE stewardship sweep consumes:
+#
+#   * finds EXACTLY the un-rankable conflicts (same tier + same rank + both
+#     open validity + materially different + within the recency epsilon) —
+#     mere rankable disputes (tier, rank, or recency orders them) are
+#     excluded by design: policy already answered those,
+#   * ``rivals`` names only the statements that TRIGGERED un-rankability
+#     (lower-tier losers are policy-ranked, not human choices),
+#   * the dedupe key ``(workspace_id, object_id, property)`` and the
+#     conflict ``signature`` (sorted competing statement ids) are stable
+#     across scans — the EE sweep's one-open-proposal-per-key guarantee
+#     hangs off that stability,
+#   * a steward verb CLOSES the conflict on the next scan (pin → the pinned
+#     path is never un-rankable; ignore → the rival is struck) — no
+#     persisted conflict state to invalidate,
+#   * scoping: ``object_id`` narrows the scan; W4a workspace scope hides
+#     other tenants' statements; a deleted object's orphan statements are
+#     skipped.
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.fabric.conflicts import detect_open_conflicts
+from pocketpaw.fabric.store import FabricStore
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _store_with_object(tmp_path: Path, name: str = "fabric.db") -> tuple[FabricStore, str]:
+    store = FabricStore(tmp_path / name)
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id, {"name": "Acme"}, source_connector="crm", source_id="c-1"
+    )
+    return store, obj.id
+
+
+async def _unrankable_arr(
+    store: FabricStore,
+    obj_id: str,
+    *,
+    workspace_id: str | None = None,
+    gap: timedelta = timedelta(hours=1),
+) -> tuple[str, str]:
+    """Two same-tier (connector), same-rank, open, materially different
+    statements observed within the epsilon → un-rankable. Returns
+    (winner_stmt_id, rival_stmt_id) — the newer observation wins."""
+    now = datetime.now()
+    src_a = await store.upsert_source(
+        "connector_run", connector="crm", run_id="r1", workspace_id=workspace_id
+    )
+    src_b = await store.upsert_source(
+        "connector_run", connector="billing", run_id="r9", workspace_id=workspace_id
+    )
+    rival = await store.append_statement(
+        obj_id, "arr", 200, src_b.id, "connector", observed_at=now - gap, workspace_id=workspace_id
+    )
+    winner = await store.append_statement(
+        obj_id, "arr", 120, src_a.id, "connector", observed_at=now, workspace_id=workspace_id
+    )
+    return winner.id, rival.id
+
+
+# ---------------------------------------------------------------------------
+# Exactly the un-rankable ones — not mere disputes
+# ---------------------------------------------------------------------------
+
+
+async def test_detect_finds_exactly_the_unresolvable_conflicts(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    winner_id, rival_id = await _unrankable_arr(store, obj_id)
+
+    # A RANKABLE dispute on another property: human vs connector — the
+    # ladder orders them, policy answers it, no human needed.
+    now = datetime.now()
+    human_src = await store.upsert_source("human_actor", actor_id="user:alice")
+    crm_src = await store.upsert_source("connector_run", connector="crm", run_id="r1")
+    await store.append_statement(obj_id, "tier", "gold", human_src.id, "human", observed_at=now)
+    await store.append_statement(obj_id, "tier", "silver", crm_src.id, "connector", observed_at=now)
+
+    # An AGREEING pair on a third property: same value, no dispute at all.
+    await store.append_statement(obj_id, "region", "EU", human_src.id, "human", observed_at=now)
+    await store.append_statement(obj_id, "region", "EU", crm_src.id, "connector", observed_at=now)
+
+    conflicts = await detect_open_conflicts(store)
+
+    assert [c.property for c in conflicts] == ["arr"]
+    record = conflicts[0]
+    assert record.object_id == obj_id
+    assert record.object_type == "Customer"
+    assert record.winner.id == winner_id and record.winner.value == 120
+    assert [r.id for r in record.rivals] == [rival_id]
+
+
+async def test_rank_or_recency_difference_is_rankable_not_a_conflict(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    now = datetime.now()
+    src_a = await store.upsert_source("connector_run", connector="crm", run_id="r1")
+    src_b = await store.upsert_source("connector_run", connector="billing", run_id="r9")
+
+    # Same tier but a RANK difference (preferred vs normal) — a ranking.
+    await store.append_statement(
+        obj_id, "arr", 120, src_a.id, "connector", observed_at=now, rank="preferred"
+    )
+    await store.append_statement(obj_id, "arr", 200, src_b.id, "connector", observed_at=now)
+
+    # Same tier + rank but observed OUTSIDE the 24h epsilon — recency ranks.
+    await store.append_statement(
+        obj_id, "mrr", 10, src_a.id, "connector", observed_at=now - timedelta(hours=30)
+    )
+    await store.append_statement(obj_id, "mrr", 20, src_b.id, "connector", observed_at=now)
+
+    assert await detect_open_conflicts(store) == []
+
+
+async def test_rivals_exclude_lower_tier_losers(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    winner_id, rival_id = await _unrankable_arr(store, obj_id)
+    # A lower-tier (agent) statement, materially different and recent — a
+    # loser the ladder already ranks, NOT a choice for the human.
+    agent_src = await store.upsert_source("agent_session", session_id="sess-1")
+    await store.append_statement(
+        obj_id, "arr", 999, agent_src.id, "agent", observed_at=datetime.now()
+    )
+
+    conflicts = await detect_open_conflicts(store)
+
+    assert len(conflicts) == 1
+    record = conflicts[0]
+    assert record.winner.id == winner_id
+    assert [r.id for r in record.rivals] == [rival_id]  # the agent 999 is absent
+    assert record.signature == sorted([winner_id, rival_id])
+
+
+# ---------------------------------------------------------------------------
+# Dedupe key + signature stability
+# ---------------------------------------------------------------------------
+
+
+async def test_dedupe_key_and_signature_stable_across_scans(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    await _unrankable_arr(store, obj_id, workspace_id="w1")
+
+    first = await detect_open_conflicts(store, workspace_id="w1")
+    second = await detect_open_conflicts(store, workspace_id="w1")
+
+    assert len(first) == len(second) == 1
+    assert first[0].dedupe_key == second[0].dedupe_key == ("w1", obj_id, "arr")
+    assert first[0].signature == second[0].signature
+
+
+# ---------------------------------------------------------------------------
+# Steward verbs close the conflict — no persisted state to invalidate
+# ---------------------------------------------------------------------------
+
+
+async def test_pin_closes_the_conflict(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    winner_id, _ = await _unrankable_arr(store, obj_id)
+    assert len(await detect_open_conflicts(store)) == 1
+
+    await store.pin_statement(obj_id, "arr", winner_id)
+
+    assert await detect_open_conflicts(store) == []
+
+
+async def test_ignore_closes_the_conflict(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    _, rival_id = await _unrankable_arr(store, obj_id)
+    assert len(await detect_open_conflicts(store)) == 1
+
+    await store.ignore_statement(obj_id, "arr", rival_id)
+
+    assert await detect_open_conflicts(store) == []
+
+
+# ---------------------------------------------------------------------------
+# Scoping — object filter, tenancy, deleted objects
+# ---------------------------------------------------------------------------
+
+
+async def test_object_id_filter_narrows_the_scan(tmp_path: Path) -> None:
+    store, obj_a = await _store_with_object(tmp_path)
+    obj_type = (await store.list_types())[0]
+    obj_b = await store.create_object(
+        obj_type.id, {"name": "Globex"}, source_connector="crm", source_id="c-2"
+    )
+    await _unrankable_arr(store, obj_a)
+    await _unrankable_arr(store, obj_b.id)
+
+    all_conflicts = await detect_open_conflicts(store)
+    assert {c.object_id for c in all_conflicts} == {obj_a, obj_b.id}
+
+    only_a = await detect_open_conflicts(store, object_id=obj_a)
+    assert [c.object_id for c in only_a] == [obj_a]
+
+
+async def test_workspace_scope_hides_other_tenants_conflicts(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    await _unrankable_arr(store, obj_id, workspace_id="w1")
+
+    own = await detect_open_conflicts(store, workspace_id="w1")
+    assert len(own) == 1
+    assert own[0].workspace_id == "w1"
+
+    # w2's scope sees own + legacy-NULL rows only — w1's statements are
+    # invisible, so there is nothing to arbitrate.
+    assert await detect_open_conflicts(store, workspace_id="w2") == []
+
+
+async def test_deleted_object_statements_are_skipped(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    await _unrankable_arr(store, obj_id)
+    assert len(await detect_open_conflicts(store)) == 1
+
+    await store.remove_object(obj_id)
+
+    # The orphan statements remain in the table (append-only audit) but the
+    # object is gone — not a conflict anyone can arbitrate.
+    assert await detect_open_conflicts(store) == []

--- a/tests/test_fabric_pin_ignore.py
+++ b/tests/test_fabric_pin_ignore.py
@@ -1,0 +1,324 @@
+# tests/test_fabric_pin_ignore.py
+# Created: 2026-07-10 (FST-6 — the PIN / UNPIN / IGNORE steward verbs).
+#
+# Proves the three statement-layer steward verbs (siblings of FST-5's
+# CHANGE/CORRECT — the operations the Instinct stewardship executor calls):
+#
+#   * PIN — sets pinned=True on one existing, non-deprecated statement; the
+#     resolver's pinned short-circuit then makes it win outright, above every
+#     ladder tier and immune to newer/higher-tier rivals (pinned-beats-
+#     everything), while the losers stay intact for audit,
+#   * UNPIN — retracts the flag; resolution falls back to the trust ladder,
+#   * IGNORE — deprecates the statement with rank_reason=<reason> (struck
+#     from resolution entirely, default reason "steward_ignored"),
+#   * all three return the NEW Resolution and are mode-respecting on the
+#     cache (enforce writes the new resolver winner; shadow/off leave the
+#     cache alone),
+#   * error paths: missing object, missing/cross-workspace statement, and
+#     PIN on a deprecated statement all raise ValueError (clean seam
+#     failures for the FST-6 executor),
+#   * deprecating the ONLY live statement leaves a winner-less Resolution
+#     and (in enforce) the cache keeps its last value.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.resolver import resolve
+from pocketpaw.fabric.store import FabricStore
+from pocketpaw.fabric.trust import default_trust_rules
+
+pytestmark = pytest.mark.asyncio
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+async def _crm_object(tmp_path: Path, **props: Any) -> tuple[FabricStore, str]:
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        props or {"name": "Acme", "arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+    return store, obj.id
+
+
+async def _tracked_arr(store: FabricStore, obj_id: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Track ``arr`` via the FST-3 promotion (agent write in shadow mode so
+    the cache stays LWW during setup): seed(connector, 120) + agent(150).
+    The ladder ranks connector > agent, so the seed (120) is the winner."""
+    _set_mode(monkeypatch, "shadow")
+    await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-setup"
+    )
+    assert len(await store.get_statements(obj_id, "arr")) == 2
+
+
+async def _agent_statement_id(store: FabricStore, obj_id: str) -> str:
+    stmts = await store.get_statements(obj_id, "arr")
+    return next(s.id for s in stmts if s.writer_class == "agent")
+
+
+async def _connector_statement_id(store: FabricStore, obj_id: str) -> str:
+    stmts = await store.get_statements(obj_id, "arr")
+    return next(s.id for s in stmts if s.writer_class == "connector")
+
+
+# ---------------------------------------------------------------------------
+# PIN — the durable "this one wins"
+# ---------------------------------------------------------------------------
+
+
+async def test_pin_makes_lower_tier_statement_win(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    agent_id = await _agent_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.pin_statement(obj_id, "arr", agent_id)
+
+    # The pinned agent statement short-circuits the ladder — it beats the
+    # connector-tier winner outright.
+    assert resolution.value == 150
+    assert resolution.winner_statement is not None
+    assert resolution.winner_statement.id == agent_id
+    assert resolution.winner_statement.pinned is True
+    assert resolution.unresolvable is False  # a pin is authoritative
+
+    # The loser stays intact for audit (not deprecated, not closed).
+    loser = next(s for s in resolution.losers if s.writer_class == "connector")
+    assert loser.rank == "normal" and loser.valid_to is None
+
+    # Shadow: the cache is untouched by the verb.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150  # LWW setup value
+
+
+async def test_pin_enforce_updates_cache_to_pinned_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)  # cache holds the LWW 150
+    connector_id = await _connector_statement_id(store, obj_id)
+    agent_id = await _agent_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "enforce")
+
+    # Pin the connector statement: the cache flips 150 → 120 (proves the
+    # enforce write — the cache held the setup's LWW value before).
+    resolution = await store.pin_statement(obj_id, "arr", connector_id)
+    assert resolution.value == 120
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120  # resolver-owned cache
+
+    # Re-point the pin at the agent statement: the cache follows.
+    await store.unpin_statement(obj_id, "arr", connector_id)
+    resolution = await store.pin_statement(obj_id, "arr", agent_id)
+    assert resolution.value == 150
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150
+
+    # Un-pinning reverts resolution (and the cache) to the ladder winner.
+    reverted = await store.unpin_statement(obj_id, "arr", agent_id)
+    assert reverted.value == 120
+    assert reverted.winner_statement is not None
+    assert reverted.winner_statement.id == connector_id
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120
+
+
+async def test_pinned_beats_everything_even_later_human_statement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pinned-beats-everything via the resolver: after the pin, a NEW
+    human-tier (top of the ladder) statement still loses to the pin."""
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    agent_id = await _agent_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "shadow")
+    await store.pin_statement(obj_id, "arr", agent_id)
+
+    src = await store.upsert_source("human_actor", actor_id="user:bob")
+    await store.append_statement(obj_id, "arr", 999, src.id, "human")
+
+    stmts = await store.get_statements(obj_id, "arr")
+    resolution = resolve(stmts, default_trust_rules(), object_type="Customer")
+    assert resolution.winner_statement is not None
+    assert resolution.winner_statement.id == agent_id
+    assert resolution.value == 150
+    # The human rival is an open, materially different survivor → disputed,
+    # but never unresolvable on the pinned path.
+    assert resolution.is_disputed is True
+    assert resolution.unresolvable is False
+
+
+async def test_pin_does_not_auto_unpin_other_pins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    agent_id = await _agent_statement_id(store, obj_id)
+    connector_id = await _connector_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "shadow")
+
+    await store.pin_statement(obj_id, "arr", agent_id)
+    resolution = await store.pin_statement(obj_id, "arr", connector_id)
+
+    # Both pins survive; two pins is a curation conflict the resolver
+    # deliberately flags as disputed (newest recorded pin wins).
+    stmts = await store.get_statements(obj_id, "arr")
+    assert sum(1 for s in stmts if s.pinned) == 2
+    assert resolution.is_disputed is True
+
+
+# ---------------------------------------------------------------------------
+# IGNORE — strike a bogus claim
+# ---------------------------------------------------------------------------
+
+
+async def test_ignore_deprecates_statement_with_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    connector_id = await _connector_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.ignore_statement(obj_id, "arr", connector_id)
+
+    # The ignored (connector) winner is struck; the agent statement wins.
+    assert resolution.value == 150
+    stmts = await store.get_statements(obj_id, "arr")
+    ignored = next(s for s in stmts if s.id == connector_id)
+    assert ignored.rank == "deprecated"
+    assert ignored.rank_reason == "steward_ignored"  # the default reason
+    # Struck entirely: not the winner, not a loser.
+    assert connector_id not in {s.id for s in resolution.losers}
+
+    # Shadow: cache untouched.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150
+
+
+async def test_ignore_enforce_updates_cache_and_custom_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)  # cache holds the LWW 150
+    agent_id = await _agent_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "enforce")
+
+    # Strike the agent statement: the connector 120 is the only survivor and
+    # the cache flips 150 → 120 (proves the enforce write).
+    resolution = await store.ignore_statement(obj_id, "arr", agent_id, reason="stale export")
+
+    assert resolution.value == 120
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120
+    stmts = await store.get_statements(obj_id, "arr")
+    ignored = next(s for s in stmts if s.id == agent_id)
+    assert ignored.rank_reason == "stale export"
+
+
+async def test_ignore_only_statement_leaves_cache_and_no_winner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deprecating the ONLY live statement → winner-less Resolution; in
+    enforce the cache keeps its last value (reads never lose a key)."""
+    store, obj_id = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    # Track "name" via an explicit human change (seed + preferred change).
+    await store.change_property(
+        obj_id, "name", "Acme Corp", writer_class="human", source_actor_id="user:alice"
+    )
+    stmts = await store.get_statements(obj_id, "name")
+    assert len(stmts) == 2
+    _set_mode(monkeypatch, "enforce")
+    # Strike both statements, one at a time (oldest first: the promotion
+    # seed, then the human change).
+    first = await store.ignore_statement(obj_id, "name", stmts[0].id, reason="bogus")
+    assert first.winner_statement is not None  # one live statement remains
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["name"] == "Acme Corp"  # enforce write
+    second = await store.ignore_statement(obj_id, "name", stmts[1].id, reason="bogus")
+    assert second.winner_statement is None
+    assert second.value is None
+
+    # No winner → no cache write: the last enforced value is kept.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["name"] == "Acme Corp"
+
+
+# ---------------------------------------------------------------------------
+# Error paths — clean ValueErrors for the FST-6 executor
+# ---------------------------------------------------------------------------
+
+
+async def test_verbs_raise_on_missing_object(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, _ = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    with pytest.raises(ValueError, match="not found"):
+        await store.pin_statement("obj-missing", "arr", "stm-x")
+    with pytest.raises(ValueError, match="not found"):
+        await store.unpin_statement("obj-missing", "arr", "stm-x")
+    with pytest.raises(ValueError, match="not found"):
+        await store.ignore_statement("obj-missing", "arr", "stm-x")
+
+
+async def test_verbs_raise_on_missing_statement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    _set_mode(monkeypatch, "shadow")
+    with pytest.raises(ValueError, match="statement"):
+        await store.pin_statement(obj_id, "arr", "stm-nope")
+    with pytest.raises(ValueError, match="statement"):
+        await store.ignore_statement(obj_id, "arr", "stm-nope")
+    # A statement id that exists but under ANOTHER property is equally invalid.
+    agent_id = await _agent_statement_id(store, obj_id)
+    with pytest.raises(ValueError, match="statement"):
+        await store.pin_statement(obj_id, "name", agent_id)
+
+
+async def test_pin_raises_on_deprecated_statement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    connector_id = await _connector_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "shadow")
+    await store.ignore_statement(obj_id, "arr", connector_id)
+    with pytest.raises(ValueError, match="deprecated"):
+        await store.pin_statement(obj_id, "arr", connector_id)
+
+
+async def test_verbs_respect_workspace_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A statement stamped for workspace w1 is invisible from w2's scope —
+    the verb fails with a clean ValueError, no cross-tenant curation."""
+    store, obj_id = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    src = await store.upsert_source("connector_run", connector="crm", workspace_id="w1")
+    stmt = await store.append_statement(obj_id, "arr", 500, src.id, "connector", workspace_id="w1")
+    # Visible in w1's scope: the pin succeeds.
+    resolution = await store.pin_statement(obj_id, "arr", stmt.id, workspace_id="w1")
+    assert resolution.winner_statement is not None
+    await store.unpin_statement(obj_id, "arr", stmt.id, workspace_id="w1")
+    # Invisible from w2's scope: ValueError.
+    with pytest.raises(ValueError, match="statement"):
+        await store.pin_statement(obj_id, "arr", stmt.id, workspace_id="w2")
+    with pytest.raises(ValueError, match="statement"):
+        await store.ignore_statement(obj_id, "arr", stmt.id, workspace_id="w2")


### PR DESCRIPTION
## What this does

Builds on #1695. The conflict lifecycle: conflicts the trust policy can rank keep auto-resolving silently; the un-rankable ones (same tier, same rank, both fresh, materially different) become Instinct proposals a human arbitrates in the Tray — the same agents-propose-humans-decide gate the rest of the OS uses, now arbitrating facts.

- OSS steward verbs as siblings of change/correct: `pin_statement` (durable "this one wins" — the resolver short-circuits on pins, so future rival observations stay settled), `unpin_statement`, `ignore_statement` (deprecate a bogus claim). Mode-respecting cache updates; every action returns the new Resolution.
- OSS conflict surface: `detect_open_conflicts` recomputes from statements (no separate conflicts table — the statements are the state), keyed `(workspace, object, property)`.
- EE gate glue (`cloud/fabric_conflicts/`, mirroring the rule-proposals precedent): a post-ingest sweep stages one proposal per conflicted property with the competing values + full provenance as read-only choices; approve executes PIN on the chosen statement (choice validated against the staged set — an edit can't smuggle an arbitrary id); reject closes with zero statement changes. Volume guard warns past 5 open proposals per workspace.
- Reject-memory: a dismissed conflict is not re-filed by the next sweep unless a new rival observation changes the conflict signature — without this, the 5-minute sweep would re-nag every human decision forever.

## Wiring

The sweep rides the existing fabric-ingest scheduler tick plus fires after ingest batches (one exception-shielded tail hook — conflicts are born at merge sites, so after-ingest is the natural beat). Mode-gated: off = zero reads. Conflict proposals deliberately do not participate in discovery's supersede sweep — they aren't discovery artifacts and survive re-runs.

## Verification

34 new tests (11 verb, 9 conflict-surface, 14 gate e2e incl. dedupe, reject-memory, approve→PIN→cache-in-enforce, tenancy). Full fabric selection 308; the live-gate regression sweep: 383 cloud instinct + 131 OSS instinct tests green; shadow/enforce guard suites byte-for-byte untouched; ruff + import-linter clean.

Stacked on #1695. Next: freshness (the stale-authority demotion the enforce slice deliberately deferred).