### PR TITLE
Paw Bar frame endpoint + CSP frame-ancestors origin model

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -694,6 +694,25 @@ def mount_cloud(app: FastAPI) -> None:
     uploads_dir.mkdir(parents=True, exist_ok=True)
     app.mount("/uploads", StaticFiles(directory=str(uploads_dir)), name="uploads")
 
+    # Paw Bar glass app (A1) — the iframe served by GET /api/v1/paw-bar/frame loads
+    # pawbar.js + pawbar.css from THIS root-absolute mount. The dir is configurable
+    # (PAWBAR_APP_DIR) so the built Vite/Svelte dist can be dropped in at deploy/smoke
+    # time; it defaults under ~/.pocketpaw and is created empty so the mount always
+    # binds (an empty dir just 404s the asset until the real bundle is copied in).
+    # PAWBAR_APP_MOUNT is imported from the router so the mount path and the frame
+    # HTML's <script src> can never drift.
+    from pocketpaw_ee.paw_bar.router import PAWBAR_APP_MOUNT
+
+    pawbar_app_dir = Path(
+        os.environ.get("PAWBAR_APP_DIR", str(Path.home() / ".pocketpaw" / "pawbar-app"))
+    )
+    pawbar_app_dir.mkdir(parents=True, exist_ok=True)
+    app.mount(
+        PAWBAR_APP_MOUNT,
+        StaticFiles(directory=str(pawbar_app_dir)),
+        name="pawbar-app",
+    )
+
     # Mount WebSocket at root path (not under /api/v1 prefix)
     # so frontend can connect to ws://host/ws/cloud?token=...
     from pocketpaw_ee.cloud.chat.router import websocket_endpoint

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -701,6 +701,8 @@ def mount_cloud(app: FastAPI) -> None:
     # binds (an empty dir just 404s the asset until the real bundle is copied in).
     # PAWBAR_APP_MOUNT is imported from the router so the mount path and the frame
     # HTML's <script src> can never drift.
+    import os
+
     from pocketpaw_ee.paw_bar.router import PAWBAR_APP_MOUNT
 
     pawbar_app_dir = Path(

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -699,19 +699,16 @@ def mount_cloud(app: FastAPI) -> None:
     # (PAWBAR_APP_DIR) so the built Vite/Svelte dist can be dropped in at deploy/smoke
     # time; it defaults under ~/.pocketpaw and is created empty so the mount always
     # binds (an empty dir just 404s the asset until the real bundle is copied in).
-    # PAWBAR_APP_MOUNT is imported from the router so the mount path and the frame
-    # HTML's <script src> can never drift.
-    import os
+    # PAWBAR_APP_MOUNT and the dir resolver are imported from the router so the
+    # mount path, the frame HTML's <script src>, and the ?v= cache-buster all read
+    # the same config and can never drift.
+    from pocketpaw_ee.paw_bar.router import PAWBAR_APP_MOUNT, pawbar_app_dir
 
-    from pocketpaw_ee.paw_bar.router import PAWBAR_APP_MOUNT
-
-    pawbar_app_dir = Path(
-        os.environ.get("PAWBAR_APP_DIR", str(Path.home() / ".pocketpaw" / "pawbar-app"))
-    )
-    pawbar_app_dir.mkdir(parents=True, exist_ok=True)
+    pawbar_dir = pawbar_app_dir()
+    pawbar_dir.mkdir(parents=True, exist_ok=True)
     app.mount(
         PAWBAR_APP_MOUNT,
-        StaticFiles(directory=str(pawbar_app_dir)),
+        StaticFiles(directory=str(pawbar_dir)),
         name="pawbar-app",
     )
 

--- a/ee/pocketpaw_ee/cloud/auth/site_keys.py
+++ b/ee/pocketpaw_ee/cloud/auth/site_keys.py
@@ -29,6 +29,24 @@
 # credential value, so a smuggled ``{"$ne": ""}`` operator dict is rejected 401,
 # not leaned on ``len`` to block; (FIX 3) copy the scope list null-safe
 # (``site.scopes or []``) so a Mongo doc with ``scopes: null`` can't TypeError.
+#
+# Updated 2026-07-15 (Paw Bar glass frame, A1): the key→Site lookup + the context
+# build were factored OUT of ``resolve_site_key`` so the new iframe FRAME endpoint
+# (``paw_bar/router.py::frame``) can reuse the SAME credential path without forking
+# it. (1) ``lookup_site_by_key`` runs the isinstance / min-len / find_one / revoked
+# / constant-time-compare chain and returns the live Site — NO origin gate (the
+# frame path gates the embedder with a CSP ``frame-ancestors`` header at render
+# time, not a per-request Origin check). (2) ``_context_from_site`` builds the
+# CONCIERGE ``RequestContext`` (the old tail of ``resolve_site_key``). (3)
+# ``resolve_site_key`` now takes an optional ``frame_origin``: with it unset the
+# behavior is byte-identical to before (inline widget → fail-closed
+# ``origin_allowed`` gate); when the request ``Origin`` equals our configured frame
+# origin, the embedder was ALREADY gated by the frame CSP, so the per-request
+# origin gate degenerates to "is this our frame" and the ``allowed_origins`` check
+# is skipped. This is the origin-model shift the glass bar rides on. The residual
+# is unchanged: the key is world-visible, so a raw ``curl`` POST was always
+# possible — CSP binds BROWSERS only; the real controls stay the rate-limit +
+# injection screen + the zero-authority CONCIERGE scope.
 
 from __future__ import annotations
 
@@ -53,59 +71,54 @@ from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 _MIN_SITE_KEY_LEN = 16
 
 
-async def resolve_site_key(
-    key: str,
-    origin: str | None,
-    customer_ref: str,
-) -> RequestContext:
-    """Resolve a Paw Bar embed key into a CONCIERGE-scoped :class:`RequestContext`.
+def _normalize_origin(value: str | None) -> str:
+    """Reduce a value to a comparable ``scheme://host[:port]`` origin.
 
-    Fail-closed, in order — every rejection is an :class:`HTTPException` (matching
-    the ``request_context`` auth-resolver precedent in ``_core/context.py``), so a
-    router can surface it directly:
-
-      1. **Empty / too-short key → 401.** Guards the ``signed_key=""`` collision
-         (see ``_MIN_SITE_KEY_LEN``) before any DB read.
-      2. **Unknown key → 401.** ``find_one`` returns nothing.
-      3. **Revoked key → 401.** The kill switch; a leaked key is cut off without
-         deleting the Site.
-      4. **Disallowed / missing origin → 403.** ``origin_allowed`` fails closed on
-         an empty allowlist or a missing ``Origin`` header — the embed key is only
-         valid from the origins the owner allowlisted.
-      5. **Key mismatch → 401.** Constant-time ``secrets.compare_digest``. With the
-         exact-match lookup above this is defense-in-depth (and keeps shape-parity
-         with the leads path); it becomes the real gate if the lookup is ever
-         changed to a prefix/range scan.
-
-    On success the returned context is bound to the Site's tenant + pocket, carries
-    the Site's ``scopes`` (what a concierge request may do), and stamps the caller's
-    ``customer_ref`` as ``user_id`` — the concierge is NOT a signed-in user, so
-    ``user_id`` is the anonymous customer handle the widget minted, never a real
-    account id. ``scope`` is ``CONCIERGE`` so downstream gates treat it as the
-    world-visible, non-session credential it is.
-
-    Args:
-        key: The public embed key presented by the widget (``Site.signed_key``).
-        origin: The request's ``Origin`` header (host is matched against the
-            Site's ``allowed_origins``).
-        customer_ref: The anonymous, widget-minted customer handle to record as
-            the request's ``user_id``.
-
-    Returns:
-        A ``RequestContext`` with ``scope=CONCIERGE``, ``workspace_id`` +
-        ``pocket_id`` from the Site, ``scopes`` copied from the Site.
-
-    Raises:
-        HTTPException: 401 (bad/unknown/revoked/mismatched key) or 403 (origin not
-            allowed). Deliberately no distinct code for "does not exist" vs "wrong
-            key" beyond the status — both are 401 so an attacker can't enumerate
-            which embed keys are live.
+    Lowercased, trailing slash + any path dropped. Used to compare a request's
+    ``Origin`` header against the configured frame origin exactly (scheme + host +
+    port), a STRICTER match than the host-only ``origin_allowed`` — "is this our
+    frame" must not be satisfied by a mere host collision under a different scheme.
     """
-    # ``isinstance`` FIRST: this value flows straight into a Mongo
-    # ``find_one({"signed_key": key})``, so a non-str (e.g. a ``{"$ne": ""}``
-    # operator dict smuggled through a JSON body) must be rejected outright rather
-    # than reaching the query or the ``len`` check. Then the empty/short-key guard
-    # (unchanged) blocks the ``signed_key=""`` DB collision.
+    if not value:
+        return ""
+    v = value.strip().lower().rstrip("/")
+    if "://" in v:
+        scheme, rest = v.split("://", 1)
+        host = rest.split("/", 1)[0]
+        return f"{scheme}://{host}"
+    return v
+
+
+def _is_same_origin(a: str | None, b: str | None) -> bool:
+    """True when both normalize to the same non-empty ``scheme://host[:port]``."""
+    na, nb = _normalize_origin(a), _normalize_origin(b)
+    return bool(na) and na == nb
+
+
+async def lookup_site_by_key(key: str) -> _SiteDoc:
+    """Authenticate a public embed key to its live Site — the SHARED key path.
+
+    Runs the full fail-closed credential chain and returns the Site doc, WITHOUT
+    any origin gate. Both callers reuse it: ``resolve_site_key`` (the concierge
+    chat path, which adds the origin gate) and the FRAME endpoint (which gates the
+    embedder with a CSP ``frame-ancestors`` header at render time instead of a
+    per-request Origin check). Keeping the chain in one place means the
+    isinstance / min-len / revoked / constant-time-compare guards can never drift
+    between the two entry points.
+
+    Order (every rejection is a 401 so an attacker can't enumerate which keys are
+    live — bad / unknown / revoked / mismatched are indistinguishable):
+
+      1. Non-str or too-short key → 401. ``isinstance`` FIRST so a smuggled Mongo
+         operator dict (``{"$ne": ""}``) never reaches ``find_one``; the min-len
+         guard then blocks the ``signed_key=""`` DB collision (see
+         ``_MIN_SITE_KEY_LEN``).
+      2. Unknown key → 401.
+      3. Revoked key → 401 (the kill switch — a leaked key is cut off without
+         deleting the Site).
+      4. Constant-time mismatch → 401. Redundant against the exact-match query
+         today, kept as defense-in-depth + shape-parity with the leads path.
+    """
     if not isinstance(key, str) or len(key) < _MIN_SITE_KEY_LEN:
         raise HTTPException(status_code=401, detail="invalid_site_key")
 
@@ -116,15 +129,23 @@ async def resolve_site_key(
     if site.revoked:
         raise HTTPException(status_code=401, detail="invalid_site_key")
 
-    if not origin_allowed(site.allowed_origins, origin):
-        raise HTTPException(status_code=403, detail="origin_not_allowed")
-
     # Constant-time compare so the key check can't be probed via timing, and so the
     # gate holds even if the lookup above is ever loosened. Redundant against the
     # exact-match query today, kept as defense-in-depth + shape-parity with leads.
     if not secrets.compare_digest(key, site.signed_key):
         raise HTTPException(status_code=401, detail="invalid_site_key")
 
+    return site
+
+
+def _context_from_site(site: _SiteDoc, customer_ref: str) -> RequestContext:
+    """Build the CONCIERGE ``RequestContext`` a resolved embed key stands for.
+
+    Bound to the Site's tenant + pocket, carrying a COPY of the Site's ``scopes``
+    (null-safe) and stamping the anonymous ``customer_ref`` as ``user_id`` — the
+    concierge is never a signed-in principal. ``scope=CONCIERGE`` so downstream
+    gates treat it as the world-visible, non-session credential it is.
+    """
     return RequestContext(
         user_id=customer_ref,
         workspace_id=site.workspace,
@@ -138,4 +159,76 @@ async def resolve_site_key(
     )
 
 
-__all__ = ["resolve_site_key"]
+async def resolve_site_key(
+    key: str,
+    origin: str | None,
+    customer_ref: str,
+    *,
+    frame_origin: str | None = None,
+) -> RequestContext:
+    """Resolve a Paw Bar embed key into a CONCIERGE-scoped :class:`RequestContext`.
+
+    Fail-closed, in order — every rejection is an :class:`HTTPException` (matching
+    the ``request_context`` auth-resolver precedent in ``_core/context.py``), so a
+    router can surface it directly:
+
+      1-4. **Key auth** (``lookup_site_by_key``): empty/short → 401, unknown → 401,
+         revoked → 401, constant-time mismatch → 401.
+      5. **Origin gate — dual-mode.**
+         * ``frame_origin`` unset (inline / legacy widget): the request ``Origin``
+           IS the embedder, so ``origin_allowed`` must place its host in the Site's
+           ``allowed_origins`` — fail-closed on an empty allowlist or missing
+           ``Origin``. This is byte-identical to the pre-frame behavior.
+         * ``frame_origin`` set AND ``origin`` equals it (iframe / glass bar): the
+           embedder was ALREADY gated by the frame's CSP ``frame-ancestors`` header
+           at render time, and every chat request from the iframe carries OUR frame
+           origin (identical for all embedders), so the per-request origin gate
+           degenerates to "is this our frame" — which the equality check confirms.
+           The ``allowed_origins`` check is skipped (it would reject our own frame).
+         * ``frame_origin`` set but ``origin`` does NOT equal it: fall back to the
+           inline ``allowed_origins`` gate, so a request that merely CLAIMS to be
+           the frame but isn't must still be an allowlisted embedder.
+
+    On success the returned context is bound to the Site's tenant + pocket, carries
+    the Site's ``scopes`` (what a concierge request may do), and stamps the caller's
+    ``customer_ref`` as ``user_id`` — the concierge is NOT a signed-in user, so
+    ``user_id`` is the anonymous customer handle the widget minted, never a real
+    account id. ``scope`` is ``CONCIERGE`` so downstream gates treat it as the
+    world-visible, non-session credential it is.
+
+    Args:
+        key: The public embed key presented by the widget (``Site.signed_key``).
+        origin: The request's ``Origin`` header (host is matched against the
+            Site's ``allowed_origins`` in inline mode).
+        customer_ref: The anonymous, widget-minted customer handle to record as
+            the request's ``user_id``.
+        frame_origin: OUR configured iframe origin (``PAWBAR_FRAME_ORIGIN``, or the
+            request's own origin by default). When the request ``Origin`` matches
+            it, the embedder was gated by the frame CSP and the ``allowed_origins``
+            check is skipped. ``None`` keeps the pure inline behavior.
+
+    Returns:
+        A ``RequestContext`` with ``scope=CONCIERGE``, ``workspace_id`` +
+        ``pocket_id`` from the Site, ``scopes`` copied from the Site.
+
+    Raises:
+        HTTPException: 401 (bad/unknown/revoked/mismatched key) or 403 (origin not
+            allowed). Deliberately no distinct code for "does not exist" vs "wrong
+            key" beyond the status — both are 401 so an attacker can't enumerate
+            which embed keys are live.
+    """
+    site = await lookup_site_by_key(key)
+
+    # Dual-mode origin gate. Frame mode (request Origin == our frame origin) means
+    # the embedder was already gated by the frame CSP, so we accept; otherwise the
+    # request Origin is the embedder itself and must be on the Site's fail-closed
+    # allowlist. ``origin_allowed`` rejects an empty allowlist / missing Origin.
+    if frame_origin is not None and _is_same_origin(origin, frame_origin):
+        pass
+    elif not origin_allowed(site.allowed_origins, origin):
+        raise HTTPException(status_code=403, detail="origin_not_allowed")
+
+    return _context_from_site(site, customer_ref)
+
+
+__all__ = ["lookup_site_by_key", "resolve_site_key"]

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -195,6 +195,11 @@ def _sanitize_ancestor(raw: Any) -> str | None:
     if "://" in v:
         v = v.split("://", 1)[1]
     v = v.split("/", 1)[0]  # drop any path
+    # SECURITY (ordering is load-bearing): ``v`` was ``.strip()``-ed above, so it
+    # carries no trailing newline. ``$`` in this pattern matches just BEFORE a
+    # trailing ``\n``, so a regex-before-strip reorder would let ``"host\n"`` pass
+    # and ``return v`` would emit that newline into the CSP header (classic header
+    # injection / directive split). Keep .strip() ahead of this match.
     if not _SAFE_ANCESTOR_RE.match(v):
         return None
     return v
@@ -208,7 +213,7 @@ def _frame_ancestors_csp(allowed_origins: list[str]) -> str | None:
     source-less directive. Mirrors ``site_keys.origin_allowed``'s empty=deny model,
     NOT the router's ``_origin_allowed`` empty=allow-all footgun.
     """
-    sources = [s for s in (_sanitize_ancestor(o) for o in allowed_origins) if s]
+    sources = [s for s in (_sanitize_ancestor(o) for o in (allowed_origins or [])) if s]
     if not sources:
         return None
     return "frame-ancestors " + " ".join(sources)
@@ -247,7 +252,7 @@ def _safe_parent_origin(po: str, allowed_origins: list[str]) -> str:
     hostport = rest.split("/", 1)[0]
     hostonly = hostport.split(":", 1)[0]
     allowed_hostonly = {
-        h.split(":", 1)[0] for h in (_sanitize_ancestor(o) for o in allowed_origins) if h
+        h.split(":", 1)[0] for h in (_sanitize_ancestor(o) for o in (allowed_origins or [])) if h
     }
     if hostonly not in allowed_hostonly:
         return ""

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,26 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-15 (Paw Bar glass frame, A1) — the iframe FRAME endpoint + the
+#   CSP-based origin model. (1) GET /paw-bar/frame?key=<signed_key>[&w=&po=] serves
+#   the glass app document from OUR origin: it authenticates the embed key
+#   (``lookup_site_by_key`` — the SAME chain resolve_site_key runs), FAILS CLOSED on
+#   an empty ``allowed_origins`` (403 refuse-to-render), and emits
+#   ``Content-Security-Policy: frame-ancestors <Site.allowed_origins>`` so the
+#   browser refuses to render the iframe inside any non-allowlisted parent — THIS
+#   (not a per-request Origin header) becomes the embedder gate. The body seeds
+#   ``window.__PAWBAR__`` (JSON-safe, ``<``-escaped) before loading pawbar.js/css
+#   from a configurable StaticFiles mount (``PAWBAR_APP_MOUNT`` / ``PAWBAR_APP_DIR``,
+#   wired in cloud/__init__.py). No ``X-Frame-Options`` — it is OBSOLETE beside
+#   frame-ancestors and a conflicting XFO:DENY would block the frame. (2) The
+#   /paw-bar/chat origin check is now DUAL-MODE: an inline/legacy widget request is
+#   still gated against ``Site.allowed_origins`` (fail-closed, via resolve_site_key),
+#   while an iframe-mode request (Origin == our ``PAWBAR_FRAME_ORIGIN``) is accepted
+#   because the embedder was already gated by the frame CSP at render time. The old
+#   step-2 ``_origin_allowed(widget, ...)`` footgun (empty widget.allowed_domains =
+#   allow-all) NO LONGER gates chat — the chat path converges on the fail-closed
+#   ``Site.allowed_origins`` allowlist. RESIDUAL (unchanged): CSP binds BROWSERS
+#   only; the world-visible key + a raw curl POST was always possible — the real
+#   controls remain the rate-limit + injection screen + zero-authority CONCIERGE
+#   scope. ``_origin_allowed`` stays in use for the spec/ingest/decision endpoints.
 # Updated: 2026-07-14 (Paw Bar concierge seam, T2) — added POST /paw-bar/chat, a
 #   PUBLIC, anonymous, streaming (SSE) concierge chat endpoint. Front-gate:
 #   _origin_allowed (403) → within_rate_limit (429) → injection-screen the
@@ -73,13 +95,14 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import uuid
 from collections.abc import AsyncIterator
 from typing import Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from pocketpaw.api.deps import require_scope
@@ -128,6 +151,206 @@ def _origin_allowed(widget: PawBarWidget, origin: str | None) -> bool:
     host = host.split("/", 1)[0]
     host = host.split(":", 1)[0]
     return host in widget.allowed_domains
+
+
+# ---------------------------------------------------------------------------
+# Glass frame (iframe) — CSP-based origin model (A1)
+#
+# The vanilla widget runs in the HOST page's origin, so a chat request's Origin
+# header IS the embedder and the per-request Origin gate authenticates WHO
+# embedded. Served in an iframe from OUR domain, every request carries OUR frame
+# origin — identical for all embedders — so that gate degenerates. The frame
+# endpoint moves the embedder gate to a CSP ``frame-ancestors`` header (the browser
+# refuses to render our iframe inside a non-allowlisted parent), and the chat
+# endpoint's origin check becomes dual-mode (see ``concierge_chat``).
+# ---------------------------------------------------------------------------
+
+# URL path the glass app bundle (pawbar.js + pawbar.css) is served from. The
+# StaticFiles mount lives in ``ee/cloud/__init__.py``; both the mount and the frame
+# HTML import THIS constant so the ``<script src>`` and the mount path never drift.
+PAWBAR_APP_MOUNT = "/pawbar-app"
+
+# A frame-ancestors host-source is host[:port] with NO scheme, path, or whitespace.
+# ``allowed_origins`` is owner-controlled data flowing into a response HEADER, so
+# each entry is reduced to this safe shape (or dropped) — a stray space / ``;`` /
+# newline would otherwise inject extra CSP directives or split the header.
+_SAFE_ANCESTOR_RE = re.compile(r"^[a-z0-9.\-]+(:[0-9]{1,5})?$")
+
+
+def _sanitize_ancestor(raw: Any) -> str | None:
+    """Reduce one ``allowed_origins`` entry to a safe frame-ancestors host-source.
+
+    Returns the bare ``host[:port]`` (scheme + path stripped) or ``None`` if it
+    can't be safely represented. Emitting the bare host (no scheme) is deliberate:
+    it matches the rest of the origin model (``origin_allowed`` is host-only) AND a
+    schemeless frame-ancestors source adapts to the frame's OWN scheme — https-tight
+    when the frame is served over https, http-permissive in local dev — instead of
+    hard-pinning a scheme that would break one or the other.
+    """
+    if not isinstance(raw, str):
+        return None
+    v = raw.strip().lower()
+    if not v:
+        return None
+    if "://" in v:
+        v = v.split("://", 1)[1]
+    v = v.split("/", 1)[0]  # drop any path
+    if not _SAFE_ANCESTOR_RE.match(v):
+        return None
+    return v
+
+
+def _frame_ancestors_csp(allowed_origins: list[str]) -> str | None:
+    """Build the ``frame-ancestors`` CSP value from a Site's ``allowed_origins``.
+
+    Returns ``None`` when NO entry survives sanitization (including an empty
+    allowlist) — the caller FAILS CLOSED (refuses to render) rather than emit a
+    source-less directive. Mirrors ``site_keys.origin_allowed``'s empty=deny model,
+    NOT the router's ``_origin_allowed`` empty=allow-all footgun.
+    """
+    sources = [s for s in (_sanitize_ancestor(o) for o in allowed_origins) if s]
+    if not sources:
+        return None
+    return "frame-ancestors " + " ".join(sources)
+
+
+def _configured_frame_origin(request: Request) -> str:
+    """OUR iframe's origin — the trusted parent for the dual-mode chat gate.
+
+    Configurable via ``PAWBAR_FRAME_ORIGIN`` (set it in any multi-origin / proxied
+    deploy where the frame is served from a fixed public origin). Defaults to the
+    request's own ``scheme://host`` for single-origin / local deploys where the
+    frame and the API share an origin.
+    """
+    configured = os.environ.get("PAWBAR_FRAME_ORIGIN", "").strip()
+    if configured:
+        return configured
+    return f"{request.url.scheme}://{request.url.netloc}"
+
+
+def _safe_parent_origin(po: str, allowed_origins: list[str]) -> str:
+    """Validate the loader-supplied parent origin against the Site's allowlist.
+
+    ``po`` rides in the iframe URL (set by the loader running in the embedder page),
+    so it is attacker-influenceable and never trusted verbatim. Returns a clean
+    ``scheme://host[:port]`` origin — usable as the glass app's postMessage
+    ``targetOrigin`` — ONLY when its host is on the Site's allowlist; otherwise "".
+    (The real embedder is allowlisted by definition, else the CSP blocks the frame.)
+    """
+    if not po:
+        return ""
+    v = po.strip().lower().rstrip("/")
+    if "://" in v:
+        scheme, rest = v.split("://", 1)
+    else:
+        scheme, rest = "https", v
+    hostport = rest.split("/", 1)[0]
+    hostonly = hostport.split(":", 1)[0]
+    allowed_hostonly = {
+        h.split(":", 1)[0] for h in (_sanitize_ancestor(o) for o in allowed_origins) if h
+    }
+    if hostonly not in allowed_hostonly:
+        return ""
+    if scheme not in ("http", "https") or not _SAFE_ANCESTOR_RE.match(hostport):
+        return ""
+    return f"{scheme}://{hostport}"
+
+
+def _pawbar_bootstrap_html(config: dict[str, Any], asset_mount: str) -> str:
+    """Render the glass frame document: seed ``window.__PAWBAR__`` then load the app.
+
+    The config dict is ``json.dumps``'d with ``<`` escaped to ``\\u003c`` so no
+    value (the world-visible key, the attacker-influenceable ``widgetId`` /
+    ``parentOrigin`` query params) can break out of the inline ``<script>`` with a
+    ``</script>`` sequence or inject markup. Assets load from ``asset_mount`` (the
+    root-absolute StaticFiles mount), so the document is valid wherever the API
+    router is mounted.
+    """
+    config_json = json.dumps(config).replace("<", "\\u003c")
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "<title>Paw Bar</title>\n"
+        f'<link rel="stylesheet" href="{asset_mount}/pawbar.css">\n'
+        "</head>\n"
+        "<body>\n"
+        '<div id="pawbar-root"></div>\n'
+        f"<script>window.__PAWBAR__ = {config_json};</script>\n"
+        f'<script src="{asset_mount}/pawbar.js"></script>\n'
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+@router.get("/paw-bar/frame")
+async def frame(
+    request: Request,
+    key: str = Query("", description="The public Site.signed_key baked into the loader"),
+    w: str = Query("", description="Optional Paw Bar widget id"),
+    po: str = Query("", description="Parent origin the loader passes for postMessage"),
+) -> HTMLResponse:
+    """Serve the glass Paw Bar app inside an iframe, gated by CSP frame-ancestors.
+
+    The embedder gate is NOT a per-request Origin check (in an iframe every request
+    carries OUR frame origin) — it is the ``Content-Security-Policy: frame-ancestors``
+    header the browser enforces at render time: it refuses to display this iframe
+    inside any parent whose origin isn't on the Site's ``allowed_origins``.
+
+    Order (fail-closed):
+      1. Authenticate the embed key — ``lookup_site_by_key`` (the SAME chain the
+         chat path runs): blank / short / unknown / revoked → 401.
+      2. Build the ``frame-ancestors`` value from ``Site.allowed_origins``. FAIL
+         CLOSED on an empty / unusable allowlist → 403 (refuse to render), mirroring
+         ``site_keys.origin_allowed`` — NOT the ``_origin_allowed`` allow-all footgun.
+      3. Seed ``window.__PAWBAR__`` (JSON-safe) and load pawbar.js/css.
+
+    No ``X-Frame-Options``: it is obsolete beside ``frame-ancestors`` and a
+    conflicting ``XFO: DENY`` would stop the frame from rendering at all.
+
+    Residual: ``frame-ancestors`` binds BROWSERS only. The key is world-visible and
+    a raw ``curl`` POST to /paw-bar/chat was always possible and is unchanged here —
+    the real controls stay the rate-limit + injection screen + the zero-authority
+    CONCIERGE scope. CSP does not close the curl path.
+    """
+    from pocketpaw_ee.cloud.auth.site_keys import lookup_site_by_key
+
+    # (1) Authenticate the embed key. A missing/blank ``key`` query param is a
+    # too-short key → 401 (never a 422), so the refusal is uniform with the chat path.
+    site = await lookup_site_by_key(key)
+
+    # (2) The embedder gate: the CSP frame-ancestors header. Fail closed when no
+    # allowlisted origin survives sanitization — refuse to render.
+    csp = _frame_ancestors_csp(site.allowed_origins)
+    if csp is None:
+        raise HTTPException(status_code=403, detail="frame_ancestors_unset")
+
+    # (3) Bootstrap config. ``endpoint`` is the API base derived from the request
+    # path (mount-agnostic: /api/v1 in prod, "" when the router is mounted bare in
+    # tests); the glass app POSTs ``{endpoint}/paw-bar/chat``. ``parentOrigin`` is
+    # validated against the allowlist. ``siteKey`` in the page is fine — it is a
+    # world-visible embed key by design.
+    api_base = request.url.path.rsplit("/paw-bar/frame", 1)[0]
+    config: dict[str, Any] = {
+        "siteKey": key,
+        "widgetId": w or "",
+        "endpoint": api_base,
+        "parentOrigin": _safe_parent_origin(po, site.allowed_origins),
+        "mode": "concierge",
+        "tokens": {},
+    }
+    html = _pawbar_bootstrap_html(config, PAWBAR_APP_MOUNT)
+    return HTMLResponse(
+        content=html,
+        headers={
+            "Content-Security-Policy": csp,
+            # The embed key is baked into the loader HTML per-embedder; the frame
+            # doc itself must not be cached across keys/parents by a shared proxy.
+            "Cache-Control": "no-store",
+        },
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -584,10 +807,12 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
 
     Order (fail-closed, cheap gates first):
       1. Widget exists (404).
-      2. Origin on the widget's allowlist (403) — the front-gate.
+      2. Resolve our frame origin (dual-mode origin model — no rejection here; the
+         authoritative, fail-closed origin gate is folded into step 5).
       3. Rate limit, overall + per-customer (429).
       4. Injection screen the free-text message; drop on HIGH (400).
-      5. Authenticate the embed key (``resolve_site_key`` — 401/403 fail-closed).
+      5. Authenticate the embed key + dual-mode origin gate (``resolve_site_key`` —
+         401 bad key / 403 disallowed origin, fail-closed).
       6. Bind the widget to the RESOLVED key: the widget must belong to the key's
          workspace AND pocket (403) — a key for pocket A must not drive a widget
          for a sibling pocket B (finding #2).
@@ -607,9 +832,16 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     if widget is None:
         raise HTTPException(404, "Widget not found")
 
-    # (2) Origin front-gate.
-    if not _origin_allowed(widget, origin):
-        raise HTTPException(403, "Origin not allowed for this widget")
+    # (2) Origin model — DUAL-MODE (A1). The chat origin gate now converges on the
+    # fail-closed ``Site.allowed_origins`` allowlist, enforced at step 5 by
+    # ``resolve_site_key``. It is NOT gated on ``widget.allowed_domains`` anymore —
+    # that check's empty=allow-all footgun would (a) silently allow any origin for
+    # an unconfigured widget and (b) reject OUR frame origin for a configured one,
+    # breaking the iframe path. ``frame_origin`` is our configured iframe origin: a
+    # request whose Origin equals it was already gated by the frame CSP at render
+    # time (iframe mode); any other Origin must be an allowlisted embedder (inline
+    # mode). The authoritative, fail-closed decision is made in ``resolve_site_key``.
+    frame_origin = _configured_frame_origin(request)
 
     # (3) Rate limit (reuse the ingest limiter). Counts prior events for this
     # (widget, customer); a recorded chat marker below feeds subsequent checks.
@@ -626,11 +858,16 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     if not await _screen_message_for_injection(body.message, body.widget_id):
         raise HTTPException(400, "message_rejected")
 
-    # (5) Authenticate the embed key — fail-closed (401 bad/unknown/revoked key,
-    # 403 disallowed/missing origin). This is THE credential; there is no user.
+    # (5) Authenticate the embed key + apply the dual-mode origin gate — fail-closed
+    # (401 bad/unknown/revoked key, 403 disallowed/missing origin). This is THE
+    # credential; there is no user. ``frame_origin`` makes the origin gate accept an
+    # iframe-mode request (Origin == our frame, already gated by the frame CSP) while
+    # still requiring an inline-mode request's Origin to be on ``Site.allowed_origins``.
     from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
 
-    ctx = await resolve_site_key(body.signed_key, origin, body.customer_ref)
+    ctx = await resolve_site_key(
+        body.signed_key, origin, body.customer_ref, frame_origin=frame_origin
+    )
 
     # (6) Bind the widget to the RESOLVED key (finding #2). A legacy '' widget
     # workspace matches any; a non-empty mismatch is refused. The pocket MUST

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,11 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-15 (glass frame asset versioning) — the frame HTML now appends
+#   ``?v=<newest bundle mtime>`` to the pawbar.js/css URLs (``_asset_version``).
+#   The StaticFiles mount sends no Cache-Control, so browsers heuristically cache
+#   the bundle and pin embedders to a STALE app after a deploy (bit the first live
+#   demo). Versioned URLs bust every embedder's cache on deploy, no restart, no
+#   hard-reload. ``pawbar_app_dir()`` is now the shared dir resolver (imported by
+#   the cloud mount — same never-drift pattern as PAWBAR_APP_MOUNT).
 # Updated: 2026-07-15 (Paw Bar glass frame, A1) — the iframe FRAME endpoint + the
 #   CSP-based origin model. (1) GET /paw-bar/frame?key=<signed_key>[&w=&po=] serves
 #   the glass app document from OUR origin: it authenticates the embed key
@@ -99,6 +106,7 @@ import os
 import re
 import uuid
 from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
@@ -169,6 +177,36 @@ def _origin_allowed(widget: PawBarWidget, origin: str | None) -> bool:
 # StaticFiles mount lives in ``ee/cloud/__init__.py``; both the mount and the frame
 # HTML import THIS constant so the ``<script src>`` and the mount path never drift.
 PAWBAR_APP_MOUNT = "/pawbar-app"
+
+
+def pawbar_app_dir() -> Path:
+    """Directory the glass app bundle is served from (PAWBAR_APP_DIR overridable).
+
+    Single source of truth shared with the StaticFiles mount in
+    ``ee/cloud/__init__.py`` (same never-drift pattern as ``PAWBAR_APP_MOUNT``).
+    """
+    return Path(os.environ.get("PAWBAR_APP_DIR", str(Path.home() / ".pocketpaw" / "pawbar-app")))
+
+
+def _asset_version() -> str:
+    """Cache-busting version stamp for the glass app assets.
+
+    The StaticFiles mount serves pawbar.js/css with no ``Cache-Control``, so
+    browsers fall back to heuristic freshness and can pin an embedder to a STALE
+    bundle after a deploy (bit the first live demo: a sizing fix shipped but the
+    browser kept replaying the old JS). The frame HTML appends ``?v=<newest
+    mtime>`` to both asset URLs so every deploy mints new URLs and busts every
+    embedder's cache with no server restart and no manual hard-reload. Two
+    ``stat`` calls per frame render — negligible next to the DB key lookup.
+    Returns "0" when the bundle isn't dropped in yet (assets 404 either way).
+    """
+    newest = 0
+    for name in ("pawbar.js", "pawbar.css"):
+        try:
+            newest = max(newest, int((pawbar_app_dir() / name).stat().st_mtime))
+        except OSError:
+            continue
+    return str(newest)
 
 # A frame-ancestors host-source is host[:port] with NO scheme, path, or whitespace.
 # ``allowed_origins`` is owner-controlled data flowing into a response HEADER, so
@@ -272,6 +310,7 @@ def _pawbar_bootstrap_html(config: dict[str, Any], asset_mount: str) -> str:
     router is mounted.
     """
     config_json = json.dumps(config).replace("<", "\\u003c")
+    v = _asset_version()
     return (
         "<!doctype html>\n"
         '<html lang="en">\n'
@@ -279,12 +318,12 @@ def _pawbar_bootstrap_html(config: dict[str, Any], asset_mount: str) -> str:
         '<meta charset="utf-8">\n'
         '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
         "<title>Paw Bar</title>\n"
-        f'<link rel="stylesheet" href="{asset_mount}/pawbar.css">\n'
+        f'<link rel="stylesheet" href="{asset_mount}/pawbar.css?v={v}">\n'
         "</head>\n"
         "<body>\n"
         '<div id="pawbar-root"></div>\n'
         f"<script>window.__PAWBAR__ = {config_json};</script>\n"
-        f'<script src="{asset_mount}/pawbar.js"></script>\n'
+        f'<script src="{asset_mount}/pawbar.js?v={v}"></script>\n'
         "</body>\n"
         "</html>\n"
     )

--- a/tests/cloud/test_paw_bar_frame.py
+++ b/tests/cloud/test_paw_bar_frame.py
@@ -1,0 +1,354 @@
+# tests/cloud/test_paw_bar_frame.py — Paw Bar glass FRAME endpoint + CSP origin
+# model (A1).
+# Created 2026-07-15: covers GET /paw-bar/frame (the iframe document + the CSP
+# frame-ancestors embedder gate) and the CSP/parent-origin helper functions.
+# Three layers:
+#   * Pure-function proofs (no I/O): the frame-ancestors builder emits EXACTLY the
+#     Site's allowed_origins, fails closed (None) on an empty/unusable allowlist,
+#     sanitizes header-injection attempts, and the parent-origin validator only
+#     echoes an allowlisted origin.
+#   * Endpoint (httpx): valid key → 200 + CSP frame-ancestors header + a body that
+#     seeds window.__PAWBAR__; empty allowed_origins → 403 (fail-closed refuse); a
+#     blank / unknown / revoked key → 401; NO X-Frame-Options; and the world-visible
+#     key + attacker-influenceable params can't break out of the inline <script>.
+#   * Dual-mode chat: an iframe-mode request (Origin == our frame origin) passes the
+#     origin gate that would reject it inline; a non-frame disallowed origin is still
+#     403; the frozen inline path (Origin in allowed_origins) still works.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.paw_bar.models import PawBarBlock, PawBarSpec, PawBarWidget
+from pocketpaw.paw_bar.store import PawBarStore
+
+_VALID_KEY = "site_key_" + "a" * 24
+_FRAME_ORIGIN = "https://frame.pocketpaw.test"
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — the CSP + parent-origin helpers (pure functions, no I/O)
+# --------------------------------------------------------------------------- #
+
+
+def test_frame_ancestors_emits_exactly_allowed_origins():
+    from pocketpaw_ee.paw_bar.router import _frame_ancestors_csp
+
+    assert _frame_ancestors_csp(["brewco.com"]) == "frame-ancestors brewco.com"
+    assert (
+        _frame_ancestors_csp(["brewco.com", "shop.example.com"])
+        == "frame-ancestors brewco.com shop.example.com"
+    )
+
+
+def test_frame_ancestors_fails_closed_on_empty():
+    """An empty (or all-unusable) allowlist yields None — the endpoint refuses to
+    render rather than emit a source-less policy. Mirrors origin_allowed, NOT the
+    _origin_allowed empty=allow-all footgun."""
+    from pocketpaw_ee.paw_bar.router import _frame_ancestors_csp
+
+    assert _frame_ancestors_csp([]) is None
+    assert _frame_ancestors_csp(["", "   "]) is None
+
+
+def test_frame_ancestors_sanitizes_header_injection():
+    """allowed_origins is owner-controlled and flows into a response header — a
+    value carrying a space / ``;`` / newline must be dropped, never allowed to
+    inject a second CSP directive or split the header."""
+    from pocketpaw_ee.paw_bar.router import _frame_ancestors_csp
+
+    csp = _frame_ancestors_csp(
+        ["brewco.com", "evil.com; default-src *", "bad\nhost", "https://ok.example.com/path"]
+    )
+    # The two malformed entries are dropped; the scheme+path entry is reduced to host.
+    assert csp == "frame-ancestors brewco.com ok.example.com"
+    assert ";" not in csp
+    assert "\n" not in csp
+
+
+def test_safe_parent_origin_only_echoes_allowlisted():
+    from pocketpaw_ee.paw_bar.router import _safe_parent_origin
+
+    allowed = ["brewco.com"]
+    # Allowlisted parent → echoed as a clean scheme://host origin.
+    assert _safe_parent_origin("https://brewco.com", allowed) == "https://brewco.com"
+    # Not on the allowlist → dropped.
+    assert _safe_parent_origin("https://evil.example", allowed) == ""
+    # Junk / empty → dropped.
+    assert _safe_parent_origin("", allowed) == ""
+    assert _safe_parent_origin("not an origin", allowed) == ""
+    assert _safe_parent_origin("javascript:alert(1)", allowed) == ""
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — the endpoint (httpx)
+# --------------------------------------------------------------------------- #
+
+
+async def _site(**ov):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        script_name="",
+        signed_key=_VALID_KEY,
+        allowed_origins=["brewco.com"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+@pytest_asyncio.fixture
+async def frame_client(mongo_db):
+    """A public app client for GET /paw-bar/frame. The frame endpoint reads only the
+    Beanie Site (no paw_bar store), so no store patch is needed."""
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_frame_valid_key_renders_with_csp(frame_client):
+    await _site(allowed_origins=["brewco.com", "shop.example.com"])
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY, "w": "pp_seed"})
+
+    assert res.status_code == 200
+    assert res.headers["content-type"].startswith("text/html")
+    # The embedder gate: frame-ancestors with EXACTLY the Site's allowed_origins.
+    assert res.headers["content-security-policy"] == "frame-ancestors brewco.com shop.example.com"
+    body = res.text
+    # The document seeds window.__PAWBAR__ before loading the app.
+    assert "window.__PAWBAR__" in body
+    assert '"mode": "concierge"' in body
+    assert '"widgetId": "pp_seed"' in body
+    assert '"siteKey": "site_key_' in body  # world-visible embed key, by design
+    assert "/pawbar-app/pawbar.js" in body
+    assert "/pawbar-app/pawbar.css" in body
+
+
+@pytest.mark.asyncio
+async def test_frame_sends_no_x_frame_options(frame_client):
+    """XFO is obsolete beside frame-ancestors; a conflicting XFO:DENY would block
+    the frame from ever rendering, so we must NOT send it."""
+    await _site()
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert res.status_code == 200
+    assert "x-frame-options" not in {k.lower() for k in res.headers}
+
+
+@pytest.mark.asyncio
+async def test_frame_empty_allowed_origins_is_403(frame_client):
+    """Fail closed: a Site with no allowlist refuses to render (no CSP to gate the
+    embedder means anyone could frame it)."""
+    await _site(allowed_origins=[])
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_frame_blank_key_is_401(frame_client):
+    await _site()
+    # Missing/blank key resolves as a too-short key → 401 (never a 422).
+    res = await frame_client.get("/paw-bar/frame")
+    assert res.status_code == 401
+    res2 = await frame_client.get("/paw-bar/frame", params={"key": "short"})
+    assert res2.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_frame_unknown_key_is_401(frame_client):
+    await _site()
+    res = await frame_client.get("/paw-bar/frame", params={"key": "site_key_" + "z" * 24})
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_frame_revoked_key_is_401(frame_client):
+    await _site(revoked=True)
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_frame_parent_origin_validated(frame_client):
+    await _site(allowed_origins=["brewco.com"])
+    # An allowlisted parent origin is echoed into the bootstrap config.
+    ok = await frame_client.get(
+        "/paw-bar/frame", params={"key": _VALID_KEY, "po": "https://brewco.com"}
+    )
+    assert '"parentOrigin": "https://brewco.com"' in ok.text
+    # A non-allowlisted parent origin is dropped (empty), never trusted verbatim.
+    bad = await frame_client.get(
+        "/paw-bar/frame", params={"key": _VALID_KEY, "po": "https://evil.example"}
+    )
+    assert '"parentOrigin": ""' in bad.text
+
+
+@pytest.mark.asyncio
+async def test_frame_escapes_script_breakout(frame_client):
+    """The attacker-influenceable widget id / parent-origin params cannot break out
+    of the inline <script> — a literal </script> sequence must be escaped."""
+    await _site()
+    res = await frame_client.get(
+        "/paw-bar/frame",
+        params={"key": _VALID_KEY, "w": "</script><script>alert(1)</script>"},
+    )
+    assert res.status_code == 200
+    # No raw closing tag survived inside the config; < was escaped to <.
+    assert "</script><script>alert(1)" not in res.text
+    assert "\\u003c/script" in res.text
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — dual-mode chat origin gate
+# --------------------------------------------------------------------------- #
+
+
+def _spec(pocket_id="pocket-1") -> PawBarSpec:
+    return PawBarSpec(
+        widget_id="pp_seed",
+        pocket_id=pocket_id,
+        blocks=[PawBarBlock(type="text", content="Hi")],
+    )
+
+
+def _widget(**ov) -> PawBarWidget:
+    d = dict(
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        spec=_spec(),
+        allowed_domains=["brewco.com"],
+        agent_id="agent-xyz",
+        workspace_id="ws-1",
+        rate_limit_per_min=60,
+        per_customer_limit_per_min=10,
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+class _FakeExecutor:
+    def __init__(self, transport) -> None:
+        self.transport = transport
+        self.submitted: list = []
+
+    async def submit(self, spec) -> None:
+        self.submitted.append(spec)
+        await self.transport.append_event(
+            spec.run_id, "chunk", {"content": "We open at 8am!", "type": "text"}
+        )
+        await self.transport.append_event(
+            spec.run_id, "stream_end", {"assistant_message_id": "m1", "cancelled": False}
+        )
+
+
+@pytest_asyncio.fixture
+async def chat_client(tmp_path, mongo_db):
+    from unittest.mock import patch
+
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    store = PawBarStore(tmp_path / "concierge.db")
+    with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            yield client, store
+
+
+def _payload(widget_id: str, **ov) -> dict:
+    p = dict(
+        widget_id=widget_id,
+        signed_key=_VALID_KEY,
+        customer_ref="cust-1",
+        message="What time do you open?",
+    )
+    p.update(ov)
+    return p
+
+
+def _stub_run(monkeypatch):
+    from pocketpaw_ee.cloud.chat.runs.memory_stream import InMemoryStreamTransport
+
+    transport = InMemoryStreamTransport()
+    fake_exec = _FakeExecutor(transport)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.transport.get_stream_transport", lambda: transport
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.executor.get_executor", lambda: fake_exec)
+
+    async def _fake_create_run(spec):
+        return SimpleNamespace(run_id=spec.run_id)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.create_run", _fake_create_run)
+    return fake_exec
+
+
+@pytest.mark.asyncio
+async def test_chat_frame_origin_passes_gate(chat_client, monkeypatch):
+    """Iframe mode: the chat request carries OUR frame origin (not the embedder's
+    domain), which is NOT in Site.allowed_origins — but because the embedder was
+    already gated by the frame CSP at render, the frame origin is accepted."""
+    client, store = chat_client
+    await _site()  # allowed_origins=["brewco.com"] — does NOT include the frame origin
+    widget = await store.create_widget(_widget(agent_id="agent-xyz"))
+    monkeypatch.setenv("PAWBAR_FRAME_ORIGIN", _FRAME_ORIGIN)
+    fake_exec = _stub_run(monkeypatch)
+
+    res = await client.post(
+        "/paw-bar/chat", json=_payload(widget.id), headers={"Origin": _FRAME_ORIGIN}
+    )
+    assert res.status_code == 200
+    assert len(fake_exec.submitted) == 1  # reached dispatch
+
+
+@pytest.mark.asyncio
+async def test_chat_non_frame_disallowed_origin_still_403(chat_client, monkeypatch):
+    """Frame mode does not open a hole: a request from an origin that is neither our
+    frame origin NOR an allowlisted embedder is still refused (fail-closed)."""
+    client, store = chat_client
+    await _site()
+    widget = await store.create_widget(_widget(agent_id="agent-xyz"))
+    monkeypatch.setenv("PAWBAR_FRAME_ORIGIN", _FRAME_ORIGIN)
+
+    res = await client.post(
+        "/paw-bar/chat", json=_payload(widget.id), headers={"Origin": "https://evil.example"}
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_chat_frozen_inline_origin_still_works(chat_client, monkeypatch):
+    """The frozen inline widget path is preserved: a request whose Origin host is on
+    Site.allowed_origins passes the (now Site-converged) gate even with the frame
+    origin configured."""
+    client, store = chat_client
+    await _site()
+    widget = await store.create_widget(_widget(agent_id="agent-xyz"))
+    monkeypatch.setenv("PAWBAR_FRAME_ORIGIN", _FRAME_ORIGIN)
+    fake_exec = _stub_run(monkeypatch)
+
+    res = await client.post(
+        "/paw-bar/chat", json=_payload(widget.id), headers={"Origin": "https://brewco.com"}
+    )
+    assert res.status_code == 200
+    assert len(fake_exec.submitted) == 1

--- a/tests/cloud/test_paw_bar_frame.py
+++ b/tests/cloud/test_paw_bar_frame.py
@@ -142,6 +142,36 @@ async def test_frame_valid_key_renders_with_csp(frame_client):
 
 
 @pytest.mark.asyncio
+async def test_frame_assets_carry_cache_busting_version(frame_client, tmp_path, monkeypatch):
+    """The asset URLs must carry ?v=<newest bundle mtime> so a deploy busts every
+    embedder's browser cache (StaticFiles sends no Cache-Control; heuristic
+    caching pinned the first live demo to a stale bundle)."""
+    (tmp_path / "pawbar.js").write_text("// bundle")
+    (tmp_path / "pawbar.css").write_text("/* styles */")
+    monkeypatch.setenv("PAWBAR_APP_DIR", str(tmp_path))
+    expected = max(
+        int((tmp_path / "pawbar.js").stat().st_mtime),
+        int((tmp_path / "pawbar.css").stat().st_mtime),
+    )
+
+    await _site()
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert res.status_code == 200
+    assert f"/pawbar-app/pawbar.js?v={expected}" in res.text
+    assert f"/pawbar-app/pawbar.css?v={expected}" in res.text
+
+
+@pytest.mark.asyncio
+async def test_frame_assets_version_zero_when_bundle_missing(frame_client, tmp_path, monkeypatch):
+    """No bundle dropped in yet → ?v=0 (assets 404 either way; the frame must not 500)."""
+    monkeypatch.setenv("PAWBAR_APP_DIR", str(tmp_path / "empty"))
+    await _site()
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert res.status_code == 200
+    assert "/pawbar-app/pawbar.js?v=0" in res.text
+
+
+@pytest.mark.asyncio
 async def test_frame_sends_no_x_frame_options(frame_client):
     """XFO is obsolete beside frame-ancestors; a conflicting XFO:DENY would block
     the frame from ever rendering, so we must NOT send it."""

--- a/tests/cloud/test_site_keys.py
+++ b/tests/cloud/test_site_keys.py
@@ -9,13 +9,18 @@
 # Updated 2026-07-14 (adversarial review follow-up): + a non-str key → 401 guard
 # (FIX 2), and mint_foreign_site now mocks pockets_service.get with a cross-tenant
 # → Forbidden + no-Site-written assertion (FIX 1).
+# Updated 2026-07-15 (Paw Bar glass frame, A1): + coverage for the two extracted /
+# added surfaces — ``lookup_site_by_key`` (the shared key-auth chain, no origin
+# gate) and ``resolve_site_key``'s new ``frame_origin`` dual-mode gate (an Origin
+# equal to our frame origin is accepted without an allowlist check; a mismatched
+# Origin still falls back to the fail-closed ``allowed_origins`` gate).
 
 from __future__ import annotations
 
 import pytest
 from fastapi import HTTPException
 from pocketpaw_ee.cloud._core.context import ScopeKind
-from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
+from pocketpaw_ee.cloud.auth.site_keys import lookup_site_by_key, resolve_site_key
 from pocketpaw_ee.cloud.models.site import Site
 from pocketpaw_ee.sites import service as sites_service
 
@@ -261,3 +266,79 @@ async def test_mint_foreign_site_denies_cross_tenant_pocket(mongo_db):
     assert exc.value.code == "pocket.access_denied"
     # Fail-before-write: no Site was inserted for the victim pocket.
     assert await Site.find_one({"pocket_id": "pk-victim-xyz"}) is None
+
+
+# --------------------------------------------------------------------------- #
+# lookup_site_by_key — the shared key-auth chain (no origin gate)  [A1]
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_lookup_site_by_key_returns_live_site(mongo_db):
+    """The frame path authenticates the key WITHOUT an origin gate — a valid key
+    returns the Site regardless of any Origin (the CSP gates the embedder instead)."""
+    site = await _site()
+    got = await lookup_site_by_key(_VALID_KEY)
+    assert got.id == site.id
+    assert got.signed_key == _VALID_KEY
+
+
+@pytest.mark.asyncio
+async def test_lookup_site_by_key_rejects_bad_keys(mongo_db):
+    """Same fail-closed 401s as resolve_site_key's key chain: blank/short, unknown,
+    revoked, and a non-str (NoSQL-operator) key."""
+    await _site()
+    for bad in ("", "   ", "short", "site_key_" + "z" * 24, {"$ne": ""}, None):
+        with pytest.raises(HTTPException) as exc:
+            await lookup_site_by_key(bad)  # type: ignore[arg-type]
+        assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_lookup_site_by_key_rejects_revoked(mongo_db):
+    await _site(revoked=True)
+    with pytest.raises(HTTPException) as exc:
+        await lookup_site_by_key(_VALID_KEY)
+    assert exc.value.status_code == 401
+
+
+# --------------------------------------------------------------------------- #
+# resolve_site_key frame_origin dual-mode  [A1]
+# --------------------------------------------------------------------------- #
+
+_FRAME_ORIGIN = "https://frame.pocketpaw.test"
+
+
+@pytest.mark.asyncio
+async def test_frame_origin_accepted_without_allowlist(mongo_db):
+    """Iframe mode: a request whose Origin equals our frame origin is accepted even
+    though that origin is NOT in the Site's allowed_origins — the embedder was gated
+    by the frame CSP at render time."""
+    await _site(allowed_origins=["brewco.com"])
+    ctx = await resolve_site_key(_VALID_KEY, _FRAME_ORIGIN, "cust-1", frame_origin=_FRAME_ORIGIN)
+    assert ctx.scope is ScopeKind.CONCIERGE
+    assert ctx.workspace_id == "ws-1"
+
+
+@pytest.mark.asyncio
+async def test_frame_origin_mismatch_falls_back_to_allowlist(mongo_db):
+    """A frame_origin is configured, but the request Origin is neither the frame nor
+    an allowlisted embedder → the fail-closed allowlist gate still refuses (403)."""
+    await _site(allowed_origins=["brewco.com"])
+    with pytest.raises(HTTPException) as exc:
+        await resolve_site_key(
+            _VALID_KEY, "https://evil.example", "cust-1", frame_origin=_FRAME_ORIGIN
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_frame_origin_none_is_pure_inline_behavior(mongo_db):
+    """Default (frame_origin=None): behavior is byte-identical to before A1 — the
+    allowlisted embedder passes, a disallowed one is 403."""
+    await _site(allowed_origins=["brewco.com"])
+    ctx = await resolve_site_key(_VALID_KEY, "https://brewco.com", "cust-1")
+    assert ctx.scope is ScopeKind.CONCIERGE
+    with pytest.raises(HTTPException) as exc:
+        await resolve_site_key(_VALID_KEY, "https://evil.example", "cust-1")
+    assert exc.value.status_code == 403


### PR DESCRIPTION
Stacks on #1714 (the concierge seam). Review this on top of it.

## What this adds

The iframe FRAME endpoint and the CSP-based origin model for the glass bar. It is the security foundation for embedding the bar as a sandboxed iframe instead of inline in the host page.

## How it works

`GET /paw-bar/frame?key=...` looks up the Site by its public embed key and server-renders the iframe document with a `Content-Security-Policy: frame-ancestors <the Site's allowed origins>` header. The browser then refuses to render the iframe inside any parent that is not on the Site's allowlist. This moves the per-embedder gate off the per-request `Origin` header (which stops identifying the embedder once the iframe is served from our own domain) and onto the document's CSP, which is the control Intercom and Stripe Elements use. An empty or all-unusable allowlist fails closed with a 403 rather than rendering an ungated frame.

The `/paw-bar/chat` origin check becomes dual-mode: a legacy inline-widget request is still gated against the Site's allowed origins (fail-closed), and an iframe-mode request is accepted when its `Origin` is exactly our configured frame origin (the embedder having already been gated by the CSP at frame-render). With no frame origin configured the behavior is byte-identical to before, so the frozen inline widget keeps working.

Each owner-controlled allowed-origin value is reduced to a strict host-source shape before it reaches the header, so it cannot inject a second CSP directive or split the header. The loader-supplied parent origin is validated against the same allowlist before it is used as the glass app's postMessage target.

## Honest residual

The CSP binds browsers only. The embed key is world-visible and a raw curl POST to the chat endpoint (spoofing any `Origin`) was always possible and is unchanged. CSP does not close that. The real controls remain the rate limit, the injection screen, and the zero-authority concierge scope. The dual-mode change opens no new browser-reachable hole: a browser cannot spoof its `Origin`, and cross-origin fetches are CORS-gated.

## Verification

53 tests, including header-injection, script-breakout, revoked key, and the dual-mode gate. import-linter clean on both configs. An independent adversarial review walked all six vectors (CSP injection and splitting, frame fail-open, the Host-header/proxy dual-mode case, targetOrigin leaks, the static mount, origin normalization) and found no blocker; its two info-level notes are folded in (a comment locking the sanitize ordering against a future CSP-injection regression, and None-safe allowlist guards).

## Deploy note

Behind a proxy or in any multi-origin deploy, set `PAWBAR_FRAME_ORIGIN` to the fixed public frame origin so the frame-origin check cannot be Host-header influenced. Single-origin and local deploys work on the default. The glass app assets (built separately) go in `PAWBAR_APP_DIR`.
