### PR TITLE
Pin connector-derived skill surfacing with an end-to-end test; fix stale doc

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -61,6 +61,15 @@
 # so the belt handler's ``build_preamble`` injects them into the preamble and
 # tells the agent NOT to ask for the repo (and to pass exactly these into
 # ``belt_propose_change``). Absent → the handler keeps the ask-first behavior.
+# Changes: 2026-07-16 (feat/senses-skill-surfacing, SR-5) — corrected the stale
+# ``SurfaceProfile`` field-doc below: ``skill_names`` is NO LONGER inert. It is
+# CONSUMED per run — the entity/connector-derived ``surface_profile.skill_names``
+# composes into ``resolved_profile`` (``compose_entity_profile``, a UNION) and
+# ``run_core`` forwards it to ``AgentPool.run(skill_names=...)``, where the Claude
+# SDK backend materializes the named skills into a per-run local-plugin dir (RFC 14
+# M3 keystone, #1343 / #1374). ``system_message_override`` is likewise consumed
+# now. Doc-only correction — no behavior change; the end-to-end proof lives at
+# ``tests/cloud/runs/test_run_core_connector_skill_surfacing.py``.
 
 from __future__ import annotations
 
@@ -229,8 +238,16 @@ class SurfaceProfile:
         ``frozenset[str]`` (``deny_mcp_tool_ids``) and subtracted from
         ``allowed_tools`` before the SDK launches. Non-empty only on the /sites
         svelte-create row.
-      * ``skill_names`` — skills this surface surfaces to the agent. Tested DATA;
-        skill-surfacing consumption lands in a later pass.
+      * ``skill_names`` — skills this surface (or its entity/connector-derived
+        override) surfaces to the agent. CONSUMED: ``compose_entity_profile``
+        UNIONs the pocket's ``surface_profile.skill_names`` (auto-authored from a
+        pocket's bound connectors — gmail → "gmail", github → "github") over the
+        surface base; ``run_core`` reads the composed set off ``resolved_profile``,
+        folds in the agent's own ``skill_refs`` (still a UNION — additive), and
+        forwards it to ``AgentPool.run(skill_names=...)`` where the Claude SDK
+        backend materializes the named skills into a per-run local-plugin dir.
+        Binding a connector adds its skill to the NEXT run; unbinding removes only
+        the derived skill (pre-existing ``skill_refs`` are untouched).
       * ``system_message_override`` — the surface's own system prompt, replacing
         the pocket-shaped DELIVERABLE stack. CONSUMED since 2026-07-22
         (fix/code-surface-denies-pocket-authoring); set on the CODE row, ``None``
@@ -248,11 +265,10 @@ class SurfaceProfile:
         pockets still lost to a request whose vocabulary matched the
         create-pocket skill, because a prohibition does not create a default.
 
-    ``ripple_mode``, ``deny_mcp_tool_ids``, ``allow_mcp_tool_ids`` and
-    ``system_message_override`` are CONSUMED today; ``allowed_sdk_tools`` and
-    ``skill_names`` remain populated-but-inert so the descriptor's shape is
-    locked now and later passes add enforcement without re-designing the
-    primitive.
+    ``ripple_mode``, ``deny_mcp_tool_ids``, ``allow_mcp_tool_ids``, ``skill_names``
+    and ``system_message_override`` are CONSUMED today; ``allowed_sdk_tools``
+    remains populated-but-inert so the descriptor's shape is locked now and a
+    later pass adds enforcement without re-designing the primitive.
     """
 
     ripple_mode: Literal["on", "off", "trim"]

--- a/tests/cloud/runs/test_run_core_connector_skill_surfacing.py
+++ b/tests/cloud/runs/test_run_core_connector_skill_surfacing.py
@@ -1,0 +1,177 @@
+# tests/cloud/runs/test_run_core_connector_skill_surfacing.py
+# Created: 2026-07-16 (feat/senses-skill-surfacing, SR-5) — end-to-end pins that a
+#   connector's DERIVED skill (M3 ``derive_surface_profile``) surfaces in the NEXT
+#   agent run's materialized skill set for the bound pocket. Ties the two halves
+#   that were previously only tested in isolation — connector-bind →
+#   ``pocket.surface_profile`` (``test_surface_profile_authoring``) and
+#   ``surface_profile.skill_names`` → run forward
+#   (``test_run_core_entity_profile_threading``) — into ONE "connect once, the
+#   agent immediately knows how" narrative through the REAL derive → model_dump →
+#   ``_resolve_entity_profile`` (compose) → ``_drive_agent_loop`` forward path
+#   (only the agent pool and the pocket-load are stubbed). Asserts the four SR-5
+#   contracts: binding SURFACES the skill; the derived skill UNIONs with (never
+#   replaces) the agent's own ``skill_refs``; unbinding removes ONLY the derived
+#   skill; a skill-only connector leaves ``ripple_mode`` / ``deny_mcp_tool_ids``
+#   untouched. No pocketpaw_ee symbol crosses the EE→OSS boundary — only a
+#   ``frozenset[str]`` reaches ``AgentPool.run(skill_names=...)``.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+from pocketpaw_ee.cloud.connectors.derivation import derive_surface_profile
+from pocketpaw_ee.cloud.connectors.domain import (
+    AvailableConnector,
+    ConnectorSurfaceContribution,
+)
+from pocketpaw_ee.cloud.surface import (
+    SurfaceContext,
+    SurfaceKind,
+    SurfaceMeta,
+    resolve_profile,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _connector(name: str, skill: str) -> AvailableConnector:
+    """A minimal available connector whose surface contribution is one skill."""
+    return AvailableConnector(
+        name=name,
+        display_name=name.title(),
+        type="communication",
+        icon="",
+        auth_method="oauth",
+        surface_profile=ConnectorSurfaceContribution(skill=skill),
+    )
+
+
+class _CapturingPool:
+    """Pool stub: captures ``run`` kwargs and lets a test seed the agent instance
+    config so ``_agent_skill_set`` can see the agent's own ``skill_refs``."""
+
+    def __init__(self, instance_config: dict[str, Any] | None = None) -> None:
+        self.run_kwargs: dict[str, Any] | None = None
+        self._config = {"backend": "claude_agent_sdk", **(instance_config or {})}
+
+    async def get(self, _agent_id):
+        config = self._config
+        return type("Inst", (), {"config": config})()
+
+    def run(self, *args, **kwargs):
+        self.run_kwargs = kwargs
+
+        async def _empty():
+            return
+            yield  # pragma: no cover
+
+        return _empty()
+
+
+def _ctx() -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        surface_context=SurfaceContext(
+            workspace_id="w1",
+            user_id="u1",
+            kind=SurfaceKind.CHAT,
+            meta=SurfaceMeta(pocket_id="pkt_1"),
+            preamble="",
+        ),
+    )
+
+
+async def _resolve_with_connectors(monkeypatch, ctx, connectors) -> None:
+    """Exercise the REAL derive → model_dump → ``_load_entity_profile_override`` →
+    ``compose_entity_profile`` path and stash the result on ``ctx.resolved_profile``
+    exactly as ``execute_run`` does once per run. ``connectors`` is the pocket's
+    enabled set; the empty set models a fully-unbound pocket (derive → ``None``)."""
+    derived = derive_surface_profile(connectors)
+    override = derived.model_dump() if derived is not None else None
+
+    async def _fake_load(_ws, _pkt):
+        return override
+
+    monkeypatch.setattr(run_core, "_load_entity_profile_override", _fake_load)
+    ctx.resolved_profile = await run_core._resolve_entity_profile(ctx)
+
+
+async def _drive(monkeypatch, ctx, pool) -> _CapturingPool:
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: pool)
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda *a, **k: "INSTR")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda *a, **k: None, raising=False)
+
+    async def _is_cancelled():
+        return False
+
+    gen = run_core._drive_agent_loop(
+        ctx,
+        user_content="hi",
+        attachments_in=None,
+        mentions_in=None,
+        history=[],
+        is_cancelled=_is_cancelled,
+        emit_stream_start=False,
+    )
+    async for _ in gen:
+        pass
+    return pool
+
+
+async def test_bound_connector_skill_surfaces_in_next_run(monkeypatch):
+    """Binding gmail (skill 'gmail') to a pocket surfaces that skill in the run."""
+    ctx = _ctx()
+    await _resolve_with_connectors(monkeypatch, ctx, [_connector("gmail", "gmail")])
+    pool = await _drive(monkeypatch, ctx, _CapturingPool())
+    assert pool.run_kwargs is not None
+    assert pool.run_kwargs.get("skill_names") == frozenset({"gmail"})
+
+
+async def test_derived_skill_unions_with_agent_skill_refs(monkeypatch):
+    """The derived connector skill UNIONs with the agent's own skill_refs — the
+    derived skill is ADDED, the pre-existing skill_refs are NOT replaced."""
+    ctx = _ctx()
+    await _resolve_with_connectors(monkeypatch, ctx, [_connector("github", "github")])
+    pool = await _drive(
+        monkeypatch, ctx, _CapturingPool(instance_config={"skill_refs": ["team-playbook"]})
+    )
+    assert pool.run_kwargs.get("skill_names") == frozenset({"github", "team-playbook"})
+
+
+async def test_unbind_removes_only_derived_skill(monkeypatch):
+    """A fully-unbound pocket (no connectors) drops the derived skill while the
+    agent's pre-existing skill_refs stay intact — union removal, not replacement."""
+    ctx = _ctx()
+    await _resolve_with_connectors(monkeypatch, ctx, [])  # re-derive from empty set
+    pool = await _drive(
+        monkeypatch, ctx, _CapturingPool(instance_config={"skill_refs": ["team-playbook"]})
+    )
+    assert pool.run_kwargs.get("skill_names") == frozenset({"team-playbook"})
+
+
+async def test_skill_only_connector_leaves_ripple_and_deny_unchanged(monkeypatch):
+    """A skill-only connector must not perturb ripple_mode / deny_mcp_tool_ids —
+    those dims stay whatever the surface base composed to."""
+    base = resolve_profile(SurfaceKind.CHAT, SurfaceMeta())
+    ctx = _ctx()
+    await _resolve_with_connectors(monkeypatch, ctx, [_connector("gmail", "gmail")])
+    assert ctx.resolved_profile.ripple_mode == base.ripple_mode
+    assert ctx.resolved_profile.deny_mcp_tool_ids == base.deny_mcp_tool_ids
+    pool = await _drive(monkeypatch, ctx, _CapturingPool())
+    assert pool.run_kwargs.get("deny_mcp_tool_ids") == base.deny_mcp_tool_ids


### PR DESCRIPTION
While building the Senses Router, our recon flagged a gap: the `SurfaceProfile.skill_names` field looked inert — a doc note in `surface/domain.py` said "skill-surfacing consumption lands in a later pass." That note is stale. Tracing the actual runtime path shows the wiring already landed (via #1343, #1374, #1461): binding a connector already surfaces its skill in the next run.

Rather than force a redundant second union (which would double-apply and risk a regression), this PR does two things: proves the existing behavior with an end-to-end test, and corrects the misleading doc.

## The chain that already works
1. Bind a connector → `enable_connector` → `_rederive_pocket_surface_profile` → `derive_surface_profile` produces `skill_names` → written to `pocket.surface_profile.skill_names`.
2. Next run → `compose_entity_profile` unions those skill_names over the surface base (`surface/service.py:210`).
3. `run_core` reads the composed set, folds in the agent's own `skill_refs` (still additive), and forwards `skill_names` to `AgentPool.run(...)`.
4. The Claude SDK backend materializes the named skills into a per-run local-plugin dir.

## What's in the PR
- `tests/cloud/runs/test_run_core_connector_skill_surfacing.py` — a new end-to-end test (4 cases) tying connector-bind → run forward through the real derive → compose → drive path (only the agent pool and pocket-load are stubbed, so the union logic under test is exercised for real, not mocked). It asserts: binding surfaces the skill; the derived skill unions with, never replaces, the agent's `skill_refs`; unbinding removes only the derived skill; a skill-only connector leaves `ripple_mode` and `deny_mcp_tool_ids` untouched.
- `ee/pocketpaw_ee/cloud/surface/domain.py` — doc-only. Rewrote the stale field docs; no code lines changed.

## Verification
- New test: `pytest tests/cloud/runs/test_run_core_connector_skill_surfacing.py -v` → 4 passed against unmodified production code (the point: it proves the wiring is already live).
- Broader seam (13 surface/connector/derivation/skill/entity-profile files): 95 passed.
- Note: a fresh worktree venv shows ~21 pre-existing failures in the connectors/home/studio auth-fixture area (401 vs expected 404); they reproduce identically on pristine `dev` and are unrelated to this change. Worth a separate look.

Part of the Senses Router plan (SR-5). Design: docs/design/drafts/2026-07-16-senses-router.md
