### PR TITLE
feat(fabric): shadow-divergence report + full-ladder e2e + source-truth docs (FST-8)

### DIFF
--- a/docs/api/configuration-reference.mdx
+++ b/docs/api/configuration-reference.mdx
@@ -7,6 +7,13 @@ keywords: ["configuration", "environment variables", "settings reference", "conf
 tags: ["api", "configuration"]
 ---
 
+{/*
+  docs/api/configuration-reference.mdx
+  Updated 2026-07-11 (feat/fst-8-harness, FST-8) — added the "Fabric" section
+  with fabric_source_truth_mode (the off/shadow/enforce rollout switch) and
+  its divergence-report enforce gate.
+*/}
+
 # Configuration Reference
 
 Complete reference of all configuration settings. All environment variables use the `POCKETPAW_` prefix.
@@ -214,3 +221,9 @@ The pocket specialist does NOT receive Composio — its tool surface stays narro
 | `mem0_embedder_provider` | `POCKETPAW_MEM0_EMBEDDER_PROVIDER` | enum | `openai` | Embedder provider (`openai`, `ollama`, `huggingface`) |
 | `mem0_embedder_model` | `POCKETPAW_MEM0_EMBEDDER_MODEL` | string | `text-embedding-3-small` | Embedder model |
 | `mem0_vector_store` | `POCKETPAW_MEM0_VECTOR_STORE` | enum | `qdrant` | Vector store (`qdrant`, `chroma`) |
+
+## Fabric
+
+| Setting | Env Variable | Type | Default | Description |
+|---------|-------------|------|---------|-------------|
+| `fabric_source_truth_mode` | `POCKETPAW_FABRIC_SOURCE_TRUTH_MODE` | enum | `off` | Rollout mode for Fabric source truth (`off`, `shadow`, `enforce`). `off` = pure last-writer-wins, no statements. `shadow` = provenance statements + divergence log lines recorded alongside the LWW cache. `enforce` = the trust-ladder resolver's winner owns the cache. Gate the flip to `enforce` with `python -m pocketpaw.fabric.divergence_report` — see [Fabric Source Truth](/concepts/architecture#fabric-source-truth). |

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -7,6 +7,15 @@ keywords: ["event-driven architecture", "message bus pattern", "protocol-oriente
 tags: ["architecture", "design"]
 ---
 
+{/*
+  docs/concepts/architecture.mdx
+  Updated 2026-07-11 (feat/fst-8-harness, FST-8) — added the "Fabric Source
+  Truth" section: the statement model, the trust ladder, the off/shadow/
+  enforce mode ladder, the divergence report as the enforce gate, PIN/IGNORE
+  + the stewardship queue, and freshness decay. The section documents the
+  FST-1..8 chain in src/pocketpaw/fabric/ for devs who haven't read it.
+*/}
+
 # PocketPaw Architecture: Event-Driven Message Bus
 
 PocketPaw is built on an **event-driven message bus** architecture. This design decouples channels from agent backends, making it easy to add new channels and swap backends without touching the core pipeline.
@@ -76,3 +85,43 @@ The AgentLoop is the central coordinator:
 - **Memory** — Context builder assembles session history, long-term facts, and semantic search results
 - **Tools** — The tool registry provides available tools filtered by the policy system
 - **Backends** — The router delegates to the selected agent backend
+
+## Fabric Source Truth
+
+Fabric is PocketPaw's typed workspace ontology — objects like `Customer` or `Deal` with a flat `properties` dict that connectors, agents, and humans all write to. By default those writes are **last-writer-wins (LWW)**: whoever writes last owns the value, regardless of how trustworthy they are. The source-truth chain (`src/pocketpaw/fabric/`) fixes that without changing the read path.
+
+### The statement model
+
+Instead of only overwriting the cache, a tracked property accumulates **statements**: append-only claims (`fabric_statements` + `fabric_sources`), each carrying the value, who wrote it (`writer_class`), which source it came from (connector run, agent session, document, human actor), and when it was observed. Statements are opt-in per property — a property is only *promoted* to tracking when a **second distinct source** writes a materially different value. Single-source properties stay cheap scalar writes with zero extra rows.
+
+### The trust ladder
+
+A resolver (`resolver.py` + `trust.py`) orders a property's open statements by a global writer-class ladder, strongest first:
+
+`human > connector > mirror > agent > inferred`
+
+Within a tier, recency wins. Two same-tier claims with materially different values observed within a 24h epsilon are **unresolvable** — the ladder can't order them confidently, so the resolver returns a provisional winner and flags it. Two claims from different writer families disagreeing marks the resolution **disputed**. Human pins short-circuit the ladder entirely.
+
+### Freshness
+
+Every value decays: `fresh → aging → stale`, on per-class TTLs (volatile = 1 day, default = 30 days, stable = 1 year). A stale higher-tier value can be demoted below a fresh same-family one, and every resolution reports the winner's freshness — so a "the CRM said so, eight months ago" value is visible for what it is.
+
+### The mode ladder: off → shadow → enforce
+
+Rollout is a three-position switch, `fabric_source_truth_mode` (default `off`):
+
+| Mode | Statements | Cache (`properties`) |
+|------|-----------|---------------------|
+| `off` | never touched | pure LWW — byte-for-byte the pre-FST behavior |
+| `shadow` | recorded at every merge site | still LWW; the resolver runs advisory-only |
+| `enforce` | recorded | the **resolver's winner** is written — a lower-trust write no longer lands |
+
+In shadow and enforce, every statement-producing property logs one grep-stable divergence line (`fabric shadow: object=... lww=... resolver=... diverged=... disputed=... unresolvable=... freshness=...`). A failure in the statement pass never breaks the cache write — the write degrades to plain LWW with a warning. Flipping back to `off` is always safe: reads serve the last-resolved cache, LWW resumes, and statement history stays on disk. Shadow recording is at-most-once per journal event, so divergence logs are a lower bound on traffic, not an exact ledger.
+
+### The divergence report — the enforce gate
+
+`python -m pocketpaw.fabric.divergence_report <logfile>` (or stdin) parses those lines and answers "is shadow clean enough to enforce?". A divergence is **explained** when the line shows why the resolver disagreed with LWW (a flagged dispute, an unresolvable tie, freshness demotion — multi-source ordering doing its job). **Unexplained** divergences — the resolver overrode fresh, undisputed data with no visible reason — must be ZERO before flipping to enforce. The report exits 0/1 on its `ENFORCE-READY` verdict, so it drops into CI or a rollout script as-is.
+
+### Curation and stewardship
+
+Humans stay in the loop through four verbs on the store: **CHANGE** (supersede the winner with a preferred claim), **CORRECT** (deprecate a wrong claim with a reason), **PIN** (this value wins outright until unpinned), and **IGNORE** (strike a claim from resolution). Unresolvable conflicts are recomputed on scan (`conflicts.py` — no conflicts table to drift) and surface as one Instinct **stewardship-queue** proposal per conflicted property; answering with any verb, or a new higher-tier observation, closes the conflict on the next scan.

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,13 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-07-11 (FST-8 — divergence report + docs): Refreshed the
+    ``fabric_source_truth_mode`` Field description — shadow/enforce semantics
+    SHIPPED in FST-3..7 (the FST-1 "RESERVED / INERT" wording was stale):
+    shadow records statements + divergence lines while the cache stays LWW,
+    enforce hands the cache to the trust-ladder resolver, and the flip to
+    enforce is gated by ``python -m pocketpaw.fabric.divergence_report``.
+    Description text only — no behavioral change.
   - 2026-07-10 (FST-1 — Fabric source-truth schema): Added
     ``fabric_source_truth_mode`` (Literal off|shadow|enforce, default 'off';
     POCKETPAW_FABRIC_SOURCE_TRUTH_MODE) — the three-position rollout switch for
@@ -1927,17 +1934,23 @@ class Settings(BaseSettings):
         description=(
             "Rollout mode for the Fabric source-truth chain (FST). Three-position "
             "switch, mirroring litellm_spend_mode:\n"
-            "  * 'off'     (default) — byte-for-byte today: nothing reads or writes "
-            "the fabric_statements / fabric_sources provenance tables; the flat "
-            "FabricObject.properties dict is the only read path.\n"
-            "  * 'shadow'  — RESERVED (semantics land in a later FST slice): "
-            "statement writes mirror alongside the flat properties dict, which "
-            "keeps serving every read.\n"
-            "  * 'enforce' — RESERVED (semantics land in a later FST slice): "
-            "resolved statements become authoritative for reads.\n"
-            "As of FST-1 the flag is INERT — no code path consumes it yet; only "
-            "the schema and append-only store CRUD exist. The flat properties "
-            "dict remains the primary read path in every mode. Set via "
+            "  * 'off'     (default) — byte-for-byte pre-FST behavior: pure "
+            "last-writer-wins; nothing reads or writes the fabric_statements / "
+            "fabric_sources provenance tables; the flat FabricObject.properties "
+            "dict is the only read path.\n"
+            "  * 'shadow'  — provenance statements are recorded at every merge "
+            "site and one grep-stable divergence line is logged per "
+            "statement-producing property; the cache still takes the LWW value "
+            "(the trust-ladder resolver runs advisory-only) and keeps serving "
+            "every read.\n"
+            "  * 'enforce' — the resolver's winner owns the cache: a lower-trust "
+            "write no longer lands in the flat properties dict; the losing claim "
+            "is recorded as a statement, not dropped.\n"
+            "Flipping back to 'off' is always safe: reads serve the last-resolved "
+            "cache, LWW resumes, statement history stays on disk. Gate the flip "
+            "to 'enforce' with the FST-8 divergence report (python -m "
+            "pocketpaw.fabric.divergence_report <logfile>) — target ZERO "
+            "unexplained divergences. Set via "
             "POCKETPAW_FABRIC_SOURCE_TRUTH_MODE."
         ),
     )

--- a/src/pocketpaw/fabric/divergence_report.py
+++ b/src/pocketpaw/fabric/divergence_report.py
@@ -1,0 +1,316 @@
+# src/pocketpaw/fabric/divergence_report.py
+# Created: 2026-07-11 (FST-8 — the operational proof kit).
+#
+# The shadow-divergence report: parse the store's grep-stable divergence
+# lines out of a log capture, summarize them, and answer the one rollout
+# question that gates enforce — "is shadow clean enough to enforce?".
+# Read-only and dependency-free (stdlib argparse + json + re): it never
+# imports the store, never touches a database, and is safe to run against
+# production logs. CLI: ``python -m pocketpaw.fabric.divergence_report
+# <logfile> [logfile2 ...]`` (or stdin).
+"""Parse + summarize Fabric shadow-divergence log lines (FST-8).
+
+The contract (emitted by ``pocketpaw.fabric.store`` at every merge site,
+one single line per statement-producing property)::
+
+    fabric shadow: object=<id> property=<p> lww=<json> resolver=<json>
+        diverged=<True|False> disputed=<True|False> unresolvable=<True|False>
+        freshness=<fresh|aging|stale|none>
+
+``lww`` and ``resolver`` are ``json.dumps``'d (strings quoted), so the
+line never wraps and both values round-trip losslessly. The failure-shield
+warning uses a distinct prefix (``fabric shadow: statement pass failed for
+object=...``) so ``fabric shadow: object=`` isolates divergence lines
+exactly.
+
+Coverage caveat (FST-4): shadow recording is **at-most-once** per journal
+event — replays and retries are not double-counted, but a report is a
+lower bound on write traffic, not an exact ledger. An empty report can
+also mean shadow mode never ran; confirm the mode before reading "no
+lines" as "no divergence".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+#: The exact prefix of a divergence line. The failure-shield warning starts
+#: with "fabric shadow: statement pass failed for object=" — it never
+#: matches this, so the prefix alone isolates divergence lines.
+DIVERGENCE_PREFIX = "fabric shadow: object="
+
+# Head: everything before the JSON-encoded lww value. object ids and
+# property names are token-shaped (no whitespace) — the same assumption the
+# FST-3/5 contract-guard regexes in the test suite make.
+_HEAD_RE = re.compile(r"^fabric shadow: object=(?P<object_id>\S+) property=(?P<property>\S+) lww=")
+
+# Tail: the four fixed flags after the JSON-encoded resolver value.
+_TAIL_RE = re.compile(
+    r"^ diverged=(?P<diverged>True|False)"
+    r" disputed=(?P<disputed>True|False)"
+    r" unresolvable=(?P<unresolvable>True|False)"
+    r" freshness=(?P<freshness>fresh|aging|stale|none)\s*$"
+)
+
+_DECODER = json.JSONDecoder()
+
+
+@dataclass(frozen=True)
+class DivergenceRecord:
+    """One parsed divergence line (or one malformed line, kept for counting).
+
+    A line that starts with :data:`DIVERGENCE_PREFIX` but does not parse
+    becomes a record with ``parse_error`` set (and neutral field values) —
+    the tolerant-parser contract: malformed lines are *counted*, never
+    raised, and never silently dropped.
+    """
+
+    object_id: str
+    property: str
+    lww: Any
+    resolver: Any
+    diverged: bool
+    disputed: bool
+    unresolvable: bool
+    freshness: str  # "fresh" | "aging" | "stale" | "none"
+    raw: str
+    parse_error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        """True when the line parsed cleanly."""
+        return self.parse_error is None
+
+    @property
+    def unexplained(self) -> bool:
+        """The enforce-gate heuristic, per divergence line (PRD metric).
+
+        A divergence is *explained* when the line itself shows why the
+        resolver disagreed with LWW: the conflict is flagged
+        (``disputed=True``), the resolver fell back on an unresolvable tie
+        (``unresolvable=True``), or freshness demotion was in play
+        (``freshness != "fresh"``). Those are multi-source ordering doing
+        its job — expected in shadow, safe to enforce.
+
+        *Unexplained* = ``diverged=True`` with none of those markers: the
+        resolver overrode the freshest, undisputed data and nothing on the
+        line says why. Target ZERO before flipping to enforce — each one is
+        either a trust-ladder surprise or a bug, and both need a human look.
+
+        Honest limits: this is a line-local heuristic. It cannot see
+        PIN/IGNORE curation, per-type ladder overrides, or cross-line
+        context — an "explained" line can still be wrong data winning for
+        a legible reason, and coverage is at-most-once per journal event
+        (see the module docstring).
+        """
+        return (
+            self.ok
+            and self.diverged
+            and not (self.disputed or self.unresolvable or self.freshness != "fresh")
+        )
+
+
+def _malformed(raw: str, why: str) -> DivergenceRecord:
+    return DivergenceRecord(
+        object_id="",
+        property="",
+        lww=None,
+        resolver=None,
+        diverged=False,
+        disputed=False,
+        unresolvable=False,
+        freshness="none",
+        raw=raw,
+        parse_error=why,
+    )
+
+
+def parse_divergence_lines(lines: Iterable[str]) -> list[DivergenceRecord]:
+    """Tolerantly parse divergence lines out of arbitrary log text.
+
+    * Lines that do not start with :data:`DIVERGENCE_PREFIX` (other log
+      output, the failure-shield warning, blanks) are skipped entirely.
+    * Lines that carry the prefix but violate the contract yield a record
+      with ``parse_error`` set — counted by :func:`summarize` as
+      ``parse_errors``. This function NEVER raises on input content.
+
+    The ``lww``/``resolver`` values are decoded with a JSON-aware scan
+    (``JSONDecoder.raw_decode``), not whitespace splitting, so values
+    containing spaces (quoted strings, objects, lists) parse exactly.
+    """
+    records: list[DivergenceRecord] = []
+    for raw_line in lines:
+        line = raw_line.rstrip("\r\n")
+        if not line.startswith(DIVERGENCE_PREFIX):
+            continue
+        head = _HEAD_RE.match(line)
+        if head is None:
+            records.append(_malformed(line, "head does not match the contract"))
+            continue
+        rest = line[head.end() :]
+        try:
+            lww, end = _DECODER.raw_decode(rest)
+        except ValueError:
+            records.append(_malformed(line, "lww value is not valid JSON"))
+            continue
+        rest = rest[end:]
+        if not rest.startswith(" resolver="):
+            records.append(_malformed(line, "missing resolver= field after lww"))
+            continue
+        rest = rest[len(" resolver=") :]
+        try:
+            resolver, end = _DECODER.raw_decode(rest)
+        except ValueError:
+            records.append(_malformed(line, "resolver value is not valid JSON"))
+            continue
+        tail = _TAIL_RE.match(rest[end:])
+        if tail is None:
+            records.append(_malformed(line, "tail flags do not match the contract"))
+            continue
+        records.append(
+            DivergenceRecord(
+                object_id=head.group("object_id"),
+                property=head.group("property"),
+                lww=lww,
+                resolver=resolver,
+                diverged=tail.group("diverged") == "True",
+                disputed=tail.group("disputed") == "True",
+                unresolvable=tail.group("unresolvable") == "True",
+                freshness=tail.group("freshness"),
+                raw=line,
+                parse_error=None,
+            )
+        )
+    return records
+
+
+@dataclass(frozen=True)
+class DivergenceSummary:
+    """Aggregate view over parsed divergence records — the go/no-go input."""
+
+    total: int  # cleanly parsed lines
+    parse_errors: int  # prefix-matching lines that violated the contract
+    diverged: int
+    diverged_rate: float  # diverged / total (0.0 when total == 0)
+    disputed: int
+    unresolvable: int
+    unexplained: int  # see DivergenceRecord.unexplained — target ZERO
+    top_diverged_properties: tuple[tuple[str, int], ...]  # (property, diverged-count), descending
+    freshness: dict[str, int] = field(default_factory=dict)  # over all parsed lines
+
+    @property
+    def enforce_ready(self) -> bool:
+        """The go/no-go verdict: zero unexplained divergences AND zero
+        parse errors (an unparseable line could hide an unexplained
+        divergence, so malformed input blocks the green light too)."""
+        return self.unexplained == 0 and self.parse_errors == 0
+
+
+def summarize(records: Iterable[DivergenceRecord], *, top_n: int = 5) -> DivergenceSummary:
+    """Fold parsed records into a :class:`DivergenceSummary`.
+
+    Malformed records (``parse_error`` set) count toward ``parse_errors``
+    only; every other statistic is computed over cleanly parsed lines.
+    """
+    materialized = list(records)  # records may be a one-shot generator
+    valid = [r for r in materialized if r.ok]
+    parse_errors = len(materialized) - len(valid)
+
+    diverged = [r for r in valid if r.diverged]
+    per_property = Counter(r.property for r in diverged)
+    freshness = Counter(r.freshness for r in valid)
+    total = len(valid)
+    return DivergenceSummary(
+        total=total,
+        parse_errors=parse_errors,
+        diverged=len(diverged),
+        diverged_rate=(len(diverged) / total) if total else 0.0,
+        disputed=sum(1 for r in valid if r.disputed),
+        unresolvable=sum(1 for r in valid if r.unresolvable),
+        unexplained=sum(1 for r in valid if r.unexplained),
+        top_diverged_properties=tuple(per_property.most_common(top_n)),
+        freshness=dict(freshness),
+    )
+
+
+def format_report(summary: DivergenceSummary) -> str:
+    """A compact human-readable block ending in the verdict line."""
+    pct = f"{summary.diverged_rate * 100:.1f}%"
+    lines = [
+        "fabric divergence report",
+        f"  lines:         {summary.total} parsed, {summary.parse_errors} malformed",
+        f"  diverged:      {summary.diverged}/{summary.total} ({pct})",
+        f"  disputed:      {summary.disputed}",
+        f"  unresolvable:  {summary.unresolvable}",
+        f"  unexplained:   {summary.unexplained}",
+    ]
+    if summary.freshness:
+        dist = " ".join(
+            f"{k}={summary.freshness[k]}"
+            for k in ("fresh", "aging", "stale", "none")
+            if k in summary.freshness
+        )
+        lines.append(f"  freshness:     {dist}")
+    if summary.top_diverged_properties:
+        lines.append("  top diverged properties:")
+        width = max(len(p) for p, _ in summary.top_diverged_properties)
+        lines.extend(f"    {p:<{width}}  {n}" for p, n in summary.top_diverged_properties)
+    if summary.total == 0 and summary.parse_errors == 0:
+        lines.append("  note: no divergence lines found — confirm shadow mode actually ran")
+    verdict = "yes" if summary.enforce_ready else "no"
+    detail = f"{summary.unexplained} unexplained"
+    if summary.parse_errors:
+        detail += f", {summary.parse_errors} parse errors"
+    lines.append(f"ENFORCE-READY: {verdict} ({detail})")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: report over one or more log files (or stdin).
+
+    Exit code 0 when ENFORCE-READY, 1 when not — usable as a CI/rollout
+    gate. Exit 2 on unreadable input files.
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m pocketpaw.fabric.divergence_report",
+        description=(
+            "Summarize Fabric shadow-divergence log lines and answer the "
+            "enforce go/no-go. Reads the given log files, or stdin when no "
+            "files (or '-') are given."
+        ),
+    )
+    parser.add_argument("logfiles", nargs="*", help="log files to scan ('-' or none = stdin)")
+    parser.add_argument(
+        "--top", type=int, default=5, metavar="N", help="top-N diverged properties (default 5)"
+    )
+    args = parser.parse_args(argv)
+
+    lines: list[str] = []
+    sources = args.logfiles or ["-"]
+    for name in sources:
+        if name == "-":
+            lines.extend(sys.stdin.read().splitlines())
+            continue
+        try:
+            with open(name, encoding="utf-8", errors="replace") as fh:
+                lines.extend(fh.read().splitlines())
+        except OSError as exc:
+            print(f"error: cannot read {name}: {exc}", file=sys.stderr)
+            return 2
+
+    summary = summarize(parse_divergence_lines(lines), top_n=args.top)
+    print(format_report(summary))
+    return 0 if summary.enforce_ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fabric_divergence_report.py
+++ b/tests/test_fabric_divergence_report.py
@@ -1,0 +1,273 @@
+# tests/test_fabric_divergence_report.py
+# Created: 2026-07-11 (FST-8 — the operational proof kit).
+#
+# Unit tests for the shadow-divergence report harness
+# (pocketpaw.fabric.divergence_report):
+#
+#   * the tolerant parser — exact-contract lines parse with JSON round-trip
+#     (spaces in quoted strings, objects, null), non-matching lines and the
+#     failure-shield warning are skipped, malformed prefix-matching lines
+#     become parse_error records and NEVER raise,
+#   * the unexplained-divergence heuristic — diverged with no visible reason
+#     (not disputed, not unresolvable, freshness=fresh) is unexplained;
+#     each visible reason explains it,
+#   * summarize — totals, rate, disputed/unresolvable counts, per-property
+#     top-N, freshness distribution, parse_errors, the enforce_ready verdict
+#     (blocked by unexplained AND by parse errors), generator input,
+#   * format_report smoke — verdict line shape, empty-input caution,
+#   * the CLI — files/stdin in, report out, exit codes 0/1/2.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.fabric.divergence_report import (
+    DivergenceRecord,
+    format_report,
+    main,
+    parse_divergence_lines,
+    summarize,
+)
+
+
+def _line(
+    *,
+    object_id: str = "obj-1",
+    prop: str = "arr",
+    lww: str = "200",
+    resolver: str = "150",
+    diverged: bool = True,
+    disputed: bool = False,
+    unresolvable: bool = False,
+    freshness: str = "fresh",
+) -> str:
+    return (
+        f"fabric shadow: object={object_id} property={prop} lww={lww} resolver={resolver}"
+        f" diverged={diverged} disputed={disputed} unresolvable={unresolvable}"
+        f" freshness={freshness}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_divergence_lines — the tolerant parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_good_line_round_trips_values() -> None:
+    records = parse_divergence_lines([_line()])
+    assert len(records) == 1
+    r = records[0]
+    assert r.ok and r.parse_error is None
+    assert r.object_id == "obj-1"
+    assert r.property == "arr"
+    assert r.lww == 200 and r.resolver == 150
+    assert r.diverged is True
+    assert r.disputed is False
+    assert r.unresolvable is False
+    assert r.freshness == "fresh"
+
+
+def test_parse_json_values_with_spaces_objects_and_null() -> None:
+    lines = [
+        _line(lww='"Acme Corp Ltd"', resolver='"Acme Corp"', prop="name"),
+        _line(lww='{"city": "San Francisco", "zip": "94110"}', resolver='{"city": "SF"}'),
+        _line(lww="null", resolver="[1, 2, 3]", diverged=True),
+    ]
+    records = parse_divergence_lines(lines)
+    assert [r.ok for r in records] == [True, True, True]
+    assert records[0].lww == "Acme Corp Ltd" and records[0].resolver == "Acme Corp"
+    assert records[1].lww == {"city": "San Francisco", "zip": "94110"}
+    assert records[2].lww is None and records[2].resolver == [1, 2, 3]
+
+
+def test_parse_skips_noise_and_failure_shield_lines() -> None:
+    lines = [
+        "",
+        "INFO some unrelated log line",
+        "fabric shadow: statement pass failed for object=o1 — cache write unaffected",
+        _line(),
+        "another trailer",
+    ]
+    records = parse_divergence_lines(lines)
+    assert len(records) == 1 and records[0].ok
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        # head violations
+        "fabric shadow: object= property=arr lww=1 resolver=1 diverged=True"
+        " disputed=False unresolvable=False freshness=fresh",
+        "fabric shadow: object=o1 lww=1 resolver=1 diverged=True"
+        " disputed=False unresolvable=False freshness=fresh",
+        # lww not JSON
+        _line(lww="BROKEN"),
+        # missing resolver field
+        "fabric shadow: object=o1 property=arr lww=1 diverged=True"
+        " disputed=False unresolvable=False freshness=fresh",
+        # resolver not JSON
+        _line(resolver="{unclosed"),
+        # tail violations: bad bool, bad freshness, truncated
+        _line().replace("diverged=True", "diverged=maybe"),
+        _line(freshness="rotten"),
+        _line().rsplit(" freshness=", 1)[0],
+    ],
+)
+def test_malformed_prefix_lines_become_parse_errors_never_raise(bad: str) -> None:
+    records = parse_divergence_lines([bad])
+    assert len(records) == 1
+    assert records[0].ok is False
+    assert records[0].parse_error
+    assert records[0].raw == bad
+
+
+def test_parse_strips_trailing_newlines() -> None:
+    records = parse_divergence_lines([_line() + "\n", _line() + "\r\n"])
+    assert all(r.ok for r in records) and len(records) == 2
+
+
+# ---------------------------------------------------------------------------
+# the unexplained heuristic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("diverged", "disputed", "unresolvable", "freshness", "expected"),
+    [
+        (True, False, False, "fresh", True),  # no visible reason → unexplained
+        (True, True, False, "fresh", False),  # dispute explains it
+        (True, False, True, "fresh", False),  # unresolvable tie explains it
+        (True, False, False, "aging", False),  # freshness demotion explains it
+        (True, False, False, "stale", False),
+        (True, False, False, "none", False),
+        (False, False, False, "fresh", False),  # no divergence at all
+    ],
+)
+def test_unexplained_heuristic(
+    diverged: bool, disputed: bool, unresolvable: bool, freshness: str, expected: bool
+) -> None:
+    [r] = parse_divergence_lines(
+        [
+            _line(
+                diverged=diverged, disputed=disputed, unresolvable=unresolvable, freshness=freshness
+            )
+        ]
+    )
+    assert r.unexplained is expected
+
+
+def test_malformed_record_is_never_unexplained() -> None:
+    [r] = parse_divergence_lines([_line(lww="BROKEN")])
+    assert r.unexplained is False
+
+
+# ---------------------------------------------------------------------------
+# summarize
+# ---------------------------------------------------------------------------
+
+
+def _mixed_records() -> list[DivergenceRecord]:
+    return parse_divergence_lines(
+        [
+            _line(prop="arr", diverged=True, disputed=True),  # explained
+            _line(prop="arr", object_id="obj-2", diverged=True),  # unexplained
+            _line(prop="industry", diverged=True, freshness="stale"),  # explained
+            _line(prop="name", diverged=False),
+            _line(prop="owner", diverged=True, unresolvable=True, freshness="aging"),  # explained
+            _line(lww="BROKEN"),  # parse error
+        ]
+    )
+
+
+def test_summarize_counts_rates_topn_freshness() -> None:
+    s = summarize(_mixed_records(), top_n=2)
+    assert s.total == 5
+    assert s.parse_errors == 1
+    assert s.diverged == 4
+    assert s.diverged_rate == pytest.approx(4 / 5)
+    assert s.disputed == 1
+    assert s.unresolvable == 1
+    assert s.unexplained == 1
+    assert s.top_diverged_properties[0] == ("arr", 2)
+    assert len(s.top_diverged_properties) == 2  # top_n honored
+    assert s.freshness == {"fresh": 3, "stale": 1, "aging": 1}
+    assert s.enforce_ready is False
+
+
+def test_summarize_enforce_ready_requires_zero_unexplained_and_zero_parse_errors() -> None:
+    clean_explained = parse_divergence_lines(
+        [_line(diverged=True, disputed=True), _line(diverged=False)]
+    )
+    assert summarize(clean_explained).enforce_ready is True
+
+    with_parse_error = [*clean_explained, *parse_divergence_lines([_line(lww="BROKEN")])]
+    assert summarize(with_parse_error).enforce_ready is False
+
+
+def test_summarize_empty_and_generator_input() -> None:
+    empty = summarize([])
+    assert empty.total == 0 and empty.diverged_rate == 0.0 and empty.enforce_ready is True
+
+    gen = (r for r in _mixed_records())
+    assert summarize(gen).total == 5  # one-shot iterators are materialized once
+
+
+# ---------------------------------------------------------------------------
+# format_report — smoke
+# ---------------------------------------------------------------------------
+
+
+def test_format_report_verdict_and_sections() -> None:
+    report = format_report(summarize(_mixed_records()))
+    assert report.startswith("fabric divergence report")
+    assert "diverged:      4/5" in report
+    assert "unexplained:   1" in report
+    assert "arr" in report
+    assert report.splitlines()[-1] == "ENFORCE-READY: no (1 unexplained, 1 parse errors)"
+
+
+def test_format_report_clean_and_empty() -> None:
+    clean = format_report(summarize(parse_divergence_lines([_line(diverged=True, disputed=True)])))
+    assert clean.splitlines()[-1] == "ENFORCE-READY: yes (0 unexplained)"
+
+    empty = format_report(summarize([]))
+    assert "no divergence lines found" in empty
+    assert empty.splitlines()[-1] == "ENFORCE-READY: yes (0 unexplained)"
+
+
+# ---------------------------------------------------------------------------
+# the CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_reads_files_and_exits_by_verdict(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    clean = tmp_path / "clean.log"
+    clean.write_text("noise\n" + _line(diverged=True, disputed=True) + "\n")
+    assert main([str(clean)]) == 0
+    out = capsys.readouterr().out
+    assert "ENFORCE-READY: yes (0 unexplained)" in out
+
+    dirty = tmp_path / "dirty.log"
+    dirty.write_text(_line(diverged=True) + "\n")
+    assert main([str(clean), str(dirty)]) == 1
+    out = capsys.readouterr().out
+    assert "ENFORCE-READY: no (1 unexplained)" in out
+
+
+def test_cli_stdin_and_unreadable_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import io
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(_line(diverged=False) + "\n"))
+    assert main([]) == 0
+    assert "ENFORCE-READY: yes" in capsys.readouterr().out
+
+    assert main([str(tmp_path / "missing.log")]) == 2
+    assert "cannot read" in capsys.readouterr().err

--- a/tests/test_fabric_mode_ladder.py
+++ b/tests/test_fabric_mode_ladder.py
@@ -1,0 +1,198 @@
+# tests/test_fabric_mode_ladder.py
+# Created: 2026-07-11 (FST-8 — the operational proof kit).
+#
+# THE FULL ROLLOUT LADDER, end to end: ONE store walked through
+# off → shadow → enforce → off, asserting the mode contract at every rung:
+#
+#   rung 1 (off)     — writes are pure LWW, ZERO statements, ZERO log lines;
+#   rung 2 (shadow)  — multi-source writes produce statements + divergence
+#                      lines while the cache still takes the LWW value;
+#   rung 3 (enforce) — the resolver owns the cache (a lower-trust write no
+#                      longer lands), and the CHANGE curation verb works;
+#   rung 4 (off)     — reads serve the last-resolved cache, LWW resumes with
+#                      the statement machinery untouched, history intact,
+#                      nothing errors.
+#
+# Plus the harness integration: the REAL divergence lines captured at rung 2
+# are fed through parse_divergence_lines + summarize — the FST-8 report
+# consumes actual store emissions, so this doubles as the contract
+# integration test (if the line format drifts, THIS breaks, not production
+# rollouts).
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.divergence_report import (
+    format_report,
+    parse_divergence_lines,
+    summarize,
+)
+from pocketpaw.fabric.store import FabricStore
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """The divergence lines (excludes the failure-shield warning)."""
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+def _table_count(db_path: Path, table: str) -> int:
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    finally:
+        con.close()
+
+
+async def test_full_mode_ladder_off_shadow_enforce_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+
+    # A connector-owned object: the crm connector is the property baseline.
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        {"name": "Acme", "industry": "fintech", "arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+
+    # ---------------- rung 1: mode=off — pure LWW, zero statements --------
+    _set_mode(monkeypatch, "off")
+    updated = await store.update_object(obj.id, {"arr": 150}, writer_class="agent")
+    assert updated is not None
+    assert updated.properties == {"name": "Acme", "industry": "fintech", "arr": 150}
+    assert _table_count(db_path, "fabric_statements") == 0
+    assert _table_count(db_path, "fabric_sources") == 0
+    assert _shadow_lines(caplog) == []
+
+    # ---------------- rung 2: flip shadow — statements + lines, cache LWW -
+    _set_mode(monkeypatch, "shadow")
+    caplog.clear()
+
+    # A second distinct source (agent session vs the crm baseline) touching
+    # two connector-held properties → both get PROMOTED (seed + incoming
+    # statement each) and each produces one divergence line.
+    updated = await store.update_object(
+        obj.id,
+        {"arr": 200, "industry": "crypto"},
+        writer_class="agent",
+        source_session_id="sess-1",
+    )
+    assert updated is not None
+
+    # The cache still takes the LWW value in shadow — resolver is advisory.
+    assert updated.properties["arr"] == 200
+    assert updated.properties["industry"] == "crypto"
+
+    # Statements exist: one promotion seed + one incoming, per property.
+    assert _table_count(db_path, "fabric_statements") == 4
+    arr_stmts = await store.get_statements(obj.id, "arr")
+    assert {s.writer_class for s in arr_stmts} == {"connector", "agent"}
+    assert {s.value for s in arr_stmts} == {150, 200}
+
+    # One divergence line per statement-producing property, and the resolver
+    # disagreed with LWW (connector seed outranks the agent write) — a
+    # DISPUTED, therefore EXPLAINED, divergence on both.
+    rung2_lines = _shadow_lines(caplog)
+    assert len(rung2_lines) == 2
+    assert all(" diverged=True disputed=True unresolvable=False" in ln for ln in rung2_lines)
+
+    # ---------------- rung 3: flip enforce — the resolver owns the cache --
+    _set_mode(monkeypatch, "enforce")
+    caplog.clear()
+
+    # A lower-trust write (inferred < connector seed) NO LONGER lands in the
+    # cache: LWW would have written 300; enforce keeps the resolved winner.
+    updated = await store.update_object(
+        obj.id, {"arr": 300}, writer_class="inferred", source_session_id="sess-2"
+    )
+    assert updated is not None
+    assert updated.properties["arr"] == 150  # the connector seed's value, not 300
+    reread = await store.get_object(obj.id)
+    assert reread is not None and reread.properties["arr"] == 150
+
+    # The losing claim is recorded, not dropped, and the line shows the
+    # override (lww=what LWW would have kept, resolver=what the cache holds).
+    assert any(s.value == 300 for s in await store.get_statements(obj.id, "arr"))
+    [enforce_line] = _shadow_lines(caplog)
+    assert "property=arr lww=300 resolver=150 diverged=True" in enforce_line
+
+    # The CHANGE curation verb works in enforce: a human preferred statement
+    # takes the top trust tier and the cache follows the new winner.
+    resolution = await store.change_property(
+        obj.id, "arr", 500, writer_class="human", source_actor_id="captain"
+    )
+    assert resolution.value == 500
+    assert resolution.winner_statement is not None
+    assert resolution.winner_statement.rank == "preferred"
+    reread = await store.get_object(obj.id)
+    assert reread is not None and reread.properties["arr"] == 500
+
+    # ---------------- rung 4: flip back off — LWW resumes, history intact -
+    _set_mode(monkeypatch, "off")
+    caplog.clear()
+    statements_before = _table_count(db_path, "fabric_statements")
+
+    # Reads serve the last-RESOLVED cache.
+    obj_after = await store.get_object(obj.id)
+    assert obj_after is not None
+    assert obj_after.properties["arr"] == 500  # the enforced CHANGE result
+    assert obj_after.properties["industry"] == "crypto"  # shadow-era LWW cache
+
+    # Subsequent writes are pure LWW and never touch the statement verbs.
+    async def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("statements path touched in mode=off")
+
+    monkeypatch.setattr(store, "get_statements", _boom)
+    monkeypatch.setattr(store, "append_statement", _boom)
+    monkeypatch.setattr(store, "upsert_source", _boom)
+
+    updated = await store.update_object(obj.id, {"arr": 700, "name": "Acme Corp"})
+    assert updated is not None
+    assert updated.properties["arr"] == 700  # LWW resumed
+    assert updated.properties["name"] == "Acme Corp"
+    assert _table_count(db_path, "fabric_statements") == statements_before  # history intact
+    assert _shadow_lines(caplog) == []
+
+    # ---------------- the harness consumes the REAL rung-2 emissions ------
+    records = parse_divergence_lines(rung2_lines)
+    assert len(records) == 2
+    assert all(r.ok for r in records), [r.parse_error for r in records]
+    by_prop = {r.property: r for r in records}
+    assert set(by_prop) == {"arr", "industry"}
+    assert by_prop["arr"].lww == 200 and by_prop["arr"].resolver == 150
+    assert by_prop["industry"].lww == "crypto" and by_prop["industry"].resolver == "fintech"
+    assert all(r.object_id == obj.id for r in records)
+    assert all(r.diverged and r.disputed and not r.unresolvable for r in records)
+    assert all(r.freshness == "fresh" for r in records)
+
+    # Both divergences are EXPLAINED (flagged disputes — multi-source
+    # ordering doing its job), so the shadow run reads as enforce-ready.
+    summary = summarize(records)
+    assert summary.total == 2
+    assert summary.diverged == 2
+    assert summary.disputed == 2
+    assert summary.unexplained == 0
+    assert summary.parse_errors == 0
+    assert summary.enforce_ready is True
+    report = format_report(summary)
+    assert report.splitlines()[-1] == "ENFORCE-READY: yes (0 unexplained)"


### PR DESCRIPTION
## What this does

Closes the source-truth chain with the operational proof kit:

- **The divergence report** (`python -m pocketpaw.fabric.divergence_report <logs>`): parses the shadow telemetry and answers the rollout question in one verdict line — `ENFORCE-READY: yes|no`. The heuristic: an *unexplained* divergence is the resolver overriding fresh, undisputed data with no visible reason; explained ones (disputes, unresolvable ties, freshness demotion) are multi-source ordering doing its job. Parse errors also block the green light (a malformed line could hide a real one), and the report states its coverage honestly (at-most-once per journal event). Exit codes make it scriptable.
- **The full-ladder e2e**: one store walked off → shadow → enforce → off, asserting each rung's contract — including feeding the real captured shadow lines through the report (the contract integration test).
- **Docs in the same PR**: a "Fabric Source Truth" section in the architecture concept doc (statement model, trust ladder + families, the mode ladder, the report as the enforce gate, the steward verbs + queue, freshness), the config-reference row for `fabric_source_truth_mode`, and a refresh of the flag's Field description (the FST-1 "reserved/inert" wording was stale since shadow/enforce shipped).

No behavior change anywhere — a read-only harness, tests, and docs.

## Verification

28 new tests (27 harness units + the ladder e2e); full fabric selection 369 (341 baseline + 28, isolation-checked); cloud dirs 37; prior test files untouched; CLI smoke on mixed stdin; ruff + format + import-linter clean.

Stacked on #1697 — the last slice of the chain (#1690 -> #1697).