### PR TITLE
feat(realtime): route site.published + workspace_job events to the workspace

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
@@ -340,6 +340,30 @@ class AudienceResolver:
                 return []
             return await self._group(gid)
 
+        # --- Sites (published site lifecycle) -----------------------------------
+        # Workspace-scoped: the /sites gallery is a per-workspace view, and a
+        # publish lands asynchronously relative to the chat turn that started it
+        # (the agent creates + publishes server-side). Fan out to every workspace
+        # member so an open gallery flips the new site to Live on its own — no
+        # poll, no manual refresh. Payload carries {workspace_id, site_id,
+        # pocket_id, owner, plan_tier}; the client keys the gallery row off
+        # site_id / pocket_id.
+        if t == "site.published":
+            if wid := d.get("workspace_id"):
+                return await self._workspace(wid)
+            return []
+
+        # --- Workspace jobs (durable ARQ job lifecycle) -------------------------
+        # Workspace-scoped: a dynamic site's provisioning runs as a durable job
+        # that completes well after the publish, in the ARQ worker. Fan out the
+        # queued/terminal update to every workspace member so the gallery/builder
+        # can advance provisioning -> live without polling job status. Payload
+        # carries {job_id, workspace_id, pocket_id, action, job_name, status}.
+        if t in {"workspace_job.queued", "workspace_job.updated"}:
+            if wid := d.get("workspace_id"):
+                return await self._workspace(wid)
+            return []
+
         # Room-scoped events (typing.*) are routed by the ConnectionManager directly,
         # not via this resolver. Falling through returns [] and the bus will no-op.
         return []

--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -398,7 +398,7 @@ def _create_preamble(meta: SurfaceMeta) -> str:
         "(and on a paid tier can open a checkout), so it is the user's call, not "
         "an automatic next step. Tell the user the draft is ready, point them at "
         "the Preview, and OFFER to take it live — e.g. 'Your site is ready as a "
-        "draft — preview it under /sites, and say publish (or \"make it live\") "
+        'draft — preview it under /sites, and say publish (or "make it live") '
         "when you're happy with it.' Then STOP. Publish IN THIS SAME TURN only if "
         "the user's request ALREADY asked to go live ('publish', 'make it live', "
         "'ship it', 'put it online'): in that case call "

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -934,9 +934,7 @@ async def _prewarm_native_artifact(
     pocket = await pockets_service.get(pocket_id, user_id)
     # Only svelte sites have a native shadow-render build; ripple/html don't use this
     # path (an html site's served artifact IS its source). Nothing to arm otherwise.
-    if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(
-        pocket.get("source"), dict
-    ):
+    if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(pocket.get("source"), dict):
         return
     source = pocket["source"]
     ripple_spec = pocket.get("rippleSpec") or {}

--- a/tests/cloud/realtime/test_audience.py
+++ b/tests/cloud/realtime/test_audience.py
@@ -349,3 +349,69 @@ async def test_composio_events_route_to_single_user():
     for cls in (ComposioConnectionVerified, ComposioConnectionMismatch):
         ev = cls(data={"workspace_id": "w1", "user_id": "u1", "toolkit": "gmail"})
         assert await r.audience(ev) == ["u1"], cls.__name__
+
+
+@pytest.mark.asyncio
+async def test_site_published_routes_to_workspace_members():
+    # The /sites gallery is per-workspace, and a publish lands async relative to
+    # the chat turn — so every workspace member with the gallery open must get the
+    # push to flip the new site to Live without a poll.
+    async def ws_members(_wid: str) -> list[str]:
+        return ["a", "b", "c"]
+
+    from pocketpaw_ee.cloud._core.realtime.events import SitePublished
+
+    r = AudienceResolver(workspace_members=ws_members)
+    ev = SitePublished(
+        data={
+            "workspace_id": "w1",
+            "site_id": "s1",
+            "pocket_id": "pkt1",
+            "owner": "a",
+            "plan_tier": "pro",
+        }
+    )
+    assert set(await r.audience(ev)) == {"a", "b", "c"}
+
+
+@pytest.mark.asyncio
+async def test_site_published_without_workspace_id_has_no_audience():
+    # Defensive: a malformed event with no workspace_id must not fan out anywhere
+    # (it falls through to []), never to an unscoped/global audience. The fetcher
+    # raises to prove the guard short-circuits before any member lookup.
+    async def ws_members(_wid: str) -> list[str]:
+        raise AssertionError("workspace_members must not be called without a workspace_id")
+
+    from pocketpaw_ee.cloud._core.realtime.events import SitePublished
+
+    r = AudienceResolver(workspace_members=ws_members)
+    ev = SitePublished(data={"site_id": "s1", "pocket_id": "pkt1"})
+    assert await r.audience(ev) == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_job_events_route_to_workspace_members():
+    # A dynamic site's provisioning job finishes in the ARQ worker, long after
+    # publish — the terminal update fans out to the workspace so the gallery can
+    # advance provisioning -> live without polling job status.
+    async def ws_members(_wid: str) -> list[str]:
+        return ["a", "b"]
+
+    from pocketpaw_ee.cloud._core.realtime.events import (
+        WorkspaceJobQueued,
+        WorkspaceJobUpdated,
+    )
+
+    r = AudienceResolver(workspace_members=ws_members)
+    for cls in (WorkspaceJobQueued, WorkspaceJobUpdated):
+        ev = cls(
+            data={
+                "job_id": "j1",
+                "workspace_id": "w1",
+                "pocket_id": "pkt1",
+                "action": "provision",
+                "job_name": "provision_site",
+                "status": "done",
+            }
+        )
+        assert set(await r.audience(ev)) == {"a", "b"}, cls.__name__


### PR DESCRIPTION
## Why

Two events already fire on the backend but reach no browser: `site.published` (a site went live) and `workspace_job.queued`/`workspace_job.updated` (a dynamic site's provisioning job). The audience resolver had no case for either, so they fell through to "deliver to nobody" and died in-process. The `/sites` gallery compensated with a bounded time-based poll (~14s) and a manual Refresh button; the builder's Live badge polled `is_live` on a timer.

## What

Route both to the site's workspace members via the existing workspace fetcher — the same path `pocket.*`, `agent.*`, `cycle.*`, and `belt_*` already use. Now the client gets an authoritative "a site changed, refetch" push and can drop the polling.

- `site.published` → workspace members
- `workspace_job.queued` / `workspace_job.updated` → workspace members

## Scope + safety

- **Workspace-scoped, nothing crosses tenants.** `self._workspace(wid)` only resolves members of that one workspace. A missing `workspace_id` falls through to an empty audience, never an unscoped fan-out.
- Payloads are ID-only (no tokens, no presigned URLs). A published site is already public, so broadcasting its metadata to the workspace gallery carries no confidentiality loss — consistent with how `agent.*`/`connector.*` fan out.
- Ran a security-review pass on the change: clean, no cross-tenant leak, fail-closed on malformed events, delivery still gated on an authenticated socket.

## Tests

`tests/cloud/realtime/test_audience.py` — 27 pass, including three new cases: `site.published` → workspace members, the no-`workspace_id` guard → empty audience, and `workspace_job.*` → workspace members. Ruff + format clean.

## Paired change

The frontend that consumes these events (live gallery + builder badge) is a separate PR on paw-enterprise (`fix/sites-realtime`). This backend change is inert on its own and safe to merge independently — the frontend simply keeps polling until it lands.