### PR TITLE
Stop the Svelte skill hijacking plain landing requests

### DIFF
--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
@@ -4,11 +4,13 @@ description: |
   Build a marketing landing page as a Paw Site — a real, standalone
   website composed by conversion role (navbar, hero, services, social
   proof, pricing, CTA, lead form, footer) and rendered statically to the
-  edge. Invoke when the user describes a BRAND-NEW marketing / landing
-  site: "build a dentist landing site", "make a marketing page for my
-  bakery", "a landing page for my SaaS", or when the create-site flow
-  routes a new-site request here. This is the marketing-first authoring
-  brain — it composes a sales page, NOT a dashboard. You provide the COPY
+  edge. This is the DEFAULT landing-site brain: use it for ANY brand-new
+  marketing / landing site — "build a dentist landing site", "make a
+  marketing page for my bakery", "a landing page for my SaaS", or when the
+  create-site flow routes a new-site request here — UNLESS the Svelte
+  engine is explicitly selected (the "Use Svelte pages" toggle → then use
+  pocketpaw-create-svelte-site instead). This is the marketing-first
+  authoring brain — it composes a sales page, NOT a dashboard. You provide the COPY
   only; a deterministic tool assembles the page structure and stamps the
   pocket with type="site" + pattern="landing" so the published page
   renders as a landing page. For publishing an EXISTING pocket as a site,

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-svelte-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-svelte-site/SKILL.md
@@ -3,21 +3,23 @@ name: pocketpaw-create-svelte-site
 description: |
   Build a marketing landing page as a Paw Site on the SVELTE TRACK — a
   real, standalone website you author as premium hand-written SvelteKit
-  components, prerendered statically to the edge. Invoke when the user
-  asks for a BRAND-NEW marketing / landing site AND the create flow is on
-  the Svelte engine ("Use Svelte pages" toggle → engine="svelte"): "build
-  a dentist landing site", "make a marketing page for my bakery", "a
-  landing page for my SaaS". This is the component-authoring brain — YOU
-  write the Svelte sections (Hero, Pricing, Faq, ...) at the quality bar of
-  the proven spike, assemble them into a source map, and a deterministic
-  tool persists the pocket stamped type="site" + pattern="landing" +
-  engine="svelte" so the published page renders from your components. You
-  do NOT compose a rippleSpec, do NOT call get_widget_spec, do NOT use the
-  pocket specialist. For the ripple track (the default engine) use
-  pocketpaw-create-paw-site; for publishing an EXISTING pocket use
-  pocketpaw-create-site. Loading this skill keeps the chat agent's
-  always-on system prompt small while still delivering the full Svelte
-  authoring brain when a svelte-track site is actually requested.
+  components, prerendered statically to the edge. Use this ONLY when the
+  Svelte engine is EXPLICITLY selected — the "Use Svelte pages" toggle is
+  on, i.e. engine="svelte". A plain landing-site request is NOT a signal to
+  use this: if the user just says "build a dentist landing page", "a
+  marketing page for my bakery", or "a landing page for my SaaS" and the
+  Svelte engine is NOT on, this is the WRONG skill — use
+  pocketpaw-create-paw-site (the default landing brain) instead. Do NOT
+  pick this skill from the topic alone; the Svelte engine must already be
+  selected. When it IS selected: YOU write the Svelte sections (Hero,
+  Pricing, Faq, ...) at the quality bar of the proven spike, assemble them
+  into a source map, and a deterministic tool persists the pocket stamped
+  type="site" + pattern="landing" + engine="svelte" so the published page
+  renders from your components. You do NOT compose a rippleSpec, do NOT
+  call get_widget_spec, do NOT use the pocket specialist. For publishing an
+  EXISTING pocket use pocketpaw-create-site. Loading this skill keeps the
+  chat agent's always-on system prompt small while still delivering the
+  full Svelte authoring brain when the Svelte engine is actually selected.
 ---
 
 # Build a Paw Site — the Svelte-track authoring brain


### PR DESCRIPTION
## The bug

A plain "build a modern dentist landing page with a booking form,
services, and contact info" launched `pocketpaw-create-svelte-site` — the
hand-authored Svelte track — instead of the default ripple landing brain.

## Why

The svelte and ripple create skills carried the **same trigger examples**
in their descriptions: "build a dentist landing site", "a marketing page
for my bakery", "a landing page for my SaaS". The svelte one added a prose
caveat ("only when the Svelte engine is on"), but the agent's
natural-language skill selection matched on the shared examples and fired
svelte anyway.

The "Use Svelte pages" toggle is only authoritative through the surface
profile — when it's on, the profile pins the skill set to svelte. When
it's **off**, the default surface doesn't exclude the svelte skill, so the
description alone can pull the agent to it. That happens on any surface,
and especially in general chat where there's no sites-profile gating at
all.

## The fix

Rewrite the two descriptions so the split is unmistakable:

- **create-svelte-site** — use ONLY when `engine="svelte"` is explicitly
  selected. A plain landing request is now stated as the *wrong* signal,
  with a direct pointer to `create-paw-site`. The old shared examples are
  reframed as "if you see these and the Svelte engine is off, this is the
  wrong skill".
- **create-paw-site** — stated as the DEFAULT landing brain: use for any
  brand-new landing site UNLESS the Svelte engine is on.

Description-only — no code or routing tables touched. It's the portable
lever because it corrects natural-language selection on every surface,
not just `/sites`.

## Follow-up (not here)

The authoritative belt-and-suspenders — having the default `/sites`
surface profile expose every sites-create skill *except* svelte (without
breaking dynamic/landing/html routing) — belongs with the sites-profile
rework, since that restructures the profile anyway.

## Verification

YAML frontmatter parses for both skills; surface/routing tests green (45);
no test pins the changed prose.