### PR TITLE
feat(sites): create sites as drafts, publish only when asked

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -561,7 +561,9 @@ def make_create_landing_site_tool(tool: Any) -> Any:
             "contact {address, phone, email}; footer {copyright}. Variable-length "
             "services/testimonials/tiers are handled. Returns {ok, pocket_id, "
             "pocket}; hand `pocket_id` to "
-            "`mcp__pocketpaw_sites_manager__publish` to publish. ok=false with an "
+            "`mcp__pocketpaw_sites_manager__publish` to publish ONLY when the user "
+            "asks to go live (draft-first: a plain create stops at the draft for "
+            "in-app preview). ok=false with an "
             "error means relay the reason, do NOT report a created pocket."
         ),
         {
@@ -745,7 +747,9 @@ def make_create_dynamic_site_tool(tool: Any) -> Any:
             "spec must declare `objects` AND at least one source/action/auth, and "
             "every source/action must reference a declared object. Returns {ok, "
             "pocket_id, pocket}; hand `pocket_id` to "
-            "`mcp__pocketpaw_sites_manager__publish` to publish. ok=false with an "
+            "`mcp__pocketpaw_sites_manager__publish` to publish ONLY when the user "
+            "asks to go live (draft-first: a plain create stops at the draft for "
+            "in-app preview). ok=false with an "
             "error means relay the reason, do NOT report a created pocket."
         ),
         {
@@ -958,7 +962,9 @@ def make_create_svelte_site_tool(tool: Any) -> Any:
             "because the page is PRERENDERED and onMount does not run at prerender "
             "time (a count-up initialized to 0 bakes '$0.00'; initialize it to the "
             "final value). Returns {ok, pocket_id, pocket}; hand `pocket_id` to "
-            "`mcp__pocketpaw_sites_manager__publish` to publish. ok=false with an "
+            "`mcp__pocketpaw_sites_manager__publish` to publish ONLY when the user "
+            "asks to go live (draft-first: a plain create stops at the draft for "
+            "in-app preview). ok=false with an "
             "error means relay the reason, do NOT report a created pocket."
         ),
         {
@@ -1157,7 +1163,9 @@ def make_create_html_site_tool(tool: Any) -> Any:
             "files are served exactly as authored, so the page must be complete on "
             "its own (inline or linked CSS/JS, real copy — never 'TBD'/'Lorem "
             "ipsum'). Returns {ok, pocket_id, pocket}; hand `pocket_id` to "
-            "`mcp__pocketpaw_sites_manager__publish` to publish. ok=false with an "
+            "`mcp__pocketpaw_sites_manager__publish` to publish ONLY when the user "
+            "asks to go live (draft-first: a plain create stops at the draft for "
+            "in-app preview). ok=false with an "
             "error means relay the reason, do NOT report a created pocket."
         ),
         {

--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -100,6 +100,19 @@
 # does NOT author markup by hand). `_crew_enabled()` and the two removed preambles
 # are gone; `sites_crew_enabled` in config is now vestigial. The refine/chat
 # branches (keyed on `pocket_id`) are untouched.
+#
+# Updated: 2026-07-17 (feat/sites-draft-first-create) — the CREATE preamble is now
+# DRAFT-FIRST. The create tools already persist a reviewable DRAFT (they never
+# publish); the preamble used to tell the agent to publish in the same turn
+# ("auto-publishes to a live URL", step 6 "PUBLISH and SHOW the live url", each
+# engine build step "then publish"), which shipped a site live off a plain "create a
+# landing page" — no draft, no preview, and on a paid tier an unasked checkout. Now
+# the orientation frames the pocket as a draft the user previews; each engine build
+# step STOPS at the draft; and the final step points the user at the in-app Preview
+# (/sites), offers to publish, and calls `mcp__pocketpaw_sites_manager__publish` IN
+# THE SAME TURN only when the user's request already asked to go live ("publish",
+# "make it live", "ship it"). The publish tool is still NAMED (the on-request path),
+# so nothing regresses for an explicit publish. Refine/chat branches untouched.
 
 from __future__ import annotations
 
@@ -160,7 +173,8 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     Modes, keyed on the meta:
 
     * **Create** (no ``pocket_id``) — the /sites gallery / describe-to-create
-      rail. Build AND publish a brand-new marketing site.
+      rail. Build a brand-new marketing site as a reviewable DRAFT; publish only
+      when the user explicitly asks (draft-first — see ``_create_preamble``).
     * **Chat** (``pocket_id`` present AND ``mode == "chat"``) — the per-site
       chat with the Build/Chat toggle set to Chat. Answer QUESTIONS about the
       existing site with NO mutation: never edit, republish, or create a pocket.
@@ -195,6 +209,14 @@ def _create_preamble(meta: SurfaceMeta) -> str:
     high-value questions via the ``ask_user`` chips (with a "just build it"
     escape hatch); Phase 2 picks a design system, gathers real assets, states a
     one-line brief, then builds via the engine-appropriate tool above.
+
+    DRAFT-FIRST (feat/sites-draft-first-create): the create tools persist a
+    reviewable DRAFT and do NOT publish, so the build step stops at the draft.
+    The final step points the user at the in-app Preview (/sites) and offers to
+    publish; it calls the publish tool IN THE SAME TURN only when the user's
+    request already asked to go live ("publish", "make it live", "ship it").
+    Publishing deploys to the public edge (and can open a paid checkout), so it
+    is the user's call — not an automatic step off a plain "create a site".
     """
     route = meta.route_path or "/sites"
     engine = (meta.engine or "html").lower()
@@ -217,11 +239,12 @@ def _create_preamble(meta: SurfaceMeta) -> str:
             "system's tokens, "
             "THEME them with those tokens + your asset URLs, and it persists the "
             'source pocket `type="site"` + `pattern="landing"` + `engine="svelte"` '
-            "and publishes it. There is NO rippleSpec and NO widget catalog on "
+            "as a reviewable DRAFT — it does NOT publish (see the DRAFT-FIRST "
+            "step). There is NO rippleSpec and NO widget catalog on "
             "this track — do not draft a rippleSpec or call the pocket "
             "specialist. If the skill is unavailable, author the source map "
             "yourself and call `mcp__pocketpaw_sites_manager__create_svelte_site` "
-            "then `mcp__pocketpaw_sites_manager__publish`."
+            "(then STOP at the draft — publish only on explicit request)."
         )
     elif engine == "ripple":
         engine_note = " The page is rendered STATICALLY (no JavaScript runs for the visitor)."
@@ -236,8 +259,9 @@ def _create_preamble(meta: SurfaceMeta) -> str:
             "`newsletter` widget, which nests an invalid `<form>` on a static "
             "site and captures zero leads. If the skill is unavailable, fall back "
             "to `mcp__pocketpaw_pocket_specialist__create` (build the "
-            "conversion-ordered ripple landing spec) then "
-            "`mcp__pocketpaw_sites_manager__publish`. This is the ripple/widget "
+            "conversion-ordered ripple landing spec, then STOP at the draft — "
+            "publish only on explicit request per the DRAFT-FIRST step). This is "
+            "the ripple/widget "
             "track — the page is a widget spec, not hand-authored markup."
         )
     else:  # html (default)
@@ -257,8 +281,8 @@ def _create_preamble(meta: SurfaceMeta) -> str:
             "your asset URLs, then persist it by calling "
             "`mcp__pocketpaw_sites_manager__create_html_site` with the `source` "
             'map (it stamps the source pocket `type="site"` + `pattern="landing"` '
-            '+ `engine="html"`), then `mcp__pocketpaw_sites_manager__publish` '
-            "with the returned pocket_id. There is NO rippleSpec and NO widget "
+            '+ `engine="html"`), then STOP at the draft — publish only on '
+            "explicit request per the DRAFT-FIRST step. There is NO rippleSpec and NO widget "
             "catalog on this track — do not draft a rippleSpec or call the pocket "
             "specialist; the HTML files ARE the page. The lead-capture form must "
             "be a real `<form>` with FLAT named `input`/`textarea` fields (name, "
@@ -312,7 +336,9 @@ def _create_preamble(meta: SurfaceMeta) -> str:
         "bottom as a conversion funnel: nav, hero, services, social proof, "
         "pricing, a call-to-action, a lead-capture form, footer. Talk about it "
         "as a 'site' or 'page' — never a 'pocket'. The pocket is only the "
-        f"source spec; it auto-publishes to a live URL.{engine_note} You are a "
+        "source spec; you create the site as a reviewable DRAFT the user "
+        "previews in-app, then publish to a live URL only when they ask — do "
+        f"NOT auto-publish.{engine_note} You are a "
         "SENIOR DESIGNER + engineer: YOU decide the look and build a coherent, "
         "premium, on-brand site — you do not ask the user what theme to use.\n"
         "</sites-orientation>\n"
@@ -366,8 +392,19 @@ def _create_preamble(meta: SurfaceMeta) -> str:
         "'Building a [design-system vibe] site for [business] with sections "
         "[…], palette [primary].' Then build.\n"
         f"5. {build_step}\n"
-        "6. PUBLISH and SHOW the live `url` plus a link to /sites where the "
-        "user manages their sites.\n"
+        "6. DRAFT-FIRST — STOP at the draft; do NOT publish by default. The create "
+        "tool persists a reviewable DRAFT the user previews IN-APP (open /sites → "
+        "the site's Preview tab). Publishing deploys the site to the public edge "
+        "(and on a paid tier can open a checkout), so it is the user's call, not "
+        "an automatic next step. Tell the user the draft is ready, point them at "
+        "the Preview, and OFFER to take it live — e.g. 'Your site is ready as a "
+        "draft — preview it under /sites, and say publish (or \"make it live\") "
+        "when you're happy with it.' Then STOP. Publish IN THIS SAME TURN only if "
+        "the user's request ALREADY asked to go live ('publish', 'make it live', "
+        "'ship it', 'put it online'): in that case call "
+        "`mcp__pocketpaw_sites_manager__publish` with the pocket_id and SHOW the "
+        "returned live `url` plus a link to /sites. Do not publish on a plain "
+        "'create'/'build'/'make' request.\n"
         "\n"
         "ROBUSTNESS (this flow must never stall or disappoint in real use):\n"
         "- If ANY tool errors (design-system, stock, palette, or icons), do "
@@ -378,8 +415,10 @@ def _create_preamble(meta: SurfaceMeta) -> str:
         "- ONE round of questions maximum. If the user already gave detail or "
         "says 'just build it', skip straight to Phase 2 with sensible "
         "defaults.\n"
-        "- Never claim a publish that didn't happen — relay the real publish "
-        "error and show the real `url`. No phantom URLs.\n"
+        "- When you DO publish (the user asked), never claim a publish that "
+        "didn't happen — relay the real publish error and show the real `url`. "
+        "No phantom URLs. On the default draft path there is no `url` yet — point "
+        "at the in-app Preview, don't invent a live link.\n"
         "- Keep the 'site' / 'page' vocabulary throughout; never say 'pocket'.\n"
         "</sites-procedure>\n"
         f"{_design_taste_system()}"

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-dynamic-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-dynamic-site/SKILL.md
@@ -192,9 +192,21 @@ source referencing an undeclared object); fix the spec and retry. If the request
 is actually a static marketing page (no live data), the tool steers you to
 `create_landing_site` — follow that.
 
-## STEP 3 — Publish
+## STEP 3 — Stop at the draft (publish only when asked)
 
-Publish the new pocket as a site:
+**Default: create the draft, do NOT publish.** After `create_dynamic_site`
+returns, the pocket exists as a reviewable **draft** the user can preview in-app
+(open **/sites** → the site's **Preview** tab). Publishing provisions the live
+D1 + deploys to the public edge (and, on a paid tier, can open a checkout), so
+taking it live is the user's call, not an automatic step.
+
+So **do NOT call `publish` by default.** Tell the user the draft is ready, point
+them at the Preview, and offer to take it live — e.g. *"Your site is ready as a
+draft. Preview it under /sites, and say **publish** (or 'make it live') when
+you're happy with it."* Then stop.
+
+**Publish in this same turn ONLY if the user's request already asked to go
+live** — "publish it", "make it live", "ship it", "put it online":
 
 ```
 mcp__pocketpaw_sites_manager__publish(pocket_id = <the id from STEP 2>)
@@ -220,8 +232,10 @@ deploys. Show the user the returned `url` plus a pointer to **/sites**. Relay an
    form inputs.
 3. **The object is lean.** Only the columns the writer provides plus the
    primary key — no auto-set columns forced into the write form.
-4. **You showed the live URL.** The user got the `url` from publish and a
-   pointer to /sites — not just "done". Errors were relayed, never masked.
+4. **You stopped at the draft (or published only if asked).** By default the
+   user got a pointer to the in-app Preview under /sites and an offer to
+   publish — not an auto-publish. If they explicitly asked to go live, they got
+   the `url` from publish. Errors were relayed, never masked.
 
 ## Related tools (via MCP)
 
@@ -229,6 +243,8 @@ deploys. Show the user the returned `url` plus a pointer to **/sites**. Relay an
   Pass the dynamic `spec` you authored; the tool persists the pocket stamped
   `type="site"` + `pattern="dynamic"`. Returns `{ok, pocket_id, pocket}`.
 - `mcp__pocketpaw_sites_manager__publish` — publish the pocket as a live site
-  (generates the D1 + remote functions); show the user the `url`.
+  (generates the D1 + remote functions); show the user the `url`. Call it only
+  when the user asks to go live (draft-first — STEP 3); a plain "create a site"
+  stops at the draft.
 - `mcp__pocketpaw_sites_manager__create_landing_site` — for a STATIC marketing
   page instead (no live data).

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
@@ -174,9 +174,21 @@ It returns `{ ok, pocket_id, pocket }`. Keep `pocket_id` for STEP 3. If
 `ok` is false, relay the error — do **not** claim a phantom create and do
 **not** fall back to drafting a spec yourself.
 
-## STEP 3 — Publish
+## STEP 3 — Stop at the draft (publish only when asked)
 
-Publish the new pocket as a site:
+**Default: create the draft, do NOT publish.** After `create_landing_site`
+returns, the pocket exists as a reviewable **draft** the user can preview
+in-app (open **/sites** → the site's **Preview** tab). Publishing deploys it to
+the public edge (and, on a paid tier, can open a checkout), so taking it live
+is the user's call, not an automatic step.
+
+So **do NOT call `publish` by default.** Tell the user the draft is ready,
+point them at the Preview, and offer to take it live — e.g. *"Your site is
+ready as a draft. Preview it under /sites, and say **publish** (or 'make it
+live') when you're happy with it."* Then stop.
+
+**Publish in this same turn ONLY if the user's request already asked to go
+live** — "publish it", "make it live", "ship it", "put it online":
 
 ```
 mcp__pocketpaw_sites_manager__publish(pocket_id = <the id from STEP 2>)
@@ -185,8 +197,9 @@ mcp__pocketpaw_sites_manager__publish(pocket_id = <the id from STEP 2>)
 Show the user the returned `url` plus a pointer to **/sites**. Relay any
 `ok: false` error — never claim a phantom publish.
 
-If you arrived here from the `pocketpaw-create-site` skill's Path B, that
-skill owns the publish call — return the created `pocket_id` to it.
+If you arrived here from the `pocketpaw-create-site` skill's Path B, the user
+already asked to publish, so that skill owns the publish call — return the
+created `pocket_id` to it instead of publishing here.
 
 ## What the tool builds (so you know what your copy becomes)
 
@@ -232,6 +245,7 @@ your copy is the only variable. Write it well.
   page and persists it stamped `type="site"` + `pattern="landing"`.
   Returns `{ok, pocket_id, pocket}`.
 - `mcp__pocketpaw_sites_manager__publish` — publish the pocket as a live
-  site; show the user the `url`.
+  site; show the user the `url`. Call it only when the user asks to go live
+  (draft-first — STEP 3); a plain "create a site" stops at the draft.
 - `mcp__pocketpaw_pocket__list_pockets` — find an existing pocket if the
   user named one rather than describing a new site.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-svelte-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-svelte-site/SKILL.md
@@ -283,9 +283,24 @@ do **not** fall back to drafting a rippleSpec. The tool fails closed when
 the map is missing a required §4.3 file and names which one; add it and
 retry.
 
-## STEP 4 — Publish
+## STEP 4 — Stop at the draft (publish only when asked)
 
-Publish the new pocket as a site:
+**Default: create the draft, do NOT publish.** After `create_svelte_site`
+returns, the pocket exists as a reviewable **draft** — a real, editable svelte
+site the user can preview in-app right now (open **/sites** → the site's
+**Preview** tab). Publishing deploys it to the public edge (and, on a paid
+tier, can open a checkout), so taking it live is the user's call, not an
+automatic next step.
+
+So **do NOT call `publish` by default.** Instead, tell the user the draft is
+ready, point them at the Preview, and offer to take it live — e.g. *"Your
+Bright Smile site is ready as a draft. Preview it under /sites, and say
+**publish** (or 'make it live') when you're happy with it."* Then stop. Keep
+iterating on the draft if they want changes; an edit is a draft too.
+
+**Publish in this same turn ONLY if the user's request already asked to go
+live** — "publish it", "make it live", "ship it", "put it online". When they
+did, publish the pocket:
 
 ```
 mcp__pocketpaw_sites_manager__publish(pocket_id = <the id from STEP 3>)
@@ -470,8 +485,10 @@ D1 + wires the read/write layer. Done.
    `src/lib/components/*.svelte` sections — every import resolvable.
 4. **It converts + captures.** CTAs are anchors, there's a real priced
    pricing section, and a flat lead form POSTing to `/api/submit`.
-5. **You showed the live URL.** The user got the `url` from publish and a
-   pointer to /sites — not just "done". Errors were relayed, never masked.
+5. **You stopped at the draft (or published only if asked).** By default the
+   user got a pointer to the in-app Preview under /sites and an offer to
+   publish — not an auto-publish. If they explicitly asked to go live, they got
+   the `url` from publish. Errors were relayed, never masked.
 
 ## Related tools (via MCP)
 
@@ -482,6 +499,7 @@ D1 + wires the read/write layer. Done.
   `auth` bindings — see [Dynamic svelte sites](#dynamic-svelte-sites--live-data-on-the-svelte-track)).
   Returns `{ok, pocket_id, pocket}`.
 - `mcp__pocketpaw_sites_manager__publish` — publish the pocket as a live
-  site; show the user the `url`.
+  site; show the user the `url`. Call it only when the user asks to go live
+  (draft-first — STEP 4); a plain "create a site" stops at the draft.
 - `mcp__pocketpaw_pocket__list_pockets` — find an existing pocket if the
   user named one rather than describing a new site.

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -75,6 +75,13 @@
 # pocket-specialist landing spec. The old flag tests are gone; the create tests
 # below pin the always-asks behavior + per-engine build tool, and the refine/chat
 # tests are unchanged.
+#
+# Updated: 2026-07-17 (feat/sites-draft-first-create) — added
+# test_create_is_draft_first_publish_on_request: the create preamble now stops at a
+# reviewable DRAFT and offers to publish, gating the publish tool on an EXPLICIT
+# go-live request instead of auto-publishing off a plain "create a site". Asserts the
+# draft/preview framing + the explicit-go-live gate across all engines, and that the
+# publish tool is still named (the on-request path) so an explicit publish is unbroken.
 
 from __future__ import annotations
 
@@ -140,6 +147,28 @@ async def test_create_default_engine_is_html() -> None:
     # The svelte/ripple tools appear ONLY after the html one (i.e. in the
     # do-not-use / explicit-exception context, never as the primary path).
     assert preamble.index("create_html_site") < preamble.index("create_svelte_site")
+
+
+async def test_create_is_draft_first_publish_on_request() -> None:
+    """feat/sites-draft-first-create: the create preamble is DRAFT-FIRST. It frames the
+    site as a reviewable draft the user previews, tells the agent to STOP at the draft
+    and offer to publish, and gates publish on an EXPLICIT go-live request — it no
+    longer auto-publishes. The publish tool is still NAMED (the on-request path)."""
+    for engine in (None, "svelte", "ripple"):
+        preamble = await sites_handler.build_preamble(
+            WORKSPACE, USER, SurfaceMeta(route_path="/sites", engine=engine)
+        )
+        lower = preamble.lower()
+        # It frames the deliverable as a draft the user previews first.
+        assert "draft" in lower
+        assert "preview" in lower
+        # Publish is conditioned on an explicit go-live ask, not automatic.
+        assert "make it live" in lower
+        # The old auto-publish framing is gone (the preamble now says "do NOT
+        # auto-publish", so guard against the specific old auto-publish claim).
+        assert "auto-publishes to a live url" not in lower
+        # The publish tool is still available for the on-request path.
+        assert "mcp__pocketpaw_sites_manager__publish" in preamble
 
 
 async def test_create_ripple_engine_uses_pocket_specialist_fallback() -> None:

--- a/tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
@@ -1,4 +1,9 @@
 # tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
+# Updated: 2026-07-17 (feat/sites-draft-first-create) — added
+# test_create_result_is_draft_shaped_no_live_url: the create tool persists a DRAFT and
+# never publishes, so its result payload carries no live-site fields (url/live/deployed)
+# — only {ok, pocket_id, pocket}. Pins the draft-path payload the FE renders as
+# unpublished (draft/preview affordances), so draft-first never shows a dead live button.
 # Updated: 2026-06-17 (fix/sites-plan-gate-asymmetry) — create_svelte_site now
 # calls the shared Sites plan gate (sites.service.require_sites_plan) before
 # agent_create, so an autouse fixture defaults get_workspace_plan to "go"
@@ -214,6 +219,48 @@ class TestCreateSvelteSiteEndToEnd:
         assert doc.source == source
         # The svelte path persists NO rippleSpec.
         assert doc.rippleSpec is None
+
+    @pytest.mark.asyncio
+    async def test_create_result_is_draft_shaped_no_live_url(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """feat/sites-draft-first-create: the create tool persists a DRAFT and never
+        publishes, so its result payload carries NO live-site fields (no url / live /
+        deployed) — only {ok, pocket_id, pocket:{id,name,type,pattern,engine}}. This is
+        the payload the FE already renders for an unpublished pocket (draft/preview
+        affordances), so draft-first never surfaces a dead 'Open live site' button."""
+        from unittest.mock import patch
+
+        from bson import ObjectId
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value=str(ObjectId()),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value=str(ObjectId()),
+            ),
+        ):
+            out = await sites_create_mcp._create_svelte_site_handler(
+                {"source": _sample_source(), "name": "Draft Svelte"}
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        # Draft-shaped: the create result identifies the pocket for the in-app
+        # preview but carries no live-site fields (publish is a separate, on-request
+        # step).
+        assert body["ok"] is True
+        assert body["pocket_id"]
+        assert set(body["pocket"]) == {"id", "name", "type", "pattern", "engine"}
+        assert body["pocket"]["engine"] == "svelte"
+        # No live-site fields leak into the create (draft) payload.
+        for leaked in ("url", "live", "deployed", "site_url"):
+            assert leaked not in body, f"create (draft) payload must not carry {leaked!r}"
+            assert leaked not in body["pocket"]
 
     @pytest.mark.asyncio
     async def test_missing_identity_is_error(self) -> None:


### PR DESCRIPTION
> **Stacked on #1742** (`fix/sites-prewarm-origin`). This PR targets that branch, so its diff is only the draft-first change. Review it after the base; GitHub retargets it to `dev` once #1742 merges.

## What

On the `/sites` surface, "create a landing page" made the chat agent create AND publish the site in one turn, so the draft state never existed. The user could not preview before the site went live, and on a paid tier the publish could open a checkout they never asked for. Now that a draft svelte site has an instant in-app visual preview, draft-first is the better default: create, let the user preview, publish on request.

## Root cause

The create tools already persist a draft and never publish. The agent published because its brain told it to. The main driver was the `/sites` create surface preamble (it said the pocket "auto-publishes to a live URL", carried a "PUBLISH and SHOW the live url" step, and ended each engine build step with a publish call), reinforced by the three create-site skills and the create-tool descriptions.

## Change

- **Surface preamble (`_create_preamble`):** frames the pocket as a draft the user previews, ends each engine build step at create, and adds a draft-first final step that points at the in-app Preview (`/sites`), offers to publish, and calls the publish tool in the same turn only when the user's request already asked to go live ("publish", "make it live", "ship it").
- **The three create-site skills (svelte, paw, dynamic):** the publish step now stops at the draft and publishes only on explicit request. `pocketpaw-create-site` (the dedicated publish skill) is unchanged, since it is invoked to publish.
- **Create-tool descriptions:** the publish handoff is gated on an explicit go-live ask.
- The publish tool is still named everywhere for the on-request path, so an explicit publish is unchanged.

## Frontend

Out of scope and untouched. The create result already carries no live-site fields, so the frontend renders the draft/preview affordances for an unpublished pocket, never a dead "Open live site" button. A test pins that payload shape.

## Tests

- The create preamble is draft-first across all engines (draft/preview framing, explicit go-live gate, publish tool still named).
- The `create_svelte_site` result is draft-shaped (no `url` / `live` / `deployed` fields).

Targeted run: 160 passed across the sites service, surface, and MCP create-tool suites. Two pre-existing reds in `tests/cloud/surface` (the home and code handlers, files this PR does not touch) are non-hermetic state leaks that fail on the base too.
