### PR TITLE
Render delivered files as artifact cards in local mode

### DIFF
--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -11,6 +11,15 @@ Updated: feat/pocketpaw-cognitive-engine
   and passes it to SoulManager.initialize() so the soul's cognition pipeline
   (sentiment, significance, fact extraction, reflection) uses the same LLM
   as the conversation rather than falling back to heuristics.
+
+Updated: 2026-07-11 (ART-OSS) — OSS/local-mode artifact parity. At persist time
+_process_message_inner uploads every produced file (media_paths minus the
+auto-TTS voice replies) into the shared uploads store via
+``uploads.artifact_delivery.upload_local_artifact``, emits one ``artifact``
+SystemEvent apiece ({file_id,name,mime,size}) ahead of ``stream_end``, and
+persists a matching ``{type:"artifact", meta}`` attachment on the assistant
+message (persisting even on an artifact-only, empty-text turn). Mirrors the cloud
+run_core collector-drain contract so the client's card+viewer works in local mode.
 """
 
 import asyncio
@@ -1561,6 +1570,40 @@ class AgentLoop:
             # Deduplicate while preserving order
             seen: set[str] = set()
             media_paths = [p for p in media_paths if not (p in seen or seen.add(p))]
+
+            # Artifact parity (OSS/local mode). Every file the agent produced this
+            # turn — media_paths minus the auto-TTS voice replies, which render as
+            # an inline audio reply, not an artifact card — is landed in the shared
+            # uploads store and surfaced through the SAME frozen contract the cloud
+            # path uses: one ``{file_id,name,mime,size}`` ``artifact`` event apiece
+            # (emitted before ``stream_end`` so the client renders the card live)
+            # plus a matching ``{type:"artifact", meta}`` attachment persisted on
+            # the assistant message so the card+viewer also survive a history
+            # reload. Cloud lands the file inside ``deliver_artifact`` and drains a
+            # per-run collector; OSS has no deliver MCP under the default backend,
+            # so the AgentLoop is the one place that sees every produced file across
+            # every backend (media tags + the generated-path fallback).
+            artifact_metas: list[dict[str, Any]] = []
+            if not cancelled and media_paths:
+                voice_set = set(voice_media_paths)
+                for art_path in media_paths:
+                    if art_path in voice_set:
+                        continue
+                    meta = await self._deliver_oss_artifact(art_path)
+                    if meta is None:
+                        continue
+                    artifact_metas.append(meta)
+                    await self.bus.publish_system(
+                        SystemEvent(
+                            event_type="artifact",
+                            data={
+                                **meta,
+                                "session_key": session_key,
+                                "trace_id": trace_id,
+                            },
+                        )
+                    )
+
             metadata_out: dict[str, Any] = {"trace_id": trace_id}
             if voice_media_paths:
                 metadata_out["voice_media_paths"] = voice_media_paths
@@ -1582,18 +1625,36 @@ class AgentLoop:
                 full_response = _strip_tts_links(full_response)
             if cancelled and full_response:
                 full_response += "\n\n[Response interrupted]"
-            if full_response:
+            # Persist when there's assistant text OR at least one delivered
+            # artifact — an artifact-only turn (the agent handed back a file with
+            # no prose) still needs its ``{type:"artifact"}`` attachment on the
+            # stored message so the card survives a reload (mirrors run_core's
+            # ``not full_text.strip() and not delivered_artifacts`` guard).
+            if full_response or artifact_metas:
                 stored_response = full_response
-                if self.settings.pii_scan_enabled and self.settings.pii_scan_memory:
+                if (
+                    full_response
+                    and self.settings.pii_scan_enabled
+                    and self.settings.pii_scan_memory
+                ):
                     from pocketpaw.security.pii import get_pii_scanner
 
                     pii_result = get_pii_scanner().scan(full_response, source="assistant_response")
                     if pii_result.has_pii:
                         stored_response = pii_result.sanitized_text
+                assistant_metadata: dict[str, Any] = {}
+                if artifact_metas:
+                    assistant_metadata["attachments"] = [
+                        {"type": "artifact", "meta": m} for m in artifact_metas
+                    ]
                 await self.memory.add_to_session(
-                    session_key=session_key, role="assistant", content=stored_response
+                    session_key=session_key,
+                    role="assistant",
+                    content=stored_response,
+                    metadata=assistant_metadata or None,
                 )
 
+            if full_response:
                 # 6. Auto-learn: extract facts from conversation (non-blocking)
                 # Skip auto-learn on cancelled responses — partial data is unreliable.
                 # Also skip when soul is active — soul.observe() + reflect() handles
@@ -1722,6 +1783,17 @@ class AgentLoop:
                     )
                 except Exception:
                     pass
+
+    async def _deliver_oss_artifact(self, path: str) -> dict[str, Any] | None:
+        """Land a locally-produced file in the shared uploads store for OSS/local
+        artifact parity, returning ``{file_id, name, mime, size}`` or ``None``.
+
+        Thin seam over ``uploads.artifact_delivery.upload_local_artifact`` so the
+        AgentLoop can mock it in tests and so the (best-effort) call site stays a
+        one-liner. Never raises — the helper swallows its own failures."""
+        from pocketpaw.uploads.artifact_delivery import upload_local_artifact
+
+        return await upload_local_artifact(path)
 
     async def _send_response(self, original: InboundMessage, content: str) -> None:
         """Helper to send a simple text response."""

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -6,6 +6,10 @@
 # Updated: 2026-04-22 — Thread cloud user + active_workspace from the
 #   authenticated request into ``InboundMessage.metadata`` so agent-created
 #   pockets land under the caller, not the first user in the DB.
+# Updated: 2026-07-11 (ART-OSS) — ``_APISessionBridge`` forwards the AgentLoop's
+#   ``artifact`` SystemEvent as an ``artifact`` SSE event ({file_id,name,mime,
+#   size}) so OSS/local mode renders artifact cards live, matching the cloud
+#   run's ``append_event(run_id,"artifact",meta)`` contract.
 #
 # Enables external clients to send messages and receive responses via HTTP.
 # SSE streaming reuses the entire AgentLoop pipeline via _APISessionBridge.
@@ -212,6 +216,22 @@ class _APISessionBridge:
                     {
                         "event": "pocket_mutation",
                         "data": {"mutation": data.get("mutation", {})},
+                    }
+                )
+            elif evt.event_type == "artifact":
+                # OSS/local-mode artifact parity: forward the frozen
+                # {file_id,name,mime,size} meta as an ``artifact`` SSE event so the
+                # client renders the artifact card+viewer live, exactly as the
+                # cloud run emits via ``transport.append_event(run_id,"artifact")``.
+                await self.queue.put(
+                    {
+                        "event": "artifact",
+                        "data": {
+                            "file_id": data.get("file_id", ""),
+                            "name": data.get("name", ""),
+                            "mime": data.get("mime", ""),
+                            "size": data.get("size", 0),
+                        },
                     }
                 )
             elif evt.event_type == "session_titled":

--- a/src/pocketpaw/memory/manager.py
+++ b/src/pocketpaw/memory/manager.py
@@ -3,6 +3,10 @@
 # Updated: 2026-02-04 - Added Mem0 backend support
 # Updated: 2026-02-07 - Configurable providers, auto-learn, semantic context - Memory System
 # Updated: 2026-02-11 - Sender-scoped memory isolation
+# Updated: 2026-07-11 (ART-OSS) - get_session_history lifts metadata["attachments"]
+#   to a TOP-LEVEL "attachments" key per message (mirrors the EE Mongo history
+#   shape the client reads) so delivered artifact cards and user files survive a
+#   reload; the OSS read path previously returned only {role, content}.
 
 import hashlib
 import logging
@@ -312,15 +316,32 @@ class MemoryManager:
         self,
         session_key: str,
         limit: int = 50,
-    ) -> list[dict[str, str]]:
+    ) -> list[dict[str, Any]]:
         """
-        Get session history in LLM message format.
+        Get session history for display / the chat history API.
 
-        Returns:
-            List of {"role": "...", "content": "..."} dicts.
+        Returns a list of ``{"role", "content", "attachments"}`` dicts. Any
+        attachments persisted under ``entry.metadata["attachments"]`` — artifact
+        cards the agent delivered, or files the user sent — are lifted to a
+        TOP-LEVEL ``attachments`` key so the client reads them exactly as it does
+        in cloud mode (the EE Mongo history serializes attachments top-level). The
+        OSS read path used to return only ``{role, content}``, so a delivered
+        artifact card vanished on reload. ``attachments`` is always present (empty
+        list when none) to match the cloud shape. This is a display path, not the
+        LLM-history feed (that is ``get_compacted_history``), so the extra key
+        never reaches a model.
         """
         entries = await self._store.get_session(session_key)
-        return [{"role": e.role or "user", "content": e.content} for e in entries[-limit:]]
+        history: list[dict[str, Any]] = []
+        for e in entries[-limit:]:
+            history.append(
+                {
+                    "role": e.role or "user",
+                    "content": e.content,
+                    "attachments": (e.metadata or {}).get("attachments") or [],
+                }
+            )
+        return history
 
     async def search(
         self,

--- a/src/pocketpaw/uploads/artifact_delivery.py
+++ b/src/pocketpaw/uploads/artifact_delivery.py
@@ -1,0 +1,133 @@
+# artifact_delivery.py — land a locally-generated agent file into the shared OSS
+# uploads store and return the frozen artifact meta the chat contract carries.
+# Created: 2026-07-11 (ART-OSS): OSS/local-mode parity for the cloud artifacts
+# pipeline. In cloud mode the ``deliver_artifact`` MCP server uploads to the
+# tenant blob store and ``run_core`` drains a per-run collector into
+# ``{type:"artifact", meta}`` attachments + ``artifact`` SSE events. OSS mode has
+# no deliver MCP (the default ``claude_agent_sdk`` backend never runs the OSS
+# ``DeliverArtifactTool``; agents write files via Bash/Write and the AgentLoop
+# detects them through ``media_paths``). This helper is the OSS equivalent of the
+# cloud tool's upload half: given a local file path the agent produced, it copies
+# the bytes into the SAME store the ``/api/v1/uploads`` router serves from
+# (``~/.pocketpaw/uploads`` + ``_idx.jsonl``, owner ``local``) so the resulting
+# ``file_id`` resolves through the client's existing ``/uploads/{id}`` +
+# ``/grant`` flow, then hands back ``{file_id, name, mime, size}`` — the exact
+# meta shape the frozen artifact attachment/event contract is built against.
+#
+# Mirrors the cloud ``_upload_artifact`` (ee deliver.py): a per-call service with
+# a RELAXED mime allowlist (the file's own guessed mime + zip + the defaults) so
+# a first-party artifact (a report, an export, a built bundle) is never rejected
+# by the browser-upload mime gate, and a larger per-artifact cap
+# (``POCKETPAW_DELIVER_MAX_MB``, default 100). Best-effort: any failure returns
+# ``None`` and never raises into the AgentLoop — a store hiccup must not break an
+# otherwise-successful turn.
+
+from __future__ import annotations
+
+import logging
+import mimetypes
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Same store the OSS uploads router (``api/v1/uploads.py``) serves from, so a
+# delivered artifact's ``file_id`` is addressable through ``GET
+# /api/v1/uploads/{id}`` and its ``/grant`` sibling with no extra plumbing.
+_UPLOADS_ROOT = Path.home() / ".pocketpaw" / "uploads"
+_UPLOADS_INDEX = _UPLOADS_ROOT / "_idx.jsonl"
+# OSS is single-user; the uploads router owns every row as ``local`` and streams
+# with ``requester_id="local"``. Match it so the download/grant routes can serve
+# the delivered file back.
+_OWNER = "local"
+
+_DEFAULT_DELIVER_MAX_MB = 100.0
+
+
+def _deliver_max_bytes() -> int:
+    """Per-artifact size cap in bytes (``POCKETPAW_DELIVER_MAX_MB``, default 100).
+
+    Shares the env knob with the cloud deliver tool so an operator tunes one
+    value for both deployment modes."""
+    raw = os.environ.get("POCKETPAW_DELIVER_MAX_MB", "").strip()
+    mb = _DEFAULT_DELIVER_MAX_MB
+    if raw:
+        try:
+            mb = float(raw)
+        except ValueError:
+            logger.warning("ignoring non-numeric POCKETPAW_DELIVER_MAX_MB=%r; using %s", raw, mb)
+    return int(mb * 1024 * 1024)
+
+
+async def upload_local_artifact(path: str) -> dict[str, Any] | None:
+    """Upload the local file at ``path`` into the shared OSS uploads store.
+
+    Returns ``{file_id, name, mime, size}`` on success (the frozen artifact meta
+    the chat attachment/event contract carries), or ``None`` when the path is
+    missing / not a regular file / too large / the upload fails. Never raises:
+    the AgentLoop calls this per produced file at persist time and a failure for
+    one artifact must not abort the turn.
+    """
+    from fastapi import UploadFile
+
+    from pocketpaw.uploads.config import DEFAULT_ALLOWED_MIMES, UploadSettings
+    from pocketpaw.uploads.factory import build_adapter
+    from pocketpaw.uploads.file_store import JSONLFileStore
+    from pocketpaw.uploads.service import UploadService
+
+    try:
+        file_path = Path(path).expanduser()
+        if not file_path.is_file():
+            return None
+
+        deliver_max = _deliver_max_bytes()
+        try:
+            if file_path.stat().st_size > deliver_max:
+                logger.info(
+                    "artifact %s over the %s MB deliver cap; skipping",
+                    file_path.name,
+                    deliver_max / 1024 / 1024,
+                )
+                return None
+        except OSError:
+            return None
+
+        name = file_path.name
+        mime = mimetypes.guess_type(name)[0] or "application/octet-stream"
+
+        _UPLOADS_ROOT.mkdir(parents=True, exist_ok=True)
+        adapter = build_adapter(_UPLOADS_ROOT)
+        cfg = UploadSettings(
+            max_file_bytes=deliver_max,
+            # Relax the gate like the cloud deliver path: a first-party artifact
+            # can be any type the agent produced, not just a browser-upload mime.
+            allowed_mimes=frozenset({mime, "application/zip", *DEFAULT_ALLOWED_MIMES}),
+            local_root=_UPLOADS_ROOT,
+        )
+        svc = UploadService(
+            adapter=adapter,
+            meta=JSONLFileStore(path=_UPLOADS_INDEX),
+            cfg=cfg,
+        )
+
+        with open(file_path, "rb") as fh:
+            upload = UploadFile(
+                file=fh,
+                filename=name,
+                headers={"content-type": mime},  # type: ignore[arg-type]
+            )
+            rec = await svc.upload(upload, owner_id=_OWNER, chat_id=None)
+    except Exception:  # noqa: BLE001 — best-effort; a delivery hiccup never fails the turn
+        logger.debug("OSS artifact upload failed for %r", path, exc_info=True)
+        return None
+
+    return {
+        "file_id": rec.id,
+        "name": rec.filename,
+        "mime": rec.mime,
+        "size": rec.size,
+    }
+
+
+__all__ = ["upload_local_artifact"]

--- a/src/pocketpaw/uploads/artifact_delivery.py
+++ b/src/pocketpaw/uploads/artifact_delivery.py
@@ -69,14 +69,18 @@ async def upload_local_artifact(path: str) -> dict[str, Any] | None:
     the AgentLoop calls this per produced file at persist time and a failure for
     one artifact must not abort the turn.
     """
-    from fastapi import UploadFile
-
-    from pocketpaw.uploads.config import DEFAULT_ALLOWED_MIMES, UploadSettings
-    from pocketpaw.uploads.factory import build_adapter
-    from pocketpaw.uploads.file_store import JSONLFileStore
-    from pocketpaw.uploads.service import UploadService
-
     try:
+        # Imports live inside the try so an import failure (a missing optional
+        # dep, a partial install) is caught by the best-effort guard below rather
+        # than escaping into the AgentLoop's main turn try — this helper's
+        # contract is that it never raises.
+        from fastapi import UploadFile
+
+        from pocketpaw.uploads.config import DEFAULT_ALLOWED_MIMES, UploadSettings
+        from pocketpaw.uploads.factory import build_adapter
+        from pocketpaw.uploads.file_store import JSONLFileStore
+        from pocketpaw.uploads.service import UploadService
+
         file_path = Path(path).expanduser()
         if not file_path.is_file():
             return None

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -185,8 +185,11 @@ class TestMemoryManager:
         # Get history
         history = await memory_manager.get_session_history(session_key)
         assert len(history) == 3
-        assert history[0] == {"role": "user", "content": "Hello!"}
-        assert history[1] == {"role": "assistant", "content": "Hi there!"}
+        # get_session_history now includes a top-level ``attachments`` key per
+        # message (empty list when none), mirroring the EE Mongo history shape the
+        # client reads on reload.
+        assert history[0] == {"role": "user", "content": "Hello!", "attachments": []}
+        assert history[1] == {"role": "assistant", "content": "Hi there!", "attachments": []}
 
         # Clear
         count = await memory_manager.clear_session(session_key)

--- a/tests/test_oss_artifact_delivery.py
+++ b/tests/test_oss_artifact_delivery.py
@@ -1,5 +1,5 @@
 # Tests for OSS/local-mode artifact parity (ART-OSS).
-# Covers three seams of the new pipeline:
+# Covers four seams of the new pipeline:
 #   1. uploads.artifact_delivery.upload_local_artifact — a produced local file
 #      lands in the shared uploads store and returns {file_id,name,mime,size},
 #      with the relaxed mime gate accepting a non-default type and best-effort
@@ -9,6 +9,9 @@
 #      message, INCLUDING an artifact-only (empty-text) turn.
 #   3. _APISessionBridge — an ``artifact`` SystemEvent is forwarded as an
 #      ``artifact`` SSE event carrying just the frozen meta.
+#   4. MemoryManager.get_session_history — persisted attachments are lifted to a
+#      TOP-LEVEL ``attachments`` key (the shape the client reads on reload), so a
+#      delivered card survives a refresh; plain messages return an empty list.
 
 from __future__ import annotations
 
@@ -286,3 +289,46 @@ class TestBridgeArtifactEvent:
             assert bridge.queue.empty()
         finally:
             await bridge.stop()
+
+
+# ── 4. history reload surfaces attachments top-level ─────────────────────────
+class TestHistoryReloadSurfacesAttachments:
+    """The client reads message.attachments TOP-LEVEL (same as cloud). The OSS
+    /sessions/{id}/history route returns get_session_history verbatim, so the
+    lift must happen there or a delivered card vanishes on reload."""
+
+    @pytest.mark.asyncio
+    async def test_artifact_attachment_lifted_to_top_level(self, tmp_path):
+        from pocketpaw.memory.manager import MemoryManager
+
+        mgr = MemoryManager(base_path=tmp_path)
+        sk = "websocket:reload1"
+        meta = {"file_id": "fid", "name": "report.pdf", "mime": "application/pdf", "size": 5}
+        await mgr.add_to_session(
+            session_key=sk,
+            role="assistant",
+            content="",
+            metadata={"attachments": [{"type": "artifact", "meta": meta}]},
+        )
+
+        history = await mgr.get_session_history(sk)
+
+        assert len(history) == 1
+        assert history[0]["role"] == "assistant"
+        assert history[0]["content"] == ""
+        # Top-level, NOT buried under a metadata key — this is what the client maps.
+        assert history[0]["attachments"] == [{"type": "artifact", "meta": meta}]
+
+    @pytest.mark.asyncio
+    async def test_plain_message_returns_empty_attachments(self, tmp_path):
+        from pocketpaw.memory.manager import MemoryManager
+
+        mgr = MemoryManager(base_path=tmp_path)
+        sk = "websocket:reload2"
+        await mgr.add_to_session(session_key=sk, role="user", content="hi there")
+
+        history = await mgr.get_session_history(sk)
+
+        assert history[0]["content"] == "hi there"
+        # Always-present empty list mirrors the cloud shape (no undefined at the client).
+        assert history[0]["attachments"] == []

--- a/tests/test_oss_artifact_delivery.py
+++ b/tests/test_oss_artifact_delivery.py
@@ -1,0 +1,288 @@
+# Tests for OSS/local-mode artifact parity (ART-OSS).
+# Covers three seams of the new pipeline:
+#   1. uploads.artifact_delivery.upload_local_artifact — a produced local file
+#      lands in the shared uploads store and returns {file_id,name,mime,size},
+#      with the relaxed mime gate accepting a non-default type and best-effort
+#      None on a missing path.
+#   2. AgentLoop — a turn that produces media emits one ``artifact`` SystemEvent
+#      per file and persists {type:"artifact", meta} attachments on the assistant
+#      message, INCLUDING an artifact-only (empty-text) turn.
+#   3. _APISessionBridge — an ``artifact`` SystemEvent is forwarded as an
+#      ``artifact`` SSE event carrying just the frozen meta.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pocketpaw.agents.loop import AgentLoop
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.bus import Channel, InboundMessage
+
+
+# ── 1. upload_local_artifact ────────────────────────────────────────────────
+class TestUploadLocalArtifact:
+    @pytest.mark.asyncio
+    async def test_uploads_and_returns_meta(self, tmp_path, monkeypatch):
+        from pocketpaw.uploads import artifact_delivery
+
+        store_root = tmp_path / "uploads"
+        monkeypatch.setattr(artifact_delivery, "_UPLOADS_ROOT", store_root)
+        monkeypatch.setattr(artifact_delivery, "_UPLOADS_INDEX", store_root / "_idx.jsonl")
+
+        produced = tmp_path / "report.csv"
+        produced.write_text("a,b,c\n1,2,3\n")
+
+        meta = await artifact_delivery.upload_local_artifact(str(produced))
+
+        assert meta is not None
+        assert meta["name"] == "report.csv"
+        assert meta["mime"] == "text/csv"
+        assert meta["size"] == produced.stat().st_size
+        assert meta["file_id"]
+        # The row landed in the SAME index the /uploads router serves from, so
+        # the file_id is resolvable through the client's grant/download flow.
+        assert (store_root / "_idx.jsonl").exists()
+
+    @pytest.mark.asyncio
+    async def test_relaxed_mime_accepts_non_default_type(self, tmp_path, monkeypatch):
+        from pocketpaw.uploads import artifact_delivery
+
+        store_root = tmp_path / "uploads"
+        monkeypatch.setattr(artifact_delivery, "_UPLOADS_ROOT", store_root)
+        monkeypatch.setattr(artifact_delivery, "_UPLOADS_INDEX", store_root / "_idx.jsonl")
+
+        # .bin → application/octet-stream, which is NOT in DEFAULT_ALLOWED_MIMES.
+        # The per-call relaxed allowlist (the file's own guessed mime) must accept
+        # it — a first-party artifact can be any type the agent produced.
+        produced = tmp_path / "bundle.bin"
+        produced.write_bytes(b"\x00\x01\x02binary-blob\x03")
+
+        meta = await artifact_delivery.upload_local_artifact(str(produced))
+
+        assert meta is not None
+        assert meta["name"] == "bundle.bin"
+        assert meta["mime"] == "application/octet-stream"
+
+    @pytest.mark.asyncio
+    async def test_missing_path_returns_none(self, tmp_path, monkeypatch):
+        from pocketpaw.uploads import artifact_delivery
+
+        monkeypatch.setattr(artifact_delivery, "_UPLOADS_ROOT", tmp_path / "uploads")
+        monkeypatch.setattr(
+            artifact_delivery, "_UPLOADS_INDEX", tmp_path / "uploads" / "_idx.jsonl"
+        )
+
+        assert await artifact_delivery.upload_local_artifact(str(tmp_path / "nope.png")) is None
+
+
+# ── loop harness ────────────────────────────────────────────────────────────
+@pytest.fixture
+def mock_bus():
+    bus = MagicMock()
+    bus.consume_inbound = AsyncMock()
+    bus.publish_outbound = AsyncMock()
+    bus.publish_system = AsyncMock()
+    return bus
+
+
+@pytest.fixture
+def mock_memory():
+    mem = MagicMock()
+    mem.add_to_session = AsyncMock(return_value="entry-id")
+    mem.get_session_history = AsyncMock(return_value=[])
+    mem.get_compacted_history = AsyncMock(return_value=[])
+    mem.resolve_session_key = AsyncMock(side_effect=lambda k: k)
+    return mem
+
+
+def _settings() -> MagicMock:
+    s = MagicMock()
+    s.agent_backend = "claude_agent_sdk"
+    s.max_concurrent_conversations = 5
+    s.welcome_hint_enabled = False
+    s.injection_scan_enabled = False
+    s.pii_scan_enabled = False
+    s.pii_scan_memory = False
+    s.soul_enabled = False
+    s.voice_reply_enabled = False
+    s.tool_profile = "full"
+    return s
+
+
+async def _run_loop_with(router, mock_bus, mock_memory, artifact_meta):
+    """Drive one message through AgentLoop with ``_deliver_oss_artifact`` stubbed
+    to return ``artifact_meta`` (a dict) for every produced path. Returns the loop
+    so the caller can inspect the mocked bus/memory."""
+    with (
+        patch("pocketpaw.agents.loop.get_message_bus", return_value=mock_bus),
+        patch("pocketpaw.agents.loop.get_memory_manager", return_value=mock_memory),
+        patch("pocketpaw.agents.loop.AgentContextBuilder") as builder_cls,
+        patch("pocketpaw.agents.loop.AgentRouter", return_value=router),
+        patch("pocketpaw.agents.loop.get_settings", return_value=_settings()),
+        patch("pocketpaw.agents.loop.Settings") as settings_cls,
+    ):
+        settings_cls.load.return_value = _settings()
+        builder_cls.return_value.build_system_prompt = AsyncMock(return_value="SP")
+
+        loop = AgentLoop()
+        loop._deliver_oss_artifact = AsyncMock(return_value=artifact_meta)
+
+        msg = InboundMessage(
+            channel=Channel.WEBSOCKET,
+            sender_id="user1",
+            chat_id="chat1",
+            content="make me a file",
+        )
+        await loop._process_message(msg)
+        return loop
+
+
+def _artifact_events(mock_bus) -> list[dict]:
+    return [
+        c.args[0].data
+        for c in mock_bus.publish_system.call_args_list
+        if c.args and getattr(c.args[0], "event_type", None) == "artifact"
+    ]
+
+
+def _assistant_call(mock_memory):
+    for c in mock_memory.add_to_session.call_args_list:
+        if c.kwargs.get("role") == "assistant":
+            return c
+    return None
+
+
+# ── 2. AgentLoop artifact emission + persistence ─────────────────────────────
+class TestLoopArtifactEmission:
+    @pytest.mark.asyncio
+    async def test_media_tag_emits_event_and_persists_attachment(self, mock_bus, mock_memory):
+        meta = {"file_id": "fid1", "name": "chart.png", "mime": "image/png", "size": 42}
+
+        async def run(message, *, system_prompt=None, history=None, session_key=None):
+            yield AgentEvent(type="message", content="Here is your chart.")
+            yield AgentEvent(
+                type="tool_result",
+                content="<!-- media:/tmp/chart.png -->",
+                metadata={"name": "deliver_artifact"},
+            )
+            yield AgentEvent(type="done", content="")
+
+        router = MagicMock()
+        router.run = run
+        router.stop = AsyncMock()
+
+        await _run_loop_with(router, mock_bus, mock_memory, meta)
+
+        events = _artifact_events(mock_bus)
+        assert len(events) == 1
+        assert events[0]["file_id"] == "fid1"
+        assert events[0]["name"] == "chart.png"
+        assert events[0]["session_key"].endswith(":chat1")
+
+        assistant = _assistant_call(mock_memory)
+        assert assistant is not None
+        attachments = (assistant.kwargs.get("metadata") or {}).get("attachments")
+        assert attachments == [{"type": "artifact", "meta": meta}]
+
+    @pytest.mark.asyncio
+    async def test_artifact_only_turn_persists_assistant_message(self, mock_bus, mock_memory):
+        # The agent delivered a file with NO prose — the assistant message must
+        # still be persisted so its artifact attachment survives a reload.
+        meta = {"file_id": "fid2", "name": "export.zip", "mime": "application/zip", "size": 9}
+
+        async def run(message, *, system_prompt=None, history=None, session_key=None):
+            yield AgentEvent(
+                type="tool_result",
+                content="<!-- media:/tmp/export.zip -->",
+                metadata={"name": "deliver_artifact"},
+            )
+            yield AgentEvent(type="done", content="")
+
+        router = MagicMock()
+        router.run = run
+        router.stop = AsyncMock()
+
+        await _run_loop_with(router, mock_bus, mock_memory, meta)
+
+        assert len(_artifact_events(mock_bus)) == 1
+        assistant = _assistant_call(mock_memory)
+        assert assistant is not None
+        assert assistant.kwargs.get("content") == ""
+        attachments = (assistant.kwargs.get("metadata") or {}).get("attachments")
+        assert attachments == [{"type": "artifact", "meta": meta}]
+
+    @pytest.mark.asyncio
+    async def test_no_media_no_artifact_and_no_attachment(self, mock_bus, mock_memory):
+        async def run(message, *, system_prompt=None, history=None, session_key=None):
+            yield AgentEvent(type="message", content="Just a plain answer.")
+            yield AgentEvent(type="done", content="")
+
+        router = MagicMock()
+        router.run = run
+        router.stop = AsyncMock()
+
+        await _run_loop_with(router, mock_bus, mock_memory, {"file_id": "x"})
+
+        assert _artifact_events(mock_bus) == []
+        assistant = _assistant_call(mock_memory)
+        assert assistant is not None
+        # No attachments → metadata omitted (None) on a plain text turn.
+        assert assistant.kwargs.get("metadata") is None
+
+
+# ── 3. bridge translation ────────────────────────────────────────────────────
+class TestBridgeArtifactEvent:
+    @pytest.mark.asyncio
+    async def test_artifact_system_event_becomes_sse_event(self):
+        from pocketpaw.api.v1.chat import _APISessionBridge
+        from pocketpaw.bus import get_message_bus
+        from pocketpaw.bus.events import SystemEvent
+
+        bridge = _APISessionBridge("chatX")
+        await bridge.start()
+        try:
+            await get_message_bus().publish_system(
+                SystemEvent(
+                    event_type="artifact",
+                    data={
+                        "file_id": "fid9",
+                        "name": "doc.pdf",
+                        "mime": "application/pdf",
+                        "size": 123,
+                        "session_key": "websocket:chatX",
+                        "trace_id": "t1",
+                    },
+                )
+            )
+            item = bridge.queue.get_nowait()
+        finally:
+            await bridge.stop()
+
+        assert item["event"] == "artifact"
+        assert item["data"] == {
+            "file_id": "fid9",
+            "name": "doc.pdf",
+            "mime": "application/pdf",
+            "size": 123,
+        }
+
+    @pytest.mark.asyncio
+    async def test_artifact_event_for_other_session_is_filtered(self):
+        from pocketpaw.api.v1.chat import _APISessionBridge
+        from pocketpaw.bus import get_message_bus
+        from pocketpaw.bus.events import SystemEvent
+
+        bridge = _APISessionBridge("mine")
+        await bridge.start()
+        try:
+            await get_message_bus().publish_system(
+                SystemEvent(
+                    event_type="artifact",
+                    data={"file_id": "f", "session_key": "websocket:other"},
+                )
+            )
+            assert bridge.queue.empty()
+        finally:
+            await bridge.stop()


### PR DESCRIPTION
## What

Local-mode chats now render the files an agent produces as artifact cards with a viewer panel — the same experience cloud mode already ships.

## Why

The artifacts pipeline landed cloud-only. In cloud mode, `deliver_artifact` uploads to the tenant blob store and the run path emits an `artifact` SSE event plus a persisted `{type:"artifact"}` attachment; the paw-enterprise client renders cards and a viewer from those two signals. Local (OSS) mode emitted neither. A file the agent made only rode the legacy `<!-- media:path -->` path, which the web bridge drops, so local users saw nothing.

## How

The fix sits at the `AgentLoop`, which is the one place that sees every produced file across every backend. This matters: the default `claude_agent_sdk` backend never runs the OSS `deliver_artifact` tool — the agent writes files via Bash and the loop picks them up through `media_paths` — so a collector fed by the tool (the cloud approach) would be dead there. Working from `media_paths` catches both the generated-file case and the deliver tool's media tag under other backends.

At persist time, each produced file (excluding auto-TTS voice replies, which stay inline audio) is:

1. landed in the shared uploads store through a new `uploads/artifact_delivery.py` helper, so its `file_id` resolves through the existing `/uploads/{id}` + `/grant` routes (owner `local`, relaxed mime allowlist so any first-party artifact is accepted);
2. emitted as one `artifact` SSE event `{file_id, name, mime, size}` ahead of `stream_end` (bridged in `chat.py`);
3. persisted as a `{type:"artifact", meta}` attachment on the assistant message — including on an artifact-only turn with no prose, so the card survives a history reload.

The reload path is closed too: `get_session_history` now lifts persisted attachments to a top-level `attachments` key per message (the shape the client reads, matching the EE Mongo history), so a delivered card survives a refresh instead of returning as a blank bubble. That also fixes user-sent file attachments on reload, which had the same gap.

Event and attachment shapes match the cloud contract exactly, which the client already reads. The existing `OutboundMessage.media` path is untouched, so Telegram/Discord/dashboard behavior is unchanged.

## Tests

`tests/test_oss_artifact_delivery.py` (four seams): the upload helper (roundtrip, relaxed-mime accept, missing-path None), the loop (media tag → event + attachment, artifact-only turn persists, plain text turn stays clean), the bridge (artifact event → SSE, cross-session filtered), and history reload (attachment lifted top-level; plain message returns an empty list).

```
POCKETPAW_LLM_PROVIDER=ollama uv run pytest \
  tests/test_oss_artifact_delivery.py tests/test_memory_edge_cases.py \
  tests/test_agent_loop.py tests/test_api_chat.py::TestAPISessionBridge -q
63 passed
```

Session/dashboard consumers of `get_session_history` (proving the added key breaks nothing): 205 passed. Both import-linter configs pass (OSS-core-may-not-import-EE kept; 28 EE contracts kept). Pre-existing suite pollution unrelated to this change: `tests/uploads/test_router.py` errors with a mongodb-backend RuntimeError on the clean base too.

## Docs

Runtime behavior change with no new CLI/API surface; the artifact event/attachment contract it targets is the one documented for cloud mode. Top-of-file change notes updated in all touched modules.
