### PR TITLE
fix(scripts): load .env in ensure_bucket_cors before building the adapter

### DIFF
--- a/scripts/ensure_bucket_cors.py
+++ b/scripts/ensure_bucket_cors.py
@@ -48,6 +48,16 @@ def _origins_from_env() -> list[str]:
 
 
 async def _main(origins: list[str], *, replace: bool) -> int:
+    # _build_s3 reads S3_* from os.environ. Unlike build_adapter it does NOT
+    # call load_dotenv itself, so load .env here (idempotent, won't override
+    # vars already in the environment) — otherwise a repo-root .env is ignored.
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+    except ImportError:
+        pass
+
     adapter = _build_s3()
     if not isinstance(adapter, S3StorageAdapter):  # pragma: no cover - defensive
         print("error: the configured upload adapter is not S3.", file=sys.stderr)


### PR DESCRIPTION
## What

`scripts/ensure_bucket_cors.py` failed with `POCKETPAW_UPLOAD_ADAPTER=s3 requires S3_PRIVATE_BUCKET to be set` even when `.env` had every S3 var, when run from the repo root.

## Why

The script calls `_build_s3()` directly. `_build_s3` reads `S3_*` from `os.environ` but does **not** call `load_dotenv` — that lives in the sibling `build_adapter()`, which the script bypasses. So a repo-root `.env` was never loaded into the environment.

## Fix

Call `load_dotenv()` in the script before `_build_s3()` (idempotent, won't override real env vars). The inline comment that already claimed the factory "calls load_dotenv defensively" was describing `build_adapter`, not the `_build_s3` path the script uses.

## Verification

Ran against the live `interacly-dev-private` bucket after the fix: the script loaded `.env`, read the existing CORS rules, and merged in the new origin. Confirmed the pre-existing interacly-backend rule was preserved (merge-by-default), not clobbered.