### PR TITLE
Artifact deliveries now ride the chat stream as attachments + events

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/deliver.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/deliver.py
@@ -1,6 +1,15 @@
 # deliver.py — in-process MCP server exposing ``deliver_artifact`` to the cloud
 # chat agent (claude_agent_sdk). Created: 2026-06-26 (ART-4).
 #
+# 2026-07-11 (ART-1): on a SUCCESSFUL delivery the tool now records the delivery
+# facts ({file_id, name, mime, size}) to the per-run collector in
+# ``ee.cloud.chat.agent_service`` (``record_delivered_artifact``). ``run_core``
+# drains that collector at persist time into a ``{type:"artifact", meta}``
+# attachment on the assistant message plus one ``artifact`` SSE event apiece, so
+# the client gets a structured signal instead of only a link buried in the
+# tool-result text. Failed deliveries record nothing (they return before the
+# recording call); the recording is best-effort and never fails the delivery.
+#
 # This is the payoff of the cloud-artifacts stack: a cloud agent builds a file
 # (or a whole directory) inside its per-tenant jail (ART-2), then calls this tool
 # to LAND that artifact in the tenant's blob storage and hand the user back a
@@ -123,6 +132,20 @@ def _success_response(body: dict[str, Any]) -> dict[str, Any]:
             }
         ]
     }
+
+
+def _record_delivery(meta: dict[str, Any]) -> None:
+    """Publish a successful delivery to the per-run collector in
+    ``ee.cloud.chat.agent_service`` (drained by ``run_core`` into an ``artifact``
+    attachment + SSE event). Best-effort: outside a chat run it's a no-op, and a
+    collector failure must never fail an otherwise-successful delivery — so any
+    error here is swallowed."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import record_delivered_artifact
+
+        record_delivered_artifact(meta)
+    except Exception:  # noqa: BLE001
+        logger.debug("recording delivered artifact failed", exc_info=True)
 
 
 def _identity() -> tuple[str | None, str | None]:
@@ -376,6 +399,18 @@ async def _deliver_handler(args: dict) -> dict:
     finally:
         if tmp_to_clean is not None:
             tmp_to_clean.unlink(missing_ok=True)
+
+    # Record the delivery for the run's assistant message + SSE stream. Uses
+    # ``name`` (not the result body's ``filename``) to match the frozen artifact
+    # attachment/event contract the client is built against.
+    _record_delivery(
+        {
+            "file_id": rec.id,
+            "name": rec.filename,
+            "mime": rec.mime,
+            "size": rec.size,
+        }
+    )
 
     return _success_response(
         {

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -152,6 +152,16 @@ now REJECTS an empty ``workspace_id`` / ``user_id`` (raises ``ValueError``)
 instead of binding ``""``, so any future caller that loses tenancy fails loudly
 at the seam, not deep inside an MCP tool.
 
+Changes: 2026-07-11 (ART-1) — added the per-run ``_delivered_artifacts``
+collector ContextVar beside the identity ContextVars (+ ``record_delivered_artifact``
+and the ``attach_/detach_delivered_artifacts_collector`` primitives and the
+``collect_delivered_artifacts`` context manager). The ``deliver_artifact`` MCP
+tool appends one meta dict per SUCCESSFUL delivery; ``run_core`` binds a fresh
+list at run start and drains it at persist time into ``{type:"artifact", meta}``
+attachments plus one ``artifact`` SSE event apiece (in delivery order). It holds
+a MUTABLE list so the tool's append (never a rebind) is visible to the run task
+that bound it across the SDK task boundary — the same shared-object propagation
+``_sse_event_sink`` relies on.
 Changes: 2026-06-27 (fix/cloud-artifacts-reland) — added the per-run
 ``_active_cloud_chat_run`` marker ContextVar (+ ``current_cloud_chat_run`` and
 the ``mark_cloud_chat_run`` context manager) beside the identity ContextVars.
@@ -400,6 +410,70 @@ def detach_sse_event_sink(token: Token) -> None:
 # pocket-specific names. Both pairs operate on the same underlying sink.
 attach_pocket_event_sink = attach_sse_event_sink
 detach_pocket_event_sink = detach_sse_event_sink
+
+
+# ---------------------------------------------------------------------------
+# Per-run delivered-artifact collector (ART-1)
+#
+# ``deliver_artifact`` (``mcp_servers/deliver.py``) appends one meta dict —
+# ``{file_id, name, mime, size}`` — per SUCCESSFUL delivery. ``run_core`` binds a
+# fresh list at run start and drains it at persist time into a
+# ``{type:"artifact", meta:...}`` attachment on the assistant message plus one
+# ``artifact`` SSE event apiece, in delivery order (mirroring the ripple event).
+# The ContextVar holds a MUTABLE list: the tool mutates it (``append``), never
+# rebinds, so every delivery is visible to the run task that bound the list even
+# though the tool runs in a descendant SDK task — the same shared-object
+# propagation ``_sse_event_sink`` relies on. ``None`` (unbound) => no-op, so a
+# deliver call outside a chat run (a CLI invocation, a direct unit test) records
+# nothing.
+# ---------------------------------------------------------------------------
+
+
+_delivered_artifacts: ContextVar[list[dict[str, Any]] | None] = ContextVar(
+    "agent_delivered_artifacts", default=None
+)
+
+
+def attach_delivered_artifacts_collector(collector: list[dict[str, Any]]) -> Token:
+    """Bind ``collector`` as the active run's delivered-artifact sink.
+
+    Mirrors ``attach_sse_event_sink`` — the caller keeps its own reference to
+    ``collector`` and reads it post-run; deliver-tool appends land on the same
+    object.
+    """
+    return _delivered_artifacts.set(collector)
+
+
+def detach_delivered_artifacts_collector(token: Token) -> None:
+    """Restore the previous collector binding."""
+    _delivered_artifacts.reset(token)
+
+
+@contextmanager
+def collect_delivered_artifacts() -> Iterator[list[dict[str, Any]]]:
+    """Bind a fresh per-run delivered-artifact collector and yield it.
+
+    The yielded list stays valid after the block exits (Python keeps the ``as``
+    target in scope), so the run can drain it at persist time even though the
+    ContextVar is reset on exit.
+    """
+    collector: list[dict[str, Any]] = []
+    token = attach_delivered_artifacts_collector(collector)
+    try:
+        yield collector
+    finally:
+        detach_delivered_artifacts_collector(token)
+
+
+def record_delivered_artifact(meta: dict[str, Any]) -> None:
+    """Append one successful delivery's ``meta`` (file_id/name/mime/size) to the
+    active run's collector. No-op when unbound (a deliver call outside a chat
+    run). Never raises — a collector hiccup must not fail an otherwise-successful
+    delivery."""
+    collector = _delivered_artifacts.get()
+    if collector is None:
+        return
+    collector.append(meta)
 
 
 class ScopeKind(StrEnum):

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -232,6 +232,7 @@ from pocketpaw_ee.cloud.chat.agent_service import (
     attach_sse_event_sink,
     build_behavior_instructions,
     build_knowledge_context,
+    collect_delivered_artifacts,
     detach_agent_identity,
     detach_sse_event_sink,
     mark_cloud_chat_run,
@@ -1641,7 +1642,13 @@ async def execute_run(spec: RunSpec) -> None:
     # trips the guard. Reset in the context manager's finally so it never leaks
     # past this run. The post-loop persist below resolves no cwd, so it sits
     # outside the marked region.
-    with mark_cloud_chat_run():
+    # ``collect_delivered_artifacts`` binds a fresh per-run collector list HERE,
+    # in execute_run's own task context and BEFORE the prewarm/SDK ``create_task``
+    # calls that copy it — so the ``deliver_artifact`` tool (running in a
+    # descendant SDK task) appends onto the SAME list this task drains at persist
+    # time. The ``as`` target stays in scope after the block, so the post-loop
+    # persist below can still read it once the ContextVar is reset.
+    with mark_cloud_chat_run(), collect_delivered_artifacts() as delivered_artifacts:
         # PREWARM (feat/claude-sdk-prewarm): kick off warming the agent's CLI
         # subprocess for this session NOW — concurrently with the remaining pre-turn
         # work below (mark-running, typing broadcast, and inside _drive_agent_loop:
@@ -1787,6 +1794,15 @@ async def execute_run(spec: RunSpec) -> None:
         attachments.append({"type": "ripple", "meta": ripple_spec})
         full_text = remaining_text
         await transport.append_event(spec.run_id, "ripple", {"spec": ripple_spec})
+
+    # ART-1: drain the per-run delivered-artifact collector. Each successful
+    # ``deliver_artifact`` call appended one ``{file_id, name, mime, size}`` meta;
+    # persist one ``{type:"artifact", meta}`` attachment apiece (alongside any
+    # ripple attachment — appended, never clobbering it) and emit one ``artifact``
+    # SSE event per delivery, in delivery order, mirroring the ripple event.
+    for meta in delivered_artifacts:
+        attachments.append({"type": "artifact", "meta": meta})
+        await transport.append_event(spec.run_id, "artifact", meta)
 
     assistant_id = await _persist_and_complete(spec, ctx, full_text, attachments, usage=usage)
     await transport.append_event(

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,15 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-07-11 (ART-1) — ``execute_run`` binds a per-run delivered-artifact
+  collector (``collect_delivered_artifacts``) around the run and, at persist
+  time, drains it into one ``{type:"artifact", meta}`` attachment on the
+  assistant message plus one ``artifact`` SSE event apiece (in delivery order,
+  mirroring the ripple event). A non-cancelled run that delivered artifacts but
+  produced no closing text no longer early-returns — it routes through the
+  persist path so the attachments + events are never dropped (the files already
+  landed in blob storage). ``deliver_artifact`` (``mcp_servers/deliver.py``)
+  feeds the collector via ``record_delivered_artifact`` on each success.
 - 2026-07-08 (CS-13, feat/per-send-model-override) — ``execute_run`` copies
   ``spec.model_override`` onto the rebuilt ``ctx`` and ``_drive_agent_loop``
   forwards it into ``pool.run`` as ``model_override`` ONLY when set (the same
@@ -1755,10 +1764,16 @@ async def execute_run(spec: RunSpec) -> None:
         await transport.set_ttl(spec.run_id, _stream_ttl())
         return
 
-    if cancelled or not full_text.strip():
+    if cancelled or (not full_text.strip() and not delivered_artifacts):
         # Empty-text non-cancelled runs still complete cleanly — without this,
         # the doc would sit in ``running`` until the 10-minute sweeper marked
         # it ``interrupted``, surfacing a phantom active_run to the frontend.
+        # ART-1 exception: a non-cancelled run that DELIVERED artifacts but
+        # produced no closing text must NOT early-return — the files landed in
+        # blob storage, so it falls through to the persist path below to record
+        # the ``{type:"artifact"}`` attachments + emit their SSE events (empty
+        # message text is fine). A cancelled run keeps the early return regardless
+        # (no assistant message on a cancel).
         try:
             if cancelled:
                 await run_service.mark_terminal(

--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -30,6 +30,13 @@ Updated 2026-06-28 (feat/aiam-agent-revoke, AW-4): ``_run_agent_response``
 catches ``AgentDisabled`` from ``pool.get`` explicitly and SKIPS the agent
 (returns None, no error to the channel) — a soft-disabled agent simply stops
 responding in groups/DMs until re-enabled.
+
+Updated 2026-07-11 (ART-1): ``_run_agent_response`` binds a per-run
+delivered-artifact collector around ``pool.run`` and drains it into a
+``{type:"artifact", meta}`` attachment per successful ``deliver_artifact`` call,
+so a group/DM agent that delivers a file persists the structured signal too.
+This path has no run-transport SSE stream, so it emits no ``artifact`` event —
+that applies only to the streaming ``run_core`` path.
 """
 
 from __future__ import annotations
@@ -422,7 +429,9 @@ async def _run_agent_response(
     from pocketpaw_ee.cloud.chat import message_service
     from pocketpaw_ee.cloud.chat.agent_service import (
         attach_agent_identity,
+        attach_delivered_artifacts_collector,
         detach_agent_identity,
+        detach_delivered_artifacts_collector,
     )
 
     pool = get_agent_pool()
@@ -502,6 +511,14 @@ async def _run_agent_response(
     # (call from a cloud chat session)". ``user_id`` is the agent itself — it is
     # the actor on this path, matching the cloud MCP tests' setup.
     identity_tokens = attach_agent_identity(workspace_id=workspace_id, user_id=agent_id)
+    # ART-1: bind a per-run collector so a ``deliver_artifact`` call on THIS
+    # (group/DM) path lands a ``{type:"artifact", meta}`` attachment on the agent
+    # message. This path has no run-transport SSE stream, so it persists the
+    # attachment only — no ``artifact`` event (that applies to the streaming
+    # ``run_core`` path). The list is bound before ``pool.run`` so the descendant
+    # SDK task's tool appends onto the same object this function drains below.
+    delivered_artifacts: list[dict[str, Any]] = []
+    delivered_token = attach_delivered_artifacts_collector(delivered_artifacts)
     try:
         async for event in pool.run(
             agent_id, user_message, session_key, history, knowledge_context=knowledge_context
@@ -560,6 +577,7 @@ async def _run_agent_response(
         full_text = full_text or "[Agent response failed]"
     finally:
         detach_agent_identity(identity_tokens)
+        detach_delivered_artifacts_collector(delivered_token)
 
     if saw_error_event and not full_text.strip():
         details = f": {error_summary}" if error_summary else ""
@@ -584,6 +602,12 @@ async def _run_agent_response(
                 full_text = full_text.strip()
     except Exception:
         pass
+
+    # ART-1: persist one ``{type:"artifact", meta}`` attachment per successful
+    # delivery on this path too (alongside any ripple attachment). No SSE event —
+    # the group/DM bridge has no run transport stream.
+    for meta in delivered_artifacts:
+        attachment_dicts.append({"type": "artifact", "meta": meta})
 
     # Auto-create pocket from ripple spec
     pocket_id = None

--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -583,7 +583,10 @@ async def _run_agent_response(
         details = f": {error_summary}" if error_summary else ""
         full_text = f"[Agent encountered an error and could not produce a full response{details}]"
 
-    if not full_text.strip():
+    # ART-1: an empty reply that nonetheless DELIVERED artifacts must not be
+    # dropped — the files landed in blob storage, so fall through to persist a
+    # message carrying the ``{type:"artifact"}`` attachments (empty text is fine).
+    if not full_text.strip() and not delivered_artifacts:
         return None
 
     # Check for ripple spec in response

--- a/tests/cloud/agents/test_deliver_tool.py
+++ b/tests/cloud/agents/test_deliver_tool.py
@@ -369,3 +369,60 @@ async def test_build_deliver_server_gated_on_cloud(monkeypatch: pytest.MonkeyPat
     built = deliver.build_deliver_server()
     assert built is not None
     assert built[0] == "pocketpaw_deliver"
+
+
+async def test_successful_delivery_records_to_collector(beanie_db) -> None:
+    """ART-1: a successful ``deliver_artifact`` records one meta on the per-run
+    collector in the frozen contract shape ({file_id, name, mime, size}) — the
+    fact ``run_core`` drains into an ``artifact`` attachment + SSE event."""
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+    from pocketpaw_ee.cloud.chat.agent_service import collect_delivered_artifacts
+
+    tokens = _bind("wsA", "uA", "sessA")
+    try:
+        (_agent_cwd() / "index.html").write_text("<html>hi</html>")
+        with collect_delivered_artifacts() as delivered:
+            resp = await _deliver_handler({"path": "index.html"})
+    finally:
+        _detach(tokens)
+
+    body = _body(resp)
+    assert body["ok"] is True
+    assert len(delivered) == 1
+    meta = delivered[0]
+    assert set(meta) == {"file_id", "name", "mime", "size"}
+    assert meta["name"] == "index.html"
+    assert meta["mime"] == "text/html"
+    assert meta["file_id"] == body["file_id"]
+    assert meta["size"] == body["size"]
+
+
+async def test_failed_delivery_records_nothing(beanie_db) -> None:
+    """ART-1 criterion 3: a failed delivery (missing file) records nothing."""
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+    from pocketpaw_ee.cloud.chat.agent_service import collect_delivered_artifacts
+
+    tokens = _bind("wsA", "uA", "sessA")
+    try:
+        with collect_delivered_artifacts() as delivered:
+            resp = await _deliver_handler({"path": "does-not-exist.txt"})
+    finally:
+        _detach(tokens)
+
+    assert resp.get("is_error") is True
+    assert delivered == []
+
+
+async def test_delivery_outside_run_is_noop(beanie_db) -> None:
+    """No collector bound (a deliver outside a chat run) => recording is a
+    silent no-op, delivery still succeeds."""
+    from pocketpaw_ee.agent.mcp_servers.deliver import _deliver_handler
+
+    tokens = _bind("wsA", "uA", "sessA")
+    try:
+        (_agent_cwd() / "report.txt").write_text("hello")
+        resp = await _deliver_handler({"path": "report.txt"})
+    finally:
+        _detach(tokens)
+
+    assert _body(resp)["ok"] is True

--- a/tests/cloud/runs/test_run_core.py
+++ b/tests/cloud/runs/test_run_core.py
@@ -927,3 +927,39 @@ async def test_execute_run_no_delivery_emits_no_artifact_event(monkeypatch):
     assert not any(e.event == "artifact" for e in events)
     assert all(a["type"] != "artifact" for a in attachments)
     assert [e.event for e in events][-1] == "stream_end"
+
+
+def _recording_only_events(metas: list[dict]):
+    """A fake ``_iter_agent_events`` that records each meta (as a successful
+    ``deliver_artifact`` would) but yields NO text — the empty-reply case that
+    used to early-return and silently drop the delivered artifacts."""
+
+    async def _gen(spec, ctx):
+        from pocketpaw_ee.cloud.chat.agent_service import record_delivered_artifact
+
+        for meta in metas:
+            record_delivered_artifact(meta)
+        if False:  # pragma: no cover — makes this an async generator with no yields
+            yield None
+
+    return _gen
+
+
+async def test_execute_run_persists_artifacts_when_reply_text_empty(monkeypatch):
+    """ART-1 regression: a non-cancelled run that delivered an artifact but
+    produced NO closing text must still persist the ``{type:"artifact"}``
+    attachment and emit the ``artifact`` event — the file already landed in blob
+    storage, so the empty-text early return must not drop it."""
+    meta = {"file_id": "f9", "name": "export.csv", "mime": "text/csv", "size": 42}
+    events, attachments = await _run_and_capture(monkeypatch, _recording_only_events([meta]))
+
+    # The artifact event fired despite the empty reply...
+    artifact_events = [e for e in events if e.event == "artifact"]
+    assert len(artifact_events) == 1
+    assert artifact_events[0].data == meta
+    # ...and the assistant message was persisted carrying the attachment.
+    assert attachments == [{"type": "artifact", "meta": meta}]
+    # stream_end carries a real assistant_message_id (persist ran, not the
+    # empty-text early return whose stream_end has assistant_message_id=None).
+    stream_end = [e for e in events if e.event == "stream_end"][-1]
+    assert stream_end.data["assistant_message_id"] == "assistant-msg-1"

--- a/tests/cloud/runs/test_run_core.py
+++ b/tests/cloud/runs/test_run_core.py
@@ -826,3 +826,104 @@ async def test_execute_run_legacy_path_leaves_surface_context_none(monkeypatch):
     resolved = captured.get("resolved_profile")
     assert resolved is not None
     assert resolved.deny_mcp_tool_ids == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# ART-1 — deliver_artifact rides the same persist/SSE seam as ripple. A
+# successful delivery lands a ``{type:"artifact", meta}`` attachment on the
+# assistant message AND an ``artifact`` SSE event carrying the frozen contract
+# payload; multiple deliveries in one run produce multiple of each, in delivery
+# order, alongside any ripple attachment (never clobbering it).
+# ---------------------------------------------------------------------------
+
+
+def _delivering_events(metas: list[dict], *, block: str | None = None):
+    """A fake ``_iter_agent_events`` that records each meta in ``metas`` to the
+    per-run collector (as ``deliver_artifact`` would on success), optionally
+    streaming a fenced ``block`` so the run also carries a ripple attachment."""
+
+    async def _gen(spec, ctx):
+        from pocketpaw_ee.cloud.chat.agent_service import record_delivered_artifact
+
+        for meta in metas:
+            record_delivered_artifact(meta)
+            yield ("chunk", {"content": f"delivered {meta['name']}\n", "type": "text"})
+        if block is not None:
+            yield ("chunk", {"content": block, "type": "text"})
+
+    return _gen
+
+
+async def _run_and_capture(monkeypatch, events_gen):
+    """Drive ``execute_run`` with ``events_gen`` and return
+    ``(sse_events, persisted_attachments)``."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    captured: dict[str, Any] = {}
+
+    async def _capture_persist(spec, ctx, full_text, attachments, usage=None):
+        captured["attachments"] = list(attachments)
+        return "assistant-msg-1"
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", events_gen)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _capture_persist)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+
+    await run_core.execute_run(_spec())
+
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    return events, captured.get("attachments", [])
+
+
+async def test_execute_run_emits_artifact_event_and_persists_attachment(monkeypatch):
+    meta = {"file_id": "f1", "name": "index.html", "mime": "text/html", "size": 12345}
+    events, attachments = await _run_and_capture(monkeypatch, _delivering_events([meta]))
+
+    artifact_events = [e for e in events if e.event == "artifact"]
+    assert len(artifact_events) == 1
+    # The event payload is the flat contract shape (not wrapped in a key).
+    assert artifact_events[0].data == meta
+    # ...persisted as one {type:"artifact", meta} attachment.
+    assert attachments == [{"type": "artifact", "meta": meta}]
+    # The artifact event fires before the terminal stream_end.
+    assert [e.event for e in events][-1] == "stream_end"
+
+
+async def test_execute_run_multiple_deliveries_preserve_order(monkeypatch):
+    metas = [
+        {"file_id": "f1", "name": "a.txt", "mime": "text/plain", "size": 1},
+        {"file_id": "f2", "name": "b.zip", "mime": "application/zip", "size": 2},
+        {"file_id": "f3", "name": "c.pdf", "mime": "application/pdf", "size": 3},
+    ]
+    events, attachments = await _run_and_capture(monkeypatch, _delivering_events(metas))
+
+    artifact_events = [e.data for e in events if e.event == "artifact"]
+    assert artifact_events == metas
+    assert attachments == [{"type": "artifact", "meta": m} for m in metas]
+
+
+async def test_execute_run_artifact_rides_alongside_ripple(monkeypatch):
+    meta = {"file_id": "f1", "name": "site.zip", "mime": "application/zip", "size": 9}
+    events, attachments = await _run_and_capture(
+        monkeypatch, _delivering_events([meta], block=_CANONICAL_UI_SPEC_BLOCK)
+    )
+
+    # Both a ripple event AND an artifact event fire.
+    assert any(e.event == "ripple" for e in events)
+    assert any(e.event == "artifact" for e in events)
+    # The ripple attachment is not clobbered by the artifact one; both persist.
+    types = [a["type"] for a in attachments]
+    assert "ripple" in types
+    assert {"type": "artifact", "meta": meta} in attachments
+
+
+async def test_execute_run_no_delivery_emits_no_artifact_event(monkeypatch):
+    events, attachments = await _run_and_capture(monkeypatch, _delivering_events([]))
+
+    assert not any(e.event == "artifact" for e in events)
+    assert all(a["type"] != "artifact" for a in attachments)
+    assert [e.event for e in events][-1] == "stream_end"

--- a/tests/cloud/shared/test_agent_bridge_attachments.py
+++ b/tests/cloud/shared/test_agent_bridge_attachments.py
@@ -278,3 +278,80 @@ async def test_run_agent_response_applies_response_label_prefix() -> None:
     assert result.startswith("Final response:\n\n")
     assert "Synthesized answer body" in result
     assert created["content"].startswith("Final response:\n\n")
+
+
+@pytest.mark.asyncio
+async def test_run_agent_response_persists_artifact_when_text_empty():
+    """ART-1 regression: an empty reply that DELIVERED an artifact must still
+    persist a message carrying the {type:"artifact"} attachment. Before the fix,
+    ``if not full_text.strip(): return None`` dropped it even though the file
+    landed in blob storage."""
+    from pocketpaw_ee.cloud.chat.agent_service import record_delivered_artifact
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    instance = SimpleNamespace(agent_name="Test Agent")
+    pool = MagicMock()
+    pool.get = AsyncMock(return_value=instance)
+    pool.observe = AsyncMock()
+
+    meta = {"file_id": "f7", "name": "out.pdf", "mime": "application/pdf", "size": 88}
+
+    async def fake_run(*_args, **_kwargs):
+        # A successful deliver_artifact mid-run records the fact...
+        record_delivered_artifact(meta)
+        # ...but the agent produced no closing text.
+        yield _done_event()
+
+    pool.run = fake_run
+
+    from pocketpaw_ee.cloud.models.message import Message as _RealMessage
+
+    to_list_mock = AsyncMock(return_value=[])
+    limit_mock = MagicMock()
+    limit_mock.to_list = to_list_mock
+    sort_mock = MagicMock()
+    sort_mock.limit = MagicMock(return_value=limit_mock)
+    find_mock = MagicMock()
+    find_mock.sort = MagicMock(return_value=sort_mock)
+
+    created = {}
+
+    async def fake_create_agent_message(*, group_id, agent_id, content, attachments=None):
+        created["content"] = content
+        created["attachments"] = attachments
+        return SimpleNamespace(id="msg-art")
+
+    with (
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=AsyncMock()),
+        patch.multiple(
+            _RealMessage,
+            create=True,
+            group=MagicMock(),
+            deleted=MagicMock(),
+            createdAt=MagicMock(),
+        ),
+        patch.object(_RealMessage, "find", MagicMock(return_value=find_mock)),
+        patch("pocketpaw.agents.pool.get_agent_pool", return_value=pool),
+        patch(
+            "pocketpaw_ee.cloud.chat.message_service.create_agent_message",
+            new=AsyncMock(side_effect=fake_create_agent_message),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context",
+            new=AsyncMock(return_value=""),
+        ),
+    ):
+        result = await agent_bridge._run_agent_response(
+            agent_id="agent-1",
+            group_id="group-1",
+            workspace_id="ws-1",
+            user_message="make me a pdf",
+            group_members=["user-1"],
+            attachments=None,
+        )
+
+    # The message was persisted (NOT dropped) carrying the artifact attachment,
+    # even though the reply text was empty.
+    assert created["attachments"] == [{"type": "artifact", "meta": meta}]
+    assert created["content"] == ""
+    assert result is not None


### PR DESCRIPTION
## What

When a cloud agent calls `deliver_artifact`, the file already lands in tenant blob storage — but the client only ever saw a link buried in tool-result text. This gives it a structured signal, the same way ripple attachments work:

- each successful delivery is recorded to a per-run collector (ContextVar, bound alongside the existing identity/SSE-sink vars)
- at persist time, `run_core` drains the collector into one `{type: "artifact", meta: {file_id, name, mime, size}}` attachment per delivery on the assistant message, and emits an `artifact` SSE event apiece via the run transport
- the group/DM bridge path persists the attachment too (no event — that path has no run transport)
- failed deliveries record nothing

A run whose *final* action is a delivery with no closing prose used to hit the empty-text early return and drop everything; that's fixed on both paths (second commit), with regression tests that fail against the pre-fix source.

## What this doesn't touch

`EEUploadService` presign/disposition logic is untouched — delivered HTML still downloads as an attachment rather than rendering inline.

## Tests

`163 passed` across `tests/cloud/runs/`, `tests/cloud/agents/test_deliver_tool.py`, `tests/cloud/shared/test_agent_bridge_attachments.py`. New coverage: event frame shape, persisted attachment shape, multi-delivery ordering, ripple coexistence, failure-records-nothing, out-of-run no-op, and the empty-text cases on both paths.

One known limitation: the tests can't spin a real `claude_agent_sdk` subprocess, so cross-task ContextVar propagation is covered by parity with the shipped identity/SSE-sink mechanism (the collector binds at an ancestor context of both) rather than a direct end-to-end test — same limitation the existing seam has.

## Client counterpart

paw-enterprise consumes these shapes in a sibling PR (`feat/artifacts-client-surface`): SSE case, artifact store, in-chat trigger card, right-pane viewer.