### PR TITLE
Show the cloned files: unify the sandbox on /home/daytona

### DIFF
--- a/ee/pocketpaw_ee/cloud/websandbox/constants.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/constants.py
@@ -1,0 +1,13 @@
+# constants.py — shared Web Cursor sandbox constants.
+# Created 2026-07-15: single source of truth for the in-VM workspace directory.
+#
+# Everything the user touches lives under ONE directory in the VM: the repo is
+# cloned here, the file tree/RPC is jailed here, and the terminal opens here.
+# We deliberately use ``/home/daytona`` (the sandbox user's home) rather than the
+# SDK's ``get_project_dir()`` — which on the current Daytona image returns
+# ``/root``, mismatching the PTY's default cwd (``/home/daytona``). Pinning one
+# constant keeps the clone target, the jail root, and the terminal cwd identical
+# so files a user clones are exactly what the tree lists and the shell sees.
+from __future__ import annotations
+
+WEBSANDBOX_WORKDIR = "/home/daytona"

--- a/ee/pocketpaw_ee/cloud/websandbox/files.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/files.py
@@ -40,6 +40,7 @@ import os
 import posixpath
 
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +85,23 @@ def _jail(project_dir: str, rel_path: str, op: str) -> str:
     into a ``file.error`` frame, so download/upload is never reached for a
     traversal attempt.
     """
-    if not isinstance(rel_path, str) or not rel_path.strip():
+    if not isinstance(rel_path, str):
         raise FileRpcError(op, "a 'path' (relative to the project dir) is required")
 
     root = posixpath.normpath(project_dir)
+    # Empty string or '.' addresses the project root itself. The editor's file
+    # tree lists the repo root by requesting path '' (see the frontend
+    # loadTree -> listDir('')), so this MUST resolve to the jail root rather than
+    # being rejected — otherwise the root listing always errors and the tree
+    # shows nothing. Absolute paths and '..' escapes are still refused below.
+    stripped = rel_path.strip()
+    if stripped in ("", ".", "./"):
+        # Listing the root is valid (the tree needs it); reading/writing the
+        # directory itself is not — those still require a real file path.
+        if op == "list":
+            return root
+        raise FileRpcError(op, "a 'path' (relative to the project dir) is required")
+
     # posixpath.join drops the left side entirely if rel_path is absolute, so an
     # absolute path resolves outside the root and is rejected below (belt: the
     # explicit is_absolute check makes the intent obvious).
@@ -133,9 +147,14 @@ class FileRpc:
         self._project_dir = project_dir
 
     async def _root(self) -> str:
-        """Resolve + cache the sandbox project dir (the jail root)."""
+        """The jail root: the pinned in-VM workspace dir (``WEBSANDBOX_WORKDIR``).
+
+        Uses the shared constant, NOT the SDK's ``get_project_dir()`` (which
+        returns ``/root`` on this image and mismatches where the repo is cloned
+        and where the terminal opens). A ``project_dir`` passed to ``__init__``
+        still overrides it (tests inject a fake root)."""
         if self._project_dir is None:
-            self._project_dir = await self._client.get_project_dir(self._sandbox_id)
+            self._project_dir = WEBSANDBOX_WORKDIR
         return self._project_dir
 
     # ── Ops (raise FileRpcError on failure) ───────────────────────────────

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -43,6 +43,7 @@ from fastapi import FastAPI
 from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError, ConflictError, with_cause
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
 from pocketpaw_ee.cloud.websandbox.dto import (
     OpenSandboxRequest,
@@ -186,7 +187,12 @@ async def open_sandbox(
 
         # 4. Clone the PUBLIC repo — pass NO credentials (clean; no token ever
         #    involved). Clone into the sandbox's project dir.
-        project_dir = await daytona.get_project_dir(daytona_id)
+        # Clone INTO the pinned workspace dir (WEBSANDBOX_WORKDIR = /home/daytona)
+        # so the file tree, the terminal cwd, and the clone all agree on one
+        # directory. get_project_dir() returns /root on this image, which the
+        # terminal never opens in — that mismatch is why the tree looked empty.
+        project_dir = WEBSANDBOX_WORKDIR
+        await daytona.execute_command(daytona_id, f"mkdir -p {project_dir}")
         await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
     except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
         # Best-effort teardown of a half-created VM so a failure can't leak it.
@@ -240,7 +246,7 @@ async def get_tree(
     # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
     await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
 
-    project_dir = await daytona.get_project_dir(row.sandbox_id)
+    project_dir = WEBSANDBOX_WORKDIR
     files = await daytona.list_files(row.sandbox_id, project_dir)
     entries = [
         TreeEntryResponse(

--- a/ee/pocketpaw_ee/cloud/websandbox/terminal.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/terminal.py
@@ -24,6 +24,7 @@ from collections.abc import Awaitable, Callable
 from daytona import PtySize
 
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,7 @@ class PtyBridge:
         self._handle = await sb.process.create_pty_session(
             self._session_id,
             self._on_data,
+            cwd=WEBSANDBOX_WORKDIR,  # open the shell where the repo is cloned
             pty_size=PtySize(rows=rows, cols=cols),
         )
         # Wait until the pty WebSocket is live before we accept input. Guarded by

--- a/tests/cloud/test_websandbox_file_rpc.py
+++ b/tests/cloud/test_websandbox_file_rpc.py
@@ -28,7 +28,9 @@ from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
 from pocketpaw_ee.cloud.websandbox.files import FileRpc, FileRpcError
 from pocketpaw_ee.cloud.websandbox.ws import terminal_websocket_endpoint
 
-PROJECT_DIR = "/home/daytona/project"
+# The pinned in-VM workspace dir (WEBSANDBOX_WORKDIR). ws.py builds FileRpc
+# without an explicit project_dir, so it uses this; Tier-1 tests inject it too.
+PROJECT_DIR = "/home/daytona"
 
 
 # ---------------------------------------------------------------------------
@@ -78,7 +80,20 @@ class _FakeFsClient:
 
 
 def _rpc(client: _FakeFsClient) -> FileRpc:
-    return FileRpc(client, "dtn-1")
+    # Inject the fake's project dir so path assertions are independent of the
+    # WEBSANDBOX_WORKDIR default (covered separately below).
+    return FileRpc(client, "dtn-1", project_dir=client.project_dir)
+
+
+async def test_root_defaults_to_websandbox_workdir() -> None:
+    # With no injected project_dir, the jail root is the pinned in-VM workspace
+    # (/home/daytona) — NOT the SDK's get_project_dir() (which returns /root).
+    from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+    client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
+    rpc = FileRpc(client, "dtn-1")
+    await rpc.list_dir("")
+    assert client.list_paths == [WEBSANDBOX_WORKDIR]
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +121,18 @@ async def test_list_returns_entries_with_relative_paths() -> None:
 async def test_list_root_uses_project_dir() -> None:
     client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
     entries = await _rpc(client).list_dir(".")
+    assert client.list_paths == [PROJECT_DIR]
+    assert entries[0]["path"] == "README.md"
+
+
+async def test_list_empty_path_lists_project_root() -> None:
+    # Regression: the editor's file tree lists the repo root by sending path ''
+    # (frontend loadTree -> listDir('')). An empty path MUST resolve to the
+    # project dir, not raise — otherwise the tree comes back empty even though
+    # the repo cloned fine. (Diagnosed live 2026-07-15: clone lands in the
+    # project dir, but list('') was rejected.)
+    client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
+    entries = await _rpc(client).list_dir("")
     assert client.list_paths == [PROJECT_DIR]
     assert entries[0]["path"] == "README.md"
 

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -53,7 +53,7 @@ class _FakeDaytonaClient:
     DI seam. ``clone_fails`` flips ``git_clone`` into a raise to exercise the
     provisioning-failure path."""
 
-    project_dir: str = "/home/daytona/project"
+    project_dir: str = "/home/daytona"  # matches WEBSANDBOX_WORKDIR (clone target + jail root)
     files: list[_FakeFileInfo] = field(
         default_factory=lambda: [
             _FakeFileInfo("README.md", is_dir=False, size=42),
@@ -65,6 +65,7 @@ class _FakeDaytonaClient:
     create_calls: list[dict] = field(default_factory=list)
     wait_calls: list[dict] = field(default_factory=list)
     clone_calls: list[dict] = field(default_factory=list)
+    exec_calls: list[str] = field(default_factory=list)
     stop_calls: list[str] = field(default_factory=list)
     delete_calls: list[str] = field(default_factory=list)
     _counter: int = 0
@@ -85,6 +86,11 @@ class _FakeDaytonaClient:
 
     async def get_project_dir(self, sandbox_id):  # noqa: ANN001
         return self.project_dir
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        # open_sandbox runs ``mkdir -p <workdir>`` before cloning.
+        self.exec_calls.append(command)
+        return None
 
     async def git_clone(self, sandbox_id, repo_url, path, branch=None, commit_id=None):  # noqa: ANN001
         if self.clone_fails:


### PR DESCRIPTION
Bugfix found by actually running it: you clone a repo, it succeeds, but the file tree is empty. Two causes, both fixed here, verified live against a real Daytona VM cloning a real repo.

## 1. The tree asked for the root and got rejected

The editor lists the repo root by sending an empty path. The file-RPC jail treated an empty path as an error, so the root listing always failed and the tree showed nothing. Empty (and `.`) now resolve to the jail root for `list`; `read`/`write` still require a real file path.

## 2. The clone, the terminal, and the tree disagreed on the directory

The clone and the tree used `get_project_dir()`, which returns `/root` on this Daytona image. But the terminal PTY opens in `/home/daytona`. So the repo landed in `/root`, the shell started in an empty `/home/daytona`, and the tree listed a directory that didn't match either in a consistent way. Checking the VM directly showed the disconnect.

A single pinned constant — `WEBSANDBOX_WORKDIR = /home/daytona` — now drives the clone target, the jail root, and the PTY cwd, so all three point at the same place. `/home/daytona` is the sandbox user's home and starts empty, so the repo lands there cleanly.

## Proof

Live run against a real VM cloning a real project repo:

```
cloned into /home/daytona
FileRpc.list_dir('') -> 21 entries: ['.git', 'README.md', 'package.json', 'docs', ...]
terminal: root@...:/home/daytona# pwd && ls  ->  /home/daytona + the repo files
PASS: clone + tree('') + terminal all agree on /home/daytona
```

69 websandbox unit tests pass, including a new regression that `list_dir('')` returns the root listing and that the jail root defaults to the workspace dir.

Stacked on #1724. Merge bases with rebase, not squash.