### PR TITLE
feat(fabric): freshness tri-state, within-family staleness demotion, provenance on reads (FST-7)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
@@ -1,6 +1,12 @@
 # fabric.py — in-process MCP server exposing read-only Fabric ontology access
 # to the claude_agent_sdk cloud chat backend. Created: 2026-06-11
 # (feat/fabric-instinct-mcp-providers).
+# Updated: 2026-07-11 (FST-7 — provenance on reads) — fabric_query gained an
+#   opt-in ``include_provenance`` arg (default false; response shape unchanged
+#   without it): attaches per-property trust detail for statement-tracked
+#   properties via store.get_object_provenance — disputed/unresolvable flags,
+#   freshness tri-state, and the winning value's writer + source. Best-effort
+#   per object; a provenance failure never breaks the query.
 # Updated: 2026-06-11 (fix/fabric-stats-workspace-scope) — fabric_stats now
 # passes the resolved workspace into the store's scoped stats()/list_types(),
 # closing the live cross-tenant type-name leak the original instance-wide
@@ -180,6 +186,10 @@ async def _fabric_query_handler(args: dict) -> dict:
     link_type = args.get("link_type")
     filters = args.get("filters")
     limit = args.get("limit", 20)
+    # FST-7: opt-in provenance — default False so the default response shape
+    # (and its byte budget) is unchanged; the agent asks for it when trust
+    # matters ("where did this figure come from / is it disputed / stale?").
+    include_provenance = bool(args.get("include_provenance", False))
 
     for field_name, value in (
         ("type_name", type_name),
@@ -231,6 +241,20 @@ async def _fabric_query_handler(args: dict) -> dict:
         logger.debug("fabric_query trace emission skipped", exc_info=True)
 
     objects = [_serialize_object(o) for o in result.objects]
+
+    # FST-7: attach per-property provenance (disputed / unresolvable /
+    # freshness / winner source) for statement-TRACKED properties only —
+    # untracked properties don't appear (single-source, nothing to explain).
+    # Best-effort per object: a provenance failure never breaks the query.
+    if include_provenance:
+        for entry in objects:
+            try:
+                entry["provenance"] = await store.get_object_provenance(
+                    entry["id"], workspace_id=workspace_id
+                )
+            except Exception:  # noqa: BLE001 — additive surface, never fatal
+                logger.debug("fabric_query provenance skipped for %s", entry["id"], exc_info=True)
+
     objects, truncated = _cap_objects(objects)
 
     return _success_response(
@@ -312,9 +336,15 @@ def build_fabric_server() -> tuple[str, Any] | None:
             "search), `linked_to` (find objects linked to this object id), "
             "`link_type` (filter links by type), `filters` (property filters — "
             'a scalar for equality or an operator map like {"rent": {">": '
-            "1000}}), `limit` (max results, default 20, cap 50). Returns "
+            "1000}}), `limit` (max results, default 20, cap 50), "
+            "`include_provenance` (bool, default false — adds per-property "
+            "trust detail for multi-source properties: disputed/unresolvable "
+            "flags, freshness fresh|aging|stale, and the winning value's "
+            "writer + source; use it when asked where a figure came from or "
+            "whether it can be trusted). Returns "
             "{total, returned, truncated, objects:[{id, type_name, properties, "
-            "source_connector, source_id}]}. An error means relay the reason."
+            "source_connector, source_id, provenance?}]}. An error means relay "
+            "the reason."
         ),
         {
             "type": "object",
@@ -341,6 +371,13 @@ def build_fabric_server() -> tuple[str, Any] | None:
                 "limit": {
                     "type": "integer",
                     "description": "Max results (default 20, cap 50).",
+                },
+                "include_provenance": {
+                    "type": "boolean",
+                    "description": (
+                        "Attach per-property trust detail (disputed, freshness, "
+                        "winning source) for multi-source properties. Default false."
+                    ),
                 },
             },
             "additionalProperties": False,

--- a/src/pocketpaw/fabric/resolver.py
+++ b/src/pocketpaw/fabric/resolver.py
@@ -6,6 +6,34 @@
 #   valid_to + append a new PREFERRED statement) is visible to resolution;
 #   is_disputed and unresolvable tightened accordingly (closed-validity
 #   losers are resolved history, not live disputes).
+# Updated: 2026-07-11 (FST-7 — within-FAMILY staleness demotion) — the ``now``
+#   seam is live. ``now=None`` (every legacy caller) skips freshness ENTIRELY:
+#   resolution is byte-identical to FST-2..6. With ``now`` passed, the EXACT
+#   algorithm, applied on the ladder path only (a pin stays authoritative —
+#   the pinned short-circuit runs before and ignores freshness):
+#   1. Each unpinned survivor is classified fresh/aging/stale via
+#      ``trust.freshness`` with the property's TTL class
+#      (``rules.max_age_for`` — per-(object_type, property) overridable,
+#      default class "default" = 30d). Timezone convention lives in
+#      ``trust._as_utc``: compare in UTC, naive datetimes read AS UTC.
+#   2. DEMOTION AT TIER SELECTION: if the ladder-order top candidate is
+#      STALE, the winner becomes the FIRST candidate in ladder order that is
+#      (a) in the SAME writer FAMILY as that top (FST-4 families: connector +
+#      mirror = one machine-sync family; human, agent, inferred each their
+#      own) and (b) fresh or aging. Everything else keeps its ladder order,
+#      so the stale ex-top becomes the first loser. No same-family non-stale
+#      candidate → NO demotion: a stale value never loses to a fresh value
+#      from ANOTHER family (a stale connector beats a fresh inferred), and a
+#      lone stale value still wins (reads never block). One pass — the
+#      replacement is non-stale by construction, so demotion cannot cascade.
+#   3. FRESHNESS-DEMOTED LOSERS ARE RESOLVED: when the (possibly demoted)
+#      winner is non-stale, a STALE loser in the winner's family is treated
+#      like closed-validity history — excluded from both the dispute and the
+#      un-rankable checks (no conflict noise for "the sync moved on").
+#      Cross-family stale losers and every loser under a STALE winner keep
+#      the FST-2 semantics unchanged.
+#   ``_family`` replicates store._writer_family's FST-4 mapping (the store
+#   imports THIS module, so importing it back would cycle) — keep in sync.
 #
 # ``resolve(statements, rules)`` takes every Statement recorded for ONE
 # (object_id, property) and picks the value the flat properties dict SHOULD
@@ -46,8 +74,8 @@
 # the flag later).
 #
 # Pure and deterministic: no store access, no settings, no clock reads —
-# the optional ``now`` parameter is an unused seam for FST-7 freshness
-# demotion. Nothing in production calls this yet (unwired until FST-3).
+# the optional ``now`` parameter (FST-7) is the caller-supplied clock for
+# freshness demotion; ``now=None`` keeps the pre-FST-7 behavior exactly.
 
 from __future__ import annotations
 
@@ -57,7 +85,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from pocketpaw.fabric.models import Statement
-from pocketpaw.fabric.trust import TrustRules, WriterClass
+from pocketpaw.fabric.trust import Freshness, TrustRules, WriterClass, freshness
 
 
 class Resolution(BaseModel):
@@ -77,6 +105,11 @@ class Resolution(BaseModel):
     is_disputed: bool = False
     losers: list[Statement] = Field(default_factory=list)
     unresolvable: bool = False
+    # FST-7: the winner's freshness tri-state when ``now`` was passed to
+    # resolve() on the ladder path; None on the pinned path (a pin ignores
+    # freshness) and for legacy ``now=None`` callers. Consumed by the
+    # divergence log line and the provenance read surface.
+    winner_freshness: Freshness | None = None
 
 
 def _normalize(value: Any) -> Any:
@@ -110,6 +143,17 @@ def _tier(writer_class: str, ladder: list[WriterClass]) -> int:
         return ladder.index(writer_class)  # type: ignore[arg-type]
     except ValueError:
         return len(ladder)
+
+
+def _family(writer_class: str) -> str:
+    """Writer FAMILY for FST-7 staleness demotion — the demotion boundary.
+
+    Replicates :func:`store._writer_family` (FST-4): "connector" and
+    "mirror" are ONE machine-sync family; "human", "agent", "inferred" are
+    each their own. Replicated rather than imported because the store
+    imports THIS module (importing it back would cycle) — keep in sync.
+    """
+    return "sync" if writer_class in ("connector", "mirror") else writer_class
 
 
 def _rank_key(statement: Statement) -> int:
@@ -160,14 +204,16 @@ def resolve(
     rules: TrustRules,
     *,
     object_type: str | None = None,
-    now: datetime | None = None,  # noqa: ARG001 — FST-7 freshness seam, unused
+    now: datetime | None = None,
 ) -> Resolution:
     """Resolve one (object_id, property)'s statements to a single value.
 
     Pure and deterministic: same input (in any order) → same Resolution.
     ``rules`` is passed in — no settings access. ``object_type`` selects
     per-property ladder overrides (``None`` = global ladder only). ``now``
-    is an unused seam for FST-7 freshness demotion.
+    (FST-7) is the caller-supplied clock for within-family staleness
+    demotion — see the module comment for the exact algorithm; ``None``
+    (every legacy caller) skips freshness entirely.
 
     Raises ``ValueError`` if the statements span more than one
     (object_id, property) — the resolver is per-property by contract.
@@ -217,14 +263,58 @@ def resolve(
 
     # Steps 3–4 — ladder tier, then within-tier rank > validity > recency > id.
     ranked = unpinned
+
+    # FST-7 — within-FAMILY staleness demotion, only when the caller passed
+    # ``now`` (legacy callers skip freshness entirely; resolution is
+    # byte-identical to pre-FST-7). If the ladder-order top is STALE, the
+    # first fresh/aging candidate in ladder order FROM THE SAME WRITER
+    # FAMILY (see _family — connector+mirror are one machine-sync family)
+    # takes the win; everything else keeps ladder order, so the stale ex-top
+    # is the first loser. Demotion never crosses families, and a lone stale
+    # value still wins (reads never block). One pass — the replacement is
+    # non-stale by construction, so demotion cannot cascade.
+    freshness_state: dict[str, Freshness] = {}
+    if now is not None:
+        max_age = rules.max_age_for(object_type, prop)
+        freshness_state = {s.id: freshness(s.observed_at, max_age, now) for s in ranked}
+        top = ranked[0]
+        if freshness_state[top.id] == "stale":
+            replacement = next(
+                (
+                    s
+                    for s in ranked[1:]
+                    if _family(s.writer_class) == _family(top.writer_class)
+                    and freshness_state[s.id] != "stale"
+                ),
+                None,
+            )
+            if replacement is not None:
+                ranked = [replacement, *(s for s in ranked if s is not replacement)]
+
     winner = ranked[0]
     losers = ranked[1:]
 
+    def _freshness_resolved(s: Statement) -> bool:
+        """FST-7: a STALE loser in a NON-STALE winner's family is resolved
+        history ("the sync moved on"), not conflict noise — excluded from
+        the dispute and un-rankable checks. Always False when ``now`` was
+        not passed (empty freshness_state) or when the winner is stale."""
+        return (
+            bool(freshness_state)
+            and freshness_state[winner.id] != "stale"
+            and freshness_state[s.id] == "stale"
+            and _family(s.writer_class) == _family(winner.writer_class)
+        )
+
     # Disputes count OPEN-validity losers only: a closed-validity statement
     # that lost (e.g. the old half of a CHANGE) is resolved history, not a
-    # live dispute. It stays in losers[] for audit.
+    # live dispute. It stays in losers[] for audit. FST-7 adds the
+    # freshness-resolved exclusion (see _freshness_resolved).
     disputed = any(
-        s.valid_to is None and _materially_different(s.value, winner.value) for s in losers
+        s.valid_to is None
+        and _materially_different(s.value, winner.value)
+        and not _freshness_resolved(s)
+        for s in losers
     )
 
     # Un-rankable detection: a contender at the SAME tier and SAME rank as
@@ -239,6 +329,7 @@ def resolve(
         and s.valid_to is None
         and _materially_different(s.value, winner.value)
         and abs((winner.observed_at - s.observed_at).total_seconds()) <= epsilon
+        and not _freshness_resolved(s)
         for s in losers
     )
 
@@ -248,4 +339,5 @@ def resolve(
         is_disputed=disputed,
         losers=losers,
         unresolvable=unresolvable,
+        winner_freshness=freshness_state.get(winner.id),
     )

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -1,5 +1,13 @@
 # Fabric store — async SQLite operations for the ontology layer.
 # Created: 2026-03-28 — CRUD for object types, objects, and links.
+# Updated: 2026-07-11 (FST-7 — freshness) — the merge-site statement pass now
+#   threads an aware-UTC ``now`` into resolve() (within-family staleness
+#   demotion live in shadow AND enforce); the divergence line gained a
+#   trailing `` freshness=<fresh|aging|stale|none>`` token (additive — field
+#   order unchanged, the FST-8 grep contract holds); NEW opt-in read surface
+#   ``get_object_provenance(object_id)`` — per TRACKED property: disputed /
+#   unresolvable / freshness / statement count / winner writer+source summary
+#   (a sibling method, the default read path pays nothing).
 # Updated: 2026-04-19 (Cluster C / PR3) — Added list_links() for the new
 #   GET /api/v1/fabric/links endpoint that the Links sub-tab in
 #   PocketDataPanel now consumes instead of its hardcoded placeholder.
@@ -289,7 +297,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -1392,6 +1400,13 @@ class FabricStore:
         seed_source: SourceRef | None = None
         resolutions: dict[str, Resolution] = {}
 
+        # FST-7 — the store's clock convention: ONE aware-UTC read per pass
+        # (datetime.now(UTC)), threaded into resolve() so shadow AND enforce
+        # apply within-family staleness demotion live. Statement stamps are
+        # UTC-normalized at the comparison boundary (naive = UTC — see
+        # trust._as_utc); stored data is never rewritten.
+        now = datetime.now(UTC)
+
         for prop, value in incoming.items():
             stmts = await self.get_statements(existing.id, prop, workspace_id=workspace_id)
             if not stmts:
@@ -1444,6 +1459,7 @@ class FabricStore:
                 stmts,
                 default_trust_rules(),
                 object_type=existing.type_name or None,
+                now=now,
             )
             # ``lww`` is the incoming value — what the cache holds in shadow
             # and what LWW WOULD have kept in enforce (where the caller
@@ -1451,7 +1467,7 @@ class FabricStore:
             # way: the FST-8 harness contract.
             logger.info(
                 "fabric shadow: object=%s property=%s lww=%s resolver=%s"
-                " diverged=%s disputed=%s unresolvable=%s",
+                " diverged=%s disputed=%s unresolvable=%s freshness=%s",
                 existing.id,
                 prop,
                 json.dumps(value, default=str),
@@ -1459,6 +1475,7 @@ class FabricStore:
                 _materially_different(value, resolution.value),
                 resolution.is_disputed,
                 resolution.unresolvable,
+                resolution.winner_freshness or "none",
             )
             resolutions[prop] = resolution
         return resolutions
@@ -2336,6 +2353,66 @@ class FabricStore:
             async with db.execute(sql, params) as cur:
                 row = await cur.fetchone()
         return self._row_to_source(row) if row else None
+
+    async def get_object_provenance(
+        self, object_id: str, *, workspace_id: str | None = None
+    ) -> dict[str, dict[str, Any]]:
+        """Opt-in provenance read surface (FST-7).
+
+        Per statement-TRACKED property of one object:
+        ``{property: {disputed, unresolvable, freshness, statements, winner}}``
+        where ``winner`` carries the resolving statement's writer_class /
+        observed_at / rank / pinned plus a compact source summary. Untracked
+        properties (the scalar majority) do not appear — absence means
+        "single-source, nothing to explain". A SIBLING method rather than a
+        ``get_object`` flag so the default read path pays nothing; the
+        agent-facing ``fabric_query`` MCP tool and the future "disputed
+        facts" view are the consumers. Freshness/dispute state is computed
+        live (statements + resolve() with the store clock), never persisted.
+        """
+        keys = await self.list_statement_keys(workspace_id=workspace_id, object_id=object_id)
+        if not keys:
+            return {}
+        obj = await self.get_object(object_id, workspace_id=workspace_id)
+        object_type = (obj.type_name or None) if obj else None
+        now = datetime.now(UTC)
+        rules = default_trust_rules()
+        out: dict[str, dict[str, Any]] = {}
+        for _oid, prop in keys:
+            stmts = await self.get_statements(object_id, prop, workspace_id=workspace_id)
+            if not stmts:
+                continue
+            resolution = resolve(stmts, rules, object_type=object_type, now=now)
+            winner = resolution.winner_statement
+            winner_info: dict[str, Any] | None = None
+            if winner is not None:
+                src = await self.get_source(winner.source_ref_id, workspace_id=workspace_id)
+                winner_info = {
+                    "writer_class": winner.writer_class,
+                    "observed_at": winner.observed_at.isoformat(),
+                    "rank": winner.rank,
+                    "pinned": winner.pinned,
+                    "source": (
+                        {
+                            "kind": src.kind,
+                            "connector": src.connector,
+                            "run_id": src.run_id,
+                            "document_uri": src.document_uri,
+                            "actor_id": src.actor_id,
+                            "session_id": src.session_id,
+                        }
+                        if src
+                        else None
+                    ),
+                }
+            out[prop] = {
+                "disputed": resolution.is_disputed,
+                "unresolvable": resolution.unresolvable,
+                "freshness": resolution.winner_freshness,
+                "statements": len(stmts),
+                "winner": winner_info,
+            }
+        return out
 
     async def get_linked_objects(
         self, obj_id: str, link_type: str | None = None, workspace_id: str | None = None

--- a/src/pocketpaw/fabric/trust.py
+++ b/src/pocketpaw/fabric/trust.py
@@ -4,17 +4,40 @@
 #   agent can print and explain: a global writer-class ladder (strongest
 #   first), optional per-(object_type, property) ladder overrides, and the
 #   ``recency_epsilon_seconds`` closeness window the resolver uses for
-#   un-rankable detection. ``freshness_ttl_classes`` is a declared-but-unused
-#   placeholder for the freshness TTL classes arriving in FST-7 — no TTL
-#   logic lives here yet. Nothing reads settings or the store: rules are
+#   un-rankable detection. Nothing reads settings or the store: rules are
 #   constructed by the caller and passed into ``resolver.resolve``, keeping
 #   the whole resolution path pure.
+# Updated: 2026-07-11 (FST-7 — freshness TTL classes + the pure tri-state) —
+#   the FST-2 ``freshness_ttl_classes`` placeholder comes alive: three named
+#   volatility classes (volatile=1d, default=30d, stable=365d — see
+#   DEFAULT_FRESHNESS_TTL_CLASSES) map a class name to a max-age in seconds.
+#   The INSTANCE dict stays empty by default (the FST-2 wire format is
+#   unchanged — stored rules need no migration and ``default_trust_rules()``
+#   still serializes byte-identically); it is an OVERRIDE layer consulted
+#   before the module defaults by ``max_age_for``. Per-(object_type,
+#   property) class assignment rides ``freshness_overrides`` (same
+#   first-exact-match-wins style as the ladder overrides; unassigned
+#   properties get class "default"). ``freshness(observed_at,
+#   max_age_seconds, now)`` is the pure tri-state: fresh (age <= max_age),
+#   aging (age <= 2*max_age), stale beyond. TIMEZONE CONVENTION (one rule for
+#   the whole freshness path): every comparison happens in UTC; a NAIVE
+#   datetime is interpreted AS UTC at the comparison boundary (the store's
+#   own persisted stamps — SQLite datetime('now'), the touch-time backfill
+#   from updated_at/created_at — are naive UTC, and the store's live clock is
+#   datetime.now(timezone.utc), so naive-as-UTC reads all of those exactly;
+#   a naive-LOCAL outlier, e.g. Statement's datetime.now() default, is
+#   mis-read by at most the local-UTC offset — hours against day-scale TTLs).
+#   Stored data is never rewritten; conversion happens only at comparison.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
+
+# The freshness tri-state a resolved value can carry (FST-7).
+Freshness = Literal["fresh", "aging", "stale"]
 
 # The writer classes a Statement can carry (mirrors Statement.writer_class).
 WriterClass = Literal["human", "connector", "mirror", "agent", "inferred"]
@@ -38,6 +61,37 @@ DEFAULT_LADDER: list[WriterClass] = [
 # observations of conflicting values are a real conflict, not a stale echo.
 DEFAULT_RECENCY_EPSILON_SECONDS = 24 * 60 * 60.0
 
+# FST-7 — the named volatility classes: TTL class name → max-age in seconds.
+# A value older than its class's max-age starts decaying (fresh → aging →
+# stale, see ``freshness``). Three classes cover the realistic spread:
+#
+# - "volatile" (86400s = 1 day)   — values that churn daily and whose staleness
+#   bites fast: presence/status flags, queue depths, live availability.
+#   Most connectors sync at least daily, so a volatile value that missed one
+#   sync cycle is already suspect.
+# - "default" (2592000s = 30 days) — the unassigned-property fallback: ordinary
+#   business facts (titles, owners, stages, amounts) that drift on a
+#   weeks-to-month cadence. A month without re-observation is the point where
+#   "probably still true" stops being a safe default.
+# - "stable" (31536000s = 365 days) — near-immutable identity facts: legal
+#   names, founding dates, tax ids. Only a year of silence makes these worth
+#   flagging at all.
+#
+# These are MODULE defaults: ``TrustRules.freshness_ttl_classes`` (the
+# instance dict) stays empty by default — the FST-2 wire format is unchanged,
+# stored rules need no migration — and acts as an override layer consulted
+# first by ``TrustRules.max_age_for``.
+DEFAULT_FRESHNESS_TTL_CLASSES: dict[str, float] = {
+    "volatile": 24 * 60 * 60.0,
+    "default": 30 * 24 * 60 * 60.0,
+    "stable": 365 * 24 * 60 * 60.0,
+}
+
+# The class assigned when no freshness override matches (also the lookup
+# fallback for an override naming an unknown class — reads never crash on a
+# typo'd rule set).
+DEFAULT_FRESHNESS_CLASS = "default"
+
 
 class TrustOverride(BaseModel):
     """A per-(object_type, property) ladder override.
@@ -54,6 +108,22 @@ class TrustOverride(BaseModel):
     ladder: list[WriterClass]
 
 
+class FreshnessOverride(BaseModel):
+    """A per-(object_type, property) freshness-class assignment (FST-7).
+
+    Same shape and matching semantics as :class:`TrustOverride`: the first
+    override matching BOTH fields exactly wins; a property with no match
+    gets class ``"default"``. ``ttl_class`` names a key of the effective TTL
+    map (instance ``freshness_ttl_classes`` layered over
+    ``DEFAULT_FRESHNESS_TTL_CLASSES``); an unknown name falls back to the
+    default class rather than failing — reads never block on a bad rule.
+    """
+
+    object_type: str
+    property: str
+    ttl_class: str
+
+
 class TrustRules(BaseModel):
     """The full rule set the resolver consumes. Plain data, no behavior
     beyond the ``ladder_for`` lookup.
@@ -63,16 +133,21 @@ class TrustRules(BaseModel):
       exact match wins.
     - ``recency_epsilon_seconds`` — the un-rankable closeness window (see
       module docstring / ``DEFAULT_RECENCY_EPSILON_SECONDS``).
-    - ``freshness_ttl_classes`` — FST-7 placeholder: will map a TTL class
-      name to a max-age in seconds for freshness demotion. Carried in the
-      format now so stored rules don't need a migration later; NO logic
-      consumes it in FST-2.
+    - ``freshness_ttl_classes`` — FST-7: per-rule-set OVERRIDES of the named
+      TTL classes (class name → max-age seconds), layered over
+      ``DEFAULT_FRESHNESS_TTL_CLASSES`` by :meth:`max_age_for`. Empty by
+      default — the FST-2 wire format is unchanged; the named defaults
+      (volatile=1d, default=30d, stable=365d) apply without any migration.
+    - ``freshness_overrides`` — per-(object_type, property) TTL-class
+      assignments (first exact match wins, like ``overrides``); an
+      unassigned property gets class ``"default"``.
     """
 
     ladder: list[WriterClass] = Field(default_factory=lambda: list(DEFAULT_LADDER))
     overrides: list[TrustOverride] = Field(default_factory=list)
     recency_epsilon_seconds: float = DEFAULT_RECENCY_EPSILON_SECONDS
     freshness_ttl_classes: dict[str, float] = Field(default_factory=dict)
+    freshness_overrides: list[FreshnessOverride] = Field(default_factory=list)
 
     def ladder_for(self, object_type: str | None, property: str) -> list[WriterClass]:
         """Return the effective ladder for one (object_type, property).
@@ -88,8 +163,78 @@ class TrustRules(BaseModel):
                     return override.ladder
         return self.ladder
 
+    def ttl_class_for(self, object_type: str | None, property: str) -> str:
+        """The effective freshness TTL class for one (object_type, property).
+
+        Mirrors :meth:`ladder_for`: the first ``freshness_overrides`` entry
+        matching BOTH fields exactly wins; ``object_type=None`` never matches
+        an override (overrides are keyed on concrete type names); no match →
+        ``DEFAULT_FRESHNESS_CLASS``.
+        """
+        if object_type is not None:
+            for override in self.freshness_overrides:
+                if override.object_type == object_type and override.property == property:
+                    return override.ttl_class
+        return DEFAULT_FRESHNESS_CLASS
+
+    def max_age_for(self, object_type: str | None, property: str) -> float:
+        """The effective max-age in seconds for one (object_type, property).
+
+        Resolves :meth:`ttl_class_for`'s class name against the instance
+        ``freshness_ttl_classes`` first, then the module
+        ``DEFAULT_FRESHNESS_TTL_CLASSES``. An unknown class name falls back
+        to the ``"default"`` class through the same two layers — a typo'd
+        rule set degrades to the 30-day default instead of raising.
+        """
+        ttl_class = self.ttl_class_for(object_type, property)
+        for name in (ttl_class, DEFAULT_FRESHNESS_CLASS):
+            if name in self.freshness_ttl_classes:
+                return self.freshness_ttl_classes[name]
+            if name in DEFAULT_FRESHNESS_TTL_CLASSES:
+                return DEFAULT_FRESHNESS_TTL_CLASSES[name]
+        return DEFAULT_FRESHNESS_TTL_CLASSES[DEFAULT_FRESHNESS_CLASS]
+
+
+def _as_utc(value: datetime) -> datetime:
+    """THE timezone convention for the freshness path (FST-7).
+
+    Every freshness comparison happens in UTC; a NAIVE datetime is
+    interpreted AS UTC here, at the comparison boundary. Why naive-as-UTC:
+    the store's persisted stamps (SQLite ``datetime('now')``, the touch-time
+    backfill from ``updated_at``/``created_at``) are naive UTC and the
+    store's live clock is ``datetime.now(timezone.utc)`` — this rule reads
+    all of those exactly. The known naive-LOCAL outlier (``Statement``'s
+    ``datetime.now()`` default_factory) is mis-read by at most the
+    local-UTC offset, i.e. hours against TTLs measured in days. Stored data
+    is never rewritten.
+    """
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def freshness(observed_at: datetime, max_age_seconds: float, now: datetime) -> Freshness:
+    """Classify one observation's age into the FST-7 tri-state.
+
+    Pure: no clock reads — the caller supplies ``now``. Both datetimes are
+    UTC-normalized via :func:`_as_utc` (naive = UTC by convention), so naive
+    and aware inputs can be mixed without raising.
+
+    - ``fresh`` — age <= max_age (a future observed_at is fresh: negative age)
+    - ``aging`` — max_age < age <= 2*max_age (past its TTL but within one
+      more TTL window — worth flagging, not yet worth demoting)
+    - ``stale`` — age > 2*max_age
+    """
+    age = (_as_utc(now) - _as_utc(observed_at)).total_seconds()
+    if age <= max_age_seconds:
+        return "fresh"
+    if age <= 2 * max_age_seconds:
+        return "aging"
+    return "stale"
+
 
 def default_trust_rules() -> TrustRules:
     """The out-of-the-box rule set: global default ladder, no overrides,
-    24h recency epsilon, no TTL classes."""
+    24h recency epsilon, empty TTL-class override map (the named module
+    defaults — volatile=1d, default=30d, stable=365d — apply)."""
     return TrustRules()

--- a/tests/test_fabric_enforce_site1.py
+++ b/tests/test_fabric_enforce_site1.py
@@ -34,7 +34,8 @@ STORE_LOGGER = "pocketpaw.fabric.store"
 
 DIVERGENCE_RE = re.compile(
     r"^fabric shadow: object=\S+ property=\S+ lww=.+ resolver=.+"
-    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)$"
+    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)"
+    r" freshness=(fresh|aging|stale|none)$"
 )
 
 
@@ -177,7 +178,7 @@ async def test_enforce_divergence_line_logs_lww_vs_written(
     lines = _shadow_lines(caplog)
     assert lines == [
         f"fabric shadow: object={obj_id} property=arr lww=150 resolver=120"
-        " diverged=True disputed=True unresolvable=False"
+        " diverged=True disputed=True unresolvable=False freshness=fresh"
     ]
     assert DIVERGENCE_RE.fullmatch(lines[0])
     # And "resolver" really is what the cache holds now (enforce semantics).
@@ -272,7 +273,7 @@ class TestSzdProof:
         lines = _shadow_lines(caplog)
         assert lines == [
             f'fabric shadow: object={obj_id} property=industry lww="crypto"'
-            ' resolver="fintech" diverged=True disputed=True unresolvable=False'
+            ' resolver="fintech" diverged=True disputed=True unresolvable=False freshness=fresh'
         ]
 
     async def test_reversed_order_connector_fact_still_wins_cache(

--- a/tests/test_fabric_freshness.py
+++ b/tests/test_fabric_freshness.py
@@ -1,0 +1,453 @@
+# tests/test_fabric_freshness.py
+# Created: 2026-07-11 (FST-7 — freshness: TTL classes, the pure tri-state,
+#   within-family staleness demotion, provenance on reads).
+#
+# Part 1 — trust.py: the named TTL classes (volatile=1d, default=30d,
+#   stable=365d), per-(object_type, property) class overrides mirroring the
+#   ladder-override style, the layered max_age_for lookup (instance dict over
+#   module defaults, unknown class → "default"), and the pure
+#   freshness(observed_at, max_age_seconds, now) tri-state including the
+#   UTC-normalization convention (naive = UTC at the comparison boundary).
+#   Back-compat: default_trust_rules() still serializes with an EMPTY
+#   freshness_ttl_classes dict (the FST-2 wire format).
+# Part 2 — resolver.py: within-FAMILY staleness demotion at tier selection —
+#   the FST-5 flagged case (stale connector seed loses to the fresh mirror
+#   value), demotion never crossing families (stale connector still beats
+#   fresh inferred), within-tier demotion across the rank leg, aging does
+#   NOT demote, all-stale keeps ladder order, a lone stale value still wins,
+#   pins ignore freshness, per-property TTL-class overrides steer demotion,
+#   freshness-demoted losers are RESOLVED (no dispute / un-rankable noise),
+#   and now=None is byte-identical legacy behavior.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.models import Statement
+from pocketpaw.fabric.resolver import resolve
+from pocketpaw.fabric.trust import (
+    DEFAULT_FRESHNESS_CLASS,
+    DEFAULT_FRESHNESS_TTL_CLASSES,
+    FreshnessOverride,
+    TrustRules,
+    default_trust_rules,
+    freshness,
+)
+
+NOW = datetime(2026, 7, 11, 12, 0, 0, tzinfo=UTC)
+DAY = 86400.0
+
+
+# ------------------------------------------------------------- TTL classes
+
+
+def test_default_ttl_classes_named_values():
+    """The three named volatility classes carry the documented max-ages."""
+    assert DEFAULT_FRESHNESS_TTL_CLASSES == {
+        "volatile": 86400.0,  # 1 day
+        "default": 2592000.0,  # 30 days
+        "stable": 31536000.0,  # 365 days
+    }
+
+
+def test_default_trust_rules_wire_format_unchanged():
+    """FST-2 back-compat: the INSTANCE dict stays empty (module defaults
+    apply through max_age_for) and no freshness overrides ship by default."""
+    rules = default_trust_rules()
+    assert rules.freshness_ttl_classes == {}
+    assert rules.freshness_overrides == []
+
+
+def test_ttl_class_for_unassigned_property_is_default():
+    rules = default_trust_rules()
+    assert rules.ttl_class_for("person", "email") == DEFAULT_FRESHNESS_CLASS
+
+
+def test_ttl_class_for_override_first_exact_match_wins():
+    rules = TrustRules(
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="volatile"),
+            FreshnessOverride(object_type="person", property="status", ttl_class="stable"),
+            FreshnessOverride(object_type="company", property="founded", ttl_class="stable"),
+        ]
+    )
+    assert rules.ttl_class_for("person", "status") == "volatile"  # first match
+    assert rules.ttl_class_for("company", "founded") == "stable"
+    assert rules.ttl_class_for("person", "founded") == "default"  # both must match
+
+
+def test_ttl_class_for_none_object_type_never_matches_override():
+    rules = TrustRules(
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="volatile"),
+        ]
+    )
+    assert rules.ttl_class_for(None, "status") == DEFAULT_FRESHNESS_CLASS
+
+
+def test_max_age_for_resolves_named_classes_from_module_defaults():
+    rules = TrustRules(
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="volatile"),
+            FreshnessOverride(object_type="company", property="founded", ttl_class="stable"),
+        ]
+    )
+    assert rules.max_age_for("person", "status") == 86400.0
+    assert rules.max_age_for("company", "founded") == 31536000.0
+    assert rules.max_age_for("person", "email") == 2592000.0  # unassigned → default
+
+
+def test_max_age_for_instance_dict_overrides_module_default():
+    """The instance dict is an OVERRIDE layer: redefining a class name wins
+    over the module default for that class."""
+    rules = TrustRules(
+        freshness_ttl_classes={"volatile": 3600.0},
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="volatile"),
+        ],
+    )
+    assert rules.max_age_for("person", "status") == 3600.0
+    # Untouched classes still come from the module defaults.
+    assert rules.max_age_for("person", "email") == 2592000.0
+
+
+def test_max_age_for_unknown_class_falls_back_to_default():
+    """A typo'd class name degrades to the default class, never raises."""
+    rules = TrustRules(
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="nope"),
+        ]
+    )
+    assert rules.max_age_for("person", "status") == 2592000.0
+
+
+def test_max_age_for_unknown_class_uses_instance_default_when_redefined():
+    rules = TrustRules(
+        freshness_ttl_classes={"default": 100.0},
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="nope"),
+        ],
+    )
+    assert rules.max_age_for("person", "status") == 100.0
+    assert rules.max_age_for("person", "email") == 100.0
+
+
+# ------------------------------------------------------- freshness tri-state
+
+
+@pytest.mark.parametrize(
+    ("age_seconds", "expected"),
+    [
+        (0.0, "fresh"),
+        (DAY, "fresh"),  # exactly max_age → still fresh
+        (DAY + 1, "aging"),
+        (2 * DAY, "aging"),  # exactly 2*max_age → still aging
+        (2 * DAY + 1, "stale"),
+        (100 * DAY, "stale"),
+    ],
+)
+def test_freshness_boundaries(age_seconds, expected):
+    observed = NOW - timedelta(seconds=age_seconds)
+    assert freshness(observed, DAY, NOW) == expected
+
+
+def test_freshness_future_observed_at_is_fresh():
+    """Negative age (source clock ahead) classifies fresh, never raises."""
+    assert freshness(NOW + timedelta(hours=3), DAY, NOW) == "fresh"
+
+
+def test_freshness_naive_inputs_are_read_as_utc():
+    """THE convention: a naive datetime is interpreted AS UTC at the
+    comparison boundary — a naive-UTC stamp (SQLite datetime('now')) and the
+    same instant written as aware-UTC classify identically."""
+    naive_utc_observed = datetime(2026, 7, 11, 12, 0, 0) - timedelta(days=1, seconds=1)
+    aware_observed = naive_utc_observed.replace(tzinfo=UTC)
+    assert freshness(naive_utc_observed, DAY, NOW) == "aging"
+    assert freshness(aware_observed, DAY, NOW) == freshness(naive_utc_observed, DAY, NOW)
+
+
+def test_freshness_naive_now_matches_aware_now():
+    """A naive-UTC ``now`` (e.g. parsed back from datetime('now')) and the
+    aware datetime.now(timezone.utc) convention agree."""
+    naive_now = datetime(2026, 7, 11, 12, 0, 0)
+    observed = datetime(2026, 7, 8, 12, 0, 0)
+    assert freshness(observed, DAY, naive_now) == freshness(observed, DAY, NOW) == "stale"
+
+
+def test_freshness_mixed_naive_and_aware_never_raises_and_orders_correctly():
+    """Naive-local vs naive-UTC: under the naive-as-UTC rule both are read on
+    ONE axis, so ages stay monotonic — an earlier naive stamp is always at
+    least as decayed as a later one, and mixing naive/aware never raises."""
+    older_naive = datetime(2026, 7, 1, 12, 0, 0)  # e.g. a naive-local default
+    newer_naive = datetime(2026, 7, 11, 11, 0, 0)  # e.g. a naive-UTC stamp
+    order = {"fresh": 0, "aging": 1, "stale": 2}
+    older_state = freshness(older_naive, DAY, NOW)  # aware now
+    newer_state = freshness(newer_naive, DAY, NOW)
+    assert order[older_state] >= order[newer_state]
+    assert older_state == "stale"
+    assert newer_state == "fresh"
+
+
+def test_freshness_aware_non_utc_input_converts():
+    """An aware non-UTC datetime is CONVERTED (not stripped): +05:30 wall
+    time 36h ago is 36h old regardless of its zone."""
+    ist = timezone(timedelta(hours=5, minutes=30))
+    observed = (NOW - timedelta(hours=36)).astimezone(ist)
+    assert freshness(observed, DAY, NOW) == "aging"
+
+
+# ---------------------------------------- Part 2: within-family demotion
+
+_counter = 0
+
+
+def fstmt(
+    *,
+    value: Any,
+    writer_class: str = "connector",
+    observed_at: datetime = NOW,
+    rank: str = "normal",
+    pinned: bool = False,
+    object_id: str = "obj-1",
+    property: str = "email",
+) -> Statement:
+    """Statement factory with deterministic ids (fst7-0001, fst7-0002, ...).
+
+    All timestamps in these tests are aware UTC — the freshness/naive
+    conventions are covered by the Part 1 unit tests above."""
+    global _counter
+    _counter += 1
+    return Statement(
+        id=f"fst7-{_counter:04d}",
+        object_id=object_id,
+        property=property,
+        value=value,
+        source_ref_id="src-test",
+        writer_class=writer_class,  # type: ignore[arg-type]
+        observed_at=observed_at,
+        recorded_at=observed_at,
+        valid_from=observed_at,
+        rank=rank,  # type: ignore[arg-type]
+        pinned=pinned,
+    )
+
+
+def test_stale_connector_seed_loses_to_fresh_mirror_value():
+    """THE FST-5 FLAGGED CASE: a connector seed observed 90d ago (class
+    "default" → max-age 30d → stale beyond 60d) loses to the mirror's fresh
+    value when ``now`` is passed, even though the ladder ranks connector >
+    mirror — same machine-sync family, so demotion applies. The demoted
+    stale loser is RESOLVED: no dispute, no un-rankable noise."""
+    stale_seed = fstmt(
+        value="old@x.com", writer_class="connector", observed_at=NOW - timedelta(days=90)
+    )
+    fresh_mirror = fstmt(
+        value="new@x.com", writer_class="mirror", observed_at=NOW - timedelta(days=1)
+    )
+    res = resolve([stale_seed, fresh_mirror], default_trust_rules(), now=NOW)
+    assert res.winner_statement is fresh_mirror
+    assert res.value == "new@x.com"
+    assert res.losers == [stale_seed]
+    assert res.is_disputed is False
+    assert res.unresolvable is False
+
+
+def test_stale_connector_does_not_lose_to_fresh_inferred():
+    """Demotion NEVER crosses families: a stale connector value still beats
+    a fresh inferred value — and the cross-family fresh loser keeps the
+    normal dispute semantics (no freshness exclusion)."""
+    stale_conn = fstmt(
+        value="old@x.com", writer_class="connector", observed_at=NOW - timedelta(days=90)
+    )
+    fresh_inferred = fstmt(
+        value="new@x.com", writer_class="inferred", observed_at=NOW - timedelta(days=1)
+    )
+    res = resolve([stale_conn, fresh_inferred], default_trust_rules(), now=NOW)
+    assert res.winner_statement is stale_conn
+    assert res.value == "old@x.com"
+    assert res.is_disputed is True  # open, materially different, not resolved by freshness
+    assert res.unresolvable is False
+
+
+def test_now_none_skips_freshness_entirely():
+    """Back-compat: without ``now`` the FST-5 flagged pair resolves exactly
+    as pre-FST-7 — the ladder puts connector above mirror, stale or not."""
+    stale_seed = fstmt(
+        value="old@x.com", writer_class="connector", observed_at=NOW - timedelta(days=90)
+    )
+    fresh_mirror = fstmt(
+        value="new@x.com", writer_class="mirror", observed_at=NOW - timedelta(days=1)
+    )
+    res = resolve([stale_seed, fresh_mirror], default_trust_rules())
+    assert res.winner_statement is stale_seed
+    assert res.value == "old@x.com"
+    assert res.is_disputed is True  # normal FST-2 semantics, no freshness pass
+
+
+def test_stale_preferred_loses_to_fresh_normal_within_tier():
+    """Within one tier the rank leg puts preferred first — but a STALE
+    preferred still loses to a fresh normal from the same family."""
+    stale_preferred = fstmt(
+        value="old",
+        writer_class="connector",
+        observed_at=NOW - timedelta(days=90),
+        rank="preferred",
+    )
+    fresh_normal = fstmt(value="new", writer_class="connector", observed_at=NOW - timedelta(days=1))
+    res = resolve([stale_preferred, fresh_normal], default_trust_rules(), now=NOW)
+    assert res.winner_statement is fresh_normal
+    assert res.is_disputed is False
+
+
+def test_aging_winner_is_not_demoted():
+    """Only STALE demotes: an aging top candidate (40d on the 30d default
+    class) keeps the win over a fresh same-family value."""
+    aging_conn = fstmt(value="old", writer_class="connector", observed_at=NOW - timedelta(days=40))
+    fresh_mirror = fstmt(value="new", writer_class="mirror", observed_at=NOW - timedelta(days=1))
+    res = resolve([aging_conn, fresh_mirror], default_trust_rules(), now=NOW)
+    assert res.winner_statement is aging_conn
+    assert res.is_disputed is True  # fresh loser is NOT freshness-resolved
+
+
+def test_all_stale_same_family_keeps_ladder_order():
+    """No non-stale candidate in the family → no demotion: ladder order
+    stands even though everything is stale (reads never block)."""
+    stale_conn = fstmt(value="a", writer_class="connector", observed_at=NOW - timedelta(days=90))
+    stale_mirror = fstmt(value="b", writer_class="mirror", observed_at=NOW - timedelta(days=80))
+    res = resolve([stale_conn, stale_mirror], default_trust_rules(), now=NOW)
+    assert res.winner_statement is stale_conn
+    assert res.is_disputed is True  # winner stale → no freshness exclusion
+
+
+def test_lone_stale_value_still_wins():
+    stale = fstmt(value="old", writer_class="connector", observed_at=NOW - timedelta(days=400))
+    res = resolve([stale], default_trust_rules(), now=NOW)
+    assert res.winner_statement is stale
+    assert res.value == "old"
+
+
+def test_pinned_stale_still_wins_with_now():
+    """A pin is authoritative — the pinned short-circuit runs before the
+    ladder path and ignores freshness entirely."""
+    stale_pinned = fstmt(
+        value="pinned", writer_class="mirror", observed_at=NOW - timedelta(days=400), pinned=True
+    )
+    fresh_conn = fstmt(value="new", writer_class="connector", observed_at=NOW - timedelta(days=1))
+    res = resolve([stale_pinned, fresh_conn], default_trust_rules(), now=NOW)
+    assert res.winner_statement is stale_pinned
+    assert res.value == "pinned"
+
+
+def test_freshness_class_override_steers_demotion():
+    """The per-(object_type, property) TTL class drives the demotion: a 3d-old
+    connector value is stale on the "volatile" class (1d) but fresh on the
+    default class (30d)."""
+    conn_3d = fstmt(
+        value="old",
+        writer_class="connector",
+        observed_at=NOW - timedelta(days=3),
+        object_id="obj-2",
+        property="status",
+    )
+    mirror_1h = fstmt(
+        value="new",
+        writer_class="mirror",
+        observed_at=NOW - timedelta(hours=1),
+        object_id="obj-2",
+        property="status",
+    )
+    volatile_rules = TrustRules(
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="volatile"),
+        ]
+    )
+    res = resolve([conn_3d, mirror_1h], volatile_rules, object_type="person", now=NOW)
+    assert res.winner_statement is mirror_1h  # stale on volatile → demoted
+    res_default = resolve(
+        [conn_3d, mirror_1h], default_trust_rules(), object_type="person", now=NOW
+    )
+    assert res_default.winner_statement is conn_3d  # fresh on default → ladder stands
+
+
+def test_boundary_straddling_pair_resolves_with_now():
+    """Two same-tier same-rank connector values within the 24h epsilon would
+    be UN-RANKABLE under FST-2 — but when one side is stale and the winner is
+    not, the stale side is freshness-resolved: no unresolvable, no dispute."""
+    just_stale = fstmt(
+        value="a", writer_class="connector", observed_at=NOW - timedelta(days=60, hours=2)
+    )
+    just_aging = fstmt(
+        value="b", writer_class="connector", observed_at=NOW - timedelta(days=59, hours=12)
+    )
+    legacy = resolve([just_stale, just_aging], default_trust_rules())
+    assert legacy.unresolvable is True  # the FST-2 semantics, unchanged without now
+    res = resolve([just_stale, just_aging], default_trust_rules(), now=NOW)
+    assert res.winner_statement is just_aging  # newer → ranked first, no demotion needed
+    assert res.unresolvable is False
+    assert res.is_disputed is False
+
+
+# ---------------------------------------------------------------------------
+# Part 3 — the provenance read surface (store.get_object_provenance, FST-7)
+# ---------------------------------------------------------------------------
+
+
+async def _tracked_crm_object(tmp_path, monkeypatch):
+    """A store in shadow mode with one object whose ``arr`` property is
+    statement-tracked (promoted by a second-source agent write)."""
+    from pocketpaw.fabric.store import FabricStore
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: "shadow")
+    store = FabricStore(tmp_path / "fabric.db")
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id, {"name": "Acme", "arr": 120}, source_connector="crm", source_id="c-1"
+    )
+    await store.update_object(obj.id, {"arr": 150}, writer_class="agent", source_session_id="s1")
+    return store, obj.id
+
+
+async def test_get_object_provenance_reports_tracked_property(tmp_path, monkeypatch):
+    """The opt-in read surface: a tracked property reports dispute state,
+    freshness, statement count, and the WINNER's writer + source summary;
+    untracked properties (``name``) don't appear at all."""
+    store, obj_id = await _tracked_crm_object(tmp_path, monkeypatch)
+
+    prov = await store.get_object_provenance(obj_id)
+
+    assert set(prov.keys()) == {"arr"}  # "name" untracked -> absent
+    entry = prov["arr"]
+    assert entry["statements"] == 2
+    assert entry["disputed"] is True  # open agent rival vs connector seed
+    assert entry["freshness"] == "fresh"  # both written moments ago
+    winner = entry["winner"]
+    assert winner["writer_class"] == "connector"  # ladder: connector > agent
+    assert winner["source"]["kind"] == "connector_run"
+    assert winner["source"]["connector"] == "crm"
+
+
+async def test_get_object_provenance_empty_when_nothing_tracked(tmp_path, monkeypatch):
+    from pocketpaw.fabric.store import FabricStore
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: "shadow")
+    store = FabricStore(tmp_path / "fabric.db")
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(obj_type.id, {"name": "Acme"}, source_connector="crm")
+
+    assert await store.get_object_provenance(obj.id) == {}
+
+
+async def test_resolution_exposes_winner_freshness(tmp_path, monkeypatch):
+    """The Resolution model carries the winner's tri-state when ``now`` is
+    passed (the divergence line + read surface consume it) and None for
+    legacy ``now=None`` callers."""
+    stmts = [
+        fstmt(value="a@b.co", writer_class="connector", observed_at=NOW - timedelta(days=2)),
+    ]
+    with_now = resolve(stmts, default_trust_rules(), now=NOW)
+    assert with_now.winner_freshness == "fresh"
+    legacy = resolve(stmts, default_trust_rules())
+    assert legacy.winner_freshness is None

--- a/tests/test_fabric_shadow_site1.py
+++ b/tests/test_fabric_shadow_site1.py
@@ -44,9 +44,13 @@ from pocketpaw.fabric.store import FabricStore, _source_truth_mode
 STORE_LOGGER = "pocketpaw.fabric.store"
 
 # The FST-8 harness contract: one line, grep-stable, values JSON-encoded.
+# FST-7 extended the line ADDITIVELY with a trailing ` freshness=<tri-state>`
+# (existing field order untouched) — the one deliberate format evolution this
+# guard exists to gate; updated with it, like the FST-5 enforce placeholder.
 DIVERGENCE_RE = re.compile(
     r"^fabric shadow: object=\S+ property=\S+ lww=.+ resolver=.+"
-    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)$"
+    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)"
+    r" freshness=(fresh|aging|stale|none)$"
 )
 
 
@@ -210,7 +214,7 @@ async def test_shadow_two_writers_promotes_logs_and_keeps_lww_cache(
     lines = _shadow_lines(caplog)
     assert lines == [
         f"fabric shadow: object={obj_id} property=arr lww=150 resolver=120"
-        " diverged=True disputed=True unresolvable=False"
+        " diverged=True disputed=True unresolvable=False freshness=fresh"
     ]
     assert DIVERGENCE_RE.fullmatch(lines[0])
     assert "\n" not in lines[0]
@@ -335,7 +339,7 @@ async def test_shadow_tracked_property_appends_and_reconverges(
     # The fresh connector write wins the ladder → resolver agrees with LWW.
     assert lines == [
         f"fabric shadow: object={obj_id} property=arr lww=200 resolver=200"
-        " diverged=False disputed=True unresolvable=False"
+        " diverged=False disputed=True unresolvable=False freshness=fresh"
     ]
 
 

--- a/tests/test_fabric_shadow_site2.py
+++ b/tests/test_fabric_shadow_site2.py
@@ -161,7 +161,7 @@ async def test_journal_update_by_user_actor_records_both_claims(
     lines = _shadow_lines(caplog)
     assert lines == [
         f"fabric shadow: object={obj.id} property=arr lww=150 resolver=150"
-        " diverged=False disputed=True unresolvable=False"
+        " diverged=False disputed=True unresolvable=False freshness=fresh"
     ]
 
 


### PR DESCRIPTION
## What this does

Builds on #1696. Facts now age visibly, and trust becomes readable:

- **TTL classes as data** (volatile 1d / default 30d / stable 365d, per-property overridable) + a pure `freshness()` tri-state: fresh / aging / stale. Datetime handling normalized to UTC at the comparison boundary (the naive-local vs naive-UTC wrinkle carried since FST-3, closed).
- **Within-family staleness demotion** in the resolver: when a tier's best candidate is stale, a fresh value from the SAME writer family (connector+mirror = one machine-sync family) takes the win — closing the case FST-5 flagged, where a stale connector seed beat a fresher mirror value forever. Demotion never crosses families: a stale connector fact still beats a fresh agent/inferred claim. `now=None` callers skip freshness entirely (legacy behavior byte-identical); a freshness-demoted loser is resolved history, not dispute noise.
- **Provenance on reads** (opt-in): `store.get_object_provenance(object_id)` reports, per statement-tracked property, the dispute/unresolvable flags, freshness, statement count, and the winning value's writer + source summary. The `fabric_query` MCP tool gains `include_provenance` (default false — response shape unchanged without it), so an agent asked "where did this figure come from / can it be trusted" can answer.
- The divergence line gains a trailing ` freshness=<tri-state>` token — additive, field order untouched; the three format-guard assertions were updated with it (the deliberate format evolution those guards exist to gate).

## Build note

The implementing agent stalled twice on infra (stream watchdog) after completing the trust/resolver core with 30 passing tests; the controller finished the read surface, MCP wiring, and format-guard updates by hand and reviewed the combined diff.

## Verification

341 fabric tests (308 baseline + 33: TTL/tri-state units incl. UTC-mixing, the named stale-seed-vs-fresh-mirror case, never-across-family, now=None back-compat, pin-ignores-freshness, read-surface e2e); cloud fabric dirs 37 green; prior-suite diff confined to the three format-guard assertions; ruff + format + import-linter clean.

Stacked on #1696. Final slice next: the shadow-divergence harness + docs.