### PR TITLE
Add create_html_site tool for the html track (HE-6)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites.py
@@ -22,6 +22,13 @@
 # ``create_dynamic_site`` tool also registers on this SAME server. Dynamic sites
 # are ripple-engine sites whose spec carries live-data bindings; publish carries
 # those through to the paw-sites generator.
+#
+# Updated 2026-07-12 (feat/sites-html-create-tool, HE-6): the ``create_html_site``
+# tool also registers on this SAME server. An html site is a raw {path: contents}
+# HTML/CSS/JS map with no framework; publish materializes it and skips the Node
+# build. Its id rides ``SITES_TOOL_IDS`` so the per-surface allowlist picks it up
+# automatically. Opt-in — the default marketing brain stays create_landing_site
+# (ripple); the default flip to html is HE-12.
 """Agent-side MCP surface for publishing a PocketPaw pocket as a Paw Site.
 
 A site is published FROM a pocket: the chat agent identifies the pocket to
@@ -76,6 +83,10 @@ EDIT_SVELTE_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_svelte_component"
 # (see sites_create.py). Dynamic sites are ripple-engine sites whose spec carries
 # live-data bindings; publish carries those through to the paw-sites generator.
 CREATE_DYNAMIC_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_dynamic_site"
+# The html-track create tool (HE-6) also registers on this SAME server (see
+# sites_create.py). An html site is a raw {path: contents} HTML/CSS/JS map with no
+# framework; publish materializes it and skips the Node build.
+CREATE_HTML_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_html_site"
 
 SITES_TOOL_IDS = (
     PUBLISH_TOOL_ID,
@@ -83,6 +94,7 @@ SITES_TOOL_IDS = (
     CREATE_SVELTE_SITE_TOOL_ID,
     EDIT_SVELTE_COMPONENT_TOOL_ID,
     CREATE_DYNAMIC_SITE_TOOL_ID,
+    CREATE_HTML_SITE_TOOL_ID,
 )
 
 
@@ -249,6 +261,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
     # keys servers by name and a second server under this name would clobber it.
     from pocketpaw_ee.agent.mcp_servers.sites_create import (
         make_create_dynamic_site_tool,
+        make_create_html_site_tool,
         make_create_landing_site_tool,
         make_create_svelte_site_tool,
         make_edit_svelte_component_tool,
@@ -265,6 +278,10 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
     # author-spec → create_dynamic_site → publish hops sit on one allowlisted
     # server. Publish carries the spec's dynamic blocks through to the generator.
     create_dynamic_site = make_create_dynamic_site_tool(tool)
+    # The html-track create tool (HE-6) — same server, so the author-html-map →
+    # create_html_site → publish hops sit on one allowlisted server. Opt-in: the
+    # tool steers the agent to it only on an explicit raw-HTML request.
+    create_html_site = make_create_html_site_tool(tool)
 
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
@@ -275,6 +292,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
             create_svelte_site,
             edit_svelte_component,
             create_dynamic_site,
+            create_html_site,
         ],
     )
     return SERVER_NAME, server
@@ -282,6 +300,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
 
 __all__ = [
     "CREATE_DYNAMIC_SITE_TOOL_ID",
+    "CREATE_HTML_SITE_TOOL_ID",
     "CREATE_LANDING_SITE_TOOL_ID",
     "CREATE_SVELTE_SITE_TOOL_ID",
     "EDIT_SVELTE_COMPONENT_TOOL_ID",

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -109,6 +109,23 @@
 # ``pocketpaw_sites_manager`` server (``mcp__pocketpaw_sites_manager__
 # create_landing_site``) so the create + publish hops sit side by side for the
 # chat agent — the SKILL produces copy → create_landing_site → publish.
+#
+# Updated: 2026-07-12 (feat/sites-html-create-tool, HE-6) — added a FOURTH create
+# tool ``create_html_site`` for the Paw Sites "html track". It mirrors
+# ``create_svelte_site`` (the agent IS the author; a raw {relative_path:
+# file_contents} source MAP is persisted verbatim via ``agent_create(
+# engine="html", source=<map>, type_="site", pattern="landing", ripple_spec=None,
+# trusted=True)`` — no ``assemble_*`` step, no rippleSpec, no catalog gate) but the
+# map is plain HTML/CSS/JS with NO SvelteKit scaffold and NO bundler. Validation is
+# lighter than svelte's §4.3: the only required key is the entry ``index.html`` (the
+# edge serves it at the root); ``_missing_html_keys`` fails the create CLOSED
+# without it. html has NO live-data binding siblings (that is the svelte/ripple
+# dynamic track), so the whole map is {path: str} and every value must be a content
+# string — no exemption list. Publishing an html site skips the Node build entirely
+# (generator_client.needs_node_build("html") is False). This is OPT-IN: the tool
+# description steers the agent to it ONLY on an explicit raw/plain-HTML request; the
+# default marketing brain stays create_landing_site (ripple). The default flip is
+# HE-12, gated behind HE-11.
 """Agent-side MCP surface for DETERMINISTIC Paw Site landing-page creation.
 
 A landing site is built from an LLM ``content`` copy object. This tool:
@@ -162,12 +179,18 @@ EDIT_SVELTE_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_svelte_component"
 # create_dynamic_site → publish (publish carries the dynamic blocks through to the
 # paw-sites generator, which scaffolds the per-tenant D1 + read/write remote fns).
 CREATE_DYNAMIC_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_dynamic_site"
+# The html-track create tool (HE-6) — also the SAME server. The skill flow is:
+# author a raw HTML/CSS/JS source map → create_html_site → publish. Publishing an
+# html site skips the Node build entirely (generator_client.needs_node_build is
+# False for html); the raw markup is materialized and served as-is.
+CREATE_HTML_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_html_site"
 
 SITES_CREATE_TOOL_IDS = (
     CREATE_LANDING_SITE_TOOL_ID,
     CREATE_SVELTE_SITE_TOOL_ID,
     EDIT_SVELTE_COMPONENT_TOOL_ID,
     CREATE_DYNAMIC_SITE_TOOL_ID,
+    CREATE_HTML_SITE_TOOL_ID,
 )
 
 
@@ -243,6 +266,25 @@ def _missing_source_keys(source: dict[str, Any]) -> list[str]:
         if not any(k.startswith(prefix) for k in source):
             missing.append(f"{prefix}*.svelte")
     return missing
+
+
+# ── html-track source map (HE-6) ────────────────────────────────────────────
+# An html-engine ``source`` map is a raw {relative_path: file_contents} map of
+# HTML/CSS/JS — no SvelteKit scaffold, no bundler. The only hard requirement is
+# the entry document ``index.html``: the paw-sites generator materializes the map
+# verbatim (html-scaffold.ts:materializeHtml) and the edge serves ``index.html``
+# at the site root, so a map without it is unservable. Everything else (styles,
+# scripts, extra pages, assets) is optional and passes through as authored.
+HTML_REQUIRED_KEYS = ("index.html",)
+
+
+def _missing_html_keys(source: dict[str, Any]) -> list[str]:
+    """Return the required html keys absent from ``source`` (empty list = valid).
+
+    Only ``index.html`` is required — it is the entry the generator materializes
+    and the edge serves at the site root. Used to fail the create closed with an
+    actionable message rather than persisting a site with no servable entry."""
+    return [k for k in HTML_REQUIRED_KEYS if k not in source]
 
 
 # ── Dynamic-track spec surface (RFC 12 A2) ──────────────────────────────────
@@ -965,6 +1007,194 @@ def make_create_svelte_site_tool(tool: Any) -> Any:
     return create_svelte_site
 
 
+async def _create_html_site_handler(args: dict) -> dict:
+    """MCP handler for ``sites_manager__create_html_site`` (the html track, HE-6).
+
+    Reads workspace/user identity from the per-stream ContextVars, validates the
+    ``source`` map (a raw {relative_path: file_contents} HTML/CSS/JS map that MUST
+    carry ``index.html``), and persists it DIRECTLY via ``agent_create``
+    (engine="html", source=<map>, type="site", pattern="landing", ripple_spec=None,
+    trusted=True). Returns ``{ok, pocket_id, pocket}`` on success; sets ``is_error``
+    when identity is missing, ``source`` is absent/malformed/incomplete, or the
+    persist fails.
+
+    Like ``create_svelte_site`` there is no ``assemble_*`` step — the agent authored
+    the markup, so the map is persisted verbatim and the generator materializes it
+    at publish. Unlike svelte, an html publish skips the Node build entirely
+    (``generator_client.needs_node_build("html")`` is False): the raw files are
+    served as authored. html has NO live-data binding siblings — the whole map is
+    {path: str}, so every value must be a content string."""
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "create_html_site requires workspace and user context (call from a cloud chat session)."
+        )
+
+    record_tool_call(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        tool_server="pocketpaw_sites",
+        tool_name="_create_html_site",
+        status="ok",
+        ok=True,
+    )
+
+    args = coerce_json_object_args(args, ("source",))
+    source = args.get("source")
+    if not isinstance(source, dict) or not source:
+        return _error_response(
+            "create_html_site requires a `source` object — the raw HTML/CSS/JS "
+            "source map { relative_path: file_contents } you authored. It must "
+            "include `index.html` (the page the edge serves); add stylesheets, "
+            "scripts, and assets as sibling entries. You write the markup; this "
+            "tool persists it."
+        )
+    # The whole map is {path: contents} — every value is a file content string.
+    # html has no live-data binding siblings (that is the svelte/ripple dynamic
+    # track), so unlike create_svelte_site there is no exemption list.
+    bad = [k for k, v in source.items() if not isinstance(v, str)]
+    if bad:
+        return _error_response(
+            "create_html_site `source` file values must be content strings; these "
+            f"keys are not strings: {', '.join(sorted(bad)[:8])}."
+        )
+    missing = _missing_html_keys(source)
+    if missing:
+        return _error_response(
+            "create_html_site `source` is missing required files: "
+            f"{', '.join(missing)}. An html site needs an `index.html` entry "
+            "document — the edge serves it at the site root."
+        )
+
+    # Plan gate (Sites = "sites"): reject a free-plan workspace here so the
+    # create can't bypass the router's require_plan_feature("sites") gate.
+    if (gate := await _require_sites_plan_or_error(workspace_id)) is not None:
+        return gate
+
+    name_raw = args.get("name")
+    name = name_raw.strip() if isinstance(name_raw, str) and name_raw.strip() else "HTML site"
+    description_raw = args.get("description")
+    description = description_raw if isinstance(description_raw, str) else ""
+    icon_raw = args.get("icon")
+    icon = icon_raw if isinstance(icon_raw, str) else ""
+    color_raw = args.get("color")
+    color = color_raw if isinstance(color_raw, str) else ""
+
+    # Persist DIRECTLY through the pockets service — NO pocket_specialist, NO
+    # rippleSpec, NO catalog gate (there is no spec to gate). ``engine="html"``
+    # + ``source`` stamp the html track so the generator materializes the map
+    # verbatim and publish skips the Node build; ``type_="site"`` +
+    # ``pattern="landing"`` keep the site identity the rest of the pipeline
+    # (publish, /sites listing) keys on. ``trusted=True`` short-circuits the strict
+    # catalog gate, which only runs on a non-null rippleSpec anyway — the html
+    # path passes ``ripple_spec=None``.
+    from pocketpaw_ee.cloud.pockets.service import agent_create
+
+    try:
+        view, new_pocket_id, err = await agent_create(
+            workspace_id=workspace_id,
+            owner_id=user_id,
+            name=name,
+            description=description,
+            type_="site",
+            pattern="landing",
+            icon=icon,
+            color=color,
+            ripple_spec=None,
+            engine="html",
+            source=source,
+            trusted=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("create_html_site: persist raised", exc_info=True)
+        return _error_response(f"create failed: {exc}")
+
+    if err is not None or view is None or new_pocket_id is None:
+        return _error_response(f"create failed: {err or 'create returned no view'}")
+
+    await _bind_session_and_emit(new_pocket_id, view, user_id)
+
+    return _success_response(
+        {
+            "ok": True,
+            "pocket_id": new_pocket_id,
+            "pocket": {
+                "id": new_pocket_id,
+                "name": view.get("name"),
+                "type": view.get("type"),
+                "pattern": view.get("pattern"),
+                "engine": view.get("engine"),
+            },
+        }
+    )
+
+
+def make_create_html_site_tool(tool: Any) -> Any:
+    """Build the ``create_html_site`` SDK tool object using the SDK's ``tool``
+    decorator (passed in by the caller that already imported it).
+
+    Registered on the SAME ``pocketpaw_sites_manager`` server as publish +
+    create_landing_site + create_svelte_site + create_dynamic_site (see
+    ``make_create_landing_site_tool`` for why one server)."""
+
+    @tool(
+        "create_html_site",
+        (
+            "Create a Paw Site landing page on the HTML TRACK — a raw, "
+            "hand-authored static site (plain HTML/CSS/JS, no framework, no build "
+            "step). Use this ONLY when the user EXPLICITLY asks for a plain / "
+            "raw / single-file HTML site or 'no framework' ('give me a bare HTML "
+            "landing page', 'just an index.html', 'no Svelte'). For a normal "
+            "marketing request the default is create_landing_site (ripple) — do "
+            "NOT pick this one by default. You AUTHOR the markup yourself and pass "
+            "it as a `source` MAP { relative_path: file_contents }; the tool "
+            "persists the map and stamps the pocket type='site', pattern='landing', "
+            "engine='html'. You do NOT compose a rippleSpec, do NOT author Svelte, "
+            "do NOT call pocket_specialist. The map MUST include `index.html` (the "
+            "page the edge serves at the root); add stylesheets, scripts, extra "
+            "pages, and assets as sibling entries — every value is a content "
+            "STRING. Publishing an html site skips the Node build entirely: the raw "
+            "files are served exactly as authored, so the page must be complete on "
+            "its own (inline or linked CSS/JS, real copy — never 'TBD'/'Lorem "
+            "ipsum'). Returns {ok, pocket_id, pocket}; hand `pocket_id` to "
+            "`mcp__pocketpaw_sites_manager__publish` to publish. ok=false with an "
+            "error means relay the reason, do NOT report a created pocket."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "object",
+                    "description": (
+                        "The raw HTML/CSS/JS source map you authored — a "
+                        "{ relative_path: file_contents } map, paths relative to the "
+                        "site root, every value a content STRING. MUST include "
+                        "`index.html` (the entry document served at the root). Add "
+                        "styles, scripts, and assets as sibling entries."
+                    ),
+                    "additionalProperties": {"type": "string"},
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Optional pocket/site name. Defaults to 'HTML site'.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional one-line pocket description.",
+                },
+                "icon": {"type": "string", "description": "Optional lucide icon name."},
+                "color": {"type": "string", "description": "Optional accent color hex."},
+            },
+            "required": ["source"],
+            "additionalProperties": False,
+        },
+    )
+    async def create_html_site(args):  # type: ignore[no-untyped-def]
+        return await _create_html_site_handler(args)
+
+    return create_html_site
+
+
 async def _edit_svelte_component_handler(args: dict) -> dict:
     """MCP handler for ``sites_manager__edit_svelte_component``.
 
@@ -1227,14 +1457,17 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
 
 __all__ = [
     "CREATE_DYNAMIC_SITE_TOOL_ID",
+    "CREATE_HTML_SITE_TOOL_ID",
     "CREATE_LANDING_SITE_TOOL_ID",
     "CREATE_SVELTE_SITE_TOOL_ID",
     "EDIT_SVELTE_COMPONENT_TOOL_ID",
+    "HTML_REQUIRED_KEYS",
     "SERVER_NAME",
     "SITES_CREATE_TOOL_IDS",
     "SVELTE_REQUIRED_EXACT_KEYS",
     "SVELTE_REQUIRED_PREFIXES",
     "make_create_dynamic_site_tool",
+    "make_create_html_site_tool",
     "make_create_landing_site_tool",
     "make_create_svelte_site_tool",
     "make_edit_svelte_component_tool",

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
@@ -37,6 +37,33 @@ as a conversion funnel: grab attention, explain the offer, prove it,
 price it, and capture the lead. The tool emits exactly that funnel from
 your copy.
 
+## Opt-in: the raw-HTML track (only when explicitly asked)
+
+The copy-only path above is the **default** and what you should use for a
+normal "build me a landing site" request. There is one exception. When the
+user **explicitly** asks for a plain / raw / single-file **HTML** site — "just
+give me an `index.html`", "no framework", "hand-written HTML/CSS", "no
+Svelte" — author the markup yourself and call **`create_html_site`** instead:
+
+```
+mcp__pocketpaw_sites_manager__create_html_site(
+  source = { "index.html": "<!doctype html>…", "styles.css": "…" },
+  name   = "…"                       // optional; defaults to "HTML site"
+)
+```
+
+`source` is a `{ relative_path: file_contents }` map of raw HTML/CSS/JS.
+It **must** include `index.html` (the edge serves it at the root); add
+stylesheets, scripts, and assets as sibling entries — every value is a
+content string. Publishing an html site skips the build step entirely, so
+the page must be complete on its own (inline or linked CSS/JS, real copy —
+never "TBD"/"Lorem ipsum"). It returns `{ ok, pocket_id, pocket }`; hand
+`pocket_id` to `publish` exactly like the copy path (STEP 3). If `ok` is
+false, relay the error.
+
+**Do not reach for this by default.** Unless the user explicitly wants raw
+HTML, use the copy-only `create_landing_site` path below.
+
 ## Why copy-only (and why this is the reliable path)
 
 Earlier versions of this skill asked the agent to draft the rippleSpec

--- a/tests/ee/agent/test_sites_mcp_server/test_create_html_site.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_create_html_site.py
@@ -1,0 +1,279 @@
+# tests/ee/agent/test_sites_mcp_server/test_create_html_site.py
+# Created: 2026-07-12 (feat/sites-html-create-tool, HE-6) — coverage for the Paw
+# Sites "html track" create tool ``create_html_site`` on the in-process
+# ``pocketpaw_sites_manager`` server. It is the 4th create tool, mirroring
+# ``create_svelte_site`` (the agent IS the author; a raw {path: contents} source
+# map is persisted verbatim via ``agent_create`` with ``engine="html"`` +
+# ``ripple_spec=None`` + ``trusted=True``) but the map is raw HTML/CSS/JS with no
+# SvelteKit scaffold. Three layers:
+#   1. source-map validation (``_missing_html_keys``) — the entry ``index.html``
+#      is required (the generator/deploy serve it), so the create fails CLOSED on
+#      a map with no entry document instead of persisting an unservable site.
+#   2. Registration — the tool id rides the SAME server allowlist as publish +
+#      the other three create tools.
+#   3. End-to-end handler — against a real (mongomock) Beanie DB it persists the
+#      source map via ``agent_create`` and reads the PERSISTED _PocketDoc back to
+#      confirm engine=="html", source==<map>, type=="site", pattern=="landing"
+#      (ground truth in Mongo, NOT agent narration), and NO rippleSpec.
+"""Tests for the html-track create tool (create_html_site)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+@pytest.fixture(autouse=True)
+def _default_sites_plan():
+    """create_html_site calls the shared Sites plan gate
+    (sites.service.require_sites_plan) before agent_create. These tests use
+    synthetic workspace ids with no seeded Workspace doc, so default the plan to
+    one that unlocks Sites ("go") to exercise the create mechanics. Plan-gate
+    denial is covered separately in tests/ee/sites/test_plan_gate.py."""
+    with patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value="go"),
+    ):
+        yield
+
+
+# A representative raw-HTML source map (paths -> file contents). Multi-file to
+# prove the whole map persists, not just the entry document.
+def _sample_source() -> dict[str, str]:
+    return {
+        "index.html": (
+            '<!doctype html>\n<html lang="en">\n<head>\n'
+            '  <meta charset="utf-8" />\n  <link rel="stylesheet" href="styles.css" />\n'
+            "  <title>Bright Smile Dental</title>\n</head>\n<body>\n"
+            "  <h1>Care that fits your whole family</h1>\n</body>\n</html>\n"
+        ),
+        "styles.css": ":root { --ink: #17130f; }\nbody { color: var(--ink); }\n",
+    }
+
+
+# ---------------------------------------------------------------------------
+# source-map validation (pure — no identity / Mongo needed)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceMapValidation:
+    def test_complete_map_has_no_missing_keys(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _missing_html_keys
+
+        assert _missing_html_keys(_sample_source()) == []
+
+    def test_required_keys_are_the_entry_document(self) -> None:
+        """Pin the required entry key so the contract can't silently drift — the
+        edge serves index.html, so a map without it is unservable."""
+        from pocketpaw_ee.agent.mcp_servers.sites_create import HTML_REQUIRED_KEYS
+
+        assert set(HTML_REQUIRED_KEYS) == {"index.html"}
+
+    def test_missing_entry_document_is_reported(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _missing_html_keys
+
+        no_entry = {k: v for k, v in _sample_source().items() if k != "index.html"}
+        assert "index.html" in _missing_html_keys(no_entry)
+
+    def test_entry_only_map_is_valid(self) -> None:
+        """A single index.html with no extra assets is a complete html site."""
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _missing_html_keys
+
+        assert _missing_html_keys({"index.html": "<h1>hi</h1>"}) == []
+
+
+# ---------------------------------------------------------------------------
+# Registration — the tool rides the shared sites_manager allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_tool_id_on_shared_server_allowlist(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import (
+            CREATE_HTML_SITE_TOOL_ID,
+            SITES_TOOL_IDS,
+        )
+
+        assert CREATE_HTML_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_html_site"
+        assert CREATE_HTML_SITE_TOOL_ID in SITES_TOOL_IDS
+
+    def test_create_module_exports_matching_tool_id(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import CREATE_HTML_SITE_TOOL_ID
+        from pocketpaw_ee.agent.mcp_servers.sites_create import (
+            CREATE_HTML_SITE_TOOL_ID as CREATE_ID,
+        )
+        from pocketpaw_ee.agent.mcp_servers.sites_create import SITES_CREATE_TOOL_IDS
+
+        assert CREATE_ID == CREATE_HTML_SITE_TOOL_ID
+        assert CREATE_ID in SITES_CREATE_TOOL_IDS
+
+    def test_provider_advertises_html_tool_id(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import CREATE_HTML_SITE_TOOL_ID
+        from pocketpaw_ee.extensions import CloudSitesMcpProvider
+
+        assert CREATE_HTML_SITE_TOOL_ID in CloudSitesMcpProvider().tool_ids()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end handler — persist + read back from Mongo (ground truth)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def recording_bus():
+    """Install a recording EventBus so ``agent_create``'s ``emit(PocketCreated)``
+    doesn't raise (the real bus is only wired by ``init_realtime()`` at boot).
+    Mirrors ``tests/cloud/conftest.py``, which isn't visible from this package."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+class TestCreateHtmlSiteEndToEnd:
+    @pytest.mark.asyncio
+    async def test_persists_html_pocket_with_source_map(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """Drive the handler against a real (mongomock) Beanie DB and read the
+        persisted _PocketDoc back. Proves a pocket lands with engine=="html",
+        source==<map>, type=="site", pattern=="landing" — and NO rippleSpec."""
+        from bson import ObjectId
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+        from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+        source = _sample_source()
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value=workspace_id,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value=user_id,
+            ),
+        ):
+            out = await sites_create_mcp._create_html_site_handler(
+                {"source": source, "name": "Bright Smile"}
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["ok"] is True
+        assert body["pocket"]["engine"] == "html"
+        pocket_id = body["pocket_id"]
+        assert pocket_id
+
+        # Ground truth: read the persisted doc straight from Mongo.
+        doc = await _PocketDoc.get(ObjectId(pocket_id))
+        assert doc is not None
+        assert doc.type == "site"
+        assert doc.pattern == "landing"
+        assert doc.engine == "html"
+        assert doc.source == source
+        # The html path persists NO rippleSpec.
+        assert doc.rippleSpec is None
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value=None,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value=None,
+            ),
+        ):
+            out = await sites_create_mcp._create_html_site_handler({"source": _sample_source()})
+
+        assert out.get("is_error") is True
+        assert "workspace and user context" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_source_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value="ws_1",
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value="u_1",
+            ),
+        ):
+            out = await sites_create_mcp._create_html_site_handler({"name": "X"})
+
+        assert out.get("is_error") is True
+        assert "`source`" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_entry_document_is_error_naming_index_html(self) -> None:
+        """A map with no index.html fails closed and names it — so the agent can
+        fix it rather than persist a site the edge can't serve."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        no_entry = {k: v for k, v in _sample_source().items() if k != "index.html"}
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value="ws_1",
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value="u_1",
+            ),
+        ):
+            out = await sites_create_mcp._create_html_site_handler({"source": no_entry})
+
+        assert out.get("is_error") is True
+        assert "index.html" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_non_string_file_value_is_rejected(self) -> None:
+        """Every value in an html source map is file contents — a non-string value
+        is rejected (html has no binding siblings; the whole map is {path: str})."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        bad = _sample_source()
+        bad["data.json"] = {"not": "a string"}
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value="ws_1",
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value="u_1",
+            ),
+        ):
+            out = await sites_create_mcp._create_html_site_handler({"source": bad})
+
+        assert out.get("is_error") is True
+        assert "data.json" in out["content"][0]["text"]

--- a/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
@@ -26,6 +26,7 @@ class TestSitesMcpServerRegistration:
     def test_server_name_and_tool_id(self) -> None:
         from pocketpaw_ee.agent.mcp_servers.sites import (
             CREATE_DYNAMIC_SITE_TOOL_ID,
+            CREATE_HTML_SITE_TOOL_ID,
             CREATE_LANDING_SITE_TOOL_ID,
             CREATE_SVELTE_SITE_TOOL_ID,
             EDIT_SVELTE_COMPONENT_TOOL_ID,
@@ -48,12 +49,14 @@ class TestSitesMcpServerRegistration:
             EDIT_SVELTE_COMPONENT_TOOL_ID == "mcp__pocketpaw_sites_manager__edit_svelte_component"
         )
         assert CREATE_DYNAMIC_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_dynamic_site"
+        assert CREATE_HTML_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_html_site"
         assert PUBLISH_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_LANDING_SITE_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_SVELTE_SITE_TOOL_ID in SITES_TOOL_IDS
         assert EDIT_SVELTE_COMPONENT_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_DYNAMIC_SITE_TOOL_ID in SITES_TOOL_IDS
-        assert len(SITES_TOOL_IDS) == 5
+        assert CREATE_HTML_SITE_TOOL_ID in SITES_TOOL_IDS
+        assert len(SITES_TOOL_IDS) == 6
 
     def test_extension_provider_advertises_tool_id(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk


### PR DESCRIPTION
## What this does

Adds `create_html_site` as the fourth create tool on the shared
`pocketpaw_sites_manager` MCP server, alongside `create_landing_site`
(ripple), `create_svelte_site`, and `create_dynamic_site`. It lets an
agent author a raw HTML/CSS/JS site and hand it straight to `publish`.

The tool persists a `{ relative_path: file_contents }` source map
verbatim — `engine="html"`, `ripple_spec=None`, `trusted=True` — and
stamps the pocket `type="site"`, `pattern="landing"`. That is the same
author-owns-the-source shape `create_svelte_site` uses, minus the
SvelteKit scaffold and the bundler. Validation is intentionally light:
the only required key is `index.html` (the edge serves it at the root),
and every value must be a content string, since an html site carries no
live-data binding siblings.

## Opt-in, not a default flip

The default marketing path is unchanged. The tool description steers the
agent here only on an explicit "plain HTML / no framework / just an
`index.html`" request, and `pocketpaw-create-paw-site` gains a scoped
opt-in section that points at it while keeping `create_landing_site`
(ripple) as the default. Skill count stays at three.

Making html the *default* — rewriting the marketing brain to author html
out of the box — is a separate change. It has to ship the refine-mode fix
in the same PR (otherwise refining an html site opens ripple mode against
a pocket with no rippleSpec) and it is gated behind the taste work, so it
is deliberately left out here.

## Scope note

This is the create half of the slice. The full create → publish →
live-URL demo also needs the assets-only Worker deploy path, which lands
separately. Create works now; the build-skip for html publishes already
merged.

## Tests

- `test_create_html_site.py` — source-map validation (`index.html`
  required, non-string values rejected), registration on the shared
  allowlist, and an end-to-end persist that reads the pocket back from
  Mongo to confirm `engine="html"`, the full source map, and no
  rippleSpec.
- `test_mcp_tool.py` — pinned tool count bumped to six with the new id
  asserted on the server allowlist.

`tests/ee/agent/test_sites_mcp_server/` is green (67 pass). Lint and
format are clean on the changed files; the two modules carry no new mypy
errors (the pre-existing `_validate_dynamic_spec` union-attr notes are
unchanged). One unrelated installer test fails on this box from a Windows
cp1252 encoding quirk that also fails on `dev`.