### PR TITLE
feat(paw-bar): concierge kill switch and greeting settings

### DIFF
--- a/ee/pocketpaw_ee/cloud/auth/site_keys.py
+++ b/ee/pocketpaw_ee/cloud/auth/site_keys.py
@@ -47,6 +47,18 @@
 # is unchanged: the key is world-visible, so a raw ``curl`` POST was always
 # possible — CSP binds BROWSERS only; the real controls stay the rate-limit +
 # injection screen + the zero-authority CONCIERGE scope.
+#
+# Updated 2026-07-16 (Paw Bar concierge kill switch, D1 / SS-6): ``resolve_site_key``
+# now fails closed with a 403 when the resolved Site has ``concierge_enabled=False``
+# — the owner's on/off switch for the concierge (chat / action / cart all go through
+# this resolver). It is checked AFTER ``lookup_site_by_key`` (which stays 401-only to
+# preserve its anti-enumeration contract) and BEFORE the origin gate, at the point
+# where the Site is resolved, and is re-read on every request (a fresh ``find_one``,
+# never cached) so a toggle takes effect immediately. This is DISTINCT from
+# ``revoked``: ``revoked`` cuts the KEY (401, indistinguishable from a bad key);
+# ``concierge_enabled=False`` refuses the resolved concierge (403 ``concierge_disabled``).
+# The FRAME endpoint enforces the same switch inline (it calls ``lookup_site_by_key``
+# directly, not this resolver).
 
 from __future__ import annotations
 
@@ -174,6 +186,10 @@ async def resolve_site_key(
 
       1-4. **Key auth** (``lookup_site_by_key``): empty/short → 401, unknown → 401,
          revoked → 401, constant-time mismatch → 401.
+      4b. **Kill switch** (D1 / SS-6): the owner's ``concierge_enabled`` toggle. When
+         False the concierge is off → 403 ``concierge_disabled``. Re-read per request
+         (never cached) so toggling off takes effect immediately; distinct from
+         ``revoked`` (which cuts the KEY at 401).
       5. **Origin gate — dual-mode.**
          * ``frame_origin`` unset (inline / legacy widget): the request ``Origin``
            IS the embedder, so ``origin_allowed`` must place its host in the Site's
@@ -212,12 +228,21 @@ async def resolve_site_key(
         ``pocket_id`` from the Site, ``scopes`` copied from the Site.
 
     Raises:
-        HTTPException: 401 (bad/unknown/revoked/mismatched key) or 403 (origin not
+        HTTPException: 401 (bad/unknown/revoked/mismatched key), 403
+            (``concierge_disabled`` — owner kill switch off) or 403 (origin not
             allowed). Deliberately no distinct code for "does not exist" vs "wrong
             key" beyond the status — both are 401 so an attacker can't enumerate
             which embed keys are live.
     """
     site = await lookup_site_by_key(key)
+
+    # Kill switch (D1 / SS-6): the owner's on/off toggle for the concierge, checked
+    # the moment the Site is resolved and re-read on every request (never cached), so
+    # toggling it off silences chat/action/cart immediately. Distinct from ``revoked``
+    # (which cuts the KEY at 401): a disabled concierge is a 403 on a valid key. Placed
+    # before the origin gate so "this concierge is off" is the authoritative refusal.
+    if not site.concierge_enabled:
+        raise HTTPException(status_code=403, detail="concierge_disabled")
 
     # Dual-mode origin gate. Frame mode (request Origin == our frame origin) means
     # the embedder was already gated by the frame CSP, so we accept; otherwise the

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -115,6 +115,19 @@
 # ``auth.site_keys.resolve_site_key`` does on every concierge request. All defaults
 # are backward-compatible (existing docs read ``revoked=False`` + the default
 # scope set), so no migration.
+#
+# Updated 2026-07-16 (Paw Bar concierge settings + kill switch, D1 — folds in
+# staffed-sites SS-6): added the owner-facing concierge controls, distinct from the
+# key-level ``revoked`` flag above. ``concierge_enabled`` is the owner's on/off kill
+# switch for the concierge itself (NOT the embed key): the three public paw-bar
+# entry points (frame / chat / action) fail closed with a 403 when it is False, so
+# an owner can silence the bar without deleting the Site or rotating the key.
+# ``revoked`` still cuts the KEY (401, anti-enumeration); ``concierge_enabled=False``
+# refuses the resolved concierge (403) — two different switches. ``concierge_greeting``
+# is the opening line the glass bar renders; it rides into the frame's
+# ``window.__PAWBAR__`` config payload. Both default backward-compatibly
+# (``concierge_enabled=True`` + ``concierge_greeting=""``), so every existing Site
+# reads as enabled with no greeting — no migration.
 
 from __future__ import annotations
 
@@ -226,6 +239,19 @@ class Site(TimestampedDocument):
     # cut off without deleting the Site. Defaults False (every existing doc is
     # live), so no migration.
     revoked: bool = False
+    # Paw Bar concierge (D1 / SS-6): the OWNER's on/off kill switch for the
+    # concierge — distinct from ``revoked`` (which cuts the KEY). When False, the
+    # three public entry points (frame / chat / action) refuse with a 403, so the
+    # owner can silence the bar instantly without deleting the Site or rotating the
+    # key. Re-read on EVERY request (never cached on a warm client) so a toggle
+    # takes effect immediately. Defaults True (every existing site stays live), so
+    # no migration.
+    concierge_enabled: bool = True
+    # Paw Bar concierge (D1 / SS-6): the opening line the glass bar renders. Rides
+    # into the frame's ``window.__PAWBAR__`` config as ``greeting``; the glass app
+    # reads it in a parallel slice and falls back to its own default when "".
+    # Defaults "" (no custom greeting), so no migration.
+    concierge_greeting: str = ""
 
     def rotate_signed_key(self) -> str:
         """Regenerate the public embed key and return the new value (T1).

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,15 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-16 (Paw Bar concierge settings + kill switch, D1 / SS-6) — the
+#   owner's on/off toggle + greeting. (a) GET /paw-bar/frame now refuses (403
+#   ``concierge_disabled``) when the resolved Site has ``concierge_enabled=False``,
+#   mirroring the empty-allowlist 403; chat + action/cart get the SAME 403 via
+#   ``resolve_site_key`` (the shared resolver), so all three public entry points fail
+#   closed on the kill switch, re-read per request. (b) The frame's ``window.__PAWBAR__``
+#   config now carries ``greeting`` (``Site.concierge_greeting``) for the glass app.
+#   (c) New admin surface: GET + PATCH /paw-bar/admin/site/{site_id}/settings —
+#   ``require_scope("admin")`` + workspace-scoped (cross-tenant id → 404), reads/writes
+#   ONLY ``concierge_enabled`` + ``concierge_greeting`` on the Site doc (the natural
+#   owner key — the fields live on the Site, not the widget).
 # Updated: 2026-07-16 (C1 hardening) — (a) the shared front-gate now validates
 #   customer_ref against a charset+length bound (400) as its cheapest check;
 #   (b) GET /paw-bar/cart records a cart-read marker so read enumeration counts
@@ -386,6 +397,14 @@ async def frame(
     # too-short key → 401 (never a 422), so the refusal is uniform with the chat path.
     site = await lookup_site_by_key(key)
 
+    # (1b) Kill switch (D1 / SS-6): the owner's ``concierge_enabled`` toggle. When
+    # off, refuse to render (403) — the same fail-closed shape as the empty-allowlist
+    # refusal below. Re-read on every request (``lookup_site_by_key`` does a fresh
+    # find_one, nothing is cached), so toggling off silences the frame immediately.
+    # Distinct from ``revoked`` (which cuts the KEY at 401 inside lookup_site_by_key).
+    if not site.concierge_enabled:
+        raise HTTPException(status_code=403, detail="concierge_disabled")
+
     # (2) The embedder gate: the CSP frame-ancestors header. Fail closed when no
     # allowlisted origin survives sanitization — refuse to render.
     csp = _frame_ancestors_csp(site.allowed_origins)
@@ -404,6 +423,9 @@ async def frame(
         "endpoint": api_base,
         "parentOrigin": _safe_parent_origin(po, site.allowed_origins),
         "mode": "concierge",
+        # D1 / SS-6 — the owner's opening line rides into the bootstrap config; the
+        # glass app renders it (D4) and falls back to its own default when "".
+        "greeting": site.concierge_greeting or "",
         "tokens": {},
     }
     html = _pawbar_bootstrap_html(config, PAWBAR_APP_MOUNT)
@@ -713,6 +735,114 @@ async def list_events(
     _require_owner_token(widget, x_paw_bar_token)
     events = await _store().recent_events(widget_id, limit=limit)
     return EventsListResponse(events=events, total=len(events))
+
+
+# ---------------------------------------------------------------------------
+# Admin: per-Site concierge settings (D1 / SS-6)
+#
+# The kill switch + greeting live on the SITE doc (not the widget), so the owner
+# read/update is keyed on ``site_id``, not a widget id. Auth mirrors the widget
+# admin CRUD above: ``require_scope("admin")`` (a signed-in dashboard session) +
+# the caller's ACTIVE workspace via ``current_workspace_id``. The lookup is
+# workspace-scoped, so another tenant's site id resolves to 404 and never leaks or
+# mutates. Reads/writes touch ONLY the two concierge fields — the site's publish /
+# billing / capture config is out of scope here. Co-located with the paw-bar
+# enforcement (the frame/chat/action gates) rather than the heavier sites control
+# plane so the owner surface and the switch it drives sit in one place.
+# ---------------------------------------------------------------------------
+
+
+class ConciergeSettingsUpdate(BaseModel):
+    """Partial update of a Site's concierge settings (D1).
+
+    Every field is optional; only the ones the client SENDS are written (tracked
+    via ``model_fields_set``), so a PATCH that carries just ``concierge_enabled``
+    leaves the greeting untouched and vice-versa.
+    """
+
+    concierge_enabled: bool | None = None
+    concierge_greeting: str | None = None
+
+
+class ConciergeSettingsResponse(BaseModel):
+    """The owner-facing view of a Site's concierge settings (D1)."""
+
+    site_id: str
+    concierge_enabled: bool
+    concierge_greeting: str
+
+
+async def _load_site_scoped(site_id: str, workspace_id: str) -> Any:
+    """Load a Site by id, scoped to the caller's workspace (cross-tenant → 404).
+
+    Mirrors ``sites.service._load`` (the canonical tenant-scoped Site reader) but
+    raises the router's ``HTTPException(404)`` instead of the service's domain
+    ``NotFound`` — a malformed/foreign/absent id is all one 404 so nothing leaks
+    across tenants. Kept local so the paw-bar router doesn't reach into the sites
+    service's private helper or its exception-translation layer.
+    """
+    from bson import ObjectId
+    from bson.errors import InvalidId
+
+    from pocketpaw_ee.cloud.models.site import Site
+
+    try:
+        oid = ObjectId(site_id)
+    except (InvalidId, TypeError):
+        raise HTTPException(404, "Site not found")
+    site = await Site.find_one({"_id": oid, "workspace": workspace_id})
+    if site is None:
+        raise HTTPException(404, "Site not found")
+    return site
+
+
+@router.get(
+    "/paw-bar/admin/site/{site_id}/settings",
+    response_model=ConciergeSettingsResponse,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def get_site_concierge_settings(
+    site_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConciergeSettingsResponse:
+    """Read a Site's concierge settings so the dashboard can render the toggle +
+    greeting field. Admin-authed, workspace-scoped (cross-tenant id → 404)."""
+    site = await _load_site_scoped(site_id, workspace_id)
+    return ConciergeSettingsResponse(
+        site_id=str(site.id),
+        concierge_enabled=site.concierge_enabled,
+        concierge_greeting=site.concierge_greeting,
+    )
+
+
+@router.patch(
+    "/paw-bar/admin/site/{site_id}/settings",
+    response_model=ConciergeSettingsResponse,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def update_site_concierge_settings(
+    site_id: str,
+    req: ConciergeSettingsUpdate,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConciergeSettingsResponse:
+    """Toggle the kill switch and/or set the greeting on a Site (D1 / SS-6).
+
+    Only the fields the client SENT are applied (``model_fields_set``). Admin-authed
+    and workspace-scoped, so a cross-tenant site id 404s before anything is written.
+    The change is read on the NEXT public request (the gates re-``find_one`` the Site
+    every time), so toggling ``concierge_enabled`` off silences the bar immediately.
+    """
+    site = await _load_site_scoped(site_id, workspace_id)
+    for name in req.model_fields_set:
+        value = getattr(req, name)
+        if value is not None:
+            setattr(site, name, value)
+    await site.save()
+    return ConciergeSettingsResponse(
+        site_id=str(site.id),
+        concierge_enabled=site.concierge_enabled,
+        concierge_greeting=site.concierge_greeting,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_paw_bar_concierge_settings.py
+++ b/tests/cloud/test_paw_bar_concierge_settings.py
@@ -1,0 +1,312 @@
+# tests/cloud/test_paw_bar_concierge_settings.py — Paw Bar concierge settings +
+# kill switch (D1 / SS-6).
+# Created 2026-07-16: covers the owner's on/off toggle + greeting. Layers:
+#   * The shared resolver (resolve_site_key) — a disabled Site raises 403
+#     ``concierge_disabled`` before the origin gate; an enabled Site resolves a ctx.
+#   * The three public entry points fail closed on the kill switch: GET
+#     /paw-bar/frame, POST /paw-bar/chat, POST /paw-bar/action each 403 when
+#     ``concierge_enabled=False``, while a default (enabled=True) Site renders.
+#   * The greeting rides into the frame's ``window.__PAWBAR__`` config payload.
+#   * The admin settings surface: GET + PATCH /paw-bar/admin/site/{id}/settings
+#     round-trips the two fields, rejects a cross-tenant id (404), and a PATCH that
+#     flips the switch off silences the frame on the NEXT request (immediate effect).
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.paw_bar.models import PawBarBlock, PawBarSpec, PawBarWidget
+from pocketpaw.paw_bar.store import PawBarStore
+
+_VALID_KEY = "site_key_" + "a" * 24
+_ORIGIN = "https://brewco.com"
+_CUST = "cust-0001"  # a valid customer_ref (>= 8 chars, allowed charset)
+
+
+async def _site(**ov: Any):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        script_name="",
+        signed_key=_VALID_KEY,
+        allowed_origins=["brewco.com"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+def _spec(pocket_id: str = "pocket-1") -> PawBarSpec:
+    return PawBarSpec(
+        widget_id="pp_seed",
+        pocket_id=pocket_id,
+        blocks=[PawBarBlock(type="text", content="Hi from Brew & Co")],
+    )
+
+
+def _widget(**ov: Any) -> PawBarWidget:
+    d = dict(
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        spec=_spec(),
+        allowed_domains=["brewco.com"],
+        agent_id="agent-xyz",
+        workspace_id="ws-1",
+        rate_limit_per_min=60,
+        per_customer_limit_per_min=10,
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path, mongo_db):
+    """One public+admin app client for every D1 endpoint, backed by a tmp paw_bar
+    store (widget) + Beanie (Site). ``current_workspace_id`` is pinned to ws-1 for
+    the admin settings routes; the public frame/chat/action routes ignore it.
+    Yields ``(client, store)``.
+    """
+    from unittest.mock import patch
+
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[current_workspace_id] = lambda: "ws-1"
+
+    store = PawBarStore(tmp_path / "settings.db")
+    with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as c:
+            yield c, store
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — the shared resolver kill switch (resolve_site_key)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_resolve_site_key_disabled_concierge_is_403(mongo_db):
+    """A resolved Site with concierge_enabled=False refuses (403 concierge_disabled)
+    at the shared resolver — the single gate chat/action/cart all pass through."""
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
+
+    await _site(concierge_enabled=False)
+    with pytest.raises(HTTPException) as exc:
+        await resolve_site_key(_VALID_KEY, _ORIGIN, _CUST)
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "concierge_disabled"
+
+
+@pytest.mark.asyncio
+async def test_resolve_site_key_enabled_concierge_resolves(mongo_db):
+    """The default (enabled=True) Site still resolves a CONCIERGE ctx — no regression."""
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
+
+    await _site()  # concierge_enabled defaults True
+    ctx = await resolve_site_key(_VALID_KEY, _ORIGIN, _CUST)
+    assert ctx.workspace_id == "ws-1"
+    assert ctx.pocket_id == "pocket-1"
+    assert ctx.user_id == _CUST
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — the three public entry points fail closed on the kill switch
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_frame_default_enabled_renders(client):
+    """A default Site (concierge_enabled=True) still renders the frame — no regression."""
+    c, _store = client
+    await _site()
+    res = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert res.status_code == 200
+    assert "window.__PAWBAR__" in res.text
+
+
+@pytest.mark.asyncio
+async def test_frame_disabled_concierge_is_403(client):
+    c, _store = client
+    await _site(concierge_enabled=False)
+    res = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert res.status_code == 403
+    assert "concierge_disabled" in res.text
+
+
+@pytest.mark.asyncio
+async def test_chat_disabled_concierge_is_403(client):
+    """POST /paw-bar/chat refuses (403) before dispatching a run when the kill
+    switch is off."""
+    c, store = client
+    await _site(concierge_enabled=False)
+    widget = await store.create_widget(_widget())
+    res = await c.post(
+        "/paw-bar/chat",
+        json={
+            "widget_id": widget.id,
+            "signed_key": _VALID_KEY,
+            "customer_ref": _CUST,
+            "message": "What time do you open?",
+        },
+        headers={"Origin": _ORIGIN},
+    )
+    assert res.status_code == 403
+    assert "concierge_disabled" in res.text
+
+
+@pytest.mark.asyncio
+async def test_action_disabled_concierge_is_403(client):
+    """POST /paw-bar/action refuses (403) in the shared front gate when the kill
+    switch is off — the executor is never reached."""
+    c, store = client
+    await _site(concierge_enabled=False)
+    widget = await store.create_widget(_widget())
+    res = await c.post(
+        "/paw-bar/action",
+        json={
+            "key": _VALID_KEY,
+            "w": widget.id,
+            "customer_ref": _CUST,
+            "verb": "add_to_cart",
+            "args": {"product_id": "espresso"},
+        },
+        headers={"Origin": _ORIGIN},
+    )
+    assert res.status_code == 403
+    assert "concierge_disabled" in res.text
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — the greeting rides into the frame config
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_frame_carries_greeting(client):
+    c, _store = client
+    await _site(concierge_greeting="Welcome to Brew & Co")
+    res = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert res.status_code == 200
+    assert '"greeting": "Welcome to Brew & Co"' in res.text
+
+
+@pytest.mark.asyncio
+async def test_frame_empty_greeting_emits_empty_string(client):
+    c, _store = client
+    await _site()  # concierge_greeting defaults ""
+    res = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert res.status_code == 200
+    assert '"greeting": ""' in res.text
+
+
+# --------------------------------------------------------------------------- #
+# Layer 4 — the admin settings surface (GET + PATCH, workspace-scoped)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_settings_get_defaults(client):
+    c, _store = client
+    site = await _site()
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/settings")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["site_id"] == str(site.id)
+    assert body["concierge_enabled"] is True
+    assert body["concierge_greeting"] == ""
+
+
+@pytest.mark.asyncio
+async def test_settings_patch_round_trips(client):
+    c, _store = client
+    site = await _site()
+    res = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/settings",
+        json={"concierge_enabled": False, "concierge_greeting": "Back at 9am"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["concierge_enabled"] is False
+    assert body["concierge_greeting"] == "Back at 9am"
+
+    # The read reflects the write.
+    got = await c.get(f"/paw-bar/admin/site/{site.id}/settings")
+    assert got.json()["concierge_enabled"] is False
+    assert got.json()["concierge_greeting"] == "Back at 9am"
+
+
+@pytest.mark.asyncio
+async def test_settings_patch_is_partial(client):
+    """A PATCH carrying only one field leaves the other untouched (model_fields_set)."""
+    c, _store = client
+    site = await _site(concierge_greeting="Original line")
+    res = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/settings",
+        json={"concierge_enabled": False},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["concierge_enabled"] is False
+    assert body["concierge_greeting"] == "Original line"  # untouched
+
+
+@pytest.mark.asyncio
+async def test_settings_cross_tenant_is_404(client):
+    """A site owned by another workspace 404s for the ws-1 admin session."""
+    c, _store = client
+    site = await _site(workspace="ws-other")
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/settings")
+    assert res.status_code == 404
+    patched = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/settings",
+        json={"concierge_enabled": False},
+    )
+    assert patched.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_settings_malformed_id_is_404(client):
+    c, _store = client
+    res = await c.get("/paw-bar/admin/site/not-an-objectid/settings")
+    assert res.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Layer 5 — end-to-end: toggling off takes effect on the next public request
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_toggle_off_silences_frame_immediately(client):
+    """The frame renders while enabled, then 403s right after the owner PATCHes the
+    switch off — the gate re-reads the Site every request (no warm-client caching)."""
+    c, _store = client
+    site = await _site()
+
+    ok = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert ok.status_code == 200
+
+    off = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/settings",
+        json={"concierge_enabled": False},
+    )
+    assert off.status_code == 200
+
+    after = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert after.status_code == 403
+    assert "concierge_disabled" in after.text


### PR DESCRIPTION
## What

Adds an owner on/off kill switch and a greeting to the Paw Bar concierge, enforced fail-closed. Stacked on top of the paw-bar action stack (`feat/paw-bar-actions`); the diff is only this slice.

## Changes

**Site doc fields** (`ee/pocketpaw_ee/cloud/models/site.py`)
- `concierge_enabled: bool = True` and `concierge_greeting: str = ""`. Additive with backward-compatible defaults, so every existing site reads as enabled with no greeting and no migration runs.

**Kill switch, fail-closed, re-checked per request**
- When `concierge_enabled` is False the three public entry points refuse with `403 concierge_disabled`:
  - `GET /paw-bar/frame` checks it inline right after key auth, mirroring the existing empty-allowlist 403.
  - `POST /paw-bar/chat` and `POST /paw-bar/action` / `GET /paw-bar/cart` get the same 403 through `resolve_site_key`, the shared resolver both paths already run.
- The flag is read on every request (the resolver does a fresh `find_one`, nothing is cached on a warm client), so toggling it off silences the bar immediately.
- This is separate from `revoked`, which cuts the embed key at 401 for anti-enumeration. `lookup_site_by_key` stays 401-only; the kill switch is a distinct 403 on a valid key. A disabled concierge is a legitimate owner state, not a probe signal.

**Greeting into the frame config**
- `concierge_greeting` rides into the `window.__PAWBAR__` bootstrap payload as `greeting` (empty string when unset; the glass app defaults). The glass app reads it in the D4 slice.

**Owner read/update surface**
- `GET` and `PATCH /paw-bar/admin/site/{site_id}/settings`, admin-authed (`require_scope("admin")`) and workspace-scoped via `current_workspace_id`, reading and writing only the two concierge fields. A cross-tenant or malformed site id 404s before anything is read or written. PATCH is partial (`model_fields_set`).

### Why this surface

The two fields live on the **Site** doc, not the widget, so the natural owner key is the Site. The C1 widget PATCH keys on a widget id and would need a widget-to-site hop to reach these. The new endpoint reuses the same lightweight admin-auth pattern the widget CRUD already uses (`require_scope("admin")` + `current_workspace_id`), keeps the owner surface next to the enforcement it drives, and stays off the heavier sites control plane (plan-feature + action-scope gates). It touches only the two fields, so it is a small new surface rather than an extension of an unrelated update path.

This folds in staffed-sites SS-6's kill switch and greeting fields.

## Tests

New `tests/cloud/test_paw_bar_concierge_settings.py` covers: the shared resolver refuses a disabled site and still resolves an enabled one; frame, chat, and action each 403 when disabled while a default site renders; the greeting appears in the frame config; the settings GET/PATCH round-trips, is partial, and 404s cross-tenant; and toggling off silences the frame on the very next request.

```
uv run pytest tests/cloud/test_paw_bar_frame.py tests/cloud/test_paw_bar_concierge_chat.py tests/cloud/test_paw_bar_actions.py tests/cloud/test_paw_bar_concierge_settings.py -o addopts="" -q
86 passed in 6.25s
```