### PR TITLE
Let the terminal socket authenticate by first-message frame

### DIFF
--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -7,15 +7,35 @@
 # single-use ws_ticket auth, because browsers can't set auth headers on a WS
 # upgrade.
 #
+# 2026-07-15 (WC-4b): the ticket now resolves via EITHER of two auth paths, so
+# the browser can authenticate without leaking the ticket in the URL (URL query
+# strings leak into access logs, browser history, and proxies — the same
+# REVIEW-4 reasoning that moved the chat WS off URL tickets):
+#   * Path 1 — single-use ws_ticket in ``?token=``, consumed BEFORE accept
+#     (unchanged; the only path a cross-origin WS upgrade can carry in the URL).
+#   * Path 3 — no ``?token=``: accept() FIRST (a frame can only be read after the
+#     handshake completes), then read the first frame under a 5s timeout and
+#     parse ``{"type":"auth","ticket"|"token":"..."}``. On timeout, a malformed
+#     frame, a non-auth frame, or a failed ``consume_ws_ticket`` -> close 4001 and
+#     the socket never reaches the message loop.
+# ``websocket.accept()`` is called exactly once on every path, tracked by the
+# ``accepted`` flag: Path 1 accepts AFTER the authz checks (as before); Path 3
+# accepts BEFORE reading the frame, so the shared authz section must not accept
+# again.
+#
 # Connect flow (fail-closed at every step; a PTY is opened ONLY after all pass):
-#   accept-gate: license present -> ticket in ?token= present
-#   consume_ws_ticket(token) -> user_id           (single-use, Redis fail-closed)
+#   license present                                (else 4003)
+#   Path 1: ticket in ?token= -> consume_ws_ticket (pre-accept; 1008 on failure)
+#   Path 3: no ?token= -> accept, read first auth   (post-accept; 4001 on failure)
+#           frame under 5s timeout -> consume_ws_ticket
+#   -> user_id                                     (single-use, Redis fail-closed)
 #   auth_service.get_active_workspace(user_id)     -> workspace_id
 #   websandbox_service.get_sandbox(ws, user, row)  -> row (NotFound if not owned)
 #   row.sandbox_id present (row is ``ready``)      (else 1008 not-ready)
 #   authorize_sandbox(ws, user, row.sandbox_id)    -> bind socket to the VM
-# Any failure closes 1008 BEFORE accept/PTY — a second user's ticket for someone
-# else's row is denied by get_sandbox/authorize_sandbox before any PTY opens.
+# A second user's ticket for someone else's row is denied by get_sandbox/
+# authorize_sandbox before any PTY opens. Path 1 closes 1008 pre-accept; Path 3
+# is already accepted, so an authz denial closes 1008 on the accepted socket.
 #
 # Message framing: client->server JSON — {"type":"input","data":"<str>"},
 # {"type":"resize","cols":N,"rows":N}, {"type":"ping"}. server->client — raw
@@ -34,6 +54,7 @@
 # DO bump the same throttled activity heartbeat.
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -52,12 +73,19 @@ from pocketpaw_ee.cloud.websandbox.terminal import DEFAULT_COLS, DEFAULT_ROWS, P
 
 logger = logging.getLogger(__name__)
 
-# WS close codes. 1008 == policy violation (auth / authz denial). 4003 mirrors
+# WS close codes. 1008 == policy violation (authz denial). 4001 == the Path 3
+# first-frame auth failed (mirrors the chat WS auth-frame close). 4003 mirrors
 # the chat WS "enterprise license required". 1011 == internal error (PTY open
 # failed after auth succeeded).
 _CLOSE_POLICY = 1008
+_CLOSE_AUTH_FRAME = 4001
 _CLOSE_LICENSE = 4003
 _CLOSE_INTERNAL = 1011
+
+# Seconds to wait for the Path 3 first-message auth frame before giving up. A
+# half-open socket must not hold resources waiting for a credential that may
+# never arrive. Mirrors the chat WS 5s auth-frame timeout.
+_AUTH_FRAME_TIMEOUT_SECONDS = 5.0
 
 # Minimum seconds between activity heartbeats per socket (throttle): a burst of
 # keystrokes becomes one ``updated_at`` write, not one per frame.
@@ -118,25 +146,59 @@ async def terminal_websocket_endpoint(
 ) -> None:
     """Stream a real bash PTY from the owning sandbox's VM to the browser.
 
-    See the module docstring for the full connect/auth flow. The ws_ticket is
-    consumed (single-use) BEFORE accept; any auth/authz failure closes 1008 and
-    never opens a PTY.
+    See the module docstring for the full connect/auth flow. The ws_ticket
+    resolves via Path 1 (``?token=``, consumed pre-accept) or Path 3 (a
+    first-message auth frame read post-accept under a 5s timeout). Any auth
+    failure closes 1008 (Path 1) or 4001 (Path 3); any authz failure closes 1008
+    and never opens a PTY.
     """
-    # License gate — parity with the REST /websandbox routes and chat WS.
+    # License gate first on BOTH paths — parity with the REST /websandbox routes
+    # and chat WS.
     lic = get_license()
     if lic is None or lic.expired:
         await websocket.close(code=_CLOSE_LICENSE, reason="Enterprise license required")
         return
 
-    # Path 1 — single-use ws_ticket in ?token= (the only auth path the browser
-    # can use on a cross-origin WS upgrade). No ticket -> no access.
-    if not token:
-        await websocket.close(code=_CLOSE_POLICY, reason="Missing ticket")
-        return
-    user_id = await consume_ws_ticket(token)
-    if not user_id:
-        await websocket.close(code=_CLOSE_POLICY, reason="Invalid ticket")
-        return
+    # ``accepted`` tracks whether accept() has run so accept() happens exactly
+    # once: Path 1 accepts AFTER the authz checks below; Path 3 accepts BEFORE it
+    # can read the first frame, then the shared authz section must not re-accept.
+    accepted = False
+
+    if token:
+        # Path 1 — single-use ws_ticket in ?token=. Consumed BEFORE accept, so a
+        # bad ticket is refused during the handshake (close 1008, no accept).
+        user_id = await consume_ws_ticket(token)
+        if not user_id:
+            await websocket.close(code=_CLOSE_POLICY, reason="Invalid ticket")
+            return
+    else:
+        # Path 3 — no URL token. Authenticate from the first frame so the ticket
+        # never travels in the URL. We MUST accept() before we can receive, and
+        # the 5s timeout stops a half-open socket from holding resources while we
+        # wait for a credential that may never come.
+        await websocket.accept()
+        accepted = True
+        try:
+            raw = await asyncio.wait_for(
+                websocket.receive_text(), timeout=_AUTH_FRAME_TIMEOUT_SECONDS
+            )
+            frame = json.loads(raw)
+        except Exception:
+            # Timeout, disconnect, or non-JSON first frame.
+            await websocket.close(code=_CLOSE_AUTH_FRAME, reason="Missing auth")
+            return
+
+        if not isinstance(frame, dict) or frame.get("type") != "auth":
+            await websocket.close(code=_CLOSE_AUTH_FRAME, reason="Missing auth")
+            return
+
+        # Accept ``token`` as an alias for ``ticket`` (parity with the chat WS
+        # auth frame); either carries the single-use ws_ticket.
+        ticket = frame.get("ticket") or frame.get("token")
+        user_id = await consume_ws_ticket(ticket) if isinstance(ticket, str) and ticket else None
+        if not user_id:
+            await websocket.close(code=_CLOSE_AUTH_FRAME, reason="Invalid ticket")
+            return
 
     # Resolve the caller's workspace from the same membership field the HTTP
     # request context reads. Fail closed if the user has no active workspace.
@@ -166,8 +228,10 @@ async def terminal_websocket_endpoint(
         await websocket.close(code=_CLOSE_LICENSE, reason="Sandbox runtime unavailable")
         return
 
-    # Every gate passed — accept the socket and open the PTY.
-    await websocket.accept()
+    # Every gate passed — accept the socket (unless Path 3 already did) and open
+    # the PTY. ``accepted`` keeps accept() exactly-once across both paths.
+    if not accepted:
+        await websocket.accept()
 
     session_id = f"term-{uuid.uuid4().hex}"
 

--- a/tests/cloud/test_websandbox_terminal.py
+++ b/tests/cloud/test_websandbox_terminal.py
@@ -24,6 +24,15 @@
 #   * activity heartbeat is throttled (many frames -> one touch) and bumps
 #     updated_at at the service level.
 #   * the _ActivityThrottle unit gates to first-call-then-interval.
+#
+# 2026-07-15 (WC-4b): Path 3 first-message auth frame (no ?token=). Covers:
+#   * no ?token= + a valid {"type":"auth","ticket":<valid>} frame -> accept()
+#     first, then PTY opens (and the "token" alias works too).
+#   * no ?token= + malformed / non-auth / missing first frame -> closed 4001
+#     after accept, no PTY.
+#   * no ?token= + auth frame with an INVALID ticket -> closed 4001, no PTY.
+#   * no ?token= + valid ticket but a sandbox the caller does NOT own -> closed
+#     1008 after accept, no PTY.
 from __future__ import annotations
 
 import os
@@ -253,15 +262,18 @@ async def test_valid_ticket_opens_pty_streams_and_resizes(wire_terminal) -> None
 # ---------------------------------------------------------------------------
 
 
-async def test_missing_ticket_closes_1008_no_pty(wire_terminal) -> None:
+async def test_no_token_and_no_auth_frame_closes_4001_no_pty(wire_terminal) -> None:
+    # No ?token= now routes to Path 3 (first-message auth frame). With nothing on
+    # the wire, receive_text raises before any frame arrives -> 4001 after accept,
+    # never the old pre-accept 1008. (Path 3 detail covered further below.)
     client, _tokens = wire_terminal
-    await _seed_user("w1")  # existence irrelevant; no token supplied
+    await _seed_user("w1")  # existence irrelevant; no credential supplied
 
     ws = FakeWebSocket()
     await terminal_websocket_endpoint(ws, "any-row", token=None)
 
-    assert ws.accepted is False
-    assert ws.closed is not None and ws.closed[0] == 1008
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
     assert client.sandbox.process.handle is None
 
 
@@ -310,6 +322,129 @@ async def test_not_ready_sandbox_closes_1008_no_pty(wire_terminal) -> None:
     await terminal_websocket_endpoint(ws, view.id, token="good-ticket")
 
     assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+# ---------------------------------------------------------------------------
+# Path 3 — first-message auth frame (no ?token=), leak-free browser auth.
+# ---------------------------------------------------------------------------
+
+
+async def test_authframe_valid_opens_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    # No ?token=; the ticket rides in the FIRST frame, followed by a real input.
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"auth","ticket":"good-ticket"}',
+            '{"type":"input","data":"echo hi\\n"}',
+        ]
+    )
+
+    await terminal_websocket_endpoint(ws, row_id, token=None)
+
+    # Path 3 accepts BEFORE reading the frame; auth then succeeded, so no close.
+    assert ws.accepted is True
+    assert ws.closed is None
+
+    # The auth frame was consumed by the handshake, not the input loop: only the
+    # actual keystroke reached the pty.
+    handle = client.sandbox.process.handle
+    assert handle is not None
+    assert handle.sent == ["echo hi\n"]
+    assert b"echo:echo hi\n" in ws.sent_bytes
+
+    # Disconnect tore the pty down (no leaked session).
+    assert client.kill_calls
+    assert handle.connected is False
+
+
+async def test_authframe_token_alias_opens_pty(wire_terminal) -> None:
+    # "token" is accepted as an alias for "ticket" in the auth frame (chat parity).
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(inbound=['{"type":"auth","token":"good-ticket"}'])
+    await terminal_websocket_endpoint(ws, row_id, token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is None
+    assert client.sandbox.process.handle is not None
+
+
+async def test_authframe_malformed_closes_4001_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")
+
+    ws = FakeWebSocket(inbound=["this is not json"])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    # Accepted (Path 3 must accept before it can read), then closed 4001.
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_non_auth_first_frame_closes_4001_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")
+
+    # Well-formed JSON but not an auth frame -> rejected.
+    ws = FakeWebSocket(inbound=['{"type":"input","data":"whoami"}'])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_missing_frame_closes_4001_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")
+
+    # Empty inbound -> receive_text raises WebSocketDisconnect before any frame
+    # arrives (stands in for the client that never sends a credential).
+    ws = FakeWebSocket(inbound=[])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_invalid_ticket_closes_4001_no_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    tokens["good-ticket"] = "someone"
+
+    ws = FakeWebSocket(inbound=['{"type":"auth","ticket":"WRONG"}'])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_valid_ticket_not_owned_closes_1008_after_accept(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    owner_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", owner_id)
+
+    # A different user in the same workspace authenticates via the auth frame but
+    # asks for a row they don't own: authz denial closes 1008 on the already-
+    # accepted socket, and no PTY opens.
+    intruder_id = await _seed_user("w1")
+    tokens["intruder-ticket"] = intruder_id
+
+    ws = FakeWebSocket(inbound=['{"type":"auth","ticket":"intruder-ticket"}'])
+    await terminal_websocket_endpoint(ws, row_id, token=None)
+
+    assert ws.accepted is True  # Path 3 accepted before the authz check
     assert ws.closed is not None and ws.closed[0] == 1008
     assert client.sandbox.process.handle is None
 


### PR DESCRIPTION
Small auth fix on the terminal WebSocket, needed before the editor frontend connects to it.

The terminal socket from WC-3 only authenticates via `?token=` in the URL. The frontend WS convention moved off that back in June (REVIEW-4) because a ticket in the query string leaks into access logs, browser history, and proxies — the chat socket already accepts a first-message `{type:"auth", ticket}` frame instead. This brings the terminal socket to parity so the new editor can connect the same leak-free way.

## What changed

`terminal_websocket_endpoint` now resolves the user by either path, then runs the same unchanged authz flow (workspace → owner-scoped sandbox read → ready check → `authorize_sandbox` → open PTY):

- `?token=` ws-ticket, consumed before accept (unchanged).
- When there's no `?token=`: accept first, read the first frame under a 5s timeout, parse the auth frame (`token` accepted as an alias for `ticket`), consume the ticket. Timeout, a malformed or non-auth frame, or a bad ticket closes 4001 and never reaches the message loop.

`accept()` is called exactly once on every path, tracked by an `accepted` flag so the shared authz section doesn't double-accept. Framing, file-RPC, and teardown are untouched — this is only the auth resolution.

## Tests

15 tests: the original `?token=` cases still pass, plus the new frame path — happy path, the `token` alias, malformed/non-auth/missing first frame all closing 4001, an invalid ticket closing 4001, and a valid ticket on an unowned sandbox closing 1008 after accept.

```
15 passed in 3.86s
```

One existing test was repurposed rather than kept: the old "no token closes 1008 before accept" asserted a contract that no longer exists — no token now routes to the frame path — so it's replaced by "no token and no auth frame closes 4001." All genuine `?token=` cases are unchanged.

Stacked on #1723. Merge bases with rebase, not squash.