### PR TITLE
Owner aggregation reads for the per-site concierge dashboard

### DIFF
--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -3,6 +3,14 @@
 # machine-readable `code` emitted on denial. Tests iterate ACTIONS to
 # guarantee every guarded operation is covered.
 #
+# Updated: 2026-07-16 (D2 concierge dashboard reads) — added ``paw_bar.read``
+# (ADMIN) so the per-site Concierge dashboard reads (ee.pocketpaw_ee.paw_bar
+# .router: overview / conversations / decisions / handoffs) gate on the caller's
+# workspace ROLE instead of the coarse ``require_scope("admin")`` (which admits
+# any authenticated dashboard user). ADMIN, mirroring ``audit.read``: a site's
+# concierge conversations, decisions, and handoffs carry visitor PII and owner
+# decision context, so they must not be visible to every workspace member.
+#
 # Updated: 2026-07-11 (feat/external-alerting-c2c3) — registered
 # ``automations.read`` (MEMBER) and ``automations.manage`` (ADMIN) for the
 # always-on automation status surface (ee.cloud.automations_status.router): view
@@ -255,6 +263,13 @@ ACTIONS: dict[str, ActionRule] = {
     # pocket produced), with no credentials or decision payloads — any
     # workspace member may view it, mirroring instinct.read.
     "outcomes.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
+    # Paw Bar concierge dashboard — the per-site owner aggregation reads
+    # (ee.pocketpaw_ee.paw_bar.router: overview / conversations / decisions /
+    # handoffs, D2). ADMIN, mirroring audit.read (NOT the MEMBER bar of
+    # outcomes.read): a site's visitor conversations, decisions, and handoffs
+    # carry visitor PII and owner decision context, so the surface is owner/admin
+    # only and must not be visible to every workspace member.
+    "paw_bar.read": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Belt console — the develop-station read + repo-admin surface
     # (ee.cloud.belt.router, feat/belt-console-backend SC-1). read is MEMBER so
     # any team member can list discoverable repos + their own station runs.

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,24 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-16 (Paw Bar concierge dashboard reads, D2) — added four OWNER
+#   aggregation reads for the per-site Concierge dashboard, all under
+#   /paw-bar/admin/site/{site_id}/*, all ``require_scope("admin")`` +
+#   workspace-scoped: (1) GET /overview — {widget, enabled, greeting, counts} with
+#   cheap COUNT/distinct counters; (2) GET /conversations — recent concierge
+#   ``ChatRunDoc`` runs grouped by customer_ref (LISTABLE via the run model's
+#   (workspace, context_type, scope_id, createdAt) index; bounded scan + optional
+#   cursor); (3) GET /decisions — the site widget's paw_bar ``DecisionStatus`` rows
+#   (``WHERE widget_id = ?``); (4) GET /handoffs — ``_paw_handoffs`` reserved Fabric
+#   objects scoped to the widget (no producer yet → empty in v1). Tenancy runs at
+#   TWO gates: the Site is loaded workspace-scoped (cross-tenant id → 404), then its
+#   paw-bar widget is resolved from ``Site.pocket_id`` ALSO workspace-scoped; the
+#   decisions/conversations/handoffs filters then bind to THAT widget/pocket — never
+#   pocket-wide or workspace-wide — so a sibling site or a second widget in the same
+#   workspace can never appear (the leak surface the security review checks).
+#   Decisions read the singleton ``DecisionStatus`` table (the 1:1 mirror of the
+#   Instinct proposals) rather than the Instinct store directly, because paw-bar
+#   stamps the Instinct row's in-row ``workspace_id`` with the widget OWNER, not the
+#   physical workspace, and the Instinct proposal's physical file is
+#   ContextVar-dependent — the DecisionStatus table has neither hazard.
 # Updated: 2026-07-16 (Paw Bar concierge settings + kill switch, D1 / SS-6) — the
 #   owner's on/off toggle + greeting. (a) GET /paw-bar/frame now refuses (403
 #   ``concierge_disabled``) when the resolved Site has ``concierge_enabled=False``,
@@ -843,6 +863,471 @@ async def update_site_concierge_settings(
         concierge_enabled=site.concierge_enabled,
         concierge_greeting=site.concierge_greeting,
     )
+
+
+# ---------------------------------------------------------------------------
+# Admin: per-Site concierge aggregation reads (D2)
+#
+# Read-only aggregation over ONE site's paw-bar operational data, for the
+# paw-enterprise Concierge dashboard. OWNER endpoints (admin session +
+# ``current_workspace_id``), NOT the public visitor surface. Every read is
+# scoped to the caller's ACTIVE workspace at TWO gates:
+#   1. the Site is loaded workspace-scoped (``_load_site_scoped`` — cross-tenant
+#      id → 404, never leaks existence), then
+#   2. its paw-bar widget is resolved from ``Site.pocket_id`` ALSO workspace-scoped
+#      (``list_widgets(pocket_id=…, workspace_id=…)``), so the widget in hand
+#      always belongs to the caller's tenant.
+# The decisions / conversations / handoffs reads then filter to THAT widget /
+# pocket — never pocket-wide, never workspace-wide — so a sibling site or a
+# second widget in the same workspace can never appear in this site's data. This
+# widget/site-scoping is the leak surface the security review checks.
+#
+# Data sources (all reuse existing stores — nothing new is written here):
+#   * decisions  — the paw_bar ``DecisionStatus`` table (get_paw_bar_store, a
+#       SINGLETON store), filtered ``WHERE widget_id = ?``. This is the 1:1 mirror
+#       of the Instinct proposals the decision loop raises (parked by
+#       ``instinct_action_id``), but keyed on a real ``widget_id`` column and
+#       served from ONE file regardless of deployment mode. It is chosen over
+#       querying the Instinct store directly because (a) paw-bar stamps the
+#       Instinct row's in-row ``workspace_id`` with the widget OWNER
+#       (``decision_loop.resolve_workspace_id`` → ``widget.owner``), NOT the
+#       physical dashboard workspace, so a workspace-scoped Instinct read would
+#       hide every row, and (b) the Instinct proposal's physical file is
+#       ContextVar-dependent (per-workspace on the run path, shared on the ingest
+#       path) — the singleton DecisionStatus table has neither hazard, giving an
+#       airtight ``WHERE widget_id = ?`` isolation seam.
+#   * conversations — concierge runs are persisted as ``ChatRunDoc`` (context_type
+#       "concierge", scope_id = the site's pocket). LISTABLE: the model's compound
+#       (workspace, context_type, scope_id, createdAt DESC) index backs an
+#       efficient per-site query; a Site is 1:1 with (workspace, pocket_id), so a
+#       pocket-scoped read IS site-scoped. Runs are grouped by ``user_id``
+#       (customer_ref) into one conversation each. No full-collection scan — the
+#       fetch window is bounded.
+#   * handoffs — the ``_paw_handoffs`` reserved Fabric object (SS-6). NO producer
+#       exists yet, so v1 defines the shape (contact / question / transcript_ref /
+#       created_at) and queries Fabric for objects of that type carrying this
+#       widget's id — an empty list until the capture path ships (deferred). The
+#       widget-id property filter is the same cross-site isolation guarantee.
+# Overview counts are cheap (COUNT / distinct) — never load a full list.
+# ---------------------------------------------------------------------------
+
+
+# The reserved Fabric object type for a human-handoff request (SS-6). No producer
+# yet; v1 only READS it. The shape below is the contract a future capture path
+# must write (each field is a Fabric object property; ``widget_id`` is the scope
+# key this read filters on).
+_PAW_HANDOFFS_TYPE = "_paw_handoffs"
+
+# The concierge run marker on ``ChatRunDoc`` — a concierge dispatch stamps
+# ``context_type="concierge"`` and ``scope_id=<pocket_id>`` (see ``concierge_chat``).
+_CONCIERGE_CONTEXT_TYPE = "concierge"
+
+# Preview length for a conversation's last message — enough for the dashboard row
+# without shipping the whole transcript.
+_CONVERSATION_PREVIEW_CHARS = 140
+
+# Upper bound on how many raw runs a single conversations page scans before
+# grouping — keeps the read bounded (never a full-collection scan) while leaving
+# room to dedupe several runs per customer down to ``limit`` conversations.
+_CONVERSATION_SCAN_CAP = 200
+
+
+class AdminWidgetView(BaseModel):
+    """The site's paw-bar widget as the owner dashboard needs it (D2 overview)."""
+
+    id: str
+    spec: PawBarSpec
+    agent_id: str = ""
+
+
+class OverviewCounts(BaseModel):
+    """Cheap per-site counters for the dashboard header (D2)."""
+
+    conversations: int = 0
+    pending_decisions: int = 0
+    handoffs: int = 0
+
+
+class SiteOverviewResponse(BaseModel):
+    """GET /paw-bar/admin/site/{id}/overview payload (D2).
+
+    ``widget`` is ``None`` when the site has no paw-bar widget yet (a published
+    site whose concierge widget was never created) — the toggle + greeting still
+    render off the Site, and every count is 0.
+    """
+
+    widget: AdminWidgetView | None = None
+    enabled: bool
+    greeting: str
+    counts: OverviewCounts
+
+
+class ConversationItem(BaseModel):
+    customer_ref: str
+    last_message_at: str
+    preview: str
+
+
+class ConversationsResponse(BaseModel):
+    """GET /paw-bar/admin/site/{id}/conversations payload (D2).
+
+    ``unsupported`` stays False on this deployment: concierge runs ARE listable
+    (the ChatRunDoc compound index backs the per-site query). The field is part of
+    the frozen contract so the frontend degrades gracefully if a future backend
+    can't serve the list. ``cursor`` is the ISO ``createdAt`` to page older
+    conversations from; ``None`` when the scan reached the end.
+    """
+
+    items: list[ConversationItem] = Field(default_factory=list)
+    cursor: str | None = None
+    unsupported: bool = False
+
+
+class DecisionItem(BaseModel):
+    id: str
+    verb_or_kind: str
+    summary: str
+    status: str
+    created_at: str
+
+
+class DecisionsResponse(BaseModel):
+    items: list[DecisionItem] = Field(default_factory=list)
+
+
+class HandoffItem(BaseModel):
+    contact: str
+    question: str
+    transcript_ref: str
+    created_at: str
+
+
+class HandoffsResponse(BaseModel):
+    items: list[HandoffItem] = Field(default_factory=list)
+
+
+async def _resolve_site_and_widget(
+    site_id: str, workspace_id: str
+) -> tuple[Any, PawBarWidget | None]:
+    """Resolve a site id → (Site, its paw-bar widget) both workspace-scoped (D2).
+
+    Step 1 loads the Site scoped to the caller's workspace (cross-tenant / bad id
+    → 404, via the shared ``_load_site_scoped``). Step 2 resolves the site's
+    paw-bar widget from ``Site.pocket_id``, ALSO workspace-scoped, so the returned
+    widget always belongs to the caller's tenant. Returns ``widget=None`` when the
+    site has no paw-bar widget yet (the concierge was never wired) — the callers
+    degrade to an empty view rather than 404, because the SITE exists and its
+    owner-facing settings are still meaningful.
+    """
+    site = await _load_site_scoped(site_id, workspace_id)
+    widgets = await _store().list_widgets(
+        pocket_id=site.pocket_id, workspace_id=workspace_id, limit=1
+    )
+    widget = widgets[0] if widgets else None
+    return site, widget
+
+
+def _decision_verb_or_kind(event_type: str) -> str:
+    """Map a parked decision's ``event_type`` to the contract's ``verb_or_kind``.
+
+    A gated concierge action parks ``event_type="paw_bar_action:<verb>"`` (see
+    ``decision_loop.propose_customer_action``) → return ``<verb>``. Any other
+    event is an ingest customer reply → return ``"customer_reply"``.
+    """
+    if event_type.startswith("paw_bar_action:"):
+        return event_type.split(":", 1)[1] or "action"
+    return "customer_reply"
+
+
+def _decision_summary(decision: Any) -> str:
+    """One-line owner-facing summary of a parked decision (D2 decisions list).
+
+    Once a human has answered (delivered / declined), the operator's reply is the
+    most useful summary; while pending, describe the request from its
+    ``verb_or_kind``. Kept terse — the dashboard row is a glance, not the detail
+    view.
+    """
+    reply = str(getattr(decision, "reply", "") or "").strip()
+    if reply:
+        return reply
+    kind = _decision_verb_or_kind(str(getattr(decision, "event_type", "") or ""))
+    if kind == "customer_reply":
+        return "Customer request awaiting a reply"
+    return f"Visitor '{kind}' action awaiting a decision"
+
+
+@router.get(
+    "/paw-bar/admin/site/{site_id}/overview",
+    response_model=SiteOverviewResponse,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def get_site_overview(
+    site_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+) -> SiteOverviewResponse:
+    """Aggregate a site's concierge widget, kill-switch state, and cheap counts.
+
+    Admin-authed, workspace-scoped (cross-tenant site id → 404). Counts are cheap
+    (COUNT / distinct) and each is scoped to THIS site's widget / pocket — never
+    pocket-wide or workspace-wide. Every count degrades to 0 on a missing widget
+    or an unavailable backing store rather than failing the whole overview.
+    """
+    site, widget = await _resolve_site_and_widget(site_id, workspace_id)
+
+    counts = OverviewCounts()
+    widget_view: AdminWidgetView | None = None
+    if widget is not None:
+        widget_view = AdminWidgetView(id=widget.id, spec=widget.spec, agent_id=widget.agent_id)
+        counts.pending_decisions = await _store().count_pending_decisions(widget.id)
+        counts.handoffs = await _count_handoffs(widget.id, workspace_id)
+    # Conversations are pocket-scoped (a Site is 1:1 with its pocket), so the
+    # count stands even when the widget row is absent.
+    counts.conversations = await _count_conversations(site.pocket_id, workspace_id)
+
+    return SiteOverviewResponse(
+        widget=widget_view,
+        enabled=site.concierge_enabled,
+        greeting=site.concierge_greeting,
+        counts=counts,
+    )
+
+
+@router.get(
+    "/paw-bar/admin/site/{site_id}/conversations",
+    response_model=ConversationsResponse,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def get_site_conversations(
+    site_id: str,
+    limit: int = Query(20, ge=1, le=100),
+    cursor: str | None = Query(None),
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConversationsResponse:
+    """Recent concierge conversations for a site, newest first (D2).
+
+    Concierge runs persist as ``ChatRunDoc`` (context_type "concierge",
+    scope_id = the site's pocket). The compound (workspace, context_type,
+    scope_id, createdAt) index backs an efficient per-site query, so this is
+    LISTABLE (``unsupported`` stays False). Runs are grouped by customer_ref into
+    one conversation each (most-recent run wins for the preview + timestamp). The
+    scan window is bounded (never a full-collection read). Cross-site isolation:
+    scope_id is the site's OWN pocket, so a sibling site's runs never match.
+    """
+    site = await _load_site_scoped(site_id, workspace_id)
+    return await _list_conversations(site.pocket_id, workspace_id, limit=limit, cursor=cursor)
+
+
+@router.get(
+    "/paw-bar/admin/site/{site_id}/decisions",
+    response_model=DecisionsResponse,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def get_site_decisions(
+    site_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    workspace_id: str = Depends(current_workspace_id),
+) -> DecisionsResponse:
+    """Recent decisions raised on a site's concierge widget, newest first (D2).
+
+    Reads the paw_bar ``DecisionStatus`` rows filtered ``WHERE widget_id = ?`` —
+    the airtight cross-site isolation seam (the widget was resolved
+    workspace-scoped, so its id belongs to this tenant, and a sibling widget's id
+    never matches). Each row maps to {id (the Instinct action id, the Tray join
+    key), verb_or_kind, summary, status, created_at}. No widget → empty list.
+    """
+    _site, widget = await _resolve_site_and_widget(site_id, workspace_id)
+    if widget is None:
+        return DecisionsResponse(items=[])
+    decisions = await _store().list_decisions_for_widget(widget.id, limit=limit)
+    items = [
+        DecisionItem(
+            # Prefer the Instinct action id so the dashboard can deep-link the
+            # decision into The Tray; fall back to the row id for a pre-loop row.
+            id=d.instinct_action_id or d.id,
+            verb_or_kind=_decision_verb_or_kind(d.event_type),
+            summary=_decision_summary(d),
+            status=d.state.value,
+            created_at=d.created_at.isoformat(),
+        )
+        for d in decisions
+    ]
+    return DecisionsResponse(items=items)
+
+
+@router.get(
+    "/paw-bar/admin/site/{site_id}/handoffs",
+    response_model=HandoffsResponse,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def get_site_handoffs(
+    site_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    workspace_id: str = Depends(current_workspace_id),
+) -> HandoffsResponse:
+    """Human-handoff requests captured for a site's concierge widget (D2).
+
+    Reads ``_paw_handoffs`` Fabric objects scoped to this widget + workspace. The
+    capture path does not exist yet (SS-6, deferred), so this returns an empty but
+    well-shaped list in v1. When a producer ships, each object's properties map to
+    {contact, question, transcript_ref, created_at}. Cross-site isolation is the
+    ``widget_id`` property filter (a sibling widget's handoffs never match).
+    """
+    _site, widget = await _resolve_site_and_widget(site_id, workspace_id)
+    if widget is None:
+        return HandoffsResponse(items=[])
+    objects = await _query_handoff_objects(widget.id, workspace_id, limit=limit)
+    items = [
+        HandoffItem(
+            contact=str(o.properties.get("contact", "") or ""),
+            question=str(o.properties.get("question", "") or ""),
+            transcript_ref=str(o.properties.get("transcript_ref", "") or ""),
+            created_at=o.created_at.isoformat() if getattr(o, "created_at", None) else "",
+        )
+        for o in objects
+    ]
+    return HandoffsResponse(items=items)
+
+
+# --- D2 aggregation data-source helpers -------------------------------------
+
+
+async def _list_conversations(
+    pocket_id: str, workspace_id: str, *, limit: int, cursor: str | None
+) -> ConversationsResponse:
+    """Group concierge ``ChatRunDoc`` runs into per-customer conversations.
+
+    Fetches a BOUNDED window of the site's concierge runs (index-backed, newest
+    first, optionally older than ``cursor``), then dedupes by customer_ref keeping
+    the most-recent run per customer. Returns up to ``limit`` conversations plus a
+    cursor (the oldest scanned run's timestamp) when the window filled — the
+    signal that older conversations remain. Best-effort: a store error degrades to
+    an empty, well-shaped payload rather than failing the dashboard.
+    """
+    from datetime import datetime
+
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    try:
+        conditions: list[Any] = [
+            ChatRunDoc.workspace == workspace_id,
+            ChatRunDoc.context_type == _CONCIERGE_CONTEXT_TYPE,
+            ChatRunDoc.scope_id == pocket_id,
+        ]
+        if cursor:
+            try:
+                conditions.append(ChatRunDoc.createdAt < datetime.fromisoformat(cursor))
+            except ValueError:
+                pass  # A malformed cursor is ignored — start from the newest run.
+        runs = (
+            await ChatRunDoc.find(*conditions)
+            .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
+            .limit(_CONVERSATION_SCAN_CAP)
+            .to_list()
+        )
+    except Exception:  # noqa: BLE001 — a read failure must not 500 the dashboard
+        logger.warning("conversations read failed for pocket %s", pocket_id, exc_info=True)
+        return ConversationsResponse(items=[], cursor=None, unsupported=False)
+
+    items: list[ConversationItem] = []
+    seen: set[str] = set()
+    for run in runs:
+        if run.user_id in seen:
+            continue
+        seen.add(run.user_id)
+        when = run.ended_at or run.createdAt
+        items.append(
+            ConversationItem(
+                customer_ref=run.user_id,
+                last_message_at=when.isoformat() if when else "",
+                preview=(run.partial_text or "")[:_CONVERSATION_PREVIEW_CHARS],
+            )
+        )
+        if len(items) >= limit:
+            break
+
+    # A cursor is offered only when the scan hit its cap (older runs may remain);
+    # it is the oldest run we looked at, so the next page continues strictly older.
+    next_cursor = (
+        runs[-1].createdAt.isoformat()
+        if len(runs) >= _CONVERSATION_SCAN_CAP and runs
+        else None
+    )
+    return ConversationsResponse(items=items, cursor=next_cursor, unsupported=False)
+
+
+async def _count_conversations(pocket_id: str, workspace_id: str) -> int:
+    """Count DISTINCT concierge customers for a site (D2 overview).
+
+    Scans a BOUNDED window of the site's concierge runs (index-backed, capped at
+    ``_CONVERSATION_SCAN_CAP`` — never a full-collection read) and counts distinct
+    customer_refs. Bounded rather than exact so a very busy site can't turn the
+    overview into an unbounded scan; the badge is a "recent activity" signal, not
+    an audited total. Best-effort: any read error degrades to 0.
+    """
+    try:
+        from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+        runs = (
+            await ChatRunDoc.find(
+                ChatRunDoc.workspace == workspace_id,
+                ChatRunDoc.context_type == _CONCIERGE_CONTEXT_TYPE,
+                ChatRunDoc.scope_id == pocket_id,
+            )
+            .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
+            .limit(_CONVERSATION_SCAN_CAP)
+            .to_list()
+        )
+        return len({run.user_id for run in runs})
+    except Exception:  # noqa: BLE001 — an overview count is best-effort
+        logger.debug("conversations count failed for pocket %s", pocket_id, exc_info=True)
+        return 0
+
+
+async def _query_handoff_objects(widget_id: str, workspace_id: str, *, limit: int) -> list[Any]:
+    """Query ``_paw_handoffs`` Fabric objects for one widget (D2 handoffs).
+
+    Scoped to the widget (a ``widget_id`` object property) AND the workspace. No
+    producer exists yet, so this returns [] in v1. Best-effort: a Fabric error
+    degrades to an empty list.
+    """
+    try:
+        from pocketpaw.fabric.models import FabricQuery
+        from pocketpaw_ee.api import get_fabric_store
+
+        fabric = get_fabric_store(workspace_id=workspace_id)
+        result = await fabric.query(
+            FabricQuery(
+                type_name=_PAW_HANDOFFS_TYPE,
+                filters={"widget_id": widget_id},
+                limit=limit,
+            ),
+            workspace_id=workspace_id,
+        )
+        return list(result.objects)
+    except Exception:  # noqa: BLE001 — a read failure must not 500 the dashboard
+        logger.warning("handoffs read failed for widget %s", widget_id, exc_info=True)
+        return []
+
+
+async def _count_handoffs(widget_id: str, workspace_id: str) -> int:
+    """Cheap COUNT of a widget's ``_paw_handoffs`` objects (D2 overview).
+
+    Reuses the scoped Fabric query but reads only its ``total`` (a COUNT(*)) — the
+    row payload isn't materialized. 0 in v1 (no producer). Best-effort → 0.
+    """
+    try:
+        from pocketpaw.fabric.models import FabricQuery
+        from pocketpaw_ee.api import get_fabric_store
+
+        fabric = get_fabric_store(workspace_id=workspace_id)
+        result = await fabric.query(
+            FabricQuery(type_name=_PAW_HANDOFFS_TYPE, filters={"widget_id": widget_id}, limit=1),
+            workspace_id=workspace_id,
+        )
+        return result.total
+    except Exception:  # noqa: BLE001 — an overview count is best-effort
+        logger.debug("handoffs count failed for widget %s", widget_id, exc_info=True)
+        return 0
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,16 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-17 (D5 owner preview frame) — added GET
+#   /paw-bar/admin/site/{site_id}/preview-frame → the concierge bar frame HTML for
+#   the OWNER to test inside the dashboard. SESSION-authed (paw_bar.read role gate)
+#   sibling of the public /paw-bar/frame: REUSES ``_pawbar_bootstrap_html`` + a new
+#   shared ``_pawbar_frame_config`` builder (the public frame now calls the same
+#   builder — behavior unchanged, just no forked config dict). Two differences from
+#   the public frame: (1) CSP ``frame-ancestors`` = the dashboard origin from the new
+#   ``PAWBAR_DASHBOARD_ORIGIN`` env (default http://localhost:5173), sanitized to a
+#   single host[:port] — never the Site allowlist, never ``*``/Origin/Referer; (2)
+#   served REGARDLESS of ``concierge_enabled`` so a paused bar can be previewed
+#   (chat/action still obey the kill switch, unchanged). The public visitor frame's
+#   security (CSP from allowed_origins, kill-switch 403) is untouched.
 # Updated: 2026-07-17 (D2 conversation transcript) — added GET
 #   /paw-bar/admin/site/{site_id}/conversations/{customer_ref} → {customer_ref,
 #   messages:[{role,content,created_at}], count}. Same role gate (paw_bar.read) +
@@ -409,6 +421,49 @@ def _pawbar_bootstrap_html(config: dict[str, Any], asset_mount: str) -> str:
     )
 
 
+def _pawbar_frame_config(
+    *,
+    site_key: str,
+    widget_id: str,
+    api_base: str,
+    parent_origin: str,
+    greeting: str,
+) -> dict[str, Any]:
+    """Build the ``window.__PAWBAR__`` bootstrap config shared by the public frame
+    and the owner preview frame (D5).
+
+    Single source of truth for the config shape so the two framing paths never
+    drift: both seed the SAME glass app with the SAME fields. The callers differ
+    only in WHERE the values come from — the public frame reads ``siteKey`` +
+    ``parentOrigin`` from the world-visible key + allowlist, the owner preview from
+    the resolved Site + the dashboard origin — and in the CSP ancestor they set.
+    """
+    return {
+        "siteKey": site_key,
+        "widgetId": widget_id or "",
+        "endpoint": api_base,
+        "parentOrigin": parent_origin,
+        "mode": "concierge",
+        # D1 / SS-6 — the owner's opening line; the glass app renders it (D4) and
+        # falls back to its own default when "".
+        "greeting": greeting or "",
+        "tokens": {},
+    }
+
+
+def _dashboard_origin() -> str:
+    """The paw-enterprise dashboard origin allowed to frame the owner preview (D5).
+
+    Read from ``PAWBAR_DASHBOARD_ORIGIN`` (set it to the deployed dashboard origin,
+    e.g. ``https://app.example.com``). Defaults to the Vite dev server
+    (``http://localhost:5173``) so local dev works with no config. This is the ONLY
+    origin the preview frame's CSP ``frame-ancestors`` permits — deliberately NOT
+    the Site's public ``allowed_origins`` (that gates the visitor frame) and never
+    ``*`` or the request's own Origin/Referer.
+    """
+    return os.environ.get("PAWBAR_DASHBOARD_ORIGIN", "").strip() or "http://localhost:5173"
+
+
 @router.get("/paw-bar/frame")
 async def frame(
     request: Request,
@@ -465,17 +520,13 @@ async def frame(
     # validated against the allowlist. ``siteKey`` in the page is fine — it is a
     # world-visible embed key by design.
     api_base = request.url.path.rsplit("/paw-bar/frame", 1)[0]
-    config: dict[str, Any] = {
-        "siteKey": key,
-        "widgetId": w or "",
-        "endpoint": api_base,
-        "parentOrigin": _safe_parent_origin(po, site.allowed_origins),
-        "mode": "concierge",
-        # D1 / SS-6 — the owner's opening line rides into the bootstrap config; the
-        # glass app renders it (D4) and falls back to its own default when "".
-        "greeting": site.concierge_greeting or "",
-        "tokens": {},
-    }
+    config = _pawbar_frame_config(
+        site_key=key,
+        widget_id=w or "",
+        api_base=api_base,
+        parent_origin=_safe_parent_origin(po, site.allowed_origins),
+        greeting=site.concierge_greeting or "",
+    )
     html = _pawbar_bootstrap_html(config, PAWBAR_APP_MOUNT)
     return HTMLResponse(
         content=html,
@@ -1290,6 +1341,68 @@ async def get_site_handoffs(
         for o in objects
     ]
     return HandoffsResponse(items=items)
+
+
+@router.get(
+    "/paw-bar/admin/site/{site_id}/preview-frame",
+    response_class=HTMLResponse,
+    dependencies=[Depends(_require_paw_bar_read)],
+)
+async def get_site_preview_frame(
+    site_id: str,
+    request: Request,
+    workspace_id: str = Depends(current_workspace_id),
+) -> HTMLResponse:
+    """Serve the concierge bar frame for the OWNER to preview inside the dashboard (D5).
+
+    This is the SESSION-authed sibling of the public GET /paw-bar/frame: same glass
+    app, same ``_pawbar_bootstrap_html`` + config builder, but gated by the admin
+    role (``paw_bar.read``) instead of the world-visible embed key, and framed by
+    the DASHBOARD origin instead of the Site's public ``allowed_origins``. It exists
+    so an owner can test their bar in the dashboard without exposing a permissive
+    ancestor to the public.
+
+    Differences from the public frame (everything else is identical):
+      * Auth: admin/owner role (route-level ``_require_paw_bar_read``), workspace-
+        scoped site resolution (cross-tenant / bad id → 404, no widget → 404).
+      * CSP ``frame-ancestors`` = the configured dashboard origin
+        (``PAWBAR_DASHBOARD_ORIGIN``), sanitized to a single host[:port] — never the
+        Site allowlist, never ``*``, never the request's own Origin/Referer.
+      * Kill switch: served REGARDLESS of ``concierge_enabled`` so the owner can
+        preview a PAUSED bar. Chat/action are unchanged and still obey the kill
+        switch, so a paused bar renders in preview but won't answer — correct and
+        consistent. The preview iframe is same-origin with the backend, so its
+        chat/action calls already satisfy the existing dual-mode Origin gate.
+    """
+    site, widget = await _resolve_site_and_widget(site_id, workspace_id)
+    if widget is None:
+        raise HTTPException(status_code=404, detail="no_concierge_widget")
+
+    # The ONLY embedder allowed to frame the preview is the dashboard origin.
+    # Reuse the SAME sanitizer the public frame uses on allowed_origins, so the
+    # ancestor is reduced to a safe host[:port] with no header injection. Fail
+    # closed (500 — a misconfiguration, not a client error) if the configured
+    # origin can't be represented; NEVER emit a source-less or wildcard directive.
+    dash = _dashboard_origin()
+    csp = _frame_ancestors_csp([dash])
+    if csp is None:
+        raise HTTPException(status_code=500, detail="dashboard_origin_invalid")
+
+    api_base = request.url.path.split("/paw-bar/", 1)[0]
+    config = _pawbar_frame_config(
+        site_key=site.signed_key,
+        widget_id=widget.id,
+        api_base=api_base,
+        # The dashboard is the trusted parent; validate it against itself so the
+        # glass app's postMessage targetOrigin is a clean scheme://host[:port].
+        parent_origin=_safe_parent_origin(dash, [dash]),
+        greeting=site.concierge_greeting or "",
+    )
+    html = _pawbar_bootstrap_html(config, PAWBAR_APP_MOUNT)
+    return HTMLResponse(
+        content=html,
+        headers={"Content-Security-Policy": csp, "Cache-Control": "no-store"},
+    )
 
 
 # --- D2 aggregation data-source helpers -------------------------------------

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,13 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-17 (D2 conversation transcript) — added GET
+#   /paw-bar/admin/site/{site_id}/conversations/{customer_ref} → {customer_ref,
+#   messages:[{role,content,created_at}], count}. Same role gate (paw_bar.read) +
+#   site→widget→pocket resolution as the other reads; the transcript is the
+#   concierge ``ChatRunDoc`` runs for (pocket, customer_ref), most-recent 200,
+#   oldest-first; 400 on a bad customer_ref, 404 when the ref has no conversation
+#   here. v1 caveat: the concierge MVP does not persist the visitor's message, so
+#   every turn is role "assistant" (the agent reply on ``partial_text``) until
+#   visitor-text capture is approved (a PII-posture decision).
 # Updated: 2026-07-16 (D2 security review — role gate + empty-pocket guard) —
 #   the four D2 reads now gate on ``require_action("paw_bar.read")`` (ADMIN — the
 #   caller's WORKSPACE ROLE), NOT the coarse ``require_scope("admin")`` that
@@ -950,6 +959,11 @@ _CONVERSATION_PREVIEW_CHARS = 140
 # room to dedupe several runs per customer down to ``limit`` conversations.
 _CONVERSATION_SCAN_CAP = 200
 
+# Max turns returned in one conversation transcript (the most recent N, presented
+# oldest-first). Bounds the drill-in read; a long-running visitor conversation
+# never ships the whole history in one response.
+_TRANSCRIPT_CAP = 200
+
 
 class AdminWidgetView(BaseModel):
     """The site's paw-bar widget as the owner dashboard needs it (D2 overview)."""
@@ -1000,6 +1014,28 @@ class ConversationsResponse(BaseModel):
     items: list[ConversationItem] = Field(default_factory=list)
     cursor: str | None = None
     unsupported: bool = False
+
+
+class TranscriptMessage(BaseModel):
+    """One message in a conversation transcript (D2 drill-in).
+
+    ``role`` is "user" or "assistant" per the frozen contract. NOTE (v1): the
+    concierge run path is a stateless MVP that does NOT persist the visitor's
+    (user) message — only the agent reply survives, on ``ChatRunDoc.partial_text``
+    — so today every message is role "assistant". Persisting visitor text is a
+    privacy posture decision (it stores visitor PII) tracked as a follow-up; when
+    it lands, user turns fill in here with no shape change.
+    """
+
+    role: str
+    content: str
+    created_at: str
+
+
+class ConversationTranscriptResponse(BaseModel):
+    customer_ref: str
+    messages: list[TranscriptMessage] = Field(default_factory=list)
+    count: int
 
 
 class DecisionItem(BaseModel):
@@ -1144,6 +1180,48 @@ async def get_site_conversations(
 
 
 @router.get(
+    "/paw-bar/admin/site/{site_id}/conversations/{customer_ref}",
+    response_model=ConversationTranscriptResponse,
+    dependencies=[Depends(_require_paw_bar_read)],
+)
+async def get_site_conversation_transcript(
+    site_id: str,
+    customer_ref: str,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConversationTranscriptResponse:
+    """One visitor's concierge transcript on a site, oldest-first (D2 drill-in).
+
+    Admin/owner-authed (``paw_bar.read``), workspace-scoped. Resolves site → widget
+    → pocket exactly like the sibling reads, then returns the messages of the
+    concierge conversation for ``customer_ref`` on THIS site's pocket
+    (``ChatRunDoc`` with context_type "concierge", scope_id = the pocket, user_id =
+    customer_ref). Capped at the most recent ``_TRANSCRIPT_CAP`` (200) turns,
+    presented oldest-first. 404 when the ref has no concierge conversation here.
+
+    ROLE COVERAGE (v1): the concierge run path is a stateless MVP that does not
+    persist the visitor's message (see ``concierge_chat`` — user_message_id="",
+    "no persisted user message"), so the only per-visitor content that survives is
+    the agent reply on ``ChatRunDoc.partial_text``. Every message is therefore role
+    "assistant" today. Persisting visitor text (to fill in the "user" turns) stores
+    visitor PII and is a privacy-posture decision for a follow-up, NOT done here.
+    """
+    if not _CUSTOMER_REF_RE.match(customer_ref or ""):
+        raise HTTPException(400, "invalid_customer_ref")
+    site, widget = await _resolve_site_and_widget(site_id, workspace_id)
+    # No concierge widget on this site → no conversation exists to read.
+    if widget is None:
+        raise HTTPException(404, "conversation_not_found")
+    messages = await _load_transcript(site.pocket_id, customer_ref, workspace_id)
+    if messages is None:
+        # No concierge run for this (pocket, customer_ref) — the ref has no
+        # conversation on this site's widget.
+        raise HTTPException(404, "conversation_not_found")
+    return ConversationTranscriptResponse(
+        customer_ref=customer_ref, messages=messages, count=len(messages)
+    )
+
+
+@router.get(
     "/paw-bar/admin/site/{site_id}/decisions",
     response_model=DecisionsResponse,
     dependencies=[Depends(_require_paw_bar_read)],
@@ -1279,6 +1357,51 @@ async def _list_conversations(
         else None
     )
     return ConversationsResponse(items=items, cursor=next_cursor, unsupported=False)
+
+
+async def _load_transcript(
+    pocket_id: str, customer_ref: str, workspace_id: str
+) -> list[TranscriptMessage] | None:
+    """Build one visitor's concierge transcript, oldest-first (D2 drill-in).
+
+    Fetches this (pocket, customer_ref)'s concierge ``ChatRunDoc`` runs (index-
+    backed, most-recent ``_TRANSCRIPT_CAP``), then presents them oldest-first. Each
+    completed run contributes the agent reply (``partial_text``) as an "assistant"
+    message; the visitor's own message is not persisted by the stateless concierge
+    MVP, so it does not appear (see the endpoint docstring). Returns ``None`` when
+    the ref has NO concierge run here (the caller 404s) — distinct from an empty
+    list, which means runs exist but none carried reply text yet.
+    """
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    runs = (
+        await ChatRunDoc.find(
+            ChatRunDoc.workspace == workspace_id,
+            ChatRunDoc.context_type == _CONCIERGE_CONTEXT_TYPE,
+            ChatRunDoc.scope_id == pocket_id,
+            ChatRunDoc.user_id == customer_ref,
+        )
+        .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
+        .limit(_TRANSCRIPT_CAP)
+        .to_list()
+    )
+    if not runs:
+        return None
+
+    messages: list[TranscriptMessage] = []
+    for run in reversed(runs):  # oldest-first
+        text = run.partial_text or ""
+        if not text:
+            continue
+        when = run.ended_at or run.createdAt
+        messages.append(
+            TranscriptMessage(
+                role="assistant",
+                content=text,
+                created_at=when.isoformat() if when else "",
+            )
+        )
+    return messages
 
 
 async def _count_conversations(pocket_id: str, workspace_id: str) -> int:

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,8 +1,17 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-16 (D2 security review — role gate + empty-pocket guard) —
+#   the four D2 reads now gate on ``require_action("paw_bar.read")`` (ADMIN — the
+#   caller's WORKSPACE ROLE), NOT the coarse ``require_scope("admin")`` that
+#   admitted any authenticated dashboard user (a member/viewer could read another
+#   owner's visitor conversations). The role check binds to the SESSION workspace
+#   (``workspace_dep=current_workspace_id``), the same one the reads scope data to,
+#   so tenancy stays session-derived. Also ``_resolve_site_and_widget`` now returns
+#   no widget on an empty ``Site.pocket_id`` (finding #2 — an empty pocket_id would
+#   otherwise widen ``list_widgets`` and resolve a sibling's widget).
 # Updated: 2026-07-16 (Paw Bar concierge dashboard reads, D2) — added four OWNER
 #   aggregation reads for the per-site Concierge dashboard, all under
-#   /paw-bar/admin/site/{site_id}/*, all ``require_scope("admin")`` +
-#   workspace-scoped: (1) GET /overview — {widget, enabled, greeting, counts} with
+#   /paw-bar/admin/site/{site_id}/*, role-gated (``require_action("paw_bar.read")``)
+#   + workspace-scoped: (1) GET /overview — {widget, enabled, greeting, counts} with
 #   cheap COUNT/distinct counters; (2) GET /conversations — recent concierge
 #   ``ChatRunDoc`` runs grouped by customer_ref (LISTABLE via the run model's
 #   (workspace, context_type, scope_id, createdAt) index; bounded scan + optional
@@ -170,9 +179,19 @@ from pocketpaw.paw_bar.models import (
     PawBarWidget,
     PawBarWidgetPublic,
 )
-from pocketpaw_ee.cloud._core.deps import current_workspace_id
+from pocketpaw_ee.cloud._core.deps import current_workspace_id, require_action
 
 logger = logging.getLogger(__name__)
+
+# Role gate for the D2 concierge dashboard reads. ``require_action`` enforces the
+# caller's WORKSPACE ROLE against the ``paw_bar.read`` rule (ADMIN — owner/admin
+# only, not member); replaces the coarse ``require_scope("admin")`` that admitted
+# any authenticated dashboard user. ``workspace_dep=current_workspace_id`` binds
+# the role check to the SESSION's active workspace (never a path/query value — the
+# D2 routes carry ``{site_id}``, not ``{workspace_id}``, so the default
+# path-sourced dep would read an attacker-suppliable query param), the SAME
+# workspace the reads scope their data to.
+_require_paw_bar_read = require_action("paw_bar.read", workspace_dep=current_workspace_id)
 
 router = APIRouter(tags=["PawBar"])
 
@@ -1020,6 +1039,13 @@ async def _resolve_site_and_widget(
     owner-facing settings are still meaningful.
     """
     site = await _load_site_scoped(site_id, workspace_id)
+    # Belt-and-suspenders (security review finding #2): never resolve a widget on
+    # an EMPTY pocket_id. ``list_widgets`` drops the pocket filter on a falsy
+    # pocket_id, so a bad write that ever left ``Site.pocket_id`` blank would
+    # otherwise match the workspace's FIRST widget — a sibling site's concierge.
+    # A site with no pocket has no concierge widget by definition; return None.
+    if not site.pocket_id:
+        return site, None
     widgets = await _store().list_widgets(
         pocket_id=site.pocket_id, workspace_id=workspace_id, limit=1
     )
@@ -1059,7 +1085,7 @@ def _decision_summary(decision: Any) -> str:
 @router.get(
     "/paw-bar/admin/site/{site_id}/overview",
     response_model=SiteOverviewResponse,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_read)],
 )
 async def get_site_overview(
     site_id: str,
@@ -1095,7 +1121,7 @@ async def get_site_overview(
 @router.get(
     "/paw-bar/admin/site/{site_id}/conversations",
     response_model=ConversationsResponse,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_read)],
 )
 async def get_site_conversations(
     site_id: str,
@@ -1120,7 +1146,7 @@ async def get_site_conversations(
 @router.get(
     "/paw-bar/admin/site/{site_id}/decisions",
     response_model=DecisionsResponse,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_read)],
 )
 async def get_site_decisions(
     site_id: str,
@@ -1157,7 +1183,7 @@ async def get_site_decisions(
 @router.get(
     "/paw-bar/admin/site/{site_id}/handoffs",
     response_model=HandoffsResponse,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_read)],
 )
 async def get_site_handoffs(
     site_id: str,

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -1,4 +1,16 @@
 # ee/paw_bar/store.py — Async SQLite store for Paw Bar widgets and events.
+# Updated: 2026-07-16 (D2 owner aggregation reads) — added two widget-keyed
+#   decision reads for the per-site Concierge dashboard: list_decisions_for_widget
+#   (recent decisions for ONE widget, newest first) and count_pending_decisions
+#   (cheap COUNT of the widget's undecided rows for the overview). Both filter on
+#   ``widget_id`` ONLY — deliberately NOT on the in-row ``workspace_id`` column,
+#   because that column stores the widget OWNER (decision_loop.resolve_workspace_id
+#   returns widget.owner, e.g. "user:maya"), NOT the physical workspace id the
+#   dashboard authenticates with. The caller resolves the widget workspace-scoped
+#   FIRST (site -> Site -> its paw-bar widget, all tenant-scoped), so a widget_id
+#   in hand already belongs to the caller's tenant; scoping the decision read on
+#   the owner column too would wrongly hide every row. This is the airtight
+#   cross-site isolation seam (one widget -> its own decisions only).
 # Updated: 2026-07-16 (C1 hardening) — count_events_since gains an optional
 #   event_type filter so the dedicated gated-action rate cap can count only
 #   proposal-generating actions ("pawbar_gated_action") separately from the
@@ -685,6 +697,53 @@ class PawBarStore:
             ) as cur:
                 row = await cur.fetchone()
                 return self._row_to_decision(row) if row else None
+
+    async def list_decisions_for_widget(
+        self, widget_id: str, limit: int = 50
+    ) -> list[DecisionStatus]:
+        """Recent decisions for ONE widget, newest first (D2 owner dashboard).
+
+        The owner-facing read behind GET /paw-bar/admin/site/{id}/decisions: the
+        operator sees the customer requests that raised a decision on THIS site's
+        concierge widget, and whether each is still pending or has been answered.
+
+        Filters on ``widget_id`` ONLY. The row's ``workspace_id`` column holds the
+        widget OWNER (decision_loop stamps it from ``widget.owner``), not the
+        physical dashboard workspace, so it is NOT a valid tenant filter here — and
+        it doesn't need to be: the caller resolved the widget workspace-scoped
+        before this call, so ``widget_id`` already names a widget in the caller's
+        tenant. That makes this the cross-site isolation seam — a sibling site's
+        widget has a different id and never matches. Served by the existing
+        ``idx_pp_decisions_customer`` (widget_id, customer_ref, created_at DESC)
+        index; ``limit`` bounds the scan so the dashboard never loads the world.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM paw_bar_decisions"
+                " WHERE widget_id = ?"
+                " ORDER BY created_at DESC LIMIT ?",
+                (widget_id, limit),
+            ) as cur:
+                return [self._row_to_decision(row) async for row in cur]
+
+    async def count_pending_decisions(self, widget_id: str) -> int:
+        """Count the widget's undecided (state='pending') decisions (D2 overview).
+
+        A cheap COUNT for the dashboard's ``pending_decisions`` badge — never loads
+        the rows. Same widget-only filter (and same isolation rationale) as
+        :meth:`list_decisions_for_widget`: the widget is already tenant-resolved,
+        and the in-row ``workspace_id`` column is the OWNER, not a tenant key.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(
+                "SELECT COUNT(*) FROM paw_bar_decisions WHERE widget_id = ? AND state = 'pending'",
+                (widget_id,),
+            ) as cur:
+                row = await cur.fetchone()
+                return row[0] if row else 0
 
     # ---------------- Carts (C1 — visitor-scoped commerce state) ----------------
 

--- a/tests/cloud/test_paw_bar_admin_aggregation.py
+++ b/tests/cloud/test_paw_bar_admin_aggregation.py
@@ -2,12 +2,17 @@
 # (D2). Created 2026-07-16: covers the four per-site Concierge dashboard reads under
 # /paw-bar/admin/site/{site_id}/* — overview, conversations, decisions, handoffs.
 # Layers:
-#   * Auth: require_scope("admin") — an unauthenticated caller gets 403 (enforce_scope).
+#   * Auth ROLE gate (D2 security review): the reads use require_action("paw_bar.read")
+#     (ADMIN). A member session gets 403 on all 4 reads; admin + owner get 200.
 #   * Tenancy: a cross-tenant / malformed site id → 404 (never leaks existence).
 #   * CROSS-SITE ISOLATION (the key security test): a second site + widget in the
 #     SAME workspace is absent from this site's decisions, conversations, and
 #     handoffs — each read is bound to THIS site's widget/pocket, never pocket-wide
 #     or workspace-wide.
+#   * CROSS-WORKSPACE ISOLATION (belt-and-suspenders): a second workspace's widget +
+#     decisions never appear in workspace-1's reads.
+#   * Empty-pocket_id guard: a site with a blank pocket_id resolves widget=None (no
+#     sibling leak) rather than widening the widget lookup.
 #   * Overview shape + counts (pending decisions from the DecisionStatus table,
 #     conversations from ChatRunDoc, handoffs from Fabric).
 #   * Decisions filtered to the widget + mapped to {id, verb_or_kind, summary,
@@ -19,6 +24,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -121,7 +127,9 @@ async def _mk_run(**ov: Any):
     return doc
 
 
-async def _mk_handoff(fabric, widget_id: str, **props: Any):
+async def _mk_handoff(fabric, widget_id: str, *, workspace: str = "ws-1", **props: Any):
+    # The type is defined for ws-1 in the fixture; create_object resolves it by id
+    # unscoped, so a ws-2 object reuses the same type_id but stamps its own workspace.
     type_ = await fabric.get_type_by_name("_paw_handoffs", workspace_id="ws-1")
     p = dict(
         widget_id=widget_id,
@@ -130,7 +138,7 @@ async def _mk_handoff(fabric, widget_id: str, **props: Any):
         transcript_ref="tr-1",
     )
     p.update(props)
-    return await fabric.create_object(type_id=type_.id, properties=p, workspace_id="ws-1")
+    return await fabric.create_object(type_id=type_.id, properties=p, workspace_id=workspace)
 
 
 # --------------------------------------------------------------------------- #
@@ -153,58 +161,88 @@ async def fabric(tmp_path):
     return fs
 
 
-@pytest_asyncio.fixture
-async def client(mongo_db, store, fabric, monkeypatch):
-    """One admin app client backed by the tmp paw_bar store (widget + decisions),
-    Beanie (Site + ChatRunDoc), and a tmp Fabric store (handoffs).
-    ``current_workspace_id`` is pinned to ws-1. Yields ``(client, store, fabric)``.
+def _fake_user(role: str, workspace_id: str = "ws-1", user_id: str = "u1") -> SimpleNamespace:
+    """User stand-in shaped like ``ee.cloud.models.user.User`` — only the fields
+    the RBAC chain reads (``id``, ``active_workspace``, ``workspaces``). ``role`` is
+    the caller's WorkspaceRole in ``workspace_id`` (member | admin | owner)."""
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role=role)],
+    )
+
+
+def _build_app(store, fabric, monkeypatch, *, role: str = "admin", workspace_id: str = "ws-1"):
+    """Mount the paw_bar router with the given caller ROLE + workspace.
+
+    ``current_active_user`` is overridden with a role-scoped stand-in so
+    ``require_action("paw_bar.read")`` runs its REAL role check;
+    ``current_workspace_id`` is pinned so the reads scope data to the same
+    workspace. The tmp paw_bar + Fabric stores are patched in.
     """
     from pocketpaw_ee.cloud._core.deps import current_workspace_id
     from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
     from pocketpaw_ee.paw_bar.router import router
 
     app = FastAPI()
     add_error_handler(app)
     app.include_router(router)
-    app.dependency_overrides[current_workspace_id] = lambda: "ws-1"
+
+    user = _fake_user(role=role, workspace_id=workspace_id)
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
 
     monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda: store)
     monkeypatch.setattr("pocketpaw_ee.api.get_fabric_store", lambda *a, **k: fabric)
+    return app
 
+
+@pytest_asyncio.fixture
+async def client(mongo_db, store, fabric, monkeypatch):
+    """Default (ADMIN) app client backed by the tmp paw_bar store (widget +
+    decisions), Beanie (Site + ChatRunDoc), and a tmp Fabric store (handoffs).
+    Pinned to ws-1. Yields ``(client, store, fabric)``.
+    """
+    app = _build_app(store, fabric, monkeypatch, role="admin")
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://t") as c:
         yield c, store, fabric
 
 
 # --------------------------------------------------------------------------- #
-# Layer 1 — auth: require_scope("admin")
+# Layer 1 — auth ROLE gate: require_action("paw_bar.read") (ADMIN)
 # --------------------------------------------------------------------------- #
 
+_ALL_READS = ("overview", "conversations", "decisions", "handoffs")
 
-@pytest.mark.enforce_scope
+
 @pytest.mark.asyncio
-async def test_overview_requires_admin(mongo_db, tmp_path, monkeypatch):
-    """An unauthenticated caller is 403'd before any resolution (require_scope)."""
-    from pocketpaw_ee.cloud._core.http import add_error_handler
-    from pocketpaw_ee.paw_bar.router import router
-
-    app = FastAPI()
-    add_error_handler(app)
-
-    @app.middleware("http")
-    async def _no_auth(request, call_next):
-        return await call_next(request)  # stamps nothing → unauthenticated
-
-    app.include_router(router)
-    monkeypatch.setattr(
-        "pocketpaw_ee.paw_bar.router._store",
-        lambda: PawBarStore(tmp_path / "auth.db"),
-    )
+async def test_member_role_is_forbidden_on_all_reads(mongo_db, store, fabric, monkeypatch):
+    """A workspace MEMBER (below admin) gets 403 on every read — the reads carry
+    visitor PII + owner decision context, so member/viewer must not see them."""
+    site = await _site()
+    await store.create_widget(_widget())
+    app = _build_app(store, fabric, monkeypatch, role="member")
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://t") as c:
-        for path in ("overview", "conversations", "decisions", "handoffs"):
-            res = await c.get(f"/paw-bar/admin/site/000000000000000000000001/{path}")
-            assert res.status_code == 403, f"{path}: {res.status_code}"
+        for path in _ALL_READS:
+            res = await c.get(f"/paw-bar/admin/site/{site.id}/{path}")
+            assert res.status_code == 403, f"{path}: {res.status_code} {res.text}"
+
+
+@pytest.mark.parametrize("role", ["admin", "owner"])
+@pytest.mark.asyncio
+async def test_admin_and_owner_roles_are_allowed(role, mongo_db, store, fabric, monkeypatch):
+    """Admin and owner both clear the role gate (200) on every read."""
+    site = await _site()
+    await store.create_widget(_widget())
+    app = _build_app(store, fabric, monkeypatch, role=role)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        for path in _ALL_READS:
+            res = await c.get(f"/paw-bar/admin/site/{site.id}/{path}")
+            assert res.status_code == 200, f"{role}/{path}: {res.status_code} {res.text}"
 
 
 # --------------------------------------------------------------------------- #
@@ -454,3 +492,69 @@ async def test_sibling_site_absent_from_all_reads(client):
     assert overview["counts"]["pending_decisions"] == 1
     assert overview["counts"]["conversations"] == 1
     assert overview["counts"]["handoffs"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Layer 8 — CROSS-WORKSPACE ISOLATION (belt-and-suspenders) + empty pocket_id
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_second_workspace_absent_from_reads(client):
+    """A second workspace's widget + decisions + runs + handoffs never appear in
+    workspace-1's reads. Even when the foreign widget reuses the SAME pocket_id,
+    the workspace-scoped widget lookup + the workspace-filtered conversations query
+    keep the tenants apart.
+    """
+    c, store, fabric = client  # this client is scoped to ws-1
+
+    # ws-1: the site + its widget (workspace_id ws-1).
+    site_a = await _site(workspace="ws-1", pocket_id="pocket-1")
+    widget_a = await store.create_widget(_widget(pocket_id="pocket-1", workspace_id="ws-1"))
+    await _mk_decision(store, widget_a.id, instinct_action_id="ws1-dec")
+    await _mk_run(workspace="ws-1", scope_id="pocket-1", user_id="cust-1")
+    await _mk_handoff(fabric, widget_a.id, workspace="ws-1", contact="ws1-contact")
+
+    # ws-2: a foreign widget on the SAME pocket id, with its own data.
+    widget_b = await store.create_widget(
+        _widget(pocket_id="pocket-1", workspace_id="ws-2", spec=_spec("pocket-1", "pp_b"))
+    )
+    await _mk_decision(store, widget_b.id, instinct_action_id="ws2-dec", workspace_id="ws-2")
+    await _mk_run(workspace="ws-2", scope_id="pocket-1", user_id="cust-2")
+    await _mk_handoff(fabric, widget_b.id, workspace="ws-2", contact="ws2-contact")
+
+    # ws-1 admin reads site_a: the widget resolves to ws-1's widget (not ws-2's),
+    # and none of ws-2's data bleeds through.
+    decisions = (await c.get(f"/paw-bar/admin/site/{site_a.id}/decisions")).json()["items"]
+    assert [d["id"] for d in decisions] == ["ws1-dec"]
+
+    convos = (await c.get(f"/paw-bar/admin/site/{site_a.id}/conversations")).json()["items"]
+    assert [x["customer_ref"] for x in convos] == ["cust-1"]
+
+    handoffs = (await c.get(f"/paw-bar/admin/site/{site_a.id}/handoffs")).json()["items"]
+    assert [h["contact"] for h in handoffs] == ["ws1-contact"]
+
+    overview = (await c.get(f"/paw-bar/admin/site/{site_a.id}/overview")).json()
+    assert overview["widget"]["id"] == widget_a.id
+    assert overview["counts"] == {"conversations": 1, "pending_decisions": 1, "handoffs": 1}
+
+
+@pytest.mark.asyncio
+async def test_empty_pocket_id_resolves_no_widget(client):
+    """A site whose pocket_id is blank must resolve widget=None, never widen the
+    widget lookup into a sibling's widget (security review finding #2)."""
+    c, store, _fabric = client
+    # A sibling widget exists in the same workspace; the empty-pocket site must NOT
+    # pick it up.
+    await store.create_widget(_widget(pocket_id="pocket-real"))
+    site = await _site(pocket_id="")
+
+    overview = (await c.get(f"/paw-bar/admin/site/{site.id}/overview")).json()
+    assert overview["widget"] is None
+    assert overview["counts"]["pending_decisions"] == 0
+
+    decisions = (await c.get(f"/paw-bar/admin/site/{site.id}/decisions")).json()
+    assert decisions["items"] == []
+
+    handoffs = (await c.get(f"/paw-bar/admin/site/{site.id}/handoffs")).json()
+    assert handoffs["items"] == []

--- a/tests/cloud/test_paw_bar_admin_aggregation.py
+++ b/tests/cloud/test_paw_bar_admin_aggregation.py
@@ -558,3 +558,96 @@ async def test_empty_pocket_id_resolves_no_widget(client):
 
     handoffs = (await c.get(f"/paw-bar/admin/site/{site.id}/handoffs")).json()
     assert handoffs["items"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Layer 9 — conversation transcript drill-in
+# --------------------------------------------------------------------------- #
+
+_CUST = "cust-0001"  # valid customer_ref (>= 8 chars, allowed charset)
+
+
+@pytest.mark.asyncio
+async def test_transcript_happy_path_ordered_and_shaped(client):
+    """The transcript is this visitor's concierge turns, oldest-first, shaped
+    {customer_ref, messages:[{role,content,created_at}], count}. v1: assistant-only
+    (the concierge MVP doesn't persist the visitor's message)."""
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    now = datetime.now(UTC)
+    await _mk_run(user_id=_CUST, partial_text="second", createdAt=now, ended_at=now)
+    await _mk_run(
+        user_id=_CUST,
+        partial_text="first",
+        createdAt=now - timedelta(minutes=5),
+        ended_at=now - timedelta(minutes=5),
+    )
+    # A different visitor's run must not leak into this transcript.
+    await _mk_run(user_id="cust-9999", partial_text="other visitor")
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_CUST}")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["customer_ref"] == _CUST
+    assert body["count"] == 2
+    assert [m["content"] for m in body["messages"]] == ["first", "second"]  # oldest-first
+    assert {m["role"] for m in body["messages"]} == {"assistant"}
+    assert all(m["created_at"] for m in body["messages"])
+
+
+@pytest.mark.asyncio
+async def test_transcript_404_on_unknown_ref(client):
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/nosuchcustomer")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_transcript_invalid_customer_ref_is_400(client):
+    """A ref that fails the charset/length bound is rejected before any lookup."""
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/short")  # < 8 chars
+    assert res.status_code == 400
+    assert "invalid_customer_ref" in res.text
+
+
+@pytest.mark.asyncio
+async def test_transcript_cross_site_isolation(client):
+    """A visitor's conversation on a SIBLING site (different pocket) is not readable
+    through this site — 404, never another pocket's transcript."""
+    c, store, _fabric = client
+    site_a = await _site(pocket_id="pocket-1")
+    await store.create_widget(_widget(pocket_id="pocket-1"))
+    _site_b = await _site(pocket_id="pocket-2")
+    await store.create_widget(_widget(pocket_id="pocket-2", spec=_spec("pocket-2", "pp_b")))
+    # The conversation lives on site B's pocket only.
+    await _mk_run(scope_id="pocket-2", user_id=_CUST, partial_text="only on B")
+
+    res = await c.get(f"/paw-bar/admin/site/{site_a.id}/conversations/{_CUST}")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_transcript_member_role_is_forbidden(mongo_db, store, fabric, monkeypatch):
+    site = await _site()
+    await store.create_widget(_widget())
+    await _mk_run(user_id=_CUST, partial_text="hi")
+    app = _build_app(store, fabric, monkeypatch, role="member")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_CUST}")
+        assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_transcript_cross_tenant_site_is_404(client):
+    c, store, _fabric = client
+    site = await _site(workspace="ws-other")
+    await _mk_run(workspace="ws-other", user_id=_CUST, partial_text="hi")
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_CUST}")
+    assert res.status_code == 404

--- a/tests/cloud/test_paw_bar_admin_aggregation.py
+++ b/tests/cloud/test_paw_bar_admin_aggregation.py
@@ -651,3 +651,93 @@ async def test_transcript_cross_tenant_site_is_404(client):
     await _mk_run(workspace="ws-other", user_id=_CUST, partial_text="hi")
     res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_CUST}")
     assert res.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Layer 10 — owner preview frame (D5)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("role", ["admin", "owner"])
+@pytest.mark.asyncio
+async def test_preview_frame_serves_html_for_owner_admin(
+    role, mongo_db, store, fabric, monkeypatch
+):
+    """Owner/admin get the glass bar HTML seeded with this site's key + widget."""
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    app = _build_app(store, fabric, monkeypatch, role=role)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
+    assert res.status_code == 200, res.text
+    assert res.headers["content-type"].startswith("text/html")
+    body = res.text
+    assert "window.__PAWBAR__" in body
+    assert "/pawbar-app/pawbar.js" in body  # the bundle ref (PAWBAR_APP_MOUNT)
+    assert _KEY in body  # the site's signed_key seeded into the config
+    assert widget.id in body  # the resolved widget id
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_member_role_forbidden(mongo_db, store, fabric, monkeypatch):
+    site = await _site()
+    await store.create_widget(_widget())
+    app = _build_app(store, fabric, monkeypatch, role="member")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_cross_tenant_is_404(client):
+    c, _store, _fabric = client
+    site = await _site(workspace="ws-other")
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_no_widget_is_404(client):
+    c, _store, _fabric = client
+    site = await _site(pocket_id="pocket-empty")  # no widget created for this pocket
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_csp_is_dashboard_origin(client, monkeypatch):
+    """CSP frame-ancestors is exactly the configured dashboard origin (sanitized to
+    a single host[:port]) — never the Site's allowed_origins, never '*'."""
+    monkeypatch.setenv("PAWBAR_DASHBOARD_ORIGIN", "dash.example.com")
+    c, store, _fabric = client
+    site = await _site(allowed_origins=["brewco.com"])
+    await store.create_widget(_widget())
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
+    assert res.status_code == 200
+    assert res.headers["content-security-policy"] == "frame-ancestors dash.example.com"
+    # The Site's public allowlist must NOT be the framer here.
+    assert "brewco.com" not in res.headers["content-security-policy"]
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_default_dashboard_origin(client):
+    """With no env set, the CSP defaults to the Vite dev origin (scheme stripped)."""
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
+    assert res.headers["content-security-policy"] == "frame-ancestors localhost:5173"
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_served_when_concierge_disabled(client):
+    """The preview renders even when the kill switch is OFF, so the owner can test a
+    paused bar (chat/action stay gated by the switch, unchanged)."""
+    c, store, _fabric = client
+    site = await _site(concierge_enabled=False)
+    await store.create_widget(_widget())
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
+    assert res.status_code == 200
+    assert "window.__PAWBAR__" in res.text

--- a/tests/cloud/test_paw_bar_admin_aggregation.py
+++ b/tests/cloud/test_paw_bar_admin_aggregation.py
@@ -1,0 +1,456 @@
+# tests/cloud/test_paw_bar_admin_aggregation.py — Paw Bar owner aggregation reads
+# (D2). Created 2026-07-16: covers the four per-site Concierge dashboard reads under
+# /paw-bar/admin/site/{site_id}/* — overview, conversations, decisions, handoffs.
+# Layers:
+#   * Auth: require_scope("admin") — an unauthenticated caller gets 403 (enforce_scope).
+#   * Tenancy: a cross-tenant / malformed site id → 404 (never leaks existence).
+#   * CROSS-SITE ISOLATION (the key security test): a second site + widget in the
+#     SAME workspace is absent from this site's decisions, conversations, and
+#     handoffs — each read is bound to THIS site's widget/pocket, never pocket-wide
+#     or workspace-wide.
+#   * Overview shape + counts (pending decisions from the DecisionStatus table,
+#     conversations from ChatRunDoc, handoffs from Fabric).
+#   * Decisions filtered to the widget + mapped to {id, verb_or_kind, summary,
+#     status, created_at}.
+#   * Handoffs empty-but-well-shaped in v1 (no producer), and isolated by widget.
+#   * Conversations list (LISTABLE — grouped by customer_ref, unsupported=False).
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.paw_bar.models import (
+    DecisionState,
+    DecisionStatus,
+    PawBarBlock,
+    PawBarSpec,
+    PawBarWidget,
+)
+from pocketpaw.paw_bar.store import PawBarStore
+
+_KEY = "site_key_" + "a" * 24
+
+
+# --------------------------------------------------------------------------- #
+# Builders
+# --------------------------------------------------------------------------- #
+
+
+async def _site(**ov: Any):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        script_name="",
+        signed_key=_KEY,
+        allowed_origins=["brewco.com"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+def _spec(pocket_id: str = "pocket-1", widget_id: str = "pp_seed") -> PawBarSpec:
+    return PawBarSpec(
+        widget_id=widget_id,
+        pocket_id=pocket_id,
+        blocks=[PawBarBlock(type="text", content="Hi from Brew & Co")],
+    )
+
+
+def _widget(**ov: Any) -> PawBarWidget:
+    d = dict(
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        spec=_spec(),
+        allowed_domains=["brewco.com"],
+        agent_id="agent-xyz",
+        workspace_id="ws-1",
+        rate_limit_per_min=60,
+        per_customer_limit_per_min=10,
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+async def _mk_decision(store: PawBarStore, widget_id: str, **ov: Any) -> DecisionStatus:
+    d = dict(
+        customer_ref="cust-0001",
+        event_type="paw_bar_action:checkout",
+        instinct_action_id="act-" + uuid.uuid4().hex[:8],
+        # The row's workspace_id column stores the widget OWNER, not the physical
+        # workspace — mirror that here so the tests exercise the real shape.
+        workspace_id="user:maya",
+        state=DecisionState.PENDING,
+        reply="",
+    )
+    d.update(ov)
+    return await store.create_decision(DecisionStatus(widget_id=widget_id, **d))
+
+
+async def _mk_run(**ov: Any):
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    d = dict(
+        run_id=uuid.uuid4().hex,
+        workspace="ws-1",
+        context_type="concierge",
+        scope_id="pocket-1",
+        session_key="cloud:concierge:pocket-1:cust-0001:agent-xyz",
+        user_id="cust-0001",
+        agent_id="agent-xyz",
+        client_message_id=uuid.uuid4().hex,
+        user_message_id="",
+        status="completed",
+        partial_text="Hello, what time do you open?",
+    )
+    d.update(ov)
+    doc = ChatRunDoc(**d)
+    await doc.insert()
+    return doc
+
+
+async def _mk_handoff(fabric, widget_id: str, **props: Any):
+    type_ = await fabric.get_type_by_name("_paw_handoffs", workspace_id="ws-1")
+    p = dict(
+        widget_id=widget_id,
+        contact="visitor@brewco.com",
+        question="Can I book?",
+        transcript_ref="tr-1",
+    )
+    p.update(props)
+    return await fabric.create_object(type_id=type_.id, properties=p, workspace_id="ws-1")
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    return PawBarStore(tmp_path / "agg.db")
+
+
+@pytest_asyncio.fixture
+async def fabric(tmp_path):
+    from pocketpaw.fabric.store import FabricStore
+
+    fs = FabricStore(tmp_path / "fabric.db")
+    # Empty-schema type accepts any properties (declared-only validation).
+    await fs.define_type("_paw_handoffs", properties=[], workspace_id="ws-1")
+    return fs
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db, store, fabric, monkeypatch):
+    """One admin app client backed by the tmp paw_bar store (widget + decisions),
+    Beanie (Site + ChatRunDoc), and a tmp Fabric store (handoffs).
+    ``current_workspace_id`` is pinned to ws-1. Yields ``(client, store, fabric)``.
+    """
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[current_workspace_id] = lambda: "ws-1"
+
+    monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda: store)
+    monkeypatch.setattr("pocketpaw_ee.api.get_fabric_store", lambda *a, **k: fabric)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c, store, fabric
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — auth: require_scope("admin")
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.enforce_scope
+@pytest.mark.asyncio
+async def test_overview_requires_admin(mongo_db, tmp_path, monkeypatch):
+    """An unauthenticated caller is 403'd before any resolution (require_scope)."""
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+
+    @app.middleware("http")
+    async def _no_auth(request, call_next):
+        return await call_next(request)  # stamps nothing → unauthenticated
+
+    app.include_router(router)
+    monkeypatch.setattr(
+        "pocketpaw_ee.paw_bar.router._store",
+        lambda: PawBarStore(tmp_path / "auth.db"),
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        for path in ("overview", "conversations", "decisions", "handoffs"):
+            res = await c.get(f"/paw-bar/admin/site/000000000000000000000001/{path}")
+            assert res.status_code == 403, f"{path}: {res.status_code}"
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — tenancy: cross-tenant / malformed id → 404
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_site_is_404(client):
+    """A site owned by another workspace 404s for the ws-1 admin (never leaks)."""
+    c, _store, _fabric = client
+    site = await _site(workspace="ws-other")
+    for path in ("overview", "conversations", "decisions", "handoffs"):
+        res = await c.get(f"/paw-bar/admin/site/{site.id}/{path}")
+        assert res.status_code == 404, f"{path}: {res.status_code}"
+
+
+@pytest.mark.asyncio
+async def test_malformed_site_id_is_404(client):
+    c, _store, _fabric = client
+    res = await c.get("/paw-bar/admin/site/not-an-objectid/overview")
+    assert res.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — overview shape + counts
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_overview_shape_and_counts(client):
+    c, store, fabric = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    # Two pending decisions + one delivered (only pending counts).
+    await _mk_decision(store, widget.id, state=DecisionState.PENDING)
+    await _mk_decision(store, widget.id, state=DecisionState.PENDING)
+    await _mk_decision(store, widget.id, state=DecisionState.DELIVERED, reply="Done")
+    # Two runs, one customer each → two conversations.
+    await _mk_run(user_id="cust-A")
+    await _mk_run(user_id="cust-B")
+    await _mk_handoff(fabric, widget.id)
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/overview")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["widget"]["id"] == widget.id
+    assert body["widget"]["agent_id"] == "agent-xyz"
+    assert "spec" in body["widget"]
+    assert body["enabled"] is True
+    assert body["greeting"] == ""
+    assert body["counts"]["pending_decisions"] == 2
+    assert body["counts"]["conversations"] == 2
+    assert body["counts"]["handoffs"] == 1
+
+
+@pytest.mark.asyncio
+async def test_overview_no_widget_degrades(client):
+    """A site with no paw-bar widget yet still renders (widget=null, counts 0)."""
+    c, _store, _fabric = client
+    site = await _site(pocket_id="pocket-empty")
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/overview")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["widget"] is None
+    assert body["enabled"] is True
+    assert body["counts"] == {"conversations": 0, "pending_decisions": 0, "handoffs": 0}
+
+
+@pytest.mark.asyncio
+async def test_overview_reflects_kill_switch_and_greeting(client):
+    c, store, _fabric = client
+    site = await _site(concierge_enabled=False, concierge_greeting="Back at 9am")
+    await store.create_widget(_widget())
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/overview")
+    body = res.json()
+    assert body["enabled"] is False
+    assert body["greeting"] == "Back at 9am"
+
+
+# --------------------------------------------------------------------------- #
+# Layer 4 — decisions filtered to the widget
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_decisions_shape_and_verb_mapping(client):
+    c, store, _fabric = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_decision(
+        store,
+        widget.id,
+        event_type="paw_bar_action:checkout",
+        instinct_action_id="act-checkout",
+        state=DecisionState.PENDING,
+    )
+    await _mk_decision(
+        store,
+        widget.id,
+        event_type="contact_form",
+        instinct_action_id="act-reply",
+        state=DecisionState.DELIVERED,
+        reply="Thanks!",
+    )
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/decisions")
+    assert res.status_code == 200, res.text
+    items = res.json()["items"]
+    assert len(items) == 2
+    by_id = {i["id"]: i for i in items}
+    # Gated action → verb; the action id is the Tray join key.
+    assert by_id["act-checkout"]["verb_or_kind"] == "checkout"
+    assert by_id["act-checkout"]["status"] == "pending"
+    assert "created_at" in by_id["act-checkout"]
+    # Non-action event → customer_reply; delivered → summary is the reply.
+    assert by_id["act-reply"]["verb_or_kind"] == "customer_reply"
+    assert by_id["act-reply"]["status"] == "delivered"
+    assert by_id["act-reply"]["summary"] == "Thanks!"
+
+
+@pytest.mark.asyncio
+async def test_decisions_empty_without_widget(client):
+    c, _store, _fabric = client
+    site = await _site(pocket_id="pocket-empty")
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/decisions")
+    assert res.status_code == 200
+    assert res.json()["items"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Layer 5 — handoffs empty-but-well-shaped (v1, no producer)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_handoffs_empty_v1(client):
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/handoffs")
+    assert res.status_code == 200, res.text
+    assert res.json() == {"items": []}
+
+
+@pytest.mark.asyncio
+async def test_handoffs_shape_when_present(client):
+    """When a handoff object exists it maps to the frozen item shape."""
+    c, store, fabric = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_handoff(
+        fabric, widget.id, contact="a@b.com", question="Book a table?", transcript_ref="tr-9"
+    )
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/handoffs")
+    items = res.json()["items"]
+    assert len(items) == 1
+    assert items[0]["contact"] == "a@b.com"
+    assert items[0]["question"] == "Book a table?"
+    assert items[0]["transcript_ref"] == "tr-9"
+    assert items[0]["created_at"]  # ISO timestamp present
+
+
+# --------------------------------------------------------------------------- #
+# Layer 6 — conversations list (LISTABLE)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_conversations_lists_grouped_by_customer(client):
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    now = datetime.now(UTC)
+    # cust-A has two runs; the newer one wins the preview + timestamp.
+    await _mk_run(user_id="cust-A", partial_text="older", createdAt=now - timedelta(minutes=10))
+    await _mk_run(user_id="cust-A", partial_text="newer", createdAt=now, ended_at=now)
+    await _mk_run(user_id="cust-B", partial_text="hi from B", createdAt=now - timedelta(minutes=5))
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["unsupported"] is False
+    refs = [i["customer_ref"] for i in body["items"]]
+    assert refs == ["cust-A", "cust-B"]  # newest-first, deduped
+    a = next(i for i in body["items"] if i["customer_ref"] == "cust-A")
+    assert a["preview"] == "newer"
+
+
+@pytest.mark.asyncio
+async def test_conversations_empty_well_shaped(client):
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["items"] == []
+    assert body["unsupported"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Layer 7 — CROSS-SITE ISOLATION (the key security test)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sibling_site_absent_from_all_reads(client):
+    """A second site + widget in the SAME workspace must never bleed into this
+    site's decisions, conversations, or handoffs. This is the leak surface the
+    security review checks — the reads bind to THIS widget / pocket only.
+    """
+    c, store, fabric = client
+
+    # This site: pocket-1 / widget A.
+    site_a = await _site(pocket_id="pocket-1")
+    widget_a = await store.create_widget(
+        _widget(pocket_id="pocket-1", spec=_spec("pocket-1", "pp_a"))
+    )
+    # Sibling site in the SAME workspace: pocket-2 / widget B.
+    _site_b = await _site(pocket_id="pocket-2")
+    widget_b = await store.create_widget(
+        _widget(pocket_id="pocket-2", spec=_spec("pocket-2", "pp_b"))
+    )
+
+    # Seed data for BOTH widgets/pockets.
+    await _mk_decision(store, widget_a.id, instinct_action_id="a-dec")
+    await _mk_decision(store, widget_b.id, instinct_action_id="b-dec")
+    await _mk_run(scope_id="pocket-1", user_id="cust-A", partial_text="for A")
+    await _mk_run(scope_id="pocket-2", user_id="cust-B", partial_text="for B")
+    await _mk_handoff(fabric, widget_a.id, contact="a-contact")
+    await _mk_handoff(fabric, widget_b.id, contact="b-contact")
+
+    # Decisions: only widget A's.
+    decisions = (await c.get(f"/paw-bar/admin/site/{site_a.id}/decisions")).json()["items"]
+    assert [d["id"] for d in decisions] == ["a-dec"]
+
+    # Conversations: only pocket-1's customer.
+    convos = (await c.get(f"/paw-bar/admin/site/{site_a.id}/conversations")).json()["items"]
+    assert [c_["customer_ref"] for c_ in convos] == ["cust-A"]
+
+    # Handoffs: only widget A's.
+    handoffs = (await c.get(f"/paw-bar/admin/site/{site_a.id}/handoffs")).json()["items"]
+    assert [h["contact"] for h in handoffs] == ["a-contact"]
+
+    # Overview counts for site A never include B's row.
+    overview = (await c.get(f"/paw-bar/admin/site/{site_a.id}/overview")).json()
+    assert overview["counts"]["pending_decisions"] == 1
+    assert overview["counts"]["conversations"] == 1
+    assert overview["counts"]["handoffs"] == 1


### PR DESCRIPTION
Stacked on `feat/concierge-dashboard-settings` (D1). The diff here is only the D2 slice.

## What this adds

Four owner-facing, admin-authed, workspace-scoped reads for the paw-enterprise concierge dashboard, all under `/paw-bar/admin/site/{site_id}`:

- `GET .../overview` returns `{widget:{id,spec,agent_id}, enabled, greeting, counts:{conversations, pending_decisions, handoffs}}`
- `GET .../conversations?limit&cursor` returns `{items:[{customer_ref, last_message_at, preview}], cursor?, unsupported}`
- `GET .../decisions` returns `{items:[{id, verb_or_kind, summary, status, created_at}]}`
- `GET .../handoffs` returns `{items:[{contact, question, transcript_ref, created_at}]}`

These are owner reads, not the public visitor surface. The decisions, conversations, and handoffs filters are the leak surface, so `/security-review` applies.

## Tenancy and the isolation guarantee

Every read runs two workspace gates. First it loads the Site scoped to the caller's active workspace, so a cross-tenant or malformed id is a 404 with no existence leak. Then it resolves that site's paw-bar widget from `Site.pocket_id`, also workspace-scoped. From there each read binds to that one widget or pocket, never pocket-wide and never workspace-wide, so a sibling site or a second widget in the same workspace can never appear. There is an explicit test for that.

## Where decisions come from (a deliberate change from the task's suggested source)

The task suggested reading the Instinct store filtered by the `widget_id` in the proposal blob. Reading the code, that path is fragile: paw-bar stamps the Instinct row's in-row `workspace_id` with the widget owner (`decision_loop.resolve_workspace_id` returns `widget.owner`, for example `user:maya`), not the physical dashboard workspace, so a workspace-scoped Instinct read comes back empty; and the Instinct proposal's physical file depends on request context (per-workspace on the run path, shared on the ingest path).

So decisions read the paw_bar `DecisionStatus` table instead. The decision loop parks a `DecisionStatus` row alongside every Instinct proposal, keyed on the Instinct action id, so it is the 1:1 mirror of those proposals but keyed on a real `widget_id` column and served from a single store regardless of deployment mode. That turns cross-site isolation into a plain `WHERE widget_id = ?` and removes the physical-file hazard. The returned `id` is the Instinct action id so the dashboard can still deep-link into The Tray.

## Conversations feasibility answer

Listable. Concierge dispatches persist as `ChatRunDoc` with `context_type="concierge"` and `scope_id=<pocket_id>`, and the model carries a compound `(workspace, context_type, scope_id, createdAt)` index that backs an efficient per-site query. A Site is 1:1 with `(workspace, pocket_id)`, so a pocket-scoped read is site-scoped. Runs are grouped by `customer_ref` into one conversation each over a bounded scan (never a full-collection read), so `unsupported` stays `false`.

## Handoffs

`_paw_handoffs` is a reserved Fabric object type (SS-6) with no producer yet, so this defines the read shape and returns an empty list in v1. When a capture path ships it writes objects of that type carrying the widget id, and the same widget-id property filter keeps them isolated per site. The capture path is deferred and not built here.

## Tests

New `tests/cloud/test_paw_bar_admin_aggregation.py` covers: admin auth required (403 under `enforce_scope`), cross-tenant and malformed site id 404, overview shape and counts, decisions filtered to the widget with verb and kind mapping, handoffs empty-but-well-shaped plus the mapped shape when present, conversations grouped by customer, and the cross-site isolation test that a sibling site and widget in the same workspace is absent from decisions, conversations, handoffs, and the overview counts.

Run: `uv run pytest tests/cloud/test_paw_bar_admin_aggregation.py tests/cloud/test_paw_bar_backend.py -o addopts="" -q` gives 46 passed. The wider paw-bar set (admin aggregation, backend, concierge settings, decision loop) is 74 passed.


## Security review follow-up (commit e398d2d3)

Isolation held under review (no cross-tenant leak). Two hardening fixes landed on top:

- Role gate. The four reads used `require_scope("admin")`, which admits any authenticated dashboard user, so a workspace member could read another owner's visitor conversations, decisions, and handoffs. Registered a `paw_bar.read` RBAC action (ADMIN, mirroring `audit.read`) and gated all four reads on `require_action("paw_bar.read", workspace_dep=current_workspace_id)`. The role check resolves the workspace from the session, not a path or query value, so tenancy stays session-derived and matches the data scope. Owner and admin get 200, member gets 403.
- Empty pocket_id guard. `_resolve_site_and_widget` now returns no widget when `Site.pocket_id` is blank, since the store drops the pocket filter on a falsy value and would otherwise resolve a sibling site's widget.

Added tests: member 403 on all four reads, admin and owner 200, the empty-pocket_id path resolves widget=None with a sibling widget present, and a cross-workspace test where a second workspace's widget, decisions, runs, and handoffs never appear in workspace-1's reads. `test_paw_bar_admin_aggregation` is now 17 tests; the targeted run with the backend suite is 50 passed.
