### PR TITLE
Fix Paw Bar decision-loop tenancy: store split + cross-tenant approve

### DIFF
--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,15 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-07-15 (B0 H2 — _customer_reply tenancy gate) — closed a gap in the
+#   FOUR-path dispatch: the paw-bar ``_customer_reply`` blob (carried by
+#   ``decision_loop.propose_customer_decision``) had a delivery hook on the
+#   approve/reject paths but NO workspace assertion, while every other gated blob
+#   kind did. Added ``_customer_reply_blob`` + ``_assert_customer_reply_workspace``
+#   (peers of the ``_external_action`` pair) and wired the 403 into ALL FOUR
+#   locations (approve / bulk-approve / reject / bulk-reject) BEFORE any delivery.
+#   Without it, a ws-A admin could approve/reject a ws-B ``_customer_reply`` action
+#   and ``deliver_customer_decision`` would flip a decision row in ws-B (it routes
+#   by the blob's ``workspace_id``). The other kinds are unchanged.
 # Updated: 2026-07-10 (FST-6 — _fabric_conflict proposal type) — wired the
 #   conflict-stewardship gate kind into the FOUR-path dispatch.
 #   ``_fabric_conflict_blob`` + ``_assert_fabric_conflict_workspace`` are the
@@ -799,6 +809,58 @@ def _assert_external_action_workspace(action: Any, current_workspace: str) -> No
         )
 
 
+def _customer_reply_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_customer_reply`` blob on an Action, or ``None``.
+
+    The blob is the paw-bar customer-decision payload
+    ``decision_loop.propose_customer_decision`` stores under
+    ``Action.parameters._customer_reply`` (widget / customer / event routing + the
+    editable reply + the originating ``workspace_id``). The approve/reject paths
+    dispatch ``deliver_customer_decision`` on its presence, exactly as they
+    dispatch the external-action executor on ``_external_action``. Anything that
+    is not a dict is treated as "no customer reply". (The key is inlined — mirror
+    of the peer ``_blob`` accessors — so the OSS instinct router carries no
+    EE-paw_bar import at module load.)
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_customer_reply")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_customer_reply_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting a customer-reply action from another workspace.
+
+    Mirror of ``_assert_external_action_workspace`` for the ``_customer_reply``
+    blob. ``require_action_any_workspace("instinct.approve")`` only proves the
+    caller holds the role SOMEWHERE; this binds the customer-reply Action to the
+    caller's active workspace. A customer reply carries no pocket the way a parked
+    write does — its tenancy lives entirely on the blob's ``workspace_id``, and
+    the delivery hook (``deliver_customer_decision``) routes the reply to THAT
+    workspace's decision row (``set_decision(workspace_id=...)``). So a blob whose
+    ``workspace_id`` differs from the caller's active workspace would deliver a
+    decision into another tenant's paw-bar surface → 403. A non-customer-reply
+    Action (no blob) is unaffected.
+    """
+    blob = _customer_reply_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    # Empty workspace claim fails closed (the delivery hook resolves the decision
+    # row from this field; an empty one would misfile onto the shared surface).
+    if not blob_workspace:
+        raise Forbidden(
+            "instinct.missing_workspace_in_blob",
+            "This customer reply has no workspace claim — cannot verify tenancy",
+        )
+    if blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This customer reply belongs to a different workspace",
+        )
+
+
 def _admin_action_blob(action: Any) -> dict[str, Any] | None:
     """Return the ``_admin_action`` blob on an Action, or ``None``.
 
@@ -1419,6 +1481,7 @@ async def bulk_approve_actions(
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
             _assert_admin_action_workspace(action, workspace_id)
+            _assert_customer_reply_workspace(action, workspace_id)
 
     approved, missing, bulk_id = await store.bulk_approve(
         list(req.ids), approver=approver_id, note=req.note
@@ -1809,6 +1872,7 @@ async def bulk_reject_actions(
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
             _assert_admin_action_workspace(action, workspace_id)
+            _assert_customer_reply_workspace(action, workspace_id)
 
     rejected, missing, bulk_id = await store.bulk_reject(
         list(req.ids), reason=req.reason, rejector=rejector_id
@@ -2155,6 +2219,10 @@ async def approve_action(
     # fires a workspace-admin write (e.g. a member role change) after an
     # execute-time RBAC re-check, so the cross-workspace gate is mandatory here.
     _assert_admin_action_workspace(before, workspace_id)
+    # ``_customer_reply`` (paw-bar) — the delivery hook routes the reply to the
+    # blob's workspace, so a cross-workspace approve would deliver a decision into
+    # another tenant's paw-bar surface. Gate it like every other blob kind.
+    _assert_customer_reply_workspace(before, workspace_id)
 
     req = req or ApproveRequest()
     # SHOULD-FIX 1 — the audit actor is the authenticated identity, not
@@ -2667,6 +2735,10 @@ async def reject_action(
     # side. Asymmetric tenant scope is no tenant scope: a cross-workspace reject
     # must 403 before any mutation, exactly like the approve side.
     _assert_admin_action_workspace(before, workspace_id)
+    # ``_customer_reply`` (paw-bar) — same tenancy gate on the REJECT side: a
+    # cross-workspace reject would deliver a DECLINED decision into another
+    # tenant's paw-bar surface. Asymmetric tenant scope is no tenant scope.
+    _assert_customer_reply_workspace(before, workspace_id)
 
     reason = req.reason if req else ""
     rejector_id = str(user.id)

--- a/ee/pocketpaw_ee/paw_bar/decision_loop.py
+++ b/ee/pocketpaw_ee/paw_bar/decision_loop.py
@@ -1,4 +1,15 @@
 # ee/paw_bar/decision_loop.py — Close the customer decision loop via Instinct.
+# Updated: 2026-07-15 (B0 H1 — store-split tenancy fix) — propose_customer_decision
+#   now routes the write through the PER-WORKSPACE store the cloud dashboard reads
+#   from — get_instinct_store(workspace_id=widget.workspace_id) — instead of the
+#   bare get_instinct_store(). Root cause: the widget carries a real, server-stamped
+#   workspace_id (the header's old "no workspace_id column" claim was STALE), but
+#   resolve_workspace_id returned the widget OWNER and the write used the bare
+#   factory. In cloud/flag mode the workspace-less public ingest path made that bare
+#   factory raise WorkspaceScopeRequired → swallowed → the proposal was DROPPED
+#   (invisible to the owner's Tray); in shared mode it was stamped in-row with the
+#   owner label the dashboard never filters by. Now: real workspace_id = store route
+#   + in-row scope; owner = assignee only. See resolve_workspace_id + the store block.
 # Updated: 2026-07-08 — Renamed widget "Paw Print" → "Paw Bar" (module paw_print→paw_bar,
 #   source/requested_by labels paw_print→paw_bar). The separate one-word audit feed
 #   (past-tense record) is a DIFFERENT feature, unaffected.
@@ -25,11 +36,14 @@
 #
 # Tenancy: the proposal's ``_customer_reply`` blob carries ``workspace_id`` so
 #   the Instinct Action is workspace-scoped exactly like a parked pocket write.
-#   paw_bar's widget model predates per-row tenancy and has no workspace_id
-#   column, so the workspace is resolved from the widget OWNER (the freelancer /
-#   operator who owns the widget IS the tenant boundary here). This is the same
-#   scoping key the paw_bar store already indexes on. When the widget model
-#   grows a real workspace_id this resolver is the one line to change.
+#   The tenant boundary is the widget's real ``workspace_id`` (stamped server-side
+#   at create from the authenticated session — the SAME token the dashboard reads
+#   its pending feed by), which ALSO routes the physical instinct.db. The widget
+#   OWNER is a within-tenant human label used as the assignee (and as a back-compat
+#   in-row scope for a legacy widget whose ``workspace_id`` is still empty). The
+#   ``_customer_reply`` approve/reject paths carry a workspace assertion
+#   (``_assert_customer_reply_workspace``) comparing the blob's ``workspace_id`` to
+#   the caller's active workspace, like every other gated blob kind.
 #
 # Security: the blob carries NO secret — only the widget id, customer_ref,
 #   event type/payload-summary, workspace, and the default reply text. The
@@ -67,17 +81,24 @@ _MAX_SUMMARY_CHARS = 280
 
 
 def resolve_workspace_id(widget: Any) -> str:
-    """Resolve the owning workspace for a Paw Bar widget.
+    """Resolve the owning workspace (tenancy scope) for a Paw Bar widget.
 
-    The widget model predates per-row tenancy and has no ``workspace_id``; the
-    OWNER (the operator who created the widget) is the tenant boundary, and it is
-    the column the paw_bar store already scopes on. A widget with a
-    colon-qualified owner (``user:maya``) keeps the full string — the instinct
-    workspace assertion compares the blob's ``workspace_id`` to the caller's
-    active workspace as an opaque string, so consistency, not format, is what
-    matters here.
+    The widget carries a real ``workspace_id`` — stamped server-side at create
+    time from the authenticated session (``create_widget`` /
+    ``current_workspace_id``), the SAME token the cloud dashboard reads its
+    pending feed by. That is the tenant boundary, so prefer it. Fall back to the
+    OWNER only for a legacy / single-tenant widget whose ``workspace_id`` is
+    still empty (pre-tenancy rows); the owner is a within-tenant human label
+    (possibly colon-qualified, ``user:maya``) and is used as the in-row scope in
+    that back-compat case exactly as before.
+
+    This is the in-row / blob tenancy scope. Store ROUTING (which physical
+    instinct.db) is done separately in ``propose_customer_decision`` from the
+    real ``workspace_id`` only — an owner label is never a store-path token.
     """
-    return str(getattr(widget, "owner", "") or "")
+    return str(getattr(widget, "workspace_id", "") or "") or str(
+        getattr(widget, "owner", "") or ""
+    )
 
 
 def _summarize_payload(payload: dict[str, Any]) -> str:
@@ -139,6 +160,18 @@ async def propose_customer_decision(
 
         widget_id = str(getattr(widget, "id", "") or "")
         pocket_id = str(getattr(widget, "pocket_id", "") or "")
+        # Two DISTINCT identities on the widget (the H1 bug conflated them):
+        #   * ``store_ws`` — the real, server-stamped ``workspace_id`` (a
+        #     store-path-safe token). It routes the physical instinct.db AND is
+        #     the in-row tenancy scope, so the proposal lands in the SAME
+        #     per-workspace store the cloud dashboard reads its pending feed from.
+        #   * ``owner`` — the within-tenant human label (possibly colon-qualified,
+        #     ``user:maya``). It is the ASSIGNEE (routes The Tray to that human),
+        #     never a store-path token.
+        store_ws = str(getattr(widget, "workspace_id", "") or "")
+        owner = str(getattr(widget, "owner", "") or "")
+        # In-row / blob tenancy scope: the real workspace, or the owner for a
+        # legacy widget whose workspace_id is still empty (back-compat).
         workspace_id = resolve_workspace_id(widget)
         # Tenancy guard: an owner-less widget resolves to an EMPTY workspace. A
         # proposal raised with no workspace scope is NULL-scoped in Instinct, so
@@ -196,14 +229,19 @@ async def propose_customer_decision(
             "payload_summary": summary,
         }
 
-        # ISO note: paw-bar's tenant key is the widget OWNER, which is a
-        # logical, possibly colon-qualified string (``user:maya``) used for the
-        # in-row W4a ``workspace_id`` filter on ``store.propose`` below — NOT a
-        # physical-store-path workspace id (those must pass the strict
-        # path-traversal allowlist, which rejects a ``:``). So this path keeps
-        # the BARE store + in-row scoping; it does NOT thread the owner into the
-        # store factory (that would ValueError on a colon-qualified owner).
-        store = get_instinct_store()
+        # ISO-2 store routing (the H1 fix): route the write through the SAME
+        # per-workspace factory the cloud dashboard reads from —
+        # ``get_instinct_store(workspace_id=<real workspace>)`` lands the Action
+        # in ``~/.pocketpaw/workspaces/<store_ws>/instinct.db``, the exact file
+        # ``GET /instinct/actions/pending`` resolves for that tenant. The real
+        # ``workspace_id`` is a store-path-safe token, so no allowlist ValueError.
+        # A legacy widget with an empty ``store_ws`` keeps the BARE store +
+        # in-row scoping (owner as the scope) exactly as before — the owner label
+        # is never threaded into the store factory (it would ValueError on ``:``).
+        # Previously this called the bare ``get_instinct_store()`` unconditionally,
+        # which in cloud/flag mode raised ``WorkspaceScopeRequired`` on the
+        # workspace-less public ingest path → the proposal was silently dropped.
+        store = get_instinct_store(workspace_id=store_ws or None)
         action = await store.propose(
             pocket_id=pocket_id or widget_id,
             title=title,
@@ -215,9 +253,10 @@ async def propose_customer_decision(
             # Workspace-scope the Action so it appears only in the owning
             # tenant's pending list (deny-by-default Instinct tenancy — W4a).
             workspace_id=workspace_id or None,
-            # Route the approval to the widget owner — the operator who owns the
-            # customer relationship is the human in the loop.
-            assignee=workspace_id or None,
+            # Route the approval to the widget OWNER (the human who owns the
+            # customer relationship), NOT the workspace — The Tray filters by
+            # assignee to show an operator only the items they own.
+            assignee=owner or None,
         )
 
         # Park the PENDING decision row so the customer surface has something to

--- a/tests/cloud/test_paw_bar_decision_loop.py
+++ b/tests/cloud/test_paw_bar_decision_loop.py
@@ -1,11 +1,19 @@
 # tests/cloud/test_paw_bar_decision_loop.py — gap2: the closed customer
 # decision loop, end to end.
+# Updated: 2026-07-15 (B0 H1 — store-split fix) — the open-loop tenancy assertions
+# now read the widget's REAL ``workspace_id`` (the create dep override "w-test"),
+# not the OWNER label ("ws:bright-smile"). A widget created through the admin route
+# is stamped with the caller's active workspace; the proposal scopes to THAT (the
+# token the dashboard reads by) and the owner becomes the Action assignee. The old
+# assertions read the proposal by the owner, which encoded the very store-split bug
+# B0 fixes. The direct-construction tests below keep owner-fallback scoping (their
+# widgets have no workspace_id).
 # Created: 2026-06-11 (gap2) — Proves the loop the module promised but never
 # wired: a customer event raises a PENDING Instinct proposal + parked decision;
 # approving it delivers the reply back, retrievable for that (widget, customer);
 # rejecting it declines with the reason. Also covers tenancy (the proposal is
-# workspace-scoped to the widget owner), the public poll endpoint (CORS-gated),
-# and the best-effort guarantee (a loop failure never fails ingest).
+# workspace-scoped to the widget's workspace_id), the public poll endpoint
+# (CORS-gated), and the best-effort guarantee (a loop failure never fails ingest).
 #
 # asyncio_mode = "auto" (see pyproject) → every ``async def test_*`` is run by
 # pytest-asyncio without a per-test marker. The TestClient calls are synchronous
@@ -134,15 +142,20 @@ class TestOpenLoop:
         action_id = body["instinct_action_id"]
         assert action_id, "ingest of a mapped event must raise an Instinct proposal"
 
-        # The proposal lands in the OWNER's workspace-scoped pending list.
-        pending = await instinct_store.pending(workspace_id="ws:bright-smile")
+        # The proposal lands in the tenant's workspace-scoped pending list —
+        # scoped to the widget's REAL workspace_id (the create dep override
+        # "w-test"), the SAME token the cloud dashboard reads its feed by.
+        pending = await instinct_store.pending(workspace_id="w-test")
         assert len(pending) == 1
         assert pending[0].id == action_id
+        # Owner and workspace are DISTINCT: the owner is the Action assignee (routes
+        # The Tray to the human), the workspace is the tenancy scope.
+        assert pending[0].assignee == "ws:bright-smile"
         blob = pending[0].parameters["_customer_reply"]
         assert blob["widget_id"] == created["id"]
         assert blob["customer_ref"] == "patient_42"
         assert blob["event_type"] == "appointment_request"
-        assert blob["workspace_id"] == "ws:bright-smile"
+        assert blob["workspace_id"] == "w-test"
 
     async def test_proposal_is_workspace_scoped(self, client, stores) -> None:
         """A different tenant must NOT see this proposal (deny-by-default)."""
@@ -176,7 +189,7 @@ class TestOpenLoop:
         )
         assert res.status_code == 200
         assert res.json()["instinct_action_id"] is None
-        assert await instinct_store.pending(workspace_id="ws:bright-smile") == []
+        assert await instinct_store.pending(workspace_id="w-test") == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_paw_bar_decision_loop_tenancy.py
+++ b/tests/cloud/test_paw_bar_decision_loop_tenancy.py
@@ -1,0 +1,109 @@
+# tests/cloud/test_paw_bar_decision_loop_tenancy.py — B0 H1 (store-split repro).
+#
+# Created: 2026-07-15 (fix/paw-bar-decision-loop-tenancy). Reproduces the H1
+# tenancy defect: a paw-bar customer-decision proposal was written through the
+# BARE ``get_instinct_store()`` (no workspace) with the in-row workspace resolved
+# from the widget OWNER, while the cloud dashboard's pending feed reads the
+# PER-WORKSPACE store keyed by the widget's REAL ``workspace_id``. In cloud /
+# flag mode (``POCKETPAW_REQUIRE_WORKSPACE_SCOPE``) the public ingest path has NO
+# ``current_workspace`` context, so the bare factory raised ``WorkspaceScopeRequired``
+# — swallowed by the best-effort loop — and the proposal was DROPPED: the owner
+# never saw it in The Tray.
+#
+# Unlike ``tests/cloud/test_paw_bar_decision_loop.py`` this test does NOT
+# monkeypatch ``get_instinct_store`` (that stub — one store, arg-ignoring — is
+# exactly what hides the split). It drives the REAL store factory against a tmp
+# data dir with the cloud flag on, and asserts the proposal is visible in the
+# tenant's OWN per-workspace pending read.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.paw_bar.decision_loop import CUSTOMER_REPLY_KEY, propose_customer_decision
+
+import pocketpaw.stores as stores
+from pocketpaw.paw_bar.models import PawBarEvent, PawBarSpec, PawBarWidget
+from pocketpaw.paw_bar.store import PawBarStore
+
+# A REAL, server-stamped workspace id (create_widget stamps this from the
+# authenticated session): a store-path-safe token, NOT the colon-qualified owner.
+WS_REAL = "wreal01"
+OWNER = "user:maya"  # a within-tenant human label — colon-qualified, NOT a ws id
+
+
+@pytest.fixture(autouse=True)
+def _cloud_flag_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Real store factory, tmp data dir, cloud flag ON, no workspace context.
+
+    Mirrors ``tests/test_instinct_workspace_isolation.py::_isolate_data_dir`` but
+    with the required-scope flag SET and the ContextVar cleared — the exact state
+    of the PUBLIC ``POST /paw-bar/events/{id}`` ingest path in cloud mode.
+    """
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    stores.reset_store_caches()
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+        stores.reset_store_caches()
+
+
+def _widget() -> PawBarWidget:
+    spec = PawBarSpec(widget_id="pp_x", pocket_id="pocket-1")
+    return PawBarWidget(
+        id="pp_x",
+        pocket_id="pocket-1",
+        owner=OWNER,
+        workspace_id=WS_REAL,
+        name="Appointment Widget",
+        spec=spec,
+    )
+
+
+def _event() -> PawBarEvent:
+    return PawBarEvent(
+        widget_id="pp_x",
+        type="appointment_request",
+        payload={"when": "tuesday 9am"},
+        customer_ref="cust-1",
+    )
+
+
+async def test_cloud_proposal_lands_in_the_tenants_pending_feed(tmp_path: Path) -> None:
+    """The proposal must be visible in the widget's REAL-workspace pending read.
+
+    Pre-fix: the bare ``get_instinct_store()`` raises ``WorkspaceScopeRequired``
+    (flag on + no context) → swallowed → ``action_id is None`` and the tenant's
+    pending feed is empty. Post-fix: the write routes through
+    ``get_instinct_store(workspace_id=widget.workspace_id)`` so it lands in the
+    SAME per-workspace store the dashboard reads.
+    """
+    pp_store = PawBarStore(tmp_path / "paw_bar.db")
+    action_id = await propose_customer_decision(
+        widget=_widget(), event=_event(), paw_bar_store=pp_store
+    )
+
+    assert action_id is not None, (
+        "the cloud proposal was dropped — the owner never sees it in The Tray"
+    )
+
+    # The dashboard's GET /instinct/actions/pending resolves the PER-WORKSPACE
+    # store keyed by the caller's REAL active workspace and filters in-row by it.
+    dashboard_store = stores.get_instinct_store(workspace_id=WS_REAL)
+    pending = await dashboard_store.pending(workspace_id=WS_REAL)
+
+    assert [a.id for a in pending] == [action_id], (
+        "the proposal is not in the tenant's per-workspace pending feed"
+    )
+    # And its tenancy key is the REAL workspace, not the colon-qualified owner.
+    blob = pending[0].parameters[CUSTOMER_REPLY_KEY]
+    assert blob["workspace_id"] == WS_REAL, (
+        f"proposal scoped to {blob['workspace_id']!r}, expected the real workspace"
+    )

--- a/tests/ee/test_paw_bar_customer_reply_router.py
+++ b/tests/ee/test_paw_bar_customer_reply_router.py
@@ -1,0 +1,215 @@
+# tests/ee/test_paw_bar_customer_reply_router.py — B0 H2 (four-path tenancy gate).
+#
+# Created: 2026-07-15 (fix/paw-bar-decision-loop-tenancy). The security gate on
+# the paw-bar ``_customer_reply`` Instinct proposal type. Clones the
+# cross-workspace-403 discipline of ``tests/ee/test_instinct_rule_router.py``
+# (its ``_instinct_rule`` peer) for the customer-decision blob.
+#
+# THE LOAD-BEARING ASSERTION: a foreign-workspace ``_customer_reply`` Action is
+# refused with 403 + ``instinct.cross_workspace_approval`` on ALL FOUR router
+# entry points — approve, bulk-approve, reject, bulk-reject. Missing the guard on
+# even ONE is a cross-tenant escalation: ``deliver_customer_decision`` routes the
+# reply to the blob's ``workspace_id`` (``set_decision(workspace_id=...)``), so a
+# ws-A admin approving a ws-B ``_customer_reply`` action delivers a decision into
+# ws-B's paw-bar surface. Every OTHER blob kind already has this assert; this one
+# did not.
+#
+# The 403 tests are sync and drive the router over HTTP via ``TestClient`` — they
+# 403 BEFORE any delivery/DB touch, so no Beanie is needed.
+#
+# Run with:
+#   uv run --group ee pytest tests/ee/test_paw_bar_customer_reply_router.py -q
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+from pocketpaw_ee.paw_bar.decision_loop import CUSTOMER_REPLY_KEY  # noqa: E402
+
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+TRIGGER = {"type": "connector", "source": "paw_bar:pp_x", "reason": "customer reply test"}
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "user-A", workspace_id: str = "ws-A") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Inert recording EventBus so any emit() on the approve/reject path is quiet."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        async def publish(self, event: Any) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler: Any) -> None:  # noqa: ARG002
+            return
+
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = _RecordingBus()  # type: ignore[attr-defined]
+    yield bus_mod._bus
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+def _customer_reply_params(workspace_id: str) -> dict:
+    """A ``_customer_reply`` blob — the shape ``decision_loop.propose_customer_decision``
+    stores. The cross-workspace gate reads the top-level ``workspace_id``."""
+    return {
+        CUSTOMER_REPLY_KEY: {
+            "schema": 1,
+            "widget_id": "pp_x",
+            "pocket_id": "pocket-1",
+            "customer_ref": "cust-1",
+            "event_type": "appointment_request",
+            "workspace_id": workspace_id,
+            "default_reply": "Thanks — we'll follow up shortly.",
+            "payload_summary": "{}",
+        }
+    }
+
+
+@pytest.fixture
+def router_store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "customer_reply_router.db")
+
+
+def _make_app(user: _FakeUser, monkeypatch) -> FastAPI:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return app
+
+
+def _make_client(user: _FakeUser, monkeypatch) -> TestClient:
+    return TestClient(_make_app(user, monkeypatch))
+
+
+def _propose_customer_reply(client: TestClient, *, workspace_id: str, name: str = "reply") -> str:
+    """Seed a pending Action carrying a ``_customer_reply`` blob over HTTP."""
+    resp = client.post(
+        "/instinct/actions",
+        json={
+            "pocket_id": "pocket-1",
+            "title": f"customer request {name}",
+            "trigger": TRIGGER,
+            "parameters": _customer_reply_params(workspace_id),
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _status_of(client: TestClient, action_id: str) -> str:
+    resp = client.get("/instinct/actions", params={"limit": 500})
+    assert resp.status_code == 200, resp.text
+    for action in resp.json()["actions"]:
+        if action["id"] == action_id:
+            return action["status"]
+    raise AssertionError(f"action {action_id} not found")
+
+
+class TestCustomerReplyCrossWorkspace403:
+    """``_assert_customer_reply_workspace`` must refuse a foreign-workspace
+    ``_customer_reply`` Action with 403 + ``instinct.cross_workspace_approval`` on
+    the approve, bulk-approve, reject, AND bulk-reject paths."""
+
+    def test_single_approve_of_foreign_workspace_reply_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(_FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose_customer_reply(client, workspace_id="ws-B")
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_bulk_approve_of_foreign_workspace_reply_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(_FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose_customer_reply(client, workspace_id="ws-A", name="own")
+            foreign = _propose_customer_reply(client, workspace_id="ws-B", name="foreign")
+            resp = client.post("/instinct/actions/bulk-approve", json={"ids": [own, foreign]})
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, foreign) == "pending"
+
+    def test_single_reject_of_foreign_workspace_reply_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(_FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose_customer_reply(client, workspace_id="ws-B")
+            resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "nope"})
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_bulk_reject_of_foreign_workspace_reply_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(_FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose_customer_reply(client, workspace_id="ws-A", name="own")
+            foreign = _propose_customer_reply(client, workspace_id="ws-B", name="foreign")
+            resp = client.post(
+                "/instinct/actions/bulk-reject",
+                json={"ids": [own, foreign], "reason": "batch nope"},
+            )
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, foreign) == "pending"
+
+    def test_same_workspace_reply_is_not_blocked_by_the_gate(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A SAME-workspace ``_customer_reply`` approve must NOT 403 on the gate.
+
+        Proves the assert keys on tenancy, not on the blob's mere presence — a
+        ws-A admin approving a ws-A customer reply passes the workspace check.
+        """
+        client = _make_client(_FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose_customer_reply(client, workspace_id="ws-A")
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            # The tenancy gate must not fire; the action flips to approved.
+            assert resp.status_code == 200, resp.text
+            assert _status_of(client, action_id) == "approved"


### PR DESCRIPTION
## What this fixes

Two tenancy defects in the Paw Bar customer-decision loop, both found while grounding the glass-bar design and reproduced with failing tests before any fix.

### 1. Proposals were dropped or mis-scoped (store split)

When a visitor's event raised an Instinct proposal, the write went to the bare instinct store with the workspace resolved from the widget owner. But the widget already carries a real, server-stamped `workspace_id` (the old code comment claiming it does not was stale). On the public, unauthenticated ingest path there is no active workspace, so in workspace-scoped (cloud) mode the bare store raised `WorkspaceScopeRequired`, the best-effort loop swallowed it, and the proposal was dropped entirely. The owner never saw it. In shared mode it was stamped with the owner label the dashboard never filters by.

Now the write routes through the same per-workspace store the dashboard reads from, keyed by the real `workspace_id`, with the owner kept as the human assignee.

### 2. A cross-tenant approve was possible (missing assert)

The approve, reject, and bulk paths run a per-blob workspace assertion for every gated blob kind except the customer-reply blob, which had a delivery hook but no assert. Since the delivery hook routes the reply to the blob's own workspace, an approver in one workspace could approve a customer-reply action belonging to another and flip a decision row in that other tenant.

This adds `_assert_customer_reply_workspace`, mirroring the existing peer assert: it fails closed on a missing workspace claim and refuses a cross-workspace approve with a 403. It is wired into all four state-flip entry points: approve, reject, bulk-approve, bulk-reject.

## Verification

Both defects were reproduced with failing tests first, then fixed. The store-split test drives the real store factory in workspace-scoped mode (it deliberately does not mock the store, which is how the earlier test hid the split). The cross-tenant test exercises the 403 on all four wirings plus a same-workspace control that still succeeds. Regression: the decision-loop, tenancy, customer-reply, and paw_bar backend suites pass, and import-linter is clean on both configs. An independent adversarial review confirmed there is no fifth un-gated approve path (it walked every state-flip site in the tree, including the mission-control bulk facade and the separate approvals router) and no blob-shape bypass.

## Follow-ups (not in this PR)

- Bulk approve and reject flip a customer-reply's status but do not run the delivery hook, so a bulk-approved reply never reaches the customer. Fail-safe and pre-existing, worth a ticket if bulk delivery is wanted.
- A legacy widget with no `workspace_id` would fall back to the owner label and then always fail the new assert. This fails closed and is unreachable today (widget creation always stamps a real `workspace_id` and there are no deployments), but the fallback and the assert should be reconciled.
- Pre-existing and unrelated: `edit_proposal` calls the store with no workspace argument where one is required, a 500 in production that the tests hide with a no-arg mock. Flagging only.
