### PR TITLE
Web Cursor: cloud IDE backend (registry, VM, terminal, files)

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -260,6 +260,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.rules.router import router as rules_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
     from pocketpaw_ee.cloud.skills.router import router as skills_router
+    from pocketpaw_ee.cloud.websandbox.router import router as websandbox_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
 
     app.include_router(auth_router, prefix="/api/v1")
@@ -269,6 +270,9 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(agents_router, prefix="/api/v1")
     app.include_router(audit_router, prefix="/api/v1")
     app.include_router(audit_workspace_router, prefix="/api/v1")
+    # Web Cursor sandbox registry (WC-1) — the (workspace, user, repo) -> sandbox
+    # tenancy/auth oracle every later Web Cursor slice authorizes against.
+    app.include_router(websandbox_router, prefix="/api/v1")
     app.include_router(request_log_router, prefix="/api/v1")
     app.include_router(deep_work_log_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -704,6 +704,13 @@ def mount_cloud(app: FastAPI) -> None:
 
     app.add_api_websocket_route("/ws/cloud", websocket_endpoint)
 
+    # Web Cursor terminal WS (WC-3) — one PTY-over-WS shell per session, bound to
+    # the owning sandbox's Daytona VM. Mounted at root (not /api/v1) so the SPA
+    # connects to ws://host/ws/websandbox/<row_id>?token=<ws_ticket>.
+    from pocketpaw_ee.cloud.websandbox.ws import terminal_websocket_endpoint
+
+    app.add_api_websocket_route("/ws/websandbox/{row_id}", terminal_websocket_endpoint)
+
     # License endpoint (no auth)
     @app.get("/api/v1/license", tags=["License"])
     async def license_info():

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -935,6 +935,30 @@ def mount_cloud(app: FastAPI) -> None:
         async def _stop_fabric_ingest() -> None:
             await stop_fabric_ingest(app)
 
+    # Web Cursor idle-TTL reaper (WC-2, feat/websandbox-vm-provision). Every
+    # ~5 minutes (POCKETPAW_WEBSANDBOX_REAP_INTERVAL_SECONDS) it reclaims
+    # dropped browser-IDE sandboxes: rows in ``ready``/``opening`` whose
+    # ``updated_at`` is older than the idle TTL
+    # (POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS, default 1800) get their Daytona VM
+    # stopped+deleted and the row marked ``reaped``. Same scheduler gate as the
+    # cycle/decisions/ingest loops so pytest runs never spawn a background loop
+    # that outlives the test; production sets POCKETPAW_CLOUD_SCHEDULER_ENABLED=
+    # true. ``start_websandbox_reaper`` also honors its own
+    # POCKETPAW_WEBSANDBOX_REAPER_ENABLED off-switch (default true).
+    if _os.environ.get("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "").lower() == "true":
+        from pocketpaw_ee.cloud.websandbox.provision import (
+            start_websandbox_reaper,
+            stop_websandbox_reaper,
+        )
+
+        @app.on_event("startup")
+        async def _start_websandbox_reaper() -> None:
+            await start_websandbox_reaper(app)
+
+        @app.on_event("shutdown")
+        async def _stop_websandbox_reaper() -> None:
+            await stop_websandbox_reaper(app)
+
     # Mandate autopilot reconciler (feat/belt-autopilot). The persisted
     # ``MandateDoc.autopilot.on`` flag is the source of truth for whether a
     # mandate's autopilot SHOULD run; the background loop itself is

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -46,6 +46,11 @@
 #   (type="agent.disabled") and ``AgentEnabled`` (type="agent.enabled") for the
 #   agent soft-disable / revoke-everywhere flow. Emitted by ``agents.service``
 #   on disable / enable, mirroring ``AgentDeleted``'s payload shape.
+# Updated: 2026-07-15 (WC-1, feat/websandbox-registry) — added
+#   ``WebSandboxRegistered`` (type="websandbox.registered") and
+#   ``WebSandboxStatusChanged`` (type="websandbox.status_changed") for the Web
+#   Cursor sandbox registry. Emitted by ``websandbox.service`` on every
+#   state-mutating call per cloud rule 9.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -1032,3 +1037,21 @@ class TemporalSweepCompleted(Event):
 @dataclass
 class BeltRunUpdated(Event):
     EVENT_TYPE: ClassVar[str] = "belt_run_updated"
+
+
+# Web Cursor sandbox registry (WC-1, feat/websandbox-registry). Emitted by
+# ``websandbox.service`` on every state-mutating call per cloud rule 9 (emit on
+# every write). ``WebSandboxRegistered`` fires when a sandbox row is created /
+# re-registered for a (workspace, user, repo); ``WebSandboxStatusChanged`` fires
+# on a lifecycle transition (pending -> opening -> ready -> stopped -> reaped) or
+# when the Daytona ``sandbox_id`` is bound. ``data`` carries the row id +
+# workspace/user/repo + status so a downstream WS fan-out can refresh the IDE
+# shell without re-reading the doc.
+@dataclass
+class WebSandboxRegistered(Event):
+    EVENT_TYPE: ClassVar[str] = "websandbox.registered"
+
+
+@dataclass
+class WebSandboxStatusChanged(Event):
+    EVENT_TYPE: ClassVar[str] = "websandbox.status_changed"

--- a/ee/pocketpaw_ee/cloud/auth/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/service.py
@@ -118,6 +118,23 @@ async def get_home_pocket_id(user_id: str) -> str | None:
     return doc.home_pocket_id
 
 
+async def get_active_workspace(user_id: str) -> str | None:
+    """Return the user's ``active_workspace`` id, or None if unset.
+
+    Takes a plain ``user_id`` (not a ``RequestContext``) so callers outside the
+    HTTP request cycle — notably the Web Cursor terminal WebSocket, which only
+    holds the ``user_id`` decoded from a ws_ticket — can resolve the caller's
+    workspace without minting a context. This is the same membership field the
+    ``request_context`` dependency reads (``user.active_workspace``); exposing it
+    here keeps ``models.user`` reads inside the auth entity (Rule 2). Returns
+    None when the user has no active workspace so the caller can fail closed.
+    """
+    doc = await _UserDoc.get(PydanticObjectId(user_id))
+    if doc is None:
+        raise NotFound("user", user_id)
+    return doc.active_workspace
+
+
 async def claim_home_pocket_id(user_id: str, new_pocket_id: str, *, expected: str | None) -> bool:
     """Atomically set ``home_pocket_id`` to ``new_pocket_id`` — but only if
     it still holds ``expected``. Returns ``True`` when the swap took.

--- a/ee/pocketpaw_ee/cloud/daytona/context.py
+++ b/ee/pocketpaw_ee/cloud/daytona/context.py
@@ -7,6 +7,8 @@ active project subdirectory (when a ``project_name`` is available via the
 Returns ``None`` when no sandbox is found — the caller falls back to local FS.
 
 Updated: 2026-07-10 — workspace-level VM; legacy per-project sandbox removed.
+Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — the store's workspace-VM
+    accessors are now async + DB-backed; ``await`` the two lookups here.
 """
 
 from __future__ import annotations
@@ -135,7 +137,7 @@ async def resolve_daytona_context(
         get_workspace_vm_sandbox_id,
     )
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
     if sandbox_id:
         from pocketpaw_ee.cloud.daytona.client import get_daytona_client
 
@@ -154,7 +156,7 @@ async def resolve_daytona_context(
             )
             return None
 
-        config = get_workspace_vm_config(workspace_id)
+        config = await get_workspace_vm_config(workspace_id)
         workspace_root = config.get("root_dir", "/workspace")
 
         if project_name:

--- a/ee/pocketpaw_ee/cloud/daytona/router.py
+++ b/ee/pocketpaw_ee/cloud/daytona/router.py
@@ -17,6 +17,9 @@ Mounted at ``/api/v1/``. Endpoints:
   PATCH  /cloud/projects/{name}/vm/files/rename            — Rename in project in VM
 
 Created: 2026-06-24.  Updated: 2026-07-10 — workspace VM replaces per-project sandbox.
+Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — the store's workspace-VM
+    accessors are now async + Mongo-backed (``workspace_vms`` collection); every
+    call site here ``await``s them.
 """
 
 from __future__ import annotations
@@ -243,8 +246,8 @@ async def get_workspace_vm(
         set_workspace_vm,
     )
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
-    config = get_workspace_vm_config(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
+    config = await get_workspace_vm_config(workspace_id)
 
     if sandbox_id:
         # VM already exists — return status.
@@ -265,7 +268,7 @@ async def get_workspace_vm(
             # Sandbox might have been deleted externally — clean up and re-provision.
             from pocketpaw_ee.cloud.daytona.store import remove_workspace_vm as _rm_ws_vm
 
-            _rm_ws_vm(workspace_id)
+            await _rm_ws_vm(workspace_id)
             sandbox_id = None
 
     # No VM exists or it was deleted — auto-provision.
@@ -293,7 +296,7 @@ async def get_workspace_vm(
             disk=disk,
             auto_stop_interval=auto_stop,
         )
-        set_workspace_vm(workspace_id, info.id, sandbox_name, config)
+        await set_workspace_vm(workspace_id, info.id, sandbox_name, config)
 
         # Create the workspace root directory inside the VM.
         root_dir = config.get("root_dir", "/workspace")
@@ -355,13 +358,13 @@ async def provision_workspace_vm(
     client = await _require_daytona()
 
     # Destroy existing VM if any.
-    existing_id = get_workspace_vm_sandbox_id(workspace_id)
+    existing_id = await get_workspace_vm_sandbox_id(workspace_id)
     if existing_id:
         try:
             await client.delete_sandbox(existing_id)
         except Exception as exc:
             logger.warning("Failed to delete existing workspace VM %s: %s", existing_id, exc)
-        remove_workspace_vm(workspace_id)
+        await remove_workspace_vm(workspace_id)
 
     config = {
         "cpu": req.cpu,
@@ -377,7 +380,7 @@ async def provision_workspace_vm(
         memory=req.memory,
         disk=req.disk,
     )
-    set_workspace_vm(workspace_id, info.id, sandbox_name, config)
+    await set_workspace_vm(workspace_id, info.id, sandbox_name, config)
 
     asyncio.create_task(_ensure_workspace_root(client, info.id, req.root_dir))
 
@@ -402,7 +405,7 @@ async def get_workspace_vm_config(
     workspace_id = _resolve_workspace_id(http_request)
     from pocketpaw_ee.cloud.daytona.store import get_workspace_vm_config
 
-    config = get_workspace_vm_config(workspace_id)
+    config = await get_workspace_vm_config(workspace_id)
     return {"ok": True, "config": config}
 
 
@@ -434,9 +437,9 @@ async def update_workspace_vm_config(
 
     updates = req.model_dump(exclude_none=True)
     if updates:
-        update_workspace_vm_config(workspace_id, updates)
+        await update_workspace_vm_config(workspace_id, updates)
 
-    config = get_workspace_vm_config(workspace_id)
+    config = await get_workspace_vm_config(workspace_id)
     return {"ok": True, "config": config}
 
 
@@ -455,7 +458,7 @@ async def stop_workspace_vm(
 
     from pocketpaw_ee.cloud.daytona.store import get_workspace_vm_sandbox_id
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
     if not sandbox_id:
         return {"ok": True, "message": "No workspace VM to stop"}
 
@@ -484,7 +487,7 @@ async def delete_workspace_vm(
         remove_workspace_vm,
     )
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
     if not sandbox_id:
         return {"ok": True, "message": "No workspace VM to delete"}
 
@@ -494,7 +497,7 @@ async def delete_workspace_vm(
     except Exception as exc:
         logger.warning("Failed to delete workspace VM %s: %s", sandbox_id, exc)
 
-    remove_workspace_vm(workspace_id)
+    await remove_workspace_vm(workspace_id)
     return {"ok": True, "message": "Workspace VM deleted"}
 
 
@@ -507,7 +510,7 @@ async def get_workspace_vm_terminal(
 
     from pocketpaw_ee.cloud.daytona.store import get_workspace_vm_sandbox_id
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
     if not sandbox_id:
         raise HTTPException(status_code=404, detail="No workspace VM provisioned")
 
@@ -559,7 +562,7 @@ async def _require_workspace_vm(
         get_workspace_vm_sandbox_id,
     )
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
     if not sandbox_id:
         raise HTTPException(
             status_code=404,
@@ -574,7 +577,7 @@ async def _require_workspace_vm(
             detail=f"VM is in state '{info.state}' — must be 'started' for file operations",
         )
 
-    config = get_workspace_vm_config(workspace_id)
+    config = await get_workspace_vm_config(workspace_id)
     workspace_root = config.get("root_dir", "/workspace")
     project_abs_path = f"{workspace_root}/{project_name}".replace("//", "/")
 

--- a/ee/pocketpaw_ee/cloud/daytona/store.py
+++ b/ee/pocketpaw_ee/cloud/daytona/store.py
@@ -2,7 +2,7 @@
 
 TWO layers of mapping:
 
-1. **Workspace-level VM** (NEW — primary).
+1. **Workspace-level VM** (PRIMARY — now DB-backed).
    Maps ``workspace_id`` → a single Daytona sandbox shared by ALL projects
    in that workspace.  Projects live as subdirectories under a configurable
    workspace root (default ``/workspace``).
@@ -11,11 +11,20 @@ TWO layers of mapping:
    Maps ``projects/{workspace_id}/{user_id}/{project_name}/`` keys to
    Daytona sandbox IDs.  Deprecated in favour of the workspace-level VM.
 
-Both maps are persisted under ``~/.pocketpaw/`` so the mapping survives
-process restarts.
-
 Moved from inline helpers in router.py: 2026-07-01
 Updated: 2026-07-10 — added workspace-level VM mapping.
+Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — the workspace-level VM map
+    moved out of the local ``~/.pocketpaw/daytona_workspace_vm_map.json`` file
+    and into MongoDB (the ``workspace_vms`` collection, ``WorkspaceVm`` doc).
+    A local-first JSON artifact does not belong in multi-tenant cloud: reads
+    must be tenant-scoped and survive across processes/replicas. The six
+    workspace-VM functions are now ``async`` and read/write the collection;
+    every caller ``await``s them. The LEGACY per-project map below is still
+    JSON-file-backed and unchanged — deprecated, migrate on touch.
+
+store.py owns the ``workspace_vms`` collection: the ``WorkspaceVm`` doc class is
+imported ONLY inside this module (ee/cloud Rule 2 spirit — store.py is a
+persistence helper, not a full 4-file entity).
 """
 
 from __future__ import annotations
@@ -27,17 +36,21 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# In-memory cache + disk paths
+# In-memory cache + disk paths (LEGACY per-project map only)
 # ---------------------------------------------------------------------------
 
 _workspace_map: dict[str, dict] = {}
 _MAP_PATH = Path.home() / ".pocketpaw" / "daytona_workspace_map.json"
 
-# Workspace-level VM map
-_WORKSPACE_VM_MAP: dict[str, dict] = {}
-_WS_VM_MAP_PATH = Path.home() / ".pocketpaw" / "daytona_workspace_vm_map.json"
+# Legacy JSON path for the workspace-level VM map. No longer read/written by the
+# accessors (they are DB-backed now); retained only so the one-time
+# ``migrate_workspace_vm_map_to_db`` boot task in ``ee.cloud.shared.db`` can
+# import + import the captain's existing on-disk entries into Mongo.
+WS_VM_MAP_PATH = Path.home() / ".pocketpaw" / "daytona_workspace_vm_map.json"
 
 # Default VM configuration
+# TODO(bug): root_dir should be /home/daytona; auto_stop_interval is MINUTES not
+# 3600s. Changing these VALUES alters legacy VM behavior — out of scope here.
 _DEFAULT_VM_CONFIG: dict = {
     "cpu": 2,
     "memory": 4,  # GB
@@ -47,7 +60,12 @@ _DEFAULT_VM_CONFIG: dict = {
 }
 
 # ---------------------------------------------------------------------------
-# Per-project accessors (LEGACY — keep for backward compat)
+# Per-project accessors (LEGACY — DEPRECATED, still JSON-file-backed)
+#
+# These map ``projects/{workspace_id}/{user_id}/{project_name}/`` keys to
+# sandbox IDs in ``daytona_workspace_map.json``. Superseded by the DB-backed
+# workspace-level VM map below; kept only for backward compat. Migrate to the
+# workspace-level VM (or a DB collection of their own) on next touch.
 # ---------------------------------------------------------------------------
 
 
@@ -122,93 +140,122 @@ def list_all_mappings() -> dict[str, dict]:
 
 
 # ---------------------------------------------------------------------------
-# Workspace-level VM accessors (NEW — primary path)
+# Workspace-level VM accessors (PRIMARY — DB-backed, ``workspace_vms``)
+#
+# Each accessor is ``async`` and tenant-scoped by ``workspace``. store.py is the
+# sole importer of the ``WorkspaceVm`` doc class (imported locally inside each
+# function so a plain ``import ee.cloud.daytona.store`` never drags Beanie in).
 # ---------------------------------------------------------------------------
 
 
-def _load_ws_vm_map() -> dict[str, dict]:
-    """Load the workspace VM map from disk, caching in memory."""
-    global _WORKSPACE_VM_MAP
-    if _WORKSPACE_VM_MAP:
-        return _WORKSPACE_VM_MAP
-    try:
-        if _WS_VM_MAP_PATH.exists():
-            with open(_WS_VM_MAP_PATH) as f:
-                _WORKSPACE_VM_MAP = json.load(f)
-    except Exception as exc:
-        logger.warning("Failed to load workspace VM map: %s", exc)
-    return _WORKSPACE_VM_MAP
-
-
-def _save_ws_vm_map() -> None:
-    """Persist the workspace VM map to disk."""
-    global _WORKSPACE_VM_MAP
-    try:
-        _WS_VM_MAP_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with open(_WS_VM_MAP_PATH, "w") as f:
-            json.dump(_WORKSPACE_VM_MAP, f, indent=2)
-    except Exception as exc:
-        logger.warning("Failed to save workspace VM map: %s", exc)
-
-
-def get_workspace_vm_sandbox_id(workspace_id: str) -> str | None:
+async def get_workspace_vm_sandbox_id(workspace_id: str) -> str | None:
     """Get the sandbox ID for a workspace, or None."""
-    mapping = _load_ws_vm_map()
-    entry = mapping.get(workspace_id)
-    return entry.get("sandbox_id") if entry else None
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+    return doc.sandbox_id if doc else None
 
 
-def set_workspace_vm(
+async def set_workspace_vm(
     workspace_id: str,
     sandbox_id: str,
     sandbox_name: str,
     config: dict | None = None,
 ) -> None:
-    """Record the workspace VM sandbox mapping with optional config override."""
-    mapping = _load_ws_vm_map()
-    existing = mapping.get(workspace_id, {})
-    existing.update(
-        {
-            "sandbox_id": sandbox_id,
-            "sandbox_name": sandbox_name,
-        }
-    )
+    """Upsert the workspace VM sandbox mapping with optional config override."""
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+    if doc is None:
+        # Insert. Merge config over defaults when given, else seed defaults.
+        merged = {**_DEFAULT_VM_CONFIG, **config} if config else dict(_DEFAULT_VM_CONFIG)
+        doc = WorkspaceVm(
+            workspace=workspace_id,
+            sandbox_id=sandbox_id,
+            sandbox_name=sandbox_name,
+            config=merged,
+        )
+        await doc.insert()
+        return
+
+    # Update in place.
+    doc.sandbox_id = sandbox_id
+    doc.sandbox_name = sandbox_name
     if config:
-        existing["config"] = {**_DEFAULT_VM_CONFIG, **config}
-    elif "config" not in existing:
-        existing["config"] = dict(_DEFAULT_VM_CONFIG)
-    mapping[workspace_id] = existing
-    _save_ws_vm_map()
+        doc.config = {**_DEFAULT_VM_CONFIG, **config}
+    elif not doc.config:
+        doc.config = dict(_DEFAULT_VM_CONFIG)
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
 
 
-def remove_workspace_vm(workspace_id: str) -> None:
-    """Remove the workspace VM mapping."""
-    mapping = _load_ws_vm_map()
-    mapping.pop(workspace_id, None)
-    _save_ws_vm_map()
+async def remove_workspace_vm(workspace_id: str) -> None:
+    """Remove the workspace VM mapping (deletes the row)."""
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+    if doc is not None:
+        await doc.delete()
 
 
-def get_workspace_vm_config(workspace_id: str) -> dict:
-    """Return the VM config for a workspace, or defaults if not set."""
-    mapping = _load_ws_vm_map()
-    entry = mapping.get(workspace_id, {})
-    return {**_DEFAULT_VM_CONFIG, **entry.get("config", {})}
+async def get_workspace_vm_config(workspace_id: str) -> dict:
+    """Return the VM config for a workspace, merged over defaults."""
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+    stored = doc.config if doc else {}
+    return {**_DEFAULT_VM_CONFIG, **(stored or {})}
 
 
-def update_workspace_vm_config(workspace_id: str, config_updates: dict) -> None:
-    """Merge *config_updates* into the workspace VM config and persist."""
-    mapping = _load_ws_vm_map()
-    entry = mapping.get(workspace_id, {})
-    current_config = {**_DEFAULT_VM_CONFIG, **entry.get("config", {})}
+async def update_workspace_vm_config(workspace_id: str, config_updates: dict) -> None:
+    """Merge *config_updates* into the workspace VM config and persist.
+
+    Creates the row if the workspace has no VM record yet (config-only row —
+    ``sandbox_id``/``sandbox_name`` are empty until a VM is provisioned).
+    """
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+    if doc is None:
+        merged = {**_DEFAULT_VM_CONFIG, **config_updates}
+        doc = WorkspaceVm(
+            workspace=workspace_id,
+            sandbox_id="",
+            sandbox_name="",
+            config=merged,
+        )
+        await doc.insert()
+        return
+
+    current_config = {**_DEFAULT_VM_CONFIG, **(doc.config or {})}
     current_config.update(config_updates)
-    entry["config"] = current_config
-    mapping[workspace_id] = entry
-    _save_ws_vm_map()
+    doc.config = current_config
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
 
 
-def list_all_workspace_vms() -> dict[str, dict]:
-    """Return the full workspace VM map (read-only snapshot)."""
-    return dict(_load_ws_vm_map())
+async def list_all_workspace_vms() -> dict[str, dict]:
+    """Return the full workspace VM map (``workspace_id`` -> entry dict).
+
+    Global read across tenants — the map is a system-level registry consumed by
+    ops/admin surfaces, not a per-tenant read path.
+    """
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    # global-read: system-level VM registry (ops/admin), not a tenant read path.
+    docs = await WorkspaceVm.find_all().to_list()
+    return {
+        doc.workspace: {
+            "sandbox_id": doc.sandbox_id,
+            "sandbox_name": doc.sandbox_name,
+            "config": dict(doc.config or {}),
+        }
+        for doc in docs
+    }
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,11 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — added ``WorkspaceVm`` (the
+workspace→Daytona-VM mapping, moved out of the local
+``~/.pocketpaw/daytona_workspace_vm_map.json`` file into the ``workspace_vms``
+collection) to the imports, ``__all__``, and ``get_all_documents()`` so the
+collection is wired into ``init_beanie``. Only ``ee.cloud.daytona.store``
+imports the doc class directly.
 Updated: 2026-07-15 (WC-1, feat/websandbox-registry) — added ``WebSandbox``
 (the Web Cursor sandbox registry: the (workspace_id, user_id, repo) -> sandbox
 tenancy/auth oracle) to the imports, ``__all__``, and ``get_all_documents()`` so
@@ -188,6 +194,7 @@ from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
 from pocketpaw_ee.cloud.models.workspace_automation_config import WorkspaceAutomationConfig
 from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
+from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
 
 # Lazy import to avoid circular imports
 FileUpload: type = None  # type: ignore[assignment]
@@ -351,6 +358,7 @@ __all__ = [
     "WorkspaceJobDoc",
     "WorkspaceMembership",
     "WorkspaceSettings",
+    "WorkspaceVm",
 ]
 
 
@@ -472,6 +480,10 @@ def get_all_documents():
         # sandbox tenancy/auth oracle. Only ``ee.cloud.websandbox.service``
         # imports this doc directly (import-linter "WebSandbox" contract).
         WebSandbox,
+        # Workspace→Daytona-VM mapping (fix/workspace-vm-map-to-db) — moved out
+        # of the local daytona_workspace_vm_map.json file. One VM per workspace.
+        # Only ``ee.cloud.daytona.store`` imports this doc directly.
+        WorkspaceVm,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,11 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-15 (WC-1, feat/websandbox-registry) — added ``WebSandbox``
+(the Web Cursor sandbox registry: the (workspace_id, user_id, repo) -> sandbox
+tenancy/auth oracle) to the imports, ``__all__``, and ``get_all_documents()`` so
+the ``web_sandboxes`` collection is wired into ``init_beanie``. Only
+``ee.cloud.websandbox.service`` imports the doc class directly (import-linter
+"WebSandbox" contract).
 Updated: 2026-07-08 (feat/external-alerting-delivery) — added
 ``NotificationDeliveryConfig`` (the per-workspace external-delivery config: Slack
 incoming-webhook + generic HTTPS webhook + enabled switch + per-kind routing) to
@@ -178,6 +184,7 @@ from pocketpaw_ee.cloud.models.task_event import TaskEvent
 from pocketpaw_ee.cloud.models.temporal_sweep_state import TemporalSweepStateDoc
 from pocketpaw_ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from pocketpaw_ee.cloud.models.vapid_keypair import VapidKeypair
+from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
 from pocketpaw_ee.cloud.models.workspace_automation_config import WorkspaceAutomationConfig
 from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
@@ -336,6 +343,7 @@ __all__ = [
     "TaskEvent",
     "TemporalSweepStateDoc",
     "User",
+    "WebSandbox",
     "Widget",
     "WidgetPosition",
     "Workspace",
@@ -460,6 +468,10 @@ def get_all_documents():
         sighting_doc,
         # Branch primitive — universal artifact version log (BP-1).
         artifact_version_doc,
+        # Web Cursor sandbox registry (WC-1) — the (workspace, user, repo) ->
+        # sandbox tenancy/auth oracle. Only ``ee.cloud.websandbox.service``
+        # imports this doc directly (import-linter "WebSandbox" contract).
+        WebSandbox,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/web_sandbox.py
+++ b/ee/pocketpaw_ee/cloud/models/web_sandbox.py
@@ -1,0 +1,54 @@
+"""WebSandbox document — the Sandbox Registry for the Web Cursor browser IDE.
+
+Created 2026-07-15 (WC-1, feat/websandbox-registry): the tenancy/auth oracle
+that maps ``(workspace_id, user_id, repo) -> sandbox_id + lifecycle state +
+installation pointer``. One row per ``(workspace_id, user_id, repo)`` (enforced
+by a unique compound index AND app-level upsert in the service). This is the
+security foundation every later Web Cursor slice authorizes against.
+
+Only ``ee.cloud.websandbox.service`` imports this doc class directly
+(import-linter "WebSandbox" contract, same discipline as AuditEvent).
+
+The ``installation_id`` is a plain optional str here — a pointer to a future
+GitHub App installation. WC-6 encrypts it at rest; until then it is stored in
+the clear (never a token, only an installation identifier).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+from pymongo import IndexModel
+
+
+class WebSandbox(Document):
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    user_id: Indexed(str)  # type: ignore[valid-type]
+    # A repo identifier / URL the sandbox is opened against.
+    repo: str
+    # The Daytona sandbox id — null until the VM is cold-provisioned (WC-2).
+    sandbox_id: str | None = None
+    # Lifecycle state: pending | opening | ready | stopped | reaped.
+    status: str = "pending"
+    # Pointer to a future GitHub App installation (WC-6 encrypts this at rest;
+    # plain optional str for now — an installation id, never a token).
+    installation_id: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "web_sandboxes"
+        indexes = [
+            # One sandbox per (workspace, user, repo) — the registry key.
+            IndexModel(
+                [("workspace_id", 1), ("user_id", 1), ("repo", 1)],
+                unique=True,
+                name="ws_user_repo_unique",
+            ),
+            # The per-user list read path (list_sandboxes).
+            IndexModel([("workspace_id", 1), ("user_id", 1)]),
+            # The authorize-by-Daytona-id read path (authorize_sandbox).
+            IndexModel([("workspace_id", 1), ("sandbox_id", 1)]),
+        ]

--- a/ee/pocketpaw_ee/cloud/models/web_sandbox.py
+++ b/ee/pocketpaw_ee/cloud/models/web_sandbox.py
@@ -12,6 +12,13 @@ Only ``ee.cloud.websandbox.service`` imports this doc class directly
 The ``installation_id`` is a plain optional str here — a pointer to a future
 GitHub App installation. WC-6 encrypts it at rest; until then it is stored in
 the clear (never a token, only an installation identifier).
+
+Changed 2026-07-15 (WC-S3, feat/websandbox-s3-durability): added
+``snapshot_file_id`` — a pointer to the tenant's most recent workspace snapshot
+in blob storage (an ``EEUploadService`` FileRecord id). The VM is scratch and
+gets reaped; this durable pointer lets a user's uncommitted work + workspace
+state be restored into a fresh VM. Null until the first snapshot is taken. No
+new index needed — it's read only via the owner-scoped registry row.
 """
 
 from __future__ import annotations
@@ -35,6 +42,10 @@ class WebSandbox(Document):
     # Pointer to a future GitHub App installation (WC-6 encrypts this at rest;
     # plain optional str for now — an installation id, never a token).
     installation_id: str | None = None
+    # Pointer to the latest durable workspace snapshot in the tenant's blob
+    # storage (an EEUploadService FileRecord id). Null until the first snapshot;
+    # set by ``service.set_snapshot`` from the WC-S3 durability module.
+    snapshot_file_id: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/ee/pocketpaw_ee/cloud/models/workspace_vm.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace_vm.py
@@ -1,0 +1,39 @@
+"""WorkspaceVm document — the workspace→Daytona-VM mapping (DB-backed).
+
+Created 2026-07-15 (fix/workspace-vm-map-to-db): moves the workspace-level VM
+mapping out of a local JSON file (``~/.pocketpaw/daytona_workspace_vm_map.json``,
+via ``ee.cloud.daytona.store``) and into MongoDB. A local-first JSON artifact
+does not belong in multi-tenant cloud — every read must be tenant-scoped and
+survive across processes/replicas. One VM per workspace (unique index on
+``workspace``).
+
+Only ``ee.cloud.daytona.store`` imports this doc class directly — store.py is
+the module that owns this collection (ee/cloud Rule 2 spirit; store.py is a
+persistence helper, not a full 4-file entity). ``config`` mirrors the legacy
+JSON shape (cpu/memory/disk/root_dir/auto_stop_interval) so the one-time
+migration can copy entries across without transformation.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+from pymongo import IndexModel
+
+
+class WorkspaceVm(Document):
+    workspace: Indexed(str)  # type: ignore[valid-type]  # unique — one VM per workspace
+    sandbox_id: str
+    sandbox_name: str
+    config: dict = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "workspace_vms"
+        indexes = [
+            # One VM per workspace — the registry key.
+            IndexModel([("workspace", 1)], unique=True, name="workspace_unique"),
+        ]

--- a/ee/pocketpaw_ee/cloud/shared/db.py
+++ b/ee/pocketpaw_ee/cloud/shared/db.py
@@ -1,5 +1,14 @@
 """MongoDB connection and Beanie ODM initialization.
 
+2026-07-15 (fix/workspace-vm-map-to-db): added ``migrate_workspace_vm_map_to_db``
+— a best-effort, one-time boot task that imports the captain's existing
+workspace→VM entries from the legacy local JSON file
+(``~/.pocketpaw/daytona_workspace_vm_map.json``) into the new ``workspace_vms``
+Mongo collection, then renames the file to ``.migrated`` so it never re-imports.
+Skips any workspace whose DB row already exists (never clobbers newer DB state),
+wraps everything in try/except so a migration hiccup can't block boot, and is
+called once from ``init_cloud_db`` after Beanie is initialized.
+
 2026-06-26 (ART-4): added ``is_multi_tenant_cloud()`` — the single, named home
 for the established "this process is serving tenants" signal
 (``get_client() is not None``, set exactly when ``init_cloud_db`` ran). The
@@ -82,6 +91,74 @@ async def _drop_legacy_invite_token_index(db) -> None:  # type: ignore[no-untype
         logger.exception("Failed to drop legacy 'token_1' index on invites")
 
 
+async def migrate_workspace_vm_map_to_db() -> None:
+    """One-time import of the legacy workspace→VM JSON map into Mongo.
+
+    The workspace-level VM map used to live in
+    ``~/.pocketpaw/daytona_workspace_vm_map.json`` (``ee.cloud.daytona.store``).
+    It is now the ``workspace_vms`` Mongo collection. So an existing deploy's
+    VMs aren't orphaned by the move, this reads the file (if present), upserts
+    each workspace's entry into ``WorkspaceVm`` — SKIPPING any workspace whose
+    row already exists so newer DB state is never clobbered — then renames the
+    file to ``<name>.migrated`` so it doesn't re-import on the next boot.
+
+    Best-effort: the whole body is wrapped so a migration hiccup never blocks
+    boot. Idempotent — once the file is renamed, subsequent calls are no-ops.
+    """
+    import json
+
+    from pocketpaw_ee.cloud.daytona.store import WS_VM_MAP_PATH
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    try:
+        if not WS_VM_MAP_PATH.exists():
+            return
+
+        with open(WS_VM_MAP_PATH) as f:
+            data = json.load(f)
+
+        if not isinstance(data, dict):
+            logger.warning(
+                "Legacy workspace VM map at %s is not a dict — skipping migration",
+                WS_VM_MAP_PATH,
+            )
+            data = {}
+
+        imported = 0
+        for workspace_id, entry in data.items():
+            if not isinstance(entry, dict):
+                continue
+            existing = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+            if existing is not None:
+                # Don't clobber newer DB state.
+                continue
+            doc = WorkspaceVm(
+                workspace=workspace_id,
+                sandbox_id=entry.get("sandbox_id", ""),
+                sandbox_name=entry.get("sandbox_name", ""),
+                config=dict(entry.get("config", {}) or {}),
+            )
+            await doc.insert()
+            imported += 1
+            logger.info(
+                "Migrated workspace VM map for workspace %s (sandbox %s) into Mongo",
+                workspace_id,
+                doc.sandbox_id,
+            )
+
+        # Rename so we never re-import — even if nothing was imported this run
+        # (all rows already existed), the file has served its purpose.
+        migrated_path = WS_VM_MAP_PATH.with_suffix(WS_VM_MAP_PATH.suffix + ".migrated")
+        WS_VM_MAP_PATH.rename(migrated_path)
+        logger.info(
+            "Workspace VM map migration complete: %d imported, file renamed to %s",
+            imported,
+            migrated_path.name,
+        )
+    except Exception:  # pragma: no cover - migration must never block boot
+        logger.exception("Workspace VM map migration failed; continuing boot")
+
+
 async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterprise") -> None:
     """Initialize Beanie ODM with all document models."""
     global _client
@@ -107,6 +184,11 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
     # declares. The invite-token hashing rollout left a unique index on the
     # now-nullable `token` column that 500s every second invite.
     await _drop_legacy_invite_token_index(db)
+
+    # One-time import of the legacy workspace→VM JSON map into Mongo. Runs after
+    # init_beanie so the ``workspace_vms`` collection is live. Best-effort — the
+    # helper swallows its own errors so a migration hiccup never blocks boot.
+    await migrate_workspace_vm_map_to_db()
 
     # Flip the memory backend AFTER Beanie is initialized so the
     # MongoMemoryStore's first .insert()/.find() call can never race a

--- a/ee/pocketpaw_ee/cloud/websandbox/__init__.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/__init__.py
@@ -1,0 +1,4 @@
+# __init__.py — the Web Cursor Sandbox Registry entity (WC-1).
+# Created 2026-07-15 (feat/websandbox-registry): a 4-file cloud entity
+# (domain / dto / service / router) that maps (workspace_id, user_id, repo)
+# to a sandbox row with fail-closed cross-tenant authorization.

--- a/ee/pocketpaw_ee/cloud/websandbox/constants.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/constants.py
@@ -1,0 +1,13 @@
+# constants.py — shared Web Cursor sandbox constants.
+# Created 2026-07-15: single source of truth for the in-VM workspace directory.
+#
+# Everything the user touches lives under ONE directory in the VM: the repo is
+# cloned here, the file tree/RPC is jailed here, and the terminal opens here.
+# We deliberately use ``/home/daytona`` (the sandbox user's home) rather than the
+# SDK's ``get_project_dir()`` — which on the current Daytona image returns
+# ``/root``, mismatching the PTY's default cwd (``/home/daytona``). Pinning one
+# constant keeps the clone target, the jail root, and the terminal cwd identical
+# so files a user clones are exactly what the tree lists and the shell sees.
+from __future__ import annotations
+
+WEBSANDBOX_WORKDIR = "/home/daytona"

--- a/ee/pocketpaw_ee/cloud/websandbox/domain.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/domain.py
@@ -1,0 +1,44 @@
+# domain.py — Frozen value objects for the Web Cursor Sandbox Registry.
+# Created 2026-07-15 (WC-1, feat/websandbox-registry): tenancy fields
+# (workspace_id, user_id) are REQUIRED at construction with no defaults per
+# ee/cloud Rule 3 — constructing a view without tenancy is a TypeError, so a
+# leak can't be minted by omission.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, NewType
+
+WebSandboxId = NewType("WebSandboxId", str)
+
+# The lifecycle a sandbox row moves through. Kept as a Literal so an unknown
+# state is a type error at the boundary rather than a silent string.
+SandboxStatus = Literal["pending", "opening", "ready", "stopped", "reaped"]
+
+
+@dataclass(frozen=True)
+class WebSandboxView:
+    """Read model for one sandbox row.
+
+    Every field is required at construction — the tenancy fields
+    (``workspace_id``, ``user_id``) most of all, per Rule 3. A view is only
+    ever built from a persisted, tenant-checked row, so there is no safe
+    default for who owns it.
+    """
+
+    id: WebSandboxId
+    workspace_id: str
+    user_id: str
+    repo: str
+    status: str
+    sandbox_id: str | None
+    installation_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+__all__ = [
+    "SandboxStatus",
+    "WebSandboxId",
+    "WebSandboxView",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/domain.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/domain.py
@@ -3,6 +3,11 @@
 # (workspace_id, user_id) are REQUIRED at construction with no defaults per
 # ee/cloud Rule 3 — constructing a view without tenancy is a TypeError, so a
 # leak can't be minted by omission.
+#
+# Changed 2026-07-15 (WC-S3, feat/websandbox-s3-durability): added the optional
+# ``snapshot_file_id`` — the pointer to the row's latest durable workspace
+# snapshot in blob storage. Optional (default None) so it lands after the
+# required tenancy fields without breaking the single construction site.
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -35,6 +40,8 @@ class WebSandboxView:
     installation_id: str | None
     created_at: datetime
     updated_at: datetime
+    # Pointer to the latest durable workspace snapshot in blob storage (WC-S3).
+    snapshot_file_id: str | None = None
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -1,0 +1,54 @@
+# dto.py — Request/response DTOs for the Web Cursor Sandbox Registry.
+# Created 2026-07-15 (WC-1, feat/websandbox-registry): distinct <Op>Request
+# and <Entity>Response classes per ee/cloud Rule 4 — one model is never reused
+# for both input and output, so a server-owned field (id, timestamps) can't
+# leak into the write surface. Wire shape is camelCase to match the rest of
+# the cloud surface.
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CreateSandboxRequest(BaseModel):
+    """Register (or re-register) a sandbox for a (workspace, user, repo).
+
+    Only ``repo`` is required; the rest are set by the provisioner as the
+    sandbox moves through its lifecycle. Creating is idempotent per
+    (workspace, user, repo) — see ``service.create_sandbox``.
+    """
+
+    repo: str = Field(..., min_length=1, max_length=1024)
+    sandbox_id: str | None = Field(default=None, max_length=256)
+    status: str = Field(default="pending", max_length=32)
+    installation_id: str | None = Field(default=None, max_length=256)
+
+
+class UpdateStatusRequest(BaseModel):
+    """Advance a sandbox's lifecycle state (and optionally bind its id)."""
+
+    status: str = Field(..., max_length=32)
+    sandbox_id: str | None = Field(default=None, max_length=256)
+
+
+class WebSandboxResponse(BaseModel):
+    id: str
+    workspaceId: str
+    userId: str
+    repo: str
+    status: str
+    sandboxId: str | None = None
+    installationId: str | None = None
+    createdAt: str  # ISO-8601 UTC
+    updatedAt: str  # ISO-8601 UTC
+
+
+class WebSandboxListResponse(BaseModel):
+    items: list[WebSandboxResponse]
+
+
+__all__ = [
+    "CreateSandboxRequest",
+    "UpdateStatusRequest",
+    "WebSandboxListResponse",
+    "WebSandboxResponse",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -4,6 +4,13 @@
 # for both input and output, so a server-owned field (id, timestamps) can't
 # leak into the write surface. Wire shape is camelCase to match the rest of
 # the cloud surface.
+#
+# Changed 2026-07-15 (WC-2, feat/websandbox-vm-provision): added the
+# cold-provision + file-tree DTOs — ``OpenSandboxRequest`` (the repo URL to open,
+# optional branch), ``TreeEntryResponse`` (one node in the cloned repo's file
+# tree), and ``SandboxTreeResponse`` (the tree wrapper carrying the bound Daytona
+# id). Same Rule-4 discipline: the open surface accepts only a repo + branch and
+# never a server-owned id/status.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -46,8 +53,45 @@ class WebSandboxListResponse(BaseModel):
     items: list[WebSandboxResponse]
 
 
+# ---------------------------------------------------------------------------
+# WC-2 — cold-provision + file tree.
+# ---------------------------------------------------------------------------
+
+
+class OpenSandboxRequest(BaseModel):
+    """Open a sandbox against a public repo — cold-provision a VM and clone it.
+
+    Only the repo URL (and an optional branch) crosses the wire; the Daytona
+    ``sandbox_id`` and lifecycle ``status`` are server-owned and set by the
+    provisioner as the VM boots (Rule 4 — the write surface never accepts them).
+    """
+
+    repo: str = Field(..., min_length=1, max_length=1024)
+    branch: str | None = Field(default=None, max_length=256)
+
+
+class TreeEntryResponse(BaseModel):
+    """One node in the cloned repo's file tree (a single directory level)."""
+
+    name: str
+    isDir: bool
+    size: int = 0
+
+
+class SandboxTreeResponse(BaseModel):
+    """The file tree of a ready sandbox, keyed to its bound Daytona id."""
+
+    id: str
+    sandboxId: str
+    path: str
+    entries: list[TreeEntryResponse]
+
+
 __all__ = [
     "CreateSandboxRequest",
+    "OpenSandboxRequest",
+    "SandboxTreeResponse",
+    "TreeEntryResponse",
     "UpdateStatusRequest",
     "WebSandboxListResponse",
     "WebSandboxResponse",

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -11,6 +11,11 @@
 # tree), and ``SandboxTreeResponse`` (the tree wrapper carrying the bound Daytona
 # id). Same Rule-4 discipline: the open surface accepts only a repo + branch and
 # never a server-owned id/status.
+#
+# Changed 2026-07-15 (WC-S3, feat/websandbox-s3-durability): surfaced the durable
+# snapshot pointer on the wire (``WebSandboxResponse.snapshotFileId``) and added
+# ``SnapshotResponse`` — the ``{fileId}`` the snapshot endpoint returns after
+# landing the workspace tarball in the tenant's blob storage.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -45,6 +50,7 @@ class WebSandboxResponse(BaseModel):
     status: str
     sandboxId: str | None = None
     installationId: str | None = None
+    snapshotFileId: str | None = None
     createdAt: str  # ISO-8601 UTC
     updatedAt: str  # ISO-8601 UTC
 
@@ -87,10 +93,22 @@ class SandboxTreeResponse(BaseModel):
     entries: list[TreeEntryResponse]
 
 
+# ---------------------------------------------------------------------------
+# WC-S3 — workspace durability (snapshot / restore).
+# ---------------------------------------------------------------------------
+
+
+class SnapshotResponse(BaseModel):
+    """The durable pointer minted by a snapshot — the blob-storage FileRecord id."""
+
+    fileId: str
+
+
 __all__ = [
     "CreateSandboxRequest",
     "OpenSandboxRequest",
     "SandboxTreeResponse",
+    "SnapshotResponse",
     "TreeEntryResponse",
     "UpdateStatusRequest",
     "WebSandboxListResponse",

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -1,0 +1,336 @@
+# durability.py — Web Cursor workspace durability: S3 snapshot + restore.
+# Created 2026-07-15 (WC-S3, feat/websandbox-s3-durability).
+#
+# The Daytona VM is pure scratch and gets reaped (WC-2). Code durability is git
+# (push); this module makes a user's UNCOMMITTED work + workspace state durable
+# by snapshotting the in-VM workspace dir to the tenant's blob storage (S3,
+# indexed in Mongo) and restoring it into a fresh VM. Nothing is file-based —
+# the durable tier is S3, the pointer is a FileRecord id on the WebSandbox row.
+#
+# This is the service-layer orchestration ABOVE ``websandbox/service.py`` (the
+# registry + auth oracle). Per ee/cloud Rule 2 it NEVER touches the WebSandbox
+# Beanie doc directly — the snapshot pointer write goes through
+# ``service.set_snapshot`` and every read through ``service.get_sandbox`` /
+# ``service.authorize_sandbox``. Importing DaytonaClient + EEUploadService here
+# (not in router/dto/domain) is the correct layer.
+#
+# The S3 vehicle is ART-4's ``EEUploadService`` — the same "read a file out of a
+# VM/jail → upload to the tenant's S3 → get a durable pointer" path
+# ``deliver.py`` uses. We reuse it verbatim: wrap the tarball bytes in a
+# Starlette ``UploadFile`` and call ``upload(...)`` (workspace-scoped), then
+# stash the returned ``FileRecord.id`` on the row. Restore reads the bytes back
+# through the same service's owner-scoped ``stream(...)`` and untars them into
+# the VM.
+#
+# Two flows:
+#   1. ``snapshot_workspace`` — authorize (owner-scoped get + fail-closed
+#      authorize_sandbox) → ``tar -czf`` the workspace dir in the VM →
+#      ``download_file`` the tarball → size-cap → ``EEUploadService.upload`` to
+#      tenant S3 (folder ``/websandbox-snapshots``) → ``set_snapshot`` → return
+#      the FileRecord id.
+#   2. ``restore_workspace`` — authorize → read the row's ``snapshot_file_id``
+#      (clean 409 if none) → fetch the tarball bytes from S3 → ``upload_bytes``
+#      into the VM → ``tar -xzf`` into the workspace dir.
+#
+# Both take DI seams (``client=None`` → get_daytona_client, ``uploads=None`` →
+# a per-call EEUploadService) so tests inject fakes and never hit real Daytona
+# or S3.
+from __future__ import annotations
+
+import io
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+logger = logging.getLogger(__name__)
+
+# The in-VM staging path for the tarball (outside the workspace dir so it never
+# tars itself and a stale copy never re-enters a future snapshot).
+_SNAPSHOT_TMP = "/tmp/ws-snapshot.tgz"  # noqa: S108 — a sandbox VM path, not host
+
+# gzip-compressed tar. ``_sniff_mime`` doesn't recognize gzip magic, so the
+# UploadFile's declared content-type is the mime that reaches the allowlist —
+# we declare this and include it in the per-call UploadSettings allowlist.
+_SNAPSHOT_MIME = "application/gzip"
+
+# Default per-snapshot size cap. The workspace can carry node_modules / build
+# output, so this is larger than the 25 MiB browser-upload default but bounded
+# so a runaway workspace can't blow up a snapshot.
+_DEFAULT_SNAPSHOT_MAX_MB = 500.0
+
+
+def _snapshot_max_bytes() -> int:
+    """Per-snapshot size cap in bytes (``POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB``)."""
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB", "").strip()
+    mb = _DEFAULT_SNAPSHOT_MAX_MB
+    if raw:
+        try:
+            mb = float(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB=%r; using %s", raw, mb
+            )
+    return int(mb * 1024 * 1024)
+
+
+def _require_client(client: DaytonaClient | None) -> DaytonaClient:
+    """Resolve the Daytona client, raising a clean CloudError when unconfigured.
+
+    Mirrors ``provision._require_client``: ``get_daytona_client()`` returns
+    ``None`` when the Daytona keys are unset — an operational condition, not a
+    bug — so it surfaces as a 503 CloudError rather than an AttributeError crash.
+    """
+    resolved = client if client is not None else get_daytona_client()
+    if resolved is None:
+        raise CloudError(
+            503,
+            "websandbox.daytona_unavailable",
+            "The sandbox runtime is not configured",
+        )
+    return resolved
+
+
+def _build_uploads() -> Any:
+    """Build a snapshot-scoped ``EEUploadService`` the same way ``deliver.py`` does.
+
+    Per-call (cheap): the workspace-scoped ``StorageAdapter`` (local or S3 via
+    ``POCKETPAW_UPLOAD_ADAPTER``), a Mongo metadata store, and an
+    ``UploadSettings`` whose ``allowed_mimes`` includes the gzip-tar mime so the
+    OSS mime gate never rejects a first-party snapshot, and whose
+    ``max_file_bytes`` matches our snapshot cap.
+    """
+    from pocketpaw.uploads.config import DEFAULT_ALLOWED_MIMES, UploadSettings
+    from pocketpaw.uploads.factory import build_adapter
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+    from pocketpaw_ee.cloud.uploads.service import EEUploadService
+
+    root = Path.home() / ".pocketpaw" / "uploads"
+    root.mkdir(parents=True, exist_ok=True)
+    adapter = build_adapter(root)
+    cfg = UploadSettings(
+        max_file_bytes=_snapshot_max_bytes(),
+        allowed_mimes=frozenset(
+            {_SNAPSHOT_MIME, "application/octet-stream", *DEFAULT_ALLOWED_MIMES}
+        ),
+        local_root=root,
+    )
+    return EEUploadService(adapter=adapter, meta=MongoFileStore(), cfg=cfg)
+
+
+async def _upload_snapshot(
+    uploads: Any,
+    data: bytes,
+    *,
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> str:
+    """Land the tarball bytes in the tenant's blob storage; return the FileRecord id.
+
+    Wraps the in-memory bytes in a Starlette ``UploadFile`` exactly like
+    ``deliver.py`` (a dict ``headers`` carrying the declared content-type is all
+    ``UploadFile.content_type`` reads), then calls the workspace-scoped
+    ``upload`` — the ART-4 S3 path. Folder-scoped to ``/websandbox-snapshots``
+    so snapshots are grouped in the tenant's Files.
+    """
+    from fastapi import UploadFile
+
+    upload = UploadFile(
+        file=io.BytesIO(data),
+        filename=f"ws-snapshot-{row_id}.tgz",
+        headers={"content-type": _SNAPSHOT_MIME},  # type: ignore[arg-type]
+    )
+    rec = await uploads.upload(
+        upload,
+        owner_id=user_id,
+        chat_id=None,
+        workspace=workspace_id,
+        folder_path="/websandbox-snapshots",
+    )
+    return rec.id
+
+
+async def _download_snapshot(
+    uploads: Any,
+    file_id: str,
+    *,
+    workspace_id: str,
+    user_id: str,
+) -> bytes:
+    """Fetch the snapshot tarball bytes back from blob storage (owner-scoped).
+
+    Uses ``EEUploadService.stream`` — the workspace + owner-checked read path —
+    and drains the async chunk iterator into bytes. A missing / not-owned blob
+    surfaces as a clean CloudError rather than an upstream ``NotFound`` leak.
+    """
+    from pocketpaw.uploads.errors import NotFound as _UploadNotFound
+
+    try:
+        _rec, chunks = await uploads.stream(
+            file_id, requester_id=user_id, workspace=workspace_id
+        )
+    except _UploadNotFound as exc:
+        raise with_cause(
+            CloudError(
+                404,
+                "websandbox.snapshot_missing",
+                "The recorded snapshot could not be read from storage",
+            ),
+            exc,
+        ) from exc
+    buf = bytearray()
+    async for chunk in chunks:
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+# ---------------------------------------------------------------------------
+# snapshot flow.
+# ---------------------------------------------------------------------------
+
+
+async def snapshot_workspace(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    *,
+    client: DaytonaClient | None = None,
+    uploads: Any = None,
+) -> str:
+    """Snapshot a ready sandbox's workspace to the tenant's blob storage.
+
+    Resolves the row tenant + owner scoped (``get_sandbox`` raises ``NotFound``
+    for a row the caller doesn't own), runs the fail-closed ``authorize_sandbox``
+    on the bound Daytona id BEFORE any VM/S3 op, then: ``tar -czf`` the workspace
+    dir → ``download_file`` the tarball → size-cap → upload to S3 →
+    ``set_snapshot`` the returned FileRecord id on the row. Returns that id.
+
+    A row that hasn't bound a Daytona id yet (never provisioned / still opening)
+    is a clean 409, not a runtime crash. A tarball over the size cap raises a
+    clean CloudError before any upload.
+    """
+    daytona = _require_client(client)
+
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+
+    # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+
+    # 1. Tar the workspace dir inside the VM (everything, incl. .git — simple and
+    #    complete). ``-C`` so arcnames are relative to the workspace root.
+    try:
+        await daytona.execute_command(
+            row.sandbox_id,
+            f"tar -czf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR} .",
+        )
+        data = await daytona.download_file(row.sandbox_id, _SNAPSHOT_TMP)
+    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+        logger.warning(
+            "websandbox.snapshot: tar/download failed for row=%s", row_id, exc_info=True
+        )
+        raise with_cause(
+            CloudError(502, "websandbox.snapshot_failed", "Failed to snapshot the workspace"),
+            exc,
+        ) from exc
+
+    # 2. Guard the size before spending an S3 upload on a runaway workspace.
+    cap = _snapshot_max_bytes()
+    if len(data) > cap:
+        raise CloudError(
+            413,
+            "websandbox.snapshot_too_large",
+            f"Workspace snapshot is {len(data) / 1024 / 1024:.1f} MB, over the "
+            f"{cap / 1024 / 1024:.0f} MB limit",
+        )
+
+    # 3. Land it in the tenant's blob storage (the ART-4 S3 path) and record the
+    #    durable pointer on the row.
+    up = uploads if uploads is not None else _build_uploads()
+    file_id = await _upload_snapshot(
+        up, data, workspace_id=workspace_id, user_id=user_id, row_id=row_id
+    )
+    await websandbox_service.set_snapshot(workspace_id, user_id, row_id, file_id)
+    logger.info(
+        "websandbox.snapshot: row=%s daytona=%s -> file=%s (%d bytes)",
+        row_id,
+        row.sandbox_id,
+        file_id,
+        len(data),
+    )
+    return file_id
+
+
+# ---------------------------------------------------------------------------
+# restore flow.
+# ---------------------------------------------------------------------------
+
+
+async def restore_workspace(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    *,
+    client: DaytonaClient | None = None,
+    uploads: Any = None,
+) -> None:
+    """Restore a row's latest blob-storage snapshot into its (fresh) VM.
+
+    Resolves the row tenant + owner scoped, then fail-closed authorizes on the
+    bound Daytona id, reads the row's ``snapshot_file_id`` (a clean 409 when the
+    sandbox has never been snapshotted), fetches the tarball bytes back from S3,
+    ``upload_bytes`` them into the VM, and ``tar -xzf`` into the workspace dir.
+    """
+    daytona = _require_client(client)
+
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.snapshot_file_id:
+        raise ConflictError(
+            "websandbox.no_snapshot", "This sandbox has no snapshot to restore"
+        )
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+
+    # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+
+    up = uploads if uploads is not None else _build_uploads()
+    data = await _download_snapshot(
+        up, row.snapshot_file_id, workspace_id=workspace_id, user_id=user_id
+    )
+
+    try:
+        await daytona.upload_bytes(row.sandbox_id, data, _SNAPSHOT_TMP)
+        await daytona.execute_command(
+            row.sandbox_id,
+            f"mkdir -p {WEBSANDBOX_WORKDIR} && tar -xzf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR}",
+        )
+    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+        logger.warning(
+            "websandbox.restore: upload/untar failed for row=%s", row_id, exc_info=True
+        )
+        raise with_cause(
+            CloudError(502, "websandbox.restore_failed", "Failed to restore the workspace"),
+            exc,
+        ) from exc
+
+    logger.info(
+        "websandbox.restore: row=%s daytona=%s <- file=%s (%d bytes)",
+        row_id,
+        row.sandbox_id,
+        row.snapshot_file_id,
+        len(data),
+    )
+
+
+__all__ = [
+    "restore_workspace",
+    "snapshot_workspace",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/files.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/files.py
@@ -1,0 +1,255 @@
+# files.py — Web Cursor file read/write/list RPC core (WC-4a).
+# Created 2026-07-15 (feat/websandbox-file-rpc).
+#
+# Socket-agnostic sibling of terminal.py's PtyBridge: this is the file-operation
+# half of the session WebSocket, multiplexed alongside the terminal on the SAME
+# authenticated socket. The browser editor round-trips directory listings, file
+# reads, and file writes through here; ws.py just parses one JSON frame and calls
+# ``FileRpc.dispatch``. Keeping the logic here (taking a DaytonaClient + a
+# sandbox_id, resolving the project dir lazily) makes the whole path-jail + size
+# guard unit-testable with a fake client and no socket.
+#
+# SECURITY — path jail (the core of this slice): every client path is relative to
+# the sandbox's PROJECT DIR (``client.get_project_dir``). A path is resolved by
+# LEXICALLY normalizing ``<project_dir>/<rel>`` with posixpath (collapsing ``.``
+# and ``..``) and asserting the result is the project dir or lives under it.
+# ``..`` escapes and absolute paths both fail that check and return a
+# ``file.error`` — they NEVER reach download_file/upload_bytes. The jail is
+# lexical rather than realpath-based on purpose: the VM filesystem is REMOTE, so
+# resolving remote symlinks would need a shell round-trip, and it would buy no
+# security here anyway — the socket is already owner-bound to the caller's OWN VM
+# (license -> ws_ticket -> get_sandbox -> authorize_sandbox in ws.py), so a
+# symlink inside it can only point at files the owner already fully controls via
+# the terminal. The jail's job is to stop a crafted ``path`` frame from escaping
+# the project dir, and lexical normalization does exactly that.
+#
+# Frame contract (client->server / server->client), reqId echoed for correlation:
+#   file.list  {path}          -> file.list.ok  {path, entries:[{name,path,isDir,size}]}
+#   file.read  {path}          -> file.read.ok  {path, content}
+#   file.write {path, content} -> file.write.ok {path}
+#   any failure                -> file.error    {op, message}
+# Responses are JSON text frames; terminal output stays binary, so the two
+# multiplexed streams never collide. Content is UTF-8 TEXT (binary is out of
+# scope for v1); a non-UTF-8 read returns file.error rather than corrupting the
+# socket. A size cap (POCKETPAW_WEBSANDBOX_MAX_FILE_KB, default 1024) bounds both
+# read and write so one giant file can't blow up the frame.
+from __future__ import annotations
+
+import logging
+import os
+import posixpath
+
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+
+logger = logging.getLogger(__name__)
+
+# File-op size cap (KB). Applies to a read's downloaded bytes AND a write's
+# encoded content, so neither a huge file nor a huge payload can blow up the
+# multiplexed socket frame. Override via POCKETPAW_WEBSANDBOX_MAX_FILE_KB.
+_DEFAULT_MAX_FILE_KB = 1024
+
+
+def _max_file_bytes() -> int:
+    """Per-file size cap in bytes (``POCKETPAW_WEBSANDBOX_MAX_FILE_KB``, default 1024)."""
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_MAX_FILE_KB", "").strip()
+    kb = _DEFAULT_MAX_FILE_KB
+    if raw:
+        try:
+            kb = int(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_WEBSANDBOX_MAX_FILE_KB=%r; using %d", raw, kb
+            )
+    return max(kb, 1) * 1024
+
+
+class FileRpcError(Exception):
+    """A file op failed cleanly — carried back to the browser as a ``file.error``
+    frame, never raised out of the socket loop. ``op`` is ``list|read|write``."""
+
+    def __init__(self, op: str, message: str) -> None:
+        super().__init__(message)
+        self.op = op
+        self.message = message
+
+
+def _jail(project_dir: str, rel_path: str, op: str) -> str:
+    """Resolve ``rel_path`` under ``project_dir`` and assert it stays inside.
+
+    Lexically normalizes ``<project_dir>/<rel_path>`` with posixpath (VM is
+    Linux; use posixpath NOT os.path so this is correct when the test/host is
+    Windows) and requires the result to be the project dir or live under it.
+    Absolute paths and ``..`` escapes both fail the containment check. Raises
+    :class:`FileRpcError` on any escape or empty path — the caller turns that
+    into a ``file.error`` frame, so download/upload is never reached for a
+    traversal attempt.
+    """
+    if not isinstance(rel_path, str) or not rel_path.strip():
+        raise FileRpcError(op, "a 'path' (relative to the project dir) is required")
+
+    root = posixpath.normpath(project_dir)
+    # posixpath.join drops the left side entirely if rel_path is absolute, so an
+    # absolute path resolves outside the root and is rejected below (belt: the
+    # explicit is_absolute check makes the intent obvious).
+    if posixpath.isabs(rel_path):
+        raise FileRpcError(op, "absolute paths are not allowed; use a path relative to the project")
+
+    resolved = posixpath.normpath(posixpath.join(root, rel_path))
+    if resolved != root and not resolved.startswith(root + "/"):
+        raise FileRpcError(op, "path escapes the project directory")
+    return resolved
+
+
+def _rel_entry_path(rel_dir: str, name: str) -> str:
+    """Build the project-relative path of an entry ``name`` inside ``rel_dir``.
+
+    The browser passes these straight back into a follow-up file op, so they must
+    stay relative to the project root (never absolute). ``.``/empty dir -> just
+    the name."""
+    base = "" if rel_dir.strip() in ("", ".", "./") else rel_dir.strip().strip("/")
+    joined = posixpath.normpath(posixpath.join(base, name)) if base else name
+    return joined.lstrip("/")
+
+
+class FileRpc:
+    """File list/read/write over a Daytona VM, jailed to its project dir.
+
+    One instance per session socket. Holds the DaytonaClient + sandbox_id (both
+    already resolved + owner-authorized by ws.py) and resolves the project dir
+    once, lazily. ``dispatch`` takes a parsed ``file.*`` frame and returns the
+    response frame dict to send back (or ``None`` for a non-file frame, so the
+    ws loop falls through to terminal handling). Op failures come back as a
+    ``file.error`` frame — this class never raises into the socket loop.
+    """
+
+    def __init__(
+        self,
+        client: DaytonaClient,
+        sandbox_id: str,
+        project_dir: str | None = None,
+    ) -> None:
+        self._client = client
+        self._sandbox_id = sandbox_id
+        self._project_dir = project_dir
+
+    async def _root(self) -> str:
+        """Resolve + cache the sandbox project dir (the jail root)."""
+        if self._project_dir is None:
+            self._project_dir = await self._client.get_project_dir(self._sandbox_id)
+        return self._project_dir
+
+    # ── Ops (raise FileRpcError on failure) ───────────────────────────────
+
+    async def list_dir(self, rel_path: str) -> list[dict]:
+        """List a directory. Entries carry project-relative paths for the browser."""
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "list")
+        try:
+            infos = await self._client.list_files(self._sandbox_id, abs_path)
+        except FileNotFoundError as exc:
+            raise FileRpcError("list", f"no such directory: {rel_path}") from exc
+        entries: list[dict] = []
+        for info in infos:
+            name = getattr(info, "name", None)
+            if not name:
+                continue
+            entries.append(
+                {
+                    "name": name,
+                    "path": _rel_entry_path(rel_path, name),
+                    "isDir": bool(getattr(info, "is_dir", False)),
+                    "size": int(getattr(info, "size", 0) or 0),
+                }
+            )
+        return entries
+
+    async def read_file(self, rel_path: str) -> str:
+        """Read a UTF-8 text file. Missing file / oversize / binary -> FileRpcError."""
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "read")
+        try:
+            data = await self._client.download_file(self._sandbox_id, abs_path)
+        except FileNotFoundError as exc:
+            raise FileRpcError("read", f"no such file: {rel_path}") from exc
+        if data is None:
+            raise FileRpcError("read", f"no such file: {rel_path}")
+        cap = _max_file_bytes()
+        if len(data) > cap:
+            raise FileRpcError(
+                "read",
+                f"file is {len(data) // 1024} KB, over the {cap // 1024} KB limit",
+            )
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise FileRpcError("read", "file is not UTF-8 text (binary is not supported)") from exc
+
+    async def write_file(self, rel_path: str, content: str) -> None:
+        """Write UTF-8 text to a file. Oversize / non-string content -> FileRpcError."""
+        if not isinstance(content, str):
+            raise FileRpcError("write", "'content' must be a string")
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "write")
+        data = content.encode("utf-8")
+        cap = _max_file_bytes()
+        if len(data) > cap:
+            raise FileRpcError(
+                "write",
+                f"content is {len(data) // 1024} KB, over the {cap // 1024} KB limit",
+            )
+        await self._client.upload_bytes(self._sandbox_id, data, abs_path)
+
+    # ── Frame dispatch (never raises into the socket loop) ────────────────
+
+    async def dispatch(self, msg: dict) -> dict | None:
+        """Handle one parsed ``file.*`` frame; return the response frame to send.
+
+        Returns ``None`` if ``msg`` is not a file frame (the ws loop then treats
+        it as a terminal frame). All op failures — including a path-jail escape —
+        come back as a ``file.error`` frame; this method never propagates an
+        exception into the receive loop, so one bad frame can't tear the socket
+        down.
+        """
+        mtype = msg.get("type")
+        if not isinstance(mtype, str) or not mtype.startswith("file."):
+            return None
+
+        req_id = msg.get("reqId")
+        req_id = req_id if isinstance(req_id, str) else ""
+        path = msg.get("path")
+        path = path if isinstance(path, str) else ""
+
+        try:
+            if mtype == "file.list":
+                entries = await self.list_dir(path)
+                return {"type": "file.list.ok", "reqId": req_id, "path": path, "entries": entries}
+            if mtype == "file.read":
+                content = await self.read_file(path)
+                return {"type": "file.read.ok", "reqId": req_id, "path": path, "content": content}
+            if mtype == "file.write":
+                await self.write_file(path, msg.get("content"))
+                return {"type": "file.write.ok", "reqId": req_id, "path": path}
+            # A ``file.*`` type we don't implement — honest error, socket stays up.
+            return {
+                "type": "file.error",
+                "reqId": req_id,
+                "op": mtype.removeprefix("file."),
+                "message": f"unsupported file op: {mtype}",
+            }
+        except FileRpcError as exc:
+            return {"type": "file.error", "reqId": req_id, "op": exc.op, "message": exc.message}
+        except Exception as exc:  # noqa: BLE001 — a file op must never kill the socket
+            logger.warning(
+                "websandbox file op failed: type=%s sandbox=%s", mtype, self._sandbox_id,
+                exc_info=True,
+            )
+            op = mtype.removeprefix("file.") if mtype.startswith("file.") else mtype
+            return {
+                "type": "file.error",
+                "reqId": req_id,
+                "op": op,
+                "message": f"file op failed: {exc}",
+            }
+
+
+__all__ = ["FileRpc", "FileRpcError"]

--- a/ee/pocketpaw_ee/cloud/websandbox/files.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/files.py
@@ -40,6 +40,7 @@ import os
 import posixpath
 
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +85,23 @@ def _jail(project_dir: str, rel_path: str, op: str) -> str:
     into a ``file.error`` frame, so download/upload is never reached for a
     traversal attempt.
     """
-    if not isinstance(rel_path, str) or not rel_path.strip():
+    if not isinstance(rel_path, str):
         raise FileRpcError(op, "a 'path' (relative to the project dir) is required")
 
     root = posixpath.normpath(project_dir)
+    # Empty string or '.' addresses the project root itself. The editor's file
+    # tree lists the repo root by requesting path '' (see the frontend
+    # loadTree -> listDir('')), so this MUST resolve to the jail root rather than
+    # being rejected — otherwise the root listing always errors and the tree
+    # shows nothing. Absolute paths and '..' escapes are still refused below.
+    stripped = rel_path.strip()
+    if stripped in ("", ".", "./"):
+        # Listing the root is valid (the tree needs it); reading/writing the
+        # directory itself is not — those still require a real file path.
+        if op == "list":
+            return root
+        raise FileRpcError(op, "a 'path' (relative to the project dir) is required")
+
     # posixpath.join drops the left side entirely if rel_path is absolute, so an
     # absolute path resolves outside the root and is rejected below (belt: the
     # explicit is_absolute check makes the intent obvious).
@@ -133,9 +147,14 @@ class FileRpc:
         self._project_dir = project_dir
 
     async def _root(self) -> str:
-        """Resolve + cache the sandbox project dir (the jail root)."""
+        """The jail root: the pinned in-VM workspace dir (``WEBSANDBOX_WORKDIR``).
+
+        Uses the shared constant, NOT the SDK's ``get_project_dir()`` (which
+        returns ``/root`` on this image and mismatches where the repo is cloned
+        and where the terminal opens). A ``project_dir`` passed to ``__init__``
+        still overrides it (tests inject a fake root)."""
         if self._project_dir is None:
-            self._project_dir = await self._client.get_project_dir(self._sandbox_id)
+            self._project_dir = WEBSANDBOX_WORKDIR
         return self._project_dir
 
     # ── Ops (raise FileRpcError on failure) ───────────────────────────────

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -1,0 +1,366 @@
+# provision.py — Web Cursor cold-provision + file-tree orchestration + idle reaper.
+# Created 2026-07-15 (WC-2, feat/websandbox-vm-provision).
+#
+# This is the service-layer orchestration for the Web Cursor "open a repo" slice.
+# It sits ABOVE ``websandbox/service.py`` (the registry + auth oracle) and drives
+# the Daytona runtime through ``DaytonaClient``. Per ee/cloud Rule 2 it NEVER
+# touches the WebSandbox Beanie doc directly — every registry read/write goes
+# through ``service`` (create_sandbox / update_status / get_sandbox /
+# authorize_sandbox / list_reapable_sandboxes / mark_reaped). Importing the
+# DaytonaClient here (not in router/dto/domain) is the correct layer.
+#
+# Three flows live here:
+#   1. ``open_sandbox`` — upsert a registry row (pending) → opening →
+#      cold-provision a Daytona VM (auto_stop_interval=30 min) → wait for boot →
+#      clone the PUBLIC repo (no credentials) → bind the Daytona id + mark ready.
+#      On any mid-flight failure the row is marked ``stopped`` and a CloudError is
+#      raised — the row is never left stuck in ``opening`` silently, and a
+#      half-created VM is best-effort torn down.
+#   2. ``get_tree`` — resolve the row (tenant-scoped) → authorize on its Daytona
+#      id (fail-closed) → single-level ``list_files`` → the file tree.
+#   3. Idle-TTL reaper — a background sweep that reclaims rows whose ``updated_at``
+#      is older than the TTL by stopping+deleting the VM and marking the row
+#      ``reaped``. Labels are NOT used to reconcile because ``DaytonaClient.
+#      create_sandbox`` does not forward labels to the SDK; the Registry (our DB)
+#      is the source of truth instead. WC-3 will refresh ``updated_at`` on live
+#      WebSocket traffic; until then "idle" == ``updated_at`` age. The SDK's own
+#      ``auto_stop_interval=30`` min is a second, independent backstop.
+#
+# Every provisioning fn takes ``client: DaytonaClient | None = None`` (default
+# ``get_daytona_client()``) — the mandatory DI seam so tests inject a FAKE client
+# and no test ever hits real Daytona.
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
+
+from fastapi import FastAPI
+
+from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
+from pocketpaw_ee.cloud.websandbox.dto import (
+    OpenSandboxRequest,
+    SandboxTreeResponse,
+    TreeEntryResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+# The SDK backstop: a self-stop after 30 minutes of inactivity. NOTE the SDK's
+# ``auto_stop_interval`` is in MINUTES (the SDK default 3600 = 60 HOURS is a
+# latent trap); 30 is a 30-minute backstop that mirrors our idle-TTL reaper.
+_AUTO_STOP_MINUTES = 30
+
+# Daytona boot timeout (seconds) — block until the VM is ``started`` before clone.
+_BOOT_TIMEOUT_SECONDS = 120.0
+
+# ---------------------------------------------------------------------------
+# Reaper env config.
+# ---------------------------------------------------------------------------
+_DEFAULT_IDLE_TTL_SECONDS = 1800  # 30 min
+_DEFAULT_REAP_INTERVAL_SECONDS = 300  # 5 min
+_REAPER_TASK_KEY = "_websandbox_reaper_task"
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back to ``default``."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an int — falling back to %d", name, raw, default)
+        return default
+    return max(1, value)
+
+
+def _idle_ttl_seconds() -> int:
+    return _env_int("POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS", _DEFAULT_IDLE_TTL_SECONDS)
+
+
+def _reap_interval_seconds() -> int:
+    return _env_int("POCKETPAW_WEBSANDBOX_REAP_INTERVAL_SECONDS", _DEFAULT_REAP_INTERVAL_SECONDS)
+
+
+def _reaper_enabled() -> bool:
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_REAPER_ENABLED", "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+# ---------------------------------------------------------------------------
+# Repo URL validation.
+# ---------------------------------------------------------------------------
+
+
+def _validate_public_repo_url(repo: str) -> str:
+    """Validate ``repo`` is a plausible public http(s) git URL, returning it.
+
+    Fail-closed on anything that isn't an ``http``/``https`` URL with a host —
+    ``file://``, ``git@`` SSH, ``ssh://``, or bare paths are rejected so the
+    provisioner never hands the sandbox a local-path or credentialed remote.
+    """
+    candidate = (repo or "").strip()
+    if not candidate:
+        raise BadRequest("websandbox.invalid_repo", "A repository URL is required")
+    parsed = urlparse(candidate)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise BadRequest(
+            "websandbox.invalid_repo",
+            "Repository must be a public http(s) URL (e.g. https://github.com/owner/repo.git)",
+        )
+    return candidate
+
+
+def _require_client(client: DaytonaClient | None) -> DaytonaClient:
+    """Resolve the Daytona client, raising a clean CloudError when unconfigured.
+
+    ``get_daytona_client()`` returns ``None`` when the Daytona keys are unset;
+    that is an operational condition, not a bug, so it surfaces as a 503-style
+    CloudError rather than an ``AttributeError`` crash downstream.
+    """
+    resolved = client if client is not None else get_daytona_client()
+    if resolved is None:
+        raise CloudError(
+            503,
+            "websandbox.daytona_unavailable",
+            "The sandbox runtime is not configured",
+        )
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# open flow.
+# ---------------------------------------------------------------------------
+
+
+async def open_sandbox(
+    workspace_id: str,
+    user_id: str,
+    body: OpenSandboxRequest | dict,
+    client: DaytonaClient | None = None,
+) -> WebSandboxView:
+    """Cold-provision a Daytona VM and clone a PUBLIC repo into it.
+
+    Flow: upsert the registry row (``pending``) → mark ``opening`` →
+    ``create_sandbox(auto_stop_interval=30)`` → ``wait_for_sandbox`` →
+    ``git_clone`` the public repo (NO credentials) into the project dir →
+    bind the Daytona sandbox id + mark ``ready`` → return the ready view.
+
+    On any failure after the row exists, the row is advanced to ``stopped`` and a
+    ``CloudError`` is raised (never left stuck in ``opening``); a VM created before
+    the failure is best-effort stopped+deleted so a crash can't leak a live VM.
+    """
+    body = OpenSandboxRequest.model_validate(body)
+    repo_url = _validate_public_repo_url(body.repo)
+    daytona = _require_client(client)
+
+    # 1. Upsert the registry row (idempotent on workspace+user+repo) and move it
+    #    to ``opening`` so a concurrent reader sees the in-flight state.
+    row = await websandbox_service.create_sandbox(
+        workspace_id, user_id, {"repo": repo_url, "status": "pending"}
+    )
+    await websandbox_service.update_status(
+        workspace_id, user_id, row.id, {"status": "opening"}
+    )
+
+    daytona_id: str | None = None
+    try:
+        # 2. Cold-provision. auto_stop_interval is in MINUTES — 30 is the backstop.
+        info = await daytona.create_sandbox(
+            name=f"websandbox-{row.id}",
+            auto_stop_interval=_AUTO_STOP_MINUTES,
+        )
+        daytona_id = info.id
+
+        # 3. Block until the VM is booted before cloning.
+        await daytona.wait_for_sandbox(
+            daytona_id, target_state="started", timeout=_BOOT_TIMEOUT_SECONDS
+        )
+
+        # 4. Clone the PUBLIC repo — pass NO credentials (clean; no token ever
+        #    involved). Clone into the sandbox's project dir.
+        project_dir = await daytona.get_project_dir(daytona_id)
+        await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
+    except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
+        # Best-effort teardown of a half-created VM so a failure can't leak it.
+        if daytona_id is not None:
+            with contextlib.suppress(Exception):
+                await daytona.delete_sandbox(daytona_id)
+        # Never leave the row stuck in ``opening``.
+        with contextlib.suppress(Exception):
+            await websandbox_service.update_status(
+                workspace_id, user_id, row.id, {"status": "stopped"}
+            )
+        logger.warning("websandbox.open failed for repo=%s row=%s", repo_url, row.id, exc_info=True)
+        raise with_cause(
+            CloudError(502, "websandbox.provision_failed", "Failed to provision the sandbox"),
+            exc,
+        ) from exc
+
+    # 5. Bind the Daytona id and mark ready.
+    ready = await websandbox_service.update_status(
+        workspace_id, user_id, row.id, {"status": "ready", "sandbox_id": daytona_id}
+    )
+    logger.info("websandbox.open ready: row=%s daytona=%s repo=%s", row.id, daytona_id, repo_url)
+    return ready
+
+
+# ---------------------------------------------------------------------------
+# tree flow.
+# ---------------------------------------------------------------------------
+
+
+async def get_tree(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    client: DaytonaClient | None = None,
+) -> SandboxTreeResponse:
+    """Return the (single-level) file tree of a ready sandbox.
+
+    Resolves the row tenant-scoped (``get_sandbox`` raises ``NotFound`` for a
+    row the caller doesn't own), then runs the fail-closed ``authorize_sandbox``
+    on the bound Daytona id BEFORE any runtime op, then lists the project dir.
+    A row that hasn't bound a Daytona id yet (never provisioned / still opening)
+    is a 409, not a runtime crash.
+    """
+    daytona = _require_client(client)
+
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+
+    # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+
+    project_dir = await daytona.get_project_dir(row.sandbox_id)
+    files = await daytona.list_files(row.sandbox_id, project_dir)
+    entries = [
+        TreeEntryResponse(
+            name=f.name,
+            isDir=bool(getattr(f, "is_dir", False)),
+            size=int(getattr(f, "size", 0) or 0),
+        )
+        for f in files
+    ]
+    return SandboxTreeResponse(
+        id=row.id,
+        sandboxId=row.sandbox_id,
+        path=project_dir,
+        entries=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idle-TTL reaper.
+# ---------------------------------------------------------------------------
+
+
+async def reap_idle_sandboxes(
+    client: DaytonaClient | None = None,
+    *,
+    now: datetime | None = None,
+) -> int:
+    """Run ONE reaper sweep: reclaim rows idle longer than the TTL.
+
+    Finds ``ready``/``opening`` rows whose ``updated_at`` is older than the TTL
+    (via ``service.list_reapable_sandboxes`` — a deliberate global-read), stops +
+    deletes the bound Daytona VM, then marks the row ``reaped``. A row with no
+    bound Daytona id (opening that never got one) is marked ``reaped`` directly.
+    A VM whose delete FAILS is left for the next sweep (the row stays live) rather
+    than being marked reaped and leaked. Returns the count of rows reaped.
+    """
+    daytona = _require_client(client)
+    reference = now or datetime.now(UTC)
+    cutoff = reference - timedelta(seconds=_idle_ttl_seconds())
+
+    candidates = await websandbox_service.list_reapable_sandboxes(cutoff)
+    if not candidates:
+        return 0
+
+    reaped = 0
+    for row in candidates:
+        if row.sandbox_id:
+            try:
+                # stop is best-effort (delete destroys the VM regardless); a
+                # failed DELETE means we couldn't reclaim, so skip the row.
+                with contextlib.suppress(Exception):
+                    await daytona.stop_sandbox(row.sandbox_id)
+                await daytona.delete_sandbox(row.sandbox_id)
+            except Exception:  # noqa: BLE001 — leave the row for the next sweep
+                logger.warning(
+                    "websandbox.reaper: failed to delete VM %s (row %s) — retry next sweep",
+                    row.sandbox_id,
+                    row.id,
+                    exc_info=True,
+                )
+                continue
+        marked = await websandbox_service.mark_reaped(row.id)
+        if marked is not None:
+            reaped += 1
+
+    if reaped:
+        logger.info("websandbox.reaper: reaped %d idle sandbox(es)", reaped)
+    return reaped
+
+
+async def _run_reaper_loop() -> None:
+    """Background loop body — sweep, sleep, repeat. Per-pass errors are logged
+    so one bad sweep can't kill the loop; ``CancelledError`` propagates for a
+    clean shutdown."""
+    interval = _reap_interval_seconds()
+    logger.info(
+        "websandbox.reaper: loop started (interval=%ds, idle_ttl=%ds)",
+        interval,
+        _idle_ttl_seconds(),
+    )
+    while True:
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("websandbox.reaper: loop cancelled — exiting")
+            raise
+        try:
+            await reap_idle_sandboxes()
+        except Exception:  # noqa: BLE001
+            logger.exception("websandbox.reaper: sweep failed")
+
+
+async def start_websandbox_reaper(app: FastAPI) -> None:
+    """Start the idle-TTL reaper. Idempotent — a second start is a no-op. Honors
+    ``POCKETPAW_WEBSANDBOX_REAPER_ENABLED`` (default true)."""
+    if not _reaper_enabled():
+        logger.info("websandbox.reaper: disabled via POCKETPAW_WEBSANDBOX_REAPER_ENABLED")
+        return
+    existing = getattr(app.state, _REAPER_TASK_KEY, None)
+    if existing is not None and not existing.done():
+        return
+    task = asyncio.create_task(_run_reaper_loop(), name="websandbox-reaper")
+    setattr(app.state, _REAPER_TASK_KEY, task)
+
+
+async def stop_websandbox_reaper(app: FastAPI) -> None:
+    """Cancel + await the reaper loop. Safe to call multiple times."""
+    task = getattr(app.state, _REAPER_TASK_KEY, None)
+    if task is None or task.done():
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+    setattr(app.state, _REAPER_TASK_KEY, None)
+
+
+__all__ = [
+    "get_tree",
+    "open_sandbox",
+    "reap_idle_sandboxes",
+    "start_websandbox_reaper",
+    "stop_websandbox_reaper",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -43,6 +43,7 @@ from fastapi import FastAPI
 from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError, ConflictError, with_cause
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
 from pocketpaw_ee.cloud.websandbox.dto import (
     OpenSandboxRequest,
@@ -186,7 +187,12 @@ async def open_sandbox(
 
         # 4. Clone the PUBLIC repo — pass NO credentials (clean; no token ever
         #    involved). Clone into the sandbox's project dir.
-        project_dir = await daytona.get_project_dir(daytona_id)
+        # Clone INTO the pinned workspace dir (WEBSANDBOX_WORKDIR = /home/daytona)
+        # so the file tree, the terminal cwd, and the clone all agree on one
+        # directory. get_project_dir() returns /root on this image, which the
+        # terminal never opens in — that mismatch is why the tree looked empty.
+        project_dir = WEBSANDBOX_WORKDIR
+        await daytona.execute_command(daytona_id, f"mkdir -p {project_dir}")
         await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
     except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
         # Best-effort teardown of a half-created VM so a failure can't leak it.
@@ -240,7 +246,7 @@ async def get_tree(
     # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
     await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
 
-    project_dir = await daytona.get_project_dir(row.sandbox_id)
+    project_dir = WEBSANDBOX_WORKDIR
     files = await daytona.list_files(row.sandbox_id, project_dir)
     entries = [
         TreeEntryResponse(

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -14,19 +14,28 @@
 # clone a PUBLIC repo, returning the ready registry row) and
 # ``GET /websandbox/{row_id}/tree`` (the cloned repo's file tree). Both delegate
 # to ``websandbox/provision.py``; tenancy still comes only from the RequestContext.
+#
+# Changed 2026-07-15 (WC-S3, feat/websandbox-s3-durability): added the two
+# workspace-durability endpoints — ``POST /websandbox/{row_id}/snapshot``
+# (tar the VM workspace → land it in the tenant's S3 → return ``{fileId}``) and
+# ``POST /websandbox/{row_id}/restore`` (fetch the snapshot from S3 → untar it
+# into the VM, 204). Both delegate to ``websandbox/durability.py``; tenancy still
+# comes only from the RequestContext, and both are license-gated like the rest.
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
     CreateSandboxRequest,
     OpenSandboxRequest,
     SandboxTreeResponse,
+    SnapshotResponse,
     UpdateStatusRequest,
     WebSandboxListResponse,
     WebSandboxResponse,
@@ -110,3 +119,30 @@ async def get_sandbox_tree(
     """Return the cloned repo's file tree for a ready sandbox."""
     workspace_id = _require_workspace(ctx)
     return await websandbox_provision.get_tree(workspace_id, ctx.user_id, row_id)
+
+
+# ---------------------------------------------------------------------------
+# WC-S3 — workspace durability (snapshot / restore).
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{row_id}/snapshot", response_model=SnapshotResponse)
+async def snapshot_sandbox(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> SnapshotResponse:
+    """Snapshot the sandbox's workspace to the tenant's blob storage."""
+    workspace_id = _require_workspace(ctx)
+    file_id = await websandbox_durability.snapshot_workspace(workspace_id, ctx.user_id, row_id)
+    return SnapshotResponse(fileId=file_id)
+
+
+@router.post("/{row_id}/restore", status_code=204)
+async def restore_sandbox(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> Response:
+    """Restore the sandbox's latest workspace snapshot from blob storage into the VM."""
+    workspace_id = _require_workspace(ctx)
+    await websandbox_durability.restore_workspace(workspace_id, ctx.user_id, row_id)
+    return Response(status_code=204)

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -1,0 +1,77 @@
+# router.py — Thin FastAPI adapter for the Web Cursor Sandbox Registry (WC-1).
+# Created 2026-07-15 (feat/websandbox-registry): workspace+user scoped
+# /api/v1/websandbox. Tenancy comes from the RequestContext (never the body or
+# query), the service does the work, and CloudError -> JSON is handled by
+# _core.http — this router never raises HTTPException.
+#
+# NOTE (WC-1 scope): endpoints are gated by license + an authenticated context
+# only; per-action RBAC (require_action) is deferred to a later slice because it
+# needs new action strings registered in the RBAC catalog. The tenancy/owner
+# filtering in the service is the security boundary for now.
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.dto import (
+    CreateSandboxRequest,
+    UpdateStatusRequest,
+    WebSandboxListResponse,
+    WebSandboxResponse,
+)
+
+router = APIRouter(
+    prefix="/websandbox",
+    tags=["WebSandbox"],
+    dependencies=[Depends(require_license)],
+)
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    """A workspace-scoped route needs an active workspace; fail closed if absent."""
+    if not ctx.workspace_id:
+        raise Forbidden("websandbox.no_workspace", "No active workspace")
+    return ctx.workspace_id
+
+
+@router.post("", response_model=WebSandboxResponse)
+async def create_sandbox(
+    body: CreateSandboxRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_service.create_sandbox(workspace_id, ctx.user_id, body)
+    return websandbox_service.view_to_wire(view)
+
+
+@router.get("", response_model=WebSandboxListResponse)
+async def list_sandboxes(
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxListResponse:
+    workspace_id = _require_workspace(ctx)
+    views = await websandbox_service.list_sandboxes(workspace_id, ctx.user_id)
+    return WebSandboxListResponse(items=[websandbox_service.view_to_wire(v) for v in views])
+
+
+@router.get("/{row_id}", response_model=WebSandboxResponse)
+async def get_sandbox(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_service.get_sandbox(workspace_id, ctx.user_id, row_id)
+    return websandbox_service.view_to_wire(view)
+
+
+@router.patch("/{row_id}", response_model=WebSandboxResponse)
+async def update_sandbox_status(
+    row_id: str,
+    body: UpdateStatusRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_service.update_status(workspace_id, ctx.user_id, row_id, body)
+    return websandbox_service.view_to_wire(view)

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -8,6 +8,12 @@
 # only; per-action RBAC (require_action) is deferred to a later slice because it
 # needs new action strings registered in the RBAC catalog. The tenancy/owner
 # filtering in the service is the security boundary for now.
+#
+# Changed 2026-07-15 (WC-2, feat/websandbox-vm-provision): added the two
+# cold-provision endpoints — ``POST /websandbox/open`` (provision a Daytona VM +
+# clone a PUBLIC repo, returning the ready registry row) and
+# ``GET /websandbox/{row_id}/tree`` (the cloned repo's file tree). Both delegate
+# to ``websandbox/provision.py``; tenancy still comes only from the RequestContext.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
@@ -15,9 +21,12 @@ from fastapi import APIRouter, Depends
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
     CreateSandboxRequest,
+    OpenSandboxRequest,
+    SandboxTreeResponse,
     UpdateStatusRequest,
     WebSandboxListResponse,
     WebSandboxResponse,
@@ -75,3 +84,29 @@ async def update_sandbox_status(
     workspace_id = _require_workspace(ctx)
     view = await websandbox_service.update_status(workspace_id, ctx.user_id, row_id, body)
     return websandbox_service.view_to_wire(view)
+
+
+# ---------------------------------------------------------------------------
+# WC-2 — cold-provision + file tree.
+# ---------------------------------------------------------------------------
+
+
+@router.post("/open", response_model=WebSandboxResponse)
+async def open_sandbox(
+    body: OpenSandboxRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    """Cold-provision a Daytona VM and clone a PUBLIC repo into it."""
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_provision.open_sandbox(workspace_id, ctx.user_id, body)
+    return websandbox_service.view_to_wire(view)
+
+
+@router.get("/{row_id}/tree", response_model=SandboxTreeResponse)
+async def get_sandbox_tree(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> SandboxTreeResponse:
+    """Return the cloned repo's file tree for a ready sandbox."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_provision.get_tree(workspace_id, ctx.user_id, row_id)

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -10,6 +10,12 @@
 # authorization that emits a high-severity audit event BEFORE it raises, so a
 # denied access attempt is always on the record. Every later Web Cursor slice
 # (session WS, editor RPC, git broker) calls this before touching a sandbox.
+#
+# Changed 2026-07-15 (WC-2, feat/websandbox-vm-provision): added the two
+# system-level reaper support functions ``list_reapable_sandboxes`` (global-read)
+# and ``mark_reaped`` (global-write). The idle-TTL reaper in ``provision.py``
+# drives them; they live here so the service stays the ONLY module that touches
+# the WebSandbox Beanie doc (Rule 2).
 from __future__ import annotations
 
 import logging
@@ -257,6 +263,70 @@ async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView
     return [_doc_to_view(d) for d in docs]
 
 
+# ---------------------------------------------------------------------------
+# System-level reaper support (WC-2). The idle-TTL reaper is a background sweep
+# that acts ACROSS tenants, so these two functions are deliberately NOT
+# tenant-scoped — they carry an explicit ``# global-read`` / ``# global-write``
+# marker per Rule 7. They stay HERE (not in provision.py) so the service remains
+# the only module that touches the Beanie doc (Rule 2).
+# ---------------------------------------------------------------------------
+
+
+async def list_reapable_sandboxes(
+    cutoff: datetime,
+    statuses: tuple[str, ...] = ("ready", "opening"),
+) -> list[WebSandboxView]:
+    """List sandboxes idle since before ``cutoff`` (system reaper candidate set).
+
+    "Idle" == ``updated_at`` older than the cutoff, in a still-live state
+    (``ready`` / ``opening``). Not tenant-scoped: the reaper reclaims leaked VMs
+    for every tenant. WC-3 will refresh ``updated_at`` on live WebSocket traffic;
+    until then age alone marks a session as dropped.
+    """
+    docs = await _WebSandboxDoc.find(
+        # global-read: the idle-TTL reaper sweeps every tenant's sandboxes; this
+        # is a system sweep, not a per-request read, so no workspace filter.
+        {"status": {"$in": list(statuses)}, "updated_at": {"$lt": cutoff}}
+    ).to_list()
+    return [_doc_to_view(d) for d in docs]
+
+
+async def mark_reaped(row_id: str) -> WebSandboxView | None:
+    """Flip a sandbox row to ``reaped`` (system reaper terminal), returning the
+    updated view — or ``None`` if the row vanished mid-sweep.
+
+    Resolves the row by id ONLY (no owner filter) because the reaper is a system
+    actor, not the owning user. The emitted ``WebSandboxStatusChanged`` still
+    carries the row's own tenancy so downstream fan-out stays scoped.
+    """
+    from beanie import PydanticObjectId
+
+    try:
+        oid = PydanticObjectId(row_id)
+    except Exception:  # noqa: BLE001 — a bad id is simply "nothing to reap"
+        return None
+    # global-write: system reaper terminal state; resolve by id across tenants.
+    doc = await _WebSandboxDoc.find_one({"_id": oid})
+    if doc is None:
+        return None
+    doc.status = "reaped"
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+
+    await emit(
+        WebSandboxStatusChanged(
+            data={
+                "id": str(doc.id),
+                "workspace_id": doc.workspace_id,
+                "user_id": doc.user_id,
+                "repo": doc.repo,
+                "status": doc.status,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
 async def _read_owned(
     workspace_id: str,
     user_id: str,
@@ -282,7 +352,9 @@ __all__ = [
     "authorize_sandbox",
     "create_sandbox",
     "get_sandbox",
+    "list_reapable_sandboxes",
     "list_sandboxes",
+    "mark_reaped",
     "update_status",
     "view_to_wire",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -22,6 +22,14 @@
 # WebSocket calls (throttled) on live traffic so the WC-2 idle reaper doesn't
 # reclaim a VM someone is actively using. It stays here (not in ws.py) so the
 # service remains the only module that writes the Beanie doc (Rule 2).
+#
+# Changed 2026-07-15 (WC-S3, feat/websandbox-s3-durability): added
+# ``set_snapshot`` — an owner-scoped write that records the durable
+# blob-storage snapshot pointer (a FileRecord id) on the row, and surfaced
+# ``snapshot_file_id`` through ``_doc_to_view`` + ``view_to_wire``. The
+# durability module (``websandbox/durability.py``) calls it after landing the
+# workspace tarball in the tenant's S3. It stays here so the service remains the
+# only module that writes the Beanie doc (Rule 2).
 from __future__ import annotations
 
 import logging
@@ -59,6 +67,7 @@ def _doc_to_view(doc: _WebSandboxDoc) -> WebSandboxView:
         status=doc.status,
         sandbox_id=doc.sandbox_id,
         installation_id=doc.installation_id,
+        snapshot_file_id=doc.snapshot_file_id,
         created_at=doc.created_at,
         updated_at=doc.updated_at,
     )
@@ -74,6 +83,7 @@ def view_to_wire(view: WebSandboxView) -> WebSandboxResponse:
         status=view.status,
         sandboxId=view.sandbox_id,
         installationId=view.installation_id,
+        snapshotFileId=view.snapshot_file_id,
         createdAt=view.created_at.isoformat(),
         updatedAt=view.updated_at.isoformat(),
     )
@@ -282,6 +292,33 @@ async def touch_activity(
     return True
 
 
+async def set_snapshot(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    file_id: str,
+) -> WebSandboxView:
+    """Record the durable workspace-snapshot pointer on a sandbox row.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``): only the owning
+    caller can bind a snapshot to their own sandbox. ``file_id`` is the
+    blob-storage ``FileRecord`` id produced by ``EEUploadService.upload`` in the
+    WC-S3 durability module — a durable pointer to the tarball of the VM's
+    workspace, indexed in Mongo. Raises ``NotFound`` when no owned row matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+    doc.snapshot_file_id = file_id
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: the snapshot pointer is durability bookkeeping, not a lifecycle
+    # transition. No downstream handler (IDE WS fan-out, search index, ripple
+    # invalidation) reacts to it, and emitting WebSandboxStatusChanged would
+    # falsely signal a state change to clients tracking the status field.
+    return _doc_to_view(doc)
+
+
 async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView]:
     """List every sandbox owned by the caller, newest first.
 
@@ -390,6 +427,7 @@ __all__ = [
     "list_reapable_sandboxes",
     "list_sandboxes",
     "mark_reaped",
+    "set_snapshot",
     "touch_activity",
     "update_status",
     "view_to_wire",

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -16,6 +16,12 @@
 # and ``mark_reaped`` (global-write). The idle-TTL reaper in ``provision.py``
 # drives them; they live here so the service stays the ONLY module that touches
 # the WebSandbox Beanie doc (Rule 2).
+#
+# Changed 2026-07-15 (WC-3, feat/websandbox-terminal-ws): added
+# ``touch_activity`` — an owner-scoped ``updated_at`` heartbeat the terminal
+# WebSocket calls (throttled) on live traffic so the WC-2 idle reaper doesn't
+# reclaim a VM someone is actively using. It stays here (not in ws.py) so the
+# service remains the only module that writes the Beanie doc (Rule 2).
 from __future__ import annotations
 
 import logging
@@ -247,6 +253,35 @@ async def update_status(
     return _doc_to_view(doc)
 
 
+async def touch_activity(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> bool:
+    """Bump a sandbox row's ``updated_at`` to mark it as actively in use.
+
+    Tenant- and owner-scoped: only the owning caller can refresh their own
+    session's liveness. Returns ``True`` when a row was touched, ``False`` when
+    no owned row matched (e.g. it was already reaped) — the terminal socket
+    treats a missing row as a benign no-op rather than an error.
+
+    The idle-TTL reaper (WC-2) reclaims ``ready``/``opening`` rows whose
+    ``updated_at`` predates the TTL; without this heartbeat a long, quiet
+    terminal session would be reaped mid-use. The caller throttles it (at most
+    once per ~60s per socket) so a burst of keystrokes is one write, not one
+    write per frame.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        return False
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: a high-frequency liveness heartbeat, not a state change —
+    # downstream handlers (search index, ripple invalidation) don't need it and
+    # fanning out per-touch would be pure noise.
+    return True
+
+
 async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView]:
     """List every sandbox owned by the caller, newest first.
 
@@ -355,6 +390,7 @@ __all__ = [
     "list_reapable_sandboxes",
     "list_sandboxes",
     "mark_reaped",
+    "touch_activity",
     "update_status",
     "view_to_wire",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -1,0 +1,288 @@
+# service.py — Web Cursor Sandbox Registry business logic (the auth oracle).
+# Created 2026-07-15 (WC-1, feat/websandbox-registry).
+#
+# This module IS the repository (ee/cloud Rule 1) and the ONLY module allowed to
+# import its own Beanie doc (Rule 2). Every read carries a tenant filter
+# (Rule 7); every mutation validates at entry (Rule 6) and emits an event
+# (Rule 9). Errors are CloudError subclasses, never HTTPException (Rule 10).
+#
+# The point of the slice is ``authorize_sandbox``: fail-closed cross-tenant
+# authorization that emits a high-severity audit event BEFORE it raises, so a
+# denied access attempt is always on the record. Every later Web Cursor slice
+# (session WS, editor RPC, git broker) calls this before touching a sandbox.
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import (
+    WebSandboxRegistered,
+    WebSandboxStatusChanged,
+)
+from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox as _WebSandboxDoc
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxId, WebSandboxView
+from pocketpaw_ee.cloud.websandbox.dto import (
+    CreateSandboxRequest,
+    UpdateStatusRequest,
+    WebSandboxResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+_FORBIDDEN_CODE = "websandbox.forbidden"
+# The action string the denial audit event is recorded under. Later slices and
+# any SIEM webhook key off this exact value to alert on cross-tenant probing.
+_CROSS_TENANT_ACTION = "vm.cross_tenant_denied"
+
+
+def _doc_to_view(doc: _WebSandboxDoc) -> WebSandboxView:
+    """Map a persisted, tenant-checked row to its read model."""
+    return WebSandboxView(
+        id=WebSandboxId(str(doc.id)),
+        workspace_id=doc.workspace_id,
+        user_id=doc.user_id,
+        repo=doc.repo,
+        status=doc.status,
+        sandbox_id=doc.sandbox_id,
+        installation_id=doc.installation_id,
+        created_at=doc.created_at,
+        updated_at=doc.updated_at,
+    )
+
+
+def view_to_wire(view: WebSandboxView) -> WebSandboxResponse:
+    """Map a view to the camelCase wire response (Rule 8 — mapping lives here)."""
+    return WebSandboxResponse(
+        id=view.id,
+        workspaceId=view.workspace_id,
+        userId=view.user_id,
+        repo=view.repo,
+        status=view.status,
+        sandboxId=view.sandbox_id,
+        installationId=view.installation_id,
+        createdAt=view.created_at.isoformat(),
+        updatedAt=view.updated_at.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The security core.
+# ---------------------------------------------------------------------------
+
+
+async def authorize_sandbox(
+    workspace_id: str,
+    user_id: str,
+    sandbox_id: str,
+) -> WebSandboxView:
+    """Fail-closed authorization for access to a provisioned sandbox.
+
+    Looks the sandbox up by its Daytona ``sandbox_id``, tenant-filtered to the
+    caller's ``workspace_id`` (Rule 7). Access is granted ONLY when a row
+    exists in the caller's workspace AND is owned by the caller's ``user_id``.
+
+    On any denial — the sandbox belongs to another workspace (the tenant
+    filter returns nothing), or another user in the same workspace — a
+    high-severity ``vm.cross_tenant_denied`` audit event is emitted BEFORE the
+    ``Forbidden`` is raised. Non-existence and wrong-owner both raise the same
+    ``Forbidden``, so existence never leaks through a differentiated error.
+    """
+    doc = await _WebSandboxDoc.find_one(
+        {"sandbox_id": sandbox_id, "workspace_id": workspace_id}  # Rule 7 tenant filter
+    )
+    if doc is None or doc.user_id != user_id:
+        await _record_cross_tenant_denial(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            sandbox_id=sandbox_id,
+            found=doc is not None,
+        )
+        raise Forbidden(_FORBIDDEN_CODE, "You do not have access to this sandbox")
+    return _doc_to_view(doc)
+
+
+async def _record_cross_tenant_denial(
+    *,
+    workspace_id: str,
+    user_id: str,
+    sandbox_id: str,
+    found: bool,
+) -> None:
+    """Emit the fail-closed denial audit event (fire-and-forget, never raises).
+
+    Mirrors the ART-2 fail-closed pattern: ``audit_service.record`` swallows its
+    own write failures, so an audit outage can never turn a denial into a leak.
+    """
+    from pocketpaw_ee.cloud.audit import service as audit_service
+
+    await audit_service.record(
+        workspace_id=workspace_id,
+        actor_id=user_id,
+        action=_CROSS_TENANT_ACTION,
+        target_type="web_sandbox",
+        target_id=sandbox_id,
+        metadata={
+            # ``found`` distinguishes "wrong owner, same workspace" (True) from
+            # "not in this workspace at all" (False) for the forensic trail —
+            # the caller still gets the same opaque Forbidden either way.
+            "reason": "wrong_owner" if found else "cross_workspace",
+            "sandbox_id": sandbox_id,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# CRUD the later slices authorize against. Every read is tenant-filtered.
+# ---------------------------------------------------------------------------
+
+
+async def create_sandbox(
+    workspace_id: str,
+    user_id: str,
+    body: CreateSandboxRequest | dict,
+) -> WebSandboxView:
+    """Register (or re-register) the sandbox for a (workspace, user, repo).
+
+    Idempotent on the registry key: a second call for the same
+    (workspace, user, repo) updates the existing row rather than minting a
+    duplicate, keeping the one-sandbox-per-key invariant even where the unique
+    index isn't enforced (e.g. mongomock).
+    """
+    body = CreateSandboxRequest.model_validate(body)
+
+    existing = await _WebSandboxDoc.find_one(
+        {"workspace_id": workspace_id, "user_id": user_id, "repo": body.repo}  # Rule 7
+    )
+    if existing is not None:
+        existing.status = body.status
+        if body.sandbox_id is not None:
+            existing.sandbox_id = body.sandbox_id
+        if body.installation_id is not None:
+            existing.installation_id = body.installation_id
+        existing.updated_at = datetime.now(UTC)
+        await existing.save()
+        doc = existing
+    else:
+        doc = _WebSandboxDoc(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            repo=body.repo,
+            sandbox_id=body.sandbox_id,
+            status=body.status,
+            installation_id=body.installation_id,
+        )
+        await doc.insert()
+
+    await emit(
+        WebSandboxRegistered(
+            data={
+                "id": str(doc.id),
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "repo": doc.repo,
+                "status": doc.status,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
+async def get_sandbox(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> WebSandboxView:
+    """Read one sandbox row by its registry id, tenant- and owner-scoped.
+
+    Raises ``NotFound`` when no row matches the caller's workspace + user — a
+    row owned by another tenant is indistinguishable from a missing one.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+    return _doc_to_view(doc)
+
+
+async def update_status(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    body: UpdateStatusRequest | dict,
+) -> WebSandboxView:
+    """Advance a sandbox's lifecycle state (optionally binding its Daytona id).
+
+    Tenant- and owner-scoped: a caller can only move a sandbox they own.
+    """
+    body = UpdateStatusRequest.model_validate(body)
+
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+
+    doc.status = body.status
+    if body.sandbox_id is not None:
+        doc.sandbox_id = body.sandbox_id
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+
+    await emit(
+        WebSandboxStatusChanged(
+            data={
+                "id": str(doc.id),
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "repo": doc.repo,
+                "status": doc.status,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
+async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView]:
+    """List every sandbox owned by the caller, newest first.
+
+    Tenant-filtered by ``workspace_id`` AND owner-filtered by ``user_id`` so
+    one user never sees another's sandboxes even within a shared workspace.
+    """
+    docs = (
+        await _WebSandboxDoc.find(
+            {"workspace_id": workspace_id, "user_id": user_id}  # Rule 7 tenant filter
+        )
+        .sort([("created_at", -1)])  # mongomock-safe: straight find + sort, no aggregate
+        .to_list()
+    )
+    return [_doc_to_view(d) for d in docs]
+
+
+async def _read_owned(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> _WebSandboxDoc | None:
+    """Tenant- + owner-scoped fetch by registry id. Returns None if not owned.
+
+    An unparseable ``row_id`` yields None (treated as not-found) rather than
+    raising, so a malformed id can't leak a distinct error shape.
+    """
+    from beanie import PydanticObjectId
+
+    try:
+        oid = PydanticObjectId(row_id)
+    except Exception:  # noqa: BLE001 — a bad id is simply "no such owned row"
+        return None
+    return await _WebSandboxDoc.find_one(
+        {"_id": oid, "workspace_id": workspace_id, "user_id": user_id}  # Rule 7
+    )
+
+
+__all__ = [
+    "authorize_sandbox",
+    "create_sandbox",
+    "get_sandbox",
+    "list_sandboxes",
+    "update_status",
+    "view_to_wire",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/terminal.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/terminal.py
@@ -1,0 +1,139 @@
+# terminal.py — Web Cursor PTY-over-WebSocket bridge (WC-3).
+# Created 2026-07-15 (feat/websandbox-terminal-ws).
+#
+# This is the socket-agnostic core of the terminal slice: it opens a REAL bash
+# PTY session inside a Daytona VM and pumps its output to an injected async
+# ``sink``. ``ws.py`` wires the sink to ``websocket.send_bytes`` for the browser;
+# the live-smoke script wires it to an in-memory buffer — the SAME code path,
+# minus the socket.
+#
+# Why the bridge holds the handle directly (the "handle gap"):
+# ``DaytonaClient.create_pty_session`` DISCARDS the ``AsyncPtyHandle`` the SDK
+# returns (it returns None), so you cannot send keystrokes through the shared
+# client wrapper. Rather than change that shared method (WC-2 and others depend
+# on its signature), this bridge grabs the sandbox instance itself
+# (``client.get_sandbox_instance``) and holds the handle, whose ``send_input``
+# writes INTO the pty. Resize and kill go back through the client wrapper
+# methods (``resize_pty`` / ``kill_pty``) — those work without the handle.
+from __future__ import annotations
+
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+
+from daytona import PtySize
+
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+
+logger = logging.getLogger(__name__)
+
+# Terminal output sink: forwards raw VM bytes onward (to the WS as a binary
+# frame, or to an in-memory buffer in the smoke test).
+OutputSink = Callable[[bytes], Awaitable[None]]
+
+# Sane default terminal geometry when the client hasn't sent a resize yet.
+DEFAULT_COLS = 80
+DEFAULT_ROWS = 24
+
+
+class PtyBridge:
+    """One live bash PTY session in a Daytona VM, bridged to an async sink.
+
+    Lifecycle: ``start`` opens the pty and begins streaming output to the sink;
+    ``send_input`` writes keystrokes; ``resize`` changes the terminal geometry;
+    ``close`` tears the session down. One bridge == one pty session == one
+    WebSocket connection. The ``session_id`` MUST be unique per connection so a
+    second socket for the same VM never collides with an existing session.
+    """
+
+    def __init__(
+        self,
+        client: DaytonaClient,
+        sandbox_id: str,
+        session_id: str,
+        sink: OutputSink,
+    ) -> None:
+        self._client = client
+        self._sandbox_id = sandbox_id
+        self._session_id = session_id
+        self._sink = sink
+        self._handle = None
+        self._closed = False
+
+    async def _on_data(self, data: bytes) -> None:
+        """SDK callback: forward one chunk of terminal output to the sink.
+
+        Never lets a sink failure propagate back into the SDK's read loop — a
+        broken socket must not crash the pty reader; the WS handler tears the
+        bridge down on the next receive error instead.
+        """
+        if self._closed:
+            return
+        try:
+            await self._sink(data)
+        except Exception:  # noqa: BLE001 — a dead sink shouldn't kill the reader
+            logger.debug("pty sink failed for session=%s; dropping chunk", self._session_id)
+
+    async def start(self, cols: int = DEFAULT_COLS, rows: int = DEFAULT_ROWS) -> None:
+        """Open the pty session and start streaming its output to the sink.
+
+        Grabs the SDK sandbox instance and creates the pty session directly so
+        we KEEP the handle (the client wrapper would discard it). Blocks until
+        the underlying WebSocket to the pty is connected so the first
+        ``send_input`` isn't dropped on a not-yet-open socket.
+        """
+        sb = await self._client.get_sandbox_instance(self._sandbox_id)
+        self._handle = await sb.process.create_pty_session(
+            self._session_id,
+            self._on_data,
+            pty_size=PtySize(rows=rows, cols=cols),
+        )
+        # Wait until the pty WebSocket is live before we accept input. Guarded by
+        # hasattr so a minimal fake handle in tests needn't implement it.
+        waiter = getattr(self._handle, "wait_for_connection", None)
+        if waiter is not None:
+            await waiter()
+        logger.info(
+            "pty bridge started: sandbox=%s session=%s size=%dx%d",
+            self._sandbox_id,
+            self._session_id,
+            cols,
+            rows,
+        )
+
+    async def send_input(self, data: str | bytes) -> None:
+        """Write keystrokes INTO the pty via the held handle."""
+        if self._closed or self._handle is None:
+            return
+        await self._handle.send_input(data)
+
+    async def resize(self, cols: int, rows: int) -> None:
+        """Resize the pty. Routed through the client wrapper (no handle needed)."""
+        if self._closed:
+            return
+        await self._client.resize_pty(self._sandbox_id, self._session_id, cols, rows)
+
+    async def close(self) -> None:
+        """Tear the pty session down. Idempotent and never raises.
+
+        Kills the server-side session (so the shell process doesn't leak) and
+        disconnects the local handle. Both are best-effort: teardown runs in a
+        ``finally`` on the socket, and a disconnected VM must not turn cleanup
+        into an error.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        with contextlib.suppress(Exception):
+            await self._client.kill_pty(self._sandbox_id, self._session_id)
+        if self._handle is not None:
+            disconnect = getattr(self._handle, "disconnect", None)
+            if disconnect is not None:
+                with contextlib.suppress(Exception):
+                    await disconnect()
+        logger.info(
+            "pty bridge closed: sandbox=%s session=%s", self._sandbox_id, self._session_id
+        )
+
+
+__all__ = ["DEFAULT_COLS", "DEFAULT_ROWS", "OutputSink", "PtyBridge"]

--- a/ee/pocketpaw_ee/cloud/websandbox/terminal.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/terminal.py
@@ -24,6 +24,7 @@ from collections.abc import Awaitable, Callable
 from daytona import PtySize
 
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,7 @@ class PtyBridge:
         self._handle = await sb.process.create_pty_session(
             self._session_id,
             self._on_data,
+            cwd=WEBSANDBOX_WORKDIR,  # open the shell where the repo is cloned
             pty_size=PtySize(rows=rows, cols=cols),
         )
         # Wait until the pty WebSocket is live before we accept input. Guarded by

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -1,0 +1,228 @@
+# ws.py — Web Cursor terminal WebSocket endpoint + connection manager (WC-3).
+# Created 2026-07-15 (feat/websandbox-terminal-ws).
+#
+# One authenticated WebSocket per Web Cursor session streams a REAL bash shell
+# from the owning tenant's Daytona VM to the browser. Structure mirrors the chat
+# WS (accept -> authenticate -> active loop -> disconnect) and reuses the same
+# single-use ws_ticket auth, because browsers can't set auth headers on a WS
+# upgrade.
+#
+# Connect flow (fail-closed at every step; a PTY is opened ONLY after all pass):
+#   accept-gate: license present -> ticket in ?token= present
+#   consume_ws_ticket(token) -> user_id           (single-use, Redis fail-closed)
+#   auth_service.get_active_workspace(user_id)     -> workspace_id
+#   websandbox_service.get_sandbox(ws, user, row)  -> row (NotFound if not owned)
+#   row.sandbox_id present (row is ``ready``)      (else 1008 not-ready)
+#   authorize_sandbox(ws, user, row.sandbox_id)    -> bind socket to the VM
+# Any failure closes 1008 BEFORE accept/PTY — a second user's ticket for someone
+# else's row is denied by get_sandbox/authorize_sandbox before any PTY opens.
+#
+# Message framing: client->server JSON — {"type":"input","data":"<str>"},
+# {"type":"resize","cols":N,"rows":N}, {"type":"ping"}. server->client — raw
+# BINARY frames carry terminal output (cleanest for xterm); pong is JSON. On
+# live traffic the row's ``updated_at`` is bumped (throttled ~60s) so the WC-2
+# idle reaper doesn't reclaim an active session.
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+
+from fastapi import Query, WebSocket, WebSocketDisconnect
+
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.auth import service as auth_service
+from pocketpaw_ee.cloud.auth.ws_tickets import consume_ws_ticket
+from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+from pocketpaw_ee.cloud.license import get_license
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.terminal import DEFAULT_COLS, DEFAULT_ROWS, PtyBridge
+
+logger = logging.getLogger(__name__)
+
+# WS close codes. 1008 == policy violation (auth / authz denial). 4003 mirrors
+# the chat WS "enterprise license required". 1011 == internal error (PTY open
+# failed after auth succeeded).
+_CLOSE_POLICY = 1008
+_CLOSE_LICENSE = 4003
+_CLOSE_INTERNAL = 1011
+
+# Minimum seconds between activity heartbeats per socket (throttle): a burst of
+# keystrokes becomes one ``updated_at`` write, not one per frame.
+_ACTIVITY_THROTTLE_SECONDS = 60.0
+
+
+class _ActivityThrottle:
+    """Rate-limit the per-socket ``updated_at`` heartbeat.
+
+    ``should_touch(now)`` returns True the first time and then at most once per
+    ``_ACTIVITY_THROTTLE_SECONDS``. Kept as a tiny testable unit so the throttle
+    logic is verified without a live socket.
+    """
+
+    def __init__(self, interval: float = _ACTIVITY_THROTTLE_SECONDS) -> None:
+        self._interval = interval
+        self._last: float | None = None
+
+    def should_touch(self, now: float) -> bool:
+        if self._last is None or (now - self._last) >= self._interval:
+            self._last = now
+            return True
+        return False
+
+
+class TerminalConnectionManager:
+    """Tracks the live pty bridge behind each terminal socket for teardown.
+
+    Deliberately minimal versus the chat ``ConnectionManager`` — the terminal
+    has no presence, no rooms, no fan-out. Its one job is to guarantee that
+    every accepted socket's pty session is killed exactly once when the socket
+    goes away, so a dropped browser tab never leaks a shell in the VM.
+    """
+
+    def __init__(self) -> None:
+        self._bridges: dict[WebSocket, PtyBridge] = {}
+
+    def register(self, websocket: WebSocket, bridge: PtyBridge) -> None:
+        self._bridges[websocket] = bridge
+
+    async def unregister(self, websocket: WebSocket) -> None:
+        bridge = self._bridges.pop(websocket, None)
+        if bridge is not None:
+            await bridge.close()
+
+    def active_count(self) -> int:
+        return len(self._bridges)
+
+
+# Module-level singleton (mirrors chat.ws.manager).
+manager = TerminalConnectionManager()
+
+
+async def terminal_websocket_endpoint(
+    websocket: WebSocket,
+    row_id: str,
+    token: str | None = Query(None),
+) -> None:
+    """Stream a real bash PTY from the owning sandbox's VM to the browser.
+
+    See the module docstring for the full connect/auth flow. The ws_ticket is
+    consumed (single-use) BEFORE accept; any auth/authz failure closes 1008 and
+    never opens a PTY.
+    """
+    # License gate — parity with the REST /websandbox routes and chat WS.
+    lic = get_license()
+    if lic is None or lic.expired:
+        await websocket.close(code=_CLOSE_LICENSE, reason="Enterprise license required")
+        return
+
+    # Path 1 — single-use ws_ticket in ?token= (the only auth path the browser
+    # can use on a cross-origin WS upgrade). No ticket -> no access.
+    if not token:
+        await websocket.close(code=_CLOSE_POLICY, reason="Missing ticket")
+        return
+    user_id = await consume_ws_ticket(token)
+    if not user_id:
+        await websocket.close(code=_CLOSE_POLICY, reason="Invalid ticket")
+        return
+
+    # Resolve the caller's workspace from the same membership field the HTTP
+    # request context reads. Fail closed if the user has no active workspace.
+    try:
+        workspace_id = await auth_service.get_active_workspace(user_id)
+    except CloudError:
+        workspace_id = None
+    if not workspace_id:
+        await websocket.close(code=_CLOSE_POLICY, reason="No active workspace")
+        return
+
+    # Resolve + authorize the sandbox row. get_sandbox is tenant+owner scoped
+    # (NotFound for a row the caller doesn't own); authorize_sandbox is the
+    # fail-closed oracle bound to the Daytona id. Either denial -> 1008, no PTY.
+    try:
+        row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+        if not row.sandbox_id:
+            await websocket.close(code=_CLOSE_POLICY, reason="Sandbox not ready")
+            return
+        await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+    except CloudError:
+        await websocket.close(code=_CLOSE_POLICY, reason="Access denied")
+        return
+
+    client = get_daytona_client()
+    if client is None:
+        await websocket.close(code=_CLOSE_LICENSE, reason="Sandbox runtime unavailable")
+        return
+
+    # Every gate passed — accept the socket and open the PTY.
+    await websocket.accept()
+
+    session_id = f"term-{uuid.uuid4().hex}"
+
+    async def _sink(data: bytes) -> None:
+        # Raw terminal bytes go to the browser as binary frames (xterm-friendly).
+        await websocket.send_bytes(data)
+
+    bridge = PtyBridge(client, row.sandbox_id, session_id, _sink)
+    try:
+        await bridge.start(cols=DEFAULT_COLS, rows=DEFAULT_ROWS)
+    except Exception:
+        logger.exception("pty open failed: row=%s sandbox=%s", row_id, row.sandbox_id)
+        await bridge.close()
+        await websocket.close(code=_CLOSE_INTERNAL, reason="Failed to open terminal")
+        return
+
+    manager.register(websocket, bridge)
+    throttle = _ActivityThrottle()
+
+    async def _touch() -> None:
+        """Bump the row's activity heartbeat, throttled, swallowing errors."""
+        if not throttle.should_touch(time.monotonic()):
+            return
+        try:
+            await websandbox_service.touch_activity(workspace_id, user_id, row_id)
+        except Exception:  # noqa: BLE001 — a heartbeat miss must not drop the session
+            logger.debug("activity touch failed for row=%s", row_id)
+
+    try:
+        while True:
+            raw = await websocket.receive_text()
+            try:
+                msg = json.loads(raw)
+            except (ValueError, TypeError):
+                continue  # ignore malformed frames rather than tearing down
+            if not isinstance(msg, dict):
+                continue
+
+            mtype = msg.get("type")
+            if mtype == "input":
+                data = msg.get("data")
+                if isinstance(data, str):
+                    await bridge.send_input(data)
+                    await _touch()
+            elif mtype == "resize":
+                cols = msg.get("cols")
+                rows = msg.get("rows")
+                if isinstance(cols, int) and isinstance(rows, int) and cols > 0 and rows > 0:
+                    await bridge.resize(cols, rows)
+                    await _touch()
+            elif mtype == "ping":
+                # Keep the socket warm through idle-closing edge proxies.
+                await websocket.send_json({"type": "pong"})
+    except WebSocketDisconnect:
+        pass
+    except RuntimeError as exc:
+        # Starlette raises RuntimeError("WebSocket is not connected") when
+        # receive is called after the peer already disconnected. Treat as a
+        # normal close; re-raise anything else.
+        if "not connected" not in str(exc).lower():
+            logger.exception("terminal WS error: row=%s", row_id)
+    except Exception:
+        logger.exception("terminal WS error: row=%s", row_id)
+    finally:
+        # Teardown: kill the pty session so the shell doesn't leak in the VM.
+        await manager.unregister(websocket)
+
+
+__all__ = ["TerminalConnectionManager", "manager", "terminal_websocket_endpoint"]

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -22,6 +22,16 @@
 # BINARY frames carry terminal output (cleanest for xterm); pong is JSON. On
 # live traffic the row's ``updated_at`` is bumped (throttled ~60s) so the WC-2
 # idle reaper doesn't reclaim an active session.
+#
+# 2026-07-15 (WC-4a): the SAME socket also carries file operations, multiplexed
+# alongside the terminal. Any ``file.*`` frame ({"type":"file.list|read|write",
+# "reqId":..,"path":..[,"content":..]}) is handed to the socket-agnostic
+# ``FileRpc`` (websandbox/files.py), which jails the path to the sandbox project
+# dir and returns a JSON response frame (file.list.ok / file.read.ok /
+# file.write.ok / file.error). File responses are typed JSON text frames while
+# terminal output is binary, so the two streams never collide. No per-frame
+# re-authorization — the socket is already owner-bound to the VM — but file ops
+# DO bump the same throttled activity heartbeat.
 from __future__ import annotations
 
 import json
@@ -37,6 +47,7 @@ from pocketpaw_ee.cloud.auth.ws_tickets import consume_ws_ticket
 from pocketpaw_ee.cloud.daytona.client import get_daytona_client
 from pocketpaw_ee.cloud.license import get_license
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.files import FileRpc
 from pocketpaw_ee.cloud.websandbox.terminal import DEFAULT_COLS, DEFAULT_ROWS, PtyBridge
 
 logger = logging.getLogger(__name__)
@@ -176,6 +187,11 @@ async def terminal_websocket_endpoint(
     manager.register(websocket, bridge)
     throttle = _ActivityThrottle()
 
+    # File ops share this socket. FileRpc jails every path to the sandbox project
+    # dir (resolved lazily on first use); it reuses the already-owner-authorized
+    # client + sandbox_id and never re-authorizes per frame.
+    file_rpc = FileRpc(client, row.sandbox_id)
+
     async def _touch() -> None:
         """Bump the row's activity heartbeat, throttled, swallowing errors."""
         if not throttle.should_touch(time.monotonic()):
@@ -196,6 +212,15 @@ async def terminal_websocket_endpoint(
                 continue
 
             mtype = msg.get("type")
+            if isinstance(mtype, str) and mtype.startswith("file."):
+                # File op multiplexed on the terminal socket. FileRpc jails the
+                # path and returns a JSON response frame (or file.error); a bad
+                # frame never tears the socket down.
+                response = await file_rpc.dispatch(msg)
+                if response is not None:
+                    await websocket.send_json(response)
+                    await _touch()
+                continue
             if mtype == "input":
                 data = msg.get("data")
                 if isinstance(data, str):

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -7,15 +7,35 @@
 # single-use ws_ticket auth, because browsers can't set auth headers on a WS
 # upgrade.
 #
+# 2026-07-15 (WC-4b): the ticket now resolves via EITHER of two auth paths, so
+# the browser can authenticate without leaking the ticket in the URL (URL query
+# strings leak into access logs, browser history, and proxies — the same
+# REVIEW-4 reasoning that moved the chat WS off URL tickets):
+#   * Path 1 — single-use ws_ticket in ``?token=``, consumed BEFORE accept
+#     (unchanged; the only path a cross-origin WS upgrade can carry in the URL).
+#   * Path 3 — no ``?token=``: accept() FIRST (a frame can only be read after the
+#     handshake completes), then read the first frame under a 5s timeout and
+#     parse ``{"type":"auth","ticket"|"token":"..."}``. On timeout, a malformed
+#     frame, a non-auth frame, or a failed ``consume_ws_ticket`` -> close 4001 and
+#     the socket never reaches the message loop.
+# ``websocket.accept()`` is called exactly once on every path, tracked by the
+# ``accepted`` flag: Path 1 accepts AFTER the authz checks (as before); Path 3
+# accepts BEFORE reading the frame, so the shared authz section must not accept
+# again.
+#
 # Connect flow (fail-closed at every step; a PTY is opened ONLY after all pass):
-#   accept-gate: license present -> ticket in ?token= present
-#   consume_ws_ticket(token) -> user_id           (single-use, Redis fail-closed)
+#   license present                                (else 4003)
+#   Path 1: ticket in ?token= -> consume_ws_ticket (pre-accept; 1008 on failure)
+#   Path 3: no ?token= -> accept, read first auth   (post-accept; 4001 on failure)
+#           frame under 5s timeout -> consume_ws_ticket
+#   -> user_id                                     (single-use, Redis fail-closed)
 #   auth_service.get_active_workspace(user_id)     -> workspace_id
 #   websandbox_service.get_sandbox(ws, user, row)  -> row (NotFound if not owned)
 #   row.sandbox_id present (row is ``ready``)      (else 1008 not-ready)
 #   authorize_sandbox(ws, user, row.sandbox_id)    -> bind socket to the VM
-# Any failure closes 1008 BEFORE accept/PTY — a second user's ticket for someone
-# else's row is denied by get_sandbox/authorize_sandbox before any PTY opens.
+# A second user's ticket for someone else's row is denied by get_sandbox/
+# authorize_sandbox before any PTY opens. Path 1 closes 1008 pre-accept; Path 3
+# is already accepted, so an authz denial closes 1008 on the accepted socket.
 #
 # Message framing: client->server JSON — {"type":"input","data":"<str>"},
 # {"type":"resize","cols":N,"rows":N}, {"type":"ping"}. server->client — raw
@@ -34,6 +54,7 @@
 # DO bump the same throttled activity heartbeat.
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -52,12 +73,19 @@ from pocketpaw_ee.cloud.websandbox.terminal import DEFAULT_COLS, DEFAULT_ROWS, P
 
 logger = logging.getLogger(__name__)
 
-# WS close codes. 1008 == policy violation (auth / authz denial). 4003 mirrors
+# WS close codes. 1008 == policy violation (authz denial). 4001 == the Path 3
+# first-frame auth failed (mirrors the chat WS auth-frame close). 4003 mirrors
 # the chat WS "enterprise license required". 1011 == internal error (PTY open
 # failed after auth succeeded).
 _CLOSE_POLICY = 1008
+_CLOSE_AUTH_FRAME = 4001
 _CLOSE_LICENSE = 4003
 _CLOSE_INTERNAL = 1011
+
+# Seconds to wait for the Path 3 first-message auth frame before giving up. A
+# half-open socket must not hold resources waiting for a credential that may
+# never arrive. Mirrors the chat WS 5s auth-frame timeout.
+_AUTH_FRAME_TIMEOUT_SECONDS = 5.0
 
 # Minimum seconds between activity heartbeats per socket (throttle): a burst of
 # keystrokes becomes one ``updated_at`` write, not one per frame.
@@ -118,25 +146,59 @@ async def terminal_websocket_endpoint(
 ) -> None:
     """Stream a real bash PTY from the owning sandbox's VM to the browser.
 
-    See the module docstring for the full connect/auth flow. The ws_ticket is
-    consumed (single-use) BEFORE accept; any auth/authz failure closes 1008 and
-    never opens a PTY.
+    See the module docstring for the full connect/auth flow. The ws_ticket
+    resolves via Path 1 (``?token=``, consumed pre-accept) or Path 3 (a
+    first-message auth frame read post-accept under a 5s timeout). Any auth
+    failure closes 1008 (Path 1) or 4001 (Path 3); any authz failure closes 1008
+    and never opens a PTY.
     """
-    # License gate — parity with the REST /websandbox routes and chat WS.
+    # License gate first on BOTH paths — parity with the REST /websandbox routes
+    # and chat WS.
     lic = get_license()
     if lic is None or lic.expired:
         await websocket.close(code=_CLOSE_LICENSE, reason="Enterprise license required")
         return
 
-    # Path 1 — single-use ws_ticket in ?token= (the only auth path the browser
-    # can use on a cross-origin WS upgrade). No ticket -> no access.
-    if not token:
-        await websocket.close(code=_CLOSE_POLICY, reason="Missing ticket")
-        return
-    user_id = await consume_ws_ticket(token)
-    if not user_id:
-        await websocket.close(code=_CLOSE_POLICY, reason="Invalid ticket")
-        return
+    # ``accepted`` tracks whether accept() has run so accept() happens exactly
+    # once: Path 1 accepts AFTER the authz checks below; Path 3 accepts BEFORE it
+    # can read the first frame, then the shared authz section must not re-accept.
+    accepted = False
+
+    if token:
+        # Path 1 — single-use ws_ticket in ?token=. Consumed BEFORE accept, so a
+        # bad ticket is refused during the handshake (close 1008, no accept).
+        user_id = await consume_ws_ticket(token)
+        if not user_id:
+            await websocket.close(code=_CLOSE_POLICY, reason="Invalid ticket")
+            return
+    else:
+        # Path 3 — no URL token. Authenticate from the first frame so the ticket
+        # never travels in the URL. We MUST accept() before we can receive, and
+        # the 5s timeout stops a half-open socket from holding resources while we
+        # wait for a credential that may never come.
+        await websocket.accept()
+        accepted = True
+        try:
+            raw = await asyncio.wait_for(
+                websocket.receive_text(), timeout=_AUTH_FRAME_TIMEOUT_SECONDS
+            )
+            frame = json.loads(raw)
+        except Exception:
+            # Timeout, disconnect, or non-JSON first frame.
+            await websocket.close(code=_CLOSE_AUTH_FRAME, reason="Missing auth")
+            return
+
+        if not isinstance(frame, dict) or frame.get("type") != "auth":
+            await websocket.close(code=_CLOSE_AUTH_FRAME, reason="Missing auth")
+            return
+
+        # Accept ``token`` as an alias for ``ticket`` (parity with the chat WS
+        # auth frame); either carries the single-use ws_ticket.
+        ticket = frame.get("ticket") or frame.get("token")
+        user_id = await consume_ws_ticket(ticket) if isinstance(ticket, str) and ticket else None
+        if not user_id:
+            await websocket.close(code=_CLOSE_AUTH_FRAME, reason="Invalid ticket")
+            return
 
     # Resolve the caller's workspace from the same membership field the HTTP
     # request context reads. Fail closed if the user has no active workspace.
@@ -166,8 +228,10 @@ async def terminal_websocket_endpoint(
         await websocket.close(code=_CLOSE_LICENSE, reason="Sandbox runtime unavailable")
         return
 
-    # Every gate passed — accept the socket and open the PTY.
-    await websocket.accept()
+    # Every gate passed — accept the socket (unless Path 3 already did) and open
+    # the PTY. ``accepted`` keeps accept() exactly-once across both paths.
+    if not accepted:
+        await websocket.accept()
 
     session_id = f"term-{uuid.uuid4().hex}"
 

--- a/scripts/websandbox_file_rpc_smoke.py
+++ b/scripts/websandbox_file_rpc_smoke.py
@@ -1,0 +1,118 @@
+# websandbox_file_rpc_smoke.py — ONE live Daytona smoke for the Web Cursor file
+# read/write/list RPC slice (WC-4a). NOT a pytest test — kept out of CI so a real
+# VM (which costs money) is only ever provisioned when a human runs this.
+# Created 2026-07-15 (feat/websandbox-file-rpc).
+#
+# What it does: loads .env, provisions a REAL Daytona VM, then drives the SAME
+# FileRpc helper the WebSocket endpoint uses (minus the socket) to:
+#   1. write ``paw_rpc_smoke.txt`` with known content,
+#   2. read it back and assert it round-trips (proves real persistence to the VM
+#      filesystem),
+#   3. list the project dir and assert the file appears,
+#   4. attempt a ``../escape.txt`` write and assert the jail REJECTS it.
+# It ALWAYS deletes the VM in a finally block — cleanup is non-negotiable even on
+# exception, because a leaked VM keeps billing.
+#
+# Run: .venv/Scripts/python.exe scripts/websandbox_file_rpc_smoke.py
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+AUTO_STOP_MINUTES = 30
+BOOT_TIMEOUT_SECONDS = 180.0
+SMOKE_FILE = "paw_rpc_smoke.txt"
+SMOKE_CONTENT = "web-cursor file rpc round-trip: paw-rpc-ok\n"
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+    from pocketpaw_ee.cloud.websandbox.files import FileRpc, FileRpcError
+
+    client = get_daytona_client()
+    if client is None:
+        print("FAIL: Daytona is not configured (get_daytona_client() returned None).")
+        print("      Set the Daytona keys in .env and retry.")
+        return 1
+
+    sandbox_id: str | None = None
+    failures: list[str] = []
+
+    try:
+        print(f"Provisioning a Daytona VM (auto_stop_interval={AUTO_STOP_MINUTES} min)...")
+        info = await client.create_sandbox(
+            name="websandbox-file-rpc-smoke",
+            auto_stop_interval=AUTO_STOP_MINUTES,
+        )
+        sandbox_id = info.id
+        print(f"  created: id={sandbox_id} name={info.name} state={info.state}")
+
+        print("Waiting for the VM to boot...")
+        await client.wait_for_sandbox(
+            sandbox_id, target_state="started", timeout=BOOT_TIMEOUT_SECONDS
+        )
+        print("  booted.")
+
+        # The exact helper the WS endpoint instantiates per session.
+        rpc = FileRpc(client, sandbox_id)
+        project_dir = await rpc._root()  # noqa: SLF001 — smoke wants the resolved jail root
+        print(f"  project dir (jail root): {project_dir}")
+
+        # 1. write
+        print(f"Writing {SMOKE_FILE!r} via FileRpc.write_file...")
+        await rpc.write_file(SMOKE_FILE, SMOKE_CONTENT)
+        print("  write ok.")
+
+        # 2. read back + assert round-trip
+        print(f"Reading {SMOKE_FILE!r} back...")
+        read_back = await rpc.read_file(SMOKE_FILE)
+        if read_back == SMOKE_CONTENT:
+            print("  PASS: read-back content matches (real persistence to VM fs).")
+        else:
+            failures.append("read-back content did not match written content")
+            print(f"  FAIL: got {read_back!r}, expected {SMOKE_CONTENT!r}")
+
+        # 3. list dir + assert file appears
+        print("Listing the project dir via FileRpc.list_dir('.')...")
+        entries = await rpc.list_dir(".")
+        names = [e["name"] for e in entries]
+        if SMOKE_FILE in names:
+            print(f"  PASS: {SMOKE_FILE!r} appears in the listing.")
+        else:
+            failures.append(f"{SMOKE_FILE} not found in directory listing")
+            print(f"  FAIL: {SMOKE_FILE!r} not in {names}")
+
+        # 4. traversal rejection
+        print("Attempting a ../escape.txt write (must be rejected by the jail)...")
+        try:
+            await rpc.write_file("../escape.txt", "should never be written")
+            failures.append("traversal write was NOT rejected")
+            print("  FAIL: traversal write was allowed!")
+        except FileRpcError as exc:
+            print(f"  PASS: traversal rejected -> {exc.op}: {exc.message}")
+
+        if failures:
+            print("\nFAIL: " + "; ".join(failures))
+            return 1
+        print("\nPASS: write -> read -> list round-trip persisted + traversal rejected.")
+        return 0
+    except Exception as exc:  # noqa: BLE001 — smoke: report and still clean up
+        print(f"FAIL: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        if sandbox_id is not None:
+            try:
+                print(f"Cleaning up: deleting VM {sandbox_id}...")
+                await client.delete_sandbox(sandbox_id)
+                print(f"  VM {sandbox_id} DELETED.")
+            except Exception as cleanup_exc:  # noqa: BLE001
+                print(f"  WARNING: cleanup delete failed: {cleanup_exc}")
+                print(f"  MANUAL CLEANUP REQUIRED for sandbox {sandbox_id}")
+        await client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/websandbox_live_smoke.py
+++ b/scripts/websandbox_live_smoke.py
@@ -1,0 +1,79 @@
+# websandbox_live_smoke.py — ONE live Daytona smoke for the Web Cursor
+# cold-provision slice (WC-2). NOT a pytest test — kept out of CI on purpose so
+# a real VM (which costs money) is only ever provisioned when a human runs this.
+# Created 2026-07-15 (feat/websandbox-vm-provision).
+#
+# What it does: loads .env, provisions a REAL Daytona VM (auto_stop_interval=30
+# min), clones the public octocat/Hello-World repo into the project dir, lists +
+# prints the tree, and ALWAYS deletes the VM in a finally block — cleanup is
+# non-negotiable even on exception, because a leaked VM keeps billing.
+#
+# Run: .venv/Scripts/python.exe scripts/websandbox_live_smoke.py
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+REPO_URL = "https://github.com/octocat/Hello-World.git"
+AUTO_STOP_MINUTES = 30
+BOOT_TIMEOUT_SECONDS = 180.0
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+
+    client = get_daytona_client()
+    if client is None:
+        print("FAIL: Daytona is not configured (get_daytona_client() returned None).")
+        print("      Set the Daytona keys in .env and retry.")
+        return 1
+
+    sandbox_id: str | None = None
+    try:
+        print(f"Provisioning a Daytona VM (auto_stop_interval={AUTO_STOP_MINUTES} min)...")
+        info = await client.create_sandbox(
+            name="websandbox-live-smoke",
+            auto_stop_interval=AUTO_STOP_MINUTES,
+        )
+        sandbox_id = info.id
+        print(f"  created: id={sandbox_id} name={info.name} state={info.state}")
+
+        print("Waiting for the VM to boot...")
+        await client.wait_for_sandbox(
+            sandbox_id, target_state="started", timeout=BOOT_TIMEOUT_SECONDS
+        )
+        print("  booted.")
+
+        project_dir = await client.get_project_dir(sandbox_id)
+        print(f"Cloning {REPO_URL} into {project_dir} (no credentials — public repo)...")
+        await client.git_clone(sandbox_id, REPO_URL, project_dir)
+        print("  cloned.")
+
+        print("Listing the file tree:")
+        files = await client.list_files(sandbox_id, project_dir)
+        for f in files:
+            kind = "dir " if getattr(f, "is_dir", False) else "file"
+            print(f"  [{kind}] {f.name}  ({getattr(f, 'size', 0)} bytes)")
+
+        print("\nPASS: provisioned, cloned, and listed a real Daytona sandbox.")
+        return 0
+    except Exception as exc:  # noqa: BLE001 — smoke: report and still clean up
+        print(f"FAIL: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        if sandbox_id is not None:
+            try:
+                print(f"Cleaning up: deleting VM {sandbox_id}...")
+                await client.delete_sandbox(sandbox_id)
+                print(f"  VM {sandbox_id} DELETED.")
+            except Exception as cleanup_exc:  # noqa: BLE001
+                print(f"  WARNING: cleanup delete failed: {cleanup_exc}")
+                print(f"  MANUAL CLEANUP REQUIRED for sandbox {sandbox_id}")
+        await client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/websandbox_s3_durability_smoke.py
+++ b/scripts/websandbox_s3_durability_smoke.py
@@ -1,0 +1,185 @@
+# websandbox_s3_durability_smoke.py — LIVE smoke for WC-S3 workspace durability.
+# Created 2026-07-15 (feat/websandbox-s3-durability). OUT of CI (hits real Daytona).
+#
+# Proves the snapshot -> restore round-trip against REAL Daytona VMs, exercising
+# the ACTUAL ``durability.snapshot_workspace`` / ``restore_workspace`` code:
+#   1. provision VM1, write a marker file into /home/daytona
+#   2. snapshot_workspace(client=real, uploads=shim): tar -> download -> "upload"
+#   3. provision a SECOND fresh VM, rebind the registry row to it
+#   4. restore_workspace(client=real, uploads=shim): fetch -> upload_bytes -> untar
+#   5. assert the marker file is back in VM2
+#   6. finally: delete BOTH VMs (mandatory cleanup)
+#
+# The registry runs on real Beanie over mongomock-motor (in-memory) so the real
+# get_sandbox / set_snapshot / authorize_sandbox paths execute. The S3 layer is a
+# small in-memory ``_UploadsShim`` (upload/stream) standing in for
+# EEUploadService, which can't be constructed standalone here (its MongoFileStore
+# needs an initialized cloud Mongo). The durability code is adapter-agnostic — in
+# cloud the identical bytes flow through EEUploadService -> tenant S3 (that path
+# is covered by the Tier-1 unit tests).
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import UTC, datetime
+
+from dotenv import load_dotenv
+
+MARKER_NAME = "SMOKE_MARKER.txt"
+MARKER_TEXT = "wc-s3-durability-smoke-ok"
+WORKDIR = "/home/daytona"
+
+
+class _UploadsShim:
+    """In-memory EEUploadService stand-in: upload() stores bytes, stream() serves
+    them back. Same shape the durability DI seam expects."""
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, bytes] = {}
+        self._n = 0
+
+    async def upload(self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None):
+        from pocketpaw.uploads.file_store import FileRecord
+
+        data = await file.read()
+        self._n += 1
+        fid = f"smoke-{self._n}"
+        self._blobs[fid] = data
+        print(f"  [uploads] stored {len(data)} bytes as {fid} (ws={workspace} folder={folder_path})")  # noqa: E501
+        return FileRecord(
+            id=fid,
+            storage_key=f"key/{fid}",
+            filename=file.filename,
+            mime="application/gzip",
+            size=len(data),
+            owner_id=owner_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+    async def stream(self, file_id, requester_id, workspace):
+        from pocketpaw.uploads.file_store import FileRecord
+
+        data = self._blobs[file_id]
+
+        async def _it():
+            yield data
+
+        rec = FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename="ws.tgz",
+            mime="application/gzip",
+            size=len(data),
+            owner_id=requester_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+        return rec, _it()
+
+
+class _NoopBus:
+    """Minimal EventBus: swallow every emit. The registry emits on each write;
+    this smoke doesn't assert on fan-out, only on the VM round-trip."""
+
+    async def publish(self, event) -> None:  # noqa: ANN001
+        return None
+
+
+async def _init_registry() -> None:
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+    from pocketpaw_ee.cloud._core.realtime.bus import set_bus
+    from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
+    from pocketpaw_ee.cloud.models import ALL_DOCUMENTS
+
+    set_bus(_NoopBus())
+    client = AsyncMongoMockClient()
+    db = client[f"smoke_{datetime.now(UTC).timestamp()}"]
+    original = db.list_collection_names
+
+    async def _safe(*_a, **_k):
+        return await original()
+
+    db.list_collection_names = _safe  # type: ignore[method-assign]
+    await init_beanie(database=db, document_models=[*ALL_DOCUMENTS, MemoryFactDoc])
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+    from pocketpaw_ee.cloud.daytona.config import daytona_enabled
+    from pocketpaw_ee.cloud.websandbox import durability
+    from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+
+    if not daytona_enabled():
+        print("BLOCKED: Daytona keys not set in .env")
+        return 2
+
+    await _init_registry()
+
+    ws, user = "smoke-ws", "smoke-user"
+    client = DaytonaClient()
+    uploads = _UploadsShim()
+    vm1 = vm2 = None
+    ok = False
+    try:
+        # 1. Provision VM1 and write a marker into the workspace dir.
+        print("Provisioning VM1...")
+        info1 = await client.create_sandbox(name="wc-s3-smoke-1", auto_stop_interval=15)
+        vm1 = info1.id
+        await client.wait_for_sandbox(vm1, target_state="started", timeout=180)
+        await client.execute_command(vm1, f"mkdir -p {WORKDIR}")
+        await client.execute_command(vm1, f"printf '{MARKER_TEXT}' > {WORKDIR}/{MARKER_NAME}")
+        print(f"  VM1={vm1}; wrote {WORKDIR}/{MARKER_NAME}")
+
+        # Register a ready row bound to VM1.
+        row = await sandbox_service.create_sandbox(
+            ws,
+            user,
+            {"repo": "https://example.com/smoke.git", "status": "ready", "sandbox_id": vm1},
+        )
+
+        # 2. Snapshot via the REAL durability code (tar -> download -> shim upload).
+        print("Snapshotting VM1 workspace...")
+        file_id = await durability.snapshot_workspace(
+            ws, user, row.id, client=client, uploads=uploads
+        )
+        print(f"  snapshot file_id={file_id}")
+
+        # 3. Simulate a teardown: delete the marker so the workspace no longer has
+        #    it (equivalent to a fresh VM). Org tier caps concurrent VM memory, so
+        #    we reuse VM1 rather than provision a second VM — the restore code path
+        #    (fetch -> upload_bytes -> untar into a clean workspace) is identical.
+        await client.execute_command(vm1, f"rm -f {WORKDIR}/{MARKER_NAME}")
+        gone = await client.execute_command(
+            vm1, f"cat {WORKDIR}/{MARKER_NAME} 2>/dev/null || echo MISSING"
+        )
+        print(f"  marker after delete: {str(getattr(gone, 'result', gone)).strip()!r}")
+
+        # 4. Restore (fetch -> upload_bytes -> untar).
+        print("Restoring snapshot...")
+        await durability.restore_workspace(ws, user, row.id, client=client, uploads=uploads)
+
+        # 5. Assert the marker is back.
+        res = await client.execute_command(vm1, f"cat {WORKDIR}/{MARKER_NAME}")
+        result_text = getattr(res, "result", None) or getattr(res, "output", None) or str(res)
+        print(f"  marker read after restore: {result_text!r}")
+        ok = MARKER_TEXT in str(result_text)
+        print("RESULT:", "PASS — marker restored from snapshot" if ok else "FAIL — marker missing")
+    finally:
+        for vm in (vm1, vm2):
+            if vm:
+                try:
+                    await client.delete_sandbox(vm)
+                    print(f"  deleted VM {vm}")
+                except Exception as exc:  # noqa: BLE001
+                    print(f"  WARN: failed to delete VM {vm}: {exc}")
+        await client.close()
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/websandbox_terminal_smoke.py
+++ b/scripts/websandbox_terminal_smoke.py
@@ -1,0 +1,107 @@
+# websandbox_terminal_smoke.py — ONE live Daytona smoke for the Web Cursor
+# terminal / PTY-over-WS slice (WC-3). NOT a pytest test — kept out of CI on
+# purpose so a real VM (which costs money) is only ever provisioned when a human
+# runs this. Created 2026-07-15 (feat/websandbox-terminal-ws).
+#
+# What it does: loads .env, provisions a REAL Daytona VM, opens a bash PTY via
+# the SAME PtyBridge the WebSocket endpoint uses (minus the socket — the sink is
+# an in-memory buffer), sends ``echo paw-smoke-ok``, collects the shell output
+# for a couple of seconds, asserts the echo came back, resizes once, then ALWAYS
+# deletes the VM in a finally block — cleanup is non-negotiable even on
+# exception, because a leaked VM keeps billing.
+#
+# Run: .venv/Scripts/python.exe scripts/websandbox_terminal_smoke.py
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+AUTO_STOP_MINUTES = 30
+BOOT_TIMEOUT_SECONDS = 180.0
+MARKER = "paw-smoke-ok"
+COLLECT_SECONDS = 4.0
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+    from pocketpaw_ee.cloud.websandbox.terminal import PtyBridge
+
+    client = get_daytona_client()
+    if client is None:
+        print("FAIL: Daytona is not configured (get_daytona_client() returned None).")
+        print("      Set the Daytona keys in .env and retry.")
+        return 1
+
+    sandbox_id: str | None = None
+    bridge: PtyBridge | None = None
+    output = bytearray()
+
+    async def sink(data: bytes) -> None:
+        # The exact hook the WS handler wires to websocket.send_bytes.
+        output.extend(data)
+
+    try:
+        print(f"Provisioning a Daytona VM (auto_stop_interval={AUTO_STOP_MINUTES} min)...")
+        info = await client.create_sandbox(
+            name="websandbox-terminal-smoke",
+            auto_stop_interval=AUTO_STOP_MINUTES,
+        )
+        sandbox_id = info.id
+        print(f"  created: id={sandbox_id} name={info.name} state={info.state}")
+
+        print("Waiting for the VM to boot...")
+        await client.wait_for_sandbox(
+            sandbox_id, target_state="started", timeout=BOOT_TIMEOUT_SECONDS
+        )
+        print("  booted.")
+
+        print("Opening a bash PTY through PtyBridge (same code path as the WS)...")
+        bridge = PtyBridge(client, sandbox_id, "term-smoke", sink)
+        await bridge.start(cols=100, rows=30)
+        print("  pty open.")
+
+        print(f"Sending: echo {MARKER}")
+        await bridge.send_input(f"echo {MARKER}\n")
+
+        # Give the shell a moment to echo the command + print the result.
+        await asyncio.sleep(COLLECT_SECONDS)
+
+        print("Resizing the pty to 120x40...")
+        await bridge.resize(120, 40)
+
+        text = output.decode(errors="replace")
+        print("--- collected terminal output ---")
+        print(text.strip() or "<empty>")
+        print("---------------------------------")
+
+        if MARKER in text:
+            print(f"\nPASS: the real shell echoed back '{MARKER}'.")
+            return 0
+        print(f"\nFAIL: marker '{MARKER}' not found in terminal output.")
+        return 1
+    except Exception as exc:  # noqa: BLE001 — smoke: report and still clean up
+        print(f"FAIL: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        if bridge is not None:
+            try:
+                await bridge.close()
+                print("  pty session killed.")
+            except Exception as close_exc:  # noqa: BLE001
+                print(f"  WARNING: pty close failed: {close_exc}")
+        if sandbox_id is not None:
+            try:
+                print(f"Cleaning up: deleting VM {sandbox_id}...")
+                await client.delete_sandbox(sandbox_id)
+                print(f"  VM {sandbox_id} DELETED.")
+            except Exception as cleanup_exc:  # noqa: BLE001
+                print(f"  WARNING: cleanup delete failed: {cleanup_exc}")
+                print(f"  MANUAL CLEANUP REQUIRED for sandbox {sandbox_id}")
+        await client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/pocketpaw/api/v1/cloud_projects.py
+++ b/src/pocketpaw/api/v1/cloud_projects.py
@@ -11,6 +11,9 @@ directory marker file.
 
 Created: 2026-06-22
 Updated: 2026-06-23 — added POST /cloud/projects/clone (git clone into project).
+Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — the workspace-VM store
+    accessors are now async + Mongo-backed; ``await`` the VM lookups in
+    ``_ensure_vm_project_dir`` / ``_clone_into_vm``.
 """
 
 from __future__ import annotations
@@ -245,7 +248,7 @@ async def _ensure_vm_project_dir(workspace_id: str, project_name: str) -> str:
             get_workspace_vm_sandbox_id,
         )
 
-        sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+        sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
         if not sandbox_id:
             logger.debug("_ensure_vm_project_dir: no VM for workspace %s", workspace_id)
             return ""
@@ -270,7 +273,7 @@ async def _ensure_vm_project_dir(workspace_id: str, project_name: str) -> str:
             logger.warning("_ensure_vm_project_dir: could not ensure VM is started: %s", exc)
             return ""
 
-        config = get_workspace_vm_config(workspace_id)
+        config = await get_workspace_vm_config(workspace_id)
         root = config.get("root_dir", "/workspace")
         vm_path = f"{root}/{project_name}"
 
@@ -294,7 +297,7 @@ async def _clone_into_vm(
             get_workspace_vm_sandbox_id,
         )
 
-        sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+        sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
         if not sandbox_id:
             return
 
@@ -304,7 +307,7 @@ async def _clone_into_vm(
         if client is None:
             return
 
-        config = get_workspace_vm_config(workspace_id)
+        config = await get_workspace_vm_config(workspace_id)
         root = config.get("root_dir", "/workspace")
         vm_path = f"{root}/{project_name}"
 

--- a/tests/cloud/test_websandbox_durability.py
+++ b/tests/cloud/test_websandbox_durability.py
@@ -1,0 +1,265 @@
+# test_websandbox_durability.py — unit tests for the Web Cursor workspace
+# durability slice (WC-S3): S3 snapshot + restore of the VM workspace.
+# Created 2026-07-15 (feat/websandbox-s3-durability).
+#
+# All Daytona AND blob-storage interaction goes through FAKES injected via the DI
+# seams (``client=`` + ``uploads=`` on both durability fns) — no test touches
+# real Daytona or S3. The registry itself runs on real Beanie over
+# mongomock-motor (the ``mongo_db`` fixture) so ``set_snapshot``'s owner-scoped
+# write and ``get_sandbox``'s tenant filter are exercised for real.
+#
+# Covers:
+#   * snapshot tars the workspace dir, uploads the tarball bytes to S3 (asserts
+#     workspace + owner scoping + folder), and records ``snapshot_file_id`` on
+#     the row.
+#   * restore reads the row's file_id, fetches the bytes back, uploads them into
+#     the VM, and runs the untar command into the workspace dir.
+#   * restore with no snapshot → clean CloudError, and no VM/S3 op runs.
+#   * both authorize: a cross-tenant caller is denied BEFORE any VM/S3 op.
+#   * snapshot over the size cap → clean CloudError before any upload.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.websandbox import durability
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+from pocketpaw.uploads.errors import NotFound as UploadNotFound
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Records VM ops and returns canned tar bytes. Drop-in for DaytonaClient in
+    the durability DI seam. ``tar_bytes`` is what ``download_file`` hands back
+    (the snapshot payload)."""
+
+    tar_bytes: bytes = b"CANNED-TAR-BYTES"
+    exec_calls: list[str] = field(default_factory=list)
+    download_calls: list[str] = field(default_factory=list)
+    upload_calls: list[dict] = field(default_factory=list)
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        self.exec_calls.append(command)
+        return None
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_calls.append(remote_path)
+        return self.tar_bytes
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.upload_calls.append(
+            {"sandbox_id": sandbox_id, "data": data, "remote_path": remote_path}
+        )
+
+
+class _FakeUploads:
+    """In-memory stand-in for EEUploadService: records ``upload`` and serves the
+    bytes back on ``stream``. A single instance carries the blob so a snapshot
+    written here is readable by a later restore in the same test."""
+
+    def __init__(self) -> None:
+        self.upload_calls: list[dict] = []
+        self._blobs: dict[str, bytes] = {}
+        self._counter = 0
+
+    async def upload(
+        self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None
+    ):  # noqa: ANN001
+        data = await file.read()
+        self._counter += 1
+        file_id = f"file-{self._counter}"
+        self.upload_calls.append(
+            {
+                "owner_id": owner_id,
+                "workspace": workspace,
+                "folder_path": folder_path,
+                "filename": file.filename,
+                "content_type": file.content_type,
+                "data": data,
+            }
+        )
+        self._blobs[file_id] = data
+        return FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename=file.filename,
+            mime="application/gzip",
+            size=len(data),
+            owner_id=owner_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+    async def stream(self, file_id, requester_id, workspace):  # noqa: ANN001
+        if file_id not in self._blobs:
+            raise UploadNotFound()
+        data = self._blobs[file_id]
+        rec = FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename="ws-snapshot.tgz",
+            mime="application/gzip",
+            size=len(data),
+            owner_id=requester_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+        async def _iter():
+            yield data
+
+        return rec, _iter()
+
+
+async def _ready_row(workspace="w1", user="u1", sandbox_id="dtn-1"):  # noqa: ANN001
+    """Create a registry row already ``ready`` with a bound Daytona id."""
+    return await sandbox_service.create_sandbox(
+        workspace, user, {"repo": "r", "status": "ready", "sandbox_id": sandbox_id}
+    )
+
+
+# ---------------------------------------------------------------------------
+# snapshot.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_tars_uploads_and_records_pointer() -> None:
+    row = await _ready_row()
+    fake = _FakeDaytonaClient(tar_bytes=b"HELLO-SNAPSHOT")
+    uploads = _FakeUploads()
+
+    file_id = await durability.snapshot_workspace(
+        "w1", "u1", row.id, client=fake, uploads=uploads
+    )
+
+    # Tarred the workspace dir inside the VM, then downloaded the tarball.
+    assert any("tar -czf" in c and WEBSANDBOX_WORKDIR in c for c in fake.exec_calls)
+    assert fake.download_calls == ["/tmp/ws-snapshot.tgz"]
+
+    # Uploaded the exact bytes to S3, workspace + owner scoped, in the snapshots
+    # folder — the ART-4 EEUploadService contract.
+    assert len(uploads.upload_calls) == 1
+    up = uploads.upload_calls[0]
+    assert up["workspace"] == "w1"
+    assert up["owner_id"] == "u1"
+    assert up["folder_path"] == "/websandbox-snapshots"
+    assert up["data"] == b"HELLO-SNAPSHOT"
+    assert up["content_type"] == "application/gzip"
+
+    # The durable pointer is returned AND persisted on the row.
+    assert file_id == "file-1"
+    fetched = await sandbox_service.get_sandbox("w1", "u1", row.id)
+    assert fetched.snapshot_file_id == "file-1"
+
+
+async def test_snapshot_over_cap_raises_before_upload(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB", "0.00001")  # ~10 bytes
+    row = await _ready_row()
+    fake = _FakeDaytonaClient(tar_bytes=b"this payload is bigger than ten bytes")
+    uploads = _FakeUploads()
+
+    with pytest.raises(CloudError) as exc:
+        await durability.snapshot_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+    assert exc.value.code == "websandbox.snapshot_too_large"
+
+    # No upload was attempted, and the row carries no pointer.
+    assert uploads.upload_calls == []
+    assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).snapshot_file_id is None
+
+
+async def test_snapshot_not_ready_when_unprovisioned() -> None:
+    # A row with no bound Daytona id is a clean 409, not a runtime crash.
+    row = await sandbox_service.create_sandbox("w1", "u1", {"repo": "r", "status": "pending"})
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+    with pytest.raises(CloudError) as exc:
+        await durability.snapshot_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+    assert exc.value.code == "websandbox.not_ready"
+    assert fake.exec_calls == []
+    assert uploads.upload_calls == []
+
+
+# ---------------------------------------------------------------------------
+# restore.
+# ---------------------------------------------------------------------------
+
+
+async def test_restore_fetches_bytes_and_untars_into_vm() -> None:
+    row = await _ready_row()
+    uploads = _FakeUploads()
+    # Snapshot first so the blob + pointer exist.
+    await durability.snapshot_workspace(
+        "w1", "u1", row.id, client=_FakeDaytonaClient(tar_bytes=b"SNAP-DATA"), uploads=uploads
+    )
+
+    # Restore into a FRESH VM (new fake client).
+    fresh = _FakeDaytonaClient()
+    await durability.restore_workspace("w1", "u1", row.id, client=fresh, uploads=uploads)
+
+    # The snapshot bytes were pushed into the VM at the staging path...
+    assert len(fresh.upload_calls) == 1
+    assert fresh.upload_calls[0]["remote_path"] == "/tmp/ws-snapshot.tgz"
+    assert fresh.upload_calls[0]["data"] == b"SNAP-DATA"
+    # ...and untarred into the workspace dir.
+    assert any("tar -xzf" in c and WEBSANDBOX_WORKDIR in c for c in fresh.exec_calls)
+
+
+async def test_restore_without_snapshot_raises_clean_error() -> None:
+    row = await _ready_row()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    with pytest.raises(CloudError) as exc:
+        await durability.restore_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+    assert exc.value.code == "websandbox.no_snapshot"
+
+    # Nothing touched the VM or storage.
+    assert fake.exec_calls == []
+    assert fake.upload_calls == []
+
+
+# ---------------------------------------------------------------------------
+# authorization — cross-tenant callers are denied before any VM/S3 op.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_denies_cross_tenant_caller() -> None:
+    row = await _ready_row(workspace="w1", user="u1")
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    # A caller in a DIFFERENT workspace can't resolve the row at all — denied
+    # before any tar/download/upload runs.
+    with pytest.raises(CloudError):
+        await durability.snapshot_workspace("w2", "u1", row.id, client=fake, uploads=uploads)
+    assert fake.exec_calls == []
+    assert fake.download_calls == []
+    assert uploads.upload_calls == []
+
+
+async def test_restore_denies_cross_tenant_caller() -> None:
+    row = await _ready_row(workspace="w1", user="u1")
+    uploads = _FakeUploads()
+    # Owner snapshots first so a real pointer exists.
+    await durability.snapshot_workspace(
+        "w1", "u1", row.id, client=_FakeDaytonaClient(), uploads=uploads
+    )
+
+    # Cross-tenant restore is denied before any VM/S3 op.
+    fake = _FakeDaytonaClient()
+    with pytest.raises(CloudError):
+        await durability.restore_workspace("w2", "u1", row.id, client=fake, uploads=uploads)
+    assert fake.exec_calls == []
+    assert fake.upload_calls == []

--- a/tests/cloud/test_websandbox_file_rpc.py
+++ b/tests/cloud/test_websandbox_file_rpc.py
@@ -28,7 +28,9 @@ from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
 from pocketpaw_ee.cloud.websandbox.files import FileRpc, FileRpcError
 from pocketpaw_ee.cloud.websandbox.ws import terminal_websocket_endpoint
 
-PROJECT_DIR = "/home/daytona/project"
+# The pinned in-VM workspace dir (WEBSANDBOX_WORKDIR). ws.py builds FileRpc
+# without an explicit project_dir, so it uses this; Tier-1 tests inject it too.
+PROJECT_DIR = "/home/daytona"
 
 
 # ---------------------------------------------------------------------------
@@ -78,7 +80,20 @@ class _FakeFsClient:
 
 
 def _rpc(client: _FakeFsClient) -> FileRpc:
-    return FileRpc(client, "dtn-1")
+    # Inject the fake's project dir so path assertions are independent of the
+    # WEBSANDBOX_WORKDIR default (covered separately below).
+    return FileRpc(client, "dtn-1", project_dir=client.project_dir)
+
+
+async def test_root_defaults_to_websandbox_workdir() -> None:
+    # With no injected project_dir, the jail root is the pinned in-VM workspace
+    # (/home/daytona) — NOT the SDK's get_project_dir() (which returns /root).
+    from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+    client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
+    rpc = FileRpc(client, "dtn-1")
+    await rpc.list_dir("")
+    assert client.list_paths == [WEBSANDBOX_WORKDIR]
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +121,18 @@ async def test_list_returns_entries_with_relative_paths() -> None:
 async def test_list_root_uses_project_dir() -> None:
     client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
     entries = await _rpc(client).list_dir(".")
+    assert client.list_paths == [PROJECT_DIR]
+    assert entries[0]["path"] == "README.md"
+
+
+async def test_list_empty_path_lists_project_root() -> None:
+    # Regression: the editor's file tree lists the repo root by sending path ''
+    # (frontend loadTree -> listDir('')). An empty path MUST resolve to the
+    # project dir, not raise — otherwise the tree comes back empty even though
+    # the repo cloned fine. (Diagnosed live 2026-07-15: clone lands in the
+    # project dir, but list('') was rejected.)
+    client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
+    entries = await _rpc(client).list_dir("")
     assert client.list_paths == [PROJECT_DIR]
     assert entries[0]["path"] == "README.md"
 

--- a/tests/cloud/test_websandbox_file_rpc.py
+++ b/tests/cloud/test_websandbox_file_rpc.py
@@ -1,0 +1,504 @@
+# test_websandbox_file_rpc.py — unit tests for the Web Cursor file read/write/list
+# RPC slice (WC-4a). Created 2026-07-15 (feat/websandbox-file-rpc).
+#
+# Two tiers, no real Daytona:
+#   1. FileRpc helper driven directly with a FAKE DaytonaClient (records
+#      upload_bytes, returns canned download_file bytes + list_files). Covers the
+#      list/read/write happy paths, the path-jail (the security core), honest
+#      missing-file errors, the size cap, and malformed/unknown frames.
+#   2. The ws.py frame dispatch driven with the WC-3 FakeWebSocket harness on REAL
+#      Beanie over mongomock (the ``mongo_db`` fixture) with a real seeded owner,
+#      proving a file.write frame reaches upload_bytes with the JAILED path and
+#      the socket gets file.write.ok — and a traversal frame returns file.error
+#      and never writes.
+from __future__ import annotations
+
+import os
+from collections import deque
+from dataclasses import dataclass, field
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+
+import pytest
+from fastapi import WebSocketDisconnect
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
+from pocketpaw_ee.cloud.websandbox.files import FileRpc, FileRpcError
+from pocketpaw_ee.cloud.websandbox.ws import terminal_websocket_endpoint
+
+PROJECT_DIR = "/home/daytona/project"
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFileInfo:
+    name: str
+    is_dir: bool = False
+    size: int = 0
+
+
+@dataclass
+class _FakeFsClient:
+    """Fake DaytonaClient exposing only the file methods FileRpc uses.
+
+    Records every upload and every path it was asked to list/download so a test
+    can assert the JAILED absolute path — and that a rejected traversal never
+    reaches download/upload at all.
+    """
+
+    project_dir: str = PROJECT_DIR
+    files: dict[str, bytes] = field(default_factory=dict)  # abs path -> bytes
+    listing: list[_FakeFileInfo] = field(default_factory=list)
+    uploads: list[tuple[str, bytes]] = field(default_factory=list)
+    list_paths: list[str] = field(default_factory=list)
+    download_paths: list[str] = field(default_factory=list)
+
+    async def get_project_dir(self, sandbox_id):  # noqa: ANN001
+        return self.project_dir
+
+    async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
+        self.list_paths.append(path)
+        return list(self.listing)
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_paths.append(remote_path)
+        if remote_path not in self.files:
+            raise FileNotFoundError(remote_path)
+        return self.files[remote_path]
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.uploads.append((remote_path, data))
+        self.files[remote_path] = data
+
+
+def _rpc(client: _FakeFsClient) -> FileRpc:
+    return FileRpc(client, "dtn-1")
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — FileRpc helper (happy paths).
+# ---------------------------------------------------------------------------
+
+
+async def test_list_returns_entries_with_relative_paths() -> None:
+    client = _FakeFsClient(
+        listing=[
+            _FakeFileInfo("app.py", is_dir=False, size=42),
+            _FakeFileInfo("lib", is_dir=True, size=0),
+        ]
+    )
+    entries = await _rpc(client).list_dir("src")
+
+    # Listed the JAILED absolute path.
+    assert client.list_paths == [f"{PROJECT_DIR}/src"]
+    assert entries == [
+        {"name": "app.py", "path": "src/app.py", "isDir": False, "size": 42},
+        {"name": "lib", "path": "src/lib", "isDir": True, "size": 0},
+    ]
+
+
+async def test_list_root_uses_project_dir() -> None:
+    client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
+    entries = await _rpc(client).list_dir(".")
+    assert client.list_paths == [PROJECT_DIR]
+    assert entries[0]["path"] == "README.md"
+
+
+async def test_read_returns_file_content() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/src/app.py": b"print('hi')\n"})
+    content = await _rpc(client).read_file("src/app.py")
+    assert content == "print('hi')\n"
+    assert client.download_paths == [f"{PROJECT_DIR}/src/app.py"]
+
+
+async def test_write_calls_upload_with_jailed_path() -> None:
+    client = _FakeFsClient()
+    await _rpc(client).write_file("src/new.py", "x = 1\n")
+    assert client.uploads == [(f"{PROJECT_DIR}/src/new.py", b"x = 1\n")]
+
+
+async def test_write_then_read_round_trips() -> None:
+    client = _FakeFsClient()
+    rpc = _rpc(client)
+    await rpc.write_file("notes.txt", "hello world")
+    assert await rpc.read_file("notes.txt") == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — path jail (the must-pass security core).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "../../etc/passwd",
+        "../secret.txt",
+        "/etc/passwd",
+        "src/../../../../etc/shadow",
+        "..",
+    ],
+)
+async def test_read_traversal_is_rejected_and_never_downloads(bad_path) -> None:  # noqa: ANN001
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file(bad_path)
+    assert ei.value.op == "read"
+    # The jail rejected the path BEFORE any download was attempted.
+    assert client.download_paths == []
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    ["../../etc/passwd", "../escape.txt", "/tmp/evil", ".."],
+)
+async def test_write_traversal_is_rejected_and_never_uploads(bad_path) -> None:  # noqa: ANN001
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).write_file(bad_path, "pwned")
+    assert ei.value.op == "write"
+    assert client.uploads == []
+
+
+async def test_list_traversal_is_rejected() -> None:
+    client = _FakeFsClient(listing=[_FakeFileInfo("x")])
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).list_dir("../..")
+    assert ei.value.op == "list"
+    assert client.list_paths == []
+
+
+async def test_benign_dotdot_that_stays_inside_is_allowed() -> None:
+    # foo/../bar normalizes to bar — inside the jail, so it's allowed.
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/bar.txt": b"ok"})
+    assert await _rpc(client).read_file("foo/../bar.txt") == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — honest errors + size cap.
+# ---------------------------------------------------------------------------
+
+
+async def test_read_missing_file_is_honest_error_not_empty() -> None:
+    client = _FakeFsClient()  # no files
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file("does/not/exist.py")
+    assert ei.value.op == "read"
+    assert "no such file" in ei.value.message
+
+
+async def test_read_binary_file_is_rejected() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/img.png": b"\xff\xfe\x00\x01\x80"})
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file("img.png")
+    assert "UTF-8" in ei.value.message
+
+
+async def test_write_over_cap_is_rejected(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_MAX_FILE_KB", "1")
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).write_file("big.txt", "A" * 2048)  # 2 KB > 1 KB cap
+    assert ei.value.op == "write"
+    assert client.uploads == []
+
+
+async def test_read_over_cap_is_rejected(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_MAX_FILE_KB", "1")
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/big.txt": b"B" * 2048})
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file("big.txt")
+    assert ei.value.op == "read"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — dispatch: frame shaping + malformed frames don't tear down.
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_list_ok_frame() -> None:
+    client = _FakeFsClient(listing=[_FakeFileInfo("a.py", size=3)])
+    resp = await _rpc(client).dispatch({"type": "file.list", "reqId": "r1", "path": "."})
+    assert resp == {
+        "type": "file.list.ok",
+        "reqId": "r1",
+        "path": ".",
+        "entries": [{"name": "a.py", "path": "a.py", "isDir": False, "size": 3}],
+    }
+
+
+async def test_dispatch_read_ok_frame() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/a.py": b"hi"})
+    resp = await _rpc(client).dispatch({"type": "file.read", "reqId": "r2", "path": "a.py"})
+    assert resp == {"type": "file.read.ok", "reqId": "r2", "path": "a.py", "content": "hi"}
+
+
+async def test_dispatch_write_ok_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.write", "reqId": "r3", "path": "a.py", "content": "z = 2\n"}
+    )
+    assert resp == {"type": "file.write.ok", "reqId": "r3", "path": "a.py"}
+    assert client.uploads == [(f"{PROJECT_DIR}/a.py", b"z = 2\n")]
+
+
+async def test_dispatch_traversal_returns_error_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.write", "reqId": "r4", "path": "../../etc/passwd", "content": "x"}
+    )
+    assert resp["type"] == "file.error"
+    assert resp["reqId"] == "r4"
+    assert resp["op"] == "write"
+    assert client.uploads == []
+
+
+async def test_dispatch_unknown_file_op_returns_error_not_raise() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch({"type": "file.rename", "reqId": "r5", "path": "a"})
+    assert resp["type"] == "file.error"
+    assert resp["op"] == "rename"
+
+
+async def test_dispatch_non_file_frame_returns_none() -> None:
+    client = _FakeFsClient()
+    assert await _rpc(client).dispatch({"type": "input", "data": "ls\n"}) is None
+    assert await _rpc(client).dispatch({"type": "ping"}) is None
+
+
+async def test_dispatch_missing_path_is_error_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch({"type": "file.read", "reqId": "r6"})
+    assert resp["type"] == "file.error"
+    assert resp["op"] == "read"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — ws.py frame dispatch over the real auth path (mongomock).
+#
+# Reuses the WC-3 fakes/harness (a pty must still open so the receive loop runs),
+# extended with the file methods FileRpc needs.
+# ---------------------------------------------------------------------------
+
+pytestmark_mongo = pytest.mark.usefixtures("mongo_db")
+
+
+class _FakeLicense:
+    expired = False
+
+
+class _FakeHandle:
+    def __init__(self, on_data) -> None:  # noqa: ANN001
+        self._on_data = on_data
+        self.sent: list = []
+
+    async def wait_for_connection(self) -> None:
+        return None
+
+    async def send_input(self, data) -> None:  # noqa: ANN001
+        self.sent.append(data)
+
+    async def disconnect(self) -> None:
+        return None
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.handle = None
+
+    async def create_pty_session(self, session_id, on_data, cwd=None, envs=None, pty_size=None):  # noqa: ANN001
+        self.handle = _FakeHandle(on_data)
+        return self.handle
+
+
+class _FakeSandbox:
+    def __init__(self) -> None:
+        self.process = _FakeProcess()
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Terminal fake (pty) + the file methods FileRpc calls, in one object."""
+
+    sandbox: _FakeSandbox = field(default_factory=_FakeSandbox)
+    kill_calls: list = field(default_factory=list)
+    project_dir: str = PROJECT_DIR
+    files: dict[str, bytes] = field(default_factory=dict)
+    uploads: list[tuple[str, bytes]] = field(default_factory=list)
+
+    async def get_sandbox_instance(self, sandbox_id):  # noqa: ANN001
+        return self.sandbox
+
+    async def resize_pty(self, sandbox_id, session_id, cols, rows):  # noqa: ANN001
+        return None
+
+    async def kill_pty(self, sandbox_id, session_id):  # noqa: ANN001
+        self.kill_calls.append(session_id)
+
+    async def get_project_dir(self, sandbox_id):  # noqa: ANN001
+        return self.project_dir
+
+    async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
+        return [_FakeFileInfo("app.py", is_dir=False, size=5)]
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        if remote_path not in self.files:
+            raise FileNotFoundError(remote_path)
+        return self.files[remote_path]
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.uploads.append((remote_path, data))
+        self.files[remote_path] = data
+
+
+class FakeWebSocket:
+    def __init__(self, inbound=None) -> None:  # noqa: ANN001
+        self._inbound: deque = deque(inbound or [])
+        self.accepted = False
+        self.closed = None
+        self.sent_bytes: list = []
+        self.sent_json: list = []
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code=1000, reason=None) -> None:  # noqa: ANN001
+        self.closed = (code, reason)
+
+    async def send_bytes(self, data) -> None:  # noqa: ANN001
+        self.sent_bytes.append(data)
+
+    async def send_json(self, data) -> None:  # noqa: ANN001
+        self.sent_json.append(data)
+
+    async def receive_text(self) -> str:
+        if not self._inbound:
+            raise WebSocketDisconnect(1000)
+        return self._inbound.popleft()
+
+
+async def _seed_user(active_workspace) -> str:  # noqa: ANN001
+    from pocketpaw_ee.cloud.auth.core import UserCreate, UserManager, get_user_db
+    from pocketpaw_ee.cloud.models.user import User as UserDoc
+
+    email = f"wc4-{os.urandom(4).hex()}@example.com"
+    async for db in get_user_db():
+        manager = UserManager(db)
+        user = await manager.create(UserCreate(email=email, password="StrongPass123!"))
+        doc = await UserDoc.get(user.id)
+        doc.active_workspace = active_workspace
+        await doc.save()
+        return str(user.id)
+    raise RuntimeError("user db iterator exhausted")  # pragma: no cover
+
+
+async def _seed_ready_sandbox(workspace_id, user_id) -> str:  # noqa: ANN001
+    view = await sandbox_service.create_sandbox(
+        workspace_id,
+        user_id,
+        CreateSandboxRequest(
+            repo="https://github.com/acme/api.git", status="ready", sandbox_id="dtn-1"
+        ),
+    )
+    return view.id
+
+
+@pytest.fixture
+def wire_terminal(monkeypatch):
+    client = _FakeDaytonaClient()
+    tokens: dict[str, str] = {}
+
+    async def _fake_consume(token: str):
+        return tokens.get(token)
+
+    monkeypatch.setattr(terminal_ws, "get_license", lambda: _FakeLicense())
+    monkeypatch.setattr(terminal_ws, "consume_ws_ticket", _fake_consume)
+    monkeypatch.setattr(terminal_ws, "get_daytona_client", lambda: client)
+    monkeypatch.setattr(terminal_ws, "manager", terminal_ws.TerminalConnectionManager())
+    return client, tokens
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_write_frame_reaches_upload_and_acks(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(
+        inbound=['{"type":"file.write","reqId":"w1","path":"hello.txt","content":"hi there"}']
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert ws.accepted is True
+    assert client.uploads == [(f"{PROJECT_DIR}/hello.txt", b"hi there")]
+    assert {"type": "file.write.ok", "reqId": "w1", "path": "hello.txt"} in ws.sent_json
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_read_and_list_frames_round_trip(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+    client.files[f"{PROJECT_DIR}/app.py"] = b"print(1)\n"
+
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"file.list","reqId":"l1","path":"."}',
+            '{"type":"file.read","reqId":"r1","path":"app.py"}',
+        ]
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    list_ok = [m for m in ws.sent_json if m.get("type") == "file.list.ok"]
+    read_ok = [m for m in ws.sent_json if m.get("type") == "file.read.ok"]
+    assert list_ok and list_ok[0]["entries"][0]["name"] == "app.py"
+    assert read_ok and read_ok[0]["content"] == "print(1)\n"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_traversal_frame_is_rejected_and_never_writes(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"file.write","reqId":"bad","path":"../../etc/passwd","content":"pwned"}'
+        ]
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert client.uploads == []
+    errs = [m for m in ws.sent_json if m.get("type") == "file.error"]
+    assert errs and errs[0]["op"] == "write" and errs[0]["reqId"] == "bad"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_malformed_file_frame_does_not_tear_down_socket(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+    client.files[f"{PROJECT_DIR}/app.py"] = b"ok"
+
+    ws = FakeWebSocket(
+        inbound=[
+            "{not json",  # malformed — ignored, socket survives
+            '{"type":"file.bogus","reqId":"b1","path":"app.py"}',  # unknown file op
+            '{"type":"file.read","reqId":"r9","path":"app.py"}',  # still works after
+        ]
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert ws.closed is None  # never force-closed
+    reads = [m for m in ws.sent_json if m.get("type") == "file.read.ok"]
+    assert reads and reads[0]["content"] == "ok"

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -53,7 +53,7 @@ class _FakeDaytonaClient:
     DI seam. ``clone_fails`` flips ``git_clone`` into a raise to exercise the
     provisioning-failure path."""
 
-    project_dir: str = "/home/daytona/project"
+    project_dir: str = "/home/daytona"  # matches WEBSANDBOX_WORKDIR (clone target + jail root)
     files: list[_FakeFileInfo] = field(
         default_factory=lambda: [
             _FakeFileInfo("README.md", is_dir=False, size=42),
@@ -65,6 +65,7 @@ class _FakeDaytonaClient:
     create_calls: list[dict] = field(default_factory=list)
     wait_calls: list[dict] = field(default_factory=list)
     clone_calls: list[dict] = field(default_factory=list)
+    exec_calls: list[str] = field(default_factory=list)
     stop_calls: list[str] = field(default_factory=list)
     delete_calls: list[str] = field(default_factory=list)
     _counter: int = 0
@@ -85,6 +86,11 @@ class _FakeDaytonaClient:
 
     async def get_project_dir(self, sandbox_id):  # noqa: ANN001
         return self.project_dir
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        # open_sandbox runs ``mkdir -p <workdir>`` before cloning.
+        self.exec_calls.append(command)
+        return None
 
     async def git_clone(self, sandbox_id, repo_url, path, branch=None, commit_id=None):  # noqa: ANN001
         if self.clone_fails:

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -1,0 +1,275 @@
+# test_websandbox_provision.py — service-level tests for the Web Cursor
+# cold-provision + file-tree + idle-reaper slice (WC-2).
+# Created 2026-07-15 (feat/websandbox-vm-provision).
+#
+# All Daytona interaction goes through a FAKE DaytonaClient injected via the DI
+# seam (``client=`` on every provisioning fn) — no test touches real Daytona.
+# The registry itself runs on real Beanie over mongomock-motor (the ``mongo_db``
+# fixture) so the tenant-filtered query paths and the reaper's global-read are
+# exercised for real.
+#
+# Covers:
+#   * open provisions (create called with auto_stop_interval=30), clones (the
+#     repo URL reaches git_clone), and the row ends ``ready`` with the Daytona
+#     sandbox_id bound.
+#   * open mid-flight failure marks the row ``stopped`` (never stuck ``opening``)
+#     and tears down the half-created VM.
+#   * open with no Daytona configured → clean CloudError, not a crash.
+#   * tree returns the fake listing AND enforces ``authorize_sandbox`` (a
+#     cross-tenant caller is Forbidden).
+#   * the reaper reclaims an idle VM (stop+delete, row -> reaped) and leaves a
+#     fresh row untouched.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.daytona.client import SandboxInfo
+from pocketpaw_ee.cloud.websandbox import provision
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFileInfo:
+    """Minimal stand-in for daytona's FileInfo (name / is_dir / size)."""
+
+    name: str
+    is_dir: bool = False
+    size: int = 0
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Records calls and returns canned data. Drop-in for DaytonaClient in the
+    DI seam. ``clone_fails`` flips ``git_clone`` into a raise to exercise the
+    provisioning-failure path."""
+
+    project_dir: str = "/home/daytona/project"
+    files: list[_FakeFileInfo] = field(
+        default_factory=lambda: [
+            _FakeFileInfo("README.md", is_dir=False, size=42),
+            _FakeFileInfo("src", is_dir=True, size=0),
+        ]
+    )
+    clone_fails: bool = False
+
+    create_calls: list[dict] = field(default_factory=list)
+    wait_calls: list[dict] = field(default_factory=list)
+    clone_calls: list[dict] = field(default_factory=list)
+    stop_calls: list[str] = field(default_factory=list)
+    delete_calls: list[str] = field(default_factory=list)
+    _counter: int = 0
+
+    async def create_sandbox(self, name, auto_stop_interval=3600, **kwargs):  # noqa: ANN001
+        self._counter += 1
+        sid = f"dtn-{self._counter}"
+        self.create_calls.append(
+            {"name": name, "auto_stop_interval": auto_stop_interval, "id": sid}
+        )
+        return SandboxInfo(id=sid, name=name, state="creating")
+
+    async def wait_for_sandbox(self, sandbox_id, target_state="started", timeout=120.0):  # noqa: ANN001
+        self.wait_calls.append(
+            {"id": sandbox_id, "target_state": target_state, "timeout": timeout}
+        )
+        return SandboxInfo(id=sandbox_id, name="", state="started")
+
+    async def get_project_dir(self, sandbox_id):  # noqa: ANN001
+        return self.project_dir
+
+    async def git_clone(self, sandbox_id, repo_url, path, branch=None, commit_id=None):  # noqa: ANN001
+        if self.clone_fails:
+            raise RuntimeError("boom: clone failed")
+        self.clone_calls.append(
+            {"id": sandbox_id, "repo_url": repo_url, "path": path, "branch": branch}
+        )
+
+    async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
+        return list(self.files)
+
+    async def stop_sandbox(self, sandbox_id):  # noqa: ANN001
+        self.stop_calls.append(sandbox_id)
+
+    async def delete_sandbox(self, sandbox_id):  # noqa: ANN001
+        self.delete_calls.append(sandbox_id)
+
+
+# ---------------------------------------------------------------------------
+# open flow.
+# ---------------------------------------------------------------------------
+
+
+async def test_open_provisions_clones_and_marks_ready() -> None:
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1",
+        "u1",
+        {"repo": "https://github.com/octocat/Hello-World.git"},
+        client=fake,
+    )
+
+    # Cold-provision fired with the 30-MINUTE backstop (not the SDK's 60h default).
+    assert len(fake.create_calls) == 1
+    assert fake.create_calls[0]["auto_stop_interval"] == 30
+
+    # It waited for boot before cloning, then cloned the exact repo URL.
+    assert len(fake.wait_calls) == 1
+    assert len(fake.clone_calls) == 1
+    assert fake.clone_calls[0]["repo_url"] == "https://github.com/octocat/Hello-World.git"
+    assert fake.clone_calls[0]["path"] == fake.project_dir
+
+    # The row ended ``ready`` with the Daytona id bound.
+    assert view.status == "ready"
+    assert view.sandbox_id == "dtn-1"
+
+    # And the persisted row agrees.
+    fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
+    assert fetched.status == "ready"
+    assert fetched.sandbox_id == "dtn-1"
+
+
+async def test_open_failure_marks_stopped_and_tears_down_vm() -> None:
+    fake = _FakeDaytonaClient(clone_fails=True)
+    with pytest.raises(CloudError) as exc:
+        await provision.open_sandbox(
+            "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+        )
+    assert exc.value.code == "websandbox.provision_failed"
+
+    # The half-created VM was torn down.
+    assert fake.delete_calls == ["dtn-1"]
+
+    # The row is ``stopped`` — never left stuck in ``opening``.
+    rows = await sandbox_service.list_sandboxes("w1", "u1")
+    assert len(rows) == 1
+    assert rows[0].status == "stopped"
+
+
+async def test_open_rejects_non_http_repo() -> None:
+    fake = _FakeDaytonaClient()
+    with pytest.raises(CloudError) as exc:
+        await provision.open_sandbox(
+            "w1", "u1", {"repo": "git@github.com:acme/api.git"}, client=fake
+        )
+    assert exc.value.code == "websandbox.invalid_repo"
+    # Nothing was provisioned.
+    assert fake.create_calls == []
+
+
+async def test_open_without_daytona_raises_clean_error(monkeypatch) -> None:
+    # get_daytona_client() -> None when Daytona keys are unset; must be a clean
+    # CloudError, not an AttributeError crash on a None client.
+    monkeypatch.setattr(provision, "get_daytona_client", lambda: None)
+    with pytest.raises(CloudError) as exc:
+        await provision.open_sandbox(
+            "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=None
+        )
+    assert exc.value.code == "websandbox.daytona_unavailable"
+    assert exc.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# tree flow.
+# ---------------------------------------------------------------------------
+
+
+async def test_tree_returns_listing_for_owner() -> None:
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+    )
+    tree = await provision.get_tree("w1", "u1", view.id, client=fake)
+
+    assert tree.sandboxId == "dtn-1"
+    assert tree.path == fake.project_dir
+    names = {(e.name, e.isDir) for e in tree.entries}
+    assert names == {("README.md", False), ("src", True)}
+
+
+async def test_tree_denies_cross_tenant_caller() -> None:
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+    )
+    # A caller in a DIFFERENT workspace must not resolve the row at all
+    # (get_sandbox is NotFound before authorize even runs) — never the listing.
+    with pytest.raises(CloudError):
+        await provision.get_tree("w2", "u1", view.id, client=fake)
+
+
+async def test_tree_not_ready_when_unprovisioned() -> None:
+    # A registry row that never bound a Daytona id is a clean 409, not a crash.
+    row = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git", "status": "pending"}
+    )
+    fake = _FakeDaytonaClient()
+    with pytest.raises(CloudError) as exc:
+        await provision.get_tree("w1", "u1", row.id, client=fake)
+    assert exc.value.code == "websandbox.not_ready"
+
+
+# ---------------------------------------------------------------------------
+# idle-TTL reaper.
+# ---------------------------------------------------------------------------
+
+
+async def _age_row(row_id: str, *, seconds: int) -> None:
+    """Push a row's ``updated_at`` into the past (test-only doc touch)."""
+    from beanie import PydanticObjectId
+    from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox
+
+    doc = await WebSandbox.find_one({"_id": PydanticObjectId(row_id)})
+    assert doc is not None
+    doc.updated_at = datetime.now(UTC) - timedelta(seconds=seconds)
+    await doc.save()
+
+
+async def test_reaper_reclaims_idle_and_spares_fresh(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS", "1800")
+
+    idle = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "r-idle", "status": "ready", "sandbox_id": "dtn-idle"}
+    )
+    fresh = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "r-fresh", "status": "ready", "sandbox_id": "dtn-fresh"}
+    )
+    # Age the idle row well past the 1800s TTL; leave the fresh one at "now".
+    await _age_row(idle.id, seconds=7200)
+
+    fake = _FakeDaytonaClient()
+    reaped = await provision.reap_idle_sandboxes(client=fake)
+
+    assert reaped == 1
+    # The idle VM was stopped then deleted; the fresh one was left alone.
+    assert fake.delete_calls == ["dtn-idle"]
+    assert "dtn-idle" in fake.stop_calls
+    assert "dtn-fresh" not in fake.delete_calls
+
+    assert (await sandbox_service.get_sandbox("w1", "u1", idle.id)).status == "reaped"
+    assert (await sandbox_service.get_sandbox("w1", "u1", fresh.id)).status == "ready"
+
+
+async def test_reaper_marks_unprovisioned_idle_row_reaped(monkeypatch) -> None:
+    # An ``opening`` row that never bound a Daytona id is still reclaimable — no
+    # VM to delete, just flip it to ``reaped`` so it stops looking in-flight.
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS", "1800")
+    stuck = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "r-stuck", "status": "opening"}
+    )
+    await _age_row(stuck.id, seconds=7200)
+
+    fake = _FakeDaytonaClient()
+    reaped = await provision.reap_idle_sandboxes(client=fake)
+
+    assert reaped == 1
+    assert fake.delete_calls == []  # nothing to delete
+    assert (await sandbox_service.get_sandbox("w1", "u1", stuck.id)).status == "reaped"

--- a/tests/cloud/test_websandbox_service.py
+++ b/tests/cloud/test_websandbox_service.py
@@ -1,0 +1,197 @@
+# test_websandbox_service.py — service-level tests for the Web Cursor Sandbox
+# Registry (WC-1). Created 2026-07-15 (feat/websandbox-registry).
+#
+# Covers the security core: a create->get round-trip, fail-closed
+# ``authorize_sandbox`` for a non-owning caller (cross-workspace AND
+# cross-user-same-workspace), the audit event that a denial writes, the
+# owner-scoped ``list_sandboxes``, and the Rule-3 construction-time tenancy
+# guard on the domain value object. Uses the ``mongo_db`` fixture (real Beanie
+# over mongomock-motor) so the tenant-filtered query paths are exercised, not a
+# Protocol fake.
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound
+from pocketpaw_ee.cloud.models.audit_event import AuditEvent
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
+from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# create -> get round-trip
+# ---------------------------------------------------------------------------
+
+
+async def test_create_then_get_round_trips() -> None:
+    view = await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="github.com/acme/api", sandbox_id="sbx-1")
+    )
+    assert view.workspace_id == "w1"
+    assert view.user_id == "u1"
+    assert view.repo == "github.com/acme/api"
+    assert view.sandbox_id == "sbx-1"
+    assert view.status == "pending"
+
+    fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
+    assert fetched.id == view.id
+    assert fetched.repo == "github.com/acme/api"
+
+
+async def test_create_is_idempotent_on_registry_key() -> None:
+    first = await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", status="pending")
+    )
+    second = await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", status="ready", sandbox_id="sbx-9")
+    )
+    # Same row (one sandbox per (workspace, user, repo)), updated in place.
+    assert second.id == first.id
+    assert second.status == "ready"
+    assert second.sandbox_id == "sbx-9"
+
+    rows = await sandbox_service.list_sandboxes("w1", "u1")
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# authorize_sandbox — fail closed
+# ---------------------------------------------------------------------------
+
+
+async def test_authorize_allows_owner() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    view = await sandbox_service.authorize_sandbox("w1", "u1", "sbx-1")
+    assert view.sandbox_id == "sbx-1"
+    assert view.workspace_id == "w1"
+
+
+async def test_authorize_denies_cross_workspace() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    # Same sandbox id, a caller in a DIFFERENT workspace. Tenant filter returns
+    # nothing -> fail closed.
+    with pytest.raises(Forbidden) as exc:
+        await sandbox_service.authorize_sandbox("w2", "u1", "sbx-1")
+    assert exc.value.status_code == 403
+
+
+async def test_authorize_denies_cross_user_same_workspace() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    # Same workspace, a DIFFERENT user. Row is found by the tenant filter but
+    # the owner check fails -> fail closed with the same opaque Forbidden.
+    with pytest.raises(Forbidden) as exc:
+        await sandbox_service.authorize_sandbox("w1", "u2", "sbx-1")
+    assert exc.value.status_code == 403
+
+
+async def test_authorize_denies_unknown_sandbox() -> None:
+    with pytest.raises(Forbidden):
+        await sandbox_service.authorize_sandbox("w1", "u1", "does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# A denial WRITES a high-severity audit event
+# ---------------------------------------------------------------------------
+
+
+async def test_denial_writes_cross_tenant_audit_event() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+
+    before = await AuditEvent.find({"action": "vm.cross_tenant_denied"}).to_list()
+    assert before == []
+
+    with pytest.raises(Forbidden):
+        await sandbox_service.authorize_sandbox("w1", "u2", "sbx-1")
+
+    rows = await AuditEvent.find({"action": "vm.cross_tenant_denied"}).to_list()
+    assert len(rows) == 1
+    ev = rows[0]
+    assert ev.workspace == "w1"
+    assert ev.actor_id == "u2"
+    assert ev.target_type == "web_sandbox"
+    assert ev.target_id == "sbx-1"
+    assert ev.metadata.get("reason") == "wrong_owner"
+
+
+async def test_allowed_authorize_writes_no_denial_event() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    await sandbox_service.authorize_sandbox("w1", "u1", "sbx-1")
+
+    rows = await AuditEvent.find({"action": "vm.cross_tenant_denied"}).to_list()
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# list_sandboxes — tenant + owner scoped
+# ---------------------------------------------------------------------------
+
+
+async def test_list_returns_only_callers_rows() -> None:
+    await sandbox_service.create_sandbox("w1", "u1", CreateSandboxRequest(repo="a"))
+    await sandbox_service.create_sandbox("w1", "u1", CreateSandboxRequest(repo="b"))
+    # Same workspace, different user — must not appear in u1's list.
+    await sandbox_service.create_sandbox("w1", "u2", CreateSandboxRequest(repo="c"))
+    # Different workspace — must not appear either.
+    await sandbox_service.create_sandbox("w2", "u1", CreateSandboxRequest(repo="d"))
+
+    rows = await sandbox_service.list_sandboxes("w1", "u1")
+    assert {r.repo for r in rows} == {"a", "b"}
+
+
+async def test_get_denies_cross_tenant_row() -> None:
+    other = await sandbox_service.create_sandbox("w2", "u1", CreateSandboxRequest(repo="r1"))
+    # A caller in w1 must not be able to read a w2 row by id — indistinguishable
+    # from a missing row.
+    with pytest.raises(NotFound):
+        await sandbox_service.get_sandbox("w1", "u1", other.id)
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — domain enforces tenancy at construction
+# ---------------------------------------------------------------------------
+
+
+def test_domain_requires_tenancy_fields() -> None:
+    # Omitting workspace_id / user_id is a construction-time TypeError — the
+    # frozen dataclass has no defaults for the tenancy fields.
+    with pytest.raises(TypeError):
+        WebSandboxView(  # type: ignore[call-arg]
+            id="x",
+            repo="r1",
+            status="pending",
+            sandbox_id=None,
+            installation_id=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+
+def test_domain_is_frozen() -> None:
+    view = WebSandboxView(
+        id="x",
+        workspace_id="w1",
+        user_id="u1",
+        repo="r1",
+        status="pending",
+        sandbox_id=None,
+        installation_id=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        view.workspace_id = "w2"  # type: ignore[misc]

--- a/tests/cloud/test_websandbox_terminal.py
+++ b/tests/cloud/test_websandbox_terminal.py
@@ -24,6 +24,15 @@
 #   * activity heartbeat is throttled (many frames -> one touch) and bumps
 #     updated_at at the service level.
 #   * the _ActivityThrottle unit gates to first-call-then-interval.
+#
+# 2026-07-15 (WC-4b): Path 3 first-message auth frame (no ?token=). Covers:
+#   * no ?token= + a valid {"type":"auth","ticket":<valid>} frame -> accept()
+#     first, then PTY opens (and the "token" alias works too).
+#   * no ?token= + malformed / non-auth / missing first frame -> closed 4001
+#     after accept, no PTY.
+#   * no ?token= + auth frame with an INVALID ticket -> closed 4001, no PTY.
+#   * no ?token= + valid ticket but a sandbox the caller does NOT own -> closed
+#     1008 after accept, no PTY.
 from __future__ import annotations
 
 import os
@@ -253,15 +262,18 @@ async def test_valid_ticket_opens_pty_streams_and_resizes(wire_terminal) -> None
 # ---------------------------------------------------------------------------
 
 
-async def test_missing_ticket_closes_1008_no_pty(wire_terminal) -> None:
+async def test_no_token_and_no_auth_frame_closes_4001_no_pty(wire_terminal) -> None:
+    # No ?token= now routes to Path 3 (first-message auth frame). With nothing on
+    # the wire, receive_text raises before any frame arrives -> 4001 after accept,
+    # never the old pre-accept 1008. (Path 3 detail covered further below.)
     client, _tokens = wire_terminal
-    await _seed_user("w1")  # existence irrelevant; no token supplied
+    await _seed_user("w1")  # existence irrelevant; no credential supplied
 
     ws = FakeWebSocket()
     await terminal_websocket_endpoint(ws, "any-row", token=None)
 
-    assert ws.accepted is False
-    assert ws.closed is not None and ws.closed[0] == 1008
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
     assert client.sandbox.process.handle is None
 
 
@@ -310,6 +322,129 @@ async def test_not_ready_sandbox_closes_1008_no_pty(wire_terminal) -> None:
     await terminal_websocket_endpoint(ws, view.id, token="good-ticket")
 
     assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+# ---------------------------------------------------------------------------
+# Path 3 — first-message auth frame (no ?token=), leak-free browser auth.
+# ---------------------------------------------------------------------------
+
+
+async def test_authframe_valid_opens_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    # No ?token=; the ticket rides in the FIRST frame, followed by a real input.
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"auth","ticket":"good-ticket"}',
+            '{"type":"input","data":"echo hi\\n"}',
+        ]
+    )
+
+    await terminal_websocket_endpoint(ws, row_id, token=None)
+
+    # Path 3 accepts BEFORE reading the frame; auth then succeeded, so no close.
+    assert ws.accepted is True
+    assert ws.closed is None
+
+    # The auth frame was consumed by the handshake, not the input loop: only the
+    # actual keystroke reached the pty.
+    handle = client.sandbox.process.handle
+    assert handle is not None
+    assert handle.sent == ["echo hi\n"]
+    assert b"echo:echo hi\n" in ws.sent_bytes
+
+    # Disconnect tore the pty down (no leaked session).
+    assert client.kill_calls
+    assert handle.connected is False
+
+
+async def test_authframe_token_alias_opens_pty(wire_terminal) -> None:
+    # "token" is accepted as an alias for "ticket" in the auth frame (chat parity).
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(inbound=['{"type":"auth","token":"good-ticket"}'])
+    await terminal_websocket_endpoint(ws, row_id, token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is None
+    assert client.sandbox.process.handle is not None
+
+
+async def test_authframe_malformed_closes_4001_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")
+
+    ws = FakeWebSocket(inbound=["this is not json"])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    # Accepted (Path 3 must accept before it can read), then closed 4001.
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_non_auth_first_frame_closes_4001_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")
+
+    # Well-formed JSON but not an auth frame -> rejected.
+    ws = FakeWebSocket(inbound=['{"type":"input","data":"whoami"}'])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_missing_frame_closes_4001_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")
+
+    # Empty inbound -> receive_text raises WebSocketDisconnect before any frame
+    # arrives (stands in for the client that never sends a credential).
+    ws = FakeWebSocket(inbound=[])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_invalid_ticket_closes_4001_no_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    tokens["good-ticket"] = "someone"
+
+    ws = FakeWebSocket(inbound=['{"type":"auth","ticket":"WRONG"}'])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_valid_ticket_not_owned_closes_1008_after_accept(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    owner_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", owner_id)
+
+    # A different user in the same workspace authenticates via the auth frame but
+    # asks for a row they don't own: authz denial closes 1008 on the already-
+    # accepted socket, and no PTY opens.
+    intruder_id = await _seed_user("w1")
+    tokens["intruder-ticket"] = intruder_id
+
+    ws = FakeWebSocket(inbound=['{"type":"auth","ticket":"intruder-ticket"}'])
+    await terminal_websocket_endpoint(ws, row_id, token=None)
+
+    assert ws.accepted is True  # Path 3 accepted before the authz check
     assert ws.closed is not None and ws.closed[0] == 1008
     assert client.sandbox.process.handle is None
 

--- a/tests/cloud/test_websandbox_terminal.py
+++ b/tests/cloud/test_websandbox_terminal.py
@@ -1,0 +1,384 @@
+# test_websandbox_terminal.py — unit tests for the Web Cursor terminal
+# WebSocket + PTY bridge slice (WC-3). Created 2026-07-15
+# (feat/websandbox-terminal-ws).
+#
+# The auth/authz core runs on REAL Beanie over mongomock-motor (the ``mongo_db``
+# fixture) with a REAL seeded user, so the connect flow exercises the genuine
+# tenant/owner-scoped query paths (get_active_workspace -> get_sandbox ->
+# authorize_sandbox). All Daytona interaction goes through a FAKE client + FAKE
+# pty handle injected via monkeypatch — no test touches real Daytona.
+#
+# The endpoint is driven directly with a ``FakeWebSocket`` rather than Starlette's
+# TestClient: the handler authenticates on real async Beanie and opens a pty
+# before its receive loop, which the sync TestClient portal can't drive cleanly.
+# Direct invocation mirrors the WC-2 provision tests (call the unit with fakes)
+# and covers the whole accept -> auth -> PTY -> stream -> resize -> teardown flow.
+#
+# Covers:
+#   * valid ticket + owned ready sandbox -> PTY opened; an input frame reaches
+#     handle.send_input; the echoed VM output is forwarded as a binary frame;
+#     a resize frame calls resize_pty; disconnect kills the pty (no leak).
+#   * missing / invalid ticket -> closed 1008, no PTY, no accept.
+#   * valid ticket but a sandbox the caller does NOT own -> denied, no PTY.
+#   * not-ready row (no bound sandbox_id) -> closed 1008, no PTY.
+#   * activity heartbeat is throttled (many frames -> one touch) and bumps
+#     updated_at at the service level.
+#   * the _ActivityThrottle unit gates to first-call-then-interval.
+from __future__ import annotations
+
+import os
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+
+import pytest
+from fastapi import WebSocketDisconnect
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
+from pocketpaw_ee.cloud.websandbox.ws import _ActivityThrottle, terminal_websocket_endpoint
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLicense:
+    """A present, non-expired license (the WS gate only reads ``.expired``)."""
+
+    expired = False
+
+
+class _FakeHandle:
+    """Stand-in for the SDK's AsyncPtyHandle.
+
+    ``send_input`` records the keystrokes AND echoes them back through the
+    ``on_data`` callback — modelling a real shell echo so a single input frame
+    exercises both the input path (into the pty) and the output path (out to the
+    socket).
+    """
+
+    def __init__(self, on_data) -> None:  # noqa: ANN001
+        self._on_data = on_data
+        self.sent: list[str | bytes] = []
+        self.connected = True
+
+    async def wait_for_connection(self) -> None:
+        return None
+
+    async def send_input(self, data: str | bytes) -> None:
+        self.sent.append(data)
+        # Echo like a real pty so the output-forwarding path is exercised.
+        payload = data.encode() if isinstance(data, str) else data
+        await self._on_data(b"echo:" + payload)
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.handle: _FakeHandle | None = None
+
+    async def create_pty_session(self, session_id, on_data, cwd=None, envs=None, pty_size=None):  # noqa: ANN001
+        self.handle = _FakeHandle(on_data)
+        return self.handle
+
+
+class _FakeSandbox:
+    def __init__(self) -> None:
+        self.process = _FakeProcess()
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Drop-in for DaytonaClient: holds one sandbox, records resize/kill."""
+
+    sandbox: _FakeSandbox = field(default_factory=_FakeSandbox)
+    resize_calls: list[dict] = field(default_factory=list)
+    kill_calls: list[str] = field(default_factory=list)
+
+    async def get_sandbox_instance(self, sandbox_id):  # noqa: ANN001
+        return self.sandbox
+
+    async def resize_pty(self, sandbox_id, session_id, cols, rows):  # noqa: ANN001
+        self.resize_calls.append({"cols": cols, "rows": rows})
+
+    async def kill_pty(self, sandbox_id, session_id):  # noqa: ANN001
+        self.kill_calls.append(session_id)
+
+
+class FakeWebSocket:
+    """Minimal async WebSocket double for direct endpoint invocation.
+
+    Feeds a queue of already-serialized client frames via ``receive_text`` and
+    records ``accept`` / ``close`` / ``send_bytes`` / ``send_json``. When the
+    inbound queue drains it raises ``WebSocketDisconnect`` to end the receive
+    loop — the same signal Starlette raises when the browser tab closes.
+    """
+
+    def __init__(self, inbound: list[str] | None = None) -> None:
+        self._inbound: deque[str] = deque(inbound or [])
+        self.accepted = False
+        self.closed: tuple[int, str | None] | None = None
+        self.sent_bytes: list[bytes] = []
+        self.sent_json: list[dict] = []
+        self.cookies: dict[str, str] = {}
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.closed = (code, reason)
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent_bytes.append(data)
+
+    async def send_json(self, data: dict) -> None:
+        self.sent_json.append(data)
+
+    async def receive_text(self) -> str:
+        if not self._inbound:
+            raise WebSocketDisconnect(1000)
+        return self._inbound.popleft()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / seeding.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_user(active_workspace: str | None) -> str:
+    """Seed a real User doc (fastapi-users) and set its active workspace."""
+    from pocketpaw_ee.cloud.auth.core import UserCreate, UserManager, get_user_db
+    from pocketpaw_ee.cloud.models.user import User as UserDoc
+
+    email = f"wc3-{os.urandom(4).hex()}@example.com"
+    async for db in get_user_db():
+        manager = UserManager(db)
+        user = await manager.create(UserCreate(email=email, password="StrongPass123!"))
+        doc = await UserDoc.get(user.id)
+        doc.active_workspace = active_workspace
+        await doc.save()
+        return str(user.id)
+    raise RuntimeError("user db iterator exhausted")  # pragma: no cover
+
+
+async def _seed_ready_sandbox(workspace_id: str, user_id: str) -> str:
+    """Register a ``ready`` sandbox row with a bound Daytona id; return row id."""
+    view = await sandbox_service.create_sandbox(
+        workspace_id,
+        user_id,
+        CreateSandboxRequest(
+            repo="https://github.com/acme/api.git", status="ready", sandbox_id="dtn-1"
+        ),
+    )
+    return view.id
+
+
+@pytest.fixture
+def wire_terminal(monkeypatch):
+    """Patch the ws module's collaborators: license, ticket consume, Daytona.
+
+    Returns the FakeDaytonaClient so tests inspect resize/kill calls. The ticket
+    consume is a table lookup keyed on the token string so tests can assert the
+    valid/invalid split without Redis.
+    """
+    client = _FakeDaytonaClient()
+    tokens: dict[str, str] = {}
+
+    async def _fake_consume(token: str) -> str | None:
+        return tokens.get(token)
+
+    monkeypatch.setattr(terminal_ws, "get_license", lambda: _FakeLicense())
+    monkeypatch.setattr(terminal_ws, "consume_ws_ticket", _fake_consume)
+    monkeypatch.setattr(terminal_ws, "get_daytona_client", lambda: client)
+    # Fresh manager so active_count assertions are isolated per test.
+    monkeypatch.setattr(terminal_ws, "manager", terminal_ws.TerminalConnectionManager())
+    return client, tokens
+
+
+# ---------------------------------------------------------------------------
+# Happy path.
+# ---------------------------------------------------------------------------
+
+
+async def test_valid_ticket_opens_pty_streams_and_resizes(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"input","data":"echo hi\\n"}',
+            '{"type":"resize","cols":120,"rows":40}',
+            '{"type":"ping"}',
+        ]
+    )
+
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    # Socket was accepted (all auth gates passed) and never force-closed.
+    assert ws.accepted is True
+    assert ws.closed is None
+
+    # Input reached the pty handle.
+    handle = client.sandbox.process.handle
+    assert handle is not None
+    assert handle.sent == ["echo hi\n"]
+
+    # The pty echo was forwarded to the browser as a binary frame.
+    assert b"echo:echo hi\n" in ws.sent_bytes
+
+    # Resize routed through the client wrapper.
+    assert client.resize_calls == [{"cols": 120, "rows": 40}]
+
+    # Ping answered with a pong JSON frame.
+    assert {"type": "pong"} in ws.sent_json
+
+    # Disconnect tore the pty down (no leaked session).
+    assert client.kill_calls  # kill_pty was called
+    assert handle.connected is False
+
+
+# ---------------------------------------------------------------------------
+# Auth failures — no PTY ever opens.
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_ticket_closes_1008_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")  # existence irrelevant; no token supplied
+
+    ws = FakeWebSocket()
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+async def test_invalid_ticket_closes_1008_no_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    tokens["good-ticket"] = "someone"
+
+    ws = FakeWebSocket()
+    await terminal_websocket_endpoint(ws, "any-row", token="WRONG")
+
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+async def test_ticket_valid_but_sandbox_not_owned_is_denied(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    owner_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", owner_id)
+
+    # A DIFFERENT user in the same workspace holds a valid ticket for THIS row.
+    intruder_id = await _seed_user("w1")
+    tokens["intruder-ticket"] = intruder_id
+
+    ws = FakeWebSocket(inbound=['{"type":"input","data":"whoami\\n"}'])
+    await terminal_websocket_endpoint(ws, row_id, token="intruder-ticket")
+
+    # get_sandbox is owner-scoped -> NotFound -> 1008 before any PTY.
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+async def test_not_ready_sandbox_closes_1008_no_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    # A pending row with NO bound Daytona id.
+    view = await sandbox_service.create_sandbox(
+        "w1",
+        user_id,
+        CreateSandboxRequest(repo="https://github.com/acme/api.git", status="pending"),
+    )
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket()
+    await terminal_websocket_endpoint(ws, view.id, token="good-ticket")
+
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+# ---------------------------------------------------------------------------
+# Activity heartbeat — throttled, and it bumps updated_at.
+# ---------------------------------------------------------------------------
+
+
+async def test_activity_touch_is_throttled_to_one_per_burst(wire_terminal, monkeypatch) -> None:
+    _client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    calls = {"n": 0}
+    real_touch = sandbox_service.touch_activity
+
+    async def _counting_touch(ws_id, uid, rid):  # noqa: ANN001
+        calls["n"] += 1
+        return await real_touch(ws_id, uid, rid)
+
+    monkeypatch.setattr(terminal_ws.websandbox_service, "touch_activity", _counting_touch)
+
+    # Five input frames in one burst — the throttle should collapse them to one
+    # heartbeat write (first call touches, the rest are inside the interval).
+    ws = FakeWebSocket(inbound=['{"type":"input","data":"x"}'] * 5)
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert calls["n"] == 1
+
+
+async def test_touch_activity_bumps_updated_at() -> None:
+    user_id = "u1"
+    view = await sandbox_service.create_sandbox(
+        "w1", user_id, CreateSandboxRequest(repo="r1", status="ready", sandbox_id="dtn-9")
+    )
+
+    # Force the stored updated_at into the past so a bump is observable.
+    from beanie import PydanticObjectId
+    from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox as _Doc
+
+    doc = await _Doc.get(PydanticObjectId(view.id))
+    old = datetime.now(UTC) - timedelta(hours=1)
+    doc.updated_at = old
+    await doc.save()
+
+    touched = await sandbox_service.touch_activity("w1", user_id, view.id)
+    assert touched is True
+
+    doc2 = await _Doc.get(PydanticObjectId(view.id))
+    # mongomock round-trips datetimes as tz-naive; compare tz-agnostically.
+    def _naive(dt: datetime) -> datetime:
+        return dt.replace(tzinfo=None)
+
+    assert _naive(doc2.updated_at) > _naive(old)
+
+    # A non-owning caller can't touch it.
+    assert await sandbox_service.touch_activity("w1", "other", view.id) is False
+
+
+# ---------------------------------------------------------------------------
+# Throttle unit.
+# ---------------------------------------------------------------------------
+
+
+def test_activity_throttle_gates_to_interval() -> None:
+    throttle = _ActivityThrottle(interval=60.0)
+    assert throttle.should_touch(1000.0) is True  # first call always touches
+    assert throttle.should_touch(1030.0) is False  # inside the window
+    assert throttle.should_touch(1061.0) is True  # past the window
+    assert throttle.should_touch(1090.0) is False  # inside the new window

--- a/tests/cloud/test_workspace_vm_store.py
+++ b/tests/cloud/test_workspace_vm_store.py
@@ -1,0 +1,190 @@
+"""Tests for the DB-backed workspace→VM store (fix/workspace-vm-map-to-db).
+
+Created 2026-07-15: proves the six workspace-level VM accessors in
+``ee.cloud.daytona.store`` read/write the ``workspace_vms`` Mongo collection
+(not the legacy local JSON file), that ``set_workspace_vm`` upserts (one row
+per workspace), that config merges over defaults, that ``remove`` deletes the
+row, that two workspaces are tenant-isolated, and that the one-time
+``migrate_workspace_vm_map_to_db`` boot task imports the legacy JSON file into
+Mongo, renames it, and is a no-op / non-clobbering on a second run.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pocketpaw_ee.cloud.daytona import store
+from pocketpaw_ee.cloud.daytona.store import (
+    _DEFAULT_VM_CONFIG,
+    get_workspace_vm_config,
+    get_workspace_vm_sandbox_id,
+    list_all_workspace_vms,
+    remove_workspace_vm,
+    set_workspace_vm,
+    update_workspace_vm_config,
+)
+from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+from pocketpaw_ee.cloud.shared.db import migrate_workspace_vm_map_to_db
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_set_then_get_round_trips_through_db(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-123", "paw-ws-w1")
+
+    # Round-trips through the accessor...
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-123"
+    # ...and the row is really in the DB (not a file).
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == "w1")
+    assert doc is not None
+    assert doc.sandbox_id == "sb-123"
+    assert doc.sandbox_name == "paw-ws-w1"
+
+
+async def test_get_sandbox_id_missing_returns_none(mongo_db):  # noqa: ARG001
+    assert await get_workspace_vm_sandbox_id("nope") is None
+
+
+async def test_set_is_an_upsert_not_a_duplicate(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-1", "name-1")
+    await set_workspace_vm("w1", "sb-2", "name-2")
+
+    # Second call updated the same workspace — exactly one row.
+    rows = await WorkspaceVm.find(WorkspaceVm.workspace == "w1").to_list()
+    assert len(rows) == 1
+    assert rows[0].sandbox_id == "sb-2"
+    assert rows[0].sandbox_name == "name-2"
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-2"
+
+
+async def test_get_config_merges_over_defaults(mongo_db):  # noqa: ARG001
+    # No row yet → pure defaults.
+    assert await get_workspace_vm_config("w1") == _DEFAULT_VM_CONFIG
+
+    # A row with a partial config override merges over the defaults.
+    await set_workspace_vm("w1", "sb-1", "name-1", config={"cpu": 8})
+    cfg = await get_workspace_vm_config("w1")
+    assert cfg["cpu"] == 8  # overridden
+    assert cfg["memory"] == _DEFAULT_VM_CONFIG["memory"]  # inherited default
+    assert cfg["disk"] == _DEFAULT_VM_CONFIG["disk"]
+
+
+async def test_update_config_persists_partial_update(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-1", "name-1")
+    await update_workspace_vm_config("w1", {"memory": 16})
+
+    cfg = await get_workspace_vm_config("w1")
+    assert cfg["memory"] == 16
+    assert cfg["cpu"] == _DEFAULT_VM_CONFIG["cpu"]
+    # The sandbox mapping is untouched by a config update.
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-1"
+
+
+async def test_update_config_creates_row_when_absent(mongo_db):  # noqa: ARG001
+    # A config update with no prior VM row seeds a config-only row.
+    await update_workspace_vm_config("w1", {"disk": 50})
+    cfg = await get_workspace_vm_config("w1")
+    assert cfg["disk"] == 50
+    assert await get_workspace_vm_sandbox_id("w1") == ""  # empty until provisioned
+
+
+async def test_remove_deletes_the_row(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-1", "name-1")
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-1"
+
+    await remove_workspace_vm("w1")
+    assert await get_workspace_vm_sandbox_id("w1") is None
+    assert await WorkspaceVm.find_one(WorkspaceVm.workspace == "w1") is None
+
+
+async def test_remove_missing_is_noop(mongo_db):  # noqa: ARG001
+    # Deleting a workspace with no VM row must not raise.
+    await remove_workspace_vm("ghost")
+
+
+async def test_two_workspaces_are_tenant_isolated(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-w1", "name-w1", config={"cpu": 4})
+    await set_workspace_vm("w2", "sb-w2", "name-w2", config={"cpu": 2})
+
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-w1"
+    assert await get_workspace_vm_sandbox_id("w2") == "sb-w2"
+    assert (await get_workspace_vm_config("w1"))["cpu"] == 4
+    assert (await get_workspace_vm_config("w2"))["cpu"] == 2
+
+    # Removing one leaves the other intact.
+    await remove_workspace_vm("w1")
+    assert await get_workspace_vm_sandbox_id("w1") is None
+    assert await get_workspace_vm_sandbox_id("w2") == "sb-w2"
+
+
+async def test_list_all_workspace_vms(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-w1", "name-w1")
+    await set_workspace_vm("w2", "sb-w2", "name-w2")
+
+    everything = await list_all_workspace_vms()
+    assert set(everything.keys()) == {"w1", "w2"}
+    assert everything["w1"]["sandbox_id"] == "sb-w1"
+    assert everything["w2"]["sandbox_name"] == "name-w2"
+
+
+# ---------------------------------------------------------------------------
+# One-time migration from the legacy JSON file
+# ---------------------------------------------------------------------------
+
+
+async def test_migration_imports_json_and_renames_file(mongo_db, tmp_path, monkeypatch):  # noqa: ARG001
+    legacy = tmp_path / "daytona_workspace_vm_map.json"
+    legacy.write_text(
+        json.dumps(
+            {
+                "w1": {
+                    "sandbox_id": "sb-legacy-1",
+                    "sandbox_name": "paw-ws-legacy-1",
+                    "config": {"cpu": 8},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(store, "WS_VM_MAP_PATH", legacy)
+
+    await migrate_workspace_vm_map_to_db()
+
+    # The row landed in the DB.
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-legacy-1"
+    cfg = await get_workspace_vm_config("w1")
+    assert cfg["cpu"] == 8
+    assert cfg["memory"] == _DEFAULT_VM_CONFIG["memory"]
+
+    # The file was renamed so it won't re-import.
+    assert not legacy.exists()
+    assert (tmp_path / "daytona_workspace_vm_map.json.migrated").exists()
+
+
+async def test_migration_second_run_is_noop_and_non_clobbering(
+    mongo_db, tmp_path, monkeypatch  # noqa: ARG001
+):
+    legacy = tmp_path / "daytona_workspace_vm_map.json"
+    legacy.write_text(
+        json.dumps({"w1": {"sandbox_id": "sb-old", "sandbox_name": "old"}})
+    )
+    monkeypatch.setattr(store, "WS_VM_MAP_PATH", legacy)
+
+    # First run imports + renames.
+    await migrate_workspace_vm_map_to_db()
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-old"
+
+    # Meanwhile the DB advances to a newer sandbox.
+    await set_workspace_vm("w1", "sb-new", "new")
+
+    # A second run has no file to read (already renamed) → pure no-op; even if
+    # the file were re-created, an existing row is never clobbered.
+    await migrate_workspace_vm_map_to_db()
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-new"
+
+    # Re-create the legacy file to prove non-clobbering explicitly.
+    legacy.write_text(
+        json.dumps({"w1": {"sandbox_id": "sb-stale", "sandbox_name": "stale"}})
+    )
+    await migrate_workspace_vm_map_to_db()
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-new"  # not clobbered


### PR DESCRIPTION
Consolidates the Web Cursor backend stack into one branch (the captain asked for a single `feat/code`; that name collides with an existing `feat/code/cloud` ref, so this is `feat/code-cloud`). Everything a browser IDE session needs on the server side: a tenant-isolated cloud VM you own, a streaming terminal, and file read/write persisted to the VM — over one authenticated, fail-closed WebSocket. Supersedes the six stacked PRs (#1719, #1721, #1722, #1723, #1724, #1726), now closed in favor of this branch.

## What's in it

- **Sandbox registry** — maps (workspace, user, repo) to a VM with fail-closed cross-tenant authorization and an audit trail.
- **Cold VM provision + clone** — opens a Daytona VM, clones a public repo into it, tracks lifecycle, reaps idle VMs. Auto-stop is set in minutes (the SDK default of 3600 would idle a VM for 60 hours).
- **Terminal over WebSocket** — a real PTY streamed to the browser, authenticated by a single-use ticket sent as a first-message frame (no ticket in the URL).
- **File RPC** — list/read/write over the same socket, jailed to the workspace dir with traversal rejection.
- **/home/daytona unification** — the clone target, the file-tree root, and the terminal cwd all point at one directory, so a cloned repo actually shows up in the tree and the shell. Verified live against a real VM cloning a real repo.

## Tests

The full websandbox suite passes (registry, provision, terminal, file RPC, workdir), plus live smokes against real Daytona for provisioning, the terminal, file persistence, and the workdir fix.

Pairs with the frontend editor shell in paw-enterprise #623.