### PR TITLE
Provision a VM and clone a repo into it

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -935,6 +935,30 @@ def mount_cloud(app: FastAPI) -> None:
         async def _stop_fabric_ingest() -> None:
             await stop_fabric_ingest(app)
 
+    # Web Cursor idle-TTL reaper (WC-2, feat/websandbox-vm-provision). Every
+    # ~5 minutes (POCKETPAW_WEBSANDBOX_REAP_INTERVAL_SECONDS) it reclaims
+    # dropped browser-IDE sandboxes: rows in ``ready``/``opening`` whose
+    # ``updated_at`` is older than the idle TTL
+    # (POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS, default 1800) get their Daytona VM
+    # stopped+deleted and the row marked ``reaped``. Same scheduler gate as the
+    # cycle/decisions/ingest loops so pytest runs never spawn a background loop
+    # that outlives the test; production sets POCKETPAW_CLOUD_SCHEDULER_ENABLED=
+    # true. ``start_websandbox_reaper`` also honors its own
+    # POCKETPAW_WEBSANDBOX_REAPER_ENABLED off-switch (default true).
+    if _os.environ.get("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "").lower() == "true":
+        from pocketpaw_ee.cloud.websandbox.provision import (
+            start_websandbox_reaper,
+            stop_websandbox_reaper,
+        )
+
+        @app.on_event("startup")
+        async def _start_websandbox_reaper() -> None:
+            await start_websandbox_reaper(app)
+
+        @app.on_event("shutdown")
+        async def _stop_websandbox_reaper() -> None:
+            await stop_websandbox_reaper(app)
+
     # Mandate autopilot reconciler (feat/belt-autopilot). The persisted
     # ``MandateDoc.autopilot.on`` flag is the source of truth for whether a
     # mandate's autopilot SHOULD run; the background loop itself is

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -4,6 +4,13 @@
 # for both input and output, so a server-owned field (id, timestamps) can't
 # leak into the write surface. Wire shape is camelCase to match the rest of
 # the cloud surface.
+#
+# Changed 2026-07-15 (WC-2, feat/websandbox-vm-provision): added the
+# cold-provision + file-tree DTOs — ``OpenSandboxRequest`` (the repo URL to open,
+# optional branch), ``TreeEntryResponse`` (one node in the cloned repo's file
+# tree), and ``SandboxTreeResponse`` (the tree wrapper carrying the bound Daytona
+# id). Same Rule-4 discipline: the open surface accepts only a repo + branch and
+# never a server-owned id/status.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -46,8 +53,45 @@ class WebSandboxListResponse(BaseModel):
     items: list[WebSandboxResponse]
 
 
+# ---------------------------------------------------------------------------
+# WC-2 — cold-provision + file tree.
+# ---------------------------------------------------------------------------
+
+
+class OpenSandboxRequest(BaseModel):
+    """Open a sandbox against a public repo — cold-provision a VM and clone it.
+
+    Only the repo URL (and an optional branch) crosses the wire; the Daytona
+    ``sandbox_id`` and lifecycle ``status`` are server-owned and set by the
+    provisioner as the VM boots (Rule 4 — the write surface never accepts them).
+    """
+
+    repo: str = Field(..., min_length=1, max_length=1024)
+    branch: str | None = Field(default=None, max_length=256)
+
+
+class TreeEntryResponse(BaseModel):
+    """One node in the cloned repo's file tree (a single directory level)."""
+
+    name: str
+    isDir: bool
+    size: int = 0
+
+
+class SandboxTreeResponse(BaseModel):
+    """The file tree of a ready sandbox, keyed to its bound Daytona id."""
+
+    id: str
+    sandboxId: str
+    path: str
+    entries: list[TreeEntryResponse]
+
+
 __all__ = [
     "CreateSandboxRequest",
+    "OpenSandboxRequest",
+    "SandboxTreeResponse",
+    "TreeEntryResponse",
     "UpdateStatusRequest",
     "WebSandboxListResponse",
     "WebSandboxResponse",

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -1,0 +1,366 @@
+# provision.py — Web Cursor cold-provision + file-tree orchestration + idle reaper.
+# Created 2026-07-15 (WC-2, feat/websandbox-vm-provision).
+#
+# This is the service-layer orchestration for the Web Cursor "open a repo" slice.
+# It sits ABOVE ``websandbox/service.py`` (the registry + auth oracle) and drives
+# the Daytona runtime through ``DaytonaClient``. Per ee/cloud Rule 2 it NEVER
+# touches the WebSandbox Beanie doc directly — every registry read/write goes
+# through ``service`` (create_sandbox / update_status / get_sandbox /
+# authorize_sandbox / list_reapable_sandboxes / mark_reaped). Importing the
+# DaytonaClient here (not in router/dto/domain) is the correct layer.
+#
+# Three flows live here:
+#   1. ``open_sandbox`` — upsert a registry row (pending) → opening →
+#      cold-provision a Daytona VM (auto_stop_interval=30 min) → wait for boot →
+#      clone the PUBLIC repo (no credentials) → bind the Daytona id + mark ready.
+#      On any mid-flight failure the row is marked ``stopped`` and a CloudError is
+#      raised — the row is never left stuck in ``opening`` silently, and a
+#      half-created VM is best-effort torn down.
+#   2. ``get_tree`` — resolve the row (tenant-scoped) → authorize on its Daytona
+#      id (fail-closed) → single-level ``list_files`` → the file tree.
+#   3. Idle-TTL reaper — a background sweep that reclaims rows whose ``updated_at``
+#      is older than the TTL by stopping+deleting the VM and marking the row
+#      ``reaped``. Labels are NOT used to reconcile because ``DaytonaClient.
+#      create_sandbox`` does not forward labels to the SDK; the Registry (our DB)
+#      is the source of truth instead. WC-3 will refresh ``updated_at`` on live
+#      WebSocket traffic; until then "idle" == ``updated_at`` age. The SDK's own
+#      ``auto_stop_interval=30`` min is a second, independent backstop.
+#
+# Every provisioning fn takes ``client: DaytonaClient | None = None`` (default
+# ``get_daytona_client()``) — the mandatory DI seam so tests inject a FAKE client
+# and no test ever hits real Daytona.
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
+
+from fastapi import FastAPI
+
+from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
+from pocketpaw_ee.cloud.websandbox.dto import (
+    OpenSandboxRequest,
+    SandboxTreeResponse,
+    TreeEntryResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+# The SDK backstop: a self-stop after 30 minutes of inactivity. NOTE the SDK's
+# ``auto_stop_interval`` is in MINUTES (the SDK default 3600 = 60 HOURS is a
+# latent trap); 30 is a 30-minute backstop that mirrors our idle-TTL reaper.
+_AUTO_STOP_MINUTES = 30
+
+# Daytona boot timeout (seconds) — block until the VM is ``started`` before clone.
+_BOOT_TIMEOUT_SECONDS = 120.0
+
+# ---------------------------------------------------------------------------
+# Reaper env config.
+# ---------------------------------------------------------------------------
+_DEFAULT_IDLE_TTL_SECONDS = 1800  # 30 min
+_DEFAULT_REAP_INTERVAL_SECONDS = 300  # 5 min
+_REAPER_TASK_KEY = "_websandbox_reaper_task"
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back to ``default``."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an int — falling back to %d", name, raw, default)
+        return default
+    return max(1, value)
+
+
+def _idle_ttl_seconds() -> int:
+    return _env_int("POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS", _DEFAULT_IDLE_TTL_SECONDS)
+
+
+def _reap_interval_seconds() -> int:
+    return _env_int("POCKETPAW_WEBSANDBOX_REAP_INTERVAL_SECONDS", _DEFAULT_REAP_INTERVAL_SECONDS)
+
+
+def _reaper_enabled() -> bool:
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_REAPER_ENABLED", "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+# ---------------------------------------------------------------------------
+# Repo URL validation.
+# ---------------------------------------------------------------------------
+
+
+def _validate_public_repo_url(repo: str) -> str:
+    """Validate ``repo`` is a plausible public http(s) git URL, returning it.
+
+    Fail-closed on anything that isn't an ``http``/``https`` URL with a host —
+    ``file://``, ``git@`` SSH, ``ssh://``, or bare paths are rejected so the
+    provisioner never hands the sandbox a local-path or credentialed remote.
+    """
+    candidate = (repo or "").strip()
+    if not candidate:
+        raise BadRequest("websandbox.invalid_repo", "A repository URL is required")
+    parsed = urlparse(candidate)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise BadRequest(
+            "websandbox.invalid_repo",
+            "Repository must be a public http(s) URL (e.g. https://github.com/owner/repo.git)",
+        )
+    return candidate
+
+
+def _require_client(client: DaytonaClient | None) -> DaytonaClient:
+    """Resolve the Daytona client, raising a clean CloudError when unconfigured.
+
+    ``get_daytona_client()`` returns ``None`` when the Daytona keys are unset;
+    that is an operational condition, not a bug, so it surfaces as a 503-style
+    CloudError rather than an ``AttributeError`` crash downstream.
+    """
+    resolved = client if client is not None else get_daytona_client()
+    if resolved is None:
+        raise CloudError(
+            503,
+            "websandbox.daytona_unavailable",
+            "The sandbox runtime is not configured",
+        )
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# open flow.
+# ---------------------------------------------------------------------------
+
+
+async def open_sandbox(
+    workspace_id: str,
+    user_id: str,
+    body: OpenSandboxRequest | dict,
+    client: DaytonaClient | None = None,
+) -> WebSandboxView:
+    """Cold-provision a Daytona VM and clone a PUBLIC repo into it.
+
+    Flow: upsert the registry row (``pending``) → mark ``opening`` →
+    ``create_sandbox(auto_stop_interval=30)`` → ``wait_for_sandbox`` →
+    ``git_clone`` the public repo (NO credentials) into the project dir →
+    bind the Daytona sandbox id + mark ``ready`` → return the ready view.
+
+    On any failure after the row exists, the row is advanced to ``stopped`` and a
+    ``CloudError`` is raised (never left stuck in ``opening``); a VM created before
+    the failure is best-effort stopped+deleted so a crash can't leak a live VM.
+    """
+    body = OpenSandboxRequest.model_validate(body)
+    repo_url = _validate_public_repo_url(body.repo)
+    daytona = _require_client(client)
+
+    # 1. Upsert the registry row (idempotent on workspace+user+repo) and move it
+    #    to ``opening`` so a concurrent reader sees the in-flight state.
+    row = await websandbox_service.create_sandbox(
+        workspace_id, user_id, {"repo": repo_url, "status": "pending"}
+    )
+    await websandbox_service.update_status(
+        workspace_id, user_id, row.id, {"status": "opening"}
+    )
+
+    daytona_id: str | None = None
+    try:
+        # 2. Cold-provision. auto_stop_interval is in MINUTES — 30 is the backstop.
+        info = await daytona.create_sandbox(
+            name=f"websandbox-{row.id}",
+            auto_stop_interval=_AUTO_STOP_MINUTES,
+        )
+        daytona_id = info.id
+
+        # 3. Block until the VM is booted before cloning.
+        await daytona.wait_for_sandbox(
+            daytona_id, target_state="started", timeout=_BOOT_TIMEOUT_SECONDS
+        )
+
+        # 4. Clone the PUBLIC repo — pass NO credentials (clean; no token ever
+        #    involved). Clone into the sandbox's project dir.
+        project_dir = await daytona.get_project_dir(daytona_id)
+        await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
+    except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
+        # Best-effort teardown of a half-created VM so a failure can't leak it.
+        if daytona_id is not None:
+            with contextlib.suppress(Exception):
+                await daytona.delete_sandbox(daytona_id)
+        # Never leave the row stuck in ``opening``.
+        with contextlib.suppress(Exception):
+            await websandbox_service.update_status(
+                workspace_id, user_id, row.id, {"status": "stopped"}
+            )
+        logger.warning("websandbox.open failed for repo=%s row=%s", repo_url, row.id, exc_info=True)
+        raise with_cause(
+            CloudError(502, "websandbox.provision_failed", "Failed to provision the sandbox"),
+            exc,
+        ) from exc
+
+    # 5. Bind the Daytona id and mark ready.
+    ready = await websandbox_service.update_status(
+        workspace_id, user_id, row.id, {"status": "ready", "sandbox_id": daytona_id}
+    )
+    logger.info("websandbox.open ready: row=%s daytona=%s repo=%s", row.id, daytona_id, repo_url)
+    return ready
+
+
+# ---------------------------------------------------------------------------
+# tree flow.
+# ---------------------------------------------------------------------------
+
+
+async def get_tree(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    client: DaytonaClient | None = None,
+) -> SandboxTreeResponse:
+    """Return the (single-level) file tree of a ready sandbox.
+
+    Resolves the row tenant-scoped (``get_sandbox`` raises ``NotFound`` for a
+    row the caller doesn't own), then runs the fail-closed ``authorize_sandbox``
+    on the bound Daytona id BEFORE any runtime op, then lists the project dir.
+    A row that hasn't bound a Daytona id yet (never provisioned / still opening)
+    is a 409, not a runtime crash.
+    """
+    daytona = _require_client(client)
+
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+
+    # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+
+    project_dir = await daytona.get_project_dir(row.sandbox_id)
+    files = await daytona.list_files(row.sandbox_id, project_dir)
+    entries = [
+        TreeEntryResponse(
+            name=f.name,
+            isDir=bool(getattr(f, "is_dir", False)),
+            size=int(getattr(f, "size", 0) or 0),
+        )
+        for f in files
+    ]
+    return SandboxTreeResponse(
+        id=row.id,
+        sandboxId=row.sandbox_id,
+        path=project_dir,
+        entries=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idle-TTL reaper.
+# ---------------------------------------------------------------------------
+
+
+async def reap_idle_sandboxes(
+    client: DaytonaClient | None = None,
+    *,
+    now: datetime | None = None,
+) -> int:
+    """Run ONE reaper sweep: reclaim rows idle longer than the TTL.
+
+    Finds ``ready``/``opening`` rows whose ``updated_at`` is older than the TTL
+    (via ``service.list_reapable_sandboxes`` — a deliberate global-read), stops +
+    deletes the bound Daytona VM, then marks the row ``reaped``. A row with no
+    bound Daytona id (opening that never got one) is marked ``reaped`` directly.
+    A VM whose delete FAILS is left for the next sweep (the row stays live) rather
+    than being marked reaped and leaked. Returns the count of rows reaped.
+    """
+    daytona = _require_client(client)
+    reference = now or datetime.now(UTC)
+    cutoff = reference - timedelta(seconds=_idle_ttl_seconds())
+
+    candidates = await websandbox_service.list_reapable_sandboxes(cutoff)
+    if not candidates:
+        return 0
+
+    reaped = 0
+    for row in candidates:
+        if row.sandbox_id:
+            try:
+                # stop is best-effort (delete destroys the VM regardless); a
+                # failed DELETE means we couldn't reclaim, so skip the row.
+                with contextlib.suppress(Exception):
+                    await daytona.stop_sandbox(row.sandbox_id)
+                await daytona.delete_sandbox(row.sandbox_id)
+            except Exception:  # noqa: BLE001 — leave the row for the next sweep
+                logger.warning(
+                    "websandbox.reaper: failed to delete VM %s (row %s) — retry next sweep",
+                    row.sandbox_id,
+                    row.id,
+                    exc_info=True,
+                )
+                continue
+        marked = await websandbox_service.mark_reaped(row.id)
+        if marked is not None:
+            reaped += 1
+
+    if reaped:
+        logger.info("websandbox.reaper: reaped %d idle sandbox(es)", reaped)
+    return reaped
+
+
+async def _run_reaper_loop() -> None:
+    """Background loop body — sweep, sleep, repeat. Per-pass errors are logged
+    so one bad sweep can't kill the loop; ``CancelledError`` propagates for a
+    clean shutdown."""
+    interval = _reap_interval_seconds()
+    logger.info(
+        "websandbox.reaper: loop started (interval=%ds, idle_ttl=%ds)",
+        interval,
+        _idle_ttl_seconds(),
+    )
+    while True:
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("websandbox.reaper: loop cancelled — exiting")
+            raise
+        try:
+            await reap_idle_sandboxes()
+        except Exception:  # noqa: BLE001
+            logger.exception("websandbox.reaper: sweep failed")
+
+
+async def start_websandbox_reaper(app: FastAPI) -> None:
+    """Start the idle-TTL reaper. Idempotent — a second start is a no-op. Honors
+    ``POCKETPAW_WEBSANDBOX_REAPER_ENABLED`` (default true)."""
+    if not _reaper_enabled():
+        logger.info("websandbox.reaper: disabled via POCKETPAW_WEBSANDBOX_REAPER_ENABLED")
+        return
+    existing = getattr(app.state, _REAPER_TASK_KEY, None)
+    if existing is not None and not existing.done():
+        return
+    task = asyncio.create_task(_run_reaper_loop(), name="websandbox-reaper")
+    setattr(app.state, _REAPER_TASK_KEY, task)
+
+
+async def stop_websandbox_reaper(app: FastAPI) -> None:
+    """Cancel + await the reaper loop. Safe to call multiple times."""
+    task = getattr(app.state, _REAPER_TASK_KEY, None)
+    if task is None or task.done():
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+    setattr(app.state, _REAPER_TASK_KEY, None)
+
+
+__all__ = [
+    "get_tree",
+    "open_sandbox",
+    "reap_idle_sandboxes",
+    "start_websandbox_reaper",
+    "stop_websandbox_reaper",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -8,6 +8,12 @@
 # only; per-action RBAC (require_action) is deferred to a later slice because it
 # needs new action strings registered in the RBAC catalog. The tenancy/owner
 # filtering in the service is the security boundary for now.
+#
+# Changed 2026-07-15 (WC-2, feat/websandbox-vm-provision): added the two
+# cold-provision endpoints — ``POST /websandbox/open`` (provision a Daytona VM +
+# clone a PUBLIC repo, returning the ready registry row) and
+# ``GET /websandbox/{row_id}/tree`` (the cloned repo's file tree). Both delegate
+# to ``websandbox/provision.py``; tenancy still comes only from the RequestContext.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
@@ -15,9 +21,12 @@ from fastapi import APIRouter, Depends
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
     CreateSandboxRequest,
+    OpenSandboxRequest,
+    SandboxTreeResponse,
     UpdateStatusRequest,
     WebSandboxListResponse,
     WebSandboxResponse,
@@ -75,3 +84,29 @@ async def update_sandbox_status(
     workspace_id = _require_workspace(ctx)
     view = await websandbox_service.update_status(workspace_id, ctx.user_id, row_id, body)
     return websandbox_service.view_to_wire(view)
+
+
+# ---------------------------------------------------------------------------
+# WC-2 — cold-provision + file tree.
+# ---------------------------------------------------------------------------
+
+
+@router.post("/open", response_model=WebSandboxResponse)
+async def open_sandbox(
+    body: OpenSandboxRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    """Cold-provision a Daytona VM and clone a PUBLIC repo into it."""
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_provision.open_sandbox(workspace_id, ctx.user_id, body)
+    return websandbox_service.view_to_wire(view)
+
+
+@router.get("/{row_id}/tree", response_model=SandboxTreeResponse)
+async def get_sandbox_tree(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> SandboxTreeResponse:
+    """Return the cloned repo's file tree for a ready sandbox."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_provision.get_tree(workspace_id, ctx.user_id, row_id)

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -10,6 +10,12 @@
 # authorization that emits a high-severity audit event BEFORE it raises, so a
 # denied access attempt is always on the record. Every later Web Cursor slice
 # (session WS, editor RPC, git broker) calls this before touching a sandbox.
+#
+# Changed 2026-07-15 (WC-2, feat/websandbox-vm-provision): added the two
+# system-level reaper support functions ``list_reapable_sandboxes`` (global-read)
+# and ``mark_reaped`` (global-write). The idle-TTL reaper in ``provision.py``
+# drives them; they live here so the service stays the ONLY module that touches
+# the WebSandbox Beanie doc (Rule 2).
 from __future__ import annotations
 
 import logging
@@ -257,6 +263,70 @@ async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView
     return [_doc_to_view(d) for d in docs]
 
 
+# ---------------------------------------------------------------------------
+# System-level reaper support (WC-2). The idle-TTL reaper is a background sweep
+# that acts ACROSS tenants, so these two functions are deliberately NOT
+# tenant-scoped — they carry an explicit ``# global-read`` / ``# global-write``
+# marker per Rule 7. They stay HERE (not in provision.py) so the service remains
+# the only module that touches the Beanie doc (Rule 2).
+# ---------------------------------------------------------------------------
+
+
+async def list_reapable_sandboxes(
+    cutoff: datetime,
+    statuses: tuple[str, ...] = ("ready", "opening"),
+) -> list[WebSandboxView]:
+    """List sandboxes idle since before ``cutoff`` (system reaper candidate set).
+
+    "Idle" == ``updated_at`` older than the cutoff, in a still-live state
+    (``ready`` / ``opening``). Not tenant-scoped: the reaper reclaims leaked VMs
+    for every tenant. WC-3 will refresh ``updated_at`` on live WebSocket traffic;
+    until then age alone marks a session as dropped.
+    """
+    docs = await _WebSandboxDoc.find(
+        # global-read: the idle-TTL reaper sweeps every tenant's sandboxes; this
+        # is a system sweep, not a per-request read, so no workspace filter.
+        {"status": {"$in": list(statuses)}, "updated_at": {"$lt": cutoff}}
+    ).to_list()
+    return [_doc_to_view(d) for d in docs]
+
+
+async def mark_reaped(row_id: str) -> WebSandboxView | None:
+    """Flip a sandbox row to ``reaped`` (system reaper terminal), returning the
+    updated view — or ``None`` if the row vanished mid-sweep.
+
+    Resolves the row by id ONLY (no owner filter) because the reaper is a system
+    actor, not the owning user. The emitted ``WebSandboxStatusChanged`` still
+    carries the row's own tenancy so downstream fan-out stays scoped.
+    """
+    from beanie import PydanticObjectId
+
+    try:
+        oid = PydanticObjectId(row_id)
+    except Exception:  # noqa: BLE001 — a bad id is simply "nothing to reap"
+        return None
+    # global-write: system reaper terminal state; resolve by id across tenants.
+    doc = await _WebSandboxDoc.find_one({"_id": oid})
+    if doc is None:
+        return None
+    doc.status = "reaped"
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+
+    await emit(
+        WebSandboxStatusChanged(
+            data={
+                "id": str(doc.id),
+                "workspace_id": doc.workspace_id,
+                "user_id": doc.user_id,
+                "repo": doc.repo,
+                "status": doc.status,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
 async def _read_owned(
     workspace_id: str,
     user_id: str,
@@ -282,7 +352,9 @@ __all__ = [
     "authorize_sandbox",
     "create_sandbox",
     "get_sandbox",
+    "list_reapable_sandboxes",
     "list_sandboxes",
+    "mark_reaped",
     "update_status",
     "view_to_wire",
 ]

--- a/scripts/websandbox_live_smoke.py
+++ b/scripts/websandbox_live_smoke.py
@@ -1,0 +1,79 @@
+# websandbox_live_smoke.py — ONE live Daytona smoke for the Web Cursor
+# cold-provision slice (WC-2). NOT a pytest test — kept out of CI on purpose so
+# a real VM (which costs money) is only ever provisioned when a human runs this.
+# Created 2026-07-15 (feat/websandbox-vm-provision).
+#
+# What it does: loads .env, provisions a REAL Daytona VM (auto_stop_interval=30
+# min), clones the public octocat/Hello-World repo into the project dir, lists +
+# prints the tree, and ALWAYS deletes the VM in a finally block — cleanup is
+# non-negotiable even on exception, because a leaked VM keeps billing.
+#
+# Run: .venv/Scripts/python.exe scripts/websandbox_live_smoke.py
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+REPO_URL = "https://github.com/octocat/Hello-World.git"
+AUTO_STOP_MINUTES = 30
+BOOT_TIMEOUT_SECONDS = 180.0
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+
+    client = get_daytona_client()
+    if client is None:
+        print("FAIL: Daytona is not configured (get_daytona_client() returned None).")
+        print("      Set the Daytona keys in .env and retry.")
+        return 1
+
+    sandbox_id: str | None = None
+    try:
+        print(f"Provisioning a Daytona VM (auto_stop_interval={AUTO_STOP_MINUTES} min)...")
+        info = await client.create_sandbox(
+            name="websandbox-live-smoke",
+            auto_stop_interval=AUTO_STOP_MINUTES,
+        )
+        sandbox_id = info.id
+        print(f"  created: id={sandbox_id} name={info.name} state={info.state}")
+
+        print("Waiting for the VM to boot...")
+        await client.wait_for_sandbox(
+            sandbox_id, target_state="started", timeout=BOOT_TIMEOUT_SECONDS
+        )
+        print("  booted.")
+
+        project_dir = await client.get_project_dir(sandbox_id)
+        print(f"Cloning {REPO_URL} into {project_dir} (no credentials — public repo)...")
+        await client.git_clone(sandbox_id, REPO_URL, project_dir)
+        print("  cloned.")
+
+        print("Listing the file tree:")
+        files = await client.list_files(sandbox_id, project_dir)
+        for f in files:
+            kind = "dir " if getattr(f, "is_dir", False) else "file"
+            print(f"  [{kind}] {f.name}  ({getattr(f, 'size', 0)} bytes)")
+
+        print("\nPASS: provisioned, cloned, and listed a real Daytona sandbox.")
+        return 0
+    except Exception as exc:  # noqa: BLE001 — smoke: report and still clean up
+        print(f"FAIL: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        if sandbox_id is not None:
+            try:
+                print(f"Cleaning up: deleting VM {sandbox_id}...")
+                await client.delete_sandbox(sandbox_id)
+                print(f"  VM {sandbox_id} DELETED.")
+            except Exception as cleanup_exc:  # noqa: BLE001
+                print(f"  WARNING: cleanup delete failed: {cleanup_exc}")
+                print(f"  MANUAL CLEANUP REQUIRED for sandbox {sandbox_id}")
+        await client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -1,0 +1,275 @@
+# test_websandbox_provision.py — service-level tests for the Web Cursor
+# cold-provision + file-tree + idle-reaper slice (WC-2).
+# Created 2026-07-15 (feat/websandbox-vm-provision).
+#
+# All Daytona interaction goes through a FAKE DaytonaClient injected via the DI
+# seam (``client=`` on every provisioning fn) — no test touches real Daytona.
+# The registry itself runs on real Beanie over mongomock-motor (the ``mongo_db``
+# fixture) so the tenant-filtered query paths and the reaper's global-read are
+# exercised for real.
+#
+# Covers:
+#   * open provisions (create called with auto_stop_interval=30), clones (the
+#     repo URL reaches git_clone), and the row ends ``ready`` with the Daytona
+#     sandbox_id bound.
+#   * open mid-flight failure marks the row ``stopped`` (never stuck ``opening``)
+#     and tears down the half-created VM.
+#   * open with no Daytona configured → clean CloudError, not a crash.
+#   * tree returns the fake listing AND enforces ``authorize_sandbox`` (a
+#     cross-tenant caller is Forbidden).
+#   * the reaper reclaims an idle VM (stop+delete, row -> reaped) and leaves a
+#     fresh row untouched.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.daytona.client import SandboxInfo
+from pocketpaw_ee.cloud.websandbox import provision
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFileInfo:
+    """Minimal stand-in for daytona's FileInfo (name / is_dir / size)."""
+
+    name: str
+    is_dir: bool = False
+    size: int = 0
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Records calls and returns canned data. Drop-in for DaytonaClient in the
+    DI seam. ``clone_fails`` flips ``git_clone`` into a raise to exercise the
+    provisioning-failure path."""
+
+    project_dir: str = "/home/daytona/project"
+    files: list[_FakeFileInfo] = field(
+        default_factory=lambda: [
+            _FakeFileInfo("README.md", is_dir=False, size=42),
+            _FakeFileInfo("src", is_dir=True, size=0),
+        ]
+    )
+    clone_fails: bool = False
+
+    create_calls: list[dict] = field(default_factory=list)
+    wait_calls: list[dict] = field(default_factory=list)
+    clone_calls: list[dict] = field(default_factory=list)
+    stop_calls: list[str] = field(default_factory=list)
+    delete_calls: list[str] = field(default_factory=list)
+    _counter: int = 0
+
+    async def create_sandbox(self, name, auto_stop_interval=3600, **kwargs):  # noqa: ANN001
+        self._counter += 1
+        sid = f"dtn-{self._counter}"
+        self.create_calls.append(
+            {"name": name, "auto_stop_interval": auto_stop_interval, "id": sid}
+        )
+        return SandboxInfo(id=sid, name=name, state="creating")
+
+    async def wait_for_sandbox(self, sandbox_id, target_state="started", timeout=120.0):  # noqa: ANN001
+        self.wait_calls.append(
+            {"id": sandbox_id, "target_state": target_state, "timeout": timeout}
+        )
+        return SandboxInfo(id=sandbox_id, name="", state="started")
+
+    async def get_project_dir(self, sandbox_id):  # noqa: ANN001
+        return self.project_dir
+
+    async def git_clone(self, sandbox_id, repo_url, path, branch=None, commit_id=None):  # noqa: ANN001
+        if self.clone_fails:
+            raise RuntimeError("boom: clone failed")
+        self.clone_calls.append(
+            {"id": sandbox_id, "repo_url": repo_url, "path": path, "branch": branch}
+        )
+
+    async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
+        return list(self.files)
+
+    async def stop_sandbox(self, sandbox_id):  # noqa: ANN001
+        self.stop_calls.append(sandbox_id)
+
+    async def delete_sandbox(self, sandbox_id):  # noqa: ANN001
+        self.delete_calls.append(sandbox_id)
+
+
+# ---------------------------------------------------------------------------
+# open flow.
+# ---------------------------------------------------------------------------
+
+
+async def test_open_provisions_clones_and_marks_ready() -> None:
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1",
+        "u1",
+        {"repo": "https://github.com/octocat/Hello-World.git"},
+        client=fake,
+    )
+
+    # Cold-provision fired with the 30-MINUTE backstop (not the SDK's 60h default).
+    assert len(fake.create_calls) == 1
+    assert fake.create_calls[0]["auto_stop_interval"] == 30
+
+    # It waited for boot before cloning, then cloned the exact repo URL.
+    assert len(fake.wait_calls) == 1
+    assert len(fake.clone_calls) == 1
+    assert fake.clone_calls[0]["repo_url"] == "https://github.com/octocat/Hello-World.git"
+    assert fake.clone_calls[0]["path"] == fake.project_dir
+
+    # The row ended ``ready`` with the Daytona id bound.
+    assert view.status == "ready"
+    assert view.sandbox_id == "dtn-1"
+
+    # And the persisted row agrees.
+    fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
+    assert fetched.status == "ready"
+    assert fetched.sandbox_id == "dtn-1"
+
+
+async def test_open_failure_marks_stopped_and_tears_down_vm() -> None:
+    fake = _FakeDaytonaClient(clone_fails=True)
+    with pytest.raises(CloudError) as exc:
+        await provision.open_sandbox(
+            "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+        )
+    assert exc.value.code == "websandbox.provision_failed"
+
+    # The half-created VM was torn down.
+    assert fake.delete_calls == ["dtn-1"]
+
+    # The row is ``stopped`` — never left stuck in ``opening``.
+    rows = await sandbox_service.list_sandboxes("w1", "u1")
+    assert len(rows) == 1
+    assert rows[0].status == "stopped"
+
+
+async def test_open_rejects_non_http_repo() -> None:
+    fake = _FakeDaytonaClient()
+    with pytest.raises(CloudError) as exc:
+        await provision.open_sandbox(
+            "w1", "u1", {"repo": "git@github.com:acme/api.git"}, client=fake
+        )
+    assert exc.value.code == "websandbox.invalid_repo"
+    # Nothing was provisioned.
+    assert fake.create_calls == []
+
+
+async def test_open_without_daytona_raises_clean_error(monkeypatch) -> None:
+    # get_daytona_client() -> None when Daytona keys are unset; must be a clean
+    # CloudError, not an AttributeError crash on a None client.
+    monkeypatch.setattr(provision, "get_daytona_client", lambda: None)
+    with pytest.raises(CloudError) as exc:
+        await provision.open_sandbox(
+            "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=None
+        )
+    assert exc.value.code == "websandbox.daytona_unavailable"
+    assert exc.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# tree flow.
+# ---------------------------------------------------------------------------
+
+
+async def test_tree_returns_listing_for_owner() -> None:
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+    )
+    tree = await provision.get_tree("w1", "u1", view.id, client=fake)
+
+    assert tree.sandboxId == "dtn-1"
+    assert tree.path == fake.project_dir
+    names = {(e.name, e.isDir) for e in tree.entries}
+    assert names == {("README.md", False), ("src", True)}
+
+
+async def test_tree_denies_cross_tenant_caller() -> None:
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+    )
+    # A caller in a DIFFERENT workspace must not resolve the row at all
+    # (get_sandbox is NotFound before authorize even runs) — never the listing.
+    with pytest.raises(CloudError):
+        await provision.get_tree("w2", "u1", view.id, client=fake)
+
+
+async def test_tree_not_ready_when_unprovisioned() -> None:
+    # A registry row that never bound a Daytona id is a clean 409, not a crash.
+    row = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git", "status": "pending"}
+    )
+    fake = _FakeDaytonaClient()
+    with pytest.raises(CloudError) as exc:
+        await provision.get_tree("w1", "u1", row.id, client=fake)
+    assert exc.value.code == "websandbox.not_ready"
+
+
+# ---------------------------------------------------------------------------
+# idle-TTL reaper.
+# ---------------------------------------------------------------------------
+
+
+async def _age_row(row_id: str, *, seconds: int) -> None:
+    """Push a row's ``updated_at`` into the past (test-only doc touch)."""
+    from beanie import PydanticObjectId
+    from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox
+
+    doc = await WebSandbox.find_one({"_id": PydanticObjectId(row_id)})
+    assert doc is not None
+    doc.updated_at = datetime.now(UTC) - timedelta(seconds=seconds)
+    await doc.save()
+
+
+async def test_reaper_reclaims_idle_and_spares_fresh(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS", "1800")
+
+    idle = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "r-idle", "status": "ready", "sandbox_id": "dtn-idle"}
+    )
+    fresh = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "r-fresh", "status": "ready", "sandbox_id": "dtn-fresh"}
+    )
+    # Age the idle row well past the 1800s TTL; leave the fresh one at "now".
+    await _age_row(idle.id, seconds=7200)
+
+    fake = _FakeDaytonaClient()
+    reaped = await provision.reap_idle_sandboxes(client=fake)
+
+    assert reaped == 1
+    # The idle VM was stopped then deleted; the fresh one was left alone.
+    assert fake.delete_calls == ["dtn-idle"]
+    assert "dtn-idle" in fake.stop_calls
+    assert "dtn-fresh" not in fake.delete_calls
+
+    assert (await sandbox_service.get_sandbox("w1", "u1", idle.id)).status == "reaped"
+    assert (await sandbox_service.get_sandbox("w1", "u1", fresh.id)).status == "ready"
+
+
+async def test_reaper_marks_unprovisioned_idle_row_reaped(monkeypatch) -> None:
+    # An ``opening`` row that never bound a Daytona id is still reclaimable — no
+    # VM to delete, just flip it to ``reaped`` so it stops looking in-flight.
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS", "1800")
+    stuck = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "r-stuck", "status": "opening"}
+    )
+    await _age_row(stuck.id, seconds=7200)
+
+    fake = _FakeDaytonaClient()
+    reaped = await provision.reap_idle_sandboxes(client=fake)
+
+    assert reaped == 1
+    assert fake.delete_calls == []  # nothing to delete
+    assert (await sandbox_service.get_sandbox("w1", "u1", stuck.id)).status == "reaped"


### PR DESCRIPTION
Second slice of the browser IDE, stacked on the sandbox registry (#1719). This one boots a real VM and gets code into it — no auth yet, a public repo URL is enough to prove the runtime works end to end.

## What's here

`POST /websandbox/open` takes a public repo URL, registers a row, provisions a cold Daytona sandbox, waits for it to boot, clones the repo in with no credentials, and marks the row ready with the sandbox id bound. `GET /websandbox/{id}/tree` authorizes the caller against the registry and lists the tree. Orchestration lives in a new `provision.py` in the service layer; the registry doc is still only ever touched through `service.py`.

A background reaper sweeps sandboxes whose row has gone idle past a TTL, stops and deletes the VM, and marks the row reaped. If the delete fails it leaves the row for the next sweep rather than marking it reaped over a VM that's still alive. It's wired into the cloud lifespan under the existing scheduler gate, with `POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS` (1800), `POCKETPAW_WEBSANDBOX_REAP_INTERVAL_SECONDS` (300), and `POCKETPAW_WEBSANDBOX_REAPER_ENABLED`.

One thing worth calling out from reading the Daytona docs: `auto_stop_interval` is in minutes, not seconds. The SDK default of 3600 means a VM sits idle for 60 hours before it self-stops. This slice passes 30 explicitly as a backstop under the reaper. The legacy daytona path still passes 3600 — worth a separate look.

## Tests

9 unit tests over a faked Daytona client (injected through a DI seam, so nothing in CI hits real infra): open provisions/clones/marks-ready, tree enforces tenancy, the reaper reclaims an idle VM and spares a fresh one, and a missing Daytona client surfaces a clean error instead of crashing. WC-1's 12 registry tests still pass.

```
21 passed in 3.28s
```

I also ran a one-off live smoke against real Daytona (kept out of CI): it provisioned a VM, cloned octocat/Hello-World, listed the tree with the real README and .git present, and deleted the VM in a finally block. Output confirms the delete.

## Notes

- A cross-tenant caller on `/tree` gets a not-found, not a forbidden — the row is resolved through the owner-scoped read first, so existence never leaks. `authorize_sandbox` stays as a second guard on the sandbox id.
- The clone lands in the sandbox home (`get_project_dir()` returns `/root`), so the tree shows home dotfiles alongside the repo. A later slice can move it to a dedicated subdir if we want a cleaner root.
- Tree listing is single-level for now.

Stacked on #1719 — review/merge that first. Merge this base with rebase, not squash, per the stacked-PR rule.