### PR TITLE
fix(livekit): action items always unassigned in meeting notes

### DIFF
--- a/ee/pocketpaw_ee/cloud/livekit/agent.py
+++ b/ee/pocketpaw_ee/cloud/livekit/agent.py
@@ -1476,7 +1476,16 @@ class CallMeetingAgent:
         return summary, []
 
     def _parse_summary_json(self, content: str) -> tuple[str, list[str]]:
-        """Parse JSON summary response from LLM."""
+        """Parse JSON summary response from LLM.
+
+        When the LLM returns structured JSON (Anthropic / OpenAI direct
+        summary), the ``action_items`` list is extracted directly.  When the
+        LLM returns Markdown (DeepSeek or the progressive-merge path), JSON
+        parsing fails — in that case we extract action items from the
+        ``## ✅ Action Items`` or ``### ✅ Action Items`` section of the
+        Markdown so the final meeting-notes payload always carries assignable
+        action items regardless of which LLM produced the summary.
+        """
         content = content.strip()
         if "```json" in content:
             content = content.split("```json")[1].split("```")[0].strip()
@@ -1489,7 +1498,62 @@ class CallMeetingAgent:
             action_items = parsed.get("action_items", [])
             return summary, action_items
         except (json.JSONDecodeError, KeyError):
-            return content, []
+            # Markdown output – extract action items from the rendered section
+            action_items = self._extract_action_items_from_markdown(content)
+            return content, action_items
+
+    @staticmethod
+    def _extract_action_items_from_markdown(markdown: str) -> list[str]:
+        """Extract bullet-point action items from a Markdown meeting summary.
+
+        Looks for a heading matching "Action Items" (with optional emoji
+        prefix) at any heading level (``##`` or ``###``) and collects all
+        following list items until the next heading or end of text.
+        Strips markdown bold markers (``**``) from extracted items so the
+        ``@Name:`` assignee prefix is at position 0 for downstream parsing.
+        """
+        import re as _re
+
+        lines = markdown.split("\n")
+        in_section = False
+        items: list[str] = []
+
+        for line in lines:
+            stripped = line.strip()
+
+            # Detect the start of the Action Items section — accepts ``##`` or
+            # ``###`` headings, with or without emoji prefix.  The DeepSeek
+            # + merge prompts use ``###`` level headings; the regex also
+            # accepts ``##`` for backwards-compatibility with older prompt
+            # versions.
+            if (
+                _re.match(r"^#{2,3}\s*[✅📋📌⚠️🔜❓⚙️]*\s*Action\s*Items", stripped, _re.IGNORECASE)
+                or _re.match(r"^#{2,3}\s*✅\s*Action\s*Items", stripped, _re.IGNORECASE)
+                or _re.match(r"^#{2,3}\s*Action\s*Items", stripped, _re.IGNORECASE)
+            ):
+                in_section = True
+                continue
+
+            # If we hit another heading, stop
+            if in_section and stripped.startswith("##"):
+                break
+
+            if in_section:
+                # Match bullet points: -, *, or numbered 1.
+                m = _re.match(r"\s*[-*]\s+(.*)", stripped)
+                if not m:
+                    m = _re.match(r"\s*\d+[.)]\s+(.*)", stripped)
+                if m:
+                    text = m.group(1).strip()
+                    # Strip bold markers so ``**@Name:** description``
+                    # becomes ``@Name: description`` — the assignee
+                    # parser in the parent process expects ``@`` at the
+                    # start of the string.
+                    text = text.replace("**", "")
+                    if text and text != "None" and not text.startswith("```"):
+                        items.append(text)
+
+        return items
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/livekit/prompts.py
+++ b/ee/pocketpaw_ee/cloud/livekit/prompts.py
@@ -128,6 +128,12 @@ provide:
 Format your response as JSON with keys 'summary' (string) and \
 'action_items' (list of strings).
 
+For each action item, prefix the item with \"@Name:\" where Name is the \
+person responsible (use participant names from the transcript). \
+Example: \"@Alice: Schedule follow-up meeting with the design team\".
+
+If no clear owner is mentioned in the transcript, omit the @Name prefix.
+
 Transcript:
 {transcript}"""
 
@@ -238,6 +244,12 @@ provide:
 
 Format your response as JSON with keys 'summary' (string) and \
 'action_items' (list of strings).
+
+For each action item, prefix the item with \"@Name:\" where Name is the \
+person responsible (use participant names from the transcript). \
+Example: \"@Alice: Schedule follow-up meeting with the design team\".
+
+If no clear owner is mentioned in the transcript, omit the @Name prefix.
 
 Transcript:
 {transcript}"""

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -1258,20 +1258,39 @@ async def _create_tasks_from_meeting_notes(
 
 
 def _parse_action_item_assignee(item: str) -> tuple[str, str]:
-    """Extract ``@Name`` prefix from an action item, returning (assignee, rest)."""
+    """Extract ``@Name`` prefix from an action item, returning (assignee, rest).
+
+    Strips markdown bold markers (``**``) before matching so the ``@``
+    prefix is at position 0 regardless of whether the LLM rendered
+    ``@Name:`` or ``**@Name:**`` (the format the DeepSeek + merge
+    prompts ask for).
+    """
     import re
 
-    m = re.match(r"@(\S[\w\s]*?)\s*[:—\-]\s*(.*)", item.strip())
+    cleaned = item.strip()
+    # Strip bold markers so **@Name:** becomes @Name: (the regex requires
+    # @ at the start of the string).
+    cleaned = cleaned.replace("**", "").strip()
+
+    m = re.match(r"@(\S[\w\s]*?)\s*[:—\-]\s*(.*)", cleaned)
     if m:
         return m.group(1).strip(), m.group(2).strip()
     return "__unassigned__", item
 
 
 def _extract_action_items_from_markdown(markdown: str) -> list[str]:
-    """Extract bullet-point action items from the ## ✅ Action Items section.
+    """Extract bullet-point action items from the ✅ Action Items section.
 
     Looks for a heading matching "Action Items" (with optional emoji prefix)
-    and collects all following list items until the next heading or end of text.
+    at any heading level (``##`` or ``###``) and collects all following list
+    items until the next heading or end of text.  The DeepSeek + merge
+    prompts use ``###`` level headings; the regex also accepts ``##`` for
+    backwards-compatibility with older prompt versions and LLMs that
+    normalise heading levels.
+
+    Strips markdown bold markers (``**``) from extracted items so the
+    ``@Name:`` assignee prefix is at position 0 for
+    ``_parse_action_item_assignee``.
     """
     import re
 
@@ -1282,17 +1301,18 @@ def _extract_action_items_from_markdown(markdown: str) -> list[str]:
     for line in lines:
         stripped = line.strip()
 
-        # Detect the start of the Action Items section
+        # Detect the start of the Action Items section — accepts ``##`` or
+        # ``###`` headings, with or without emoji prefix.
         if (
-            re.match(r"^##\s*[✅📋📌⚠️🔜❓⚙️]*\s*Action\s*Items", stripped, re.IGNORECASE)
-            or re.match(r"^##\s*✅\s*Action\s*Items", stripped, re.IGNORECASE)
-            or re.match(r"^##\s*Action\s*Items", stripped, re.IGNORECASE)
+            re.match(r"^#{2,3}\s*[✅📋📌⚠️🔜❓⚙️]*\s*Action\s*Items", stripped, re.IGNORECASE)
+            or re.match(r"^#{2,3}\s*✅\s*Action\s*Items", stripped, re.IGNORECASE)
+            or re.match(r"^#{2,3}\s*Action\s*Items", stripped, re.IGNORECASE)
         ):
             in_section = True
             continue
 
         # If we hit another heading, stop
-        if in_section and stripped.startswith("## "):
+        if in_section and stripped.startswith("##"):
             break
 
         if in_section:
@@ -1302,6 +1322,9 @@ def _extract_action_items_from_markdown(markdown: str) -> list[str]:
                 m = re.match(r"\s*\d+[.)]\s+(.*)", stripped)
             if m:
                 text = m.group(1).strip()
+                # Strip bold markers so **@Name:** becomes @Name: —
+                # the assignee parser expects @ at the start of the string.
+                text = text.replace("**", "")
                 if text and text != "None" and not text.startswith("```"):
                     items.append(text)
 

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -556,11 +556,13 @@ async def agent_reassign_task(
     body = ReassignTaskRequest.model_validate(body)
     doc = await _fetch_task(ctx, task_id)
     if doc.creator_id != ctx.user_id and doc.assignee_id != ctx.user_id:
-        # Only the creator or current assignee can reassign. Workspace
-        # members at large must go through their own delegation path.
-        raise Forbidden(
-            "task.reassign_denied", "Only the creator or assignee can reassign this task"
-        )
+        # Workspace owners can also reassign tasks (bulk reassign from MC,
+        # picking up unassigned meeting-notes action items, etc.).
+        if not await _is_workspace_owner(ctx.user_id, doc.workspace_id):
+            raise Forbidden(
+                "task.reassign_denied",
+                "Only the creator, assignee, or workspace owner can reassign this task",
+            )
     doc.assignee = _AssigneeDoc(
         kind=body.assignee_kind,
         id=body.assignee_id,


### PR DESCRIPTION
## Problem

When a LiveKit meeting ends, meeting notes are parsed into action items and listed in Mission Control. But action items were **always unassigned** — the assignee always showed as `__unassigned__`.

## Root Cause

Four interrelated bugs across 3 files:

### 1. JSON parser vs Markdown output mismatch (`agent.py`)
`_parse_summary_json` tries `json.loads()` on the LLM response, but **DeepSeek** (the primary LLM) outputs **Markdown**, not JSON. When JSON parsing failed, it returned `(content, [])` — dropping ALL action items. This also broke the progressive-merge path.

**Fix:** When JSON parsing fails, extract action items from the rendered Markdown section.

### 2. Heading level mismatch (`service.py`)
`_extract_action_items_from_markdown` matched only `## Action Items` (h2), but the DeepSeek/merge prompts specify `### ✅ Action Items` (h3). The section was never found.

**Fix:** Changed regex from `^##` to `^#{2,3}` to match both h2 and h3.

### 3. Bold markers blocked `@Name:` matching (`service.py`)
The prompts format items as `* **@Name:** description` with bold markers. `_parse_action_item_assignee` uses `re.match(r"@...")` which requires `@` at position 0 — but `**@Name:` starts with `**`. Every item became `__unassigned__`.

**Fix:** Strip `**` before matching in both `_parse_action_item_assignee` and `_extract_action_items_from_markdown`.

### 4. Missing `@Name:` format in Anthropic/OpenAI prompts (`prompts.py`)
The JSON-producing prompts never specified the `@Name:` format, so action items arrived as plain strings like `"Review the Q3 roadmap"` with no assignee prefix.

**Fix:** Added `@Name:` format instructions to both prompts.

---

## Bonus: Reassign permission for unassigned tasks

`agent_reassign_task` only allowed the **creator** or **current assignee** to reassign. For meeting-notes tasks, `creator_id` is the LiveKit bot and `assignee_id` is `__unassigned__` — no human could reassign them.

**Fix:** Added the workspace-owner bypass (already present in `agent_complete_task` and `agent_block_task`) so admins/owners can reassign any task from Mission Control.

---

## Files changed
| File | Change |
|------|--------|
| `ee/.../livekit/agent.py` | `_parse_summary_json` now extracts action items from Markdown on JSON failure; added `_extract_action_items_from_markdown` |
| `ee/.../livekit/service.py` | `_extract_action_items_from_markdown` matches `#{2,3}` headings + strips `**`; `_parse_action_item_assignee` strips `**` before matching |
| `ee/.../livekit/prompts.py` | Added `@Name:` format to Anthropic + OpenAI prompts |
| `ee/.../cloud/tasks/service.py` | Added workspace-owner bypass to `agent_reassign_task` |