### PR TITLE
fix(sites): pre-warm the native artifact at the origin a view resolves

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1189,6 +1189,20 @@ from the request's `Origin` header, falling back to the configured
 `PAW_SITES_BUILDER_ORIGIN` when absent (the same precedence as `/editable` and
 `/dev-preview`), so the call works with no header.
 
+**Origin stability — the pre-warm must match the view.** The builder origin is part
+of the content hash, so a pre-warm only saves a view a build when it builds with the
+**same** origin that view resolves. A browser view resolves its origin from the
+request `Origin` header (the dashboard origin), so `POST /sites/publish` and
+`POST /sites/by-pocket/{id}/leaf-edits` thread their request `Origin` into the
+background pre-warm — otherwise the pre-warm would fall back to
+`PAW_SITES_BUILDER_ORIGIN` while the view uses the dashboard origin, the two hashes
+would differ, and every view would stay a cold miss. Chat-agent / MCP publishes and
+edits have no request origin, so their pre-warm keeps the env fallback: **set
+`PAW_SITES_BUILDER_ORIGIN` to the dashboard origin** (e.g.
+`https://paw.example.com`, not the `http://localhost:8888` default) in every
+deployment so that fallback matches the origin views ask for — a belt-and-braces
+default even where the request `Origin` is threaded.
+
 **CSS reader is path-traversal-guarded.** Stylesheet `href`s from the built
 `index.html` are resolved against the build tree (relative `./_app/…` and
 absolute `/_app/…` hrefs both) and each resolved path is checked to be contained

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -8,6 +8,15 @@
 # name) and RAISES NotFound when missing / access-denied (it does not return
 # None). theme is pulled from the rippleSpec subtree.
 #
+# Updated 2026-07-17 (fix/sites-prewarm-origin): ``publish_site`` and
+# ``apply_leaf_edits_by_pocket`` now thread the request ``Origin`` header into the
+# service as ``prewarm_origin`` so the background native-artifact pre-warm builds with
+# the SAME origin the browser's ``GET /native-artifact`` view resolves — otherwise the
+# pre-warm falls back to PAW_SITES_BUILDER_ORIGIN, its content hash never matches the
+# view's, and every view is a cold miss. The PUBLIC deploy is unchanged (still plain —
+# ``prewarm_origin`` steers only the pre-warmed armed artifact), mirroring the existing
+# Origin precedence /editable + /dev-preview + /native-artifact already use.
+#
 # Updated 2026-06-01 (Phase 4 — chat→create-site): publish_site now delegates to
 # sites_service.publish_pocket(), the shared pocket-read + publish path the new
 # in-process MCP tool also calls. The pocket-read/theme-derive logic that used to
@@ -173,6 +182,7 @@ router = APIRouter(
 @router.post("/sites/publish", response_model=SiteResponse)
 async def publish_site(
     body: PublishRequest,
+    request: Request,
     ctx: RequestContext = Depends(request_context),
     _: object = Depends(require_action_any_workspace("fabric.write")),
 ) -> SiteResponse:
@@ -181,11 +191,20 @@ async def publish_site(
     # tool via ``publish_pocket``. ``pockets_service.get`` (called inside) raises
     # NotFound / Forbidden itself, which the standard error envelope maps to
     # 404 / 403 — no extra existence check is needed here.
+    #
+    # ORIGIN-STABILITY (fix/sites-prewarm-origin): thread the request Origin header as
+    # ``prewarm_origin`` so the background native-artifact pre-warm builds with the
+    # SAME origin the browser's GET /native-artifact view resolves (its own request
+    # Origin) — otherwise the pre-warm falls back to PAW_SITES_BUILDER_ORIGIN, its hash
+    # never matches the view's, and every view is a cold miss. This does NOT arm the
+    # PUBLIC deploy (builder_origin stays unset here — the public site stays plain); it
+    # only steers the pre-warmed armed artifact the native editor consumes.
     doc = await sites_service.publish_pocket(
         workspace_id=ctx.workspace_id,
         user_id=ctx.user_id,
         pocket_id=body.pocket_id,
         site_plan_key=body.site_plan_key,
+        prewarm_origin=request.headers.get("origin") or None,
     )
     return sites_service._to_response(doc)
 
@@ -242,6 +261,7 @@ async def make_site_editable(
 async def apply_leaf_edits_by_pocket(
     pocket_id: str,
     body: LeafEditsRequest,
+    request: Request,
     ctx: RequestContext = Depends(request_context),
     _: object = Depends(require_action_any_workspace("fabric.write")),
 ) -> LeafEditsResponse:
@@ -252,12 +272,20 @@ async def apply_leaf_edits_by_pocket(
     already renders the change optimistically; skipping the per-edit iframe rebuild
     is the UX win over the old edit path). Returns one verdict per edit. A missing /
     access-denied pocket is a 404 (the pockets service raises NotFound); a non-svelte
-    pocket or an empty edit batch is a 422."""
+    pocket or an empty edit batch is a 422.
+
+    ORIGIN-STABILITY (fix/sites-prewarm-origin): thread the request Origin header as
+    ``prewarm_origin`` so the background native-artifact pre-warm this schedules builds
+    with the SAME origin the browser's GET /native-artifact view resolves (its own
+    request Origin) — the native editor calls both from the same dashboard, so without
+    this the pre-warm falls back to PAW_SITES_BUILDER_ORIGIN and its hash never matches
+    the view's (mirrors the /sites/publish fix)."""
     results = await sites_service.apply_leaf_edits(
         workspace_id=ctx.workspace_id,
         user_id=ctx.user_id,
         pocket_id=pocket_id,
         edits=[e.model_dump() for e in body.edits],
+        prewarm_origin=request.headers.get("origin") or None,
     )
     return LeafEditsResponse(
         pocket_id=pocket_id,

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,21 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-17 (fix/sites-prewarm-origin — pre-warm the origin a VIEW asks for):
+# the native-artifact pre-warm must build with the SAME origin the browser's
+# ``GET /native-artifact`` view resolves (the request Origin header), or the content
+# hashes differ and the pre-warmed artifact is never hit — every view stays a cold
+# miss. ``publish_pocket`` and ``apply_leaf_edits`` gained a ``prewarm_origin`` param
+# the REST routers thread the request Origin into; it steers ONLY the pre-warm's armed
+# artifact (``builder_origin=prewarm_origin or builder_origin``), never the PUBLIC
+# deploy (a ``/sites/publish`` live deploy stays plain). Chat-agent / MCP callers pass
+# no ``prewarm_origin`` (no request origin), so the pre-warm keeps its
+# PAW_SITES_BUILDER_ORIGIN env fallback — set that env to the dashboard origin in
+# deployments as a belt-and-braces default so the fallback matches the view too.
+# ``edit_svelte_component`` is UNCHANGED: it is MCP-only (no request origin) and warms
+# with the origin the site was armed/published with (``prior.builder_origin``), which
+# already equals the dashboard origin a view asks for.
+#
 # Updated 2026-07-17 (feat/sites-native-artifact-no-build — kill preview-time builds):
 # ``get_native_artifact`` is now a READ-THROUGH cache instead of building on every
 # call. It hashes the pocket's render inputs (svelte source map + theme + builder
@@ -2327,6 +2342,7 @@ async def publish_pocket(
     name: str = "",
     site_plan_key: str | None = None,
     builder_origin: str | None = None,
+    prewarm_origin: str | None = None,
     preview: bool = False,
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
@@ -2375,6 +2391,18 @@ async def publish_pocket(
     ``builder_origin`` (SE-2b) is forwarded straight through so a publish via this
     shared path can request an editable site (the edit-bridge gates on it). It
     defaults to ``None`` (a normal, non-editable publish).
+
+    ``prewarm_origin`` is the origin the background native-artifact pre-warm should
+    build with — SEPARATE from ``builder_origin`` so it steers ONLY the pre-warmed
+    armed artifact, never the PUBLIC deploy (a live ``/sites/publish`` stays plain).
+    The REST ``/sites/publish`` router passes the request ``Origin`` header here so
+    the pre-warm produces the SAME content hash a browser's ``GET /native-artifact``
+    view (which resolves origin from its own request Origin header) will ask for;
+    otherwise the pre-warm would fall back to ``PAW_SITES_BUILDER_ORIGIN`` while the
+    view uses the dashboard origin, so their hashes never match and every view is a
+    cold miss. It defaults to ``None`` (chat-agent / MCP callers have no request
+    origin, so the pre-warm keeps the env fallback — set PAW_SITES_BUILDER_ORIGIN to
+    the dashboard origin in deployments so that fallback matches too).
 
     The generator / Cloudflare / bundle-reader / local-deploy seams are forwarded
     straight through to ``publish`` so the shared path is unit-testable without
@@ -2493,6 +2521,15 @@ async def publish_pocket(
     # PLAIN (non-armed) public site (the /sites/publish endpoint threads no
     # builder_origin — see the armed-vs-plain finding in the PR); the pre-warm produces
     # the ARMED artifact the native editor needs, so the public deploy is unchanged.
+    #
+    # ORIGIN-STABILITY (fix/sites-prewarm-origin): the pre-warm must build with the SAME
+    # origin the browser's native-artifact VIEW resolves — the request Origin header —
+    # or the content hashes never match and the pre-warmed artifact is dead weight. So
+    # steer the pre-warm by ``prewarm_origin`` (the request Origin the /sites/publish
+    # router threads), falling back to ``builder_origin`` (an armed publish) and then —
+    # inside the pre-warm — the PAW_SITES_BUILDER_ORIGIN env. This does NOT touch the
+    # public deploy above (still plain on the REST path); it only picks the arm origin.
+    #
     # Only svelte sites have a native build; a dynamic site deferred to the provision
     # job returns deployed=False, so guard on doc.deployed too. Best-effort, off the
     # publish's path. Forwards the injected generator so a faked publish warms with the
@@ -2502,7 +2539,7 @@ async def publish_pocket(
             workspace_id=workspace_id,
             user_id=user_id,
             pocket_id=pocket_id,
-            builder_origin=builder_origin,
+            builder_origin=prewarm_origin or builder_origin,
             _generator=_generator,
         )
 
@@ -2977,6 +3014,7 @@ async def apply_leaf_edits(
     user_id: str,
     pocket_id: str,
     edits: list[dict[str, Any]],
+    prewarm_origin: str | None = None,
     _apply: Any = None,
 ) -> list[dict[str, Any]]:
     """Persist native-editor leaf edits as a reviewable Branch draft (NE-4b).
@@ -3002,6 +3040,15 @@ async def apply_leaf_edits(
          naturally persists nothing and never churns an empty draft), each write
          auto-writing the Branch draft snapshot;
       5. return the per-uid verdicts unchanged.
+
+    ``prewarm_origin`` is the origin the background native-artifact pre-warm should
+    build with — the leaf-edits router passes the request ``Origin`` header so the
+    pre-warm produces the SAME content hash the browser's native-artifact VIEW
+    (which resolves origin from its own request Origin header) will ask for. Without
+    it the pre-warm falls back to ``PAW_SITES_BUILDER_ORIGIN`` while the view uses the
+    dashboard origin — different hash, so the warmed artifact is never hit. Defaults
+    to ``None`` (the pre-warm keeps the env fallback for callers with no request
+    origin).
 
     ``_apply`` is an injectable seam for the generator bridge (defaults to
     ``generator_client.apply_leaf_edits``) so the orchestration is unit-testable
@@ -3086,9 +3133,17 @@ async def apply_leaf_edits(
     # instead of an on-view build. Only when something actually changed (a fully
     # rejected batch persists nothing, so it warms nothing). Best-effort + off the
     # edit's path; a pre-warm failure never affects this call.
+    #
+    # ORIGIN-STABILITY (fix/sites-prewarm-origin): warm with the request Origin the
+    # native editor called from (``prewarm_origin``) so the hash matches the browser's
+    # native-artifact view; ``None`` keeps the pre-warm's PAW_SITES_BUILDER_ORIGIN env
+    # fallback for callers with no request origin.
     if changed:
         _schedule_native_prewarm(
-            workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            builder_origin=prewarm_origin,
         )
 
     return results

--- a/tests/ee/sites/test_native_artifact.py
+++ b/tests/ee/sites/test_native_artifact.py
@@ -1,5 +1,11 @@
 # tests/ee/sites/test_native_artifact.py — the native-artifact render path (NE-5b).
 # Created 2026-07-01 (feat/native-editing-ne4b).
+# Updated 2026-07-17 (fix/sites-prewarm-origin): the pre-warm must build with the SAME
+# origin a browser VIEW resolves (its request Origin header) or the content hashes never
+# match. New tests prove: a publish given an explicit prewarm_origin warms THAT origin
+# (a view there HITs zero builds) even when the env fallback differs; a publish with no
+# prewarm_origin keeps the env fallback (the defaulted-param no-request-origin path); and
+# apply_leaf_edits forwards its prewarm_origin into the pre-warm's builder_origin.
 # Updated 2026-07-02: + test_native_artifact_build_failure_maps_to_cloud_error — DEP-3
 # hardening: a generator build failure (SmokeGateFailed / missing toolchain) now
 # surfaces as a clean CloudError (sites.generator_failed), not an opaque 500, because
@@ -533,6 +539,127 @@ async def test_component_edit_schedules_prewarm(beanie_test_db, _captured_prewar
     )
 
     assert len(_captured_prewarms) == 1, "a component edit must schedule a native-artifact pre-warm"
+
+
+# ---------------------------------------------------------------------------
+# fix/sites-prewarm-origin — the pre-warm must build with the SAME origin a browser
+# VIEW resolves (its request Origin header), or the content hashes never match and the
+# pre-warmed artifact is dead weight. publish_pocket / apply_leaf_edits take a
+# ``prewarm_origin`` the REST routers thread the request Origin into.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_prewarm_uses_prewarm_origin_over_env(
+    beanie_test_db, tmp_path, monkeypatch, _captured_prewarms
+):
+    """A live publish given an explicit ``prewarm_origin`` warms the artifact for THAT
+    origin — the one a browser view resolves from its request Origin header — NOT the
+    PAW_SITES_BUILDER_ORIGIN env fallback. Proven by setting the env to a DIFFERENT
+    origin: with the pre-warm-origin bug, the pre-warm would warm at the env origin and
+    the next view AT THE REQUEST ORIGIN would MISS — the _NoBuildGenerator would fire."""
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
+    # The env fallback is a DIFFERENT origin than the request origin: the OLD behaviour
+    # warmed here, so a view at the request origin would have been a cold miss.
+    monkeypatch.setenv("PAW_SITES_BUILDER_ORIGIN", "http://localhost:8888")
+    view_origin = "https://paw.hzd.interacly.com"
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    _write_built_output(tmp_path)
+    gen = _CountingGenerator(str(tmp_path))
+
+    await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        prewarm_origin=view_origin,
+        _generator=gen,
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    assert len(_captured_prewarms) == 1, "a live svelte publish must schedule a pre-warm"
+    await _captured_prewarms[0]  # build + store the armed artifact at view_origin
+
+    # The next view AT THE REQUEST ORIGIN is a read-through HIT (zero builds) — the
+    # pre-warm used prewarm_origin, not the (different) env fallback.
+    result = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin=view_origin,
+        _generator=_NoBuildGenerator(),
+    )
+    assert result["pocket_id"] == pocket_id
+    assert 'data-uid="Hero:headline:0"' in result["body_html"]
+
+
+@pytest.mark.asyncio
+async def test_publish_no_prewarm_origin_keeps_env_fallback(
+    beanie_test_db, tmp_path, monkeypatch, _captured_prewarms
+):
+    """A publish with NO prewarm_origin (a chat-agent / MCP publish — no request origin)
+    keeps the pre-warm's PAW_SITES_BUILDER_ORIGIN env fallback, so a view with no origin
+    (which resolves the same env fallback) still HITs. Guards the defaulted param: the
+    fix must not regress the no-request-origin path."""
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
+    monkeypatch.setenv("PAW_SITES_BUILDER_ORIGIN", "https://configured.paw.example")
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    _write_built_output(tmp_path)
+    gen = _CountingGenerator(str(tmp_path))
+
+    await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=gen,
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+    assert len(_captured_prewarms) == 1
+    await _captured_prewarms[0]
+
+    result = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="",  # resolves the same env fallback the pre-warm used
+        _generator=_NoBuildGenerator(),
+    )
+    assert result["pocket_id"] == pocket_id
+
+
+@pytest.mark.asyncio
+async def test_leaf_edit_prewarm_uses_prewarm_origin(beanie_test_db, monkeypatch):
+    """apply_leaf_edits forwards its ``prewarm_origin`` (the request Origin the
+    leaf-edits router threads) into the native-artifact pre-warm's builder_origin, so
+    the warmed artifact matches the origin the browser view asks for — not the env
+    fallback. Captures the scheduling call to assert the threaded origin."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    captured: dict = {}
+
+    def _capture(**kw):
+        captured.update(kw)
+
+    monkeypatch.setattr(sites_service, "_schedule_native_prewarm", _capture)
+
+    async def _fake_apply(*, source, edits):
+        new = dict(source)
+        new["src/lib/components/Hero.svelte"] = "<section class='hero'><h1>Edited</h1></section>"
+        return {"source": new, "results": [{"uid": edits[0]["uid"], "applied": True}]}
+
+    await sites_service.apply_leaf_edits(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        edits=[{"uid": "Hero:headline:0", "op": {"kind": "text", "value": "Edited"}}],
+        prewarm_origin="https://paw.hzd.interacly.com",
+        _apply=_fake_apply,
+    )
+
+    assert captured.get("builder_origin") == "https://paw.hzd.interacly.com", (
+        "the leaf-edit pre-warm must build with the request origin, not the env fallback"
+    )
 
 
 def test_filesystem_store_missing_and_corrupt_read_as_miss(tmp_path, monkeypatch):

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -50,6 +50,14 @@
 # route returns {pocket_id, body_html, css} AND threads the request Origin header as
 # the builder_origin the armed build needs. A non-svelte pocket (real service, mocked
 # ripple pocket read) is a 422.
+#
+# Updated 2026-07-17 (fix/sites-prewarm-origin): POST /sites/publish and POST
+# /sites/by-pocket/{pocket_id}/leaf-edits now thread the request Origin header into the
+# service as ``prewarm_origin`` so the background native-artifact pre-warm builds with
+# the same origin a browser view resolves. New tests patch publish_pocket /
+# apply_leaf_edits and assert the route forwards the request Origin as prewarm_origin
+# (and, for publish, that builder_origin is NOT set from the header — the public deploy
+# stays plain), plus the no-Origin-header case forwards None.
 
 from __future__ import annotations
 
@@ -1019,3 +1027,98 @@ async def test_native_artifact_route_non_svelte_is_422(beanie_test_db, monkeypat
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         resp = await c.get("/api/v1/sites/by-pocket/pk_ripple/native-artifact")
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# fix/sites-prewarm-origin: POST /sites/publish + POST .../leaf-edits thread the
+# request Origin header into the service as ``prewarm_origin`` so the background
+# native-artifact pre-warm warms the origin a browser view will ask for. The publish
+# route must NOT arm the public deploy from the header (builder_origin stays unset).
+# ---------------------------------------------------------------------------
+
+
+def _stub_published_site_doc():
+    from bson import ObjectId
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    return _SiteDoc(
+        id=ObjectId(),
+        workspace="ws_owner",
+        pocket_id="pk1",
+        owner="user-test-1",
+        name="Owner Site",
+        script_name="site1",
+        deployed=True,
+        signed_key="k",
+        builder_origin="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_route_threads_origin_as_prewarm_origin(beanie_test_db, monkeypatch):
+    """POST /sites/publish forwards the request Origin header as ``prewarm_origin`` (so
+    the pre-warm warms the origin a browser view resolves) WITHOUT setting
+    ``builder_origin`` from it — the public deploy stays plain. publish_pocket is patched
+    (a real publish would spawn bun)."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_publish_pocket(*, prewarm_origin=None, builder_origin=None, **kw):
+        captured["prewarm_origin"] = prewarm_origin
+        captured["builder_origin"] = builder_origin
+        return _stub_published_site_doc()
+
+    monkeypatch.setattr(sites_service, "publish_pocket", _fake_publish_pocket)
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/publish",
+            json={"pocket_id": "pk1"},
+            headers={"Origin": "https://paw.hzd.interacly.com"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert captured["prewarm_origin"] == "https://paw.hzd.interacly.com"
+    # The public deploy is unchanged — the header must NOT arm it.
+    assert captured["builder_origin"] in (None, "")
+
+
+@pytest.mark.asyncio
+async def test_publish_route_no_origin_header_prewarm_origin_none(beanie_test_db, monkeypatch):
+    """POST /sites/publish with NO Origin header forwards ``prewarm_origin=None`` so the
+    pre-warm keeps its PAW_SITES_BUILDER_ORIGIN env fallback (a call with no browser
+    origin, e.g. server-to-server)."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_publish_pocket(*, prewarm_origin=None, **kw):
+        captured["prewarm_origin"] = prewarm_origin
+        return _stub_published_site_doc()
+
+    monkeypatch.setattr(sites_service, "publish_pocket", _fake_publish_pocket)
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/publish", json={"pocket_id": "pk1"})
+    assert resp.status_code == 200, resp.text
+    assert captured["prewarm_origin"] is None
+
+
+@pytest.mark.asyncio
+async def test_leaf_edits_route_threads_origin_as_prewarm_origin(beanie_test_db, monkeypatch):
+    """POST /sites/by-pocket/{id}/leaf-edits forwards the request Origin header as
+    ``prewarm_origin`` so the background native-artifact pre-warm warms the origin the
+    browser's native-artifact view (called from the same dashboard) will ask for.
+    apply_leaf_edits is patched to capture the forwarded origin."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_apply_leaf_edits(*, prewarm_origin=None, **kw):
+        captured["prewarm_origin"] = prewarm_origin
+        return [{"uid": "Hero:headline:0", "applied": True, "reason": None}]
+
+    monkeypatch.setattr(sites_service, "apply_leaf_edits", _fake_apply_leaf_edits)
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/by-pocket/pk1/leaf-edits",
+            json={"edits": [{"uid": "Hero:headline:0", "op": {"kind": "setText", "html": "y"}}]},
+            headers={"Origin": "https://paw.hzd.interacly.com"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert captured["prewarm_origin"] == "https://paw.hzd.interacly.com"


### PR DESCRIPTION
## What

The native-artifact read-through cache keys on the builder origin, but the publish pre-warm and a browser view resolved that origin differently, so the pre-warmed artifact was never hit.

A browser view of `GET /native-artifact` reads the builder origin from the request `Origin` header (the dashboard origin, e.g. `https://paw.hzd.interacly.com`). The publish pre-warm resolved it from `PAW_SITES_BUILDER_ORIGIN` (fallback `http://localhost:8888`), because the `/sites/publish` router called `publish_pocket` with no origin. A different origin means a different content hash, so the pre-warmed artifact never matched what a view asked for. Every view stayed a cold miss, which on the prod box is a 1-2 minute SvelteKit build.

## Change

- `publish_pocket` and `apply_leaf_edits` take a new `prewarm_origin` param. The REST routers (`/sites/publish`, `/sites/by-pocket/{id}/leaf-edits`) thread the request `Origin` header into it.
- `prewarm_origin` steers only the pre-warm's armed artifact (`builder_origin=prewarm_origin or builder_origin`). It does not change the public deploy: a live `/sites/publish` still ships a plain public site.
- The param defaults to `None`, so chat-agent / MCP callers and the instinct executor are untouched and keep the env fallback.

## Per-path origin-threading findings

- **`/sites/publish` (REST):** the original bug. Fixed by threading the request `Origin` as `prewarm_origin`.
- **publish MCP tool:** no request origin (chat agent), so it keeps the env fallback. Belt-and-braces: set `PAW_SITES_BUILDER_ORIGIN` to the dashboard origin in deployments.
- **`apply_leaf_edits` (REST, native editor):** the same bug as publish. The router did not read the request `Origin` and the pre-warm fell back to env while the sibling view used the header. Fixed the same way.
- **`edit_svelte_component`:** unchanged. It is MCP-only (no request origin) and warms with `prior.builder_origin`, the origin the site was armed or published with, which already equals what a view asks for. When a site was only ever published plain, `prior.builder_origin` is empty and the pre-warm uses env, so the same belt-and-braces env setting covers that case.

## Docs

`docs/api-reference.md` native-artifact section documents the origin-stability requirement and the `PAW_SITES_BUILDER_ORIGIN` belt-and-braces default. Service and router header comments updated.

## Tests

- Publish and leaf-edit pre-warm origin threading end to end: a view at the request origin hits with zero builds even when the env differs.
- The no-request-origin path keeps the env fallback (the defaulted param).
- Router threading: the publish and leaf-edits routes forward the request `Origin` as `prewarm_origin`, and publish does not arm the public deploy from it.

Targeted run: 483 passed across `tests/ee/sites`, `tests/ee/agent/test_sites_mcp_server`, and `tests/ee/versions/test_instinct_executor.py`.
