### PR TITLE
Serve the native artifact from a read-through cache, not a per-view build

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1170,17 +1170,24 @@ Response `200`:
 - `css` is the built stylesheet(s) — inline `<style>` blocks plus every linked
   stylesheet — concatenated into one string, injected as a single `<style>`.
 
-**Auth is `fabric.write`, not a read scope,** because the GET **arms a build**:
-it (re)builds the pocket with a builder origin set so the generator stamps
-`data-uid` on the editable leaves and embeds the edit manifest. The builder
-origin is resolved from the request's `Origin` header, falling back to the
-configured `PAW_SITES_BUILDER_ORIGIN` when absent (the same precedence as
-`/editable` and `/dev-preview`), so the call works with no header. **Every GET
-rebuilds** — the arm build runs on each request. The build is keyed on
-`pocket_id` in a stable directory, so `node_modules` / `bun install` stay cached
-across requests, but the compile still runs on each call; treat this as a
-heavier read. The arm build skips the SSR smoke fail-gate (`smoke=False`) but
-still emits the static output that is read.
+**Read-through cache — a plain view no longer rebuilds.** The endpoint hashes the
+pocket's render inputs (svelte source map + theme + builder origin + generator
+version) and serves a prior render from the on-disk artifact store
+(`~/.pocketpaw/site-artifacts/<pocket_id>/<hash>.json`) on a **cache hit** — zero
+subprocess builds. It builds once only on a **cold miss** (then stores the result),
+and publishing a site plus every source-changing edit **pre-warm** the store in the
+background, so a live/clean site is a hit and a view never triggers a build. A cold
+miss's build is keyed on `pocket_id` in a stable directory, so `node_modules` /
+`bun install` stay cached; it skips the SSR smoke fail-gate (`smoke=False`) but still
+emits the static output that is read.
+
+**Auth is `fabric.write`, not a read scope,** because a cold miss still **arms a
+build**: it builds the pocket with a builder origin set so the generator stamps
+`data-uid` on the editable leaves and embeds the edit manifest — the endpoint can
+still trigger on-disk work, so it is not a pure read. The builder origin is resolved
+from the request's `Origin` header, falling back to the configured
+`PAW_SITES_BUILDER_ORIGIN` when absent (the same precedence as `/editable` and
+`/dev-preview`), so the call works with no header.
 
 **CSS reader is path-traversal-guarded.** Stylesheet `href`s from the built
 `index.html` are resolved against the build tree (relative `./_app/…` and

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -8,6 +8,14 @@
 # behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-07-17 (feat/sites-native-artifact-no-build): added ``artifact_home()``
+# (the ~/.pocketpaw/site-artifacts root for the native-artifact read-through cache,
+# mirroring build_home) and ``generator_version()`` (an artifact-format + dep epoch
+# the cache key rides so a generator/dep upgrade invalidates stored renders). These
+# back service.get_native_artifact becoming read-through: a preview VIEW no longer
+# triggers a build, so the prod box stops running a 1-2 min SvelteKit build on every
+# site view. Builds now happen only at publish and (cached/pre-warmed) at edit-arm.
+#
 # Updated 2026-07-10 (HE-3 — html publish skips the Node build): build()/_build_one()
 # now branch the STAGE-2 payload AND the build chain on the engine's CAPABILITY, via
 # ``needs_node_build(engine)`` / ``is_source_engine(engine)`` from the canonical
@@ -769,6 +777,41 @@ def _gen_cmd_argv() -> list[str]:
     "node /abs/path/paw-sites/dist/cli.js". PROD TODO: install the bin and drop
     the override."""
     return shlex.split(os.environ.get("PAW_SITES_GEN_CMD", "paw-sites-gen"))
+
+
+def artifact_home() -> Path:
+    """Root dir for the persistent per-pocket native-artifact CACHE (the read-through
+    store behind ``get_native_artifact``). Each pocket's rendered ``{body_html, css}``
+    artifacts live under ``artifact_home()/<pocket_id>/<content_hash>.json`` so a
+    preview view can serve a prior render from disk WITHOUT a subprocess build.
+
+    ``~/.pocketpaw/site-artifacts`` by default so it rides the prod ``backend-data``
+    volume alongside ``build_home()`` (``~/.pocketpaw/site-builds``); override with
+    PAW_SITES_ARTIFACT_DIR (tests point it at a temp dir so they never write the real
+    home). Mirrors ``build_home()`` / ``local_server.sites_home()``'s convention."""
+    raw = os.environ.get("PAW_SITES_ARTIFACT_DIR")
+    base = Path(raw) if raw else Path.home() / ".pocketpaw" / "site-artifacts"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+# Cache-format epoch for the native-artifact store. Bump this string whenever the
+# artifact EXTRACTION shape changes (what ``_read_native_artifact`` pulls out of a
+# build) so a code change that alters the stored ``{body_html, css}`` invalidates
+# every previously-cached artifact instead of serving a stale render.
+_ARTIFACT_FORMAT_EPOCH = "v1"
+
+
+def generator_version() -> str:
+    """A stable identifier of the paw-sites GENERATOR + artifact-format the cache is
+    keyed on, so a generator/dep upgrade (which changes the built output) invalidates
+    the native-artifact store rather than serving a render from the old toolchain.
+
+    Combines the artifact-format epoch with the pinned ripple + motion dep specs —
+    the inputs that most directly move the built HTML/CSS. It rides the content hash
+    in ``service._artifact_content_hash``; a bump to any of these yields a fresh key,
+    so the next preview rebuilds once and re-caches."""
+    return f"{_ARTIFACT_FORMAT_EPOCH}|{_ripple_dep_source()}|{_ripple_motion_dep()}"
 
 
 def _ripple_dep_source() -> str:

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -128,6 +128,13 @@
 # mirroring /editable + /dev-preview. A non-svelte pocket → 422; a missing /
 # access-denied pocket → 404 / 403 (the pockets service raises it). Delegates to
 # sites_service.get_native_artifact.
+#
+# Updated 2026-07-17 (feat/sites-native-artifact-no-build): get_native_artifact is now a
+# READ-THROUGH cache — a repeat view with unchanged source is a disk read with ZERO
+# subprocess builds (publish + the post-edit pre-warm populate the store ahead of the
+# view). fabric.write is RETAINED because a COLD miss still builds (mutates on-disk
+# state), so the endpoint can still trigger work; it is not a pure read. The wire
+# contract (request/response, origin resolution, 422/404/403) is unchanged.
 
 from __future__ import annotations
 
@@ -276,11 +283,14 @@ async def native_artifact_by_pocket(
     stylesheet(s) concatenated. The native editor injects both into a shadow root
     instead of framing an iframe.
 
-    Carries fabric.write because it ENSURES/triggers the armed build (mutates the
-    on-disk build). The builder origin — which the armed build needs to stamp
-    data-uid + the manifest — is resolved from the request's ``Origin`` header, with
-    the service applying the ``PAW_SITES_BUILDER_ORIGIN`` env fallback when it is
-    absent (the same precedence as ``/editable`` / ``/dev-preview``), so the call
+    READ-THROUGH cache (feat/sites-native-artifact-no-build): the service serves a
+    prior render from disk when the pocket's render inputs are unchanged (ZERO builds
+    — a plain VIEW never triggers a build), and builds once only on a cold miss.
+    Carries fabric.write because a cold miss still triggers the armed build (mutates
+    on-disk state) — it is not a pure read. The builder origin — which the armed build
+    needs to stamp data-uid + the manifest — is resolved from the request's ``Origin``
+    header, with the service applying the ``PAW_SITES_BUILDER_ORIGIN`` env fallback when
+    it is absent (the same precedence as ``/editable`` / ``/dev-preview``), so the call
     works with no header. A non-svelte pocket is a 422; a missing / access-denied
     pocket surfaces as a 404 / 403 (the pockets service raises it inside the
     service)."""

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,27 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-17 (feat/sites-native-artifact-no-build — kill preview-time builds):
+# ``get_native_artifact`` is now a READ-THROUGH cache instead of building on every
+# call. It hashes the pocket's render inputs (svelte source map + theme + builder
+# origin + ``generator_client.generator_version()``) into a content hash and serves a
+# prior ``{body_html, css}`` from the new filesystem artifact store
+# (``_FilesystemArtifactStore`` → ``generator_client.artifact_home()``,
+# ``~/.pocketpaw/site-artifacts/<pocket_id>/<hash>.json``) on a HIT — ZERO subprocess
+# builds. A MISS builds once (armed, via the factored ``_build_native_artifact``),
+# stores, and returns. Builds now happen only at publish and (pre-warmed) at edit-arm,
+# never on a plain view (the prod box ran a 1-2 min SvelteKit build on every site
+# view before this). A background pre-warm (``_prewarm_native_artifact`` →
+# ``_safe_prewarm`` scheduled via ``_default_prewarm_scheduler``) repopulates the store
+# after ``apply_leaf_edits`` / ``edit_svelte_component`` mutate source and after a LIVE
+# svelte ``publish_pocket``, so the next view/arm is a hit; it is best-effort and never
+# gates the mutation. ARMED-VS-PLAIN PUBLISH FINDING: the ``/sites/publish`` live
+# deploy threads NO builder_origin (router calls ``publish_pocket`` without one), so the
+# public deploy is PLAIN — no data-uid / no ``paw-edit-manifest`` on public pages; the
+# armed artifact the native editor needs is produced by the pre-warm, NOT by shipping
+# the edit-bridge to public pages. The ``_store`` seam keeps "where the render comes
+# from" injectable so a later client-side-REPL compile wave can swap it cheaply.
+#
 # Updated 2026-07-10 (HE-2 — canonical engine module): the engine content-selection
 # checks now route through ``sites.engines`` predicates instead of inline
 # ``== "svelte"`` string equality. ``is_source_engine(engine)`` replaces the
@@ -511,6 +532,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -658,6 +680,320 @@ def _read_native_artifact(project_dir: str) -> tuple[str, str]:
     cloudflare_dir = Path(project_dir, _CLOUDFLARE_BUILD_REL)
     html = (cloudflare_dir / "index.html").read_text(encoding="utf-8")
     return _extract_body_inner(html), _extract_css(html, cloudflare_dir)
+
+
+# ---------------------------------------------------------------------------
+# Native-artifact read-through cache (feat/sites-native-artifact-no-build).
+#
+# Viewing a svelte Paw Site in the native editor USED to run a full SvelteKit build
+# on every ``GET /native-artifact`` call — fine on a fast laptop, 1-2 min on the prod
+# Hetzner box. The cache below makes a VIEW a disk read: get_native_artifact hashes
+# the pocket's current render inputs and serves a prior ``{body_html, css}`` from disk
+# on a hit; a miss builds once, stores, and returns. Builds now happen only at publish
+# and (pre-warmed in the background, then cached) at edit-arm — never on a plain view.
+# The artifact SOURCE stays behind one seam (the store) so a later "compile in the
+# client-side REPL" wave can swap where the render comes from without touching callers.
+# ---------------------------------------------------------------------------
+
+
+def _artifact_content_hash(
+    *, source: dict[str, Any], theme: dict[str, Any], builder_origin: str, gen_version: str
+) -> str:
+    """Fingerprint the inputs that determine a native artifact's rendered output — the
+    svelte source map, the theme, the builder origin (it changes the stamped
+    data-uid + edit-bridge), and the generator version (a toolchain/dep bump changes
+    the built HTML/CSS). A stable hash for an unchanged render; it changes the moment
+    any input does, which is exactly when the cached artifact is stale and a rebuild is
+    required. The store is already keyed per pocket by path, so this need only separate
+    an unchanged render from a changed one within a pocket."""
+    import hashlib
+
+    h = hashlib.sha256()
+    for part in (
+        gen_version,
+        builder_origin or "",
+        json.dumps(source, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
+        json.dumps(theme, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
+    ):
+        h.update(part.encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+# Keep at most this many artifact files per pocket (current + previous by default), so
+# the store never grows unbounded as a pocket is edited. Override PAW_SITES_ARTIFACT_KEEP.
+_ARTIFACT_KEEP_DEFAULT = 2
+
+
+def _artifact_keep() -> int:
+    import os
+
+    raw = os.environ.get("PAW_SITES_ARTIFACT_KEEP")
+    try:
+        n = int(raw) if raw else _ARTIFACT_KEEP_DEFAULT
+    except (TypeError, ValueError):
+        return _ARTIFACT_KEEP_DEFAULT
+    return n if n > 0 else _ARTIFACT_KEEP_DEFAULT
+
+
+class _FilesystemArtifactStore:
+    """Default read-through store for get_native_artifact — persists a rendered
+    ``{body_html, css}`` as a JSON file at ``artifact_home()/<pocket_id>/<hash>.json``.
+
+    Tenant isolation: the path is keyed on ``pocket_id`` (resolved from a
+    tenant-scoped pockets read), so one tenant's store dir is never addressable from
+    another tenant's request. Reads and writes are best-effort — a missing / corrupt /
+    partial file reads as a MISS (return ``None``) so a bad entry degrades to a rebuild
+    rather than surfacing an error, and a failed write is swallowed (the render still
+    returns, just uncached). This class is the injection seam (the ``_store`` param) so
+    tests exercise the read-through logic with an in-memory fake and never touch disk."""
+
+    def read(self, pocket_id: str, content_hash: str) -> tuple[str, str] | None:
+        from pocketpaw_ee.sites.generator_client import artifact_home
+
+        path = artifact_home() / pocket_id / f"{content_hash}.json"
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except (FileNotFoundError, NotADirectoryError, OSError):
+            return None
+        try:
+            data = json.loads(raw)
+            body_html = data["body_html"]
+            css = data["css"]
+        except (ValueError, KeyError, TypeError):
+            return None
+        if not isinstance(body_html, str) or not isinstance(css, str):
+            return None
+        return body_html, css
+
+    def write(self, pocket_id: str, content_hash: str, body_html: str, css: str) -> None:
+        import os
+        import tempfile
+
+        from pocketpaw_ee.sites.generator_client import artifact_home
+
+        pocket_dir = artifact_home() / pocket_id
+        try:
+            pocket_dir.mkdir(parents=True, exist_ok=True)
+            payload = json.dumps(
+                {
+                    "body_html": body_html,
+                    "css": css,
+                    "stored_at": datetime.now(UTC).isoformat(),
+                }
+            )
+            # Atomic write: a partial file must never read as a hit. Write a temp file in
+            # the same dir, then os.replace (atomic on the same filesystem).
+            fd, tmp = tempfile.mkstemp(dir=str(pocket_dir), suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    fh.write(payload)
+                os.replace(tmp, str(pocket_dir / f"{content_hash}.json"))
+            except OSError:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+        except OSError:
+            # Best-effort cache — a write failure must not break the render path.
+            logger.warning(
+                "sites.artifact_store: write failed for pocket %s", pocket_id, exc_info=True
+            )
+            return
+        self._evict(pocket_dir)
+
+    def _evict(self, pocket_dir: Path) -> None:
+        """Keep only the newest ``_artifact_keep()`` artifact files (current + previous
+        by default) in the pocket dir, deleting the oldest by mtime. Best-effort."""
+        try:
+            files = sorted(
+                (p for p in pocket_dir.glob("*.json") if p.is_file()),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+        except OSError:
+            return
+        for stale in files[_artifact_keep() :]:
+            try:
+                stale.unlink()
+            except OSError:
+                pass
+
+
+_DEFAULT_ARTIFACT_STORE = _FilesystemArtifactStore()
+
+
+def _default_artifact_store() -> _FilesystemArtifactStore:
+    """The process-wide default native-artifact store (a filesystem store). Factored so
+    ``get_native_artifact`` / the pre-warm resolve the same instance and tests can pass
+    an in-memory ``_store`` instead."""
+    return _DEFAULT_ARTIFACT_STORE
+
+
+async def _build_native_artifact(
+    *,
+    generator: GeneratorClient,
+    theme: dict[str, Any],
+    source: dict[str, Any],
+    site_name: str,
+    builder_origin: str,
+    pocket_id: str,
+    read: Callable[[str], tuple[str, str]],
+) -> tuple[str, str]:
+    """Run the ARMED svelte build for a native artifact and extract ``(body_html, css)``.
+
+    The single build path shared by get_native_artifact's cache MISS and the
+    background pre-warm. It builds with ``builder_origin`` set (so the paw-sites
+    generator stamps ``data-uid`` on the editable leaves + embeds the
+    ``paw-edit-manifest``) through ``_build_or_cloud_error`` (a toolchain / non-zero /
+    SmokeGate failure becomes a clean CloudError, not an opaque 500), then reads the
+    built ``<body>`` inner HTML + concatenated CSS off disk. ``smoke=False`` is the
+    arm/preview gate — skip the SSR fail-check but still emit the static output. A
+    svelte pocket has no rippleSpec, so ``ripple_spec={}`` (mirrors the prior inline
+    call); PERF-3's stable per-pocket build dir keeps node_modules / bun install
+    cached across builds so the arm build reuses the publish build's install."""
+    build = await _build_or_cloud_error(
+        generator,
+        ripple_spec={},
+        theme=theme,
+        # Transient, per-pocket-stable id — cosmetic here (only rides the built page's
+        # capture config, which the native editor ignores). The build DIR is keyed on
+        # pocket_id (PERF-3), not this, so it does not affect where the output lands.
+        site_id=_preview_id(pocket_id),
+        title=site_name,
+        capture_api_base=_capture_base(),
+        capture_signed_key=f"site_key_{secrets.token_urlsafe(24)}",
+        engine="svelte",
+        source=source,
+        builder_origin=builder_origin,
+        pocket_id=pocket_id,
+        smoke=False,
+    )
+    return read(build.project_dir)
+
+
+async def _prewarm_native_artifact(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    builder_origin: str | None = None,
+    _generator: GeneratorClient | None = None,
+    _read_built: Callable[[str], tuple[str, str]] | None = None,
+    _store: Any | None = None,
+) -> None:
+    """Produce + cache the ARMED native artifact for a pocket in the BACKGROUND so the
+    next preview/arm is a read-through cache HIT instead of an on-interaction build.
+
+    Fired after a source mutation (leaf edit / component edit) and after a LIVE svelte
+    publish. It re-reads the pocket (source is the source of truth and may have just
+    changed), computes the SAME content hash ``get_native_artifact`` uses, and — only
+    if the store does not already hold that render — builds once and stores it. So a
+    mutation that lands identical source, or a re-publish of unchanged source, rebuilds
+    nothing.
+
+    Best-effort by contract: callers schedule it through ``_safe_prewarm`` (which
+    swallows + logs) so the edit / publish they own returns regardless of a pre-warm
+    failure (missing toolchain, a non-svelte pocket, a read error)."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.sites import generator_client
+
+    pocket = await pockets_service.get(pocket_id, user_id)
+    # Only svelte sites have a native shadow-render build; ripple/html don't use this
+    # path (an html site's served artifact IS its source). Nothing to arm otherwise.
+    if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(
+        pocket.get("source"), dict
+    ):
+        return
+    source = pocket["source"]
+    ripple_spec = pocket.get("rippleSpec") or {}
+    theme = (ripple_spec.get("theme") if isinstance(ripple_spec, dict) else {}) or {}
+    site_name = (pocket.get("name") or "").strip() or "Untitled site"
+    origin = (builder_origin or "").strip() or _builder_origin()
+
+    store = _store or _default_artifact_store()
+    content_hash = _artifact_content_hash(
+        source=source,
+        theme=theme,
+        builder_origin=origin,
+        gen_version=generator_client.generator_version(),
+    )
+    if store.read(pocket_id, content_hash) is not None:
+        return  # already warm — no rebuild
+    generator = _generator or GeneratorClient()
+    read = _read_built or _read_native_artifact
+    body_html, css = await _build_native_artifact(
+        generator=generator,
+        theme=theme,
+        source=source,
+        site_name=site_name,
+        builder_origin=origin,
+        pocket_id=pocket_id,
+        read=read,
+    )
+    store.write(pocket_id, content_hash, body_html, css)
+
+
+async def _safe_prewarm(**kwargs: Any) -> None:
+    """Run ``_prewarm_native_artifact`` swallowing ALL errors — pre-warm is best-effort
+    and must never break the edit / publish that scheduled it."""
+    try:
+        await _prewarm_native_artifact(**kwargs)
+    except Exception:  # noqa: BLE001 — pre-warm is best-effort, never a gate
+        logger.warning(
+            "sites.prewarm: native-artifact pre-warm failed for pocket %s",
+            kwargs.get("pocket_id"),
+            exc_info=True,
+        )
+
+
+# Background-task keepalive: asyncio holds only a WEAK ref to a bare create_task, so a
+# fire-and-forget task can be garbage-collected mid-run. Hold a strong ref until done.
+_PREWARM_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _default_prewarm_scheduler(coro: Any) -> None:
+    """The production pre-warm scheduler — detach the coroutine as a background task on
+    the running loop and return immediately (off the caller's critical path). With no
+    running loop (a sync call site), close the coroutine and skip; pre-warm is
+    best-effort. Tests patch this module attr to capture the coroutine instead."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        coro.close()
+        return
+    task = loop.create_task(coro)
+    _PREWARM_TASKS.add(task)
+    task.add_done_callback(_PREWARM_TASKS.discard)
+
+
+def _schedule_native_prewarm(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    builder_origin: str | None = None,
+    _generator: GeneratorClient | None = None,
+    _read_built: Callable[[str], tuple[str, str]] | None = None,
+    _store: Any | None = None,
+) -> None:
+    """Fire a background native-artifact pre-warm for a pocket. A thin, non-async
+    wrapper the mutation / publish call sites invoke; it never blocks or raises. The
+    injected ``_generator`` seam is forwarded so a faked-generator publish/edit
+    pre-warms with the SAME fake (unit tests never shell out). The scheduler is looked
+    up on the module (``_default_prewarm_scheduler``) so tests can patch it."""
+    _default_prewarm_scheduler(
+        _safe_prewarm(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            builder_origin=builder_origin,
+            _generator=_generator,
+            _read_built=_read_built,
+            _store=_store,
+        )
+    )
 
 
 async def _build_or_cloud_error(
@@ -2151,6 +2487,25 @@ async def publish_pocket(
         _local_deploy=_local_deploy,
     )
 
+    # feat/sites-native-artifact-no-build: a LIVE svelte publish pre-warms the native
+    # artifact cache in the BACKGROUND so the FIRST preview after publish is a
+    # read-through HIT instead of an on-view build. The live publish itself deploys the
+    # PLAIN (non-armed) public site (the /sites/publish endpoint threads no
+    # builder_origin — see the armed-vs-plain finding in the PR); the pre-warm produces
+    # the ARMED artifact the native editor needs, so the public deploy is unchanged.
+    # Only svelte sites have a native build; a dynamic site deferred to the provision
+    # job returns deployed=False, so guard on doc.deployed too. Best-effort, off the
+    # publish's path. Forwards the injected generator so a faked publish warms with the
+    # same fake (unit tests never shell out).
+    if engine == "svelte" and getattr(doc, "deployed", False):
+        _schedule_native_prewarm(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            builder_origin=builder_origin,
+            _generator=_generator,
+        )
+
     # Stamp the per-site annual plan, open the per-site Dodo sub (degrading
     # gracefully when Dodo is unconfigured), and emit SitePublished. No checkout_url
     # on this path — the site is already live.
@@ -2716,6 +3071,7 @@ async def apply_leaf_edits(
     # otherwise overwrite a live-data binding or 404 on an unknown path). Each write
     # auto-writes a Branch draft snapshotting the FULL edited map, so after the loop
     # the draft == the fully edited source. Multi-file safe.
+    changed = False
     for path, contents in new_map.items():
         if path not in files:
             continue
@@ -2723,6 +3079,17 @@ async def apply_leaf_edits(
             await pockets_service.set_svelte_source_file(
                 pocket_id, user_id, component_path=path, new_source=contents
             )
+            changed = True
+
+    # feat/sites-native-artifact-no-build: source changed → pre-warm the native
+    # artifact cache in the BACKGROUND so the next preview/arm is a read-through HIT
+    # instead of an on-view build. Only when something actually changed (a fully
+    # rejected batch persists nothing, so it warms nothing). Best-effort + off the
+    # edit's path; a pre-warm failure never affects this call.
+    if changed:
+        _schedule_native_prewarm(
+            workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id
+        )
 
     return results
 
@@ -2735,37 +3102,42 @@ async def get_native_artifact(
     builder_origin: str | None = None,
     _generator: GeneratorClient | None = None,
     _read_built: Callable[[str], tuple[str, str]] | None = None,
+    _store: Any | None = None,
 ) -> dict[str, str]:
-    """Serve a svelte Paw Site's ARMED build as ``{pocket_id, body_html, css}`` so the
+    """Serve a svelte Paw Site's ARMED render as ``{pocket_id, body_html, css}`` so the
     native editor can shadow-render it (NE-5b) instead of framing an iframe.
 
-    The native-editing render path. It:
-      1. reads the pocket (the pockets service's PUBLIC ``get`` raises NotFound /
-         Forbidden itself — a missing / cross-tenant pocket surfaces as 404 / 403)
-         and asserts it is a svelte site (else ``ValidationError`` → 422), mirroring
+    READ-THROUGH cache (feat/sites-native-artifact-no-build). Viewing a site must NOT
+    trigger a build — the prior behaviour ran a full SvelteKit build on EVERY call
+    (1-2 min on the prod box). Now:
+      1. read the pocket (the pockets service's PUBLIC ``get`` raises NotFound /
+         Forbidden itself — a missing / cross-tenant pocket surfaces as 404 / 403) and
+         assert it is a svelte site (else ``ValidationError`` → 422), mirroring
          ``apply_leaf_edits`` / ``edit_svelte_component``;
-      2. ENSURES the ARMED build: it builds the pocket with ``builder_origin`` set so
-         the paw-sites generator stamps ``data-uid`` on the editable leaves AND embeds
-         the ``<script id="paw-edit-manifest">`` (SE-1 / EP-6 gate on ``builderOrigin``).
-         ``builder_origin`` defaults to the configured dashboard origin
-         (``PAW_SITES_BUILDER_ORIGIN``) exactly like ``make_site_editable``, so the
-         call works with no explicit origin. It builds via a DIRECT
-         ``GeneratorClient.build`` — the SAME arm/preview gate ``make_site_editable``
-         uses (``smoke=False`` skips the SSR FAIL-check but the static build still
-         runs; ``static_build`` stays the default ``True`` so ``.svelte-kit/cloudflare/``
-         is emitted) — instead of the full ``publish_pocket`` preview path, because
-         this is a READ: it needs neither a deploy, a Site doc, a promote, nor billing,
-         and ``build()`` RETURNS the ``project_dir`` so the built output is located
-         without reconstructing a path. PERF-3 builds into the stable
-         ``build_home()/<pocket_id>/`` so node_modules / bun install stay cached;
-      3. reads the built ``<body>`` inner HTML + concatenated CSS from that
-         ``project_dir``'s ``.svelte-kit/cloudflare/index.html`` (the SAME tree
-         ``_default_bundle_reader`` / ``local_server`` read) and returns them.
+      2. resolve the ARM inputs (source map, theme, builder origin — defaulting to the
+         configured ``PAW_SITES_BUILDER_ORIGIN`` when the caller passes none, exactly
+         like ``make_site_editable``) and hash them with the generator version into a
+         content hash;
+      3. CACHE HIT — the store already holds that render → return it from disk with
+         ZERO subprocess builds (the whole point). Publish and the post-edit pre-warm
+         populate the store ahead of the view, so a live/clean site is a hit;
+      4. CACHE MISS — build ONCE (armed: ``builder_origin`` set so the generator stamps
+         ``data-uid`` + embeds ``paw-edit-manifest``; ``smoke=False`` arm gate) through
+         ``_build_or_cloud_error`` (a toolchain / non-zero / SmokeGate failure becomes a
+         clean CloudError, not an opaque 500), read the built ``<body>`` inner HTML +
+         concatenated CSS, STORE it, and return. PERF-3's stable per-pocket build dir
+         keeps node_modules / bun install cached across builds.
 
-    ``_generator`` (defaults to a real ``GeneratorClient``) and ``_read_built``
-    (defaults to ``_read_native_artifact`` — the disk read + HTML/CSS extraction) are
-    injectable seams so the path is unit-testable without Bun / a real build."""
+    Local-mode degrade: a store miss on a box where no build has ever run just takes
+    the MISS branch (build once); a build failure still maps to a clean CloudError, so
+    the endpoint degrades cleanly rather than 500ing opaquely — unchanged from before.
+
+    ``_generator`` (defaults to a real ``GeneratorClient``), ``_read_built`` (defaults
+    to ``_read_native_artifact`` — the disk read + HTML/CSS extraction), and ``_store``
+    (defaults to the filesystem artifact store) are injectable seams so the path is
+    unit-testable without Bun / a real build / disk."""
     from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.sites import generator_client
 
     # The pockets service's PUBLIC get raises NotFound / Forbidden itself (entity
     # isolation) — a missing / cross-tenant pocket surfaces as 404 / 403.
@@ -2789,39 +3161,35 @@ async def get_native_artifact(
     # data-uid + embed the manifest. Default to the configured dashboard origin when
     # the caller passes none, exactly like make_site_editable.
     origin = (builder_origin or "").strip() or _builder_origin()
-    generator = _generator or GeneratorClient()
-    # DEP-3: route the arm build through _build_or_cloud_error (the SAME helper the
-    # publish paths at ~1152 / ~1293 use) so a missing-toolchain / non-zero build /
-    # SmokeGateFailed becomes a clean CloudError (sites.generator_failed → 5xx)
-    # instead of escaping as an opaque unhandled 500. Unlike edit_svelte_component's
-    # preview build (map_smoke_gate=False, which preserves its
-    # rollback-on-SmokeGateFailed contract), this is a READ-ONLY render with no source
-    # mutation to roll back, so SmokeGateFailed is mapped too (default
-    # map_smoke_gate=True) — the caller just gets a structured error.
-    build = await _build_or_cloud_error(
-        generator,
-        ripple_spec=ripple_spec,
-        theme=theme,
-        # Transient, per-pocket-stable id — cosmetic here (it only rides the built
-        # page's capture config, which the native editor ignores). The build DIR is
-        # keyed on pocket_id (PERF-3), not this, so it does not affect where the
-        # output lands.
-        site_id=_preview_id(pocket_id),
-        title=site_name,
-        capture_api_base=_capture_base(),
-        capture_signed_key=f"site_key_{secrets.token_urlsafe(24)}",
-        engine="svelte",
+    store = _store or _default_artifact_store()
+    content_hash = _artifact_content_hash(
         source=source,
+        theme=theme,
+        builder_origin=origin,
+        gen_version=generator_client.generator_version(),
+    )
+    # READ-THROUGH: a hit serves the prior render straight off disk — no generator, no
+    # subprocess, no build. This is what makes a VIEW instant on the prod box.
+    cached = store.read(pocket_id, content_hash)
+    if cached is not None:
+        body_html, css = cached
+        return {"pocket_id": pocket_id, "body_html": body_html, "css": css}
+
+    # MISS: build once (armed), cache, return. ``_build_native_artifact`` routes through
+    # _build_or_cloud_error so a missing-toolchain / non-zero build / SmokeGateFailed
+    # becomes a clean CloudError (sites.generator_failed → 5xx), not an opaque 500.
+    generator = _generator or GeneratorClient()
+    read = _read_built or _read_native_artifact
+    body_html, css = await _build_native_artifact(
+        generator=generator,
+        theme=theme,
+        source=source,
+        site_name=site_name,
         builder_origin=origin,
         pocket_id=pocket_id,
-        # Arm/preview gate: skip the SSR FAIL-check but STILL emit the static
-        # .svelte-kit/cloudflare/ output (static_build defaults True) so there is an
-        # index.html to read.
-        smoke=False,
+        read=read,
     )
-
-    read = _read_built or _read_native_artifact
-    body_html, css = read(build.project_dir)
+    store.write(pocket_id, content_hash, body_html, css)
     return {"pocket_id": pocket_id, "body_html": body_html, "css": css}
 
 
@@ -2943,7 +3311,7 @@ async def edit_svelte_component(
     #    surfaces the reason. The prior deploy is untouched because the gate fires
     #    before publish deploys.
     try:
-        return await publish_pocket(
+        doc = await publish_pocket(
             workspace_id=workspace_id,
             user_id=user_id,
             pocket_id=pocket_id,
@@ -2963,6 +3331,19 @@ async def edit_svelte_component(
             new_source=previous_source,
         )
         raise
+
+    # feat/sites-native-artifact-no-build: the component source changed → pre-warm the
+    # native artifact cache in the BACKGROUND (re-applying the SE-2b builder origin) so
+    # the next native shadow-render is a read-through HIT. Best-effort, off this call's
+    # path; fired only after the preview republish above succeeded (no arm on rollback).
+    _schedule_native_prewarm(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        builder_origin=builder_origin or None,
+        _generator=_generator,
+    )
+    return doc
 
 
 async def _latest_site_for_pocket(workspace_id: str, pocket_id: str) -> _SiteDoc | None:

--- a/tests/ee/sites/conftest.py
+++ b/tests/ee/sites/conftest.py
@@ -1,5 +1,11 @@
 # tests/ee/sites/conftest.py
 # Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+# Updated 2026-07-17 (feat/sites-native-artifact-no-build): added two autouse fixtures
+#   for the native-artifact read-through cache — ``_artifact_store_tmp`` points
+#   PAW_SITES_ARTIFACT_DIR at a temp dir so a cache MISS never writes the real home, and
+#   ``_captured_prewarms`` patches the pre-warm scheduler to capture (not run) scheduled
+#   pre-warm coroutines so the suite never spawns a stray background build; a pre-warm
+#   test requests it by name to assert scheduling / await the coroutine to run it.
 # Updated 2026-06-24 (BC-9): added an autouse ``_recording_bus_for_sites`` fixture.
 #   ``publish_pocket`` now emits ``SitePublished`` after a live publish, and
 #   ``emit()`` asserts a bus is initialised; this installs a recording bus for the
@@ -69,6 +75,41 @@ async def _sites_beanie_settings() -> Any:
 
     await init_beanie(database=db, document_models=[*ALL_DOCUMENTS, MemoryFactDoc])
     yield
+
+
+@pytest.fixture(autouse=True)
+def _artifact_store_tmp(tmp_path, monkeypatch):
+    """Redirect the native-artifact cache root (PAW_SITES_ARTIFACT_DIR) to a per-test
+    temp dir (feat/sites-native-artifact-no-build), mirroring how the build dir is kept
+    out of the real ~/.pocketpaw. get_native_artifact's default filesystem store writes
+    the rendered {body_html, css} here on a cache MISS, so without this a test that
+    exercises the miss path would pollute the developer's real home."""
+    monkeypatch.setenv("PAW_SITES_ARTIFACT_DIR", str(tmp_path / "site-artifacts"))
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _captured_prewarms(monkeypatch):
+    """Capture (do NOT run) native-artifact pre-warm coroutines the sites service
+    schedules (feat/sites-native-artifact-no-build).
+
+    ``apply_leaf_edits`` / ``edit_svelte_component`` / a live svelte ``publish_pocket``
+    fire a background pre-warm via ``_default_prewarm_scheduler``. In production that
+    detaches an ``asyncio`` task; in tests we DON'T want a stray background build, so
+    this patches the scheduler to append each scheduled coroutine to a list instead.
+    A pre-warm test requests this fixture by name to assert one was scheduled and, if it
+    wants the pre-warm to actually run + populate the store, ``await``s the captured
+    coroutine itself. Un-awaited coroutines are closed on teardown so no "coroutine was
+    never awaited" warning leaks into unrelated tests."""
+    from pocketpaw_ee.sites import service as sites_service
+
+    captured: list = []
+    monkeypatch.setattr(
+        sites_service, "_default_prewarm_scheduler", lambda coro: captured.append(coro)
+    )
+    yield captured
+    for coro in captured:
+        coro.close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ee/sites/test_native_artifact.py
+++ b/tests/ee/sites/test_native_artifact.py
@@ -4,6 +4,17 @@
 # hardening: a generator build failure (SmokeGateFailed / missing toolchain) now
 # surfaces as a clean CloudError (sites.generator_failed), not an opaque 500, because
 # get_native_artifact routes its build through _build_or_cloud_error.
+# Updated 2026-07-17 (feat/sites-native-artifact-no-build): get_native_artifact is now a
+# READ-THROUGH cache — a preview VIEW must not trigger a build. New tests prove:
+#   * a repeat call with unchanged source is a cache HIT → ZERO extra builds;
+#   * an injected _store hit skips the build entirely;
+#   * a source change is a MISS → rebuild (the content hash tracks source);
+#   * a LIVE svelte publish schedules a pre-warm that stores the armed artifact, so the
+#     next native-artifact call is a HIT (DoD: publish stores → next preview is a hit);
+#   * a leaf edit / component edit that changes source schedules a pre-warm; a rejected
+#     leaf edit schedules none;
+#   * the filesystem store degrades cleanly (missing dir / corrupt file read as a MISS)
+#     and evicts to keep only current + previous.
 #
 # Under test: sites_service.get_native_artifact — the backend of the native
 # shadow-render path. It ensures the pocket's ARMED svelte build (builder_origin set,
@@ -275,3 +286,292 @@ async def test_native_artifact_build_failure_maps_to_cloud_error(beanie_test_db)
     # SmokeGateFailed is a RuntimeError subclass, so confirm what surfaced is the
     # mapped CloudError, not the raw RuntimeError.
     assert not isinstance(excinfo.value, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# feat/sites-native-artifact-no-build — read-through cache + background pre-warm.
+# ---------------------------------------------------------------------------
+
+
+class _CountingGenerator:
+    """Records EACH build call so a test can assert the read-through cache skipped a
+    rebuild. Returns a BuildResult pointing at a pre-populated project_dir."""
+
+    def __init__(self, project_dir: str) -> None:
+        self.project_dir = project_dir
+        self.calls = 0
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.calls += 1
+        return BuildResult(project_dir=self.project_dir, ripple_version=None)
+
+
+class _MemoryArtifactStore:
+    """In-memory ``_store`` seam — exercises the read-through logic without disk."""
+
+    def __init__(self) -> None:
+        self.data: dict[tuple[str, str], tuple[str, str]] = {}
+        self.writes = 0
+
+    def read(self, pocket_id: str, content_hash: str) -> tuple[str, str] | None:
+        return self.data.get((pocket_id, content_hash))
+
+    def write(self, pocket_id: str, content_hash: str, body_html: str, css: str) -> None:
+        self.data[(pocket_id, content_hash)] = (body_html, css)
+        self.writes += 1
+
+
+class _FakeCF:
+    async def put_worker(self, *, script_name, bundle, bindings=None):  # noqa: ARG002
+        return True
+
+
+def _fake_local_deploy(site_id: str, project_dir: str) -> str:  # noqa: ARG001
+    return f"http://127.0.0.1:9999/{site_id}/"
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_repeat_call_is_cache_hit_zero_builds(beanie_test_db, tmp_path):
+    """The core DoD: a repeat GET with UNCHANGED source performs ZERO subprocess builds.
+    The first call is a MISS (build once, store); the second is a read-through HIT off
+    the default filesystem store (redirected to tmp by the conftest fixture)."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    _write_built_output(tmp_path)
+    gen = _CountingGenerator(str(tmp_path))
+
+    r1 = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="https://dash.paw.example",
+        _generator=gen,
+    )
+    r2 = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="https://dash.paw.example",
+        _generator=gen,
+    )
+
+    assert r1 == r2
+    assert gen.calls == 1, "the second identical view must be a cache HIT — zero rebuilds"
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_store_hit_skips_build(beanie_test_db):
+    """A store that already holds the content-hashed render serves it WITHOUT any build
+    — proven by a generator whose build must never run."""
+    from pocketpaw_ee.sites import generator_client
+
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    store = _MemoryArtifactStore()
+    wire = await pockets_service.get(pocket_id, "u1")
+    content_hash = sites_service._artifact_content_hash(
+        source=wire["source"],
+        theme={},
+        builder_origin="https://dash.paw.example",
+        gen_version=generator_client.generator_version(),
+    )
+    store.data[(pocket_id, content_hash)] = ("<h1>cached</h1>", ".x{color:red}")
+
+    result = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="https://dash.paw.example",
+        _generator=_NoBuildGenerator(),
+        _store=store,
+    )
+
+    assert result == {
+        "pocket_id": pocket_id,
+        "body_html": "<h1>cached</h1>",
+        "css": ".x{color:red}",
+    }
+    assert store.writes == 0, "a cache hit must not re-store"
+
+
+@pytest.mark.asyncio
+async def test_native_artifact_source_change_is_cache_miss(beanie_test_db, tmp_path):
+    """The content hash tracks the source: an unchanged view HITs, but a source mutation
+    changes the hash → MISS → rebuild."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    _write_built_output(tmp_path)
+    gen = _CountingGenerator(str(tmp_path))
+    store = _MemoryArtifactStore()
+    kw = dict(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="https://dash.paw.example",
+        _generator=gen,
+        _store=store,
+    )
+
+    await sites_service.get_native_artifact(**kw)  # MISS → build 1
+    await sites_service.get_native_artifact(**kw)  # HIT → still 1
+    assert gen.calls == 1
+
+    await pockets_service.set_svelte_source_file(
+        pocket_id,
+        "u1",
+        component_path="src/lib/components/Hero.svelte",
+        new_source="<section class='hero'><h1>Changed</h1></section>",
+    )
+    await sites_service.get_native_artifact(**kw)  # source changed → MISS → build 2
+    assert gen.calls == 2, "a source change must be a cache MISS and rebuild"
+
+
+@pytest.mark.asyncio
+async def test_publish_prewarms_then_native_artifact_hits(
+    beanie_test_db, tmp_path, monkeypatch, _captured_prewarms
+):
+    """DoD: a LIVE svelte publish stores an artifact (via the scheduled pre-warm) so the
+    NEXT native-artifact view is a cache HIT — no on-view build."""
+    # Force the LOCAL deploy branch so the live publish never shells out to a real
+    # deployer (the workspace .env sets PAW_CF_DEPLOY_MODE=workers, which would route to
+    # a real wrangler deploy); the fake local deploy makes doc.deployed=True.
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    _write_built_output(tmp_path)
+    gen = _CountingGenerator(str(tmp_path))
+
+    await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=gen,
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    # A live svelte publish scheduled exactly one background pre-warm.
+    assert len(_captured_prewarms) == 1, "a live svelte publish must schedule a pre-warm"
+    # Run it — the pre-warm builds the ARMED artifact and stores it (default fs store).
+    await _captured_prewarms[0]
+
+    # The next view is a read-through HIT — proven by a generator that must not build.
+    result = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        # No explicit origin → the same PAW_SITES_BUILDER_ORIGIN fallback the publish
+        # pre-warm resolved, so the content hash matches and the store hits.
+        builder_origin="",
+        _generator=_NoBuildGenerator(),
+    )
+    assert result["pocket_id"] == pocket_id
+    assert 'data-uid="Hero:headline:0"' in result["body_html"]
+    assert 'id="paw-edit-manifest"' in result["body_html"]
+
+
+@pytest.mark.asyncio
+async def test_leaf_edit_change_schedules_prewarm(beanie_test_db, _captured_prewarms):
+    """DoD: a leaf edit that CHANGES source schedules a background pre-warm (the seam is
+    captured, not run)."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    async def _fake_apply(*, source, edits):
+        new = dict(source)
+        new["src/lib/components/Hero.svelte"] = "<section class='hero'><h1>Edited</h1></section>"
+        return {"source": new, "results": [{"uid": edits[0]["uid"], "applied": True}]}
+
+    await sites_service.apply_leaf_edits(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        edits=[{"uid": "Hero:headline:0", "op": {"kind": "text", "value": "Edited"}}],
+        _apply=_fake_apply,
+    )
+
+    assert len(_captured_prewarms) == 1, "a source-changing leaf edit must schedule a pre-warm"
+
+
+@pytest.mark.asyncio
+async def test_leaf_edit_rejected_schedules_no_prewarm(beanie_test_db, _captured_prewarms):
+    """A REJECTED leaf edit persists nothing, so it warms nothing — no pre-warm scheduled."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    async def _fake_apply(*, source, edits):
+        # Byte-identical source back (a rejected edit) → the persist loop writes nothing.
+        return {
+            "source": dict(source),
+            "results": [{"uid": edits[0]["uid"], "applied": False, "reason": "no unique match"}],
+        }
+
+    await sites_service.apply_leaf_edits(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        edits=[{"uid": "Hero:headline:0", "op": {"kind": "text", "value": "Edited"}}],
+        _apply=_fake_apply,
+    )
+
+    assert len(_captured_prewarms) == 0, "a rejected edit changes nothing → no pre-warm"
+
+
+@pytest.mark.asyncio
+async def test_component_edit_schedules_prewarm(beanie_test_db, _captured_prewarms):
+    """A targeted component edit (edit_svelte_component) also schedules a pre-warm after
+    its preview republish succeeds."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen = _CountingGenerator("/tmp/paw-native-artifact-unused")
+
+    await sites_service.edit_svelte_component(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/lib/components/Hero.svelte",
+        new_source="<section class='hero'><h1>Edited</h1></section>",
+        _generator=gen,
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    assert len(_captured_prewarms) == 1, "a component edit must schedule a native-artifact pre-warm"
+
+
+def test_filesystem_store_missing_and_corrupt_read_as_miss(tmp_path, monkeypatch):
+    """Local-mode degrade: the filesystem store treats a missing dir / file and a corrupt
+    file as a MISS (returns None) so a bad cache entry degrades to a rebuild, never a 500."""
+    from pocketpaw_ee.sites.generator_client import artifact_home
+
+    monkeypatch.setenv("PAW_SITES_ARTIFACT_DIR", str(tmp_path / "artifacts"))
+    store = sites_service._FilesystemArtifactStore()
+
+    # Nothing written yet → miss, no error.
+    assert store.read("pocketX", "deadbeef") is None
+    # Round-trips a write.
+    store.write("pocketX", "deadbeef", "<b>hi</b>", ".a{}")
+    assert store.read("pocketX", "deadbeef") == ("<b>hi</b>", ".a{}")
+    # A corrupt file reads as a miss.
+    corrupt = artifact_home() / "pocketY"
+    corrupt.mkdir(parents=True, exist_ok=True)
+    (corrupt / "abc123.json").write_text("{ not json", encoding="utf-8")
+    assert store.read("pocketY", "abc123") is None
+
+
+def test_filesystem_store_evicts_to_keep_cap(tmp_path, monkeypatch):
+    """The store keeps only current + previous (PAW_SITES_ARTIFACT_KEEP) per pocket,
+    evicting the oldest by mtime so it never grows unbounded."""
+    import time
+
+    from pocketpaw_ee.sites.generator_client import artifact_home
+
+    monkeypatch.setenv("PAW_SITES_ARTIFACT_DIR", str(tmp_path / "artifacts"))
+    monkeypatch.setenv("PAW_SITES_ARTIFACT_KEEP", "2")
+    store = sites_service._FilesystemArtifactStore()
+
+    for i in range(4):
+        store.write("pocketZ", f"hash{i}", f"<b>{i}</b>", ".a{}")
+        time.sleep(0.01)  # distinct mtimes so eviction order is deterministic
+
+    files = list((artifact_home() / "pocketZ").glob("*.json"))
+    assert len(files) == 2, "eviction keeps only current + previous"
+    assert store.read("pocketZ", "hash3") is not None  # newest survives
+    assert store.read("pocketZ", "hash2") is not None
+    assert store.read("pocketZ", "hash0") is None  # oldest evicted


### PR DESCRIPTION
## What and why

Viewing a svelte Paw Site in the native editor triggered a full SvelteKit build on every `GET /sites/by-pocket/{pocket_id}/native-artifact` call. That is quick on a fast laptop but takes 1 to 2 minutes on the prod Hetzner box, so every site view stalled behind a build.

After this change, viewing a site never triggers a build. `get_native_artifact` is a read-through cache; builds remain only at publish and, warmed in the background, at edit-arm.

## How it works

- **Artifact store** (`_FilesystemArtifactStore`, `generator_client.artifact_home()`): rendered `{body_html, css}` is persisted as JSON at `~/.pocketpaw/site-artifacts/<pocket_id>/<content_hash>.json`, so it rides the prod `backend-data` volume next to `build_home()`. Keyed per pocket by a content hash of `source map + theme + builder origin + generator version`. Eviction keeps current plus previous (`PAW_SITES_ARTIFACT_KEEP`, default 2). No `Site` doc schema change: the read-through recomputes the hash from live source, so no stored pointer is needed, the publish write path stays untouched, and paths are keyed by the tenant-scoped `pocket_id`.
- **`get_native_artifact` is read-through**: hash current inputs, cache hit is a disk read with zero subprocess builds, cache miss builds once (armed, via the factored `_build_native_artifact`), stores, and returns. The `_store` seam is injectable alongside the existing `_generator` and `_read_built` seams, so tests never touch Bun or disk.
- **Background pre-warm** (`_prewarm_native_artifact` via `_default_prewarm_scheduler`, an `asyncio` task): fired after a live svelte `publish_pocket`, `apply_leaf_edits`, and `edit_svelte_component`. It re-reads the pocket, computes the same hash, and builds plus stores only if the store is cold, so the next view or arm is a hit. Best-effort: a pre-warm failure is logged and never surfaces to the edit or publish caller.
- **Local-mode degrade preserved**: a store miss on a box where no build has ever run just builds once; a corrupt or missing artifact reads as a miss; a build failure still maps to a clean `CloudError`, not an opaque 500.

## Armed vs plain publish finding (the open design question)

**The live publish build is PLAIN, not armed.** Evidence:

- `router.py` `publish_site` calls `sites_service.publish_pocket(...)` with no `builder_origin`, so the live deploy build in `_deploy_site_doc` gets `builder_origin=None`. In `generator_client.build()` the `builderOrigin` key is only added to `siteConfig` when `builder_origin` is truthy, so the generator stamps no `data-uid` and embeds no `paw-edit-manifest` on the deployed public page.
- Component edits (`edit_svelte_component`, `service.py`) republish with `preview=True`, which is a local transient preview, never a public armed deploy.

So public pages carry no edit-bridge today. **Chosen approach:** do not thread `builder_origin` into the live publish (that would newly ship the anchors and the postMessage bridge to public pages, and the generator that gates them is a separate binary I cannot prove inert from this repo). Instead, a unified background pre-warm produces the ARMED artifact the native editor needs. The public deploy is byte-for-byte unchanged; the armed artifact is a cache concern only.

## Frontend

No paw-enterprise change. `SitePreview.svelte` already routes svelte drafts and not-yet-live sites to the client-side REPL preview (`SvelteReplPreview`, zero backend build) and live sites to `NativeSiteEditor`, which fetches `native-artifact` once on mount (not per keystroke). That fetch is now a cache read served by the pre-warm. Routing dirty-live sites to the REPL would remove the native inline-edit surface, so it belongs to the later REPL-everywhere wave, not here.

## Verification

- `A repeat GET with unchanged source performs zero builds`: `test_native_artifact_repeat_call_is_cache_hit_zero_builds` (build count stays 1 across two views), `test_native_artifact_store_hit_skips_build` (a generator that must never build).
- `Publish stores an artifact, next preview is a hit`: `test_publish_prewarms_then_native_artifact_hits`.
- `Source mutation pre-warms, manual arm builds once`: `test_leaf_edit_change_schedules_prewarm`, `test_leaf_edit_rejected_schedules_no_prewarm`, `test_component_edit_schedules_prewarm`, `test_native_artifact_source_change_is_cache_miss`.
- `Local-mode degrade`: `test_filesystem_store_missing_and_corrupt_read_as_miss`, plus the existing build-failure-to-CloudError test.
- `uv run pytest tests/ee/sites/test_native_artifact.py` is 15 passed. Direct consumers (leaf edits, component edit, diff edit, preview, generator client, sites MCP tools) all pass.
- Pre-existing reds: the sites publish and deploy tests fail identically on base (61 failed on `origin/dev`, 61 failed here) because the workspace `.env` sets `PAW_CF_DEPLOY_MODE=workers`, which routes fake-generator publishes to a real wrangler deploy. My change adds 9 passing tests and zero new failures. Same 8 pre-existing mypy errors on base and here.

## Docs

Updated the `service.py`, `generator_client.py`, and `router.py` module and endpoint docs, and the `native-artifact` section of `docs/api-reference.md` (which previously stated "Every GET rebuilds").
