### PR TITLE
Backend AI edit agent and auto feature branch

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/web_sandbox.py
+++ b/ee/pocketpaw_ee/cloud/models/web_sandbox.py
@@ -19,6 +19,12 @@ in blob storage (an ``EEUploadService`` FileRecord id). The VM is scratch and
 gets reaped; this durable pointer lets a user's uncommitted work + workspace
 state be restored into a fresh VM. Null until the first snapshot is taken. No
 new index needed — it's read only via the owner-scoped registry row.
+
+Changed 2026-07-15 (WC-5a, feat/websandbox-edit-agent): added ``branch`` — the
+auto-created ``paw/edit-<hex>`` feature branch the repo is checked out onto in
+the VM at open time, so AI edits never touch the checked-out default branch.
+Null until the provisioner creates it (right after the clone). No new index
+needed — it's read only via the owner-scoped registry row.
 """
 
 from __future__ import annotations
@@ -46,6 +52,9 @@ class WebSandbox(Document):
     # storage (an EEUploadService FileRecord id). Null until the first snapshot;
     # set by ``service.set_snapshot`` from the WC-S3 durability module.
     snapshot_file_id: str | None = None
+    # The auto-created ``paw/edit-<hex>`` feature branch checked out in the VM at
+    # open time (WC-5a). Null until the provisioner creates it after the clone.
+    branch: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/ee/pocketpaw_ee/cloud/websandbox/domain.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/domain.py
@@ -8,6 +8,11 @@
 # ``snapshot_file_id`` — the pointer to the row's latest durable workspace
 # snapshot in blob storage. Optional (default None) so it lands after the
 # required tenancy fields without breaking the single construction site.
+#
+# Changed 2026-07-15 (WC-5a, feat/websandbox-edit-agent): added the optional
+# ``branch`` — the auto-created ``paw/edit-<hex>`` feature branch the repo is
+# checked out onto in the VM so AI edits never touch the default branch. Optional
+# (default None) so it lands after the required tenancy fields.
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -42,6 +47,9 @@ class WebSandboxView:
     updated_at: datetime
     # Pointer to the latest durable workspace snapshot in blob storage (WC-S3).
     snapshot_file_id: str | None = None
+    # The auto-created ``paw/edit-<hex>`` feature branch checked out in the VM
+    # so AI edits never touch the default branch (WC-5a).
+    branch: str | None = None
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -16,6 +16,14 @@
 # snapshot pointer on the wire (``WebSandboxResponse.snapshotFileId``) and added
 # ``SnapshotResponse`` — the ``{fileId}`` the snapshot endpoint returns after
 # landing the workspace tarball in the tenant's blob storage.
+#
+# Changed 2026-07-15 (WC-5a, feat/websandbox-edit-agent): surfaced the
+# auto-feature-branch on the wire (``WebSandboxResponse.branch``), let the
+# provisioner bind it via ``UpdateStatusRequest.branch``, and added the AI
+# edit-agent DTOs — ``EditRequest`` (a file path + instruction + optional
+# selection range) and ``EditResponse`` (the original + PROPOSED file content the
+# frontend reviews per-hunk and writes back via the existing file-RPC). The edit
+# agent is generate-only; it never writes to the VM.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -36,10 +44,13 @@ class CreateSandboxRequest(BaseModel):
 
 
 class UpdateStatusRequest(BaseModel):
-    """Advance a sandbox's lifecycle state (and optionally bind its id)."""
+    """Advance a sandbox's lifecycle state (and optionally bind its id/branch)."""
 
     status: str = Field(..., max_length=32)
     sandbox_id: str | None = Field(default=None, max_length=256)
+    # The auto-created feature branch the provisioner checked out in the VM
+    # (WC-5a). Bound in the same write that marks the row ``ready``.
+    branch: str | None = Field(default=None, max_length=256)
 
 
 class WebSandboxResponse(BaseModel):
@@ -51,6 +62,7 @@ class WebSandboxResponse(BaseModel):
     sandboxId: str | None = None
     installationId: str | None = None
     snapshotFileId: str | None = None
+    branch: str | None = None
     createdAt: str  # ISO-8601 UTC
     updatedAt: str  # ISO-8601 UTC
 
@@ -104,8 +116,58 @@ class SnapshotResponse(BaseModel):
     fileId: str
 
 
+# ---------------------------------------------------------------------------
+# WC-5a — AI edit agent (Cmd-K).
+# ---------------------------------------------------------------------------
+
+
+class EditSelection(BaseModel):
+    """A 1-indexed inclusive line range within the target file the edit scopes to.
+
+    Optional on an ``EditRequest`` — when present it focuses the model on the
+    selected lines (the rest of the file is still supplied as context). When
+    absent the whole file is the edit target.
+    """
+
+    startLine: int = Field(..., ge=1)
+    endLine: int = Field(..., ge=1)
+
+
+class EditRequest(BaseModel):
+    """Ask the backend edit agent to PROPOSE a rewrite of a file (or selection).
+
+    ``path`` is relative to the in-VM workspace dir (jailed — ``..`` / absolute
+    paths are refused). ``instruction`` is the natural-language edit. ``selection``
+    optionally narrows the edit to a line range. The agent reads the file
+    server-side, calls a frontier model, and returns the proposal — it never
+    writes anything to the VM (Rule 4: the write surface never carries a proposed
+    body; the frontend applies accepted hunks via the existing file-RPC).
+    """
+
+    path: str = Field(..., min_length=1, max_length=1024)
+    instruction: str = Field(..., min_length=1, max_length=8192)
+    selection: EditSelection | None = None
+
+
+class EditResponse(BaseModel):
+    """The edit agent's PROPOSAL — original vs. proposed file content.
+
+    The frontend diffs ``originalContent`` against ``proposedContent`` to render
+    per-hunk review and writes accepted changes back via the file-RPC. ``selection``
+    echoes the requested range (if any) so the reviewer can scope the diff.
+    """
+
+    path: str
+    originalContent: str
+    proposedContent: str
+    selection: EditSelection | None = None
+
+
 __all__ = [
     "CreateSandboxRequest",
+    "EditRequest",
+    "EditResponse",
+    "EditSelection",
     "OpenSandboxRequest",
     "SandboxTreeResponse",
     "SnapshotResponse",

--- a/ee/pocketpaw_ee/cloud/websandbox/edit.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/edit.py
@@ -1,0 +1,303 @@
+# edit.py — Web Cursor AI edit agent (Cmd-K), BACKEND-SIDE (WC-5a).
+# Created 2026-07-15 (feat/websandbox-edit-agent).
+#
+# Given a file + an instruction (+ optional selection), a backend-side frontier
+# model returns a PROPOSED rewrite of the file. This module is GENERATE-ONLY: it
+# reads the file over the network via ``DaytonaClient``, optionally greps the repo
+# for a symbol from the selection, calls the model, and returns the proposal for
+# the frontend to review per-hunk and save via the existing file-RPC. It does NOT
+# write anything to the VM.
+#
+# ARCHITECTURE (hard rule): the edit agent runs BACKEND-SIDE. There is NO in-VM
+# agent, NO UDS bridge, NO code_mode — the only VM interaction is ``download_file``
+# (read the target) and best-effort ``execute_command("rg …")`` (optional context).
+#
+# SECURITY: tenancy is enforced first (owner-scoped ``get_sandbox`` +
+# fail-closed ``authorize_sandbox``, same guards the tree/ws use) BEFORE any model
+# call or VM read; the target path is run through the SAME lexical jail as the
+# file-RPC (``files._jail``, rooted at ``WEBSANDBOX_WORKDIR``) so a crafted
+# ``path`` can't escape the workspace and no download happens for a traversal
+# attempt.
+#
+# LLM SEAM: mirrors ``decisions/explain/narrator.py`` — ``AsyncAnthropic`` with
+# the key from ``get_settings().anthropic_api_key``. The model id is
+# env-configurable (``POCKETPAW_WEBSANDBOX_EDIT_MODEL``, default the Sonnet-class
+# id narrator uses). The edit fn takes ``client=None`` (default builds the real
+# client) so unit tests inject a fake and never hit the real API. Any model /
+# read failure surfaces as a clean ``websandbox.edit_failed`` CloudError — never a
+# fake success.
+from __future__ import annotations
+
+import logging
+import os
+import re
+
+from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+from pocketpaw_ee.cloud.websandbox.dto import EditRequest, EditResponse
+from pocketpaw_ee.cloud.websandbox.files import FileRpcError, _jail
+
+logger = logging.getLogger(__name__)
+
+# Default model id — matches what narrator uses (Sonnet-class). Env-overridable.
+_DEFAULT_EDIT_MODEL = "claude-sonnet-4-7"
+# Output ceiling for the proposed file. Non-streaming-safe (well under the SDK's
+# ~10-min timeout guard). Very large files may truncate — the read cap below
+# keeps targets in a sane range.
+_EDIT_MAX_TOKENS = 16000
+# Model call timeout (seconds) and retry budget — mirror narrator's shape.
+_EDIT_TIMEOUT_SECONDS = 60.0
+# Ripgrep context is bounded so one huge match set can't blow up the prompt.
+_MAX_CONTEXT_CHARS = 4000
+
+_SYSTEM_PROMPT = (
+    "You are a precise code-editing assistant embedded in an IDE. You are given a "
+    "file and an instruction. Apply the instruction and return ONLY the FULL "
+    "updated file content — the entire file from first line to last, with your "
+    "edit applied. Do not add prose, explanations, or markdown code fences. Do not "
+    "omit or elide any unchanged part of the file. Preserve the file's existing "
+    "indentation, style, and trailing newline. If the instruction cannot be "
+    "applied, return the file unchanged."
+)
+
+# An identifier-like token, used to pull a symbol out of the selection for a
+# best-effort ripgrep of the rest of the repo.
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+
+
+def _edit_max_file_bytes() -> int:
+    """Editable-file size cap in bytes (``POCKETPAW_WEBSANDBOX_EDIT_MAX_KB``,
+    default 256). Bounds both the read and, indirectly, the model's output."""
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_EDIT_MAX_KB", "").strip()
+    kb = 256
+    if raw:
+        try:
+            kb = int(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_WEBSANDBOX_EDIT_MAX_KB=%r; using %d", raw, kb
+            )
+    return max(kb, 1) * 1024
+
+
+def _edit_model() -> str:
+    return os.environ.get("POCKETPAW_WEBSANDBOX_EDIT_MODEL", "").strip() or _DEFAULT_EDIT_MODEL
+
+
+def _require_daytona(daytona: DaytonaClient | None) -> DaytonaClient:
+    """Resolve the Daytona client, raising a clean CloudError when unconfigured
+    (mirrors ``provision._require_client`` — a None client is a 503, not a crash)."""
+    resolved = daytona if daytona is not None else get_daytona_client()
+    if resolved is None:
+        raise CloudError(
+            503,
+            "websandbox.daytona_unavailable",
+            "The sandbox runtime is not configured",
+        )
+    return resolved
+
+
+def _strip_code_fences(text: str) -> str:
+    """Best-effort strip of a wrapping ```lang … ``` block.
+
+    The system prompt forbids fences, but models occasionally wrap output anyway;
+    stripping keeps the proposal a clean file body rather than diffing fence lines.
+    Only strips when the WHOLE payload is a single fenced block.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return text
+    lines = stripped.splitlines()
+    if len(lines) < 2 or not lines[-1].strip().startswith("```"):
+        return text
+    # Drop the opening fence (with optional language) and the closing fence.
+    return "\n".join(lines[1:-1])
+
+
+def _selection_symbol(content: str, start_line: int, end_line: int) -> str | None:
+    """Pull the first identifier-like token from the selected line range (1-indexed
+    inclusive) for a best-effort ripgrep of the rest of the repo. None if the
+    range is out of bounds or has no usable symbol."""
+    lines = content.splitlines()
+    lo = max(start_line, 1)
+    hi = min(end_line, len(lines))
+    if lo > hi:
+        return None
+    snippet = "\n".join(lines[lo - 1 : hi])
+    match = _IDENTIFIER_RE.search(snippet)
+    return match.group(0) if match else None
+
+
+async def _gather_context(daytona: DaytonaClient, sandbox_id: str, symbol: str) -> str:
+    """Best-effort: ripgrep ``symbol`` across the workspace for extra context.
+
+    Bounded (``rg`` line cap + a hard char cap) and fully defensive — any failure
+    returns an empty string, because context is a nice-to-have, never load-bearing.
+    ``rg`` is on the Paw dev image.
+    """
+    try:
+        # -n line numbers, --max-count caps per-file hits, -g excludes the VCS dir.
+        cmd = f"rg -n --max-count 5 --no-heading -g '!.git' -- {symbol!r} ."
+        resp = await daytona.execute_command(
+            sandbox_id, cmd, cwd=WEBSANDBOX_WORKDIR, timeout=15
+        )
+    except Exception:  # noqa: BLE001 — context is best-effort; never fail the edit on it
+        logger.debug("websandbox.edit: context ripgrep failed for %r", symbol, exc_info=True)
+        return ""
+    out = getattr(resp, "result", None)
+    if not isinstance(out, str) or not out.strip():
+        return ""
+    return out[:_MAX_CONTEXT_CHARS]
+
+
+def _build_user_message(body: EditRequest, file_content: str, context: str) -> str:
+    """Assemble the user turn: instruction + the file (+ optional selection markers
+    + optional grepped context)."""
+    parts = [f"Instruction:\n{body.instruction}\n"]
+    if body.selection is not None:
+        parts.append(
+            f"Focus your edit on lines {body.selection.startLine}–"
+            f"{body.selection.endLine} of the file, but still return the FULL "
+            "updated file.\n"
+        )
+    if context:
+        parts.append(
+            "Related occurrences elsewhere in the repository (for context only — "
+            f"do not edit other files):\n{context}\n"
+        )
+    parts.append(f"File `{body.path}`:\n{file_content}")
+    return "\n".join(parts)
+
+
+async def _run_model(model: str, system: str, user_message: str, client) -> str:  # noqa: ANN001
+    """Call the frontier model and return the raw text. Builds the real
+    ``AsyncAnthropic`` client when none is injected (the DI seam for tests).
+
+    Any failure — missing key, SDK error, empty response — raises a clean
+    ``websandbox.edit_failed`` CloudError, never a fake success.
+    """
+    if client is None:
+        try:
+            from anthropic import AsyncAnthropic
+
+            from pocketpaw.config import get_settings
+
+            api_key = get_settings().anthropic_api_key
+        except Exception as exc:  # noqa: BLE001
+            raise with_cause(
+                CloudError(503, "websandbox.edit_unavailable", "The edit model is not configured"),
+                exc,
+            ) from exc
+        if not api_key:
+            raise CloudError(
+                503, "websandbox.edit_unavailable", "The edit model is not configured"
+            )
+        client = AsyncAnthropic(api_key=api_key, timeout=_EDIT_TIMEOUT_SECONDS, max_retries=1)
+
+    try:
+        response = await client.messages.create(
+            model=model,
+            max_tokens=_EDIT_MAX_TOKENS,
+            system=[{"type": "text", "text": system}],
+            messages=[{"role": "user", "content": user_message}],
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("websandbox.edit: model call failed", exc_info=True)
+        raise with_cause(
+            CloudError(502, "websandbox.edit_failed", "The edit model call failed"),
+            exc,
+        ) from exc
+
+    try:
+        raw_text = response.content[0].text
+    except (AttributeError, IndexError) as exc:
+        raise with_cause(
+            CloudError(502, "websandbox.edit_failed", "The edit model returned no content"),
+            exc,
+        ) from exc
+    if not isinstance(raw_text, str) or not raw_text.strip():
+        raise CloudError(502, "websandbox.edit_failed", "The edit model returned empty content")
+    return raw_text
+
+
+async def propose_edit(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    body: EditRequest | dict,
+    *,
+    client=None,  # noqa: ANN001 — an AsyncAnthropic-shaped object (DI seam for tests)
+    daytona: DaytonaClient | None = None,
+) -> EditResponse:
+    """Propose a model-authored rewrite of a file in a ready sandbox (generate-only).
+
+    Flow: validate → resolve the row owner-scoped (``get_sandbox`` → NotFound for a
+    row the caller doesn't own) → 409 if it never bound a Daytona id → fail-closed
+    ``authorize_sandbox`` BEFORE any VM touch → jail the path (``..``/absolute are
+    refused, no download for a traversal attempt) → ``download_file`` the target →
+    optional best-effort ripgrep context → call the model → return the proposal.
+
+    NEVER writes to the VM: the frontend reviews the proposed content per-hunk and
+    applies accepted changes via the existing file-RPC.
+    """
+    body = EditRequest.model_validate(body)
+    dt = _require_daytona(daytona)
+
+    # 1. Tenancy — owner-scoped resolve (NotFound cross-tenant), then the row must
+    #    have a bound VM, then the fail-closed authorize before ANY VM touch.
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+
+    # 2. Path safety — the SAME lexical jail the file-RPC uses, rooted at the
+    #    pinned workspace dir. An escape raises before any download.
+    try:
+        abs_path = _jail(WEBSANDBOX_WORKDIR, body.path, "read")
+    except FileRpcError as exc:
+        raise CloudError(400, "websandbox.edit_invalid_path", exc.message) from exc
+
+    # 3. Read the target file over the network (backend-side, no in-VM agent).
+    try:
+        data = await dt.download_file(row.sandbox_id, abs_path)
+    except FileNotFoundError as exc:
+        raise CloudError(404, "websandbox.edit_no_file", f"no such file: {body.path}") from exc
+    if data is None:
+        raise CloudError(404, "websandbox.edit_no_file", f"no such file: {body.path}")
+    cap = _edit_max_file_bytes()
+    if len(data) > cap:
+        raise CloudError(
+            413,
+            "websandbox.edit_too_large",
+            f"file is {len(data) // 1024} KB, over the {cap // 1024} KB edit limit",
+        )
+    try:
+        original = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CloudError(
+            400, "websandbox.edit_not_text", "file is not UTF-8 text (binary is not supported)"
+        ) from exc
+
+    # 4. Optional, bounded, best-effort context from a symbol in the selection.
+    context = ""
+    if body.selection is not None:
+        symbol = _selection_symbol(original, body.selection.startLine, body.selection.endLine)
+        if symbol:
+            context = await _gather_context(dt, row.sandbox_id, symbol)
+
+    # 5. Call the model and return the PROPOSAL (never written to the VM).
+    user_message = _build_user_message(body, original, context)
+    raw_text = await _run_model(_edit_model(), _SYSTEM_PROMPT, user_message, client)
+    proposed = _strip_code_fences(raw_text)
+
+    return EditResponse(
+        path=body.path,
+        originalContent=original,
+        proposedContent=proposed,
+        selection=body.selection,
+    )
+
+
+__all__ = ["propose_edit"]

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -12,10 +12,12 @@
 # Three flows live here:
 #   1. ``open_sandbox`` — upsert a registry row (pending) → opening →
 #      cold-provision a Daytona VM (auto_stop_interval=30 min) → wait for boot →
-#      clone the PUBLIC repo (no credentials) → bind the Daytona id + mark ready.
-#      On any mid-flight failure the row is marked ``stopped`` and a CloudError is
-#      raised — the row is never left stuck in ``opening`` silently, and a
-#      half-created VM is best-effort torn down.
+#      clone the PUBLIC repo (no credentials) → create + check out a
+#      ``paw/edit-<hex>`` feature branch IN the VM so AI edits never touch the
+#      checked-out default branch (WC-5a) → bind the Daytona id + branch + mark
+#      ready. On any mid-flight failure the row is marked ``stopped`` and a
+#      CloudError is raised — the row is never left stuck in ``opening`` silently,
+#      and a half-created VM is best-effort torn down.
 #   2. ``get_tree`` — resolve the row (tenant-scoped) → authorize on its Daytona
 #      id (fail-closed) → single-level ``list_files`` → the file tree.
 #   3. Idle-TTL reaper — a background sweep that reclaims rows whose ``updated_at``
@@ -37,6 +39,7 @@ import logging
 import os
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
+from uuid import uuid4
 
 from fastapi import FastAPI
 
@@ -60,6 +63,17 @@ _AUTO_STOP_MINUTES = 30
 
 # Daytona boot timeout (seconds) — block until the VM is ``started`` before clone.
 _BOOT_TIMEOUT_SECONDS = 120.0
+
+# Auto-feature-branch (WC-5a): the repo is checked out onto a fresh
+# ``paw/edit-<8 hex>`` branch in the VM so AI edits never touch the default
+# branch. The slug is derived from a uuid4 (no time/random-in-loop concerns) and
+# the checkout is a quick git op, so a short timeout is plenty.
+_BRANCH_CHECKOUT_TIMEOUT_SECONDS = 30
+
+
+def _new_edit_branch() -> str:
+    """Mint a fresh, collision-safe ``paw/edit-<8 hex>`` branch name."""
+    return f"paw/edit-{uuid4().hex[:8]}"
 
 # ---------------------------------------------------------------------------
 # Reaper env config.
@@ -172,6 +186,7 @@ async def open_sandbox(
     )
 
     daytona_id: str | None = None
+    branch = _new_edit_branch()
     try:
         # 2. Cold-provision. auto_stop_interval is in MINUTES — 30 is the backstop.
         info = await daytona.create_sandbox(
@@ -194,6 +209,16 @@ async def open_sandbox(
         project_dir = WEBSANDBOX_WORKDIR
         await daytona.execute_command(daytona_id, f"mkdir -p {project_dir}")
         await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
+
+        # 4b. Check out a fresh ``paw/edit-<hex>`` branch IN the VM (WC-5a) so
+        #     every AI edit lands on an isolated branch, never the checked-out
+        #     default. cwd is the pinned workspace dir where the repo was cloned.
+        await daytona.execute_command(
+            daytona_id,
+            f"git checkout -b {branch}",
+            cwd=project_dir,
+            timeout=_BRANCH_CHECKOUT_TIMEOUT_SECONDS,
+        )
     except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
         # Best-effort teardown of a half-created VM so a failure can't leak it.
         if daytona_id is not None:
@@ -210,11 +235,20 @@ async def open_sandbox(
             exc,
         ) from exc
 
-    # 5. Bind the Daytona id and mark ready.
+    # 5. Bind the Daytona id + the auto-created feature branch, and mark ready.
     ready = await websandbox_service.update_status(
-        workspace_id, user_id, row.id, {"status": "ready", "sandbox_id": daytona_id}
+        workspace_id,
+        user_id,
+        row.id,
+        {"status": "ready", "sandbox_id": daytona_id, "branch": branch},
     )
-    logger.info("websandbox.open ready: row=%s daytona=%s repo=%s", row.id, daytona_id, repo_url)
+    logger.info(
+        "websandbox.open ready: row=%s daytona=%s branch=%s repo=%s",
+        row.id,
+        daytona_id,
+        branch,
+        repo_url,
+    )
     return ready
 
 

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -21,6 +21,13 @@
 # ``POST /websandbox/{row_id}/restore`` (fetch the snapshot from S3 → untar it
 # into the VM, 204). Both delegate to ``websandbox/durability.py``; tenancy still
 # comes only from the RequestContext, and both are license-gated like the rest.
+#
+# Changed 2026-07-15 (WC-5a, feat/websandbox-edit-agent): added the AI edit
+# endpoint — ``POST /websandbox/{row_id}/edit`` (a file + instruction → a PROPOSED
+# rewrite from a backend-side frontier model). Thin adapter over
+# ``websandbox/edit.py``; tenancy comes only from the RequestContext, and it's
+# license-gated like the rest. Generate-only — the frontend applies accepted hunks
+# via the existing file-RPC.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Response
@@ -29,10 +36,13 @@ from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
+from pocketpaw_ee.cloud.websandbox import edit as websandbox_edit
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
     CreateSandboxRequest,
+    EditRequest,
+    EditResponse,
     OpenSandboxRequest,
     SandboxTreeResponse,
     SnapshotResponse,
@@ -119,6 +129,22 @@ async def get_sandbox_tree(
     """Return the cloned repo's file tree for a ready sandbox."""
     workspace_id = _require_workspace(ctx)
     return await websandbox_provision.get_tree(workspace_id, ctx.user_id, row_id)
+
+
+# ---------------------------------------------------------------------------
+# WC-5a — AI edit agent (Cmd-K).
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{row_id}/edit", response_model=EditResponse)
+async def propose_edit(
+    row_id: str,
+    body: EditRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> EditResponse:
+    """Propose a model-authored rewrite of a file (generate-only, no VM write)."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_edit.propose_edit(workspace_id, ctx.user_id, row_id, body)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -30,6 +30,13 @@
 # durability module (``websandbox/durability.py``) calls it after landing the
 # workspace tarball in the tenant's S3. It stays here so the service remains the
 # only module that writes the Beanie doc (Rule 2).
+#
+# Changed 2026-07-15 (WC-5a, feat/websandbox-edit-agent): ``update_status`` now
+# also binds the auto-created ``paw/edit-<hex>`` feature branch (via the new
+# ``UpdateStatusRequest.branch``) so the provisioner records it in the same write
+# that marks the row ``ready``; ``branch`` is surfaced through ``_doc_to_view`` +
+# ``view_to_wire``. The doc-write stays here so the service remains the only
+# module that touches the Beanie doc (Rule 2).
 from __future__ import annotations
 
 import logging
@@ -68,6 +75,7 @@ def _doc_to_view(doc: _WebSandboxDoc) -> WebSandboxView:
         sandbox_id=doc.sandbox_id,
         installation_id=doc.installation_id,
         snapshot_file_id=doc.snapshot_file_id,
+        branch=doc.branch,
         created_at=doc.created_at,
         updated_at=doc.updated_at,
     )
@@ -84,6 +92,7 @@ def view_to_wire(view: WebSandboxView) -> WebSandboxResponse:
         sandboxId=view.sandbox_id,
         installationId=view.installation_id,
         snapshotFileId=view.snapshot_file_id,
+        branch=view.branch,
         createdAt=view.created_at.isoformat(),
         updatedAt=view.updated_at.isoformat(),
     )
@@ -246,6 +255,8 @@ async def update_status(
     doc.status = body.status
     if body.sandbox_id is not None:
         doc.sandbox_id = body.sandbox_id
+    if body.branch is not None:
+        doc.branch = body.branch
     doc.updated_at = datetime.now(UTC)
     await doc.save()
 

--- a/scripts/websandbox_edit_smoke.py
+++ b/scripts/websandbox_edit_smoke.py
@@ -1,0 +1,110 @@
+# websandbox_edit_smoke.py — ONE live smoke for the Web Cursor AI edit agent (WC-5a).
+# Created 2026-07-15 (feat/websandbox-edit-agent).
+#
+# Out of CI. Exercises the REAL Daytona runtime + the REAL Anthropic model:
+#   1. init the cloud registry (localhost mongo) so the tenancy guards work.
+#   2. provision a VM and clone a SMALL public repo (octocat/Hello-World).
+#   3. confirm the auto-created ``paw/edit-<hex>`` branch is checked out IN the VM
+#      (git branch --show-current == the row's stored branch).
+#   4. call ``edit.propose_edit`` with the REAL model on a real file and assert the
+#      proposed content differs from the original and is non-empty.
+#   5. ALWAYS delete the VM in ``finally`` (mandatory cleanup).
+#
+# Run:  .venv/Scripts/python.exe scripts/websandbox_edit_smoke.py
+# Requires live Daytona + Anthropic keys in .env. If the Anthropic key is
+# missing/invalid the script reports it honestly rather than faking a pass.
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv(".env")  # load creds BEFORE importing config-reading modules
+
+WORKSPACE = "smoke-ws"
+USER = "smoke-user"
+REPO = "https://github.com/octocat/Hello-World.git"
+EDIT_PATH = "README"  # Hello-World ships a single README file
+INSTRUCTION = "Add a new trailing line that is a comment saying 'edited by paw'."
+
+
+async def main() -> int:
+    from pocketpaw_ee.cloud import init_realtime
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+    from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
+    from pocketpaw_ee.cloud.websandbox import edit, provision
+    from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+    daytona = get_daytona_client()
+    if daytona is None:
+        print("BLOCKED: Daytona is not configured (get_daytona_client() -> None). Check .env.")
+        return 1
+
+    await init_cloud_db()
+    init_realtime()  # the registry emits events on every write
+    sandbox_id: str | None = None
+    try:
+        print("[1/4] Provisioning VM + cloning", REPO, "...")
+        view = await provision.open_sandbox(WORKSPACE, USER, {"repo": REPO}, client=daytona)
+        sandbox_id = view.sandbox_id
+        print(f"      ready: row={view.id} sandbox={sandbox_id} branch={view.branch}")
+
+        print("[2/4] Confirming the auto-branch is checked out IN the VM ...")
+        resp = await daytona.execute_command(
+            sandbox_id, "git branch --show-current", cwd=WEBSANDBOX_WORKDIR, timeout=30
+        )
+        current = (getattr(resp, "result", "") or "").strip()
+        print(f"      git branch --show-current -> {current!r}  (stored: {view.branch!r})")
+        assert view.branch, "no branch stored on the row"
+        assert current == view.branch, f"VM branch {current!r} != stored {view.branch!r}"
+        assert current.startswith("paw/edit-"), f"unexpected branch name {current!r}"
+        print("      OK: branch created + checked out in the VM")
+
+        print("[3/4] Calling propose_edit with the REAL model on", EDIT_PATH, "...")
+        try:
+            result = await edit.propose_edit(
+                WORKSPACE, USER, view.id,
+                {"path": EDIT_PATH, "instruction": INSTRUCTION},
+                daytona=daytona,  # client=None -> builds the real AsyncAnthropic
+            )
+        except CloudError as exc:
+            if exc.code == "websandbox.edit_unavailable":
+                # Honest report (task contract): no direct Anthropic key in this
+                # env. The branch half is proven; the model half can't run here.
+                print(f"      MODEL HALF BLOCKED: {exc.code}: {exc.message}")
+                print("      (this deployment has no anthropic_api_key — Claude is")
+                print("       routed via the claude_code OAuth provider, which the")
+                print("       direct AsyncAnthropic seam cannot use)")
+                print("\nSMOKE PARTIAL: auto-branch PASS; model half BLOCKED (no key)")
+                return 2
+            raise
+        print("      --- original ---")
+        print(result.originalContent)
+        print("      --- proposed ---")
+        print(result.proposedContent)
+        assert result.proposedContent.strip(), "proposed content is empty"
+        assert result.proposedContent != result.originalContent, "model returned no change"
+        print("[4/4] OK: model returned a real, non-empty diff")
+        print("\nSMOKE PASS")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"\nSMOKE FAIL: {type(exc).__name__}: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return 1
+    finally:
+        if sandbox_id is not None:
+            try:
+                await daytona.delete_sandbox(sandbox_id)
+                print(f"[cleanup] deleted VM {sandbox_id}")
+            except Exception as exc:  # noqa: BLE001
+                print(f"[cleanup] WARNING: failed to delete VM {sandbox_id}: {exc}")
+        await close_cloud_db()
+        await daytona.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/cloud/test_websandbox_edit.py
+++ b/tests/cloud/test_websandbox_edit.py
@@ -1,0 +1,231 @@
+# test_websandbox_edit.py — service-level tests for the Web Cursor AI edit agent
+# (WC-5a, feat/websandbox-edit-agent).
+#
+# The model call and all Daytona interaction go through FAKES injected via the DI
+# seams (``client=`` / ``daytona=`` on ``propose_edit``) — no test touches the real
+# Anthropic API or real Daytona. The registry runs on real Beanie over
+# mongomock-motor (the ``mongo_db`` fixture) so the tenant-filtered guards are
+# exercised for real.
+#
+# Covers:
+#   * propose_edit returns the model's proposed content; original == the file's
+#     current content; the target file is read at the JAILED path.
+#   * tenancy: a cross-tenant caller is denied BEFORE any model call or VM read.
+#   * a path-traversal ``path`` is refused by the jail — no download, no model call.
+#   * a model/client failure surfaces as a clean ``websandbox.edit_failed`` error.
+#   * a selection triggers a bounded, best-effort ripgrep for context.
+#   * an unprovisioned row (no bound Daytona id) is a clean 409, not a crash.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.websandbox import edit
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeBlock:
+    text: str
+
+
+@dataclass
+class _FakeMessage:
+    content: list
+
+
+@dataclass
+class _FakeExec:
+    result: str = ""
+
+
+class _FakeMessages:
+    def __init__(self, outer: _FakeAnthropic) -> None:
+        self._outer = outer
+
+    async def create(self, **kwargs):  # noqa: ANN003
+        self._outer.create_calls.append(kwargs)
+        if self._outer.raise_exc:
+            raise RuntimeError("boom: model call failed")
+        return _FakeMessage(content=[_FakeBlock(text=self._outer.proposed)])
+
+
+class _FakeAnthropic:
+    """Drop-in for the AsyncAnthropic DI seam. Records calls; returns a canned
+    proposed file (or raises to exercise the failure path)."""
+
+    def __init__(self, proposed: str = "PROPOSED FILE BODY\n", raise_exc: bool = False) -> None:
+        self.proposed = proposed
+        self.raise_exc = raise_exc
+        self.create_calls: list[dict] = []
+        self.messages = _FakeMessages(self)
+
+
+@dataclass
+class _FakeDaytona:
+    """Records download + exec calls; returns canned file bytes. Drop-in for the
+    DaytonaClient DI seam."""
+
+    file_bytes: bytes = b"line one\nline two\n"
+    missing: bool = False
+    download_calls: list[str] = field(default_factory=list)
+    exec_calls: list[dict] = field(default_factory=list)
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_calls.append(remote_path)
+        if self.missing:
+            raise FileNotFoundError(remote_path)
+        return self.file_bytes
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001, ANN003
+        self.exec_calls.append({"command": command, "cwd": kwargs.get("cwd")})
+        return _FakeExec(result="src/other.py:12:    my_function()\n")
+
+
+async def _ready_row(workspace_id: str = "w1", user_id: str = "u1"):
+    return await sandbox_service.create_sandbox(
+        workspace_id,
+        user_id,
+        {"repo": "https://github.com/octocat/Hello-World.git", "status": "ready",
+         "sandbox_id": "dtn-1"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# happy path.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_edit_returns_proposal() -> None:
+    row = await _ready_row()
+    fake_model = _FakeAnthropic(proposed="line one CHANGED\nline two\n")
+    fake_dt = _FakeDaytona()
+
+    resp = await edit.propose_edit(
+        "w1", "u1", row.id,
+        {"path": "app.py", "instruction": "change line one"},
+        client=fake_model, daytona=fake_dt,
+    )
+
+    assert resp.path == "app.py"
+    assert resp.originalContent == "line one\nline two\n"
+    assert resp.proposedContent == "line one CHANGED\nline two\n"
+    # The file was read at the JAILED absolute path under the pinned workspace dir.
+    assert fake_dt.download_calls == [f"{WEBSANDBOX_WORKDIR}/app.py"]
+    # The model was called exactly once.
+    assert len(fake_model.create_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# tenancy.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_edit_denies_cross_tenant() -> None:
+    row = await _ready_row("w1", "u1")
+    fake_model = _FakeAnthropic()
+    fake_dt = _FakeDaytona()
+
+    with pytest.raises(CloudError):
+        await edit.propose_edit(
+            "w2", "u1", row.id,  # different workspace
+            {"path": "app.py", "instruction": "x"},
+            client=fake_model, daytona=fake_dt,
+        )
+
+    # Denied BEFORE any model call or VM read.
+    assert fake_model.create_calls == []
+    assert fake_dt.download_calls == []
+
+
+# ---------------------------------------------------------------------------
+# path safety.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_edit_rejects_traversal() -> None:
+    row = await _ready_row()
+    fake_model = _FakeAnthropic()
+    fake_dt = _FakeDaytona()
+
+    with pytest.raises(CloudError) as exc:
+        await edit.propose_edit(
+            "w1", "u1", row.id,
+            {"path": "../../etc/passwd", "instruction": "read secrets"},
+            client=fake_model, daytona=fake_dt,
+        )
+    assert exc.value.code == "websandbox.edit_invalid_path"
+    # No download, no model call for a traversal attempt.
+    assert fake_dt.download_calls == []
+    assert fake_model.create_calls == []
+
+
+# ---------------------------------------------------------------------------
+# honest failure.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_edit_model_failure_is_clean_error() -> None:
+    row = await _ready_row()
+    fake_model = _FakeAnthropic(raise_exc=True)
+    fake_dt = _FakeDaytona()
+
+    with pytest.raises(CloudError) as exc:
+        await edit.propose_edit(
+            "w1", "u1", row.id,
+            {"path": "app.py", "instruction": "x"},
+            client=fake_model, daytona=fake_dt,
+        )
+    assert exc.value.code == "websandbox.edit_failed"
+
+
+async def test_propose_edit_not_ready_when_unprovisioned() -> None:
+    # A registry row that never bound a Daytona id is a clean 409, not a crash.
+    row = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git", "status": "pending"}
+    )
+    fake_model = _FakeAnthropic()
+    fake_dt = _FakeDaytona()
+
+    with pytest.raises(CloudError) as exc:
+        await edit.propose_edit(
+            "w1", "u1", row.id,
+            {"path": "app.py", "instruction": "x"},
+            client=fake_model, daytona=fake_dt,
+        )
+    assert exc.value.code == "websandbox.not_ready"
+    assert fake_model.create_calls == []
+
+
+# ---------------------------------------------------------------------------
+# optional selection context.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_edit_with_selection_gathers_context() -> None:
+    row = await _ready_row()
+    fake_model = _FakeAnthropic()
+    fake_dt = _FakeDaytona(file_bytes=b"def my_function():\n    return 1\n")
+
+    await edit.propose_edit(
+        "w1", "u1", row.id,
+        {"path": "app.py", "instruction": "add a docstring",
+         "selection": {"startLine": 1, "endLine": 1}},
+        client=fake_model, daytona=fake_dt,
+    )
+
+    # A best-effort ripgrep ran under the pinned workspace dir.
+    rg_calls = [c for c in fake_dt.exec_calls if c["command"].startswith("rg ")]
+    assert len(rg_calls) == 1
+    assert rg_calls[0]["cwd"] == WEBSANDBOX_WORKDIR
+    # The proposal still came back from the model.
+    assert len(fake_model.create_calls) == 1

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -66,6 +66,9 @@ class _FakeDaytonaClient:
     wait_calls: list[dict] = field(default_factory=list)
     clone_calls: list[dict] = field(default_factory=list)
     exec_calls: list[str] = field(default_factory=list)
+    # Full ``execute_command`` invocations (command + cwd + timeout) so tests can
+    # assert the auto-branch ``git checkout -b`` ran with cwd=WEBSANDBOX_WORKDIR.
+    exec_invocations: list[dict] = field(default_factory=list)
     stop_calls: list[str] = field(default_factory=list)
     delete_calls: list[str] = field(default_factory=list)
     _counter: int = 0
@@ -88,8 +91,12 @@ class _FakeDaytonaClient:
         return self.project_dir
 
     async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
-        # open_sandbox runs ``mkdir -p <workdir>`` before cloning.
+        # open_sandbox runs ``mkdir -p <workdir>`` before cloning, then
+        # ``git checkout -b paw/edit-<hex>`` after (the WC-5a auto-branch).
         self.exec_calls.append(command)
+        self.exec_invocations.append(
+            {"command": command, "cwd": kwargs.get("cwd"), "timeout": kwargs.get("timeout")}
+        )
         return None
 
     async def git_clone(self, sandbox_id, repo_url, path, branch=None, commit_id=None):  # noqa: ANN001
@@ -141,6 +148,33 @@ async def test_open_provisions_clones_and_marks_ready() -> None:
     fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
     assert fetched.status == "ready"
     assert fetched.sandbox_id == "dtn-1"
+
+
+async def test_open_creates_and_binds_edit_branch() -> None:
+    # WC-5a: opening checks out a fresh ``paw/edit-<hex>`` branch IN the VM (via
+    # execute_command with cwd=WEBSANDBOX_WORKDIR) and records it on the row.
+    from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+    )
+
+    # The branch is minted, checked out in the VM, and stored on the ready row.
+    assert view.branch is not None
+    assert view.branch.startswith("paw/edit-")
+    assert view.status == "ready"
+
+    checkouts = [
+        inv for inv in fake.exec_invocations if inv["command"].startswith("git checkout -b ")
+    ]
+    assert len(checkouts) == 1
+    assert checkouts[0]["command"] == f"git checkout -b {view.branch}"
+    assert checkouts[0]["cwd"] == WEBSANDBOX_WORKDIR
+
+    # The persisted row agrees.
+    fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
+    assert fetched.branch == view.branch
 
 
 async def test_open_failure_marks_stopped_and_tears_down_vm() -> None:


### PR DESCRIPTION
The backend half of Cmd-K editing, stacked on the cloud IDE backend (#1727). The per-hunk review UI is a separate frontend slice — this generates the proposal and never applies anything.

## What's here

Two things:

**Auto feature branch.** When a repo opens into a VM, the provision flow now creates and checks out `paw/edit-<hex>` right after the clone, so AI edits never touch the checked-out default. The branch is stored on the registry row and surfaced on the response. Proven end to end against real Daytona — the smoke confirms the branch is checked out inside the VM.

**Edit endpoint.** `POST /websandbox/{id}/edit` takes a path, an instruction, and an optional selection. It authorizes the caller, jails the path to the workspace root, reads the file, gathers a little ripgrep context, and asks a model for a rewrite — then returns the original and proposed content for the frontend to review per hunk and save through the existing file RPC. It's generate-only: it never writes to the VM. The agent runs entirely backend-side (reads and greps over DaytonaClient network calls) — no in-VM agent, no UDS bridge.

## Tests

6 unit tests over a faked model client and faked Daytona (proposed content flows through, cross-tenant denied before any model call, path traversal rejected, a model failure surfaces a clean error not a crash), plus a new provision test proving the auto-branch is created and bound. Full websandbox suite green.

```
16 passed (edit + provision) · 67 passed (rest of websandbox) · import-linter clean
```

## One thing needs your input: the model seam

The edit agent calls the model the same way the decisions/explain narrator does — direct `AsyncAnthropic` with `anthropic_api_key`. But this deployment has no direct Anthropic key; it routes Claude through the `claude_code` OAuth provider and a LiteLLM proxy. I probed both the proxy's Anthropic passthrough and its OpenAI-compatible route (`deepseek-v4-flash`) and both return `no available server` right now — so the live model half of the smoke couldn't run (the code fails closed with a clean error, exactly as designed).

So: how should Cmd-K call a model here — through the same `claude_code`/agent path chat uses, or a specific LiteLLM model your proxy actually serves? The seam is a one-line swap behind `POCKETPAW_WEBSANDBOX_EDIT_MODEL` once we know the target. Everything up to the model call already runs against the real registry + real VM.

Stacked on #1727.