### PR TITLE
feat(senses): just-in-time connector bind via Tray approval (sense_request_bind)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -59,6 +59,28 @@
 #   chokepoint contracts stay 0-broken. (``propose.py`` itself statically imports
 #   no Beanie document class — it lazy-imports ``pocketpaw.stores`` /
 #   ``pocketpaw.instinct.models`` internally.)
+# Updated: 2026-07-16 (SR-4 just-in-time bind) — added a SIXTH tool,
+#   ``sense_request_bind(connector)``: the BIND step after discovery. sense_search
+#   lets the agent find an UNBOUND connector; this proposes enabling it for the
+#   current pocket so the agent can use it — one conversation, no settings-page
+#   trip. Modeled on ``_propose_connector_write``'s propose-and-suspend shape but,
+#   because binding a connector is a workspace-admin CONFIG op (``enable_connector``)
+#   and NOT a connector ACTION (``execute``), it files through the ADMIN-proposal
+#   gate (``admin_proposals.propose.propose_admin_action`` with action key
+#   ``connector.manage``), NOT the external-action gate. THE load-bearing rule is
+#   identical: it NEVER calls ``enable_connector`` inline — the bind fires only when
+#   an admin approves in The Tray, at which point the instinct router runs
+#   ``execute_approved_admin_action`` → whitelist ``connector.manage`` op=enable →
+#   ``enable_connector`` (scope=pocket), RE-CHECKING the PROPOSER's CURRENT
+#   ``connector.manage`` (ADMIN) role. Admin one-click approval only in this slice
+#   (member→admin request-routing is SR-6). OAUTH REALITY (v1): the bind ENABLES the
+#   connector regardless of credentials, but its actions only actually run if stored
+#   config (PAT/token) exists — there is no interactive-OAuth-inline flow in v1, so a
+#   connector needing fresh OAuth binds but stays unusable until an admin adds config
+#   (a documented v1 limitation, not built here). Unknown connector names are rejected
+#   at propose time via the registry-only ``connectors.service.is_known_connector``.
+#   Tool id ``mcp__pocketpaw_connectors__sense_request_bind``. OSS-EE boundary held —
+#   the registry/Beanie reads stay in ``connectors.service``.
 # Updated: 2026-07-16 (SR-1 catalog-wide discovery) — added a FIFTH tool,
 #   ``sense_search(query)``: catalog-WIDE discovery over all 35 connectors, not
 #   just the ones a pocket already bound. The other tools can only enumerate
@@ -119,6 +141,7 @@ CONNECTOR_EXECUTE_TOOL_ID = f"mcp__{SERVER_NAME}__connector_execute"
 LIST_SENSES_TOOL_ID = f"mcp__{SERVER_NAME}__list_senses"
 SENSE_EXECUTE_TOOL_ID = f"mcp__{SERVER_NAME}__sense_execute"
 SENSE_SEARCH_TOOL_ID = f"mcp__{SERVER_NAME}__sense_search"
+SENSE_REQUEST_BIND_TOOL_ID = f"mcp__{SERVER_NAME}__sense_request_bind"
 
 CONNECTOR_TOOL_IDS = (
     LIST_CONNECTOR_ACTIONS_TOOL_ID,
@@ -126,6 +149,7 @@ CONNECTOR_TOOL_IDS = (
     LIST_SENSES_TOOL_ID,
     SENSE_EXECUTE_TOOL_ID,
     SENSE_SEARCH_TOOL_ID,
+    SENSE_REQUEST_BIND_TOOL_ID,
 )
 
 
@@ -814,6 +838,131 @@ async def _sense_search_handler(args: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Tool handler — just-in-time connector bind (propose-and-suspend via Instinct)
+# ---------------------------------------------------------------------------
+
+
+async def _sense_request_bind_handler(args: dict) -> dict:
+    workspace_id, user_id, pocket_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "no active workspace — sense_request_bind can only be called from "
+            "inside a cloud chat stream"
+        )
+    if not user_id:
+        # The bind is an admin action attributed to a proposer; the execute-time
+        # RBAC re-check loads THIS user fresh. No user → nothing to attribute /
+        # re-check, so fail closed rather than propose an unownable action.
+        return _error_response(
+            "no active user — sense_request_bind needs a signed-in user to file "
+            "the bind request under"
+        )
+
+    connector = args.get("connector")
+    if not isinstance(connector, str) or not connector.strip():
+        return _error_response(
+            "connector is required (string — the connector to enable, e.g. 'github')"
+        )
+    connector = connector.strip()
+
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    # Reject an unknown connector NOW (registry-only check, no Beanie) so the
+    # agent gets a clean error instead of a doomed proposal that only fails at
+    # execute time. The Beanie/registry read stays in the service (OSS-EE §2).
+    if not connectors_service.is_known_connector(connector):
+        return _error_response(
+            f"connector '{connector}' is not in the catalog. Call sense_search to "
+            "find a real connector name before requesting a bind."
+        )
+
+    return await _propose_connector_bind(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        connector=connector,
+    )
+
+
+async def _propose_connector_bind(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str | None,
+    connector: str,
+) -> dict[str, Any]:
+    """Propose enabling (binding) ``connector`` and suspend — NEVER bind inline.
+
+    Files a PENDING Instinct ``Action`` via ``propose_admin_action`` (the
+    workspace-admin gate, action key ``connector.manage``) and returns a
+    pending-shaped success envelope so the chat agent relays "I've proposed
+    enabling <connector> — approve it in your Tray" to the user. THE load-bearing
+    security rule: this NEVER calls ``connectors.service.enable_connector``. The
+    bind fires only when an admin approves in The Tray — the instinct router then
+    runs ``execute_approved_admin_action`` → (whitelist ``connector.manage``
+    op=enable) → ``enable_connector`` (re-validated: the executor RE-CHECKS the
+    PROPOSER's CURRENT ``connector.manage`` (ADMIN) role, so a since-demoted or
+    non-admin proposer's bind fails closed). We propose-and-suspend, STOP.
+
+    Binding is a workspace-admin CONFIG op (``enable_connector``), NOT a connector
+    ACTION (``execute``) — so it rides the admin-proposal gate (which enforces
+    ``connector.manage``), not the external-action gate (which the connector-WRITE
+    path uses and which does no RBAC re-check). ``scope`` follows the pocket: a
+    pocket-anchored chat proposes a ``pocket``-scoped bind (so the connector lands
+    for THIS pocket and ``list_connector_actions`` then shows it here); an
+    unanchored chat proposes a ``workspace``-scoped enable.
+    """
+    # Lazy import — keeps the module's import surface identical to today (the
+    # READ path already lazy-imports ``connectors.service`` function-locally).
+    from pocketpaw_ee.cloud.admin_proposals.propose import propose_admin_action
+
+    scope = "pocket" if pocket_id else "workspace"
+    call_args: dict[str, Any] = {"op": "enable", "name": connector, "scope": scope}
+    if pocket_id:
+        call_args["pocket_id"] = pocket_id
+    where = f"pocket {pocket_id}" if pocket_id else "the workspace"
+    try:
+        action_id = await propose_admin_action(
+            workspace_id=workspace_id,
+            action="connector.manage",
+            args=call_args,
+            proposer_user_id=user_id,
+            summary=f"Enable the '{connector}' connector for {where}.",
+            title=f"Enable connector '{connector}'",
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500.
+        logger.warning("sense_request_bind propose failed", exc_info=True)
+        return _error_response(f"could not request enabling {connector!r} for approval: {exc}")
+
+    logger.info(
+        "sense_request_bind proposed: connector=%r scope=%r pocket=%r action_id=%s",
+        connector,
+        scope,
+        pocket_id,
+        action_id,
+    )
+    # Pending-shaped success: an admin gates the bind. ``status`` is the string
+    # ``"pending_approval"`` (not an HTTP code); ``action_id`` lets the user (and
+    # the agent) correlate the proposal with the pending Action in The Tray. The
+    # ``message`` is phrased for the agent to relay verbatim — it must NOT claim
+    # the connector is connected yet.
+    return _success_response(
+        {
+            "executed": False,
+            "status": "pending_approval",
+            "action_id": action_id,
+            "connector": connector,
+            "scope": scope,
+            "message": (
+                f"I've proposed enabling '{connector}' — it's waiting for an admin "
+                "to approve it in the Tray. Once approved, it'll be connected here "
+                "and I can use it. No change has been made yet."
+            ),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # Server factory
 # ---------------------------------------------------------------------------
 
@@ -998,15 +1147,54 @@ def build_connectors_context_server() -> tuple[str, Any] | None:
     async def sense_search(args):  # type: ignore[no-untyped-def]
         return await _sense_search_handler(args)
 
+    @tool(
+        "sense_request_bind",
+        (
+            "Request that a connector be ENABLED (bound) for the current "
+            "pocket/room so you can then use it. Call this AFTER sense_search "
+            "surfaces a connector the user wants that is NOT yet bound here "
+            "(`bound`=false) — instead of telling the user to visit the settings "
+            "page, propose the bind right from the chat. Args: `connector` (the "
+            "registry name from a sense_search result, e.g. 'github' or 'stripe'). "
+            "This does NOT connect the tool inline — binding a connector is an "
+            "admin action, so it is PROPOSED to the user's Tray: the tool returns "
+            "status 'pending_approval' with an action_id, and the connector is "
+            "enabled only once an admin approves it there. When you get a pending "
+            "result, tell the user you've requested it and it needs an admin's "
+            "approval in the Tray — do NOT claim the connector is connected or try "
+            "to use it yet. After approval the connector's actions become "
+            "available automatically on your next turn (call list_connector_actions "
+            "again to confirm). Use this only for a real connector name; if you're "
+            "unsure it exists, sense_search first."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "connector": {
+                    "type": "string",
+                    "description": (
+                        "Registry name of the connector to enable, e.g. 'github', "
+                        "'gmail', 'stripe'. Must be a real connector — take it from "
+                        "a sense_search result's `connector` field."
+                    ),
+                },
+            },
+            "required": ["connector"],
+        },
+    )
+    async def sense_request_bind(args):  # type: ignore[no-untyped-def]
+        return await _sense_request_bind_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
-        version="1.2.0",
+        version="1.3.0",
         tools=[
             list_connector_actions,
             connector_execute,
             list_senses,
             sense_execute,
             sense_search,
+            sense_request_bind,
         ],
     )
     return SERVER_NAME, server
@@ -1018,6 +1206,7 @@ __all__ = [
     "LIST_CONNECTOR_ACTIONS_TOOL_ID",
     "LIST_SENSES_TOOL_ID",
     "SENSE_EXECUTE_TOOL_ID",
+    "SENSE_REQUEST_BIND_TOOL_ID",
     "SENSE_SEARCH_TOOL_ID",
     "SERVER_NAME",
     "build_connectors_context_server",

--- a/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
@@ -61,6 +61,18 @@
 #   ``_adapt_member_role_change``. The execute-time RBAC re-check + args-hash +
 #   idempotency + fail-closed chokepoint are UNCHANGED and already apply to every
 #   whitelist entry (they key off the blob, not the specific action).
+# Updated: 2026-07-16 (SR-4 just-in-time connector bind) — the ``connector.manage``
+#   op=enable dispatch now accepts an OPTIONAL connector SCOPE so the agent's
+#   ``sense_request_bind`` MCP tool can bind a discovered connector to the CURRENT
+#   pocket (scope=pocket + pocket_id), not only workspace-wide. ``_adapt_connector_
+#   manage`` reads ONLY the extra ``scope`` + ``pocket_id`` keys (STRICT — enum-
+#   constrained, pocket_id required for scope=pocket), and ``_call_connector_manage``
+#   folds them into the typed ``EnableConnectorRequest``. Absent scope → the
+#   historical workspace-scope enable, so ``workspace_admin.connector_enable`` is
+#   unchanged. THE security posture is reused wholesale: a bind is still a
+#   ``connector.manage`` (ADMIN) write, RE-CHECKED against the PROPOSER's CURRENT
+#   role at execute time (a member's bind proposal fails closed — member→admin
+#   routing is SR-6, not built here). No new approve→execute path, no new subsystem.
 #
 # What this module does (the apply-on-approve half of the admin-action gate): the
 # propose helper (``admin_proposals.propose.propose_admin_action``) files an
@@ -365,6 +377,28 @@ def _adapt_connector_manage(
         if not isinstance(config, dict):
             raise ValueError("connector.manage op=config requires a config object")
         out["config"] = config  # opaque data — the service validates + merges it
+    if op == "enable":
+        # SR-4 just-in-time bind — op=enable may carry an optional connector
+        # SCOPE so the agent's ``sense_request_bind`` can bind a connector to the
+        # CURRENT pocket (not just workspace-wide). STRICT: read ONLY ``scope`` +
+        # ``pocket_id``, constrain scope to the enum, and require pocket_id for a
+        # pocket-scoped bind. Absent ``scope`` → the historical workspace-scope
+        # enable (backward compatible with workspace_admin.connector_enable). The
+        # values ride into the typed EnableConnectorRequest in the call wrapper —
+        # never splatted as kwargs.
+        scope = args.get("scope")
+        if scope is not None:
+            scope = str(scope)
+            if scope not in ("pocket", "workspace", "user"):
+                raise ValueError(
+                    "connector.manage op=enable scope must be one of pocket|workspace|user"
+                )
+            out["scope"] = scope
+            if scope == "pocket":
+                pocket_id = str(args.get("pocket_id") or "")
+                if not pocket_id:
+                    raise ValueError("connector.manage op=enable scope=pocket requires pocket_id")
+                out["pocket_id"] = pocket_id
     return out
 
 
@@ -381,9 +415,16 @@ async def _call_connector_manage(**kwargs: Any) -> Any:
     if op == "enable":
         from pocketpaw_ee.cloud.connectors.dto import EnableConnectorRequest
 
-        return await connectors_service.enable_connector(
-            workspace_id, name, EnableConnectorRequest()
+        # SR-4 — carry the optional connector scope (pocket-scoped bind) into the
+        # typed request. The adapter already validated scope/pocket_id; absent
+        # scope defaults to workspace (the DTO's own default), so the historical
+        # workspace-wide enable is unchanged. The service re-validates that
+        # scope=pocket has a pocket_id (defense in depth).
+        req = EnableConnectorRequest(
+            scope=kwargs.get("scope") or "workspace",
+            pocket_id=kwargs.get("pocket_id"),
         )
+        return await connectors_service.enable_connector(workspace_id, name, req)
     if op == "disable":
         return await connectors_service.disable_connector(workspace_id, name)
     # op == "config"

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -68,6 +68,13 @@
 #   per-connector ``is_connector_bound_to_pocket`` calls. Keeps the
 #   WorkspaceConnector read in THIS service (OSS-EE boundary §2 + tenant rule
 #   §7) so the catalog / MCP layers never import the Beanie doc.
+# Updated: 2026-07-16 (SR-4 just-in-time bind) — added ``is_known_connector``: a
+#   registry-only (no Beanie) existence check the new ``sense_request_bind`` MCP
+#   tool calls at PROPOSE time so an unknown connector name fails with a clean
+#   error immediately, rather than filing a doomed Instinct bind proposal that
+#   only ``NotFound``s at execute time. The bind itself reuses ``enable_connector``
+#   (scope=pocket) through the existing admin-proposal approve→execute path — no
+#   new enable code here.
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -966,6 +973,20 @@ async def is_connector_enabled_for_workspace(workspace_id: str, name: str) -> bo
     return doc is not None
 
 
+def is_known_connector(name: str) -> bool:
+    """True when ``name`` is a connector the registry knows (no Beanie read).
+
+    Registry-only existence check — the lightweight companion to
+    ``is_connector_enabled_for_workspace`` (which ALSO reads the tenant's
+    WorkspaceConnector row). SR-4's ``sense_request_bind`` MCP tool calls this at
+    PROPOSE time so an unknown connector fails with a clean error immediately,
+    instead of filing a doomed Instinct proposal that only ``NotFound``s at
+    execute time. Keeping the registry read HERE (not in the MCP layer) holds the
+    OSS-EE boundary — the MCP module never touches the registry/Beanie directly.
+    """
+    return name in {a.name for a in _available_from_registry()}
+
+
 def _adapter_for_definition(defn, name: str):
     """Build an adapter without connecting — for static metadata reads.
 
@@ -1138,6 +1159,7 @@ __all__ = [
     "get_connector",
     "is_connector_bound_to_pocket",
     "is_connector_enabled_for_workspace",
+    "is_known_connector",
     "list_bound_connector_names",
     "list_connectors",
     "list_pocket_connectors",

--- a/tests/cloud/test_admin_action_gate.py
+++ b/tests/cloud/test_admin_action_gate.py
@@ -2,6 +2,12 @@
 # type (the 8th gated Instinct kind, WA-2), plus the WA-5 whitelist extensions.
 #
 # Created: 2026-07-03 (feat/workspace-admin-tools, WA-2).
+# Updated: 2026-07-16 (SR-4 just-in-time connector bind) — the ``connector.manage``
+#   op=enable dispatch now accepts an optional connector SCOPE. Two new tests:
+#   scope=pocket + pocket_id → enable_connector is called with an
+#   EnableConnectorRequest carrying scope=pocket + the pocket_id (the JIT bind the
+#   agent's sense_request_bind proposes, landing ONLY on approval); scope=pocket
+#   with NO pocket_id → the strict adapter raises → FAILED, no service call.
 # Updated: 2026-07-03 (WA-6) — coverage for the three OWNER writes
 #   (instinct.activate / workspace.delete / billing.manage). Per action: approve →
 #   the whitelisted service fires EXACTLY ONCE with the adapted args; reject via
@@ -722,6 +728,46 @@ async def test_executor_connector_enable_fires_once(store, monkeypatch):
     workspace_id, name, body = call_args
     assert workspace_id == "w1"
     assert name == "gmail"
+
+
+async def test_executor_connector_enable_pocket_scope_fires_with_scope(store, monkeypatch):
+    """SR-4 — op=enable with scope=pocket + pocket_id binds the connector to THAT
+    pocket: enable_connector is called with an EnableConnectorRequest carrying
+    scope=pocket + the pocket_id (the just-in-time bind the agent's
+    sense_request_bind proposes). This is the ONLY path that reaches
+    enable_connector — proving a bind lands ONLY on approval, never inline."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.enable_connector", spy)
+    await _propose_approve_execute(
+        store,
+        monkeypatch,
+        action="connector.manage",
+        args={"op": "enable", "name": "github", "scope": "pocket", "pocket_id": "pk_9"},
+    )
+    assert len(spy.calls) == 1
+    workspace_id, name, body = spy.calls[0][0]
+    assert workspace_id == "w1"
+    assert name == "github"
+    # The scope + pocket_id ride INSIDE the typed DTO (never as top-level kwargs).
+    assert body.scope == "pocket"
+    assert body.pocket_id == "pk_9"
+    assert spy.calls[0][1] == {}  # nothing smuggled as kwargs
+
+
+async def test_executor_connector_enable_pocket_scope_missing_pocket_id_fails(store, monkeypatch):
+    """SR-4 — scope=pocket with NO pocket_id → the strict adapter raises →
+    MalformedArgs failure, enable_connector is NEVER called."""
+    spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.enable_connector", spy)
+    approved = await _propose_approve_execute(
+        store,
+        monkeypatch,
+        action="connector.manage",
+        args={"op": "enable", "name": "github", "scope": "pocket"},
+    )
+    assert spy.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
 
 
 async def test_executor_connector_disable_fires_once(store, monkeypatch):

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -19,6 +19,16 @@
 #   trust) actions PROPOSE without ever calling execute inline, connectors not
 #   bound to the pocket are rejected, and a missing pocket / workspace
 #   ContextVar (called off-stream) yields a clear error.
+# Updated: 2026-07-16 (SR-4 just-in-time bind) — the server now carries a SIXTH
+#   tool, ``sense_request_bind``. Bumped the tool-count assertion (5 -> 6) and
+#   added ``SENSE_REQUEST_BIND_TOOL_ID`` to the registration test. New
+#   ``TestSenseRequestBind`` proves the SR-4 security contract: the tool PROPOSES
+#   the bind through the ADMIN-proposal gate (``propose_admin_action`` with action
+#   ``connector.manage`` op=enable, scope=pocket for anchored / workspace for
+#   unanchored) and ``connectors.service.enable_connector`` is NEVER awaited inline;
+#   an unknown connector fails at propose time via ``is_known_connector`` (no
+#   proposal filed); a propose failure is a clean error that still never enables
+#   inline; and no-workspace / no-user / missing-connector all fail closed.
 # Updated: 2026-07-16 (SR-1 catalog-wide discovery) — the server now carries a
 #   FIFTH tool, ``sense_search``. Bumped the tool-count assertion (4 -> 5) and
 #   added ``SENSE_SEARCH_TOOL_ID`` to the registration test. New ``TestSenseSearch``
@@ -54,6 +64,7 @@ class TestConnectorsMcpServerRegistration:
             CONNECTOR_EXECUTE_TOOL_ID,
             CONNECTOR_TOOL_IDS,
             LIST_CONNECTOR_ACTIONS_TOOL_ID,
+            SENSE_REQUEST_BIND_TOOL_ID,
             SENSE_SEARCH_TOOL_ID,
             SERVER_NAME,
         )
@@ -63,11 +74,14 @@ class TestConnectorsMcpServerRegistration:
         assert LIST_CONNECTOR_ACTIONS_TOOL_ID == "mcp__pocketpaw_connectors__list_connector_actions"
         assert CONNECTOR_EXECUTE_TOOL_ID == "mcp__pocketpaw_connectors__connector_execute"
         assert SENSE_SEARCH_TOOL_ID == "mcp__pocketpaw_connectors__sense_search"
+        assert SENSE_REQUEST_BIND_TOOL_ID == "mcp__pocketpaw_connectors__sense_request_bind"
         assert LIST_CONNECTOR_ACTIONS_TOOL_ID in CONNECTOR_TOOL_IDS
         assert CONNECTOR_EXECUTE_TOOL_ID in CONNECTOR_TOOL_IDS
         assert SENSE_SEARCH_TOOL_ID in CONNECTOR_TOOL_IDS
-        # Connector surface + two Sense-tier tools (chunk 4) + sense_search (SR-1).
-        assert len(CONNECTOR_TOOL_IDS) == 5
+        assert SENSE_REQUEST_BIND_TOOL_ID in CONNECTOR_TOOL_IDS
+        # Connector surface + two Sense-tier tools (chunk 4) + sense_search (SR-1)
+        # + sense_request_bind (SR-4).
+        assert len(CONNECTOR_TOOL_IDS) == 6
 
     def test_extension_provider_advertises_tool_ids(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk
@@ -924,3 +938,213 @@ class TestSenseSearch:
         body = _decode_payload(out)
         assert body["results"] == []
         assert "No catalog actions matched" in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# Handler — sense_request_bind (just-in-time bind: propose-and-suspend)
+# ---------------------------------------------------------------------------
+
+
+class TestSenseRequestBind:
+    @pytest.mark.asyncio
+    async def test_proposes_pocket_bind_and_never_enables_inline(self) -> None:
+        """THE SR-4 security rule — sense_request_bind PROPOSES the bind through
+        the admin-proposal gate (``connector.manage`` op=enable, scope=pocket) and
+        ``connectors.service.enable_connector`` is NEVER called inline. An admin
+        gates it in The Tray; only their approval (via the instinct router →
+        ``execute_approved_admin_action``) fires the enable."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        proposed_id = "act-bind-555"
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_known_connector",
+                return_value=True,
+            ) as mock_known,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.enable_connector",
+                new=AsyncMock(),
+            ) as mock_enable,
+            patch(
+                "pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action",
+                new=AsyncMock(return_value=proposed_id),
+            ) as mock_propose,
+        ):
+            out = await connectors_mcp._sense_request_bind_handler({"connector": "github"})
+
+        # Assertion #1 — the bind was PROPOSED as a connector.manage op=enable
+        # with the pocket scope resolved from the per-stream ContextVars.
+        mock_propose.assert_awaited_once()
+        kw = mock_propose.await_args.kwargs
+        assert kw["workspace_id"] == "ws_1"
+        assert kw["action"] == "connector.manage"
+        assert kw["args"] == {
+            "op": "enable",
+            "name": "github",
+            "scope": "pocket",
+            "pocket_id": "pk_1",
+        }
+        assert kw["proposer_user_id"] == "u_1"
+        mock_known.assert_called_once_with("github")
+
+        # Assertion #2 — enable_connector was NEVER awaited inline. THE rule.
+        mock_enable.assert_not_awaited()
+
+        # Assertion #3 — pending-shaped success carrying the proposed action_id.
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["executed"] is False
+        assert body["status"] == "pending_approval"
+        assert body["action_id"] == proposed_id
+        assert body["connector"] == "github"
+        assert body["scope"] == "pocket"
+        assert "Tray" in body["message"]
+
+    @pytest.mark.asyncio
+    async def test_unanchored_proposes_workspace_scope(self) -> None:
+        """A bind requested from an UNANCHORED chat (pocket_id=None) proposes a
+        ``workspace``-scoped enable and carries NO pocket_id. Still never enables
+        inline."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", None)
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_known_connector",
+                return_value=True,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.enable_connector",
+                new=AsyncMock(),
+            ) as mock_enable,
+            patch(
+                "pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action",
+                new=AsyncMock(return_value="act-ws-bind"),
+            ) as mock_propose,
+        ):
+            out = await connectors_mcp._sense_request_bind_handler({"connector": "gmail"})
+
+        mock_propose.assert_awaited_once()
+        kw = mock_propose.await_args.kwargs
+        assert kw["args"] == {"op": "enable", "name": "gmail", "scope": "workspace"}
+        assert "pocket_id" not in kw["args"]
+        mock_enable.assert_not_awaited()
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["scope"] == "workspace"
+
+    @pytest.mark.asyncio
+    async def test_unknown_connector_is_clean_error_no_propose_no_enable(self) -> None:
+        """An unknown connector name is rejected at PROPOSE time (registry check)
+        — no admin proposal is filed and enable_connector is never called."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_known_connector",
+                return_value=False,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.enable_connector",
+                new=AsyncMock(),
+            ) as mock_enable,
+            patch(
+                "pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action",
+                new=AsyncMock(),
+            ) as mock_propose,
+        ):
+            out = await connectors_mcp._sense_request_bind_handler(
+                {"connector": "not_a_real_connector"}
+            )
+
+        assert out.get("is_error") is True
+        assert "not in the catalog" in out["content"][0]["text"]
+        mock_propose.assert_not_awaited()
+        mock_enable.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_propose_failure_is_clean_error_not_inline_enable(self) -> None:
+        """If ``propose_admin_action`` raises the handler returns a clean MCP error
+        and STILL never enables inline — a propose failure must not fall through to
+        an inline bind."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_known_connector",
+                return_value=True,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.enable_connector",
+                new=AsyncMock(),
+            ) as mock_enable,
+            patch(
+                "pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action",
+                new=AsyncMock(side_effect=RuntimeError("instinct store unavailable")),
+            ),
+        ):
+            out = await connectors_mcp._sense_request_bind_handler({"connector": "github"})
+
+        assert out.get("is_error") is True
+        assert "for approval" in out["content"][0]["text"]
+        mock_enable.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity(None, None, None)
+        with ws_patch, user_patch, pocket_patch:
+            out = await connectors_mcp._sense_request_bind_handler({"connector": "github"})
+
+        assert out.get("is_error") is True
+        assert "no active workspace" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_no_user_is_error(self) -> None:
+        """No signed-in user → fail closed (the bind is attributed to a proposer
+        the executor re-checks; there is nothing to attribute)."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", None, "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action",
+                new=AsyncMock(),
+            ) as mock_propose,
+        ):
+            out = await connectors_mcp._sense_request_bind_handler({"connector": "github"})
+
+        assert out.get("is_error") is True
+        assert "no active user" in out["content"][0]["text"]
+        mock_propose.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_connector_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with ws_patch, user_patch, pocket_patch:
+            out = await connectors_mcp._sense_request_bind_handler({})
+
+        assert out.get("is_error") is True
+        assert "connector is required" in out["content"][0]["text"]


### PR DESCRIPTION
The bind step of the Senses Router: when the agent finds a connector nobody has enabled, it can propose enabling it right from the chat instead of sending the user to a settings page.

`sense_request_bind(connector)` is a sixth tool on the connectors MCP server. After `sense_search` surfaces an unbound connector, the agent calls this; it files a pending proposal, tells the user to approve it in their Tray, and the connector is enabled only once an admin approves. It never binds inline.

## The design decision worth reviewing
The obvious path was to reuse the connector-write propose gate (`_propose_connector_write` / external-action gate). Investigating it showed that gate is the wrong fit: its executor is hard-wired to `connectors.service.execute` (a connector *action*) and does no RBAC re-check. Binding is not a connector action — it's a workspace-admin config op (`enable_connector`, which is `connector.manage` / ADMIN).

So the bind rides the existing **admin-proposal gate** instead. That gate already dispatches `connector.manage` op=enable → `enable_connector` and, crucially, **re-checks the proposer's current `connector.manage` role at execute time** — a member's proposal, or a since-demoted proposer's, fails closed. That re-check is exactly the security property a bind needs, and reusing the gate means no new approve→execute subsystem. The tool handler still mirrors the propose-and-suspend shape of the write path.

The only code added to the gate is a ~15-line, backward-compatible extension: `connector.manage` op=enable now accepts an optional connector scope so a bind can target the current pocket (scope=pocket + pocket_id), folded into the typed `EnableConnectorRequest`. Absent scope → the historical workspace-wide enable, unchanged.

## Scope and one honest v1 limitation
- Admin one-click approval only. Member→admin request routing is SR-6 (a member's proposal currently fails closed at the re-check; routing it to admins for approval is the next task).
- OAuth: `enable_connector` binds the connector regardless of credentials, but a connector's actions only run if stored config (PAT/token) exists. v1 has no interactive-OAuth-inline flow, so a connector needing fresh OAuth binds but stays unusable until an admin adds config. The happy path targets connectors that bind from already-present config. This is a documented v1 limitation, not force-built around.
- No skill-surfacing changes — connector binds already surface their skill on the next run (that landed earlier on dev; see SR-5's test).

## Verification
- `pytest tests/ee/agent/test_connectors_mcp_server/ tests/cloud/test_admin_action_gate.py` → 79 passed. New coverage (9 tests): proposal filed + never binds inline; unknown connector → clean error; pocket-scope enable fires with scope+pocket_id on approval; missing pocket_id → fails, no call; fail-closed on no workspace/user.
- The 2 known pre-existing `test_ui_agent_invariant` failures (auth-fixture env) are unrelated and reproduce on clean `dev`.
- ruff clean; import-linter clean on both configs (OSS-EE boundary held — registry/Beanie reads stay in `connectors.service`, incl. a new registry-only `is_known_connector`).

Stacked on SR-1 (#1734) — targets `feat/senses-catalog-search` for a clean diff; retargets to `dev` when SR-1 merges.

Part of the Senses Router plan (SR-4). Design: docs/design/drafts/2026-07-16-senses-router.md
