### PR TITLE
 fix(pockets): persist widget span on resize via PATCH endpoint

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -268,6 +268,7 @@ class UpdateWidgetRequest(BaseModel):
     name: str | None = None
     type: str | None = None
     icon: str | None = None
+    span: str | None = None
     config: dict | None = None
     props: dict | None = None
     data: Any = None

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -2270,6 +2270,8 @@ async def update_widget(
         widget.data = body.data
     if body.assigned_agent is not None:
         widget.assignedAgent = body.assigned_agent
+    if body.span is not None:
+        widget.span = body.span
     await doc.save()
     await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
     return await _resolved_wire_dict(doc, user_id)

--- a/tests/cloud/jobs/test_provision_site.py
+++ b/tests/cloud/jobs/test_provision_site.py
@@ -323,9 +323,7 @@ async def test_workers_mode_deploys_via_wrangler_not_put_worker(
 
     monkeypatch.setattr(workers_deploy_mod, "deploy_workers", _fake_deploy)
 
-    await ProvisionSiteJob()(
-        workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-6", params={}
-    )
+    await ProvisionSiteJob()(workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-6", params={})
 
     # Deployed through wrangler with the D1 bound — and never through the WfP upload.
     assert len(calls) == 1
@@ -340,18 +338,14 @@ async def test_workers_mode_deploys_via_wrangler_not_put_worker(
 
 
 @pytest.mark.asyncio
-async def test_wfp_mode_still_uses_put_worker(
-    seed: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_wfp_mode_still_uses_put_worker(seed: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression guard: ``wfp`` mode keeps the pre-existing dispatch-namespace upload."""
     ctx = await seed(d1_database_id="d1-existing-0008")
     cf = _FakeCF()
     _install_fakes(monkeypatch, cf=cf)
     monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "wfp")
 
-    await ProvisionSiteJob()(
-        workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-7", params={}
-    )
+    await ProvisionSiteJob()(workspace_id=WS, pocket_id=ctx["pocket_id"], job_id="job-7", params={})
 
     assert len(cf.put_calls) == 1
     assert cf.put_calls[0]["bindings"] == [{"type": "d1", "name": "DB", "id": "d1-existing-0008"}]


### PR DESCRIPTION
### Problem

When a user resizes a widget on a pocket grid, the new column span (how many
grid columns the widget occupies) was not being persisted. The
`PATCH /api/v1/pockets/{pocket_id}/widgets/{widget_id}` endpoint silently
ignored the `span` field in the request body, so the widget reverted to its
default size on page reload.

### Solution

- Added `span: str | None = None` to the `UpdateWidgetRequest` Pydantic DTO
  so the endpoint accepts the field
- Added `widget.span = body.span` to the `update_widget` service function so
  the value is written to the widget document before save

### Files Changed

| File | Change |
|------|--------|
| `ee/pocketpaw_ee/cloud/pockets/dto.py` | Added `span` field to `UpdateWidgetRequest` |
| `ee/pocketpaw_ee/cloud/pockets/service.py` | Persist `body.span` on the widget document |

### Testing

1. Open a pocket with a widget grid
2. Resize a widget by dragging its resize handle
3. Reload the page — the widget keeps its new span