### PR TITLE
fix(sites): mint a draft Site doc at create so drafts show in the gallery

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,6 +1,18 @@
 # sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
 # create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
 #
+# Updated: 2026-07-17 (fix/sites-draft-visible — a DRAFT lists in the gallery) —
+# every create handler (landing / svelte / html / dynamic) now mints a DRAFT Site
+# doc right after the pocket is persisted, via the shared best-effort helper
+# ``_mint_draft_site`` → ``sites.service.create_draft_site``. Draft-first create
+# (pocketpaw#1744) persisted the site POCKET but no Site doc, and the /sites gallery
+# lists Site docs — so a plain create appeared in neither the All nor the Draft
+# filter until a publish first minted one. Minting the draft doc (``deployed=False``
+# — a draft, NOT a deploy, NO build, NO billing) keyed on the stable per-pocket id
+# publish upserts makes the draft list immediately and flip live in place on a later
+# publish (one doc per pocket). Best-effort: the pocket already exists (the primary
+# contract), so a mint failure logs and returns rather than failing the create.
+#
 # Updated 2026-06-14 (feat/dynamic-sites-authoring — Paw Sites "Dynamic track",
 # RFC 12 A2) — added the create tool ``create_dynamic_site``. It mirrors
 # ``create_svelte_site`` (the agent IS the author; the payload is persisted
@@ -417,6 +429,33 @@ async def _bind_session_and_emit(pocket_id: str, view: dict[str, Any], user_id: 
         )
 
 
+async def _mint_draft_site(workspace_id: str, user_id: str, pocket_id: str, name: str) -> None:
+    """Mint the DRAFT Site doc for a freshly created site pocket so it lists in the
+    /sites gallery immediately (fix/sites-draft-visible).
+
+    Draft-first create persists a site POCKET but no Site doc, and the gallery reads
+    Site docs — so without this a plain create shows in neither the All nor the Draft
+    filter until a publish first mints one. This creates ONE canonical Site doc
+    (``deployed=False`` — a draft, NOT a deploy, NO build, NO billing) keyed on the
+    stable per-pocket id publish upserts, so a later publish flips this SAME doc live
+    (one doc per pocket). Best-effort: the pocket already exists in Mongo (the primary
+    contract), so a mint failure logs and returns rather than undoing a successful
+    create — the site is simply not yet listable (the prior behaviour), never a hard
+    error. The plan gate already ran before ``agent_create``, so this adds no gate."""
+    try:
+        from pocketpaw_ee.sites.service import create_draft_site
+
+        await create_draft_site(
+            workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id, name=name
+        )
+    except Exception:  # noqa: BLE001 — draft-doc mint is best-effort, never fails a create
+        logger.warning(
+            "create-site: draft Site doc mint failed for pocket %s (non-fatal)",
+            pocket_id,
+            exc_info=True,
+        )
+
+
 async def _create_landing_site_handler(args: dict) -> dict:
     """MCP handler for ``sites_manager__create_landing_site``.
 
@@ -514,6 +553,11 @@ async def _create_landing_site_handler(args: dict) -> dict:
 
     if err is not None or view is None or new_pocket_id is None:
         return _error_response(f"create failed: {err or 'create returned no view'}")
+
+    # Mint the DRAFT Site doc so the new site lists in the /sites gallery right away
+    # (draft-first create persists the pocket but no Site doc; the gallery reads Site
+    # docs). Best-effort — a draft, NOT a publish, and it never fails the create.
+    await _mint_draft_site(workspace_id, user_id, new_pocket_id, name)
 
     await _bind_session_and_emit(new_pocket_id, view, user_id)
 
@@ -699,6 +743,11 @@ async def _create_dynamic_site_handler(args: dict) -> dict:
 
     if err is not None or view is None or new_pocket_id is None:
         return _error_response(f"create failed: {err or 'create returned no view'}")
+
+    # Mint the DRAFT Site doc so the new site lists in the /sites gallery right away
+    # (draft-first create persists the pocket but no Site doc; the gallery reads Site
+    # docs). Best-effort — a draft, NOT a publish, and it never fails the create.
+    await _mint_draft_site(workspace_id, user_id, new_pocket_id, name)
 
     await _bind_session_and_emit(new_pocket_id, view, user_id)
 
@@ -910,6 +959,11 @@ async def _create_svelte_site_handler(args: dict) -> dict:
     if err is not None or view is None or new_pocket_id is None:
         return _error_response(f"create failed: {err or 'create returned no view'}")
 
+    # Mint the DRAFT Site doc so the new site lists in the /sites gallery right away
+    # (draft-first create persists the pocket but no Site doc; the gallery reads Site
+    # docs). Best-effort — a draft, NOT a publish, and it never fails the create.
+    await _mint_draft_site(workspace_id, user_id, new_pocket_id, name)
+
     await _bind_session_and_emit(new_pocket_id, view, user_id)
 
     return _success_response(
@@ -1117,6 +1171,11 @@ async def _create_html_site_handler(args: dict) -> dict:
 
     if err is not None or view is None or new_pocket_id is None:
         return _error_response(f"create failed: {err or 'create returned no view'}")
+
+    # Mint the DRAFT Site doc so the new site lists in the /sites gallery right away
+    # (draft-first create persists the pocket but no Site doc; the gallery reads Site
+    # docs). Best-effort — a draft, NOT a publish, and it never fails the create.
+    await _mint_draft_site(workspace_id, user_id, new_pocket_id, name)
 
     await _bind_session_and_emit(new_pocket_id, view, user_id)
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,23 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-17 (fix/sites-draft-visible — a DRAFT lists in the gallery):
+# added ``create_draft_site`` — the create-site MCP handlers now mint ONE Site doc
+# at CREATE time in a NOT-YET-DEPLOYED state so a draft-first pocket (pocketpaw#1744)
+# lists in the /sites gallery immediately, instead of appearing nowhere until a
+# publish first mints a Site doc. It is keyed on the SAME stable
+# ``_id = _live_object_id(workspace, pocket)`` that publish upserts, so a later
+# publish FINDS this draft and flips it in place (``deployed=True`` + url) rather
+# than inserting a second doc — the PERF-1/PERF-2 one-doc-per-pocket invariant is
+# preserved across create → publish. It is IDEMPOTENT (an existing doc — this draft
+# or an already-live one — is returned untouched, never clobbered or duplicated),
+# is NOT a deploy, and never touches billing (a draft opens no checkout / Dodo sub —
+# only publish does). It seeds the SAME capture defaults publish's first-insert
+# seeds (signed_key / allowed_origins / event_mapping) so a first publish taking the
+# UPDATE branch over the draft keeps a working captureSignedKey + lead mapping. A
+# draft reads draft/not-live everywhere because BP-2 keys ``is_live`` on
+# ``doc.deployed`` (False here), never on doc-existence.
+#
 # Updated 2026-07-17 (fix/sites-prewarm-origin — pre-warm the origin a VIEW asks for):
 # the native-artifact pre-warm must build with the SAME origin the browser's
 # ``GET /native-artifact`` view resolves (the request Origin header), or the content
@@ -1447,6 +1464,77 @@ async def require_sites_plan(workspace_id: str) -> None:
             f"Sites requires the {needed.capitalize()} plan — upgrade, or switch "
             "to a workspace that has it.",
         )
+
+
+async def create_draft_site(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    name: str = "",
+) -> _SiteDoc:
+    """Mint the DRAFT Site doc for a freshly created site pocket so it lists in the
+    /sites gallery BEFORE it is ever published (fix/sites-draft-visible).
+
+    Draft-first create (pocketpaw#1744) persists a site POCKET but no Site doc — Site
+    docs were only minted at PUBLISH — so a draft appeared in neither the gallery's
+    All nor its Draft filter (``list_for_workspace`` reads Site docs, and a draft had
+    none). This mints ONE canonical Site doc in a NOT-YET-DEPLOYED state so the draft
+    lists naturally and reads as a draft everywhere (``pocket_status`` and the card
+    badge key on ``deployed``, not on doc-existence — BP-2), while a plain create still
+    does NOT deploy.
+
+    Dedupe invariant (PERF-1/PERF-2): the doc is keyed on the SAME stable
+    ``_id = _live_object_id(workspace_id, pocket_id)`` that ``publish`` upserts, so a
+    later publish FINDS this draft and flips it in place (``deployed=True`` + url)
+    instead of minting a second doc — exactly ONE Site doc per pocket across
+    create → publish. IDEMPOTENT: if a Site doc already exists for the pocket (this
+    draft on a duplicate create, or an already-published/live one), it is returned
+    UNCHANGED — the mint never clobbers a live doc back to draft and never duplicates.
+
+    NOT a deploy and NOT a billing event: a draft never builds, never contacts
+    Cloudflare, and never opens a checkout / Dodo subscription (only ``publish`` does).
+    It seeds the SAME capture defaults ``publish``'s first-insert seeds — a minted
+    ``signed_key``, ``allowed_origins``, ``event_mapping`` — so when publish later takes
+    the UPDATE branch over this draft (which preserves those fields), the built page's
+    ``captureSignedKey`` matches the persisted doc and lead capture works on the first
+    publish. ``publish`` reuses a stored non-empty ``signed_key``, so minting one here is
+    what keeps the built key and the doc in sync (the same invariant
+    ``test_republish_reuses_signed_key`` pins for a re-publish).
+    """
+    oid = _live_object_id(workspace_id, pocket_id)
+    # Idempotent + dedupe-safe: never mint a second doc for a pocket, and never reset
+    # an already-published/live doc back to draft. If a doc already exists (this draft
+    # on a repeat create, or a live one), return it untouched.
+    existing = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if existing is not None:
+        return existing
+
+    doc = _SiteDoc(
+        id=oid,
+        workspace=workspace_id,
+        pocket_id=pocket_id,
+        owner=user_id,
+        name=name.strip() if name else "",
+        # Not deployed yet — a plain create stops at the draft. publish stamps
+        # script_name (== the stable id) / url / deployed_at when it goes live.
+        script_name="",
+        deployed=False,
+        url="",
+        builder_origin="",
+        # Seed the capture config publish's first-insert seeds so a first publish
+        # (which finds this draft and takes the UPDATE branch, preserving these
+        # fields) keeps a working signed_key + lead mapping. Minting the key here is
+        # also what publish reuses, so the built captureSignedKey matches the doc.
+        signed_key=f"site_key_{secrets.token_urlsafe(24)}",
+        allowed_origins=_default_allowed_origins(),
+        event_mapping=_DEFAULT_EVENT_MAPPING,
+    )
+    # no-event: a DRAFT is not a published/deployed mutation — nothing downstream
+    # (search index, soul memory, ripple invalidation) keys on a draft Site doc;
+    # publish emits SitePublished when the site actually goes live.
+    await doc.insert()
+    return doc
 
 
 async def publish(
@@ -4318,6 +4406,7 @@ async def revert_pocket_version(
 
 __all__ = [
     "apply_edits",
+    "create_draft_site",
     "publish",
     "publish_pocket",
     "activate_site",

--- a/tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
@@ -1,4 +1,10 @@
 # tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
+# Updated: 2026-07-17 (fix/sites-draft-visible) — added
+# test_create_mints_draft_site_doc_that_lists: the create handler now mints a DRAFT
+# Site doc so the new site LISTS in the /sites gallery immediately (deployed=False),
+# with no publish and no billing. Before the fix a draft-first pocket had no Site doc,
+# and the gallery reads Site docs, so it appeared in neither the All nor the Draft
+# filter. Ground truth: the Site card read straight from sites.service.list_for_workspace.
 # Updated: 2026-07-17 (feat/sites-draft-first-create) — added
 # test_create_result_is_draft_shaped_no_live_url: the create tool persists a DRAFT and
 # never publishes, so its result payload carries no live-site fields (url/live/deployed)
@@ -261,6 +267,50 @@ class TestCreateSvelteSiteEndToEnd:
         for leaked in ("url", "live", "deployed", "site_url"):
             assert leaked not in body, f"create (draft) payload must not carry {leaked!r}"
             assert leaked not in body["pocket"]
+
+    @pytest.mark.asyncio
+    async def test_create_mints_draft_site_doc_that_lists(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """fix/sites-draft-visible: the create handler mints a DRAFT Site doc so the
+        new site LISTS in the /sites gallery right away (deployed=False, no live url),
+        with no publish and no billing. Ground truth: the Site card read straight from
+        the service's gallery read, keyed on the pocket the handler just created."""
+        from unittest.mock import patch
+
+        from bson import ObjectId
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+        from pocketpaw_ee.sites import service as sites_service
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value=workspace_id,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value=user_id,
+            ),
+        ):
+            out = await sites_create_mcp._create_svelte_site_handler(
+                {"source": _sample_source(), "name": "Draft Lister"}
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        pocket_id = body["pocket_id"]
+
+        # The draft lists in the gallery read — exactly one card for this pocket,
+        # reading as a DRAFT (deployed False, no live url, no checkout).
+        cards = await sites_service.list_for_workspace(workspace_id)
+        assert [c.pocket_id for c in cards] == [pocket_id]
+        assert cards[0].deployed is False
+        assert cards[0].url == ""
+        assert cards[0].checkout_url is None
+        # SR-9 resolves the engine from the source pocket for the card badge.
+        assert cards[0].engine == "svelte"
 
     @pytest.mark.asyncio
     async def test_missing_identity_is_error(self) -> None:

--- a/tests/ee/sites/test_draft_first_visibility.py
+++ b/tests/ee/sites/test_draft_first_visibility.py
@@ -1,0 +1,253 @@
+# tests/ee/sites/test_draft_first_visibility.py — fix/sites-draft-visible: a
+# draft-first site pocket (pocketpaw#1744) must LIST in the /sites gallery before it
+# is ever published. The bug: draft-first create persisted a site POCKET but no Site
+# doc, and the gallery read (``list_for_workspace``) lists Site docs — so a draft
+# appeared in neither the All nor the Draft filter until a publish first minted one.
+#
+# Created: 2026-07-17 (fix/sites-draft-visible).
+#
+# These pin the fix + its invariants:
+#   * ``create_draft_site`` mints ONE Site doc in a NOT-YET-DEPLOYED state (deployed
+#     False, url "") that ``list_for_workspace`` returns, so a draft lists as a draft.
+#   * THE ONE-DOC INVARIANT (PERF-1/PERF-2): create → publish yields EXACTLY ONE Site
+#     doc for the pocket — publish FINDS the draft (same stable ``_id``) and flips it
+#     live in place, never a second doc.
+#   * IDEMPOTENT: a repeat create is a no-op (one doc), and it never resets an
+#     already-published/live doc back to draft.
+#   * CAPTURE INVARIANT: publishing over a draft REUSES the draft's ``signed_key`` so
+#     the built ``captureSignedKey`` matches the persisted doc (lead capture works on
+#     the first publish) — the create-side twin of ``test_republish_reuses_signed_key``.
+#   * BILLING-SAFE: a draft carries no subscription and opens no checkout.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.sites import service as sites_service
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+async def _publish_local(pocket_id: str, *, name: str, generator=None, deploy=None):
+    """Publish a pocket through the LIVE path in LOCAL deploy mode. PAW_CF_DEPLOY_MODE
+    is pinned to ``local`` (the workspace .env leaks ``workers`` into the test env,
+    which would send publish down the workers.dev branch and hit the network); with
+    ``local`` + the injected ``_local_deploy`` seam no build tree / CF is needed."""
+    wire = {"name": name, "engine": "ripple", "rippleSpec": {"type": "container"}}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        return await sites_service.publish_pocket(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            _generator=generator or _FakeGenerator(),
+            _bundle_reader=lambda d: b"unused-in-local-mode",
+            _local_deploy=deploy or (lambda sid, pd: f"http://127.0.0.1:9999/{sid}/"),
+        )
+
+
+async def test_create_draft_site_lists_as_draft(beanie_test_db):
+    """``create_draft_site`` mints ONE Site doc that ``list_for_workspace`` returns as
+    a DRAFT — this is the whole bug: before the fix the gallery listed nothing for a
+    draft-first pocket, so it showed in neither the All nor the Draft filter."""
+    doc = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_draft", name="Minimal Test"
+    )
+    assert doc.deployed is False
+    assert doc.url == ""
+
+    # It lists — one card, and it reads as a draft (deployed False, no live url).
+    cards = await sites_service.list_for_workspace("ws1")
+    assert [c.pocket_id for c in cards] == ["pk_draft"]
+    assert cards[0].deployed is False
+    assert cards[0].url == ""
+    assert cards[0].name == "Minimal Test"
+
+
+async def test_create_then_publish_yields_exactly_one_doc(beanie_test_db, monkeypatch):
+    """THE ONE-DOC INVARIANT: create → publish leaves EXACTLY ONE Site doc for the
+    pocket. Publish FINDS the draft by its stable ``_id`` and flips it live in place
+    (``deployed=True`` + a real url), never minting a second doc — the PERF-1/PERF-2
+    dedupe guarantee, now spanning create → publish."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
+
+    draft = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk1", name="Bright Smile"
+    )
+    assert draft.deployed is False
+
+    # Exactly one doc after create.
+    docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk1"}).to_list()
+    assert len(docs) == 1
+
+    published = await _publish_local("pk1", name="Bright Smile")
+
+    # SAME doc id — publish upserted the draft, did not replace/insert.
+    assert str(published.id) == str(draft.id)
+    # The draft flipped LIVE in place.
+    assert published.deployed is True
+    assert published.url, "publish must stamp a live url over the draft"
+
+    # STILL exactly one Site doc for the pocket.
+    docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk1"}).to_list()
+    assert len(docs) == 1, f"expected ONE Site doc per pocket, found {len(docs)}"
+    assert docs[0].deployed is True
+
+    # And the gallery now lists it as live (deployed True).
+    cards = await sites_service.list_for_workspace("ws1")
+    assert len(cards) == 1
+    assert cards[0].deployed is True
+
+
+async def test_create_draft_is_idempotent(beanie_test_db):
+    """A repeat create is a no-op — one doc, same id, still a draft. (A create tool
+    minting the SAME site twice must not make two Site docs.)"""
+    first = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_idem", name="Once"
+    )
+    second = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_idem", name="Twice"
+    )
+
+    assert str(first.id) == str(second.id)
+    # The second call returned the existing doc untouched (name not overwritten).
+    assert second.name == "Once"
+    docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk_idem"}).to_list()
+    assert len(docs) == 1
+
+
+async def test_create_draft_never_clobbers_a_live_doc(beanie_test_db, monkeypatch):
+    """``create_draft_site`` on a pocket that is already PUBLISHED/LIVE returns the live
+    doc UNCHANGED — it never resets a live site back to a draft (deployed stays True)."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
+
+    await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_live", name="Live One"
+    )
+    live = await _publish_local("pk_live", name="Live One")
+    assert live.deployed is True
+
+    # A stray re-create must NOT undo the live state.
+    again = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_live", name="Live One"
+    )
+    assert again.deployed is True
+    assert again.url == live.url
+    docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk_live"}).to_list()
+    assert len(docs) == 1
+
+
+async def test_publish_over_draft_reuses_signed_key(beanie_test_db, monkeypatch):
+    """CAPTURE INVARIANT: publishing over a draft REUSES the draft's ``signed_key`` so
+    the built ``captureSignedKey`` matches the persisted doc — otherwise lead capture
+    silently breaks on the first publish (the built key would not match the stored one,
+    since publish's UPDATE branch preserves the doc's key)."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
+
+    draft = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_key", name="Keyed"
+    )
+    assert draft.signed_key, "a draft must seed a non-empty signed_key"
+
+    keys: list[str] = []
+
+    class _RecordingGen:
+        async def build(self, **kw):
+            from pocketpaw_ee.sites.generator_client import BuildResult
+
+            keys.append(kw.get("capture_signed_key"))
+            return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+    published = await _publish_local("pk_key", name="Keyed", generator=_RecordingGen())
+
+    assert keys[0] == draft.signed_key, "the build must reuse the draft's signed_key"
+    assert published.signed_key == draft.signed_key, "the live doc keeps the draft key"
+
+
+_DYNAMIC_SPEC = {
+    "type": "container",
+    "objects": [{"name": "signups", "fields": {"email": "text"}}],
+    "sources": [{"name": "all", "kind": "data", "object": "signups", "refresh": "pocket_open"}],
+}
+
+
+async def test_dynamic_create_then_publish_yields_one_doc(beanie_test_db, monkeypatch):
+    """The one-doc invariant across the DYNAMIC publish branch too: a dynamic publish
+    goes through ``_provision_dynamic_site`` (not the inline deploy), which must FIND
+    the pre-existing draft doc (same stable ``_id``) and flip it to
+    provision_status="provisioning" in place — not insert a second doc."""
+
+    class _RecordingDispatch:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        async def __call__(
+            self, *, workspace_id, pocket_id, action, job_name, params, triggered_by
+        ):
+            self.calls.append({"pocket_id": pocket_id, "job_name": job_name})
+            return {"ok": True, "code": "job_enqueued", "job_id": "job_xyz"}
+
+    dispatch = _RecordingDispatch()
+    monkeypatch.setattr("pocketpaw_ee.cloud.jobs.service.dispatch_job", dispatch)
+
+    draft = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_dyn", name="Guestbook"
+    )
+    assert draft.deployed is False
+
+    wire = {
+        "name": "Guestbook",
+        "engine": "ripple",
+        "rippleSpec": _DYNAMIC_SPEC,
+        "pattern": "dynamic",
+    }
+    with patch("pocketpaw_ee.cloud.pockets.service.get", new=AsyncMock(return_value=wire)):
+        published = await sites_service.publish_pocket(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk_dyn",
+            _generator=_FakeGenerator(),
+            _bundle_reader=lambda d: b"export default {}",
+        )
+
+    assert str(published.id) == str(draft.id)
+    assert published.provision_status == "provisioning"
+    assert published.deployed is False
+    assert len(dispatch.calls) == 1 and dispatch.calls[0]["job_name"] == "provision_site"
+
+    docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk_dyn"}).to_list()
+    assert len(docs) == 1, f"expected ONE Site doc per pocket, found {len(docs)}"
+
+
+async def test_draft_carries_no_billing(beanie_test_db):
+    """BILLING-SAFE: a draft opens no checkout and carries no subscription — only
+    publish bills. The minted draft doc has no sub state and lists with no checkout."""
+    doc = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_bill", name="Free Draft"
+    )
+    assert doc.deployed is False
+    assert doc.subscription_status == "none"
+    assert doc.subscription_id is None
+    assert doc.plan_tier is None
+    assert doc.pending_deploy_inputs == {}
+
+    cards = await sites_service.list_for_workspace("ws1")
+    assert cards[0].checkout_url is None


### PR DESCRIPTION
## What was broken

A live smoke found that draft-first site creation (#1744) makes a site that shows up nowhere. A plain create persists a site **pocket** but no **Site doc**, and the `/sites` gallery lists Site docs, so the draft lands in neither the All nor the Draft filter. The agent's "preview it under /sites" points at nothing until a publish first mints a Site doc.

## The fix

Mint a Site doc at create time in a not-yet-deployed state, so it lists naturally, and let publish update that same doc instead of adding a new one.

- New `create_draft_site` in `ee/pocketpaw_ee/sites/service.py` mints one Site doc keyed on the same stable per-pocket id (`_live_object_id`) that publish upserts. It is idempotent (a repeat create is a no-op) and never resets an already-live doc back to draft.
- The four create tools (`create_landing_site` / `create_svelte_site` / `create_html_site` / `create_dynamic_site`) call it right after the pocket is persisted, via a best-effort helper that logs and returns on failure rather than failing the create.
- A draft never builds, never contacts Cloudflare, and never opens a checkout or Dodo subscription. Only publish deploys and bills.

## Why it stays one doc per pocket

Both publish branches find the doc by its stable `_id` and update in place: the static path (`_deploy_site_doc`) and the dynamic path (`_provision_dynamic_site`). Because the draft carries that same `_id`, a later publish flips it live (`deployed=True` plus a url) rather than inserting a second row, so the PERF-1/PERF-2 dedupe invariant holds across create then publish. The draft also seeds the capture defaults publish's first insert seeds (`signed_key`, `allowed_origins`, `event_mapping`), so a first publish over the draft keeps a working `captureSignedKey` and lead mapping.

A draft reads draft and not-live everywhere because `pocket_status` and the card badge key on `deployed` (False on a draft), not on doc existence (BP-2).

## No frontend change

The gallery already renders a `deployed=false` row correctly: `siteBadgeState` falls back to `deployed ? 'live' : 'draft'` for a list row (list rows carry no `status`/`is_live`), so a draft gets a Draft badge, shows under the All and Draft filters, and opens the builder (which carries the Publish affordance) on click. There is no dead live-url button on the card. The DTO contract is unchanged, so no api-reference update is needed.

## Tests

New `tests/ee/sites/test_draft_first_visibility.py`:

- `test_create_then_publish_yields_exactly_one_doc` and `test_dynamic_create_then_publish_yields_one_doc` pin the one-doc invariant across both publish branches.
- `test_create_draft_site_lists_as_draft`, `test_create_draft_is_idempotent`, `test_create_draft_never_clobbers_a_live_doc`, `test_publish_over_draft_reuses_signed_key`, `test_draft_carries_no_billing`.
- A handler test that after a create tool runs, the draft Site doc lists as a draft with no checkout.

Targeted suite green: `tests/ee/sites/ tests/cloud/surface/test_sites_handler.py tests/ee/agent/test_sites_mcp_server/` = 519 passed, 2 skipped. The suite carries a pre-existing env leak (`PAW_CF_DEPLOY_MODE=workers` from the workspace `.env` reaches publish tests that do not pin it); runs use `PAW_CF_DEPLOY_MODE=local` to neutralize it, and the reds are confirmed identical on the clean base. Ruff clean; import-linter green on both the core and `ee/pyproject.toml` configs.
