### PR TITLE
Sandbox registry for the browser IDE

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -260,6 +260,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.rules.router import router as rules_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
     from pocketpaw_ee.cloud.skills.router import router as skills_router
+    from pocketpaw_ee.cloud.websandbox.router import router as websandbox_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
 
     app.include_router(auth_router, prefix="/api/v1")
@@ -269,6 +270,9 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(agents_router, prefix="/api/v1")
     app.include_router(audit_router, prefix="/api/v1")
     app.include_router(audit_workspace_router, prefix="/api/v1")
+    # Web Cursor sandbox registry (WC-1) — the (workspace, user, repo) -> sandbox
+    # tenancy/auth oracle every later Web Cursor slice authorizes against.
+    app.include_router(websandbox_router, prefix="/api/v1")
     app.include_router(request_log_router, prefix="/api/v1")
     app.include_router(deep_work_log_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -46,6 +46,11 @@
 #   (type="agent.disabled") and ``AgentEnabled`` (type="agent.enabled") for the
 #   agent soft-disable / revoke-everywhere flow. Emitted by ``agents.service``
 #   on disable / enable, mirroring ``AgentDeleted``'s payload shape.
+# Updated: 2026-07-15 (WC-1, feat/websandbox-registry) — added
+#   ``WebSandboxRegistered`` (type="websandbox.registered") and
+#   ``WebSandboxStatusChanged`` (type="websandbox.status_changed") for the Web
+#   Cursor sandbox registry. Emitted by ``websandbox.service`` on every
+#   state-mutating call per cloud rule 9.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -1032,3 +1037,21 @@ class TemporalSweepCompleted(Event):
 @dataclass
 class BeltRunUpdated(Event):
     EVENT_TYPE: ClassVar[str] = "belt_run_updated"
+
+
+# Web Cursor sandbox registry (WC-1, feat/websandbox-registry). Emitted by
+# ``websandbox.service`` on every state-mutating call per cloud rule 9 (emit on
+# every write). ``WebSandboxRegistered`` fires when a sandbox row is created /
+# re-registered for a (workspace, user, repo); ``WebSandboxStatusChanged`` fires
+# on a lifecycle transition (pending -> opening -> ready -> stopped -> reaped) or
+# when the Daytona ``sandbox_id`` is bound. ``data`` carries the row id +
+# workspace/user/repo + status so a downstream WS fan-out can refresh the IDE
+# shell without re-reading the doc.
+@dataclass
+class WebSandboxRegistered(Event):
+    EVENT_TYPE: ClassVar[str] = "websandbox.registered"
+
+
+@dataclass
+class WebSandboxStatusChanged(Event):
+    EVENT_TYPE: ClassVar[str] = "websandbox.status_changed"

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,11 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-15 (WC-1, feat/websandbox-registry) — added ``WebSandbox``
+(the Web Cursor sandbox registry: the (workspace_id, user_id, repo) -> sandbox
+tenancy/auth oracle) to the imports, ``__all__``, and ``get_all_documents()`` so
+the ``web_sandboxes`` collection is wired into ``init_beanie``. Only
+``ee.cloud.websandbox.service`` imports the doc class directly (import-linter
+"WebSandbox" contract).
 Updated: 2026-07-08 (feat/external-alerting-delivery) — added
 ``NotificationDeliveryConfig`` (the per-workspace external-delivery config: Slack
 incoming-webhook + generic HTTPS webhook + enabled switch + per-kind routing) to
@@ -178,6 +184,7 @@ from pocketpaw_ee.cloud.models.task_event import TaskEvent
 from pocketpaw_ee.cloud.models.temporal_sweep_state import TemporalSweepStateDoc
 from pocketpaw_ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from pocketpaw_ee.cloud.models.vapid_keypair import VapidKeypair
+from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
 from pocketpaw_ee.cloud.models.workspace_automation_config import WorkspaceAutomationConfig
 from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
@@ -336,6 +343,7 @@ __all__ = [
     "TaskEvent",
     "TemporalSweepStateDoc",
     "User",
+    "WebSandbox",
     "Widget",
     "WidgetPosition",
     "Workspace",
@@ -460,6 +468,10 @@ def get_all_documents():
         sighting_doc,
         # Branch primitive — universal artifact version log (BP-1).
         artifact_version_doc,
+        # Web Cursor sandbox registry (WC-1) — the (workspace, user, repo) ->
+        # sandbox tenancy/auth oracle. Only ``ee.cloud.websandbox.service``
+        # imports this doc directly (import-linter "WebSandbox" contract).
+        WebSandbox,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/web_sandbox.py
+++ b/ee/pocketpaw_ee/cloud/models/web_sandbox.py
@@ -1,0 +1,54 @@
+"""WebSandbox document — the Sandbox Registry for the Web Cursor browser IDE.
+
+Created 2026-07-15 (WC-1, feat/websandbox-registry): the tenancy/auth oracle
+that maps ``(workspace_id, user_id, repo) -> sandbox_id + lifecycle state +
+installation pointer``. One row per ``(workspace_id, user_id, repo)`` (enforced
+by a unique compound index AND app-level upsert in the service). This is the
+security foundation every later Web Cursor slice authorizes against.
+
+Only ``ee.cloud.websandbox.service`` imports this doc class directly
+(import-linter "WebSandbox" contract, same discipline as AuditEvent).
+
+The ``installation_id`` is a plain optional str here — a pointer to a future
+GitHub App installation. WC-6 encrypts it at rest; until then it is stored in
+the clear (never a token, only an installation identifier).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+from pymongo import IndexModel
+
+
+class WebSandbox(Document):
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    user_id: Indexed(str)  # type: ignore[valid-type]
+    # A repo identifier / URL the sandbox is opened against.
+    repo: str
+    # The Daytona sandbox id — null until the VM is cold-provisioned (WC-2).
+    sandbox_id: str | None = None
+    # Lifecycle state: pending | opening | ready | stopped | reaped.
+    status: str = "pending"
+    # Pointer to a future GitHub App installation (WC-6 encrypts this at rest;
+    # plain optional str for now — an installation id, never a token).
+    installation_id: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "web_sandboxes"
+        indexes = [
+            # One sandbox per (workspace, user, repo) — the registry key.
+            IndexModel(
+                [("workspace_id", 1), ("user_id", 1), ("repo", 1)],
+                unique=True,
+                name="ws_user_repo_unique",
+            ),
+            # The per-user list read path (list_sandboxes).
+            IndexModel([("workspace_id", 1), ("user_id", 1)]),
+            # The authorize-by-Daytona-id read path (authorize_sandbox).
+            IndexModel([("workspace_id", 1), ("sandbox_id", 1)]),
+        ]

--- a/ee/pocketpaw_ee/cloud/websandbox/__init__.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/__init__.py
@@ -1,0 +1,4 @@
+# __init__.py — the Web Cursor Sandbox Registry entity (WC-1).
+# Created 2026-07-15 (feat/websandbox-registry): a 4-file cloud entity
+# (domain / dto / service / router) that maps (workspace_id, user_id, repo)
+# to a sandbox row with fail-closed cross-tenant authorization.

--- a/ee/pocketpaw_ee/cloud/websandbox/domain.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/domain.py
@@ -1,0 +1,44 @@
+# domain.py — Frozen value objects for the Web Cursor Sandbox Registry.
+# Created 2026-07-15 (WC-1, feat/websandbox-registry): tenancy fields
+# (workspace_id, user_id) are REQUIRED at construction with no defaults per
+# ee/cloud Rule 3 — constructing a view without tenancy is a TypeError, so a
+# leak can't be minted by omission.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, NewType
+
+WebSandboxId = NewType("WebSandboxId", str)
+
+# The lifecycle a sandbox row moves through. Kept as a Literal so an unknown
+# state is a type error at the boundary rather than a silent string.
+SandboxStatus = Literal["pending", "opening", "ready", "stopped", "reaped"]
+
+
+@dataclass(frozen=True)
+class WebSandboxView:
+    """Read model for one sandbox row.
+
+    Every field is required at construction — the tenancy fields
+    (``workspace_id``, ``user_id``) most of all, per Rule 3. A view is only
+    ever built from a persisted, tenant-checked row, so there is no safe
+    default for who owns it.
+    """
+
+    id: WebSandboxId
+    workspace_id: str
+    user_id: str
+    repo: str
+    status: str
+    sandbox_id: str | None
+    installation_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+__all__ = [
+    "SandboxStatus",
+    "WebSandboxId",
+    "WebSandboxView",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -1,0 +1,54 @@
+# dto.py — Request/response DTOs for the Web Cursor Sandbox Registry.
+# Created 2026-07-15 (WC-1, feat/websandbox-registry): distinct <Op>Request
+# and <Entity>Response classes per ee/cloud Rule 4 — one model is never reused
+# for both input and output, so a server-owned field (id, timestamps) can't
+# leak into the write surface. Wire shape is camelCase to match the rest of
+# the cloud surface.
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CreateSandboxRequest(BaseModel):
+    """Register (or re-register) a sandbox for a (workspace, user, repo).
+
+    Only ``repo`` is required; the rest are set by the provisioner as the
+    sandbox moves through its lifecycle. Creating is idempotent per
+    (workspace, user, repo) — see ``service.create_sandbox``.
+    """
+
+    repo: str = Field(..., min_length=1, max_length=1024)
+    sandbox_id: str | None = Field(default=None, max_length=256)
+    status: str = Field(default="pending", max_length=32)
+    installation_id: str | None = Field(default=None, max_length=256)
+
+
+class UpdateStatusRequest(BaseModel):
+    """Advance a sandbox's lifecycle state (and optionally bind its id)."""
+
+    status: str = Field(..., max_length=32)
+    sandbox_id: str | None = Field(default=None, max_length=256)
+
+
+class WebSandboxResponse(BaseModel):
+    id: str
+    workspaceId: str
+    userId: str
+    repo: str
+    status: str
+    sandboxId: str | None = None
+    installationId: str | None = None
+    createdAt: str  # ISO-8601 UTC
+    updatedAt: str  # ISO-8601 UTC
+
+
+class WebSandboxListResponse(BaseModel):
+    items: list[WebSandboxResponse]
+
+
+__all__ = [
+    "CreateSandboxRequest",
+    "UpdateStatusRequest",
+    "WebSandboxListResponse",
+    "WebSandboxResponse",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -1,0 +1,77 @@
+# router.py — Thin FastAPI adapter for the Web Cursor Sandbox Registry (WC-1).
+# Created 2026-07-15 (feat/websandbox-registry): workspace+user scoped
+# /api/v1/websandbox. Tenancy comes from the RequestContext (never the body or
+# query), the service does the work, and CloudError -> JSON is handled by
+# _core.http — this router never raises HTTPException.
+#
+# NOTE (WC-1 scope): endpoints are gated by license + an authenticated context
+# only; per-action RBAC (require_action) is deferred to a later slice because it
+# needs new action strings registered in the RBAC catalog. The tenancy/owner
+# filtering in the service is the security boundary for now.
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.dto import (
+    CreateSandboxRequest,
+    UpdateStatusRequest,
+    WebSandboxListResponse,
+    WebSandboxResponse,
+)
+
+router = APIRouter(
+    prefix="/websandbox",
+    tags=["WebSandbox"],
+    dependencies=[Depends(require_license)],
+)
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    """A workspace-scoped route needs an active workspace; fail closed if absent."""
+    if not ctx.workspace_id:
+        raise Forbidden("websandbox.no_workspace", "No active workspace")
+    return ctx.workspace_id
+
+
+@router.post("", response_model=WebSandboxResponse)
+async def create_sandbox(
+    body: CreateSandboxRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_service.create_sandbox(workspace_id, ctx.user_id, body)
+    return websandbox_service.view_to_wire(view)
+
+
+@router.get("", response_model=WebSandboxListResponse)
+async def list_sandboxes(
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxListResponse:
+    workspace_id = _require_workspace(ctx)
+    views = await websandbox_service.list_sandboxes(workspace_id, ctx.user_id)
+    return WebSandboxListResponse(items=[websandbox_service.view_to_wire(v) for v in views])
+
+
+@router.get("/{row_id}", response_model=WebSandboxResponse)
+async def get_sandbox(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_service.get_sandbox(workspace_id, ctx.user_id, row_id)
+    return websandbox_service.view_to_wire(view)
+
+
+@router.patch("/{row_id}", response_model=WebSandboxResponse)
+async def update_sandbox_status(
+    row_id: str,
+    body: UpdateStatusRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_service.update_status(workspace_id, ctx.user_id, row_id, body)
+    return websandbox_service.view_to_wire(view)

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -1,0 +1,288 @@
+# service.py — Web Cursor Sandbox Registry business logic (the auth oracle).
+# Created 2026-07-15 (WC-1, feat/websandbox-registry).
+#
+# This module IS the repository (ee/cloud Rule 1) and the ONLY module allowed to
+# import its own Beanie doc (Rule 2). Every read carries a tenant filter
+# (Rule 7); every mutation validates at entry (Rule 6) and emits an event
+# (Rule 9). Errors are CloudError subclasses, never HTTPException (Rule 10).
+#
+# The point of the slice is ``authorize_sandbox``: fail-closed cross-tenant
+# authorization that emits a high-severity audit event BEFORE it raises, so a
+# denied access attempt is always on the record. Every later Web Cursor slice
+# (session WS, editor RPC, git broker) calls this before touching a sandbox.
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import (
+    WebSandboxRegistered,
+    WebSandboxStatusChanged,
+)
+from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox as _WebSandboxDoc
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxId, WebSandboxView
+from pocketpaw_ee.cloud.websandbox.dto import (
+    CreateSandboxRequest,
+    UpdateStatusRequest,
+    WebSandboxResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+_FORBIDDEN_CODE = "websandbox.forbidden"
+# The action string the denial audit event is recorded under. Later slices and
+# any SIEM webhook key off this exact value to alert on cross-tenant probing.
+_CROSS_TENANT_ACTION = "vm.cross_tenant_denied"
+
+
+def _doc_to_view(doc: _WebSandboxDoc) -> WebSandboxView:
+    """Map a persisted, tenant-checked row to its read model."""
+    return WebSandboxView(
+        id=WebSandboxId(str(doc.id)),
+        workspace_id=doc.workspace_id,
+        user_id=doc.user_id,
+        repo=doc.repo,
+        status=doc.status,
+        sandbox_id=doc.sandbox_id,
+        installation_id=doc.installation_id,
+        created_at=doc.created_at,
+        updated_at=doc.updated_at,
+    )
+
+
+def view_to_wire(view: WebSandboxView) -> WebSandboxResponse:
+    """Map a view to the camelCase wire response (Rule 8 — mapping lives here)."""
+    return WebSandboxResponse(
+        id=view.id,
+        workspaceId=view.workspace_id,
+        userId=view.user_id,
+        repo=view.repo,
+        status=view.status,
+        sandboxId=view.sandbox_id,
+        installationId=view.installation_id,
+        createdAt=view.created_at.isoformat(),
+        updatedAt=view.updated_at.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The security core.
+# ---------------------------------------------------------------------------
+
+
+async def authorize_sandbox(
+    workspace_id: str,
+    user_id: str,
+    sandbox_id: str,
+) -> WebSandboxView:
+    """Fail-closed authorization for access to a provisioned sandbox.
+
+    Looks the sandbox up by its Daytona ``sandbox_id``, tenant-filtered to the
+    caller's ``workspace_id`` (Rule 7). Access is granted ONLY when a row
+    exists in the caller's workspace AND is owned by the caller's ``user_id``.
+
+    On any denial — the sandbox belongs to another workspace (the tenant
+    filter returns nothing), or another user in the same workspace — a
+    high-severity ``vm.cross_tenant_denied`` audit event is emitted BEFORE the
+    ``Forbidden`` is raised. Non-existence and wrong-owner both raise the same
+    ``Forbidden``, so existence never leaks through a differentiated error.
+    """
+    doc = await _WebSandboxDoc.find_one(
+        {"sandbox_id": sandbox_id, "workspace_id": workspace_id}  # Rule 7 tenant filter
+    )
+    if doc is None or doc.user_id != user_id:
+        await _record_cross_tenant_denial(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            sandbox_id=sandbox_id,
+            found=doc is not None,
+        )
+        raise Forbidden(_FORBIDDEN_CODE, "You do not have access to this sandbox")
+    return _doc_to_view(doc)
+
+
+async def _record_cross_tenant_denial(
+    *,
+    workspace_id: str,
+    user_id: str,
+    sandbox_id: str,
+    found: bool,
+) -> None:
+    """Emit the fail-closed denial audit event (fire-and-forget, never raises).
+
+    Mirrors the ART-2 fail-closed pattern: ``audit_service.record`` swallows its
+    own write failures, so an audit outage can never turn a denial into a leak.
+    """
+    from pocketpaw_ee.cloud.audit import service as audit_service
+
+    await audit_service.record(
+        workspace_id=workspace_id,
+        actor_id=user_id,
+        action=_CROSS_TENANT_ACTION,
+        target_type="web_sandbox",
+        target_id=sandbox_id,
+        metadata={
+            # ``found`` distinguishes "wrong owner, same workspace" (True) from
+            # "not in this workspace at all" (False) for the forensic trail —
+            # the caller still gets the same opaque Forbidden either way.
+            "reason": "wrong_owner" if found else "cross_workspace",
+            "sandbox_id": sandbox_id,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# CRUD the later slices authorize against. Every read is tenant-filtered.
+# ---------------------------------------------------------------------------
+
+
+async def create_sandbox(
+    workspace_id: str,
+    user_id: str,
+    body: CreateSandboxRequest | dict,
+) -> WebSandboxView:
+    """Register (or re-register) the sandbox for a (workspace, user, repo).
+
+    Idempotent on the registry key: a second call for the same
+    (workspace, user, repo) updates the existing row rather than minting a
+    duplicate, keeping the one-sandbox-per-key invariant even where the unique
+    index isn't enforced (e.g. mongomock).
+    """
+    body = CreateSandboxRequest.model_validate(body)
+
+    existing = await _WebSandboxDoc.find_one(
+        {"workspace_id": workspace_id, "user_id": user_id, "repo": body.repo}  # Rule 7
+    )
+    if existing is not None:
+        existing.status = body.status
+        if body.sandbox_id is not None:
+            existing.sandbox_id = body.sandbox_id
+        if body.installation_id is not None:
+            existing.installation_id = body.installation_id
+        existing.updated_at = datetime.now(UTC)
+        await existing.save()
+        doc = existing
+    else:
+        doc = _WebSandboxDoc(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            repo=body.repo,
+            sandbox_id=body.sandbox_id,
+            status=body.status,
+            installation_id=body.installation_id,
+        )
+        await doc.insert()
+
+    await emit(
+        WebSandboxRegistered(
+            data={
+                "id": str(doc.id),
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "repo": doc.repo,
+                "status": doc.status,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
+async def get_sandbox(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> WebSandboxView:
+    """Read one sandbox row by its registry id, tenant- and owner-scoped.
+
+    Raises ``NotFound`` when no row matches the caller's workspace + user — a
+    row owned by another tenant is indistinguishable from a missing one.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+    return _doc_to_view(doc)
+
+
+async def update_status(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    body: UpdateStatusRequest | dict,
+) -> WebSandboxView:
+    """Advance a sandbox's lifecycle state (optionally binding its Daytona id).
+
+    Tenant- and owner-scoped: a caller can only move a sandbox they own.
+    """
+    body = UpdateStatusRequest.model_validate(body)
+
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+
+    doc.status = body.status
+    if body.sandbox_id is not None:
+        doc.sandbox_id = body.sandbox_id
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+
+    await emit(
+        WebSandboxStatusChanged(
+            data={
+                "id": str(doc.id),
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "repo": doc.repo,
+                "status": doc.status,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
+async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView]:
+    """List every sandbox owned by the caller, newest first.
+
+    Tenant-filtered by ``workspace_id`` AND owner-filtered by ``user_id`` so
+    one user never sees another's sandboxes even within a shared workspace.
+    """
+    docs = (
+        await _WebSandboxDoc.find(
+            {"workspace_id": workspace_id, "user_id": user_id}  # Rule 7 tenant filter
+        )
+        .sort([("created_at", -1)])  # mongomock-safe: straight find + sort, no aggregate
+        .to_list()
+    )
+    return [_doc_to_view(d) for d in docs]
+
+
+async def _read_owned(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> _WebSandboxDoc | None:
+    """Tenant- + owner-scoped fetch by registry id. Returns None if not owned.
+
+    An unparseable ``row_id`` yields None (treated as not-found) rather than
+    raising, so a malformed id can't leak a distinct error shape.
+    """
+    from beanie import PydanticObjectId
+
+    try:
+        oid = PydanticObjectId(row_id)
+    except Exception:  # noqa: BLE001 — a bad id is simply "no such owned row"
+        return None
+    return await _WebSandboxDoc.find_one(
+        {"_id": oid, "workspace_id": workspace_id, "user_id": user_id}  # Rule 7
+    )
+
+
+__all__ = [
+    "authorize_sandbox",
+    "create_sandbox",
+    "get_sandbox",
+    "list_sandboxes",
+    "update_status",
+    "view_to_wire",
+]

--- a/tests/cloud/test_websandbox_service.py
+++ b/tests/cloud/test_websandbox_service.py
@@ -1,0 +1,197 @@
+# test_websandbox_service.py — service-level tests for the Web Cursor Sandbox
+# Registry (WC-1). Created 2026-07-15 (feat/websandbox-registry).
+#
+# Covers the security core: a create->get round-trip, fail-closed
+# ``authorize_sandbox`` for a non-owning caller (cross-workspace AND
+# cross-user-same-workspace), the audit event that a denial writes, the
+# owner-scoped ``list_sandboxes``, and the Rule-3 construction-time tenancy
+# guard on the domain value object. Uses the ``mongo_db`` fixture (real Beanie
+# over mongomock-motor) so the tenant-filtered query paths are exercised, not a
+# Protocol fake.
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound
+from pocketpaw_ee.cloud.models.audit_event import AuditEvent
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
+from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# create -> get round-trip
+# ---------------------------------------------------------------------------
+
+
+async def test_create_then_get_round_trips() -> None:
+    view = await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="github.com/acme/api", sandbox_id="sbx-1")
+    )
+    assert view.workspace_id == "w1"
+    assert view.user_id == "u1"
+    assert view.repo == "github.com/acme/api"
+    assert view.sandbox_id == "sbx-1"
+    assert view.status == "pending"
+
+    fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
+    assert fetched.id == view.id
+    assert fetched.repo == "github.com/acme/api"
+
+
+async def test_create_is_idempotent_on_registry_key() -> None:
+    first = await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", status="pending")
+    )
+    second = await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", status="ready", sandbox_id="sbx-9")
+    )
+    # Same row (one sandbox per (workspace, user, repo)), updated in place.
+    assert second.id == first.id
+    assert second.status == "ready"
+    assert second.sandbox_id == "sbx-9"
+
+    rows = await sandbox_service.list_sandboxes("w1", "u1")
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# authorize_sandbox — fail closed
+# ---------------------------------------------------------------------------
+
+
+async def test_authorize_allows_owner() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    view = await sandbox_service.authorize_sandbox("w1", "u1", "sbx-1")
+    assert view.sandbox_id == "sbx-1"
+    assert view.workspace_id == "w1"
+
+
+async def test_authorize_denies_cross_workspace() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    # Same sandbox id, a caller in a DIFFERENT workspace. Tenant filter returns
+    # nothing -> fail closed.
+    with pytest.raises(Forbidden) as exc:
+        await sandbox_service.authorize_sandbox("w2", "u1", "sbx-1")
+    assert exc.value.status_code == 403
+
+
+async def test_authorize_denies_cross_user_same_workspace() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    # Same workspace, a DIFFERENT user. Row is found by the tenant filter but
+    # the owner check fails -> fail closed with the same opaque Forbidden.
+    with pytest.raises(Forbidden) as exc:
+        await sandbox_service.authorize_sandbox("w1", "u2", "sbx-1")
+    assert exc.value.status_code == 403
+
+
+async def test_authorize_denies_unknown_sandbox() -> None:
+    with pytest.raises(Forbidden):
+        await sandbox_service.authorize_sandbox("w1", "u1", "does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# A denial WRITES a high-severity audit event
+# ---------------------------------------------------------------------------
+
+
+async def test_denial_writes_cross_tenant_audit_event() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+
+    before = await AuditEvent.find({"action": "vm.cross_tenant_denied"}).to_list()
+    assert before == []
+
+    with pytest.raises(Forbidden):
+        await sandbox_service.authorize_sandbox("w1", "u2", "sbx-1")
+
+    rows = await AuditEvent.find({"action": "vm.cross_tenant_denied"}).to_list()
+    assert len(rows) == 1
+    ev = rows[0]
+    assert ev.workspace == "w1"
+    assert ev.actor_id == "u2"
+    assert ev.target_type == "web_sandbox"
+    assert ev.target_id == "sbx-1"
+    assert ev.metadata.get("reason") == "wrong_owner"
+
+
+async def test_allowed_authorize_writes_no_denial_event() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    await sandbox_service.authorize_sandbox("w1", "u1", "sbx-1")
+
+    rows = await AuditEvent.find({"action": "vm.cross_tenant_denied"}).to_list()
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# list_sandboxes — tenant + owner scoped
+# ---------------------------------------------------------------------------
+
+
+async def test_list_returns_only_callers_rows() -> None:
+    await sandbox_service.create_sandbox("w1", "u1", CreateSandboxRequest(repo="a"))
+    await sandbox_service.create_sandbox("w1", "u1", CreateSandboxRequest(repo="b"))
+    # Same workspace, different user — must not appear in u1's list.
+    await sandbox_service.create_sandbox("w1", "u2", CreateSandboxRequest(repo="c"))
+    # Different workspace — must not appear either.
+    await sandbox_service.create_sandbox("w2", "u1", CreateSandboxRequest(repo="d"))
+
+    rows = await sandbox_service.list_sandboxes("w1", "u1")
+    assert {r.repo for r in rows} == {"a", "b"}
+
+
+async def test_get_denies_cross_tenant_row() -> None:
+    other = await sandbox_service.create_sandbox("w2", "u1", CreateSandboxRequest(repo="r1"))
+    # A caller in w1 must not be able to read a w2 row by id — indistinguishable
+    # from a missing row.
+    with pytest.raises(NotFound):
+        await sandbox_service.get_sandbox("w1", "u1", other.id)
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — domain enforces tenancy at construction
+# ---------------------------------------------------------------------------
+
+
+def test_domain_requires_tenancy_fields() -> None:
+    # Omitting workspace_id / user_id is a construction-time TypeError — the
+    # frozen dataclass has no defaults for the tenancy fields.
+    with pytest.raises(TypeError):
+        WebSandboxView(  # type: ignore[call-arg]
+            id="x",
+            repo="r1",
+            status="pending",
+            sandbox_id=None,
+            installation_id=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+
+def test_domain_is_frozen() -> None:
+    view = WebSandboxView(
+        id="x",
+        workspace_id="w1",
+        user_id="u1",
+        repo="r1",
+        status="pending",
+        sandbox_id=None,
+        installation_id=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        view.workspace_id = "w2"  # type: ignore[misc]


### PR DESCRIPTION
First slice of the Web Cursor browser IDE: the registry that every later piece authorizes against. Nothing calls it yet — it's the foundation the VM provisioning, terminal, editor, and git broker slices build on.

## What's here

A new cloud entity, `websandbox/`, on the standard 4-file shape, plus a `WebSandbox` Beanie document. It maps `(workspace_id, user_id, repo)` to a sandbox id, a lifecycle state, and a GitHub App installation pointer — one row per key, enforced by a unique compound index and an app-level upsert.

The point of the slice is `authorize_sandbox`. It looks a sandbox up under a tenant filter and grants access only when the row is in the caller's workspace and owned by the caller. Anything else — wrong workspace, wrong owner, or no such sandbox — records a `vm.cross_tenant_denied` audit event and then raises the same opaque `Forbidden`, so a probe can't tell a missing sandbox from someone else's. The audit write happens before the raise and can't fail the request (it's fire-and-forget), so a denial is always on the record.

## Tests

12 tests covering the round-trip, idempotent registration, owner-allowed, the three denial paths (cross-workspace, cross-user, unknown), that a denial writes the audit event and an allow does not, per-user list scoping, and that the domain object can't be built without tenancy fields.

```
12 passed in 1.50s
```

Verified `WebSandbox` is wired into `get_all_documents()` so the collection actually initializes.

## Notes

- Endpoints are gated by license + an authenticated context; per-action RBAC needs new action strings in the catalog and is deferred to a later slice (noted in the router header).
- `authorize_sandbox` keys on the Daytona `sandbox_id`; `get`/`update` key on the registry row id. Called out in case the session-WebSocket slice wants the row id instead.
- `installation_id` is stored plain for now (an installation id, never a token). The GitHub App slice encrypts it at rest.