### PR TITLE
feat(senses): render connector results as live pocket widgets

### DIFF
--- a/src/pocketpaw/bundled_skills/_bundled/skills/github/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/github/SKILL.md
@@ -12,6 +12,18 @@ description: |
   pocket, so you only see it when GitHub is actually available.
 ---
 
+<!--
+  Updated: 2026-07-16 (feat/senses-render-convention / SR-8) — added the
+  "Render results as a live pocket" section (the Ripple fusion): after a
+  connector_execute read, render the result as TYPED Ripple widgets pushed to
+  the pocket via POST /api/v1/pockets/<id>/spec/merge, instead of pasting raw
+  JSON into chat. Documents the two hard rules (typed widgets only / never raw
+  HTML from attacker-controllable connector payloads; value/label split), plus a
+  worked example (open PRs -> data-grid with a follow-up Refresh button wired
+  back via invoke_tool -> connector_execute). The static widget-recipes
+  home-rail fallback is untouched; the read surface is otherwise unchanged.
+-->
+
 # GitHub in a Room
 
 This room has the **GitHub connector** bound to it. You can read repositories,
@@ -144,6 +156,146 @@ The list actions take `per_page` (issues default 25, most others 10–100) and
 `page`. Don't pull everything — for "the open issues" the first page is usually
 enough. If the user wants a count or asks for "all", say how many the first page
 returned and offer to page further rather than fetching every page silently.
+
+## Render results as a live pocket (the Ripple fusion)
+
+Summarizing in chat is the floor, not the ceiling. When the result is a
+**set of records** — open PRs, issues, releases, CI runs — don't stop at a
+bulleted list and don't paste raw JSON. Render it as **typed Ripple widgets**
+on the canvas: a live table the user can sort, cards they can scan, a chart of
+counts. A table of PRs beats ten lines of text.
+
+The flow is: **`connector_execute` → build a typed rippleSpec → merge it into a
+pocket.**
+
+1. Run the read action (you already know how — see the examples above).
+2. Shape the returned records into a small state array (see value/label below).
+3. Deliver a typed spec to a pocket. In a room you do this the normal way —
+   the `pocketpaw-create-pocket` skill for a fresh canvas, or
+   `pocketpaw-edit-pocket` to add to the one already open. Both apply the spec
+   through the merge endpoint **`POST /api/v1/pockets/<id>/spec/merge`**; the
+   pocket specialist subagent is what actually posts it (see the
+   `pocketpaw-pocket-specialist` skill for the HTTP mechanics and the
+   merge-vs-replace rule). The payloads below are exactly what lands on that
+   wire — copy the shape.
+
+### Two hard rules
+
+**1. Typed widgets ONLY — never raw HTML.** A PR title, an issue body, a repo
+description, a committer name — every string a connector returns is
+**attacker-controllable**. Anyone can open a PR titled `<img src=x
+onerror=...>` on a public repo. So connector strings go ONLY into typed-widget
+props (`text`, `badge`, `data-grid` cell values, `stat`) where the Ripple
+renderer escapes them. NEVER assemble an HTML string from connector data, and
+NEVER route it into an `embed` (`mode: "srcdoc"`) node or any other HTML sink.
+There is no "html" widget to reach for — the merge endpoint's catalog gate
+rejects any node whose `type` isn't a known widget — but treat this as a
+security invariant you never try to route around, not just a validator you
+happen to trip. Raw HTML in the render path is a stored-XSS / injection vector.
+
+**2. value/label split.** Machine ids are lowercase and live in the id slot;
+human-facing text lives in the label. A `data-grid` column is
+`{"key": "<lowercase field id>", "label": "<header text>"}` — `key` matches the
+row-object field, `label` is what the header shows. A `select` filter's options
+are `{"value": "<lowercase id>", "label": "<text>"}` and the **bound state holds
+the value**, never the label. Same rule that governs kanban column ids: store
+`"open"`, not `"Open"`. Get it backwards and rows silently fail to resolve.
+
+### Worked example — "show my open PRs" → a live table
+
+Read, then merge. First the read:
+
+```
+connector_execute(connector_name="github", action="list_pull_requests",
+  params={"owner": "acme", "repo": "api", "state": "open"})
+```
+
+Then shape each PR into a row and merge a `data-grid`. This is the copyable
+`/spec/merge` payload:
+
+```json
+{
+  "merge": {
+    "state": {
+      "pr_rows": [
+        {"number": 142, "title": "Fix timeout in the retry loop",
+         "author": "octocat", "reviews": "changes_requested"},
+        {"number": 139, "title": "Paginate the search endpoint",
+         "author": "hubot", "reviews": "approved"}
+      ]
+    },
+    "ui": {
+      "id": "n_prroot01",
+      "type": "flex",
+      "props": {"direction": "column", "gap": "12px"},
+      "children": [
+        {"id": "n_prhdr01", "type": "page-header",
+         "props": {"title": "Open PRs — acme/api"}},
+        {
+          "id": "n_prgrid01",
+          "type": "data-grid",
+          "props": {
+            "columns": [
+              {"key": "number",  "label": "#",      "align": "right", "width": "70px"},
+              {"key": "title",   "label": "Title",  "sortable": true, "align": "left"},
+              {"key": "author",  "label": "Author", "align": "left"},
+              {"key": "reviews", "label": "Review", "align": "left"}
+            ],
+            "rows": "{state.pr_rows}",
+            "dense": true
+          }
+        },
+        {
+          "id": "n_prrefresh01",
+          "type": "button",
+          "props": {
+            "label": "Refresh",
+            "on_click": [
+              {
+                "action": "invoke_tool",
+                "tool": "connector_execute",
+                "args": {
+                  "connector_name": "github",
+                  "action": "list_pull_requests",
+                  "params": {"owner": "acme", "repo": "api", "state": "open"}
+                },
+                "on_success": [{"action": "set", "target": "pr_rows"}],
+                "on_error": [{"action": "toast",
+                  "message": "Couldn't refresh PRs", "variant": "error"}]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Note the column `key`s (`number`, `title`, `author`, `reviews`) match the row
+fields exactly and are lowercase; the `label`s carry the human text — that IS
+the value/label split. The **Refresh** button wires a follow-up action back to
+the sense: `invoke_tool` re-runs `connector_execute` through the pocket's
+tool-run wire and `on_success` writes the fresh result into `pr_rows`, so the
+grid updates without a chat round-trip. (`set` with no `value` falls back to the
+tool result payload — make sure the sense returns the same row shape the columns
+bind to, or add a mapping step. If the tool-run wire isn't enabled for the
+pocket, drop the button and just re-run the read yourself and merge again — an
+agent-driven refresh.)
+
+For a second display kind: to show PR **counts by review state** instead of the
+list, merge a `chart` (`{"type": "chart", "props": {"type": "bar", "data":
+"{state.review_counts}", "title": "PRs by review state"}}`) over a
+`review_counts` array you tally from the same read.
+
+### This does not replace the static widget-recipes rail
+
+The connector also ships **pre-baked widget recipes** — the "From connectors"
+rail in the Add-Widget picker (`GET /api/v1/cloud/connectors/widget-recipes`),
+which lets a user drop a default GitHub widget onto a home dashboard with no
+agent involved. That no-agent fallback stays exactly as-is. The convention here
+is the **agent-driven** path: you render a bespoke, live-typed view in response
+to what the user actually asked for. Use both — they don't overlap.
 
 ## Guardrails
 

--- a/src/pocketpaw/bundled_skills/_bundled/skills/gmail/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/gmail/SKILL.md
@@ -14,6 +14,17 @@ description: |
 ---
 
 <!--
+  Updated: 2026-07-16 (feat/senses-render-convention / SR-8) — added the
+  "Render results as a live pocket" section (the Ripple fusion): after a
+  connector_execute read, render the result as TYPED Ripple widgets pushed to
+  the pocket via POST /api/v1/pockets/<id>/spec/merge, instead of pasting raw
+  JSON into chat. Documents the two hard rules (typed widgets only / never raw
+  HTML from attacker-controllable email payloads; value/label split) and a
+  worked example (recent inbox -> each+card cards with a value/label select
+  filter, follow-up wired via invoke_tool -> connector_execute). The static
+  widget-recipes home-rail fallback is untouched. Read/send safety guidance
+  below is unchanged.
+
   Updated: 2026-06-08 (feat/connector-mcp-execution / keystone) — the skill now
   instructs the agent to invoke Gmail actions through the agent-callable
   ``connector_execute`` tool (the new pocketpaw_connectors MCP server) instead
@@ -147,6 +158,172 @@ Reading labels is allowed; changing them is a blocked write in v1.
 `gmail_summary` (read) returns unread count and today's count cheaply — run it
 via `connector_execute(connector_name="gmail", action="gmail_summary")` when
 the user asks "how's my inbox" or "anything new" before a heavier search.
+
+## Render results as a live pocket (the Ripple fusion)
+
+Summarizing in chat is the floor, not the ceiling. When a search returns a
+**set of messages**, don't stop at a bulleted list and don't paste raw JSON.
+Render it as **typed Ripple widgets** on the canvas: a stack of inbox cards the
+user can scan, a filter to narrow them, a count. Cards beat ten lines of text.
+
+The flow is: **`connector_execute` → build a typed rippleSpec → merge it into a
+pocket.**
+
+1. Run the read action (`gmail_search`, then `gmail_read` if you need bodies).
+2. Shape the returned stubs into a small state array (see value/label below).
+3. Deliver a typed spec to a pocket. In a room you do this the normal way —
+   the `pocketpaw-create-pocket` skill for a fresh canvas, or
+   `pocketpaw-edit-pocket` to add to the one already open. Both apply the spec
+   through the merge endpoint **`POST /api/v1/pockets/<id>/spec/merge`**; the
+   pocket specialist subagent is what actually posts it (see the
+   `pocketpaw-pocket-specialist` skill for the HTTP mechanics and the
+   merge-vs-replace rule). The payload below is exactly what lands on that
+   wire — copy the shape.
+
+### Two hard rules
+
+**1. Typed widgets ONLY — never raw HTML.** A subject line, a sender name, an
+email body, a snippet — every string Gmail returns is
+**attacker-controllable**. Anyone can email the user a subject full of
+`<script>`. So email strings go ONLY into typed-widget props (`text`, `badge`,
+`data-grid` cell values) where the Ripple renderer escapes them. NEVER assemble
+an HTML string from message content, and NEVER route it into an `embed`
+(`mode: "srcdoc"`) node or any other HTML sink. There is no "html" widget to
+reach for — the merge endpoint's catalog gate rejects any node whose `type`
+isn't a known widget — but treat this as a security invariant you never try to
+route around, not just a validator you happen to trip. Rendering raw email HTML
+is a stored-XSS / injection vector.
+
+**2. value/label split.** Machine ids are lowercase and live in the id slot;
+human-facing text lives in the label. The `select` filter below has options
+`{"value": "unread", "label": "Unread"}` and the **bound state holds the
+value** (`"unread"`), never the label (`"Unread"`). A `status-dot`'s `variant`
+is a lowercase status id (`"info"`, `"neutral"`) while its `label` carries the
+human text. Same rule that governs `data-grid` column keys and kanban column
+ids: store `"unread"`, not `"Unread"`. Get it backwards and the filter matches
+nothing.
+
+### Worked example — "show my recent inbox" → live cards
+
+Read, then merge. First the read:
+
+```
+connector_execute(connector_name="gmail", action="gmail_search",
+  params={"query": "in:inbox newer_than:2d", "max_results": 10})
+```
+
+Then shape each stub into a message object and merge a filtered card list. This
+is the copyable `/spec/merge` payload:
+
+```json
+{
+  "merge": {
+    "state": {
+      "filter": "all",
+      "inbox": [
+        {"id": "18f2a1", "from": "Sarah Chen", "subject": "Q3 planning notes",
+         "snippet": "Pulled together the notes from Tuesday…",
+         "status": "unread", "dot": "info"},
+        {"id": "18f0c9", "from": "Acme Billing", "subject": "Invoice #4471",
+         "snippet": "Your July invoice is ready to view…",
+         "status": "read", "dot": "neutral"}
+      ]
+    },
+    "ui": {
+      "id": "n_inboxroot",
+      "type": "flex",
+      "props": {"direction": "column", "gap": "10px"},
+      "children": [
+        {"id": "n_inboxhdr", "type": "page-header",
+         "props": {"title": "Recent inbox"}},
+        {
+          "id": "n_inboxfilter",
+          "type": "select",
+          "bind": "filter",
+          "props": {
+            "options": [
+              {"value": "all",    "label": "All"},
+              {"value": "unread", "label": "Unread"}
+            ]
+          }
+        },
+        {
+          "type": "each",
+          "items": "{state.inbox}",
+          "item_as": "msg",
+          "children": [
+            {
+              "type": "card",
+              "props": {"variant": "outlined", "density": "compact"},
+              "children": [
+                {
+                  "type": "flex",
+                  "props": {"direction": "row", "gap": "8px", "align": "center"},
+                  "children": [
+                    {"type": "status-dot",
+                     "props": {"variant": "{msg.dot}", "label": "{msg.from}", "size": 8}},
+                    {"type": "badge",
+                     "props": {"text": "{msg.status}", "variant": "outline"}}
+                  ]
+                },
+                {"type": "text", "props": {"text": "{msg.subject}", "weight": "bold"}},
+                {"type": "text",
+                 "props": {"text": "{msg.snippet}", "size": "sm", "color": "muted"}}
+              ]
+            }
+          ]
+        },
+        {
+          "id": "n_inboxrefresh",
+          "type": "button",
+          "props": {
+            "label": "Refresh",
+            "on_click": [
+              {
+                "action": "invoke_tool",
+                "tool": "connector_execute",
+                "args": {
+                  "connector_name": "gmail",
+                  "action": "gmail_search",
+                  "params": {"query": "in:inbox newer_than:2d", "max_results": 10}
+                },
+                "on_success": [{"action": "set", "target": "inbox"}],
+                "on_error": [{"action": "toast",
+                  "message": "Couldn't refresh the inbox", "variant": "error"}]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Note the `status` field and the `select` option `value`s are lowercase ids
+(`"unread"`, `"read"`) while every human-facing string lives in a `label` or a
+`text`/`badge` prop — that IS the value/label split, and it's what lets the
+filter match. Nodes inside the `each` loop carry no `id` (they're templated
+per-item); only top-level nodes get ids. The **Refresh** button wires a
+follow-up action back to the sense: `invoke_tool` re-runs `connector_execute`
+through the pocket's tool-run wire and `on_success` writes the fresh result into
+`inbox`. (`set` with no `value` falls back to the tool result payload — make
+sure the sense returns the same message shape the cards bind to, or add a
+mapping step. If the tool-run wire isn't enabled for the pocket, drop the button
+and just re-run the search yourself and merge again — an agent-driven refresh.)
+
+Remember the read-before-you-act rule still holds: the snippet in a search stub
+is enough for a card, but `gmail_read` the message before quoting its body.
+
+### This does not replace the static widget-recipes rail
+
+Gmail also ships **pre-baked widget recipes** — the three default home widgets
+(Email Stats, etc.) surfaced in the Add-Widget picker's "From connectors" rail
+(`GET /api/v1/cloud/connectors/widget-recipes`), which a user can drop onto a
+home dashboard with no agent involved. That no-agent fallback stays exactly
+as-is. The convention here is the **agent-driven** path: you render a bespoke,
+live-typed view in response to what the user actually asked for. Use both —
+they don't overlap.
 
 ## Guardrails
 


### PR DESCRIPTION
Part of the Senses Router work: connectors that can render, not just report.

Today a connector read comes back as a JSON blob or a bulleted list in chat. This teaches the two bundled connector skills (github, gmail) to instead push the result to the pocket as typed Ripple widgets — a sortable table of PRs, a stack of inbox cards — through `POST /api/v1/pockets/<id>/spec/merge`. A table of pull requests reads better than ten lines of text, and the follow-up buttons wire back to the connector so the view refreshes without another chat round-trip.

## What's in it
- `github` skill: a "render results as a live pocket" section with a copyable data-grid payload and a Refresh button that re-runs the read via `invoke_tool`.
- `gmail` skill: the same convention with an inbox-cards example (`each` + `card`), so the two skills show two different display shapes.
- Both state two hard rules up front.

## The two rules (why they matter)
1. **Typed widgets only, never raw HTML.** Every string a connector returns — a PR title, an email subject, a sender name — is attacker-controllable. Those strings go only into typed-widget props where the renderer escapes them. No HTML assembled from connector data, no `embed`/srcdoc sink. This is the same class of risk as the S3 inline-render issue, treated as a security invariant rather than a validator you happen to trip.
2. **value/label split.** Machine ids stay lowercase in the id slot; human text goes in the label. Column `key` matches the row field; a select's bound state holds the value, not the label. Get it backwards and rows silently fail to resolve.

## Scope
- Skill markdown only. No code paths change.
- The static widget-recipes rail (the no-agent "From connectors" picker) is untouched and called out as the fallback — this is the agent-driven path beside it.

## Verification
- Every widget kind, action verb, and endpoint cited was grep-confirmed against the code first: `data-grid` (bundled templates + schema), `invoke_tool` (`_KNOWN_ACTION_VERBS`, manifest.py:643), the `/spec/merge` route (`ripple/_pockets.py`).
- Both fenced `/spec/merge` payloads parse as valid JSON.
- `pytest tests/test_bundled_skills_installer.py tests/test_skills_materialize.py` → 20 passed; `tests/test_skills.py` → 14 passed. Frontmatter still parses.

## Known follow-up
The Refresh button routes through the pocket's `tools/run` wire, which may not be enabled for every pocket yet. The skill documents the graceful fallback (drop the button, agent re-runs the read and re-merges); the initial render is the load-bearing part and is fully verified.

Part of the Senses Router plan (SR-8). Design: docs/design/drafts/2026-07-16-senses-router.md
