### PR TITLE
File read, write, and list over the session socket

### DIFF
--- a/ee/pocketpaw_ee/cloud/websandbox/files.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/files.py
@@ -1,0 +1,255 @@
+# files.py — Web Cursor file read/write/list RPC core (WC-4a).
+# Created 2026-07-15 (feat/websandbox-file-rpc).
+#
+# Socket-agnostic sibling of terminal.py's PtyBridge: this is the file-operation
+# half of the session WebSocket, multiplexed alongside the terminal on the SAME
+# authenticated socket. The browser editor round-trips directory listings, file
+# reads, and file writes through here; ws.py just parses one JSON frame and calls
+# ``FileRpc.dispatch``. Keeping the logic here (taking a DaytonaClient + a
+# sandbox_id, resolving the project dir lazily) makes the whole path-jail + size
+# guard unit-testable with a fake client and no socket.
+#
+# SECURITY — path jail (the core of this slice): every client path is relative to
+# the sandbox's PROJECT DIR (``client.get_project_dir``). A path is resolved by
+# LEXICALLY normalizing ``<project_dir>/<rel>`` with posixpath (collapsing ``.``
+# and ``..``) and asserting the result is the project dir or lives under it.
+# ``..`` escapes and absolute paths both fail that check and return a
+# ``file.error`` — they NEVER reach download_file/upload_bytes. The jail is
+# lexical rather than realpath-based on purpose: the VM filesystem is REMOTE, so
+# resolving remote symlinks would need a shell round-trip, and it would buy no
+# security here anyway — the socket is already owner-bound to the caller's OWN VM
+# (license -> ws_ticket -> get_sandbox -> authorize_sandbox in ws.py), so a
+# symlink inside it can only point at files the owner already fully controls via
+# the terminal. The jail's job is to stop a crafted ``path`` frame from escaping
+# the project dir, and lexical normalization does exactly that.
+#
+# Frame contract (client->server / server->client), reqId echoed for correlation:
+#   file.list  {path}          -> file.list.ok  {path, entries:[{name,path,isDir,size}]}
+#   file.read  {path}          -> file.read.ok  {path, content}
+#   file.write {path, content} -> file.write.ok {path}
+#   any failure                -> file.error    {op, message}
+# Responses are JSON text frames; terminal output stays binary, so the two
+# multiplexed streams never collide. Content is UTF-8 TEXT (binary is out of
+# scope for v1); a non-UTF-8 read returns file.error rather than corrupting the
+# socket. A size cap (POCKETPAW_WEBSANDBOX_MAX_FILE_KB, default 1024) bounds both
+# read and write so one giant file can't blow up the frame.
+from __future__ import annotations
+
+import logging
+import os
+import posixpath
+
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+
+logger = logging.getLogger(__name__)
+
+# File-op size cap (KB). Applies to a read's downloaded bytes AND a write's
+# encoded content, so neither a huge file nor a huge payload can blow up the
+# multiplexed socket frame. Override via POCKETPAW_WEBSANDBOX_MAX_FILE_KB.
+_DEFAULT_MAX_FILE_KB = 1024
+
+
+def _max_file_bytes() -> int:
+    """Per-file size cap in bytes (``POCKETPAW_WEBSANDBOX_MAX_FILE_KB``, default 1024)."""
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_MAX_FILE_KB", "").strip()
+    kb = _DEFAULT_MAX_FILE_KB
+    if raw:
+        try:
+            kb = int(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_WEBSANDBOX_MAX_FILE_KB=%r; using %d", raw, kb
+            )
+    return max(kb, 1) * 1024
+
+
+class FileRpcError(Exception):
+    """A file op failed cleanly — carried back to the browser as a ``file.error``
+    frame, never raised out of the socket loop. ``op`` is ``list|read|write``."""
+
+    def __init__(self, op: str, message: str) -> None:
+        super().__init__(message)
+        self.op = op
+        self.message = message
+
+
+def _jail(project_dir: str, rel_path: str, op: str) -> str:
+    """Resolve ``rel_path`` under ``project_dir`` and assert it stays inside.
+
+    Lexically normalizes ``<project_dir>/<rel_path>`` with posixpath (VM is
+    Linux; use posixpath NOT os.path so this is correct when the test/host is
+    Windows) and requires the result to be the project dir or live under it.
+    Absolute paths and ``..`` escapes both fail the containment check. Raises
+    :class:`FileRpcError` on any escape or empty path — the caller turns that
+    into a ``file.error`` frame, so download/upload is never reached for a
+    traversal attempt.
+    """
+    if not isinstance(rel_path, str) or not rel_path.strip():
+        raise FileRpcError(op, "a 'path' (relative to the project dir) is required")
+
+    root = posixpath.normpath(project_dir)
+    # posixpath.join drops the left side entirely if rel_path is absolute, so an
+    # absolute path resolves outside the root and is rejected below (belt: the
+    # explicit is_absolute check makes the intent obvious).
+    if posixpath.isabs(rel_path):
+        raise FileRpcError(op, "absolute paths are not allowed; use a path relative to the project")
+
+    resolved = posixpath.normpath(posixpath.join(root, rel_path))
+    if resolved != root and not resolved.startswith(root + "/"):
+        raise FileRpcError(op, "path escapes the project directory")
+    return resolved
+
+
+def _rel_entry_path(rel_dir: str, name: str) -> str:
+    """Build the project-relative path of an entry ``name`` inside ``rel_dir``.
+
+    The browser passes these straight back into a follow-up file op, so they must
+    stay relative to the project root (never absolute). ``.``/empty dir -> just
+    the name."""
+    base = "" if rel_dir.strip() in ("", ".", "./") else rel_dir.strip().strip("/")
+    joined = posixpath.normpath(posixpath.join(base, name)) if base else name
+    return joined.lstrip("/")
+
+
+class FileRpc:
+    """File list/read/write over a Daytona VM, jailed to its project dir.
+
+    One instance per session socket. Holds the DaytonaClient + sandbox_id (both
+    already resolved + owner-authorized by ws.py) and resolves the project dir
+    once, lazily. ``dispatch`` takes a parsed ``file.*`` frame and returns the
+    response frame dict to send back (or ``None`` for a non-file frame, so the
+    ws loop falls through to terminal handling). Op failures come back as a
+    ``file.error`` frame — this class never raises into the socket loop.
+    """
+
+    def __init__(
+        self,
+        client: DaytonaClient,
+        sandbox_id: str,
+        project_dir: str | None = None,
+    ) -> None:
+        self._client = client
+        self._sandbox_id = sandbox_id
+        self._project_dir = project_dir
+
+    async def _root(self) -> str:
+        """Resolve + cache the sandbox project dir (the jail root)."""
+        if self._project_dir is None:
+            self._project_dir = await self._client.get_project_dir(self._sandbox_id)
+        return self._project_dir
+
+    # ── Ops (raise FileRpcError on failure) ───────────────────────────────
+
+    async def list_dir(self, rel_path: str) -> list[dict]:
+        """List a directory. Entries carry project-relative paths for the browser."""
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "list")
+        try:
+            infos = await self._client.list_files(self._sandbox_id, abs_path)
+        except FileNotFoundError as exc:
+            raise FileRpcError("list", f"no such directory: {rel_path}") from exc
+        entries: list[dict] = []
+        for info in infos:
+            name = getattr(info, "name", None)
+            if not name:
+                continue
+            entries.append(
+                {
+                    "name": name,
+                    "path": _rel_entry_path(rel_path, name),
+                    "isDir": bool(getattr(info, "is_dir", False)),
+                    "size": int(getattr(info, "size", 0) or 0),
+                }
+            )
+        return entries
+
+    async def read_file(self, rel_path: str) -> str:
+        """Read a UTF-8 text file. Missing file / oversize / binary -> FileRpcError."""
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "read")
+        try:
+            data = await self._client.download_file(self._sandbox_id, abs_path)
+        except FileNotFoundError as exc:
+            raise FileRpcError("read", f"no such file: {rel_path}") from exc
+        if data is None:
+            raise FileRpcError("read", f"no such file: {rel_path}")
+        cap = _max_file_bytes()
+        if len(data) > cap:
+            raise FileRpcError(
+                "read",
+                f"file is {len(data) // 1024} KB, over the {cap // 1024} KB limit",
+            )
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise FileRpcError("read", "file is not UTF-8 text (binary is not supported)") from exc
+
+    async def write_file(self, rel_path: str, content: str) -> None:
+        """Write UTF-8 text to a file. Oversize / non-string content -> FileRpcError."""
+        if not isinstance(content, str):
+            raise FileRpcError("write", "'content' must be a string")
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "write")
+        data = content.encode("utf-8")
+        cap = _max_file_bytes()
+        if len(data) > cap:
+            raise FileRpcError(
+                "write",
+                f"content is {len(data) // 1024} KB, over the {cap // 1024} KB limit",
+            )
+        await self._client.upload_bytes(self._sandbox_id, data, abs_path)
+
+    # ── Frame dispatch (never raises into the socket loop) ────────────────
+
+    async def dispatch(self, msg: dict) -> dict | None:
+        """Handle one parsed ``file.*`` frame; return the response frame to send.
+
+        Returns ``None`` if ``msg`` is not a file frame (the ws loop then treats
+        it as a terminal frame). All op failures — including a path-jail escape —
+        come back as a ``file.error`` frame; this method never propagates an
+        exception into the receive loop, so one bad frame can't tear the socket
+        down.
+        """
+        mtype = msg.get("type")
+        if not isinstance(mtype, str) or not mtype.startswith("file."):
+            return None
+
+        req_id = msg.get("reqId")
+        req_id = req_id if isinstance(req_id, str) else ""
+        path = msg.get("path")
+        path = path if isinstance(path, str) else ""
+
+        try:
+            if mtype == "file.list":
+                entries = await self.list_dir(path)
+                return {"type": "file.list.ok", "reqId": req_id, "path": path, "entries": entries}
+            if mtype == "file.read":
+                content = await self.read_file(path)
+                return {"type": "file.read.ok", "reqId": req_id, "path": path, "content": content}
+            if mtype == "file.write":
+                await self.write_file(path, msg.get("content"))
+                return {"type": "file.write.ok", "reqId": req_id, "path": path}
+            # A ``file.*`` type we don't implement — honest error, socket stays up.
+            return {
+                "type": "file.error",
+                "reqId": req_id,
+                "op": mtype.removeprefix("file."),
+                "message": f"unsupported file op: {mtype}",
+            }
+        except FileRpcError as exc:
+            return {"type": "file.error", "reqId": req_id, "op": exc.op, "message": exc.message}
+        except Exception as exc:  # noqa: BLE001 — a file op must never kill the socket
+            logger.warning(
+                "websandbox file op failed: type=%s sandbox=%s", mtype, self._sandbox_id,
+                exc_info=True,
+            )
+            op = mtype.removeprefix("file.") if mtype.startswith("file.") else mtype
+            return {
+                "type": "file.error",
+                "reqId": req_id,
+                "op": op,
+                "message": f"file op failed: {exc}",
+            }
+
+
+__all__ = ["FileRpc", "FileRpcError"]

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -22,6 +22,16 @@
 # BINARY frames carry terminal output (cleanest for xterm); pong is JSON. On
 # live traffic the row's ``updated_at`` is bumped (throttled ~60s) so the WC-2
 # idle reaper doesn't reclaim an active session.
+#
+# 2026-07-15 (WC-4a): the SAME socket also carries file operations, multiplexed
+# alongside the terminal. Any ``file.*`` frame ({"type":"file.list|read|write",
+# "reqId":..,"path":..[,"content":..]}) is handed to the socket-agnostic
+# ``FileRpc`` (websandbox/files.py), which jails the path to the sandbox project
+# dir and returns a JSON response frame (file.list.ok / file.read.ok /
+# file.write.ok / file.error). File responses are typed JSON text frames while
+# terminal output is binary, so the two streams never collide. No per-frame
+# re-authorization — the socket is already owner-bound to the VM — but file ops
+# DO bump the same throttled activity heartbeat.
 from __future__ import annotations
 
 import json
@@ -37,6 +47,7 @@ from pocketpaw_ee.cloud.auth.ws_tickets import consume_ws_ticket
 from pocketpaw_ee.cloud.daytona.client import get_daytona_client
 from pocketpaw_ee.cloud.license import get_license
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.files import FileRpc
 from pocketpaw_ee.cloud.websandbox.terminal import DEFAULT_COLS, DEFAULT_ROWS, PtyBridge
 
 logger = logging.getLogger(__name__)
@@ -176,6 +187,11 @@ async def terminal_websocket_endpoint(
     manager.register(websocket, bridge)
     throttle = _ActivityThrottle()
 
+    # File ops share this socket. FileRpc jails every path to the sandbox project
+    # dir (resolved lazily on first use); it reuses the already-owner-authorized
+    # client + sandbox_id and never re-authorizes per frame.
+    file_rpc = FileRpc(client, row.sandbox_id)
+
     async def _touch() -> None:
         """Bump the row's activity heartbeat, throttled, swallowing errors."""
         if not throttle.should_touch(time.monotonic()):
@@ -196,6 +212,15 @@ async def terminal_websocket_endpoint(
                 continue
 
             mtype = msg.get("type")
+            if isinstance(mtype, str) and mtype.startswith("file."):
+                # File op multiplexed on the terminal socket. FileRpc jails the
+                # path and returns a JSON response frame (or file.error); a bad
+                # frame never tears the socket down.
+                response = await file_rpc.dispatch(msg)
+                if response is not None:
+                    await websocket.send_json(response)
+                    await _touch()
+                continue
             if mtype == "input":
                 data = msg.get("data")
                 if isinstance(data, str):

--- a/scripts/websandbox_file_rpc_smoke.py
+++ b/scripts/websandbox_file_rpc_smoke.py
@@ -1,0 +1,118 @@
+# websandbox_file_rpc_smoke.py — ONE live Daytona smoke for the Web Cursor file
+# read/write/list RPC slice (WC-4a). NOT a pytest test — kept out of CI so a real
+# VM (which costs money) is only ever provisioned when a human runs this.
+# Created 2026-07-15 (feat/websandbox-file-rpc).
+#
+# What it does: loads .env, provisions a REAL Daytona VM, then drives the SAME
+# FileRpc helper the WebSocket endpoint uses (minus the socket) to:
+#   1. write ``paw_rpc_smoke.txt`` with known content,
+#   2. read it back and assert it round-trips (proves real persistence to the VM
+#      filesystem),
+#   3. list the project dir and assert the file appears,
+#   4. attempt a ``../escape.txt`` write and assert the jail REJECTS it.
+# It ALWAYS deletes the VM in a finally block — cleanup is non-negotiable even on
+# exception, because a leaked VM keeps billing.
+#
+# Run: .venv/Scripts/python.exe scripts/websandbox_file_rpc_smoke.py
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+AUTO_STOP_MINUTES = 30
+BOOT_TIMEOUT_SECONDS = 180.0
+SMOKE_FILE = "paw_rpc_smoke.txt"
+SMOKE_CONTENT = "web-cursor file rpc round-trip: paw-rpc-ok\n"
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+    from pocketpaw_ee.cloud.websandbox.files import FileRpc, FileRpcError
+
+    client = get_daytona_client()
+    if client is None:
+        print("FAIL: Daytona is not configured (get_daytona_client() returned None).")
+        print("      Set the Daytona keys in .env and retry.")
+        return 1
+
+    sandbox_id: str | None = None
+    failures: list[str] = []
+
+    try:
+        print(f"Provisioning a Daytona VM (auto_stop_interval={AUTO_STOP_MINUTES} min)...")
+        info = await client.create_sandbox(
+            name="websandbox-file-rpc-smoke",
+            auto_stop_interval=AUTO_STOP_MINUTES,
+        )
+        sandbox_id = info.id
+        print(f"  created: id={sandbox_id} name={info.name} state={info.state}")
+
+        print("Waiting for the VM to boot...")
+        await client.wait_for_sandbox(
+            sandbox_id, target_state="started", timeout=BOOT_TIMEOUT_SECONDS
+        )
+        print("  booted.")
+
+        # The exact helper the WS endpoint instantiates per session.
+        rpc = FileRpc(client, sandbox_id)
+        project_dir = await rpc._root()  # noqa: SLF001 — smoke wants the resolved jail root
+        print(f"  project dir (jail root): {project_dir}")
+
+        # 1. write
+        print(f"Writing {SMOKE_FILE!r} via FileRpc.write_file...")
+        await rpc.write_file(SMOKE_FILE, SMOKE_CONTENT)
+        print("  write ok.")
+
+        # 2. read back + assert round-trip
+        print(f"Reading {SMOKE_FILE!r} back...")
+        read_back = await rpc.read_file(SMOKE_FILE)
+        if read_back == SMOKE_CONTENT:
+            print("  PASS: read-back content matches (real persistence to VM fs).")
+        else:
+            failures.append("read-back content did not match written content")
+            print(f"  FAIL: got {read_back!r}, expected {SMOKE_CONTENT!r}")
+
+        # 3. list dir + assert file appears
+        print("Listing the project dir via FileRpc.list_dir('.')...")
+        entries = await rpc.list_dir(".")
+        names = [e["name"] for e in entries]
+        if SMOKE_FILE in names:
+            print(f"  PASS: {SMOKE_FILE!r} appears in the listing.")
+        else:
+            failures.append(f"{SMOKE_FILE} not found in directory listing")
+            print(f"  FAIL: {SMOKE_FILE!r} not in {names}")
+
+        # 4. traversal rejection
+        print("Attempting a ../escape.txt write (must be rejected by the jail)...")
+        try:
+            await rpc.write_file("../escape.txt", "should never be written")
+            failures.append("traversal write was NOT rejected")
+            print("  FAIL: traversal write was allowed!")
+        except FileRpcError as exc:
+            print(f"  PASS: traversal rejected -> {exc.op}: {exc.message}")
+
+        if failures:
+            print("\nFAIL: " + "; ".join(failures))
+            return 1
+        print("\nPASS: write -> read -> list round-trip persisted + traversal rejected.")
+        return 0
+    except Exception as exc:  # noqa: BLE001 — smoke: report and still clean up
+        print(f"FAIL: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        if sandbox_id is not None:
+            try:
+                print(f"Cleaning up: deleting VM {sandbox_id}...")
+                await client.delete_sandbox(sandbox_id)
+                print(f"  VM {sandbox_id} DELETED.")
+            except Exception as cleanup_exc:  # noqa: BLE001
+                print(f"  WARNING: cleanup delete failed: {cleanup_exc}")
+                print(f"  MANUAL CLEANUP REQUIRED for sandbox {sandbox_id}")
+        await client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/cloud/test_websandbox_file_rpc.py
+++ b/tests/cloud/test_websandbox_file_rpc.py
@@ -1,0 +1,504 @@
+# test_websandbox_file_rpc.py — unit tests for the Web Cursor file read/write/list
+# RPC slice (WC-4a). Created 2026-07-15 (feat/websandbox-file-rpc).
+#
+# Two tiers, no real Daytona:
+#   1. FileRpc helper driven directly with a FAKE DaytonaClient (records
+#      upload_bytes, returns canned download_file bytes + list_files). Covers the
+#      list/read/write happy paths, the path-jail (the security core), honest
+#      missing-file errors, the size cap, and malformed/unknown frames.
+#   2. The ws.py frame dispatch driven with the WC-3 FakeWebSocket harness on REAL
+#      Beanie over mongomock (the ``mongo_db`` fixture) with a real seeded owner,
+#      proving a file.write frame reaches upload_bytes with the JAILED path and
+#      the socket gets file.write.ok — and a traversal frame returns file.error
+#      and never writes.
+from __future__ import annotations
+
+import os
+from collections import deque
+from dataclasses import dataclass, field
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+
+import pytest
+from fastapi import WebSocketDisconnect
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
+from pocketpaw_ee.cloud.websandbox.files import FileRpc, FileRpcError
+from pocketpaw_ee.cloud.websandbox.ws import terminal_websocket_endpoint
+
+PROJECT_DIR = "/home/daytona/project"
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFileInfo:
+    name: str
+    is_dir: bool = False
+    size: int = 0
+
+
+@dataclass
+class _FakeFsClient:
+    """Fake DaytonaClient exposing only the file methods FileRpc uses.
+
+    Records every upload and every path it was asked to list/download so a test
+    can assert the JAILED absolute path — and that a rejected traversal never
+    reaches download/upload at all.
+    """
+
+    project_dir: str = PROJECT_DIR
+    files: dict[str, bytes] = field(default_factory=dict)  # abs path -> bytes
+    listing: list[_FakeFileInfo] = field(default_factory=list)
+    uploads: list[tuple[str, bytes]] = field(default_factory=list)
+    list_paths: list[str] = field(default_factory=list)
+    download_paths: list[str] = field(default_factory=list)
+
+    async def get_project_dir(self, sandbox_id):  # noqa: ANN001
+        return self.project_dir
+
+    async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
+        self.list_paths.append(path)
+        return list(self.listing)
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_paths.append(remote_path)
+        if remote_path not in self.files:
+            raise FileNotFoundError(remote_path)
+        return self.files[remote_path]
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.uploads.append((remote_path, data))
+        self.files[remote_path] = data
+
+
+def _rpc(client: _FakeFsClient) -> FileRpc:
+    return FileRpc(client, "dtn-1")
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — FileRpc helper (happy paths).
+# ---------------------------------------------------------------------------
+
+
+async def test_list_returns_entries_with_relative_paths() -> None:
+    client = _FakeFsClient(
+        listing=[
+            _FakeFileInfo("app.py", is_dir=False, size=42),
+            _FakeFileInfo("lib", is_dir=True, size=0),
+        ]
+    )
+    entries = await _rpc(client).list_dir("src")
+
+    # Listed the JAILED absolute path.
+    assert client.list_paths == [f"{PROJECT_DIR}/src"]
+    assert entries == [
+        {"name": "app.py", "path": "src/app.py", "isDir": False, "size": 42},
+        {"name": "lib", "path": "src/lib", "isDir": True, "size": 0},
+    ]
+
+
+async def test_list_root_uses_project_dir() -> None:
+    client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
+    entries = await _rpc(client).list_dir(".")
+    assert client.list_paths == [PROJECT_DIR]
+    assert entries[0]["path"] == "README.md"
+
+
+async def test_read_returns_file_content() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/src/app.py": b"print('hi')\n"})
+    content = await _rpc(client).read_file("src/app.py")
+    assert content == "print('hi')\n"
+    assert client.download_paths == [f"{PROJECT_DIR}/src/app.py"]
+
+
+async def test_write_calls_upload_with_jailed_path() -> None:
+    client = _FakeFsClient()
+    await _rpc(client).write_file("src/new.py", "x = 1\n")
+    assert client.uploads == [(f"{PROJECT_DIR}/src/new.py", b"x = 1\n")]
+
+
+async def test_write_then_read_round_trips() -> None:
+    client = _FakeFsClient()
+    rpc = _rpc(client)
+    await rpc.write_file("notes.txt", "hello world")
+    assert await rpc.read_file("notes.txt") == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — path jail (the must-pass security core).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "../../etc/passwd",
+        "../secret.txt",
+        "/etc/passwd",
+        "src/../../../../etc/shadow",
+        "..",
+    ],
+)
+async def test_read_traversal_is_rejected_and_never_downloads(bad_path) -> None:  # noqa: ANN001
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file(bad_path)
+    assert ei.value.op == "read"
+    # The jail rejected the path BEFORE any download was attempted.
+    assert client.download_paths == []
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    ["../../etc/passwd", "../escape.txt", "/tmp/evil", ".."],
+)
+async def test_write_traversal_is_rejected_and_never_uploads(bad_path) -> None:  # noqa: ANN001
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).write_file(bad_path, "pwned")
+    assert ei.value.op == "write"
+    assert client.uploads == []
+
+
+async def test_list_traversal_is_rejected() -> None:
+    client = _FakeFsClient(listing=[_FakeFileInfo("x")])
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).list_dir("../..")
+    assert ei.value.op == "list"
+    assert client.list_paths == []
+
+
+async def test_benign_dotdot_that_stays_inside_is_allowed() -> None:
+    # foo/../bar normalizes to bar — inside the jail, so it's allowed.
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/bar.txt": b"ok"})
+    assert await _rpc(client).read_file("foo/../bar.txt") == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — honest errors + size cap.
+# ---------------------------------------------------------------------------
+
+
+async def test_read_missing_file_is_honest_error_not_empty() -> None:
+    client = _FakeFsClient()  # no files
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file("does/not/exist.py")
+    assert ei.value.op == "read"
+    assert "no such file" in ei.value.message
+
+
+async def test_read_binary_file_is_rejected() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/img.png": b"\xff\xfe\x00\x01\x80"})
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file("img.png")
+    assert "UTF-8" in ei.value.message
+
+
+async def test_write_over_cap_is_rejected(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_MAX_FILE_KB", "1")
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).write_file("big.txt", "A" * 2048)  # 2 KB > 1 KB cap
+    assert ei.value.op == "write"
+    assert client.uploads == []
+
+
+async def test_read_over_cap_is_rejected(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_MAX_FILE_KB", "1")
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/big.txt": b"B" * 2048})
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file("big.txt")
+    assert ei.value.op == "read"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — dispatch: frame shaping + malformed frames don't tear down.
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_list_ok_frame() -> None:
+    client = _FakeFsClient(listing=[_FakeFileInfo("a.py", size=3)])
+    resp = await _rpc(client).dispatch({"type": "file.list", "reqId": "r1", "path": "."})
+    assert resp == {
+        "type": "file.list.ok",
+        "reqId": "r1",
+        "path": ".",
+        "entries": [{"name": "a.py", "path": "a.py", "isDir": False, "size": 3}],
+    }
+
+
+async def test_dispatch_read_ok_frame() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/a.py": b"hi"})
+    resp = await _rpc(client).dispatch({"type": "file.read", "reqId": "r2", "path": "a.py"})
+    assert resp == {"type": "file.read.ok", "reqId": "r2", "path": "a.py", "content": "hi"}
+
+
+async def test_dispatch_write_ok_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.write", "reqId": "r3", "path": "a.py", "content": "z = 2\n"}
+    )
+    assert resp == {"type": "file.write.ok", "reqId": "r3", "path": "a.py"}
+    assert client.uploads == [(f"{PROJECT_DIR}/a.py", b"z = 2\n")]
+
+
+async def test_dispatch_traversal_returns_error_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.write", "reqId": "r4", "path": "../../etc/passwd", "content": "x"}
+    )
+    assert resp["type"] == "file.error"
+    assert resp["reqId"] == "r4"
+    assert resp["op"] == "write"
+    assert client.uploads == []
+
+
+async def test_dispatch_unknown_file_op_returns_error_not_raise() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch({"type": "file.rename", "reqId": "r5", "path": "a"})
+    assert resp["type"] == "file.error"
+    assert resp["op"] == "rename"
+
+
+async def test_dispatch_non_file_frame_returns_none() -> None:
+    client = _FakeFsClient()
+    assert await _rpc(client).dispatch({"type": "input", "data": "ls\n"}) is None
+    assert await _rpc(client).dispatch({"type": "ping"}) is None
+
+
+async def test_dispatch_missing_path_is_error_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch({"type": "file.read", "reqId": "r6"})
+    assert resp["type"] == "file.error"
+    assert resp["op"] == "read"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — ws.py frame dispatch over the real auth path (mongomock).
+#
+# Reuses the WC-3 fakes/harness (a pty must still open so the receive loop runs),
+# extended with the file methods FileRpc needs.
+# ---------------------------------------------------------------------------
+
+pytestmark_mongo = pytest.mark.usefixtures("mongo_db")
+
+
+class _FakeLicense:
+    expired = False
+
+
+class _FakeHandle:
+    def __init__(self, on_data) -> None:  # noqa: ANN001
+        self._on_data = on_data
+        self.sent: list = []
+
+    async def wait_for_connection(self) -> None:
+        return None
+
+    async def send_input(self, data) -> None:  # noqa: ANN001
+        self.sent.append(data)
+
+    async def disconnect(self) -> None:
+        return None
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.handle = None
+
+    async def create_pty_session(self, session_id, on_data, cwd=None, envs=None, pty_size=None):  # noqa: ANN001
+        self.handle = _FakeHandle(on_data)
+        return self.handle
+
+
+class _FakeSandbox:
+    def __init__(self) -> None:
+        self.process = _FakeProcess()
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Terminal fake (pty) + the file methods FileRpc calls, in one object."""
+
+    sandbox: _FakeSandbox = field(default_factory=_FakeSandbox)
+    kill_calls: list = field(default_factory=list)
+    project_dir: str = PROJECT_DIR
+    files: dict[str, bytes] = field(default_factory=dict)
+    uploads: list[tuple[str, bytes]] = field(default_factory=list)
+
+    async def get_sandbox_instance(self, sandbox_id):  # noqa: ANN001
+        return self.sandbox
+
+    async def resize_pty(self, sandbox_id, session_id, cols, rows):  # noqa: ANN001
+        return None
+
+    async def kill_pty(self, sandbox_id, session_id):  # noqa: ANN001
+        self.kill_calls.append(session_id)
+
+    async def get_project_dir(self, sandbox_id):  # noqa: ANN001
+        return self.project_dir
+
+    async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
+        return [_FakeFileInfo("app.py", is_dir=False, size=5)]
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        if remote_path not in self.files:
+            raise FileNotFoundError(remote_path)
+        return self.files[remote_path]
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.uploads.append((remote_path, data))
+        self.files[remote_path] = data
+
+
+class FakeWebSocket:
+    def __init__(self, inbound=None) -> None:  # noqa: ANN001
+        self._inbound: deque = deque(inbound or [])
+        self.accepted = False
+        self.closed = None
+        self.sent_bytes: list = []
+        self.sent_json: list = []
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code=1000, reason=None) -> None:  # noqa: ANN001
+        self.closed = (code, reason)
+
+    async def send_bytes(self, data) -> None:  # noqa: ANN001
+        self.sent_bytes.append(data)
+
+    async def send_json(self, data) -> None:  # noqa: ANN001
+        self.sent_json.append(data)
+
+    async def receive_text(self) -> str:
+        if not self._inbound:
+            raise WebSocketDisconnect(1000)
+        return self._inbound.popleft()
+
+
+async def _seed_user(active_workspace) -> str:  # noqa: ANN001
+    from pocketpaw_ee.cloud.auth.core import UserCreate, UserManager, get_user_db
+    from pocketpaw_ee.cloud.models.user import User as UserDoc
+
+    email = f"wc4-{os.urandom(4).hex()}@example.com"
+    async for db in get_user_db():
+        manager = UserManager(db)
+        user = await manager.create(UserCreate(email=email, password="StrongPass123!"))
+        doc = await UserDoc.get(user.id)
+        doc.active_workspace = active_workspace
+        await doc.save()
+        return str(user.id)
+    raise RuntimeError("user db iterator exhausted")  # pragma: no cover
+
+
+async def _seed_ready_sandbox(workspace_id, user_id) -> str:  # noqa: ANN001
+    view = await sandbox_service.create_sandbox(
+        workspace_id,
+        user_id,
+        CreateSandboxRequest(
+            repo="https://github.com/acme/api.git", status="ready", sandbox_id="dtn-1"
+        ),
+    )
+    return view.id
+
+
+@pytest.fixture
+def wire_terminal(monkeypatch):
+    client = _FakeDaytonaClient()
+    tokens: dict[str, str] = {}
+
+    async def _fake_consume(token: str):
+        return tokens.get(token)
+
+    monkeypatch.setattr(terminal_ws, "get_license", lambda: _FakeLicense())
+    monkeypatch.setattr(terminal_ws, "consume_ws_ticket", _fake_consume)
+    monkeypatch.setattr(terminal_ws, "get_daytona_client", lambda: client)
+    monkeypatch.setattr(terminal_ws, "manager", terminal_ws.TerminalConnectionManager())
+    return client, tokens
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_write_frame_reaches_upload_and_acks(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(
+        inbound=['{"type":"file.write","reqId":"w1","path":"hello.txt","content":"hi there"}']
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert ws.accepted is True
+    assert client.uploads == [(f"{PROJECT_DIR}/hello.txt", b"hi there")]
+    assert {"type": "file.write.ok", "reqId": "w1", "path": "hello.txt"} in ws.sent_json
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_read_and_list_frames_round_trip(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+    client.files[f"{PROJECT_DIR}/app.py"] = b"print(1)\n"
+
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"file.list","reqId":"l1","path":"."}',
+            '{"type":"file.read","reqId":"r1","path":"app.py"}',
+        ]
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    list_ok = [m for m in ws.sent_json if m.get("type") == "file.list.ok"]
+    read_ok = [m for m in ws.sent_json if m.get("type") == "file.read.ok"]
+    assert list_ok and list_ok[0]["entries"][0]["name"] == "app.py"
+    assert read_ok and read_ok[0]["content"] == "print(1)\n"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_traversal_frame_is_rejected_and_never_writes(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"file.write","reqId":"bad","path":"../../etc/passwd","content":"pwned"}'
+        ]
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert client.uploads == []
+    errs = [m for m in ws.sent_json if m.get("type") == "file.error"]
+    assert errs and errs[0]["op"] == "write" and errs[0]["reqId"] == "bad"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_malformed_file_frame_does_not_tear_down_socket(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+    client.files[f"{PROJECT_DIR}/app.py"] = b"ok"
+
+    ws = FakeWebSocket(
+        inbound=[
+            "{not json",  # malformed — ignored, socket survives
+            '{"type":"file.bogus","reqId":"b1","path":"app.py"}',  # unknown file op
+            '{"type":"file.read","reqId":"r9","path":"app.py"}',  # still works after
+        ]
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert ws.closed is None  # never force-closed
+    reads = [m for m in ws.sent_json if m.get("type") == "file.read.ok"]
+    assert reads and reads[0]["content"] == "ok"


### PR DESCRIPTION
Backend half of the editor slice, stacked on the terminal WebSocket (#1722). The editor UI is a separate PR — this is the transport it saves through: file operations multiplexed onto the same authenticated session socket, no separate REST write route.

## What's here

A socket-agnostic `FileRpc` helper (mirrors the terminal's `PtyBridge`) and three new frame types on `/ws/websandbox/{row_id}`: `file.list`, `file.read`, `file.write`. Each request carries a client `reqId` that the response echoes, because the socket is async and multiplexed with terminal output — file responses are typed JSON text frames, terminal output stays binary, so the two streams never collide. The socket is already owner-authorized on connect, so file ops don't re-authorize per frame; they do bump the same throttled activity heartbeat.

## The path jail

This is the security core. Every path is relative to the sandbox project dir. It's resolved by lexically normalizing `project_dir/rel` with posixpath (the VM is Linux; using posixpath keeps it correct even though CI runs on Windows) and asserting the result is the project dir or under it. Absolute paths and `..` escapes fail that check and get a `file.error` before any download or upload runs.

The jail is lexical, not realpath-based, and that's deliberate: resolving a symlink on a remote VM filesystem needs a shell round-trip, and it buys nothing here — the socket is already bound to the caller's own VM, so a symlink can only ever point at files that caller already reaches through the terminal. It's documented in the file header rather than left as an unspoken gap. Reads and writes are size-capped (`POCKETPAW_WEBSANDBOX_MAX_FILE_KB`, default 1024). A missing file on read returns an honest error, not empty success.

## Tests

33 unit tests over the helper and the frame dispatch with a faked Daytona client, plus the WC-3 terminal tests as regression since this edits `ws.py`. The must-pass security cases: `../../etc/passwd`, an absolute path, and a `..`-containing path all get rejected and never call download/upload.

```
60 passed in 4.87s
```

Live smoke against real Daytona (out of CI): wrote a file, read it back and matched, listed the dir and saw it, then tried a `../escape.txt` write and got the rejection. VM deleted in a finally block.

Stacked on #1722 → #1721 → #1719. Merge bases with rebase, not squash.