### PR TITLE
Source-truth integration: Fabric trust layer (FST-1..8) + verify_mode shadow rung

### DIFF
--- a/docs/api/configuration-reference.mdx
+++ b/docs/api/configuration-reference.mdx
@@ -7,6 +7,13 @@ keywords: ["configuration", "environment variables", "settings reference", "conf
 tags: ["api", "configuration"]
 ---
 
+{/*
+  docs/api/configuration-reference.mdx
+  Updated 2026-07-11 (feat/fst-8-harness, FST-8) — added the "Fabric" section
+  with fabric_source_truth_mode (the off/shadow/enforce rollout switch) and
+  its divergence-report enforce gate.
+*/}
+
 # Configuration Reference
 
 Complete reference of all configuration settings. All environment variables use the `POCKETPAW_` prefix.
@@ -214,3 +221,9 @@ The pocket specialist does NOT receive Composio — its tool surface stays narro
 | `mem0_embedder_provider` | `POCKETPAW_MEM0_EMBEDDER_PROVIDER` | enum | `openai` | Embedder provider (`openai`, `ollama`, `huggingface`) |
 | `mem0_embedder_model` | `POCKETPAW_MEM0_EMBEDDER_MODEL` | string | `text-embedding-3-small` | Embedder model |
 | `mem0_vector_store` | `POCKETPAW_MEM0_VECTOR_STORE` | enum | `qdrant` | Vector store (`qdrant`, `chroma`) |
+
+## Fabric
+
+| Setting | Env Variable | Type | Default | Description |
+|---------|-------------|------|---------|-------------|
+| `fabric_source_truth_mode` | `POCKETPAW_FABRIC_SOURCE_TRUTH_MODE` | enum | `off` | Rollout mode for Fabric source truth (`off`, `shadow`, `enforce`). `off` = pure last-writer-wins, no statements. `shadow` = provenance statements + divergence log lines recorded alongside the LWW cache. `enforce` = the trust-ladder resolver's winner owns the cache. Gate the flip to `enforce` with `python -m pocketpaw.fabric.divergence_report` — see [Fabric Source Truth](/concepts/architecture#fabric-source-truth). |

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -7,6 +7,15 @@ keywords: ["event-driven architecture", "message bus pattern", "protocol-oriente
 tags: ["architecture", "design"]
 ---
 
+{/*
+  docs/concepts/architecture.mdx
+  Updated 2026-07-11 (feat/fst-8-harness, FST-8) — added the "Fabric Source
+  Truth" section: the statement model, the trust ladder, the off/shadow/
+  enforce mode ladder, the divergence report as the enforce gate, PIN/IGNORE
+  + the stewardship queue, and freshness decay. The section documents the
+  FST-1..8 chain in src/pocketpaw/fabric/ for devs who haven't read it.
+*/}
+
 # PocketPaw Architecture: Event-Driven Message Bus
 
 PocketPaw is built on an **event-driven message bus** architecture. This design decouples channels from agent backends, making it easy to add new channels and swap backends without touching the core pipeline.
@@ -76,3 +85,43 @@ The AgentLoop is the central coordinator:
 - **Memory** — Context builder assembles session history, long-term facts, and semantic search results
 - **Tools** — The tool registry provides available tools filtered by the policy system
 - **Backends** — The router delegates to the selected agent backend
+
+## Fabric Source Truth
+
+Fabric is PocketPaw's typed workspace ontology — objects like `Customer` or `Deal` with a flat `properties` dict that connectors, agents, and humans all write to. By default those writes are **last-writer-wins (LWW)**: whoever writes last owns the value, regardless of how trustworthy they are. The source-truth chain (`src/pocketpaw/fabric/`) fixes that without changing the read path.
+
+### The statement model
+
+Instead of only overwriting the cache, a tracked property accumulates **statements**: append-only claims (`fabric_statements` + `fabric_sources`), each carrying the value, who wrote it (`writer_class`), which source it came from (connector run, agent session, document, human actor), and when it was observed. Statements are opt-in per property — a property is only *promoted* to tracking when a **second distinct source** writes a materially different value. Single-source properties stay cheap scalar writes with zero extra rows.
+
+### The trust ladder
+
+A resolver (`resolver.py` + `trust.py`) orders a property's open statements by a global writer-class ladder, strongest first:
+
+`human > connector > mirror > agent > inferred`
+
+Within a tier, recency wins. Two same-tier claims with materially different values observed within a 24h epsilon are **unresolvable** — the ladder can't order them confidently, so the resolver returns a provisional winner and flags it. Two claims from different writer families disagreeing marks the resolution **disputed**. Human pins short-circuit the ladder entirely.
+
+### Freshness
+
+Every value decays: `fresh → aging → stale`, on per-class TTLs (volatile = 1 day, default = 30 days, stable = 1 year). A stale higher-tier value can be demoted below a fresh same-family one, and every resolution reports the winner's freshness — so a "the CRM said so, eight months ago" value is visible for what it is.
+
+### The mode ladder: off → shadow → enforce
+
+Rollout is a three-position switch, `fabric_source_truth_mode` (default `off`):
+
+| Mode | Statements | Cache (`properties`) |
+|------|-----------|---------------------|
+| `off` | never touched | pure LWW — byte-for-byte the pre-FST behavior |
+| `shadow` | recorded at every merge site | still LWW; the resolver runs advisory-only |
+| `enforce` | recorded | the **resolver's winner** is written — a lower-trust write no longer lands |
+
+In shadow and enforce, every statement-producing property logs one grep-stable divergence line (`fabric shadow: object=... lww=... resolver=... diverged=... disputed=... unresolvable=... freshness=...`). A failure in the statement pass never breaks the cache write — the write degrades to plain LWW with a warning. Flipping back to `off` is always safe: reads serve the last-resolved cache, LWW resumes, and statement history stays on disk. Shadow recording is at-most-once per journal event, so divergence logs are a lower bound on traffic, not an exact ledger.
+
+### The divergence report — the enforce gate
+
+`python -m pocketpaw.fabric.divergence_report <logfile>` (or stdin) parses those lines and answers "is shadow clean enough to enforce?". A divergence is **explained** when the line shows why the resolver disagreed with LWW (a flagged dispute, an unresolvable tie, freshness demotion — multi-source ordering doing its job). **Unexplained** divergences — the resolver overrode fresh, undisputed data with no visible reason — must be ZERO before flipping to enforce. The report exits 0/1 on its `ENFORCE-READY` verdict, so it drops into CI or a rollout script as-is.
+
+### Curation and stewardship
+
+Humans stay in the loop through four verbs on the store: **CHANGE** (supersede the winner with a preferred claim), **CORRECT** (deprecate a wrong claim with a reason), **PIN** (this value wins outright until unpinned), and **IGNORE** (strike a claim from resolution). Unresolvable conflicts are recomputed on scan (`conflicts.py` — no conflicts table to drift) and surface as one Instinct **stewardship-queue** proposal per conflicted property; answering with any verb, or a new higher-tier observation, closes the conflict on the next scan.

--- a/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
@@ -1,6 +1,12 @@
 # fabric.py — in-process MCP server exposing read-only Fabric ontology access
 # to the claude_agent_sdk cloud chat backend. Created: 2026-06-11
 # (feat/fabric-instinct-mcp-providers).
+# Updated: 2026-07-11 (FST-7 — provenance on reads) — fabric_query gained an
+#   opt-in ``include_provenance`` arg (default false; response shape unchanged
+#   without it): attaches per-property trust detail for statement-tracked
+#   properties via store.get_object_provenance — disputed/unresolvable flags,
+#   freshness tri-state, and the winning value's writer + source. Best-effort
+#   per object; a provenance failure never breaks the query.
 # Updated: 2026-06-11 (fix/fabric-stats-workspace-scope) — fabric_stats now
 # passes the resolved workspace into the store's scoped stats()/list_types(),
 # closing the live cross-tenant type-name leak the original instance-wide
@@ -180,6 +186,10 @@ async def _fabric_query_handler(args: dict) -> dict:
     link_type = args.get("link_type")
     filters = args.get("filters")
     limit = args.get("limit", 20)
+    # FST-7: opt-in provenance — default False so the default response shape
+    # (and its byte budget) is unchanged; the agent asks for it when trust
+    # matters ("where did this figure come from / is it disputed / stale?").
+    include_provenance = bool(args.get("include_provenance", False))
 
     for field_name, value in (
         ("type_name", type_name),
@@ -231,6 +241,20 @@ async def _fabric_query_handler(args: dict) -> dict:
         logger.debug("fabric_query trace emission skipped", exc_info=True)
 
     objects = [_serialize_object(o) for o in result.objects]
+
+    # FST-7: attach per-property provenance (disputed / unresolvable /
+    # freshness / winner source) for statement-TRACKED properties only —
+    # untracked properties don't appear (single-source, nothing to explain).
+    # Best-effort per object: a provenance failure never breaks the query.
+    if include_provenance:
+        for entry in objects:
+            try:
+                entry["provenance"] = await store.get_object_provenance(
+                    entry["id"], workspace_id=workspace_id
+                )
+            except Exception:  # noqa: BLE001 — additive surface, never fatal
+                logger.debug("fabric_query provenance skipped for %s", entry["id"], exc_info=True)
+
     objects, truncated = _cap_objects(objects)
 
     return _success_response(
@@ -312,9 +336,15 @@ def build_fabric_server() -> tuple[str, Any] | None:
             "search), `linked_to` (find objects linked to this object id), "
             "`link_type` (filter links by type), `filters` (property filters — "
             'a scalar for equality or an operator map like {"rent": {">": '
-            "1000}}), `limit` (max results, default 20, cap 50). Returns "
+            "1000}}), `limit` (max results, default 20, cap 50), "
+            "`include_provenance` (bool, default false — adds per-property "
+            "trust detail for multi-source properties: disputed/unresolvable "
+            "flags, freshness fresh|aging|stale, and the winning value's "
+            "writer + source; use it when asked where a figure came from or "
+            "whether it can be trusted). Returns "
             "{total, returned, truncated, objects:[{id, type_name, properties, "
-            "source_connector, source_id}]}. An error means relay the reason."
+            "source_connector, source_id, provenance?}]}. An error means relay "
+            "the reason."
         ),
         {
             "type": "object",
@@ -341,6 +371,13 @@ def build_fabric_server() -> tuple[str, Any] | None:
                 "limit": {
                     "type": "integer",
                     "description": "Max results (default 20, cap 50).",
+                },
+                "include_provenance": {
+                    "type": "boolean",
+                    "description": (
+                        "Attach per-property trust detail (disputed, freshness, "
+                        "winning source) for multi-source properties. Default false."
+                    ),
                 },
             },
             "additionalProperties": False,

--- a/ee/pocketpaw_ee/cloud/fabric_conflicts/__init__.py
+++ b/ee/pocketpaw_ee/cloud/fabric_conflicts/__init__.py
@@ -1,0 +1,40 @@
+# ee/cloud/fabric_conflicts/__init__.py — the conflict-stewardship Instinct
+# proposal type (a peer of ``_instinct_rule`` / ``_fabric_objects`` /
+# ``_pocket_create`` / ``_pocket_write`` / ``_code_change`` /
+# ``_external_action`` / ``_belt_plan`` / ``_artifact_change`` /
+# ``_admin_action``).
+# Created: 2026-07-10 (FST-6 — the conflict lifecycle) — the hybrid conflict UX:
+#   the source-truth resolver auto-resolves every conflict it can RANK; the
+#   un-rankable残り (``Resolution.unresolvable=True``) is swept into ONE Instinct
+#   proposal per conflicted property for a human steward to arbitrate. Approve
+#   (optionally editing the choice) → the executor PINs the chosen statement via
+#   the canonical OSS steward verb (``FabricStore.pin_statement``); reject → the
+#   policy's provisional winner stands, no statement change (router owns the
+#   reject-close). Precedent mirrored: ``instinct_rule_proposals`` (one proposal
+#   per subject, propose stages / executor fires on approve).
+#
+# Re-exports the propose + sweep helpers, the apply-on-approve executor, and the
+# blob constants so callers (the ingest sweep, the instinct router) import from
+# the package root, mirroring the instinct-rule gate.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.fabric_conflicts.executor import execute_approved_fabric_conflict
+from pocketpaw_ee.cloud.fabric_conflicts.propose import (
+    FABRIC_CONFLICT_KIND,
+    FABRIC_CONFLICT_PARAM_KEY,
+    FABRIC_CONFLICT_SCHEMA,
+    STEWARDSHIP_QUEUE_WARN_THRESHOLD,
+    propose_fabric_conflict,
+    sweep_conflicts_to_proposals,
+)
+
+__all__ = [
+    "FABRIC_CONFLICT_KIND",
+    "FABRIC_CONFLICT_PARAM_KEY",
+    "FABRIC_CONFLICT_SCHEMA",
+    "STEWARDSHIP_QUEUE_WARN_THRESHOLD",
+    "execute_approved_fabric_conflict",
+    "propose_fabric_conflict",
+    "sweep_conflicts_to_proposals",
+]

--- a/ee/pocketpaw_ee/cloud/fabric_conflicts/executor.py
+++ b/ee/pocketpaw_ee/cloud/fabric_conflicts/executor.py
@@ -1,0 +1,366 @@
+# ee/cloud/fabric_conflicts/executor.py — apply an approved conflict-stewardship choice.
+# Created: 2026-07-10 (FST-6 — the conflict lifecycle: _fabric_conflict proposal type).
+#
+# What this module does (the apply-on-approve half of the conflict gate): the
+# propose helper (``fabric_conflicts.propose``) stages an un-rankable Fabric
+# conflict as an Instinct Action carrying a ``_fabric_conflict`` blob. After a
+# human approves it (optionally editing ``resolution.chosen_statement_id`` to a
+# rival via the approve-with-edits path), the ee instinct router fires
+# ``execute_approved_fabric_conflict`` here — exactly mirroring the
+# instinct-rule gate (the PRECEDENT MIRRORED; see propose.py). This function:
+#
+#   1. Reads the ``_fabric_conflict`` blob. Missing blob → return (no chain was
+#      opened for it). Schema mismatch → mark_failed + close, return.
+#   2. Tenancy guard — an empty ``workspace_id`` → mark_failed + close (a pin
+#      with no tenant to scope it is a tenancy hole). Subject guard — missing
+#      ``object_id`` / ``property`` → mark_failed + close.
+#   3. Idempotency guard — a terminal Action (executed/failed) or a blob
+#      already carrying an ``outcome`` is NOT re-run: re-approve / retry never
+#      double-pins.
+#   4. Choice validation at the entry to the write path — the (possibly
+#      edited) ``resolution.chosen_statement_id`` MUST be one of the blob's
+#      staged ``choices``; anything else fails CLEANLY (an edit cannot smuggle
+#      an arbitrary statement id in). Belt-and-braces: the OSS verb re-checks
+#      that the statement belongs to exactly this (object, property) within
+#      the workspace scope.
+#   5. THE CHOICE → VERB MAPPING: **PIN the chosen statement** via the
+#      canonical OSS steward verb ``FabricStore.pin_statement`` (workspace-
+#      scoped store, ISO-1). PIN is the durable "this one wins" — the
+#      resolver's pinned short-circuit settles today's rivals AND future ones,
+#      and the losers stay auditable (IGNORE-the-rival would strike history
+#      and only settle today's conflict). In enforce the verb also writes the
+#      new winner into the flat cache; in shadow the pin lands on the
+#      statement layer only — exactly the steward-verb contract.
+#      REJECT never reaches this module: the router owns the reject-close and
+#      the policy's provisional winner simply stands (no statement change).
+#   6. Back-writes the outcome ``{status, pinned_statement_id, value,
+#      executed_at}`` onto the blob, marks the Action executed/failed, and
+#      closes the Decision-Graph chain exactly once.
+#
+# EXACTLY-ONE-TERMINAL discipline: on APPROVE the EXECUTOR owns the
+# ``decision.completed`` close — the router does NOT emit it. On REJECT the
+# ROUTER owns the close and the executor never runs. Every terminal path goes
+# through the single ``_fail`` chokepoint or the one success emit at the end.
+#
+# Never raises — a failure here must not break the approve response. The
+# router wraps the call too; this is belt-and-braces.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.fabric_conflicts.propose import (
+    FABRIC_CONFLICT_PARAM_KEY,
+    FABRIC_CONFLICT_SCHEMA,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_uuid(raw: Any) -> UUID | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be."""
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+async def _persist_outcome(
+    *,
+    store: Any,
+    action_id: str,
+    status: str,
+    summary: dict[str, Any],
+    executed_at: str,
+) -> None:
+    """Back-write the pin outcome onto the persisted ``_fabric_conflict`` blob.
+
+    Direct SQL update — the same pattern the instinct-rule executor uses. The
+    blob's ``outcome`` carries the pinned statement id + value so a reader
+    (audit, the idempotency guard, a "disputed facts" view) sees the result
+    structurally. Best-effort: a write failure leaves the free-text
+    ``mark_executed`` / ``mark_failed`` outcome as the record.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(FABRIC_CONFLICT_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["outcome"] = {"status": status, "executed_at": executed_at, **summary}
+        params[FABRIC_CONFLICT_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — back-write is best-effort
+        logger.warning(
+            "fabric_conflict: failed to persist outcome onto action %s — the "
+            "structured outcome is unavailable (free-text outcome still recorded)",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: UUID | None,
+    summary: str | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for a conflict stewardship.
+
+    Mirrors ``instinct_rule_proposals.executor._emit_chain_close`` — the
+    executor owns the close on the approve path. Returns early when
+    ``correlation_id`` is None (no chain to close). Best-effort.
+    """
+    if correlation_id is None:
+        return
+
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if summary:
+        payload["summary"] = summary
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "fabric_conflict decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+def _already_executed(action: Any, blob: dict[str, Any]) -> bool:
+    """Idempotency guard — True when this stewardship choice already ran.
+
+    Two signals, either sufficient: the blob carries an ``outcome`` (a prior
+    run back-wrote it), or the Action is already terminal (executed/failed).
+    A PIN is idempotent at the store layer, but re-running would still emit a
+    duplicate chain terminal — so the guard mirrors the precedent exactly.
+    """
+    if isinstance(blob.get("outcome"), dict):
+        return True
+    status = getattr(action, "status", None)
+    status_value = getattr(status, "value", status)
+    return str(status_value) in ("executed", "failed")
+
+
+async def execute_approved_fabric_conflict(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """PIN the statement a freshly-approved stewardship Action chose.
+
+    Called best-effort from the instinct router's ``approve_action`` /
+    ``bulk_approve_actions`` after ``store.approve()`` succeeds — the same
+    hook shape the instinct-rule executor uses. ``human_event_id`` threads
+    the router's ``human.corrected`` event id into the terminal
+    ``decision.completed`` causation. Never raises.
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(FABRIC_CONFLICT_PARAM_KEY)
+    if not isinstance(blob, dict):
+        # Not a conflict-stewardship Action — no chain was opened for it here.
+        logger.warning("approved action %s carries no _fabric_conflict blob", action.id)
+        return
+
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    object_id = str(blob.get("object_id") or "")
+    property_name = str(blob.get("property") or "")
+    approver = str(getattr(action, "approved_by", "") or "") or "steward"
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str) -> None:
+        """Mark the Action failed AND close the chain with one terminal — the
+        single failure-path chokepoint (never both fail and double-fire)."""
+        await store.mark_failed(action.id, reason)
+        await _persist_outcome(
+            store=store,
+            action_id=str(action.id),
+            status="failed",
+            summary={"reason": reason},
+            executed_at=datetime.now(UTC).isoformat(),
+        )
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=approver,
+            causation_id=causation,
+            summary=reason,
+        )
+
+    # Schema guard — a stale blob from an incompatible build fails loud rather
+    # than pinning a misinterpreted statement.
+    if blob.get("schema") != FABRIC_CONFLICT_SCHEMA:
+        await _fail(
+            "fabric-conflict schema mismatch — the blob is from an incompatible "
+            "build and cannot be executed",
+            error_class="SchemaMismatch",
+        )
+        return
+
+    # Tenancy — a pin with no workspace to scope it is a tenancy hole.
+    if not workspace_id:
+        await _fail(
+            "fabric-conflict blob carries no workspace_id — cannot scope the pin",
+            error_class="MissingWorkspace",
+        )
+        return
+    if not object_id or not property_name:
+        await _fail(
+            "fabric-conflict blob carries no object_id/property — nothing to pin",
+            error_class="MalformedBlob",
+        )
+        return
+
+    # Idempotency — never re-run on a re-invocation (bulk re-approve, retry).
+    if _already_executed(action, blob):
+        logger.info(
+            "fabric_conflict: action %s already executed (idempotency guard) — skipping the pin",
+            action.id,
+        )
+        return
+
+    # The human's (possibly edited) choice — validated against the STAGED
+    # choices so an edit can never smuggle in an arbitrary statement id.
+    resolution_spec = blob.get("resolution")
+    chosen = ""
+    if isinstance(resolution_spec, dict):
+        chosen = str(resolution_spec.get("chosen_statement_id") or "")
+    if not chosen:
+        await _fail(
+            "fabric-conflict blob carries no resolution.chosen_statement_id",
+            error_class="MalformedBlob",
+        )
+        return
+    staged_ids = {
+        str(c.get("statement_id") or "") for c in (blob.get("choices") or []) if isinstance(c, dict)
+    }
+    if chosen not in staged_ids:
+        await _fail(
+            f"chosen statement {chosen!r} is not one of the staged choices — "
+            "refusing to pin an unstaged statement",
+            error_class="InvalidChoice",
+        )
+        return
+
+    # THE VERB: pin the chosen statement through the canonical OSS steward
+    # verb on the workspace-scoped store. Any failure (statement vanished, was
+    # deprecated by a CORRECT in the meantime, store error) is a failed
+    # outcome — NEVER re-raised into the router.
+    try:
+        from pocketpaw.stores import get_fabric_store
+
+        fabric = get_fabric_store(workspace_id=workspace_id or None)
+        resolution = await fabric.pin_statement(
+            object_id, property_name, chosen, workspace_id=workspace_id
+        )
+    except Exception as exc:  # noqa: BLE001 — never let the pin break approve
+        logger.warning(
+            "fabric_conflict: pin crashed for action %s (workspace=%s)",
+            action.id,
+            workspace_id,
+            exc_info=True,
+        )
+        await _fail(f"pin failed: {exc}", error_class=type(exc).__name__)
+        return
+
+    summary = {
+        "pinned_statement_id": chosen,
+        "object_id": object_id,
+        "property": property_name,
+        "value": resolution.value,
+    }
+
+    # Success — mark executed, back-write the structured outcome, close the
+    # chain. This is the ONLY terminal on the happy path.
+    await store.mark_executed(
+        action.id,
+        f"pinned statement {chosen} as the winner for {property_name!r} (object {object_id})",
+    )
+    await _persist_outcome(
+        store=store,
+        action_id=str(action.id),
+        status="executed",
+        summary=summary,
+        executed_at=datetime.now(UTC).isoformat(),
+    )
+    _emit_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=approver,
+        causation_id=causation,
+        summary=f"pinned statement {chosen} for {property_name!r} on {object_id}",
+    )
+    logger.info(
+        "fabric_conflict: executed action %s → pinned %s on (%s, %r) (ok)",
+        action.id,
+        chosen,
+        object_id,
+        property_name,
+    )
+
+
+__all__ = ["execute_approved_fabric_conflict"]

--- a/ee/pocketpaw_ee/cloud/fabric_conflicts/propose.py
+++ b/ee/pocketpaw_ee/cloud/fabric_conflicts/propose.py
@@ -1,0 +1,582 @@
+# ee/cloud/fabric_conflicts/propose.py — stage an un-rankable Fabric conflict for a steward.
+# Created: 2026-07-10 (FST-6 — the conflict lifecycle: _fabric_conflict proposal type).
+#
+# What this module does (the propose half of the conflict-stewardship gate): the
+# source-truth chain's resolver (FST-2) auto-resolves every conflict it can RANK;
+# the残り — same-tier, same-rank, both-open, materially-different, within-epsilon
+# conflicts (``Resolution.unresolvable=True``) — cannot be ordered by policy and
+# need a human. This module turns each such open conflict (recomputed from
+# statements by ``pocketpaw.fabric.conflicts.detect_open_conflicts`` — no
+# conflicts table) into ONE Instinct ``Action`` carrying a ``_fabric_conflict``
+# blob (schema 1) under ``Action.parameters``. A human arbitrates it in The Tray:
+# approve (optionally editing the choice) → the apply-on-approve executor
+# (``fabric_conflicts.executor.execute_approved_fabric_conflict``) PINs the
+# chosen statement via the canonical OSS steward verb
+# ``FabricStore.pin_statement``; reject → the policy's provisional winner stands,
+# NO statement changes (the router owns the reject-close). This module does NOT
+# write Fabric — it only gates.
+#
+# PRECEDENT MIRRORED: ``instinct_rule_proposals`` (propose.py stages one proposal
+# per subject, executor.py fires on approve, the router owns reject-close) — the
+# closest shape: one SUBJECT (here one conflicted property) per proposal, an
+# editable sub-dict the human may adjust before approving, tenancy pinned on
+# SEPARATE top-level blob fields. The blob sits alongside ``_instinct_rule``,
+# ``_fabric_objects``, ``_pocket_create``, ``_pocket_write``, ``_code_change``,
+# ``_external_action``, ``_belt_plan``, ``_artifact_change``, ``_admin_action``;
+# the router + executor dispatch on the ``_fabric_conflict`` parameters key.
+#
+# Schema 1 — the blob carries:
+#   * ``schema`` / ``kind`` — version + discriminator;
+#   * ``workspace_id`` — the originating tenant, a SEPARATE top-level field (NOT
+#     inside the editable ``resolution``) so an edit can never move the proposal
+#     to another workspace. The executor's tenancy gate reads it here; the PIN is
+#     executed against this workspace's Fabric store.
+#   * ``object_id`` / ``property`` — the conflict subject. Top-level (immutable
+#     via edits); together with ``workspace_id`` they form the DEDUPE KEY
+#     ``(workspace_id, object_id, property)`` — the sweep guarantees at most ONE
+#     open proposal per key.
+#   * ``object_type`` — display context for the Tray.
+#   * ``choices`` — the competing statements (the policy's provisional winner
+#     first, then the un-rankable rivals), each with value + provenance
+#     (writer_class, rank, observed_at/recorded_at, and the SourceRef fields —
+#     enough for a human to decide). Read-only context.
+#   * ``policy_winner_statement_id`` — what policy provisionally picked (what
+#     "reject" keeps).
+#   * ``conflict_signature`` — sorted competing statement ids. Reject-memory: a
+#     rejected proposal for the same key with the SAME signature blocks
+#     re-filing (the human already said "keep the policy winner" for exactly
+#     this conflict); a new rival observation changes the signature and the
+#     conflict is re-staged.
+#   * ``resolution`` — the ONE editable sub-dict:
+#     ``{"chosen_statement_id": <id>}``, defaulting to the policy winner. The
+#     human either approves as-is (endorse policy's pick — now durable) or edits
+#     the choice to a rival via the approve-with-edits path
+#     (``ApproveRequest.parameters``) before approving. The executor validates
+#     the chosen id against ``choices`` — an edit cannot smuggle in an arbitrary
+#     statement.
+#   * ``summary`` — a human-readable one-liner for the gate UI;
+#   * ``correlation_id`` / ``proposed_event_id`` — the Decision-Graph chain ids
+#     (``agent.proposed`` opens the chain; the router's approve/reject paths and
+#     the executor close the SAME chain).
+#
+# APPROVE-CHOICE → VERB MAPPING (settled here, per the FST-6 design): approving
+# with choice A **PINs A's statement** — the durable "this one wins". PIN beats
+# IGNORE-the-rival because (a) the resolver's pinned short-circuit also settles
+# FUTURE rival observations, not just today's, and (b) the losing statements
+# stay intact for audit instead of being struck. IGNORE remains available as a
+# direct OSS steward verb for genuinely bogus claims.
+#
+# SWEEP WIRING (the lightest honest trigger): ``sweep_conflicts_to_proposals``
+# is invoked at the tail of ``fabric_ingest.service.run_ingest_sweep`` for each
+# workspace the ingest touched — conflicts are born at merge sites, so
+# after-ingest is the natural beat, AND that sweep already runs every 5 minutes
+# under ``FabricIngestScheduler`` (the established cloud periodic pattern), so
+# the same hook is the periodic sweep too. No new scheduler class. Best-effort,
+# exception-shielded, mode-gated (off → zero reads).
+#
+# Mode gate: the lifecycle runs in shadow AND enforce — a queued conflict in
+# shadow is observation with a human answer (the PIN lands on the statement
+# layer; only the cache write is enforce-only, exactly the verbs' contract).
+# Off → nothing (no scans, no proposals).
+#
+# Volume guard (the PRD queue-volume metric): after each sweep the number of
+# OPEN stewardship proposals for the workspace is counted; past
+# ``STEWARDSHIP_QUEUE_WARN_THRESHOLD`` (5) a grep-stable warning line is logged
+# — conflicts outpacing steward review is a rules/trust-ladder problem, not
+# something to silently queue.
+#
+# Security:
+#   * NO Fabric mutation here — the conflict is staged as DATA; the PIN only
+#     lands after a human approves.
+#   * Tenancy + subject are SEPARATE top-level blob fields (NOT in the editable
+#     ``resolution``); the router's ``_assert_fabric_conflict_workspace`` gates
+#     all four approve/reject paths (asymmetric tenant scope is no tenant scope
+#     — pocketpaw#1183 / #1250) and the executor re-validates.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# The Instinct Action kind discriminator for a conflict-stewardship proposal.
+# The router + executor dispatch on the presence of the parameters key below;
+# the blob also carries ``kind="fabric_conflict"`` for readers that introspect it.
+FABRIC_CONFLICT_KIND = "fabric_conflict"
+
+# The parameters key under which the conflict blob rides — peer of
+# ``_instinct_rule`` / ``_fabric_objects`` / ``_pocket_create`` et al.
+FABRIC_CONFLICT_PARAM_KEY = "_fabric_conflict"
+
+# Schema version stamped on the ``_fabric_conflict`` blob. Bump when the blob
+# shape changes so a stale pending Action approved after a deploy fails loud
+# instead of pinning a misinterpreted statement. Starts at 1 — first version.
+FABRIC_CONFLICT_SCHEMA = 1
+
+# The PRD queue-volume metric: past this many OPEN stewardship proposals in one
+# workspace, the sweep logs a warning — un-rankable conflicts are outpacing
+# steward review.
+STEWARDSHIP_QUEUE_WARN_THRESHOLD = 5
+
+
+def _source_truth_mode() -> str:
+    """The fabric_source_truth_mode setting, read through the OSS chokepoint.
+
+    Late import + late call so a test monkeypatch of
+    ``pocketpaw.fabric.store._source_truth_mode`` (the suite-wide seam every
+    FST test uses) is observed here too — ONE definition of the mode read.
+    """
+    from pocketpaw.fabric import store as fabric_store_mod
+
+    return fabric_store_mod._source_truth_mode()
+
+
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    workspace_id: str,
+    user_id: str,
+    object_type: str,
+    property: str,
+    choice_count: int,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for a conflict proposal.
+
+    Mirrors ``instinct_rule_proposals.propose._emit_agent_proposed``: the
+    proposing caller is the actor (``kind="agent"``); a conflict isn't bound
+    to a pocket — its tenancy is the workspace — so ``pocket_id`` on the chain
+    carries the workspace id (matching the Action's ``pocket_id``).
+
+    Returns the emitted event id (back-written onto the blob for the
+    ``human.corrected`` causation chain) or ``None`` when the emit raised —
+    best-effort per RFC 09; the Slice 4 reconciler picks up orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = f"arbitrate {choice_count} competing values for {object_type or 'object'}.{property}"
+    payload: dict[str, Any] = {
+        # Fields the projection's ``_fold_proposed`` consumes.
+        "intent": intent,
+        "action": "fabric_conflict",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        # Richer fields for the explain narrator.
+        "proposal_kind": "fabric_conflict",
+        "proposal": {
+            "object_type": object_type,
+            "property": property,
+            "choice_count": choice_count,
+        },
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "fabric_conflict agent.proposed emit failed for correlation_id=%s "
+            "(action_id=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Back-write ``correlation_id`` + ``proposed_event_id`` onto the persisted
+    Action's ``parameters._fabric_conflict`` blob after ``agent.proposed`` fired.
+
+    Direct SQL update — the same pattern the instinct-rule gate's
+    ``_persist_chain_ids`` uses. Best-effort: a write failure leaves
+    ``proposed_event_id`` None and the eventual ``human.corrected`` emits
+    without a causation_id (the chain still folds).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(FABRIC_CONFLICT_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[FABRIC_CONFLICT_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "fabric_conflict: failed to persist chain ids onto action %s — the "
+            "chain's human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _short(value: Any, limit: int = 60) -> str:
+    """A compact display form of a statement value for titles/summaries."""
+    text = repr(value)
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+async def _statement_choice(fabric: Any, stmt: Any, workspace_id: str) -> dict[str, Any]:
+    """One entry of the blob's ``choices`` list: value + full provenance.
+
+    Enough for a human to decide: WHO wrote it (writer_class), WHEN the
+    source says it was true (observed_at), when we learned it (recorded_at),
+    and WHERE it came from (the SourceRef identity fields). The source lookup
+    is best-effort — a missing SourceRef (pruned, out of scope) degrades to
+    ``source: None`` rather than blocking the proposal.
+    """
+    source_payload: dict[str, Any] | None = None
+    try:
+        source = await fabric.get_source(stmt.source_ref_id, workspace_id=workspace_id or None)
+    except Exception:  # noqa: BLE001 — provenance display is best-effort
+        source = None
+    if source is not None:
+        source_payload = {
+            "kind": source.kind,
+            "connector": source.connector,
+            "run_id": source.run_id,
+            "document_uri": source.document_uri,
+            "actor_id": source.actor_id,
+            "session_id": source.session_id,
+        }
+    return {
+        "statement_id": stmt.id,
+        "value": stmt.value,
+        "writer_class": stmt.writer_class,
+        "rank": stmt.rank,
+        "pinned": stmt.pinned,
+        "observed_at": stmt.observed_at.isoformat(),
+        "recorded_at": stmt.recorded_at.isoformat(),
+        "source": source_payload,
+    }
+
+
+async def propose_fabric_conflict(
+    *,
+    workspace_id: str,
+    conflict: Any,
+    requested_by: str = "fabric_steward",
+    summary: str | None = None,
+    correlation_id: str | None = None,
+    assignee: str | None = None,
+    fabric_store: Any | None = None,
+) -> str:
+    """Build + store an Instinct ``Action`` for ONE un-rankable conflict.
+
+    ``conflict`` is a ``pocketpaw.fabric.conflicts.ConflictRecord`` (winner +
+    rivals). Files an Action carrying the ``_fabric_conflict`` blob (schema 1)
+    and opens the Decision-Graph chain. Returns the proposed Action id. NO
+    Fabric mutation happens here — the choice is staged as DATA and the PIN
+    only lands after a human approves.
+
+    Callers normally reach this through :func:`sweep_conflicts_to_proposals`
+    (which dedupes); calling it directly bypasses the one-open-per-key
+    guarantee.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_fabric_store, get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("propose_fabric_conflict requires a non-empty workspace_id")
+    if conflict.winner is None or not conflict.rivals:
+        raise ValueError("propose_fabric_conflict requires a conflict with a winner and rivals")
+
+    fabric = fabric_store or get_fabric_store(workspace_id=workspace_id or None)
+
+    competing = [conflict.winner, *conflict.rivals]
+    choices = [await _statement_choice(fabric, s, workspace_id) for s in competing]
+
+    corr = correlation_id or str(uuid4())
+
+    values_text = " vs ".join(_short(c["value"]) for c in choices)
+    subject = f"{conflict.object_type or 'object'}.{conflict.property}"
+    human_summary = summary or (
+        f"Policy cannot rank {len(choices)} competing values for {subject}"
+        f" ({values_text}). Approve to make the selected value the durable"
+        f" winner (PIN); reject to keep the policy winner."
+    )
+
+    blob: dict[str, Any] = {
+        "kind": FABRIC_CONFLICT_KIND,
+        "schema": FABRIC_CONFLICT_SCHEMA,
+        # Tenancy + subject are SEPARATE top-level fields (NOT in the editable
+        # ``resolution``) so an edit can never re-scope or re-target the pin.
+        "workspace_id": workspace_id,
+        "object_id": conflict.object_id,
+        "property": conflict.property,
+        "object_type": conflict.object_type or "",
+        # Read-only decision context.
+        "choices": choices,
+        "policy_winner_statement_id": conflict.winner.id,
+        "conflict_signature": list(conflict.signature),
+        # The ONE editable sub-dict — the human's choice (defaults to the
+        # policy winner; approving unedited endorses policy's pick durably).
+        "resolution": {"chosen_statement_id": conflict.winner.id},
+        "summary": human_summary,
+        # RFC 09 chain-correlation fields (schema 1 carries them from the start).
+        "correlation_id": corr,
+        "proposed_event_id": None,
+    }
+
+    title = f"Disputed fact — {subject} has {len(choices)} competing values"
+    recommendation = f"Pick the value that should win. {human_summary}"
+    trigger = ActionTrigger(
+        type="agent",
+        source=requested_by or "fabric_conflicts",
+        reason="un-rankable Fabric conflict requires a steward decision",
+    )
+
+    # ISO: scope the store to the caller's workspace (validated non-empty
+    # above) — this propose path has no ``current_workspace`` ContextVar set.
+    store = get_instinct_store(workspace_id=workspace_id or None)
+    action_obj = await store.propose(
+        # ``pocket_id`` carries the workspace — a conflict isn't bound to a
+        # pocket (mirrors the instinct-rule gate); the workspace also rides on
+        # the blob (the executor's tenancy gate reads it there).
+        pocket_id=workspace_id,
+        title=title,
+        description=recommendation,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.WORKFLOW,
+        priority=ActionPriority.MEDIUM,
+        parameters={FABRIC_CONFLICT_PARAM_KEY: blob},
+        assignee=assignee or None,
+        workspace_id=workspace_id,
+    )
+
+    logger.info(
+        "fabric_conflict: proposed stewardship for %s (object=%s, %d choices) → "
+        "Instinct action %s (workspace=%s, correlation_id=%s)",
+        subject,
+        conflict.object_id,
+        len(choices),
+        action_obj.id,
+        workspace_id,
+        corr,
+    )
+
+    # Open the Decision-Graph chain now that the Action is stored. Best-effort:
+    # a Decision-Graph wiring failure must NOT fail the propose.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=UUID(corr),
+        action_id=action_obj.id,
+        workspace_id=workspace_id,
+        user_id=requested_by,
+        object_type=conflict.object_type or "",
+        property=conflict.property,
+        choice_count=len(choices),
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action_obj.id,
+            correlation_id=corr,
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    return action_obj.id
+
+
+def _conflict_blob(action: Any) -> dict[str, Any] | None:
+    """The ``_fabric_conflict`` blob on an Action, or ``None``."""
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get(FABRIC_CONFLICT_PARAM_KEY)
+    return blob if isinstance(blob, dict) else None
+
+
+def _blob_dedupe_key(blob: dict[str, Any]) -> tuple[str, str, str]:
+    """The proposal's dedupe key off the blob's top-level subject fields."""
+    return (
+        str(blob.get("workspace_id") or ""),
+        str(blob.get("object_id") or ""),
+        str(blob.get("property") or ""),
+    )
+
+
+async def sweep_conflicts_to_proposals(
+    workspace_id: str,
+    *,
+    requested_by: str = "fabric_steward",
+    assignee: str | None = None,
+    fabric_store: Any | None = None,
+) -> list[str]:
+    """Turn one workspace's open un-rankable conflicts into Instinct proposals.
+
+    The sweep half of the FST-6 lifecycle (see the module header for the
+    wiring: post-ingest hook + the 5-minute ingest scheduler beat). Steps:
+
+    1. Mode gate — ``fabric_source_truth_mode`` off → return [] with ZERO
+       reads. Shadow and enforce both sweep (a queued conflict in shadow is
+       observation with a human answer).
+    2. Recompute the open conflicts from statements
+       (``detect_open_conflicts`` — no persisted conflict state).
+    3. Dedupe — ONE open proposal per ``(workspace_id, object_id, property)``:
+       a key with a PENDING ``_fabric_conflict`` Action is skipped, so
+       re-sweeps never duplicate while one is open (the instinct-rule
+       precedent's one-proposal-per-subject discipline). Additionally,
+       reject-memory: a key whose most recent REJECTED proposal carries the
+       SAME ``conflict_signature`` is skipped — the human already answered
+       "keep the policy winner" for exactly this conflict; a new rival
+       observation changes the signature and re-stages it.
+    4. File a proposal per remaining conflict (isolated — one failure never
+       blocks the rest).
+    5. Volume guard — warn past :data:`STEWARDSHIP_QUEUE_WARN_THRESHOLD` open
+       stewardship proposals for the workspace.
+
+    Returns the NEWLY filed Action ids.
+    """
+    from pocketpaw.fabric.conflicts import detect_open_conflicts
+    from pocketpaw.instinct.models import ActionStatus
+    from pocketpaw.stores import get_fabric_store, get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("sweep_conflicts_to_proposals requires a non-empty workspace_id")
+
+    mode = _source_truth_mode()  # read ONCE per sweep
+    if mode not in ("shadow", "enforce"):
+        return []
+
+    fabric = fabric_store or get_fabric_store(workspace_id=workspace_id or None)
+    conflicts = await detect_open_conflicts(fabric, workspace_id=workspace_id)
+
+    store = get_instinct_store(workspace_id=workspace_id or None)
+
+    # Open (PENDING) stewardship proposals → the one-open-per-key guarantee.
+    open_keys: set[tuple[str, str, str]] = set()
+    try:
+        pending = await store.list_actions(
+            pocket_id=workspace_id,
+            status=ActionStatus.PENDING,
+            workspace_id=workspace_id,
+            limit=500,
+        )
+    except Exception:  # noqa: BLE001 — a failed listing must not crash the sweep
+        logger.warning(
+            "fabric_conflict: failed to list open proposals for workspace %s — "
+            "skipping this sweep rather than risking duplicates",
+            workspace_id,
+            exc_info=True,
+        )
+        return []
+    for action in pending:
+        blob = _conflict_blob(action)
+        if blob is not None:
+            open_keys.add(_blob_dedupe_key(blob))
+
+    # Reject-memory: (key, signature) pairs a human already dismissed.
+    rejected_signatures: set[tuple[tuple[str, str, str], tuple[str, ...]]] = set()
+    try:
+        rejected = await store.list_actions(
+            pocket_id=workspace_id,
+            status=ActionStatus.REJECTED,
+            workspace_id=workspace_id,
+            limit=500,
+        )
+    except Exception:  # noqa: BLE001 — reject-memory is best-effort
+        rejected = []
+    for action in rejected:
+        blob = _conflict_blob(action)
+        if blob is not None:
+            signature = tuple(str(s) for s in blob.get("conflict_signature") or [])
+            rejected_signatures.add((_blob_dedupe_key(blob), signature))
+
+    filed: list[str] = []
+    for conflict in conflicts:
+        key = (workspace_id, conflict.object_id, conflict.property)
+        if key in open_keys:
+            continue  # one open proposal per key — re-sweeps never duplicate
+        if (key, tuple(conflict.signature)) in rejected_signatures:
+            continue  # the human already kept the policy winner for THIS conflict
+        try:
+            action_id = await propose_fabric_conflict(
+                workspace_id=workspace_id,
+                conflict=conflict,
+                requested_by=requested_by,
+                assignee=assignee,
+                fabric_store=fabric,
+            )
+        except Exception:  # noqa: BLE001 — one bad conflict never blocks the rest
+            logger.warning(
+                "fabric_conflict: failed to file a proposal for %s.%s (object=%s, ws=%s)",
+                conflict.object_type or "object",
+                conflict.property,
+                conflict.object_id,
+                workspace_id,
+                exc_info=True,
+            )
+            continue
+        filed.append(action_id)
+        open_keys.add(key)
+
+    # Volume guard — the PRD queue-volume metric. ``open_keys`` now holds the
+    # pre-existing open proposals plus everything just filed.
+    open_count = len(open_keys)
+    if open_count > STEWARDSHIP_QUEUE_WARN_THRESHOLD:
+        logger.warning(
+            "fabric_conflict: stewardship queue for workspace %s has %d open "
+            "proposal(s) (threshold %d) — un-rankable conflicts are outpacing "
+            "steward review; consider a trust-rule override for the noisy "
+            "properties",
+            workspace_id,
+            open_count,
+            STEWARDSHIP_QUEUE_WARN_THRESHOLD,
+        )
+
+    if filed:
+        logger.info(
+            "fabric_conflict: sweep filed %d stewardship proposal(s) for workspace %s",
+            len(filed),
+            workspace_id,
+        )
+    return filed
+
+
+__all__ = [
+    "FABRIC_CONFLICT_KIND",
+    "FABRIC_CONFLICT_PARAM_KEY",
+    "FABRIC_CONFLICT_SCHEMA",
+    "STEWARDSHIP_QUEUE_WARN_THRESHOLD",
+    "propose_fabric_conflict",
+    "sweep_conflicts_to_proposals",
+]

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -34,6 +34,17 @@
 #   conflict between sources, so the source-truth chain has nothing to
 #   arbitrate there. Proven by
 #   tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py.
+# Updated: 2026-07-10 (FST-6 — the conflict lifecycle: post-ingest stewardship
+#   sweep) — run_ingest_sweep now ends with a best-effort per-workspace call to
+#   fabric_conflicts.sweep_conflicts_to_proposals: every workspace the ingest
+#   touched gets its open un-rankable conflicts staged as Instinct stewardship
+#   proposals. THIS is the FST-6 sweep wiring (the lightest honest trigger):
+#   conflicts are born at the merge sites this worker drives, so after-ingest
+#   is the natural beat — and because FabricIngestScheduler already ticks
+#   run_ingest_sweep every 5 minutes, the same hook doubles as the periodic
+#   sweep with no new scheduler class. Exception-shielded (a conflict-sweep
+#   failure never fails the ingest summary) and mode-gated inside the sweep
+#   itself (fabric_source_truth_mode 'off' → zero reads, zero proposals).
 #
 # What this does
 # --------------
@@ -364,6 +375,32 @@ async def run_ingest_sweep(
         errors,
         workspace_id or "ALL",
     )
+
+    # FST-6 — after the ingest batches land, stage each touched workspace's
+    # un-rankable conflicts as Instinct stewardship proposals. Best-effort per
+    # workspace (a conflict-sweep failure never fails the ingest summary);
+    # mode-gated inside the sweep (off → zero reads); lazy import so the
+    # ingest worker carries no module-top dependency on the gate package.
+    for ws in sorted({s["workspace_id"] for s in sources}):
+        try:
+            from pocketpaw_ee.cloud.fabric_conflicts import sweep_conflicts_to_proposals
+
+            filed = await sweep_conflicts_to_proposals(ws)
+            if filed:
+                logger.info(
+                    "fabric_ingest: post-ingest conflict sweep filed %d stewardship "
+                    "proposal(s) for workspace %s",
+                    len(filed),
+                    ws,
+                )
+        except Exception:  # noqa: BLE001 — the conflict sweep is best-effort
+            logger.warning(
+                "fabric_ingest: post-ingest conflict sweep failed for workspace %s "
+                "(non-fatal)",
+                ws,
+                exc_info=True,
+            )
+
     return {"sources": len(sources), "ok": ok, "errors": errors}
 
 

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -11,6 +11,17 @@
 #   pinned via the mapping's new optional type_id). Behavior note inherited
 #   from the canonical loop: a mapped field absent from a document projects as
 #   None (the mirror reflects the source) rather than being skipped.
+# Updated: 2026-07-10 (FST-4 — SHADOW mode at merge site 3) — the mirror now
+#   threads its TRUE provenance through ingest_records' new keyword params:
+#   writer_class="mirror" (a Firestore mirror is not a primary connector —
+#   the trust ladder ranks connector > mirror), source_document_uri = the
+#   full Firestore doc path (per-record, via the existing _DOC_PATH_KEY
+#   sentinel), and observed_at = the best available SOURCE time per doc
+#   (via the new _OBSERVED_AT_KEY sentinel — see _doc_observed_at for the
+#   per-field audit: cursor_field value first, snapshot update_time second,
+#   ingest-time default when neither parses). Only the shadow statements are
+#   affected; with fabric_source_truth_mode 'off' (default) the kwargs are
+#   inert and the mirror's writes are byte-for-byte unchanged.
 #
 # What this does
 # --------------
@@ -81,6 +92,10 @@ _SOURCE_CONNECTOR = "firestore"
 # extracts the source id from a record key, so we graft it on under a name no
 # real Firestore field would use (and which would be overwritten if one did).
 _DOC_PATH_KEY = "__firestore_doc_path__"
+# Sentinel record key carrying the per-doc SOURCE timestamp (FST-4) into the
+# OSS mapper's observed_at threading — same grafting trick as _DOC_PATH_KEY.
+# Holds a datetime or None (None → the statement defaults to ingest time).
+_OBSERVED_AT_KEY = "__fabric_observed_at__"
 
 # Per-collection page cap so one huge collection can't wedge a sweep tick.
 _MAX_DOCS_PER_RUN = 1000
@@ -416,6 +431,41 @@ def _doc_cursor(doc: dict[str, Any], cursor_field: str) -> str:
     return str(raw)
 
 
+def _doc_observed_at(doc: dict[str, Any], cursor_field: str) -> datetime | None:
+    """The best available SOURCE timestamp for one Firestore doc (FST-4).
+
+    Audit of what the worker actually knows per document (nothing else is on
+    the wire — the reader returns ``{path, data, update_time}`` only):
+
+    1. ``data[cursor_field]`` — the mapping's configured cursor field,
+       conventionally the document's own updated-at. The REAL source time
+       when present; may be a Firestore timestamp (google's
+       DatetimeWithNanoseconds subclasses datetime) or an RFC3339/ISO
+       string. Best choice when it parses.
+    2. ``update_time`` — the Firestore snapshot's server update time,
+       rendered RFC3339 by the reader. Not field-precise (any write to the
+       doc bumps it) but still a true source-side time; the fallback.
+    3. Neither parses → ``None``: the statement falls back to ingest time
+       (append_statement's observed_at default) — the honest floor, never a
+       fabricated timestamp.
+
+    There is NO per-field timestamp in Firestore, so one doc-level time
+    covers every property the doc updates.
+    """
+    data = doc.get("data") or {}
+    candidates = (data.get(cursor_field) if cursor_field else None, doc.get("update_time"))
+    for raw in candidates:
+        if raw is None or raw == "":
+            continue
+        if isinstance(raw, datetime):
+            return raw
+        try:
+            return datetime.fromisoformat(str(raw))
+        except ValueError:
+            continue
+    return None
+
+
 async def _mirror_docs(
     store: StoreLike,
     workspace_id: str,
@@ -442,13 +492,26 @@ async def _mirror_docs(
     otherwise — legacy NULL-workspace rows are globally visible),
     ``source_connector="firestore"``, and ``source_id`` = the full doc path.
     Returns the number of objects created + updated.
+
+    FST-4 (merge site 3): shadow-statement provenance rides the same call —
+    ``writer_class="mirror"`` (the mirror is not a primary connector), the
+    doc path doubles as the per-record ``source_document_uri`` (so each
+    statement's SourceRef names the exact Firestore collection/doc), and the
+    best available source time per doc (see ``_doc_observed_at``) becomes
+    ``observed_at``. All of it is inert when fabric_source_truth_mode is
+    'off'.
     """
     # Lazy import — keeps EE module import light and consistent with the other
     # OSS imports in this module (_default_store).
     from pocketpaw.connectors.fabric_ingest import FabricMapping, ingest_records
 
     records = [
-        {**(doc.get("data") or {}), _DOC_PATH_KEY: str(doc.get("path") or "")} for doc in docs
+        {
+            **(doc.get("data") or {}),
+            _DOC_PATH_KEY: str(doc.get("path") or ""),
+            _OBSERVED_AT_KEY: _doc_observed_at(doc, mapping.cursor_field),
+        }
+        for doc in docs
     ]
     oss_mapping = FabricMapping(
         type_name=mapping.object_type_id,  # label only; type_id pins the type
@@ -462,6 +525,9 @@ async def _mirror_docs(
         records,
         oss_mapping,
         workspace_id=workspace_id,
+        writer_class="mirror",
+        document_uri_field=_DOC_PATH_KEY,
+        observed_at_field=_OBSERVED_AT_KEY,
     )
     return summary.total
 

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -22,6 +22,18 @@
 #   ingest-time default when neither parses). Only the shadow statements are
 #   affected; with fabric_source_truth_mode 'off' (default) the kwargs are
 #   inert and the mirror's writes are byte-for-byte unchanged.
+# Updated: 2026-07-10 (FST-5 — ENFORCE at merge site 3, no code change) —
+#   enforce flows through this worker automatically because the update path
+#   delegates to store.update_object (via ingest_records): tracked properties
+#   land in the cache as the resolver's winner, untracked keep LWW. Ruling on
+#   the field-map collapse in _mirror_docs (two Firestore fields mapping to
+#   ONE property → the LAST mapping wins inside the dict comprehension): it
+#   STAYS as-is. The collapse happens BEFORE the store write and is
+#   WITHIN-SOURCE — one document from one source deciding which of its own
+#   fields feeds a property is a mapping-configuration concern, not a trust
+#   conflict between sources, so the source-truth chain has nothing to
+#   arbitrate there. Proven by
+#   tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py.
 #
 # What this does
 # --------------

--- a/ee/pocketpaw_ee/cloud/planner/service.py
+++ b/ee/pocketpaw_ee/cloud/planner/service.py
@@ -29,6 +29,21 @@
 #   ``preconditions`` from each OSS TaskSpec onto the cloud Task it
 #   creates, so completion-time verification (pocketpaw#1162) can read
 #   machine-checkable criteria off the materialized Task.
+# Updated: 2026-07-10 (feat/verify-mode-shadow) — three-position
+#   ``verify_mode`` at the cloud terminal: ``_run_one`` now resolves
+#   ``effective_cloud_plan_verify_mode()`` ONCE (off | shadow | enforce;
+#   the legacy ``cloud_plan_verify_loop_enabled`` bool resolves to ENFORCE
+#   for back-compat) and passes it to ``_verify_plan_task_outcome``. off ⇒
+#   byte-for-byte today's default. shadow ⇒ the verdict is stamped on
+#   ``Task.verify['verdict']`` plus ``verify['mode']='shadow'`` and
+#   ``verify['would_have']=<done|requeued|escalated>`` (what enforce WOULD
+#   have decided, computed READ-ONLY — no requeue_count bump, no feedback
+#   growth, no status change) with a ``verify shadow mode: would_have=...``
+#   log line; the helper returns "done" so every DONE side-effect (output
+#   file, artifact upload, auto-complete) runs exactly as today. enforce ⇒
+#   the prior flag-on behaviour, unchanged. The rejected-attempt feedback
+#   block in the run instructions renders ONLY in enforce — shadow must not
+#   alter the run itself.
 # Updated: 2026-07-02 (feat/svl-5-cloud-verify) — Self-Verifying Loop at
 #   the CLOUD planner terminal (SVL-5), behind
 #   ``cloud_plan_verify_loop_enabled`` (default False ⇒ byte-for-byte
@@ -1281,6 +1296,11 @@ async def _execute_ready_plan_tasks(
 
     # Run all concurrently
     async def _run_one(tid, aid, d):
+        # Resolve the three-position verify mode ONCE per run (off | shadow
+        # | enforce — the legacy cloud_plan_verify_loop_enabled bool resolves
+        # to 'enforce' via effective_cloud_plan_verify_mode()). Everything
+        # verify-related below keys off this single resolution.
+        verify_mode = get_settings().effective_cloud_plan_verify_mode()
         instr = "You are executing a task from a project plan.\\n\\n"
         instr += "## Task: " + d.title + "\\n\\n"
         instr += d.summary + "\\n\\n"
@@ -1293,9 +1313,12 @@ async def _execute_ready_plan_tasks(
         # first — so the re-dispatched agent sees exactly what to fix
         # rather than a bare "try again". Mirrors the OSS executor's
         # ``_build_task_prompt`` "Why the last attempt was rejected"
-        # block. Flag-gated so a disabled loop renders today's
-        # instructions byte-for-byte even if old feedback is on the doc.
-        if get_settings().cloud_plan_verify_loop_enabled:
+        # block. ENFORCE-only: off renders today's instructions
+        # byte-for-byte even if old feedback is on the doc, and shadow
+        # must be observe-only — it never writes feedback itself, and
+        # rendering leftovers from a prior enforce phase would change the
+        # run in a mode that promises zero behavioural delta.
+        if verify_mode == "enforce":
             feedback = (getattr(d, "verify", None) or {}).get("feedback") or []
             if feedback:
                 instr += "\\n## Why the last attempt was rejected\\n"
@@ -1339,20 +1362,23 @@ async def _execute_ready_plan_tasks(
 
             # SVL-5 (Self-Verifying Loop, cloud planner terminal): judge
             # the run's output against the Task's success_criteria BEFORE
-            # any DONE side-effect fires. "done" = SOLVED / UNKNOWN (or
-            # flag off) — fall through to today's completion path
-            # untouched. "requeued" / "escalated" = the verify helper
-            # already moved the task (back to ``proposed`` / to
-            # ``failed``) and stamped why; a rejected attempt must NOT
-            # save its output file, upload artifacts, or auto-complete —
-            # returning here is what enforces that invariant.
+            # any DONE side-effect fires. "done" = SOLVED / UNKNOWN, mode
+            # off, or SHADOW mode (which stamps the verdict + would_have
+            # and always passes through) — fall through to today's
+            # completion path untouched. "requeued" / "escalated"
+            # (enforce only) = the verify helper already moved the task
+            # (back to ``proposed`` / to ``failed``) and stamped why; a
+            # rejected attempt must NOT save its output file, upload
+            # artifacts, or auto-complete — returning here is what
+            # enforces that invariant.
             resolution = "done"
-            if get_settings().cloud_plan_verify_loop_enabled:
+            if verify_mode != "off":
                 resolution = await _verify_plan_task_outcome(
                     workspace_id=workspace_id,
                     project_id=project_id,
                     task_id=tid,
                     full_output=full_output,
+                    mode=verify_mode,
                 )
             if resolution != "done":
                 return resolution
@@ -1501,14 +1527,29 @@ async def _verify_plan_task_outcome(
     project_id: str,
     task_id: str,
     full_output: str,
+    mode: str = "enforce",
 ) -> str:
     """SVL-5 verify hook — judge a finished plan-task run before completion.
 
-    Called from ``_run_one`` only when ``cloud_plan_verify_loop_enabled``
-    is on, after the agent run produced ``full_output`` and BEFORE any
-    DONE side-effect. The verifier is the OSS
-    ``DeterministicVerdictProvider`` — external to the agent that
-    produced the output. Returns the resolution the caller must honour:
+    Called from ``_run_one`` only when the resolved
+    ``effective_cloud_plan_verify_mode()`` is non-'off', after the agent
+    run produced ``full_output`` and BEFORE any DONE side-effect. The
+    verifier is the OSS ``DeterministicVerdictProvider`` — external to the
+    agent that produced the output.
+
+    ``mode`` is the caller's resolved verify mode:
+
+      - ``"shadow"`` — observe-only rollout rung. The verdict is stamped
+        on ``verify['verdict']`` together with ``verify['mode']='shadow'``
+        and ``verify['would_have']=<done|requeued|escalated>`` (what
+        enforce WOULD have decided, computed READ-ONLY — no
+        ``requeue_count`` bump, no ``feedback`` growth, no status change),
+        a ``verify shadow mode: would_have=...`` line is logged, and the
+        helper ALWAYS returns ``"done"`` so every DONE side-effect runs
+        exactly as today.
+      - ``"enforce"`` — the full loop below.
+
+    Returns the resolution the caller must honour:
 
       - ``"done"`` — SOLVED / UNKNOWN (or the task doc vanished): a
         passing or uncheckable result is NEVER requeued or mutated. The
@@ -1558,6 +1599,16 @@ async def _verify_plan_task_outcome(
 
     if verdict.status not in (OutcomeStatus.PARTIAL, OutcomeStatus.NOT_SOLVED):
         # SOLVED / UNKNOWN — stamp the verdict and pass through.
+        if mode == "shadow":
+            # Shadow telemetry covers every completion, not just the
+            # failing ones: enforce would have passed this through too.
+            verify_state["mode"] = "shadow"
+            verify_state["would_have"] = "done"
+            logger.info(
+                "verify shadow mode: would_have=done verdict=%s task=%s",
+                verdict.status.value,
+                task_id,
+            )
         doc.verify = verify_state
         await doc.save()
         # no-event: the TaskResolved emitted by _auto_complete_task
@@ -1581,6 +1632,36 @@ async def _verify_plan_task_outcome(
         current = frozenset(cr.criterion for cr in unmet)
         prev = frozenset(item["criterion"] for item in prior_feedback[-1].get("unmet_criteria", []))
         no_progress = current == prev or len(current) >= len(prev)
+
+    if mode == "shadow":
+        # SHADOW: record what enforce WOULD have decided (no-progress vs
+        # budget vs requeue — computed read-only above) WITHOUT mutating
+        # anything the loop acts through: no status change, no
+        # requeue_count bump, no feedback growth. Returning "done" lets
+        # every DONE side-effect run exactly as today — the would_have
+        # stamp + log line are the rollout telemetry a tenant reads
+        # before daring enforce.
+        if no_progress:
+            would_have = "escalated"
+            would_reason = "no_progress"
+        elif n < max_requeues:
+            would_have = "requeued"
+            would_reason = ""
+        else:
+            would_have = "escalated"
+            would_reason = "budget_exhausted"
+        verify_state["mode"] = "shadow"
+        verify_state["would_have"] = would_have
+        doc.verify = verify_state
+        await doc.save()
+        logger.info(
+            "verify shadow mode: would_have=%s%s verdict=%s task=%s",
+            would_have,
+            f" reason={would_reason}" if would_reason else "",
+            verdict.status.value,
+            task_id,
+        )
+        return "done"
 
     if not no_progress and n < max_requeues:
         # REQUEUE: append this attempt's rejections to the CUMULATIVE

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,26 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-07-10 (FST-6 — _fabric_conflict proposal type) — wired the
+#   conflict-stewardship gate kind into the FOUR-path dispatch.
+#   ``_fabric_conflict_blob`` + ``_assert_fabric_conflict_workspace`` are the
+#   peers of the existing blob accessors + tenancy guards. The blob
+#   (``Action.parameters._fabric_conflict``) carries the un-rankable Fabric
+#   conflict's subject (top-level ``workspace_id`` / ``object_id`` /
+#   ``property`` — immutable), the read-only ``choices`` (competing values +
+#   provenance), and the ONE editable sub-dict
+#   ``resolution.chosen_statement_id`` (defaults to the policy winner; the
+#   approve-with-edits path may re-point it at a staged rival). On APPROVE the
+#   router emits ``human.corrected`` then fires
+#   ``fabric_conflicts.executor.execute_approved_fabric_conflict`` (which
+#   validates the choice against the staged set and PINs it via the OSS
+#   steward verb ``FabricStore.pin_statement`` on the workspace-scoped store,
+#   and OWNS the chain close). On REJECT the router emits ``human.corrected``
+#   + ``decision.completed(rejected)`` itself (the executor never runs — NO
+#   statement changes; the policy's provisional winner stands). The
+#   ``_assert_fabric_conflict_workspace`` 403 runs in ALL FOUR locations
+#   (approve / bulk-approve / reject / bulk-reject) BEFORE any mutation. Same
+#   exactly-one-terminal discipline as the instinct-rule gate (the precedent
+#   this kind mirrors); the other 9 kinds are unchanged.
 # Updated: 2026-07-03 (feat/workspace-admin-tools, WA-2 — _admin_action proposal
 #   type) — added the 8th gated proposal kind: a gated workspace-admin write.
 #   ``_admin_action_blob`` + ``_assert_admin_action_workspace`` are the peers of
@@ -974,6 +995,47 @@ def _assert_instinct_rule_workspace(action: Any, current_workspace: str) -> None
         )
 
 
+def _fabric_conflict_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_fabric_conflict`` blob on an Action, or ``None``.
+
+    The blob is the conflict-stewardship payload ``ee.cloud.fabric_conflicts.
+    propose`` stores under ``Action.parameters._fabric_conflict`` (FST-6): the
+    un-rankable conflict's subject (``workspace_id`` / ``object_id`` /
+    ``property`` as SEPARATE top-level fields), the read-only ``choices``, and
+    the editable ``resolution.chosen_statement_id``. A peer gated proposal
+    kind — the approve path dispatches the apply-on-approve executor (which
+    PINs the chosen statement) on its presence, exactly as it dispatches the
+    instinct-rule executor on ``_instinct_rule``. Anything that is not a dict
+    is treated as "no fabric conflict".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_fabric_conflict")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_fabric_conflict_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting a conflict stewardship from another workspace.
+
+    Mirror of ``_assert_instinct_rule_workspace`` for the ``_fabric_conflict``
+    blob (FST-6). Approving pins a statement in the tenant's Fabric, so the
+    cross-workspace gate is mandatory on BOTH the approve and reject side
+    (asymmetric tenant scope is no tenant scope — pocketpaw#1183 / #1250).
+    Tenancy lives on the blob's top-level ``workspace_id`` (NEVER inside the
+    editable ``resolution``). A non-conflict Action (no blob) is unaffected.
+    """
+    blob = _fabric_conflict_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This fabric conflict belongs to a different workspace",
+        )
+
+
 def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
     """Reject approving a parked pocket write from another workspace.
 
@@ -1353,6 +1415,7 @@ async def bulk_approve_actions(
             _assert_fabric_objects_workspace(action, workspace_id)
             _assert_pocket_create_workspace(action, workspace_id)
             _assert_instinct_rule_workspace(action, workspace_id)
+            _assert_fabric_conflict_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
             _assert_admin_action_workspace(action, workspace_id)
@@ -1541,6 +1604,40 @@ async def bulk_approve_actions(
                 )
             continue
 
+        # FST-6 — a bulk-approved ``_fabric_conflict`` Action PINs its chosen
+        # statement (the staged default — bulk-approve has no edit surface, so
+        # disposition is always ``accepted`` and the choice is the policy
+        # winner). Mirrors the instinct-rule branch above: per-item
+        # ``human.corrected(accepted)``, the ``agent.proposed`` event id as
+        # causation, then the executor (which owns the chain close). Matched
+        # BEFORE the pocket-write fallthrough and ``continue``d so the kinds
+        # never cross.
+        fabric_conflict_blob = _fabric_conflict_blob(action)
+        if fabric_conflict_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=fabric_conflict_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(fabric_conflict_blob),
+            )
+            try:
+                from pocketpaw_ee.cloud.fabric_conflicts import (
+                    executor as fabric_conflict_executor,
+                )
+
+                await fabric_conflict_executor.execute_approved_fabric_conflict(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve fabric-conflict execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
         # MANDATES — a bulk-approved ``_belt_plan`` Action fires the plan
         # executor, exactly like the single-approve hook (disposition is always
         # ``accepted`` — bulk-approve has no edit surface). The executor owns
@@ -1708,6 +1805,7 @@ async def bulk_reject_actions(
             _assert_fabric_objects_workspace(action, workspace_id)
             _assert_pocket_create_workspace(action, workspace_id)
             _assert_instinct_rule_workspace(action, workspace_id)
+            _assert_fabric_conflict_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
             _assert_admin_action_workspace(action, workspace_id)
@@ -1874,6 +1972,32 @@ async def bulk_reject_actions(
             )
             continue
 
+        # FST-6 — a bulk-rejected ``_fabric_conflict`` Action closes its chain
+        # HERE (the executor never runs on reject — the router owns the close).
+        # NO statement changes: the policy's provisional winner stands. Mirrors
+        # the instinct-rule reject branch. Matched AFTER the earlier kinds and
+        # ``continue``d so the kinds never cross.
+        fabric_conflict_blob = _fabric_conflict_blob(action)
+        if fabric_conflict_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=fabric_conflict_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(fabric_conflict_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=fabric_conflict_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            continue
+
         # MANDATES — a bulk-rejected ``_belt_plan`` Action closes its chain
         # here (the plan executor never runs on reject), mirroring the
         # code-change branch above.
@@ -2014,6 +2138,11 @@ async def approve_action(
     # top-level fields, not a pocket. Approving it creates an active governed rule
     # in the tenant's workspace, so the cross-workspace gate is mandatory here.
     _assert_instinct_rule_workspace(before, workspace_id)
+    # FST-6 — same tenancy gate for a conflict-stewardship Action — its
+    # ``_fabric_conflict`` blob carries the workspace on a SEPARATE top-level
+    # field. Approving it PINs a statement in the tenant's Fabric, so the
+    # cross-workspace gate is mandatory here.
+    _assert_fabric_conflict_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -2306,6 +2435,38 @@ async def approve_action(
         except Exception:
             logger.exception("instinct-rule execution after approval failed (non-fatal)")
 
+    # FST-6 — when the approved Action carries a ``_fabric_conflict`` blob,
+    # PIN the chosen statement via the OSS steward verb (workspace-scoped
+    # Fabric store). Same best-effort, lazy-import, never-break-the-approve-
+    # response shape as the instinct-rule hook above; the executor records
+    # success / failure on the Action itself. The router owns the
+    # ``human.corrected`` emit (disposition ``edited`` when the approver
+    # adjusted the choice via the edit surface); the EXECUTOR owns the chain
+    # CLOSE — no ``decision.completed`` here, no double terminal.
+    fabric_conflict_blob = _fabric_conflict_blob(approved)
+    if fabric_conflict_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=fabric_conflict_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(fabric_conflict_blob),
+        )
+        try:
+            from pocketpaw_ee.cloud.fabric_conflicts import (
+                executor as fabric_conflict_executor,
+            )
+
+            await fabric_conflict_executor.execute_approved_fabric_conflict(
+                approved, human_event_id=human_event_id
+            )
+        except Exception:
+            logger.exception("fabric-conflict execution after approval failed (non-fatal)")
+
     # MANDATES — when the approved Action carries a ``_belt_plan`` blob (the
     # mandate foreman's shift plan), dispatch the plan executor. Same shape as
     # the code-change hook: the router owns the ``human.corrected`` emit, the
@@ -2489,6 +2650,11 @@ async def reject_action(
     # asymmetric tenant scope is no tenant scope: a cross-workspace reject must
     # 403 before any mutation, exactly like the approve side.
     _assert_instinct_rule_workspace(before, workspace_id)
+    # FST-6 — same tenancy gate for a conflict-stewardship Action on the REJECT
+    # side. Asymmetric tenant scope is no tenant scope: a cross-workspace reject
+    # (which would dismiss another tenant's conflict) must 403 before any
+    # mutation, exactly like the approve side.
+    _assert_fabric_conflict_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -2663,6 +2829,32 @@ async def reject_action(
         )
         _emit_decision_completed_rejected(
             blob=instinct_rule_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
+        )
+
+    # FST-6 — a rejected ``_fabric_conflict`` Action closes its chain HERE
+    # (the executor never runs on reject — the router owns the close,
+    # mirroring the instinct-rule reject path). NO statement changes: the
+    # policy's provisional winner simply stands, and the sweep's
+    # reject-memory (the blob's ``conflict_signature``) keeps the same
+    # conflict from being re-staged until it materially changes.
+    fabric_conflict_blob = _fabric_conflict_blob(action)
+    if fabric_conflict_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=fabric_conflict_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(fabric_conflict_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=fabric_conflict_blob,
             action=action,
             user_id=rejector_id,
             workspace_id=workspace_id,

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,13 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-07-11 (FST-8 — divergence report + docs): Refreshed the
+    ``fabric_source_truth_mode`` Field description — shadow/enforce semantics
+    SHIPPED in FST-3..7 (the FST-1 "RESERVED / INERT" wording was stale):
+    shadow records statements + divergence lines while the cache stays LWW,
+    enforce hands the cache to the trust-ladder resolver, and the flip to
+    enforce is gated by ``python -m pocketpaw.fabric.divergence_report``.
+    Description text only — no behavioral change.
   - 2026-07-10 (FST-1 — Fabric source-truth schema): Added
     ``fabric_source_truth_mode`` (Literal off|shadow|enforce, default 'off';
     POCKETPAW_FABRIC_SOURCE_TRUTH_MODE) — the three-position rollout switch for
@@ -1927,17 +1934,23 @@ class Settings(BaseSettings):
         description=(
             "Rollout mode for the Fabric source-truth chain (FST). Three-position "
             "switch, mirroring litellm_spend_mode:\n"
-            "  * 'off'     (default) — byte-for-byte today: nothing reads or writes "
-            "the fabric_statements / fabric_sources provenance tables; the flat "
-            "FabricObject.properties dict is the only read path.\n"
-            "  * 'shadow'  — RESERVED (semantics land in a later FST slice): "
-            "statement writes mirror alongside the flat properties dict, which "
-            "keeps serving every read.\n"
-            "  * 'enforce' — RESERVED (semantics land in a later FST slice): "
-            "resolved statements become authoritative for reads.\n"
-            "As of FST-1 the flag is INERT — no code path consumes it yet; only "
-            "the schema and append-only store CRUD exist. The flat properties "
-            "dict remains the primary read path in every mode. Set via "
+            "  * 'off'     (default) — byte-for-byte pre-FST behavior: pure "
+            "last-writer-wins; nothing reads or writes the fabric_statements / "
+            "fabric_sources provenance tables; the flat FabricObject.properties "
+            "dict is the only read path.\n"
+            "  * 'shadow'  — provenance statements are recorded at every merge "
+            "site and one grep-stable divergence line is logged per "
+            "statement-producing property; the cache still takes the LWW value "
+            "(the trust-ladder resolver runs advisory-only) and keeps serving "
+            "every read.\n"
+            "  * 'enforce' — the resolver's winner owns the cache: a lower-trust "
+            "write no longer lands in the flat properties dict; the losing claim "
+            "is recorded as a statement, not dropped.\n"
+            "Flipping back to 'off' is always safe: reads serve the last-resolved "
+            "cache, LWW resumes, statement history stays on disk. Gate the flip "
+            "to 'enforce' with the FST-8 divergence report (python -m "
+            "pocketpaw.fabric.divergence_report <logfile>) — target ZERO "
+            "unexplained divergences. Set via "
             "POCKETPAW_FABRIC_SOURCE_TRUTH_MODE."
         ),
     )

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,21 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-07-10 (feat/verify-mode-shadow): Added the three-position verify
+    rollout modes — ``deep_work_verify_mode`` and ``cloud_plan_verify_mode``
+    (Literal off|shadow|enforce, default 'off'; env
+    POCKETPAW_DEEP_WORK_VERIFY_MODE / POCKETPAW_CLOUD_PLAN_VERIFY_MODE) —
+    superseding the boolean kill-switches so a real tenant can run a SAFE
+    observe-only SHADOW phase (verdict + judge stamps + a
+    ``would_have=<done|requeued|escalated>`` telemetry line; task status
+    NEVER touched) before anyone risks ENFORCE. Resolved by
+    ``effective_deep_work_verify_mode()`` /
+    ``effective_cloud_plan_verify_mode()`` (mirrors
+    ``effective_spend_mode()``): a non-'off' mode wins outright; mode 'off'
+    + legacy bool True resolves to 'enforce' — NOT shadow — because the
+    bools' SHIPPED meaning is the full acting loop, and mapping them to
+    shadow would silently strip requeue/escalate from any deployment that
+    already set them. The legacy bools stay for back-compat.
   - 2026-07-02 (feat/judge-shadow-1168): Added the LLM-as-judge SHADOW settings
     (J-1, issue #1168) — ``deep_work_verify_judge_shadow_enabled`` (default
     False; when True AND deep_work_verify_loop_enabled is on, every completing
@@ -575,15 +590,45 @@ class Settings(BaseSettings):
     deep_work_verify_loop_enabled: bool = Field(
         default=False,
         description=(
-            "Kill-switch for the deep_work Self-Verifying Loop. When False "
-            "(default) deep_work tasks complete exactly as before — no outcome "
-            "verification, byte-for-byte today's behaviour. When True, every "
-            "task that completes successfully has its result checked against "
-            "the success_criteria captured at intake and the resulting "
-            "OutcomeVerdict is stamped on the task's metadata "
-            "(``verify_verdict``) and logged. The verdict is observe-only in "
-            "this slice (SVL-1): the task's status is NOT changed by the "
-            "verification — that is the requeue slice (SVL-2)."
+            "LEGACY back-compat bool for the deep_work Self-Verifying Loop — "
+            "superseded by the three-position "
+            "POCKETPAW_DEEP_WORK_VERIFY_MODE switch. Kept so an existing "
+            "deployment that set this bool keeps the behaviour it shipped "
+            "with: when the new mode is left at its 'off' default and this "
+            "bool is True, ``effective_deep_work_verify_mode()`` resolves to "
+            "'enforce' (the FULL acting loop — verify, requeue, escalate), "
+            "NOT 'shadow' — the bool's shipped meaning IS enforce, and "
+            "mapping it to shadow would silently weaken a deploy that "
+            "already relies on requeue/escalate. Ignored once the mode is "
+            "set to any non-'off' value. Set via "
+            "POCKETPAW_DEEP_WORK_VERIFY_LOOP_ENABLED."
+        ),
+    )
+    deep_work_verify_mode: Literal["off", "shadow", "enforce"] = Field(
+        default="off",
+        description=(
+            "Three-position rollout switch for the deep_work Self-Verifying "
+            "Loop (OSS Mission Control executor terminal). Supersedes the "
+            "deep_work_verify_loop_enabled bool so a tenant can run a SAFE "
+            "observe-only phase before verification is allowed to touch "
+            "task status:\n"
+            "  * 'off'     (default) — no verification; tasks complete "
+            "byte-for-byte as today.\n"
+            "  * 'shadow'  — the safe rollout rung. The deterministic "
+            "verdict is computed and stamped (``verify_verdict``, plus a "
+            "``verify_mode='shadow'`` marker and "
+            "``verify_would_have=<done|requeued|escalated>`` — what enforce "
+            "WOULD have decided), and the judge shadow still runs when its "
+            "flag is on; but the task ALWAYS completes DONE — no requeue, "
+            "no escalation, no ``verify_requeue_count``, no "
+            "``verify_feedback`` growth. Pure telemetry.\n"
+            "  * 'enforce' — the full loop: PARTIAL / NOT_SOLVED requeues "
+            "with feedback (bounded by deep_work_verify_max_requeues) then "
+            "escalates to BLOCKED — exactly the legacy bool's behaviour.\n"
+            "Precedence (``effective_deep_work_verify_mode()``): a non-'off' "
+            "mode wins outright; mode 'off' + legacy bool True resolves to "
+            "'enforce'; otherwise 'off'. Set via "
+            "POCKETPAW_DEEP_WORK_VERIFY_MODE."
         ),
     )
     deep_work_verify_max_requeues: int = Field(
@@ -645,18 +690,47 @@ class Settings(BaseSettings):
     cloud_plan_verify_loop_enabled: bool = Field(
         default=False,
         description=(
-            "Kill-switch for the Self-Verifying Loop at the CLOUD planner "
-            "terminal (ee/cloud plan-task execution — the paw-enterprise "
-            "product path). When False (default) plan tasks auto-complete "
-            "exactly as before — no outcome verification, byte-for-byte "
-            "today's behaviour. When True, every plan task that finishes its "
-            "agent run has its output checked against the cloud Task's "
-            "success_criteria and the OutcomeVerdict is stamped on the task "
-            "(``verify.verdict``). SOLVED / UNKNOWN complete exactly as "
-            "today; PARTIAL / NOT_SOLVED is requeued with the unmet criteria "
-            "fed back to the next attempt, bounded by "
-            "cloud_plan_verify_max_requeues, then failed with a stamped "
-            "``verify.escalation_reason``."
+            "LEGACY back-compat bool for the Self-Verifying Loop at the "
+            "CLOUD planner terminal — superseded by the three-position "
+            "POCKETPAW_CLOUD_PLAN_VERIFY_MODE switch. Kept so an existing "
+            "deployment that set this bool keeps the behaviour it shipped "
+            "with: when the new mode is left at its 'off' default and this "
+            "bool is True, ``effective_cloud_plan_verify_mode()`` resolves "
+            "to 'enforce' (the FULL acting loop — verify, requeue, "
+            "escalate), NOT 'shadow' — the bool's shipped meaning IS "
+            "enforce, and mapping it to shadow would silently weaken a "
+            "deploy that already relies on requeue/escalate. Ignored once "
+            "the mode is set to any non-'off' value. Set via "
+            "POCKETPAW_CLOUD_PLAN_VERIFY_LOOP_ENABLED."
+        ),
+    )
+    cloud_plan_verify_mode: Literal["off", "shadow", "enforce"] = Field(
+        default="off",
+        description=(
+            "Three-position rollout switch for the Self-Verifying Loop at "
+            "the CLOUD planner terminal (ee/cloud plan-task execution — the "
+            "paw-enterprise product path). Supersedes the "
+            "cloud_plan_verify_loop_enabled bool so a real tenant can run a "
+            "SAFE observe-only phase before verification is allowed to "
+            "touch task status:\n"
+            "  * 'off'     (default) — no verification; plan tasks "
+            "auto-complete byte-for-byte as today.\n"
+            "  * 'shadow'  — the safe rollout rung. The deterministic "
+            "verdict is computed and stamped on the task's ``verify`` dict "
+            "(``verify.verdict``, plus ``verify.mode='shadow'`` and "
+            "``verify.would_have=<done|requeued|escalated>`` — what enforce "
+            "WOULD have decided); the task ALWAYS completes done with every "
+            "DONE side-effect intact — no requeue, no escalation, no "
+            "``verify.requeue_count``, no ``verify.feedback`` growth. Pure "
+            "telemetry.\n"
+            "  * 'enforce' — the full loop: PARTIAL / NOT_SOLVED requeues "
+            "with feedback (bounded by cloud_plan_verify_max_requeues) then "
+            "fails with ``verify.escalation_reason`` — exactly the legacy "
+            "bool's behaviour.\n"
+            "Precedence (``effective_cloud_plan_verify_mode()``): a "
+            "non-'off' mode wins outright; mode 'off' + legacy bool True "
+            "resolves to 'enforce'; otherwise 'off'. Set via "
+            "POCKETPAW_CLOUD_PLAN_VERIFY_MODE."
         ),
     )
     cloud_plan_verify_max_requeues: int = Field(
@@ -2274,6 +2348,54 @@ class Settings(BaseSettings):
             return self.litellm_spend_mode
         if self.litellm_spend_ingest_enabled:
             return "shadow"
+        return "off"
+
+    def effective_deep_work_verify_mode(self) -> Literal["off", "shadow", "enforce"]:
+        """Resolve the deep_work verify-loop mode, honouring the legacy bool.
+
+        Mirrors the ``effective_spend_mode()`` shape: the three-position
+        ``deep_work_verify_mode`` switch supersedes the
+        ``deep_work_verify_loop_enabled`` bool. Resolution, in order:
+
+          1. An EXPLICIT ``POCKETPAW_DEEP_WORK_VERIFY_MODE`` (any non-'off'
+             value) wins outright — ``shadow`` and ``enforce`` are taken as
+             set.
+          2. Mode unset / 'off' + the legacy bool True → ``enforce``.
+          3. Mode unset / 'off' + the legacy bool False/unset → ``off``.
+
+        WHY the legacy bool maps to ``enforce`` and never ``shadow`` (the
+        DELIBERATE opposite of the spend-mode precedent): the verify bool's
+        SHIPPED meaning is the full acting loop — requeue on PARTIAL /
+        NOT_SOLVED, escalate to BLOCKED on budget / no-progress. A
+        deployment that set the bool opted into that enforcement; resolving
+        it to 'shadow' would silently strip requeue/escalate from that
+        deployment on upgrade — a behaviour downgrade with no operator
+        decision. (The spend bool mapped to the safe MIDDLE position
+        because 'live' moves money and the bool's legacy path had no
+        periodic caller; here the bool's legacy behaviour IS the strong
+        position, so back-compat preserves it.)
+        """
+        if self.deep_work_verify_mode != "off":
+            return self.deep_work_verify_mode
+        if self.deep_work_verify_loop_enabled:
+            return "enforce"
+        return "off"
+
+    def effective_cloud_plan_verify_mode(self) -> Literal["off", "shadow", "enforce"]:
+        """Resolve the CLOUD planner verify-loop mode, honouring the legacy bool.
+
+        Identical shape to ``effective_deep_work_verify_mode()`` at the
+        ee/cloud planner terminal: an explicit non-'off'
+        ``POCKETPAW_CLOUD_PLAN_VERIFY_MODE`` wins outright; mode 'off' +
+        legacy ``cloud_plan_verify_loop_enabled`` True → ``enforce`` (NOT
+        shadow — the bool's shipped meaning is the acting loop, see the
+        deep_work resolver's docstring for the full rationale); otherwise
+        ``off``.
+        """
+        if self.cloud_plan_verify_mode != "off":
+            return self.cloud_plan_verify_mode
+        if self.cloud_plan_verify_loop_enabled:
+            return "enforce"
         return "off"
 
     def save(self) -> None:

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,14 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-07-10 (FST-1 — Fabric source-truth schema): Added
+    ``fabric_source_truth_mode`` (Literal off|shadow|enforce, default 'off';
+    POCKETPAW_FABRIC_SOURCE_TRUTH_MODE) — the three-position rollout switch for
+    the Fabric source-truth chain, mirroring the ``litellm_spend_mode``
+    pattern. INERT in FST-1: no code path reads it yet; only the
+    fabric_statements/fabric_sources schema + append-only store CRUD exist.
+    'off' is byte-for-byte today's behavior (the flat properties dict is the
+    only read path); shadow/enforce semantics land in later FST slices.
   - 2026-07-02 (feat/judge-shadow-1168): Added the LLM-as-judge SHADOW settings
     (J-1, issue #1168) — ``deep_work_verify_judge_shadow_enabled`` (default
     False; when True AND deep_work_verify_loop_enabled is on, every completing
@@ -1912,6 +1920,25 @@ class Settings(BaseSettings):
             "resolved before flipping to 'live'. 1 credit == $0.01, so the default "
             "10 ≈ $0.10 of tolerated per-tenant-per-window drift (rounding noise). "
             "Set via POCKETPAW_LITELLM_RECONCILE_GAP_THRESHOLD_CREDITS."
+        ),
+    )
+    fabric_source_truth_mode: Literal["off", "shadow", "enforce"] = Field(
+        default="off",
+        description=(
+            "Rollout mode for the Fabric source-truth chain (FST). Three-position "
+            "switch, mirroring litellm_spend_mode:\n"
+            "  * 'off'     (default) — byte-for-byte today: nothing reads or writes "
+            "the fabric_statements / fabric_sources provenance tables; the flat "
+            "FabricObject.properties dict is the only read path.\n"
+            "  * 'shadow'  — RESERVED (semantics land in a later FST slice): "
+            "statement writes mirror alongside the flat properties dict, which "
+            "keeps serving every read.\n"
+            "  * 'enforce' — RESERVED (semantics land in a later FST slice): "
+            "resolved statements become authoritative for reads.\n"
+            "As of FST-1 the flag is INERT — no code path consumes it yet; only "
+            "the schema and append-only store CRUD exist. The flat properties "
+            "dict remains the primary read path in every mode. Set via "
+            "POCKETPAW_FABRIC_SOURCE_TRUTH_MODE."
         ),
     )
     site_pending_alert_hours: float = Field(

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -12,6 +12,15 @@
 #   existing ObjectType by id (the EE Firestore→Fabric worker's per-workspace
 #   mapping) ride this same canonical upsert loop instead of hand-rolling a
 #   parallel one. Additive; name-based callers are unchanged.
+# Updated: 2026-07-10 (FST-3 — SHADOW mode at merge site 1) — ingest_records
+#   now threads source-truth provenance into the UPDATE path: update_object is
+#   called with writer_class="connector", source_kind="connector_run",
+#   source_connector=<this connector>, and the new optional ``run_id`` param
+#   (default None — every existing caller unchanged) as source_run_id. When
+#   fabric_source_truth_mode is shadow/enforce, statements recorded at merge
+#   site 1 therefore carry honest connector provenance end-to-end; in 'off'
+#   (default) the kwargs are inert and behavior is byte-for-byte. CREATE path
+#   untouched (FST-4's scope).
 # Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ensure_type() now
 #   threads ``workspace_id`` into both the get_type_by_name() resolve and the
 #   define_type() create, so the type catalog stays per-tenant: a connector
@@ -169,6 +178,7 @@ async def ingest_records(
     records: Iterable[Mapping[str, Any]],
     mapping: FabricMapping,
     workspace_id: str | None = None,
+    run_id: str | None = None,
 ) -> IngestResult:
     """Map connector records into typed Fabric objects with provenance (idempotent).
 
@@ -180,6 +190,10 @@ async def ingest_records(
         workspace_id: W4a tenancy scope; threaded into both the dedup read and
             the create write so an ingest stays inside its tenant. ``None`` for
             single-tenant / OSS callers.
+        run_id: optional sync-run identity (FST-3). When set, the SourceRef the
+            shadow pass records for updated objects carries it, so statements
+            from different sync runs of the same connector are distinguishable.
+            ``None`` = "this connector, unattributed run".
 
     Returns:
         IngestResult with created / updated / skipped counts and the object ids.
@@ -189,6 +203,14 @@ async def ingest_records(
     store's merge-update); a new source_id CREATES one with provenance. Records
     lacking a usable source_id are skipped (counted) — without a stable key they
     cannot be deduplicated and would silently duplicate on every sync.
+
+    FST-3: the UPDATE path passes full source-truth provenance
+    (``writer_class="connector"``, a ``connector_run`` SourceRef with this
+    connector + run_id) into ``store.update_object``, so when
+    ``fabric_source_truth_mode`` is shadow/enforce the statements recorded at
+    merge site 1 carry honest connector provenance. In mode 'off' the kwargs
+    are inert. The CREATE path is untouched (statement coverage for creates is
+    FST-4's scope).
     """
     type_id = await ensure_type(store, mapping, workspace_id=workspace_id)
     result = IngestResult(type_name=mapping.type_name)
@@ -206,7 +228,15 @@ async def ingest_records(
             workspace_id=workspace_id,
         )
         if existing is not None:
-            updated = await store.update_object(existing.id, properties, workspace_id=workspace_id)
+            updated = await store.update_object(
+                existing.id,
+                properties,
+                workspace_id=workspace_id,
+                writer_class="connector",
+                source_kind="connector_run",
+                source_connector=connector,
+                source_run_id=run_id,
+            )
             result.updated += 1
             result.object_ids.append((updated or existing).id)
         else:

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -42,6 +42,12 @@
 #   source_connector) and touch-time observed_at, so the create-then-update
 #   flow yields both claims and a visible conflict without any create hook
 #   (proven by tests/test_fabric_shadow_create_path.py).
+# Updated: 2026-07-10 (FST-5 — ENFORCE at merge site 3, no code change) — the
+#   re-ingest UPDATE path already goes through store.update_object with full
+#   provenance (FST-3/4 above), so enforce mode flows through this module
+#   AUTOMATICALLY: for a TRACKED property the store commits the resolver's
+#   winner instead of the blind LWW value; untracked properties keep LWW.
+#   Proven by tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py.
 # Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ensure_type() now
 #   threads ``workspace_id`` into both the get_type_by_name() resolve and the
 #   define_type() create, so the type catalog stays per-tenant: a connector

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -21,6 +21,27 @@
 #   site 1 therefore carry honest connector provenance end-to-end; in 'off'
 #   (default) the kwargs are inert and behavior is byte-for-byte. CREATE path
 #   untouched (FST-4's scope).
+# Updated: 2026-07-10 (FST-4 — SHADOW mode at merge site 3) — three OPTIONAL
+#   keyword-only params so the EE Firestore→Fabric mirror worker can thread
+#   its true provenance through this same loop (defaults keep every FST-3
+#   caller byte-identical):
+#     * ``writer_class`` (default "connector") — the mirror passes "mirror"
+#       (a Firestore mirror is not a primary connector; the trust ladder
+#       ranks connector > mirror);
+#     * ``document_uri_field`` — a record key whose value becomes the
+#       per-record ``source_document_uri`` (the mirror passes its doc-path
+#       sentinel, so each statement's SourceRef identifies the exact
+#       Firestore collection/doc);
+#     * ``observed_at_field`` — a record key holding a datetime that becomes
+#       the per-record ``observed_at`` (the mirror grafts the best available
+#       source time; non-datetime values are ignored → ingest-time default).
+#   CREATE-path decision (FST-4, settled): creates get NO statement hook.
+#   Promotion-time seeding already preserves the create-time claim — when a
+#   second source later updates a property, the seed statement is built from
+#   the current cache value with the OBJECT-level provenance (its
+#   source_connector) and touch-time observed_at, so the create-then-update
+#   flow yields both claims and a visible conflict without any create hook
+#   (proven by tests/test_fabric_shadow_create_path.py).
 # Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ensure_type() now
 #   threads ``workspace_id`` into both the get_type_by_name() resolve and the
 #   define_type() create, so the type catalog stays per-tenant: a connector
@@ -69,6 +90,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
 
 from pocketpaw.fabric.models import PropertyDef
@@ -179,6 +201,10 @@ async def ingest_records(
     mapping: FabricMapping,
     workspace_id: str | None = None,
     run_id: str | None = None,
+    *,
+    writer_class: str = "connector",
+    document_uri_field: str | None = None,
+    observed_at_field: str | None = None,
 ) -> IngestResult:
     """Map connector records into typed Fabric objects with provenance (idempotent).
 
@@ -194,6 +220,20 @@ async def ingest_records(
             shadow pass records for updated objects carries it, so statements
             from different sync runs of the same connector are distinguishable.
             ``None`` = "this connector, unattributed run".
+        writer_class: the writer class stamped on shadow statements from the
+            UPDATE path (FST-4). Default "connector" — byte-identical to
+            FST-3 for every real connector. The EE Firestore mirror passes
+            "mirror": a mirror is not a primary connector, and the trust
+            ladder ranks it below one.
+        document_uri_field: optional record key whose value becomes the
+            per-record ``source_document_uri`` (FST-4). Gives each statement's
+            SourceRef a document-precise identity (the mirror passes its
+            doc-path sentinel key). Empty/absent values → no document URI.
+        observed_at_field: optional record key holding a ``datetime`` that
+            becomes the per-record ``observed_at`` (FST-4) — when the SOURCE
+            says the value was true, not when we ingested it. Values that are
+            not datetimes are ignored (the statement then defaults to
+            ingest time).
 
     Returns:
         IngestResult with created / updated / skipped counts and the object ids.
@@ -205,12 +245,20 @@ async def ingest_records(
     cannot be deduplicated and would silently duplicate on every sync.
 
     FST-3: the UPDATE path passes full source-truth provenance
-    (``writer_class="connector"``, a ``connector_run`` SourceRef with this
-    connector + run_id) into ``store.update_object``, so when
-    ``fabric_source_truth_mode`` is shadow/enforce the statements recorded at
-    merge site 1 carry honest connector provenance. In mode 'off' the kwargs
-    are inert. The CREATE path is untouched (statement coverage for creates is
-    FST-4's scope).
+    (``writer_class`` + a ``connector_run`` SourceRef with this connector,
+    run_id, and optionally a per-record document URI + observed_at) into
+    ``store.update_object``, so when ``fabric_source_truth_mode`` is
+    shadow/enforce the statements recorded at merge site 1 carry honest
+    provenance. In mode 'off' the kwargs are inert.
+
+    CREATE path (FST-4 decision): creates append NO statements, by design.
+    A create doesn't merge — there is no prior claim to preserve and no
+    conflict to observe. The create-time claim is NOT lost: if a second
+    source later updates a tracked-able property, the FST-3 promotion gate
+    seeds a statement from the current cache value with the object's own
+    provenance (source_connector) and touch-time observed_at, so the
+    create-then-update flow surfaces both claims. Proven by
+    tests/test_fabric_shadow_create_path.py — do not add a create hook.
     """
     type_id = await ensure_type(store, mapping, workspace_id=workspace_id)
     result = IngestResult(type_name=mapping.type_name)
@@ -228,14 +276,29 @@ async def ingest_records(
             workspace_id=workspace_id,
         )
         if existing is not None:
+            # FST-4: per-record provenance. The document URI (when a field is
+            # declared) pins the SourceRef to the exact upstream document;
+            # observed_at (when a field is declared AND holds a datetime)
+            # carries the source's own timestamp instead of ingest time.
+            source_document_uri: str | None = None
+            if document_uri_field is not None:
+                raw_uri = record.get(document_uri_field)
+                source_document_uri = str(raw_uri) if raw_uri else None
+            observed_at: datetime | None = None
+            if observed_at_field is not None:
+                raw_observed = record.get(observed_at_field)
+                if isinstance(raw_observed, datetime):
+                    observed_at = raw_observed
             updated = await store.update_object(
                 existing.id,
                 properties,
                 workspace_id=workspace_id,
-                writer_class="connector",
+                writer_class=writer_class,
                 source_kind="connector_run",
                 source_connector=connector,
                 source_run_id=run_id,
+                source_document_uri=source_document_uri,
+                observed_at=observed_at,
             )
             result.updated += 1
             result.object_ids.append((updated or existing).id)

--- a/src/pocketpaw/fabric/__init__.py
+++ b/src/pocketpaw/fabric/__init__.py
@@ -8,7 +8,12 @@
 # The legacy SQLite FabricStore still ships here for types + links; object lifecycle
 # + scope-filtered queries are the journal path. See ee/fabric/journal_store.py for
 # the rationale (Wave 3 / Org Architecture RFC, Phase 3; supersedes #938).
+# Updated: 2026-07-10 (FST-6 — conflict lifecycle) — exported the open-conflict
+# surface (ConflictRecord, detect_open_conflicts): the un-rankable残り the trust
+# ladder cannot order, recomputed from statements (no conflicts table). The EE
+# stewardship sweep and a future "disputed facts" view read it from here.
 
+from pocketpaw.fabric.conflicts import ConflictRecord, detect_open_conflicts
 from pocketpaw.fabric.events import (
     ACTION_OBJECT_ARCHIVED,
     ACTION_OBJECT_CREATED,
@@ -40,6 +45,9 @@ from pocketpaw.fabric.store import FabricStore
 __all__ = [
     # Legacy SQLite store — still the home for types + links.
     "FabricStore",
+    # Open-conflict surface (FST-6) — recomputed from statements.
+    "ConflictRecord",
+    "detect_open_conflicts",
     # Journal-backed object lifecycle (Wave 3).
     "FabricJournalStore",
     "FabricProjection",

--- a/src/pocketpaw/fabric/conflicts.py
+++ b/src/pocketpaw/fabric/conflicts.py
@@ -1,0 +1,172 @@
+# fabric/conflicts.py — the open-conflict surface for the lifecycle slice (FST-6).
+# Created: 2026-07-10 (feat/fst-6-stewardship) — recompute, don't persist.
+#
+# ``detect_open_conflicts(store)`` scans the tracked properties (only objects
+# WITH statements, via ``FabricStore.list_statement_keys``) and returns a
+# :class:`ConflictRecord` for every property whose CURRENT resolution is
+# ``unresolvable=True`` — the un-rankable残り the trust ladder cannot order
+# (same tier, same rank, both open validity, materially different values,
+# observed within the recency epsilon). Policy auto-resolves everything it CAN
+# rank; only these records ever reach a human.
+#
+# Design choices:
+#   * NO conflicts table. A conflict is recomputed from statements via the
+#     FST-2 resolver on every scan — the statements ARE the state, so a
+#     conflict "closes" the moment a steward verb (PIN/IGNORE), a curation
+#     verb (CHANGE/CORRECT), or a new higher-tier observation changes the
+#     resolution. Nothing to invalidate, nothing to drift.
+#   * ``rivals`` carries exactly the statements that TRIGGERED the
+#     un-rankable flag (the resolver's own condition, re-applied here via the
+#     resolver's private helpers — intra-package reuse, the same deliberate
+#     pattern store.py uses for ``_materially_different``). Lower-tier /
+#     closed / same-value losers are policy-ranked history, not choices a
+#     human needs to arbitrate.
+#   * The dedupe key is ``(workspace_id, object_id, property)`` — the EE
+#     stewardship glue uses it to guarantee ONE open Instinct proposal per
+#     conflicted property across re-sweeps. ``workspace_id`` on the record is
+#     the CALLER'S scope (the tenancy the proposal will be filed under), not
+#     any individual statement's stamp — legacy NULL-stamped statements are
+#     visible inside a workspace scope and must dedupe under it.
+#
+# Pure read path: this module never writes. The steward verbs that ANSWER a
+# conflict live on the store (pin/unpin/ignore, FST-6) next to their FST-5
+# siblings (change/correct).
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from pocketpaw.fabric.models import FabricObject, Statement
+from pocketpaw.fabric.resolver import _materially_different, _tier, resolve
+from pocketpaw.fabric.trust import TrustRules, default_trust_rules
+
+if TYPE_CHECKING:
+    from pocketpaw.fabric.store import FabricStore
+
+
+class ConflictRecord(BaseModel):
+    """One un-rankable conflict: a property the trust ladder cannot order.
+
+    ``winner`` is the resolver's PROVISIONAL winner (reads never block —
+    FST-2 always returns one); ``rivals`` are the open-validity, same-tier,
+    same-rank, materially-different, within-epsilon contenders that made the
+    resolution un-rankable. Together they are the CHOICES a steward
+    arbitrates between. ``workspace_id`` is the detection scope (see the
+    module header), part of the dedupe key.
+    """
+
+    object_id: str
+    object_type: str = ""  # the object's type_name; "" when unknown
+    property: str
+    workspace_id: str | None = None
+    winner: Statement
+    rivals: list[Statement] = Field(default_factory=list)
+
+    @property
+    def dedupe_key(self) -> tuple[str | None, str, str]:
+        """``(workspace_id, object_id, property)`` — one open proposal per key.
+
+        The EE stewardship sweep compares these tuples against the open
+        Instinct proposals' blobs so re-sweeps never file a duplicate while
+        one is open.
+        """
+        return (self.workspace_id, self.object_id, self.property)
+
+    @property
+    def signature(self) -> list[str]:
+        """Sorted ids of the competing statements (winner + rivals).
+
+        Two scans of the SAME unresolved conflict produce the same
+        signature; a new rival observation (or a steward/curation verb)
+        changes it. The EE sweep uses it as reject-memory: a human's
+        explicit "keep the policy winner" (reject) stands until the conflict
+        materially changes shape.
+        """
+        return sorted([self.winner.id] + [r.id for r in self.rivals])
+
+
+def _unrankable_rivals(
+    winner: Statement,
+    losers: list[Statement],
+    rules: TrustRules,
+    object_type: str | None,
+) -> list[Statement]:
+    """The losers that triggered ``unresolvable`` — the resolver's own
+    condition (same tier, same rank, both open validity, materially
+    different, observed within the recency epsilon), re-applied to name the
+    contenders. Preserves the losers' best-to-worst order."""
+    ladder = rules.ladder_for(object_type, winner.property)
+    top_tier = _tier(winner.writer_class, ladder)
+    epsilon = rules.recency_epsilon_seconds
+    return [
+        s
+        for s in losers
+        if _tier(s.writer_class, ladder) == top_tier
+        and s.rank == winner.rank
+        and s.valid_to is None
+        and _materially_different(s.value, winner.value)
+        and abs((winner.observed_at - s.observed_at).total_seconds()) <= epsilon
+    ]
+
+
+async def detect_open_conflicts(
+    store: FabricStore,
+    *,
+    workspace_id: str | None = None,
+    object_id: str | None = None,
+    rules: TrustRules | None = None,
+) -> list[ConflictRecord]:
+    """Scan tracked properties and return the currently un-rankable conflicts.
+
+    Recomputes from statements via :func:`resolve` — no persisted conflict
+    state (see the module header). Only (object, property) pairs that HAVE
+    statements are visited, so the scan is cheap relative to the fabric.
+    Disputes the ladder CAN rank (``is_disputed`` without ``unresolvable``)
+    are excluded by design: policy already answered them. Pinned properties
+    never appear (a pin is authoritative — the pinned path is never
+    un-rankable).
+
+    ``workspace_id`` applies the standard W4a read scope to every underlying
+    read and stamps the returned records (the dedupe-key tenancy);
+    ``object_id`` narrows the scan to one object; ``rules`` overrides the
+    trust rules (default: :func:`default_trust_rules`, the same set the
+    store's shadow/enforce paths resolve with). Deterministic order:
+    ``(object_id, property)``.
+    """
+    effective_rules = rules if rules is not None else default_trust_rules()
+    keys = await store.list_statement_keys(workspace_id=workspace_id, object_id=object_id)
+
+    records: list[ConflictRecord] = []
+    object_cache: dict[str, FabricObject | None] = {}
+    for obj_id, prop in keys:
+        if obj_id not in object_cache:
+            object_cache[obj_id] = await store.get_object(obj_id, workspace_id=workspace_id)
+        obj = object_cache[obj_id]
+        if obj is None:
+            # Statements for an object outside the caller's scope (or a
+            # deleted object) are not this scope's conflict to arbitrate.
+            continue
+
+        object_type = obj.type_name or ""
+        statements = await store.get_statements(obj_id, prop, workspace_id=workspace_id)
+        resolution = resolve(statements, effective_rules, object_type=object_type or None)
+        if not resolution.unresolvable or resolution.winner_statement is None:
+            continue
+        winner = resolution.winner_statement
+        rivals = _unrankable_rivals(winner, resolution.losers, effective_rules, object_type or None)
+        records.append(
+            ConflictRecord(
+                object_id=obj_id,
+                object_type=object_type,
+                property=prop,
+                workspace_id=workspace_id,
+                winner=winner,
+                rivals=rivals,
+            )
+        )
+    return records
+
+
+__all__ = ["ConflictRecord", "detect_open_conflicts"]

--- a/src/pocketpaw/fabric/divergence_report.py
+++ b/src/pocketpaw/fabric/divergence_report.py
@@ -1,0 +1,316 @@
+# src/pocketpaw/fabric/divergence_report.py
+# Created: 2026-07-11 (FST-8 — the operational proof kit).
+#
+# The shadow-divergence report: parse the store's grep-stable divergence
+# lines out of a log capture, summarize them, and answer the one rollout
+# question that gates enforce — "is shadow clean enough to enforce?".
+# Read-only and dependency-free (stdlib argparse + json + re): it never
+# imports the store, never touches a database, and is safe to run against
+# production logs. CLI: ``python -m pocketpaw.fabric.divergence_report
+# <logfile> [logfile2 ...]`` (or stdin).
+"""Parse + summarize Fabric shadow-divergence log lines (FST-8).
+
+The contract (emitted by ``pocketpaw.fabric.store`` at every merge site,
+one single line per statement-producing property)::
+
+    fabric shadow: object=<id> property=<p> lww=<json> resolver=<json>
+        diverged=<True|False> disputed=<True|False> unresolvable=<True|False>
+        freshness=<fresh|aging|stale|none>
+
+``lww`` and ``resolver`` are ``json.dumps``'d (strings quoted), so the
+line never wraps and both values round-trip losslessly. The failure-shield
+warning uses a distinct prefix (``fabric shadow: statement pass failed for
+object=...``) so ``fabric shadow: object=`` isolates divergence lines
+exactly.
+
+Coverage caveat (FST-4): shadow recording is **at-most-once** per journal
+event — replays and retries are not double-counted, but a report is a
+lower bound on write traffic, not an exact ledger. An empty report can
+also mean shadow mode never ran; confirm the mode before reading "no
+lines" as "no divergence".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+#: The exact prefix of a divergence line. The failure-shield warning starts
+#: with "fabric shadow: statement pass failed for object=" — it never
+#: matches this, so the prefix alone isolates divergence lines.
+DIVERGENCE_PREFIX = "fabric shadow: object="
+
+# Head: everything before the JSON-encoded lww value. object ids and
+# property names are token-shaped (no whitespace) — the same assumption the
+# FST-3/5 contract-guard regexes in the test suite make.
+_HEAD_RE = re.compile(r"^fabric shadow: object=(?P<object_id>\S+) property=(?P<property>\S+) lww=")
+
+# Tail: the four fixed flags after the JSON-encoded resolver value.
+_TAIL_RE = re.compile(
+    r"^ diverged=(?P<diverged>True|False)"
+    r" disputed=(?P<disputed>True|False)"
+    r" unresolvable=(?P<unresolvable>True|False)"
+    r" freshness=(?P<freshness>fresh|aging|stale|none)\s*$"
+)
+
+_DECODER = json.JSONDecoder()
+
+
+@dataclass(frozen=True)
+class DivergenceRecord:
+    """One parsed divergence line (or one malformed line, kept for counting).
+
+    A line that starts with :data:`DIVERGENCE_PREFIX` but does not parse
+    becomes a record with ``parse_error`` set (and neutral field values) —
+    the tolerant-parser contract: malformed lines are *counted*, never
+    raised, and never silently dropped.
+    """
+
+    object_id: str
+    property: str
+    lww: Any
+    resolver: Any
+    diverged: bool
+    disputed: bool
+    unresolvable: bool
+    freshness: str  # "fresh" | "aging" | "stale" | "none"
+    raw: str
+    parse_error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        """True when the line parsed cleanly."""
+        return self.parse_error is None
+
+    @property
+    def unexplained(self) -> bool:
+        """The enforce-gate heuristic, per divergence line (PRD metric).
+
+        A divergence is *explained* when the line itself shows why the
+        resolver disagreed with LWW: the conflict is flagged
+        (``disputed=True``), the resolver fell back on an unresolvable tie
+        (``unresolvable=True``), or freshness demotion was in play
+        (``freshness != "fresh"``). Those are multi-source ordering doing
+        its job — expected in shadow, safe to enforce.
+
+        *Unexplained* = ``diverged=True`` with none of those markers: the
+        resolver overrode the freshest, undisputed data and nothing on the
+        line says why. Target ZERO before flipping to enforce — each one is
+        either a trust-ladder surprise or a bug, and both need a human look.
+
+        Honest limits: this is a line-local heuristic. It cannot see
+        PIN/IGNORE curation, per-type ladder overrides, or cross-line
+        context — an "explained" line can still be wrong data winning for
+        a legible reason, and coverage is at-most-once per journal event
+        (see the module docstring).
+        """
+        return (
+            self.ok
+            and self.diverged
+            and not (self.disputed or self.unresolvable or self.freshness != "fresh")
+        )
+
+
+def _malformed(raw: str, why: str) -> DivergenceRecord:
+    return DivergenceRecord(
+        object_id="",
+        property="",
+        lww=None,
+        resolver=None,
+        diverged=False,
+        disputed=False,
+        unresolvable=False,
+        freshness="none",
+        raw=raw,
+        parse_error=why,
+    )
+
+
+def parse_divergence_lines(lines: Iterable[str]) -> list[DivergenceRecord]:
+    """Tolerantly parse divergence lines out of arbitrary log text.
+
+    * Lines that do not start with :data:`DIVERGENCE_PREFIX` (other log
+      output, the failure-shield warning, blanks) are skipped entirely.
+    * Lines that carry the prefix but violate the contract yield a record
+      with ``parse_error`` set — counted by :func:`summarize` as
+      ``parse_errors``. This function NEVER raises on input content.
+
+    The ``lww``/``resolver`` values are decoded with a JSON-aware scan
+    (``JSONDecoder.raw_decode``), not whitespace splitting, so values
+    containing spaces (quoted strings, objects, lists) parse exactly.
+    """
+    records: list[DivergenceRecord] = []
+    for raw_line in lines:
+        line = raw_line.rstrip("\r\n")
+        if not line.startswith(DIVERGENCE_PREFIX):
+            continue
+        head = _HEAD_RE.match(line)
+        if head is None:
+            records.append(_malformed(line, "head does not match the contract"))
+            continue
+        rest = line[head.end() :]
+        try:
+            lww, end = _DECODER.raw_decode(rest)
+        except ValueError:
+            records.append(_malformed(line, "lww value is not valid JSON"))
+            continue
+        rest = rest[end:]
+        if not rest.startswith(" resolver="):
+            records.append(_malformed(line, "missing resolver= field after lww"))
+            continue
+        rest = rest[len(" resolver=") :]
+        try:
+            resolver, end = _DECODER.raw_decode(rest)
+        except ValueError:
+            records.append(_malformed(line, "resolver value is not valid JSON"))
+            continue
+        tail = _TAIL_RE.match(rest[end:])
+        if tail is None:
+            records.append(_malformed(line, "tail flags do not match the contract"))
+            continue
+        records.append(
+            DivergenceRecord(
+                object_id=head.group("object_id"),
+                property=head.group("property"),
+                lww=lww,
+                resolver=resolver,
+                diverged=tail.group("diverged") == "True",
+                disputed=tail.group("disputed") == "True",
+                unresolvable=tail.group("unresolvable") == "True",
+                freshness=tail.group("freshness"),
+                raw=line,
+                parse_error=None,
+            )
+        )
+    return records
+
+
+@dataclass(frozen=True)
+class DivergenceSummary:
+    """Aggregate view over parsed divergence records — the go/no-go input."""
+
+    total: int  # cleanly parsed lines
+    parse_errors: int  # prefix-matching lines that violated the contract
+    diverged: int
+    diverged_rate: float  # diverged / total (0.0 when total == 0)
+    disputed: int
+    unresolvable: int
+    unexplained: int  # see DivergenceRecord.unexplained — target ZERO
+    top_diverged_properties: tuple[tuple[str, int], ...]  # (property, diverged-count), descending
+    freshness: dict[str, int] = field(default_factory=dict)  # over all parsed lines
+
+    @property
+    def enforce_ready(self) -> bool:
+        """The go/no-go verdict: zero unexplained divergences AND zero
+        parse errors (an unparseable line could hide an unexplained
+        divergence, so malformed input blocks the green light too)."""
+        return self.unexplained == 0 and self.parse_errors == 0
+
+
+def summarize(records: Iterable[DivergenceRecord], *, top_n: int = 5) -> DivergenceSummary:
+    """Fold parsed records into a :class:`DivergenceSummary`.
+
+    Malformed records (``parse_error`` set) count toward ``parse_errors``
+    only; every other statistic is computed over cleanly parsed lines.
+    """
+    materialized = list(records)  # records may be a one-shot generator
+    valid = [r for r in materialized if r.ok]
+    parse_errors = len(materialized) - len(valid)
+
+    diverged = [r for r in valid if r.diverged]
+    per_property = Counter(r.property for r in diverged)
+    freshness = Counter(r.freshness for r in valid)
+    total = len(valid)
+    return DivergenceSummary(
+        total=total,
+        parse_errors=parse_errors,
+        diverged=len(diverged),
+        diverged_rate=(len(diverged) / total) if total else 0.0,
+        disputed=sum(1 for r in valid if r.disputed),
+        unresolvable=sum(1 for r in valid if r.unresolvable),
+        unexplained=sum(1 for r in valid if r.unexplained),
+        top_diverged_properties=tuple(per_property.most_common(top_n)),
+        freshness=dict(freshness),
+    )
+
+
+def format_report(summary: DivergenceSummary) -> str:
+    """A compact human-readable block ending in the verdict line."""
+    pct = f"{summary.diverged_rate * 100:.1f}%"
+    lines = [
+        "fabric divergence report",
+        f"  lines:         {summary.total} parsed, {summary.parse_errors} malformed",
+        f"  diverged:      {summary.diverged}/{summary.total} ({pct})",
+        f"  disputed:      {summary.disputed}",
+        f"  unresolvable:  {summary.unresolvable}",
+        f"  unexplained:   {summary.unexplained}",
+    ]
+    if summary.freshness:
+        dist = " ".join(
+            f"{k}={summary.freshness[k]}"
+            for k in ("fresh", "aging", "stale", "none")
+            if k in summary.freshness
+        )
+        lines.append(f"  freshness:     {dist}")
+    if summary.top_diverged_properties:
+        lines.append("  top diverged properties:")
+        width = max(len(p) for p, _ in summary.top_diverged_properties)
+        lines.extend(f"    {p:<{width}}  {n}" for p, n in summary.top_diverged_properties)
+    if summary.total == 0 and summary.parse_errors == 0:
+        lines.append("  note: no divergence lines found — confirm shadow mode actually ran")
+    verdict = "yes" if summary.enforce_ready else "no"
+    detail = f"{summary.unexplained} unexplained"
+    if summary.parse_errors:
+        detail += f", {summary.parse_errors} parse errors"
+    lines.append(f"ENFORCE-READY: {verdict} ({detail})")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: report over one or more log files (or stdin).
+
+    Exit code 0 when ENFORCE-READY, 1 when not — usable as a CI/rollout
+    gate. Exit 2 on unreadable input files.
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m pocketpaw.fabric.divergence_report",
+        description=(
+            "Summarize Fabric shadow-divergence log lines and answer the "
+            "enforce go/no-go. Reads the given log files, or stdin when no "
+            "files (or '-') are given."
+        ),
+    )
+    parser.add_argument("logfiles", nargs="*", help="log files to scan ('-' or none = stdin)")
+    parser.add_argument(
+        "--top", type=int, default=5, metavar="N", help="top-N diverged properties (default 5)"
+    )
+    args = parser.parse_args(argv)
+
+    lines: list[str] = []
+    sources = args.logfiles or ["-"]
+    for name in sources:
+        if name == "-":
+            lines.extend(sys.stdin.read().splitlines())
+            continue
+        try:
+            with open(name, encoding="utf-8", errors="replace") as fh:
+                lines.extend(fh.read().splitlines())
+        except OSError as exc:
+            print(f"error: cannot read {name}: {exc}", file=sys.stderr)
+            return 2
+
+    summary = summarize(parse_divergence_lines(lines), top_n=args.top)
+    print(format_report(summary))
+    return 0 if summary.enforce_ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pocketpaw/fabric/journal_store.py
+++ b/src/pocketpaw/fabric/journal_store.py
@@ -18,11 +18,19 @@
 # projection applies the event immediately so the next read sees the change without
 # a full rebuild. On process start, bootstrap() replays from genesis to warm the
 # projection; operators who persist a cursor can skip ahead.
+#
+# Updated: 2026-07-10 (FST-4 — SHADOW mode at merge site 2) — optional
+# ``statement_store`` on the constructor wires the default projection to the
+# SQLite FabricStore's shadow machinery; update() drains the projection's
+# staged shadow observations after every live write (await flush_shadow()),
+# and the public flush_shadow() lets replay consumers drain after a sync
+# bootstrap(). Without a statement_store nothing changes — the flush is a
+# no-op and the projection never reads the mode flag.
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from soul_protocol.engine.journal import Journal
@@ -38,6 +46,11 @@ from pocketpaw.fabric.events import (
 )
 from pocketpaw.fabric.models import FabricObject, FabricQuery, FabricQueryResult
 from pocketpaw.fabric.projection import FabricProjection
+
+if TYPE_CHECKING:
+    # Typing only (FST-4) — the statement_store kwarg is forwarded to the
+    # projection; this module never touches the SQLite store at runtime.
+    from pocketpaw.fabric.store import FabricStore
 
 _SYSTEM_ACTOR_ID = "system:fabric"
 
@@ -65,9 +78,13 @@ class FabricJournalStore:
         *,
         projection: FabricProjection | None = None,
         default_actor: Actor | None = None,
+        statement_store: FabricStore | None = None,
     ) -> None:
+        # FST-4: ``statement_store`` wires the DEFAULT projection's shadow
+        # treatment (merge site 2). When the caller passes an explicit
+        # ``projection`` it owns that wiring itself and this kwarg is unused.
         self._journal = journal
-        self._projection = projection or FabricProjection()
+        self._projection = projection or FabricProjection(statement_store=statement_store)
         self._default_actor = default_actor or Actor(
             kind="system",
             id=_SYSTEM_ACTOR_ID,
@@ -80,9 +97,25 @@ class FabricJournalStore:
         """Warm the projection from the journal. Returns the number of
         events applied. Call once at process start; callers that persist
         a cursor can pass ``since_seq`` to skip already-applied events.
+
+        FST-4: with a statement_store-wired projection in shadow/enforce
+        mode, the replay STAGES shadow observations but cannot record them
+        (bootstrap is sync) — follow up with ``await flush_shadow()``.
+        Skipping the flush only delays it: the next live update() drains the
+        queue, and the store's event-id dedupe keeps any ordering honest.
         """
 
         return self._projection.rebuild(self._journal, since_seq=since_seq)
+
+    async def flush_shadow(self) -> int:
+        """Drain the projection's staged shadow observations (FST-4) —
+        the async companion to the sync :meth:`bootstrap`. Returns how many
+        journal events had their statements recorded. Safe to call anytime:
+        already-recorded events are deduped by id, an unwired projection
+        returns 0.
+        """
+
+        return await self._projection.flush_shadow()
 
     @property
     def projection(self) -> FabricProjection:
@@ -171,6 +204,10 @@ class FabricJournalStore:
         )
         self._journal.append(entry)
         self._projection.apply(entry)
+        # FST-4: drain the shadow observation this update may have staged so
+        # statements land as part of the write call, matching site 1's
+        # semantics. No statement_store wired (or mode off) → no-op.
+        await self._projection.flush_shadow()
         return self._lookup(object_id)
 
     async def archive(

--- a/src/pocketpaw/fabric/models.py
+++ b/src/pocketpaw/fabric/models.py
@@ -28,6 +28,23 @@
 #   legacy/global type predating tenancy (or an OSS / single-tenant caller),
 #   which a scoped read still sees — exactly the NULL-as-legacy boundary the
 #   W4a object/link scoping already uses.
+# Updated: 2026-07-10 (FST-1 — Fabric source-truth schema) — added ``Statement``
+#   and ``SourceRef``: the provenance layer for the source-truth chain. A
+#   Statement records ONE observed (object, property, value) claim with full
+#   provenance (who wrote it — ``writer_class``; where it came from —
+#   ``source_ref_id``; bitemporal fields — observed/recorded/valid_from/
+#   valid_to) plus a curation rank. A SourceRef identifies WHERE a statement
+#   came from (a connector run, a document, a human actor, an agent session)
+#   and is deduplicated on that identity by ``FabricStore.upsert_source``.
+#   Both models carry ``workspace_id`` (W4a tenancy, same type/default as
+#   ObjectType.workspace_id: ``str | None = None``); on SourceRef it is PART
+#   of the dedup identity — the same source identity in two workspaces is two
+#   rows, so tenant data never rendezvouses on a shared SourceRef.
+#   ADDITIVE ONLY: nothing in the existing read path (FabricObject.properties,
+#   fabric_query, widgets, projections) consumes these yet — statements are
+#   inert until the ``fabric_source_truth_mode`` flag (default "off") gains
+#   shadow/enforce semantics in later slices. The flat properties dict remains
+#   the primary read path.
 
 from __future__ import annotations
 
@@ -105,6 +122,80 @@ class FabricLink(BaseModel):
     link_type: str  # "has_orders", "belongs_to", "purchased"
     properties: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime = Field(default_factory=datetime.now)
+
+
+class SourceRef(BaseModel):
+    """The identity of WHERE a :class:`Statement` came from (FST-1).
+
+    One row per distinct source identity: a connector run, a document, a
+    human actor, or an agent session. ``FabricStore.upsert_source`` dedups on
+    the identity tuple ``(kind, connector, run_id, document_uri, actor_id,
+    session_id, workspace_id)`` — calling it twice with the same identity
+    returns the same row, so statements from the same source share one
+    SourceRef. ``workspace_id`` IS part of the identity: the same source seen
+    from two workspaces is two rows (tenancy isolation beats dedup).
+
+    The identity fields are a union across the four kinds; only the ones
+    relevant to a given ``kind`` are expected to be set (e.g. a
+    ``connector_run`` carries ``connector`` + ``run_id``; a ``document``
+    carries ``document_uri``; a ``human_actor`` carries ``actor_id``; an
+    ``agent_session`` carries ``session_id``). Unset fields are ``None`` and
+    still participate in the identity (as "absent").
+    """
+
+    id: str = Field(default_factory=lambda: _gen_id("src"))
+    kind: Literal["connector_run", "document", "human_actor", "agent_session"]
+    connector: str | None = None
+    run_id: str | None = None
+    document_uri: str | None = None
+    actor_id: str | None = None
+    session_id: str | None = None
+    retrieved_at: datetime | None = None
+    # Tenancy (W4a semantics, carried on the model like ObjectType.workspace_id):
+    # the owning workspace. ``None`` = OSS / single-tenant caller. Unlike the
+    # other tables, this is PART OF THE DEDUP IDENTITY (see the docstring).
+    workspace_id: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
+class Statement(BaseModel):
+    """One observed (object, property, value) claim with provenance (FST-1).
+
+    Statements are APPEND-ONLY: the store exposes no update/delete verbs for
+    them (rank changes land in a later slice as new curation writes). Nothing
+    reads statements in production paths yet — the flat
+    ``FabricObject.properties`` dict remains the primary read path until the
+    ``fabric_source_truth_mode`` flag gains shadow/enforce semantics.
+
+    Bitemporal fields:
+
+    - ``observed_at`` — when the source says the value was true / was seen.
+    - ``recorded_at`` — when THIS store recorded the claim (stamped on write).
+    - ``valid_from`` / ``valid_to`` — the validity interval of the claim;
+      ``valid_to=None`` means "still valid as far as this statement knows".
+
+    ``rank`` is the curation knob resolvers will consume later:
+    ``preferred`` outranks ``normal`` outranks ``deprecated``; ``pinned``
+    marks a statement a human explicitly fixed in place.
+    """
+
+    id: str = Field(default_factory=lambda: _gen_id("stm"))
+    object_id: str
+    property: str
+    value: Any = None
+    source_ref_id: str
+    writer_class: Literal["human", "connector", "mirror", "agent", "inferred"]
+    observed_at: datetime = Field(default_factory=datetime.now)
+    recorded_at: datetime = Field(default_factory=datetime.now)
+    valid_from: datetime = Field(default_factory=datetime.now)
+    valid_to: datetime | None = None
+    rank: Literal["preferred", "normal", "deprecated"] = "normal"
+    rank_reason: str | None = None
+    pinned: bool = False
+    # Tenancy (W4a semantics): the owning workspace, stamped on append.
+    # ``None`` = OSS / single-tenant caller; a scoped read still sees NULL
+    # rows (own rows + legacy NULL — the standard W4a read scope).
+    workspace_id: str | None = None
 
 
 class PathHop(BaseModel):

--- a/src/pocketpaw/fabric/projection.py
+++ b/src/pocketpaw/fabric/projection.py
@@ -35,6 +35,34 @@
 # double-apply is deduped on the event id (see shadow_record_event_update).
 # Default construction (no statement_store) is byte-for-byte the prior
 # behavior — the mode flag is never even read.
+#
+# Updated: 2026-07-10 (FST-5 — ENFORCE decision for merge site 2, READ THIS):
+# in enforce mode THE PROJECTION STAYS EVENT-FAITHFUL — it folds exactly what
+# the journal says (plain LWW merge), and enforce ownership of values applies
+# at the STORE CACHE layer only (fabric/store.py — the flat properties dict,
+# which is the primary read path per the FST constraints). Consequence: an
+# object served from this projection can show a journal-folded LWW value that
+# the resolver has overruled in the store cache. That divergence is KNOWN and
+# DELIBERATE, and it is exactly what the shadow machinery's divergence line
+# records per event — nobody has to discover it by accident. Why event-faithful
+# won over write-back (the rejected option (a) — flush_shadow() also rewriting
+# the projection's entry with the resolver's winner):
+#   1. The projection's core guarantee is "rebuild() from the journal and
+#      you're back in sync" — a deterministic CQRS fold of the journal alone.
+#      Write-back makes projection state a function of (journal + statements
+#      DB + flush timing); worse, shadow_record_event_update dedupes replayed
+#      events, so after a rebuild the flush records nothing and the write-back
+#      would NOT re-apply — live state and rebuilt state would silently
+#      disagree, breaking the one invariant this class exists to keep.
+#   2. The flat properties dict on the SQLite store is the read path the FST
+#      chain governs; the journal-store path keeps the journal itself as its
+#      system of record. Resolver-vs-journal disagreement there belongs to the
+#      statement layer (statements + divergence log), not to a mutated fold.
+#   3. The CHANGE/CORRECT verbs and FST-6's PIN/IGNORE executor act on the
+#      store layer — a curated value reaches journal consumers the same way
+#      every other correction does: as a new journal event.
+# Proven by tests/test_fabric_enforce_site2.py: the store cache holds the
+# resolved value while this projection's fold (event-faithfully) differs.
 
 from __future__ import annotations
 

--- a/src/pocketpaw/fabric/projection.py
+++ b/src/pocketpaw/fabric/projection.py
@@ -16,13 +16,32 @@
 #   - query(...): return a FabricQueryResult scoped to the caller
 # No persistence layer, no caching beyond the in-memory dict. Reopen a journal,
 # rebuild(), and you're back in sync — same guarantee as a good CQRS read model.
+#
+# Updated: 2026-07-10 (FST-4 — SHADOW mode at merge site 2) — the
+# ``merged = {**existing.obj.properties, **patch}`` fold in _apply_updated is
+# the journal-replay merge site. The projection writes IN MEMORY (it never
+# calls store.update_object), so it cannot thread provenance kwargs the way
+# site 1 does; instead, when an optional ``statement_store`` is wired and
+# ``fabric_source_truth_mode`` is shadow/enforce, _apply_updated STAGES a
+# shadow observation (pre-merge snapshot + patch + the event's identity,
+# actor, and ts) and the async ``flush_shadow()`` records it through
+# ``FabricStore.shadow_record_event_update`` — the SAME FST-3 machinery as
+# site 1, never a duplicate. apply() stays sync (staging is a list append);
+# the async boundary (FabricJournalStore.update, or an explicit flush after a
+# bootstrap replay) drains the queue. Provenance maps from the journal actor:
+# user → human/human_actor, agent → agent/agent_session (correlation_id, else
+# actor id), system/root → the store's derivation default. observed_at is the
+# event's ts, so a replayed event yields the same claims the live write did;
+# double-apply is deduped on the event id (see shadow_record_event_update).
+# Default construction (no statement_store) is byte-for-byte the prior
+# behavior — the mode flag is never even read.
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from soul_protocol.engine.journal import Journal
 from soul_protocol.spec.journal import EventEntry
@@ -35,6 +54,12 @@ from pocketpaw.fabric.events import (
 )
 from pocketpaw.fabric.models import FabricObject, FabricQuery, FabricQueryResult
 from pocketpaw.fabric.policy import filter_visible
+
+if TYPE_CHECKING:
+    # Import for typing only — the runtime dependency is lazy (see
+    # _apply_updated / flush_shadow) so a store-less projection never pays
+    # for the SQLite store stack.
+    from pocketpaw.fabric.store import FabricStore
 
 logger = logging.getLogger(__name__)
 
@@ -68,16 +93,72 @@ class _ProjectedObject:
         return payload
 
 
+@dataclass
+class _ShadowObservation:
+    """One staged shadow pass for a ``fabric.object.updated`` event (FST-4).
+
+    Captured synchronously in _apply_updated (which cannot await) and drained
+    by :meth:`FabricProjection.flush_shadow`. ``existing`` is the PRE-merge
+    FabricObject snapshot — _apply_updated rebinds ``row.obj`` to a fresh
+    model_copy, so the staged instance is never mutated afterwards.
+    """
+
+    event_id: str
+    existing: FabricObject
+    patch: dict[str, Any]
+    actor_kind: str
+    actor_id: str
+    correlation_id: str | None
+    ts: datetime
+
+
+def _journal_provenance(obs: _ShadowObservation) -> dict[str, str]:
+    """Map a journal event's actor onto site-1 provenance kwargs (FST-4).
+
+    - ``user`` actor → writer_class "human", a ``human_actor`` source carrying
+      the actor id;
+    - ``agent`` actor → writer_class "agent", an ``agent_session`` source
+      whose session identity is the event's correlation_id (the session/flow
+      per the journal spec), falling back to the actor id when the event
+      stands alone;
+    - ``system`` / ``root`` actors → NO kwargs: these are subsystem writes
+      (e.g. the journal store's default ``system:fabric``), i.e. exactly the
+      "unattributed" case, so the store's documented derivation default
+      applies (the object's own connector when it has one, else an
+      unattributed agent session).
+    """
+    if obs.actor_kind == "user":
+        return {
+            "writer_class": "human",
+            "source_kind": "human_actor",
+            "source_actor_id": obs.actor_id,
+        }
+    if obs.actor_kind == "agent":
+        return {
+            "writer_class": "agent",
+            "source_kind": "agent_session",
+            "source_session_id": obs.correlation_id or obs.actor_id,
+        }
+    return {}
+
+
 class FabricProjection:
     """Rebuilds and maintains a current-state view of Fabric objects from
     the org journal. One instance per process is the usual pattern; the
     projection is cheap to rebuild (O(events)) so operators can drop and
     rebuild at will if they suspect drift.
+
+    FST-4: pass ``statement_store`` to give the replay merge site the shadow
+    treatment — updates then stage observations (in shadow/enforce mode only)
+    that :meth:`flush_shadow` records through the store's FST-3 machinery.
+    Without it (the default) nothing changes: no staging, no mode read.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, statement_store: FabricStore | None = None) -> None:
         self._objects: dict[str, _ProjectedObject] = {}
         self._cursor: int = 0
+        self._statement_store = statement_store
+        self._pending_shadow: list[_ShadowObservation] = []
 
     # -- Build / rebuild ----------------------------------------------------
 
@@ -95,6 +176,11 @@ class FabricProjection:
         if since_seq == 0:
             self._objects.clear()
             self._cursor = 0
+            # A true reset also drops staged-but-unflushed shadow work: the
+            # replay will re-stage the same events, and the store's event-id
+            # dedupe makes a double-stage harmless anyway — this just keeps
+            # the queue from holding duplicates across back-to-back rebuilds.
+            self._pending_shadow.clear()
 
         applied = 0
         for entry in journal.replay_from(since_seq):
@@ -179,6 +265,32 @@ class FabricProjection:
             return
 
         patch = dict(payload.get("properties") or {})
+
+        # FST-4 (merge site 2): stage the shadow observation BEFORE the merge
+        # rebinds existing.obj, so the staged snapshot is the pre-update cache
+        # state (what the seed statement must preserve). Gate order matters:
+        # the statement_store check comes first so a store-less projection
+        # never reads the mode; in mode 'off' nothing is staged and the fold
+        # below is byte-for-byte the pre-FST-4 behavior. The import is lazy so
+        # tests can monkeypatch pocketpaw.fabric.store._source_truth_mode.
+        if self._statement_store is not None:
+            from pocketpaw.fabric.store import _source_truth_mode
+
+            if _source_truth_mode() != "off":
+                self._pending_shadow.append(
+                    _ShadowObservation(
+                        event_id=str(entry.id),
+                        existing=existing.obj,
+                        patch=dict(patch),
+                        actor_kind=entry.actor.kind,
+                        actor_id=entry.actor.id,
+                        correlation_id=(
+                            str(entry.correlation_id) if entry.correlation_id else None
+                        ),
+                        ts=_as_datetime(entry.ts),
+                    )
+                )
+
         merged = {**existing.obj.properties, **patch}
         existing.obj = existing.obj.model_copy(
             update={"properties": merged, "updated_at": _as_datetime(entry.ts)},
@@ -194,6 +306,49 @@ class FabricProjection:
             return
         existing.archived = True
         existing.last_seq = seq
+
+    # -- Shadow flush (FST-4) -------------------------------------------------
+
+    async def flush_shadow(self) -> int:
+        """Record every staged shadow observation through the statement
+        store's FST-3 machinery; returns how many events were recorded.
+
+        Called from the async boundary: FabricJournalStore.update() drains
+        after every live write, and replay consumers (bootstrap) call it
+        explicitly once the sync rebuild finishes. Replaying the same journal
+        twice cannot double-append — the store dedupes on the event id (see
+        FabricStore.shadow_record_event_update) — so a redundant flush is a
+        cheap no-op per already-recorded event.
+
+        Failure-shielded per observation, mirroring FST-3's shield at site 1:
+        a failing event logs a warning and is dropped; the projection state
+        and the remaining observations are unaffected.
+        """
+        if self._statement_store is None or not self._pending_shadow:
+            return 0
+        pending, self._pending_shadow = self._pending_shadow, []
+        recorded = 0
+        for obs in pending:
+            try:
+                done = await self._statement_store.shadow_record_event_update(
+                    obs.existing,
+                    obs.patch,
+                    event_id=obs.event_id,
+                    observed_at=obs.ts,
+                    **_journal_provenance(obs),
+                )
+            except Exception:
+                logger.warning(
+                    "fabric shadow: statement pass failed for event=%s object=%s"
+                    " — projection unaffected",
+                    obs.event_id,
+                    obs.existing.id,
+                    exc_info=True,
+                )
+                continue
+            if done:
+                recorded += 1
+        return recorded
 
     # -- Query --------------------------------------------------------------
 

--- a/src/pocketpaw/fabric/resolver.py
+++ b/src/pocketpaw/fabric/resolver.py
@@ -1,0 +1,251 @@
+# fabric/resolver.py — Trust-ladder resolution over Statements (FST-2).
+# Created: 2026-07-10 (feat/fst-2-resolver) — the brain of the source-truth
+#   chain as a PURE function.
+# Updated: 2026-07-10 (FST-2 spec review) — rank + validity joined the
+#   within-tier ordering so FST-5's CHANGE verb (close the old statement's
+#   valid_to + append a new PREFERRED statement) is visible to resolution;
+#   is_disputed and unresolvable tightened accordingly (closed-validity
+#   losers are resolved history, not live disputes).
+#
+# ``resolve(statements, rules)`` takes every Statement recorded for ONE
+# (object_id, property) and picks the value the flat properties dict SHOULD
+# hold, in this order:
+#   1. deprecated statements are filtered out entirely (never winner, never
+#      loser, never counted for disputes);
+#   2. pinned short-circuit — a pinned survivor wins outright; multiple
+#      pinned → newest recorded_at wins (id tiebreak), and multiple pins
+#      always flag is_disputed (two humans pinning is a curation conflict
+#      the lifecycle slice must surface, even when the values agree);
+#   3. writer-class precedence from the TrustRules ladder (global default
+#      human > connector > mirror > agent > inferred, per-(object_type,
+#      property) overridable);
+#   4. WITHIN the winning tier, in order:
+#      a. rank: preferred > normal — within the tier ONLY; rank never
+#         crosses tiers (a low-tier writer marking itself preferred must
+#         never beat a higher-tier normal statement — that would break the
+#         trust model);
+#      b. validity: open (valid_to is None) > closed (valid_to set) — a
+#         closed statement is superseded history but STAYS a candidate, so
+#         reads never block even when every statement is closed;
+#      c. recency on observed_at (when the source says it was true — NEVER
+#         recorded_at/ingest time);
+#      d. deterministic tiebreak: lexicographically smallest statement id.
+#
+# "Materially different" = normalized inequality, where normalization is:
+# str values are .strip()ed, everything else compared with plain Python
+# ``==``. is_disputed = any OPEN-validity survivor materially differs from
+# the winner (closed-validity losers are RESOLVED history — e.g. a CHANGE's
+# closed loser — and are excluded from the dispute check while remaining in
+# losers[] for audit), or multiple pins per step 2. Un-rankable: on the
+# ladder path, a survivor at the SAME tier and SAME rank as the winner, with
+# BOTH open validity, a materially different value, and observed_at within
+# rules.recency_epsilon_seconds of the winner's → the ordering is not
+# trustworthy → unresolvable=True (a rank or validity difference IS a
+# ranking — resolvable by definition). A deterministic provisional winner is
+# STILL returned (reads never block; the conflict-lifecycle slice consumes
+# the flag later).
+#
+# Pure and deterministic: no store access, no settings, no clock reads —
+# the optional ``now`` parameter is an unused seam for FST-7 freshness
+# demotion. Nothing in production calls this yet (unwired until FST-3).
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from pocketpaw.fabric.models import Statement
+from pocketpaw.fabric.trust import TrustRules, WriterClass
+
+
+class Resolution(BaseModel):
+    """The outcome of resolving one (object_id, property)'s statements.
+
+    ``winner_statement is None`` means "no value could be resolved" (empty
+    input, or every statement deprecated) — distinct from a winner whose
+    ``value`` happens to be None. ``losers`` holds every non-deprecated,
+    non-winning statement, ordered best-to-worst by the same ranking that
+    picked the winner (so the whole Resolution is deterministic).
+    ``unresolvable=True`` still carries a provisional winner: reads never
+    block; the flag is the hand-off to the conflict lifecycle slice.
+    """
+
+    value: Any = None
+    winner_statement: Statement | None = None
+    is_disputed: bool = False
+    losers: list[Statement] = Field(default_factory=list)
+    unresolvable: bool = False
+
+
+def _normalize(value: Any) -> Any:
+    """The small normalization behind "materially different".
+
+    Exact rule: strings are compared after ``.strip()`` (leading/trailing
+    whitespace is immaterial; case and inner whitespace ARE material);
+    every other type is returned as-is and compared with plain Python
+    ``==`` (so ``1 == 1.0`` is the same value, ``None`` only equals
+    ``None``, dicts/lists compare structurally).
+    """
+    if isinstance(value, str):
+        return value.strip()
+    return value
+
+
+def _materially_different(a: Any, b: Any) -> bool:
+    """True when two values differ after :func:`_normalize`."""
+    return _normalize(a) != _normalize(b)
+
+
+def _tier(writer_class: str, ladder: list[WriterClass]) -> int:
+    """Rank of a writer_class on the effective ladder (0 = strongest).
+
+    A class missing from the ladder (possible under a partial override)
+    ranks BELOW every listed class, all unlisted classes sharing one bottom
+    tier — statements are never dropped just because an override forgot a
+    class.
+    """
+    try:
+        return ladder.index(writer_class)  # type: ignore[arg-type]
+    except ValueError:
+        return len(ladder)
+
+
+def _rank_key(statement: Statement) -> int:
+    """Within-tier rank leg: preferred (0) beats normal (1).
+
+    Deprecated never reaches a sort (filtered in step 1). Because this leg
+    sits AFTER the tier leg in the key tuple, rank never crosses tiers.
+    """
+    return 0 if statement.rank == "preferred" else 1
+
+
+def _validity_key(statement: Statement) -> int:
+    """Within-tier validity leg: open (valid_to is None, 0) beats closed (1).
+
+    A closed statement is superseded history but stays a candidate — reads
+    never block even when every survivor is closed.
+    """
+    return 0 if statement.valid_to is None else 1
+
+
+def _ladder_sort_key(
+    statement: Statement, ladder: list[WriterClass]
+) -> tuple[int, int, int, float, str]:
+    """Total order for the ladder path: tier asc, then within the tier
+    rank (preferred > normal), validity (open > closed), observed_at desc,
+    id asc.
+
+    observed_at is keyed via ``timestamp()`` so it can be negated for the
+    descending leg; naive datetimes are interpreted in local time (the
+    store's default), aware ones absolutely.
+    """
+    return (
+        _tier(statement.writer_class, ladder),
+        _rank_key(statement),
+        _validity_key(statement),
+        -statement.observed_at.timestamp(),
+        statement.id,
+    )
+
+
+def _pin_sort_key(statement: Statement) -> tuple[float, str]:
+    """Total order among pinned survivors: recorded_at desc, id asc."""
+    return (-statement.recorded_at.timestamp(), statement.id)
+
+
+def resolve(
+    statements: list[Statement],
+    rules: TrustRules,
+    *,
+    object_type: str | None = None,
+    now: datetime | None = None,  # noqa: ARG001 — FST-7 freshness seam, unused
+) -> Resolution:
+    """Resolve one (object_id, property)'s statements to a single value.
+
+    Pure and deterministic: same input (in any order) → same Resolution.
+    ``rules`` is passed in — no settings access. ``object_type`` selects
+    per-property ladder overrides (``None`` = global ladder only). ``now``
+    is an unused seam for FST-7 freshness demotion.
+
+    Raises ``ValueError`` if the statements span more than one
+    (object_id, property) — the resolver is per-property by contract.
+    An empty list is NOT an error: it returns the no-value Resolution.
+    """
+    if not statements:
+        return Resolution()
+
+    keys = {(s.object_id, s.property) for s in statements}
+    if len(keys) > 1:
+        raise ValueError(
+            f"resolve() expects statements for ONE (object_id, property); got {sorted(keys)}"
+        )
+
+    # Step 1 — deprecated statements are out entirely.
+    survivors = [s for s in statements if s.rank != "deprecated"]
+    if not survivors:
+        return Resolution()
+
+    prop = survivors[0].property
+    ladder = rules.ladder_for(object_type, prop)
+
+    # Step 2 — pinned short-circuit.
+    pinned = sorted((s for s in survivors if s.pinned), key=_pin_sort_key)
+    unpinned = sorted(
+        (s for s in survivors if not s.pinned), key=lambda s: _ladder_sort_key(s, ladder)
+    )
+
+    if pinned:
+        ranked = pinned + unpinned
+        winner = ranked[0]
+        losers = ranked[1:]
+        # Multiple pins always dispute (curation conflict), and any
+        # OPEN-validity survivor materially differing from the pinned winner
+        # disputes too (closed losers are resolved history). A pin is
+        # authoritative, so the pinned path is never unresolvable.
+        disputed = len(pinned) > 1 or any(
+            s.valid_to is None and _materially_different(s.value, winner.value) for s in losers
+        )
+        return Resolution(
+            value=winner.value,
+            winner_statement=winner,
+            is_disputed=disputed,
+            losers=losers,
+            unresolvable=False,
+        )
+
+    # Steps 3–4 — ladder tier, then within-tier rank > validity > recency > id.
+    ranked = unpinned
+    winner = ranked[0]
+    losers = ranked[1:]
+
+    # Disputes count OPEN-validity losers only: a closed-validity statement
+    # that lost (e.g. the old half of a CHANGE) is resolved history, not a
+    # live dispute. It stays in losers[] for audit.
+    disputed = any(
+        s.valid_to is None and _materially_different(s.value, winner.value) for s in losers
+    )
+
+    # Un-rankable detection: a contender at the SAME tier and SAME rank as
+    # the winner, BOTH open-validity, materially different value, observed_at
+    # within the recency epsilon — recency can't be trusted to order them.
+    # A rank or validity difference IS a ranking: resolvable by definition.
+    top_tier = _tier(winner.writer_class, ladder)
+    epsilon = rules.recency_epsilon_seconds
+    unresolvable = winner.valid_to is None and any(
+        _tier(s.writer_class, ladder) == top_tier
+        and s.rank == winner.rank
+        and s.valid_to is None
+        and _materially_different(s.value, winner.value)
+        and abs((winner.observed_at - s.observed_at).total_seconds()) <= epsilon
+        for s in losers
+    )
+
+    return Resolution(
+        value=winner.value,
+        winner_statement=winner,
+        is_disputed=disputed,
+        losers=losers,
+        unresolvable=unresolvable,
+    )

--- a/src/pocketpaw/fabric/resolver.py
+++ b/src/pocketpaw/fabric/resolver.py
@@ -6,6 +6,34 @@
 #   valid_to + append a new PREFERRED statement) is visible to resolution;
 #   is_disputed and unresolvable tightened accordingly (closed-validity
 #   losers are resolved history, not live disputes).
+# Updated: 2026-07-11 (FST-7 — within-FAMILY staleness demotion) — the ``now``
+#   seam is live. ``now=None`` (every legacy caller) skips freshness ENTIRELY:
+#   resolution is byte-identical to FST-2..6. With ``now`` passed, the EXACT
+#   algorithm, applied on the ladder path only (a pin stays authoritative —
+#   the pinned short-circuit runs before and ignores freshness):
+#   1. Each unpinned survivor is classified fresh/aging/stale via
+#      ``trust.freshness`` with the property's TTL class
+#      (``rules.max_age_for`` — per-(object_type, property) overridable,
+#      default class "default" = 30d). Timezone convention lives in
+#      ``trust._as_utc``: compare in UTC, naive datetimes read AS UTC.
+#   2. DEMOTION AT TIER SELECTION: if the ladder-order top candidate is
+#      STALE, the winner becomes the FIRST candidate in ladder order that is
+#      (a) in the SAME writer FAMILY as that top (FST-4 families: connector +
+#      mirror = one machine-sync family; human, agent, inferred each their
+#      own) and (b) fresh or aging. Everything else keeps its ladder order,
+#      so the stale ex-top becomes the first loser. No same-family non-stale
+#      candidate → NO demotion: a stale value never loses to a fresh value
+#      from ANOTHER family (a stale connector beats a fresh inferred), and a
+#      lone stale value still wins (reads never block). One pass — the
+#      replacement is non-stale by construction, so demotion cannot cascade.
+#   3. FRESHNESS-DEMOTED LOSERS ARE RESOLVED: when the (possibly demoted)
+#      winner is non-stale, a STALE loser in the winner's family is treated
+#      like closed-validity history — excluded from both the dispute and the
+#      un-rankable checks (no conflict noise for "the sync moved on").
+#      Cross-family stale losers and every loser under a STALE winner keep
+#      the FST-2 semantics unchanged.
+#   ``_family`` replicates store._writer_family's FST-4 mapping (the store
+#   imports THIS module, so importing it back would cycle) — keep in sync.
 #
 # ``resolve(statements, rules)`` takes every Statement recorded for ONE
 # (object_id, property) and picks the value the flat properties dict SHOULD
@@ -46,8 +74,8 @@
 # the flag later).
 #
 # Pure and deterministic: no store access, no settings, no clock reads —
-# the optional ``now`` parameter is an unused seam for FST-7 freshness
-# demotion. Nothing in production calls this yet (unwired until FST-3).
+# the optional ``now`` parameter (FST-7) is the caller-supplied clock for
+# freshness demotion; ``now=None`` keeps the pre-FST-7 behavior exactly.
 
 from __future__ import annotations
 
@@ -57,7 +85,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from pocketpaw.fabric.models import Statement
-from pocketpaw.fabric.trust import TrustRules, WriterClass
+from pocketpaw.fabric.trust import Freshness, TrustRules, WriterClass, freshness
 
 
 class Resolution(BaseModel):
@@ -77,6 +105,11 @@ class Resolution(BaseModel):
     is_disputed: bool = False
     losers: list[Statement] = Field(default_factory=list)
     unresolvable: bool = False
+    # FST-7: the winner's freshness tri-state when ``now`` was passed to
+    # resolve() on the ladder path; None on the pinned path (a pin ignores
+    # freshness) and for legacy ``now=None`` callers. Consumed by the
+    # divergence log line and the provenance read surface.
+    winner_freshness: Freshness | None = None
 
 
 def _normalize(value: Any) -> Any:
@@ -110,6 +143,17 @@ def _tier(writer_class: str, ladder: list[WriterClass]) -> int:
         return ladder.index(writer_class)  # type: ignore[arg-type]
     except ValueError:
         return len(ladder)
+
+
+def _family(writer_class: str) -> str:
+    """Writer FAMILY for FST-7 staleness demotion — the demotion boundary.
+
+    Replicates :func:`store._writer_family` (FST-4): "connector" and
+    "mirror" are ONE machine-sync family; "human", "agent", "inferred" are
+    each their own. Replicated rather than imported because the store
+    imports THIS module (importing it back would cycle) — keep in sync.
+    """
+    return "sync" if writer_class in ("connector", "mirror") else writer_class
 
 
 def _rank_key(statement: Statement) -> int:
@@ -160,14 +204,16 @@ def resolve(
     rules: TrustRules,
     *,
     object_type: str | None = None,
-    now: datetime | None = None,  # noqa: ARG001 — FST-7 freshness seam, unused
+    now: datetime | None = None,
 ) -> Resolution:
     """Resolve one (object_id, property)'s statements to a single value.
 
     Pure and deterministic: same input (in any order) → same Resolution.
     ``rules`` is passed in — no settings access. ``object_type`` selects
     per-property ladder overrides (``None`` = global ladder only). ``now``
-    is an unused seam for FST-7 freshness demotion.
+    (FST-7) is the caller-supplied clock for within-family staleness
+    demotion — see the module comment for the exact algorithm; ``None``
+    (every legacy caller) skips freshness entirely.
 
     Raises ``ValueError`` if the statements span more than one
     (object_id, property) — the resolver is per-property by contract.
@@ -217,14 +263,58 @@ def resolve(
 
     # Steps 3–4 — ladder tier, then within-tier rank > validity > recency > id.
     ranked = unpinned
+
+    # FST-7 — within-FAMILY staleness demotion, only when the caller passed
+    # ``now`` (legacy callers skip freshness entirely; resolution is
+    # byte-identical to pre-FST-7). If the ladder-order top is STALE, the
+    # first fresh/aging candidate in ladder order FROM THE SAME WRITER
+    # FAMILY (see _family — connector+mirror are one machine-sync family)
+    # takes the win; everything else keeps ladder order, so the stale ex-top
+    # is the first loser. Demotion never crosses families, and a lone stale
+    # value still wins (reads never block). One pass — the replacement is
+    # non-stale by construction, so demotion cannot cascade.
+    freshness_state: dict[str, Freshness] = {}
+    if now is not None:
+        max_age = rules.max_age_for(object_type, prop)
+        freshness_state = {s.id: freshness(s.observed_at, max_age, now) for s in ranked}
+        top = ranked[0]
+        if freshness_state[top.id] == "stale":
+            replacement = next(
+                (
+                    s
+                    for s in ranked[1:]
+                    if _family(s.writer_class) == _family(top.writer_class)
+                    and freshness_state[s.id] != "stale"
+                ),
+                None,
+            )
+            if replacement is not None:
+                ranked = [replacement, *(s for s in ranked if s is not replacement)]
+
     winner = ranked[0]
     losers = ranked[1:]
 
+    def _freshness_resolved(s: Statement) -> bool:
+        """FST-7: a STALE loser in a NON-STALE winner's family is resolved
+        history ("the sync moved on"), not conflict noise — excluded from
+        the dispute and un-rankable checks. Always False when ``now`` was
+        not passed (empty freshness_state) or when the winner is stale."""
+        return (
+            bool(freshness_state)
+            and freshness_state[winner.id] != "stale"
+            and freshness_state[s.id] == "stale"
+            and _family(s.writer_class) == _family(winner.writer_class)
+        )
+
     # Disputes count OPEN-validity losers only: a closed-validity statement
     # that lost (e.g. the old half of a CHANGE) is resolved history, not a
-    # live dispute. It stays in losers[] for audit.
+    # live dispute. It stays in losers[] for audit. FST-7 adds the
+    # freshness-resolved exclusion (see _freshness_resolved).
     disputed = any(
-        s.valid_to is None and _materially_different(s.value, winner.value) for s in losers
+        s.valid_to is None
+        and _materially_different(s.value, winner.value)
+        and not _freshness_resolved(s)
+        for s in losers
     )
 
     # Un-rankable detection: a contender at the SAME tier and SAME rank as
@@ -239,6 +329,7 @@ def resolve(
         and s.valid_to is None
         and _materially_different(s.value, winner.value)
         and abs((winner.observed_at - s.observed_at).total_seconds()) <= epsilon
+        and not _freshness_resolved(s)
         for s in losers
     )
 
@@ -248,4 +339,5 @@ def resolve(
         is_disputed=disputed,
         losers=losers,
         unresolvable=unresolvable,
+        winner_freshness=freshness_state.get(winner.id),
     )

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -143,12 +143,37 @@
 #   gets truncated instead of growing unbounded across 128+ cached tenants. The
 #   W4a in-row workspace_id WHERE-filter is UNCHANGED — physical file isolation
 #   is ADDITIVE defense-in-depth layered on top of it, never a replacement.
+# Updated: 2026-07-10 (FST-1 — Fabric source-truth schema) — two NEW tables,
+#   ``fabric_statements`` + ``fabric_sources``, with append-only CRUD:
+#   ``append_statement()`` / ``get_statements()`` / ``upsert_source()``. A
+#   statement is one observed (object, property, value) claim with provenance
+#   (writer_class, a SourceRef FK, bitemporal observed/recorded/valid_from/
+#   valid_to, a curation rank); a source row is deduplicated on its identity
+#   tuple (kind + connector/run_id/document_uri/actor_id/session_id +
+#   workspace_id) both by an upsert-time lookup and a DB-level expression
+#   UNIQUE index (race guard, NULLs normalized via IFNULL so absent fields
+#   dedup too). Both tables carry the W4a ``workspace_id`` (schema-freeze
+#   ruling): ``append_statement`` stamps it, ``get_statements`` applies the
+#   standard ``_workspace_scope`` read scope (own rows + legacy NULL), and on
+#   sources it is PART of the dedup identity — the same source identity in two
+#   workspaces is two rows (tenancy isolation beats dedup). The tables ride
+#   SCHEMA_SQL's CREATE TABLE IF NOT EXISTS, so the migration is idempotent on
+#   an existing fabric.db (brand-new tables; the W4a ALTER loop additionally
+#   covers them so a DB from an early FST-1 build without workspace_id is
+#   healed, and that build's identity index is dropped for the
+#   workspace-aware ``idx_sources_identity_ws``). Statements are APPEND-ONLY:
+#   no update/delete verbs (rank changes come later as curation writes). NO
+#   existing read or write path is touched — the flat
+#   ``fabric_objects.properties`` dict remains the primary read path; nothing
+#   writes statements in production until ``fabric_source_truth_mode``
+#   (default "off") gains shadow/enforce semantics in later slices.
 
 
 from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -162,6 +187,8 @@ from pocketpaw.fabric.models import (
     ObjectType,
     PathHop,
     PropertyDef,
+    SourceRef,
+    Statement,
 )
 
 logger = logging.getLogger(__name__)
@@ -220,11 +247,65 @@ CREATE TABLE IF NOT EXISTS fabric_links (
     created_at TEXT DEFAULT (datetime('now'))
 );
 
+-- Source-truth provenance (FST-1). Two NEW tables. On a pre-FST fabric.db
+-- this CREATE TABLE IF NOT EXISTS creates them whole; a DB created by an
+-- early FST-1 build (before the schema-freeze review added workspace_id) is
+-- healed by the same ALTER loop the W4a columns use (see _ensure_schema).
+-- Nothing in the existing read/write path touches them; they are inert until
+-- fabric_source_truth_mode gains shadow/enforce semantics in later slices.
+CREATE TABLE IF NOT EXISTS fabric_sources (
+    id TEXT PRIMARY KEY,
+    -- 'connector_run' | 'document' | 'human_actor' | 'agent_session'
+    kind TEXT NOT NULL,
+    -- Identity fields (union across kinds; NULL = absent, still part of the
+    -- dedup identity — see _SOURCES_IDENTITY_UNIQUE_INDEX_SQL).
+    connector TEXT,
+    run_id TEXT,
+    document_uri TEXT,
+    actor_id TEXT,
+    session_id TEXT,
+    retrieved_at TEXT,
+    -- Tenancy (W4a semantics): the owning workspace. NULL = OSS /
+    -- single-tenant caller. PART OF THE DEDUP IDENTITY — the same source
+    -- identity in two workspaces is two rows (tenancy isolation beats dedup).
+    -- On an early-FST-1 DB this column is added by the ALTER migration in
+    -- _ensure_schema, NOT here.
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS fabric_statements (
+    id TEXT PRIMARY KEY,
+    object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    property TEXT NOT NULL,
+    -- JSON-encoded value (any JSON type, incl. null).
+    value TEXT NOT NULL DEFAULT 'null',
+    source_ref_id TEXT NOT NULL REFERENCES fabric_sources(id),
+    -- 'human' | 'connector' | 'mirror' | 'agent' | 'inferred'
+    writer_class TEXT NOT NULL,
+    -- Bitemporal fields, ISO-8601 TEXT (same affinity as every other
+    -- timestamp column in this schema).
+    observed_at TEXT NOT NULL,
+    recorded_at TEXT NOT NULL,
+    valid_from TEXT NOT NULL,
+    valid_to TEXT,
+    -- Curation: 'preferred' | 'normal' | 'deprecated'; pinned = human-fixed.
+    rank TEXT NOT NULL DEFAULT 'normal',
+    rank_reason TEXT,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    -- Tenancy (W4a): same workspace semantics as fabric_objects. Stamped on
+    -- append; scoped reads see own rows + legacy NULL. Same ALTER-migration
+    -- note as fabric_sources.workspace_id above.
+    workspace_id TEXT
+);
+
 CREATE INDEX IF NOT EXISTS idx_objects_type ON fabric_objects(type_id);
 CREATE INDEX IF NOT EXISTS idx_objects_source ON fabric_objects(source_connector, source_id);
 CREATE INDEX IF NOT EXISTS idx_links_from ON fabric_links(from_object_id);
 CREATE INDEX IF NOT EXISTS idx_links_to ON fabric_links(to_object_id);
 CREATE INDEX IF NOT EXISTS idx_links_type ON fabric_links(link_type);
+CREATE INDEX IF NOT EXISTS idx_statements_object ON fabric_statements(object_id);
+CREATE INDEX IF NOT EXISTS idx_statements_object_property ON fabric_statements(object_id, property);
 """
 
 # Tenancy indexes are created AFTER the ALTER migration (see _ensure_schema),
@@ -240,6 +321,38 @@ _WORKSPACE_INDEX_SQL = (
     # list_types / stats reads. The UNIQUE (workspace_id, LOWER(name)) index is
     # created separately (_TYPE_NAME_UNIQUE_INDEX_SQL) after the de-dup pass.
     "CREATE INDEX IF NOT EXISTS idx_object_types_workspace ON fabric_object_types(workspace_id)",
+    # FST-1: same W4a pairing for the source-truth tables — the plain
+    # workspace index rides ALONGSIDE the (object_id, property) read index in
+    # SCHEMA_SQL, exactly like idx_objects_workspace pairs with
+    # idx_objects_type/idx_objects_source.
+    "CREATE INDEX IF NOT EXISTS idx_statements_workspace ON fabric_statements(workspace_id)",
+    "CREATE INDEX IF NOT EXISTS idx_sources_workspace ON fabric_sources(workspace_id)",
+)
+
+# Race guard for upsert_source: one row per source identity PER WORKSPACE.
+# Created AFTER the ALTER migration (same "no such column" hazard as
+# _WORKSPACE_INDEX_SQL: an early-FST-1 DB has the tables but not the
+# workspace_id column until the ALTER runs). SQLite treats NULLs as DISTINCT
+# in a UNIQUE index, so every nullable identity field — INCLUDING
+# workspace_id — is normalized through IFNULL(..., '') : two rows that both
+# omit run_id ARE the same identity, and two OSS (NULL-workspace) upserts of
+# the same source dedup to one row, while the same identity in two different
+# workspaces stays two rows (tenancy isolation beats dedup). upsert_source
+# does a lookup-first anyway; this index only closes the concurrent-insert
+# race the same way the type-name index does. The early-FST-1 index of the
+# same shape MINUS workspace_id is dropped first (it would collapse two
+# tenants' rows into one) — mirror of _OLD_GLOBAL_TYPE_NAME_INDEX.
+_OLD_SOURCES_IDENTITY_INDEX = "idx_sources_identity"
+_SOURCES_IDENTITY_UNIQUE_INDEX_SQL = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_sources_identity_ws ON fabric_sources("
+    " kind,"
+    " IFNULL(connector, ''),"
+    " IFNULL(run_id, ''),"
+    " IFNULL(document_uri, ''),"
+    " IFNULL(actor_id, ''),"
+    " IFNULL(session_id, ''),"
+    " IFNULL(workspace_id, '')"
+    ")"
 )
 
 # A UNIQUE index on (workspace_id, case-folded type name) closes a concurrent
@@ -382,15 +495,24 @@ class FabricStore:
             return
         async with aiosqlite.connect(self._db_path) as db:
             await db.executescript(SCHEMA_SQL)
-            # Additive migration (W4a + SZD-2): tenancy columns on a pre-existing
-            # DB. CREATE TABLE IF NOT EXISTS won't add a column to a table that
-            # already exists, so ALTER and swallow the duplicate-column error
-            # that fires on every subsequent boot — same pattern as the W2b
-            # instinct hash-chain / assignee migrations. Pre-existing rows keep
-            # NULL workspace_id (legacy/global; see the module header). SZD-2
-            # extends the same ALTER to fabric_object_types so the type catalog
-            # is per-tenant too.
-            for _tbl in ("fabric_objects", "fabric_links", "fabric_object_types"):
+            # Additive migration (W4a + SZD-2 + FST-1): tenancy columns on a
+            # pre-existing DB. CREATE TABLE IF NOT EXISTS won't add a column to
+            # a table that already exists, so ALTER and swallow the
+            # duplicate-column error that fires on every subsequent boot — same
+            # pattern as the W2b instinct hash-chain / assignee migrations.
+            # Pre-existing rows keep NULL workspace_id (legacy/global; see the
+            # module header). SZD-2 extends the same ALTER to
+            # fabric_object_types; FST-1 extends it to fabric_statements /
+            # fabric_sources (a no-op on any DB whose tables were created by
+            # this SCHEMA_SQL — it only heals a DB from an early FST-1 build
+            # that predates the schema-freeze workspace_id ruling).
+            for _tbl in (
+                "fabric_objects",
+                "fabric_links",
+                "fabric_object_types",
+                "fabric_statements",
+                "fabric_sources",
+            ):
                 try:
                     await db.execute(f"ALTER TABLE {_tbl} ADD COLUMN workspace_id TEXT")
                 except aiosqlite.OperationalError:
@@ -407,6 +529,15 @@ class FabricStore:
             # above). Doing this inside SCHEMA_SQL would fail on a pre-W4a DB.
             for _idx in _WORKSPACE_INDEX_SQL:
                 await db.execute(_idx)
+            # FST-1: the per-workspace source-identity UNIQUE index. Drop the
+            # early-FST-1 identity index (no workspace in its key — it would
+            # collapse two tenants' identical source identities into one row)
+            # before creating the workspace-aware replacement; both steps are
+            # no-ops on a fresh / already-migrated DB. Created here, after the
+            # ALTER, for the same "no such column" reason as
+            # _WORKSPACE_INDEX_SQL.
+            await db.execute(f"DROP INDEX IF EXISTS {_OLD_SOURCES_IDENTITY_INDEX}")
+            await db.execute(_SOURCES_IDENTITY_UNIQUE_INDEX_SQL)
             # SZD-2 backfill: attribute a NULL-workspace type to a tenant ONLY
             # when every object of that type unambiguously shares one workspace.
             # A type whose objects span tenants (or that has no objects, or whose
@@ -938,6 +1069,200 @@ class FabricStore:
             await db.execute("DELETE FROM fabric_links WHERE id = ?", (link_id,))
             await db.commit()
 
+    # --- Statements & Sources (FST-1 — source-truth provenance) ---
+
+    async def upsert_source(
+        self,
+        kind: str,
+        *,
+        connector: str | None = None,
+        run_id: str | None = None,
+        document_uri: str | None = None,
+        actor_id: str | None = None,
+        session_id: str | None = None,
+        retrieved_at: datetime | None = None,
+        workspace_id: str | None = None,
+    ) -> SourceRef:
+        """Return the SourceRef for this source identity, creating it if new.
+
+        Dedup key is the identity tuple ``(kind, connector, run_id,
+        document_uri, actor_id, session_id, workspace_id)`` — a second call
+        with the same identity returns the SAME row (``retrieved_at`` is
+        provenance metadata, not identity; an existing row is returned as-is,
+        never mutated). ``workspace_id`` IS part of the identity, unlike the
+        other fabric tables' W4a read-scope treatment: the same source seen
+        from two workspaces yields two rows, so tenant provenance never
+        rendezvouses on a shared row (tenancy isolation beats dedup);
+        ``None`` = the OSS / single-tenant identity. A concurrent
+        double-insert is closed by the ``idx_sources_identity_ws`` expression
+        UNIQUE index: the loser's INSERT raises and resolves to a re-read of
+        the winner's row.
+        """
+        identity_sql = (
+            "SELECT * FROM fabric_sources WHERE kind = ?"
+            " AND connector IS ? AND run_id IS ? AND document_uri IS ?"
+            " AND actor_id IS ? AND session_id IS ? AND workspace_id IS ?"
+        )
+        identity_params = (
+            kind,
+            connector,
+            run_id,
+            document_uri,
+            actor_id,
+            session_id,
+            workspace_id,
+        )
+        source = SourceRef(
+            kind=kind,  # type: ignore[arg-type]  # Literal validated by pydantic
+            connector=connector,
+            run_id=run_id,
+            document_uri=document_uri,
+            actor_id=actor_id,
+            session_id=session_id,
+            retrieved_at=retrieved_at,
+            workspace_id=workspace_id,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(identity_sql, identity_params) as cur:
+                row = await cur.fetchone()
+            if row:
+                return self._row_to_source(row)
+            try:
+                await db.execute(
+                    "INSERT INTO fabric_sources"
+                    " (id, kind, connector, run_id, document_uri, actor_id,"
+                    " session_id, retrieved_at, workspace_id)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        source.id,
+                        source.kind,
+                        connector,
+                        run_id,
+                        document_uri,
+                        actor_id,
+                        session_id,
+                        retrieved_at.isoformat() if retrieved_at else None,
+                        workspace_id,
+                    ),
+                )
+                await db.commit()
+            except aiosqlite.IntegrityError:
+                # Concurrent upsert won the race — return its row.
+                async with db.execute(identity_sql, identity_params) as cur:
+                    row = await cur.fetchone()
+                if row:
+                    return self._row_to_source(row)
+                raise
+        return source
+
+    async def append_statement(
+        self,
+        object_id: str,
+        property: str,
+        value: Any,
+        source_ref_id: str,
+        writer_class: str,
+        *,
+        observed_at: datetime | None = None,
+        valid_from: datetime | None = None,
+        valid_to: datetime | None = None,
+        rank: str = "normal",
+        rank_reason: str | None = None,
+        pinned: bool = False,
+        workspace_id: str | None = None,
+    ) -> Statement:
+        """Append ONE observed (object, property, value) claim with provenance.
+
+        APPEND-ONLY: statements are never updated or deleted (this store
+        exposes no verbs for either; rank changes land in a later slice as new
+        curation writes). ``recorded_at`` is stamped here; ``observed_at``
+        defaults to now (a live observation) and ``valid_from`` defaults to
+        ``observed_at``. ``value`` is JSON-encoded — any JSON-serializable
+        value round-trips, including ``None``. ``workspace_id`` stamps the
+        owning tenant on the row (W4a write semantics, same as
+        :meth:`create_object`); ``None`` = OSS / single-tenant caller.
+
+        Does NOT touch the object's flat ``properties`` dict — that dict
+        remains the primary read path; nothing consumes statements until
+        ``fabric_source_truth_mode`` gains shadow/enforce semantics.
+        """
+        stmt = Statement(
+            object_id=object_id,
+            property=property,
+            value=value,
+            source_ref_id=source_ref_id,
+            writer_class=writer_class,  # type: ignore[arg-type]  # Literal validated by pydantic
+            rank=rank,  # type: ignore[arg-type]  # Literal validated by pydantic
+            rank_reason=rank_reason,
+            pinned=pinned,
+            workspace_id=workspace_id,
+        )
+        if observed_at is not None:
+            stmt.observed_at = observed_at
+        stmt.valid_from = valid_from if valid_from is not None else stmt.observed_at
+        stmt.valid_to = valid_to
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO fabric_statements"
+                " (id, object_id, property, value, source_ref_id, writer_class,"
+                " observed_at, recorded_at, valid_from, valid_to, rank,"
+                " rank_reason, pinned, workspace_id)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    stmt.id,
+                    stmt.object_id,
+                    stmt.property,
+                    json.dumps(stmt.value),
+                    stmt.source_ref_id,
+                    stmt.writer_class,
+                    stmt.observed_at.isoformat(),
+                    stmt.recorded_at.isoformat(),
+                    stmt.valid_from.isoformat(),
+                    stmt.valid_to.isoformat() if stmt.valid_to else None,
+                    stmt.rank,
+                    stmt.rank_reason,
+                    1 if stmt.pinned else 0,
+                    workspace_id,
+                ),
+            )
+            await db.commit()
+        return stmt
+
+    async def get_statements(
+        self,
+        object_id: str,
+        property: str | None = None,
+        workspace_id: str | None = None,
+    ) -> list[Statement]:
+        """All statements for one object, optionally narrowed to one property.
+
+        Ordered by ``recorded_at`` (then id, for a stable order within the
+        same timestamp) — oldest first, so a resolver reading the full history
+        replays claims in the order the store learned them. ``workspace_id``
+        applies the standard W4a read scope (own rows + legacy NULL rows, via
+        ``_workspace_scope`` — same as :meth:`get_object`); ``None`` leaves
+        the read unscoped (OSS / single-tenant callers).
+        """
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "SELECT * FROM fabric_statements WHERE object_id = ?"
+        params: list[Any] = [object_id]
+        if property is not None:
+            sql += " AND property = ?"
+            params.append(property)
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        sql += " ORDER BY recorded_at, id"
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(sql, params) as cur:
+                rows = await cur.fetchall()
+        return [self._row_to_statement(r) for r in rows]
+
     async def get_linked_objects(
         self, obj_id: str, link_type: str | None = None, workspace_id: str | None = None
     ) -> list[FabricObject]:
@@ -1347,4 +1672,37 @@ class FabricStore:
             to_object_id=row["to_object_id"],
             link_type=row["link_type"],
             properties=json.loads(row["properties"]) if row["properties"] else {},
+        )
+
+    def _row_to_source(self, row: Any) -> SourceRef:
+        return SourceRef(
+            id=row["id"],
+            kind=row["kind"],
+            connector=row["connector"],
+            run_id=row["run_id"],
+            document_uri=row["document_uri"],
+            actor_id=row["actor_id"],
+            session_id=row["session_id"],
+            retrieved_at=(
+                datetime.fromisoformat(row["retrieved_at"]) if row["retrieved_at"] else None
+            ),
+            workspace_id=row["workspace_id"],
+        )
+
+    def _row_to_statement(self, row: Any) -> Statement:
+        return Statement(
+            id=row["id"],
+            object_id=row["object_id"],
+            property=row["property"],
+            value=json.loads(row["value"]) if row["value"] is not None else None,
+            source_ref_id=row["source_ref_id"],
+            writer_class=row["writer_class"],
+            observed_at=datetime.fromisoformat(row["observed_at"]),
+            recorded_at=datetime.fromisoformat(row["recorded_at"]),
+            valid_from=datetime.fromisoformat(row["valid_from"]),
+            valid_to=(datetime.fromisoformat(row["valid_to"]) if row["valid_to"] else None),
+            rank=row["rank"],
+            rank_reason=row["rank_reason"],
+            pinned=bool(row["pinned"]),
+            workspace_id=row["workspace_id"],
         )

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -211,6 +211,46 @@
 #      and promote every changed property, gutting the opt-in discipline. No
 #      behavior change for pre-FST-4 cohorts: "mirror" never reached this
 #      comparison before this slice.
+# Updated: 2026-07-10 (FST-5 — ENFORCE mode: the resolver owns the cache) —
+#   three changes; 'off' and 'shadow' are byte-for-byte the FST-3/4 behavior:
+#   1. update_object() in ENFORCE runs the statement pass BEFORE the cache
+#      commit and, for every TRACKED property (one that has statements after
+#      the pass — pre-tracked or just promoted), writes the RESOLVER'S WINNER
+#      into the flat properties dict instead of the blind LWW value.
+#      Untracked properties keep LWW (no statements → nothing to resolve).
+#      Write-once: the final dict is computed first, then committed in ONE
+#      UPDATE — never LWW-then-overwrite. The divergence line still logs with
+#      the same grep-stable shape; in enforce ``lww=`` is what LWW WOULD have
+#      kept and ``resolver=`` is what the cache now holds. A statement-pass
+#      failure in enforce falls back to plain LWW for that write (log + keep
+#      writing — the cache write must never break), mirroring FST-3's shield.
+#      _shadow_record_statements now RETURNS {property: Resolution} for the
+#      statement-producing properties so enforce reuses the pass's own
+#      resolutions instead of resolving twice; shadow ignores the return.
+#   2. change_property() / correct_property(): the curation verbs (the seams
+#      FST-6's PIN/IGNORE executor calls). CHANGE closes the current winner
+#      statement's valid_to and appends the new value as rank="preferred"
+#      (open validity); CORRECT marks the current winner deprecated with
+#      rank_reason and appends the corrected value as rank="normal". Both
+#      auto-promote an untracked property first (seed the current cache value
+#      with FST-3's baseline provenance + touch-time observed_at) so history
+#      is preserved, and both return the NEW Resolution. Cache behavior is
+#      mode-respecting: enforce writes the new resolver winner into the
+#      cache; shadow/off leave the cache alone (the verbs are statement-layer
+#      operations in every mode). These verbs are the ONLY two writes that
+#      touch existing statement rows — narrow curation UPDATEs on
+#      valid_to / rank+rank_reason only (the append-only doctrine's
+#      documented "later curation writes"); value and provenance columns are
+#      never rewritten.
+#   3. The FST-3 provenance derivation is factored into _derive_provenance()
+#      (byte-identical rules) so the verbs and the shadow pass share ONE
+#      definition instead of two drifting copies.
+#   Site-2 note (settled in fabric/projection.py): the PROJECTION stays
+#   event-faithful in enforce — it folds what the journal says; enforce
+#   ownership applies at THIS store's cache layer (the primary read path).
+#   Site-3 note: the EE mirror's update path goes through update_object, so
+#   enforce flows through automatically (proven in
+#   tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py).
 
 
 from __future__ import annotations
@@ -240,7 +280,7 @@ from pocketpaw.fabric.models import (
 # duplicating it here — one definition of "materially different" for the
 # whole source-truth chain. The name is module-private in resolver.py but
 # intra-package reuse is deliberate.
-from pocketpaw.fabric.resolver import _materially_different, resolve
+from pocketpaw.fabric.resolver import Resolution, _materially_different, resolve
 from pocketpaw.fabric.trust import default_trust_rules
 
 logger = logging.getLogger(__name__)
@@ -1059,21 +1099,64 @@ class FabricStore:
         FST-3 (source-truth shadow) — the new keyword-only kwargs are OPTIONAL
         provenance for the write (all default ``None``; every pre-FST-3 caller
         keeps working unchanged). They only matter when
-        ``fabric_source_truth_mode`` is ``shadow`` or ``enforce`` (enforce is
-        treated as shadow until FST-5): the write is then ALSO recorded as
-        statements per :meth:`_shadow_record_statements` (auto-promotion,
-        provenance derivation, divergence log — see its docstring for the exact
-        rules). The CACHE WRITE IS UNCHANGED in every mode: last-write-wins
-        merge into the flat properties dict, which remains the primary read
-        path. With mode ``off`` (the default) not a single new query or write
-        happens — the mode is read once per call and the whole shadow block is
-        skipped.
+        ``fabric_source_truth_mode`` is ``shadow`` or ``enforce``: the write is
+        then ALSO recorded as statements per
+        :meth:`_shadow_record_statements` (auto-promotion, provenance
+        derivation, divergence log — see its docstring for the exact rules).
+        With mode ``off`` (the default) not a single new query or write
+        happens — the mode is read once per call and the whole statement block
+        is skipped.
+
+        Cache semantics per mode (FST-5):
+
+        - ``off`` / ``shadow`` — UNCHANGED: last-write-wins merge into the
+          flat properties dict, which remains the primary read path. In
+          shadow the statement pass runs AFTER the cache commit and only
+          observes.
+        - ``enforce`` — the RESOLVER OWNS THE CACHE for tracked properties.
+          The statement pass runs FIRST; every property that has statements
+          after the pass (already tracked, or promoted by it) lands in the
+          cache as the resolver's winner instead of the blind LWW value.
+          Untracked properties keep LWW (no statements → nothing to
+          resolve). Write-once: the final dict is computed, then committed in
+          ONE UPDATE. A statement-pass failure falls back to plain LWW for
+          this write (warning logged) — the cache write must never break.
         """
         mode = _source_truth_mode()  # read ONCE per call; "off" skips everything
         existing = await self.get_object(obj_id, workspace_id=workspace_id)
         if not existing:
             return None
         merged = {**existing.properties, **properties}
+        if mode == "enforce":
+            # FST-5: statement pass BEFORE the commit so the resolver's winner
+            # for each tracked property can be folded into the ONE cache
+            # write. Failure-shielded like shadow: a broken pass degrades this
+            # write to plain LWW rather than blocking it.
+            try:
+                resolutions = await self._shadow_record_statements(
+                    existing,
+                    properties,
+                    writer_class=writer_class,
+                    source_kind=source_kind,
+                    source_connector=source_connector,
+                    source_run_id=source_run_id,
+                    source_document_uri=source_document_uri,
+                    source_actor_id=source_actor_id,
+                    source_session_id=source_session_id,
+                    observed_at=observed_at,
+                    workspace_id=workspace_id,
+                )
+            except Exception:
+                logger.warning(
+                    "fabric enforce: statement pass failed for object=%s"
+                    " — falling back to LWW for this write",
+                    obj_id,
+                    exc_info=True,
+                )
+                resolutions = {}
+            for prop, resolution in resolutions.items():
+                if resolution.winner_statement is not None:
+                    merged[prop] = resolution.value
         ws_cond, ws_params = _workspace_scope(workspace_id)
         sql = "UPDATE fabric_objects SET properties = ?, updated_at = datetime('now') WHERE id = ?"
         params: list[Any] = [json.dumps(merged), obj_id]
@@ -1084,10 +1167,10 @@ class FabricStore:
         async with self._conn() as db:
             await db.execute(sql, params)
             await db.commit()
-        if mode != "off":
-            # shadow | enforce (enforce == shadow until FST-5). Runs AFTER the
-            # cache write so the primary path's semantics and error behavior
-            # stay byte-identical; a shadow failure must never break the write.
+        if mode == "shadow":
+            # Shadow runs AFTER the cache write so the primary path's
+            # semantics and error behavior stay byte-identical (FST-3); a
+            # shadow failure must never break the write.
             try:
                 await self._shadow_record_statements(
                     existing,
@@ -1110,6 +1193,58 @@ class FabricStore:
                 )
         return await self.get_object(obj_id, workspace_id=workspace_id)
 
+    @staticmethod
+    def _derive_provenance(
+        existing: FabricObject,
+        *,
+        writer_class: str | None,
+        source_kind: str | None,
+        source_connector: str | None,
+        source_actor_id: str | None,
+        source_session_id: str | None,
+        source_document_uri: str | None,
+    ) -> tuple[str, str | None, str]:
+        """Effective ``(kind, connector, writer_class)`` of one write (FST-3).
+
+        The single definition of the provenance derivation rules, shared by
+        the statement pass and the FST-5 curation verbs (byte-identical to
+        the inline FST-3 logic this was factored from):
+
+        - kind, in order: explicit ``source_kind`` > ``source_connector`` →
+          ``connector_run`` > ``source_actor_id`` → ``human_actor`` >
+          ``source_session_id`` → ``agent_session`` > ``source_document_uri``
+          → ``document`` > the object's own ``source_connector`` →
+          ``connector_run`` for that connector > ``agent_session`` with no
+          identity (the honest default for unattributed writes).
+        - writer_class: explicit > ``connector`` for ``connector_run`` >
+          ``human`` for ``human_actor`` > ``agent`` for everything else.
+        """
+        kind = source_kind
+        connector = source_connector
+        if kind is None:
+            if connector is not None:
+                kind = "connector_run"
+            elif source_actor_id is not None:
+                kind = "human_actor"
+            elif source_session_id is not None:
+                kind = "agent_session"
+            elif source_document_uri is not None:
+                kind = "document"
+            elif existing.source_connector:
+                kind = "connector_run"
+                connector = existing.source_connector
+            else:
+                kind = "agent_session"
+        eff_writer = writer_class
+        if eff_writer is None:
+            if kind == "connector_run":
+                eff_writer = "connector"
+            elif kind == "human_actor":
+                eff_writer = "human"
+            else:
+                eff_writer = "agent"
+        return kind, connector, eff_writer
+
     async def _shadow_record_statements(
         self,
         existing: FabricObject,
@@ -1124,13 +1259,18 @@ class FabricStore:
         source_session_id: str | None,
         observed_at: datetime | None,
         workspace_id: str | None,
-    ) -> None:
-        """The FST-3 shadow pass: record an update's claims as statements.
+    ) -> dict[str, Resolution]:
+        """The FST-3 statement pass: record an update's claims as statements.
 
         Called from :meth:`update_object` (merge site 1) only when
-        ``fabric_source_truth_mode`` is shadow/enforce, AFTER the LWW cache
-        write. ``existing`` is the PRE-update snapshot (its properties and
+        ``fabric_source_truth_mode`` is shadow/enforce — AFTER the LWW cache
+        write in shadow, BEFORE the cache commit in enforce (FST-5, so the
+        caller can fold each Resolution into the one cache write).
+        ``existing`` is the PRE-update snapshot (its properties and
         ``updated_at`` are the old cache state).
+
+        Returns ``{property: Resolution}`` for every statement-producing
+        (tracked) property — the enforce path consumes it; shadow ignores it.
 
         Provenance derivation (when the caller passed no explicit kwargs):
 
@@ -1176,37 +1316,30 @@ class FabricStore:
            grep-stable, single line, values JSON-encoded so they can never
            wrap):
 
-           ``fabric shadow: object=<id> property=<p> lww=<cache-value>
+           ``fabric shadow: object=<id> property=<p> lww=<lww-value>
            resolver=<winner-value> diverged=<bool> disputed=<bool>
            unresolvable=<bool>``
 
-        The cache is NEVER touched here — shadow only observes.
+           The line's shape is mode-independent. In shadow ``lww`` is what
+           the cache holds and ``resolver`` is what it WOULD hold; in
+           enforce (FST-5) ``lww`` is what LWW would have kept and
+           ``resolver`` is what the cache now holds — ``diverged=True``
+           means the resolver overrode the incoming write.
+
+        The cache is NEVER touched here — the CALLER owns the cache write
+        (LWW in off/shadow; the returned resolutions in enforce).
         """
-        # --- Effective provenance of the incoming write ---
-        kind = source_kind
-        connector = source_connector
-        if kind is None:
-            if connector is not None:
-                kind = "connector_run"
-            elif source_actor_id is not None:
-                kind = "human_actor"
-            elif source_session_id is not None:
-                kind = "agent_session"
-            elif source_document_uri is not None:
-                kind = "document"
-            elif existing.source_connector:
-                kind = "connector_run"
-                connector = existing.source_connector
-            else:
-                kind = "agent_session"
-        eff_writer = writer_class
-        if eff_writer is None:
-            if kind == "connector_run":
-                eff_writer = "connector"
-            elif kind == "human_actor":
-                eff_writer = "human"
-            else:
-                eff_writer = "agent"
+        # --- Effective provenance of the incoming write (FST-3 rules,
+        # shared with the FST-5 curation verbs via _derive_provenance) ---
+        kind, connector, eff_writer = self._derive_provenance(
+            existing,
+            writer_class=writer_class,
+            source_kind=source_kind,
+            source_connector=source_connector,
+            source_actor_id=source_actor_id,
+            source_session_id=source_session_id,
+            source_document_uri=source_document_uri,
+        )
 
         # --- Object-level baseline (who owns the current cache value) ---
         baseline_connector = existing.source_connector
@@ -1225,6 +1358,7 @@ class FabricStore:
         # nothing promoted) writes NOTHING — not even a SourceRef row.
         incoming_source: SourceRef | None = None
         seed_source: SourceRef | None = None
+        resolutions: dict[str, Resolution] = {}
 
         for prop, value in incoming.items():
             stmts = await self.get_statements(existing.id, prop, workspace_id=workspace_id)
@@ -1279,7 +1413,10 @@ class FabricStore:
                 default_trust_rules(),
                 object_type=existing.type_name or None,
             )
-            # The LWW cache now holds the incoming value (last write wins).
+            # ``lww`` is the incoming value — what the cache holds in shadow
+            # and what LWW WOULD have kept in enforce (where the caller
+            # writes ``resolver`` into the cache instead). Same line either
+            # way: the FST-8 harness contract.
             logger.info(
                 "fabric shadow: object=%s property=%s lww=%s resolver=%s"
                 " diverged=%s disputed=%s unresolvable=%s",
@@ -1291,6 +1428,8 @@ class FabricStore:
                 resolution.is_disputed,
                 resolution.unresolvable,
             )
+            resolutions[prop] = resolution
+        return resolutions
 
     async def shadow_record_event_update(
         self,
@@ -1362,6 +1501,271 @@ class FabricStore:
             workspace_id=workspace_id,
         )
         return True
+
+    # --- Curation verbs (FST-5 — CHANGE / CORRECT) ---
+
+    async def change_property(
+        self,
+        object_id: str,
+        property: str,
+        new_value: Any,
+        *,
+        writer_class: str | None = None,
+        source_kind: str | None = None,
+        source_connector: str | None = None,
+        source_run_id: str | None = None,
+        source_document_uri: str | None = None,
+        source_actor_id: str | None = None,
+        source_session_id: str | None = None,
+        observed_at: datetime | None = None,
+        workspace_id: str | None = None,
+    ) -> Resolution:
+        """CHANGE one property's value as an explicit curation act (FST-5).
+
+        Semantics: close the CURRENT WINNER statement's validity
+        (``valid_to = now`` — it becomes superseded history, still auditable)
+        and append ``new_value`` as a ``rank="preferred"``, open-validity
+        statement carrying the caller's provenance (same optional kwargs and
+        derivation rules as :meth:`update_object` — callers SHOULD pass
+        provenance; unattributed calls inherit the object's baseline).
+
+        The property must be TRACKED. On an untracked property the verb
+        first PROMOTES it (seeds the current cache value with the object's
+        baseline provenance + touch-time ``observed_at``, exactly FST-3's
+        promotion seed) so the pre-change history is preserved, THEN applies.
+        A property absent from both statements and the cache has no prior
+        claim — the new statement is simply appended.
+
+        Returns the NEW :class:`Resolution` over the property's statements.
+        The new preferred statement wins within its writer tier; a
+        higher-tier statement or a pin still outranks it — the resolver owns
+        the outcome, by design. Cache behavior is mode-respecting: in
+        ``enforce`` the flat properties dict is updated to the new winner; in
+        ``shadow``/``off`` the cache is untouched (the verb is a
+        statement-layer operation in every mode).
+
+        This is one of the seams FST-6's PIN/IGNORE executor calls.
+        """
+        return await self._curate_property(
+            object_id,
+            property,
+            new_value,
+            verb="change",
+            reason=None,
+            writer_class=writer_class,
+            source_kind=source_kind,
+            source_connector=source_connector,
+            source_run_id=source_run_id,
+            source_document_uri=source_document_uri,
+            source_actor_id=source_actor_id,
+            source_session_id=source_session_id,
+            observed_at=observed_at,
+            workspace_id=workspace_id,
+        )
+
+    async def correct_property(
+        self,
+        object_id: str,
+        property: str,
+        new_value: Any,
+        *,
+        reason: str,
+        writer_class: str | None = None,
+        source_kind: str | None = None,
+        source_connector: str | None = None,
+        source_run_id: str | None = None,
+        source_document_uri: str | None = None,
+        source_actor_id: str | None = None,
+        source_session_id: str | None = None,
+        observed_at: datetime | None = None,
+        workspace_id: str | None = None,
+    ) -> Resolution:
+        """CORRECT one property's value: the current winner was WRONG (FST-5).
+
+        Semantics: mark the CURRENT WINNER statement ``rank="deprecated"``
+        with ``rank_reason=reason`` (a deprecated statement never wins, never
+        loses, never disputes — it is struck from resolution entirely, unlike
+        CHANGE's closed-but-candidate history) and append ``new_value`` as a
+        ``rank="normal"``, open-validity statement with the caller's
+        provenance.
+
+        Tracking, promotion, provenance derivation, the returned NEW
+        :class:`Resolution`, and the mode-respecting cache behavior (enforce
+        writes the new winner; shadow/off leave the cache alone) all match
+        :meth:`change_property` — see its docstring.
+
+        This is one of the seams FST-6's PIN/IGNORE executor calls.
+        """
+        return await self._curate_property(
+            object_id,
+            property,
+            new_value,
+            verb="correct",
+            reason=reason,
+            writer_class=writer_class,
+            source_kind=source_kind,
+            source_connector=source_connector,
+            source_run_id=source_run_id,
+            source_document_uri=source_document_uri,
+            source_actor_id=source_actor_id,
+            source_session_id=source_session_id,
+            observed_at=observed_at,
+            workspace_id=workspace_id,
+        )
+
+    async def _curate_property(
+        self,
+        object_id: str,
+        property: str,
+        new_value: Any,
+        *,
+        verb: str,
+        reason: str | None,
+        writer_class: str | None,
+        source_kind: str | None,
+        source_connector: str | None,
+        source_run_id: str | None,
+        source_document_uri: str | None,
+        source_actor_id: str | None,
+        source_session_id: str | None,
+        observed_at: datetime | None,
+        workspace_id: str | None,
+    ) -> Resolution:
+        """Shared core of :meth:`change_property` / :meth:`correct_property`.
+
+        ``verb`` is ``"change"`` (close the winner's validity, append
+        preferred) or ``"correct"`` (deprecate the winner with ``reason``,
+        append normal). Raises ``ValueError`` when the object doesn't exist
+        (or is outside the caller's workspace scope) — the FST-6 executor
+        needs a clean failure, not a silent no-op.
+        """
+        mode = _source_truth_mode()  # read ONCE; decides only the cache write
+        existing = await self.get_object(object_id, workspace_id=workspace_id)
+        if existing is None:
+            raise ValueError(f"fabric object not found: {object_id!r}")
+
+        stmts = await self.get_statements(object_id, property, workspace_id=workspace_id)
+        if not stmts and property in existing.properties:
+            # Auto-promotion (FST-3 seeding, unconditional here — the verb is
+            # explicit curation, so preserving the pre-verb claim IS the
+            # point): seed the current cache value with the object-level
+            # baseline provenance and touch-time observed_at.
+            baseline_connector = existing.source_connector
+            baseline_writer = "connector" if baseline_connector else "agent"
+            seed_source = await self.upsert_source(
+                "connector_run" if baseline_connector else "agent_session",
+                connector=baseline_connector,
+                workspace_id=workspace_id,
+            )
+            seed = await self.append_statement(
+                object_id,
+                property,
+                existing.properties[property],
+                seed_source.id,
+                baseline_writer,
+                observed_at=existing.updated_at or existing.created_at,
+                workspace_id=workspace_id,
+            )
+            stmts = [seed]
+
+        current = resolve(stmts, default_trust_rules(), object_type=existing.type_name or None)
+        winner = current.winner_statement
+        if winner is not None:
+            if verb == "change":
+                # Close the winner's validity — only if still open; a closed
+                # winner is already superseded history and its interval must
+                # not be rewritten.
+                if winner.valid_to is None:
+                    await self._close_statement_validity(winner.id, datetime.now())
+            else:
+                await self._deprecate_statement(winner.id, reason)
+
+        kind, connector, eff_writer = self._derive_provenance(
+            existing,
+            writer_class=writer_class,
+            source_kind=source_kind,
+            source_connector=source_connector,
+            source_actor_id=source_actor_id,
+            source_session_id=source_session_id,
+            source_document_uri=source_document_uri,
+        )
+        new_source = await self.upsert_source(
+            kind,
+            connector=connector,
+            run_id=source_run_id,
+            document_uri=source_document_uri,
+            actor_id=source_actor_id,
+            session_id=source_session_id,
+            workspace_id=workspace_id,
+        )
+        await self.append_statement(
+            object_id,
+            property,
+            new_value,
+            new_source.id,
+            eff_writer,
+            observed_at=observed_at,
+            rank="preferred" if verb == "change" else "normal",
+            workspace_id=workspace_id,
+        )
+
+        refreshed = await self.get_statements(object_id, property, workspace_id=workspace_id)
+        resolution = resolve(
+            refreshed, default_trust_rules(), object_type=existing.type_name or None
+        )
+
+        if mode == "enforce" and resolution.winner_statement is not None:
+            # The resolver owns the cache in enforce (FST-5): one targeted
+            # write of the property's new winner, merged onto the FRESH cache
+            # state so concurrent-property updates aren't clobbered.
+            fresh = await self.get_object(object_id, workspace_id=workspace_id)
+            base = fresh.properties if fresh is not None else existing.properties
+            merged = {**base, property: resolution.value}
+            ws_cond, ws_params = _workspace_scope(workspace_id)
+            sql = (
+                "UPDATE fabric_objects SET properties = ?,"
+                " updated_at = datetime('now') WHERE id = ?"
+            )
+            params: list[Any] = [json.dumps(merged), object_id]
+            if ws_cond:
+                sql += f" AND {ws_cond}"
+                params.extend(ws_params)
+            async with self._conn() as db:
+                await db.execute(sql, params)
+                await db.commit()
+
+        return resolution
+
+    async def _close_statement_validity(self, statement_id: str, closed_at: datetime) -> None:
+        """Set ``valid_to`` on one statement (the CHANGE verb's close).
+
+        One of the TWO narrow curation writes permitted on statement rows
+        (see the FST-5 module-header note) — the append-only doctrine's
+        documented "later curation writes". Value/provenance columns are
+        never rewritten.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE fabric_statements SET valid_to = ? WHERE id = ?",
+                (closed_at.isoformat(), statement_id),
+            )
+            await db.commit()
+
+    async def _deprecate_statement(self, statement_id: str, reason: str | None) -> None:
+        """Mark one statement ``rank="deprecated"`` (the CORRECT verb's strike).
+
+        The second of the TWO narrow curation writes permitted on statement
+        rows (see the FST-5 module-header note). ``rank_reason`` records why;
+        value/provenance columns are never rewritten.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE fabric_statements SET rank = 'deprecated', rank_reason = ? WHERE id = ?",
+                (reason, statement_id),
+            )
+            await db.commit()
 
     async def remove_object(self, obj_id: str) -> None:
         await self._ensure_schema()

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -251,6 +251,38 @@
 #   Site-3 note: the EE mirror's update path goes through update_object, so
 #   enforce flows through automatically (proven in
 #   tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py).
+# Updated: 2026-07-10 (FST-6 — the conflict lifecycle: PIN / IGNORE steward
+#   verbs) — four changes; 'off' and 'shadow' cache behavior is untouched:
+#   1. pin_statement() / unpin_statement() / ignore_statement(): the steward
+#      verbs (siblings of change/correct — the operations FST-6's Instinct
+#      stewardship executor calls). PIN sets ``pinned=True`` on ONE existing,
+#      non-deprecated statement (the resolver's pinned short-circuit then
+#      makes it win outright — the durable "this one wins"); UNPIN retracts
+#      the flag; IGNORE deprecates the statement with rank_reason=<reason>
+#      (struck from resolution entirely — the steward's "this claim is
+#      bogus"). All three return the NEW Resolution and are mode-respecting
+#      on the cache exactly like CHANGE/CORRECT (enforce writes the new
+#      resolver winner; shadow/off leave the cache alone). PIN does NOT
+#      auto-unpin other pins: two pins on one property is a curation conflict
+#      the resolver deliberately flags as disputed. No auto-promotion here —
+#      the verbs target an EXISTING statement id, so an untracked property
+#      (no statements) has nothing to pin/ignore.
+#   2. The FST-5 "ONLY two writes" doctrine widens to THREE narrow curation
+#      UPDATEs on statement rows: valid_to (CHANGE), rank+rank_reason
+#      (CORRECT / IGNORE), and now pinned (PIN/UNPIN via
+#      _set_statement_pinned). Value and provenance columns are still never
+#      rewritten.
+#   3. list_statement_keys() + get_source(): two small read helpers.
+#      list_statement_keys returns the DISTINCT (object_id, property) pairs
+#      that HAVE statements (W4a-scoped) — the cheap scan surface
+#      fabric/conflicts.py recomputes open conflicts from (only objects WITH
+#      statements are ever visited; the statements ARE the conflict state, no
+#      conflicts table). get_source reads one SourceRef by id so the EE
+#      stewardship proposal can show a human WHERE each competing value came
+#      from.
+#   4. The enforce cache write is factored into _write_winner_to_cache()
+#      (byte-identical behavior) so _curate_property and the steward verbs
+#      share ONE definition of "the resolver owns the cache".
 
 
 from __future__ import annotations
@@ -1714,27 +1746,209 @@ class FabricStore:
             refreshed, default_trust_rules(), object_type=existing.type_name or None
         )
 
-        if mode == "enforce" and resolution.winner_statement is not None:
-            # The resolver owns the cache in enforce (FST-5): one targeted
-            # write of the property's new winner, merged onto the FRESH cache
-            # state so concurrent-property updates aren't clobbered.
-            fresh = await self.get_object(object_id, workspace_id=workspace_id)
-            base = fresh.properties if fresh is not None else existing.properties
-            merged = {**base, property: resolution.value}
-            ws_cond, ws_params = _workspace_scope(workspace_id)
-            sql = (
-                "UPDATE fabric_objects SET properties = ?,"
-                " updated_at = datetime('now') WHERE id = ?"
+        if mode == "enforce":
+            await self._write_winner_to_cache(
+                object_id, property, resolution, workspace_id=workspace_id, existing=existing
             )
-            params: list[Any] = [json.dumps(merged), object_id]
-            if ws_cond:
-                sql += f" AND {ws_cond}"
-                params.extend(ws_params)
-            async with self._conn() as db:
-                await db.execute(sql, params)
-                await db.commit()
 
         return resolution
+
+    async def _write_winner_to_cache(
+        self,
+        object_id: str,
+        property: str,
+        resolution: Resolution,
+        *,
+        workspace_id: str | None,
+        existing: FabricObject,
+    ) -> None:
+        """Write one property's resolver winner into the flat cache (enforce).
+
+        The resolver owns the cache in enforce (FST-5): one targeted write of
+        the property's new winner, merged onto the FRESH cache state so
+        concurrent-property updates aren't clobbered. A Resolution with no
+        winner (e.g. every statement deprecated) writes NOTHING — the cache
+        keeps its last value rather than losing the key. Shared by the
+        curation verbs (CHANGE/CORRECT) and the steward verbs
+        (PIN/UNPIN/IGNORE); callers gate on mode — this helper never reads it.
+        """
+        if resolution.winner_statement is None:
+            return
+        fresh = await self.get_object(object_id, workspace_id=workspace_id)
+        base = fresh.properties if fresh is not None else existing.properties
+        merged = {**base, property: resolution.value}
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "UPDATE fabric_objects SET properties = ?, updated_at = datetime('now') WHERE id = ?"
+        params: list[Any] = [json.dumps(merged), object_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        async with self._conn() as db:
+            await db.execute(sql, params)
+            await db.commit()
+
+    async def pin_statement(
+        self,
+        object_id: str,
+        property: str,
+        statement_id: str,
+        *,
+        workspace_id: str | None = None,
+    ) -> Resolution:
+        """PIN one statement: the durable steward "this one wins" (FST-6).
+
+        Sets ``pinned=True`` on the identified statement. The resolver's
+        pinned short-circuit (FST-2) then makes it win outright — above every
+        ladder tier, immune to newer rival observations — which is why the
+        conflict-lifecycle executor maps an approved stewardship choice to
+        PIN rather than IGNORE-the-rival: a pin also settles FUTURE rivals,
+        and the losing statements stay intact for audit.
+
+        The statement must exist for exactly this ``(object_id, property)``
+        (within the caller's workspace scope) and must be non-deprecated —
+        a deprecated statement never reaches resolution, so pinning it would
+        be a silent no-op lie; both violations raise ``ValueError``. Pinning
+        an already-pinned statement is idempotent. PIN does NOT auto-unpin
+        other pins: multiple pins are a curation conflict the resolver
+        deliberately surfaces as ``is_disputed``.
+
+        Returns the NEW :class:`Resolution`. Cache behavior is
+        mode-respecting like the FST-5 verbs: enforce writes the new resolver
+        winner into the flat properties dict; shadow/off leave the cache
+        alone.
+        """
+        return await self._steward_statement(
+            object_id, property, statement_id, verb="pin", reason=None, workspace_id=workspace_id
+        )
+
+    async def unpin_statement(
+        self,
+        object_id: str,
+        property: str,
+        statement_id: str,
+        *,
+        workspace_id: str | None = None,
+    ) -> Resolution:
+        """UNPIN one statement: retract a steward pin (FST-6).
+
+        Sets ``pinned=False``; resolution falls back to the trust ladder.
+        The statement must exist for exactly this ``(object_id, property)``
+        (ValueError otherwise). Unpinning a statement that isn't pinned is
+        idempotent, and rank is not checked — retracting a flag is always a
+        safe act. Returns the NEW :class:`Resolution`; cache behavior is
+        mode-respecting (see :meth:`pin_statement`).
+        """
+        return await self._steward_statement(
+            object_id, property, statement_id, verb="unpin", reason=None, workspace_id=workspace_id
+        )
+
+    async def ignore_statement(
+        self,
+        object_id: str,
+        property: str,
+        statement_id: str,
+        *,
+        reason: str = "steward_ignored",
+        workspace_id: str | None = None,
+    ) -> Resolution:
+        """IGNORE one statement: the steward's "this claim is bogus" (FST-6).
+
+        Deprecates the identified statement with ``rank_reason=reason`` —
+        the same narrow curation write CORRECT applies to a wrong winner,
+        but aimed at ANY statement (typically a losing rival) and without
+        appending a replacement value. A deprecated statement never wins,
+        never loses, never disputes: it is struck from resolution entirely
+        while remaining in the table for audit.
+
+        The statement must exist for exactly this ``(object_id, property)``
+        (within the caller's workspace scope) — ValueError otherwise.
+        Ignoring an already-deprecated statement just refreshes the reason.
+        Returns the NEW :class:`Resolution`; cache behavior is
+        mode-respecting (see :meth:`pin_statement`). Note: deprecating the
+        ONLY live statement leaves a winner-less Resolution and the cache
+        untouched — reads never lose a value to a steward strike.
+        """
+        return await self._steward_statement(
+            object_id,
+            property,
+            statement_id,
+            verb="ignore",
+            reason=reason,
+            workspace_id=workspace_id,
+        )
+
+    async def _steward_statement(
+        self,
+        object_id: str,
+        property: str,
+        statement_id: str,
+        *,
+        verb: str,
+        reason: str | None,
+        workspace_id: str | None,
+    ) -> Resolution:
+        """Shared core of :meth:`pin_statement` / :meth:`unpin_statement` /
+        :meth:`ignore_statement`.
+
+        Unlike ``_curate_property`` there is NO auto-promotion: the steward
+        verbs target an EXISTING statement id, and an untracked property has
+        no statements to target. Raises ``ValueError`` when the object or the
+        statement doesn't exist (or is outside the caller's workspace scope),
+        or when PIN targets a deprecated statement — the FST-6 executor needs
+        clean failures, not silent no-ops.
+        """
+        mode = _source_truth_mode()  # read ONCE; decides only the cache write
+        existing = await self.get_object(object_id, workspace_id=workspace_id)
+        if existing is None:
+            raise ValueError(f"fabric object not found: {object_id!r}")
+
+        stmts = await self.get_statements(object_id, property, workspace_id=workspace_id)
+        target = next((s for s in stmts if s.id == statement_id), None)
+        if target is None:
+            raise ValueError(
+                f"statement {statement_id!r} not found for"
+                f" ({object_id!r}, {property!r}) in the caller's workspace scope"
+            )
+
+        if verb == "pin":
+            if target.rank == "deprecated":
+                raise ValueError(
+                    f"cannot pin deprecated statement {statement_id!r} — a deprecated"
+                    " statement never reaches resolution; un-ignore it via a new"
+                    " curation write first"
+                )
+            await self._set_statement_pinned(statement_id, True)
+        elif verb == "unpin":
+            await self._set_statement_pinned(statement_id, False)
+        else:  # ignore
+            await self._deprecate_statement(statement_id, reason)
+
+        refreshed = await self.get_statements(object_id, property, workspace_id=workspace_id)
+        resolution = resolve(
+            refreshed, default_trust_rules(), object_type=existing.type_name or None
+        )
+
+        if mode == "enforce":
+            await self._write_winner_to_cache(
+                object_id, property, resolution, workspace_id=workspace_id, existing=existing
+            )
+
+        return resolution
+
+    async def _set_statement_pinned(self, statement_id: str, pinned: bool) -> None:
+        """Set the ``pinned`` flag on one statement (the PIN/UNPIN verbs).
+
+        The THIRD narrow curation write permitted on statement rows (see the
+        FST-6 module-header note; valid_to and rank/rank_reason are the other
+        two). Value/provenance columns are never rewritten.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE fabric_statements SET pinned = ? WHERE id = ?",
+                (1 if pinned else 0, statement_id),
+            )
+            await db.commit()
 
     async def _close_statement_validity(self, statement_id: str, closed_at: datetime) -> None:
         """Set ``valid_to`` on one statement (the CHANGE verb's close).
@@ -2064,6 +2278,64 @@ class FabricStore:
             async with db.execute(sql, params) as cur:
                 rows = await cur.fetchall()
         return [self._row_to_statement(r) for r in rows]
+
+    async def list_statement_keys(
+        self,
+        *,
+        workspace_id: str | None = None,
+        object_id: str | None = None,
+    ) -> list[tuple[str, str]]:
+        """DISTINCT ``(object_id, property)`` pairs that HAVE statements (FST-6).
+
+        The cheap scan surface the conflict lifecycle recomputes open
+        conflicts from: only objects WITH statements (the opted-in / promoted
+        minority) are ever visited, so the scan cost tracks the tracked set,
+        not the whole fabric. ``workspace_id`` applies the standard W4a read
+        scope (own rows + legacy NULL); ``object_id`` narrows to one object.
+        Ordered by ``(object_id, property)`` for a deterministic walk.
+        """
+        conditions: list[str] = []
+        params: list[Any] = []
+        if object_id is not None:
+            conditions.append("object_id = ?")
+            params.append(object_id)
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        if ws_cond:
+            conditions.append(ws_cond)
+            params.extend(ws_params)
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        sql = (
+            "SELECT DISTINCT object_id, property FROM fabric_statements"
+            f"{where} ORDER BY object_id, property"
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(sql, params) as cur:
+                rows = await cur.fetchall()
+        return [(str(r[0]), str(r[1])) for r in rows]
+
+    async def get_source(
+        self, source_ref_id: str, workspace_id: str | None = None
+    ) -> SourceRef | None:
+        """Read one SourceRef by id (FST-6).
+
+        The provenance lookup behind the stewardship proposal payload: a
+        human arbitrating a conflict sees WHERE each competing value came
+        from (connector run / document / actor / session). ``workspace_id``
+        applies the standard W4a read scope (own rows + legacy NULL).
+        """
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "SELECT * FROM fabric_sources WHERE id = ?"
+        params: list[Any] = [source_ref_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(sql, params) as cur:
+                row = await cur.fetchone()
+        return self._row_to_source(row) if row else None
 
     async def get_linked_objects(
         self, obj_id: str, link_type: str | None = None, workspace_id: str | None = None

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -192,6 +192,25 @@
 #   created_at/updated_at from the row (previously dropped — the model
 #   defaulted them to read-time now()), so the promotion backfill uses the
 #   TRUE last-touch time.
+# Updated: 2026-07-10 (FST-4 — SHADOW mode at merge sites 2 + 3) — two changes
+#   that let the remaining write paths ride the SAME shadow machinery instead
+#   of duplicating it:
+#   1. shadow_record_event_update(): a public, journal-event-keyed entry into
+#      the FST-3 shadow pass for the projection replay path (merge site 2 —
+#      fabric/projection.py stages observations, this method records them).
+#      Replay idempotence rides the NEW ``fabric_shadow_events`` table: the
+#      event id is claimed with INSERT OR IGNORE BEFORE the statement pass, so
+#      replaying the same journal N times (or two replayers racing) records a
+#      given event's statements AT MOST ONCE. Mode 'off' returns early — not
+#      even the marker row is written.
+#   2. _writer_family(): the second-distinct-source rule now compares writer
+#      FAMILIES, collapsing "connector" and "mirror" into one machine-sync
+#      family. Site 3 (the EE Firestore mirror) writes as writer_class
+#      "mirror" on objects whose baseline derives to "connector"; without the
+#      family rule every mirror self-refresh would look like a second source
+#      and promote every changed property, gutting the opt-in discipline. No
+#      behavior change for pre-FST-4 cohorts: "mirror" never reached this
+#      comparison before this slice.
 
 
 from __future__ import annotations
@@ -238,6 +257,26 @@ def _source_truth_mode() -> str:
     from pocketpaw.config import get_settings
 
     return get_settings().fabric_source_truth_mode
+
+
+def _writer_family(writer_class: str) -> str:
+    """Collapse writer classes into families for the second-distinct-source
+    comparison (FST-4).
+
+    "connector" and "mirror" are ONE machine-sync family: the EE Firestore
+    mirror (writer_class "mirror") refreshing an object whose baseline
+    derives to "connector" for the SAME connector is the object's owning
+    sync, not a second writer. Without this, every mirror self-refresh would
+    auto-promote every materially changed property — the opt-in discipline
+    ("single-source objects stay scalar/cheap") would be dead for mirrored
+    data. Every other class ("human", "agent", "inferred") is its own
+    family, so human-vs-connector and agent-vs-connector still count as
+    second sources exactly as FST-3 defined. NOTE: this only affects the
+    promotion GATE — the statement itself still records the true
+    writer_class ("mirror"), and the trust ladder still ranks connector >
+    mirror at resolve time.
+    """
+    return "sync" if writer_class in ("connector", "mirror") else writer_class
 
 
 # Hard cap on the working set during a multi-hop traversal. The per-hop query
@@ -344,6 +383,18 @@ CREATE TABLE IF NOT EXISTS fabric_statements (
     -- append; scoped reads see own rows + legacy NULL. Same ALTER-migration
     -- note as fabric_sources.workspace_id above.
     workspace_id TEXT
+);
+
+-- Journal-replay dedupe for the shadow pass (FST-4, merge site 2). One row per
+-- journal event whose update has been shadow-recorded. The event id (the
+-- journal EventEntry's UUID — stable across replays) is claimed with INSERT OR
+-- IGNORE BEFORE the statement pass runs, so replaying the same journal twice
+-- records a given event's statements at most once. No workspace column: event
+-- ids are globally unique, and the statements themselves carry workspace_id.
+CREATE TABLE IF NOT EXISTS fabric_shadow_events (
+    event_id TEXT PRIMARY KEY,
+    object_id TEXT,
+    recorded_at TEXT DEFAULT (datetime('now'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_objects_type ON fabric_objects(type_id);
@@ -1099,8 +1150,11 @@ class FabricStore:
         baseline is (``existing.source_connector``, its derived writer class —
         ``connector`` when a connector is stamped, else ``agent``). The
         incoming write is a SECOND source when its effective connector differs
-        from the baseline connector OR its effective writer class differs from
-        the baseline writer class. An unattributed write on a connector-owned
+        from the baseline connector OR its effective writer FAMILY differs
+        from the baseline writer family (FST-4: "connector" and "mirror" are
+        one machine-sync family — see :func:`_writer_family` — so the EE
+        mirror refreshing its own object is not a second source, while a
+        human or agent write still is). An unattributed write on a connector-owned
         object derives to that same connector, so it is NOT a second source —
         without provenance threading a second writer cannot be detected, which
         is exactly why ingest/API callers pass the kwargs.
@@ -1158,9 +1212,14 @@ class FabricStore:
         baseline_connector = existing.source_connector
         baseline_writer = "connector" if baseline_connector else "agent"
 
-        # --- Second-distinct-source rule ---
+        # --- Second-distinct-source rule (FST-4: compare writer FAMILIES,
+        # not raw classes, so a "mirror" write from the object's own
+        # connector is the owning sync refreshing itself, not a second
+        # source — see _writer_family) ---
         incoming_connector = connector if kind == "connector_run" else None
-        is_second_source = incoming_connector != baseline_connector or eff_writer != baseline_writer
+        is_second_source = incoming_connector != baseline_connector or _writer_family(
+            eff_writer
+        ) != _writer_family(baseline_writer)
 
         # Sources are upserted lazily so a fully scalar update (nothing tracked,
         # nothing promoted) writes NOTHING — not even a SourceRef row.
@@ -1232,6 +1291,77 @@ class FabricStore:
                 resolution.is_disputed,
                 resolution.unresolvable,
             )
+
+    async def shadow_record_event_update(
+        self,
+        existing: FabricObject,
+        incoming: dict[str, Any],
+        *,
+        event_id: str,
+        writer_class: str | None = None,
+        source_kind: str | None = None,
+        source_connector: str | None = None,
+        source_run_id: str | None = None,
+        source_document_uri: str | None = None,
+        source_actor_id: str | None = None,
+        source_session_id: str | None = None,
+        observed_at: datetime | None = None,
+        workspace_id: str | None = None,
+    ) -> bool:
+        """Journal-event-keyed entry into the FST-3 shadow pass (merge site 2).
+
+        The projection replay path (fabric/projection.py::_apply_updated)
+        merges in memory — it never goes through :meth:`update_object` — so it
+        stages observations and records them through THIS method, reusing
+        :meth:`_shadow_record_statements` verbatim (same promotion gate,
+        provenance derivation, divergence line) instead of duplicating it.
+
+        THE REPLAY-DEDUPE RULE: one shadow pass per journal event id. The
+        ``event_id`` (the journal EventEntry's UUID — stable across replays)
+        is claimed in ``fabric_shadow_events`` with INSERT OR IGNORE *before*
+        the statement pass; if the row already existed the event was recorded
+        by a previous replay (or a concurrent replayer won the race) and this
+        call returns ``False`` without writing anything. Claiming FIRST makes
+        the pass at-most-once: a failure after the claim drops that event's
+        shadow pass (consistent with FST-3's failure-shield, which also drops
+        a failed pass) rather than risking double-appended statements on
+        retry — "replaying the same journal twice never double-appends" is
+        the contract this method exists to keep.
+
+        Mode ``off`` returns ``False`` immediately — not even the marker row
+        is written (the off-mode byte-for-byte guarantee). Exceptions
+        propagate to the caller: the projection's flush shields per
+        observation, mirroring where FST-3 put the shield for site 1.
+
+        Returns ``True`` when the event's statements were recorded by this
+        call.
+        """
+        mode = _source_truth_mode()  # read ONCE per call; "off" writes NOTHING
+        if mode == "off":
+            return False
+        await self._ensure_schema()
+        async with self._conn() as db:
+            cur = await db.execute(
+                "INSERT OR IGNORE INTO fabric_shadow_events (event_id, object_id) VALUES (?, ?)",
+                (event_id, existing.id),
+            )
+            await db.commit()
+            if cur.rowcount == 0:
+                return False  # already recorded — replay/idempotency dedupe
+        await self._shadow_record_statements(
+            existing,
+            incoming,
+            writer_class=writer_class,
+            source_kind=source_kind,
+            source_connector=source_connector,
+            source_run_id=source_run_id,
+            source_document_uri=source_document_uri,
+            source_actor_id=source_actor_id,
+            source_session_id=source_session_id,
+            observed_at=observed_at,
+            workspace_id=workspace_id,
+        )
+        return True
 
     async def remove_object(self, obj_id: str) -> None:
         await self._ensure_schema()

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -167,6 +167,31 @@
 #   ``fabric_objects.properties`` dict remains the primary read path; nothing
 #   writes statements in production until ``fabric_source_truth_mode``
 #   (default "off") gains shadow/enforce semantics in later slices.
+# Updated: 2026-07-10 (FST-3 — SHADOW mode at merge site 1) — update_object()
+#   now records statements when ``fabric_source_truth_mode`` is shadow/enforce
+#   (enforce == shadow until FST-5). The mode is read ONCE per call; 'off'
+#   (default) is byte-for-byte the prior behavior — zero new queries/writes.
+#   The LWW cache write is UNCHANGED in every mode. New OPTIONAL keyword-only
+#   provenance kwargs on update_object (writer_class, source_kind,
+#   source_connector, source_run_id, source_document_uri, source_actor_id,
+#   source_session_id, observed_at — all default None, every existing caller
+#   keeps working); connectors/fabric_ingest.py threads its connector context
+#   through them. The shadow pass (_shadow_record_statements) implements: the
+#   opt-in discipline (untracked single-source properties write NO
+#   statements), auto-promotion (an untracked property hit by a SECOND
+#   distinct source with a materially different value seeds a statement from
+#   the current cache value with object-level provenance + touch-time
+#   observed_at backfill), provenance derivation for unattributed writes
+#   (object's source_connector → writer_class "connector", else "agent"),
+#   FST-2 resolution over the property's statements, and ONE grep-stable
+#   divergence log line per statement-producing property ("fabric shadow:
+#   object=... property=... lww=... resolver=... diverged=... disputed=...
+#   unresolvable=..." — the FST-8 harness contract). Shadow runs AFTER the
+#   cache commit and is exception-shielded: a shadow failure logs a warning,
+#   never breaks the primary write. Supporting fix: _row_to_object now parses
+#   created_at/updated_at from the row (previously dropped — the model
+#   defaulted them to read-time now()), so the promotion backfill uses the
+#   TRUE last-touch time.
 
 
 from __future__ import annotations
@@ -191,7 +216,29 @@ from pocketpaw.fabric.models import (
     Statement,
 )
 
+# FST-3: the shadow pass reuses the resolver's material-difference rule
+# (strings compared stripped, everything else plain ==) rather than
+# duplicating it here — one definition of "materially different" for the
+# whole source-truth chain. The name is module-private in resolver.py but
+# intra-package reuse is deliberate.
+from pocketpaw.fabric.resolver import _materially_different, resolve
+from pocketpaw.fabric.trust import default_trust_rules
+
 logger = logging.getLogger(__name__)
+
+
+def _source_truth_mode() -> str:
+    """The fabric_source_truth_mode setting: 'off' | 'shadow' | 'enforce'.
+
+    Read lazily (import inside the function) so importing the store never
+    pulls the full config module, and so tests can monkeypatch either this
+    helper or ``pocketpaw.config.get_settings``. Callers read it ONCE per
+    operation — 'off' must stay byte-for-byte free of new queries/writes.
+    """
+    from pocketpaw.config import get_settings
+
+    return get_settings().fabric_source_truth_mode
+
 
 # Hard cap on the working set during a multi-hop traversal. The per-hop query
 # binds one ``?`` per frontier id in a ``WHERE l.<col> IN (?, ?, …)`` list; left
@@ -938,6 +985,15 @@ class FabricStore:
         obj_id: str,
         properties: dict[str, Any],
         workspace_id: str | None = None,
+        *,
+        writer_class: str | None = None,
+        source_kind: str | None = None,
+        source_connector: str | None = None,
+        source_run_id: str | None = None,
+        source_document_uri: str | None = None,
+        source_actor_id: str | None = None,
+        source_session_id: str | None = None,
+        observed_at: datetime | None = None,
     ) -> FabricObject | None:
         """Merge-update one object's properties, optionally scoped to a tenant (W4a).
 
@@ -948,7 +1004,21 @@ class FabricStore:
         and the UPDATE. A cross-tenant ``obj_id`` returns ``None`` and writes
         nothing. ``None`` leaves the update unscoped (OSS / agent-tool callers),
         exactly as before.
+
+        FST-3 (source-truth shadow) — the new keyword-only kwargs are OPTIONAL
+        provenance for the write (all default ``None``; every pre-FST-3 caller
+        keeps working unchanged). They only matter when
+        ``fabric_source_truth_mode`` is ``shadow`` or ``enforce`` (enforce is
+        treated as shadow until FST-5): the write is then ALSO recorded as
+        statements per :meth:`_shadow_record_statements` (auto-promotion,
+        provenance derivation, divergence log — see its docstring for the exact
+        rules). The CACHE WRITE IS UNCHANGED in every mode: last-write-wins
+        merge into the flat properties dict, which remains the primary read
+        path. With mode ``off`` (the default) not a single new query or write
+        happens — the mode is read once per call and the whole shadow block is
+        skipped.
         """
+        mode = _source_truth_mode()  # read ONCE per call; "off" skips everything
         existing = await self.get_object(obj_id, workspace_id=workspace_id)
         if not existing:
             return None
@@ -963,7 +1033,205 @@ class FabricStore:
         async with self._conn() as db:
             await db.execute(sql, params)
             await db.commit()
+        if mode != "off":
+            # shadow | enforce (enforce == shadow until FST-5). Runs AFTER the
+            # cache write so the primary path's semantics and error behavior
+            # stay byte-identical; a shadow failure must never break the write.
+            try:
+                await self._shadow_record_statements(
+                    existing,
+                    properties,
+                    writer_class=writer_class,
+                    source_kind=source_kind,
+                    source_connector=source_connector,
+                    source_run_id=source_run_id,
+                    source_document_uri=source_document_uri,
+                    source_actor_id=source_actor_id,
+                    source_session_id=source_session_id,
+                    observed_at=observed_at,
+                    workspace_id=workspace_id,
+                )
+            except Exception:
+                logger.warning(
+                    "fabric shadow: statement pass failed for object=%s — cache write unaffected",
+                    obj_id,
+                    exc_info=True,
+                )
         return await self.get_object(obj_id, workspace_id=workspace_id)
+
+    async def _shadow_record_statements(
+        self,
+        existing: FabricObject,
+        incoming: dict[str, Any],
+        *,
+        writer_class: str | None,
+        source_kind: str | None,
+        source_connector: str | None,
+        source_run_id: str | None,
+        source_document_uri: str | None,
+        source_actor_id: str | None,
+        source_session_id: str | None,
+        observed_at: datetime | None,
+        workspace_id: str | None,
+    ) -> None:
+        """The FST-3 shadow pass: record an update's claims as statements.
+
+        Called from :meth:`update_object` (merge site 1) only when
+        ``fabric_source_truth_mode`` is shadow/enforce, AFTER the LWW cache
+        write. ``existing`` is the PRE-update snapshot (its properties and
+        ``updated_at`` are the old cache state).
+
+        Provenance derivation (when the caller passed no explicit kwargs):
+
+        - source kind, in order: explicit ``source_kind`` > ``source_connector``
+          → ``connector_run`` > ``source_actor_id`` → ``human_actor`` >
+          ``source_session_id`` → ``agent_session`` > ``source_document_uri``
+          → ``document`` > the object's own ``source_connector`` →
+          ``connector_run`` for that connector (the historical main caller of
+          update_object is the connector re-sync refreshing its own object) >
+          ``agent_session`` with no identity (the honest default for
+          unattributed legacy writes).
+        - writer_class: explicit > ``connector`` when the effective kind is
+          ``connector_run`` > ``human`` for ``human_actor`` > ``agent`` for
+          everything else.
+
+        Second-distinct-source rule (drives auto-promotion): the object-level
+        baseline is (``existing.source_connector``, its derived writer class —
+        ``connector`` when a connector is stamped, else ``agent``). The
+        incoming write is a SECOND source when its effective connector differs
+        from the baseline connector OR its effective writer class differs from
+        the baseline writer class. An unattributed write on a connector-owned
+        object derives to that same connector, so it is NOT a second source —
+        without provenance threading a second writer cannot be detected, which
+        is exactly why ingest/API callers pass the kwargs.
+
+        Per incoming property:
+
+        1. already tracked (has statements) → append the incoming statement.
+        2. untracked → PROMOTE only when (second distinct source) AND (the
+           property exists in the current cache — a brand-new key has no prior
+           claim to preserve) AND (the values materially differ): seed a
+           statement from the current cache value with the object-level
+           baseline provenance and touch-time backfill
+           (``observed_at = existing.updated_at or created_at`` — the best
+           available approximation of when the cache value was written), then
+           append the incoming statement. Otherwise the property stays
+           scalar/cheap: NO statements, NO log line (the opt-in discipline).
+        3. resolve the property's statements via the FST-2 trust ladder and
+           log ONE structured divergence line (the FST-8 harness contract —
+           grep-stable, single line, values JSON-encoded so they can never
+           wrap):
+
+           ``fabric shadow: object=<id> property=<p> lww=<cache-value>
+           resolver=<winner-value> diverged=<bool> disputed=<bool>
+           unresolvable=<bool>``
+
+        The cache is NEVER touched here — shadow only observes.
+        """
+        # --- Effective provenance of the incoming write ---
+        kind = source_kind
+        connector = source_connector
+        if kind is None:
+            if connector is not None:
+                kind = "connector_run"
+            elif source_actor_id is not None:
+                kind = "human_actor"
+            elif source_session_id is not None:
+                kind = "agent_session"
+            elif source_document_uri is not None:
+                kind = "document"
+            elif existing.source_connector:
+                kind = "connector_run"
+                connector = existing.source_connector
+            else:
+                kind = "agent_session"
+        eff_writer = writer_class
+        if eff_writer is None:
+            if kind == "connector_run":
+                eff_writer = "connector"
+            elif kind == "human_actor":
+                eff_writer = "human"
+            else:
+                eff_writer = "agent"
+
+        # --- Object-level baseline (who owns the current cache value) ---
+        baseline_connector = existing.source_connector
+        baseline_writer = "connector" if baseline_connector else "agent"
+
+        # --- Second-distinct-source rule ---
+        incoming_connector = connector if kind == "connector_run" else None
+        is_second_source = incoming_connector != baseline_connector or eff_writer != baseline_writer
+
+        # Sources are upserted lazily so a fully scalar update (nothing tracked,
+        # nothing promoted) writes NOTHING — not even a SourceRef row.
+        incoming_source: SourceRef | None = None
+        seed_source: SourceRef | None = None
+
+        for prop, value in incoming.items():
+            stmts = await self.get_statements(existing.id, prop, workspace_id=workspace_id)
+            if not stmts:
+                # Untracked property — promotion gate.
+                if not is_second_source:
+                    continue
+                if prop not in existing.properties:
+                    continue  # brand-new key: no prior claim to preserve
+                old_value = existing.properties[prop]
+                if not _materially_different(old_value, value):
+                    continue
+                if seed_source is None:
+                    seed_source = await self.upsert_source(
+                        "connector_run" if baseline_connector else "agent_session",
+                        connector=baseline_connector,
+                        workspace_id=workspace_id,
+                    )
+                seed = await self.append_statement(
+                    existing.id,
+                    prop,
+                    old_value,
+                    seed_source.id,
+                    baseline_writer,
+                    observed_at=existing.updated_at or existing.created_at,
+                    workspace_id=workspace_id,
+                )
+                stmts = [seed]
+            if incoming_source is None:
+                incoming_source = await self.upsert_source(
+                    kind,
+                    connector=connector,
+                    run_id=source_run_id,
+                    document_uri=source_document_uri,
+                    actor_id=source_actor_id,
+                    session_id=source_session_id,
+                    workspace_id=workspace_id,
+                )
+            stmts.append(
+                await self.append_statement(
+                    existing.id,
+                    prop,
+                    value,
+                    incoming_source.id,
+                    eff_writer,
+                    observed_at=observed_at,
+                    workspace_id=workspace_id,
+                )
+            )
+            resolution = resolve(
+                stmts,
+                default_trust_rules(),
+                object_type=existing.type_name or None,
+            )
+            # The LWW cache now holds the incoming value (last write wins).
+            logger.info(
+                "fabric shadow: object=%s property=%s lww=%s resolver=%s"
+                " diverged=%s disputed=%s unresolvable=%s",
+                existing.id,
+                prop,
+                json.dumps(value, default=str),
+                json.dumps(resolution.value, default=str),
+                _materially_different(value, resolution.value),
+                resolution.is_disputed,
+                resolution.unresolvable,
+            )
 
     async def remove_object(self, obj_id: str) -> None:
         await self._ensure_schema()
@@ -1656,6 +1924,17 @@ class FabricStore:
         )
 
     def _row_to_object(self, row: Any) -> FabricObject:
+        # FST-3: created_at/updated_at now come from the ROW (they were
+        # silently dropped before, so the model defaulted them to read-time
+        # ``now()``). The shadow pass needs the TRUE last-touch time for the
+        # auto-promotion backfill (observed_at of the seeded statement).
+        # SQLite's datetime('now') stamps are naive UTC "YYYY-MM-DD HH:MM:SS"
+        # strings; fromisoformat parses them as-is. Defensive: a NULL falls
+        # back to the model default rather than crashing the read.
+        timestamps: dict[str, Any] = {}
+        for ts_field in ("created_at", "updated_at"):
+            if ts_field in row.keys() and row[ts_field]:
+                timestamps[ts_field] = datetime.fromisoformat(row[ts_field])
         return FabricObject(
             id=row["id"],
             type_id=row["type_id"],
@@ -1663,6 +1942,7 @@ class FabricStore:
             properties=json.loads(row["properties"]) if row["properties"] else {},
             source_connector=row["source_connector"],
             source_id=row["source_id"],
+            **timestamps,
         )
 
     def _row_to_link(self, row: Any) -> FabricLink:

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -1,5 +1,13 @@
 # Fabric store — async SQLite operations for the ontology layer.
 # Created: 2026-03-28 — CRUD for object types, objects, and links.
+# Updated: 2026-07-11 (FST-7 — freshness) — the merge-site statement pass now
+#   threads an aware-UTC ``now`` into resolve() (within-family staleness
+#   demotion live in shadow AND enforce); the divergence line gained a
+#   trailing `` freshness=<fresh|aging|stale|none>`` token (additive — field
+#   order unchanged, the FST-8 grep contract holds); NEW opt-in read surface
+#   ``get_object_provenance(object_id)`` — per TRACKED property: disputed /
+#   unresolvable / freshness / statement count / winner writer+source summary
+#   (a sibling method, the default read path pays nothing).
 # Updated: 2026-04-19 (Cluster C / PR3) — Added list_links() for the new
 #   GET /api/v1/fabric/links endpoint that the Links sub-tab in
 #   PocketDataPanel now consumes instead of its hardcoded placeholder.
@@ -289,7 +297,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -1392,6 +1400,13 @@ class FabricStore:
         seed_source: SourceRef | None = None
         resolutions: dict[str, Resolution] = {}
 
+        # FST-7 — the store's clock convention: ONE aware-UTC read per pass
+        # (datetime.now(UTC)), threaded into resolve() so shadow AND enforce
+        # apply within-family staleness demotion live. Statement stamps are
+        # UTC-normalized at the comparison boundary (naive = UTC — see
+        # trust._as_utc); stored data is never rewritten.
+        now = datetime.now(UTC)
+
         for prop, value in incoming.items():
             stmts = await self.get_statements(existing.id, prop, workspace_id=workspace_id)
             if not stmts:
@@ -1444,6 +1459,7 @@ class FabricStore:
                 stmts,
                 default_trust_rules(),
                 object_type=existing.type_name or None,
+                now=now,
             )
             # ``lww`` is the incoming value — what the cache holds in shadow
             # and what LWW WOULD have kept in enforce (where the caller
@@ -1451,7 +1467,7 @@ class FabricStore:
             # way: the FST-8 harness contract.
             logger.info(
                 "fabric shadow: object=%s property=%s lww=%s resolver=%s"
-                " diverged=%s disputed=%s unresolvable=%s",
+                " diverged=%s disputed=%s unresolvable=%s freshness=%s",
                 existing.id,
                 prop,
                 json.dumps(value, default=str),
@@ -1459,6 +1475,7 @@ class FabricStore:
                 _materially_different(value, resolution.value),
                 resolution.is_disputed,
                 resolution.unresolvable,
+                resolution.winner_freshness or "none",
             )
             resolutions[prop] = resolution
         return resolutions
@@ -2336,6 +2353,66 @@ class FabricStore:
             async with db.execute(sql, params) as cur:
                 row = await cur.fetchone()
         return self._row_to_source(row) if row else None
+
+    async def get_object_provenance(
+        self, object_id: str, *, workspace_id: str | None = None
+    ) -> dict[str, dict[str, Any]]:
+        """Opt-in provenance read surface (FST-7).
+
+        Per statement-TRACKED property of one object:
+        ``{property: {disputed, unresolvable, freshness, statements, winner}}``
+        where ``winner`` carries the resolving statement's writer_class /
+        observed_at / rank / pinned plus a compact source summary. Untracked
+        properties (the scalar majority) do not appear — absence means
+        "single-source, nothing to explain". A SIBLING method rather than a
+        ``get_object`` flag so the default read path pays nothing; the
+        agent-facing ``fabric_query`` MCP tool and the future "disputed
+        facts" view are the consumers. Freshness/dispute state is computed
+        live (statements + resolve() with the store clock), never persisted.
+        """
+        keys = await self.list_statement_keys(workspace_id=workspace_id, object_id=object_id)
+        if not keys:
+            return {}
+        obj = await self.get_object(object_id, workspace_id=workspace_id)
+        object_type = (obj.type_name or None) if obj else None
+        now = datetime.now(UTC)
+        rules = default_trust_rules()
+        out: dict[str, dict[str, Any]] = {}
+        for _oid, prop in keys:
+            stmts = await self.get_statements(object_id, prop, workspace_id=workspace_id)
+            if not stmts:
+                continue
+            resolution = resolve(stmts, rules, object_type=object_type, now=now)
+            winner = resolution.winner_statement
+            winner_info: dict[str, Any] | None = None
+            if winner is not None:
+                src = await self.get_source(winner.source_ref_id, workspace_id=workspace_id)
+                winner_info = {
+                    "writer_class": winner.writer_class,
+                    "observed_at": winner.observed_at.isoformat(),
+                    "rank": winner.rank,
+                    "pinned": winner.pinned,
+                    "source": (
+                        {
+                            "kind": src.kind,
+                            "connector": src.connector,
+                            "run_id": src.run_id,
+                            "document_uri": src.document_uri,
+                            "actor_id": src.actor_id,
+                            "session_id": src.session_id,
+                        }
+                        if src
+                        else None
+                    ),
+                }
+            out[prop] = {
+                "disputed": resolution.is_disputed,
+                "unresolvable": resolution.unresolvable,
+                "freshness": resolution.winner_freshness,
+                "statements": len(stmts),
+                "winner": winner_info,
+            }
+        return out
 
     async def get_linked_objects(
         self, obj_id: str, link_type: str | None = None, workspace_id: str | None = None

--- a/src/pocketpaw/fabric/trust.py
+++ b/src/pocketpaw/fabric/trust.py
@@ -4,17 +4,40 @@
 #   agent can print and explain: a global writer-class ladder (strongest
 #   first), optional per-(object_type, property) ladder overrides, and the
 #   ``recency_epsilon_seconds`` closeness window the resolver uses for
-#   un-rankable detection. ``freshness_ttl_classes`` is a declared-but-unused
-#   placeholder for the freshness TTL classes arriving in FST-7 — no TTL
-#   logic lives here yet. Nothing reads settings or the store: rules are
+#   un-rankable detection. Nothing reads settings or the store: rules are
 #   constructed by the caller and passed into ``resolver.resolve``, keeping
 #   the whole resolution path pure.
+# Updated: 2026-07-11 (FST-7 — freshness TTL classes + the pure tri-state) —
+#   the FST-2 ``freshness_ttl_classes`` placeholder comes alive: three named
+#   volatility classes (volatile=1d, default=30d, stable=365d — see
+#   DEFAULT_FRESHNESS_TTL_CLASSES) map a class name to a max-age in seconds.
+#   The INSTANCE dict stays empty by default (the FST-2 wire format is
+#   unchanged — stored rules need no migration and ``default_trust_rules()``
+#   still serializes byte-identically); it is an OVERRIDE layer consulted
+#   before the module defaults by ``max_age_for``. Per-(object_type,
+#   property) class assignment rides ``freshness_overrides`` (same
+#   first-exact-match-wins style as the ladder overrides; unassigned
+#   properties get class "default"). ``freshness(observed_at,
+#   max_age_seconds, now)`` is the pure tri-state: fresh (age <= max_age),
+#   aging (age <= 2*max_age), stale beyond. TIMEZONE CONVENTION (one rule for
+#   the whole freshness path): every comparison happens in UTC; a NAIVE
+#   datetime is interpreted AS UTC at the comparison boundary (the store's
+#   own persisted stamps — SQLite datetime('now'), the touch-time backfill
+#   from updated_at/created_at — are naive UTC, and the store's live clock is
+#   datetime.now(timezone.utc), so naive-as-UTC reads all of those exactly;
+#   a naive-LOCAL outlier, e.g. Statement's datetime.now() default, is
+#   mis-read by at most the local-UTC offset — hours against day-scale TTLs).
+#   Stored data is never rewritten; conversion happens only at comparison.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
+
+# The freshness tri-state a resolved value can carry (FST-7).
+Freshness = Literal["fresh", "aging", "stale"]
 
 # The writer classes a Statement can carry (mirrors Statement.writer_class).
 WriterClass = Literal["human", "connector", "mirror", "agent", "inferred"]
@@ -38,6 +61,37 @@ DEFAULT_LADDER: list[WriterClass] = [
 # observations of conflicting values are a real conflict, not a stale echo.
 DEFAULT_RECENCY_EPSILON_SECONDS = 24 * 60 * 60.0
 
+# FST-7 — the named volatility classes: TTL class name → max-age in seconds.
+# A value older than its class's max-age starts decaying (fresh → aging →
+# stale, see ``freshness``). Three classes cover the realistic spread:
+#
+# - "volatile" (86400s = 1 day)   — values that churn daily and whose staleness
+#   bites fast: presence/status flags, queue depths, live availability.
+#   Most connectors sync at least daily, so a volatile value that missed one
+#   sync cycle is already suspect.
+# - "default" (2592000s = 30 days) — the unassigned-property fallback: ordinary
+#   business facts (titles, owners, stages, amounts) that drift on a
+#   weeks-to-month cadence. A month without re-observation is the point where
+#   "probably still true" stops being a safe default.
+# - "stable" (31536000s = 365 days) — near-immutable identity facts: legal
+#   names, founding dates, tax ids. Only a year of silence makes these worth
+#   flagging at all.
+#
+# These are MODULE defaults: ``TrustRules.freshness_ttl_classes`` (the
+# instance dict) stays empty by default — the FST-2 wire format is unchanged,
+# stored rules need no migration — and acts as an override layer consulted
+# first by ``TrustRules.max_age_for``.
+DEFAULT_FRESHNESS_TTL_CLASSES: dict[str, float] = {
+    "volatile": 24 * 60 * 60.0,
+    "default": 30 * 24 * 60 * 60.0,
+    "stable": 365 * 24 * 60 * 60.0,
+}
+
+# The class assigned when no freshness override matches (also the lookup
+# fallback for an override naming an unknown class — reads never crash on a
+# typo'd rule set).
+DEFAULT_FRESHNESS_CLASS = "default"
+
 
 class TrustOverride(BaseModel):
     """A per-(object_type, property) ladder override.
@@ -54,6 +108,22 @@ class TrustOverride(BaseModel):
     ladder: list[WriterClass]
 
 
+class FreshnessOverride(BaseModel):
+    """A per-(object_type, property) freshness-class assignment (FST-7).
+
+    Same shape and matching semantics as :class:`TrustOverride`: the first
+    override matching BOTH fields exactly wins; a property with no match
+    gets class ``"default"``. ``ttl_class`` names a key of the effective TTL
+    map (instance ``freshness_ttl_classes`` layered over
+    ``DEFAULT_FRESHNESS_TTL_CLASSES``); an unknown name falls back to the
+    default class rather than failing — reads never block on a bad rule.
+    """
+
+    object_type: str
+    property: str
+    ttl_class: str
+
+
 class TrustRules(BaseModel):
     """The full rule set the resolver consumes. Plain data, no behavior
     beyond the ``ladder_for`` lookup.
@@ -63,16 +133,21 @@ class TrustRules(BaseModel):
       exact match wins.
     - ``recency_epsilon_seconds`` — the un-rankable closeness window (see
       module docstring / ``DEFAULT_RECENCY_EPSILON_SECONDS``).
-    - ``freshness_ttl_classes`` — FST-7 placeholder: will map a TTL class
-      name to a max-age in seconds for freshness demotion. Carried in the
-      format now so stored rules don't need a migration later; NO logic
-      consumes it in FST-2.
+    - ``freshness_ttl_classes`` — FST-7: per-rule-set OVERRIDES of the named
+      TTL classes (class name → max-age seconds), layered over
+      ``DEFAULT_FRESHNESS_TTL_CLASSES`` by :meth:`max_age_for`. Empty by
+      default — the FST-2 wire format is unchanged; the named defaults
+      (volatile=1d, default=30d, stable=365d) apply without any migration.
+    - ``freshness_overrides`` — per-(object_type, property) TTL-class
+      assignments (first exact match wins, like ``overrides``); an
+      unassigned property gets class ``"default"``.
     """
 
     ladder: list[WriterClass] = Field(default_factory=lambda: list(DEFAULT_LADDER))
     overrides: list[TrustOverride] = Field(default_factory=list)
     recency_epsilon_seconds: float = DEFAULT_RECENCY_EPSILON_SECONDS
     freshness_ttl_classes: dict[str, float] = Field(default_factory=dict)
+    freshness_overrides: list[FreshnessOverride] = Field(default_factory=list)
 
     def ladder_for(self, object_type: str | None, property: str) -> list[WriterClass]:
         """Return the effective ladder for one (object_type, property).
@@ -88,8 +163,78 @@ class TrustRules(BaseModel):
                     return override.ladder
         return self.ladder
 
+    def ttl_class_for(self, object_type: str | None, property: str) -> str:
+        """The effective freshness TTL class for one (object_type, property).
+
+        Mirrors :meth:`ladder_for`: the first ``freshness_overrides`` entry
+        matching BOTH fields exactly wins; ``object_type=None`` never matches
+        an override (overrides are keyed on concrete type names); no match →
+        ``DEFAULT_FRESHNESS_CLASS``.
+        """
+        if object_type is not None:
+            for override in self.freshness_overrides:
+                if override.object_type == object_type and override.property == property:
+                    return override.ttl_class
+        return DEFAULT_FRESHNESS_CLASS
+
+    def max_age_for(self, object_type: str | None, property: str) -> float:
+        """The effective max-age in seconds for one (object_type, property).
+
+        Resolves :meth:`ttl_class_for`'s class name against the instance
+        ``freshness_ttl_classes`` first, then the module
+        ``DEFAULT_FRESHNESS_TTL_CLASSES``. An unknown class name falls back
+        to the ``"default"`` class through the same two layers — a typo'd
+        rule set degrades to the 30-day default instead of raising.
+        """
+        ttl_class = self.ttl_class_for(object_type, property)
+        for name in (ttl_class, DEFAULT_FRESHNESS_CLASS):
+            if name in self.freshness_ttl_classes:
+                return self.freshness_ttl_classes[name]
+            if name in DEFAULT_FRESHNESS_TTL_CLASSES:
+                return DEFAULT_FRESHNESS_TTL_CLASSES[name]
+        return DEFAULT_FRESHNESS_TTL_CLASSES[DEFAULT_FRESHNESS_CLASS]
+
+
+def _as_utc(value: datetime) -> datetime:
+    """THE timezone convention for the freshness path (FST-7).
+
+    Every freshness comparison happens in UTC; a NAIVE datetime is
+    interpreted AS UTC here, at the comparison boundary. Why naive-as-UTC:
+    the store's persisted stamps (SQLite ``datetime('now')``, the touch-time
+    backfill from ``updated_at``/``created_at``) are naive UTC and the
+    store's live clock is ``datetime.now(timezone.utc)`` — this rule reads
+    all of those exactly. The known naive-LOCAL outlier (``Statement``'s
+    ``datetime.now()`` default_factory) is mis-read by at most the
+    local-UTC offset, i.e. hours against TTLs measured in days. Stored data
+    is never rewritten.
+    """
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def freshness(observed_at: datetime, max_age_seconds: float, now: datetime) -> Freshness:
+    """Classify one observation's age into the FST-7 tri-state.
+
+    Pure: no clock reads — the caller supplies ``now``. Both datetimes are
+    UTC-normalized via :func:`_as_utc` (naive = UTC by convention), so naive
+    and aware inputs can be mixed without raising.
+
+    - ``fresh`` — age <= max_age (a future observed_at is fresh: negative age)
+    - ``aging`` — max_age < age <= 2*max_age (past its TTL but within one
+      more TTL window — worth flagging, not yet worth demoting)
+    - ``stale`` — age > 2*max_age
+    """
+    age = (_as_utc(now) - _as_utc(observed_at)).total_seconds()
+    if age <= max_age_seconds:
+        return "fresh"
+    if age <= 2 * max_age_seconds:
+        return "aging"
+    return "stale"
+
 
 def default_trust_rules() -> TrustRules:
     """The out-of-the-box rule set: global default ladder, no overrides,
-    24h recency epsilon, no TTL classes."""
+    24h recency epsilon, empty TTL-class override map (the named module
+    defaults — volatile=1d, default=30d, stable=365d — apply)."""
     return TrustRules()

--- a/src/pocketpaw/fabric/trust.py
+++ b/src/pocketpaw/fabric/trust.py
@@ -1,0 +1,95 @@
+# fabric/trust.py — Trust-rule data format for the source-truth resolver (FST-2).
+# Created: 2026-07-10 (feat/fst-2-resolver) — the configuration side of the
+#   trust-ladder resolver. A ``TrustRules`` object is PLAIN READABLE DATA an
+#   agent can print and explain: a global writer-class ladder (strongest
+#   first), optional per-(object_type, property) ladder overrides, and the
+#   ``recency_epsilon_seconds`` closeness window the resolver uses for
+#   un-rankable detection. ``freshness_ttl_classes`` is a declared-but-unused
+#   placeholder for the freshness TTL classes arriving in FST-7 — no TTL
+#   logic lives here yet. Nothing reads settings or the store: rules are
+#   constructed by the caller and passed into ``resolver.resolve``, keeping
+#   the whole resolution path pure.
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# The writer classes a Statement can carry (mirrors Statement.writer_class).
+WriterClass = Literal["human", "connector", "mirror", "agent", "inferred"]
+
+# The default global ladder, strongest first. "human-pin" is NOT a rung here:
+# pinning is a short-circuit the resolver applies BEFORE the ladder (a pinned,
+# non-deprecated statement wins outright), so the ladder only orders the five
+# writer_class values.
+DEFAULT_LADDER: list[WriterClass] = [
+    "human",
+    "connector",
+    "mirror",
+    "agent",
+    "inferred",
+]
+
+# Default closeness window for un-rankable detection: two same-tier statements
+# whose observed_at are within this many seconds of each other, carrying
+# materially different values, cannot be confidently ranked by recency. 24h is
+# deliberately generous for v1 — most connectors sync daily, so same-day
+# observations of conflicting values are a real conflict, not a stale echo.
+DEFAULT_RECENCY_EPSILON_SECONDS = 24 * 60 * 60.0
+
+
+class TrustOverride(BaseModel):
+    """A per-(object_type, property) ladder override.
+
+    When a resolver call matches ``object_type`` + ``property`` exactly, this
+    ``ladder`` replaces the global one. Writer classes OMITTED from an
+    override ladder are not excluded — they rank BELOW every listed class,
+    sharing one bottom tier (reads never block, so a partial override must
+    not silently drop statements).
+    """
+
+    object_type: str
+    property: str
+    ladder: list[WriterClass]
+
+
+class TrustRules(BaseModel):
+    """The full rule set the resolver consumes. Plain data, no behavior
+    beyond the ``ladder_for`` lookup.
+
+    - ``ladder`` — global writer-class precedence, strongest first.
+    - ``overrides`` — per-(object_type, property) ladder replacements; first
+      exact match wins.
+    - ``recency_epsilon_seconds`` — the un-rankable closeness window (see
+      module docstring / ``DEFAULT_RECENCY_EPSILON_SECONDS``).
+    - ``freshness_ttl_classes`` — FST-7 placeholder: will map a TTL class
+      name to a max-age in seconds for freshness demotion. Carried in the
+      format now so stored rules don't need a migration later; NO logic
+      consumes it in FST-2.
+    """
+
+    ladder: list[WriterClass] = Field(default_factory=lambda: list(DEFAULT_LADDER))
+    overrides: list[TrustOverride] = Field(default_factory=list)
+    recency_epsilon_seconds: float = DEFAULT_RECENCY_EPSILON_SECONDS
+    freshness_ttl_classes: dict[str, float] = Field(default_factory=dict)
+
+    def ladder_for(self, object_type: str | None, property: str) -> list[WriterClass]:
+        """Return the effective ladder for one (object_type, property).
+
+        The first override matching BOTH fields exactly wins; otherwise the
+        global ladder applies. ``object_type=None`` (caller didn't know the
+        type) never matches an override — overrides are keyed on concrete
+        type names.
+        """
+        if object_type is not None:
+            for override in self.overrides:
+                if override.object_type == object_type and override.property == property:
+                    return override.ladder
+        return self.ladder
+
+
+def default_trust_rules() -> TrustRules:
+    """The out-of-the-box rule set: global default ladder, no overrides,
+    24h recency epsilon, no TTL classes."""
+    return TrustRules()

--- a/src/pocketpaw/mission_control/executor.py
+++ b/src/pocketpaw/mission_control/executor.py
@@ -1,6 +1,20 @@
 """Mission Control Task Executor.
 
 Created: 2026-02-05
+Updated: 2026-07-10 — three-position ``verify_mode`` (feat/verify-mode-shadow):
+  the completion block now resolves ``effective_deep_work_verify_mode()``
+  ONCE (off | shadow | enforce; the legacy
+  ``deep_work_verify_loop_enabled`` bool resolves to ENFORCE for
+  back-compat). ``off`` skips the whole block — byte-for-byte today's
+  default. ``shadow`` is the new rollout rung: the deterministic verdict is
+  computed and stamped (``verify_verdict``), the judge shadow still runs
+  when its flag is on, and what enforce WOULD have decided is computed
+  READ-ONLY and recorded as ``verify_would_have=<done|requeued|escalated>``
+  plus a ``verify_mode='shadow'`` marker and a ``verify shadow mode:
+  would_have=...`` log line — but status/should_retry are NEVER touched, no
+  ``verify_requeue_count`` bump, no ``verify_feedback`` growth: the task
+  completes DONE with the deliverable + side-effects intact. ``enforce`` is
+  exactly the prior flag-on behaviour (SVL-1/2/3 + J-1 below, unchanged).
 Updated: 2026-07-02 — LLM-as-judge SHADOW stamp (J-1, #1168): inside the
   existing ``deep_work_verify_loop_enabled`` block, AFTER the deterministic
   verdict is computed and stamped, when ``deep_work_verify_judge_shadow_enabled``
@@ -322,15 +336,24 @@ class MCTaskExecutor:
             if final_status == "completed":
                 new_task_status = TaskStatus.DONE
 
-                # Self-Verifying Loop: when the loop is enabled, check the
-                # completed task's result against the success_criteria captured
-                # at intake and STAMP the verdict on the task — the "verify"
-                # half (SVL-1). SVL-2 then ACTS on the verdict: a result that
-                # does NOT meet its criteria is requeued with the specific unmet
-                # criteria fed back, up to a budget, then escalated to BLOCKED.
-                # When the flag is off this whole block is skipped and behaviour
-                # is byte-for-byte unchanged.
-                if get_settings().deep_work_verify_loop_enabled and task_fresh:
+                # Self-Verifying Loop: resolve the three-position mode ONCE
+                # (off | shadow | enforce — the legacy bool resolves to
+                # 'enforce' via effective_deep_work_verify_mode()).
+                #   off     → this whole block is skipped; byte-for-byte
+                #             today's default behaviour.
+                #   shadow  → the rollout rung: compute + STAMP the verdict
+                #             (SVL-1) and run the judge shadow if its flag is
+                #             on, then compute READ-ONLY what enforce WOULD
+                #             have done and record it as would_have telemetry
+                #             — but NEVER touch status/should_retry, counters,
+                #             or feedback: the task falls through to normal
+                #             DONE with deliverable + side-effects intact.
+                #   enforce → the full loop, exactly the prior flag-on
+                #             behaviour: SVL-2 ACTS on the verdict (requeue
+                #             with feedback, bounded by the budget, then
+                #             escalate to BLOCKED; SVL-3 no-progress guard).
+                verify_mode = get_settings().effective_deep_work_verify_mode()
+                if verify_mode != "off" and task_fresh:
                     success_criteria = task_fresh.metadata.get("success_criteria", [])
                     verdict = DeterministicVerdictProvider().verify(
                         task_fresh.output, success_criteria
@@ -375,9 +398,11 @@ class MCTaskExecutor:
                     # SVL-2: act on the verdict. SOLVED / UNKNOWN pass through
                     # as DONE — a passing (or uncheckable) result is NEVER
                     # requeued or mutated. PARTIAL / NOT_SOLVED means the output
-                    # missed at least one captured criterion: requeue the task
-                    # with the unmet criteria fed back, bounded by
-                    # deep_work_verify_max_requeues, then escalate to BLOCKED.
+                    # missed at least one captured criterion: in ENFORCE mode,
+                    # requeue the task with the unmet criteria fed back, bounded
+                    # by deep_work_verify_max_requeues, then escalate to
+                    # BLOCKED; in SHADOW mode only record what enforce would
+                    # have done.
                     if verdict.status in (
                         OutcomeStatus.PARTIAL,
                         OutcomeStatus.NOT_SOLVED,
@@ -410,7 +435,35 @@ class MCTaskExecutor:
                             )
                             no_progress = current == prev or len(current) >= len(prev)
 
-                        if no_progress:
+                        if verify_mode == "shadow":
+                            # SHADOW: record what enforce WOULD have decided
+                            # (no-progress vs budget vs requeue — computed
+                            # read-only above) WITHOUT mutating anything the
+                            # loop acts through: no status change, no
+                            # should_retry, no verify_requeue_count bump, no
+                            # verify_feedback growth. The task falls through
+                            # to normal DONE; the would_have stamp + log line
+                            # are the rollout telemetry a tenant reads before
+                            # daring enforce.
+                            if no_progress:
+                                would_have = "escalated"
+                                would_reason = "no_progress"
+                            elif n < max_requeues:
+                                would_have = "requeued"
+                                would_reason = ""
+                            else:
+                                would_have = "escalated"
+                                would_reason = "budget_exhausted"
+                            task_fresh.metadata["verify_mode"] = "shadow"
+                            task_fresh.metadata["verify_would_have"] = would_have
+                            logger.info(
+                                "verify shadow mode: would_have=%s%s verdict=%s task=%s",
+                                would_have,
+                                f" reason={would_reason}" if would_reason else "",
+                                verdict.status.value,
+                                task_id,
+                            )
+                        elif no_progress:
                             # Same/non-shrinking unmet set: stuck. Escalate to
                             # the SAME BLOCKED status + cascade branch as a
                             # budget exhaustion, distinguished only by the
@@ -469,6 +522,18 @@ class MCTaskExecutor:
                                 verdict.status,
                                 n,
                             )
+                    elif verify_mode == "shadow":
+                        # SHADOW + SOLVED/UNKNOWN: enforce would have passed it
+                        # through as DONE too — stamp would_have=done so the
+                        # shadow telemetry covers every completion, not just
+                        # the failing ones.
+                        task_fresh.metadata["verify_mode"] = "shadow"
+                        task_fresh.metadata["verify_would_have"] = "done"
+                        logger.info(
+                            "verify shadow mode: would_have=done verdict=%s task=%s",
+                            verdict.status.value,
+                            task_id,
+                        )
             elif final_status in ("error", "timeout") and task_fresh:
                 # Check if we should retry
                 if task_fresh.retry_count < task_fresh.max_retries:

--- a/tests/cloud/fabric_conflicts/__init__.py
+++ b/tests/cloud/fabric_conflicts/__init__.py
@@ -1,0 +1,1 @@
+# tests/cloud/fabric_conflicts/__init__.py — FST-6 conflict-stewardship gate tests.

--- a/tests/cloud/fabric_conflicts/test_fabric_conflict_gate.py
+++ b/tests/cloud/fabric_conflicts/test_fabric_conflict_gate.py
@@ -1,0 +1,461 @@
+# tests/cloud/fabric_conflicts/test_fabric_conflict_gate.py
+# Created: 2026-07-10 (FST-6 — the _fabric_conflict stewardship gate).
+#
+# Covers the sweep + propose + apply-on-approve executor for the conflict
+# lifecycle: un-rankable Fabric conflicts become Instinct stewardship
+# proposals a human arbitrates; approve PINs the chosen statement, reject
+# keeps the policy winner. Clones the discipline of
+# ``tests/ee/test_instinct_rule_propose.py`` (the precedent module — isolated
+# stores via the lazy ``pocketpaw.stores`` seams). Asserts:
+#
+#   * an un-rankable conflict yields exactly ONE proposal with the EXACT blob
+#     shape (tenancy + subject as SEPARATE top-level fields, editable
+#     ``resolution`` defaulting to the policy winner, choices with provenance);
+#   * re-sweep files NO duplicate while one is open (one open proposal per
+#     ``(workspace_id, object_id, property)`` dedupe key);
+#   * mode off → the sweep is inert (shadow AND enforce both sweep);
+#   * approve (default choice) → the executor PINs the policy winner and the
+#     cache reflects it in enforce; the answered conflict stops re-sweeping;
+#   * approve with an EDITED choice → the rival gets pinned instead;
+#   * reject → NO statement changes (the policy winner stands) and the
+#     reject-memory (conflict_signature) stops the same conflict from
+#     re-staging until a new rival changes its shape;
+#   * the volume guard warns past 5 open stewardship proposals;
+#   * tenant scoping: another workspace's sweep never sees the conflict;
+#   * schema mismatch / unstaged choice → terminal FAILED, NO pin;
+#   * idempotent re-execute → no double run, exactly ONE chain close.
+#
+# Run with:
+#   uv run pytest tests/cloud/fabric_conflicts/ -q
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.fabric_conflicts import (  # noqa: E402
+    FABRIC_CONFLICT_KIND,
+    FABRIC_CONFLICT_PARAM_KEY,
+    FABRIC_CONFLICT_SCHEMA,
+    STEWARDSHIP_QUEUE_WARN_THRESHOLD,
+    execute_approved_fabric_conflict,
+    sweep_conflicts_to_proposals,
+)
+
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+WS = "w1"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — isolated Fabric + Instinct stores via the lazy store seams,
+# cloned from the instinct-rule precedent tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    monkeypatch.setenv("AUTH_SECRET", "fabric-conflict-gate-test-secret")
+
+
+@pytest.fixture
+def fabric(tmp_path: Path, monkeypatch) -> FabricStore:
+    st = FabricStore(tmp_path / "fabric_conflict_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda *a, **k: st)
+    return st
+
+
+@pytest.fixture
+def instinct(tmp_path: Path, monkeypatch) -> InstinctStore:
+    st = InstinctStore(tmp_path / "instinct_conflict_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    return st
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    """The suite-wide FST mode seam — the gate reads it through the OSS
+    chokepoint (late-bound), so this patch governs sweep + verbs alike."""
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+async def _conflicted_object(
+    fabric: FabricStore,
+    *,
+    workspace_id: str = WS,
+    properties: tuple[str, ...] = ("arr",),
+) -> tuple[str, dict[str, tuple[str, str]]]:
+    """One Customer whose ``properties`` each carry an un-rankable pair:
+    two connector-tier, normal-rank, open, materially different statements
+    observed within the epsilon. Returns (object_id, {property:
+    (winner_stmt_id, rival_stmt_id)}) — the newer observation (value 120)
+    provisionally wins over the rival (value 200)."""
+    obj_type = await fabric.define_type(name="Customer", properties=[])
+    obj = await fabric.create_object(
+        obj_type.id, {p: 0 for p in properties}, source_connector="crm", source_id="c-1"
+    )
+    now = datetime.now()
+    src_a = await fabric.upsert_source(
+        "connector_run", connector="crm", run_id="r1", workspace_id=workspace_id
+    )
+    src_b = await fabric.upsert_source(
+        "connector_run", connector="billing", run_id="r9", workspace_id=workspace_id
+    )
+    pairs: dict[str, tuple[str, str]] = {}
+    for prop in properties:
+        rival = await fabric.append_statement(
+            obj.id,
+            prop,
+            200,
+            src_b.id,
+            "connector",
+            observed_at=now - timedelta(hours=1),
+            workspace_id=workspace_id,
+        )
+        winner = await fabric.append_statement(
+            obj.id, prop, 120, src_a.id, "connector", observed_at=now, workspace_id=workspace_id
+        )
+        pairs[prop] = (winner.id, rival.id)
+    return obj.id, pairs
+
+
+async def _pending_conflict_actions(instinct: InstinctStore, workspace_id: str = WS) -> list[Any]:
+    actions = await instinct.list_actions(
+        pocket_id=workspace_id,
+        status=ActionStatus.PENDING,
+        workspace_id=workspace_id,
+        limit=500,
+    )
+    return [a for a in actions if FABRIC_CONFLICT_PARAM_KEY in (a.parameters or {})]
+
+
+# ---------------------------------------------------------------------------
+# Sweep: exactly ONE proposal, exact blob shape.
+# ---------------------------------------------------------------------------
+
+
+async def test_sweep_files_exactly_one_proposal_with_exact_blob_shape(
+    fabric, instinct, monkeypatch
+):
+    obj_id, pairs = await _conflicted_object(fabric)
+    winner_id, rival_id = pairs["arr"]
+    _set_mode(monkeypatch, "shadow")
+
+    filed = await sweep_conflicts_to_proposals(WS)
+
+    assert len(filed) == 1
+    action = await instinct.get_action(filed[0])
+    assert action.status == ActionStatus.PENDING
+    assert str(action.pocket_id) == WS  # workspace anchoring
+
+    blob = action.parameters[FABRIC_CONFLICT_PARAM_KEY]
+
+    # EXACT key set — no stray keys.
+    assert set(blob.keys()) == {
+        "kind",
+        "schema",
+        "workspace_id",
+        "object_id",
+        "property",
+        "object_type",
+        "choices",
+        "policy_winner_statement_id",
+        "conflict_signature",
+        "resolution",
+        "summary",
+        "correlation_id",
+        "proposed_event_id",
+    }
+    assert blob["kind"] == FABRIC_CONFLICT_KIND == "fabric_conflict"
+    assert blob["schema"] == FABRIC_CONFLICT_SCHEMA == 1
+
+    # Tenancy + subject ride as SEPARATE top-level fields — NOT inside the
+    # editable ``resolution`` (so an edit can't re-scope or re-target the pin).
+    assert blob["workspace_id"] == WS
+    assert blob["object_id"] == obj_id
+    assert blob["property"] == "arr"
+    assert blob["object_type"] == "Customer"
+    assert set(blob["resolution"].keys()) == {"chosen_statement_id"}
+
+    # The editable choice defaults to the policy's provisional winner.
+    assert blob["resolution"]["chosen_statement_id"] == winner_id
+    assert blob["policy_winner_statement_id"] == winner_id
+    assert blob["conflict_signature"] == sorted([winner_id, rival_id])
+
+    # Choices: the winner first, then the rival — each with value +
+    # provenance (writer_class, observed_at, and the SourceRef identity).
+    assert [c["statement_id"] for c in blob["choices"]] == [winner_id, rival_id]
+    by_id = {c["statement_id"]: c for c in blob["choices"]}
+    assert by_id[winner_id]["value"] == 120
+    assert by_id[rival_id]["value"] == 200
+    assert by_id[winner_id]["writer_class"] == "connector"
+    assert by_id[winner_id]["source"]["connector"] == "crm"
+    assert by_id[rival_id]["source"]["connector"] == "billing"
+    assert by_id[winner_id]["observed_at"]
+
+    # Chain fields: correlation minted at propose; proposed_event_id is the
+    # best-effort back-write (present either way).
+    assert blob["correlation_id"]
+    assert "proposed_event_id" in blob
+
+
+async def test_resweep_does_not_duplicate_while_open(fabric, instinct, monkeypatch):
+    await _conflicted_object(fabric)
+    _set_mode(monkeypatch, "shadow")
+
+    first = await sweep_conflicts_to_proposals(WS)
+    second = await sweep_conflicts_to_proposals(WS)
+
+    assert len(first) == 1
+    assert second == []  # one open proposal per dedupe key
+    assert len(await _pending_conflict_actions(instinct)) == 1
+
+
+@pytest.mark.parametrize("mode", ["off", "shadow", "enforce"])
+async def test_mode_gate(fabric, instinct, monkeypatch, mode):
+    """Off → inert (zero proposals). Shadow AND enforce both sweep — a
+    queued conflict in shadow is observation with a human answer."""
+    await _conflicted_object(fabric)
+    _set_mode(monkeypatch, mode)
+
+    filed = await sweep_conflicts_to_proposals(WS)
+
+    if mode == "off":
+        assert filed == []
+        assert await _pending_conflict_actions(instinct) == []
+    else:
+        assert len(filed) == 1
+
+
+# ---------------------------------------------------------------------------
+# Approve — the choice → PIN mapping.
+# ---------------------------------------------------------------------------
+
+
+async def test_approve_default_choice_pins_policy_winner_and_enforce_cache(
+    fabric, instinct, monkeypatch
+):
+    obj_id, pairs = await _conflicted_object(fabric)
+    winner_id, _ = pairs["arr"]
+    _set_mode(monkeypatch, "enforce")
+
+    filed = await sweep_conflicts_to_proposals(WS)
+    approved = await instinct.approve(filed[0], approver="steward-1")
+    await execute_approved_fabric_conflict(approved)
+
+    final = await instinct.get_action(filed[0])
+    assert final.status == ActionStatus.EXECUTED, final.error
+
+    # The policy winner is now PINNED — the durable "this one wins".
+    stmts = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+    pinned = [s for s in stmts if s.pinned]
+    assert [s.id for s in pinned] == [winner_id]
+
+    # Enforce: the cache reflects the pinned winner.
+    obj = await fabric.get_object(obj_id, workspace_id=WS)
+    assert obj is not None and obj.properties["arr"] == 120
+
+    # The structured outcome was back-written onto the blob.
+    outcome = final.parameters[FABRIC_CONFLICT_PARAM_KEY]["outcome"]
+    assert outcome["status"] == "executed"
+    assert outcome["pinned_statement_id"] == winner_id
+    assert outcome["value"] == 120
+
+    # The answered conflict is CLOSED — a re-sweep stages nothing (the
+    # pinned path is never un-rankable).
+    assert await sweep_conflicts_to_proposals(WS) == []
+
+
+async def test_approve_with_edited_choice_pins_the_rival(fabric, instinct, monkeypatch):
+    obj_id, pairs = await _conflicted_object(fabric)
+    _, rival_id = pairs["arr"]
+    _set_mode(monkeypatch, "enforce")
+
+    filed = await sweep_conflicts_to_proposals(WS)
+    approved = await instinct.approve(filed[0], approver="steward-1")
+    # Simulate the approve-with-edits path (ApproveRequest.parameters): the
+    # human re-points the editable choice at the staged rival. Same in-memory
+    # mutation pattern the instinct-rule precedent tests use.
+    approved.parameters[FABRIC_CONFLICT_PARAM_KEY]["resolution"] = {"chosen_statement_id": rival_id}
+    await execute_approved_fabric_conflict(approved)
+
+    final = await instinct.get_action(filed[0])
+    assert final.status == ActionStatus.EXECUTED, final.error
+
+    stmts = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+    pinned = [s for s in stmts if s.pinned]
+    assert [s.id for s in pinned] == [rival_id]
+
+    # Enforce: the cache flips to the human's chosen value.
+    obj = await fabric.get_object(obj_id, workspace_id=WS)
+    assert obj is not None and obj.properties["arr"] == 200
+
+
+# ---------------------------------------------------------------------------
+# Reject — the policy winner stands; reject-memory stops the nag.
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_keeps_policy_winner_and_resweep_respects_reject_memory(
+    fabric, instinct, monkeypatch
+):
+    obj_id, pairs = await _conflicted_object(fabric)
+    _set_mode(monkeypatch, "shadow")
+
+    filed = await sweep_conflicts_to_proposals(WS)
+    before = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+
+    await instinct.reject(filed[0], reason="policy pick is fine", rejector="steward-1")
+    # The executor NEVER runs on reject (router owns the close): no pins, no
+    # deprecations, no validity changes — the policy winner simply stands.
+    after = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+    assert [(s.id, s.pinned, s.rank, s.valid_to) for s in after] == [
+        (s.id, s.pinned, s.rank, s.valid_to) for s in before
+    ]
+
+    # Reject-memory: the SAME conflict (same signature) is not re-staged —
+    # the human already answered "keep the policy winner".
+    assert await sweep_conflicts_to_proposals(WS) == []
+
+    # A NEW rival changes the conflict's signature → it re-stages.
+    src = await fabric.upsert_source(
+        "connector_run", connector="erp", run_id="r22", workspace_id=WS
+    )
+    await fabric.append_statement(
+        obj_id, "arr", 300, src.id, "connector", observed_at=datetime.now(), workspace_id=WS
+    )
+    refiled = await sweep_conflicts_to_proposals(WS)
+    assert len(refiled) == 1
+    blob = (await instinct.get_action(refiled[0])).parameters[FABRIC_CONFLICT_PARAM_KEY]
+    assert len(blob["choices"]) == 3  # the reshaped conflict carries all three
+
+
+# ---------------------------------------------------------------------------
+# Volume guard — the PRD queue-volume metric.
+# ---------------------------------------------------------------------------
+
+
+async def test_volume_guard_warns_past_threshold(fabric, instinct, monkeypatch, caplog):
+    properties = tuple(f"kpi_{i}" for i in range(STEWARDSHIP_QUEUE_WARN_THRESHOLD + 1))
+    await _conflicted_object(fabric, properties=properties)
+    _set_mode(monkeypatch, "shadow")
+
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.fabric_conflicts.propose"):
+        filed = await sweep_conflicts_to_proposals(WS)
+
+    assert len(filed) == STEWARDSHIP_QUEUE_WARN_THRESHOLD + 1
+    warnings = [r for r in caplog.records if "stewardship queue" in r.getMessage()]
+    assert len(warnings) == 1
+    assert f"has {STEWARDSHIP_QUEUE_WARN_THRESHOLD + 1} open" in warnings[0].getMessage()
+
+
+async def test_volume_guard_quiet_at_threshold(fabric, instinct, monkeypatch, caplog):
+    properties = tuple(f"kpi_{i}" for i in range(STEWARDSHIP_QUEUE_WARN_THRESHOLD))
+    await _conflicted_object(fabric, properties=properties)
+    _set_mode(monkeypatch, "shadow")
+
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.fabric_conflicts.propose"):
+        filed = await sweep_conflicts_to_proposals(WS)
+
+    assert len(filed) == STEWARDSHIP_QUEUE_WARN_THRESHOLD
+    assert [r for r in caplog.records if "stewardship queue" in r.getMessage()] == []
+
+
+# ---------------------------------------------------------------------------
+# Tenancy — another workspace never sees the conflict.
+# ---------------------------------------------------------------------------
+
+
+async def test_tenant_scoping_respected(fabric, instinct, monkeypatch):
+    await _conflicted_object(fabric, workspace_id="w1")
+    _set_mode(monkeypatch, "shadow")
+
+    # w2's sweep: the W4a scope hides w1's statements — nothing to stage.
+    assert await sweep_conflicts_to_proposals("w2") == []
+    assert await _pending_conflict_actions(instinct, "w2") == []
+
+    # w1's own sweep stages it, stamped with w1's tenancy.
+    filed = await sweep_conflicts_to_proposals("w1")
+    assert len(filed) == 1
+    blob = (await instinct.get_action(filed[0])).parameters[FABRIC_CONFLICT_PARAM_KEY]
+    assert blob["workspace_id"] == "w1"
+
+
+# ---------------------------------------------------------------------------
+# Executor guards — fail clean, never pin on a bad blob.
+# ---------------------------------------------------------------------------
+
+
+async def test_schema_mismatch_fails_terminal_no_pin(fabric, instinct, monkeypatch):
+    obj_id, _ = await _conflicted_object(fabric)
+    _set_mode(monkeypatch, "shadow")
+    filed = await sweep_conflicts_to_proposals(WS)
+
+    approved = await instinct.approve(filed[0], approver="steward-1")
+    approved.parameters[FABRIC_CONFLICT_PARAM_KEY]["schema"] = 2
+    await execute_approved_fabric_conflict(approved)
+
+    final = await instinct.get_action(filed[0])
+    assert final.status == ActionStatus.FAILED, final.error
+    assert "schema mismatch" in (final.error or "").lower()
+    stmts = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+    assert not any(s.pinned for s in stmts)
+
+
+async def test_unstaged_choice_fails_terminal_no_pin(fabric, instinct, monkeypatch):
+    """An edit cannot smuggle in an arbitrary statement id — the executor
+    validates the chosen id against the STAGED choices."""
+    obj_id, _ = await _conflicted_object(fabric)
+    _set_mode(monkeypatch, "shadow")
+    filed = await sweep_conflicts_to_proposals(WS)
+
+    approved = await instinct.approve(filed[0], approver="steward-1")
+    approved.parameters[FABRIC_CONFLICT_PARAM_KEY]["resolution"] = {
+        "chosen_statement_id": "stm-evil"
+    }
+    await execute_approved_fabric_conflict(approved)
+
+    final = await instinct.get_action(filed[0])
+    assert final.status == ActionStatus.FAILED, final.error
+    assert "staged choices" in (final.error or "")
+    stmts = await fabric.get_statements(obj_id, "arr", workspace_id=WS)
+    assert not any(s.pinned for s in stmts)
+
+
+async def test_idempotent_reexecute_single_chain_close(fabric, instinct, monkeypatch):
+    calls: list[dict[str, Any]] = []
+
+    from pocketpaw_ee.cloud.fabric_conflicts import executor as conflict_executor
+
+    real_close = conflict_executor._emit_chain_close
+
+    def _spy(**kwargs: Any) -> None:
+        calls.append(kwargs)
+        return real_close(**kwargs)
+
+    monkeypatch.setattr(conflict_executor, "_emit_chain_close", _spy)
+
+    await _conflicted_object(fabric)
+    _set_mode(monkeypatch, "shadow")
+    filed = await sweep_conflicts_to_proposals(WS)
+
+    approved = await instinct.approve(filed[0], approver="steward-1")
+    await execute_approved_fabric_conflict(approved)
+    # Re-invoke on the now-terminal Action — must NOT re-pin or re-close.
+    again = await instinct.get_action(filed[0])
+    await execute_approved_fabric_conflict(again)
+
+    final = await instinct.get_action(filed[0])
+    assert final.status == ActionStatus.EXECUTED, final.error
+    assert len(calls) == 1
+    assert calls[0]["passed"] is True
+    assert calls[0]["action_outcome"] == "landed"

--- a/tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py
+++ b/tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py
@@ -1,0 +1,184 @@
+# tests/cloud/fabric_ingest/test_fabric_ingest_enforce.py
+# Created: 2026-07-10 (FST-5 — ENFORCE at merge site 3, the Firestore mirror).
+#
+# Site 3 needed NO code change for enforce: the mirror's update path delegates
+# to store.update_object (via the canonical OSS ingest loop), so the FST-5
+# enforce cache semantics flow through AUTOMATICALLY. This file is the proof:
+#
+#   * a mirror re-sync of a TRACKED property lands in the cache as the
+#     RESOLVER'S winner (the connector-tier baseline beats the mirror tier on
+#     the trust ladder), not the mirror's blind LWW value — while the mirror's
+#     claim is still recorded as a statement,
+#   * a mirror self-refresh of UNTRACKED properties keeps plain LWW even in
+#     enforce (writer-family rule: no promotion, nothing to resolve — the
+#     mirror still mirrors).
+#
+# Ruling documented in service.py's header: the within-source field-map
+# collapse in _mirror_docs (two Firestore fields mapping to one property →
+# last mapping wins) STAYS — it happens before the store write and is a
+# mapping-configuration concern within ONE source, not a trust conflict.
+#
+# Same harness as test_fabric_ingest_shadow.py: fake reader, real FabricStore
+# on tmp SQLite, config in the mongo_db fixture — no google creds.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.fabric_ingest import service as ingest_service  # noqa: E402
+from pocketpaw_ee.cloud.models.fabric_ingest_state import (  # noqa: E402
+    FabricFieldMapping,
+    FabricIngestConfig,
+)
+
+from pocketpaw.fabric.models import PropertyDef  # noqa: E402
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeFirestoreReader:
+    def __init__(self, docs: list[dict] | None = None) -> None:
+        self._docs = docs or []
+
+    async def read_collection(self, collection, *, cursor_field, cursor, limit):  # noqa: ARG002
+        out = []
+        for d in self._docs:
+            val = (d.get("data") or {}).get(cursor_field)
+            if val is None or val == "":
+                val = d.get("update_time") or ""
+            if cursor and str(val) <= cursor:
+                continue
+            out.append(d)
+        return out[:limit]
+
+
+def _doc(path: str, **fields) -> dict:
+    update_time = fields.pop("_update_time", "2026-06-01T00:00:00Z")
+    return {"path": path, "data": dict(fields), "update_time": update_time}
+
+
+async def _make_store(tmp_path) -> FabricStore:
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type("Customer", [PropertyDef(name="name")])
+    return store
+
+
+async def _seed_config(workspace_id: str, mappings: list[FabricFieldMapping]) -> None:
+    cfg = FabricIngestConfig(workspace=workspace_id, enabled=True, mappings=mappings)
+    await cfg.insert()
+
+
+def _customer_mapping() -> FabricFieldMapping:
+    return FabricFieldMapping(
+        collection="customers",
+        object_type_id="ot-customer",
+        field_map={"display_name": "name", "tier": "tier"},
+        cursor_field="updated_at",
+    )
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+# --------------------------------------------------------------------------
+# Enforce flows through the mirror's update path automatically.
+# --------------------------------------------------------------------------
+
+
+async def test_enforce_flows_through_mirror_resync_tracked_property(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "enforce")
+
+    # Backfill mirrors the doc (CREATE — no statements, the FST-4 ruling).
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", tier="gold", updated_at="2026-06-02T10:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj is not None
+
+    # An agent edit promotes "name". In enforce the store already resolves:
+    # the connector-tier baseline seed ("Acme") beats the agent claim, so the
+    # cache keeps "Acme".
+    await store.update_object(
+        obj.id,
+        {"name": "Acme (agent edit)"},
+        workspace_id=ws,
+        writer_class="agent",
+        source_session_id="sess-1",
+    )
+    tracked = await store.get_object(obj.id, workspace_id=ws)
+    assert tracked is not None and tracked.properties["name"] == "Acme"
+
+    # The mirror re-syncs a newer doc version THROUGH ingest_collection —
+    # merge site 3, no enforce-specific code anywhere in the worker.
+    reader2 = FakeFirestoreReader(
+        [
+            _doc(
+                "customers/c1",
+                display_name="Acme v2",
+                tier="gold",
+                updated_at="2026-06-05T10:00:00Z",
+            )
+        ]
+    )
+    result = await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+    assert result["status"] == "ok" and result["mode"] == "incremental"
+
+    # The mirror's claim IS recorded...
+    stmts = await store.get_statements(obj.id, "name", workspace_id=ws)
+    assert len(stmts) == 3
+    mirror = next(s for s in stmts if s.writer_class == "mirror")
+    assert mirror.value == "Acme v2"
+
+    # ...but the cache holds the RESOLVER'S winner (the connector-tier seed
+    # outranks mirror on the ladder), not the mirror's LWW value. Enforce
+    # flowed through store.update_object automatically.
+    refreshed = await store.get_object(obj.id, workspace_id=ws)
+    assert refreshed is not None and refreshed.properties["name"] == "Acme"
+
+
+async def test_enforce_untracked_mirror_refresh_keeps_lww(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    """A mirror self-refresh promotes nothing (writer-family rule), so its
+    untracked properties have no statements and enforce has nothing to
+    resolve: plain LWW — the mirror still mirrors, byte-for-byte."""
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "enforce")
+
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", tier="gold", updated_at="2026-06-02T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    reader2 = FakeFirestoreReader(
+        [
+            _doc(
+                "customers/c1",
+                display_name="Acme Renamed",
+                tier="silver",
+                updated_at="2026-06-04T00:00:00Z",
+            )
+        ]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj is not None
+    assert obj.properties["name"] == "Acme Renamed"  # LWW refresh intact
+    assert obj.properties["tier"] == "silver"
+    assert await store.get_statements(obj.id, "name", workspace_id=ws) == []

--- a/tests/cloud/fabric_ingest/test_fabric_ingest_shadow.py
+++ b/tests/cloud/fabric_ingest/test_fabric_ingest_shadow.py
@@ -1,0 +1,305 @@
+# tests/cloud/fabric_ingest/test_fabric_ingest_shadow.py
+# Created: 2026-07-10 (FST-4 — SHADOW mode at merge site 3, the Firestore
+# mirror worker).
+#
+# Proves the EE Firestore→Fabric mirror threads TRUE provenance into the
+# shared shadow machinery via the canonical OSS ingest loop:
+#
+#   * a mirror re-sync of a TRACKED property lands a statement with
+#     writer_class="mirror" and a SourceRef naming the exact Firestore
+#     collection/doc (kind=connector_run, connector="firestore",
+#     document_uri=<doc path>), workspace-stamped,
+#   * observed_at is the best available SOURCE time: the doc's cursor_field
+#     value when it parses, the snapshot update_time as fallback — never
+#     fabricated (see service._doc_observed_at's audit),
+#   * a mirror self-refresh does NOT promote (writer-family rule): the
+#     mirror refreshing its own objects keeps them scalar/cheap,
+#   * mirror-create then agent-update yields BOTH claims (the ee variant of
+#     the FST-4 create-path proof),
+#   * mode=off — byte-for-byte: objects mirror exactly as before, zero
+#     statements/sources rows,
+#   * tenant scoping — statements + sources carry the workspace; a read
+#     scoped to another tenant sees none of them.
+#
+# Same harness as test_fabric_ingest_service.py: fake reader, real FabricStore
+# on tmp SQLite, config/state in the mongo_db fixture — no google creds.
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.fabric_ingest import service as ingest_service  # noqa: E402
+from pocketpaw_ee.cloud.models.fabric_ingest_state import (  # noqa: E402
+    FabricFieldMapping,
+    FabricIngestConfig,
+)
+
+from pocketpaw.fabric.models import PropertyDef  # noqa: E402
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------
+# Fakes + helpers (mirrors test_fabric_ingest_service.py).
+# --------------------------------------------------------------------------
+
+
+class FakeFirestoreReader:
+    def __init__(self, docs: list[dict] | None = None) -> None:
+        self._docs = docs or []
+
+    async def read_collection(self, collection, *, cursor_field, cursor, limit):  # noqa: ARG002
+        out = []
+        for d in self._docs:
+            val = (d.get("data") or {}).get(cursor_field)
+            if val is None or val == "":
+                val = d.get("update_time") or ""
+            if cursor and str(val) <= cursor:
+                continue
+            out.append(d)
+        return out[:limit]
+
+
+def _doc(path: str, **fields) -> dict:
+    update_time = fields.pop("_update_time", "2026-06-01T00:00:00Z")
+    return {"path": path, "data": dict(fields), "update_time": update_time}
+
+
+async def _make_store(tmp_path) -> FabricStore:
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type("Customer", [PropertyDef(name="name")])
+    return store
+
+
+async def _seed_config(workspace_id: str, mappings: list[FabricFieldMapping]) -> None:
+    cfg = FabricIngestConfig(workspace=workspace_id, enabled=True, mappings=mappings)
+    await cfg.insert()
+
+
+def _customer_mapping() -> FabricFieldMapping:
+    return FabricFieldMapping(
+        collection="customers",
+        object_type_id="ot-customer",
+        field_map={"display_name": "name", "tier": "tier"},
+        cursor_field="updated_at",
+    )
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _source_row(store: FabricStore, source_ref_id: str) -> dict:
+    con = sqlite3.connect(store._db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute("SELECT * FROM fabric_sources WHERE id = ?", (source_ref_id,)).fetchone()
+    finally:
+        con.close()
+    assert row is not None
+    return dict(row)
+
+
+def _table_count(store: FabricStore, table: str) -> int:
+    con = sqlite3.connect(store._db_path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        con.close()
+
+
+# --------------------------------------------------------------------------
+# Mirror provenance: writer_class="mirror" + firestore doc identity + times.
+# --------------------------------------------------------------------------
+
+
+async def test_mirror_resync_lands_mirror_statement_with_firestore_identity(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "shadow")
+
+    # Backfill mirrors the doc (CREATE — no statements, by the FST-4 ruling).
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", tier="gold", updated_at="2026-06-02T10:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj is not None
+    assert await store.get_statements(obj.id, "name", workspace_id=ws) == []
+
+    # An agent edit promotes "name" (seed from the firestore baseline + agent).
+    await store.update_object(
+        obj.id,
+        {"name": "Acme (agent edit)"},
+        workspace_id=ws,
+        writer_class="agent",
+        source_session_id="sess-1",
+    )
+    assert len(await store.get_statements(obj.id, "name", workspace_id=ws)) == 2
+
+    # Incremental re-sync with a newer doc version: the mirror UPDATE path.
+    reader2 = FakeFirestoreReader(
+        [
+            _doc(
+                "customers/c1",
+                display_name="Acme v2",
+                tier="gold",
+                updated_at="2026-06-05T10:00:00Z",
+            )
+        ]
+    )
+    result = await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+    assert result["status"] == "ok" and result["mode"] == "incremental"
+
+    stmts = await store.get_statements(obj.id, "name", workspace_id=ws)
+    assert len(stmts) == 3
+    mirror = next(s for s in stmts if s.writer_class == "mirror")
+    assert mirror.value == "Acme v2"
+    # observed_at = the doc's cursor_field time (the REAL source time).
+    assert mirror.observed_at == datetime.fromisoformat("2026-06-05T10:00:00Z")
+    src = _source_row(store, mirror.source_ref_id)
+    assert src["kind"] == "connector_run"
+    assert src["connector"] == "firestore"
+    assert src["document_uri"] == "customers/c1"  # the exact collection/doc
+    assert src["workspace_id"] == ws
+    assert mirror.workspace_id == ws
+
+    # The untracked "tier" property stayed scalar (opt-in discipline), and the
+    # cache is plain LWW.
+    assert await store.get_statements(obj.id, "tier", workspace_id=ws) == []
+    refreshed = await store.get_object(obj.id, workspace_id=ws)
+    assert refreshed is not None and refreshed.properties["name"] == "Acme v2"
+
+    # Tenant scoping: another workspace's scoped read sees NONE of it.
+    assert await store.get_statements(obj.id, "name", workspace_id="w-other") == []
+
+
+async def test_observed_at_falls_back_to_snapshot_update_time(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "shadow")
+
+    # Doc WITHOUT the cursor field: update_time is the best available time.
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", _update_time="2026-06-03T08:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    await store.update_object(obj.id, {"name": "Agent"}, workspace_id=ws, writer_class="agent")
+
+    reader2 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme v2", _update_time="2026-06-07T08:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+
+    stmts = await store.get_statements(obj.id, "name", workspace_id=ws)
+    mirror = next(s for s in stmts if s.writer_class == "mirror")
+    assert mirror.observed_at == datetime.fromisoformat("2026-06-07T08:00:00Z")
+
+
+# --------------------------------------------------------------------------
+# Writer-family rule at the worker level: self-refresh stays scalar.
+# --------------------------------------------------------------------------
+
+
+async def test_mirror_self_refresh_writes_no_statements(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "shadow")
+
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", updated_at="2026-06-02T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    # The same doc changes upstream; the mirror refreshes its OWN object.
+    reader2 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme Renamed", updated_at="2026-06-04T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj.properties["name"] == "Acme Renamed"  # LWW refresh intact
+    assert _table_count(store, "fabric_statements") == 0  # no promotion noise
+
+
+# --------------------------------------------------------------------------
+# The ee create-then-update proof: mirror creates, agent updates → conflict.
+# --------------------------------------------------------------------------
+
+
+async def test_mirror_create_then_agent_update_conflict_visible(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "shadow")
+
+    reader = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", updated_at="2026-06-02T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader, store=store)
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+
+    await store.update_object(
+        obj.id, {"name": "Acme Global"}, workspace_id=ws, writer_class="agent"
+    )
+
+    stmts = await store.get_statements(obj.id, "name", workspace_id=ws)
+    assert {s.value for s in stmts} == {"Acme", "Acme Global"}  # BOTH claims present
+
+
+# --------------------------------------------------------------------------
+# mode=off — the mirror is byte-for-byte untouched.
+# --------------------------------------------------------------------------
+
+
+async def test_mode_off_mirror_ingest_writes_no_statements(
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
+):
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(ws, [_customer_mapping()])
+    _set_mode(monkeypatch, "off")
+
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", updated_at="2026-06-02T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    reader2 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme v2", updated_at="2026-06-04T00:00:00Z")]
+    )
+    result = await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+
+    assert result["status"] == "ok"
+    obj = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj.properties["name"] == "Acme v2"  # the mirror still mirrors
+    assert _table_count(store, "fabric_statements") == 0
+    assert _table_count(store, "fabric_sources") == 0

--- a/tests/cloud/test_planner_verify_loop.py
+++ b/tests/cloud/test_planner_verify_loop.py
@@ -1,3 +1,12 @@
+# Updated: 2026-07-10 (feat/verify-mode-shadow) — three-position
+#   ``cloud_plan_verify_mode``: added shadow-mode tests (a failing task
+#   still lands ``done`` with the output-file/artifact side-effects intact,
+#   ``verify.verdict`` + ``verify.mode='shadow'`` + ``verify.would_have``
+#   stamped, NO ``requeue_count`` / ``feedback`` written; SOLVED stamps
+#   would_have=done) and a mode='enforce'-without-the-bool test. The
+#   pre-existing tests set ONLY the legacy bool (``enabled=True``), so their
+#   continued passing IS the back-compat proof that the bool still resolves
+#   to enforce through ``effective_cloud_plan_verify_mode()``.
 # Created: 2026-07-02 (feat/svl-5-cloud-verify) — SVL-5: the Self-Verifying
 #   Loop at the CLOUD planner terminal. Drives the real
 #   ``_execute_ready_plan_tasks`` → ``_run_one`` → ``_verify_plan_task_outcome``
@@ -66,11 +75,14 @@ class _FakePool:
         return _gen()
 
 
-def _settings(enabled: bool, max_requeues: int = 2):
-    """A Settings copy with the SVL-5 flag and requeue budget forced."""
+def _settings(enabled: bool, max_requeues: int = 2, mode: str = "off"):
+    """A Settings copy with the legacy bool, the three-position mode, and
+    the requeue budget forced. ``mode`` defaults to 'off' so the legacy
+    tests exercise the bool→enforce back-compat resolution."""
     return get_settings().model_copy(
         update={
             "cloud_plan_verify_loop_enabled": enabled,
+            "cloud_plan_verify_mode": mode,
             "cloud_plan_verify_max_requeues": max_requeues,
         }
     )
@@ -93,7 +105,7 @@ async def _make_plan_task(criteria: list[str]) -> str:
     return str(doc.id)
 
 
-async def _drive(pool: _FakePool, *, enabled: bool, max_requeues: int = 2):
+async def _drive(pool: _FakePool, *, enabled: bool, max_requeues: int = 2, mode: str = "off"):
     """Run the real dispatch path with the pool, settings, and DONE
     side-effects (output-file save + artifact scan) patched. Returns the
     two side-effect mocks so tests assert fired / not-fired."""
@@ -103,7 +115,7 @@ async def _drive(pool: _FakePool, *, enabled: bool, max_requeues: int = 2):
         patch("pocketpaw.agents.pool.get_agent_pool", return_value=pool),
         patch(
             "pocketpaw.config.get_settings",
-            return_value=_settings(enabled, max_requeues),
+            return_value=_settings(enabled, max_requeues, mode),
         ),
         patch.object(planner_service, "_save_task_output_file", save_mock),
         patch.object(planner_service, "_scan_and_upload_agent_files", scan_mock),
@@ -275,3 +287,81 @@ async def test_flag_off_no_verdict_no_requeue(recording_bus) -> None:
     assert save_mock.await_count == 1
     assert scan_mock.await_count == 1
     assert len(_resolved_done_events(recording_bus)) == 1
+
+
+# ---------------------------------------------------------------------------
+# verify_mode: the three-position rollout switch (off | shadow | enforce)
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_failing_task_completes_with_would_have_stamped(recording_bus) -> None:
+    """The shadow rung: a FAILING output still lands ``done`` after ONE run
+    — no requeue, no escalation — with every DONE side-effect intact, the
+    verdict + would_have + shadow marker stamped on ``verify``, and no
+    ``requeue_count`` / ``feedback`` ever written."""
+
+    tid = await _make_plan_task([_C_ALPHA])
+    pool = _FakePool(["This mentions bravo."])  # fails the alpha criterion
+
+    save_mock, scan_mock = await _drive(pool, enabled=False, mode="shadow")
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 1  # shadow never re-dispatches
+    assert doc.status == "done"
+    assert doc.verify["verdict"]["status"] == "not_solved"
+    assert doc.verify["mode"] == "shadow"
+    assert doc.verify["would_have"] == "requeued"
+    # NO enforce-side state was written.
+    assert "requeue_count" not in doc.verify
+    assert "feedback" not in doc.verify
+    assert "escalation_reason" not in doc.verify
+    # DONE side-effects fired exactly as a normal completion.
+    assert save_mock.await_count == 1
+    assert scan_mock.await_count == 1
+    assert len(_resolved_done_events(recording_bus)) == 1
+
+
+async def test_shadow_solved_stamps_would_have_done(recording_bus) -> None:
+    """SOLVED under shadow: would_have=done — the telemetry covers every
+    completion, and the task completes exactly as today."""
+
+    tid = await _make_plan_task([_C_ALPHA])
+    pool = _FakePool(["The summary mentions alpha clearly."])
+
+    save_mock, _ = await _drive(pool, enabled=False, mode="shadow")
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 1
+    assert doc.status == "done"
+    assert doc.verify["verdict"]["status"] == "solved"
+    assert doc.verify["mode"] == "shadow"
+    assert doc.verify["would_have"] == "done"
+    assert save_mock.await_count == 1
+    assert len(_resolved_done_events(recording_bus)) == 1
+
+
+async def test_mode_enforce_without_bool_drives_the_loop(recording_bus) -> None:
+    """mode='enforce' alone (legacy bool off) drives exactly the flag-on
+    behaviour — identical failing set twice escalates no_progress, no DONE
+    side-effect fires. The new switch fully supersedes the bool."""
+
+    tid = await _make_plan_task([_C_ALPHA])
+    pool = _FakePool(
+        [
+            "This mentions bravo.",  # unmet: alpha
+            "Still mentions bravo.",  # unmet: alpha — identical set
+        ]
+    )
+
+    save_mock, scan_mock = await _drive(pool, enabled=False, mode="enforce", max_requeues=2)
+
+    doc = await TaskDoc.get(tid)
+    assert len(pool.calls) == 2
+    assert doc.status == "failed"
+    assert doc.verify["escalation_reason"] == "no_progress"
+    assert doc.verify["requeue_count"] == 1
+    assert "mode" not in doc.verify  # the shadow marker is shadow-only
+    assert "would_have" not in doc.verify
+    assert save_mock.await_count == 0
+    assert scan_mock.await_count == 0
+    assert _resolved_done_events(recording_bus) == []

--- a/tests/test_deep_work_e2e.py
+++ b/tests/test_deep_work_e2e.py
@@ -1,5 +1,15 @@
 # End-to-end tests for the Deep Work interactive intake mode (issue #1161).
 # Created: 2026-05-21 (feat/deep-work-intake)
+# Updated: 2026-07-10 (feat/verify-mode-shadow) — added TestVerifyShadowMode:
+#   the three-position ``deep_work_verify_mode`` rollout switch. shadow: a
+#   FAILING task still lands DONE with its deliverable saved, the verdict +
+#   ``verify_would_have`` + ``verify_mode='shadow'`` stamped, and NO
+#   ``verify_requeue_count`` / ``verify_feedback`` written; the judge shadow
+#   keeps working under shadow mode. mode='enforce' alone (bool off) drives
+#   the full requeue loop; the legacy bool alone still ENFORCES
+#   (back-compat — it must never silently weaken to shadow); mode='off'
+#   stays byte-for-byte inert. The pre-existing TestVerify* classes set only
+#   the legacy bool, so their continued passing is the enforce==today proof.
 # Updated: 2026-07-02 (feat/judge-shadow-1168) — added TestJudgeShadow (J-1,
 #   #1168): with BOTH flags on, a deterministic FAIL + judge PASS still
 #   requeues the task (the judge NEVER rescues a failing result), the judge
@@ -1322,3 +1332,218 @@ class TestJudgeShadow:
         assert done.metadata["verify_judge_verdict"]["status"] == "solved"
         assert "verify judge shadow: deterministic=solved judge=solved" in caplog.text
         assert "agree=True" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# verify_mode: the three-position rollout switch (off | shadow | enforce)
+# ---------------------------------------------------------------------------
+
+
+def _settings_with_verify_mode(
+    mode: str,
+    *,
+    legacy_bool: bool = False,
+    max_requeues: int = 2,
+    judge_enabled: bool = False,
+):
+    """A Settings copy with the three-position mode + the legacy bool forced."""
+    return get_settings().model_copy(
+        update={
+            "deep_work_verify_mode": mode,
+            "deep_work_verify_loop_enabled": legacy_bool,
+            "deep_work_verify_max_requeues": max_requeues,
+            "deep_work_verify_judge_shadow_enabled": judge_enabled,
+        }
+    )
+
+
+class TestVerifyShadowMode:
+    """The shadow rung: verdicts + would_have telemetry are stamped but task
+    status is NEVER touched — a failing task still completes DONE with its
+    deliverable intact. The legacy bool alone still means ENFORCE."""
+
+    async def _make_agent_and_task(self):
+        from pocketpaw.mission_control import get_mission_control_manager
+
+        manager = get_mission_control_manager()
+        agent = await manager.create_agent(
+            name="FinanceBot",
+            role="Finance Assistant",
+            description="Chases overdue invoices",
+            backend="claude_agent_sdk",
+        )
+        task = await manager.create_task(
+            title="Pull the list of overdue invoices",
+            description="Query accounting for invoices 30+ days overdue",
+            priority=TaskPriority.HIGH,
+        )
+        task.metadata["success_criteria"] = list(_SUCCESS_CRITERIA)
+        await manager.save_task(task)
+        await manager.assign_task(task.id, [agent.id])
+        return manager, agent, task
+
+    async def _run_once(self, executor, task_id, agent_id, mock_router, settings):
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=mock_router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=settings,
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            return await executor.execute_task(task_id, agent_id)
+
+    @pytest.mark.asyncio
+    async def test_shadow_failing_task_lands_done_with_would_have(self, svl_singletons, caplog):
+        """The heart of the rollout rung: a FAILING task in shadow mode still
+        completes DONE with the deliverable saved, carries the verdict +
+        would_have + shadow marker, and grows NO requeue counter / feedback
+        — status and should_retry are never touched."""
+        from pocketpaw.mission_control import ActivityType
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("shadow")
+        router = _svl_failing_router()  # output fails BOTH criteria
+
+        with caplog.at_level(logging.INFO, logger="pocketpaw.mission_control.executor"):
+            result = await self._run_once(executor, task.id, agent.id, router, settings)
+        assert result["status"] == "completed"
+
+        done = await manager.get_task(task.id)
+        # The task landed DONE despite failing verify — shadow never acts.
+        assert done.status == TaskStatus.DONE
+        assert done.output == _FAILING_OUTPUT
+        # Verdict + shadow telemetry stamped.
+        assert done.metadata["verify_verdict"]["status"] == "not_solved"
+        assert done.metadata["verify_mode"] == "shadow"
+        assert done.metadata["verify_would_have"] == "requeued"
+        # NO enforce-side state was written.
+        assert "verify_requeue_count" not in done.metadata
+        assert "verify_feedback" not in done.metadata
+        assert "verify_escalation_reason" not in done.metadata
+        # The would_have telemetry line fired.
+        assert "verify shadow mode: would_have=requeued" in caplog.text
+
+        # DONE side-effects ran exactly as a normal completion: the
+        # completion activity logged and the output saved as a deliverable.
+        feed = await manager.get_activity_feed(limit=100)
+        completed = [
+            a for a in feed if a.task_id == task.id and a.type == ActivityType.TASK_COMPLETED
+        ]
+        assert completed, "shadow mode must not suppress the TASK_COMPLETED activity"
+        docs = await manager.get_task_documents(task.id)
+        assert docs, "shadow mode must not suppress the deliverable save"
+
+    @pytest.mark.asyncio
+    async def test_shadow_solved_task_stamps_would_have_done(self, svl_singletons):
+        """SOLVED under shadow: would_have=done — telemetry covers every
+        completion, not just the failing ones."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("shadow")
+        router = _svl_mock_router()  # passing output
+
+        await self._run_once(executor, task.id, agent.id, router, settings)
+
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert done.metadata["verify_verdict"]["status"] == "solved"
+        assert done.metadata["verify_mode"] == "shadow"
+        assert done.metadata["verify_would_have"] == "done"
+        assert "verify_requeue_count" not in done.metadata
+
+    @pytest.mark.asyncio
+    async def test_shadow_keeps_the_judge_shadow_running(self, svl_singletons):
+        """The judge shadow works as-is under shadow mode: its verdict is
+        stamped while the task still completes DONE."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("shadow", judge_enabled=True)
+
+        fake_llm = _FakeJudgeLlm(response=_JUDGE_ALL_MET)
+        judge_cls = MagicMock(return_value=LlmJudgeVerdictProvider(llm=fake_llm))
+        router = _svl_failing_router()
+
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=settings,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.LlmJudgeVerdictProvider",
+                judge_cls,
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            await executor.execute_task(task.id, agent.id)
+
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE  # shadow never requeues
+        assert done.metadata["verify_verdict"]["status"] == "not_solved"
+        assert done.metadata["verify_judge_verdict"]["status"] == "solved"
+        assert len(fake_llm.prompts) == 1
+
+    @pytest.mark.asyncio
+    async def test_legacy_bool_alone_still_enforces(self, svl_singletons):
+        """BACK-COMPAT: mode left at 'off' + the legacy bool True must run the
+        FULL loop (the bool's shipped meaning) — a failing task requeues, it
+        does not silently complete in shadow."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("off", legacy_bool=True)
+        router = _svl_failing_router()
+
+        await self._run_once(executor, task.id, agent.id, router, settings)
+
+        reloaded = await manager.get_task(task.id)
+        assert reloaded.status == TaskStatus.ASSIGNED, (
+            "legacy bool True must keep enforcing — never weaken to shadow"
+        )
+        assert reloaded.metadata["verify_requeue_count"] == 1
+        assert "verify_mode" not in reloaded.metadata
+        assert "verify_would_have" not in reloaded.metadata
+
+    @pytest.mark.asyncio
+    async def test_mode_enforce_without_bool_drives_the_loop(self, svl_singletons):
+        """mode='enforce' alone (legacy bool off) drives exactly today's
+        flag-on behaviour — the new switch fully supersedes the bool."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("enforce", legacy_bool=False)
+        router = _svl_failing_router()
+
+        await self._run_once(executor, task.id, agent.id, router, settings)
+
+        reloaded = await manager.get_task(task.id)
+        assert reloaded.status == TaskStatus.ASSIGNED
+        assert reloaded.metadata["verify_requeue_count"] == 1
+        assert len(reloaded.metadata["verify_feedback"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_mode_off_default_is_byte_for_byte_inert(self, svl_singletons):
+        """mode='off' + bool False (the shipped default): no verdict, no
+        shadow stamps, no requeue — exactly today's default path."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_mode("off", legacy_bool=False)
+        router = _svl_failing_router()
+
+        result = await self._run_once(executor, task.id, agent.id, router, settings)
+        assert result["status"] == "completed"
+
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert "verify_verdict" not in done.metadata
+        assert "verify_mode" not in done.metadata
+        assert "verify_would_have" not in done.metadata
+        assert "verify_requeue_count" not in done.metadata

--- a/tests/test_fabric_change_correct.py
+++ b/tests/test_fabric_change_correct.py
@@ -1,0 +1,312 @@
+# tests/test_fabric_change_correct.py
+# Created: 2026-07-10 (FST-5 — the CHANGE / CORRECT curation verbs).
+#
+# Proves the two statement-layer curation verbs (the seams FST-6's PIN/IGNORE
+# executor calls):
+#
+#   * CHANGE — closes the current winner's validity (valid_to = now, it stays
+#     auditable history) and appends the new value as rank="preferred", open
+#     validity; returns the NEW Resolution,
+#   * CORRECT — marks the current winner rank="deprecated" with
+#     rank_reason=<reason> (struck from resolution entirely) and appends the
+#     corrected value as rank="normal"; returns the NEW Resolution,
+#   * both verbs auto-promote an UNTRACKED property first (seed the current
+#     cache value with the FST-3 baseline provenance + touch-time
+#     observed_at) so pre-verb history is preserved; a property absent from
+#     both statements and cache just appends,
+#   * mode-respecting cache: enforce writes the new resolver winner into the
+#     flat properties dict; shadow and off leave the cache alone (the verbs
+#     write statements in EVERY mode — they are statement-layer operations),
+#   * a missing / cross-tenant object raises ValueError (a clean seam
+#     failure), and statements/sources are workspace-stamped.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.store import FabricStore
+
+pytestmark = pytest.mark.asyncio
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+async def _crm_object(tmp_path: Path, **props: Any) -> tuple[FabricStore, str]:
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        props or {"name": "Acme", "arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+    return store, obj.id
+
+
+async def _tracked_arr(store: FabricStore, obj_id: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Track ``arr`` via the FST-3 promotion (agent write in shadow mode so
+    the cache stays LWW during setup): seed(connector, 120) + agent(150)."""
+    _set_mode(monkeypatch, "shadow")
+    await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-setup"
+    )
+    assert len(await store.get_statements(obj_id, "arr")) == 2
+
+
+# ---------------------------------------------------------------------------
+# CHANGE — close the winner, append preferred
+# ---------------------------------------------------------------------------
+
+
+async def test_change_closes_winner_and_appends_preferred(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.change_property(
+        obj_id, "arr", 200, writer_class="human", source_actor_id="user:alice"
+    )
+
+    # The NEW Resolution: the human-preferred statement wins.
+    assert resolution.value == 200
+    assert resolution.winner_statement is not None
+    assert resolution.winner_statement.rank == "preferred"
+    assert resolution.winner_statement.writer_class == "human"
+    assert resolution.winner_statement.valid_to is None  # open validity
+
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 3
+    # The prior winner (the connector-tier seed, value 120) is CLOSED — a
+    # superseded-history statement, still present for audit.
+    old_winner = next(s for s in stmts if s.value == 120)
+    assert old_winner.valid_to is not None
+    # The other loser (the agent 150) is untouched.
+    agent = next(s for s in stmts if s.value == 150)
+    assert agent.valid_to is None and agent.rank == "normal"
+
+    # Shadow: the cache is untouched by the verb (still the LWW setup value).
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150
+
+
+async def test_change_enforce_updates_cache_to_new_winner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    _set_mode(monkeypatch, "enforce")
+
+    resolution = await store.change_property(
+        obj_id, "arr", 200, writer_class="human", source_actor_id="user:alice"
+    )
+
+    assert resolution.value == 200
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 200  # resolver-owned cache
+
+
+# ---------------------------------------------------------------------------
+# CORRECT — deprecate the winner (with reason), append normal
+# ---------------------------------------------------------------------------
+
+
+async def test_correct_deprecates_winner_and_appends_normal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.correct_property(
+        obj_id,
+        "arr",
+        130,
+        reason="connector reported the pre-discount figure",
+        writer_class="human",
+        source_actor_id="user:alice",
+    )
+
+    # The corrected value wins (human tier; the old connector winner is
+    # struck entirely).
+    assert resolution.value == 130
+    assert resolution.winner_statement is not None
+    assert resolution.winner_statement.rank == "normal"
+    assert resolution.winner_statement.writer_class == "human"
+
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 3
+    deprecated = next(s for s in stmts if s.value == 120)
+    assert deprecated.rank == "deprecated"
+    assert deprecated.rank_reason == "connector reported the pre-discount figure"
+    # A deprecated statement never wins, loses, or disputes — it is not in
+    # the Resolution at all.
+    assert deprecated.id not in {s.id for s in resolution.losers}
+
+    # Shadow: cache untouched.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150
+
+
+async def test_correct_enforce_updates_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    _set_mode(monkeypatch, "enforce")
+
+    resolution = await store.correct_property(
+        obj_id,
+        "arr",
+        130,
+        reason="wrong unit",
+        writer_class="human",
+        source_actor_id="user:alice",
+    )
+
+    assert resolution.value == 130
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 130
+
+
+# ---------------------------------------------------------------------------
+# Untracked properties: promote-then-apply (history preserved)
+# ---------------------------------------------------------------------------
+
+
+async def test_change_on_untracked_property_promotes_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path, name="Acme")
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.change_property(
+        obj_id, "name", "Acme Corp", writer_class="human", source_actor_id="user:alice"
+    )
+
+    stmts = await store.get_statements(obj_id, "name")
+    assert len(stmts) == 2  # the promotion seed + the change
+    # The seed preserved the pre-change claim with the object's baseline
+    # provenance (connector-owned object → writer "connector") and was
+    # closed by the change (it WAS the current winner).
+    seed = next(s for s in stmts if s.value == "Acme")
+    assert seed.writer_class == "connector"
+    assert seed.valid_to is not None
+    assert resolution.value == "Acme Corp"
+
+
+async def test_correct_on_untracked_property_promotes_then_deprecates_seed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path, name="Acmee")
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.correct_property(
+        obj_id,
+        "name",
+        "Acme",
+        reason="typo in the source",
+        writer_class="human",
+        source_actor_id="user:alice",
+    )
+
+    stmts = await store.get_statements(obj_id, "name")
+    assert len(stmts) == 2
+    seed = next(s for s in stmts if s.value == "Acmee")
+    assert seed.rank == "deprecated" and seed.rank_reason == "typo in the source"
+    assert resolution.value == "Acme"
+    assert resolution.is_disputed is False  # the wrong claim is struck, not disputing
+
+
+async def test_verb_on_absent_property_appends_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A property with no statements AND no cache value has no prior claim —
+    nothing to seed, nothing to close; the verb just appends. In enforce the
+    cache gains the property (the new winner)."""
+    store, obj_id = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    resolution = await store.change_property(
+        obj_id, "tier", "gold", writer_class="human", source_actor_id="user:alice"
+    )
+
+    stmts = await store.get_statements(obj_id, "tier")
+    assert len(stmts) == 1 and stmts[0].rank == "preferred"
+    assert resolution.value == "gold"
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["tier"] == "gold"
+
+
+# ---------------------------------------------------------------------------
+# The verbs are statement-layer operations in EVERY mode; only enforce
+# touches the cache
+# ---------------------------------------------------------------------------
+
+
+async def test_change_in_off_mode_writes_statements_but_not_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "off")
+
+    resolution = await store.change_property(
+        obj_id, "arr", 200, writer_class="human", source_actor_id="user:alice"
+    )
+
+    assert resolution.value == 200
+    assert len(await store.get_statements(obj_id, "arr")) == 2  # seed + change
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120  # cache untouched (off)
+
+
+# ---------------------------------------------------------------------------
+# Failure + tenancy seams
+# ---------------------------------------------------------------------------
+
+
+async def test_verb_missing_object_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store, _ = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    with pytest.raises(ValueError, match="not found"):
+        await store.change_property("obj-nope", "arr", 1, writer_class="human")
+    with pytest.raises(ValueError, match="not found"):
+        await store.correct_property("obj-nope", "arr", 1, reason="x", writer_class="human")
+
+
+async def test_verbs_respect_workspace_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[], workspace_id="ws-a")
+    obj = await store.create_object(
+        obj_type.id,
+        {"arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+        workspace_id="ws-a",
+    )
+    _set_mode(monkeypatch, "enforce")
+
+    # Cross-tenant: the object is invisible to ws-b → clean ValueError.
+    with pytest.raises(ValueError, match="not found"):
+        await store.change_property(obj.id, "arr", 200, writer_class="human", workspace_id="ws-b")
+
+    # Own tenant: works, and statements are workspace-stamped.
+    resolution = await store.change_property(
+        obj.id, "arr", 200, writer_class="human", source_actor_id="u:a", workspace_id="ws-a"
+    )
+    assert resolution.value == 200
+    stmts = await store.get_statements(obj.id, "arr", workspace_id="ws-a")
+    assert len(stmts) == 2 and all(s.workspace_id == "ws-a" for s in stmts)
+    refreshed = await store.get_object(obj.id, workspace_id="ws-a")
+    assert refreshed is not None and refreshed.properties["arr"] == 200

--- a/tests/test_fabric_conflicts.py
+++ b/tests/test_fabric_conflicts.py
@@ -1,0 +1,228 @@
+# tests/test_fabric_conflicts.py
+# Created: 2026-07-10 (FST-6 — the open-conflict surface).
+#
+# Proves ``detect_open_conflicts`` (fabric/conflicts.py) — the recompute-from-
+# statements scan the EE stewardship sweep consumes:
+#
+#   * finds EXACTLY the un-rankable conflicts (same tier + same rank + both
+#     open validity + materially different + within the recency epsilon) —
+#     mere rankable disputes (tier, rank, or recency orders them) are
+#     excluded by design: policy already answered those,
+#   * ``rivals`` names only the statements that TRIGGERED un-rankability
+#     (lower-tier losers are policy-ranked, not human choices),
+#   * the dedupe key ``(workspace_id, object_id, property)`` and the
+#     conflict ``signature`` (sorted competing statement ids) are stable
+#     across scans — the EE sweep's one-open-proposal-per-key guarantee
+#     hangs off that stability,
+#   * a steward verb CLOSES the conflict on the next scan (pin → the pinned
+#     path is never un-rankable; ignore → the rival is struck) — no
+#     persisted conflict state to invalidate,
+#   * scoping: ``object_id`` narrows the scan; W4a workspace scope hides
+#     other tenants' statements; a deleted object's orphan statements are
+#     skipped.
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.fabric.conflicts import detect_open_conflicts
+from pocketpaw.fabric.store import FabricStore
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _store_with_object(tmp_path: Path, name: str = "fabric.db") -> tuple[FabricStore, str]:
+    store = FabricStore(tmp_path / name)
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id, {"name": "Acme"}, source_connector="crm", source_id="c-1"
+    )
+    return store, obj.id
+
+
+async def _unrankable_arr(
+    store: FabricStore,
+    obj_id: str,
+    *,
+    workspace_id: str | None = None,
+    gap: timedelta = timedelta(hours=1),
+) -> tuple[str, str]:
+    """Two same-tier (connector), same-rank, open, materially different
+    statements observed within the epsilon → un-rankable. Returns
+    (winner_stmt_id, rival_stmt_id) — the newer observation wins."""
+    now = datetime.now()
+    src_a = await store.upsert_source(
+        "connector_run", connector="crm", run_id="r1", workspace_id=workspace_id
+    )
+    src_b = await store.upsert_source(
+        "connector_run", connector="billing", run_id="r9", workspace_id=workspace_id
+    )
+    rival = await store.append_statement(
+        obj_id, "arr", 200, src_b.id, "connector", observed_at=now - gap, workspace_id=workspace_id
+    )
+    winner = await store.append_statement(
+        obj_id, "arr", 120, src_a.id, "connector", observed_at=now, workspace_id=workspace_id
+    )
+    return winner.id, rival.id
+
+
+# ---------------------------------------------------------------------------
+# Exactly the un-rankable ones — not mere disputes
+# ---------------------------------------------------------------------------
+
+
+async def test_detect_finds_exactly_the_unresolvable_conflicts(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    winner_id, rival_id = await _unrankable_arr(store, obj_id)
+
+    # A RANKABLE dispute on another property: human vs connector — the
+    # ladder orders them, policy answers it, no human needed.
+    now = datetime.now()
+    human_src = await store.upsert_source("human_actor", actor_id="user:alice")
+    crm_src = await store.upsert_source("connector_run", connector="crm", run_id="r1")
+    await store.append_statement(obj_id, "tier", "gold", human_src.id, "human", observed_at=now)
+    await store.append_statement(obj_id, "tier", "silver", crm_src.id, "connector", observed_at=now)
+
+    # An AGREEING pair on a third property: same value, no dispute at all.
+    await store.append_statement(obj_id, "region", "EU", human_src.id, "human", observed_at=now)
+    await store.append_statement(obj_id, "region", "EU", crm_src.id, "connector", observed_at=now)
+
+    conflicts = await detect_open_conflicts(store)
+
+    assert [c.property for c in conflicts] == ["arr"]
+    record = conflicts[0]
+    assert record.object_id == obj_id
+    assert record.object_type == "Customer"
+    assert record.winner.id == winner_id and record.winner.value == 120
+    assert [r.id for r in record.rivals] == [rival_id]
+
+
+async def test_rank_or_recency_difference_is_rankable_not_a_conflict(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    now = datetime.now()
+    src_a = await store.upsert_source("connector_run", connector="crm", run_id="r1")
+    src_b = await store.upsert_source("connector_run", connector="billing", run_id="r9")
+
+    # Same tier but a RANK difference (preferred vs normal) — a ranking.
+    await store.append_statement(
+        obj_id, "arr", 120, src_a.id, "connector", observed_at=now, rank="preferred"
+    )
+    await store.append_statement(obj_id, "arr", 200, src_b.id, "connector", observed_at=now)
+
+    # Same tier + rank but observed OUTSIDE the 24h epsilon — recency ranks.
+    await store.append_statement(
+        obj_id, "mrr", 10, src_a.id, "connector", observed_at=now - timedelta(hours=30)
+    )
+    await store.append_statement(obj_id, "mrr", 20, src_b.id, "connector", observed_at=now)
+
+    assert await detect_open_conflicts(store) == []
+
+
+async def test_rivals_exclude_lower_tier_losers(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    winner_id, rival_id = await _unrankable_arr(store, obj_id)
+    # A lower-tier (agent) statement, materially different and recent — a
+    # loser the ladder already ranks, NOT a choice for the human.
+    agent_src = await store.upsert_source("agent_session", session_id="sess-1")
+    await store.append_statement(
+        obj_id, "arr", 999, agent_src.id, "agent", observed_at=datetime.now()
+    )
+
+    conflicts = await detect_open_conflicts(store)
+
+    assert len(conflicts) == 1
+    record = conflicts[0]
+    assert record.winner.id == winner_id
+    assert [r.id for r in record.rivals] == [rival_id]  # the agent 999 is absent
+    assert record.signature == sorted([winner_id, rival_id])
+
+
+# ---------------------------------------------------------------------------
+# Dedupe key + signature stability
+# ---------------------------------------------------------------------------
+
+
+async def test_dedupe_key_and_signature_stable_across_scans(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    await _unrankable_arr(store, obj_id, workspace_id="w1")
+
+    first = await detect_open_conflicts(store, workspace_id="w1")
+    second = await detect_open_conflicts(store, workspace_id="w1")
+
+    assert len(first) == len(second) == 1
+    assert first[0].dedupe_key == second[0].dedupe_key == ("w1", obj_id, "arr")
+    assert first[0].signature == second[0].signature
+
+
+# ---------------------------------------------------------------------------
+# Steward verbs close the conflict — no persisted state to invalidate
+# ---------------------------------------------------------------------------
+
+
+async def test_pin_closes_the_conflict(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    winner_id, _ = await _unrankable_arr(store, obj_id)
+    assert len(await detect_open_conflicts(store)) == 1
+
+    await store.pin_statement(obj_id, "arr", winner_id)
+
+    assert await detect_open_conflicts(store) == []
+
+
+async def test_ignore_closes_the_conflict(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    _, rival_id = await _unrankable_arr(store, obj_id)
+    assert len(await detect_open_conflicts(store)) == 1
+
+    await store.ignore_statement(obj_id, "arr", rival_id)
+
+    assert await detect_open_conflicts(store) == []
+
+
+# ---------------------------------------------------------------------------
+# Scoping — object filter, tenancy, deleted objects
+# ---------------------------------------------------------------------------
+
+
+async def test_object_id_filter_narrows_the_scan(tmp_path: Path) -> None:
+    store, obj_a = await _store_with_object(tmp_path)
+    obj_type = (await store.list_types())[0]
+    obj_b = await store.create_object(
+        obj_type.id, {"name": "Globex"}, source_connector="crm", source_id="c-2"
+    )
+    await _unrankable_arr(store, obj_a)
+    await _unrankable_arr(store, obj_b.id)
+
+    all_conflicts = await detect_open_conflicts(store)
+    assert {c.object_id for c in all_conflicts} == {obj_a, obj_b.id}
+
+    only_a = await detect_open_conflicts(store, object_id=obj_a)
+    assert [c.object_id for c in only_a] == [obj_a]
+
+
+async def test_workspace_scope_hides_other_tenants_conflicts(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    await _unrankable_arr(store, obj_id, workspace_id="w1")
+
+    own = await detect_open_conflicts(store, workspace_id="w1")
+    assert len(own) == 1
+    assert own[0].workspace_id == "w1"
+
+    # w2's scope sees own + legacy-NULL rows only — w1's statements are
+    # invisible, so there is nothing to arbitrate.
+    assert await detect_open_conflicts(store, workspace_id="w2") == []
+
+
+async def test_deleted_object_statements_are_skipped(tmp_path: Path) -> None:
+    store, obj_id = await _store_with_object(tmp_path)
+    await _unrankable_arr(store, obj_id)
+    assert len(await detect_open_conflicts(store)) == 1
+
+    await store.remove_object(obj_id)
+
+    # The orphan statements remain in the table (append-only audit) but the
+    # object is gone — not a conflict anyone can arbitrate.
+    assert await detect_open_conflicts(store) == []

--- a/tests/test_fabric_divergence_report.py
+++ b/tests/test_fabric_divergence_report.py
@@ -1,0 +1,273 @@
+# tests/test_fabric_divergence_report.py
+# Created: 2026-07-11 (FST-8 — the operational proof kit).
+#
+# Unit tests for the shadow-divergence report harness
+# (pocketpaw.fabric.divergence_report):
+#
+#   * the tolerant parser — exact-contract lines parse with JSON round-trip
+#     (spaces in quoted strings, objects, null), non-matching lines and the
+#     failure-shield warning are skipped, malformed prefix-matching lines
+#     become parse_error records and NEVER raise,
+#   * the unexplained-divergence heuristic — diverged with no visible reason
+#     (not disputed, not unresolvable, freshness=fresh) is unexplained;
+#     each visible reason explains it,
+#   * summarize — totals, rate, disputed/unresolvable counts, per-property
+#     top-N, freshness distribution, parse_errors, the enforce_ready verdict
+#     (blocked by unexplained AND by parse errors), generator input,
+#   * format_report smoke — verdict line shape, empty-input caution,
+#   * the CLI — files/stdin in, report out, exit codes 0/1/2.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.fabric.divergence_report import (
+    DivergenceRecord,
+    format_report,
+    main,
+    parse_divergence_lines,
+    summarize,
+)
+
+
+def _line(
+    *,
+    object_id: str = "obj-1",
+    prop: str = "arr",
+    lww: str = "200",
+    resolver: str = "150",
+    diverged: bool = True,
+    disputed: bool = False,
+    unresolvable: bool = False,
+    freshness: str = "fresh",
+) -> str:
+    return (
+        f"fabric shadow: object={object_id} property={prop} lww={lww} resolver={resolver}"
+        f" diverged={diverged} disputed={disputed} unresolvable={unresolvable}"
+        f" freshness={freshness}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_divergence_lines — the tolerant parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_good_line_round_trips_values() -> None:
+    records = parse_divergence_lines([_line()])
+    assert len(records) == 1
+    r = records[0]
+    assert r.ok and r.parse_error is None
+    assert r.object_id == "obj-1"
+    assert r.property == "arr"
+    assert r.lww == 200 and r.resolver == 150
+    assert r.diverged is True
+    assert r.disputed is False
+    assert r.unresolvable is False
+    assert r.freshness == "fresh"
+
+
+def test_parse_json_values_with_spaces_objects_and_null() -> None:
+    lines = [
+        _line(lww='"Acme Corp Ltd"', resolver='"Acme Corp"', prop="name"),
+        _line(lww='{"city": "San Francisco", "zip": "94110"}', resolver='{"city": "SF"}'),
+        _line(lww="null", resolver="[1, 2, 3]", diverged=True),
+    ]
+    records = parse_divergence_lines(lines)
+    assert [r.ok for r in records] == [True, True, True]
+    assert records[0].lww == "Acme Corp Ltd" and records[0].resolver == "Acme Corp"
+    assert records[1].lww == {"city": "San Francisco", "zip": "94110"}
+    assert records[2].lww is None and records[2].resolver == [1, 2, 3]
+
+
+def test_parse_skips_noise_and_failure_shield_lines() -> None:
+    lines = [
+        "",
+        "INFO some unrelated log line",
+        "fabric shadow: statement pass failed for object=o1 — cache write unaffected",
+        _line(),
+        "another trailer",
+    ]
+    records = parse_divergence_lines(lines)
+    assert len(records) == 1 and records[0].ok
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        # head violations
+        "fabric shadow: object= property=arr lww=1 resolver=1 diverged=True"
+        " disputed=False unresolvable=False freshness=fresh",
+        "fabric shadow: object=o1 lww=1 resolver=1 diverged=True"
+        " disputed=False unresolvable=False freshness=fresh",
+        # lww not JSON
+        _line(lww="BROKEN"),
+        # missing resolver field
+        "fabric shadow: object=o1 property=arr lww=1 diverged=True"
+        " disputed=False unresolvable=False freshness=fresh",
+        # resolver not JSON
+        _line(resolver="{unclosed"),
+        # tail violations: bad bool, bad freshness, truncated
+        _line().replace("diverged=True", "diverged=maybe"),
+        _line(freshness="rotten"),
+        _line().rsplit(" freshness=", 1)[0],
+    ],
+)
+def test_malformed_prefix_lines_become_parse_errors_never_raise(bad: str) -> None:
+    records = parse_divergence_lines([bad])
+    assert len(records) == 1
+    assert records[0].ok is False
+    assert records[0].parse_error
+    assert records[0].raw == bad
+
+
+def test_parse_strips_trailing_newlines() -> None:
+    records = parse_divergence_lines([_line() + "\n", _line() + "\r\n"])
+    assert all(r.ok for r in records) and len(records) == 2
+
+
+# ---------------------------------------------------------------------------
+# the unexplained heuristic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("diverged", "disputed", "unresolvable", "freshness", "expected"),
+    [
+        (True, False, False, "fresh", True),  # no visible reason → unexplained
+        (True, True, False, "fresh", False),  # dispute explains it
+        (True, False, True, "fresh", False),  # unresolvable tie explains it
+        (True, False, False, "aging", False),  # freshness demotion explains it
+        (True, False, False, "stale", False),
+        (True, False, False, "none", False),
+        (False, False, False, "fresh", False),  # no divergence at all
+    ],
+)
+def test_unexplained_heuristic(
+    diverged: bool, disputed: bool, unresolvable: bool, freshness: str, expected: bool
+) -> None:
+    [r] = parse_divergence_lines(
+        [
+            _line(
+                diverged=diverged, disputed=disputed, unresolvable=unresolvable, freshness=freshness
+            )
+        ]
+    )
+    assert r.unexplained is expected
+
+
+def test_malformed_record_is_never_unexplained() -> None:
+    [r] = parse_divergence_lines([_line(lww="BROKEN")])
+    assert r.unexplained is False
+
+
+# ---------------------------------------------------------------------------
+# summarize
+# ---------------------------------------------------------------------------
+
+
+def _mixed_records() -> list[DivergenceRecord]:
+    return parse_divergence_lines(
+        [
+            _line(prop="arr", diverged=True, disputed=True),  # explained
+            _line(prop="arr", object_id="obj-2", diverged=True),  # unexplained
+            _line(prop="industry", diverged=True, freshness="stale"),  # explained
+            _line(prop="name", diverged=False),
+            _line(prop="owner", diverged=True, unresolvable=True, freshness="aging"),  # explained
+            _line(lww="BROKEN"),  # parse error
+        ]
+    )
+
+
+def test_summarize_counts_rates_topn_freshness() -> None:
+    s = summarize(_mixed_records(), top_n=2)
+    assert s.total == 5
+    assert s.parse_errors == 1
+    assert s.diverged == 4
+    assert s.diverged_rate == pytest.approx(4 / 5)
+    assert s.disputed == 1
+    assert s.unresolvable == 1
+    assert s.unexplained == 1
+    assert s.top_diverged_properties[0] == ("arr", 2)
+    assert len(s.top_diverged_properties) == 2  # top_n honored
+    assert s.freshness == {"fresh": 3, "stale": 1, "aging": 1}
+    assert s.enforce_ready is False
+
+
+def test_summarize_enforce_ready_requires_zero_unexplained_and_zero_parse_errors() -> None:
+    clean_explained = parse_divergence_lines(
+        [_line(diverged=True, disputed=True), _line(diverged=False)]
+    )
+    assert summarize(clean_explained).enforce_ready is True
+
+    with_parse_error = [*clean_explained, *parse_divergence_lines([_line(lww="BROKEN")])]
+    assert summarize(with_parse_error).enforce_ready is False
+
+
+def test_summarize_empty_and_generator_input() -> None:
+    empty = summarize([])
+    assert empty.total == 0 and empty.diverged_rate == 0.0 and empty.enforce_ready is True
+
+    gen = (r for r in _mixed_records())
+    assert summarize(gen).total == 5  # one-shot iterators are materialized once
+
+
+# ---------------------------------------------------------------------------
+# format_report — smoke
+# ---------------------------------------------------------------------------
+
+
+def test_format_report_verdict_and_sections() -> None:
+    report = format_report(summarize(_mixed_records()))
+    assert report.startswith("fabric divergence report")
+    assert "diverged:      4/5" in report
+    assert "unexplained:   1" in report
+    assert "arr" in report
+    assert report.splitlines()[-1] == "ENFORCE-READY: no (1 unexplained, 1 parse errors)"
+
+
+def test_format_report_clean_and_empty() -> None:
+    clean = format_report(summarize(parse_divergence_lines([_line(diverged=True, disputed=True)])))
+    assert clean.splitlines()[-1] == "ENFORCE-READY: yes (0 unexplained)"
+
+    empty = format_report(summarize([]))
+    assert "no divergence lines found" in empty
+    assert empty.splitlines()[-1] == "ENFORCE-READY: yes (0 unexplained)"
+
+
+# ---------------------------------------------------------------------------
+# the CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_reads_files_and_exits_by_verdict(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    clean = tmp_path / "clean.log"
+    clean.write_text("noise\n" + _line(diverged=True, disputed=True) + "\n")
+    assert main([str(clean)]) == 0
+    out = capsys.readouterr().out
+    assert "ENFORCE-READY: yes (0 unexplained)" in out
+
+    dirty = tmp_path / "dirty.log"
+    dirty.write_text(_line(diverged=True) + "\n")
+    assert main([str(clean), str(dirty)]) == 1
+    out = capsys.readouterr().out
+    assert "ENFORCE-READY: no (1 unexplained)" in out
+
+
+def test_cli_stdin_and_unreadable_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import io
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(_line(diverged=False) + "\n"))
+    assert main([]) == 0
+    assert "ENFORCE-READY: yes" in capsys.readouterr().out
+
+    assert main([str(tmp_path / "missing.log")]) == 2
+    assert "cannot read" in capsys.readouterr().err

--- a/tests/test_fabric_enforce_site1.py
+++ b/tests/test_fabric_enforce_site1.py
@@ -34,7 +34,8 @@ STORE_LOGGER = "pocketpaw.fabric.store"
 
 DIVERGENCE_RE = re.compile(
     r"^fabric shadow: object=\S+ property=\S+ lww=.+ resolver=.+"
-    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)$"
+    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)"
+    r" freshness=(fresh|aging|stale|none)$"
 )
 
 
@@ -177,7 +178,7 @@ async def test_enforce_divergence_line_logs_lww_vs_written(
     lines = _shadow_lines(caplog)
     assert lines == [
         f"fabric shadow: object={obj_id} property=arr lww=150 resolver=120"
-        " diverged=True disputed=True unresolvable=False"
+        " diverged=True disputed=True unresolvable=False freshness=fresh"
     ]
     assert DIVERGENCE_RE.fullmatch(lines[0])
     # And "resolver" really is what the cache holds now (enforce semantics).
@@ -272,7 +273,7 @@ class TestSzdProof:
         lines = _shadow_lines(caplog)
         assert lines == [
             f'fabric shadow: object={obj_id} property=industry lww="crypto"'
-            ' resolver="fintech" diverged=True disputed=True unresolvable=False'
+            ' resolver="fintech" diverged=True disputed=True unresolvable=False freshness=fresh'
         ]
 
     async def test_reversed_order_connector_fact_still_wins_cache(

--- a/tests/test_fabric_enforce_site1.py
+++ b/tests/test_fabric_enforce_site1.py
@@ -1,0 +1,358 @@
+# tests/test_fabric_enforce_site1.py
+# Created: 2026-07-10 (FST-5 — ENFORCE mode: the resolver owns the cache).
+#
+# Proves the enforce cache semantics at merge site 1 (store.update_object):
+#
+#   * a TRACKED property lands in the flat properties dict as the RESOLVER'S
+#     winner, not the blind LWW value; untracked properties keep LWW (they
+#     have no statements — nothing to resolve), including inside one mixed
+#     update,
+#   * the divergence line keeps its exact FST-8 shape; in enforce ``lww=`` is
+#     what LWW would have kept and ``resolver=`` is what the cache now holds,
+#   * a statement-pass failure degrades THAT write to plain LWW (warning
+#     logged) — the cache write never breaks,
+#   * when the incoming write IS the resolver's winner, enforce and LWW agree,
+#
+# plus THE SZD TEST (TestSzdProof — the payoff of the whole source-truth
+# chain) and the REVERSAL PROOF (enforce → off leaves a fully working store).
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.resolver import resolve
+from pocketpaw.fabric.store import FabricStore
+from pocketpaw.fabric.trust import default_trust_rules
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+DIVERGENCE_RE = re.compile(
+    r"^fabric shadow: object=\S+ property=\S+ lww=.+ resolver=.+"
+    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)$"
+)
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+def _table_count(db_path: Path, table: str) -> int:
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    finally:
+        con.close()
+
+
+async def _crm_object(tmp_path: Path, **props: Any) -> tuple[FabricStore, str, Path]:
+    """A store with one connector-owned object; returns (store, object_id, db_path)."""
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        props or {"name": "Acme", "arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+    return store, obj.id, db_path
+
+
+# ---------------------------------------------------------------------------
+# Tracked properties: the resolver's winner is what the cache receives
+# ---------------------------------------------------------------------------
+
+
+async def test_enforce_tracked_property_cache_gets_resolver_winner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    # Agent write (second source): promotes arr — seed(connector, 120) +
+    # agent(150). The connector-tier seed wins the ladder, so the cache gets
+    # 120, NOT the blind LWW 150.
+    updated = await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-1"
+    )
+
+    assert updated is not None
+    assert updated.properties["arr"] == 120  # resolver's winner, not LWW
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120
+    # Both claims exist regardless — the losing write is preserved as history.
+    stmts = await store.get_statements(obj_id, "arr")
+    assert {s.value for s in stmts} == {120, 150}
+
+
+async def test_enforce_untracked_properties_keep_lww(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    # Same source as the object's owner: no promotion, no statements — the
+    # property stays scalar and enforce has nothing to resolve → plain LWW.
+    updated = await store.update_object(
+        obj_id, {"arr": 999}, writer_class="connector", source_connector="crm"
+    )
+
+    assert updated is not None and updated.properties["arr"] == 999
+    assert _table_count(db_path, "fabric_statements") == 0
+
+
+async def test_enforce_mixed_update_tracked_resolved_untracked_lww(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path, name="Acme", arr=120, note="x")
+    _set_mode(monkeypatch, "enforce")
+
+    # One update carrying a promotable property (arr — materially different,
+    # second source) and a brand-new key (label — no prior claim, stays
+    # untracked): arr gets the resolver's winner, label gets LWW.
+    updated = await store.update_object(
+        obj_id,
+        {"arr": 150, "label": "vip"},
+        writer_class="agent",
+        source_session_id="sess-1",
+    )
+
+    assert updated is not None
+    assert updated.properties["arr"] == 120  # resolved (connector seed wins)
+    assert updated.properties["label"] == "vip"  # untracked → LWW
+    assert await store.get_statements(obj_id, "label") == []
+
+
+async def test_enforce_incoming_winner_lands_in_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the incoming write IS the resolver's winner (a human write beats
+    the connector seed), enforce agrees with LWW — same cache value, but now
+    it's the resolver's decision, not blind recency."""
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    updated = await store.update_object(
+        obj_id, {"arr": 175}, writer_class="human", source_actor_id="user:alice"
+    )
+
+    assert updated is not None and updated.properties["arr"] == 175
+    stmts = await store.get_statements(obj_id, "arr")
+    resolution = resolve(stmts, default_trust_rules(), object_type="Customer")
+    assert resolution.value == 175 and resolution.winner_statement is not None
+    assert resolution.winner_statement.writer_class == "human"
+
+
+# ---------------------------------------------------------------------------
+# The divergence line in enforce: lww=what LWW would have kept,
+# resolver=what the cache now holds
+# ---------------------------------------------------------------------------
+
+
+async def test_enforce_divergence_line_logs_lww_vs_written(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-1"
+    )
+
+    lines = _shadow_lines(caplog)
+    assert lines == [
+        f"fabric shadow: object={obj_id} property=arr lww=150 resolver=120"
+        " diverged=True disputed=True unresolvable=False"
+    ]
+    assert DIVERGENCE_RE.fullmatch(lines[0])
+    # And "resolver" really is what the cache holds now (enforce semantics).
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120
+
+
+# ---------------------------------------------------------------------------
+# Failure shield: a broken statement pass degrades to LWW, never blocks
+# ---------------------------------------------------------------------------
+
+
+async def test_enforce_statement_pass_failure_falls_back_to_lww(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, _ = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    async def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("simulated statement-pass failure")
+
+    monkeypatch.setattr(store, "append_statement", _explode)
+    caplog.set_level(logging.WARNING, logger=STORE_LOGGER)
+
+    updated = await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-1"
+    )
+
+    assert updated is not None and updated.properties["arr"] == 150  # LWW fallback
+    assert any(
+        "falling back to LWW" in r.getMessage() for r in caplog.records if r.name == STORE_LOGGER
+    )
+
+
+# ---------------------------------------------------------------------------
+# THE SZD TEST — the payoff of the whole source-truth chain
+# ---------------------------------------------------------------------------
+
+
+class TestSzdProof:
+    """THE SZD TEST: what the whole Fabric source-truth chain exists to prove.
+
+    Before FST, the flat properties dict was blind last-write-wins: a
+    discovery-INFERRED value written after a connector sync silently
+    overwrote the connector's FACT, and nothing recorded that it happened.
+    With ``fabric_source_truth_mode=enforce``:
+
+    * a discovery-inferred value can NO LONGER beat a connector fact in the
+      cache — the trust ladder (connector > inferred) decides, not recency;
+    * the inferred claim is NOT lost — it lands as a rank="normal" statement,
+      the conflict is flagged (``is_disputed=True``), and the divergence line
+      records exactly what LWW would have done and what enforce did instead;
+    * order doesn't matter — when the inferred value came FIRST (the object's
+      creator) and the connector fact arrives SECOND, the connector still
+      wins the cache.
+    """
+
+    async def test_inferred_value_cannot_beat_connector_fact(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A connector-written fact...
+        store, obj_id, db_path = await _crm_object(tmp_path, industry="fintech")
+        _set_mode(monkeypatch, "enforce")
+        caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+        # ...hit by a discovery-style inferred write with a different value.
+        updated = await store.update_object(
+            obj_id,
+            {"industry": "crypto"},
+            writer_class="inferred",
+            source_session_id="discovery-run-1",
+        )
+
+        # The cache STILL shows the connector fact.
+        assert updated is not None and updated.properties["industry"] == "fintech"
+        obj = await store.get_object(obj_id)
+        assert obj is not None and obj.properties["industry"] == "fintech"
+
+        # The inferred claim exists as a rank="normal" statement — recorded,
+        # not silently discarded.
+        stmts = await store.get_statements(obj_id, "industry")
+        inferred = next(s for s in stmts if s.writer_class == "inferred")
+        assert inferred.value == "crypto" and inferred.rank == "normal"
+
+        # The conflict is flagged.
+        resolution = resolve(stmts, default_trust_rules(), object_type="Customer")
+        assert resolution.value == "fintech"
+        assert resolution.is_disputed is True
+
+        # And the divergence line shows it: LWW would have kept "crypto",
+        # enforce wrote "fintech".
+        lines = _shadow_lines(caplog)
+        assert lines == [
+            f'fabric shadow: object={obj_id} property=industry lww="crypto"'
+            ' resolver="fintech" diverged=True disputed=True unresolvable=False'
+        ]
+
+    async def test_reversed_order_connector_fact_still_wins_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The inferred value comes FIRST: discovery CREATED the object (no
+        # source_connector — an unattributed creator, so the promotion seed
+        # derives the object-level agent baseline; connector outranks both
+        # agent and inferred, so the ordering below is decided by trust
+        # either way).
+        db_path = tmp_path / "fabric.db"
+        store = FabricStore(db_path)
+        obj_type = await store.define_type(name="Customer", properties=[])
+        obj = await store.create_object(obj_type.id, {"industry": "crypto"})
+        _set_mode(monkeypatch, "enforce")
+
+        # The connector fact arrives second.
+        updated = await store.update_object(
+            obj.id,
+            {"industry": "fintech"},
+            writer_class="connector",
+            source_connector="crm",
+            source_run_id="run-1",
+        )
+
+        # The connector wins the cache — enforce is order-independent.
+        assert updated is not None and updated.properties["industry"] == "fintech"
+
+        # Both claims exist: the seeded pre-connector value + the fact.
+        stmts = await store.get_statements(obj.id, "industry")
+        assert {s.value for s in stmts} == {"crypto", "fintech"}
+        resolution = resolve(stmts, default_trust_rules(), object_type="Customer")
+        assert resolution.winner_statement is not None
+        assert resolution.winner_statement.writer_class == "connector"
+
+
+# ---------------------------------------------------------------------------
+# REVERSAL PROOF — enforce → off leaves a fully working, plain-LWW store
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_flipped_back_to_off_after_enforce(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A store that ran enforce (statements on disk + a resolver-owned cache),
+    flipped back to 'off': every read works and serves the last-RESOLVED
+    values, subsequent writes are plain LWW with ZERO statement machinery,
+    and nothing errors."""
+    store, obj_id, db_path = await _crm_object(tmp_path, industry="fintech", arr=120)
+    _set_mode(monkeypatch, "enforce")
+
+    # Enforce run: the inferred write loses; the cache holds the resolved
+    # connector fact and two statements are on disk.
+    await store.update_object(
+        obj_id,
+        {"industry": "crypto"},
+        writer_class="inferred",
+        source_session_id="discovery-run-1",
+    )
+    assert _table_count(db_path, "fabric_statements") == 2
+
+    # --- Flip back to off ---
+    _set_mode(monkeypatch, "off")
+
+    # Reads work and serve the last-resolved values.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["industry"] == "fintech"
+
+    # Subsequent writes: pure LWW, no statement verb is ever touched.
+    async def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("statements path touched in mode=off")
+
+    monkeypatch.setattr(store, "get_statements", _boom)
+    monkeypatch.setattr(store, "append_statement", _boom)
+    monkeypatch.setattr(store, "upsert_source", _boom)
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    updated = await store.update_object(obj_id, {"industry": "web3", "arr": 500})
+    assert updated is not None
+    assert updated.properties["industry"] == "web3"  # LWW resumed
+    assert updated.properties["arr"] == 500
+    assert _table_count(db_path, "fabric_statements") == 2  # untouched history
+    assert _shadow_lines(caplog) == []

--- a/tests/test_fabric_enforce_site2.py
+++ b/tests/test_fabric_enforce_site2.py
@@ -1,0 +1,159 @@
+# tests/test_fabric_enforce_site2.py
+# Created: 2026-07-10 (FST-5 — the ENFORCE decision for merge site 2).
+#
+# Site 2 (the journal projection) stays EVENT-FAITHFUL in enforce — that is
+# the deliberate FST-5 ruling documented at the top of fabric/projection.py:
+# the projection folds exactly what the journal says (plain LWW), and enforce
+# ownership of values applies at the STORE CACHE layer (the flat properties
+# dict — the primary read path per the FST constraints). This file is the
+# proof that the ruling is honest, not an accident:
+#
+#   * the store cache holds the RESOLVED value while the projection's
+#     in-memory fold (event-faithfully) differs — and the divergence line was
+#     emitted, so the gap is recorded telemetry, not a silent surprise,
+#   * a projection rebuild in enforce reproduces the same event-faithful fold
+#     (deterministic from the journal alone) with no statement double-append,
+#     and the store cache still holds the resolved value.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor
+
+from pocketpaw.fabric.journal_store import FabricJournalStore
+from pocketpaw.fabric.models import FabricObject
+from pocketpaw.fabric.resolver import resolve
+from pocketpaw.fabric.store import FabricStore
+from pocketpaw.fabric.trust import default_trust_rules
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+async def _mirrored_setup(tmp_path: Path, journal) -> tuple[FabricStore, FabricJournalStore, str]:
+    """One connector-owned object living in BOTH read models: a row in the
+    SQLite store (the flat-properties cache) and a created event in the
+    journal (the projection's source), sharing one object id."""
+    store = FabricStore(tmp_path / "fabric.db")
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        {"industry": "fintech"},
+        source_connector="crm",
+        source_id="c-1",
+    )
+    js = FabricJournalStore(journal, statement_store=store)
+    js.bootstrap()
+    await js.create(
+        FabricObject(
+            id=obj.id,
+            type_id=obj_type.id,
+            type_name="Customer",
+            properties={"industry": "fintech"},
+            source_connector="crm",
+            source_id="c-1",
+        ),
+        scope=["org"],
+    )
+    return store, js, obj.id
+
+
+async def test_store_cache_holds_resolved_value_while_projection_fold_differs(
+    tmp_path: Path,
+    journal,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, js, obj_id = await _mirrored_setup(tmp_path, journal)
+    _set_mode(monkeypatch, "enforce")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # An agent writes a different value THROUGH THE JOURNAL (site 2).
+    await js.update(
+        obj_id,
+        {"industry": "crypto"},
+        scope=["org"],
+        actor=Actor(kind="agent", id="did:soul:discovery", scope_context=[]),
+    )
+
+    # The projection is event-faithful: its fold shows the journal's LWW.
+    projected = await js.get(obj_id)
+    assert projected is not None and projected.properties["industry"] == "crypto"
+
+    # The statements were recorded through the shared machinery, and the
+    # resolver's winner is the connector fact.
+    stmts = await store.get_statements(obj_id, "industry")
+    assert {s.value for s in stmts} == {"fintech", "crypto"}
+    resolution = resolve(stmts, default_trust_rules(), object_type="Customer")
+    assert resolution.value == "fintech" and resolution.is_disputed is True
+
+    # THE RULING'S PROOF: the store cache (the primary read path) holds the
+    # resolved value even though the projection's in-memory fold differs.
+    cached = await store.get_object(obj_id)
+    assert cached is not None and cached.properties["industry"] == "fintech"
+    assert cached.properties["industry"] != projected.properties["industry"]
+
+    # ...and a site-1 write on the same object keeps the cache resolver-owned:
+    # a second inferred claim still cannot displace the connector fact.
+    updated = await store.update_object(
+        obj_id,
+        {"industry": "web3"},
+        writer_class="inferred",
+        source_session_id="discovery-run-2",
+    )
+    assert updated is not None and updated.properties["industry"] == "fintech"
+
+    # The projection/resolver gap is RECORDED telemetry, not a silent hole:
+    # the journal update's own divergence line was emitted at flush time.
+    assert any(
+        f"object={obj_id} property=industry" in line and 'lww="crypto"' in line
+        for line in _shadow_lines(caplog)
+    )
+
+
+async def test_projection_rebuild_stays_event_faithful_in_enforce(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, js, obj_id = await _mirrored_setup(tmp_path, journal)
+    _set_mode(monkeypatch, "enforce")
+
+    await js.update(
+        obj_id,
+        {"industry": "crypto"},
+        scope=["org"],
+        actor=Actor(kind="agent", id="did:soul:discovery", scope_context=[]),
+    )
+    assert len(await store.get_statements(obj_id, "industry")) == 2
+
+    # Rebuild from the journal: the fold is deterministic from the journal
+    # ALONE (the event-faithful guarantee), the event-id dedupe prevents any
+    # statement double-append, and the store cache stays resolver-owned.
+    js.bootstrap()
+    assert await js.flush_shadow() == 0  # already recorded — deduped
+    projected = await js.get(obj_id)
+    assert projected is not None and projected.properties["industry"] == "crypto"
+    assert len(await store.get_statements(obj_id, "industry")) == 2
+    cached = await store.get_object(obj_id)
+    assert cached is not None and cached.properties["industry"] == "fintech"

--- a/tests/test_fabric_freshness.py
+++ b/tests/test_fabric_freshness.py
@@ -1,0 +1,453 @@
+# tests/test_fabric_freshness.py
+# Created: 2026-07-11 (FST-7 — freshness: TTL classes, the pure tri-state,
+#   within-family staleness demotion, provenance on reads).
+#
+# Part 1 — trust.py: the named TTL classes (volatile=1d, default=30d,
+#   stable=365d), per-(object_type, property) class overrides mirroring the
+#   ladder-override style, the layered max_age_for lookup (instance dict over
+#   module defaults, unknown class → "default"), and the pure
+#   freshness(observed_at, max_age_seconds, now) tri-state including the
+#   UTC-normalization convention (naive = UTC at the comparison boundary).
+#   Back-compat: default_trust_rules() still serializes with an EMPTY
+#   freshness_ttl_classes dict (the FST-2 wire format).
+# Part 2 — resolver.py: within-FAMILY staleness demotion at tier selection —
+#   the FST-5 flagged case (stale connector seed loses to the fresh mirror
+#   value), demotion never crossing families (stale connector still beats
+#   fresh inferred), within-tier demotion across the rank leg, aging does
+#   NOT demote, all-stale keeps ladder order, a lone stale value still wins,
+#   pins ignore freshness, per-property TTL-class overrides steer demotion,
+#   freshness-demoted losers are RESOLVED (no dispute / un-rankable noise),
+#   and now=None is byte-identical legacy behavior.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.models import Statement
+from pocketpaw.fabric.resolver import resolve
+from pocketpaw.fabric.trust import (
+    DEFAULT_FRESHNESS_CLASS,
+    DEFAULT_FRESHNESS_TTL_CLASSES,
+    FreshnessOverride,
+    TrustRules,
+    default_trust_rules,
+    freshness,
+)
+
+NOW = datetime(2026, 7, 11, 12, 0, 0, tzinfo=UTC)
+DAY = 86400.0
+
+
+# ------------------------------------------------------------- TTL classes
+
+
+def test_default_ttl_classes_named_values():
+    """The three named volatility classes carry the documented max-ages."""
+    assert DEFAULT_FRESHNESS_TTL_CLASSES == {
+        "volatile": 86400.0,  # 1 day
+        "default": 2592000.0,  # 30 days
+        "stable": 31536000.0,  # 365 days
+    }
+
+
+def test_default_trust_rules_wire_format_unchanged():
+    """FST-2 back-compat: the INSTANCE dict stays empty (module defaults
+    apply through max_age_for) and no freshness overrides ship by default."""
+    rules = default_trust_rules()
+    assert rules.freshness_ttl_classes == {}
+    assert rules.freshness_overrides == []
+
+
+def test_ttl_class_for_unassigned_property_is_default():
+    rules = default_trust_rules()
+    assert rules.ttl_class_for("person", "email") == DEFAULT_FRESHNESS_CLASS
+
+
+def test_ttl_class_for_override_first_exact_match_wins():
+    rules = TrustRules(
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="volatile"),
+            FreshnessOverride(object_type="person", property="status", ttl_class="stable"),
+            FreshnessOverride(object_type="company", property="founded", ttl_class="stable"),
+        ]
+    )
+    assert rules.ttl_class_for("person", "status") == "volatile"  # first match
+    assert rules.ttl_class_for("company", "founded") == "stable"
+    assert rules.ttl_class_for("person", "founded") == "default"  # both must match
+
+
+def test_ttl_class_for_none_object_type_never_matches_override():
+    rules = TrustRules(
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="volatile"),
+        ]
+    )
+    assert rules.ttl_class_for(None, "status") == DEFAULT_FRESHNESS_CLASS
+
+
+def test_max_age_for_resolves_named_classes_from_module_defaults():
+    rules = TrustRules(
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="volatile"),
+            FreshnessOverride(object_type="company", property="founded", ttl_class="stable"),
+        ]
+    )
+    assert rules.max_age_for("person", "status") == 86400.0
+    assert rules.max_age_for("company", "founded") == 31536000.0
+    assert rules.max_age_for("person", "email") == 2592000.0  # unassigned → default
+
+
+def test_max_age_for_instance_dict_overrides_module_default():
+    """The instance dict is an OVERRIDE layer: redefining a class name wins
+    over the module default for that class."""
+    rules = TrustRules(
+        freshness_ttl_classes={"volatile": 3600.0},
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="volatile"),
+        ],
+    )
+    assert rules.max_age_for("person", "status") == 3600.0
+    # Untouched classes still come from the module defaults.
+    assert rules.max_age_for("person", "email") == 2592000.0
+
+
+def test_max_age_for_unknown_class_falls_back_to_default():
+    """A typo'd class name degrades to the default class, never raises."""
+    rules = TrustRules(
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="nope"),
+        ]
+    )
+    assert rules.max_age_for("person", "status") == 2592000.0
+
+
+def test_max_age_for_unknown_class_uses_instance_default_when_redefined():
+    rules = TrustRules(
+        freshness_ttl_classes={"default": 100.0},
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="nope"),
+        ],
+    )
+    assert rules.max_age_for("person", "status") == 100.0
+    assert rules.max_age_for("person", "email") == 100.0
+
+
+# ------------------------------------------------------- freshness tri-state
+
+
+@pytest.mark.parametrize(
+    ("age_seconds", "expected"),
+    [
+        (0.0, "fresh"),
+        (DAY, "fresh"),  # exactly max_age → still fresh
+        (DAY + 1, "aging"),
+        (2 * DAY, "aging"),  # exactly 2*max_age → still aging
+        (2 * DAY + 1, "stale"),
+        (100 * DAY, "stale"),
+    ],
+)
+def test_freshness_boundaries(age_seconds, expected):
+    observed = NOW - timedelta(seconds=age_seconds)
+    assert freshness(observed, DAY, NOW) == expected
+
+
+def test_freshness_future_observed_at_is_fresh():
+    """Negative age (source clock ahead) classifies fresh, never raises."""
+    assert freshness(NOW + timedelta(hours=3), DAY, NOW) == "fresh"
+
+
+def test_freshness_naive_inputs_are_read_as_utc():
+    """THE convention: a naive datetime is interpreted AS UTC at the
+    comparison boundary — a naive-UTC stamp (SQLite datetime('now')) and the
+    same instant written as aware-UTC classify identically."""
+    naive_utc_observed = datetime(2026, 7, 11, 12, 0, 0) - timedelta(days=1, seconds=1)
+    aware_observed = naive_utc_observed.replace(tzinfo=UTC)
+    assert freshness(naive_utc_observed, DAY, NOW) == "aging"
+    assert freshness(aware_observed, DAY, NOW) == freshness(naive_utc_observed, DAY, NOW)
+
+
+def test_freshness_naive_now_matches_aware_now():
+    """A naive-UTC ``now`` (e.g. parsed back from datetime('now')) and the
+    aware datetime.now(timezone.utc) convention agree."""
+    naive_now = datetime(2026, 7, 11, 12, 0, 0)
+    observed = datetime(2026, 7, 8, 12, 0, 0)
+    assert freshness(observed, DAY, naive_now) == freshness(observed, DAY, NOW) == "stale"
+
+
+def test_freshness_mixed_naive_and_aware_never_raises_and_orders_correctly():
+    """Naive-local vs naive-UTC: under the naive-as-UTC rule both are read on
+    ONE axis, so ages stay monotonic — an earlier naive stamp is always at
+    least as decayed as a later one, and mixing naive/aware never raises."""
+    older_naive = datetime(2026, 7, 1, 12, 0, 0)  # e.g. a naive-local default
+    newer_naive = datetime(2026, 7, 11, 11, 0, 0)  # e.g. a naive-UTC stamp
+    order = {"fresh": 0, "aging": 1, "stale": 2}
+    older_state = freshness(older_naive, DAY, NOW)  # aware now
+    newer_state = freshness(newer_naive, DAY, NOW)
+    assert order[older_state] >= order[newer_state]
+    assert older_state == "stale"
+    assert newer_state == "fresh"
+
+
+def test_freshness_aware_non_utc_input_converts():
+    """An aware non-UTC datetime is CONVERTED (not stripped): +05:30 wall
+    time 36h ago is 36h old regardless of its zone."""
+    ist = timezone(timedelta(hours=5, minutes=30))
+    observed = (NOW - timedelta(hours=36)).astimezone(ist)
+    assert freshness(observed, DAY, NOW) == "aging"
+
+
+# ---------------------------------------- Part 2: within-family demotion
+
+_counter = 0
+
+
+def fstmt(
+    *,
+    value: Any,
+    writer_class: str = "connector",
+    observed_at: datetime = NOW,
+    rank: str = "normal",
+    pinned: bool = False,
+    object_id: str = "obj-1",
+    property: str = "email",
+) -> Statement:
+    """Statement factory with deterministic ids (fst7-0001, fst7-0002, ...).
+
+    All timestamps in these tests are aware UTC — the freshness/naive
+    conventions are covered by the Part 1 unit tests above."""
+    global _counter
+    _counter += 1
+    return Statement(
+        id=f"fst7-{_counter:04d}",
+        object_id=object_id,
+        property=property,
+        value=value,
+        source_ref_id="src-test",
+        writer_class=writer_class,  # type: ignore[arg-type]
+        observed_at=observed_at,
+        recorded_at=observed_at,
+        valid_from=observed_at,
+        rank=rank,  # type: ignore[arg-type]
+        pinned=pinned,
+    )
+
+
+def test_stale_connector_seed_loses_to_fresh_mirror_value():
+    """THE FST-5 FLAGGED CASE: a connector seed observed 90d ago (class
+    "default" → max-age 30d → stale beyond 60d) loses to the mirror's fresh
+    value when ``now`` is passed, even though the ladder ranks connector >
+    mirror — same machine-sync family, so demotion applies. The demoted
+    stale loser is RESOLVED: no dispute, no un-rankable noise."""
+    stale_seed = fstmt(
+        value="old@x.com", writer_class="connector", observed_at=NOW - timedelta(days=90)
+    )
+    fresh_mirror = fstmt(
+        value="new@x.com", writer_class="mirror", observed_at=NOW - timedelta(days=1)
+    )
+    res = resolve([stale_seed, fresh_mirror], default_trust_rules(), now=NOW)
+    assert res.winner_statement is fresh_mirror
+    assert res.value == "new@x.com"
+    assert res.losers == [stale_seed]
+    assert res.is_disputed is False
+    assert res.unresolvable is False
+
+
+def test_stale_connector_does_not_lose_to_fresh_inferred():
+    """Demotion NEVER crosses families: a stale connector value still beats
+    a fresh inferred value — and the cross-family fresh loser keeps the
+    normal dispute semantics (no freshness exclusion)."""
+    stale_conn = fstmt(
+        value="old@x.com", writer_class="connector", observed_at=NOW - timedelta(days=90)
+    )
+    fresh_inferred = fstmt(
+        value="new@x.com", writer_class="inferred", observed_at=NOW - timedelta(days=1)
+    )
+    res = resolve([stale_conn, fresh_inferred], default_trust_rules(), now=NOW)
+    assert res.winner_statement is stale_conn
+    assert res.value == "old@x.com"
+    assert res.is_disputed is True  # open, materially different, not resolved by freshness
+    assert res.unresolvable is False
+
+
+def test_now_none_skips_freshness_entirely():
+    """Back-compat: without ``now`` the FST-5 flagged pair resolves exactly
+    as pre-FST-7 — the ladder puts connector above mirror, stale or not."""
+    stale_seed = fstmt(
+        value="old@x.com", writer_class="connector", observed_at=NOW - timedelta(days=90)
+    )
+    fresh_mirror = fstmt(
+        value="new@x.com", writer_class="mirror", observed_at=NOW - timedelta(days=1)
+    )
+    res = resolve([stale_seed, fresh_mirror], default_trust_rules())
+    assert res.winner_statement is stale_seed
+    assert res.value == "old@x.com"
+    assert res.is_disputed is True  # normal FST-2 semantics, no freshness pass
+
+
+def test_stale_preferred_loses_to_fresh_normal_within_tier():
+    """Within one tier the rank leg puts preferred first — but a STALE
+    preferred still loses to a fresh normal from the same family."""
+    stale_preferred = fstmt(
+        value="old",
+        writer_class="connector",
+        observed_at=NOW - timedelta(days=90),
+        rank="preferred",
+    )
+    fresh_normal = fstmt(value="new", writer_class="connector", observed_at=NOW - timedelta(days=1))
+    res = resolve([stale_preferred, fresh_normal], default_trust_rules(), now=NOW)
+    assert res.winner_statement is fresh_normal
+    assert res.is_disputed is False
+
+
+def test_aging_winner_is_not_demoted():
+    """Only STALE demotes: an aging top candidate (40d on the 30d default
+    class) keeps the win over a fresh same-family value."""
+    aging_conn = fstmt(value="old", writer_class="connector", observed_at=NOW - timedelta(days=40))
+    fresh_mirror = fstmt(value="new", writer_class="mirror", observed_at=NOW - timedelta(days=1))
+    res = resolve([aging_conn, fresh_mirror], default_trust_rules(), now=NOW)
+    assert res.winner_statement is aging_conn
+    assert res.is_disputed is True  # fresh loser is NOT freshness-resolved
+
+
+def test_all_stale_same_family_keeps_ladder_order():
+    """No non-stale candidate in the family → no demotion: ladder order
+    stands even though everything is stale (reads never block)."""
+    stale_conn = fstmt(value="a", writer_class="connector", observed_at=NOW - timedelta(days=90))
+    stale_mirror = fstmt(value="b", writer_class="mirror", observed_at=NOW - timedelta(days=80))
+    res = resolve([stale_conn, stale_mirror], default_trust_rules(), now=NOW)
+    assert res.winner_statement is stale_conn
+    assert res.is_disputed is True  # winner stale → no freshness exclusion
+
+
+def test_lone_stale_value_still_wins():
+    stale = fstmt(value="old", writer_class="connector", observed_at=NOW - timedelta(days=400))
+    res = resolve([stale], default_trust_rules(), now=NOW)
+    assert res.winner_statement is stale
+    assert res.value == "old"
+
+
+def test_pinned_stale_still_wins_with_now():
+    """A pin is authoritative — the pinned short-circuit runs before the
+    ladder path and ignores freshness entirely."""
+    stale_pinned = fstmt(
+        value="pinned", writer_class="mirror", observed_at=NOW - timedelta(days=400), pinned=True
+    )
+    fresh_conn = fstmt(value="new", writer_class="connector", observed_at=NOW - timedelta(days=1))
+    res = resolve([stale_pinned, fresh_conn], default_trust_rules(), now=NOW)
+    assert res.winner_statement is stale_pinned
+    assert res.value == "pinned"
+
+
+def test_freshness_class_override_steers_demotion():
+    """The per-(object_type, property) TTL class drives the demotion: a 3d-old
+    connector value is stale on the "volatile" class (1d) but fresh on the
+    default class (30d)."""
+    conn_3d = fstmt(
+        value="old",
+        writer_class="connector",
+        observed_at=NOW - timedelta(days=3),
+        object_id="obj-2",
+        property="status",
+    )
+    mirror_1h = fstmt(
+        value="new",
+        writer_class="mirror",
+        observed_at=NOW - timedelta(hours=1),
+        object_id="obj-2",
+        property="status",
+    )
+    volatile_rules = TrustRules(
+        freshness_overrides=[
+            FreshnessOverride(object_type="person", property="status", ttl_class="volatile"),
+        ]
+    )
+    res = resolve([conn_3d, mirror_1h], volatile_rules, object_type="person", now=NOW)
+    assert res.winner_statement is mirror_1h  # stale on volatile → demoted
+    res_default = resolve(
+        [conn_3d, mirror_1h], default_trust_rules(), object_type="person", now=NOW
+    )
+    assert res_default.winner_statement is conn_3d  # fresh on default → ladder stands
+
+
+def test_boundary_straddling_pair_resolves_with_now():
+    """Two same-tier same-rank connector values within the 24h epsilon would
+    be UN-RANKABLE under FST-2 — but when one side is stale and the winner is
+    not, the stale side is freshness-resolved: no unresolvable, no dispute."""
+    just_stale = fstmt(
+        value="a", writer_class="connector", observed_at=NOW - timedelta(days=60, hours=2)
+    )
+    just_aging = fstmt(
+        value="b", writer_class="connector", observed_at=NOW - timedelta(days=59, hours=12)
+    )
+    legacy = resolve([just_stale, just_aging], default_trust_rules())
+    assert legacy.unresolvable is True  # the FST-2 semantics, unchanged without now
+    res = resolve([just_stale, just_aging], default_trust_rules(), now=NOW)
+    assert res.winner_statement is just_aging  # newer → ranked first, no demotion needed
+    assert res.unresolvable is False
+    assert res.is_disputed is False
+
+
+# ---------------------------------------------------------------------------
+# Part 3 — the provenance read surface (store.get_object_provenance, FST-7)
+# ---------------------------------------------------------------------------
+
+
+async def _tracked_crm_object(tmp_path, monkeypatch):
+    """A store in shadow mode with one object whose ``arr`` property is
+    statement-tracked (promoted by a second-source agent write)."""
+    from pocketpaw.fabric.store import FabricStore
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: "shadow")
+    store = FabricStore(tmp_path / "fabric.db")
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id, {"name": "Acme", "arr": 120}, source_connector="crm", source_id="c-1"
+    )
+    await store.update_object(obj.id, {"arr": 150}, writer_class="agent", source_session_id="s1")
+    return store, obj.id
+
+
+async def test_get_object_provenance_reports_tracked_property(tmp_path, monkeypatch):
+    """The opt-in read surface: a tracked property reports dispute state,
+    freshness, statement count, and the WINNER's writer + source summary;
+    untracked properties (``name``) don't appear at all."""
+    store, obj_id = await _tracked_crm_object(tmp_path, monkeypatch)
+
+    prov = await store.get_object_provenance(obj_id)
+
+    assert set(prov.keys()) == {"arr"}  # "name" untracked -> absent
+    entry = prov["arr"]
+    assert entry["statements"] == 2
+    assert entry["disputed"] is True  # open agent rival vs connector seed
+    assert entry["freshness"] == "fresh"  # both written moments ago
+    winner = entry["winner"]
+    assert winner["writer_class"] == "connector"  # ladder: connector > agent
+    assert winner["source"]["kind"] == "connector_run"
+    assert winner["source"]["connector"] == "crm"
+
+
+async def test_get_object_provenance_empty_when_nothing_tracked(tmp_path, monkeypatch):
+    from pocketpaw.fabric.store import FabricStore
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: "shadow")
+    store = FabricStore(tmp_path / "fabric.db")
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(obj_type.id, {"name": "Acme"}, source_connector="crm")
+
+    assert await store.get_object_provenance(obj.id) == {}
+
+
+async def test_resolution_exposes_winner_freshness(tmp_path, monkeypatch):
+    """The Resolution model carries the winner's tri-state when ``now`` is
+    passed (the divergence line + read surface consume it) and None for
+    legacy ``now=None`` callers."""
+    stmts = [
+        fstmt(value="a@b.co", writer_class="connector", observed_at=NOW - timedelta(days=2)),
+    ]
+    with_now = resolve(stmts, default_trust_rules(), now=NOW)
+    assert with_now.winner_freshness == "fresh"
+    legacy = resolve(stmts, default_trust_rules())
+    assert legacy.winner_freshness is None

--- a/tests/test_fabric_mode_ladder.py
+++ b/tests/test_fabric_mode_ladder.py
@@ -1,0 +1,198 @@
+# tests/test_fabric_mode_ladder.py
+# Created: 2026-07-11 (FST-8 — the operational proof kit).
+#
+# THE FULL ROLLOUT LADDER, end to end: ONE store walked through
+# off → shadow → enforce → off, asserting the mode contract at every rung:
+#
+#   rung 1 (off)     — writes are pure LWW, ZERO statements, ZERO log lines;
+#   rung 2 (shadow)  — multi-source writes produce statements + divergence
+#                      lines while the cache still takes the LWW value;
+#   rung 3 (enforce) — the resolver owns the cache (a lower-trust write no
+#                      longer lands), and the CHANGE curation verb works;
+#   rung 4 (off)     — reads serve the last-resolved cache, LWW resumes with
+#                      the statement machinery untouched, history intact,
+#                      nothing errors.
+#
+# Plus the harness integration: the REAL divergence lines captured at rung 2
+# are fed through parse_divergence_lines + summarize — the FST-8 report
+# consumes actual store emissions, so this doubles as the contract
+# integration test (if the line format drifts, THIS breaks, not production
+# rollouts).
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.divergence_report import (
+    format_report,
+    parse_divergence_lines,
+    summarize,
+)
+from pocketpaw.fabric.store import FabricStore
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """The divergence lines (excludes the failure-shield warning)."""
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+def _table_count(db_path: Path, table: str) -> int:
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    finally:
+        con.close()
+
+
+async def test_full_mode_ladder_off_shadow_enforce_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+
+    # A connector-owned object: the crm connector is the property baseline.
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        {"name": "Acme", "industry": "fintech", "arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+
+    # ---------------- rung 1: mode=off — pure LWW, zero statements --------
+    _set_mode(monkeypatch, "off")
+    updated = await store.update_object(obj.id, {"arr": 150}, writer_class="agent")
+    assert updated is not None
+    assert updated.properties == {"name": "Acme", "industry": "fintech", "arr": 150}
+    assert _table_count(db_path, "fabric_statements") == 0
+    assert _table_count(db_path, "fabric_sources") == 0
+    assert _shadow_lines(caplog) == []
+
+    # ---------------- rung 2: flip shadow — statements + lines, cache LWW -
+    _set_mode(monkeypatch, "shadow")
+    caplog.clear()
+
+    # A second distinct source (agent session vs the crm baseline) touching
+    # two connector-held properties → both get PROMOTED (seed + incoming
+    # statement each) and each produces one divergence line.
+    updated = await store.update_object(
+        obj.id,
+        {"arr": 200, "industry": "crypto"},
+        writer_class="agent",
+        source_session_id="sess-1",
+    )
+    assert updated is not None
+
+    # The cache still takes the LWW value in shadow — resolver is advisory.
+    assert updated.properties["arr"] == 200
+    assert updated.properties["industry"] == "crypto"
+
+    # Statements exist: one promotion seed + one incoming, per property.
+    assert _table_count(db_path, "fabric_statements") == 4
+    arr_stmts = await store.get_statements(obj.id, "arr")
+    assert {s.writer_class for s in arr_stmts} == {"connector", "agent"}
+    assert {s.value for s in arr_stmts} == {150, 200}
+
+    # One divergence line per statement-producing property, and the resolver
+    # disagreed with LWW (connector seed outranks the agent write) — a
+    # DISPUTED, therefore EXPLAINED, divergence on both.
+    rung2_lines = _shadow_lines(caplog)
+    assert len(rung2_lines) == 2
+    assert all(" diverged=True disputed=True unresolvable=False" in ln for ln in rung2_lines)
+
+    # ---------------- rung 3: flip enforce — the resolver owns the cache --
+    _set_mode(monkeypatch, "enforce")
+    caplog.clear()
+
+    # A lower-trust write (inferred < connector seed) NO LONGER lands in the
+    # cache: LWW would have written 300; enforce keeps the resolved winner.
+    updated = await store.update_object(
+        obj.id, {"arr": 300}, writer_class="inferred", source_session_id="sess-2"
+    )
+    assert updated is not None
+    assert updated.properties["arr"] == 150  # the connector seed's value, not 300
+    reread = await store.get_object(obj.id)
+    assert reread is not None and reread.properties["arr"] == 150
+
+    # The losing claim is recorded, not dropped, and the line shows the
+    # override (lww=what LWW would have kept, resolver=what the cache holds).
+    assert any(s.value == 300 for s in await store.get_statements(obj.id, "arr"))
+    [enforce_line] = _shadow_lines(caplog)
+    assert "property=arr lww=300 resolver=150 diverged=True" in enforce_line
+
+    # The CHANGE curation verb works in enforce: a human preferred statement
+    # takes the top trust tier and the cache follows the new winner.
+    resolution = await store.change_property(
+        obj.id, "arr", 500, writer_class="human", source_actor_id="captain"
+    )
+    assert resolution.value == 500
+    assert resolution.winner_statement is not None
+    assert resolution.winner_statement.rank == "preferred"
+    reread = await store.get_object(obj.id)
+    assert reread is not None and reread.properties["arr"] == 500
+
+    # ---------------- rung 4: flip back off — LWW resumes, history intact -
+    _set_mode(monkeypatch, "off")
+    caplog.clear()
+    statements_before = _table_count(db_path, "fabric_statements")
+
+    # Reads serve the last-RESOLVED cache.
+    obj_after = await store.get_object(obj.id)
+    assert obj_after is not None
+    assert obj_after.properties["arr"] == 500  # the enforced CHANGE result
+    assert obj_after.properties["industry"] == "crypto"  # shadow-era LWW cache
+
+    # Subsequent writes are pure LWW and never touch the statement verbs.
+    async def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("statements path touched in mode=off")
+
+    monkeypatch.setattr(store, "get_statements", _boom)
+    monkeypatch.setattr(store, "append_statement", _boom)
+    monkeypatch.setattr(store, "upsert_source", _boom)
+
+    updated = await store.update_object(obj.id, {"arr": 700, "name": "Acme Corp"})
+    assert updated is not None
+    assert updated.properties["arr"] == 700  # LWW resumed
+    assert updated.properties["name"] == "Acme Corp"
+    assert _table_count(db_path, "fabric_statements") == statements_before  # history intact
+    assert _shadow_lines(caplog) == []
+
+    # ---------------- the harness consumes the REAL rung-2 emissions ------
+    records = parse_divergence_lines(rung2_lines)
+    assert len(records) == 2
+    assert all(r.ok for r in records), [r.parse_error for r in records]
+    by_prop = {r.property: r for r in records}
+    assert set(by_prop) == {"arr", "industry"}
+    assert by_prop["arr"].lww == 200 and by_prop["arr"].resolver == 150
+    assert by_prop["industry"].lww == "crypto" and by_prop["industry"].resolver == "fintech"
+    assert all(r.object_id == obj.id for r in records)
+    assert all(r.diverged and r.disputed and not r.unresolvable for r in records)
+    assert all(r.freshness == "fresh" for r in records)
+
+    # Both divergences are EXPLAINED (flagged disputes — multi-source
+    # ordering doing its job), so the shadow run reads as enforce-ready.
+    summary = summarize(records)
+    assert summary.total == 2
+    assert summary.diverged == 2
+    assert summary.disputed == 2
+    assert summary.unexplained == 0
+    assert summary.parse_errors == 0
+    assert summary.enforce_ready is True
+    report = format_report(summary)
+    assert report.splitlines()[-1] == "ENFORCE-READY: yes (0 unexplained)"

--- a/tests/test_fabric_pin_ignore.py
+++ b/tests/test_fabric_pin_ignore.py
@@ -1,0 +1,324 @@
+# tests/test_fabric_pin_ignore.py
+# Created: 2026-07-10 (FST-6 — the PIN / UNPIN / IGNORE steward verbs).
+#
+# Proves the three statement-layer steward verbs (siblings of FST-5's
+# CHANGE/CORRECT — the operations the Instinct stewardship executor calls):
+#
+#   * PIN — sets pinned=True on one existing, non-deprecated statement; the
+#     resolver's pinned short-circuit then makes it win outright, above every
+#     ladder tier and immune to newer/higher-tier rivals (pinned-beats-
+#     everything), while the losers stay intact for audit,
+#   * UNPIN — retracts the flag; resolution falls back to the trust ladder,
+#   * IGNORE — deprecates the statement with rank_reason=<reason> (struck
+#     from resolution entirely, default reason "steward_ignored"),
+#   * all three return the NEW Resolution and are mode-respecting on the
+#     cache (enforce writes the new resolver winner; shadow/off leave the
+#     cache alone),
+#   * error paths: missing object, missing/cross-workspace statement, and
+#     PIN on a deprecated statement all raise ValueError (clean seam
+#     failures for the FST-6 executor),
+#   * deprecating the ONLY live statement leaves a winner-less Resolution
+#     and (in enforce) the cache keeps its last value.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.resolver import resolve
+from pocketpaw.fabric.store import FabricStore
+from pocketpaw.fabric.trust import default_trust_rules
+
+pytestmark = pytest.mark.asyncio
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+async def _crm_object(tmp_path: Path, **props: Any) -> tuple[FabricStore, str]:
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        props or {"name": "Acme", "arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+    return store, obj.id
+
+
+async def _tracked_arr(store: FabricStore, obj_id: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Track ``arr`` via the FST-3 promotion (agent write in shadow mode so
+    the cache stays LWW during setup): seed(connector, 120) + agent(150).
+    The ladder ranks connector > agent, so the seed (120) is the winner."""
+    _set_mode(monkeypatch, "shadow")
+    await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-setup"
+    )
+    assert len(await store.get_statements(obj_id, "arr")) == 2
+
+
+async def _agent_statement_id(store: FabricStore, obj_id: str) -> str:
+    stmts = await store.get_statements(obj_id, "arr")
+    return next(s.id for s in stmts if s.writer_class == "agent")
+
+
+async def _connector_statement_id(store: FabricStore, obj_id: str) -> str:
+    stmts = await store.get_statements(obj_id, "arr")
+    return next(s.id for s in stmts if s.writer_class == "connector")
+
+
+# ---------------------------------------------------------------------------
+# PIN — the durable "this one wins"
+# ---------------------------------------------------------------------------
+
+
+async def test_pin_makes_lower_tier_statement_win(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    agent_id = await _agent_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.pin_statement(obj_id, "arr", agent_id)
+
+    # The pinned agent statement short-circuits the ladder — it beats the
+    # connector-tier winner outright.
+    assert resolution.value == 150
+    assert resolution.winner_statement is not None
+    assert resolution.winner_statement.id == agent_id
+    assert resolution.winner_statement.pinned is True
+    assert resolution.unresolvable is False  # a pin is authoritative
+
+    # The loser stays intact for audit (not deprecated, not closed).
+    loser = next(s for s in resolution.losers if s.writer_class == "connector")
+    assert loser.rank == "normal" and loser.valid_to is None
+
+    # Shadow: the cache is untouched by the verb.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150  # LWW setup value
+
+
+async def test_pin_enforce_updates_cache_to_pinned_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)  # cache holds the LWW 150
+    connector_id = await _connector_statement_id(store, obj_id)
+    agent_id = await _agent_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "enforce")
+
+    # Pin the connector statement: the cache flips 150 → 120 (proves the
+    # enforce write — the cache held the setup's LWW value before).
+    resolution = await store.pin_statement(obj_id, "arr", connector_id)
+    assert resolution.value == 120
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120  # resolver-owned cache
+
+    # Re-point the pin at the agent statement: the cache follows.
+    await store.unpin_statement(obj_id, "arr", connector_id)
+    resolution = await store.pin_statement(obj_id, "arr", agent_id)
+    assert resolution.value == 150
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150
+
+    # Un-pinning reverts resolution (and the cache) to the ladder winner.
+    reverted = await store.unpin_statement(obj_id, "arr", agent_id)
+    assert reverted.value == 120
+    assert reverted.winner_statement is not None
+    assert reverted.winner_statement.id == connector_id
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120
+
+
+async def test_pinned_beats_everything_even_later_human_statement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pinned-beats-everything via the resolver: after the pin, a NEW
+    human-tier (top of the ladder) statement still loses to the pin."""
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    agent_id = await _agent_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "shadow")
+    await store.pin_statement(obj_id, "arr", agent_id)
+
+    src = await store.upsert_source("human_actor", actor_id="user:bob")
+    await store.append_statement(obj_id, "arr", 999, src.id, "human")
+
+    stmts = await store.get_statements(obj_id, "arr")
+    resolution = resolve(stmts, default_trust_rules(), object_type="Customer")
+    assert resolution.winner_statement is not None
+    assert resolution.winner_statement.id == agent_id
+    assert resolution.value == 150
+    # The human rival is an open, materially different survivor → disputed,
+    # but never unresolvable on the pinned path.
+    assert resolution.is_disputed is True
+    assert resolution.unresolvable is False
+
+
+async def test_pin_does_not_auto_unpin_other_pins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    agent_id = await _agent_statement_id(store, obj_id)
+    connector_id = await _connector_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "shadow")
+
+    await store.pin_statement(obj_id, "arr", agent_id)
+    resolution = await store.pin_statement(obj_id, "arr", connector_id)
+
+    # Both pins survive; two pins is a curation conflict the resolver
+    # deliberately flags as disputed (newest recorded pin wins).
+    stmts = await store.get_statements(obj_id, "arr")
+    assert sum(1 for s in stmts if s.pinned) == 2
+    assert resolution.is_disputed is True
+
+
+# ---------------------------------------------------------------------------
+# IGNORE — strike a bogus claim
+# ---------------------------------------------------------------------------
+
+
+async def test_ignore_deprecates_statement_with_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    connector_id = await _connector_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "shadow")
+
+    resolution = await store.ignore_statement(obj_id, "arr", connector_id)
+
+    # The ignored (connector) winner is struck; the agent statement wins.
+    assert resolution.value == 150
+    stmts = await store.get_statements(obj_id, "arr")
+    ignored = next(s for s in stmts if s.id == connector_id)
+    assert ignored.rank == "deprecated"
+    assert ignored.rank_reason == "steward_ignored"  # the default reason
+    # Struck entirely: not the winner, not a loser.
+    assert connector_id not in {s.id for s in resolution.losers}
+
+    # Shadow: cache untouched.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150
+
+
+async def test_ignore_enforce_updates_cache_and_custom_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)  # cache holds the LWW 150
+    agent_id = await _agent_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "enforce")
+
+    # Strike the agent statement: the connector 120 is the only survivor and
+    # the cache flips 150 → 120 (proves the enforce write).
+    resolution = await store.ignore_statement(obj_id, "arr", agent_id, reason="stale export")
+
+    assert resolution.value == 120
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 120
+    stmts = await store.get_statements(obj_id, "arr")
+    ignored = next(s for s in stmts if s.id == agent_id)
+    assert ignored.rank_reason == "stale export"
+
+
+async def test_ignore_only_statement_leaves_cache_and_no_winner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deprecating the ONLY live statement → winner-less Resolution; in
+    enforce the cache keeps its last value (reads never lose a key)."""
+    store, obj_id = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    # Track "name" via an explicit human change (seed + preferred change).
+    await store.change_property(
+        obj_id, "name", "Acme Corp", writer_class="human", source_actor_id="user:alice"
+    )
+    stmts = await store.get_statements(obj_id, "name")
+    assert len(stmts) == 2
+    _set_mode(monkeypatch, "enforce")
+    # Strike both statements, one at a time (oldest first: the promotion
+    # seed, then the human change).
+    first = await store.ignore_statement(obj_id, "name", stmts[0].id, reason="bogus")
+    assert first.winner_statement is not None  # one live statement remains
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["name"] == "Acme Corp"  # enforce write
+    second = await store.ignore_statement(obj_id, "name", stmts[1].id, reason="bogus")
+    assert second.winner_statement is None
+    assert second.value is None
+
+    # No winner → no cache write: the last enforced value is kept.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["name"] == "Acme Corp"
+
+
+# ---------------------------------------------------------------------------
+# Error paths — clean ValueErrors for the FST-6 executor
+# ---------------------------------------------------------------------------
+
+
+async def test_verbs_raise_on_missing_object(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, _ = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    with pytest.raises(ValueError, match="not found"):
+        await store.pin_statement("obj-missing", "arr", "stm-x")
+    with pytest.raises(ValueError, match="not found"):
+        await store.unpin_statement("obj-missing", "arr", "stm-x")
+    with pytest.raises(ValueError, match="not found"):
+        await store.ignore_statement("obj-missing", "arr", "stm-x")
+
+
+async def test_verbs_raise_on_missing_statement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    _set_mode(monkeypatch, "shadow")
+    with pytest.raises(ValueError, match="statement"):
+        await store.pin_statement(obj_id, "arr", "stm-nope")
+    with pytest.raises(ValueError, match="statement"):
+        await store.ignore_statement(obj_id, "arr", "stm-nope")
+    # A statement id that exists but under ANOTHER property is equally invalid.
+    agent_id = await _agent_statement_id(store, obj_id)
+    with pytest.raises(ValueError, match="statement"):
+        await store.pin_statement(obj_id, "name", agent_id)
+
+
+async def test_pin_raises_on_deprecated_statement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id = await _crm_object(tmp_path)
+    await _tracked_arr(store, obj_id, monkeypatch)
+    connector_id = await _connector_statement_id(store, obj_id)
+    _set_mode(monkeypatch, "shadow")
+    await store.ignore_statement(obj_id, "arr", connector_id)
+    with pytest.raises(ValueError, match="deprecated"):
+        await store.pin_statement(obj_id, "arr", connector_id)
+
+
+async def test_verbs_respect_workspace_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A statement stamped for workspace w1 is invisible from w2's scope —
+    the verb fails with a clean ValueError, no cross-tenant curation."""
+    store, obj_id = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    src = await store.upsert_source("connector_run", connector="crm", workspace_id="w1")
+    stmt = await store.append_statement(obj_id, "arr", 500, src.id, "connector", workspace_id="w1")
+    # Visible in w1's scope: the pin succeeds.
+    resolution = await store.pin_statement(obj_id, "arr", stmt.id, workspace_id="w1")
+    assert resolution.winner_statement is not None
+    await store.unpin_statement(obj_id, "arr", stmt.id, workspace_id="w1")
+    # Invisible from w2's scope: ValueError.
+    with pytest.raises(ValueError, match="statement"):
+        await store.pin_statement(obj_id, "arr", stmt.id, workspace_id="w2")
+    with pytest.raises(ValueError, match="statement"):
+        await store.ignore_statement(obj_id, "arr", stmt.id, workspace_id="w2")

--- a/tests/test_fabric_resolver.py
+++ b/tests/test_fabric_resolver.py
@@ -1,0 +1,565 @@
+# tests/test_fabric_resolver.py
+# Created: 2026-07-10 (FST-2 — trust-ladder resolver).
+# Updated: 2026-07-10 (FST-2 spec review — rank + validity join the
+#   within-tier order) — added the CHANGE-verb simulation (old normal+closed
+#   loses to new preferred+open, clean: not disputed, not unresolvable),
+#   preferred > normal within a tier, rank never crossing tiers, open >
+#   closed validity, all-closed still resolving, and the tightened
+#   dispute/unresolvable semantics; the determinism shuffle now exercises
+#   the new sort keys too.
+#
+# Exhaustive coverage of the PURE resolution brain (fabric/resolver.py +
+# fabric/trust.py) before it touches any write path:
+#   * every ladder rung — each adjacent writer-class pair, stronger beats
+#     weaker even when the weaker statement is newer,
+#   * pinned short-circuit — a single pin beats any unpinned tier; multiple
+#     pins → newest recorded_at wins (id tiebreak on equal recorded_at) and
+#     is_disputed is always flagged; a deprecated pin does NOT short-circuit,
+#   * deprecated exclusion — deprecated statements are never winner, never
+#     loser, never counted; all-deprecated → no-value Resolution,
+#   * within-tier order: rank (preferred > normal, never crossing tiers) →
+#     validity (open > closed, closed stays a candidate) → observed_at
+#     recency (never recorded_at) → lexicographic-id tiebreak,
+#   * un-rankable detection — same tier + SAME rank + BOTH open validity +
+#     materially different values + observed_at within recency_epsilon →
+#     unresolvable=True with a deterministic provisional winner (reads never
+#     block); beyond epsilon, across tiers, across ranks, or with a closed
+#     side → resolvable (a rank/validity difference IS a ranking),
+#   * is_disputed counts OPEN-validity losers only — a closed loser (the old
+#     half of a CHANGE) is resolved history, kept in losers[] for audit,
+#   * materially-different normalization — strings compared stripped,
+#   * empty input → no-value Resolution (not an error); single statement
+#     passthrough; mixed (object_id, property) input → ValueError,
+#   * per-(object_type, property) override beats the global ladder; classes
+#     omitted from an override rank at a shared bottom tier,
+#   * determinism — seeded manual shuffle loop (50 iterations): any input
+#     order → an identical Resolution, including loser order.
+
+from __future__ import annotations
+
+import random
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+
+from pocketpaw.fabric.models import Statement
+from pocketpaw.fabric.resolver import Resolution, resolve
+from pocketpaw.fabric.trust import (
+    DEFAULT_LADDER,
+    TrustOverride,
+    TrustRules,
+    default_trust_rules,
+)
+
+T0 = datetime(2026, 7, 1, 12, 0, 0)
+
+_counter = 0
+
+
+def make_stmt(
+    *,
+    value: Any,
+    writer_class: str = "connector",
+    observed_at: datetime = T0,
+    recorded_at: datetime = T0,
+    rank: str = "normal",
+    pinned: bool = False,
+    valid_to: datetime | None = None,
+    stmt_id: str | None = None,
+    object_id: str = "obj-1",
+    property: str = "email",
+) -> Statement:
+    """Statement factory with deterministic ids (stm-0001, stm-0002, ...)."""
+    global _counter
+    _counter += 1
+    return Statement(
+        id=stmt_id or f"stm-{_counter:04d}",
+        object_id=object_id,
+        property=property,
+        value=value,
+        source_ref_id="src-test",
+        writer_class=writer_class,  # type: ignore[arg-type]
+        observed_at=observed_at,
+        recorded_at=recorded_at,
+        valid_from=observed_at,
+        valid_to=valid_to,
+        rank=rank,  # type: ignore[arg-type]
+        pinned=pinned,
+    )
+
+
+@pytest.fixture()
+def rules() -> TrustRules:
+    return default_trust_rules()
+
+
+# ---------------------------------------------------------------- ladder rungs
+
+
+@pytest.mark.parametrize(
+    ("stronger", "weaker"),
+    [
+        ("human", "connector"),
+        ("connector", "mirror"),
+        ("mirror", "agent"),
+        ("agent", "inferred"),
+    ],
+)
+def test_every_ladder_rung_stronger_beats_weaker(rules, stronger, weaker):
+    """Each adjacent rung: the stronger class wins even when the weaker
+    statement is NEWER (tier beats recency across tiers)."""
+    strong = make_stmt(value=f"{stronger}-val", writer_class=stronger, observed_at=T0)
+    weak = make_stmt(
+        value=f"{weaker}-val",
+        writer_class=weaker,
+        observed_at=T0 + timedelta(days=30),
+    )
+    res = resolve([weak, strong], rules)
+    assert res.winner_statement is strong
+    assert res.value == f"{stronger}-val"
+    assert res.losers == [weak]
+    # Different tiers → rankable, even though the values differ.
+    assert res.unresolvable is False
+    assert res.is_disputed is True
+
+
+def test_full_ladder_all_five_classes(rules):
+    """All five classes at once: human wins, losers ordered by the ladder."""
+    stmts = [
+        make_stmt(value=wc, writer_class=wc)
+        for wc in ["inferred", "agent", "mirror", "connector", "human"]
+    ]
+    res = resolve(stmts, rules)
+    assert res.value == "human"
+    assert [s.writer_class for s in res.losers] == ["connector", "mirror", "agent", "inferred"]
+
+
+# ------------------------------------------------------------------- pinning
+
+
+def test_single_pin_beats_stronger_unpinned_tier(rules):
+    """A pinned inferred statement beats an unpinned human one."""
+    human = make_stmt(value="human-val", writer_class="human")
+    pinned = make_stmt(value="pinned-val", writer_class="inferred", pinned=True)
+    res = resolve([human, pinned], rules)
+    assert res.winner_statement is pinned
+    assert res.value == "pinned-val"
+    assert res.losers == [human]
+    assert res.unresolvable is False
+
+
+def test_multiple_pins_newest_recorded_at_wins_and_disputes(rules):
+    """Multiple pins: newest recorded_at wins deterministically; disputed."""
+    old_pin = make_stmt(value="old", pinned=True, recorded_at=T0)
+    new_pin = make_stmt(value="new", pinned=True, recorded_at=T0 + timedelta(hours=1))
+    res = resolve([old_pin, new_pin], rules)
+    assert res.winner_statement is new_pin
+    assert res.is_disputed is True
+    assert res.unresolvable is False  # a pin is authoritative
+    assert res.losers == [old_pin]
+
+
+def test_multiple_pins_same_value_still_disputed(rules):
+    """Two pins agreeing on the value is still a curation conflict."""
+    a = make_stmt(value="same", pinned=True, recorded_at=T0)
+    b = make_stmt(value="same", pinned=True, recorded_at=T0 + timedelta(hours=1))
+    res = resolve([a, b], rules)
+    assert res.value == "same"
+    assert res.is_disputed is True
+
+
+def test_multiple_pins_equal_recorded_at_id_tiebreak(rules):
+    """Equal recorded_at among pins → lexicographically smallest id wins."""
+    b = make_stmt(value="b", pinned=True, stmt_id="stm-bbbb")
+    a = make_stmt(value="a", pinned=True, stmt_id="stm-aaaa")
+    res = resolve([b, a], rules)
+    assert res.winner_statement is a
+
+
+def test_deprecated_pin_does_not_short_circuit(rules):
+    """A pinned but deprecated statement is filtered in step 1."""
+    dead_pin = make_stmt(value="dead", pinned=True, rank="deprecated")
+    normal = make_stmt(value="live", writer_class="inferred")
+    res = resolve([dead_pin, normal], rules)
+    assert res.winner_statement is normal
+    assert res.value == "live"
+    assert res.losers == []
+
+
+# --------------------------------------------------------- deprecated exclusion
+
+
+def test_deprecated_excluded_entirely(rules):
+    """A deprecated human statement loses to a normal inferred one, and is
+    not even listed among the losers."""
+    dead = make_stmt(value="dead", writer_class="human", rank="deprecated")
+    live = make_stmt(value="live", writer_class="inferred")
+    res = resolve([dead, live], rules)
+    assert res.winner_statement is live
+    assert dead not in res.losers
+    assert res.is_disputed is False  # the deprecated value doesn't count
+
+
+def test_all_deprecated_returns_no_value(rules):
+    dead1 = make_stmt(value="x", rank="deprecated")
+    dead2 = make_stmt(value="y", rank="deprecated")
+    res = resolve([dead1, dead2], rules)
+    assert res.winner_statement is None
+    assert res.value is None
+    assert res.losers == []
+    assert res.is_disputed is False
+    assert res.unresolvable is False
+
+
+# ------------------------------------------------- recency + tiebreak in tier
+
+
+def test_recency_within_tier_uses_observed_at_not_recorded_at(rules):
+    """The OLDER-recorded but NEWER-observed statement wins: recency is on
+    observed_at, never ingest time."""
+    stale = make_stmt(
+        value="stale",
+        observed_at=T0,
+        recorded_at=T0 + timedelta(days=5),  # ingested later
+    )
+    fresh = make_stmt(
+        value="fresh",
+        observed_at=T0 + timedelta(days=2),
+        recorded_at=T0,  # ingested earlier
+    )
+    res = resolve([stale, fresh], rules)
+    assert res.winner_statement is fresh
+
+
+def test_id_tiebreak_same_tier_same_observed_at(rules):
+    """Same tier, same observed_at, same value → smallest id wins; no
+    dispute, no unresolvable."""
+    b = make_stmt(value="v", stmt_id="stm-bbbb")
+    a = make_stmt(value="v", stmt_id="stm-aaaa")
+    res = resolve([b, a], rules)
+    assert res.winner_statement is a
+    assert res.is_disputed is False
+    assert res.unresolvable is False
+
+
+# ------------------------------- rank + validity within tier (CHANGE verb)
+
+
+def test_change_simulation_new_preferred_open_beats_old_normal_closed(rules):
+    """FST-5's CHANGE verb: the old statement gets valid_to closed, the new
+    one lands preferred + open. Same tier, close in time, different values —
+    resolves CLEANLY: new wins, no dispute, no un-rankability."""
+    old = make_stmt(
+        value="old@a.com",
+        observed_at=T0,
+        valid_to=T0 + timedelta(minutes=5),  # closed by the CHANGE
+    )
+    new = make_stmt(
+        value="new@b.com",
+        observed_at=T0 + timedelta(minutes=5),  # inside the 24h epsilon
+        rank="preferred",
+    )
+    res = resolve([old, new], rules)
+    assert res.winner_statement is new
+    assert res.value == "new@b.com"
+    assert res.is_disputed is False  # closed loser = resolved history
+    assert res.unresolvable is False  # rank + validity differences ARE a ranking
+    assert res.losers == [old]  # ... but it stays in losers[] for audit
+
+
+def test_preferred_beats_normal_within_tier_despite_older_observed_at(rules):
+    """Within a tier, rank outranks recency: an OLDER preferred statement
+    beats a newer normal one. Both open + materially different → still a
+    live dispute, but rankable (rank difference IS a ranking)."""
+    pref = make_stmt(value="pref", rank="preferred", observed_at=T0)
+    norm = make_stmt(value="norm", observed_at=T0 + timedelta(hours=1))
+    res = resolve([norm, pref], rules)
+    assert res.winner_statement is pref
+    assert res.is_disputed is True  # open normal loser materially differs
+    assert res.unresolvable is False  # different ranks → resolvable
+
+
+def test_low_tier_preferred_loses_to_high_tier_normal(rules):
+    """Rank never crosses tiers: an inferred writer marking itself
+    preferred must NOT beat a normal human statement."""
+    sneaky = make_stmt(value="sneaky", writer_class="inferred", rank="preferred")
+    human = make_stmt(value="human-val", writer_class="human")
+    res = resolve([sneaky, human], rules)
+    assert res.winner_statement is human
+    assert res.value == "human-val"
+
+
+def test_open_validity_beats_closed_despite_older_observed_at(rules):
+    """Within tier + rank, validity outranks recency: an OLDER open
+    statement beats a newer closed one; the closed loser doesn't dispute."""
+    open_stmt = make_stmt(value="open-val", observed_at=T0)
+    closed = make_stmt(
+        value="closed-val",
+        observed_at=T0 + timedelta(hours=1),
+        valid_to=T0 + timedelta(hours=2),
+    )
+    res = resolve([closed, open_stmt], rules)
+    assert res.winner_statement is open_stmt
+    assert res.is_disputed is False  # closed loser excluded from disputes
+    assert res.unresolvable is False  # validity difference → resolvable
+
+
+def test_all_closed_statements_still_resolve(rules):
+    """Reads never block: when EVERY survivor is closed, the newest-observed
+    closed statement still wins (closed is demoted, never dropped)."""
+    older = make_stmt(value="older", observed_at=T0, valid_to=T0 + timedelta(days=1))
+    newer = make_stmt(
+        value="newer",
+        observed_at=T0 + timedelta(hours=1),
+        valid_to=T0 + timedelta(days=1),
+    )
+    res = resolve([older, newer], rules)
+    assert res.winner_statement is newer
+    assert res.value == "newer"
+    assert res.is_disputed is False  # every loser is closed history
+    assert res.unresolvable is False  # winner not open → never un-rankable
+
+
+# -------------------------------------------------------------- unresolvable
+
+
+def test_unresolvable_same_tier_close_observed_different_values(rules):
+    """Same tier, 1h apart (inside the 24h default epsilon), materially
+    different values → unresolvable, but a provisional winner IS returned
+    (the newer one) — reads never block."""
+    older = make_stmt(value="alice@a.com", observed_at=T0)
+    newer = make_stmt(value="alice@b.com", observed_at=T0 + timedelta(hours=1))
+    res = resolve([older, newer], rules)
+    assert res.unresolvable is True
+    assert res.is_disputed is True
+    assert res.winner_statement is newer  # deterministic provisional winner
+    assert res.value == "alice@b.com"
+
+
+def test_unresolvable_same_rank_preferred_pair(rules):
+    """Same rank means SAME rank — two preferred statements, same tier,
+    both open, close in time, different values → un-rankable too."""
+    a = make_stmt(value="x", rank="preferred", observed_at=T0)
+    b = make_stmt(value="y", rank="preferred", observed_at=T0 + timedelta(hours=1))
+    res = resolve([a, b], rules)
+    assert res.unresolvable is True
+    assert res.winner_statement is b
+
+
+def test_resolvable_when_gap_exceeds_epsilon(rules):
+    """Same tier, different values, 48h apart (> 24h epsilon) → recency is
+    trusted: disputed but NOT unresolvable."""
+    older = make_stmt(value="old", observed_at=T0)
+    newer = make_stmt(value="new", observed_at=T0 + timedelta(hours=48))
+    res = resolve([older, newer], rules)
+    assert res.winner_statement is newer
+    assert res.is_disputed is True
+    assert res.unresolvable is False
+
+
+def test_recency_epsilon_is_configurable():
+    """The closeness window comes from the rules, not a constant."""
+    older = make_stmt(value="old", observed_at=T0)
+    newer = make_stmt(value="new", observed_at=T0 + timedelta(minutes=2))
+    tight = TrustRules(recency_epsilon_seconds=60.0)
+    wide = TrustRules(recency_epsilon_seconds=600.0)
+    assert resolve([older, newer], tight).unresolvable is False
+    assert resolve([older, newer], wide).unresolvable is True
+
+
+def test_same_values_close_in_time_not_unresolvable(rules):
+    """Agreement inside the window is fine — only material difference
+    triggers un-rankability."""
+    a = make_stmt(value="same", observed_at=T0)
+    b = make_stmt(value="same", observed_at=T0 + timedelta(hours=1))
+    res = resolve([a, b], rules)
+    assert res.unresolvable is False
+    assert res.is_disputed is False
+
+
+def test_lower_tier_conflict_does_not_make_unresolvable(rules):
+    """A materially different value from a LOWER tier, however close in
+    time, never makes the resolution un-rankable."""
+    human = make_stmt(value="human-val", writer_class="human", observed_at=T0)
+    conn = make_stmt(value="conn-val", writer_class="connector", observed_at=T0)
+    res = resolve([human, conn], rules)
+    assert res.winner_statement is human
+    assert res.is_disputed is True
+    assert res.unresolvable is False
+
+
+# ---------------------------------------------------- materially different
+
+
+def test_strings_compared_stripped_not_disputed(rules):
+    """' Acme ' and 'Acme' are the SAME value after normalization."""
+    a = make_stmt(value=" Acme ", observed_at=T0)
+    b = make_stmt(value="Acme", observed_at=T0 + timedelta(hours=1))
+    res = resolve([a, b], rules)
+    assert res.is_disputed is False
+    assert res.unresolvable is False
+
+
+def test_case_difference_is_material(rules):
+    """Normalization is strip-only: case differences ARE material."""
+    a = make_stmt(value="acme", observed_at=T0)
+    b = make_stmt(value="Acme", observed_at=T0 + timedelta(hours=1))
+    res = resolve([a, b], rules)
+    assert res.is_disputed is True
+
+
+# --------------------------------------------------------------- edge inputs
+
+
+def test_empty_statement_list_returns_no_value_resolution(rules):
+    res = resolve([], rules)
+    assert isinstance(res, Resolution)
+    assert res.winner_statement is None
+    assert res.value is None
+    assert res.losers == []
+    assert res.is_disputed is False
+    assert res.unresolvable is False
+
+
+def test_single_statement_passthrough(rules):
+    only = make_stmt(value=42, writer_class="inferred")
+    res = resolve([only], rules)
+    assert res.winner_statement is only
+    assert res.value == 42
+    assert res.losers == []
+    assert res.is_disputed is False
+    assert res.unresolvable is False
+
+
+def test_mixed_property_input_raises(rules):
+    a = make_stmt(value="x", property="email")
+    b = make_stmt(value="y", property="phone")
+    with pytest.raises(ValueError, match="ONE"):
+        resolve([a, b], rules)
+
+
+def test_mixed_object_id_input_raises(rules):
+    a = make_stmt(value="x", object_id="obj-1")
+    b = make_stmt(value="y", object_id="obj-2")
+    with pytest.raises(ValueError, match="ONE"):
+        resolve([a, b], rules)
+
+
+# ------------------------------------------------------------------ overrides
+
+
+def test_per_property_override_beats_global_ladder():
+    """(Customer, email) trusts the connector over the human; every other
+    (object_type, property) keeps the global ladder."""
+    rules = TrustRules(
+        overrides=[
+            TrustOverride(
+                object_type="Customer",
+                property="email",
+                ladder=["connector", "human", "mirror", "agent", "inferred"],
+            )
+        ]
+    )
+    human = make_stmt(value="human-val", writer_class="human")
+    conn = make_stmt(value="conn-val", writer_class="connector")
+
+    # Override applies: connector outranks human for Customer.email.
+    res = resolve([human, conn], rules, object_type="Customer")
+    assert res.winner_statement is conn
+
+    # Different object_type → global ladder → human wins.
+    res = resolve([human, conn], rules, object_type="Deal")
+    assert res.winner_statement is human
+
+    # Different property → global ladder → human wins.
+    ph = make_stmt(value="h", writer_class="human", property="phone")
+    pc = make_stmt(value="c", writer_class="connector", property="phone")
+    res = resolve([ph, pc], rules, object_type="Customer")
+    assert res.winner_statement is ph
+
+    # No object_type given → overrides never match → global ladder.
+    res = resolve([human, conn], rules)
+    assert res.winner_statement is human
+
+
+def test_override_omitted_classes_rank_bottom():
+    """Classes missing from an override ladder share the bottom tier —
+    they are demoted, not dropped."""
+    rules = TrustRules(
+        overrides=[TrustOverride(object_type="Customer", property="email", ladder=["connector"])]
+    )
+    human = make_stmt(value="h", writer_class="human", observed_at=T0 + timedelta(days=1))
+    conn = make_stmt(value="c", writer_class="connector", observed_at=T0)
+    res = resolve([human, conn], rules, object_type="Customer")
+    assert res.winner_statement is conn  # listed class beats unlisted
+    assert res.losers == [human]  # unlisted class survives as a loser
+
+
+def test_default_trust_rules_shape():
+    rules = default_trust_rules()
+    assert rules.ladder == DEFAULT_LADDER
+    assert rules.ladder == ["human", "connector", "mirror", "agent", "inferred"]
+    assert rules.overrides == []
+    assert rules.recency_epsilon_seconds == 24 * 60 * 60.0
+    assert rules.freshness_ttl_classes == {}  # FST-7 placeholder, empty
+
+
+# --------------------------------------------------------------- determinism
+
+
+def test_resolution_deterministic_under_input_shuffle(rules):
+    """Property-based determinism: 50 seeded shuffles of a gnarly statement
+    set (pins, deprecated, preferred/normal ranks, open/closed validity,
+    ties, near-ties) all produce the IDENTICAL Resolution — winner, value,
+    flags, and loser ORDER — across every leg of the sort key."""
+    stmts = [
+        make_stmt(value="a", writer_class="human", observed_at=T0),
+        make_stmt(value="b", writer_class="human", observed_at=T0 + timedelta(hours=1)),
+        # preferred vs the two normal humans → exercises the rank leg
+        make_stmt(value="h", writer_class="human", rank="preferred", observed_at=T0),
+        # closed human → exercises the validity leg
+        make_stmt(
+            value="i",
+            writer_class="human",
+            observed_at=T0 + timedelta(hours=2),
+            valid_to=T0 + timedelta(days=1),
+        ),
+        make_stmt(value="c", writer_class="connector", observed_at=T0 + timedelta(days=2)),
+        make_stmt(value="d", writer_class="mirror"),
+        make_stmt(value="e", writer_class="agent", rank="deprecated"),
+        make_stmt(value="f", writer_class="inferred"),
+        # same tier + same observed_at as "f" → exercises the id tiebreak
+        make_stmt(value="g", writer_class="inferred"),
+    ]
+    baseline = resolve(list(stmts), rules).model_dump()
+    rng = random.Random(1337)
+    for _ in range(50):
+        shuffled = list(stmts)
+        rng.shuffle(shuffled)
+        assert resolve(shuffled, rules).model_dump() == baseline
+
+
+def test_resolution_deterministic_with_pins_shuffled(rules):
+    """Shuffle determinism on the pinned path too (multiple pins)."""
+    stmts = [
+        make_stmt(value="p1", pinned=True, recorded_at=T0),
+        make_stmt(value="p2", pinned=True, recorded_at=T0 + timedelta(hours=2)),
+        make_stmt(value="h", writer_class="human"),
+        make_stmt(value="i", writer_class="inferred"),
+    ]
+    baseline = resolve(list(stmts), rules).model_dump()
+    rng = random.Random(4242)
+    for _ in range(50):
+        shuffled = list(stmts)
+        rng.shuffle(shuffled)
+        assert resolve(shuffled, rules).model_dump() == baseline
+
+
+def test_resolve_does_not_mutate_input(rules):
+    """Purity: the caller's list is not reordered or altered."""
+    a = make_stmt(value="a", writer_class="inferred")
+    b = make_stmt(value="b", writer_class="human")
+    original = [a, b]
+    resolve(original, rules)
+    assert original == [a, b]

--- a/tests/test_fabric_shadow_create_path.py
+++ b/tests/test_fabric_shadow_create_path.py
@@ -1,0 +1,227 @@
+# tests/test_fabric_shadow_create_path.py
+# Created: 2026-07-10 (FST-4 — the CREATE-path decision + the mirror writer
+# family).
+#
+# FST-3 left ingest_records' CREATE path without a statement hook. FST-4's
+# ruling: creates need NO hook — promotion-time seeding already preserves the
+# create-time claim. This file is the PROOF that backs the decision:
+#
+#   * create-then-update — an object created by source A (via ingest_records,
+#     zero statements at create time even in shadow) then updated by source B
+#     yields BOTH claims: B's statement plus A's create-time value seeded with
+#     A's provenance and touch-time observed_at. The conflict is visible
+#     (disputed=True on the divergence line) — nothing was lost by skipping a
+#     create hook.
+#
+# Plus the FST-4 writer-family rule and per-record provenance threading:
+#
+#   * mirror self-refresh — writer_class="mirror" from the object's OWN
+#     connector is the owning sync, not a second source: no promotion, the
+#     opt-in discipline holds for mirrored data,
+#   * mirror on a FOREIGN connector's object — a real second source: promotes,
+#     and the statement records the true writer_class ("mirror"),
+#   * ingest_records' document_uri_field / observed_at_field — per-record
+#     SourceRef document identity and source-time observed_at; non-datetime
+#     observed values are ignored (ingest-time default).
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pocketpaw.connectors.fabric_ingest import FabricMapping, ingest_records
+from pocketpaw.fabric.store import FabricStore
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+async def _source(store: FabricStore, source_ref_id: str) -> dict[str, Any]:
+    import sqlite3
+
+    con = sqlite3.connect(store._db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute("SELECT * FROM fabric_sources WHERE id = ?", (source_ref_id,)).fetchone()
+    finally:
+        con.close()
+    assert row is not None
+    return dict(row)
+
+
+_MAPPING = FabricMapping(
+    type_name="Customer",
+    source_id_field="ext_id",
+    field_map={"name": "name", "arr": "arr"},
+)
+
+
+# ---------------------------------------------------------------------------
+# THE create-path proof: create by A, update by B → both claims, no hook needed
+# ---------------------------------------------------------------------------
+
+
+async def test_create_then_update_yields_both_claims_without_a_create_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    _set_mode(monkeypatch, "shadow")  # shadow from the very start — creates included
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # Source A (the crm connector) CREATES the object. Even in shadow mode the
+    # create path appends nothing — that is the documented decision under test.
+    res = await ingest_records(
+        store, "crm", [{"ext_id": "c-1", "name": "Acme", "arr": 120}], _MAPPING
+    )
+    assert res.created == 1
+    obj_id = res.object_ids[0]
+    assert await store.get_statements(obj_id, "arr") == []
+    assert _shadow_lines(caplog) == []
+
+    # Source B (an agent) UPDATES the property A created.
+    await store.update_object(
+        obj_id, {"arr": 250}, writer_class="agent", source_session_id="sess-b"
+    )
+
+    # BOTH claims are present: A's create-time value was seeded at promotion
+    # time with A's provenance — no create hook was needed to preserve it.
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 2
+    claim_a = next(s for s in stmts if s.writer_class == "connector")
+    claim_b = next(s for s in stmts if s.writer_class == "agent")
+    assert claim_a.value == 120  # the create-time claim, preserved
+    assert claim_b.value == 250
+    src_a = await _source(store, claim_a.source_ref_id)
+    assert src_a["kind"] == "connector_run" and src_a["connector"] == "crm"
+
+    # And the conflict is VISIBLE: one divergence line, disputed=True.
+    lines = _shadow_lines(caplog)
+    assert len(lines) == 1
+    assert re.search(r" disputed=True ", lines[0] + " ")
+    assert f"object={obj_id} property=arr" in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# The writer-family rule: mirror vs its own connector is NOT a second source
+# ---------------------------------------------------------------------------
+
+
+async def test_mirror_self_refresh_does_not_promote(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # The mirror creates, then re-syncs the SAME object with a changed value.
+    await ingest_records(
+        store, "firestore", [{"ext_id": "col/d1", "name": "Acme", "arr": 120}], _MAPPING
+    )
+    res = await ingest_records(
+        store,
+        "firestore",
+        [{"ext_id": "col/d1", "name": "Acme", "arr": 500}],
+        _MAPPING,
+        writer_class="mirror",
+    )
+    assert res.updated == 1
+    obj = await store.get_object_by_source("firestore", "col/d1")
+    assert obj is not None and obj.properties["arr"] == 500  # LWW refresh intact
+
+    # Same connector + machine-sync family → the owning sync, not a second
+    # source: no statements, no log line (the opt-in discipline holds).
+    assert await store.get_statements(obj.id, "arr") == []
+    assert _shadow_lines(caplog) == []
+
+
+async def test_mirror_write_on_foreign_object_is_a_second_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    _set_mode(monkeypatch, "shadow")
+
+    # Object owned by the crm connector; the firestore mirror writes it.
+    res = await ingest_records(
+        store, "crm", [{"ext_id": "c-9", "name": "Acme", "arr": 120}], _MAPPING
+    )
+    obj_id = res.object_ids[0]
+    await store.update_object(
+        obj_id,
+        {"arr": 300},
+        writer_class="mirror",
+        source_connector="firestore",
+        source_document_uri="customers/c-9",
+    )
+
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 2
+    mirror = next(s for s in stmts if s.writer_class == "mirror")  # true class recorded
+    src = await _source(store, mirror.source_ref_id)
+    assert src["connector"] == "firestore"
+    assert src["document_uri"] == "customers/c-9"
+
+
+# ---------------------------------------------------------------------------
+# ingest_records per-record provenance threading (document URI + observed_at)
+# ---------------------------------------------------------------------------
+
+
+async def test_ingest_records_threads_document_uri_and_observed_at(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    _set_mode(monkeypatch, "shadow")
+
+    res = await ingest_records(
+        store, "crm", [{"ext_id": "c-2", "name": "Acme", "arr": 120}], _MAPPING
+    )
+    obj_id = res.object_ids[0]
+    # Promote arr via a second source so subsequent writes append.
+    await store.update_object(obj_id, {"arr": 130}, writer_class="agent")
+    assert len(await store.get_statements(obj_id, "arr")) == 2
+
+    source_time = datetime(2030, 5, 1, 9, 30, 0)
+    record = {
+        "ext_id": "c-2",
+        "name": "Acme",
+        "arr": 200,
+        "__uri__": "crm://accounts/c-2",
+        "__obs__": source_time,
+    }
+    await ingest_records(
+        store,
+        "crm",
+        [record],
+        _MAPPING,
+        document_uri_field="__uri__",
+        observed_at_field="__obs__",
+    )
+
+    stmts = await store.get_statements(obj_id, "arr")
+    latest = next(s for s in stmts if s.value == 200)
+    assert latest.observed_at == source_time  # the SOURCE's time, not ingest time
+    src = await _source(store, latest.source_ref_id)
+    assert src["document_uri"] == "crm://accounts/c-2"
+
+    # A non-datetime observed value is ignored → ingest-time default (recent).
+    record2 = {"ext_id": "c-2", "name": "Acme", "arr": 210, "__obs__": "not-a-datetime"}
+    await ingest_records(store, "crm", [record2], _MAPPING, observed_at_field="__obs__")
+    newest = next(s for s in await store.get_statements(obj_id, "arr") if s.value == 210)
+    assert newest.observed_at != "not-a-datetime"
+    assert abs((datetime.now(newest.observed_at.tzinfo) - newest.observed_at).days) < 1

--- a/tests/test_fabric_shadow_site1.py
+++ b/tests/test_fabric_shadow_site1.py
@@ -1,0 +1,481 @@
+# tests/test_fabric_shadow_site1.py
+# Created: 2026-07-10 (FST-3 — SHADOW mode at merge site 1).
+#
+# Proves the first real source-truth data flow: store.update_object records
+# statements when fabric_source_truth_mode is shadow/enforce, while the LWW
+# cache write stays byte-for-byte unchanged in every mode.
+#
+#   * two writers (different sources) on one property in shadow — both
+#     statements exist, the divergence line is logged with correct
+#     diverged/disputed/unresolvable values, the cache still shows the LWW
+#     value,
+#   * single-source / same-source / immaterial-difference / brand-new-key
+#     properties — zero statements, zero log lines (the opt-in discipline),
+#   * mode=off — byte-for-byte: the mode is read ONCE and no statement verb
+#     (get_statements / append_statement / upsert_source) is ever touched,
+#     asserted via instance spies + direct table counts,
+#   * auto-promotion — the seed statement carries the OLD cache value, the
+#     object-level provenance (source_connector -> writer_class "connector",
+#     a connector_run SourceRef), and touch-time observed_at backfill (the
+#     object's TRUE pre-update updated_at from the DB row),
+#   * ingest_records provenance threading — the re-sync UPDATE path produces a
+#     statement with writer_class="connector" and a SourceRef carrying the
+#     connector name + run_id,
+#   * the divergence log line is grep-stable and single-line (FST-8's harness
+#     contract), enforce behaves as shadow (until FST-5), a shadow failure
+#     never breaks the cache write, and statements/sources are stamped with
+#     the caller's workspace_id.
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from pocketpaw.connectors.fabric_ingest import FabricMapping, ingest_records
+from pocketpaw.fabric.store import FabricStore, _source_truth_mode
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+# The FST-8 harness contract: one line, grep-stable, values JSON-encoded.
+DIVERGENCE_RE = re.compile(
+    r"^fabric shadow: object=\S+ property=\S+ lww=.+ resolver=.+"
+    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)$"
+)
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """The divergence lines (excludes the failure-shield warning)."""
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+def _table_count(db_path: Path, table: str) -> int:
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    finally:
+        con.close()
+
+
+def _db_object_timestamps(db_path: Path, obj_id: str) -> tuple[str, str]:
+    con = sqlite3.connect(db_path)
+    try:
+        row = con.execute(
+            "SELECT created_at, updated_at FROM fabric_objects WHERE id = ?", (obj_id,)
+        ).fetchone()
+    finally:
+        con.close()
+    return row[0], row[1]
+
+
+def _source_row(db_path: Path, source_ref_id: str) -> dict[str, Any]:
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute("SELECT * FROM fabric_sources WHERE id = ?", (source_ref_id,)).fetchone()
+    finally:
+        con.close()
+    assert row is not None, f"no fabric_sources row for {source_ref_id}"
+    return dict(row)
+
+
+async def _crm_object(tmp_path: Path, **props: Any) -> tuple[FabricStore, str, Path]:
+    """A store with one connector-owned object; returns (store, object_id, db_path)."""
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(
+        obj_type.id,
+        props or {"name": "Acme", "arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+    return store, obj.id, db_path
+
+
+# ---------------------------------------------------------------------------
+# The settings wiring
+# ---------------------------------------------------------------------------
+
+
+def test_mode_helper_reads_settings_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    import pocketpaw.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "get_settings",
+        lambda force_reload=False: SimpleNamespace(fabric_source_truth_mode="shadow"),
+    )
+    assert _source_truth_mode() == "shadow"
+
+
+# ---------------------------------------------------------------------------
+# (c) mode=off — byte-for-byte, mode read once, statements path untouched
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_off_never_touches_statements_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+
+    mode_reads = {"count": 0}
+
+    def counting_off() -> str:
+        mode_reads["count"] += 1
+        return "off"
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", counting_off)
+
+    async def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("statements path touched in mode=off")
+
+    monkeypatch.setattr(store, "get_statements", _boom)
+    monkeypatch.setattr(store, "append_statement", _boom)
+    monkeypatch.setattr(store, "upsert_source", _boom)
+
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+    updated = await store.update_object(obj_id, {"arr": 150}, writer_class="agent")
+
+    assert updated is not None
+    assert updated.properties == {"name": "Acme", "arr": 150}  # LWW merge intact
+    assert mode_reads["count"] == 1  # mode read ONCE per update_object call
+    assert _table_count(db_path, "fabric_statements") == 0
+    assert _table_count(db_path, "fabric_sources") == 0
+    assert _shadow_lines(caplog) == []
+
+
+# ---------------------------------------------------------------------------
+# (a) + (d) two writers, promotion seed, divergence log, cache unchanged
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_two_writers_promotes_logs_and_keeps_lww_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _, pre_updated_at = _db_object_timestamps(db_path, obj_id)
+
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # Second distinct source: an agent session, vs the object's crm connector.
+    await store.update_object(
+        obj_id, {"arr": 150}, writer_class="agent", source_session_id="sess-1"
+    )
+
+    # Cache: EXACTLY the LWW value, shadow never changes it.
+    obj = await store.get_object(obj_id)
+    assert obj is not None
+    assert obj.properties["arr"] == 150
+
+    # Both statements exist: the promoted seed + the incoming write.
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 2
+    seed = next(s for s in stmts if s.writer_class == "connector")
+    incoming = next(s for s in stmts if s.writer_class == "agent")
+
+    # (d) the seed carries the OLD cache value, object-level provenance, and
+    # touch-time backfill = the object's TRUE pre-update updated_at.
+    assert seed.value == 120
+    assert seed.observed_at == datetime.fromisoformat(pre_updated_at)
+    seed_src = _source_row(db_path, seed.source_ref_id)
+    assert seed_src["kind"] == "connector_run"
+    assert seed_src["connector"] == "crm"
+    assert seed_src["run_id"] is None
+
+    # The incoming statement carries the caller's provenance.
+    assert incoming.value == 150
+    in_src = _source_row(db_path, incoming.source_ref_id)
+    assert in_src["kind"] == "agent_session"
+    assert in_src["session_id"] == "sess-1"
+
+    # ONE divergence line, exact FST-8 shape. The connector-tier seed (120)
+    # outranks the agent write on the trust ladder, so the resolver diverges
+    # from the LWW cache (150), and the open agent loser disputes.
+    lines = _shadow_lines(caplog)
+    assert lines == [
+        f"fabric shadow: object={obj_id} property=arr lww=150 resolver=120"
+        " diverged=True disputed=True unresolvable=False"
+    ]
+    assert DIVERGENCE_RE.fullmatch(lines[0])
+    assert "\n" not in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# (b) the opt-in discipline: untracked single-source properties stay scalar
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_same_connector_resync_writes_no_statements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # Same source as the object's owner: crm refreshing its own object.
+    await store.update_object(
+        obj_id, {"arr": 999}, writer_class="connector", source_connector="crm"
+    )
+
+    assert _table_count(db_path, "fabric_statements") == 0
+    assert _table_count(db_path, "fabric_sources") == 0
+    assert _shadow_lines(caplog) == []
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 999
+
+
+async def test_shadow_unattributed_write_derives_to_owner_no_statements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No provenance kwargs on a connector-owned object derives to that same
+    connector (the honest default — the historical caller IS the re-sync), so
+    it is NOT a second distinct source and nothing is tracked."""
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    await store.update_object(obj_id, {"arr": 500})
+
+    assert _table_count(db_path, "fabric_statements") == 0
+    assert _shadow_lines(caplog) == []
+
+
+async def test_shadow_agent_object_agent_write_no_statements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unattributed object (no source_connector) written by an agent: the
+    baseline writer class is 'agent' and so is the incoming — same source."""
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Note", properties=[])
+    obj = await store.create_object(obj_type.id, {"body": "draft"})
+    _set_mode(monkeypatch, "shadow")
+
+    await store.update_object(obj.id, {"body": "final"}, writer_class="agent")
+
+    assert _table_count(db_path, "fabric_statements") == 0
+
+
+async def test_shadow_promotion_requires_material_difference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+
+    # Same value from a second source — nothing to dispute, no promotion.
+    await store.update_object(obj_id, {"arr": 120}, writer_class="agent")
+    # Whitespace-only string difference is immaterial by the resolver's rule.
+    await store.update_object(obj_id, {"name": "  Acme  "}, writer_class="agent")
+
+    assert _table_count(db_path, "fabric_statements") == 0
+
+
+async def test_shadow_new_key_from_second_source_not_promoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A brand-new property has no prior cache claim to preserve — it stays
+    untracked even when written by a second distinct source."""
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    await store.update_object(obj_id, {"tier": "gold"}, writer_class="agent")
+
+    assert _table_count(db_path, "fabric_statements") == 0
+    assert _shadow_lines(caplog) == []
+
+
+# ---------------------------------------------------------------------------
+# Tracked properties append on EVERY write; mixed updates log per-statement
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_tracked_property_appends_and_reconverges(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # Promote via an agent write (2 statements: seed 120 + agent 150).
+    await store.update_object(obj_id, {"arr": 150}, writer_class="agent")
+    caplog.clear()
+
+    # Now the owning connector writes again — tracked, so it appends even from
+    # the same source. Far-future observed_at keeps the recency leg (and the
+    # 24h un-rankable epsilon) deterministic regardless of run date/timezone.
+    await store.update_object(
+        obj_id,
+        {"arr": 200},
+        writer_class="connector",
+        source_connector="crm",
+        source_run_id="run-9",
+        observed_at=datetime(2030, 1, 1, 12, 0, 0),
+    )
+
+    stmts = await store.get_statements(obj_id, "arr")
+    assert len(stmts) == 3
+    lines = _shadow_lines(caplog)
+    # The fresh connector write wins the ladder → resolver agrees with LWW.
+    assert lines == [
+        f"fabric shadow: object={obj_id} property=arr lww=200 resolver=200"
+        " diverged=False disputed=True unresolvable=False"
+    ]
+
+
+async def test_shadow_mixed_update_logs_only_statement_properties(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path, name="Acme", arr=120, note="x")
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    # Track arr via promotion.
+    await store.update_object(obj_id, {"arr": 150}, writer_class="agent")
+    caplog.clear()
+
+    # Same-source update touching a tracked (arr) and an untracked (note)
+    # property: arr appends + logs, note stays scalar — one line total.
+    await store.update_object(
+        obj_id,
+        {"arr": 170, "note": "z"},
+        writer_class="connector",
+        source_connector="crm",
+    )
+
+    assert len(await store.get_statements(obj_id, "arr")) == 3
+    assert await store.get_statements(obj_id, "note") == []
+    lines = _shadow_lines(caplog)
+    assert len(lines) == 1 and "property=arr" in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# (e) ingest_records threads connector provenance end-to-end
+# ---------------------------------------------------------------------------
+
+
+async def test_ingest_records_threads_provenance_through_update(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    _set_mode(monkeypatch, "shadow")
+    mapping = FabricMapping(
+        type_name="CalendarEvent",
+        source_id_field="event_id",
+        field_map={"title": "title"},
+    )
+
+    # CREATE path — no statements at site 1 (creates are FST-4's scope).
+    res1 = await ingest_records(store, "gcal", [{"event_id": "e1", "title": "Standup"}], mapping)
+    assert res1.created == 1
+    obj_id = res1.object_ids[0]
+    assert await store.get_statements(obj_id, "title") == []
+
+    # An agent edit promotes the property (seed "Standup" + agent value).
+    await store.update_object(
+        obj_id, {"title": "Standup (moved)"}, writer_class="agent", source_session_id="s-9"
+    )
+    assert len(await store.get_statements(obj_id, "title")) == 2
+
+    # Re-sync: the UPDATE path passes connector provenance + run identity.
+    res2 = await ingest_records(
+        store, "gcal", [{"event_id": "e1", "title": "Standup v2"}], mapping, run_id="run-7"
+    )
+    assert res2.updated == 1
+
+    stmts = await store.get_statements(obj_id, "title")
+    assert len(stmts) == 3
+    ingest_stmt = next(s for s in stmts if s.value == "Standup v2")
+    assert ingest_stmt.writer_class == "connector"
+    src = _source_row(db_path, ingest_stmt.source_ref_id)
+    assert src["kind"] == "connector_run"
+    assert src["connector"] == "gcal"
+    assert src["run_id"] == "run-7"
+
+    # Cache is still plain LWW.
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["title"] == "Standup v2"
+
+
+# ---------------------------------------------------------------------------
+# enforce == shadow (until FST-5); shadow failures never break the write
+# ---------------------------------------------------------------------------
+
+
+async def test_enforce_mode_behaves_as_shadow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, obj_id, db_path = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "enforce")
+
+    await store.update_object(obj_id, {"arr": 150}, writer_class="agent")
+
+    assert len(await store.get_statements(obj_id, "arr")) == 2
+    obj = await store.get_object(obj_id)
+    assert obj is not None and obj.properties["arr"] == 150  # cache still LWW
+
+
+async def test_shadow_failure_never_breaks_cache_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    store, obj_id, _ = await _crm_object(tmp_path)
+    _set_mode(monkeypatch, "shadow")
+
+    async def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("simulated shadow failure")
+
+    monkeypatch.setattr(store, "append_statement", _explode)
+    caplog.set_level(logging.WARNING, logger=STORE_LOGGER)
+
+    updated = await store.update_object(obj_id, {"arr": 150}, writer_class="agent")
+
+    assert updated is not None and updated.properties["arr"] == 150
+    assert any(
+        "statement pass failed" in r.getMessage() for r in caplog.records if r.name == STORE_LOGGER
+    )
+
+
+# ---------------------------------------------------------------------------
+# Workspace stamping (W4a semantics carried into the shadow pass)
+# ---------------------------------------------------------------------------
+
+
+async def test_shadow_statements_and_sources_stamped_with_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "fabric.db"
+    store = FabricStore(db_path)
+    obj_type = await store.define_type(name="Customer", properties=[], workspace_id="ws-a")
+    obj = await store.create_object(
+        obj_type.id,
+        {"arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+        workspace_id="ws-a",
+    )
+    _set_mode(monkeypatch, "shadow")
+
+    await store.update_object(obj.id, {"arr": 150}, workspace_id="ws-a", writer_class="agent")
+
+    stmts = await store.get_statements(obj.id, "arr", workspace_id="ws-a")
+    assert len(stmts) == 2
+    assert all(s.workspace_id == "ws-a" for s in stmts)
+    for s in stmts:
+        assert _source_row(db_path, s.source_ref_id)["workspace_id"] == "ws-a"

--- a/tests/test_fabric_shadow_site1.py
+++ b/tests/test_fabric_shadow_site1.py
@@ -415,13 +415,19 @@ async def test_ingest_records_threads_provenance_through_update(
 
 
 # ---------------------------------------------------------------------------
-# enforce == shadow (until FST-5); shadow failures never break the write
+# enforce records statements like shadow; shadow failures never break the write
 # ---------------------------------------------------------------------------
 
 
-async def test_enforce_mode_behaves_as_shadow(
+async def test_enforce_mode_records_statements_like_shadow(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Enforce rides the SAME statement pass as shadow (seed + incoming both
+    land). FST-5 note: this test's pre-FST-5 form asserted "cache still LWW"
+    (enforce == shadow until FST-5); the resolver now owns the cache in
+    enforce, so the connector-tier seed (120) beats the agent write (150).
+    Full enforce cache semantics live in tests/test_fabric_enforce_site1.py.
+    """
     store, obj_id, db_path = await _crm_object(tmp_path)
     _set_mode(monkeypatch, "enforce")
 
@@ -429,7 +435,7 @@ async def test_enforce_mode_behaves_as_shadow(
 
     assert len(await store.get_statements(obj_id, "arr")) == 2
     obj = await store.get_object(obj_id)
-    assert obj is not None and obj.properties["arr"] == 150  # cache still LWW
+    assert obj is not None and obj.properties["arr"] == 120  # resolver-owned cache
 
 
 async def test_shadow_failure_never_breaks_cache_write(

--- a/tests/test_fabric_shadow_site1.py
+++ b/tests/test_fabric_shadow_site1.py
@@ -44,9 +44,13 @@ from pocketpaw.fabric.store import FabricStore, _source_truth_mode
 STORE_LOGGER = "pocketpaw.fabric.store"
 
 # The FST-8 harness contract: one line, grep-stable, values JSON-encoded.
+# FST-7 extended the line ADDITIVELY with a trailing ` freshness=<tri-state>`
+# (existing field order untouched) — the one deliberate format evolution this
+# guard exists to gate; updated with it, like the FST-5 enforce placeholder.
 DIVERGENCE_RE = re.compile(
     r"^fabric shadow: object=\S+ property=\S+ lww=.+ resolver=.+"
-    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)$"
+    r" diverged=(True|False) disputed=(True|False) unresolvable=(True|False)"
+    r" freshness=(fresh|aging|stale|none)$"
 )
 
 
@@ -210,7 +214,7 @@ async def test_shadow_two_writers_promotes_logs_and_keeps_lww_cache(
     lines = _shadow_lines(caplog)
     assert lines == [
         f"fabric shadow: object={obj_id} property=arr lww=150 resolver=120"
-        " diverged=True disputed=True unresolvable=False"
+        " diverged=True disputed=True unresolvable=False freshness=fresh"
     ]
     assert DIVERGENCE_RE.fullmatch(lines[0])
     assert "\n" not in lines[0]
@@ -335,7 +339,7 @@ async def test_shadow_tracked_property_appends_and_reconverges(
     # The fresh connector write wins the ladder → resolver agrees with LWW.
     assert lines == [
         f"fabric shadow: object={obj_id} property=arr lww=200 resolver=200"
-        " diverged=False disputed=True unresolvable=False"
+        " diverged=False disputed=True unresolvable=False freshness=fresh"
     ]
 
 

--- a/tests/test_fabric_shadow_site2.py
+++ b/tests/test_fabric_shadow_site2.py
@@ -161,7 +161,7 @@ async def test_journal_update_by_user_actor_records_both_claims(
     lines = _shadow_lines(caplog)
     assert lines == [
         f"fabric shadow: object={obj.id} property=arr lww=150 resolver=150"
-        " diverged=False disputed=True unresolvable=False"
+        " diverged=False disputed=True unresolvable=False freshness=fresh"
     ]
 
 

--- a/tests/test_fabric_shadow_site2.py
+++ b/tests/test_fabric_shadow_site2.py
@@ -1,0 +1,336 @@
+# tests/test_fabric_shadow_site2.py
+# Created: 2026-07-10 (FST-4 — SHADOW mode at merge site 2).
+#
+# Proves the journal-replay merge site (fabric/projection.py::_apply_updated,
+# the ``merged = {**existing.obj.properties, **patch}`` fold) emits shadow
+# statements through the SAME FST-3 store machinery as site 1, with
+# journal-derived provenance and replay idempotence:
+#
+#   * a live journal update by a ``user`` actor in shadow lands both claims
+#     (the promoted seed with the object's connector baseline + the human
+#     statement with a human_actor SourceRef) and the FST-8 divergence line;
+#     observed_at is the EVENT's ts (create ts for the seed, update ts for
+#     the incoming claim),
+#   * an ``agent`` actor maps to an agent_session SourceRef keyed on the
+#     event's correlation_id,
+#   * a ``system`` actor (the journal store default) passes NO provenance —
+#     the store's derivation default applies, so a system refresh of a
+#     connector-owned object is not a second source and stays scalar,
+#   * REPLAY DEDUPE — rebuilding/replaying the same journal (same store or a
+#     brand-new FabricJournalStore) never double-appends: statements are
+#     recorded at most once per journal event id (fabric_shadow_events),
+#   * REPLAY DETERMINISM — replaying a journal into a FRESH statement store
+#     produces the same claims (property, value, writer_class, observed_at)
+#     the live shadow pass produced,
+#   * mode=off — byte-for-byte: nothing staged, the statement verbs never
+#     touched, the mode read ONCE per update event; a store-LESS projection
+#     never even reads the mode flag.
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor
+
+from pocketpaw.fabric.events import ACTION_OBJECT_CREATED, ACTION_OBJECT_UPDATED
+from pocketpaw.fabric.journal_store import FabricJournalStore
+from pocketpaw.fabric.models import FabricObject
+from pocketpaw.fabric.store import FabricStore
+
+STORE_LOGGER = "pocketpaw.fabric.store"
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: mode)
+
+
+def _shadow_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == STORE_LOGGER and r.getMessage().startswith("fabric shadow: object=")
+    ]
+
+
+def _table_count(db_path: Path, table: str) -> int:
+    """Rows in ``table`` — 0 when the table (or the whole DB) doesn't exist
+    yet, which is exactly what a byte-for-byte 'off' run leaves behind: the
+    store's schema is created lazily on first write, so an untouched
+    statement store never even materializes the tables."""
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        con.close()
+
+
+def _source_row(db_path: Path, source_ref_id: str) -> dict[str, Any]:
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute("SELECT * FROM fabric_sources WHERE id = ?", (source_ref_id,)).fetchone()
+    finally:
+        con.close()
+    assert row is not None, f"no fabric_sources row for {source_ref_id}"
+    return dict(row)
+
+
+def _events(journal, action: str) -> list:
+    return [e for e in journal.replay_from(0) if e.action == action]
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+def _crm_obj(**props: Any) -> FabricObject:
+    return FabricObject(
+        type_id="t1",
+        type_name="Customer",
+        properties=props or {"arr": 120},
+        source_connector="crm",
+        source_id="c-1",
+    )
+
+
+def _human(actor_id: str = "user:alice") -> Actor:
+    return Actor(kind="user", id=actor_id, scope_context=[])
+
+
+# ---------------------------------------------------------------------------
+# Live journal update in shadow: journal-derived provenance + divergence line
+# ---------------------------------------------------------------------------
+
+
+async def test_journal_update_by_user_actor_records_both_claims(
+    tmp_path: Path,
+    journal,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    statement_db = tmp_path / "fabric.db"
+    statement_store = FabricStore(statement_db)
+    js = FabricJournalStore(journal, statement_store=statement_store)
+    js.bootstrap()
+    _set_mode(monkeypatch, "shadow")
+    caplog.set_level(logging.INFO, logger=STORE_LOGGER)
+
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+    await js.update(obj.id, {"arr": 150}, scope=["org"], actor=_human())
+
+    # The projection cache is plain LWW — shadow never touches it.
+    projected = await js.get(obj.id)
+    assert projected is not None and projected.properties["arr"] == 150
+
+    # Both claims exist: the promoted connector seed + the human statement.
+    stmts = await statement_store.get_statements(obj.id, "arr")
+    assert len(stmts) == 2
+    seed = next(s for s in stmts if s.writer_class == "connector")
+    human = next(s for s in stmts if s.writer_class == "human")
+
+    create_ts = _events(journal, ACTION_OBJECT_CREATED)[0].ts
+    update_ts = _events(journal, ACTION_OBJECT_UPDATED)[0].ts
+
+    # Seed: old cache value, object-level baseline, touch-time = create event ts.
+    assert seed.value == 120
+    assert seed.observed_at == create_ts
+    seed_src = _source_row(statement_db, seed.source_ref_id)
+    assert seed_src["kind"] == "connector_run"
+    assert seed_src["connector"] == "crm"
+
+    # Human claim: journal-derived provenance, observed_at = the update event ts.
+    assert human.value == 150
+    assert human.observed_at == update_ts
+    human_src = _source_row(statement_db, human.source_ref_id)
+    assert human_src["kind"] == "human_actor"
+    assert human_src["actor_id"] == "user:alice"
+
+    # ONE divergence line, exact FST-8 shape. Human outranks the connector
+    # seed on the ladder, so the resolver agrees with the LWW cache.
+    lines = _shadow_lines(caplog)
+    assert lines == [
+        f"fabric shadow: object={obj.id} property=arr lww=150 resolver=150"
+        " diverged=False disputed=True unresolvable=False"
+    ]
+
+
+async def test_agent_actor_maps_to_agent_session_via_correlation_id(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    statement_db = tmp_path / "fabric.db"
+    statement_store = FabricStore(statement_db)
+    js = FabricJournalStore(journal, statement_store=statement_store)
+    js.bootstrap()
+    _set_mode(monkeypatch, "shadow")
+
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+    correlation = uuid4()
+    await js.update(
+        obj.id,
+        {"arr": 175},
+        scope=["org"],
+        actor=Actor(kind="agent", id="did:soul:worker", scope_context=[]),
+        correlation_id=correlation,
+    )
+
+    stmts = await statement_store.get_statements(obj.id, "arr")
+    assert len(stmts) == 2
+    agent = next(s for s in stmts if s.writer_class == "agent")
+    src = _source_row(statement_db, agent.source_ref_id)
+    assert src["kind"] == "agent_session"
+    assert src["session_id"] == str(correlation)
+
+
+async def test_system_actor_uses_derivation_default_no_statements(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The journal store's default actor is system:fabric — an unattributed
+    subsystem write. The store's derivation default maps it to the object's
+    own connector, which is NOT a second source, so nothing is tracked."""
+    statement_db = tmp_path / "fabric.db"
+    statement_store = FabricStore(statement_db)
+    js = FabricJournalStore(journal, statement_store=statement_store)
+    js.bootstrap()
+    _set_mode(monkeypatch, "shadow")
+
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+    await js.update(obj.id, {"arr": 999}, scope=["org"])  # default system actor
+
+    assert _table_count(statement_db, "fabric_statements") == 0
+    assert _table_count(statement_db, "fabric_sources") == 0
+
+
+# ---------------------------------------------------------------------------
+# Replay dedupe: the same journal event never double-appends
+# ---------------------------------------------------------------------------
+
+
+async def test_rebuild_and_replay_never_double_append(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    statement_db = tmp_path / "fabric.db"
+    statement_store = FabricStore(statement_db)
+    js = FabricJournalStore(journal, statement_store=statement_store)
+    js.bootstrap()
+    _set_mode(monkeypatch, "shadow")
+
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+    await js.update(obj.id, {"arr": 150}, scope=["org"], actor=_human())
+    assert len(await statement_store.get_statements(obj.id, "arr")) == 2
+
+    # Rebuild the SAME store's projection from genesis: the update event is
+    # staged again, but its id is already claimed — flush records nothing.
+    js.bootstrap()
+    assert await js.flush_shadow() == 0
+    assert len(await statement_store.get_statements(obj.id, "arr")) == 2
+
+    # A brand-new FabricJournalStore over the same journal + statement store
+    # (a process restart): same outcome, still exactly two claims.
+    js2 = FabricJournalStore(journal, statement_store=statement_store)
+    js2.bootstrap()
+    assert await js2.flush_shadow() == 0
+    assert len(await statement_store.get_statements(obj.id, "arr")) == 2
+    assert _table_count(statement_db, "fabric_shadow_events") == 1
+
+
+# ---------------------------------------------------------------------------
+# Replay determinism: a replayed event produces the claims the live write did
+# ---------------------------------------------------------------------------
+
+
+async def test_replay_into_fresh_store_matches_live_statements(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    live_store = FabricStore(tmp_path / "live.db")
+    js = FabricJournalStore(journal, statement_store=live_store)
+    js.bootstrap()
+    _set_mode(monkeypatch, "shadow")
+
+    obj = await js.create(_crm_obj(arr=120, name="Acme"), scope=["org"])
+    await js.update(obj.id, {"arr": 150}, scope=["org"], actor=_human())
+    live = await live_store.get_statements(obj.id, "arr")
+    assert len(live) == 2
+
+    # Replay the same journal into a FRESH statement store (new machine, empty
+    # statements DB): bootstrap stages the update, flush records it.
+    replay_store = FabricStore(tmp_path / "replay.db")
+    js2 = FabricJournalStore(journal, statement_store=replay_store)
+    js2.bootstrap()
+    assert await js2.flush_shadow() == 1
+    replayed = await replay_store.get_statements(obj.id, "arr")
+
+    def _claims(stmts: list) -> set[tuple]:
+        return {(s.property, s.value, s.writer_class, s.observed_at) for s in stmts}
+
+    assert _claims(replayed) == _claims(live)
+
+
+# ---------------------------------------------------------------------------
+# mode=off — byte-for-byte at the projection site
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_off_stages_nothing_and_never_touches_statement_verbs(
+    tmp_path: Path, journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    statement_db = tmp_path / "fabric.db"
+    statement_store = FabricStore(statement_db)
+    js = FabricJournalStore(journal, statement_store=statement_store)
+    js.bootstrap()
+
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+
+    mode_reads = {"count": 0}
+
+    def counting_off() -> str:
+        mode_reads["count"] += 1
+        return "off"
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", counting_off)
+
+    async def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("statements path touched in mode=off")
+
+    monkeypatch.setattr(statement_store, "get_statements", _boom)
+    monkeypatch.setattr(statement_store, "append_statement", _boom)
+    monkeypatch.setattr(statement_store, "upsert_source", _boom)
+    monkeypatch.setattr(statement_store, "shadow_record_event_update", _boom)
+
+    updated = await js.update(obj.id, {"arr": 150}, scope=["org"], actor=_human())
+
+    assert updated is not None and updated.properties["arr"] == 150  # LWW fold intact
+    assert mode_reads["count"] == 1  # read ONCE per update event, at stage time
+    assert await js.flush_shadow() == 0  # nothing was staged
+    assert _table_count(statement_db, "fabric_statements") == 0
+    assert _table_count(statement_db, "fabric_shadow_events") == 0  # not even the marker
+
+
+async def test_storeless_projection_never_reads_the_mode_flag(
+    journal, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default construction (no statement_store) must be byte-for-byte the
+    pre-FST-4 projection: the statement_store gate comes before the mode
+    read, so the flag is never consulted."""
+
+    def _explode() -> str:
+        raise AssertionError("mode flag read by a store-less projection")
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", _explode)
+
+    js = FabricJournalStore(journal)  # no statement_store
+    js.bootstrap()
+    obj = await js.create(_crm_obj(arr=120), scope=["org"])
+    updated = await js.update(obj.id, {"arr": 150}, scope=["org"], actor=_human())
+    assert updated is not None and updated.properties["arr"] == 150
+    assert await js.flush_shadow() == 0

--- a/tests/test_fabric_statements.py
+++ b/tests/test_fabric_statements.py
@@ -1,0 +1,442 @@
+# tests/test_fabric_statements.py
+# Created: 2026-07-10 (FST-1 — Fabric source-truth schema).
+# Updated: 2026-07-10 (FST-1 schema-freeze ruling — workspace_id tenancy) —
+#   both new tables carry the W4a workspace_id: added tests that the same
+#   source identity in two workspaces is TWO rows (workspace is part of the
+#   dedup identity), that get_statements applies the standard W4a read scope
+#   (own rows + legacy NULL), and that a DB from the early FST-1 build
+#   (tables without workspace_id, old idx_sources_identity index) is healed
+#   by the ALTER migration (column added, index swapped for
+#   idx_sources_identity_ws).
+#
+# Proves the FST-1 foundation the rest of the source-truth chain stacks on:
+#   * statement round-trip — append_statement / get_statements preserve every
+#     field (JSON value, writer_class, bitemporal datetimes, rank, pinned),
+#   * statements are append-only — the store exposes NO update/delete verbs,
+#   * source dedup — upsert_source returns the SAME row for the same identity
+#     tuple (kind + connector/run_id/document_uri/actor_id/session_id +
+#     workspace_id), including identities with absent (None) fields, and a
+#     DIFFERENT row for a different identity or a different workspace,
+#   * get_statements property filter narrows to one property; workspace_id
+#     scopes reads per W4a (own rows + legacy NULL),
+#   * migration idempotency — booting the store on a PRE-FST fabric.db (built
+#     from the old schema, no statements/sources tables) creates the new
+#     tables without touching existing data, and a second boot / second store
+#     is a no-op (no error, no duplicate tables/indexes),
+#   * the fabric_source_truth_mode flag exists, defaults to "off", rejects
+#     junk, and accepts the three documented positions.
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.fabric.store import FabricStore
+
+# The pre-FST-1 schema (fabric.db as it existed before this slice): the three
+# original tables + their indexes, WITHOUT fabric_statements / fabric_sources.
+# Inlined (rather than importing SCHEMA_SQL) so the fixture keeps simulating an
+# OLD database even as SCHEMA_SQL evolves.
+_PRE_FST_SCHEMA = """
+CREATE TABLE IF NOT EXISTS fabric_object_types (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    icon TEXT DEFAULT 'box',
+    color TEXT DEFAULT '#0A84FF',
+    properties_schema TEXT DEFAULT '[]',
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS fabric_objects (
+    id TEXT PRIMARY KEY,
+    type_id TEXT NOT NULL REFERENCES fabric_object_types(id),
+    type_name TEXT DEFAULT '',
+    properties TEXT NOT NULL DEFAULT '{}',
+    source_connector TEXT,
+    source_id TEXT,
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS fabric_links (
+    id TEXT PRIMARY KEY,
+    from_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    to_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    link_type TEXT NOT NULL,
+    properties TEXT DEFAULT '{}',
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_objects_type ON fabric_objects(type_id);
+CREATE INDEX IF NOT EXISTS idx_objects_source
+    ON fabric_objects(source_connector, source_id);
+"""
+
+
+async def _seeded_store(tmp_path: Path) -> tuple[FabricStore, str]:
+    """A store with one type + one object; returns (store, object_id)."""
+    store = FabricStore(tmp_path / "fabric.db")
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(obj_type.id, {"name": "Acme", "arr": 120})
+    return store, obj.id
+
+
+# ---------------------------------------------------------------------------
+# Statement round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_statement_round_trip(tmp_path: Path) -> None:
+    store, obj_id = await _seeded_store(tmp_path)
+    source = await store.upsert_source("connector_run", connector="gcalendar", run_id="run-1")
+    observed = datetime(2026, 7, 1, 12, 0, 0)
+    valid_to = datetime(2026, 12, 31, 23, 59, 59)
+
+    written = await store.append_statement(
+        obj_id,
+        "arr",
+        {"amount": 120, "currency": "USD"},
+        source.id,
+        "connector",
+        observed_at=observed,
+        valid_to=valid_to,
+        rank="preferred",
+        rank_reason="most recent sync",
+        pinned=True,
+    )
+
+    stmts = await store.get_statements(obj_id)
+    assert len(stmts) == 1
+    got = stmts[0]
+    assert got.id == written.id
+    assert got.object_id == obj_id
+    assert got.property == "arr"
+    assert got.value == {"amount": 120, "currency": "USD"}  # JSON round-trips
+    assert got.source_ref_id == source.id
+    assert got.writer_class == "connector"
+    assert got.observed_at == observed
+    assert got.valid_from == observed  # defaults to observed_at
+    assert got.valid_to == valid_to
+    assert got.recorded_at == written.recorded_at
+    assert got.rank == "preferred"
+    assert got.rank_reason == "most recent sync"
+    assert got.pinned is True
+
+
+@pytest.mark.asyncio
+async def test_statement_null_value_round_trips(tmp_path: Path) -> None:
+    store, obj_id = await _seeded_store(tmp_path)
+    source = await store.upsert_source("human_actor", actor_id="user-7")
+    await store.append_statement(obj_id, "churn_reason", None, source.id, "human")
+    stmts = await store.get_statements(obj_id, property="churn_reason")
+    assert len(stmts) == 1
+    assert stmts[0].value is None
+    assert stmts[0].writer_class == "human"
+
+
+@pytest.mark.asyncio
+async def test_get_statements_property_filter_and_order(tmp_path: Path) -> None:
+    store, obj_id = await _seeded_store(tmp_path)
+    source = await store.upsert_source("agent_session", session_id="sess-1")
+    first = await store.append_statement(obj_id, "arr", 120, source.id, "agent")
+    second = await store.append_statement(obj_id, "arr", 150, source.id, "agent")
+    await store.append_statement(obj_id, "name", "Acme Corp", source.id, "agent")
+
+    arr_stmts = await store.get_statements(obj_id, property="arr")
+    assert [s.value for s in arr_stmts] == [120, 150]  # oldest first (recorded_at)
+    assert [s.id for s in arr_stmts] == [first.id, second.id]  # insertion order
+    assert len(await store.get_statements(obj_id)) == 3
+    assert await store.get_statements(obj_id, property="missing") == []
+
+
+def test_statements_are_append_only() -> None:
+    """The store exposes NO update/delete verbs for statements in FST-1."""
+    verbs = [n for n in dir(FabricStore) if "statement" in n.lower()]
+    assert "append_statement" in verbs
+    assert "get_statements" in verbs
+    assert not any("update" in v or "delete" in v or "remove" in v for v in verbs)
+
+
+# ---------------------------------------------------------------------------
+# Source dedup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_source_dedups_on_identity(tmp_path: Path) -> None:
+    store, _ = await _seeded_store(tmp_path)
+    a = await store.upsert_source("connector_run", connector="stripe", run_id="run-9")
+    b = await store.upsert_source("connector_run", connector="stripe", run_id="run-9")
+    assert a.id == b.id  # same identity -> same row
+
+    c = await store.upsert_source("connector_run", connector="stripe", run_id="run-10")
+    assert c.id != a.id  # different identity -> new row
+
+    # Absent (None) identity fields dedup too.
+    d = await store.upsert_source("document", document_uri="s3://bucket/report.pdf")
+    e = await store.upsert_source("document", document_uri="s3://bucket/report.pdf")
+    assert d.id == e.id
+
+    # Same field values under a DIFFERENT kind is a different identity.
+    f = await store.upsert_source("human_actor", actor_id="u-1")
+    g = await store.upsert_source("agent_session", actor_id="u-1")
+    assert f.id != g.id
+
+
+@pytest.mark.asyncio
+async def test_upsert_source_returns_existing_row_unmutated(tmp_path: Path) -> None:
+    store, _ = await _seeded_store(tmp_path)
+    first_seen = datetime(2026, 7, 1, 8, 0, 0)
+    a = await store.upsert_source(
+        "connector_run", connector="gmail", run_id="r1", retrieved_at=first_seen
+    )
+    # retrieved_at is provenance metadata, NOT identity: a later call with a
+    # different retrieved_at still resolves to the original row, unchanged.
+    b = await store.upsert_source(
+        "connector_run",
+        connector="gmail",
+        run_id="r1",
+        retrieved_at=datetime(2026, 7, 2, 8, 0, 0),
+    )
+    assert b.id == a.id
+    assert b.retrieved_at == first_seen
+
+
+# ---------------------------------------------------------------------------
+# Workspace tenancy (schema-freeze ruling)
+# ---------------------------------------------------------------------------
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+@pytest.mark.asyncio
+async def test_same_source_identity_in_two_workspaces_is_two_rows(tmp_path: Path) -> None:
+    """workspace_id is PART of the source identity — isolation beats dedup."""
+    store, _ = await _seeded_store(tmp_path)
+    a = await store.upsert_source(
+        "connector_run", connector="stripe", run_id="run-1", workspace_id=WS_A
+    )
+    b = await store.upsert_source(
+        "connector_run", connector="stripe", run_id="run-1", workspace_id=WS_B
+    )
+    assert a.id != b.id  # two workspaces -> two rows
+    assert a.workspace_id == WS_A
+    assert b.workspace_id == WS_B
+
+    # Same identity within ONE workspace still dedups.
+    a2 = await store.upsert_source(
+        "connector_run", connector="stripe", run_id="run-1", workspace_id=WS_A
+    )
+    assert a2.id == a.id
+
+    # The OSS (None-workspace) identity is its own row, distinct from both.
+    none_ws = await store.upsert_source("connector_run", connector="stripe", run_id="run-1")
+    assert none_ws.id not in {a.id, b.id}
+    assert none_ws.workspace_id is None
+    # ... and still dedups against itself.
+    assert (await store.upsert_source("connector_run", connector="stripe", run_id="run-1")).id == (
+        none_ws.id
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_statements_scoped_by_workspace(tmp_path: Path) -> None:
+    """W4a read scope on statements: own rows + legacy NULL rows."""
+    store, obj_id = await _seeded_store(tmp_path)
+    src_a = await store.upsert_source("human_actor", actor_id="u-a", workspace_id=WS_A)
+    src_b = await store.upsert_source("human_actor", actor_id="u-b", workspace_id=WS_B)
+    src_legacy = await store.upsert_source("human_actor", actor_id="u-legacy")
+
+    stmt_a = await store.append_statement(obj_id, "arr", 100, src_a.id, "human", workspace_id=WS_A)
+    stmt_b = await store.append_statement(obj_id, "arr", 200, src_b.id, "human", workspace_id=WS_B)
+    stmt_legacy = await store.append_statement(obj_id, "arr", 300, src_legacy.id, "human")
+
+    assert stmt_a.workspace_id == WS_A  # stamped on the returned model too
+
+    # Scoped read: own rows + legacy NULL, never the other tenant's.
+    a_ids = {s.id for s in await store.get_statements(obj_id, workspace_id=WS_A)}
+    assert a_ids == {stmt_a.id, stmt_legacy.id}
+    b_ids = {s.id for s in await store.get_statements(obj_id, workspace_id=WS_B)}
+    assert b_ids == {stmt_b.id, stmt_legacy.id}
+
+    # Property filter and workspace scope compose.
+    a_arr = await store.get_statements(obj_id, property="arr", workspace_id=WS_A)
+    assert {s.value for s in a_arr} == {100, 300}
+
+    # Unscoped read (OSS / single-tenant) sees everything, workspace surfaced.
+    all_stmts = await store.get_statements(obj_id)
+    assert {s.id for s in all_stmts} == {stmt_a.id, stmt_b.id, stmt_legacy.id}
+    assert {s.workspace_id for s in all_stmts} == {WS_A, WS_B, None}
+
+
+# ---------------------------------------------------------------------------
+# Migration idempotency
+# ---------------------------------------------------------------------------
+
+
+def _table_names(db_path: Path) -> list[str]:
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall()
+    return [r[0] for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_migration_on_existing_pre_fst_db(tmp_path: Path) -> None:
+    """Booting on a PRE-FST fabric.db adds the new tables and keeps old data."""
+    db_path = tmp_path / "fabric.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(_PRE_FST_SCHEMA)
+        conn.execute("INSERT INTO fabric_object_types (id, name) VALUES ('ot-old', 'Lease')")
+        conn.execute(
+            "INSERT INTO fabric_objects (id, type_id, type_name, properties)"
+            " VALUES ('obj-old', 'ot-old', 'Lease', '{\"rent\": 900}')"
+        )
+        conn.commit()
+
+    store = FabricStore(db_path)
+    # First boot migrates; the new tables must appear.
+    obj = await store.get_object("obj-old")
+    assert obj is not None and obj.properties == {"rent": 900}
+    tables = _table_names(db_path)
+    assert "fabric_statements" in tables
+    assert "fabric_sources" in tables
+
+    # And the new tables are immediately usable against the OLD object.
+    src = await store.upsert_source("document", document_uri="doc:1")
+    await store.append_statement("obj-old", "rent", 900, src.id, "mirror")
+    assert (await store.get_statements("obj-old", property="rent"))[0].value == 900
+
+
+@pytest.mark.asyncio
+async def test_migration_idempotent_twice_no_dup_tables(tmp_path: Path) -> None:
+    """Migrating twice (two stores, plus a forced re-run) errors nowhere and
+    duplicates nothing."""
+    db_path = tmp_path / "fabric.db"
+
+    store1 = FabricStore(db_path)
+    await store1._ensure_schema()
+    tables_after_first = _table_names(db_path)
+
+    # A second store on the SAME file re-runs the full migration from scratch.
+    store2 = FabricStore(db_path)
+    await store2._ensure_schema()
+    # Force a third pass on store1 too (aclose resets the initialized latch).
+    await store1.aclose()
+    await store1._ensure_schema()
+
+    tables_after_third = _table_names(db_path)
+    assert tables_after_third == tables_after_first  # no new/dup tables
+    assert len(set(tables_after_third)) == len(tables_after_third)
+    assert tables_after_third.count("fabric_statements") == 1
+    assert tables_after_third.count("fabric_sources") == 1
+
+    # The workspace-aware source-identity unique index survived both re-runs
+    # exactly once, and the early-FST-1 (workspace-less) index name is absent.
+    with sqlite3.connect(db_path) as conn:
+        idx_ws = conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index'"
+            " AND name='idx_sources_identity_ws'"
+        ).fetchone()[0]
+        idx_old = conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_sources_identity'"
+        ).fetchone()[0]
+    assert idx_ws == 1
+    assert idx_old == 0
+
+
+@pytest.mark.asyncio
+async def test_migration_heals_early_fst1_db_without_workspace(tmp_path: Path) -> None:
+    """A DB from the early FST-1 build (statements/sources tables WITHOUT
+    workspace_id, plus the workspace-less identity index) is healed on boot:
+    the column is ALTERed in and the old index is swapped for
+    idx_sources_identity_ws."""
+    db_path = tmp_path / "fabric.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(_PRE_FST_SCHEMA)
+        conn.executescript(
+            """
+            CREATE TABLE fabric_sources (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                connector TEXT,
+                run_id TEXT,
+                document_uri TEXT,
+                actor_id TEXT,
+                session_id TEXT,
+                retrieved_at TEXT,
+                created_at TEXT DEFAULT (datetime('now'))
+            );
+            CREATE TABLE fabric_statements (
+                id TEXT PRIMARY KEY,
+                object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+                property TEXT NOT NULL,
+                value TEXT NOT NULL DEFAULT 'null',
+                source_ref_id TEXT NOT NULL REFERENCES fabric_sources(id),
+                writer_class TEXT NOT NULL,
+                observed_at TEXT NOT NULL,
+                recorded_at TEXT NOT NULL,
+                valid_from TEXT NOT NULL,
+                valid_to TEXT,
+                rank TEXT NOT NULL DEFAULT 'normal',
+                rank_reason TEXT,
+                pinned INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE UNIQUE INDEX idx_sources_identity ON fabric_sources(
+                kind, IFNULL(connector, ''), IFNULL(run_id, ''),
+                IFNULL(document_uri, ''), IFNULL(actor_id, ''),
+                IFNULL(session_id, '')
+            );
+            """
+        )
+        conn.commit()
+
+    store = FabricStore(db_path)
+    # Boot heals the schema and the workspace-aware surface works end to end.
+    src = await store.upsert_source("document", document_uri="doc:1", workspace_id=WS_A)
+    assert src.workspace_id == WS_A
+    with sqlite3.connect(db_path) as conn:
+        stmt_cols = {r[1] for r in conn.execute("PRAGMA table_info(fabric_statements)")}
+        src_cols = {r[1] for r in conn.execute("PRAGMA table_info(fabric_sources)")}
+        idx_names = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='fabric_sources'"
+            )
+        }
+    assert "workspace_id" in stmt_cols
+    assert "workspace_id" in src_cols
+    assert "idx_sources_identity_ws" in idx_names
+    assert "idx_sources_identity" not in idx_names
+
+
+# ---------------------------------------------------------------------------
+# Mode flag (inert in FST-1)
+# ---------------------------------------------------------------------------
+
+
+def test_mode_flag_defaults_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POCKETPAW_FABRIC_SOURCE_TRUTH_MODE", raising=False)
+    from pocketpaw.config import Settings
+
+    assert Settings().fabric_source_truth_mode == "off"
+
+
+def test_mode_flag_env_positions(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pocketpaw.config import Settings
+
+    for mode in ("off", "shadow", "enforce"):
+        monkeypatch.setenv("POCKETPAW_FABRIC_SOURCE_TRUTH_MODE", mode)
+        assert Settings().fabric_source_truth_mode == mode
+
+    monkeypatch.setenv("POCKETPAW_FABRIC_SOURCE_TRUTH_MODE", "sideways")
+    with pytest.raises(Exception):
+        Settings()

--- a/tests/test_verify_mode.py
+++ b/tests/test_verify_mode.py
@@ -1,0 +1,83 @@
+# Created: 2026-07-10 (feat/verify-mode-shadow) — resolver-precedence unit
+#   tests for the three-position Self-Verifying-Loop rollout switches:
+#   ``effective_deep_work_verify_mode()`` (OSS executor terminal) and
+#   ``effective_cloud_plan_verify_mode()`` (ee/cloud planner terminal).
+#   Both mirror the ``effective_spend_mode()`` resolution shape — a
+#   non-'off' mode wins outright — EXCEPT the legacy bool maps to
+#   'enforce' (its shipped meaning), never to shadow: mapping it to the
+#   middle position would silently strip requeue/escalate from a deploy
+#   that already set the bool.
+"""Precedence tests for the verify_mode resolvers (off | shadow | enforce)."""
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.config import Settings
+
+# Every test passes BOTH the mode and the legacy bool explicitly so a local
+# config.json / env can never skew the resolution under test.
+
+
+class TestDeepWorkVerifyModeResolver:
+    """effective_deep_work_verify_mode() — OSS Mission Control terminal."""
+
+    def test_field_default_is_off(self):
+        assert Settings.model_fields["deep_work_verify_mode"].default == "off"
+
+    def test_off_plus_bool_false_resolves_off(self):
+        s = Settings(deep_work_verify_mode="off", deep_work_verify_loop_enabled=False)
+        assert s.effective_deep_work_verify_mode() == "off"
+
+    def test_legacy_bool_true_resolves_enforce_not_shadow(self):
+        # BACK-COMPAT SAFETY: the bool's shipped meaning IS the acting loop.
+        # Resolving it to 'shadow' would silently weaken any deployment that
+        # already set it — so the bool maps to 'enforce', never the middle.
+        s = Settings(deep_work_verify_mode="off", deep_work_verify_loop_enabled=True)
+        assert s.effective_deep_work_verify_mode() == "enforce"
+
+    def test_explicit_shadow_wins_over_legacy_bool(self):
+        s = Settings(deep_work_verify_mode="shadow", deep_work_verify_loop_enabled=True)
+        assert s.effective_deep_work_verify_mode() == "shadow"
+
+    def test_explicit_enforce_resolves_without_bool(self):
+        s = Settings(deep_work_verify_mode="enforce", deep_work_verify_loop_enabled=False)
+        assert s.effective_deep_work_verify_mode() == "enforce"
+
+    def test_invalid_mode_rejected(self):
+        with pytest.raises(Exception):
+            Settings(deep_work_verify_mode="on")
+
+
+class TestCloudPlanVerifyModeResolver:
+    """effective_cloud_plan_verify_mode() — ee/cloud planner terminal."""
+
+    def test_field_default_is_off(self):
+        assert Settings.model_fields["cloud_plan_verify_mode"].default == "off"
+
+    def test_off_plus_bool_false_resolves_off(self):
+        s = Settings(cloud_plan_verify_mode="off", cloud_plan_verify_loop_enabled=False)
+        assert s.effective_cloud_plan_verify_mode() == "off"
+
+    def test_legacy_bool_true_resolves_enforce_not_shadow(self):
+        s = Settings(cloud_plan_verify_mode="off", cloud_plan_verify_loop_enabled=True)
+        assert s.effective_cloud_plan_verify_mode() == "enforce"
+
+    def test_explicit_shadow_wins_over_legacy_bool(self):
+        s = Settings(cloud_plan_verify_mode="shadow", cloud_plan_verify_loop_enabled=True)
+        assert s.effective_cloud_plan_verify_mode() == "shadow"
+
+    def test_explicit_enforce_resolves_without_bool(self):
+        s = Settings(cloud_plan_verify_mode="enforce", cloud_plan_verify_loop_enabled=False)
+        assert s.effective_cloud_plan_verify_mode() == "enforce"
+
+    def test_terminals_resolve_independently(self):
+        # One terminal in shadow must not drag the other along.
+        s = Settings(
+            deep_work_verify_mode="shadow",
+            deep_work_verify_loop_enabled=False,
+            cloud_plan_verify_mode="off",
+            cloud_plan_verify_loop_enabled=True,
+        )
+        assert s.effective_deep_work_verify_mode() == "shadow"
+        assert s.effective_cloud_plan_verify_mode() == "enforce"


### PR DESCRIPTION
## What lands

The integration branch for two flag-gated waves, smoke-tested together:

- **Fabric source-truth** (the FST chain, #1690-#1698): per-property statements with normalized provenance, the trust-ladder resolver (human > connector > mirror > agent > inferred, families, freshness demotion), shadow/enforce rollout modes with a divergence report gating the flip (`ENFORCE-READY`), un-rankable conflicts to the Instinct stewardship queue, PIN/IGNORE/CHANGE/CORRECT steward verbs, and opt-in provenance on reads. Everything behind `fabric_source_truth_mode` (default off).
- **verify_mode** (#1688): the off | shadow | enforce rollout ladder for the self-verifying loop on both terminals — shadow stamps verdicts + would-have telemetry without ever touching task status, so real tenants can observe before enforcing. Legacy bools resolve to enforce (their shipped meaning).

## Verification on this branch

Deterministic: 369 fabric + 95 verify/judge + 45 cloud + 131 instinct tests green; import contracts kept; both ladder e2es green. One merge conflict (config.py changelog comment) resolved keep-both.

Live smoke (fresh worktree, real store files, real booted backend on :9251, real keyless agents): the full fabric rollout walk off -> shadow (divergence line + report CLI verdict) -> enforce (a machine-inferred/agent claim cannot displace the connector fact in the cache — recorded as a losing statement instead) -> steward verbs -> back to off with history intact; and a live deep_work task under `verify_mode=shadow` completing DONE with verdict + would_have + judge stamps and side-effects intact, never requeued or blocked. Zero defects.

Constituent PRs will be closed as landed via this integration.