### PR TITLE
fix(jobs): security hardening — workspace-scoped source reads, scrubbed failures, read-only connector actions

### DIFF
--- a/ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
+++ b/ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
@@ -39,6 +39,14 @@
 # idempotent dedup (skip ids already in the pocket's `scored_rows`), the same
 # real heuristic + band, and the same PII allowlist (id/name/score/band/stage)
 # apply to all three source modes — only WHERE the batch comes from differs.
+#
+# Updated: 2026-07-14 (fix/jobs-source-collection-tenancy) — the Mongo
+# `source_collection` read now threads this job's `workspace_id` into
+# `jobs.service.read_source_records(..., workspace_id=workspace_id, ...)`, which
+# scopes the query to the job's own workspace and denylists credential/system
+# collections. Closes a P1 cross-tenant leak: an author-controlled
+# `source_collection` previously read EVERY tenant's rows from the shared DB.
+# Connector + inline-`rows` source modes are unchanged (already tenant-safe).
 
 """Built-in `score_applications` job: real data-backed scoring + PII allowlist."""
 
@@ -359,8 +367,13 @@ class ScoreApplicationsJob:
 
         # Read a bounded page from the source. Pull a few-hundred window so the
         # next unscored batch is in reach without an unbounded scan; the page is
-        # then filtered to NEW records and capped at `batch_size`.
-        page = await jobs_service.read_source_records(source_collection, limit=300)
+        # then filtered to NEW records and capped at `batch_size`. The read is
+        # SCOPED to this job's `workspace_id` (and denylists credential/system
+        # collections) inside `read_source_records`, so an author-controlled
+        # `source_collection` can only ever surface this workspace's own rows.
+        page = await jobs_service.read_source_records(
+            source_collection, workspace_id=workspace_id, limit=300
+        )
 
         return self._score_next_batch(existing_rows=existing_rows, page=page, batch_size=batch_size)
 

--- a/ee/pocketpaw_ee/cloud/jobs/service.py
+++ b/ee/pocketpaw_ee/cloud/jobs/service.py
@@ -34,6 +34,17 @@
 # credentials, never tokens through params) and unwraps the connector's data
 # payload; a non-success response raises ``CloudError(code="job.connector_error")``
 # so the worker's failure path marks the job failed + un-hangs the button.
+#
+# Updated: 2026-07-14 (fix/jobs-source-collection-tenancy) — closed a P1
+# cross-tenant leak in ``read_source_records``. The source-collection name is
+# AUTHOR-controlled and the cloud DB is shared, but the read did an unscoped
+# ``find({})`` over ANY collection — a pocket author could set
+# ``source_collection: "users"`` (or ``workspace_connectors``) and read every
+# tenant's rows. Two guards now: (1) the read is SCOPED to the job's workspace
+# via ``find({"workspace": workspace_id})`` (new required kwarg; an untagged
+# record no longer matches — safe default), and (2) a ``_DENYLISTED_SOURCE_
+# COLLECTIONS`` constant blocks credential / identity / system collections
+# outright (returns ``[]`` + logs a warning), even intra-tenant.
 
 """Workspace-jobs service — Beanie writes + dispatch + lifecycle."""
 
@@ -208,8 +219,44 @@ async def get_job_by_id(job_id: str) -> WorkspaceJobDoc | None:
         return None
 
 
-async def read_source_records(collection: str, *, limit: int) -> list[dict[str, Any]]:
-    """Read up to ``limit`` records from a Mongo ``collection`` in the cloud DB.
+# Collections a workspace job may NEVER read, even for its own workspace. The
+# ``source_collection`` name is AUTHOR-controlled (a pocket editor sets it), so a
+# job could otherwise point at credential / identity / secret / system rows and
+# fan their contents into broadcast state. Sourced from the Beanie ``Settings.name``
+# declarations in ``ee/pocketpaw_ee/cloud/models/`` — every collection here holds
+# secrets, tokens, identity, or session material:
+#   users                        — identity + ``mfa_totp_secret``
+#   workspace_connectors         — OAuth token refs + secret ``config`` dict
+#   auth_sessions / sessions     — minted JWT / session records
+#   api_keys                     — argon2 ``hashed_secret``
+#   litellm_tenant_keys          — LiteLLM proxy bearer key
+#   composio_connections         — third-party connection credentials
+#   vapid_keypairs               — web-push private keys
+#   pocket_backend_credentials   — encrypted per-pocket backend auth token
+#   meeting_provider_credentials — encrypted provider client-secret / refresh-token
+# A denylisted request reads NOTHING (returns ``[]``) so a job can never surface
+# these rows regardless of the per-workspace scope filter below.
+_DENYLISTED_SOURCE_COLLECTIONS = frozenset(
+    {
+        "users",
+        "workspace_connectors",
+        "auth_sessions",
+        "sessions",
+        "api_keys",
+        "litellm_tenant_keys",
+        "composio_connections",
+        "vapid_keypairs",
+        "pocket_backend_credentials",
+        "meeting_provider_credentials",
+    }
+)
+
+
+async def read_source_records(
+    collection: str, *, workspace_id: str, limit: int
+) -> list[dict[str, Any]]:
+    """Read up to ``limit`` records from a Mongo ``collection`` in the cloud DB,
+    SCOPED to ``workspace_id``.
 
     The data-backed built-ins (e.g. ``score_applications``) read their input
     batch through here so they never open a second MongoClient and never touch
@@ -218,6 +265,16 @@ async def read_source_records(collection: str, *, limit: int) -> list[dict[str, 
     Beanie was initialized against — taken off
     ``WorkspaceJobDoc.get_pymongo_collection().database`` — so a job reads the
     same database the rest of the cloud writes, with no extra connection.
+
+    TENANCY: the ``collection`` name is AUTHOR-controlled, and the cloud DB is
+    shared across all tenants, so the read is filtered to
+    ``{"workspace": workspace_id}`` — a job only ever sees records tagged with
+    its OWN workspace. A record with no ``workspace`` field simply won't match
+    (safe default: it reads as nothing).
+
+    DENYLIST: even intra-tenant, a job must never read a credential / identity /
+    system collection (see :data:`_DENYLISTED_SOURCE_COLLECTIONS`); such a
+    request logs a warning and returns ``[]``.
 
     Bounded by ``limit`` (the caller pages from this slice) so a job can never
     pull an unbounded result set. ``limit <= 0`` reads nothing. A blank
@@ -228,9 +285,16 @@ async def read_source_records(collection: str, *, limit: int) -> list[dict[str, 
     capped = max(0, int(limit))
     if not name or capped == 0:
         return []
+    if name in _DENYLISTED_SOURCE_COLLECTIONS:
+        logger.warning(
+            "jobs: read_source_records blocked denylisted collection %r (workspace %s)",
+            name,
+            workspace_id,
+        )
+        return []
     try:
         db = WorkspaceJobDoc.get_pymongo_collection().database
-        cursor = db[name].find({}).limit(capped)
+        cursor = db[name].find({"workspace": workspace_id}).limit(capped)
         return [doc async for doc in cursor]
     except Exception:  # noqa: BLE001 — a missing/unreadable source is "no records"
         logger.warning("jobs: read_source_records failed for collection %r", name, exc_info=True)

--- a/ee/pocketpaw_ee/cloud/jobs/service.py
+++ b/ee/pocketpaw_ee/cloud/jobs/service.py
@@ -35,6 +35,18 @@
 # payload; a non-success response raises ``CloudError(code="job.connector_error")``
 # so the worker's failure path marks the job failed + un-hangs the button.
 #
+# Updated: 2026-07-15 (fix/jobs-source-collection-tenancy, F3 security) — closed
+# a WRITE-action bypass in ``execute_connector_action``. ``connectors_service.
+# execute`` does not classify read/write trust (that gate lives only in the MCP
+# ``connector_execute`` tool), and the connector ``action`` is an author-
+# controlled param, so a job could run a write / ``confirm`` / ``restricted``
+# action under ``system:workspace_job`` — past the interactive approval + per-
+# user permission checks. The function now resolves the action's trust via
+# ``connectors_service.get_action_trust`` FIRST and raises
+# ``CloudError(403, "job.connector_action_not_allowed")`` for any non-read
+# action (and, fail-closed, for an unknown action → ``None``) BEFORE calling
+# ``execute``. A read (``auto``-trust) action proceeds unchanged.
+#
 # Updated: 2026-07-14 (fix/jobs-source-collection-tenancy) — closed a P1
 # cross-tenant leak in ``read_source_records``. The source-collection name is
 # AUTHOR-controlled and the cloud DB is shared, but the read did an unscoped
@@ -323,6 +335,14 @@ async def execute_connector_action(
     failure path turns into a ``failed`` job + a failed-state writeback so the
     triggering button never hangs.
 
+    F3 (security): the action's trust is resolved via ``get_action_trust`` and
+    only a READ-first (``auto``-trust) action is allowed. ``action`` is an
+    author-controlled param, so a write / ``confirm`` / ``restricted`` action —
+    or an unknown one — raises :class:`CloudError`
+    (code ``job.connector_action_not_allowed``, 403) BEFORE ``execute`` runs, so
+    a job can never drive a write action under the system identity past the
+    interactive-approval gate.
+
     Returns the connector's ``data`` payload (the records) — a ``list[dict]``
     for a list-shaped action, or a single ``dict`` for a scalar one.
     """
@@ -330,6 +350,26 @@ async def execute_connector_action(
     # module load (and the import graph acyclic).
     from pocketpaw_ee.cloud.connectors import service as connectors_service
     from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
+
+    # F3 — read-only trust gate. ``connectors_service.execute`` does NOT classify
+    # an action's read/write trust; that gate otherwise lives ONLY in the MCP
+    # ``connector_execute`` tool via ``get_action_trust``. Here ``action`` is an
+    # AUTHOR-controlled param (e.g. ``score_applications``'s ``action``), so
+    # without this a job could drive a write / ``confirm`` / ``restricted``
+    # action under the system identity, bypassing the interactive approval + the
+    # per-user connector permission checks. Resolve the action's trust FIRST and
+    # allow ONLY a read-first (``auto``-trust, ``is_read``) action. An unknown
+    # action (``get_action_trust`` returns ``None``) is refused too (fail-closed).
+    # Placed BEFORE the ``try`` so this refusal keeps its own precise code and is
+    # never re-wrapped into ``job.connector_error``.
+    trust = await connectors_service.get_action_trust(connector_name, action)
+    if trust is None or not trust.is_read:
+        raise CloudError(
+            403,
+            "job.connector_action_not_allowed",
+            f"connector '{connector_name}' action '{action}' is not a read action; "
+            "workspace jobs may run read (auto-trust) connector actions only",
+        )
 
     try:
         response = await connectors_service.execute(

--- a/ee/pocketpaw_ee/cloud/jobs/worker.py
+++ b/ee/pocketpaw_ee/cloud/jobs/worker.py
@@ -45,6 +45,18 @@
 # key. The stamp happens before the ok:false → failed escalation, so a rejected
 # writeback still escalates correctly (the failed-state marker overwrites the
 # optimistic "done" the same way the rejection path always has).
+#
+# Updated: 2026-07-15 (fix/jobs-source-collection-tenancy, F2 security) — a job
+# FAILURE no longer surfaces raw ``str(exc)`` on the broadcast/audit paths. A
+# workspace-CUSTOM job (the #1536 entry-point feature) can raise with upstream
+# text carrying a secret (a token, a DB row, a URL carrying a token); that used
+# to land in the pocket's broadcast ``state`` (relayed over the WS to EVERY
+# viewer) AND the audit ``error`` field. Both failure boundaries now route the
+# message through ``_safe_failure_message``: a CONTROLLED error (``CloudError``
+# or the registry ``JobError``) surfaces its safe, fixed ``.code`` (e.g.
+# ``job.connector_error`` / ``job.result_forbidden``); any other raise surfaces
+# a generic ``"job failed"``. The FULL detail (message + traceback) stays ONLY
+# in ``logger.exception``.
 
 """ARQ entrypoint: execute one workspace job + write the result back."""
 
@@ -53,16 +65,41 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pocketpaw_ee.cloud._core.errors import CloudError
+
 # Module-scope import so tests can ``monkeypatch.setattr(worker, "merge_spec", …)``.
 from pocketpaw_ee.cloud.jobs import service as jobs_service
 from pocketpaw_ee.cloud.jobs.domain import (
     WORKSPACE_JOB_IDENTITY,
     failed_state_writeback,
 )
-from pocketpaw_ee.cloud.jobs.registry import resolve_job, validate_job_result
+from pocketpaw_ee.cloud.jobs.registry import JobError, resolve_job, validate_job_result
 from pocketpaw_ee.cloud.pockets.service import get_pocket_workspace, merge_spec
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_failure_message(exc: BaseException) -> str:
+    """Map a job failure to a SAFE, fixed message for the broadcast + audit paths.
+
+    F2 (security). A workspace-CUSTOM job (the #1536 entry-point feature) can
+    raise with raw upstream text — a DB error, a row value, a URL carrying a
+    token. That text must NOT reach the pocket's broadcast ``state`` (relayed
+    over the WS to EVERY viewer) or the audit ``error`` field. So the failure
+    boundary NEVER surfaces ``str(exc)`` on those paths:
+
+      - a CONTROLLED error (:class:`CloudError` or the registry :class:`JobError`)
+        carries a safe, fixed ``.code`` — e.g. ``job.connector_error``,
+        ``job.result_forbidden`` — so surface the code (safe AND useful);
+      - any OTHER exception (an arbitrary custom-job raise) gets a generic fixed
+        string, never the interpolated text.
+
+    The FULL detail (``str(exc)`` + traceback) stays in ``logger.exception`` at
+    the call site — this helper only decides what the viewer / audit may see.
+    """
+    if isinstance(exc, (CloudError, JobError)):
+        return exc.code
+    return "job failed"
 
 
 async def execute_workspace_job(ctx: dict[str, Any], job_id: str) -> None:
@@ -129,14 +166,11 @@ async def execute_workspace_job(ctx: dict[str, Any], job_id: str) -> None:
         # State-only contract — raises JobResultError on a template-owned write.
         result = validate_job_result(raw)
     except Exception as exc:  # noqa: BLE001 — every failure path converges here
+        # F2: the FULL detail (message + traceback) goes ONLY to the log; the
+        # broadcast/audit paths below see a SAFE value, never raw ``str(exc)`` —
+        # a custom job could otherwise leak a token / DB row / PII to viewers.
         logger.exception("jobs: job %s (%s) failed", job_id, doc.job_name)
-        # NOTE for connector-job authors: ``str(exc)`` lands in broadcast state
-        # via ``failed_state_writeback`` and is visible to every viewer of the
-        # pocket. Do NOT let raw exception text carry PII or secrets — map your
-        # job's failure modes to FIXED, safe strings (e.g. "upstream timeout")
-        # rather than surfacing the raw message. (Tracked as a follow-up; the
-        # default below is intentionally left as-is for the built-in jobs.)
-        message = str(exc) or exc.__class__.__name__
+        message = _safe_failure_message(exc)
         # Writeback FIRST so the button un-hangs even if the status save races.
         await _writeback(
             workspace_id=workspace_id,
@@ -176,7 +210,9 @@ async def execute_workspace_job(ctx: dict[str, Any], job_id: str) -> None:
             )
     except Exception as exc:  # noqa: BLE001 — converge on the same failure path
         logger.exception("jobs: job %s (%s) writeback failed/rejected", job_id, doc.job_name)
-        message = str(exc) or exc.__class__.__name__
+        # F2: safe value on broadcast/audit (the merge_spec warnings that a
+        # rejection carries stay in the log above, not on the viewer path).
+        message = _safe_failure_message(exc)
         # Best-effort failed-state writeback so the button stops spinning. This
         # call is NOT ok-checked — a doubly-rejected merge must not loop.
         await _writeback(

--- a/tests/cloud/jobs/test_jobs.py
+++ b/tests/cloud/jobs/test_jobs.py
@@ -1080,10 +1080,20 @@ async def test_route_no_kind_does_not_enqueue_job(
 # ---------------------------------------------------------------------------
 
 
-async def _seed_source(mongo_db: Any, collection: str, records: list[dict]) -> None:
-    """Insert raw source records into a Mongo collection in the test DB."""
+async def _seed_source(
+    mongo_db: Any, collection: str, records: list[dict], *, workspace: str = WS
+) -> None:
+    """Insert raw source records into a Mongo collection in the test DB.
+
+    Each record is stamped with a ``workspace`` field (default :data:`WS`) so the
+    tenancy-scoped read matches it — ``read_source_records`` now filters on
+    ``{"workspace": workspace_id}``, so an untagged record would (correctly) read
+    as nothing. A record that already carries its own ``workspace`` keeps it,
+    which lets a test seed MULTIPLE tenants into one collection (the cross-tenant
+    isolation test seeds both :data:`WS` and :data:`OTHER_WS` rows).
+    """
     for rec in records:
-        await mongo_db[collection].insert_one(dict(rec))
+        await mongo_db[collection].insert_one({"workspace": workspace, **rec})
 
 
 async def _seed_pocket_with_scored_rows(*, workspace: str, scored_rows: list[dict]) -> str:
@@ -1266,6 +1276,103 @@ async def test_score_applications_missing_source_collection_returns_empty(
     rows = result["state"]["scored_rows"]
     # Existing batch preserved; nothing new added.
     assert [r["id"] for r in rows] == ["app-1"]
+
+
+# ---------------------------------------------------------------------------
+# SECURITY (fix/jobs-source-collection-tenancy) — the source-collection read is
+# TENANCY-SCOPED and DENYLISTED. Before the fix, `read_source_records` did an
+# unscoped `db[name].find({})` over an AUTHOR-controlled collection name in the
+# SHARED cloud DB, so a pocket author could set `source_collection: "users"` (or
+# any collection) and pull EVERY tenant's rows — a cross-tenant leak. The fix
+# scopes the read to the job's own workspace AND denylists credential/identity/
+# system collections outright. These two tests FAIL on the pre-fix code (the
+# unscoped read pulls the other tenant's rows / reads the denylisted collection)
+# and PASS after the fix.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_score_applications_source_backed_is_workspace_scoped(
+    mongo_db: Any,
+) -> None:
+    """A source-backed run reads ONLY records tagged with the job's own
+    workspace — never another tenant's rows.
+
+    Seeds ONE collection with records for TWO tenants (:data:`WS` and
+    :data:`OTHER_WS`) and runs `score_applications` for :data:`WS`. The scored
+    rows come only from the WS records; the OTHER_WS rows are never read. FAILS
+    on the pre-fix code, whose unscoped `find({})` pulled every tenant's rows.
+    """
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    await _seed_source(
+        mongo_db,
+        "applications",
+        [
+            {"id": "ws-a-1", "name": "Alice A", "email": "alice@acme.com"},
+            {"id": "ws-a-2", "name": "Aaron A", "email": "aaron@acme.com"},
+        ],
+        workspace=WS,
+    )
+    await _seed_source(
+        mongo_db,
+        "applications",
+        [
+            {"id": "ws-b-1", "name": "Bianca B", "email": "bianca@other.com"},
+            {"id": "ws-b-2", "name": "Ben B", "email": "ben@other.com"},
+        ],
+        workspace=OTHER_WS,
+    )
+    pocket_id = await _seed_pocket_with_scored_rows(workspace=WS, scored_rows=[])
+
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        job_id="j-tenant-1",
+        params={"source_collection": "applications", "batch_size": 10},
+    )
+
+    ids = {r["id"] for r in result["state"]["scored_rows"]}
+    assert ids == {"ws-a-1", "ws-a-2"}
+    assert not any(str(i).startswith("ws-b") for i in ids)
+
+
+@pytest.mark.asyncio
+async def test_score_applications_denylisted_collection_reads_nothing(
+    mongo_db: Any,
+) -> None:
+    """A denylisted collection (credential/identity/system) is NEVER read, even
+    for the job's own workspace.
+
+    Seeds `workspace_connectors` rows tagged with the job's own :data:`WS` and
+    points the job at it — nothing is scored (the denylist returns `[]` before
+    any read). FAILS on the pre-fix code, which had no denylist and scored the
+    connector rows (whose `config` holds secrets).
+    """
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    await _seed_source(
+        mongo_db,
+        "workspace_connectors",
+        [
+            {"id": "conn-1", "name": "github", "config": {"token": "ghp_secret"}},
+            {"id": "conn-2", "name": "slack", "config": {"token": "xoxb-secret"}},
+        ],
+        workspace=WS,
+    )
+    pocket_id = await _seed_pocket_with_scored_rows(workspace=WS, scored_rows=[])
+
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        job_id="j-deny-1",
+        params={"source_collection": "workspace_connectors", "batch_size": 10},
+    )
+
+    assert result["state"]["scored_rows"] == []
+    assert result["state"]["score_applications_scored_count"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/jobs/test_jobs.py
+++ b/tests/cloud/jobs/test_jobs.py
@@ -641,6 +641,139 @@ async def test_worker_failure_writes_failed_state(
     assert doc.error
 
 
+# ---------------------------------------------------------------------------
+# F2 (security) — a job failure must NOT surface raw exception text on the
+# broadcast/audit paths. A workspace-CUSTOM job (the #1536 entry-point feature)
+# can raise with upstream text carrying a secret (a token, a DB row, a URL);
+# that raw text used to land in the pocket's broadcast `state` (seen by EVERY
+# viewer over the WS) AND the audit `error`. The worker now surfaces a
+# controlled error's safe, fixed `.code` — or a generic "job failed" for any
+# other raise; the FULL detail stays only in the exception log.
+# ---------------------------------------------------------------------------
+
+
+class _SecretLeakJob:
+    """A CUSTOM job that raises with raw upstream text carrying a secret."""
+
+    name = "secret_leak_job"
+
+    async def __call__(
+        self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
+    ) -> dict:
+        raise Exception("secret token abc123def")
+
+
+class _CloudErrorJob:
+    """A job that raises a CONTROLLED CloudError (safe, fixed `.code`)."""
+
+    name = "cloud_error_job"
+
+    async def __call__(
+        self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
+    ) -> dict:
+        from pocketpaw_ee.cloud._core.errors import CloudError
+
+        # The message interpolates a "secret" to prove ONLY the code is surfaced.
+        raise CloudError(502, "job.connector_error", "connector 'sf' row secret-xyz failed")
+
+
+@pytest.mark.asyncio
+async def test_worker_failure_does_not_leak_raw_exception_text(
+    mongo_db: Any,
+    fake_pool: _FakePool,
+    seed_pocket,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # noqa: ARG001
+    """A custom job raising raw text with a secret must NOT put that text on the
+    broadcast `state` or the audit `error`. Both carry the generic "job failed";
+    the secret substring appears in NEITHER. FAILS on the unfixed worker, which
+    writes `str(exc)` straight into both paths."""
+    jobs_registry.register_job(_SecretLeakJob())
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_merge_spec(workspace_id, user_id, pocket_id, body):  # type: ignore[no-untyped-def]
+        captured["body"] = body
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
+
+    recorder = _RecordingAuditLogger()
+    monkeypatch.setattr(jobs_service, "get_audit_logger", lambda: recorder)
+
+    pocket_id = await seed_pocket(workspace=WS)
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        action="run_leak",
+        job_name="secret_leak_job",
+        params={},
+        triggered_by=VIEWER,
+    )
+    job_id = result["job_id"]
+
+    await jobs_worker.execute_workspace_job({}, job_id)
+
+    # (a) broadcast state — the secret is absent; the message is the generic string.
+    broadcast_error = captured["body"]["merge"]["state"]["run_leak_error"]
+    assert "abc123def" not in broadcast_error
+    assert broadcast_error == "job failed"
+
+    # (b) audit error — same: no secret, generic string.
+    failed_events = [e for e in recorder.events if e.context.get("outcome") == "failed"]
+    assert failed_events, "the failed job must be audited"
+    audit_error = failed_events[-1].context.get("error")
+    assert "abc123def" not in str(audit_error)
+    assert audit_error == "job failed"
+
+    # (c) the persisted doc's error is the safe string too.
+    doc = await jobs_service.get_job(WS, job_id)
+    assert doc is not None
+    assert doc.status == "failed"
+    assert doc.error == "job failed"
+
+
+@pytest.mark.asyncio
+async def test_worker_failure_surfaces_controlled_error_code(
+    mongo_db: Any,
+    fake_pool: _FakePool,
+    seed_pocket,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # noqa: ARG001
+    """A CONTROLLED CloudError surfaces its safe, fixed `.code` (a useful signal)
+    on both paths — never the interpolated message (which here hides a secret)."""
+    jobs_registry.register_job(_CloudErrorJob())
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_merge_spec(workspace_id, user_id, pocket_id, body):  # type: ignore[no-untyped-def]
+        captured["body"] = body
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
+
+    pocket_id = await seed_pocket(workspace=WS)
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        action="run_cloud_err",
+        job_name="cloud_error_job",
+        params={},
+        triggered_by=VIEWER,
+    )
+    job_id = result["job_id"]
+
+    await jobs_worker.execute_workspace_job({}, job_id)
+
+    broadcast_error = captured["body"]["merge"]["state"]["run_cloud_err_error"]
+    assert broadcast_error == "job.connector_error"
+    assert "secret-xyz" not in broadcast_error
+
+    doc = await jobs_service.get_job(WS, job_id)
+    assert doc is not None
+    assert doc.error == "job.connector_error"
+
+
 @pytest.mark.asyncio
 async def test_worker_rejects_template_owned_result(
     mongo_db: Any, fake_pool: _FakePool, seed_pocket, monkeypatch: pytest.MonkeyPatch

--- a/tests/cloud/jobs/test_jobs.py
+++ b/tests/cloud/jobs/test_jobs.py
@@ -1528,11 +1528,42 @@ def _connector_response(records: Any) -> Any:
     return ExecuteActionResponse(success=True, data=records, execution_mode="cloud")
 
 
+def _read_action_info(action: str = "list_leads") -> Any:
+    """A read-first (``auto``-trust, ``is_read=True``) action classification —
+    the shape ``connectors_service.get_action_trust`` returns for a read action."""
+    from pocketpaw_ee.cloud.connectors.domain import ConnectorActionInfo
+
+    return ConnectorActionInfo(
+        name=action,
+        description="",
+        trust_level="auto",
+        execution_mode="cloud",
+        is_read=True,
+    )
+
+
+def _patch_action_trust(monkeypatch: pytest.MonkeyPatch, info: Any) -> None:
+    """Monkeypatch ``connectors_service.get_action_trust`` to return ``info``
+    (a :class:`ConnectorActionInfo` or ``None``). F3 makes
+    ``execute_connector_action`` consult this trust gate BEFORE ``execute``, so
+    the connector-backed tests must stub it as a read action to reach execute."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    async def _fake_trust(name, action):  # type: ignore[no-untyped-def]
+        return info
+
+    monkeypatch.setattr(connectors_service, "get_action_trust", _fake_trust)
+
+
 def _patch_connector_execute(monkeypatch: pytest.MonkeyPatch, records: Any):
     """Monkeypatch ``connectors_service.execute`` to return ``records`` and
     capture the call args. ``execute_connector_action`` lazy-imports the
     connectors service inside the function, so patching the real module object
     is what the lazy import resolves to.
+
+    Also stubs ``get_action_trust`` as a READ action so the F3 trust gate lets
+    the (fake) connector action through — the connector-backed built-in only
+    runs read actions, so this keeps the end-to-end path green.
 
     Returns the ``captured`` dict so a test can assert the call ran under the
     workspace job identity with ``pocket_id=None``.
@@ -1549,6 +1580,7 @@ def _patch_connector_execute(monkeypatch: pytest.MonkeyPatch, records: Any):
         return _connector_response(records)
 
     monkeypatch.setattr(connectors_service, "execute", _fake_execute)
+    _patch_action_trust(monkeypatch, _read_action_info())
     return captured
 
 
@@ -1739,6 +1771,9 @@ async def test_score_applications_connector_error_propagates(
         return ExecuteActionResponse(success=False, data=None, error="upstream 500")
 
     monkeypatch.setattr(connectors_service, "execute", _failing_execute)
+    # The action passes the F3 read gate (a real upstream error, not a blocked
+    # write) so the failure we assert is the connector's, not the trust gate's.
+    _patch_action_trust(monkeypatch, _read_action_info())
     pocket_id = await _seed_pocket_with_scored_rows(workspace=WS, scored_rows=[])
 
     job = ScoreApplicationsJob()
@@ -1750,3 +1785,103 @@ async def test_score_applications_connector_error_propagates(
             params={"connector": "snctm-api", "action": "list_leads", "batch_size": 20},
         )
     assert exc.value.code == "job.connector_error"
+
+
+# ---------------------------------------------------------------------------
+# F3 (security) — a job must not drive a WRITE connector action. `execute` does
+# NOT classify read/write trust; that gate lives only in the MCP
+# `connector_execute` tool via `get_action_trust`. `connector_action` is a free
+# author param, so without a gate here a job could run a write / confirm /
+# restricted action under the system identity, bypassing the interactive
+# approval + per-user permission checks. `execute_connector_action` now resolves
+# the action's trust FIRST and allows ONLY read-first (`auto`) actions.
+# ---------------------------------------------------------------------------
+
+
+def _write_action_info(action: str = "create_lead") -> Any:
+    """A write-shaped (``confirm``-trust, ``is_read=False``) action."""
+    from pocketpaw_ee.cloud.connectors.domain import ConnectorActionInfo
+
+    return ConnectorActionInfo(
+        name=action,
+        description="",
+        trust_level="confirm",
+        execution_mode="cloud",
+        is_read=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_connector_action_rejects_write_action(
+    mongo_db: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    """A WRITE (non-``auto``) action is refused BEFORE ``execute`` runs, so a job
+    can't drive a write connector action past the read gate under the system
+    identity. FAILS on the un-gated service, which calls ``execute`` regardless."""
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    execute_calls = {"n": 0}
+
+    async def _spy_execute(*args, **kwargs):  # type: ignore[no-untyped-def]
+        execute_calls["n"] += 1
+        return _connector_response([])
+
+    monkeypatch.setattr(connectors_service, "execute", _spy_execute)
+    _patch_action_trust(monkeypatch, _write_action_info("create_lead"))
+
+    with pytest.raises(CloudError) as exc:
+        await jobs_service.execute_connector_action(WS, "salesforce", "create_lead", {})
+
+    assert exc.value.code == "job.connector_action_not_allowed"
+    # The write action never reached execute — refused at the gate.
+    assert execute_calls["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_connector_action_allows_read_action(
+    mongo_db: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    """A READ (``auto``-trust) action passes the gate: ``execute`` runs once and
+    its data payload is returned unchanged."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    records = [{"id": "r1"}, {"id": "r2"}]
+    execute_calls = {"n": 0}
+
+    async def _fake_execute(workspace_id, name, body, *, user_id=None):  # type: ignore[no-untyped-def]
+        execute_calls["n"] += 1
+        return _connector_response(records)
+
+    monkeypatch.setattr(connectors_service, "execute", _fake_execute)
+    _patch_action_trust(monkeypatch, _read_action_info("list_leads"))
+
+    out = await jobs_service.execute_connector_action(WS, "salesforce", "list_leads", {})
+
+    assert execute_calls["n"] == 1
+    assert out == records
+
+
+@pytest.mark.asyncio
+async def test_execute_connector_action_rejects_unknown_action(
+    mongo_db: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    """An unknown action (``get_action_trust`` → ``None``) is refused fail-closed,
+    and ``execute`` never runs."""
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    execute_calls = {"n": 0}
+
+    async def _spy_execute(*args, **kwargs):  # type: ignore[no-untyped-def]
+        execute_calls["n"] += 1
+        return _connector_response([])
+
+    monkeypatch.setattr(connectors_service, "execute", _spy_execute)
+    _patch_action_trust(monkeypatch, None)
+
+    with pytest.raises(CloudError) as exc:
+        await jobs_service.execute_connector_action(WS, "salesforce", "no_such_action", {})
+
+    assert exc.value.code == "job.connector_action_not_allowed"
+    assert execute_calls["n"] == 0


### PR DESCRIPTION
Closes the three findings from the jobs-primitive security review, so the feature is clean to ship.

## F1 — [P1] cross-tenant collection read
`read_source_records` read `db[collection].find({})` with **no workspace filter**, and the collection name is an author-controlled job param. In the shared multi-tenant DB a pocket author could point a job at `users` or the secret-bearing `workspace_connectors` and read **every tenant's** rows.
**Fix:** the read now requires `workspace_id` and filters `find({"workspace": workspace_id})` (untagged records no longer match — safe default), plus a denylist of credential/identity/session collections (`users`, `workspace_connectors`, `api_keys`, …) refused outright. `score_applications` threads its `workspace_id` through.

## F2 — [P2] raw exception text leaked into broadcast + audit
On failure the worker put `str(exc)` into the pocket's broadcast `state` (seen by all viewers) and the audit `error`. A custom (entry-point) job raising with raw text — a DB error, a row value, a URL with a token — would leak it.
**Fix:** a new `_safe_failure_message` routes both failure boundaries — a controlled `CloudError`/`JobError` surfaces its safe fixed `.code`; any other exception surfaces a generic `"job failed"`. Full detail (message + traceback) stays only in `logger.exception`.

## F3 — [P2] a job could drive a WRITE connector action under the system identity
`execute_connector_action` called `connectors_service.execute` directly; the read/write trust gate lived only in the interactive MCP path. Since the connector action is a free author param, a job could run a write/`confirm` action under `system:workspace_job`, bypassing approval + per-user permissions.
**Fix:** `execute_connector_action` resolves `get_action_trust` first and refuses any non-read/`auto` action (or unknown action) with `403 job.connector_action_not_allowed` **before** `execute` runs. Read actions proceed unchanged.

## Tests
69 jobs tests pass (+5 new, each RED-before / GREEN-after): cross-tenant isolation, denylist, no-raw-exception-leak, controlled-error-code surfaced, connector write-action rejected, read-action allowed, unknown-action fail-closed. ruff + import-linter clean (29 kept, 0 broken). Diff is jobs-only.