### PR TITLE
Stream a real terminal from the VM to the browser

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -704,6 +704,13 @@ def mount_cloud(app: FastAPI) -> None:
 
     app.add_api_websocket_route("/ws/cloud", websocket_endpoint)
 
+    # Web Cursor terminal WS (WC-3) — one PTY-over-WS shell per session, bound to
+    # the owning sandbox's Daytona VM. Mounted at root (not /api/v1) so the SPA
+    # connects to ws://host/ws/websandbox/<row_id>?token=<ws_ticket>.
+    from pocketpaw_ee.cloud.websandbox.ws import terminal_websocket_endpoint
+
+    app.add_api_websocket_route("/ws/websandbox/{row_id}", terminal_websocket_endpoint)
+
     # License endpoint (no auth)
     @app.get("/api/v1/license", tags=["License"])
     async def license_info():

--- a/ee/pocketpaw_ee/cloud/auth/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/service.py
@@ -118,6 +118,23 @@ async def get_home_pocket_id(user_id: str) -> str | None:
     return doc.home_pocket_id
 
 
+async def get_active_workspace(user_id: str) -> str | None:
+    """Return the user's ``active_workspace`` id, or None if unset.
+
+    Takes a plain ``user_id`` (not a ``RequestContext``) so callers outside the
+    HTTP request cycle — notably the Web Cursor terminal WebSocket, which only
+    holds the ``user_id`` decoded from a ws_ticket — can resolve the caller's
+    workspace without minting a context. This is the same membership field the
+    ``request_context`` dependency reads (``user.active_workspace``); exposing it
+    here keeps ``models.user`` reads inside the auth entity (Rule 2). Returns
+    None when the user has no active workspace so the caller can fail closed.
+    """
+    doc = await _UserDoc.get(PydanticObjectId(user_id))
+    if doc is None:
+        raise NotFound("user", user_id)
+    return doc.active_workspace
+
+
 async def claim_home_pocket_id(user_id: str, new_pocket_id: str, *, expected: str | None) -> bool:
     """Atomically set ``home_pocket_id`` to ``new_pocket_id`` — but only if
     it still holds ``expected``. Returns ``True`` when the swap took.

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -16,6 +16,12 @@
 # and ``mark_reaped`` (global-write). The idle-TTL reaper in ``provision.py``
 # drives them; they live here so the service stays the ONLY module that touches
 # the WebSandbox Beanie doc (Rule 2).
+#
+# Changed 2026-07-15 (WC-3, feat/websandbox-terminal-ws): added
+# ``touch_activity`` — an owner-scoped ``updated_at`` heartbeat the terminal
+# WebSocket calls (throttled) on live traffic so the WC-2 idle reaper doesn't
+# reclaim a VM someone is actively using. It stays here (not in ws.py) so the
+# service remains the only module that writes the Beanie doc (Rule 2).
 from __future__ import annotations
 
 import logging
@@ -247,6 +253,35 @@ async def update_status(
     return _doc_to_view(doc)
 
 
+async def touch_activity(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> bool:
+    """Bump a sandbox row's ``updated_at`` to mark it as actively in use.
+
+    Tenant- and owner-scoped: only the owning caller can refresh their own
+    session's liveness. Returns ``True`` when a row was touched, ``False`` when
+    no owned row matched (e.g. it was already reaped) — the terminal socket
+    treats a missing row as a benign no-op rather than an error.
+
+    The idle-TTL reaper (WC-2) reclaims ``ready``/``opening`` rows whose
+    ``updated_at`` predates the TTL; without this heartbeat a long, quiet
+    terminal session would be reaped mid-use. The caller throttles it (at most
+    once per ~60s per socket) so a burst of keystrokes is one write, not one
+    write per frame.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        return False
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: a high-frequency liveness heartbeat, not a state change —
+    # downstream handlers (search index, ripple invalidation) don't need it and
+    # fanning out per-touch would be pure noise.
+    return True
+
+
 async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView]:
     """List every sandbox owned by the caller, newest first.
 
@@ -355,6 +390,7 @@ __all__ = [
     "list_reapable_sandboxes",
     "list_sandboxes",
     "mark_reaped",
+    "touch_activity",
     "update_status",
     "view_to_wire",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/terminal.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/terminal.py
@@ -1,0 +1,139 @@
+# terminal.py — Web Cursor PTY-over-WebSocket bridge (WC-3).
+# Created 2026-07-15 (feat/websandbox-terminal-ws).
+#
+# This is the socket-agnostic core of the terminal slice: it opens a REAL bash
+# PTY session inside a Daytona VM and pumps its output to an injected async
+# ``sink``. ``ws.py`` wires the sink to ``websocket.send_bytes`` for the browser;
+# the live-smoke script wires it to an in-memory buffer — the SAME code path,
+# minus the socket.
+#
+# Why the bridge holds the handle directly (the "handle gap"):
+# ``DaytonaClient.create_pty_session`` DISCARDS the ``AsyncPtyHandle`` the SDK
+# returns (it returns None), so you cannot send keystrokes through the shared
+# client wrapper. Rather than change that shared method (WC-2 and others depend
+# on its signature), this bridge grabs the sandbox instance itself
+# (``client.get_sandbox_instance``) and holds the handle, whose ``send_input``
+# writes INTO the pty. Resize and kill go back through the client wrapper
+# methods (``resize_pty`` / ``kill_pty``) — those work without the handle.
+from __future__ import annotations
+
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+
+from daytona import PtySize
+
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+
+logger = logging.getLogger(__name__)
+
+# Terminal output sink: forwards raw VM bytes onward (to the WS as a binary
+# frame, or to an in-memory buffer in the smoke test).
+OutputSink = Callable[[bytes], Awaitable[None]]
+
+# Sane default terminal geometry when the client hasn't sent a resize yet.
+DEFAULT_COLS = 80
+DEFAULT_ROWS = 24
+
+
+class PtyBridge:
+    """One live bash PTY session in a Daytona VM, bridged to an async sink.
+
+    Lifecycle: ``start`` opens the pty and begins streaming output to the sink;
+    ``send_input`` writes keystrokes; ``resize`` changes the terminal geometry;
+    ``close`` tears the session down. One bridge == one pty session == one
+    WebSocket connection. The ``session_id`` MUST be unique per connection so a
+    second socket for the same VM never collides with an existing session.
+    """
+
+    def __init__(
+        self,
+        client: DaytonaClient,
+        sandbox_id: str,
+        session_id: str,
+        sink: OutputSink,
+    ) -> None:
+        self._client = client
+        self._sandbox_id = sandbox_id
+        self._session_id = session_id
+        self._sink = sink
+        self._handle = None
+        self._closed = False
+
+    async def _on_data(self, data: bytes) -> None:
+        """SDK callback: forward one chunk of terminal output to the sink.
+
+        Never lets a sink failure propagate back into the SDK's read loop — a
+        broken socket must not crash the pty reader; the WS handler tears the
+        bridge down on the next receive error instead.
+        """
+        if self._closed:
+            return
+        try:
+            await self._sink(data)
+        except Exception:  # noqa: BLE001 — a dead sink shouldn't kill the reader
+            logger.debug("pty sink failed for session=%s; dropping chunk", self._session_id)
+
+    async def start(self, cols: int = DEFAULT_COLS, rows: int = DEFAULT_ROWS) -> None:
+        """Open the pty session and start streaming its output to the sink.
+
+        Grabs the SDK sandbox instance and creates the pty session directly so
+        we KEEP the handle (the client wrapper would discard it). Blocks until
+        the underlying WebSocket to the pty is connected so the first
+        ``send_input`` isn't dropped on a not-yet-open socket.
+        """
+        sb = await self._client.get_sandbox_instance(self._sandbox_id)
+        self._handle = await sb.process.create_pty_session(
+            self._session_id,
+            self._on_data,
+            pty_size=PtySize(rows=rows, cols=cols),
+        )
+        # Wait until the pty WebSocket is live before we accept input. Guarded by
+        # hasattr so a minimal fake handle in tests needn't implement it.
+        waiter = getattr(self._handle, "wait_for_connection", None)
+        if waiter is not None:
+            await waiter()
+        logger.info(
+            "pty bridge started: sandbox=%s session=%s size=%dx%d",
+            self._sandbox_id,
+            self._session_id,
+            cols,
+            rows,
+        )
+
+    async def send_input(self, data: str | bytes) -> None:
+        """Write keystrokes INTO the pty via the held handle."""
+        if self._closed or self._handle is None:
+            return
+        await self._handle.send_input(data)
+
+    async def resize(self, cols: int, rows: int) -> None:
+        """Resize the pty. Routed through the client wrapper (no handle needed)."""
+        if self._closed:
+            return
+        await self._client.resize_pty(self._sandbox_id, self._session_id, cols, rows)
+
+    async def close(self) -> None:
+        """Tear the pty session down. Idempotent and never raises.
+
+        Kills the server-side session (so the shell process doesn't leak) and
+        disconnects the local handle. Both are best-effort: teardown runs in a
+        ``finally`` on the socket, and a disconnected VM must not turn cleanup
+        into an error.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        with contextlib.suppress(Exception):
+            await self._client.kill_pty(self._sandbox_id, self._session_id)
+        if self._handle is not None:
+            disconnect = getattr(self._handle, "disconnect", None)
+            if disconnect is not None:
+                with contextlib.suppress(Exception):
+                    await disconnect()
+        logger.info(
+            "pty bridge closed: sandbox=%s session=%s", self._sandbox_id, self._session_id
+        )
+
+
+__all__ = ["DEFAULT_COLS", "DEFAULT_ROWS", "OutputSink", "PtyBridge"]

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -1,0 +1,228 @@
+# ws.py — Web Cursor terminal WebSocket endpoint + connection manager (WC-3).
+# Created 2026-07-15 (feat/websandbox-terminal-ws).
+#
+# One authenticated WebSocket per Web Cursor session streams a REAL bash shell
+# from the owning tenant's Daytona VM to the browser. Structure mirrors the chat
+# WS (accept -> authenticate -> active loop -> disconnect) and reuses the same
+# single-use ws_ticket auth, because browsers can't set auth headers on a WS
+# upgrade.
+#
+# Connect flow (fail-closed at every step; a PTY is opened ONLY after all pass):
+#   accept-gate: license present -> ticket in ?token= present
+#   consume_ws_ticket(token) -> user_id           (single-use, Redis fail-closed)
+#   auth_service.get_active_workspace(user_id)     -> workspace_id
+#   websandbox_service.get_sandbox(ws, user, row)  -> row (NotFound if not owned)
+#   row.sandbox_id present (row is ``ready``)      (else 1008 not-ready)
+#   authorize_sandbox(ws, user, row.sandbox_id)    -> bind socket to the VM
+# Any failure closes 1008 BEFORE accept/PTY — a second user's ticket for someone
+# else's row is denied by get_sandbox/authorize_sandbox before any PTY opens.
+#
+# Message framing: client->server JSON — {"type":"input","data":"<str>"},
+# {"type":"resize","cols":N,"rows":N}, {"type":"ping"}. server->client — raw
+# BINARY frames carry terminal output (cleanest for xterm); pong is JSON. On
+# live traffic the row's ``updated_at`` is bumped (throttled ~60s) so the WC-2
+# idle reaper doesn't reclaim an active session.
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+
+from fastapi import Query, WebSocket, WebSocketDisconnect
+
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.auth import service as auth_service
+from pocketpaw_ee.cloud.auth.ws_tickets import consume_ws_ticket
+from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+from pocketpaw_ee.cloud.license import get_license
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.terminal import DEFAULT_COLS, DEFAULT_ROWS, PtyBridge
+
+logger = logging.getLogger(__name__)
+
+# WS close codes. 1008 == policy violation (auth / authz denial). 4003 mirrors
+# the chat WS "enterprise license required". 1011 == internal error (PTY open
+# failed after auth succeeded).
+_CLOSE_POLICY = 1008
+_CLOSE_LICENSE = 4003
+_CLOSE_INTERNAL = 1011
+
+# Minimum seconds between activity heartbeats per socket (throttle): a burst of
+# keystrokes becomes one ``updated_at`` write, not one per frame.
+_ACTIVITY_THROTTLE_SECONDS = 60.0
+
+
+class _ActivityThrottle:
+    """Rate-limit the per-socket ``updated_at`` heartbeat.
+
+    ``should_touch(now)`` returns True the first time and then at most once per
+    ``_ACTIVITY_THROTTLE_SECONDS``. Kept as a tiny testable unit so the throttle
+    logic is verified without a live socket.
+    """
+
+    def __init__(self, interval: float = _ACTIVITY_THROTTLE_SECONDS) -> None:
+        self._interval = interval
+        self._last: float | None = None
+
+    def should_touch(self, now: float) -> bool:
+        if self._last is None or (now - self._last) >= self._interval:
+            self._last = now
+            return True
+        return False
+
+
+class TerminalConnectionManager:
+    """Tracks the live pty bridge behind each terminal socket for teardown.
+
+    Deliberately minimal versus the chat ``ConnectionManager`` — the terminal
+    has no presence, no rooms, no fan-out. Its one job is to guarantee that
+    every accepted socket's pty session is killed exactly once when the socket
+    goes away, so a dropped browser tab never leaks a shell in the VM.
+    """
+
+    def __init__(self) -> None:
+        self._bridges: dict[WebSocket, PtyBridge] = {}
+
+    def register(self, websocket: WebSocket, bridge: PtyBridge) -> None:
+        self._bridges[websocket] = bridge
+
+    async def unregister(self, websocket: WebSocket) -> None:
+        bridge = self._bridges.pop(websocket, None)
+        if bridge is not None:
+            await bridge.close()
+
+    def active_count(self) -> int:
+        return len(self._bridges)
+
+
+# Module-level singleton (mirrors chat.ws.manager).
+manager = TerminalConnectionManager()
+
+
+async def terminal_websocket_endpoint(
+    websocket: WebSocket,
+    row_id: str,
+    token: str | None = Query(None),
+) -> None:
+    """Stream a real bash PTY from the owning sandbox's VM to the browser.
+
+    See the module docstring for the full connect/auth flow. The ws_ticket is
+    consumed (single-use) BEFORE accept; any auth/authz failure closes 1008 and
+    never opens a PTY.
+    """
+    # License gate — parity with the REST /websandbox routes and chat WS.
+    lic = get_license()
+    if lic is None or lic.expired:
+        await websocket.close(code=_CLOSE_LICENSE, reason="Enterprise license required")
+        return
+
+    # Path 1 — single-use ws_ticket in ?token= (the only auth path the browser
+    # can use on a cross-origin WS upgrade). No ticket -> no access.
+    if not token:
+        await websocket.close(code=_CLOSE_POLICY, reason="Missing ticket")
+        return
+    user_id = await consume_ws_ticket(token)
+    if not user_id:
+        await websocket.close(code=_CLOSE_POLICY, reason="Invalid ticket")
+        return
+
+    # Resolve the caller's workspace from the same membership field the HTTP
+    # request context reads. Fail closed if the user has no active workspace.
+    try:
+        workspace_id = await auth_service.get_active_workspace(user_id)
+    except CloudError:
+        workspace_id = None
+    if not workspace_id:
+        await websocket.close(code=_CLOSE_POLICY, reason="No active workspace")
+        return
+
+    # Resolve + authorize the sandbox row. get_sandbox is tenant+owner scoped
+    # (NotFound for a row the caller doesn't own); authorize_sandbox is the
+    # fail-closed oracle bound to the Daytona id. Either denial -> 1008, no PTY.
+    try:
+        row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+        if not row.sandbox_id:
+            await websocket.close(code=_CLOSE_POLICY, reason="Sandbox not ready")
+            return
+        await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+    except CloudError:
+        await websocket.close(code=_CLOSE_POLICY, reason="Access denied")
+        return
+
+    client = get_daytona_client()
+    if client is None:
+        await websocket.close(code=_CLOSE_LICENSE, reason="Sandbox runtime unavailable")
+        return
+
+    # Every gate passed — accept the socket and open the PTY.
+    await websocket.accept()
+
+    session_id = f"term-{uuid.uuid4().hex}"
+
+    async def _sink(data: bytes) -> None:
+        # Raw terminal bytes go to the browser as binary frames (xterm-friendly).
+        await websocket.send_bytes(data)
+
+    bridge = PtyBridge(client, row.sandbox_id, session_id, _sink)
+    try:
+        await bridge.start(cols=DEFAULT_COLS, rows=DEFAULT_ROWS)
+    except Exception:
+        logger.exception("pty open failed: row=%s sandbox=%s", row_id, row.sandbox_id)
+        await bridge.close()
+        await websocket.close(code=_CLOSE_INTERNAL, reason="Failed to open terminal")
+        return
+
+    manager.register(websocket, bridge)
+    throttle = _ActivityThrottle()
+
+    async def _touch() -> None:
+        """Bump the row's activity heartbeat, throttled, swallowing errors."""
+        if not throttle.should_touch(time.monotonic()):
+            return
+        try:
+            await websandbox_service.touch_activity(workspace_id, user_id, row_id)
+        except Exception:  # noqa: BLE001 — a heartbeat miss must not drop the session
+            logger.debug("activity touch failed for row=%s", row_id)
+
+    try:
+        while True:
+            raw = await websocket.receive_text()
+            try:
+                msg = json.loads(raw)
+            except (ValueError, TypeError):
+                continue  # ignore malformed frames rather than tearing down
+            if not isinstance(msg, dict):
+                continue
+
+            mtype = msg.get("type")
+            if mtype == "input":
+                data = msg.get("data")
+                if isinstance(data, str):
+                    await bridge.send_input(data)
+                    await _touch()
+            elif mtype == "resize":
+                cols = msg.get("cols")
+                rows = msg.get("rows")
+                if isinstance(cols, int) and isinstance(rows, int) and cols > 0 and rows > 0:
+                    await bridge.resize(cols, rows)
+                    await _touch()
+            elif mtype == "ping":
+                # Keep the socket warm through idle-closing edge proxies.
+                await websocket.send_json({"type": "pong"})
+    except WebSocketDisconnect:
+        pass
+    except RuntimeError as exc:
+        # Starlette raises RuntimeError("WebSocket is not connected") when
+        # receive is called after the peer already disconnected. Treat as a
+        # normal close; re-raise anything else.
+        if "not connected" not in str(exc).lower():
+            logger.exception("terminal WS error: row=%s", row_id)
+    except Exception:
+        logger.exception("terminal WS error: row=%s", row_id)
+    finally:
+        # Teardown: kill the pty session so the shell doesn't leak in the VM.
+        await manager.unregister(websocket)
+
+
+__all__ = ["TerminalConnectionManager", "manager", "terminal_websocket_endpoint"]

--- a/scripts/websandbox_terminal_smoke.py
+++ b/scripts/websandbox_terminal_smoke.py
@@ -1,0 +1,107 @@
+# websandbox_terminal_smoke.py — ONE live Daytona smoke for the Web Cursor
+# terminal / PTY-over-WS slice (WC-3). NOT a pytest test — kept out of CI on
+# purpose so a real VM (which costs money) is only ever provisioned when a human
+# runs this. Created 2026-07-15 (feat/websandbox-terminal-ws).
+#
+# What it does: loads .env, provisions a REAL Daytona VM, opens a bash PTY via
+# the SAME PtyBridge the WebSocket endpoint uses (minus the socket — the sink is
+# an in-memory buffer), sends ``echo paw-smoke-ok``, collects the shell output
+# for a couple of seconds, asserts the echo came back, resizes once, then ALWAYS
+# deletes the VM in a finally block — cleanup is non-negotiable even on
+# exception, because a leaked VM keeps billing.
+#
+# Run: .venv/Scripts/python.exe scripts/websandbox_terminal_smoke.py
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+AUTO_STOP_MINUTES = 30
+BOOT_TIMEOUT_SECONDS = 180.0
+MARKER = "paw-smoke-ok"
+COLLECT_SECONDS = 4.0
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+    from pocketpaw_ee.cloud.websandbox.terminal import PtyBridge
+
+    client = get_daytona_client()
+    if client is None:
+        print("FAIL: Daytona is not configured (get_daytona_client() returned None).")
+        print("      Set the Daytona keys in .env and retry.")
+        return 1
+
+    sandbox_id: str | None = None
+    bridge: PtyBridge | None = None
+    output = bytearray()
+
+    async def sink(data: bytes) -> None:
+        # The exact hook the WS handler wires to websocket.send_bytes.
+        output.extend(data)
+
+    try:
+        print(f"Provisioning a Daytona VM (auto_stop_interval={AUTO_STOP_MINUTES} min)...")
+        info = await client.create_sandbox(
+            name="websandbox-terminal-smoke",
+            auto_stop_interval=AUTO_STOP_MINUTES,
+        )
+        sandbox_id = info.id
+        print(f"  created: id={sandbox_id} name={info.name} state={info.state}")
+
+        print("Waiting for the VM to boot...")
+        await client.wait_for_sandbox(
+            sandbox_id, target_state="started", timeout=BOOT_TIMEOUT_SECONDS
+        )
+        print("  booted.")
+
+        print("Opening a bash PTY through PtyBridge (same code path as the WS)...")
+        bridge = PtyBridge(client, sandbox_id, "term-smoke", sink)
+        await bridge.start(cols=100, rows=30)
+        print("  pty open.")
+
+        print(f"Sending: echo {MARKER}")
+        await bridge.send_input(f"echo {MARKER}\n")
+
+        # Give the shell a moment to echo the command + print the result.
+        await asyncio.sleep(COLLECT_SECONDS)
+
+        print("Resizing the pty to 120x40...")
+        await bridge.resize(120, 40)
+
+        text = output.decode(errors="replace")
+        print("--- collected terminal output ---")
+        print(text.strip() or "<empty>")
+        print("---------------------------------")
+
+        if MARKER in text:
+            print(f"\nPASS: the real shell echoed back '{MARKER}'.")
+            return 0
+        print(f"\nFAIL: marker '{MARKER}' not found in terminal output.")
+        return 1
+    except Exception as exc:  # noqa: BLE001 — smoke: report and still clean up
+        print(f"FAIL: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        if bridge is not None:
+            try:
+                await bridge.close()
+                print("  pty session killed.")
+            except Exception as close_exc:  # noqa: BLE001
+                print(f"  WARNING: pty close failed: {close_exc}")
+        if sandbox_id is not None:
+            try:
+                print(f"Cleaning up: deleting VM {sandbox_id}...")
+                await client.delete_sandbox(sandbox_id)
+                print(f"  VM {sandbox_id} DELETED.")
+            except Exception as cleanup_exc:  # noqa: BLE001
+                print(f"  WARNING: cleanup delete failed: {cleanup_exc}")
+                print(f"  MANUAL CLEANUP REQUIRED for sandbox {sandbox_id}")
+        await client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/cloud/test_websandbox_terminal.py
+++ b/tests/cloud/test_websandbox_terminal.py
@@ -1,0 +1,384 @@
+# test_websandbox_terminal.py — unit tests for the Web Cursor terminal
+# WebSocket + PTY bridge slice (WC-3). Created 2026-07-15
+# (feat/websandbox-terminal-ws).
+#
+# The auth/authz core runs on REAL Beanie over mongomock-motor (the ``mongo_db``
+# fixture) with a REAL seeded user, so the connect flow exercises the genuine
+# tenant/owner-scoped query paths (get_active_workspace -> get_sandbox ->
+# authorize_sandbox). All Daytona interaction goes through a FAKE client + FAKE
+# pty handle injected via monkeypatch — no test touches real Daytona.
+#
+# The endpoint is driven directly with a ``FakeWebSocket`` rather than Starlette's
+# TestClient: the handler authenticates on real async Beanie and opens a pty
+# before its receive loop, which the sync TestClient portal can't drive cleanly.
+# Direct invocation mirrors the WC-2 provision tests (call the unit with fakes)
+# and covers the whole accept -> auth -> PTY -> stream -> resize -> teardown flow.
+#
+# Covers:
+#   * valid ticket + owned ready sandbox -> PTY opened; an input frame reaches
+#     handle.send_input; the echoed VM output is forwarded as a binary frame;
+#     a resize frame calls resize_pty; disconnect kills the pty (no leak).
+#   * missing / invalid ticket -> closed 1008, no PTY, no accept.
+#   * valid ticket but a sandbox the caller does NOT own -> denied, no PTY.
+#   * not-ready row (no bound sandbox_id) -> closed 1008, no PTY.
+#   * activity heartbeat is throttled (many frames -> one touch) and bumps
+#     updated_at at the service level.
+#   * the _ActivityThrottle unit gates to first-call-then-interval.
+from __future__ import annotations
+
+import os
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+
+import pytest
+from fastapi import WebSocketDisconnect
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
+from pocketpaw_ee.cloud.websandbox.ws import _ActivityThrottle, terminal_websocket_endpoint
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLicense:
+    """A present, non-expired license (the WS gate only reads ``.expired``)."""
+
+    expired = False
+
+
+class _FakeHandle:
+    """Stand-in for the SDK's AsyncPtyHandle.
+
+    ``send_input`` records the keystrokes AND echoes them back through the
+    ``on_data`` callback — modelling a real shell echo so a single input frame
+    exercises both the input path (into the pty) and the output path (out to the
+    socket).
+    """
+
+    def __init__(self, on_data) -> None:  # noqa: ANN001
+        self._on_data = on_data
+        self.sent: list[str | bytes] = []
+        self.connected = True
+
+    async def wait_for_connection(self) -> None:
+        return None
+
+    async def send_input(self, data: str | bytes) -> None:
+        self.sent.append(data)
+        # Echo like a real pty so the output-forwarding path is exercised.
+        payload = data.encode() if isinstance(data, str) else data
+        await self._on_data(b"echo:" + payload)
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.handle: _FakeHandle | None = None
+
+    async def create_pty_session(self, session_id, on_data, cwd=None, envs=None, pty_size=None):  # noqa: ANN001
+        self.handle = _FakeHandle(on_data)
+        return self.handle
+
+
+class _FakeSandbox:
+    def __init__(self) -> None:
+        self.process = _FakeProcess()
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Drop-in for DaytonaClient: holds one sandbox, records resize/kill."""
+
+    sandbox: _FakeSandbox = field(default_factory=_FakeSandbox)
+    resize_calls: list[dict] = field(default_factory=list)
+    kill_calls: list[str] = field(default_factory=list)
+
+    async def get_sandbox_instance(self, sandbox_id):  # noqa: ANN001
+        return self.sandbox
+
+    async def resize_pty(self, sandbox_id, session_id, cols, rows):  # noqa: ANN001
+        self.resize_calls.append({"cols": cols, "rows": rows})
+
+    async def kill_pty(self, sandbox_id, session_id):  # noqa: ANN001
+        self.kill_calls.append(session_id)
+
+
+class FakeWebSocket:
+    """Minimal async WebSocket double for direct endpoint invocation.
+
+    Feeds a queue of already-serialized client frames via ``receive_text`` and
+    records ``accept`` / ``close`` / ``send_bytes`` / ``send_json``. When the
+    inbound queue drains it raises ``WebSocketDisconnect`` to end the receive
+    loop — the same signal Starlette raises when the browser tab closes.
+    """
+
+    def __init__(self, inbound: list[str] | None = None) -> None:
+        self._inbound: deque[str] = deque(inbound or [])
+        self.accepted = False
+        self.closed: tuple[int, str | None] | None = None
+        self.sent_bytes: list[bytes] = []
+        self.sent_json: list[dict] = []
+        self.cookies: dict[str, str] = {}
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.closed = (code, reason)
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent_bytes.append(data)
+
+    async def send_json(self, data: dict) -> None:
+        self.sent_json.append(data)
+
+    async def receive_text(self) -> str:
+        if not self._inbound:
+            raise WebSocketDisconnect(1000)
+        return self._inbound.popleft()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / seeding.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_user(active_workspace: str | None) -> str:
+    """Seed a real User doc (fastapi-users) and set its active workspace."""
+    from pocketpaw_ee.cloud.auth.core import UserCreate, UserManager, get_user_db
+    from pocketpaw_ee.cloud.models.user import User as UserDoc
+
+    email = f"wc3-{os.urandom(4).hex()}@example.com"
+    async for db in get_user_db():
+        manager = UserManager(db)
+        user = await manager.create(UserCreate(email=email, password="StrongPass123!"))
+        doc = await UserDoc.get(user.id)
+        doc.active_workspace = active_workspace
+        await doc.save()
+        return str(user.id)
+    raise RuntimeError("user db iterator exhausted")  # pragma: no cover
+
+
+async def _seed_ready_sandbox(workspace_id: str, user_id: str) -> str:
+    """Register a ``ready`` sandbox row with a bound Daytona id; return row id."""
+    view = await sandbox_service.create_sandbox(
+        workspace_id,
+        user_id,
+        CreateSandboxRequest(
+            repo="https://github.com/acme/api.git", status="ready", sandbox_id="dtn-1"
+        ),
+    )
+    return view.id
+
+
+@pytest.fixture
+def wire_terminal(monkeypatch):
+    """Patch the ws module's collaborators: license, ticket consume, Daytona.
+
+    Returns the FakeDaytonaClient so tests inspect resize/kill calls. The ticket
+    consume is a table lookup keyed on the token string so tests can assert the
+    valid/invalid split without Redis.
+    """
+    client = _FakeDaytonaClient()
+    tokens: dict[str, str] = {}
+
+    async def _fake_consume(token: str) -> str | None:
+        return tokens.get(token)
+
+    monkeypatch.setattr(terminal_ws, "get_license", lambda: _FakeLicense())
+    monkeypatch.setattr(terminal_ws, "consume_ws_ticket", _fake_consume)
+    monkeypatch.setattr(terminal_ws, "get_daytona_client", lambda: client)
+    # Fresh manager so active_count assertions are isolated per test.
+    monkeypatch.setattr(terminal_ws, "manager", terminal_ws.TerminalConnectionManager())
+    return client, tokens
+
+
+# ---------------------------------------------------------------------------
+# Happy path.
+# ---------------------------------------------------------------------------
+
+
+async def test_valid_ticket_opens_pty_streams_and_resizes(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"input","data":"echo hi\\n"}',
+            '{"type":"resize","cols":120,"rows":40}',
+            '{"type":"ping"}',
+        ]
+    )
+
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    # Socket was accepted (all auth gates passed) and never force-closed.
+    assert ws.accepted is True
+    assert ws.closed is None
+
+    # Input reached the pty handle.
+    handle = client.sandbox.process.handle
+    assert handle is not None
+    assert handle.sent == ["echo hi\n"]
+
+    # The pty echo was forwarded to the browser as a binary frame.
+    assert b"echo:echo hi\n" in ws.sent_bytes
+
+    # Resize routed through the client wrapper.
+    assert client.resize_calls == [{"cols": 120, "rows": 40}]
+
+    # Ping answered with a pong JSON frame.
+    assert {"type": "pong"} in ws.sent_json
+
+    # Disconnect tore the pty down (no leaked session).
+    assert client.kill_calls  # kill_pty was called
+    assert handle.connected is False
+
+
+# ---------------------------------------------------------------------------
+# Auth failures — no PTY ever opens.
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_ticket_closes_1008_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")  # existence irrelevant; no token supplied
+
+    ws = FakeWebSocket()
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+async def test_invalid_ticket_closes_1008_no_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    tokens["good-ticket"] = "someone"
+
+    ws = FakeWebSocket()
+    await terminal_websocket_endpoint(ws, "any-row", token="WRONG")
+
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+async def test_ticket_valid_but_sandbox_not_owned_is_denied(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    owner_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", owner_id)
+
+    # A DIFFERENT user in the same workspace holds a valid ticket for THIS row.
+    intruder_id = await _seed_user("w1")
+    tokens["intruder-ticket"] = intruder_id
+
+    ws = FakeWebSocket(inbound=['{"type":"input","data":"whoami\\n"}'])
+    await terminal_websocket_endpoint(ws, row_id, token="intruder-ticket")
+
+    # get_sandbox is owner-scoped -> NotFound -> 1008 before any PTY.
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+async def test_not_ready_sandbox_closes_1008_no_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    # A pending row with NO bound Daytona id.
+    view = await sandbox_service.create_sandbox(
+        "w1",
+        user_id,
+        CreateSandboxRequest(repo="https://github.com/acme/api.git", status="pending"),
+    )
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket()
+    await terminal_websocket_endpoint(ws, view.id, token="good-ticket")
+
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+# ---------------------------------------------------------------------------
+# Activity heartbeat — throttled, and it bumps updated_at.
+# ---------------------------------------------------------------------------
+
+
+async def test_activity_touch_is_throttled_to_one_per_burst(wire_terminal, monkeypatch) -> None:
+    _client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    calls = {"n": 0}
+    real_touch = sandbox_service.touch_activity
+
+    async def _counting_touch(ws_id, uid, rid):  # noqa: ANN001
+        calls["n"] += 1
+        return await real_touch(ws_id, uid, rid)
+
+    monkeypatch.setattr(terminal_ws.websandbox_service, "touch_activity", _counting_touch)
+
+    # Five input frames in one burst — the throttle should collapse them to one
+    # heartbeat write (first call touches, the rest are inside the interval).
+    ws = FakeWebSocket(inbound=['{"type":"input","data":"x"}'] * 5)
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert calls["n"] == 1
+
+
+async def test_touch_activity_bumps_updated_at() -> None:
+    user_id = "u1"
+    view = await sandbox_service.create_sandbox(
+        "w1", user_id, CreateSandboxRequest(repo="r1", status="ready", sandbox_id="dtn-9")
+    )
+
+    # Force the stored updated_at into the past so a bump is observable.
+    from beanie import PydanticObjectId
+    from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox as _Doc
+
+    doc = await _Doc.get(PydanticObjectId(view.id))
+    old = datetime.now(UTC) - timedelta(hours=1)
+    doc.updated_at = old
+    await doc.save()
+
+    touched = await sandbox_service.touch_activity("w1", user_id, view.id)
+    assert touched is True
+
+    doc2 = await _Doc.get(PydanticObjectId(view.id))
+    # mongomock round-trips datetimes as tz-naive; compare tz-agnostically.
+    def _naive(dt: datetime) -> datetime:
+        return dt.replace(tzinfo=None)
+
+    assert _naive(doc2.updated_at) > _naive(old)
+
+    # A non-owning caller can't touch it.
+    assert await sandbox_service.touch_activity("w1", "other", view.id) is False
+
+
+# ---------------------------------------------------------------------------
+# Throttle unit.
+# ---------------------------------------------------------------------------
+
+
+def test_activity_throttle_gates_to_interval() -> None:
+    throttle = _ActivityThrottle(interval=60.0)
+    assert throttle.should_touch(1000.0) is True  # first call always touches
+    assert throttle.should_touch(1030.0) is False  # inside the window
+    assert throttle.should_touch(1061.0) is True  # past the window
+    assert throttle.should_touch(1090.0) is False  # inside the new window


### PR DESCRIPTION
Third slice, stacked on the VM provisioning (#1721). The VM has a shell — this gets it into the browser over one authenticated WebSocket, which is what the old cloud terminal never managed (it imported a function that didn't exist, and the local path was a Unix-only singleton).

## What's here

A `/ws/websandbox/{row_id}` WebSocket endpoint and a socket-agnostic `PtyBridge`. The bridge holds the Daytona PTY handle directly (the shared `DaytonaClient.create_pty_session` throws the handle away, so there's no way to send keystrokes through it) and pumps VM output to a sink; the endpoint wires that sink to binary WebSocket frames, which is what xterm wants.

Auth reuses the existing single-use ws-ticket, because a browser can't put an Authorization header on a WebSocket upgrade. The connect path is fail-closed the whole way down: license, then ticket, then active workspace, then an owner-scoped registry read, then a ready check, then the `authorize_sandbox` oracle on the Daytona id. Any failure closes 1008 before the socket is even accepted, so a PTY only ever opens for a caller who owns that sandbox. Someone else's ticket for your `row_id` never gets past the registry read.

Client sends `{type:input}` and `{type:resize}`; the server streams output as binary and answers `{type:ping}` with a pong to survive idle proxies. Live traffic bumps the row's `updated_at` (throttled to once a minute) so the idle reaper from the last slice doesn't reclaim a session someone's actively using. On disconnect the `finally` kills the PTY so a closed tab never leaks a shell in the VM.

## Tests

8 unit tests: a valid ticket on an owned sandbox opens the PTY and round-trips input/resize/output; an invalid or missing ticket closes 1008 with no PTY; a valid ticket on a sandbox you don't own is denied before any PTY; disconnect kills the session; the activity throttle collapses a keystroke burst into one write. WC-1/WC-2 still green.

```
29 passed in 4.29s
```

Live smoke against real Daytona (out of CI): provisioned a VM, opened a PTY through the same bridge code the socket uses, sent `echo paw-smoke-ok`, and the real shell echoed it back. VM deleted in a finally block.

## Notes

- The ticket is consumed before the authz check, so a denied connect still spends it. That's intended — a ticket is one connection attempt.
- The prompt I worked from said `handle.send(bytes)`; the real SDK method is `handle.send_input`. Used the real one, confirmed live.
- Skipped the optional `sb.refresh_activity()` SDK call — the reaper reads the registry `updated_at`, and the VM's own 30-minute auto-stop is an independent backstop.

Stacked on #1721 (which is stacked on #1719). Merge the bases with rebase, not squash.