### PR TITLE
Scoped agent discovery + gallery presentation fields

### DIFF
--- a/ee/pocketpaw_ee/cloud/agents/domain.py
+++ b/ee/pocketpaw_ee/cloud/agents/domain.py
@@ -9,11 +9,19 @@ Beanie sub-model would require touching every caller of
 Updated: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — added ``Agent.disabled``
 mirroring the new top-level flag on the Beanie doc, so callers (and the wire
 dict) can read whether an agent has been soft-disabled / revoked.
+
+Updated: 2026-07-15 (feat/agent-scoped-discover-fields, ASG-1) — added the
+additive presentation fields that mirror the new Beanie fields:
+``AgentConfigSpec.welcome_message`` / ``conversation_starters`` / ``voice`` /
+``appearance`` and ``Agent.tags``. Lists stay frozen-friendly tuples (matching
+``tools`` / ``soul_values``); ``voice`` / ``appearance`` are free-form blobs
+kept as dicts (nothing hashes these value objects — only ``!=`` equality is
+used, in ``service.update``).
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 
 
@@ -36,6 +44,11 @@ class AgentConfigSpec:
     soul_archetype: str = ""
     soul_values: tuple[str, ...] = ()
     soul_ocean: tuple[tuple[str, float], ...] = ()  # frozen-friendly dict
+    # Presentation fields (ASG-1) — mirror ``models.agent.AgentConfig``.
+    welcome_message: str = ""
+    conversation_starters: tuple[str, ...] = ()  # frozen-friendly list
+    voice: dict | None = None
+    appearance: dict = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -53,6 +66,7 @@ class Agent:
     created_at: datetime
     updated_at: datetime
     disabled: bool = False  # soft-disable / revoke-everywhere (AW-4)
+    tags: tuple[str, ...] = ()  # free-form gallery tags (ASG-1)
 
 
 __all__ = ["Agent", "AgentConfigSpec"]

--- a/ee/pocketpaw_ee/cloud/agents/dto.py
+++ b/ee/pocketpaw_ee/cloud/agents/dto.py
@@ -7,6 +7,14 @@ exactly.
 
 Updated: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — ``agent_to_dict`` now
 emits ``disabled`` so callers can see whether an agent has been soft-disabled.
+
+Updated: 2026-07-15 (feat/agent-scoped-discover-fields, ASG-1) —
+``DiscoverRequest`` gained ``scoped: bool = True`` (the gallery default that
+excludes other members' public agents). ``CreateAgentRequest`` /
+``UpdateAgentRequest`` accept the additive presentation fields
+(``welcome_message`` / ``conversation_starters`` / ``voice`` / ``appearance`` /
+``tags``); ``agent_to_dict`` (+ ``_config_to_dict``) and ``AgentResponse`` now
+emit them on the wire.
 """
 
 from __future__ import annotations
@@ -45,6 +53,13 @@ class CreateAgentRequest(BaseModel):
     soul_archetype: str = ""
     soul_values: list[str] | None = None
     soul_ocean: dict[str, float] | None = None
+    # Presentation fields (ASG-1) — additive; all optional so old clients
+    # keep working. ``welcome_message`` defaults to "" like ``system_prompt``.
+    welcome_message: str = ""
+    conversation_starters: list[str] | None = None
+    voice: dict | None = None
+    appearance: dict | None = None
+    tags: list[str] | None = None
 
     @field_validator("scopes")
     @classmethod
@@ -72,6 +87,12 @@ class UpdateAgentRequest(BaseModel):
     soul_archetype: str | None = None
     soul_values: list[str] | None = None
     soul_ocean: dict[str, float] | None = None
+    # Presentation fields (ASG-1) — all optional (None == "leave unchanged").
+    welcome_message: str | None = None
+    conversation_starters: list[str] | None = None
+    voice: dict | None = None
+    appearance: dict | None = None
+    tags: list[str] | None = None
 
     @field_validator("scopes")
     @classmethod
@@ -98,6 +119,10 @@ class DiscoverRequest(BaseModel):
     visibility: str | None = None
     page: int = Field(default=1, ge=1)
     page_size: int = Field(default=20, ge=1, le=100)
+    # When True (the gallery default) the no-explicit-visibility union excludes
+    # other members' public agents — see ``service.discover``. Pass False to
+    # restore the legacy cross-workspace public union.
+    scoped: bool = True
 
 
 # ---------------------------------------------------------------------------
@@ -123,6 +148,10 @@ def _config_to_dict(cfg: AgentConfigSpec) -> dict[str, Any]:
         "soul_archetype": cfg.soul_archetype,
         "soul_values": list(cfg.soul_values),
         "soul_ocean": dict(cfg.soul_ocean),
+        "welcome_message": cfg.welcome_message,
+        "conversation_starters": list(cfg.conversation_starters),
+        "voice": cfg.voice,
+        "appearance": dict(cfg.appearance),
     }
 
 
@@ -144,6 +173,7 @@ def agent_to_dict(agent: Agent) -> dict[str, Any]:
         "config": _config_to_dict(agent.config),
         "owner": agent.owner,
         "disabled": agent.disabled,
+        "tags": list(agent.tags),
         "createdOn": iso_utc(agent.created_at),
         "lastUpdatedOn": iso_utc(agent.updated_at),
     }
@@ -162,6 +192,7 @@ class AgentResponse(BaseModel):
     visibility: str
     config: dict
     owner: str
+    tags: list[str] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
 

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -25,6 +25,14 @@ Updated 2026-07-02 (feat/aiam-agent-revoke, AW-4 follow-up): ``get_persona``
 now returns ``None`` for a soft-disabled agent (reusing the doc it already
 loads — no extra read), so ``agent_bridge``'s smart-relevance LLM probe never
 fires for an agent ``pool.get`` would refuse to run.
+
+Updated 2026-07-15 (feat/agent-scoped-discover-fields, ASG-1): ``discover``
+grew a ``scoped`` flag (default True) — the default viewer union now OMITS the
+``{"visibility": "public"}`` clause so a public agent from another owner can
+never leak into the scoped gallery. Also threaded the additive presentation
+fields (``welcome_message`` / ``conversation_starters`` / ``voice`` /
+``appearance`` on config, ``tags`` on the agent) through the doc↔domain mappers,
+``create`` and ``update`` so they persist and round-trip on the wire.
 """
 
 from __future__ import annotations
@@ -82,6 +90,10 @@ def _config_to_domain(c: _AgentConfigDoc) -> AgentConfigSpec:
         soul_archetype=c.soul_archetype,
         soul_values=tuple(c.soul_values),
         soul_ocean=tuple(c.soul_ocean.items()),
+        welcome_message=c.welcome_message,
+        conversation_starters=tuple(c.conversation_starters),
+        voice=dict(c.voice) if c.voice is not None else None,
+        appearance=dict(c.appearance),
     )
 
 
@@ -102,6 +114,10 @@ def _config_to_doc(c: AgentConfigSpec) -> _AgentConfigDoc:
         soul_archetype=c.soul_archetype,
         soul_values=list(c.soul_values),
         soul_ocean=dict(c.soul_ocean),
+        welcome_message=c.welcome_message,
+        conversation_starters=list(c.conversation_starters),
+        voice=dict(c.voice) if c.voice is not None else None,
+        appearance=dict(c.appearance),
     )
 
 
@@ -118,6 +134,7 @@ def _to_domain(doc: _AgentDoc) -> Agent:
         created_at=getattr(doc, "createdAt", None),  # type: ignore[arg-type]
         updated_at=getattr(doc, "updatedAt", None),  # type: ignore[arg-type]
         disabled=getattr(doc, "disabled", False),
+        tags=tuple(getattr(doc, "tags", ()) or ()),
     )
 
 
@@ -147,6 +164,7 @@ def _build_create_config(body: CreateAgentRequest) -> AgentConfigSpec:
         soul_enabled=body.soul_enabled,
         soul_persona=body.persona,
         soul_archetype=body.soul_archetype or f"The {body.name}",
+        welcome_message=body.welcome_message,
     )
     overrides: dict[str, Any] = {}
     if body.temperature is not None:
@@ -167,6 +185,12 @@ def _build_create_config(body: CreateAgentRequest) -> AgentConfigSpec:
         overrides["soul_values"] = tuple(body.soul_values)
     if body.soul_ocean is not None:
         overrides["soul_ocean"] = tuple(body.soul_ocean.items())
+    if body.conversation_starters is not None:
+        overrides["conversation_starters"] = tuple(body.conversation_starters)
+    if body.voice is not None:
+        overrides["voice"] = dict(body.voice)
+    if body.appearance is not None:
+        overrides["appearance"] = dict(body.appearance)
     return replace(base, **overrides) if overrides else base
 
 
@@ -194,6 +218,12 @@ def _apply_update(current: AgentConfigSpec, body: UpdateAgentRequest) -> AgentCo
                 if isinstance(c.get("soul_ocean", dict(current.soul_ocean)), dict)
                 else current.soul_ocean
             ),
+            welcome_message=c.get("welcome_message", current.welcome_message),
+            conversation_starters=tuple(
+                c.get("conversation_starters", list(current.conversation_starters))
+            ),
+            voice=c.get("voice", current.voice),
+            appearance=dict(c.get("appearance", dict(current.appearance))),
         )
 
     overrides: dict[str, Any] = {}
@@ -206,6 +236,7 @@ def _apply_update(current: AgentConfigSpec, body: UpdateAgentRequest) -> AgentCo
         ("trust_level", body.trust_level),
         ("soul_enabled", body.soul_enabled),
         ("soul_archetype", body.soul_archetype),
+        ("welcome_message", body.welcome_message),
     ]:
         if attr is not None:
             overrides[field] = attr
@@ -223,6 +254,12 @@ def _apply_update(current: AgentConfigSpec, body: UpdateAgentRequest) -> AgentCo
         overrides["soul_ocean"] = tuple(body.soul_ocean.items())
     if body.persona is not None:
         overrides["soul_persona"] = body.persona
+    if body.conversation_starters is not None:
+        overrides["conversation_starters"] = tuple(body.conversation_starters)
+    if body.voice is not None:
+        overrides["voice"] = dict(body.voice)
+    if body.appearance is not None:
+        overrides["appearance"] = dict(body.appearance)
 
     return replace(current, **overrides) if overrides else current
 
@@ -252,6 +289,7 @@ async def create(ctx: RequestContext, workspace_id: str, body: CreateAgentReques
         visibility=body.visibility,
         owner=ctx.user_id,
         config=_config_to_doc(config),
+        tags=list(body.tags) if body.tags is not None else [],
     )
     await doc.insert()
     agent = _to_domain(doc)
@@ -322,6 +360,8 @@ async def update(ctx: RequestContext, agent_id: str, body: UpdateAgentRequest) -
         doc.avatar = body.avatar
     if body.visibility is not None:
         doc.visibility = body.visibility
+    if body.tags is not None:
+        doc.tags = list(body.tags)
     if new_config != _config_to_domain(doc.config):
         doc.config = _config_to_doc(new_config)
     await doc.save()
@@ -336,6 +376,8 @@ async def update(ctx: RequestContext, agent_id: str, body: UpdateAgentRequest) -
         payload["avatar"] = doc.avatar
     if body.visibility is not None:
         payload["visibility"] = doc.visibility
+    if body.tags is not None:
+        payload["tags"] = doc.tags
     await emit(AgentUpdated(data=payload))
     return _to_domain(doc)
 
@@ -456,11 +498,18 @@ async def discover(
     elif body.visibility == "public":
         filters["visibility"] = "public"
     else:
-        filters["$or"] = [
+        # Default viewer union. When ``scoped`` (the gallery default) the
+        # ``{"visibility": "public"}`` clause is OMITTED so a public agent owned
+        # by another member can NEVER leak in — the result is strictly
+        # {owner==me} ∪ {visibility==workspace} within this workspace. Callers
+        # that pass ``scoped=False`` get the legacy cross-workspace public union.
+        union: list[dict[str, Any]] = [
             {"workspace": workspace_id, "owner": ctx.user_id},
             {"workspace": workspace_id, "visibility": "workspace"},
-            {"visibility": "public"},
         ]
+        if not body.scoped:
+            union.append({"visibility": "public"})
+        filters["$or"] = union
     if body.query:
         filters["name"] = {"$regex": body.query, "$options": "i"}
 

--- a/ee/pocketpaw_ee/cloud/models/agent.py
+++ b/ee/pocketpaw_ee/cloud/models/agent.py
@@ -14,6 +14,11 @@
 # agent everywhere while letting in-flight runs finish. Top-level (not on
 # AgentConfig) so toggling it bumps the doc's ``updatedAt`` and the pool's
 # staleness check + explicit cache invalidation both see the change.
+# Updated 2026-07-15 (feat/agent-scoped-discover-fields, ASG-1): added additive
+# presentation fields for the Agent Gallery / Studio — ``welcome_message``,
+# ``conversation_starters``, ``voice``, ``appearance`` on AgentConfig and
+# ``tags`` on Agent. All defaulted → zero migration; ``visibility``/``owner``/
+# ``workspace`` semantics untouched.
 
 """Agent configuration document."""
 
@@ -56,6 +61,12 @@ class AgentConfig(BaseModel):
             "neuroticism": 0.2,
         }
     )
+    # Presentation fields (ASG-1) — surfaced by the Agent Gallery / Studio.
+    # All additive + defaulted, so existing docs load unchanged (no migration).
+    welcome_message: str = ""
+    conversation_starters: list[str] = Field(default_factory=list)
+    voice: dict | None = None
+    appearance: dict = Field(default_factory=dict)
 
 
 class Agent(TimestampedDocument):
@@ -71,6 +82,8 @@ class Agent(TimestampedDocument):
     # Soft-disable / revoke-everywhere (AW-4). True == the run pool refuses to
     # resolve this agent on any NEW request; in-flight runs are unaffected.
     disabled: bool = False
+    # Free-form gallery tags (ASG-1). Additive + defaulted → no migration.
+    tags: list[str] = Field(default_factory=list)
 
     class Settings:
         name = "agents"

--- a/tests/cloud/test_agent_discover_scope.py
+++ b/tests/cloud/test_agent_discover_scope.py
@@ -1,0 +1,168 @@
+"""Regression tests for ASG-1 — scoped discover + additive agent fields.
+
+Created 2026-07-15 (feat/agent-scoped-discover-fields):
+
+1. Scoped discover (the gallery default) must NEVER surface a public agent
+   owned by another member — the load-bearing invariant. Also proves the
+   ``scoped=False`` legacy union and the explicit ``visibility="public"``
+   mode still return public agents (unchanged).
+2. The new presentation fields (``welcome_message`` / ``conversation_starters``
+   / ``voice`` / ``appearance``) and top-level ``tags`` round-trip through
+   create -> get -> update on the wire dict.
+
+Exercises the real Beanie query path against the in-memory ``mongo_db``
+mongomock fixture, so the ``$or`` union the service builds is actually run.
+Agents are created with ``soul_enabled=False`` so the eager-soul pool
+materialization (which needs the OSS AgentPool) never fires in unit scope.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.agents import service as agents_service
+from pocketpaw_ee.cloud.agents.dto import (
+    CreateAgentRequest,
+    DiscoverRequest,
+    UpdateAgentRequest,
+    agent_to_dict,
+)
+
+pytestmark = pytest.mark.asyncio
+
+W1 = "w1"
+W2 = "w2"
+VIEWER = "u_viewer"
+OTHER = "u_other"
+
+
+def _ctx(user_id: str, workspace_id: str):
+    return agents_service.legacy_ctx(user_id, workspace_id)
+
+
+async def _make(owner: str, workspace: str, slug: str, visibility: str):
+    """Create an agent as ``owner`` in ``workspace`` (soul disabled)."""
+    body = CreateAgentRequest(
+        name=slug,
+        slug=slug,
+        visibility=visibility,
+        soul_enabled=False,
+    )
+    return await agents_service.create(_ctx(owner, workspace), workspace, body)
+
+
+async def _seed_discover_fixture():
+    """Owner's private + a peer's workspace/public agents, plus a cross-ws
+    public agent. Returns nothing — tests query via ``discover``."""
+    await _make(VIEWER, W1, "mine-private", "private")  # A — owner clause
+    await _make(OTHER, W1, "peer-workspace", "workspace")  # B — workspace clause
+    await _make(OTHER, W1, "peer-public", "public")  # C — must be excluded
+    await _make(OTHER, W2, "cross-ws-public", "public")  # D — must be excluded
+
+
+async def _slugs(body: DiscoverRequest) -> set[str]:
+    items = await agents_service.discover(_ctx(VIEWER, W1), W1, body)
+    return {a.slug for a in items}
+
+
+async def test_scoped_discover_excludes_public(mongo_db):  # noqa: ARG001
+    """LOAD-BEARING: the default scoped union returns {owner==me} ∪
+    {visibility==workspace} and NEVER a public agent owned by someone else."""
+    await _seed_discover_fixture()
+
+    slugs = await _slugs(DiscoverRequest())  # scoped defaults to True
+
+    assert slugs == {"mine-private", "peer-workspace"}
+    assert "peer-public" not in slugs
+    assert "cross-ws-public" not in slugs
+
+
+async def test_discover_scoped_defaults_true():
+    """The gallery relies on scoped being the default — guard it."""
+    assert DiscoverRequest().scoped is True
+
+
+async def test_unscoped_discover_restores_public_union(mongo_db):  # noqa: ARG001
+    """scoped=False keeps the legacy cross-workspace public union so existing
+    callers that opt out see public agents again."""
+    await _seed_discover_fixture()
+
+    slugs = await _slugs(DiscoverRequest(scoped=False))
+
+    assert slugs == {
+        "mine-private",
+        "peer-workspace",
+        "peer-public",
+        "cross-ws-public",
+    }
+
+
+async def test_explicit_public_visibility_unchanged_by_scoped(mongo_db):  # noqa: ARG001
+    """Explicit ``visibility="public"`` is an intentional public query — it
+    still returns public agents even though ``scoped`` defaults to True."""
+    await _seed_discover_fixture()
+
+    # scoped=True (default) must not suppress an EXPLICIT public request.
+    items = await agents_service.discover(
+        _ctx(VIEWER, W1), W1, DiscoverRequest(visibility="public")
+    )
+    slugs = {a.slug for a in items}
+
+    assert slugs == {"peer-public", "cross-ws-public"}
+
+
+async def test_config_fields_and_tags_round_trip(mongo_db):  # noqa: ARG001
+    """welcome_message / conversation_starters / voice / appearance / tags
+    persist through create -> get and update -> get on the wire dict."""
+    create = CreateAgentRequest(
+        name="Concierge",
+        slug="concierge",
+        visibility="workspace",
+        soul_enabled=False,
+        welcome_message="Hi, how can I help?",
+        conversation_starters=["Book a demo", "Pricing"],
+        voice={"provider": "elevenlabs", "voice_id": "abc123"},
+        appearance={"theme": "dark", "accent": "#4f46e5"},
+        tags=["support", "sales"],
+    )
+    created = await agents_service.create(_ctx(VIEWER, W1), W1, create)
+
+    # Read back through the wire mapper — this is what the router returns.
+    wire = agent_to_dict(await agents_service.get(created.id))
+    assert wire["config"]["welcome_message"] == "Hi, how can I help?"
+    assert wire["config"]["conversation_starters"] == ["Book a demo", "Pricing"]
+    assert wire["config"]["voice"] == {"provider": "elevenlabs", "voice_id": "abc123"}
+    assert wire["config"]["appearance"] == {"theme": "dark", "accent": "#4f46e5"}
+    assert wire["tags"] == ["support", "sales"]
+
+    # Update every new field and confirm persistence (owner is the caller).
+    update = UpdateAgentRequest(
+        welcome_message="Welcome back!",
+        conversation_starters=["Track my order"],
+        voice={"provider": "openai", "voice_id": "nova"},
+        appearance={"theme": "light"},
+        tags=["support"],
+    )
+    await agents_service.update(_ctx(VIEWER, W1), created.id, update)
+
+    wire2 = agent_to_dict(await agents_service.get(created.id))
+    assert wire2["config"]["welcome_message"] == "Welcome back!"
+    assert wire2["config"]["conversation_starters"] == ["Track my order"]
+    assert wire2["config"]["voice"] == {"provider": "openai", "voice_id": "nova"}
+    assert wire2["config"]["appearance"] == {"theme": "light"}
+    assert wire2["tags"] == ["support"]
+
+
+async def test_new_fields_default_empty_on_wire(mongo_db):  # noqa: ARG001
+    """An agent created without the new fields exposes safe empty defaults —
+    proves the change is additive (no migration, old create paths unaffected)."""
+    created = await agents_service.create(
+        _ctx(VIEWER, W1),
+        W1,
+        CreateAgentRequest(name="Plain", slug="plain", soul_enabled=False),
+    )
+    wire = agent_to_dict(await agents_service.get(created.id))
+    assert wire["config"]["welcome_message"] == ""
+    assert wire["config"]["conversation_starters"] == []
+    assert wire["config"]["voice"] is None
+    assert wire["config"]["appearance"] == {}
+    assert wire["tags"] == []


### PR DESCRIPTION
Backend groundwork for the Agent Gallery + Studio work. Two additive changes to the cloud agents domain — no behavior change for existing callers, no migration.

## Scoped discovery
`POST /agents/discover` gains a `scoped` flag (default `true`). When scoped, the default viewer union is strictly `{owner == me} ∪ {visibility == workspace}` within the caller's workspace — another member's `public` agent can no longer appear. Pass `scoped=false` to restore the previous cross-workspace public union. The explicit `visibility=private|workspace|public` modes are unchanged.

This is the guarantee the Gallery leans on: a user browsing their agents sees their own plus what their team has shared, never a stranger's public agent. (The public storefront is a separate, later surface.)

## Gallery/Studio presentation fields
Additive, defaulted fields so the Studio can author them and the Gallery can render them:

- `AgentConfig`: `welcome_message`, `conversation_starters`, `voice`, `appearance`
- `Agent`: `tags`

All default to empty (`""`, `[]`, `None`, `{}`), so existing agent docs load unchanged. Threaded through the doc↔domain↔wire path; `visibility`/`owner`/`workspace` semantics untouched; writes stay in `service.py`.

## Tests
New `tests/cloud/test_agent_discover_scope.py` (6 tests) against the real Beanie/mongomock query path. The load-bearing case seeds the viewer's private agent, a peer's workspace-shared agent, and two peer `public` agents (same workspace + cross-workspace), then asserts the scoped default returns exactly the first two. Round-trip coverage for the new fields. `217 passed` across the agent test modules; ruff clean.

## Scope
Backend only. The Gallery, Studio polish, and Publish UX land as separate paw-enterprise PRs that consume this contract. A follow-up hardening item (enforcing visibility on the direct read + group/pocket-attach paths) is tracked separately — pre-existing, out of scope here.
