### PR TITLE
feat(uploads): apply object-storage bucket CORS from code

### DIFF
--- a/scripts/ensure_bucket_cors.py
+++ b/scripts/ensure_bucket_cors.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# ensure_bucket_cors.py — apply the object-storage bucket CORS policy from code.
+#
+# New file (2026-07-15, CORS-1). Browsers fetching presigned URLs (chat
+# attachment previews, artifact byte reads) need their origin in the bucket's
+# CORS allowlist, or the cross-origin response is blocked with
+# "No 'Access-Control-Allow-Origin' header". This does what
+# `aws s3api put-bucket-cors` does, but reuses the S3 credentials already in the
+# deploy env / pocketpaw's .env (S3_ENDPOINT, S3_REGION, S3_ACCESS_KEY_ID,
+# S3_SECRET_ACCESS_KEY, S3_PRIVATE_BUCKET) via the same StorageAdapter factory
+# the app uses — no separate aws CLI config needed.
+#
+# Usage (from the pocketpaw repo root, with .env populated):
+#   uv run python scripts/ensure_bucket_cors.py https://paw.hzd.interacly.com
+#   uv run python scripts/ensure_bucket_cors.py \
+#       https://paw.hzd.interacly.com http://localhost:1420
+#   POCKETPAW_S3_CORS_ALLOWED_ORIGINS="https://paw.hzd.interacly.com" \
+#       uv run python scripts/ensure_bucket_cors.py        # origins from env
+#
+# Origins come from argv, else POCKETPAW_S3_CORS_ALLOWED_ORIGINS (comma or
+# whitespace separated). Prints the bucket's CORS rules before and after so the
+# change is visible. Requires the credentials to carry the PutBucketCORS action.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+# The factory reads S3_* / POCKETPAW_UPLOAD_ADAPTER; it calls load_dotenv()
+# defensively, so running from the repo root picks up .env automatically.
+from pocketpaw.uploads.factory import _build_s3  # noqa: E402
+from pocketpaw.uploads.s3 import S3StorageAdapter
+
+
+def _origins_from_env() -> list[str]:
+    raw = os.environ.get("POCKETPAW_S3_CORS_ALLOWED_ORIGINS", "")
+    return [o for o in raw.replace(",", " ").split() if o]
+
+
+async def _main(origins: list[str]) -> int:
+    adapter = _build_s3()
+    if not isinstance(adapter, S3StorageAdapter):  # pragma: no cover - defensive
+        print("error: the configured upload adapter is not S3.", file=sys.stderr)
+        print("Set POCKETPAW_UPLOAD_ADAPTER=s3 and the S3_* vars.", file=sys.stderr)
+        return 2
+
+    bucket = adapter._bucket  # noqa: SLF001 - script owns the adapter it built
+    print(f"bucket: {bucket}")
+
+    before = await adapter.get_cors()
+    print("CORS before:")
+    print(json.dumps(before, indent=2) if before else "  (none)")
+
+    await adapter.ensure_cors(origins)
+
+    after = await adapter.get_cors()
+    print("\nCORS after:")
+    print(json.dumps(after, indent=2))
+    print(f"\nApplied {len(origins)} allowed origin(s): {', '.join(origins)}")
+    return 0
+
+
+def main() -> int:
+    origins = sys.argv[1:] or _origins_from_env()
+    if not origins:
+        print(
+            "usage: ensure_bucket_cors.py <origin> [<origin> ...]\n"
+            "   or: set POCKETPAW_S3_CORS_ALLOWED_ORIGINS and run with no args.",
+            file=sys.stderr,
+        )
+        return 2
+    return asyncio.run(_main(origins))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ensure_bucket_cors.py
+++ b/scripts/ensure_bucket_cors.py
@@ -10,16 +10,24 @@
 # S3_SECRET_ACCESS_KEY, S3_PRIVATE_BUCKET) via the same StorageAdapter factory
 # the app uses — no separate aws CLI config needed.
 #
+# SHARED-BUCKET SAFETY: put_bucket_cors REPLACES the whole rule set (S3 has no
+# merge), and interacly-dev-private is shared with interacly-backend. By default
+# this script MERGES — it reads the current rules and preserves them, adding
+# only our origin rule. Pass --replace to wipe existing rules and set ours only
+# (it prints a loud warning and lists what would be lost first).
+#
 # Usage (from the pocketpaw repo root, with .env populated):
 #   uv run python scripts/ensure_bucket_cors.py https://paw.hzd.interacly.com
 #   uv run python scripts/ensure_bucket_cors.py \
 #       https://paw.hzd.interacly.com http://localhost:1420
+#   uv run python scripts/ensure_bucket_cors.py --replace https://paw.hzd.interacly.com
 #   POCKETPAW_S3_CORS_ALLOWED_ORIGINS="https://paw.hzd.interacly.com" \
 #       uv run python scripts/ensure_bucket_cors.py        # origins from env
 #
 # Origins come from argv, else POCKETPAW_S3_CORS_ALLOWED_ORIGINS (comma or
 # whitespace separated). Prints the bucket's CORS rules before and after so the
-# change is visible. Requires the credentials to carry the PutBucketCORS action.
+# change is visible. Requires the credentials to carry PutBucketCORS (and
+# GetBucketCORS for the before/after read).
 
 from __future__ import annotations
 
@@ -39,7 +47,7 @@ def _origins_from_env() -> list[str]:
     return [o for o in raw.replace(",", " ").split() if o]
 
 
-async def _main(origins: list[str]) -> int:
+async def _main(origins: list[str], *, replace: bool) -> int:
     adapter = _build_s3()
     if not isinstance(adapter, S3StorageAdapter):  # pragma: no cover - defensive
         print("error: the configured upload adapter is not S3.", file=sys.stderr)
@@ -53,25 +61,37 @@ async def _main(origins: list[str]) -> int:
     print("CORS before:")
     print(json.dumps(before, indent=2) if before else "  (none)")
 
-    await adapter.ensure_cors(origins)
+    if replace and before:
+        print(
+            "\n!! --replace: the existing rules above will be REPLACED with only\n"
+            "!! the origins you passed. Any other service's rules are lost.",
+            file=sys.stderr,
+        )
+
+    # Merge by default (preserve others' rules); --replace writes only ours.
+    await adapter.ensure_cors(origins, preserve_rules=None if replace else before)
 
     after = await adapter.get_cors()
     print("\nCORS after:")
     print(json.dumps(after, indent=2))
-    print(f"\nApplied {len(origins)} allowed origin(s): {', '.join(origins)}")
+    mode = "replaced with" if replace else "merged in"
+    print(f"\n{mode} {len(origins)} allowed origin(s): {', '.join(origins)}")
     return 0
 
 
 def main() -> int:
-    origins = sys.argv[1:] or _origins_from_env()
+    args = sys.argv[1:]
+    replace = "--replace" in args
+    origins = [a for a in args if not a.startswith("--")] or _origins_from_env()
     if not origins:
         print(
-            "usage: ensure_bucket_cors.py <origin> [<origin> ...]\n"
-            "   or: set POCKETPAW_S3_CORS_ALLOWED_ORIGINS and run with no args.",
+            "usage: ensure_bucket_cors.py [--replace] <origin> [<origin> ...]\n"
+            "   or: set POCKETPAW_S3_CORS_ALLOWED_ORIGINS and run with no args.\n"
+            "Merges into existing bucket CORS by default; --replace overwrites all rules.",
             file=sys.stderr,
         )
         return 2
-    return asyncio.run(_main(origins))
+    return asyncio.run(_main(origins, replace=replace))
 
 
 if __name__ == "__main__":

--- a/src/pocketpaw/uploads/s3.py
+++ b/src/pocketpaw/uploads/s3.py
@@ -222,9 +222,7 @@ class S3StorageAdapter(StorageAdapter):
         diagnostic lie.
         """
         try:
-            resp = await asyncio.to_thread(
-                self._client.get_bucket_cors, Bucket=self._bucket
-            )
+            resp = await asyncio.to_thread(self._client.get_bucket_cors, Bucket=self._bucket)
         except Exception as exc:
             if _is_no_cors(exc):
                 return []

--- a/src/pocketpaw/uploads/s3.py
+++ b/src/pocketpaw/uploads/s3.py
@@ -170,18 +170,24 @@ class S3StorageAdapter(StorageAdapter):
         allowed_headers: list[str] | None = None,
         expose_headers: list[str] | None = None,
         max_age_seconds: int = 3600,
+        preserve_rules: list[dict] | None = None,
     ) -> None:
-        """Apply a CORS policy to the bucket so browsers on ``allowed_origins``
+        """Apply a CORS rule to the bucket so browsers on ``allowed_origins``
         may ``fetch`` presigned URLs (chat attachment previews, artifact byte
         reads). Without this the browser blocks the cross-origin response even
         though the object comes back — no ``Access-Control-Allow-Origin`` header.
 
-        Overwrites the bucket's CORS config with a single rule (S3 has no
-        merge — ``put_bucket_cors`` replaces the whole set), so pass every
-        origin the bucket must serve. ``GET``/``HEAD`` + the range-related
-        expose-headers are the defaults because attachment reads are byte-range
-        (``206``) requests. Raises the underlying boto exception on failure;
-        callers that must not fail closed (boot-time ensure) catch it.
+        ``put_bucket_cors`` REPLACES the whole rule set (S3 has no merge). On a
+        bucket shared with other services, dropping their rules would silently
+        break their CORS, so pass ``preserve_rules`` (typically the current
+        :meth:`get_cors` result) to keep them: the final set is those rules,
+        minus any exact duplicate of ours, plus our rule (idempotent on re-run).
+        ``preserve_rules=None`` writes only our rule — a full replace.
+
+        ``GET``/``HEAD`` + the range-related expose-headers are the defaults
+        because attachment reads are byte-range (``206``) requests. Raises
+        ``StorageFailure`` on the boto error; callers that must not fail closed
+        (a boot-time ensure) catch it.
         """
         rule: dict[str, object] = {
             "AllowedOrigins": list(allowed_origins),
@@ -191,11 +197,15 @@ class S3StorageAdapter(StorageAdapter):
             or ["Content-Range", "Content-Length", "Accept-Ranges", "ETag"],
             "MaxAgeSeconds": int(max_age_seconds),
         }
+        # Preserve other services' rules; drop an exact prior copy of ours so a
+        # re-run doesn't stack duplicates.
+        rules = [r for r in (preserve_rules or []) if r != rule]
+        rules.append(rule)
         try:
             await asyncio.to_thread(
                 self._client.put_bucket_cors,
                 Bucket=self._bucket,
-                CORSConfiguration={"CORSRules": [rule]},
+                CORSConfiguration={"CORSRules": rules},
             )
         except Exception as exc:
             raise StorageFailure(f"put_bucket_cors failed: {exc}") from exc
@@ -205,14 +215,20 @@ class S3StorageAdapter(StorageAdapter):
 
         Read-side companion to :meth:`ensure_cors` — lets a caller show the
         before/after when applying a policy. A bucket with no CORS config
-        raises ``NoSuchCORSConfiguration``; that's normalized to ``[]``.
+        raises ``NoSuchCORSConfiguration``; that alone is normalized to ``[]``.
+        Any other error (``AccessDenied``, network, DNS) is raised as a
+        ``StorageFailure`` rather than masked as "no CORS" — otherwise a
+        permissions gap would read as an empty policy and make the before/after
+        diagnostic lie.
         """
         try:
             resp = await asyncio.to_thread(
                 self._client.get_bucket_cors, Bucket=self._bucket
             )
-        except Exception:
-            return []
+        except Exception as exc:
+            if _is_no_cors(exc):
+                return []
+            raise StorageFailure(f"get_bucket_cors failed: {exc}") from exc
         rules = resp.get("CORSRules", [])
         return list(rules) if isinstance(rules, list) else []
 
@@ -326,3 +342,14 @@ def _is_missing_key(exc: Exception) -> bool:
         return False
     code = response.get("Error", {}).get("Code", "")
     return code in ("NoSuchKey", "404", "NotFound")
+
+
+def _is_no_cors(exc: Exception) -> bool:
+    """True if ``exc`` is S3's "bucket has no CORS config" error. Everything
+    else (AccessDenied, network) is a real failure the caller must see, so
+    ``get_cors`` only swallows this one code."""
+    response = getattr(exc, "response", None)
+    if not isinstance(response, dict):
+        return False
+    code = response.get("Error", {}).get("Code", "")
+    return code in ("NoSuchCORSConfiguration", "404", "NoSuchCorsConfiguration")

--- a/src/pocketpaw/uploads/s3.py
+++ b/src/pocketpaw/uploads/s3.py
@@ -9,6 +9,12 @@ Credentials are shared with interacly-backend's file storage module — same
 env var names (``S3_ENDPOINT``, ``S3_REGION``, ``S3_ACCESS_KEY_ID``,
 ``S3_SECRET_ACCESS_KEY``, ``S3_PRIVATE_BUCKET``) so one deployment can point
 both services at the same bucket.
+
+2026-07-15 (CORS-1): added ``ensure_cors``/``get_cors`` so the bucket's CORS
+policy can be applied from code (the creds already live in the deploy env)
+instead of an out-of-band ``aws s3api put-bucket-cors``. Browsers fetching
+presigned URLs (attachment previews, artifact byte reads) need the origin in
+the bucket's allowlist or the cross-origin response is blocked.
 """
 
 from __future__ import annotations
@@ -155,6 +161,60 @@ class S3StorageAdapter(StorageAdapter):
             )
         except Exception:
             return None
+
+    async def ensure_cors(
+        self,
+        allowed_origins: list[str],
+        *,
+        allowed_methods: list[str] | None = None,
+        allowed_headers: list[str] | None = None,
+        expose_headers: list[str] | None = None,
+        max_age_seconds: int = 3600,
+    ) -> None:
+        """Apply a CORS policy to the bucket so browsers on ``allowed_origins``
+        may ``fetch`` presigned URLs (chat attachment previews, artifact byte
+        reads). Without this the browser blocks the cross-origin response even
+        though the object comes back — no ``Access-Control-Allow-Origin`` header.
+
+        Overwrites the bucket's CORS config with a single rule (S3 has no
+        merge — ``put_bucket_cors`` replaces the whole set), so pass every
+        origin the bucket must serve. ``GET``/``HEAD`` + the range-related
+        expose-headers are the defaults because attachment reads are byte-range
+        (``206``) requests. Raises the underlying boto exception on failure;
+        callers that must not fail closed (boot-time ensure) catch it.
+        """
+        rule: dict[str, object] = {
+            "AllowedOrigins": list(allowed_origins),
+            "AllowedMethods": allowed_methods or ["GET", "HEAD"],
+            "AllowedHeaders": allowed_headers or ["*"],
+            "ExposeHeaders": expose_headers
+            or ["Content-Range", "Content-Length", "Accept-Ranges", "ETag"],
+            "MaxAgeSeconds": int(max_age_seconds),
+        }
+        try:
+            await asyncio.to_thread(
+                self._client.put_bucket_cors,
+                Bucket=self._bucket,
+                CORSConfiguration={"CORSRules": [rule]},
+            )
+        except Exception as exc:
+            raise StorageFailure(f"put_bucket_cors failed: {exc}") from exc
+
+    async def get_cors(self) -> list[dict]:
+        """Return the bucket's current CORS rules (empty list when none set).
+
+        Read-side companion to :meth:`ensure_cors` — lets a caller show the
+        before/after when applying a policy. A bucket with no CORS config
+        raises ``NoSuchCORSConfiguration``; that's normalized to ``[]``.
+        """
+        try:
+            resp = await asyncio.to_thread(
+                self._client.get_bucket_cors, Bucket=self._bucket
+            )
+        except Exception:
+            return []
+        rules = resp.get("CORSRules", [])
+        return list(rules) if isinstance(rules, list) else []
 
     async def list_prefix(self, prefix: str) -> list[str]:
         """Return the unique "sub-folder" names under ``prefix``.

--- a/tests/uploads/test_s3_adapter.py
+++ b/tests/uploads/test_s3_adapter.py
@@ -3,6 +3,10 @@
 Mocks the boto3 client directly rather than spinning up moto — the adapter's
 job is to translate the Protocol methods into the right boto calls, plus
 exception mapping. Integration coverage against real S3 is out of scope.
+
+2026-07-15 (CORS-1): added coverage for ensure_cors / get_cors — the boto
+put_bucket_cors / get_bucket_cors translation used to apply the bucket CORS
+policy from code.
 """
 
 from __future__ import annotations
@@ -159,3 +163,73 @@ async def test_presigned_get_swallows_errors():
 def test_local_path_returns_none():
     adapter = _make_adapter(MagicMock())
     assert adapter.local_path("any") is None
+
+
+async def test_ensure_cors_applies_default_rule():
+    client = MagicMock()
+    adapter = _make_adapter(client)
+
+    await adapter.ensure_cors(["https://paw.hzd.interacly.com"])
+
+    client.put_bucket_cors.assert_called_once()
+    kwargs = client.put_bucket_cors.call_args.kwargs
+    assert kwargs["Bucket"] == "test-bucket"
+    rules = kwargs["CORSConfiguration"]["CORSRules"]
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule["AllowedOrigins"] == ["https://paw.hzd.interacly.com"]
+    # Range reads (206) need GET/HEAD + the range expose-headers by default.
+    assert rule["AllowedMethods"] == ["GET", "HEAD"]
+    assert "Content-Range" in rule["ExposeHeaders"]
+    assert "Accept-Ranges" in rule["ExposeHeaders"]
+    assert rule["MaxAgeSeconds"] == 3600
+
+
+async def test_ensure_cors_honors_overrides():
+    client = MagicMock()
+    adapter = _make_adapter(client)
+
+    await adapter.ensure_cors(
+        ["https://a.example", "https://b.example"],
+        allowed_methods=["GET"],
+        expose_headers=["ETag"],
+        max_age_seconds=60,
+    )
+
+    rule = client.put_bucket_cors.call_args.kwargs["CORSConfiguration"]["CORSRules"][0]
+    assert rule["AllowedOrigins"] == ["https://a.example", "https://b.example"]
+    assert rule["AllowedMethods"] == ["GET"]
+    assert rule["ExposeHeaders"] == ["ETag"]
+    assert rule["MaxAgeSeconds"] == 60
+
+
+async def test_ensure_cors_wraps_client_errors():
+    client = MagicMock()
+    client.put_bucket_cors.side_effect = RuntimeError("access denied")
+    adapter = _make_adapter(client)
+
+    with pytest.raises(StorageFailure, match="access denied"):
+        await adapter.ensure_cors(["https://x.example"])
+
+
+async def test_get_cors_returns_rules():
+    client = MagicMock()
+    client.get_bucket_cors.return_value = {"CORSRules": [{"AllowedOrigins": ["*"]}]}
+    adapter = _make_adapter(client)
+
+    rules = await adapter.get_cors()
+
+    assert rules == [{"AllowedOrigins": ["*"]}]
+
+
+async def test_get_cors_normalizes_missing_config_to_empty():
+    class _NoCors(Exception):
+        def __init__(self):
+            super().__init__("none")
+            self.response = {"Error": {"Code": "NoSuchCORSConfiguration"}}
+
+    client = MagicMock()
+    client.get_bucket_cors.side_effect = _NoCors()
+    adapter = _make_adapter(client)
+
+    assert await adapter.get_cors() == []

--- a/tests/uploads/test_s3_adapter.py
+++ b/tests/uploads/test_s3_adapter.py
@@ -212,6 +212,40 @@ async def test_ensure_cors_wraps_client_errors():
         await adapter.ensure_cors(["https://x.example"])
 
 
+async def test_ensure_cors_preserves_other_rules():
+    """A shared bucket's existing rules are kept — ours is appended, theirs
+    stay — so applying our origin can't silently drop another service's CORS."""
+    client = MagicMock()
+    adapter = _make_adapter(client)
+    other = {"AllowedOrigins": ["https://other.example"], "AllowedMethods": ["PUT"]}
+
+    await adapter.ensure_cors(["https://x.example"], preserve_rules=[other])
+
+    rules = client.put_bucket_cors.call_args.kwargs["CORSConfiguration"]["CORSRules"]
+    assert other in rules
+    assert any(r["AllowedOrigins"] == ["https://x.example"] for r in rules)
+    assert len(rules) == 2
+
+
+async def test_ensure_cors_dedupes_identical_rule_on_rerun():
+    """Re-running with our own prior rule in preserve_rules doesn't stack a
+    duplicate — the exact copy is dropped before ours is appended."""
+    client = MagicMock()
+    adapter = _make_adapter(client)
+    ours = {
+        "AllowedOrigins": ["https://x.example"],
+        "AllowedMethods": ["GET", "HEAD"],
+        "AllowedHeaders": ["*"],
+        "ExposeHeaders": ["Content-Range", "Content-Length", "Accept-Ranges", "ETag"],
+        "MaxAgeSeconds": 3600,
+    }
+
+    await adapter.ensure_cors(["https://x.example"], preserve_rules=[ours])
+
+    rules = client.put_bucket_cors.call_args.kwargs["CORSConfiguration"]["CORSRules"]
+    assert rules == [ours]
+
+
 async def test_get_cors_returns_rules():
     client = MagicMock()
     client.get_bucket_cors.return_value = {"CORSRules": [{"AllowedOrigins": ["*"]}]}
@@ -233,3 +267,20 @@ async def test_get_cors_normalizes_missing_config_to_empty():
     adapter = _make_adapter(client)
 
     assert await adapter.get_cors() == []
+
+
+async def test_get_cors_raises_on_non_missing_error():
+    """A permissions/network error must NOT be masked as "no CORS" — otherwise
+    the before/after diagnostic would lie (an AccessDenied reads as empty)."""
+
+    class _Denied(Exception):
+        def __init__(self):
+            super().__init__("denied")
+            self.response = {"Error": {"Code": "AccessDenied"}}
+
+    client = MagicMock()
+    client.get_bucket_cors.side_effect = _Denied()
+    adapter = _make_adapter(client)
+
+    with pytest.raises(StorageFailure, match="get_bucket_cors failed"):
+        await adapter.get_cors()


### PR DESCRIPTION
## What

Add a code path to apply the object-storage bucket's CORS policy, so it can be set with the S3 credentials already in the deploy env (pocketpaw's `.env`) instead of an out-of-band `aws s3api put-bucket-cors`.

## Why

Browsers that `fetch` a presigned URL — chat text/code attachment previews, artifact byte reads (PDF/xlsx/3D) — need their origin in the bucket's CORS allowlist. Without it the cross-origin response is blocked:

```
Access to fetch at 'https://nbg1.your-objectstorage.com/interacly-dev-private/chat/...txt?X-Amz-...'
from origin 'https://paw.hzd.interacly.com' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

The object comes back (`206`), but the browser discards it. Setting bucket CORS previously meant configuring the aws CLI separately, even though the app already holds working S3 credentials.

## Change

- `S3StorageAdapter.ensure_cors(origins, ...)` and `get_cors()` — thin wrappers over boto `put_bucket_cors` / `get_bucket_cors`, run under `asyncio.to_thread` like the rest of the adapter. Defaults suit attachment reads: `GET`/`HEAD` methods and `Content-Range`/`Accept-Ranges`/`ETag` expose-headers, because these are byte-range (`206`) requests.
- `scripts/ensure_bucket_cors.py` — one-off runner. Builds the adapter through the existing factory (same `S3_*` env vars, `load_dotenv` included), prints the bucket's CORS before and after. Origins come from argv or `POCKETPAW_S3_CORS_ALLOWED_ORIGINS`.
- Unit tests for the default rule, overrides, error wrapping, and the no-config-→-`[]` normalization.

## How to run

From the pocketpaw repo root with `.env` populated (needs the `PutBucketCORS` action on the credentials):

```
uv run python scripts/ensure_bucket_cors.py https://paw.hzd.interacly.com
```

`put_bucket_cors` replaces the whole rule set (S3 has no merge), so pass every origin the bucket must serve in one call — note the bucket is shared with interacly-backend.

## Tests

`uv run pytest tests/uploads/test_s3_adapter.py` → 15 passed.

## Follow-up (not in this PR)

This is the tool. A natural next step is an idempotent boot-time ensure in `verify_cloud_storage_backend` gated on `POCKETPAW_S3_CORS_ALLOWED_ORIGINS`, failing soft, so deploys self-heal the policy. Left out here to keep the boot path and IAM surface unchanged until we decide we want it.
