### PR TITLE
feat(senses): browsable connector catalog API (GET /cloud/senses/catalog)

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -258,6 +258,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.projects.router import router as projects_router
     from pocketpaw_ee.cloud.request_log.router import router as request_log_router
     from pocketpaw_ee.cloud.rules.router import router as rules_router
+    from pocketpaw_ee.cloud.senses.router import router as senses_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
     from pocketpaw_ee.cloud.skills.router import router as skills_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
@@ -274,6 +275,11 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(chat_router, prefix="/api/v1")
     app.include_router(runs_router, prefix="/api/v1")
     app.include_router(connectors_router, prefix="/api/v1")
+    # Senses — the browsable connector catalog (GET /cloud/senses/catalog).
+    # Mounted beside connectors since it reads the same registry catalog and
+    # overlays this workspace's bound state; the connectors router owns
+    # enable/disable, this one owns the read-only discovery front door.
+    app.include_router(senses_router, prefix="/api/v1")
     # Discovery — zero-setup workspace-discovery TRIGGER
     # (POST /cloud/discovery/run). Workspace-scoped (no path param); fires the
     # orchestrator in the background and stages proposals as pending Instinct

--- a/ee/pocketpaw_ee/cloud/senses/catalog.py
+++ b/ee/pocketpaw_ee/cloud/senses/catalog.py
@@ -1,4 +1,5 @@
-# Catalog search — keyword/BM25 discovery over the FULL connector catalog.
+# Catalog search + listing — keyword/BM25 discovery AND full browse over the
+#   FULL connector catalog.
 # Created: 2026-07-16 (SR-1 catalog-wide discovery) — the search half of the
 #   new ``sense_search`` MCP tool. Where ``list_pocket_connectors`` /
 #   ``list_senses`` only enumerate what a pocket ALREADY bound, this searches
@@ -18,6 +19,19 @@
 #   store by the MCP handler), keeping this module pure + fully unit-testable.
 #   ``cost_estimate`` is a placeholder (None) — real per-action pricing lands in
 #   a later task; this module builds NO metering.
+# Updated: 2026-07-16 (SR-2 catalog listing API) — added ``list_catalog``: the
+#   BROWSE half (no query) behind ``GET /api/v1/cloud/senses/catalog``, the data
+#   behind a tools-style front door. It reuses the SAME ``_build_index`` path
+#   (trust / execution-mode / senses come from the same adapter-schema source as
+#   search — no duplicated index logic), then GROUPS every connector by CATEGORY
+#   (the connector def's ``type`` field, e.g. ``developer`` / ``communication``),
+#   deterministically sorted. Each connector carries its actions (with per-action
+#   trust + execution mode + availability + the ``cost_estimate=None``
+#   placeholder), its declared senses, and a BOUND flag overlaid from the same
+#   caller-supplied reachable set search uses. Availability follows the identical
+#   rule as search: ``local`` / ``sandbox`` actions the shared cloud can't
+#   dispatch are marked UNAVAILABLE. Pure + dependency-free — the tenant-filtered
+#   bound read still happens in the EE connectors service, not here.
 
 from __future__ import annotations
 
@@ -113,6 +127,10 @@ class _ActionDoc:
     trust_level: str
     execution_mode: str
     senses: tuple[str, ...]
+    # The connector's category — its ``type`` field (e.g. "developer",
+    # "communication"). Carried on every action doc so ``list_catalog`` can group
+    # without a second registry pass; search ignores it.
+    category: str = "generic"
     tokens: Counter[str] = field(default_factory=Counter)
 
     @property
@@ -149,6 +167,9 @@ async def _build_index(registry) -> list[_ActionDoc]:
     docs: list[_ActionDoc] = []
     for defn in registry.definitions:
         senses = tuple(getattr(defn, "senses", None) or ())
+        # Category = the connector def's ``type`` (ConnectorDef has no separate
+        # ``category`` field; ``type`` is the deterministic grouping key).
+        category = str(getattr(defn, "type", None) or "generic")
         try:
             adapter = connectors_service._adapter_for_definition(defn, defn.name)  # noqa: SLF001
             schemas = await adapter.actions()
@@ -175,6 +196,7 @@ async def _build_index(registry) -> list[_ActionDoc]:
                     trust_level=str(schema.trust_level),
                     execution_mode=str(schema.execution_mode),
                     senses=senses,
+                    category=category,
                     tokens=tokens,
                 )
             )
@@ -292,4 +314,145 @@ async def search_catalog(
     return hits
 
 
-__all__ = ["CatalogHit", "search_catalog"]
+# ---------------------------------------------------------------------------
+# Listing (browse, no query) — the grouped catalog behind GET /senses/catalog.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CatalogActionEntry:
+    """One action of a connector, as it appears in the browse catalog.
+
+    ``available`` is False for non-cloud execution modes the shared cloud can't
+    dispatch (``local`` / ``sandbox``) — the SAME rule ``search_catalog`` applies
+    — with ``unavailable_reason`` naming why. ``cost_estimate`` is a placeholder
+    (None) until per-action pricing ships.
+    """
+
+    action: str
+    description: str
+    trust_level: str  # "auto" | "confirm" | "restricted"
+    execution_mode: str  # "cloud" | "local" | "sandbox"
+    available: bool
+    unavailable_reason: str | None
+    cost_estimate: float | None
+
+
+@dataclass(frozen=True)
+class CatalogConnectorEntry:
+    """One connector in the browse catalog, with its actions + per-tenant state.
+
+    ``bound`` is True when the connector is enabled + reachable from the current
+    pocket (overlaid from the caller's reachable-set). ``senses`` are the
+    provider-agnostic capabilities the connector declares.
+    """
+
+    connector: str
+    display_name: str
+    category: str
+    senses: tuple[str, ...]
+    bound: bool
+    actions: tuple[CatalogActionEntry, ...]
+
+
+@dataclass(frozen=True)
+class CatalogCategoryGroup:
+    """Every connector sharing one category (the connector def's ``type``)."""
+
+    category: str
+    connectors: tuple[CatalogConnectorEntry, ...]
+
+
+async def list_catalog(
+    *,
+    bound_connectors: set[str] | None = None,
+    registry=None,
+) -> list[CatalogCategoryGroup]:
+    """Browse the WHOLE connector catalog, grouped by category.
+
+    The listing half of the catalog (search's sibling): no query, every connector
+    the registry knows, each with its full action list. Reuses ``_build_index``
+    verbatim so trust level, execution mode, and senses come from the SAME
+    adapter-schema source ``search_catalog`` reads — no duplicated index logic.
+
+    Grouping is deterministic: categories sorted alphabetically, connectors sorted
+    by name within a category, actions kept in the adapter's natural (YAML) order.
+    The category is the connector def's ``type`` field.
+
+    ``bound_connectors`` is the set of connector names reachable from the current
+    pocket (resolved from the EE store by the caller); each connector's ``bound``
+    flag is set from it. Passing ``None`` treats everything as unbound.
+    ``available`` is intrinsic to each action (False for ``local`` / ``sandbox``
+    the shared cloud can't dispatch). ``registry`` defaults to the EE connector-
+    service singleton; tests inject a registry built from a fixed connectors dir.
+    """
+    if registry is None:
+        from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+        registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
+
+    bound = bound_connectors or set()
+    docs = await _build_index(registry)
+
+    # Fold the flat per-action index into per-connector accumulators, preserving
+    # first-seen action order (the adapter's YAML order).
+    by_connector: dict[str, dict] = {}
+    for doc in docs:
+        entry = by_connector.setdefault(
+            doc.connector,
+            {
+                "display_name": doc.display_name,
+                "category": doc.category,
+                "senses": doc.senses,
+                "actions": [],
+            },
+        )
+        reason = _UNAVAILABLE_REASONS.get(doc.execution_mode)
+        entry["actions"].append(
+            CatalogActionEntry(
+                action=doc.action,
+                description=doc.description,
+                trust_level=doc.trust_level,
+                execution_mode=doc.execution_mode,
+                available=reason is None,
+                unavailable_reason=reason,
+                # TODO(SR-pricing): real per-action cost lands in a later task;
+                # placeholder until then. Do NOT build metering here.
+                cost_estimate=None,
+            )
+        )
+
+    connectors = [
+        CatalogConnectorEntry(
+            connector=name,
+            display_name=data["display_name"],
+            category=data["category"],
+            senses=data["senses"],
+            bound=name in bound,
+            actions=tuple(data["actions"]),
+        )
+        for name, data in by_connector.items()
+    ]
+
+    # Group by category, sorting both levels for a stable, deterministic response.
+    by_category: dict[str, list[CatalogConnectorEntry]] = {}
+    for conn in connectors:
+        by_category.setdefault(conn.category, []).append(conn)
+
+    return [
+        CatalogCategoryGroup(
+            category=category,
+            connectors=tuple(sorted(members, key=lambda c: c.connector)),
+        )
+        for category, members in sorted(by_category.items())
+    ]
+
+
+__all__ = [
+    "CatalogActionEntry",
+    "CatalogCategoryGroup",
+    "CatalogConnectorEntry",
+    "CatalogHit",
+    "list_catalog",
+    "search_catalog",
+]

--- a/ee/pocketpaw_ee/cloud/senses/dto.py
+++ b/ee/pocketpaw_ee/cloud/senses/dto.py
@@ -1,0 +1,56 @@
+# Senses — response schemas for the browsable connector catalog.
+# Created: 2026-07-16 (SR-2 catalog listing API) — the wire shape behind
+#   ``GET /api/v1/cloud/senses/catalog``: the whole connector catalog grouped by
+#   category, each connector carrying its actions (trust + execution mode +
+#   availability + a ``cost_estimate`` placeholder), its declared senses, and a
+#   per-tenant ``bound`` flag. Read-only browse surface (the data behind a
+#   tools-style front door), so there is no request schema — the endpoint takes
+#   only an optional ``pocket_id`` query param. These mirror the pure
+#   ``cloud.senses.catalog`` dataclasses (``CatalogCategoryGroup`` /
+#   ``CatalogConnectorEntry`` / ``CatalogActionEntry``); the service maps
+#   domain -> DTO so the catalog module stays Pydantic-free + unit-testable.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CatalogActionResponse(BaseModel):
+    """One connector action in the browse catalog.
+
+    ``available`` is False for ``local`` / ``sandbox`` execution modes the shared
+    cloud cannot dispatch (same rule as ``sense_search``); ``unavailable_reason``
+    names why. ``cost_estimate`` is a placeholder (None) until per-action pricing
+    ships in a later task.
+    """
+
+    action: str
+    description: str
+    trust_level: str  # "auto" | "confirm" | "restricted"
+    execution_mode: str  # "cloud" | "local" | "sandbox"
+    available: bool
+    unavailable_reason: str | None = None
+    cost_estimate: float | None = None
+
+
+class CatalogConnectorResponse(BaseModel):
+    """One connector in the browse catalog, with its actions + per-tenant state.
+
+    ``bound`` is True when the connector is enabled + reachable from the resolved
+    pocket (workspace-scope when no ``pocket_id`` is given). ``senses`` are the
+    provider-agnostic capabilities the connector declares.
+    """
+
+    connector: str
+    display_name: str
+    type: str  # category — the connector def's ``type`` field
+    senses: list[str] = Field(default_factory=list)
+    bound: bool = False
+    actions: list[CatalogActionResponse] = Field(default_factory=list)
+
+
+class CatalogCategoryResponse(BaseModel):
+    """Every connector sharing one category (the connector def's ``type``)."""
+
+    category: str
+    connectors: list[CatalogConnectorResponse] = Field(default_factory=list)

--- a/ee/pocketpaw_ee/cloud/senses/router.py
+++ b/ee/pocketpaw_ee/cloud/senses/router.py
@@ -1,0 +1,52 @@
+# Senses — FastAPI router (cloud 4-file rule).
+# Created: 2026-07-16 (SR-2 catalog listing API) — exposes
+#   ``GET /api/v1/cloud/senses/catalog`` (mounted at /api/v1/cloud/senses via
+#   mount_cloud()). The browsable connector catalog: every connector grouped by
+#   category, each with its actions + trust + senses + availability, and a
+#   per-tenant ``bound`` flag. Models the connectors router's active-workspace dep
+#   chain — NO ``{workspace_id}`` path param (the workspace resolves from
+#   ``current_workspace_id``, which the UI auto-threads via X-Workspace-Id), and
+#   license-gated at the router level. Read-only browse, so no RBAC action guard
+#   beyond the license + workspace tenant gate (mirrors the connectors GET list
+#   route, which carries only ``require_license`` + ``current_workspace_id``).
+#   ``pocket_id`` is an optional query param; absent -> workspace-scope, so the
+#   bound overlay counts only workspace-scoped connectors.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.senses import service as senses_service
+from pocketpaw_ee.cloud.senses.dto import CatalogCategoryResponse
+from pocketpaw_ee.cloud.shared.deps import current_workspace_id
+
+# Mounted under /api/v1/cloud/senses. The catalog is the discovery front door
+# for connectors: the connectors router owns workspace enable/disable state,
+# this router owns the browsable capability catalog (every connector the
+# registry knows) with per-tenant bound state overlaid.
+router = APIRouter(
+    prefix="/cloud/senses",
+    tags=["Senses"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.get("/catalog", response_model=list[CatalogCategoryResponse])
+async def list_catalog(
+    pocket_id: str | None = None,
+    workspace_id: str = Depends(current_workspace_id),
+) -> list[CatalogCategoryResponse]:
+    """Browse the whole connector catalog, grouped by category.
+
+    Returns every connector the registry knows (not just the ones this workspace
+    bound), each with its actions (trust level + execution mode + availability +
+    a ``cost_estimate`` placeholder), its declared senses, and a ``bound`` flag
+    resolved for this workspace / pocket. ``local`` / ``sandbox`` actions the
+    shared cloud can't dispatch are marked unavailable.
+
+    Tenant-filtered on workspace (via the EE connectors store read) — no other
+    workspace's bound state can leak. ``pocket_id`` is optional; absent, the bound
+    overlay counts only workspace-scoped connectors.
+    """
+    return await senses_service.list_catalog(workspace_id, pocket_id=pocket_id)

--- a/ee/pocketpaw_ee/cloud/senses/router.py
+++ b/ee/pocketpaw_ee/cloud/senses/router.py
@@ -11,15 +11,26 @@
 #   route, which carries only ``require_license`` + ``current_workspace_id``).
 #   ``pocket_id`` is an optional query param; absent -> workspace-scope, so the
 #   bound overlay counts only workspace-scoped connectors.
+# Updated: 2026-07-16 (SR-9 security fix) — the optional ``pocket_id`` overlay is
+#   now gated behind a pocket-access check. Without it a workspace member could
+#   pass another member's private pocket ObjectId and read that pocket's
+#   pocket-scoped connector bindings (a within-tenant IDOR-style metadata leak,
+#   caught at the SR-9 security-review gate). The route now resolves the caller
+#   (``current_user_id``) and honors ``pocket_id`` ONLY when the caller has
+#   run-access to that pocket (``pockets.service.has_action_run_access`` — the same
+#   member-level boundary the pocket-scoped connector surfaces enforce); otherwise
+#   it SILENTLY falls back to workspace-scope (``pocket_id=None``). Fallback, not a
+#   403 — a 403-vs-200 difference would be a pocket-existence oracle.
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.pockets import service as pockets_service
 from pocketpaw_ee.cloud.senses import service as senses_service
 from pocketpaw_ee.cloud.senses.dto import CatalogCategoryResponse
-from pocketpaw_ee.cloud.shared.deps import current_workspace_id
+from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
 
 # Mounted under /api/v1/cloud/senses. The catalog is the discovery front door
 # for connectors: the connectors router owns workspace enable/disable state,
@@ -36,6 +47,7 @@ router = APIRouter(
 async def list_catalog(
     pocket_id: str | None = None,
     workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
 ) -> list[CatalogCategoryResponse]:
     """Browse the whole connector catalog, grouped by category.
 
@@ -48,5 +60,18 @@ async def list_catalog(
     Tenant-filtered on workspace (via the EE connectors store read) — no other
     workspace's bound state can leak. ``pocket_id`` is optional; absent, the bound
     overlay counts only workspace-scoped connectors.
+
+    The pocket-scoped overlay is honored ONLY when the caller has run-access to
+    that pocket; otherwise ``pocket_id`` is dropped and the overlay falls back to
+    workspace-scope. This stops a member from reading another member's private
+    pocket bindings by passing that pocket's id (SR-9). The fallback is silent (no
+    403) so the response can't be used as a pocket-existence oracle.
     """
+    if pocket_id:
+        try:
+            has_access = await pockets_service.has_action_run_access(pocket_id, user_id)
+        except Exception:  # noqa: BLE001 — any resolve failure → treat as no access, fall back
+            has_access = False
+        if not has_access:
+            pocket_id = None
     return await senses_service.list_catalog(workspace_id, pocket_id=pocket_id)

--- a/ee/pocketpaw_ee/cloud/senses/service.py
+++ b/ee/pocketpaw_ee/cloud/senses/service.py
@@ -1,0 +1,71 @@
+# Senses — service layer for the browsable connector catalog.
+# Created: 2026-07-16 (SR-2 catalog listing API) — orchestrates the read behind
+#   ``GET /api/v1/cloud/senses/catalog``: resolve the pocket's reachable
+#   connector set from the EE connectors service (the ONLY owner of the
+#   tenant-filtered WorkspaceConnector read — OSS-EE boundary §2 + tenant rule
+#   §7), hand that set to the pure ``catalog.list_catalog`` for the BOUND overlay,
+#   then map the returned domain groups to the wire DTOs. The registry catalog
+#   itself is global/static (no tenant data); only the ``bound`` flag is
+#   per-tenant, and it comes exclusively from the tenant-scoped store read here.
+#
+# Cloud rules followed (per workspace CLAUDE.md):
+# §5  Module-level async functions, not a class.
+# §7  The only per-tenant read (bound state) filters by workspace_id via the
+#     connectors service; the catalog metadata is intentionally global (browse).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.senses import catalog
+from pocketpaw_ee.cloud.senses.dto import (
+    CatalogActionResponse,
+    CatalogCategoryResponse,
+    CatalogConnectorResponse,
+)
+
+
+async def list_catalog(
+    workspace_id: str,
+    *,
+    pocket_id: str | None = None,
+) -> list[CatalogCategoryResponse]:
+    """The whole browsable connector catalog, grouped by category, with per-tenant
+    bound state overlaid for ``workspace_id`` / ``pocket_id``.
+
+    The bound set is read from the EE connectors service (tenant-filtered on
+    ``workspace``); an absent ``pocket_id`` resolves to workspace-scope (only
+    workspace-scoped rows count), matching every other pocket-reach read. The
+    catalog metadata (connectors, actions, trust, availability) is global registry
+    data — no cross-tenant leak is possible because the only tenant-derived field
+    is ``bound``.
+    """
+    bound = await connectors_service.list_bound_connector_names(workspace_id, pocket_id or "")
+    groups = await catalog.list_catalog(bound_connectors=bound)
+    return [
+        CatalogCategoryResponse(
+            category=group.category,
+            connectors=[
+                CatalogConnectorResponse(
+                    connector=conn.connector,
+                    display_name=conn.display_name,
+                    type=conn.category,
+                    senses=list(conn.senses),
+                    bound=conn.bound,
+                    actions=[
+                        CatalogActionResponse(
+                            action=action.action,
+                            description=action.description,
+                            trust_level=action.trust_level,
+                            execution_mode=action.execution_mode,
+                            available=action.available,
+                            unavailable_reason=action.unavailable_reason,
+                            cost_estimate=action.cost_estimate,
+                        )
+                        for action in conn.actions
+                    ],
+                )
+                for conn in group.connectors
+            ],
+        )
+        for group in groups
+    ]

--- a/tests/cloud/senses/test_catalog_listing.py
+++ b/tests/cloud/senses/test_catalog_listing.py
@@ -146,16 +146,17 @@ async def test_cloud_connector_actions_available_with_trust(registry) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _build_app(workspace_id: str) -> FastAPI:
+def _build_app(workspace_id: str, user_id: str = "u-1") -> FastAPI:
     from pocketpaw_ee.cloud._core.http import add_error_handler
     from pocketpaw_ee.cloud.license import require_license
     from pocketpaw_ee.cloud.senses.router import router as senses_router
-    from pocketpaw_ee.cloud.shared.deps import current_workspace_id
+    from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
 
     app = FastAPI()
     add_error_handler(app)
     app.include_router(senses_router, prefix="/api/v1")
     app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    app.dependency_overrides[current_user_id] = lambda: user_id
     app.dependency_overrides[require_license] = lambda: None
     return app
 
@@ -225,10 +226,19 @@ async def test_route_tenant_filter_no_leak(w1_client: AsyncClient, w2_client: As
 
 
 @pytest.mark.asyncio
-async def test_route_pocket_scope_query_param(w1_client: AsyncClient) -> None:
-    """A pocket-scoped connector is bound only when ?pocket_id matches; the
-    default (no pocket_id) is workspace-scope and does not see it."""
+async def test_route_pocket_scope_query_param(
+    w1_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pocket-scoped connector is bound only when ?pocket_id matches AND the
+    caller has run-access to that pocket; the default (no pocket_id) is
+    workspace-scope and does not see it."""
     from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+    from pocketpaw_ee.cloud.senses import router as senses_router
+
+    async def _grant(_pocket_id: str, _user_id: str) -> bool:
+        return True
+
+    monkeypatch.setattr(senses_router.pockets_service, "has_action_run_access", _grant)
 
     await WorkspaceConnector(
         workspace="ws-1",
@@ -243,3 +253,35 @@ async def test_route_pocket_scope_query_param(w1_client: AsyncClient) -> None:
     without_pocket = await w1_client.get("/api/v1/cloud/senses/catalog")
     assert _flatten_route(with_pocket.json())["github"]["bound"] is True
     assert _flatten_route(without_pocket.json())["github"]["bound"] is False
+
+
+@pytest.mark.asyncio
+async def test_route_pocket_scope_denied_falls_back_to_workspace(
+    w1_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SR-9: a caller WITHOUT run-access to the requested pocket must NOT see that
+    pocket's private bindings. The route silently drops pocket_id and falls back to
+    workspace-scope (status 200, no bound leak, no 403 existence oracle)."""
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+    from pocketpaw_ee.cloud.senses import router as senses_router
+
+    async def _deny(_pocket_id: str, _user_id: str) -> bool:
+        return False
+
+    monkeypatch.setattr(senses_router.pockets_service, "has_action_run_access", _deny)
+
+    # A pocket-scoped binding in another member's private pocket.
+    await WorkspaceConnector(
+        workspace="ws-1",
+        name="github",
+        enabled=True,
+        scope="pocket",
+        pocket_id="pk-private",
+        config={},
+    ).insert()
+
+    r = await w1_client.get("/api/v1/cloud/senses/catalog", params={"pocket_id": "pk-private"})
+    assert r.status_code == 200, r.text  # silent fallback, not a 403 oracle
+    # The private pocket's binding must NOT surface — the overlay fell back to
+    # workspace-scope, where github is not bound.
+    assert _flatten_route(r.json())["github"]["bound"] is False

--- a/tests/cloud/senses/test_catalog_listing.py
+++ b/tests/cloud/senses/test_catalog_listing.py
@@ -1,0 +1,245 @@
+# Catalog listing tests — grouping, bound overlay, availability, route + tenant.
+# Created: 2026-07-16 (SR-2 catalog listing API) — coverage for the browse half
+#   of the catalog: ``cloud.senses.catalog.list_catalog`` (pure, injected
+#   registry over the real 35-connector /connectors dir) and the
+#   ``GET /api/v1/cloud/senses/catalog`` route (FastAPI app with the auth deps
+#   overridden + a mongomock store). The PURE tests assert every connector is
+#   listed exactly once, grouped by its ``type`` category (deterministically
+#   sorted), that BOUND tracks the caller-supplied reachable set, and that a
+#   LOCAL-execution connector (firebase) is marked UNAVAILABLE. The ROUTE tests
+#   seed WorkspaceConnector docs and prove the bound overlay comes from the
+#   tenant-filtered EE store — a second workspace never sees the first's bound
+#   state — and that the optional ``pocket_id`` query param narrows the overlay.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+from pocketpaw_ee.cloud.senses import catalog  # noqa: E402
+
+from pocketpaw.connectors.registry import ConnectorRegistry  # noqa: E402
+from pocketpaw.connectors.state_store import FileConnectorStateStore  # noqa: E402
+
+# Repo-root connectors/ dir (tests/cloud/senses/ -> up 3 -> repo root).
+CONNECTORS_DIR = Path(__file__).resolve().parents[3] / "connectors"
+
+
+@pytest.fixture
+def registry(tmp_path):
+    """A real registry over the repo connector catalog, hermetic (no home dir,
+    no DB-backed state store) so the pure listing tests need no Mongo."""
+    return ConnectorRegistry(
+        CONNECTORS_DIR,
+        state_store=FileConnectorStateStore(tmp_path / "state"),
+        home_connectors_dir=tmp_path / "home",
+    )
+
+
+def _all_connectors(groups) -> dict[str, Any]:
+    """Flatten grouped output to {connector_name: connector_entry}."""
+    return {c.connector: c for g in groups for c in g.connectors}
+
+
+# ---------------------------------------------------------------------------
+# Grouping (pure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lists_all_connectors_once(registry) -> None:
+    """Every connector the registry knows (all 35) is listed exactly once."""
+    groups = await catalog.list_catalog(bound_connectors=set(), registry=registry)
+    flat = [c.connector for g in groups for c in g.connectors]
+    assert len(flat) == 35
+    assert len(set(flat)) == 35  # no duplicates across categories
+
+
+@pytest.mark.asyncio
+async def test_grouped_by_connector_type_category(registry) -> None:
+    """Each connector lands under a category equal to its def ``type``, and a
+    connector's category on the entry matches the group it sits in."""
+    groups = await catalog.list_catalog(bound_connectors=set(), registry=registry)
+    by_name = _all_connectors(groups)
+    # github is type=developer, gmail is type=communication (from the YAML defs).
+    assert by_name["github"].category == "developer"
+    assert by_name["gmail"].category == "communication"
+    for g in groups:
+        for c in g.connectors:
+            assert c.category == g.category
+
+
+@pytest.mark.asyncio
+async def test_grouping_is_deterministically_sorted(registry) -> None:
+    """Categories sorted alphabetically; connectors sorted by name within each."""
+    groups = await catalog.list_catalog(bound_connectors=set(), registry=registry)
+    categories = [g.category for g in groups]
+    assert categories == sorted(categories)
+    for g in groups:
+        names = [c.connector for c in g.connectors]
+        assert names == sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# Bound overlay (pure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bound_overlay_tracks_reachable_set(registry) -> None:
+    groups = await catalog.list_catalog(bound_connectors={"github"}, registry=registry)
+    by_name = _all_connectors(groups)
+    assert by_name["github"].bound is True
+    # Everything not in the reachable set is unbound.
+    assert by_name["gmail"].bound is False
+    assert all(c.bound is False for n, c in by_name.items() if n != "github")
+
+
+@pytest.mark.asyncio
+async def test_nothing_bound_when_reachable_set_empty(registry) -> None:
+    groups = await catalog.list_catalog(bound_connectors=set(), registry=registry)
+    assert all(c.bound is False for c in _all_connectors(groups).values())
+
+
+# ---------------------------------------------------------------------------
+# Availability + action metadata (pure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_connector_actions_unavailable(registry) -> None:
+    """Firebase actions are execution_mode=local -> the shared cloud can't
+    dispatch them, so they must be marked UNAVAILABLE (same rule as search)."""
+    groups = await catalog.list_catalog(bound_connectors=set(), registry=registry)
+    fb = _all_connectors(groups)["firebase"]
+    assert fb.actions, "firebase should expose actions"
+    for a in fb.actions:
+        assert a.execution_mode == "local"
+        assert a.available is False
+        assert a.unavailable_reason == "local_runtime_unavailable"
+        assert a.cost_estimate is None  # placeholder until pricing ships
+
+
+@pytest.mark.asyncio
+async def test_cloud_connector_actions_available_with_trust(registry) -> None:
+    """GitHub is cloud-dispatchable: actions available, trust populated, and the
+    write action (create_issue) carries confirm trust."""
+    groups = await catalog.list_catalog(bound_connectors=set(), registry=registry)
+    gh = _all_connectors(groups)["github"]
+    assert gh.senses == ("paw.code.v1",)
+    assert all(a.available is True and a.unavailable_reason is None for a in gh.actions)
+    create = next((a for a in gh.actions if a.action == "create_issue"), None)
+    assert create is not None
+    assert create.trust_level == "confirm"
+    assert create.execution_mode == "cloud"
+
+
+# ---------------------------------------------------------------------------
+# Route — auth + tenant filter (mongomock store)
+# ---------------------------------------------------------------------------
+
+
+def _build_app(workspace_id: str) -> FastAPI:
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.cloud.senses.router import router as senses_router
+    from pocketpaw_ee.cloud.shared.deps import current_workspace_id
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(senses_router, prefix="/api/v1")
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_db) -> AsyncClient:  # noqa: ARG001 — wires Beanie
+    app = _build_app("ws-1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_db) -> AsyncClient:  # noqa: ARG001 — same DB, other tenant
+    app = _build_app("ws-2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _flatten_route(payload: list[dict]) -> dict[str, dict]:
+    return {c["connector"]: c for g in payload for c in g["connectors"]}
+
+
+@pytest.mark.asyncio
+async def test_route_returns_full_catalog_grouped(w1_client: AsyncClient) -> None:
+    r = await w1_client.get("/api/v1/cloud/senses/catalog")
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    # A list of {category, connectors:[...]} groups, sorted by category.
+    assert [g["category"] for g in payload] == sorted(g["category"] for g in payload)
+    flat = _flatten_route(payload)
+    assert len(flat) == 35
+    gh = flat["github"]
+    assert gh["type"] == "developer"
+    assert gh["actions"], "connector actions must be present"
+
+
+@pytest.mark.asyncio
+async def test_route_bound_state_from_store(w1_client: AsyncClient) -> None:
+    """A workspace-scoped enabled connector shows bound=true for its workspace."""
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    await WorkspaceConnector(
+        workspace="ws-1", name="github", enabled=True, scope="workspace", config={}
+    ).insert()
+
+    r = await w1_client.get("/api/v1/cloud/senses/catalog")
+    flat = _flatten_route(r.json())
+    assert flat["github"]["bound"] is True
+    assert flat["gmail"]["bound"] is False  # not enabled
+
+
+@pytest.mark.asyncio
+async def test_route_tenant_filter_no_leak(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    """ws-1's bound state must never appear in ws-2's catalog."""
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    await WorkspaceConnector(
+        workspace="ws-1", name="github", enabled=True, scope="workspace", config={}
+    ).insert()
+
+    r1 = await w1_client.get("/api/v1/cloud/senses/catalog")
+    r2 = await w2_client.get("/api/v1/cloud/senses/catalog")
+    assert _flatten_route(r1.json())["github"]["bound"] is True
+    assert _flatten_route(r2.json())["github"]["bound"] is False  # no cross-tenant leak
+
+
+@pytest.mark.asyncio
+async def test_route_pocket_scope_query_param(w1_client: AsyncClient) -> None:
+    """A pocket-scoped connector is bound only when ?pocket_id matches; the
+    default (no pocket_id) is workspace-scope and does not see it."""
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    await WorkspaceConnector(
+        workspace="ws-1",
+        name="github",
+        enabled=True,
+        scope="pocket",
+        pocket_id="pkX",
+        config={},
+    ).insert()
+
+    with_pocket = await w1_client.get("/api/v1/cloud/senses/catalog", params={"pocket_id": "pkX"})
+    without_pocket = await w1_client.get("/api/v1/cloud/senses/catalog")
+    assert _flatten_route(with_pocket.json())["github"]["bound"] is True
+    assert _flatten_route(without_pocket.json())["github"]["bound"] is False


### PR DESCRIPTION
The browse surface behind the Senses Router: one endpoint that returns the whole connector catalog for a frontend to render.

`GET /api/v1/cloud/senses/catalog` lists every connector the registry knows — all 35, grouped into 16 categories — each with its actions (trust level, execution mode, availability, a `cost_estimate` placeholder), its declared senses, and a per-tenant `bound` flag. This is the data behind a browsable "what can my agent connect to" front door, the counterpart to SR-1's agent-facing `sense_search`.

## Design
- `list_catalog` in `cloud/senses/catalog.py` reuses SR-1's `_build_index` verbatim — same parsed defs, same authoritative adapter-schema source for trust and execution mode, so a local-mode connector (e.g. firebase) is marked `available=false, unavailable_reason=local_runtime_unavailable` here exactly as it is in search. No duplicated index logic.
- Standard cloud 4-file shape: `dto.py` (wire shapes), `service.py` (orchestration), `router.py` (`GET /catalog`), mounted beside the connectors router.

## Tenant isolation
The catalog metadata is global registry data — the list of connectors Paw OS supports isn't tenant-specific. The only per-tenant field is `bound`, and it comes exclusively from `connectors.service.list_bound_connector_names(workspace_id, pocket_id)`, a workspace-filtered store read that stays inside the connectors service (the Beanie read never leaves it, so the OSS-EE boundary holds). Workspace resolves from `current_workspace_id`, the same auth dependency the connectors router uses; a test asserts one workspace can't see another's bound state.

## Verification
- `pytest tests/cloud/senses/` → 42 passed (15 new: category grouping/sorting, bound overlay, availability, plus route auth + cross-workspace tenant filter + pocket-scope query param).
- Broader run also shows the 2 known pre-existing `test_ui_agent_invariant` failures (auth-fixture env, fail on clean `dev`, file untouched here).
- ruff clean; import-linter clean on both configs (core 1/0, ee 29/0).

Stacked on SR-1 (#1734) — this PR targets `feat/senses-catalog-search` for a clean diff; it retargets to `dev` once SR-1 merges (merge SR-1 with `--rebase`).

Part of the Senses Router plan (SR-2). Design: docs/design/drafts/2026-07-16-senses-router.md
