### PR TITLE
Enforce agent visibility on read and attach paths

### DIFF
--- a/ee/pocketpaw_ee/cloud/agents/router.py
+++ b/ee/pocketpaw_ee/cloud/agents/router.py
@@ -18,6 +18,15 @@ soft-disable / revoke-everywhere flow. Both carry the SAME owner/admin guard
 (``require_agent_owner_or_admin``) + ``current_user_id`` as DELETE — symmetric
 tenant-scope protection, so a cross-workspace / non-owner caller cannot revoke
 or restore an agent it doesn't own.
+
+Updated 2026-07-15 (fix/agent-visibility-enforcement, ASG-7): the READ endpoints
+now enforce agent visibility. ``GET /agents/{id}`` routes through
+``agents_service.get_for_viewer`` (404 for another user's private agent);
+``GET /agents`` passes ``viewer_user_id`` so the list hides others' private
+agents; and the three knowledge READS (``/knowledge``, ``/knowledge/{id}``,
+``/knowledge/search``) call ``agents_service.ensure_can_read`` before hitting kb.
+Previously any licensed workspace member could read any agent's config / KB by
+id. ``GET /agents/{id}/scope`` was already owner-gated and is unchanged.
 """
 
 from __future__ import annotations
@@ -89,15 +98,26 @@ async def create_agent(
 @router.get("")
 async def list_agents(
     workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
     query: str | None = Query(default=None),
 ) -> list[dict]:
-    items = await agents_service.list_agents(workspace_id, query=query)
+    # Visibility gate: pass the caller as ``viewer_user_id`` so another user's
+    # private agents are filtered out of the tenant list.
+    items = await agents_service.list_agents(
+        workspace_id, query=query, viewer_user_id=user_id
+    )
     return [agent_to_dict(a) for a in items]
 
 
 @router.get("/{agent_id}")
-async def get_agent(agent_id: str) -> dict:
-    return agent_to_dict(await agents_service.get(agent_id))
+async def get_agent(
+    agent_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    # Visibility gate: a non-owner cannot read another user's private agent by
+    # id — surfaces as 404 so the id never confirms the agent's existence.
+    return agent_to_dict(await agents_service.get_for_viewer(agent_id, workspace_id, user_id))
 
 
 @router.get("/uname/{slug}")
@@ -230,19 +250,33 @@ async def ingest_urls(agent_id: str, body: dict):
 
 
 @router.get("/{agent_id}/knowledge/search")
-async def search_knowledge(agent_id: str, q: str = Query(..., min_length=1), limit: int = 5):
+async def search_knowledge(
+    agent_id: str,
+    q: str = Query(..., min_length=1),
+    limit: int = 5,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+):
     """Search agent's knowledge base."""
     from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
 
+    # Visibility gate: a non-owner cannot read a private agent's knowledge.
+    await agents_service.ensure_can_read(agent_id, workspace_id, user_id)
     results = await KnowledgeService.search(agent_id, q, limit)
     return {"results": results}
 
 
 @router.get("/{agent_id}/knowledge")
-async def list_knowledge(agent_id: str):
+async def list_knowledge(
+    agent_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+):
     """List all knowledge articles for an agent."""
     from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
 
+    # Visibility gate: a non-owner cannot read a private agent's knowledge.
+    await agents_service.ensure_can_read(agent_id, workspace_id, user_id)
     try:
         articles = await KnowledgeService.list_articles(agent_id)
     except RuntimeError as exc:
@@ -251,10 +285,17 @@ async def list_knowledge(agent_id: str):
 
 
 @router.get("/{agent_id}/knowledge/{article_id}")
-async def get_knowledge_article(agent_id: str, article_id: str):
+async def get_knowledge_article(
+    agent_id: str,
+    article_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+):
     """Fetch the full body of a single knowledge article."""
     from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
 
+    # Visibility gate: a non-owner cannot read a private agent's knowledge.
+    await agents_service.ensure_can_read(agent_id, workspace_id, user_id)
     try:
         return await KnowledgeService.get_article(agent_id, article_id)
     except RuntimeError as exc:

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -7,9 +7,17 @@ Sole owner of writes to the ``Agent`` Beanie document. Module-level
 
 Public API:
 - ``create(ctx, workspace_id, body)``
-- ``get(agent_id)``
+- ``get(agent_id)`` — unguarded load (internal / privileged callers only)
+- ``get_for_viewer(agent_id, workspace_id, user_id)`` — visibility-gated read
+- ``can_read_agent(doc, workspace_id, user_id)`` /
+  ``can_use_agent(doc, workspace_id, user_id)`` — the canonical visibility
+  predicate (owner always; else same-workspace + ``workspace`` visibility; else
+  ``public``), mirroring the DM path in ``group_service.get_or_create_agent_dm``
+- ``ensure_can_read`` / ``ensure_can_use`` — raise ``NotFound`` when the caller
+  may not read / attach the agent (knowledge reads + group/pocket attach)
 - ``get_by_slug(workspace_id, slug)``
-- ``list_agents(workspace_id, query=None)``
+- ``list_agents(workspace_id, query=None, viewer_user_id=None)`` — pass
+  ``viewer_user_id`` on tenant reads to hide other users' ``private`` agents
 - ``update(ctx, agent_id, body)``
 - ``delete(ctx, agent_id)``
 - ``disable(ctx, agent_id)`` / ``enable(ctx, agent_id)`` — soft-disable / revoke
@@ -25,6 +33,14 @@ Updated 2026-07-02 (feat/aiam-agent-revoke, AW-4 follow-up): ``get_persona``
 now returns ``None`` for a soft-disabled agent (reusing the doc it already
 loads — no extra read), so ``agent_bridge``'s smart-relevance LLM probe never
 fires for an agent ``pool.get`` would refuse to run.
+
+Updated 2026-07-15 (fix/agent-visibility-enforcement, ASG-7): "private means
+private" is now enforced on READS. Added the canonical visibility predicate
+``can_read_agent`` / ``can_use_agent`` and the gated entry points
+``get_for_viewer`` / ``ensure_can_read`` / ``ensure_can_use``; ``list_agents``
+grew a ``viewer_user_id`` filter. The tenant HTTP router routes reads through
+these; the unguarded ``get`` / unfiltered ``list_agents`` stay for internal
+callers. Mutation guards (``require_agent_owner_or_admin``) are unchanged.
 """
 
 from __future__ import annotations
@@ -276,14 +292,95 @@ async def create(ctx: RequestContext, workspace_id: str, body: CreateAgentReques
     return agent
 
 
-async def get(agent_id: str) -> Agent:
+async def _load_doc_or_none(agent_id: str) -> _AgentDoc | None:
+    """Load an Agent doc by id, tolerating a malformed id (returns ``None``)."""
     try:
-        doc = await _AgentDoc.get(PydanticObjectId(agent_id))
+        return await _AgentDoc.get(PydanticObjectId(agent_id))
     except Exception:
-        doc = None
+        return None
+
+
+def can_read_agent(doc: _AgentDoc, workspace_id: str | None, user_id: str | None) -> bool:
+    """Return ``True`` if the viewer may READ this agent's config / knowledge.
+
+    Policy (the canonical visibility predicate — mirrors the DM path in
+    ``chat.group_service.get_or_create_agent_dm``): the owner always may; else a
+    same-workspace viewer may read a ``workspace``-visible agent; else anyone may
+    read a ``public`` agent. A ``private`` agent is readable only by its owner.
+    """
+    if user_id is not None and doc.owner == user_id:
+        return True
+    if (
+        doc.visibility == "workspace"
+        and workspace_id is not None
+        and doc.workspace == workspace_id
+    ):
+        return True
+    return doc.visibility == "public"
+
+
+def can_use_agent(doc: _AgentDoc, workspace_id: str | None, user_id: str | None) -> bool:
+    """Return ``True`` if the acting user may USE (attach / run) this agent.
+
+    Same policy as :func:`can_read_agent` — if you can read the agent you may
+    wire it into a group or pocket. Kept as a distinct name so attach-path call
+    sites read as a USE decision, not a READ decision.
+    """
+    return can_read_agent(doc, workspace_id, user_id)
+
+
+async def get(agent_id: str) -> Agent:
+    """Load an agent by id WITHOUT a visibility check.
+
+    Internal / privileged callers (run pool, planner, surface preambles that
+    apply their own workspace guard) use this. Tenant-facing HTTP reads must
+    use :func:`get_for_viewer` so another user's ``private`` agent stays hidden.
+    """
+    doc = await _load_doc_or_none(agent_id)
     if doc is None:
         raise NotFound("agent", agent_id)
     return _to_domain(doc)
+
+
+async def get_for_viewer(
+    agent_id: str, workspace_id: str | None, user_id: str | None
+) -> Agent:
+    """Load an agent by id, enforcing visibility for ``user_id``.
+
+    Raises ``NotFound`` when the viewer may not read the agent — a private or
+    cross-workspace agent is indistinguishable from a missing one, so a leaked
+    id never confirms its existence.
+    """
+    doc = await _load_doc_or_none(agent_id)
+    if doc is None or not can_read_agent(doc, workspace_id, user_id):
+        raise NotFound("agent", agent_id)
+    return _to_domain(doc)
+
+
+async def ensure_can_read(
+    agent_id: str, workspace_id: str | None, user_id: str | None
+) -> None:
+    """Raise ``NotFound`` unless ``user_id`` may READ the agent.
+
+    Used by the knowledge-read endpoints, which key on the ``agent:{id}`` kb
+    scope but must not serve a private agent's knowledge to a non-owner.
+    """
+    doc = await _load_doc_or_none(agent_id)
+    if doc is None or not can_read_agent(doc, workspace_id, user_id):
+        raise NotFound("agent", agent_id)
+
+
+async def ensure_can_use(
+    agent_id: str, workspace_id: str | None, user_id: str | None
+) -> None:
+    """Raise ``NotFound`` unless ``user_id`` may USE (attach) the agent.
+
+    Used by the group + pocket attach paths so a group admin / pocket editor
+    cannot wire in another user's ``private`` agent.
+    """
+    doc = await _load_doc_or_none(agent_id)
+    if doc is None or not can_use_agent(doc, workspace_id, user_id):
+        raise NotFound("agent", agent_id)
 
 
 async def get_by_slug(workspace_id: str, slug: str) -> Agent:
@@ -296,8 +393,28 @@ async def get_by_slug(workspace_id: str, slug: str) -> Agent:
     return _to_domain(doc)
 
 
-async def list_agents(workspace_id: str, *, query: str | None = None) -> list[Agent]:
+async def list_agents(
+    workspace_id: str,
+    *,
+    query: str | None = None,
+    viewer_user_id: str | None = None,
+) -> list[Agent]:
+    """List a workspace's agents.
+
+    When ``viewer_user_id`` is supplied (tenant-facing reads), the result is
+    narrowed to the set that viewer may READ within the workspace: their own
+    agents plus any ``workspace``- or ``public``-visible agent — mirroring
+    :func:`can_read_agent` scoped to the workspace. Another user's ``private``
+    agents are excluded. Internal / privileged callers (planner, kb
+    aggregation) omit ``viewer_user_id`` and get every workspace agent.
+    """
     filters: dict[str, Any] = {"workspace": workspace_id}
+    if viewer_user_id is not None:
+        filters["$or"] = [
+            {"owner": viewer_user_id},
+            {"visibility": "workspace"},
+            {"visibility": "public"},
+        ]
     if query:
         filters["name"] = {"$regex": query, "$options": "i"}
     docs = await _AgentDoc.find(filters).to_list()
@@ -642,12 +759,17 @@ async def ensure_default_agent_all_workspaces() -> int:
 
 
 __all__ = [
+    "can_read_agent",
+    "can_use_agent",
     "create",
     "delete",
     "discover",
+    "ensure_can_read",
+    "ensure_can_use",
     "ensure_default_agent_all_workspaces",
     "get",
     "get_by_slug",
+    "get_for_viewer",
     "get_persona",
     "get_scopes",
     "get_workspace",

--- a/ee/pocketpaw_ee/cloud/chat/group_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/group_service.py
@@ -3,6 +3,12 @@
 Sole owner of writes to the ``Group`` Beanie document. Module-level
 ``async def`` API. The doc → domain mapping helpers (formerly in
 ``repositories.py``) live alongside the public API as private helpers.
+
+Updated: 2026-07-15 (fix/agent-visibility-enforcement, ASG-7) — ``add_agent``
+now gates on ``agents.service.ensure_can_use`` in addition to the
+workspace-membership check, so a group admin can no longer attach another
+user's PRIVATE agent (the DM path already enforced this in
+``get_or_create_agent_dm``).
 """
 
 from __future__ import annotations
@@ -907,10 +913,21 @@ async def _require_agent_in_workspace(agent_id: str, workspace_id: str) -> None:
 
 
 async def add_agent(group_id: str, user_id: str, body: AddGroupAgentRequest) -> None:
-    """Add an agent to a group. Owner only."""
+    """Add an agent to a group. Owner only.
+
+    Visibility gate (ASG-7): the acting admin must be able to USE the agent, not
+    merely find it in the workspace. Without this a group admin could attach
+    another user's PRIVATE agent and every member would then run it. Reuses the
+    canonical predicate in ``agents.service.can_use_agent`` via ``ensure_can_use``
+    (owner always; else same-workspace + ``workspace`` visibility; else
+    ``public``) — a foreign private agent surfaces as ``NotFound``.
+    """
+    from pocketpaw_ee.cloud.agents import service as agents_service
+
     group = await _get_group_domain_or_404(group_id)
     _require_domain_group_admin(group, user_id)
     await _require_agent_in_workspace(body.agent_id, group.workspace_id)
+    await agents_service.ensure_can_use(body.agent_id, group.workspace_id, user_id)
 
     for existing in group.agents:
         if existing.agent_id == body.agent_id:

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -4,6 +4,11 @@ Sole owner of writes to the ``Pocket`` Beanie document. Module-level
 ``async def`` API. The doc → domain mapping helpers (formerly in
 ``repositories.py``) live alongside the public API as private helpers.
 
+Updated: 2026-07-15 (fix/agent-visibility-enforcement, ASG-7) — ``add_agent``
+now gates on ``agents.service.ensure_can_use`` (against the pocket's workspace)
+in addition to pocket edit-access, so a pocket editor can no longer attach
+another user's PRIVATE agent.
+
 Updated: 2026-06-28 (AW-7 template gate deny-on-no-match) — added
 ``resolve_workspace_template_default_deny`` — the effective TEMPLATE-level
 deny-by-default for a workspace (per-workspace ``instinct_template_default_deny``
@@ -2591,8 +2596,18 @@ async def remove_team_member(
 
 
 async def add_agent(pocket_id: str, user_id: str, agent_id: str) -> dict:
+    # Visibility gate (ASG-7): pocket edit-access alone does not authorize
+    # attaching ANY agent. The editor must also be able to USE the agent, or a
+    # pocket editor could wire in another user's PRIVATE agent. ``ensure_can_use``
+    # applies the canonical predicate (owner always; else same-workspace +
+    # ``workspace`` visibility; else ``public``) against the pocket's workspace —
+    # a foreign private agent surfaces as ``NotFound``.
+    from pocketpaw_ee.cloud.agents import service as agents_service
+
     doc = await _fetch_pocket(pocket_id)
-    _check_domain_edit_access(_pocket_to_domain(doc), user_id)
+    pocket = _pocket_to_domain(doc)
+    _check_domain_edit_access(pocket, user_id)
+    await agents_service.ensure_can_use(agent_id, pocket.workspace_id, user_id)
     await _mutate_list_field(pocket_id, "agents", agent_id, "add")
     doc = await _fetch_pocket(pocket_id)
     return await _resolved_wire_dict(doc, user_id)

--- a/tests/cloud/agents/test_agent_visibility_enforcement.py
+++ b/tests/cloud/agents/test_agent_visibility_enforcement.py
@@ -1,0 +1,368 @@
+# tests/cloud/agents/test_agent_visibility_enforcement.py
+# Created: 2026-07-15 (fix/agent-visibility-enforcement, ASG-7) — reproduce-first
+# security tests proving that agent ``visibility`` is enforced on the READ and
+# ATTACH paths, not just on mutation.
+#
+# The product promise is "private means private": an agent set to
+# ``visibility="private"`` must be invisible to everyone except its owner —
+# on config reads, knowledge reads, group attach and pocket attach.
+#
+# Gap A (READ) — before this fix any licensed user could read ANY agent's full
+#   config / knowledge by id via ``get_for_viewer`` (was: ``get``), the list
+#   endpoint, and the three knowledge-read endpoints.
+# Gap B (ATTACH) — before this fix a group admin or pocket editor could attach
+#   another user's PRIVATE agent, and every member then ran it.
+#
+# Policy under test (mirrors the DM predicate in
+# ``chat.group_service.get_or_create_agent_dm``): owner always; else
+# same-workspace AND visibility=="workspace"; else visibility=="public".
+# A denied read/attach surfaces as ``NotFound`` (404) so a leaked id never
+# confirms a private agent's existence.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.agents import service as agents_service
+from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+WS = "w1"
+OWNER = "u_owner"
+OTHER = "u_other"
+
+
+def _ctx(user_id: str, workspace_id: str | None = WS) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _make_agent(
+    *, owner: str = OWNER, slug: str, visibility: str, workspace: str = WS
+) -> str:
+    """Create an agent owned by ``owner`` with the given visibility; return id.
+
+    soul_enabled=False keeps create() off the eager-soul pool path.
+    """
+    body = CreateAgentRequest(
+        name=slug.title(),
+        slug=slug,
+        visibility=visibility,
+        soul_enabled=False,
+    )
+    agent = await agents_service.create(_ctx(owner, workspace), workspace, body)
+    return agent.id
+
+
+# ---------------------------------------------------------------------------
+# Predicate helpers — can_read_agent / can_use_agent
+# ---------------------------------------------------------------------------
+
+
+async def test_can_read_predicate_matrix() -> None:
+    from beanie import PydanticObjectId
+    from pocketpaw_ee.cloud.models.agent import Agent as _AgentDoc
+
+    priv = await _make_agent(slug="priv", visibility="private")
+    ws = await _make_agent(slug="wsvis", visibility="workspace")
+    pub = await _make_agent(slug="pub", visibility="public")
+
+    priv_doc = await _AgentDoc.get(PydanticObjectId(priv))
+    ws_doc = await _AgentDoc.get(PydanticObjectId(ws))
+    pub_doc = await _AgentDoc.get(PydanticObjectId(pub))
+
+    can_read = agents_service.can_read_agent
+    # Owner may read all three.
+    assert can_read(priv_doc, WS, OWNER) is True
+    assert can_read(ws_doc, WS, OWNER) is True
+    assert can_read(pub_doc, WS, OWNER) is True
+    # Non-owner, same workspace: private no, workspace yes, public yes.
+    assert can_read(priv_doc, WS, OTHER) is False
+    assert can_read(ws_doc, WS, OTHER) is True
+    assert can_read(pub_doc, WS, OTHER) is True
+    # Cross-workspace viewer: only public leaks across.
+    assert can_read(priv_doc, "w2", OTHER) is False
+    assert can_read(ws_doc, "w2", OTHER) is False
+    assert can_read(pub_doc, "w2", OTHER) is True
+    # can_use mirrors can_read.
+    assert agents_service.can_use_agent(priv_doc, WS, OTHER) is False
+    assert agents_service.can_use_agent(ws_doc, WS, OTHER) is True
+
+
+# ---------------------------------------------------------------------------
+# Gap A #1 — get_for_viewer denies non-owner read of a private agent
+# ---------------------------------------------------------------------------
+
+
+async def test_get_for_viewer_denies_nonowner_private() -> None:
+    agent_id = await _make_agent(slug="secret", visibility="private")
+
+    with pytest.raises(NotFound):
+        await agents_service.get_for_viewer(agent_id, WS, OTHER)
+
+
+async def test_get_for_viewer_owner_allowed_private() -> None:
+    """POSITIVE control: the owner still reads their own private agent."""
+    agent_id = await _make_agent(slug="mine", visibility="private")
+
+    got = await agents_service.get_for_viewer(agent_id, WS, OWNER)
+    assert got.id == agent_id
+
+
+async def test_get_for_viewer_member_allowed_workspace() -> None:
+    """POSITIVE control: any workspace member reads a workspace-visible agent."""
+    agent_id = await _make_agent(slug="shared", visibility="workspace")
+
+    got = await agents_service.get_for_viewer(agent_id, WS, OTHER)
+    assert got.id == agent_id
+
+
+async def test_get_for_viewer_denies_cross_workspace_workspace_vis() -> None:
+    """A workspace-visible agent does not leak to a viewer in a DIFFERENT
+    workspace — NotFound, not the agent."""
+    agent_id = await _make_agent(slug="wsonly", visibility="workspace")
+
+    with pytest.raises(NotFound):
+        await agents_service.get_for_viewer(agent_id, "w2", OTHER)
+
+
+# ---------------------------------------------------------------------------
+# Gap A #2 — list_agents excludes other users' private agents for a viewer
+# ---------------------------------------------------------------------------
+
+
+async def test_list_agents_viewer_excludes_others_private() -> None:
+    priv = await _make_agent(slug="priv", visibility="private")
+    ws = await _make_agent(slug="wsvis", visibility="workspace")
+    pub = await _make_agent(slug="pub", visibility="public")
+    own_priv = await _make_agent(owner=OTHER, slug="mine", visibility="private")
+
+    listed = await agents_service.list_agents(WS, viewer_user_id=OTHER)
+    ids = {a.id for a in listed}
+
+    # Another user's private agent is NOT visible.
+    assert priv not in ids
+    # Workspace-visible + public + the viewer's own private agent ARE.
+    assert ws in ids
+    assert pub in ids
+    assert own_priv in ids
+
+
+async def test_list_agents_no_viewer_is_unfiltered() -> None:
+    """Internal callers (planner / kb aggregation) pass no viewer and still
+    get every workspace agent — the gate is opt-in via ``viewer_user_id``."""
+    priv = await _make_agent(slug="priv", visibility="private")
+    ws = await _make_agent(slug="wsvis", visibility="workspace")
+
+    listed = await agents_service.list_agents(WS)
+    ids = {a.id for a in listed}
+    assert priv in ids
+    assert ws in ids
+
+
+# ---------------------------------------------------------------------------
+# Gap A #3 — knowledge reads are gated (HTTP layer)
+# ---------------------------------------------------------------------------
+
+
+def _agents_app(viewer_user_id: str, workspace_id: str = WS) -> FastAPI:
+    """A FastAPI app with ONLY the agents router mounted, auth/license
+    overridden to a fixed viewer. Used to exercise the read endpoints."""
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.agents.router import router as agents_router
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(agents_router)
+    app.dependency_overrides[current_user_id] = lambda: viewer_user_id
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://t")
+
+
+# Sentinel patches so a leak (missing gate) is provable WITHOUT invoking kb-go.
+# If the gate is present the endpoint 404s BEFORE these are ever called.
+_KB = "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService"
+
+
+async def test_knowledge_list_denied_for_nonowner_private() -> None:
+    agent_id = await _make_agent(slug="secret", visibility="private")
+
+    with patch(f"{_KB}.list_articles", return_value=[{"id": "leak"}]):
+        async with _client(_agents_app(OTHER)) as client:
+            resp = await client.get(f"/agents/{agent_id}/knowledge")
+    assert resp.status_code == 404
+
+
+async def test_knowledge_search_denied_for_nonowner_private() -> None:
+    agent_id = await _make_agent(slug="secret2", visibility="private")
+
+    with patch(f"{_KB}.search", return_value=["leak"]):
+        async with _client(_agents_app(OTHER)) as client:
+            resp = await client.get(f"/agents/{agent_id}/knowledge/search", params={"q": "x"})
+    assert resp.status_code == 404
+
+
+async def test_knowledge_article_denied_for_nonowner_private() -> None:
+    agent_id = await _make_agent(slug="secret3", visibility="private")
+
+    with patch(f"{_KB}.get_article", return_value={"content": "leak"}):
+        async with _client(_agents_app(OTHER)) as client:
+            resp = await client.get(f"/agents/{agent_id}/knowledge/art1")
+    assert resp.status_code == 404
+
+
+async def test_knowledge_list_allowed_for_owner() -> None:
+    """POSITIVE control: the owner still reads their own agent's knowledge."""
+    agent_id = await _make_agent(slug="mine2", visibility="private")
+
+    with patch(f"{_KB}.list_articles", return_value=[{"id": "a1"}]):
+        async with _client(_agents_app(OWNER)) as client:
+            resp = await client.get(f"/agents/{agent_id}/knowledge")
+    assert resp.status_code == 200
+    assert resp.json() == {"items": [{"id": "a1"}]}
+
+
+async def test_knowledge_list_allowed_for_workspace_member() -> None:
+    """POSITIVE control: a workspace-visible agent's KB is readable by any
+    workspace member (view-only surfaces still work)."""
+    agent_id = await _make_agent(slug="sharedkb", visibility="workspace")
+
+    with patch(f"{_KB}.list_articles", return_value=[{"id": "a1"}]):
+        async with _client(_agents_app(OTHER)) as client:
+            resp = await client.get(f"/agents/{agent_id}/knowledge")
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Gap A — HTTP get / list endpoints apply the gate
+# ---------------------------------------------------------------------------
+
+
+async def test_http_get_agent_denies_nonowner_private() -> None:
+    agent_id = await _make_agent(slug="secret4", visibility="private")
+
+    async with _client(_agents_app(OTHER)) as client:
+        resp = await client.get(f"/agents/{agent_id}")
+    assert resp.status_code == 404
+
+
+async def test_http_get_agent_owner_ok() -> None:
+    agent_id = await _make_agent(slug="mine3", visibility="private")
+
+    async with _client(_agents_app(OWNER)) as client:
+        resp = await client.get(f"/agents/{agent_id}")
+    assert resp.status_code == 200
+    assert resp.json()["_id"] == agent_id
+
+
+async def test_http_list_agents_excludes_others_private() -> None:
+    priv = await _make_agent(slug="priv", visibility="private")
+    ws = await _make_agent(slug="wsvis", visibility="workspace")
+
+    async with _client(_agents_app(OTHER)) as client:
+        resp = await client.get("/agents")
+    assert resp.status_code == 200
+    ids = {row["_id"] for row in resp.json()}
+    assert priv not in ids
+    assert ws in ids
+
+
+# ---------------------------------------------------------------------------
+# Gap B #4 — group add_agent rejects another user's private agent
+# ---------------------------------------------------------------------------
+
+
+async def _make_group(owner: str = OTHER, workspace: str = WS) -> str:
+    from pocketpaw_ee.cloud.chat import group_service
+    from pocketpaw_ee.cloud.chat.schemas import CreateGroupRequest
+
+    resp = await group_service.create_group(
+        workspace, owner, CreateGroupRequest(name="G", type="private")
+    )
+    return resp["_id"] if "_id" in resp else resp["id"]
+
+
+async def test_group_add_agent_denies_foreign_private() -> None:
+    from pocketpaw_ee.cloud.chat import group_service
+    from pocketpaw_ee.cloud.chat.schemas import AddGroupAgentRequest
+
+    # Group owned by OTHER (the admin doing the attach).
+    group_id = await _make_group(owner=OTHER)
+    # Agent owned by OWNER, private, same workspace.
+    agent_id = await _make_agent(owner=OWNER, slug="secretgrp", visibility="private")
+
+    with pytest.raises(NotFound):
+        await group_service.add_agent(group_id, OTHER, AddGroupAgentRequest(agent_id=agent_id))
+
+
+async def test_group_add_agent_allows_workspace_visible() -> None:
+    """POSITIVE control: a workspace-visible agent can still be attached."""
+    from pocketpaw_ee.cloud.chat import group_service
+    from pocketpaw_ee.cloud.chat.schemas import AddGroupAgentRequest
+
+    group_id = await _make_group(owner=OTHER)
+    agent_id = await _make_agent(owner=OWNER, slug="sharedgrp", visibility="workspace")
+
+    # Must NOT raise.
+    await group_service.add_agent(group_id, OTHER, AddGroupAgentRequest(agent_id=agent_id))
+    group = await group_service.get_group(group_id, OTHER)
+    attached = {a.get("agent") or a.get("agent_id") for a in group.get("agents", [])}
+    assert agent_id in attached
+
+
+# ---------------------------------------------------------------------------
+# Gap B #5 — pocket add_agent rejects another user's private agent
+# ---------------------------------------------------------------------------
+
+
+async def _make_pocket(owner: str, workspace: str = WS, visibility: str = "private") -> str:
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(workspace=workspace, name="P", owner=owner, visibility=visibility)
+    await doc.insert()
+    return str(doc.id)
+
+
+async def test_pocket_add_agent_denies_foreign_private() -> None:
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    # Pocket owned by OTHER (the editor doing the attach).
+    pocket_id = await _make_pocket(owner=OTHER)
+    # Agent owned by OWNER, private, same workspace.
+    agent_id = await _make_agent(owner=OWNER, slug="secretpkt", visibility="private")
+
+    with pytest.raises(NotFound):
+        await pockets_service.add_agent(pocket_id, OTHER, agent_id)
+
+
+async def test_pocket_add_agent_allows_workspace_visible() -> None:
+    """POSITIVE control: a workspace-visible agent can still be attached."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    pocket_id = await _make_pocket(owner=OTHER)
+    agent_id = await _make_agent(owner=OWNER, slug="sharedpkt", visibility="workspace")
+
+    result = await pockets_service.add_agent(pocket_id, OTHER, agent_id)
+    # The agent id lands in the pocket's agent list.
+    assert agent_id in [
+        a if isinstance(a, str) else (a.get("_id") or a.get("id")) for a in result.get("agents", [])
+    ]


### PR DESCRIPTION
Makes "private means private" a real guarantee for agents. An audit (during the Agent Studio work) found that agent `visibility` was enforced on the publish/DM path but ignored on several read and attach paths — so any workspace member could pull another user's private agent, and admins could wire one in. None of this was introduced by the gallery work; it was pre-existing. This closes it.

## What was leaking
- **Reads:** `GET /agents/{id}`, `GET /agents`, and the three knowledge-read endpoints returned any agent by id with no visibility check — a non-owner could read a private agent's full config (system prompt, persona, scopes) and its knowledge base, even across workspaces.
- **Attach:** group and pocket `add_agent` checked workspace membership but not visibility — an admin could attach another user's private agent so the whole group/pocket runs it.

## The fix
One canonical predicate, applied at every tenant-facing seam:
- `can_read_agent` / `can_use_agent` in `agents/service.py` — owner always; else a same-workspace `workspace`-visible agent; else `public`. A private agent is owner-only. (Mirrors the existing DM-path predicate.)
- Reads now go through `get_for_viewer` / `ensure_can_read`, which raise `NotFound` (not `Forbidden`) so a leaked id never even confirms the agent exists. `list_agents` gained a `viewer_user_id` filter.
- Group + pocket attach call `ensure_can_use`.
- Mutation guards (`require_agent_owner_or_admin`) are unchanged — non-owners still can't edit.

Internal/privileged callers (planner, KB aggregation, the run pool) keep the unguarded `get` / unfiltered `list_agents` — every caller was checked so no legitimate system path breaks.

## Reproduce-first
`tests/cloud/agents/test_agent_visibility_enforcement.py` — 19 tests, written to fail first (**13 failed before the fix, 19 pass after**): the predicate matrix, deny-non-owner-private / allow-owner / allow-workspace-member / deny-cross-workspace for reads, `list_agents` exclusion, the three knowledge reads, and both attach paths — with positive controls so it doesn't over-tighten. Broad regression across agents/chat/pockets is green except 7 failures that are pre-existing on `dev` (confirmed by stashing this change — identical failures without it).

## Known residual (follow-up, not in this PR)
Two chat-preamble builders (`surface/handlers/agent.py`, `agents.py`) still stamp the **name/slug** of same-workspace private agents into an agent's context — low severity (no config or KB), a different module. Tracked as a small follow-up; happy to fold in if preferred.

## Note
Co-touches `agents/service.py` with pocketpaw#1720 (different functions), so a trivial 3-way at merge.
