### PR TITLE
feat(senses): route member connector-bind requests to admin approval

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -59,6 +59,16 @@
 #   chokepoint contracts stay 0-broken. (``propose.py`` itself statically imports
 #   no Beanie document class — it lazy-imports ``pocketpaw.stores`` /
 #   ``pocketpaw.instinct.models`` internally.)
+# Updated: 2026-07-16 (SR-6 member→admin bind requests) — ``sense_request_bind``
+#   now files its bind proposal with ``authorize="approver"`` so the executor
+#   re-checks the APPROVING admin's ``connector.manage`` (not the proposer's). A
+#   non-admin MEMBER who hits an unbound connector can now REQUEST the bind; it
+#   routes to the admins' Tray (workspace-wide pending feed) and lands ONLY when an
+#   admin approves. A member's self-approve fails closed twice over: the approve
+#   endpoint requires ``instinct.approve`` (ADMIN), and the execute-time re-check
+#   would deny a member approver. SR-4's proposer-keyed re-check (which failed a
+#   member's request even on admin approval) is replaced for THIS tool only; the
+#   admin ``workspace_admin.connector_enable`` path keeps proposer authority.
 # Updated: 2026-07-16 (SR-4 just-in-time bind) — added a SIXTH tool,
 #   ``sense_request_bind(connector)``: the BIND step after discovery. sense_search
 #   lets the agent find an UNBOUND connector; this proposes enabling it for the
@@ -900,9 +910,14 @@ async def _propose_connector_bind(
     security rule: this NEVER calls ``connectors.service.enable_connector``. The
     bind fires only when an admin approves in The Tray — the instinct router then
     runs ``execute_approved_admin_action`` → (whitelist ``connector.manage``
-    op=enable) → ``enable_connector`` (re-validated: the executor RE-CHECKS the
-    PROPOSER's CURRENT ``connector.manage`` (ADMIN) role, so a since-demoted or
-    non-admin proposer's bind fails closed). We propose-and-suspend, STOP.
+    op=enable) → ``enable_connector``. SR-6: this is a member→admin REQUEST, filed
+    with ``authorize="approver"``, so the executor RE-CHECKS the APPROVER's CURRENT
+    ``connector.manage`` (ADMIN) role — NOT the proposer's. A MEMBER can therefore
+    REQUEST a bind that only an admin's approval lands; a member's (self-)approval
+    fails closed at that re-check (a member approver lacks the role), on top of the
+    approve endpoint already requiring ``instinct.approve`` (ADMIN). An admin who
+    requests a bind still approves their own (they hold the role). We
+    propose-and-suspend, STOP.
 
     Binding is a workspace-admin CONFIG op (``enable_connector``), NOT a connector
     ACTION (``execute``) — so it rides the admin-proposal gate (which enforces
@@ -929,6 +944,14 @@ async def _propose_connector_bind(
             proposer_user_id=user_id,
             summary=f"Enable the '{connector}' connector for {where}.",
             title=f"Enable connector '{connector}'",
+            # SR-6 — a bind requested from chat is a member→admin REQUEST: the
+            # requester may be a MEMBER (no ``connector.manage``), so the AUTHORITY
+            # is the admin who approves in the Tray, not the proposer. The executor
+            # re-checks the APPROVER's ``connector.manage`` at execute time, so an
+            # admin's approval lands the bind and a member's (self-)approval fails
+            # closed. (Admins who request a bind still approve their own — they hold
+            # the role, so the approver re-check passes.)
+            authorize="approver",
         )
     except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500.
         logger.warning("sense_request_bind propose failed", exc_info=True)

--- a/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
@@ -70,9 +70,22 @@
 #   folds them into the typed ``EnableConnectorRequest``. Absent scope → the
 #   historical workspace-scope enable, so ``workspace_admin.connector_enable`` is
 #   unchanged. THE security posture is reused wholesale: a bind is still a
-#   ``connector.manage`` (ADMIN) write, RE-CHECKED against the PROPOSER's CURRENT
-#   role at execute time (a member's bind proposal fails closed — member→admin
-#   routing is SR-6, not built here). No new approve→execute path, no new subsystem.
+#   ``connector.manage`` (ADMIN) write, RE-CHECKED at execute time. SR-4 keyed that
+#   re-check on the PROPOSER, so a member's bind proposal failed closed even when an
+#   admin approved it — member→admin routing was deferred to SR-6.
+# Updated: 2026-07-16 (SR-6 member→admin connector binds) — the execute-time RBAC
+#   re-check now honors the blob's ``authorize`` field (added in
+#   ``admin_proposals.propose``): ``"proposer"`` (default) keeps the WA-2 behavior
+#   verbatim (re-check the proposer); ``"approver"`` re-checks the human who APPROVED
+#   the Action (``action.approved_by``) instead — the authority for a member→admin
+#   REQUEST, where the requester (a MEMBER) never holds ``connector.manage``. The
+#   ``sense_request_bind`` connector bind is filed with ``authorize="approver"``, so
+#   an admin's approval lands the bind while a member's (self-)approval fails closed
+#   at this re-check (a member approver lacks the role). No new approve→execute path
+#   and no threading through the router: the approver is READ from the Action, which
+#   every approve path stamps (``store.approve`` / ``store.bulk_approve``) before
+#   dispatching this executor. The proposer re-check for all other admin actions is
+#   UNCHANGED — not weakened.
 #
 # What this module does (the apply-on-approve half of the admin-action gate): the
 # propose helper (``admin_proposals.propose.propose_admin_action``) files an
@@ -1003,15 +1016,45 @@ async def _execute_approved_admin_action_locked(
         )
         return
 
-    # EXECUTE-TIME RBAC RE-CHECK (the load-bearing security rule). The proposer's
-    # CURRENT role is resolved fresh; a demoted / removed proposer fails closed
-    # here BEFORE any service call. A Forbidden → failed outcome, NOT an exception.
+    # EXECUTE-TIME RBAC RE-CHECK (the load-bearing security rule). WHOSE current
+    # role is resolved fresh depends on the blob's ``authorize`` field (SR-6):
+    #   * ``"proposer"`` (default, WA-2..WA-6, UNCHANGED) — the proposer authored
+    #     AND is the authority (only an admin can call those tools), so re-check the
+    #     PROPOSER; a demoted / removed proposer fails closed.
+    #   * ``"approver"`` (a member→admin REQUEST, e.g. the ``sense_request_bind``
+    #     connector bind) — the requester may be a MEMBER who never holds the
+    #     action's role, so the AUTHORITY is the human who APPROVED in the Tray.
+    #     Re-check the APPROVER (``action.approved_by``, stamped by every approve
+    #     path: the instinct router single/bulk approve AND mission_control
+    #     bulk-approve, BEFORE this executor runs). A member who reaches an approve
+    #     surface still fails closed here — a member approver lacks the required
+    #     role. This is NOT a weakening: it is the SAME real re-check against a fresh
+    #     User doc, just keyed to the correct subject for a request→approve flow.
+    # Either way a Forbidden → failed outcome, NOT an exception.
+    authorize = str(blob.get("authorize") or "proposer")
+    if authorize == "approver":
+        # Prefer the freshly-read guard copy (its ``approved_by`` is the persisted
+        # truth); fall back to the passed-in Action. Both carry it post-approval.
+        recheck_subject = str(
+            getattr(guard_action, "approved_by", None) or getattr(action, "approved_by", None) or ""
+        )
+        subject_label = "approver"
+        if not recheck_subject:
+            await _fail(
+                "member-request admin action carries no approver — cannot re-check "
+                "RBAC against the approving admin; refusing the write",
+                error_class="MissingApprover",
+            )
+            return
+    else:
+        recheck_subject = proposer_user_id
+        subject_label = "proposer"
     try:
-        await _recheck_rbac(workspace_id, proposer_user_id, rbac_action)
+        await _recheck_rbac(workspace_id, recheck_subject, rbac_action)
     except Exception as exc:  # noqa: BLE001 — Forbidden (deny) or a resolve error → fail closed
         await _fail(
-            f"execute-time RBAC re-check failed for proposer {proposer_user_id} on "
-            f"'{rbac_action}' — the proposer no longer holds the required role; "
+            f"execute-time RBAC re-check failed for {subject_label} {recheck_subject} on "
+            f"'{rbac_action}' — they do not hold the required role; "
             f"refusing the approved admin write: {exc}",
             error_class=type(exc).__name__,
             response_summary=str(exc),

--- a/ee/pocketpaw_ee/cloud/admin_proposals/propose.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/propose.py
@@ -1,5 +1,18 @@
 # ee/cloud/admin_proposals/propose.py — propose a gated workspace-admin action.
 # Created: 2026-07-03 (feat/workspace-admin-tools, WA-2).
+# Updated: 2026-07-16 (SR-6 member→admin connector binds) — the blob now carries an
+#   optional ``authorize`` field selecting WHOSE current role the executor re-checks
+#   at approve time: ``"proposer"`` (default — WA-2..WA-6, UNCHANGED: the proposer is
+#   the author AND the authority, since only an admin can call those tools) or
+#   ``"approver"`` (a member→admin REQUEST — e.g. the ``sense_request_bind`` connector
+#   bind — where the requester may be a MEMBER who never holds ``connector.manage``,
+#   so the AUTHORITY is the human who APPROVES in the Tray). ``propose_admin_action``
+#   accepts ``authorize`` (validated to that pair) and stamps it on the blob; the
+#   executor reads it to pick the re-check subject. The field is additive + optional
+#   (absent → ``"proposer"``), so schema stays 1 and old pending Actions are
+#   unaffected. It rides OUTSIDE ``params_hash`` (which covers only action + args),
+#   and flipping it can never ESCALATE: ``"proposer"`` is the more-restrictive
+#   default, and ``"approver"`` still requires a current admin to have approved.
 #
 # What this module does (the propose half of the admin-action gate): a
 # workspace-admin tool (e.g. ``member_update_role`` in the workspace_admin MCP
@@ -202,6 +215,7 @@ async def propose_admin_action(
     title: str | None = None,
     correlation_id: str | None = None,
     assignee: str | None = None,
+    authorize: str = "proposer",
 ) -> str:
     """Build + store an Instinct ``Action`` for a gated workspace-admin write.
 
@@ -228,6 +242,11 @@ async def propose_admin_action(
             when omitted — the common case).
         assignee: the workspace member who should approve. Defaults to
             ``proposer_user_id``.
+        authorize: whose CURRENT role the executor re-checks at approve time —
+            ``"proposer"`` (default, WA-2 behavior) or ``"approver"`` (a
+            member→admin request, where the approving admin is the authority).
+            SR-6: the ``sense_request_bind`` connector bind passes ``"approver"``
+            so a member can REQUEST a bind that only an admin's approval lands.
     """
     from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
     from pocketpaw.stores import get_instinct_store
@@ -241,6 +260,11 @@ async def propose_admin_action(
     proposer_user_id = str(proposer_user_id or "")
     if not proposer_user_id:
         raise ValueError("propose_admin_action requires a non-empty proposer_user_id")
+    authorize = str(authorize or "proposer")
+    if authorize not in ("proposer", "approver"):
+        # Fail loud on a typo — a silently-defaulted authorize could re-check the
+        # wrong subject and either strand a member request or (never) over-grant.
+        raise ValueError("propose_admin_action authorize must be 'proposer' or 'approver'")
 
     call_args = dict(args or {})
     args_hash = compute_args_hash(action, call_args)
@@ -265,6 +289,9 @@ async def propose_admin_action(
         "proposer_user_id": proposer_user_id,
         "params_hash": args_hash,
         "idempotency_key": idem,
+        # SR-6 — whose CURRENT role the executor re-checks at approve time. Absent
+        # on pre-SR-6 blobs → the executor defaults to "proposer" (WA-2 behavior).
+        "authorize": authorize,
         "summary": human_summary,
         # Decision-Graph chain-correlation fields (schema 1 carries them).
         "correlation_id": corr,

--- a/tests/cloud/test_admin_action_gate.py
+++ b/tests/cloud/test_admin_action_gate.py
@@ -2,6 +2,16 @@
 # type (the 8th gated Instinct kind, WA-2), plus the WA-5 whitelist extensions.
 #
 # Created: 2026-07-03 (feat/workspace-admin-tools, WA-2).
+# Updated: 2026-07-16 (SR-6 member→admin connector binds) — the blob's new
+#   ``authorize`` field selects whose CURRENT role the executor re-checks:
+#   ``"proposer"`` (default, WA-2 — UNCHANGED) or ``"approver"`` (a member→admin
+#   request). New tests: propose stamps ``authorize`` (default proposer) and rejects
+#   a typo; a member's bind request is visible in the workspace-wide admin queue
+#   (ACCEPTANCE #1); the executor re-checks the APPROVER not the member proposer for
+#   ``authorize="approver"`` (and still the proposer for the default — control); a
+#   member self-approve FAILS CLOSED via the REAL re-check (ACCEPTANCE #2); an admin
+#   approve LANDS the bind via the REAL re-check (ACCEPTANCE #3); a missing approver
+#   fails closed (MissingApprover defense).
 # Updated: 2026-07-16 (SR-4 just-in-time connector bind) — the ``connector.manage``
 #   op=enable dispatch now accepts an optional connector SCOPE. Two new tests:
 #   scope=pocket + pocket_id → enable_connector is called with an
@@ -809,6 +819,221 @@ async def test_executor_connector_manage_bad_op_fails(store, monkeypatch):
     )
     assert spy.calls == []
     final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+
+
+# ---- SR-6 — member→admin connector bind requests --------------------------
+# A non-admin MEMBER who hits an unbound connector can REQUEST a bind: the agent's
+# ``sense_request_bind`` files it with ``authorize="approver"``. The request routes
+# to the admins' Tray (the workspace-wide pending feed) and lands ONLY when an admin
+# approves — the executor re-checks the APPROVER's ``connector.manage``
+# (``action.approved_by``), NOT the member requester's. A member's self-approve fails
+# closed at that re-check (on top of the approve endpoint's ADMIN gate). The proposer
+# re-check for every OTHER admin action is unchanged (``authorize`` defaults to
+# ``"proposer"``).
+
+
+def _patch_approver_role(monkeypatch, *, role: str) -> None:
+    """Patch the executor's fresh User-doc load so the REAL ``_recheck_rbac``
+    resolves the given workspace role for whatever user id it's handed. No DB
+    touched — mirrors ``test_recheck_rbac_denies_demoted_proposer``."""
+
+    class _M:
+        def __init__(self, ws, r):
+            self.workspace = ws
+            self.role = r
+
+    class _User:
+        def __init__(self, uid):
+            self.id = uid
+            self.workspaces = [_M("w1", role)]
+
+    async def _get(uid):  # noqa: ANN001
+        return _User(uid)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.models.user.User.get", staticmethod(_get))
+    # PydanticObjectId(subject) must not choke on a non-ObjectId test id.
+    monkeypatch.setattr("beanie.PydanticObjectId", lambda x: x)
+
+
+def _recheck_subject_spy(monkeypatch) -> list[str]:
+    """Spy on ``_recheck_rbac`` — records the SUBJECT user id it was handed
+    (proposer vs approver) and PASSES. Returns the recording list."""
+    seen: list[str] = []
+
+    async def _spy(workspace_id, subject_user_id, rbac_action):  # noqa: ANN001
+        seen.append(subject_user_id)
+        return None
+
+    monkeypatch.setattr(aa_executor, "_recheck_rbac", _spy)
+    return seen
+
+
+async def test_propose_authorize_approver_stamps_blob(store):
+    """propose_admin_action stamps ``authorize`` on the blob: default ``"proposer"``
+    (WA-2), ``"approver"`` carried through for a member→admin request. The field
+    rides OUTSIDE ``params_hash`` (which covers action + args only)."""
+    default_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="connector.manage",
+        args={"op": "enable", "name": "github"},
+        proposer_user_id="member1",
+    )
+    default_blob = (await store.get_action(default_id)).parameters["_admin_action"]
+    assert default_blob["authorize"] == "proposer"
+
+    approver_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="connector.manage",
+        args={"op": "enable", "name": "github", "scope": "pocket", "pocket_id": "pk_1"},
+        proposer_user_id="member1",
+        authorize="approver",
+    )
+    approver_blob = (await store.get_action(approver_id)).parameters["_admin_action"]
+    assert approver_blob["authorize"] == "approver"
+    assert approver_blob["params_hash"] == aa_propose.compute_args_hash(
+        "connector.manage",
+        {"op": "enable", "name": "github", "scope": "pocket", "pocket_id": "pk_1"},
+    )
+
+
+async def test_propose_rejects_unknown_authorize(store):
+    """A typo in ``authorize`` fails loud rather than silently defaulting to a
+    subject the caller did not intend."""
+    with pytest.raises(ValueError, match="authorize"):
+        await aa_propose.propose_admin_action(
+            workspace_id="w1",
+            action="connector.manage",
+            args={"op": "enable", "name": "github"},
+            proposer_user_id="member1",
+            authorize="whoever",
+        )
+
+
+async def test_member_bind_request_visible_in_workspace_admin_queue(store):
+    """ACCEPTANCE #1 — a member's bind request is a workspace-scoped PENDING Action,
+    so it surfaces in the admins' Tray (the workspace-wide pending feed queried
+    WITHOUT an assignee filter — the authoritative admin approval queue that
+    ``mission_control.agent_list_work_items`` reads)."""
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="connector.manage",
+        args={"op": "enable", "name": "github", "scope": "pocket", "pocket_id": "pk_1"},
+        proposer_user_id="member1",
+        authorize="approver",
+    )
+    pending = await store.pending(workspace_id="w1")
+    assert action_id in {a.id for a in pending}
+
+
+async def test_executor_authorize_approver_rechecks_approver_not_proposer(store, monkeypatch):
+    """SR-6 — an ``authorize="approver"`` bind re-checks the APPROVER
+    (``approved_by``), NOT the member proposer. A default (proposer-authorized)
+    admin action still re-checks the proposer (control)."""
+    enable_spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.enable_connector", enable_spy)
+    seen = _recheck_subject_spy(monkeypatch)
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="connector.manage",
+        args={"op": "enable", "name": "github", "scope": "pocket", "pocket_id": "pk_1"},
+        proposer_user_id="member1",
+        authorize="approver",
+    )
+    approved = await store.approve(action_id, approver="admin_boss")
+    await aa_executor.execute_approved_admin_action(approved)
+
+    # The re-check subject was the APPROVER, not the member proposer.
+    assert seen == ["admin_boss"]
+    # The bind landed (re-check stubbed pass): enable_connector fired once.
+    assert len(enable_spy.calls) == 1
+
+    # Control — a default (proposer-authorized) admin action re-checks the PROPOSER.
+    seen.clear()
+    default_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="connector.manage",
+        args={"op": "enable", "name": "gmail"},
+        proposer_user_id="admin1",
+    )
+    default_approved = await store.approve(default_id, approver="admin_boss")
+    await aa_executor.execute_approved_admin_action(default_approved)
+    assert seen == ["admin1"]  # proposer, not approver — WA-2 behavior preserved
+
+
+async def test_member_self_approve_bind_fails_closed_real_recheck(store, monkeypatch):
+    """ACCEPTANCE #2 — a MEMBER cannot make their own bind execute. Even reaching an
+    approve surface, the REAL execute-time re-check of the APPROVER's (member's)
+    ``connector.manage`` DENIES → enable_connector is NEVER called, the action FAILS.
+    (The instinct approve endpoint separately 403s a member; this is the executor
+    backstop that also covers the un-gated mission_control bulk-approve path.)"""
+    enable_spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.enable_connector", enable_spy)
+    _patch_approver_role(monkeypatch, role="member")  # the approver is a MEMBER
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="connector.manage",
+        args={"op": "enable", "name": "github", "scope": "pocket", "pocket_id": "pk_1"},
+        proposer_user_id="member1",
+        authorize="approver",
+    )
+    approved = await store.approve(action_id, approver="member1")  # member self-approve
+    await aa_executor.execute_approved_admin_action(approved)
+
+    assert enable_spy.calls == []  # FAILS CLOSED — no bind
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.FAILED
+
+
+async def test_admin_approve_lands_member_bind_real_recheck(store, monkeypatch):
+    """ACCEPTANCE #3 — an ADMIN approving the member's request lands the bind. The
+    REAL re-check of the APPROVER's ``connector.manage`` (ADMIN) passes →
+    enable_connector fires ONCE with the pocket-scoped DTO, the action is EXECUTED."""
+    enable_spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.enable_connector", enable_spy)
+    _patch_approver_role(monkeypatch, role="admin")  # the approver is an ADMIN
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="connector.manage",
+        args={"op": "enable", "name": "github", "scope": "pocket", "pocket_id": "pk_1"},
+        proposer_user_id="member1",
+        authorize="approver",
+    )
+    approved = await store.approve(action_id, approver="admin_boss")
+    await aa_executor.execute_approved_admin_action(approved)
+
+    assert len(enable_spy.calls) == 1  # the bind landed
+    workspace_id, name, body = enable_spy.calls[0][0]
+    assert workspace_id == "w1"
+    assert name == "github"
+    assert body.scope == "pocket"
+    assert body.pocket_id == "pk_1"
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED
+
+
+async def test_authorize_approver_missing_approver_fails_closed(store, monkeypatch):
+    """Defense — an ``authorize="approver"`` action with NO recorded approver cannot
+    re-check the authority, so it fails closed (never binds). Exercises the
+    MissingApprover guard by running the executor on the un-approved Action."""
+    enable_spy = _CallSpy()
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.enable_connector", enable_spy)
+
+    action_id = await aa_propose.propose_admin_action(
+        workspace_id="w1",
+        action="connector.manage",
+        args={"op": "enable", "name": "github"},
+        proposer_user_id="member1",
+        authorize="approver",
+    )
+    pending = await store.get_action(action_id)  # approved_by is unset
+    await aa_executor.execute_approved_admin_action(pending)
+
+    assert enable_spy.calls == []
+    final = await store.get_action(action_id)
     assert final.status == ActionStatus.FAILED
 
 

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -19,6 +19,12 @@
 #   trust) actions PROPOSE without ever calling execute inline, connectors not
 #   bound to the pocket are rejected, and a missing pocket / workspace
 #   ContextVar (called off-stream) yields a clear error.
+# Updated: 2026-07-16 (SR-6 member→admin bind requests) — new
+#   ``TestSenseRequestBind.test_bind_request_files_with_authorize_approver`` proves
+#   the tool files its bind proposal with ``authorize="approver"`` so the executor
+#   re-checks the APPROVING admin's ``connector.manage`` (not the member
+#   requester's) — the change that lets a non-admin REQUEST a bind that only an
+#   admin's approval lands.
 # Updated: 2026-07-16 (SR-4 just-in-time bind) — the server now carries a SIXTH
 #   tool, ``sense_request_bind``. Bumped the tool-count assertion (5 -> 6) and
 #   added ``SENSE_REQUEST_BIND_TOOL_ID`` to the registration test. New
@@ -1004,6 +1010,35 @@ class TestSenseRequestBind:
         assert body["connector"] == "github"
         assert body["scope"] == "pocket"
         assert "Tray" in body["message"]
+
+    @pytest.mark.asyncio
+    async def test_bind_request_files_with_authorize_approver(self) -> None:
+        """SR-6 — a bind requested from chat is a member→admin REQUEST, filed with
+        ``authorize="approver"`` so the executor re-checks the APPROVING admin's
+        ``connector.manage``, not the (possibly member) requester's. This is what
+        lets a non-admin REQUEST a bind that only an admin's approval lands, while a
+        member's self-approve fails closed."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_known_connector",
+                return_value=True,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.admin_proposals.propose.propose_admin_action",
+                new=AsyncMock(return_value="act-bind-sr6"),
+            ) as mock_propose,
+        ):
+            out = await connectors_mcp._sense_request_bind_handler({"connector": "github"})
+
+        mock_propose.assert_awaited_once()
+        assert mock_propose.await_args.kwargs["authorize"] == "approver"
+        assert not out.get("is_error")
 
     @pytest.mark.asyncio
     async def test_unanchored_proposes_workspace_scope(self) -> None:


### PR DESCRIPTION
Lets a non-admin member request a connector bind that an admin approves — the last piece of the just-in-time bind flow.

## The finding
The task assumed the gap was visibility (a member's request never reaching admins). Investigation showed that's false: the admin Tray's pending feed (`store.pending(workspace_id)`) already returns every workspace pending item regardless of assignee, so admins already see a member's request. The real gap was execution.

SR-4 keyed the execute-time RBAC re-check on the proposer. A member never holds `connector.manage`, so a member's bind request failed closed even when an admin approved it. SR-4's own comment flagged this for SR-6.

## The fix
Admin-action proposals now carry an optional `authorize` field:
- `"proposer"` (default) — re-check the proposer's current role. Every existing admin action keeps this; behavior is byte-for-byte unchanged.
- `"approver"` — re-check the human who approved in the Tray (`action.approved_by`), with a fail-closed guard if somehow no approver is recorded.

`sense_request_bind` files binds with `authorize="approver"`. So a member can request a bind; only an admin's approval lands it (a member reaching an approve surface still fails closed — a member approver lacks `connector.manage`, and the approve endpoint already requires `instinct.approve`). The field rides outside `params_hash` and can't escalate: `proposer` is the stricter default and `approver` still requires a current admin to approve.

No assignee change (there's no "assign to all admins" primitive, and the feed doesn't filter by assignee anyway); the member stays the accurate requester. No new approve→execute path — the approver is read from the Action, which every approve path stamps before dispatch.

## Verification
- `pytest tests/cloud/test_admin_action_gate.py tests/ee/agent/test_connectors_mcp_server/` → 87 passed (79 pre-existing + 8 new). New cases: member request + admin approve → bind lands; member self-approve → fails closed; `authorize` defaults to proposer for every other action; missing-approver → fail closed.
- Also ran mission_control + instinct + bulk-approve + approval-security suites (95 more passed) since those dispatch the same executor. ruff clean.

## Security note for review (pre-existing, out of scope, flagged for a follow-up)
`/mission-control/items/bulk-approve` is gated only by license + workspace membership, not `instinct.approve` (ADMIN). For connector binds our approver re-check backstops it (a member self-approving still lacks the role). But proposer-authorized admin actions could execute if a member reached that endpoint. Not introduced here; worth an ADMIN gate on that route. Raised in the SR-9 security pass.

Stacked on SR-4 (#1736) → targets `feat/senses-jit-bind`.

Part of the Senses Router plan (SR-6). Design: docs/design/drafts/2026-07-16-senses-router.md
