### PR TITLE
Fix ruff format drift so Lint goes green

### DIFF
--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -395,8 +395,7 @@ async def run_ingest_sweep(
                 )
         except Exception:  # noqa: BLE001 — the conflict sweep is best-effort
             logger.warning(
-                "fabric_ingest: post-ingest conflict sweep failed for workspace %s "
-                "(non-fatal)",
+                "fabric_ingest: post-ingest conflict sweep failed for workspace %s (non-fatal)",
                 ws,
                 exc_info=True,
             )

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -588,8 +588,20 @@ _HTML_SMOKE_ENTRY = "index.html"
 # ``<br>`` is a valid authored input and must pass the smoke check).
 _HTML_VOID_ELEMENTS: frozenset[str] = frozenset(
     {
-        "area", "base", "br", "col", "embed", "hr", "img", "input",
-        "link", "meta", "param", "source", "track", "wbr",
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
     }
 )
 

--- a/tests/cloud/jobs/test_provision_site.py
+++ b/tests/cloud/jobs/test_provision_site.py
@@ -63,9 +63,7 @@ async def seed(mongo_db: Any):
     from pocketpaw_ee.cloud.models.pocket import Pocket
     from pocketpaw_ee.cloud.models.site import Site
 
-    async def _seed(
-        *, workspace: str = WS, d1_database_id: str = ""
-    ) -> dict[str, Any]:
+    async def _seed(*, workspace: str = WS, d1_database_id: str = "") -> dict[str, Any]:
         spec = {
             "theme": {"mode": "light"},
             "objects": [{"name": "entries", "fields": [{"name": "msg"}]}],
@@ -224,9 +222,7 @@ async def test_success_marks_provisioned_and_deployed(
     assert rec["migrate"] == [(ctx["site_id"], "/fake/project/dir")]
     assert cf.put_calls[0]["script_name"] == ctx["site_id"]
     assert cf.put_calls[0]["bundle"] == b"worker-bundle-bytes"
-    assert cf.put_calls[0]["bindings"] == [
-        {"type": "d1", "name": "DB", "id": "d1-fresh-uuid-0002"}
-    ]
+    assert cf.put_calls[0]["bindings"] == [{"type": "d1", "name": "DB", "id": "d1-fresh-uuid-0002"}]
 
     site = await Site.get(ctx["site_id"])
     assert site is not None
@@ -242,9 +238,7 @@ async def test_success_marks_provisioned_and_deployed(
 
 
 @pytest.mark.asyncio
-async def test_tenancy_mismatch_fails_closed(
-    seed: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_tenancy_mismatch_fails_closed(seed: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     ctx = await seed(workspace=OTHER_WS, d1_database_id="")
     cf = _FakeCF()
     _install_fakes(monkeypatch, cf=cf)


### PR DESCRIPTION
A ruff version bump left three files failing the repo-wide `ruff format --check` on dev, so the Lint job is red on every open PR. This reformats them — line reflow only, no behavior change — so Lint passes again.

Files: ee/pocketpaw_ee/cloud/fabric_ingest/service.py, ee/pocketpaw_ee/sites/generator_client.py, tests/cloud/jobs/test_provision_site.py.