### PR TITLE
Deploy an html site as an assets-only Worker (HE-4)

### DIFF
--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1323,7 +1323,9 @@ async def _deploy_site_doc(
     cloudflare: Any | None = None,
     bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
     local_deploy: Callable[[str, str], str] | None = None,
-    workers_deploy: Callable[[str, str], Any] | None = None,
+    # HE-4: the workers deployer is engine-aware (``deploy_workers(site_id,
+    # project_dir, *, engine=..., d1_database_id=...)``), so the seam takes kwargs.
+    workers_deploy: Callable[..., Any] | None = None,
 ) -> _SiteDoc:
     """Generate, smoke-gate, deploy, and UPSERT the LIVE canonical Site doc.
 
@@ -1456,7 +1458,9 @@ async def _deploy_site_doc(
         from pocketpaw_ee.sites import workers_deploy as workers_deploy_mod
 
         deploy_w = workers_deploy or workers_deploy_mod.deploy_workers
-        url = await deploy_w(site_id, build.project_dir)
+        # HE-4: pass the engine so an html site deploys as an assets-only Worker
+        # (no server script), while ripple/svelte keep the SvelteKit-worker config.
+        url = await deploy_w(site_id, build.project_dir, engine=engine)
     else:  # "wfp"
         cf = cloudflare or _cf_client()
         bundle = bundle_reader(build.project_dir)

--- a/ee/pocketpaw_ee/sites/workers_deploy.py
+++ b/ee/pocketpaw_ee/sites/workers_deploy.py
@@ -3,6 +3,19 @@
 #
 # Created: 2026-06-25 (feat/sites-workers-deploy-mode) — the "workers" deploy mode.
 #
+# Updated 2026-07-12 (feat/sites-html-assets-only-deploy, HE-4) — the deploy is now
+# ENGINE-AWARE. An ``engine="html"`` site deploys as an ASSETS-ONLY Worker: the
+# generator emits a raw static tree (``static_output_rel("html") == "."``, no
+# ``_worker.js``), so the emitted ``wrangler.jsonc`` drops ``main`` + ``nodejs_compat``
+# and just serves ``assets.directory: "."`` — a legal no-``main`` Worker that ships
+# ZERO bytes of JavaScript for a form-less brochure. Because the asset dir is the
+# project ROOT (which also holds ``wrangler.jsonc``), html writes a config-excluding
+# ``.assetsignore`` (``wrangler.jsonc`` + ``.assetsignore``) so wrangler does not serve
+# the config as a public asset — wrangler only auto-excludes its config when the asset
+# dir is a SUBDIR (Cloudflare static-assets docs). ripple/svelte keep the exact
+# SvelteKit-worker config + the ``_worker.js`` ``.assetsignore`` (the default engine is
+# ``"ripple"``, so every existing caller is byte-for-byte unchanged).
+#
 # This is the third deploy target for a Paw Site, beside the LOCAL static server
 # (local_server.deploy_local — dev/smoke) and Workers-for-Platforms
 # (cloudflare_client.put_worker — the multi-tenant dispatch namespace). The
@@ -57,19 +70,31 @@ from pathlib import Path
 
 from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
 from pocketpaw_ee.sites._wrangler import wrangler_argv as _wrangler_argv
+from pocketpaw_ee.sites.engines import needs_node_build, static_output_rel
 
 logger = logging.getLogger(__name__)
 
-# The static-output dir adapter-cloudflare emits, relative to the project dir. The
-# worker entry AND the asset tree both live here; ``main`` and ``assets.directory``
-# in the generated wrangler.jsonc both point at it.
+# The static-output dir adapter-cloudflare emits for a ripple/svelte build, relative
+# to the project dir. The worker entry AND the asset tree both live here. Retained as
+# a named constant for readability; the config is now driven off
+# ``static_output_rel(engine)`` (HE-4), which resolves to this for ripple/svelte and
+# to ``"."`` for html (whose raw static tree IS the project dir).
 _CF_OUTPUT_REL = ".svelte-kit/cloudflare"
 
-# The REQUIRED .assetsignore contents (exact three lines, no trailing blank). Drops
-# the Pages-style worker/routing/header files so wrangler 4.x does not try to upload
-# the worker entry as a static asset (which it HARD-ERRORS on). adapter-cloudflare
-# does not emit this file, so the deploy step writes it.
+# The REQUIRED .assetsignore contents for a ripple/svelte (server-worker) deploy —
+# exact three lines, no trailing blank. Drops the Pages-style worker/routing/header
+# files so wrangler 4.x does not try to upload the worker entry as a static asset
+# (which it HARD-ERRORS on). adapter-cloudflare does not emit this file, so the
+# deploy step writes it.
 _ASSETSIGNORE_LINES = ("_worker.js", "_routes.json", "_headers")
+
+# The .assetsignore contents for an html deploy. An html site's ``assets.directory``
+# is the project ROOT (``static_output_rel("html") == "."``), which also holds the
+# deploy scaffold — ``wrangler.jsonc`` and this ``.assetsignore`` — so wrangler would
+# otherwise upload the config file as a public asset (it only auto-excludes the config
+# when the asset dir is a SUBDIR, per the Cloudflare static-assets docs). There is no
+# ``_worker.js`` on this path; the exclusion is the config files, not a server entry.
+_HTML_ASSETSIGNORE_LINES = ("wrangler.jsonc", ".assetsignore")
 
 # wrangler reads the worker name + name-segment of the workers.dev URL from
 # ``wrangler.jsonc``'s ``name``. It must match this (lowercase alnum + hyphen,
@@ -116,17 +141,30 @@ def _worker_name(site_id: str) -> str:
     return f"paw-site-{_sanitize(site_id)}"
 
 
-def _wrangler_jsonc(name: str, d1_database_id: str | None = None) -> str:
+def _wrangler_jsonc(name: str, engine: str = "ripple", d1_database_id: str | None = None) -> str:
     """The clean wrangler config for a workers.dev deploy (the proven recipe).
-    ``main`` points at the worker entry adapter-cloudflare emits INSIDE the asset
-    dir, and ``assets.directory`` points at that SAME dir (the ``.assetsignore`` we
-    write keeps wrangler from uploading the worker entry as an asset). ``workers_dev:
-    true`` publishes to the free ``<name>.<subdomain>.workers.dev`` URL;
-    ``nodejs_compat`` is what the SvelteKit worker needs at runtime.
 
-    ``d1_database_id`` (DYNAMIC sites) adds the single ``DB`` D1 binding — the same
-    binding WfP's ``put_worker`` passes — so a dynamic site's remote functions reach
-    their per-tenant database on the FREE tier, with no dispatch namespace.
+    HE-4 — the config is ENGINE-AWARE:
+
+    * html (``not needs_node_build``) → an ASSETS-ONLY Worker. The generator emits a
+      raw static tree (no ``_worker.js``), so the config drops ``main`` and
+      ``nodejs_compat`` and just serves ``assets.directory`` (``static_output_rel`` →
+      ``"."``, the project root). An assets-only Worker with no ``main`` is legal —
+      ``assets.directory`` is the only required key — and it ships ZERO bytes of
+      JavaScript for a form-less brochure.
+    * ripple / svelte (``needs_node_build``) → the SvelteKit Cloudflare worker,
+      UNCHANGED. ``main`` points at the worker entry adapter-cloudflare emits INSIDE
+      the asset dir (``static_output_rel`` → ``.svelte-kit/cloudflare``), and
+      ``assets.directory`` points at that SAME dir (the ``.assetsignore`` we write
+      keeps wrangler from uploading the worker entry as an asset). ``nodejs_compat``
+      is what the SvelteKit worker needs at runtime.
+
+    ``workers_dev: true`` publishes to the free ``<name>.<subdomain>.workers.dev`` URL.
+
+    ``d1_database_id`` (DYNAMIC sites — ripple/svelte only) adds the single ``DB`` D1
+    binding — the same binding WfP's ``put_worker`` passes — so a dynamic site's
+    remote functions reach their per-tenant database on the FREE tier. Dynamic html is
+    out of scope (it has no server runtime), so an html config never carries a binding.
 
     Deliberately still NO Queue bindings. The generator's own wrangler.toml declares
     ``LEADS_QUEUE`` / ``WRITEBACK_QUEUE`` producers, but Cloudflare Queues is a paid
@@ -135,13 +173,25 @@ def _wrangler_jsonc(name: str, d1_database_id: str | None = None) -> str:
     gracefully on a missing binding (``api/submit`` forwards straight to the capture
     API; ``writeback.ts`` warns and skips), so omitting them costs durability
     buffering, never a dropped lead."""
-    config: dict[str, object] = {
+    output_rel = static_output_rel(engine)
+    # html: an assets-only Worker — no server script, so no ``main`` / ``nodejs_compat``
+    # and no D1 (dynamic html is out of scope). Just serve the static tree.
+    if not needs_node_build(engine):
+        config: dict[str, object] = {
+            "name": name,
+            "compatibility_date": "2024-09-23",
+            "workers_dev": True,
+            "assets": {"directory": output_rel},
+        }
+        return json.dumps(config, indent=2) + "\n"
+
+    config = {
         "name": name,
-        "main": f"{_CF_OUTPUT_REL}/_worker.js",
+        "main": f"{output_rel}/_worker.js",
         "compatibility_date": "2024-09-23",
         "compatibility_flags": ["nodejs_compat"],
         "workers_dev": True,
-        "assets": {"binding": "ASSETS", "directory": _CF_OUTPUT_REL},
+        "assets": {"binding": "ASSETS", "directory": output_rel},
     }
     if d1_database_id:
         config["d1_databases"] = [
@@ -175,13 +225,27 @@ def _parse_deploy_url(stdout: str, *, name: str) -> str:
     return ""
 
 
-def _write_deploy_files(project_dir: str, name: str, d1_database_id: str | None = None) -> None:
-    """Write the two files the recipe needs into the project: the REQUIRED
-    ``.svelte-kit/cloudflare/.assetsignore`` (exact three lines) and the clean
-    ``wrangler.jsonc`` at the project root. Both are overwritten on a re-publish so
-    a stale config can never linger. ``d1_database_id`` adds the dynamic site's D1
-    binding to the emitted config."""
-    out_dir = Path(project_dir, _CF_OUTPUT_REL)
+def _write_deploy_files(
+    project_dir: str, name: str, engine: str = "ripple", d1_database_id: str | None = None
+) -> None:
+    """Write the recipe files into the project: an ``.assetsignore`` inside the asset
+    dir + the clean ``wrangler.jsonc`` at the project root. Both are overwritten on a
+    re-publish so a stale config can never linger.
+
+    HE-4 — engine-aware. The asset dir is ``static_output_rel(engine)``
+    (``.svelte-kit/cloudflare`` for ripple/svelte, ``"."`` for html). The
+    ``.assetsignore`` differs by engine:
+
+    * ripple/svelte → drops the Pages worker entry (``_worker.js`` + friends) so
+      wrangler does not upload the server entry as a static asset.
+    * html → the asset dir IS the project root, which also holds ``wrangler.jsonc`` +
+      ``.assetsignore``, so it drops THOSE (the deploy scaffold) — otherwise wrangler
+      serves the config file as a public asset.
+
+    ``d1_database_id`` adds the dynamic site's D1 binding to the emitted config
+    (ripple/svelte only)."""
+    output_rel = static_output_rel(engine)
+    out_dir = Path(project_dir, output_rel)
     if not out_dir.is_dir():
         # The static output must exist before this runs — generator.build() emits it.
         # If it is missing the deploy can't proceed (nothing to upload).
@@ -189,8 +253,9 @@ def _write_deploy_files(project_dir: str, name: str, d1_database_id: str | None 
             "sites.workers_no_build",
             "The static build output is missing — the site must be built before a workers deploy.",
         )
-    (out_dir / ".assetsignore").write_text("\n".join(_ASSETSIGNORE_LINES) + "\n")
-    Path(project_dir, _CONFIG_FILENAME).write_text(_wrangler_jsonc(name, d1_database_id))
+    ignore_lines = _ASSETSIGNORE_LINES if needs_node_build(engine) else _HTML_ASSETSIGNORE_LINES
+    (out_dir / ".assetsignore").write_text("\n".join(ignore_lines) + "\n")
+    Path(project_dir, _CONFIG_FILENAME).write_text(_wrangler_jsonc(name, engine, d1_database_id))
 
 
 def _cf_env() -> dict[str, str]:
@@ -202,38 +267,51 @@ def _cf_env() -> dict[str, str]:
 
 
 async def deploy_workers(
-    site_id: str, project_dir: str, *, d1_database_id: str | None = None
+    site_id: str, project_dir: str, *, engine: str = "ripple", d1_database_id: str | None = None
 ) -> str:
     """Deploy a Paw Site as a regular Worker on the free workers.dev tier.
 
-    Writes the proven recipe files (``.assetsignore`` + ``wrangler.jsonc``) into the
+    Writes the recipe files (``.assetsignore`` + ``wrangler.jsonc``) into the
     already-built project, then runs ``wrangler deploy`` (PAW_CF_WRANGLER_CMD, default
     ``bunx wrangler@4.101.0``) with the CF creds in the env, and returns the deployed
     ``https://<name>.<subdomain>.workers.dev`` URL (parsed from wrangler's stdout,
     falling back to constructing it from PAW_CF_WORKERS_SUBDOMAIN).
 
-    ``d1_database_id`` (DYNAMIC sites) binds the site's per-tenant D1 as ``DB``, so a
-    dynamic site can serve its live data WITHOUT a Workers-for-Platforms dispatch
-    namespace (a paid add-on). The D1 must already exist and be migrated — the
+    HE-4 — ``engine`` selects the config shape. html deploys as an ASSETS-ONLY Worker
+    (no ``main`` / ``_worker.js``, ``assets.directory == "."``, and an ``.assetsignore``
+    that keeps the config out of the served tree); ripple/svelte deploy the SvelteKit
+    Cloudflare worker unchanged. The default (``"ripple"``) preserves the exact prior
+    behaviour for every existing caller — svelte resolves to the same
+    ``.svelte-kit/cloudflare`` output.
+
+    ``d1_database_id`` (DYNAMIC ripple/svelte sites) binds the site's per-tenant D1 as
+    ``DB``, so a dynamic site can serve its live data WITHOUT a Workers-for-Platforms
+    dispatch namespace (a paid add-on). The D1 must already exist and be migrated — the
     provision job does both before calling this.
 
-    The project MUST already carry the generator's ``.svelte-kit/cloudflare/``
-    static output (generator.build() emits it before this is called). On a non-zero
-    wrangler exit this raises ``Internal`` with the stderr tail so the failure
-    surfaces as a clean 5xx envelope, not an opaque crash."""
+    The project MUST already carry the engine's static output
+    (``static_output_rel(engine)`` — generator.build() emits it before this is called).
+    On a non-zero wrangler exit this raises ``Internal`` with the stderr tail so the
+    failure surfaces as a clean 5xx envelope, not an opaque crash."""
     name = _worker_name(site_id)
     if not _WORKER_NAME_RE.match(name):  # defensive — _worker_name always sanitizes
         raise ValidationError(
             "sites.workers_bad_name",
             f"Computed an invalid worker name from site id {site_id!r}.",
         )
-    _write_deploy_files(project_dir, name, d1_database_id)
+    _write_deploy_files(project_dir, name, engine, d1_database_id)
 
     # ``--config`` is REQUIRED, not cosmetic: a dynamic project dir also holds the
     # generator's wrangler.toml (whose queue producers reference queues that do not
     # exist on this path), and wrangler must not pick it up.
     argv = [*_wrangler_argv(), "deploy", "--config", _CONFIG_FILENAME]
-    logger.info("sites.workers: deploying %s (d1=%s) via %s", name, bool(d1_database_id), argv)
+    logger.info(
+        "sites.workers: deploying %s (engine=%s d1=%s) via %s",
+        name,
+        engine,
+        bool(d1_database_id),
+        argv,
+    )
     try:
         proc = await asyncio.create_subprocess_exec(
             *argv,

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -1296,7 +1296,9 @@ async def test_workers_mode_routes_static_publish_to_workers_deployer(beanie_tes
 
     calls: list[tuple[str, str]] = []
 
-    async def fake_workers_deploy(site_id: str, project_dir: str) -> str:
+    async def fake_workers_deploy(
+        site_id: str, project_dir: str, *, engine: str = "ripple", **_: object
+    ) -> str:
         calls.append((site_id, project_dir))
         return f"https://paw-site-{site_id}.acct.workers.dev"
 
@@ -1334,7 +1336,9 @@ async def test_workers_mode_dynamic_site_enqueues_not_deploys(beanie_test_db, mo
     monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "workers")
     monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
 
-    async def must_not_run(site_id: str, project_dir: str) -> str:  # pragma: no cover
+    async def must_not_run(  # pragma: no cover
+        site_id: str, project_dir: str, *, engine: str = "ripple", **_: object
+    ) -> str:
         raise AssertionError("a dynamic site must not reach the workers deployer")
 
     gen = _FakeGenerator()

--- a/tests/ee/sites/test_workers_deploy.py
+++ b/tests/ee/sites/test_workers_deploy.py
@@ -172,6 +172,96 @@ async def test_dynamic_deploy_declares_no_queue_producers(tmp_path, monkeypatch)
     assert "queues" not in cfg
 
 
+# ── html engine: an assets-only Worker, no server script (HE-4) ──────────────
+
+
+def _build_html_project(tmp_path: Path) -> str:
+    """Create a minimal built HTML project. ``static_output_rel("html")`` is ``"."``,
+    so the generator writes the raw static tree straight into the project dir (no
+    ``.svelte-kit/cloudflare`` build subdir) — index.html at the root."""
+    (tmp_path / "index.html").write_text("<!doctype html><h1>hi</h1>")
+    (tmp_path / "styles.css").write_text("h1{color:#111}")
+    return str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_html_deploy_is_assets_only_no_main(tmp_path, monkeypatch):
+    """An html site is a raw static tree with NO server worker, so its wrangler
+    config is assets-only: no ``main`` (there is no ``_worker.js``), no
+    ``nodejs_compat`` (nothing runs the node runtime), and ``assets.directory`` is
+    the project root itself (``static_output_rel("html") == "."``)."""
+    project = _build_html_project(tmp_path)
+    site_id = "507f1f77bcf86cd799439011"
+    proc = _FakeProc(0, b"https://paw-site-507f1f77bcf86cd799439011.acct.workers.dev\n", b"")
+    _patch_subprocess(monkeypatch, proc)
+
+    url = await workers_deploy.deploy_workers(site_id, project, engine="html")
+
+    cfg = json.loads(Path(project, "wrangler.jsonc").read_text())
+    assert cfg["name"] == f"paw-site-{site_id}"
+    assert cfg["workers_dev"] is True
+    assert cfg["assets"] == {"directory": "."}
+    # The assets-only shape drops every server-worker key.
+    assert "main" not in cfg
+    assert "compatibility_flags" not in cfg
+    assert "d1_databases" not in cfg
+    assert url == "https://paw-site-507f1f77bcf86cd799439011.acct.workers.dev"
+
+
+@pytest.mark.asyncio
+async def test_html_assetsignore_excludes_the_config_file(tmp_path, monkeypatch):
+    """With ``assets.directory == "."`` the wrangler config sits INSIDE the asset
+    dir, so wrangler would serve ``wrangler.jsonc`` as a public asset. The html
+    ``.assetsignore`` (also at the root) keeps the deploy-scaffold files out of the
+    served tree — the reason html needs an ``.assetsignore`` even though it has no
+    ``_worker.js`` to ignore."""
+    project = _build_html_project(tmp_path)
+    proc = _FakeProc(0, b"https://x.y.workers.dev\n", b"")
+    _patch_subprocess(monkeypatch, proc)
+
+    await workers_deploy.deploy_workers("507f1f77bcf86cd799439011", project, engine="html")
+
+    assetsignore = Path(project, ".assetsignore").read_text().splitlines()
+    assert "wrangler.jsonc" in assetsignore
+    # It never lists a _worker.js — that Pages-style entry does not exist on html.
+    assert "_worker.js" not in assetsignore
+
+
+@pytest.mark.asyncio
+async def test_html_deploy_passes_config_flag(tmp_path, monkeypatch):
+    """html still names its config explicitly, same as the svelte/ripple path."""
+    project = _build_html_project(tmp_path)
+    proc = _FakeProc(0, b"https://x.y.workers.dev\n", b"")
+    captured = _patch_subprocess(monkeypatch, proc)
+    monkeypatch.setenv("PAW_CF_WRANGLER_CMD", "bunx wrangler@4.101.0")
+
+    await workers_deploy.deploy_workers("507f1f77bcf86cd799439011", project, engine="html")
+
+    assert "--config" in captured["argv"]
+    assert captured["argv"][-1] == "wrangler.jsonc"
+    assert captured["cwd"] == project
+
+
+@pytest.mark.asyncio
+async def test_static_svelte_config_unchanged_by_engine_default(tmp_path, monkeypatch):
+    """Regression guard: the default engine (ripple/svelte) keeps the exact
+    server-worker config — ``main`` + ``nodejs_compat`` + the ``.svelte-kit/cloudflare``
+    asset dir — byte-for-byte, so HE-4 does not touch the proven path."""
+    project = _build_project(tmp_path)
+    proc = _FakeProc(0, b"https://x.y.workers.dev\n", b"")
+    _patch_subprocess(monkeypatch, proc)
+
+    await workers_deploy.deploy_workers("507f1f77bcf86cd799439011", project)
+
+    cfg = json.loads(Path(project, "wrangler.jsonc").read_text())
+    assert cfg["main"] == ".svelte-kit/cloudflare/_worker.js"
+    assert cfg["compatibility_flags"] == ["nodejs_compat"]
+    assert cfg["assets"] == {"binding": "ASSETS", "directory": ".svelte-kit/cloudflare"}
+    # The svelte/ripple .assetsignore still drops the Pages worker entry.
+    assetsignore = Path(project, ".svelte-kit/cloudflare/.assetsignore").read_text().splitlines()
+    assert assetsignore == ["_worker.js", "_routes.json", "_headers"]
+
+
 @pytest.mark.asyncio
 async def test_deploy_invokes_wrangler_with_deploy_in_project_dir(tmp_path, monkeypatch):
     project = _build_project(tmp_path)


### PR DESCRIPTION
## What this does

Makes the workers-mode deploy engine-aware so a form-less html brochure
goes live with no server script at all — the last piece the html
create → publish → live-URL demo was waiting on.

An html site's generator output is a raw static tree at the project root
(`static_output_rel("html")` is `"."`), with no `_worker.js`. Its
`wrangler.jsonc` now drops `main` and `nodejs_compat` and just serves
`assets.directory: "."` — a legal no-`main` Worker that ships zero bytes
of JavaScript. ripple and svelte keep the exact SvelteKit-worker config
and the `_worker.js` `.assetsignore`. The engine parameter defaults to
`ripple`, so every existing caller is byte-for-byte unchanged; the
static publish path threads the pocket's engine into `deploy_workers`.

## One deviation from the task, on purpose

The task sketch said to drop the `.assetsignore` for html "since there
is no `_worker.js` to ignore." That misses a real leak: with
`assets.directory` set to the project root, `wrangler.jsonc` lives inside
the asset directory and wrangler would serve it as a public asset —
wrangler only auto-excludes its own config when the asset directory is a
subdirectory ([Cloudflare static-assets docs](https://developers.cloudflare.com/workers/static-assets/)).
So html writes a minimal `.assetsignore` that excludes the config files
instead. Same intent (nothing but real assets gets served), different
files.

## Depends on

Built on #1685 (dynamic workers deploy), which rewrote this same file and
merged to `dev` first along with its base #1683.

## Tests

- html emits an assets-only config: no `main`, no compat flags, no D1,
  `assets.directory` of `.`
- its `.assetsignore` excludes `wrangler.jsonc` and never lists a
  `_worker.js`
- html still passes `--config wrangler.jsonc`
- a regression guard pins the svelte/ripple config and its `.assetsignore`
  unchanged

Full `ee/sites` suite green. The four failing subprocess-timeout tests
are pre-existing and reproduce on a clean `dev` on this machine
(Windows process-group timing), unrelated to this change. Lint, format,
and mypy clean on the touched files.