### PR TITLE
Add catalog-wide connector discovery (sense_search)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -59,6 +59,22 @@
 #   chokepoint contracts stay 0-broken. (``propose.py`` itself statically imports
 #   no Beanie document class — it lazy-imports ``pocketpaw.stores`` /
 #   ``pocketpaw.instinct.models`` internally.)
+# Updated: 2026-07-16 (SR-1 catalog-wide discovery) — added a FIFTH tool,
+#   ``sense_search(query)``: catalog-WIDE discovery over all 35 connectors, not
+#   just the ones a pocket already bound. The other tools can only enumerate
+#   pre-wired connectors — the agent literally could not propose a tool the admin
+#   never bound. ``sense_search`` delegates to ``cloud.senses.catalog.search_catalog``
+#   (pure BM25 over the parsed connector defs, no ML/deps) and overlays tenant
+#   state read ONLY through the EE store: ``connectors.service.list_bound_connector_names``
+#   supplies the pocket's reachable connector set so each hit is marked BOUND or
+#   UNBOUND. Each hit also carries trust level, AVAILABILITY (connectors whose
+#   action ``execution_mode`` is ``local`` are marked UNAVAILABLE — the shared
+#   cloud has no local-runtime listener and ``service.execute`` 503s them, so the
+#   agent must not select them), and a placeholder ``cost_estimate`` (real
+#   pricing lands later; NO metering here). READ-ONLY: it searches and reports,
+#   never executes. Tool id ``mcp__pocketpaw_connectors__sense_search``. OSS-EE
+#   boundary held — the Beanie read stays in ``connectors.service``; this module
+#   still imports no WorkspaceConnector doc.
 """Agent-side MCP surface for executing a chat's reachable connectors.
 
 Tools registered:
@@ -102,12 +118,14 @@ LIST_CONNECTOR_ACTIONS_TOOL_ID = f"mcp__{SERVER_NAME}__list_connector_actions"
 CONNECTOR_EXECUTE_TOOL_ID = f"mcp__{SERVER_NAME}__connector_execute"
 LIST_SENSES_TOOL_ID = f"mcp__{SERVER_NAME}__list_senses"
 SENSE_EXECUTE_TOOL_ID = f"mcp__{SERVER_NAME}__sense_execute"
+SENSE_SEARCH_TOOL_ID = f"mcp__{SERVER_NAME}__sense_search"
 
 CONNECTOR_TOOL_IDS = (
     LIST_CONNECTOR_ACTIONS_TOOL_ID,
     CONNECTOR_EXECUTE_TOOL_ID,
     LIST_SENSES_TOOL_ID,
     SENSE_EXECUTE_TOOL_ID,
+    SENSE_SEARCH_TOOL_ID,
 )
 
 
@@ -715,6 +733,87 @@ async def _sense_execute_handler(args: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Tool handler — catalog-wide discovery (search ALL connectors, bound or not)
+# ---------------------------------------------------------------------------
+
+
+async def _sense_search_handler(args: dict) -> dict:
+    workspace_id, _user_id, pocket_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "no active workspace — sense_search can only be called from inside a cloud chat stream"
+        )
+
+    query = args.get("query")
+    if not isinstance(query, str) or not query.strip():
+        return _error_response("query is required (a non-empty string)")
+
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.senses import catalog
+
+    # Bound status is tenant state — read it ONLY through the EE store service
+    # (the Beanie read lives there, never here). Unanchored chats (pocket_id=None)
+    # pass "" so only workspace-scoped rows count, matching the other tools.
+    try:
+        bound = await connectors_service.list_bound_connector_names(workspace_id, pocket_id or "")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("sense_search bound lookup failed", exc_info=True)
+        return _error_response(f"sense_search failed: {exc}")
+
+    try:
+        hits = await catalog.search_catalog(query, bound_connectors=bound, limit=10)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("sense_search failed", exc_info=True)
+        return _error_response(f"sense_search failed: {exc}")
+
+    results = [
+        {
+            "senses": list(h.senses),
+            "connector": h.connector,
+            "display_name": h.display_name,
+            "action": h.action,
+            "description": h.description,
+            "trust_level": h.trust_level,
+            "execution_mode": h.execution_mode,
+            "bound": h.bound,
+            "available": h.available,
+            "unavailable_reason": h.unavailable_reason,
+            "cost_estimate": h.cost_estimate,
+        }
+        for h in hits
+    ]
+
+    if not results:
+        return _success_response(
+            {
+                "query": query,
+                "pocket_id": pocket_id,
+                "results": [],
+                "message": (
+                    f"No catalog actions matched {query!r}. Try different words, or a "
+                    "capability like 'email', 'calendar', 'issues', or 'payments'."
+                ),
+            }
+        )
+
+    return _success_response(
+        {
+            "query": query,
+            "pocket_id": pocket_id,
+            "results": results,
+            "note": (
+                "Catalog-wide results — includes connectors NOT yet bound to this "
+                "pocket. 'bound'=true means it's reachable here now (use it via "
+                "connector_execute / sense_execute); 'bound'=false means an admin must "
+                "enable that connector first — tell the user which one. 'available'=false "
+                "(e.g. local-runtime actions) means it can't run in the cloud — do NOT "
+                "select it. 'cost_estimate' is a placeholder until pricing ships."
+            ),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # Server factory
 # ---------------------------------------------------------------------------
 
@@ -863,10 +962,52 @@ def build_connectors_context_server() -> tuple[str, Any] | None:
     async def sense_execute(args):  # type: ignore[no-untyped-def]
         return await _sense_execute_handler(args)
 
+    @tool(
+        "sense_search",
+        (
+            "Search the FULL connector catalog (every integration Paw OS supports, "
+            "not just the ones this pocket already connected) for actions that match "
+            "a natural-language `query`. Use this when the user asks for a capability "
+            "and you are NOT sure a connector for it is bound here — e.g. 'can you "
+            "create a GitHub issue?', 'do we have anything for Stripe payments?', "
+            "'find me a way to search Slack'. Unlike list_connector_actions / "
+            "list_senses (which only show what's already wired up), this proposes "
+            "tools nobody bound yet. Each result carries: `connector` + `action` + "
+            "`description`, its `senses` (capabilities), `trust_level`, `bound` (true "
+            "= reachable here now, run it via connector_execute/sense_execute; false "
+            "= an admin must enable that connector first — tell the user which one), "
+            "`available` (false means it can't run in the cloud, e.g. a local-runtime "
+            "action — do NOT select it), and a placeholder `cost_estimate`. This tool "
+            "only SEARCHES and reports; it never runs anything."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "What the user wants to do, in plain words, e.g. 'create a "
+                        "github issue', 'search email for an invoice', 'list stripe "
+                        "charges'. Connector, action, and capability names all match."
+                    ),
+                },
+            },
+            "required": ["query"],
+        },
+    )
+    async def sense_search(args):  # type: ignore[no-untyped-def]
+        return await _sense_search_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
-        version="1.1.0",
-        tools=[list_connector_actions, connector_execute, list_senses, sense_execute],
+        version="1.2.0",
+        tools=[
+            list_connector_actions,
+            connector_execute,
+            list_senses,
+            sense_execute,
+            sense_search,
+        ],
     )
     return SERVER_NAME, server
 
@@ -877,6 +1018,7 @@ __all__ = [
     "LIST_CONNECTOR_ACTIONS_TOOL_ID",
     "LIST_SENSES_TOOL_ID",
     "SENSE_EXECUTE_TOOL_ID",
+    "SENSE_SEARCH_TOOL_ID",
     "SERVER_NAME",
     "build_connectors_context_server",
 ]

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -58,6 +58,16 @@
 #   into the config blob passed to ``adapter.connect`` so the per-workspace
 #   egress allow-list additions reach the adapter on that path too (the primary
 #   ensure_connected path folds them in ``state_provider.get``).
+# Updated: 2026-07-16 (SR-1 catalog-wide discovery) — added
+#   ``list_bound_connector_names``: a names-only companion to
+#   ``is_connector_bound_to_pocket`` that returns the SET of connector names
+#   enabled + reachable from one pocket (pocket-scoped for this pocket OR
+#   workspace-scoped) in a single tenant-filtered Beanie read. The new
+#   ``sense_search`` MCP tool (catalog-wide discovery) reads this once to mark
+#   each catalog hit BOUND-vs-unbound for the current pocket, instead of N
+#   per-connector ``is_connector_bound_to_pocket`` calls. Keeps the
+#   WorkspaceConnector read in THIS service (OSS-EE boundary §2 + tenant rule
+#   §7) so the catalog / MCP layers never import the Beanie doc.
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -904,6 +914,33 @@ async def is_connector_bound_to_pocket(workspace_id: str, pocket_id: str, name: 
     return doc is not None
 
 
+async def list_bound_connector_names(workspace_id: str, pocket_id: str) -> set[str]:
+    """The SET of connector names enabled + reachable from one pocket.
+
+    The names-only companion to ``is_connector_bound_to_pocket``: same tenant
+    gate (``scope == "workspace"`` OR ``scope == "pocket"`` for THIS pocket,
+    ``enabled == True``), but returns every matching name in one read instead of
+    one bool per name. The ``sense_search`` MCP tool reads this once to mark each
+    catalog hit BOUND-vs-unbound for the current pocket — catalog discovery is
+    catalog-wide, so it needs the reachable set, not a per-connector probe.
+
+    Tenant-filtered on ``workspace`` (cloud rule §7). An empty/unknown
+    ``pocket_id`` (an unanchored chat passes ``""``) matches the pocket arm
+    against nothing, so only workspace-scoped rows come back — the same
+    fall-through the other pocket-reach reads use. The Beanie read lives HERE
+    (not in the catalog / MCP layer) so the OSS-EE boundary holds.
+    """
+    docs = await _WCDoc.find(
+        _WCDoc.workspace == workspace_id,
+        Or(
+            _WCDoc.scope == "workspace",
+            And(_WCDoc.scope == "pocket", _WCDoc.pocket_id == pocket_id),
+        ),
+        _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+    ).to_list()
+    return {d.name for d in docs}
+
+
 async def is_connector_enabled_for_workspace(workspace_id: str, name: str) -> bool:
     """True when ``name`` is a real registry connector AND enabled for the workspace.
 
@@ -1101,6 +1138,7 @@ __all__ = [
     "get_connector",
     "is_connector_bound_to_pocket",
     "is_connector_enabled_for_workspace",
+    "list_bound_connector_names",
     "list_connectors",
     "list_pocket_connectors",
     "list_widget_recipes",

--- a/ee/pocketpaw_ee/cloud/senses/catalog.py
+++ b/ee/pocketpaw_ee/cloud/senses/catalog.py
@@ -50,8 +50,26 @@ _UNAVAILABLE_REASONS: dict[str, str] = {
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 _STOPWORDS: frozenset[str] = frozenset(
     {
-        "a", "an", "the", "to", "of", "for", "in", "on", "and", "or",
-        "my", "me", "is", "it", "with", "this", "that", "from", "at", "by",
+        "a",
+        "an",
+        "the",
+        "to",
+        "of",
+        "for",
+        "in",
+        "on",
+        "and",
+        "or",
+        "my",
+        "me",
+        "is",
+        "it",
+        "with",
+        "this",
+        "that",
+        "from",
+        "at",
+        "by",
     }
 )
 
@@ -199,11 +217,7 @@ def _bm25_scores(query_tokens: list[str], docs: list[_ActionDoc]) -> list[float]
         return [0.0] * n
 
     unique_q = set(query_tokens)
-    idf = {
-        t: math.log(1 + (n - df[t] + 0.5) / (df[t] + 0.5))
-        for t in unique_q
-        if df.get(t, 0) > 0
-    }
+    idf = {t: math.log(1 + (n - df[t] + 0.5) / (df[t] + 0.5)) for t in unique_q if df.get(t, 0) > 0}
 
     scores: list[float] = []
     for doc in docs:
@@ -259,11 +273,7 @@ async def search_catalog(
     scores = _bm25_scores(query_tokens, docs)
 
     ranked = sorted(
-        (
-            (doc, score)
-            for doc, score in zip(docs, scores, strict=True)
-            if score > 0
-        ),
+        ((doc, score) for doc, score in zip(docs, scores, strict=True) if score > 0),
         key=lambda pair: pair[1],
         reverse=True,
     )[: max(0, limit)]

--- a/ee/pocketpaw_ee/cloud/senses/catalog.py
+++ b/ee/pocketpaw_ee/cloud/senses/catalog.py
@@ -1,0 +1,295 @@
+# Catalog search — keyword/BM25 discovery over the FULL connector catalog.
+# Created: 2026-07-16 (SR-1 catalog-wide discovery) — the search half of the
+#   new ``sense_search`` MCP tool. Where ``list_pocket_connectors`` /
+#   ``list_senses`` only enumerate what a pocket ALREADY bound, this searches
+#   every connector the registry knows (all 35 YAML defs), so the agent can
+#   surface an action nobody wired up yet and tell the user to enable it. Pure,
+#   dependency-free BM25 over the parsed connector defs (NO ML, NO new deps):
+#   each connector action is one document; the searchable text is the connector
+#   name + display name + action name + description + the connector's declared
+#   senses (enriched with each core sense's display name + description). Trust
+#   level and execution mode come from the connector's adapter schema (the same
+#   authoritative source ``get_action_trust`` / ``list_pocket_connectors`` use),
+#   so native LOCAL connectors (gcp, firebase) report ``execution_mode=local``
+#   correctly and are marked UNAVAILABLE — the cloud run has no local-runtime
+#   listener, so ``connectors.service.execute`` returns 503 for them and the
+#   agent must not select them. BOUND-vs-unbound is overlaid from a caller-
+#   supplied set of the pocket's reachable connector names (resolved from the EE
+#   store by the MCP handler), keeping this module pure + fully unit-testable.
+#   ``cost_estimate`` is a placeholder (None) — real per-action pricing lands in
+#   a later task; this module builds NO metering.
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+from pocketpaw.senses import CORE_SENSES
+
+# ---------------------------------------------------------------------------
+# Availability — which execution modes the cloud run can actually dispatch.
+# ---------------------------------------------------------------------------
+
+# The cloud FastAPI process only runs ``cloud`` actions in-process. ``local``
+# actions need the user's pocketpaw runtime listener (absent in the shared
+# cloud), so ``connectors.service.execute`` returns a 503
+# (``connector.local_agent_unavailable``); ``sandbox`` is reserved and raises
+# 501. Marking non-cloud actions UNAVAILABLE keeps the agent from proposing a
+# tool it cannot actually fire.
+_UNAVAILABLE_REASONS: dict[str, str] = {
+    "local": "local_runtime_unavailable",
+    "sandbox": "sandbox_not_implemented",
+}
+
+# ---------------------------------------------------------------------------
+# Tokenization — lowercase alphanumeric tokens, tiny stoplist.
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a", "an", "the", "to", "of", "for", "in", "on", "and", "or",
+        "my", "me", "is", "it", "with", "this", "that", "from", "at", "by",
+    }
+)
+
+# Field weights baked into each document's term counts so a connector-name or
+# action-name match outranks a description-only match. BM25's tf saturation
+# (k1) keeps the boost bounded.
+_W_CONNECTOR = 3
+_W_ACTION = 3
+_W_DISPLAY = 2
+_W_SENSE = 2
+_W_DESCRIPTION = 1
+
+_BM25_K1 = 1.5
+_BM25_B = 0.75
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase alphanumeric tokens, length >= 2, minus a tiny stoplist.
+
+    ``create_issue`` -> ``["create", "issue"]`` (underscore splits);
+    ``paw.code.v1`` -> ``["paw", "code", "v1"]``.
+    """
+    return [t for t in _TOKEN_RE.findall(text.lower()) if len(t) >= 2 and t not in _STOPWORDS]
+
+
+@dataclass(frozen=True)
+class CatalogHit:
+    """One connector action matched by a catalog search.
+
+    ``bound`` is True when the connector is enabled + reachable from the current
+    pocket (overlaid from the caller's reachable-set). ``available`` is False for
+    non-cloud actions the shared cloud can't dispatch (local / sandbox), with
+    ``unavailable_reason`` naming why. ``cost_estimate`` is a placeholder (None)
+    until per-action pricing ships in a later task.
+    """
+
+    connector: str
+    display_name: str
+    action: str
+    description: str
+    trust_level: str  # "auto" | "confirm" | "restricted"
+    execution_mode: str  # "cloud" | "local" | "sandbox"
+    senses: tuple[str, ...]
+    bound: bool
+    available: bool
+    unavailable_reason: str | None
+    cost_estimate: float | None
+    score: float
+
+
+@dataclass
+class _ActionDoc:
+    """One indexed action: its scored token bag + the metadata for its hit."""
+
+    connector: str
+    display_name: str
+    action: str
+    description: str
+    trust_level: str
+    execution_mode: str
+    senses: tuple[str, ...]
+    tokens: Counter[str] = field(default_factory=Counter)
+
+    @property
+    def length(self) -> int:
+        return sum(self.tokens.values())
+
+
+# Sense-id -> curated CoreSense, so a connector's declared senses contribute
+# their human display name + description to the searchable text (a query like
+# "manage calendar availability" then matches a calendar connector even when the
+# action wording differs).
+_SENSE_BY_ID = {s.id: s for s in CORE_SENSES}
+
+
+def _add(tokens: Counter[str], text: str, weight: int) -> None:
+    for tok in _tokenize(text):
+        tokens[tok] += weight
+
+
+async def _build_index(registry) -> list[_ActionDoc]:
+    """Index every action of every connector the registry knows.
+
+    Trust level + execution mode come from the connector's adapter schema (the
+    authoritative source — native LOCAL adapters stamp ``execution_mode=local``
+    even though their YAML omits the key), matching how ``get_action_trust`` and
+    ``list_pocket_connectors`` classify actions. A connector whose adapter fails
+    to enumerate is skipped rather than breaking the whole search.
+    """
+    # Reuse the EE service's registry singleton + adapter factory so the catalog
+    # reads the SAME parsed defs the rest of the connector stack does (no file
+    # re-reading, no duplicated native/REST selection logic).
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    docs: list[_ActionDoc] = []
+    for defn in registry.definitions:
+        senses = tuple(getattr(defn, "senses", None) or ())
+        try:
+            adapter = connectors_service._adapter_for_definition(defn, defn.name)  # noqa: SLF001
+            schemas = await adapter.actions()
+        except Exception:  # noqa: BLE001 — a bad adapter must not drop the catalog
+            continue
+        for schema in schemas:
+            tokens: Counter[str] = Counter()
+            _add(tokens, defn.name, _W_CONNECTOR)
+            _add(tokens, defn.display_name, _W_DISPLAY)
+            _add(tokens, schema.name, _W_ACTION)
+            _add(tokens, schema.description, _W_DESCRIPTION)
+            for sense_id in senses:
+                _add(tokens, sense_id, _W_SENSE)
+                core = _SENSE_BY_ID.get(sense_id)
+                if core is not None:
+                    _add(tokens, core.display_name, _W_SENSE)
+                    _add(tokens, core.description, _W_SENSE)
+            docs.append(
+                _ActionDoc(
+                    connector=defn.name,
+                    display_name=defn.display_name,
+                    action=schema.name,
+                    description=schema.description,
+                    trust_level=str(schema.trust_level),
+                    execution_mode=str(schema.execution_mode),
+                    senses=senses,
+                    tokens=tokens,
+                )
+            )
+    return docs
+
+
+def _bm25_scores(query_tokens: list[str], docs: list[_ActionDoc]) -> list[float]:
+    """Classic BM25 (k1=1.5, b=0.75) over the weighted token bags.
+
+    IDF is computed across the action corpus; term frequency is the field-
+    weighted count. Pure arithmetic — no ML, no vectors, no external index.
+    """
+    n = len(docs)
+    if n == 0:
+        return []
+    df: Counter[str] = Counter()
+    for doc in docs:
+        for tok in doc.tokens:
+            df[tok] += 1
+    avgdl = sum(doc.length for doc in docs) / n
+    if avgdl == 0:
+        return [0.0] * n
+
+    unique_q = set(query_tokens)
+    idf = {
+        t: math.log(1 + (n - df[t] + 0.5) / (df[t] + 0.5))
+        for t in unique_q
+        if df.get(t, 0) > 0
+    }
+
+    scores: list[float] = []
+    for doc in docs:
+        dl = doc.length
+        s = 0.0
+        for t in unique_q:
+            f = doc.tokens.get(t, 0)
+            if f == 0 or t not in idf:
+                continue
+            denom = f + _BM25_K1 * (1 - _BM25_B + _BM25_B * dl / avgdl)
+            s += idf[t] * (f * (_BM25_K1 + 1)) / denom
+        scores.append(s)
+    return scores
+
+
+async def search_catalog(
+    query: str,
+    *,
+    bound_connectors: set[str] | None = None,
+    limit: int = 10,
+    registry=None,
+) -> list[CatalogHit]:
+    """Search the FULL connector catalog for actions matching ``query``.
+
+    Catalog-wide: every connector the registry knows is searched, including
+    connectors NOT bound to the current pocket — that is the whole point (the
+    agent can surface a tool nobody wired up yet). Ranking is BM25 over the
+    parsed connector defs; only positive-scoring actions are returned, best
+    first, capped at ``limit``.
+
+    ``bound_connectors`` is the set of connector names reachable from the current
+    pocket (resolved from the EE store by the caller); each hit's ``bound`` flag
+    is set from it. Passing ``None`` treats everything as unbound. ``available``
+    is intrinsic to the action (False for ``local`` / ``sandbox`` execution
+    modes the shared cloud can't dispatch). ``registry`` defaults to the EE
+    connector-service singleton; tests inject a registry built from a fixed
+    connectors dir.
+    """
+    if not query or not query.strip():
+        return []
+
+    if registry is None:
+        from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+        registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
+
+    bound = bound_connectors or set()
+    query_tokens = _tokenize(query)
+    if not query_tokens:
+        return []
+
+    docs = await _build_index(registry)
+    scores = _bm25_scores(query_tokens, docs)
+
+    ranked = sorted(
+        (
+            (doc, score)
+            for doc, score in zip(docs, scores, strict=True)
+            if score > 0
+        ),
+        key=lambda pair: pair[1],
+        reverse=True,
+    )[: max(0, limit)]
+
+    hits: list[CatalogHit] = []
+    for doc, score in ranked:
+        reason = _UNAVAILABLE_REASONS.get(doc.execution_mode)
+        hits.append(
+            CatalogHit(
+                connector=doc.connector,
+                display_name=doc.display_name,
+                action=doc.action,
+                description=doc.description,
+                trust_level=doc.trust_level,
+                execution_mode=doc.execution_mode,
+                senses=doc.senses,
+                bound=doc.connector in bound,
+                available=reason is None,
+                unavailable_reason=reason,
+                # TODO(SR-pricing): real per-action cost lands in a later task;
+                # placeholder until then. Do NOT build metering here.
+                cost_estimate=None,
+                score=round(score, 4),
+            )
+        )
+    return hits
+
+
+__all__ = ["CatalogHit", "search_catalog"]

--- a/tests/cloud/senses/test_catalog.py
+++ b/tests/cloud/senses/test_catalog.py
@@ -1,0 +1,230 @@
+# Catalog search tests — BM25 relevance, bound overlay, availability, tenant read.
+# Created: 2026-07-16 (SR-1 catalog-wide discovery) — coverage for the new
+#   ``cloud.senses.catalog.search_catalog`` and the
+#   ``connectors.service.list_bound_connector_names`` helper that feeds it.
+#   The PURE tests inject a registry built from the repo /connectors dir (real
+#   35-connector catalog, no DB) and assert on the returned CatalogHit fields:
+#   that a query ranks the right connector/action first, that BOUND-vs-unbound
+#   tracks the caller-supplied reachable set, that catalog-wide search surfaces
+#   connectors NOT bound to the pocket, and that a LOCAL-execution-mode connector
+#   (firebase) is marked UNAVAILABLE. The INTEGRATION tests (mongo_db) seed
+#   WorkspaceConnector docs directly and assert list_bound_connector_names
+#   returns the pocket-reachable name set (pocket-scoped narrowing +
+#   workspace-scoped fall-through), then prove the end-to-end overlay.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.senses import catalog  # noqa: E402
+
+from pocketpaw.connectors.registry import ConnectorRegistry  # noqa: E402
+from pocketpaw.connectors.state_store import FileConnectorStateStore  # noqa: E402
+
+# Repo-root connectors/ dir (tests/cloud/senses/ -> up 3 -> repo root).
+CONNECTORS_DIR = Path(__file__).resolve().parents[3] / "connectors"
+
+
+@pytest.fixture
+def registry(tmp_path):
+    """A real registry over the repo connector catalog, hermetic (no home dir,
+    no DB-backed state store) so the pure search tests need no Mongo."""
+    return ConnectorRegistry(
+        CONNECTORS_DIR,
+        state_store=FileConnectorStateStore(tmp_path / "state"),
+        home_connectors_dir=tmp_path / "home",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Relevance / ranking (pure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ranks_github_create_issue_first(registry) -> None:
+    """'create a github issue' ranks GitHub's create_issue action at the top,
+    with trust level populated (confirm — it's a write) and available (cloud)."""
+    hits = await catalog.search_catalog(
+        "create a github issue", bound_connectors={"gmail"}, registry=registry
+    )
+    assert hits, "expected at least one catalog hit"
+    top = hits[0]
+    assert top.connector == "github"
+    assert top.action == "create_issue"
+    assert top.trust_level == "confirm"  # write action, trust populated
+    assert top.execution_mode == "cloud"
+    assert top.available is True
+    assert top.unavailable_reason is None
+    assert top.senses == ("paw.code.v1",)
+    assert top.cost_estimate is None  # placeholder until pricing ships
+
+
+@pytest.mark.asyncio
+async def test_read_action_trust_is_auto(registry) -> None:
+    """Email search surfaces gmail's read (auto-trust) action with the email
+    sense attached."""
+    hits = await catalog.search_catalog(
+        "search my email inbox", bound_connectors={"gmail"}, registry=registry
+    )
+    gmail_hits = [h for h in hits if h.connector == "gmail"]
+    assert gmail_hits, "expected gmail to match an email query"
+    assert any("paw.email.v1" in h.senses for h in gmail_hits)
+    assert any(h.trust_level == "auto" for h in gmail_hits)
+
+
+# ---------------------------------------------------------------------------
+# Bound vs unbound (pure — overlay from the caller-supplied reachable set)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bound_flag_tracks_reachable_set(registry) -> None:
+    # github NOT in the bound set -> UNBOUND.
+    unbound = await catalog.search_catalog(
+        "create a github issue", bound_connectors={"gmail"}, registry=registry
+    )
+    gh_unbound = next(h for h in unbound if h.connector == "github")
+    assert gh_unbound.bound is False
+
+    # github IN the bound set -> BOUND (same query, different reachable set).
+    bound = await catalog.search_catalog(
+        "create a github issue", bound_connectors={"github"}, registry=registry
+    )
+    gh_bound = next(h for h in bound if h.connector == "github")
+    assert gh_bound.bound is True
+
+
+@pytest.mark.asyncio
+async def test_search_is_catalog_wide_includes_unbound_connectors(registry) -> None:
+    """With NOTHING bound, github still surfaces — proving the search covers
+    connectors not bound to the pocket (the whole point of SR-1)."""
+    hits = await catalog.search_catalog(
+        "create a github issue", bound_connectors=set(), registry=registry
+    )
+    connectors = {h.connector for h in hits}
+    assert "github" in connectors
+    assert all(h.bound is False for h in hits)
+
+
+# ---------------------------------------------------------------------------
+# Availability — local execution mode is UNAVAILABLE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_connector_marked_unavailable(registry) -> None:
+    """Firebase actions are execution_mode=local; the shared cloud has no local
+    runtime listener, so they must be marked UNAVAILABLE (not selectable)."""
+    hits = await catalog.search_catalog(
+        "firebase firestore collections", bound_connectors=set(), registry=registry
+    )
+    fb_hits = [h for h in hits if h.connector == "firebase"]
+    assert fb_hits, "expected firebase to match"
+    fb = fb_hits[0]
+    assert fb.execution_mode == "local"
+    assert fb.available is False
+    assert fb.unavailable_reason == "local_runtime_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_cloud_connector_is_available(registry) -> None:
+    hits = await catalog.search_catalog(
+        "list github repositories", bound_connectors=set(), registry=registry
+    )
+    gh_hits = [h for h in hits if h.connector == "github"]
+    assert gh_hits
+    assert all(h.available is True and h.unavailable_reason is None for h in gh_hits)
+
+
+# ---------------------------------------------------------------------------
+# Edges — empty / no-match / limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_match_returns_empty(registry) -> None:
+    assert (
+        await catalog.search_catalog(
+            "zzzqqx wubbleflonk", bound_connectors=set(), registry=registry
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_blank_query_returns_empty(registry) -> None:
+    assert await catalog.search_catalog("   ", bound_connectors=set(), registry=registry) == []
+
+
+@pytest.mark.asyncio
+async def test_limit_caps_result_count(registry) -> None:
+    hits = await catalog.search_catalog("list", bound_connectors=set(), limit=3, registry=registry)
+    assert len(hits) <= 3
+
+
+# ---------------------------------------------------------------------------
+# Integration — list_bound_connector_names reads the EE store, then overlay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mongo_db")
+async def test_list_bound_connector_names_scope_filtering() -> None:
+    """The tenant read returns the pocket-reachable name set: workspace-scoped
+    rows reach every pocket, a pocket-scoped row reaches only its own pocket."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    ws = "ws-catalog-bound"
+    # workspace-scoped gmail -> reachable from any pocket.
+    await WorkspaceConnector(
+        workspace=ws, name="gmail", enabled=True, scope="workspace", config={}
+    ).insert()
+    # pocket-scoped github -> reachable only from pk1.
+    await WorkspaceConnector(
+        workspace=ws, name="github", enabled=True, scope="pocket", pocket_id="pk1", config={}
+    ).insert()
+    # a DISABLED workspace row must never count.
+    await WorkspaceConnector(
+        workspace=ws, name="stripe", enabled=False, scope="workspace", config={}
+    ).insert()
+    # a foreign tenant's row must never leak.
+    await WorkspaceConnector(
+        workspace="ws-OTHER", name="slack_data", enabled=True, scope="workspace", config={}
+    ).insert()
+
+    pk1 = await connectors_service.list_bound_connector_names(ws, "pk1")
+    assert pk1 == {"gmail", "github"}
+
+    pk2 = await connectors_service.list_bound_connector_names(ws, "pk2")
+    assert pk2 == {"gmail"}  # github is pocket-scoped to pk1 only
+
+    unanchored = await connectors_service.list_bound_connector_names(ws, "")
+    assert unanchored == {"gmail"}  # only workspace-scoped rows
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mongo_db")
+async def test_end_to_end_bound_overlay_from_store() -> None:
+    """A real store read feeds the overlay: with only gmail bound to the pocket,
+    a github search returns github UNBOUND (but still surfaced — catalog-wide)."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    ws = "ws-catalog-e2e"
+    await WorkspaceConnector(
+        workspace=ws, name="gmail", enabled=True, scope="pocket", pocket_id="pkX", config={}
+    ).insert()
+
+    bound = await connectors_service.list_bound_connector_names(ws, "pkX")
+    assert bound == {"gmail"}
+
+    hits = await catalog.search_catalog("create a github issue", bound_connectors=bound)
+    gh = next(h for h in hits if h.connector == "github")
+    assert gh.bound is False  # gmail is bound, github is not — but still found
+    assert gh.available is True

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -19,6 +19,14 @@
 #   trust) actions PROPOSE without ever calling execute inline, connectors not
 #   bound to the pocket are rejected, and a missing pocket / workspace
 #   ContextVar (called off-stream) yields a clear error.
+# Updated: 2026-07-16 (SR-1 catalog-wide discovery) — the server now carries a
+#   FIFTH tool, ``sense_search``. Bumped the tool-count assertion (4 -> 5) and
+#   added ``SENSE_SEARCH_TOOL_ID`` to the registration test. New ``TestSenseSearch``
+#   drives ``_sense_search_handler`` end to end: it mocks ONLY the EE store read
+#   (``list_bound_connector_names``) and runs the REAL catalog over the full
+#   connector set, proving github surfaces catalog-wide + UNBOUND when only gmail
+#   is bound, a local-execution-mode connector (firebase) is marked UNAVAILABLE,
+#   and the no-workspace / missing-query / no-match envelopes.
 """MCP server registration + handler tests for connector execution."""
 
 from __future__ import annotations
@@ -46,6 +54,7 @@ class TestConnectorsMcpServerRegistration:
             CONNECTOR_EXECUTE_TOOL_ID,
             CONNECTOR_TOOL_IDS,
             LIST_CONNECTOR_ACTIONS_TOOL_ID,
+            SENSE_SEARCH_TOOL_ID,
             SERVER_NAME,
         )
 
@@ -53,10 +62,12 @@ class TestConnectorsMcpServerRegistration:
         # Allowlist entries must use the exact ``mcp__<server>__<tool>`` form.
         assert LIST_CONNECTOR_ACTIONS_TOOL_ID == "mcp__pocketpaw_connectors__list_connector_actions"
         assert CONNECTOR_EXECUTE_TOOL_ID == "mcp__pocketpaw_connectors__connector_execute"
+        assert SENSE_SEARCH_TOOL_ID == "mcp__pocketpaw_connectors__sense_search"
         assert LIST_CONNECTOR_ACTIONS_TOOL_ID in CONNECTOR_TOOL_IDS
         assert CONNECTOR_EXECUTE_TOOL_ID in CONNECTOR_TOOL_IDS
-        # The server now also carries the two Sense-tier tools (chunk 4).
-        assert len(CONNECTOR_TOOL_IDS) == 4
+        assert SENSE_SEARCH_TOOL_ID in CONNECTOR_TOOL_IDS
+        # Connector surface + two Sense-tier tools (chunk 4) + sense_search (SR-1).
+        assert len(CONNECTOR_TOOL_IDS) == 5
 
     def test_extension_provider_advertises_tool_ids(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk
@@ -808,3 +819,108 @@ class TestSenseTools:
 
         assert out.get("is_error") is True
         assert "unknown sense" in out["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Handler — sense_search (catalog-wide discovery)
+# ---------------------------------------------------------------------------
+
+
+class TestSenseSearch:
+    @pytest.mark.asyncio
+    async def test_returns_catalog_wide_results_with_bound_overlay(self) -> None:
+        """sense_search runs the REAL catalog over the full connector set with a
+        mocked tenant read: github surfaces even though only gmail is bound, and
+        is marked UNBOUND + available, with trust level populated."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.list_bound_connector_names",
+                new=AsyncMock(return_value={"gmail"}),
+            ) as mock_bound,
+        ):
+            out = await connectors_mcp._sense_search_handler({"query": "create a github issue"})
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["query"] == "create a github issue"
+        assert body["results"], "expected catalog-wide results"
+        gh = next(r for r in body["results"] if r["connector"] == "github")
+        assert gh["action"] == "create_issue"
+        assert gh["bound"] is False  # only gmail is bound — github is catalog-wide
+        assert gh["available"] is True
+        assert gh["trust_level"] == "confirm"
+        assert gh["cost_estimate"] is None
+        # The bound set was read ONCE via the EE store (pocket "" fall-through safe).
+        mock_bound.assert_awaited_once_with("ws_1", "pk_1")
+
+    @pytest.mark.asyncio
+    async def test_marks_local_execution_mode_unavailable(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.list_bound_connector_names",
+                new=AsyncMock(return_value=set()),
+            ),
+        ):
+            out = await connectors_mcp._sense_search_handler(
+                {"query": "firebase firestore collections"}
+            )
+
+        body = _decode_payload(out)
+        fb = next(r for r in body["results"] if r["connector"] == "firebase")
+        assert fb["available"] is False
+        assert fb["unavailable_reason"] == "local_runtime_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity(None, None, None)
+        with ws_patch, user_patch, pocket_patch:
+            out = await connectors_mcp._sense_search_handler({"query": "anything"})
+
+        assert out.get("is_error") is True
+        assert "no active workspace" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_query_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with ws_patch, user_patch, pocket_patch:
+            out = await connectors_mcp._sense_search_handler({})
+
+        assert out.get("is_error") is True
+        assert "query is required" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_clear_message(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.list_bound_connector_names",
+                new=AsyncMock(return_value=set()),
+            ),
+        ):
+            out = await connectors_mcp._sense_search_handler({"query": "zzzqqx wubbleflonk"})
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["results"] == []
+        assert "No catalog actions matched" in body["message"]


### PR DESCRIPTION
The foundation of the Senses Router: let the agent discover connectors it hasn't bound yet.

Until now the agent could only enumerate connectors already wired to a pocket (`list_connector_actions`, `list_senses`). If a user asked "can you create a GitHub issue?" and nobody had bound GitHub, the agent was blind to it. This adds `sense_search(query)` — a fifth tool on the connectors MCP server that searches the full 35-connector catalog and can propose a tool that isn't enabled yet, telling the user which connector an admin needs to turn on.

## How it works
- New `cloud/senses/catalog.py`: a pure BM25 search over the parsed connector defs (stdlib only — `math`, `re`, `Counter`; no ML, no new dependencies). Each connector action is one document; the searchable text is the connector name, action name, description, and the connector's declared senses (enriched with each core sense's display name and description), with field weighting so a name match outranks a description-only match.
- Trust level and execution mode come from the connector's adapter schema — the same authoritative source `get_action_trust` uses — so native local connectors correctly report `execution_mode=local` and are marked unavailable (the shared cloud has no local-runtime listener, so those actions can't fire and the agent shouldn't select them).
- Each hit carries: connector, action, description, senses, trust level, bound-vs-unbound for the current pocket, availability + reason, and a placeholder `cost_estimate` (real pricing is a later task — no metering here).

## Tenant isolation
Bound status is read only through the EE store, via a new `list_bound_connector_names` service helper (one workspace-filtered Beanie read for the pocket's reachable set, instead of N per-connector probes). The Beanie read stays inside `connectors.service` — the catalog and MCP layers never import the document, so the OSS-EE boundary holds. The handler resolves identity per call from the same per-stream context the sibling tools use, fails closed when there's no workspace, and is strictly read-only — it searches and reports, never executes.

## Verification
- `pytest tests/cloud/senses/test_catalog.py tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py` → 40 passed. Coverage: BM25 ranking returns the right connector for a query, catalog-wide search reaches unbound connectors, bound-vs-unbound overlay, local-mode marked unavailable, and store scope-filtering.
- Broader sweep across connectors/senses/agent test dirs: 572 passed, 2 failed — both failures (`test_ui_agent_invariant`) are pre-existing, reproduce on clean `dev`, and are an auth-fixture environment issue unrelated to this change.
- import-linter clean on both configs; ruff clean.

Stacked dependents to come (SR-2 catalog API, SR-4 JIT bind) will branch off this — merge this base with `--rebase`, not squash.

Part of the Senses Router plan (SR-1). Design: docs/design/drafts/2026-07-16-senses-router.md
