### PR TITLE
feat(agents): HerdrRuntime adapter (flagged, fail-open)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -432,6 +432,10 @@ select = ["E", "F", "I", "UP"]
 "src/pocketpaw/ripple/_design.py" = ["E501"]
 "ee/pocketpaw_ee/cloud/decisions/explain/extractor.py" = ["E501"]
 "ee/pocketpaw_ee/cloud/decisions/explain/narrator.py" = ["E501"]
+# Embedded fake-herdr shim: canned JSON envelopes are single-line by
+# nature (an id + result + record) and can't be wrapped without breaking
+# the bash `echo` that emits them.
+"tests/test_herdr_runtime.py" = ["E501"]
 
 [dependency-groups]
 dev = [

--- a/src/pocketpaw/agents/errors.py
+++ b/src/pocketpaw/agents/errors.py
@@ -11,6 +11,14 @@ raised by ``AgentPool.get`` when an admin has soft-disabled an agent (the
 ``disabled`` flag on the cloud Agent doc). Distinct from ``AgentNotFound`` so
 dispatch sites can tell "no such agent" apart from "revoked, finish in-flight
 runs only" and surface a clean "agent unavailable" instead of a 500.
+
+Updated: 2026-07-18 (feat/herdr-runtime-adapter, HR-1) — added
+``HerdrUnavailable``, raised by ``HerdrRuntime`` (the flagged, fail-open
+adapter for the ``herdr`` terminal multiplexer) whenever herdr cannot service
+a call: the ``herdr_runtime_enabled`` flag is off, the ``herdr`` binary is
+missing, or a herdr command fails at runtime (server down, socket error, or a
+JSON error-envelope). Callers MUST catch it and degrade to today's non-herdr
+behaviour — the adapter never crashes PocketPaw when herdr is absent.
 """
 
 from __future__ import annotations
@@ -48,3 +56,24 @@ class AgentBackendUnavailable(AgentRuntimeError):
     def __init__(self, backend: str) -> None:
         super().__init__(f"agent backend not available: {backend}")
         self.backend = backend
+
+
+class HerdrUnavailable(AgentRuntimeError):
+    """The herdr terminal-multiplexer runtime cannot service this call.
+
+    Raised by ``HerdrRuntime`` (``pocketpaw.agents.herdr_runtime``) when herdr
+    is not usable: the ``herdr_runtime_enabled`` flag is off, the ``herdr``
+    binary is not installed, or a herdr command fails at runtime (server not
+    running, socket error, timeout, or a JSON error-envelope such as
+    ``{"error": {"code": ..., "message": ...}}``).
+
+    This is the adapter's single fail-open signal — callers MUST catch it and
+    degrade to today's non-herdr behaviour rather than let it propagate. The
+    adapter never crashes PocketPaw when herdr is absent (same discipline as
+    the Fable advisor). Guard cheaply with ``HerdrRuntime.available`` before a
+    call to avoid the exception path entirely.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"herdr runtime unavailable: {reason}")
+        self.reason = reason

--- a/src/pocketpaw/agents/herdr_runtime.py
+++ b/src/pocketpaw/agents/herdr_runtime.py
@@ -1,0 +1,586 @@
+"""HerdrRuntime — a thin, flagged, fail-open adapter for the ``herdr`` terminal multiplexer.
+
+Created: 2026-07-18 (feat/herdr-runtime-adapter, HR-1).
+
+What this is
+------------
+A single, thin adapter that lets PocketPaw spawn and drive coding-agent
+terminals ("panes") through **herdr** — a terminal multiplexer for coding
+agents. Four future consumers (Mission Control, the belt/deep-work runtimes,
+etc.) share this one adapter instead of each shelling out to herdr by hand.
+
+herdr is driven ONLY as a separate process through its ``herdr`` binary. We
+never import, link, vendor, or copy herdr code — it is AGPL-3.0 and this is a
+process-boundary integration. Every call shells out via async subprocess (the
+same discipline as ``delegation.py`` / the CLI backends) and parses the JSON
+envelope herdr's socket-API subcommands emit:
+
+  * success → ``{"id": "cli:<group>:<cmd>", "result": {...}}``
+  * error   → ``{"id": "cli:<group>:<cmd>", "error": {"code": ..., "message": ...}}``
+
+herdr exits 0 even on the error envelope, so we detect failure from the JSON
+``error`` key, never from the exit code.
+
+Flagged + fail-open
+-------------------
+The adapter is gated by the ``herdr_runtime_enabled`` settings flag (default
+False) and by the presence of the ``herdr`` binary. When herdr is unavailable
+— flag off, binary missing, server down, socket error, timeout, or an error
+envelope — every public method raises :class:`HerdrUnavailable`. That is the
+adapter's single, consistent fail-open contract: callers MUST catch it and
+degrade to today's non-herdr behaviour; nothing here ever crashes PocketPaw
+when herdr is absent (same discipline as the Fable advisor). Guard cheaply
+with the :pyattr:`available` property (no subprocess) or :pymeth:`probe`
+(a live socket check) to avoid the exception path entirely.
+
+Ids are opaque
+--------------
+Pane / agent / workspace / terminal ids are OPAQUE strings minted by herdr.
+We only ever extract them from JSON (via :class:`PaneRef` / :class:`WorktreeRef`)
+and hand them back — we never construct or parse their internal shape.
+
+Status mapping
+--------------
+herdr's agent states map onto PocketPaw's Mission Control ``AgentStatus`` enum
+(``pocketpaw.mission_control.models``): working→ACTIVE, idle→IDLE,
+blocked→BLOCKED, unknown→OFFLINE. herdr also emits ``done`` (agent finished a
+turn) which maps to IDLE (finished ≈ available). Any unrecognised value fails
+safe to OFFLINE. ``AgentStatus`` is imported lazily inside :func:`map_agent_status`
+so importing this module never pulls in the mission_control package (whose
+``__init__`` imports ``agents.router`` — a cycle we sidestep).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pocketpaw.agents.errors import HerdrUnavailable
+
+if TYPE_CHECKING:
+    from pocketpaw.config import Settings
+    from pocketpaw.mission_control.models import AgentStatus
+
+logger = logging.getLogger(__name__)
+
+# herdr's own valid agent-status strings (the authority is `herdr` v0.7.4).
+_HERDR_STATUSES: frozenset[str] = frozenset({"idle", "working", "blocked", "done", "unknown"})
+
+# herdr agent-status string -> Mission Control AgentStatus *member name*. We map
+# by name (not the enum member) so this table needs no mission_control import at
+# module-import time; :func:`map_agent_status` resolves the name to the real
+# enum lazily. ``done`` is herdr-only (a finished turn) -> IDLE.
+_HERDR_TO_MC_NAME: dict[str, str] = {
+    "working": "ACTIVE",
+    "idle": "IDLE",
+    "blocked": "BLOCKED",
+    "done": "IDLE",
+    "unknown": "OFFLINE",
+}
+_DEFAULT_MC_NAME = "OFFLINE"  # any unrecognised herdr value fails safe
+
+# Mission Control AgentStatus *value* -> herdr status, for the reverse direction
+# (a caller passing an ``AgentStatus`` to :pymeth:`HerdrRuntime.wait`). ``idle``
+# and ``blocked`` are identical on both sides and resolve via _HERDR_STATUSES
+# first, so only the two that differ need listing.
+_MC_VALUE_TO_HERDR: dict[str, str] = {
+    "active": "working",
+    "offline": "unknown",
+}
+
+_DEFAULT_TIMEOUT_MS = 15000
+
+# Sentinel so _run_json can distinguish "use the configured default timeout"
+# from an explicit ``None`` (block indefinitely — used by blocking waits).
+_USE_DEFAULT_TIMEOUT = object()
+
+
+def map_agent_status(herdr_status: str | None) -> AgentStatus:
+    """Map a herdr agent-status string onto the Mission Control ``AgentStatus``.
+
+    ``working`` → ACTIVE, ``idle`` → IDLE, ``blocked`` → BLOCKED, ``done`` →
+    IDLE, ``unknown`` (and anything unrecognised) → OFFLINE. Imports the enum
+    lazily to keep this module import-cheap and cycle-free.
+    """
+    from pocketpaw.mission_control.models import AgentStatus
+
+    name = _HERDR_TO_MC_NAME.get((herdr_status or "").lower(), _DEFAULT_MC_NAME)
+    return AgentStatus[name]
+
+
+def _to_herdr_status(status: Any) -> str:
+    """Coerce a wait-target status into a herdr status string.
+
+    Accepts a raw herdr status (``idle|working|blocked|done|unknown``) or a
+    Mission Control ``AgentStatus`` (a ``StrEnum``, so ``str()`` yields its
+    value). ``idle``/``blocked`` are valid on both sides and pass through.
+    """
+    s = str(status).lower()
+    if s in _HERDR_STATUSES:
+        return s
+    if s in _MC_VALUE_TO_HERDR:
+        return _MC_VALUE_TO_HERDR[s]
+    raise ValueError(
+        f"unknown wait status {status!r}: expected one of "
+        f"{sorted(_HERDR_STATUSES)} or a Mission Control AgentStatus"
+    )
+
+
+@dataclass(frozen=True)
+class PaneRef:
+    """Opaque handle to a herdr pane / agent, built only from herdr JSON.
+
+    ``pane_id`` is the universal target string every herdr command accepts.
+    The other ids are carried for convenience (and for :pymeth:`HerdrRuntime.attach_info`);
+    ``raw`` keeps the full record herdr returned. None of these are ever
+    constructed by us — they are opaque strings minted by herdr.
+    """
+
+    pane_id: str
+    terminal_id: str | None = None
+    workspace_id: str | None = None
+    tab_id: str | None = None
+    agent: str | None = None
+    raw: Mapping[str, Any] = field(default_factory=dict, compare=False, repr=False)
+
+    @classmethod
+    def from_record(cls, rec: Mapping[str, Any]) -> PaneRef:
+        return cls(
+            pane_id=rec["pane_id"],
+            terminal_id=rec.get("terminal_id"),
+            workspace_id=rec.get("workspace_id"),
+            tab_id=rec.get("tab_id"),
+            agent=rec.get("agent"),
+            raw=dict(rec),
+        )
+
+
+@dataclass(frozen=True)
+class WorktreeRef:
+    """Opaque handle to a herdr-created git worktree / workspace.
+
+    Returned by :pymeth:`HerdrRuntime.worktree_create` and accepted by
+    :pymeth:`HerdrRuntime.spawn` (spawn into this worktree's workspace) and
+    :pymeth:`HerdrRuntime.worktree_remove`. ``workspace_id`` is the opaque id
+    herdr uses to address the worktree.
+    """
+
+    workspace_id: str | None
+    path: str | None = None
+    branch: str | None = None
+    root_pane_id: str | None = None
+    raw: Mapping[str, Any] = field(default_factory=dict, compare=False, repr=False)
+
+
+class HerdrRuntime:
+    """Thin, flagged, fail-open adapter over the ``herdr`` CLI.
+
+    Construct with PocketPaw ``Settings``; the adapter reads
+    ``herdr_runtime_enabled``, ``herdr_cli_path`` and ``herdr_cli_timeout_ms``.
+    All methods are async and shell out to the ``herdr`` binary. When herdr is
+    unavailable they raise :class:`HerdrUnavailable` — the single fail-open
+    contract (guard with :pyattr:`available` to skip the exception path).
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self._enabled = bool(getattr(settings, "herdr_runtime_enabled", False))
+        self._binary = _resolve_binary(settings)
+        timeout_ms = int(
+            getattr(settings, "herdr_cli_timeout_ms", _DEFAULT_TIMEOUT_MS) or _DEFAULT_TIMEOUT_MS
+        )
+        self._timeout_s = max(timeout_ms, 1) / 1000.0
+        if self._enabled and self._binary is None:
+            logger.warning(
+                "herdr_runtime_enabled is set but no herdr binary was found "
+                "(install herdr or set herdr_cli_path); the adapter will report "
+                "unavailable and callers will degrade to non-herdr behaviour."
+            )
+        elif self._enabled:
+            logger.info("HerdrRuntime enabled; binary=%s", self._binary)
+
+    # -- availability -------------------------------------------------------
+
+    @property
+    def available(self) -> bool:
+        """True when the flag is on AND a herdr binary is resolved.
+
+        Cheap (no subprocess). A True here does NOT prove the herdr server is
+        running — use :pymeth:`probe` for a live check.
+        """
+        return self._enabled and self._binary is not None
+
+    @property
+    def binary(self) -> str | None:
+        """The resolved herdr executable path, or None when unresolved."""
+        return self._binary
+
+    def _require_available(self) -> None:
+        if not self._enabled:
+            raise HerdrUnavailable("herdr_runtime_enabled flag is off")
+        if self._binary is None:
+            raise HerdrUnavailable("herdr binary not found (install herdr or set herdr_cli_path)")
+
+    async def probe(self) -> bool:
+        """Best-effort live check — True if the herdr server answers.
+
+        Runs a cheap read-only socket call (``pane list``). Never raises;
+        returns False when herdr is disabled, absent, or unreachable, so it is
+        safe to call as a guard.
+        """
+        if not self.available:
+            return False
+        try:
+            await self._run_json(["pane", "list"])
+        except HerdrUnavailable:
+            return False
+        return True
+
+    # -- core subprocess/JSON plumbing --------------------------------------
+
+    async def _run_json(
+        self, args: Sequence[str], *, timeout: Any = _USE_DEFAULT_TIMEOUT
+    ) -> dict[str, Any]:
+        """Run ``herdr <args>`` and return the parsed ``result`` payload.
+
+        ``timeout`` is seconds: the ``_USE_DEFAULT_TIMEOUT`` sentinel uses the
+        configured default; ``None`` blocks indefinitely (blocking waits only).
+        Raises :class:`HerdrUnavailable` on any failure — launch error, timeout,
+        non-JSON output, or a herdr error-envelope.
+        """
+        self._require_available()
+        assert self._binary is not None  # guaranteed by _require_available
+        argv = [self._binary, *[str(a) for a in args]]
+        env = {**os.environ, "HERDR_ENV": "1"}
+        timeout_s = self._timeout_s if timeout is _USE_DEFAULT_TIMEOUT else timeout
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+        except (FileNotFoundError, OSError) as exc:
+            raise HerdrUnavailable(f"failed to launch herdr: {exc}") from exc
+
+        try:
+            if timeout_s is None:
+                stdout_b, stderr_b = await proc.communicate()
+            else:
+                stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+        except TimeoutError as exc:
+            _kill_quietly(proc)
+            cmd = " ".join(str(a) for a in args)
+            raise HerdrUnavailable(
+                f"herdr command timed out after {timeout_s:.1f}s: herdr {cmd}"
+            ) from exc
+
+        stdout = stdout_b.decode("utf-8", errors="replace").strip()
+        stderr = stderr_b.decode("utf-8", errors="replace").strip()
+
+        if not stdout:
+            raise HerdrUnavailable(
+                f"herdr produced no output (exit={proc.returncode}): {stderr or '<no stderr>'}"
+            )
+
+        try:
+            envelope = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise HerdrUnavailable(f"herdr emitted non-JSON output: {stdout[:200]!r}") from exc
+
+        if not isinstance(envelope, dict):
+            raise HerdrUnavailable(f"herdr envelope was not a JSON object: {stdout[:200]!r}")
+
+        # herdr exits 0 even on the error envelope — detect failure by the key.
+        if "error" in envelope:
+            err = envelope.get("error")
+            if isinstance(err, Mapping):
+                code = err.get("code", "unknown")
+                message = err.get("message", "")
+            else:
+                code, message = "unknown", str(err)
+            raise HerdrUnavailable(f"herdr error [{code}]: {message}")
+
+        result = envelope.get("result")
+        if not isinstance(result, dict):
+            raise HerdrUnavailable(f"herdr envelope missing 'result': {stdout[:200]!r}")
+        return result
+
+    @staticmethod
+    def _target(ref: PaneRef | str) -> str:
+        """The herdr command target for a ref — its opaque ``pane_id``.
+
+        Accepts a :class:`PaneRef` or a raw pane-id string.
+        """
+        return ref.pane_id if isinstance(ref, PaneRef) else str(ref)
+
+    # -- spawn / enumerate --------------------------------------------------
+
+    async def spawn(
+        self,
+        agent: str,
+        *,
+        argv: Sequence[str] | None = None,
+        cwd: str | os.PathLike[str] | None = None,
+        worktree: WorktreeRef | str | None = None,
+        workspace: str | None = None,
+        env: Mapping[str, str] | None = None,
+        split: str | None = None,
+        focus: bool = False,
+    ) -> PaneRef:
+        """Start an agent CLI in a new herdr pane (``herdr agent start``).
+
+        ``agent`` is the herdr agent/integration label (e.g. ``"claude"``).
+        ``argv`` is the command line to launch after ``--``; omit to let herdr
+        use its configured launch for that agent. ``worktree`` spawns into a
+        worktree's workspace (its ``workspace_id``/``path`` fill in
+        ``workspace``/``cwd`` when those are not given). ``env`` sets the spawned
+        agent's env (``--env K=V``), not herdr's. Returns an opaque
+        :class:`PaneRef`.
+        """
+        args: list[str] = ["agent", "start", agent]
+
+        ws = workspace
+        wt_cwd: str | None = None
+        if worktree is not None:
+            if isinstance(worktree, WorktreeRef):
+                ws = ws or worktree.workspace_id
+                wt_cwd = worktree.path
+            else:
+                ws = ws or str(worktree)
+        eff_cwd = cwd if cwd is not None else wt_cwd
+        if eff_cwd is not None:
+            args += ["--cwd", str(eff_cwd)]
+        if ws:
+            args += ["--workspace", str(ws)]
+        if split:
+            args += ["--split", split]
+        if env:
+            for key, value in env.items():
+                args += ["--env", f"{key}={value}"]
+        args.append("--focus" if focus else "--no-focus")
+        if argv:
+            args.append("--")
+            args += [str(a) for a in argv]
+
+        result = await self._run_json(args)
+        rec = result.get("agent") or {}
+        if not rec.get("pane_id"):
+            raise HerdrUnavailable(f"herdr agent start returned no pane: {str(result)[:200]}")
+        return PaneRef.from_record(rec)
+
+    async def list_agents(self) -> list[PaneRef]:
+        """Enumerate agent panes (``herdr agent list``)."""
+        result = await self._run_json(["agent", "list"])
+        return [PaneRef.from_record(r) for r in result.get("agents", []) if r.get("pane_id")]
+
+    async def list_panes(self) -> list[PaneRef]:
+        """Enumerate all panes (``herdr pane list``)."""
+        result = await self._run_json(["pane", "list"])
+        return [PaneRef.from_record(r) for r in result.get("panes", []) if r.get("pane_id")]
+
+    # -- drive a pane -------------------------------------------------------
+
+    async def status(self, ref: PaneRef | str) -> AgentStatus:
+        """Current agent status as a Mission Control ``AgentStatus`` (``herdr agent get``)."""
+        result = await self._run_json(["agent", "get", self._target(ref)])
+        rec = result.get("agent") or {}
+        return map_agent_status(rec.get("agent_status"))
+
+    async def read(
+        self,
+        ref: PaneRef | str,
+        *,
+        source: str = "visible",
+        lines: int | None = None,
+    ) -> str:
+        """Read a pane/agent's scrollback text (``herdr agent read``).
+
+        ``source`` is ``visible`` | ``recent`` | ``recent-unwrapped``.
+        """
+        args = ["agent", "read", self._target(ref), "--source", source]
+        if lines is not None:
+            args += ["--lines", str(int(lines))]
+        result = await self._run_json(args)
+        read = result.get("read") or {}
+        return str(read.get("text", ""))
+
+    async def send(self, ref: PaneRef | str, text: str) -> None:
+        """Send literal text to an agent (``herdr agent send``).
+
+        Writes the text verbatim — no trailing Enter. (Use a herdr pane ``run``
+        surface for command-plus-Enter; this adapter keeps to literal sends.)
+        """
+        await self._run_json(["agent", "send", self._target(ref), text])
+
+    async def wait(
+        self,
+        ref: PaneRef | str,
+        *,
+        status: Any = None,
+        output_match: str | None = None,
+        timeout_ms: int | None = None,
+        regex: bool = False,
+        source: str | None = None,
+        lines: int | None = None,
+    ) -> dict[str, Any]:
+        """Block until an agent-status or output match (``herdr wait ...``).
+
+        Pass exactly one of ``status`` (``herdr wait agent-status`` — accepts a
+        herdr status string, incl. ``done``, or a Mission Control ``AgentStatus``)
+        or ``output_match`` (``herdr wait output`` — set ``regex=True`` to treat
+        it as a regex). ``timeout_ms`` bounds the wait; without it the call
+        blocks until a match (no subprocess timeout is imposed). Returns the raw
+        herdr ``result`` payload (a ``wait_matched`` / ``output_matched``
+        envelope); a timeout surfaces as :class:`HerdrUnavailable` carrying
+        herdr's timeout error.
+        """
+        if (status is None) == (output_match is None):
+            raise ValueError("wait() requires exactly one of status= or output_match=")
+
+        target = self._target(ref)
+        if status is not None:
+            args = ["wait", "agent-status", target, "--status", _to_herdr_status(status)]
+        else:
+            args = ["wait", "output", target, "--match", str(output_match)]
+            if regex:
+                args.append("--regex")
+            if source:
+                args += ["--source", source]
+            if lines is not None:
+                args += ["--lines", str(int(lines))]
+        if timeout_ms is not None:
+            args += ["--timeout", str(int(timeout_ms))]
+
+        # The subprocess timeout must outlast herdr's own --timeout so herdr,
+        # not us, reports the timeout (as an error envelope). Without a
+        # timeout_ms the caller asked to block, so impose no subprocess bound.
+        sub_timeout = (int(timeout_ms) / 1000.0 + 5.0) if timeout_ms is not None else None
+        return await self._run_json(args, timeout=sub_timeout)
+
+    async def attach_info(self, ref: PaneRef | str) -> dict[str, Any]:
+        """What a caller needs to attach to the pane (``herdr agent get``).
+
+        Returns a fresh dict of the opaque ids a UI/CLI needs to attach:
+        ``pane_id``, ``workspace_id``, ``tab_id``, ``terminal_id``, plus the
+        ``agent`` label and current ``agent_status`` string.
+        """
+        result = await self._run_json(["agent", "get", self._target(ref)])
+        rec = result.get("agent") or {}
+        return {
+            "pane_id": rec.get("pane_id"),
+            "workspace_id": rec.get("workspace_id"),
+            "tab_id": rec.get("tab_id"),
+            "terminal_id": rec.get("terminal_id"),
+            "agent": rec.get("agent"),
+            "agent_status": rec.get("agent_status"),
+        }
+
+    # -- worktrees ----------------------------------------------------------
+
+    async def worktree_create(
+        self,
+        *,
+        branch: str | None = None,
+        base: str | None = None,
+        path: str | os.PathLike[str] | None = None,
+        workspace: str | None = None,
+        cwd: str | os.PathLike[str] | None = None,
+        focus: bool = False,
+    ) -> WorktreeRef:
+        """Create a git worktree via herdr (``herdr worktree create --json``).
+
+        Source repo is selected by ``workspace`` (a workspace id) or ``cwd`` (a
+        path inside the repo). ``branch``/``base``/``path`` map to herdr's
+        ``--branch``/``--base``/``--path``. Returns an opaque :class:`WorktreeRef`.
+        """
+        args = ["worktree", "create", "--json"]
+        if workspace:
+            args += ["--workspace", str(workspace)]
+        elif cwd is not None:
+            args += ["--cwd", str(cwd)]
+        if branch:
+            args += ["--branch", branch]
+        if base:
+            args += ["--base", base]
+        if path is not None:
+            args += ["--path", str(path)]
+        args.append("--focus" if focus else "--no-focus")
+
+        result = await self._run_json(args)
+        return _worktree_ref_from_result(result)
+
+    async def worktree_remove(
+        self, workspace: WorktreeRef | str, *, force: bool = False
+    ) -> dict[str, Any]:
+        """Remove a herdr worktree (``herdr worktree remove --json``).
+
+        ``workspace`` is a :class:`WorktreeRef` or a raw workspace id. Returns
+        herdr's ``worktree_removed`` result payload.
+        """
+        ws_id = workspace.workspace_id if isinstance(workspace, WorktreeRef) else str(workspace)
+        if not ws_id:
+            raise ValueError("worktree_remove requires a workspace id")
+        args = ["worktree", "remove", "--workspace", ws_id, "--json"]
+        if force:
+            args.append("--force")
+        return await self._run_json(args)
+
+
+def _resolve_binary(settings: Settings) -> str | None:
+    """Locate the herdr executable: explicit ``herdr_cli_path`` else PATH.
+
+    An explicit path that is not an executable file yields None (fail-safe:
+    surface the misconfig rather than silently using a different PATH herdr).
+    """
+    explicit = getattr(settings, "herdr_cli_path", None)
+    if explicit:
+        p = Path(explicit)
+        if p.is_file() and os.access(p, os.X_OK):
+            return str(p)
+        logger.warning(
+            "herdr_cli_path=%s is not an executable file; treating herdr as unavailable", explicit
+        )
+        return None
+    return shutil.which("herdr")
+
+
+def _worktree_ref_from_result(result: Mapping[str, Any]) -> WorktreeRef:
+    """Build a :class:`WorktreeRef` from a ``worktree_created`` result payload."""
+    wt = result.get("worktree") or {}
+    ws = result.get("workspace") or {}
+    root = result.get("root_pane") or {}
+    return WorktreeRef(
+        workspace_id=ws.get("workspace_id") or wt.get("open_workspace_id"),
+        path=wt.get("path"),
+        branch=wt.get("branch"),
+        root_pane_id=root.get("pane_id"),
+        raw=dict(result),
+    )
+
+
+def _kill_quietly(proc: asyncio.subprocess.Process) -> None:
+    """Best-effort kill of a timed-out subprocess; never raises."""
+    try:
+        proc.kill()
+    except ProcessLookupError:
+        pass
+    except Exception as exc:  # noqa: BLE001 — cleanup must not mask the timeout
+        logger.debug("failed to kill timed-out herdr subprocess: %s", exc)
+
+
+__all__ = [
+    "HerdrRuntime",
+    "HerdrUnavailable",
+    "PaneRef",
+    "WorktreeRef",
+    "map_agent_status",
+]

--- a/src/pocketpaw/agents/herdr_runtime.py
+++ b/src/pocketpaw/agents/herdr_runtime.py
@@ -462,9 +462,9 @@ class HerdrRuntime:
         if eff_cwd is not None:
             args += ["--cwd", str(eff_cwd)]
         if ws:
-            args += ["--workspace", str(ws)]
+            args += ["--workspace", _reject_flaglike(str(ws), "workspace id")]
         if split:
-            args += ["--split", split]
+            args += ["--split", _reject_flaglike(split, "split direction")]
         if env:
             for key, value in env.items():
                 args += ["--env", f"{key}={value}"]
@@ -508,7 +508,7 @@ class HerdrRuntime:
 
         ``source`` is ``visible`` | ``recent`` | ``recent-unwrapped``.
         """
-        args = ["agent", "read", self._target(ref), "--source", source]
+        args = ["agent", "read", self._target(ref), "--source", _reject_flaglike(source, "source")]
         if lines is not None:
             args += ["--lines", str(int(lines))]
         result = await self._run_json(args)
@@ -616,13 +616,13 @@ class HerdrRuntime:
         """
         args = ["worktree", "create", "--json"]
         if workspace:
-            args += ["--workspace", str(workspace)]
+            args += ["--workspace", _reject_flaglike(str(workspace), "workspace id")]
         elif cwd is not None:
             args += ["--cwd", str(cwd)]
         if branch:
-            args += ["--branch", branch]
+            args += ["--branch", _reject_flaglike(branch, "branch")]
         if base:
-            args += ["--base", base]
+            args += ["--base", _reject_flaglike(base, "base ref")]
         if path is not None:
             args += ["--path", str(path)]
         args.append("--focus" if focus else "--no-focus")
@@ -641,6 +641,7 @@ class HerdrRuntime:
         ws_id = workspace.workspace_id if isinstance(workspace, WorktreeRef) else str(workspace)
         if not ws_id:
             raise ValueError("worktree_remove requires a workspace id")
+        ws_id = _reject_flaglike(ws_id, "workspace id")
         args = ["worktree", "remove", "--workspace", ws_id, "--json"]
         if force:
             args.append("--force")

--- a/src/pocketpaw/agents/herdr_runtime.py
+++ b/src/pocketpaw/agents/herdr_runtime.py
@@ -3,6 +3,32 @@
 Created: 2026-07-18 (feat/herdr-runtime-adapter, HR-1).
 Updated: 2026-07-24 (HR-1b) — added ``close()`` pane teardown (the ``spawn``
 counterpart every consumer that opens a pane needs to end it and its process).
+Updated: 2026-07-27 (HR-1c) — hard deployment boundary: herdr is refused in
+shared multi-tenant cloud mode. See "Deployment boundary" below.
+
+Deployment boundary — dedicated box ONLY, never shared multi-tenant cloud
+------------------------------------------------------------------------
+herdr panes are OS processes with PTYs, and **herdr has no tenant model**: it
+mints its own flat workspace namespace (``w1``, ``w2``, …) with no notion of
+which paw workspace owns a pane. On a shared box that means one tenant's admin
+could observe another tenant's panes — a boundary we cannot configure our way
+out of, because it does not exist upstream. The per-process cost compounds it
+(one pane ≈ one agent process, so N concurrent users ≈ N processes).
+
+So this adapter is for **single-operator deployments only**: a per-tenant
+dedicated box (Track A), a developer machine, or a private/self-hosted stack,
+where the workspace admin *is* the box operator.
+
+Two gates enforce that, and both must pass:
+
+1. ``herdr_runtime_enabled`` (default **False**) — the operator opt-in.
+2. ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` must **not** be set. That env marks a
+   shared multi-tenant cloud deployment; when it is set this adapter reports
+   itself permanently unavailable regardless of the flag, and logs an error.
+
+Gate 2 degrades through the ordinary "herdr is absent" path (every method
+raises :class:`HerdrUnavailable`, callers fall back), so a shared-cloud
+deployment that sets the flag by mistake loses the feature — it does not break.
 
 What this is
 ------------
@@ -99,6 +125,23 @@ _MC_VALUE_TO_HERDR: dict[str, str] = {
 
 _DEFAULT_TIMEOUT_MS = 15000
 
+# Shared multi-tenant cloud marker. The cloud deployment sets this to mandate
+# fail-closed workspace scoping (see ``pocketpaw.stores``); we reuse it as the
+# authoritative "this box serves more than one tenant" signal. Same env name and
+# same truthy set as stores.py so the two can never disagree about the mode.
+_REQUIRE_WORKSPACE_SCOPE_ENV = "POCKETPAW_REQUIRE_WORKSPACE_SCOPE"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _shared_cloud_mode() -> bool:
+    """True when this process serves a shared multi-tenant cloud deployment.
+
+    Read at construction time (not import time) so tests and a re-created
+    runtime observe the current environment.
+    """
+    return os.environ.get(_REQUIRE_WORKSPACE_SCOPE_ENV, "").strip().lower() in _TRUTHY
+
+
 # Sentinel so _run_json can distinguish "use the configured default timeout"
 # from an explicit ``None`` (block indefinitely — used by blocking waits).
 _USE_DEFAULT_TIMEOUT = object()
@@ -194,6 +237,21 @@ class HerdrRuntime:
     def __init__(self, settings: Settings) -> None:
         self.settings = settings
         self._enabled = bool(getattr(settings, "herdr_runtime_enabled", False))
+        # Deployment boundary (see module docstring): herdr has no tenant model,
+        # so it is refused outright on a shared multi-tenant box even when the
+        # operator opted in. Disabling here routes every caller through the
+        # already-tested "herdr absent" path rather than inventing a new failure.
+        self._shared_cloud = _shared_cloud_mode()
+        if self._enabled and self._shared_cloud:
+            logger.error(
+                "herdr_runtime_enabled is set but %s marks this a shared "
+                "multi-tenant deployment — REFUSING to enable herdr. herdr panes "
+                "are not workspace-scoped, so one tenant could observe another's "
+                "panes. herdr is supported only on a dedicated/single-operator "
+                "box. Treating herdr as unavailable.",
+                _REQUIRE_WORKSPACE_SCOPE_ENV,
+            )
+            self._enabled = False
         self._binary = _resolve_binary(settings)
         timeout_ms = int(
             getattr(settings, "herdr_cli_timeout_ms", _DEFAULT_TIMEOUT_MS) or _DEFAULT_TIMEOUT_MS
@@ -226,6 +284,14 @@ class HerdrRuntime:
 
     def _require_available(self) -> None:
         if not self._enabled:
+            if self._shared_cloud:
+                # Distinguish "operator left it off" from "we refused it" — the
+                # latter is a deployment boundary, not a missing toggle.
+                raise HerdrUnavailable(
+                    "herdr is not supported on a shared multi-tenant deployment "
+                    f"({_REQUIRE_WORKSPACE_SCOPE_ENV} is set); it requires a "
+                    "dedicated/single-operator box"
+                )
             raise HerdrUnavailable("herdr_runtime_enabled flag is off")
         if self._binary is None:
             raise HerdrUnavailable("herdr binary not found (install herdr or set herdr_cli_path)")

--- a/src/pocketpaw/agents/herdr_runtime.py
+++ b/src/pocketpaw/agents/herdr_runtime.py
@@ -1,6 +1,8 @@
 """HerdrRuntime — a thin, flagged, fail-open adapter for the ``herdr`` terminal multiplexer.
 
 Created: 2026-07-18 (feat/herdr-runtime-adapter, HR-1).
+Updated: 2026-07-24 (HR-1b) — added ``close()`` pane teardown (the ``spawn``
+counterpart every consumer that opens a pane needs to end it and its process).
 
 What this is
 ------------
@@ -483,6 +485,16 @@ class HerdrRuntime:
             "agent": rec.get("agent"),
             "agent_status": rec.get("agent_status"),
         }
+
+    async def close(self, ref: PaneRef | str) -> None:
+        """Close a pane and end its process (``herdr pane close``).
+
+        The teardown counterpart to :pymeth:`spawn`. herdr has no separate
+        "kill" verb — ``pane close`` ends the pane and whatever agent/command
+        runs in it. Raises :class:`HerdrUnavailable` if herdr can't service the
+        call; callers doing best-effort cleanup typically suppress it.
+        """
+        await self._run_json(["pane", "close", self._target(ref)])
 
     # -- worktrees ----------------------------------------------------------
 

--- a/src/pocketpaw/agents/herdr_runtime.py
+++ b/src/pocketpaw/agents/herdr_runtime.py
@@ -15,9 +15,15 @@ could observe another tenant's panes — a boundary we cannot configure our way
 out of, because it does not exist upstream. The per-process cost compounds it
 (one pane ≈ one agent process, so N concurrent users ≈ N processes).
 
-So this adapter is for **single-operator deployments only**: a per-tenant
-dedicated box (Track A), a developer machine, or a private/self-hosted stack,
-where the workspace admin *is* the box operator.
+So this adapter is for **single-operator deployments only** — the ones where the
+workspace admin *is* the machine's operator:
+
+* the **desktop app** (Tauri), running on the individual user's own machine —
+  one account, one machine, so the tenancy problem simply does not arise;
+* a **per-tenant dedicated box** (Track A);
+* a developer machine or a private/self-hosted stack.
+
+It is **not** for the shared multi-tenant SaaS.
 
 Two gates enforce that, and both must pass:
 
@@ -131,6 +137,30 @@ _DEFAULT_TIMEOUT_MS = 15000
 # same truthy set as stores.py so the two can never disagree about the mode.
 _REQUIRE_WORKSPACE_SCOPE_ENV = "POCKETPAW_REQUIRE_WORKSPACE_SCOPE"
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _reject_flaglike(value: str, what: str) -> str:
+    """Reject a structured value that would be parsed as a herdr CLI flag.
+
+    We invoke herdr with ``create_subprocess_exec`` and an argv list, so there
+    is no shell and no shell-metacharacter injection. The residual risk is
+    **argument** injection: a positional value beginning with ``-`` is read by
+    herdr's parser as a flag, not as data. Ids (``w3:p1``), workspace ids,
+    branches and enum-ish values never legitimately start with ``-``, so we
+    refuse them at this single seam — which protects every current and future
+    consumer of the adapter, including ones that pass HTTP-supplied values
+    straight through (the cockpit's ``/pane/{pane_id}/preview`` does exactly
+    that).
+
+    Free-form text (``send``'s payload) is deliberately NOT run through this —
+    a message may legitimately start with ``-``. It is passed as a positional
+    after the target, so a leading ``--`` there could still be misread by
+    herdr; no HTTP surface reaches ``send`` today (the cockpit is read-only),
+    and a consumer that wires one up must revisit this.
+    """
+    if value.startswith("-"):
+        raise ValueError(f"invalid {what}: {value!r} — must not start with '-' (flag-like)")
+    return value
 
 
 def _shared_cloud_mode() -> bool:
@@ -386,9 +416,12 @@ class HerdrRuntime:
     def _target(ref: PaneRef | str) -> str:
         """The herdr command target for a ref — its opaque ``pane_id``.
 
-        Accepts a :class:`PaneRef` or a raw pane-id string.
+        Accepts a :class:`PaneRef` or a raw pane-id string. The id is refused if
+        it looks like a CLI flag — see :func:`_reject_flaglike`. This is the
+        chokepoint every pane-addressing command goes through, so validating
+        here covers status/read/send/wait/attach_info/close in one place.
         """
-        return ref.pane_id if isinstance(ref, PaneRef) else str(ref)
+        return _reject_flaglike(ref.pane_id if isinstance(ref, PaneRef) else str(ref), "pane id")
 
     # -- spawn / enumerate --------------------------------------------------
 
@@ -414,7 +447,8 @@ class HerdrRuntime:
         agent's env (``--env K=V``), not herdr's. Returns an opaque
         :class:`PaneRef`.
         """
-        args: list[str] = ["agent", "start", agent]
+        # Positional — refuse a flag-like label (see _reject_flaglike).
+        args: list[str] = ["agent", "start", _reject_flaglike(agent, "agent label")]
 
         ws = workspace
         wt_cwd: str | None = None

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -193,6 +193,10 @@ Changes:
     CREATE surface runs the guided authoring-crew flow (clarity gate →
     interview → design-system + assets → build) instead of the single-shot
     create preamble; default off (feat/sites-crew-create-flow, SC-crew).
+  - 2026-07-18: Added ``herdr_runtime_enabled`` (kill-switch, default off),
+    ``herdr_cli_path`` and ``herdr_cli_timeout_ms`` for the flagged,
+    fail-open HerdrRuntime adapter over the external ``herdr`` terminal
+    multiplexer (feat/herdr-runtime-adapter, HR-1).
   - 2026-05-22: Added ``auto_install_bundled_templates`` — toggles the
     boot-time mirror of built-in pocket templates into
     ``~/.pocketpaw/templates/`` (feat/bundled-templates, Increment 2a).
@@ -515,6 +519,47 @@ class Settings(BaseSettings):
             "use (no human to approve). Pair with codex_cli_sandbox_mode="
             "'danger-full-access' on Windows or anywhere the agent can't "
             "be interactively supervised."
+        ),
+    )
+
+    # Herdr Runtime Settings (HR-1) — the flagged, fail-open adapter that lets
+    # PocketPaw spawn and drive coding-agent terminals through the external
+    # ``herdr`` binary (a terminal multiplexer for coding agents). Off by
+    # default: when disabled or when herdr is absent the adapter reports itself
+    # unavailable and PocketPaw keeps today's behaviour.
+    herdr_runtime_enabled: bool = Field(
+        default=False,
+        description=(
+            "Kill-switch for the HerdrRuntime adapter "
+            "(``pocketpaw.agents.herdr_runtime``). When False (default) the "
+            "adapter reports itself unavailable and every method raises "
+            "``HerdrUnavailable`` — PocketPaw runs exactly as it does today "
+            "with no herdr dependency. Flip to True (and install the ``herdr`` "
+            "binary + run a headless herdr server, see the HR-2 runbook) to let "
+            "consumers spawn and drive coding-agent panes through herdr. herdr "
+            "is used ONLY as a separate process over its CLI — never imported "
+            "or linked (it is AGPL-3.0; process-boundary use only)."
+        ),
+    )
+    herdr_cli_path: str | None = Field(
+        default=None,
+        description=(
+            "Explicit path to the ``herdr`` executable. When unset (default) "
+            "the adapter resolves it from PATH via ``shutil.which('herdr')``. "
+            "Set this to pin a specific herdr install (e.g. the version the "
+            "HR-2 runbook installs) so a stray PATH entry can't shadow it. If "
+            "the path is set but not an executable file, the adapter treats "
+            "herdr as unavailable (fail-safe) rather than falling back to PATH."
+        ),
+    )
+    herdr_cli_timeout_ms: int = Field(
+        default=15000,
+        description=(
+            "Default per-command timeout (milliseconds) for non-blocking herdr "
+            "CLI calls (list/get/read/send/spawn/worktree). A command that "
+            "exceeds it raises ``HerdrUnavailable`` so a wedged herdr socket "
+            "can never hang PocketPaw. Blocking ``wait`` calls use their own "
+            "``--timeout`` plus a small buffer, not this value."
         ),
     )
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -538,7 +538,16 @@ class Settings(BaseSettings):
             "binary + run a headless herdr server, see the HR-2 runbook) to let "
             "consumers spawn and drive coding-agent panes through herdr. herdr "
             "is used ONLY as a separate process over its CLI — never imported "
-            "or linked (it is AGPL-3.0; process-boundary use only)."
+            "or linked (it is AGPL-3.0; process-boundary use only). "
+            "DEDICATED-BOX ONLY: herdr has no tenant model (it mints a flat "
+            "workspace namespace with no link to a paw workspace), so on a "
+            "shared box one tenant's admin could observe another's panes. This "
+            "flag is therefore honoured only on a single-operator deployment — "
+            "a per-tenant dedicated box, a dev machine, or a self-hosted stack. "
+            "If ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` is set (the shared "
+            "multi-tenant cloud marker) the adapter REFUSES to enable "
+            "regardless of this flag, logs an error, and degrades through the "
+            "ordinary herdr-unavailable path."
         ),
     )
     herdr_cli_path: str | None = Field(

--- a/tests/test_herdr_runtime.py
+++ b/tests/test_herdr_runtime.py
@@ -245,6 +245,38 @@ async def test_dedicated_box_still_allows_herdr(fake_herdr_on_path, monkeypatch)
     assert _make_runtime(herdr_runtime_enabled=True).available is True
 
 
+@pytest.mark.parametrize("hostile", ["--force", "-f", "--help", "--workspace"])
+@pytest.mark.asyncio
+async def test_flaglike_pane_id_is_refused(runtime, hostile):
+    """Argument injection: a flag-like id must never reach herdr's parser.
+
+    There is no shell (``create_subprocess_exec`` + argv), so the residual risk
+    is a positional value being read as a FLAG. ``/cockpit/pane/{pane_id}/preview``
+    passes a URL segment straight through, so this is reachable input.
+    """
+    for call in (
+        runtime.status(hostile),
+        runtime.read(hostile),
+        runtime.close(hostile),
+        runtime.attach_info(hostile),
+    ):
+        with pytest.raises(ValueError, match="must not start with"):
+            await call
+
+
+@pytest.mark.asyncio
+async def test_flaglike_agent_label_is_refused(runtime):
+    with pytest.raises(ValueError, match="must not start with"):
+        await runtime.spawn("--help")
+
+
+@pytest.mark.asyncio
+async def test_legitimate_ids_still_pass(runtime):
+    """The guard is narrow — real herdr ids are unaffected."""
+    assert await runtime.status("w2:p1") is not None
+    assert isinstance(await runtime.read("w2:p1"), str)
+
+
 @pytest.mark.asyncio
 async def test_binary_missing_reports_unavailable(monkeypatch, tmp_path):
     # Flag on, but no herdr anywhere on PATH.

--- a/tests/test_herdr_runtime.py
+++ b/tests/test_herdr_runtime.py
@@ -107,6 +107,20 @@ def _path_with(*dirs: str) -> str:
     return os.pathsep.join([*dirs, *_SAFE_PATH_DIRS])
 
 
+@pytest.fixture(autouse=True)
+def _no_ambient_shared_cloud(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every test in this file hermetic against a cloud-configured shell.
+
+    ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` marks a shared multi-tenant
+    deployment, which makes ``HerdrRuntime`` refuse to enable at all. If a
+    developer's (or CI lane's) environment exports it, most of this file would
+    fail for a reason unrelated to what each test asserts. Autouse so tests that
+    build their own PATH are covered too; the two tests that exercise the
+    boundary set the env themselves via monkeypatch, which still wins.
+    """
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+
+
 @pytest.fixture
 def fake_herdr_bin(tmp_path: Path) -> Path:
     """Write the fake `herdr` executable and return its path."""
@@ -124,6 +138,11 @@ def fake_herdr_on_path(fake_herdr_bin: Path, monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("PATH", _path_with(str(fake_herdr_bin.parent)))
     monkeypatch.delenv("HERDR_FAKE_MODE", raising=False)
     monkeypatch.delenv("HERDR_CAPTURE_FILE", raising=False)
+    # Hermetic against a cloud-configured shell: this env marks a shared
+    # multi-tenant deployment and makes HerdrRuntime refuse to enable at all,
+    # which would fail most of this file for reasons unrelated to the test. The
+    # two tests that care set it themselves via monkeypatch.
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
     return fake_herdr_bin
 
 

--- a/tests/test_herdr_runtime.py
+++ b/tests/test_herdr_runtime.py
@@ -215,6 +215,36 @@ async def test_flag_off_reports_unavailable(fake_herdr_on_path):
         await rt.status("w2:p1")
 
 
+@pytest.mark.parametrize("truthy", ["1", "true", "YES", "on"])
+@pytest.mark.asyncio
+async def test_shared_cloud_mode_refuses_herdr(fake_herdr_on_path, monkeypatch, truthy):
+    """The deployment boundary: a shared multi-tenant box refuses herdr outright.
+
+    Flag ON and the binary present — the ONLY reason it stays unavailable is
+    ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE``. herdr panes are not workspace-scoped,
+    so one tenant could observe another's panes.
+    """
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", truthy)
+    rt = _make_runtime(herdr_runtime_enabled=True)
+    assert rt.available is False
+    assert await rt.probe() is False
+    with pytest.raises(HerdrUnavailable, match="shared multi-tenant"):
+        await rt.status("w2:p1")
+    with pytest.raises(HerdrUnavailable, match="shared multi-tenant"):
+        await rt.spawn("claude")
+
+
+@pytest.mark.asyncio
+async def test_dedicated_box_still_allows_herdr(fake_herdr_on_path, monkeypatch):
+    """The boundary is precise: an unset/falsey scope env leaves herdr usable."""
+    for value in ("", "0", "false", "off"):
+        monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", value)
+        rt = _make_runtime(herdr_runtime_enabled=True)
+        assert rt.available is True, f"{value!r} should not trip the boundary"
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    assert _make_runtime(herdr_runtime_enabled=True).available is True
+
+
 @pytest.mark.asyncio
 async def test_binary_missing_reports_unavailable(monkeypatch, tmp_path):
     # Flag on, but no herdr anywhere on PATH.

--- a/tests/test_herdr_runtime.py
+++ b/tests/test_herdr_runtime.py
@@ -1,0 +1,457 @@
+"""Tests for the HerdrRuntime adapter (feat/herdr-runtime-adapter, HR-1).
+
+Created: 2026-07-18.
+
+These tests run WITHOUT a real herdr server. A fake ``herdr`` executable (a
+small bash script emitting canned JSON envelopes) is installed on a temp PATH
+via fixtures, so the adapter's subprocess/JSON plumbing, status mapping,
+command construction, and fail-open behaviour are all exercised hermetically.
+
+Coverage:
+  * status mapping (herdr status <-> Mission Control AgentStatus, both ways),
+  * happy-path parse for every contract method (spawn/status/read/send/wait/
+    worktree_create/worktree_remove/attach_info/list_agents/list_panes),
+  * exact command-line construction (via an argv-capture sidecar),
+  * fail-open: flag off, binary missing, error envelope, non-JSON, timeout.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.agents.errors import HerdrUnavailable
+from pocketpaw.agents.herdr_runtime import (
+    HerdrRuntime,
+    PaneRef,
+    WorktreeRef,
+    _to_herdr_status,
+    map_agent_status,
+)
+from pocketpaw.config import Settings
+from pocketpaw.mission_control.models import AgentStatus
+
+# --------------------------------------------------------------------------- #
+# Fake herdr shim
+# --------------------------------------------------------------------------- #
+
+# A stand-in `herdr` binary. Keyed on "$1 $2" (herdr group + subcommand); emits
+# the same JSON envelope shapes real herdr v0.7.4 does. HERDR_FAKE_MODE forces a
+# failure shape; HERDR_CAPTURE_FILE records the exact argv for assertions.
+FAKE_HERDR_SCRIPT = r"""#!/usr/bin/env bash
+if [ -n "$HERDR_CAPTURE_FILE" ]; then
+  printf '%s\n' "$@" > "$HERDR_CAPTURE_FILE"
+fi
+mode="${HERDR_FAKE_MODE:-ok}"
+if [ "$mode" = "badjson" ]; then
+  echo "this is definitely not json"
+  exit 0
+fi
+if [ "$mode" = "hang" ]; then
+  sleep 30
+  exit 0
+fi
+if [ "$mode" = "error" ]; then
+  echo '{"id":"cli:fake","error":{"code":"boom","message":"simulated herdr failure"}}'
+  exit 0
+fi
+case "$1 $2" in
+  "agent list")
+    echo '{"id":"cli:agent:list","result":{"type":"agent_list","agents":[{"agent":"claude","agent_status":"idle","pane_id":"w2:p1","terminal_id":"term_a","tab_id":"w2:t1","workspace_id":"w2"},{"agent":"codex","agent_status":"working","pane_id":"w3:p1","terminal_id":"term_b","tab_id":"w3:t1","workspace_id":"w3"}]}}'
+    ;;
+  "pane list")
+    echo '{"id":"cli:pane:list","result":{"type":"pane_list","panes":[{"agent":"claude","agent_status":"idle","pane_id":"w2:p1","terminal_id":"term_a","tab_id":"w2:t1","workspace_id":"w2"}]}}'
+    ;;
+  "agent get")
+    echo '{"id":"cli:agent:get","result":{"type":"agent_info","agent":{"agent":"claude","agent_status":"working","pane_id":"w2:p1","terminal_id":"term_a","tab_id":"w2:t1","workspace_id":"w2"}}}'
+    ;;
+  "agent read")
+    echo '{"id":"cli:agent:read","result":{"type":"pane_read","read":{"format":"text","pane_id":"w2:p1","source":"visible","tab_id":"w2:t1","text":"hello from pane\n> ","truncated":false,"workspace_id":"w2"}}}'
+    ;;
+  "agent send")
+    echo '{"id":"cli:agent:send","result":{"type":"ok"}}'
+    ;;
+  "agent start")
+    echo '{"id":"cli:agent:start","result":{"type":"agent_started","argv":["claude"],"agent":{"agent":"claude","agent_status":"working","pane_id":"w4:p1","terminal_id":"term_new","tab_id":"w4:t1","workspace_id":"w4"}}}'
+    ;;
+  "wait agent-status")
+    echo '{"id":"cli:wait:agent-status","result":{"type":"wait_matched","event":{"kind":"agent_status","pane_id":"w2:p1","status":"idle"}}}'
+    ;;
+  "wait output")
+    echo '{"id":"cli:wait:output","result":{"type":"output_matched","pane_id":"w2:p1","matched_line":"BUILD OK","revision":7,"read":{"format":"text","pane_id":"w2:p1","source":"recent","tab_id":"w2:t1","text":"...BUILD OK...","truncated":false,"workspace_id":"w2"}}}'
+    ;;
+  "worktree create")
+    echo '{"id":"cli:worktree:create","result":{"type":"worktree_created","worktree":{"branch":"feat/x","path":"/tmp/wt/x","open_workspace_id":"w9","is_bare":false,"is_detached":false,"is_linked_worktree":true,"is_prunable":false,"label":"repo"},"workspace":{"workspace_id":"w9","label":"repo","number":9},"root_pane":{"pane_id":"w9:p1","terminal_id":"term_w9","tab_id":"w9:t1","workspace_id":"w9","agent":null,"agent_status":"unknown"},"tab":{"tab_id":"w9:t1","workspace_id":"w9"}}}'
+    ;;
+  "worktree remove")
+    echo '{"id":"cli:worktree:remove","result":{"type":"worktree_removed","forced":false,"path":"/tmp/wt/x","workspace_id":"w9"}}'
+    ;;
+  *)
+    echo "{\"id\":\"cli:unknown\",\"error\":{\"code\":\"unknown_command\",\"message\":\"fake herdr got: $*\"}}"
+    ;;
+esac
+exit 0
+"""
+
+# Keep coreutils + the bash interpreter reachable while excluding the real
+# ~/.local/bin/herdr, so `shutil.which` only ever sees our fake (or nothing).
+_SAFE_PATH_DIRS = ("/bin", "/usr/bin")
+
+
+def _path_with(*dirs: str) -> str:
+    return os.pathsep.join([*dirs, *_SAFE_PATH_DIRS])
+
+
+@pytest.fixture
+def fake_herdr_bin(tmp_path: Path) -> Path:
+    """Write the fake `herdr` executable and return its path."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    script = bindir / "herdr"
+    script.write_text(FAKE_HERDR_SCRIPT)
+    script.chmod(0o755)
+    return script
+
+
+@pytest.fixture
+def fake_herdr_on_path(fake_herdr_bin: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Install the fake `herdr` on a temp PATH (real herdr excluded)."""
+    monkeypatch.setenv("PATH", _path_with(str(fake_herdr_bin.parent)))
+    monkeypatch.delenv("HERDR_FAKE_MODE", raising=False)
+    monkeypatch.delenv("HERDR_CAPTURE_FILE", raising=False)
+    return fake_herdr_bin
+
+
+def _make_runtime(**overrides) -> HerdrRuntime:
+    """Build a HerdrRuntime from a hermetic Settings (no .env, explicit flags)."""
+    kwargs = {"_env_file": None, "herdr_runtime_enabled": True}
+    kwargs.update(overrides)
+    return HerdrRuntime(Settings(**kwargs))
+
+
+@pytest.fixture
+def runtime(fake_herdr_on_path: Path) -> HerdrRuntime:
+    return _make_runtime()
+
+
+# --------------------------------------------------------------------------- #
+# Pure status-mapping units (no subprocess)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("herdr_status", "expected"),
+    [
+        ("working", AgentStatus.ACTIVE),
+        ("idle", AgentStatus.IDLE),
+        ("blocked", AgentStatus.BLOCKED),
+        ("unknown", AgentStatus.OFFLINE),
+        ("done", AgentStatus.IDLE),  # herdr-only: finished turn ~= available
+        ("weird-new-value", AgentStatus.OFFLINE),  # unknown -> fail safe
+        (None, AgentStatus.OFFLINE),
+        ("WORKING", AgentStatus.ACTIVE),  # case-insensitive
+    ],
+)
+def test_map_agent_status(herdr_status, expected):
+    assert map_agent_status(herdr_status) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("idle", "idle"),
+        ("working", "working"),
+        ("blocked", "blocked"),
+        ("done", "done"),  # herdr-only wait status passes through
+        ("unknown", "unknown"),
+        (AgentStatus.ACTIVE, "working"),  # MC enum reverse-maps
+        (AgentStatus.IDLE, "idle"),
+        (AgentStatus.BLOCKED, "blocked"),
+        (AgentStatus.OFFLINE, "unknown"),
+    ],
+)
+def test_to_herdr_status(value, expected):
+    assert _to_herdr_status(value) == expected
+
+
+def test_to_herdr_status_rejects_garbage():
+    with pytest.raises(ValueError, match="unknown wait status"):
+        _to_herdr_status("nonsense")
+
+
+def test_paneref_from_record_extracts_ids():
+    ref = PaneRef.from_record(
+        {
+            "pane_id": "w2:p1",
+            "terminal_id": "t",
+            "workspace_id": "w2",
+            "tab_id": "w2:t1",
+            "agent": "claude",
+        }
+    )
+    assert ref.pane_id == "w2:p1"
+    assert ref.terminal_id == "t"
+    assert ref.workspace_id == "w2"
+    assert ref.agent == "claude"
+
+
+# --------------------------------------------------------------------------- #
+# Availability / fail-open
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_flag_off_reports_unavailable(fake_herdr_on_path):
+    # Binary present on PATH, but the kill-switch is off.
+    rt = _make_runtime(herdr_runtime_enabled=False)
+    assert rt.available is False
+    assert await rt.probe() is False
+    with pytest.raises(HerdrUnavailable, match="flag is off"):
+        await rt.status("w2:p1")
+
+
+@pytest.mark.asyncio
+async def test_binary_missing_reports_unavailable(monkeypatch, tmp_path):
+    # Flag on, but no herdr anywhere on PATH.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("PATH", _path_with(str(empty)))
+    rt = _make_runtime()
+    assert rt.available is False
+    assert rt.binary is None
+    assert await rt.probe() is False
+    with pytest.raises(HerdrUnavailable, match="binary not found"):
+        await rt.spawn("claude")
+
+
+@pytest.mark.asyncio
+async def test_error_envelope_raises(runtime, monkeypatch):
+    monkeypatch.setenv("HERDR_FAKE_MODE", "error")
+    with pytest.raises(HerdrUnavailable, match=r"herdr error \[boom\]"):
+        await runtime.status("w2:p1")
+
+
+@pytest.mark.asyncio
+async def test_non_json_output_raises(runtime, monkeypatch):
+    monkeypatch.setenv("HERDR_FAKE_MODE", "badjson")
+    with pytest.raises(HerdrUnavailable, match="non-JSON"):
+        await runtime.list_agents()
+
+
+@pytest.mark.asyncio
+async def test_command_timeout_raises(fake_herdr_on_path, monkeypatch):
+    monkeypatch.setenv("HERDR_FAKE_MODE", "hang")
+    rt = _make_runtime(herdr_cli_timeout_ms=150)  # 0.15s, shim sleeps 30s
+    with pytest.raises(HerdrUnavailable, match="timed out"):
+        await rt.status("w2:p1")
+
+
+@pytest.mark.asyncio
+async def test_explicit_path_override(fake_herdr_bin, monkeypatch):
+    # No herdr on PATH, but herdr_cli_path points straight at the fake.
+    monkeypatch.setenv("PATH", _path_with())
+    monkeypatch.delenv("HERDR_FAKE_MODE", raising=False)
+    monkeypatch.delenv("HERDR_CAPTURE_FILE", raising=False)
+    rt = _make_runtime(herdr_cli_path=str(fake_herdr_bin))
+    assert rt.available is True
+    assert await rt.probe() is True
+
+
+def test_explicit_path_invalid_is_unavailable(monkeypatch, tmp_path):
+    monkeypatch.setenv("PATH", _path_with())
+    rt = _make_runtime(herdr_cli_path=str(tmp_path / "does-not-exist"))
+    assert rt.available is False
+    assert rt.binary is None
+
+
+# --------------------------------------------------------------------------- #
+# Happy-path parse + map (fake shim)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_probe_true_when_server_answers(runtime):
+    assert await runtime.probe() is True
+
+
+@pytest.mark.asyncio
+async def test_status_maps_working_to_active(runtime):
+    assert await runtime.status("w2:p1") is AgentStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_list_agents_parses_records(runtime):
+    agents = await runtime.list_agents()
+    assert [a.pane_id for a in agents] == ["w2:p1", "w3:p1"]
+    assert agents[0].agent == "claude"
+    assert agents[1].workspace_id == "w3"
+
+
+@pytest.mark.asyncio
+async def test_list_panes_parses_records(runtime):
+    panes = await runtime.list_panes()
+    assert [p.pane_id for p in panes] == ["w2:p1"]
+
+
+@pytest.mark.asyncio
+async def test_read_returns_text(runtime):
+    text = await runtime.read("w2:p1", source="visible", lines=10)
+    assert text == "hello from pane\n> "
+
+
+@pytest.mark.asyncio
+async def test_send_returns_none(runtime):
+    assert await runtime.send("w2:p1", "hello") is None
+
+
+@pytest.mark.asyncio
+async def test_attach_info_shape(runtime):
+    info = await runtime.attach_info("w2:p1")
+    assert info == {
+        "pane_id": "w2:p1",
+        "workspace_id": "w2",
+        "tab_id": "w2:t1",
+        "terminal_id": "term_a",
+        "agent": "claude",
+        "agent_status": "working",
+    }
+
+
+@pytest.mark.asyncio
+async def test_spawn_returns_paneref(runtime):
+    ref = await runtime.spawn("claude", argv=["claude"])
+    assert isinstance(ref, PaneRef)
+    assert ref.pane_id == "w4:p1"
+    assert ref.workspace_id == "w4"
+
+
+@pytest.mark.asyncio
+async def test_worktree_create_returns_ref(runtime):
+    wt = await runtime.worktree_create(branch="feat/x")
+    assert isinstance(wt, WorktreeRef)
+    assert wt.workspace_id == "w9"
+    assert wt.path == "/tmp/wt/x"
+    assert wt.branch == "feat/x"
+    assert wt.root_pane_id == "w9:p1"
+
+
+@pytest.mark.asyncio
+async def test_worktree_remove_returns_result(runtime):
+    result = await runtime.worktree_remove(WorktreeRef(workspace_id="w9"))
+    assert result["workspace_id"] == "w9"
+    assert result["type"] == "worktree_removed"
+
+
+@pytest.mark.asyncio
+async def test_wait_requires_exactly_one_condition(runtime):
+    with pytest.raises(ValueError, match="exactly one"):
+        await runtime.wait("w2:p1")
+    with pytest.raises(ValueError, match="exactly one"):
+        await runtime.wait("w2:p1", status="idle", output_match="x")
+
+
+@pytest.mark.asyncio
+async def test_wait_status_returns_match(runtime):
+    result = await runtime.wait("w2:p1", status="idle", timeout_ms=1000)
+    assert result["type"] == "wait_matched"
+
+
+@pytest.mark.asyncio
+async def test_wait_output_returns_match(runtime):
+    result = await runtime.wait("w2:p1", output_match="BUILD OK", regex=True, timeout_ms=1000)
+    assert result["type"] == "output_matched"
+
+
+# --------------------------------------------------------------------------- #
+# Exact command-line construction (argv capture)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def capture(fake_herdr_on_path, tmp_path, monkeypatch):
+    """Capture the exact argv the adapter passes to herdr."""
+    cap = tmp_path / "argv.txt"
+    monkeypatch.setenv("HERDR_CAPTURE_FILE", str(cap))
+
+    def read_argv() -> list[str]:
+        return cap.read_text().splitlines()
+
+    return read_argv
+
+
+@pytest.mark.asyncio
+async def test_spawn_builds_full_command(runtime, capture):
+    await runtime.spawn(
+        "claude",
+        argv=["claude", "--dangerously-skip-permissions"],
+        cwd="/repo",
+        workspace="w2",
+        env={"FOO": "bar"},
+        split="right",
+    )
+    assert capture() == [
+        "agent",
+        "start",
+        "claude",
+        "--cwd",
+        "/repo",
+        "--workspace",
+        "w2",
+        "--split",
+        "right",
+        "--env",
+        "FOO=bar",
+        "--no-focus",
+        "--",
+        "claude",
+        "--dangerously-skip-permissions",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_spawn_worktree_ref_fills_workspace_and_cwd(runtime, capture):
+    await runtime.spawn("claude", worktree=WorktreeRef(workspace_id="w9", path="/wt/x"))
+    argv = capture()
+    assert "--workspace" in argv and argv[argv.index("--workspace") + 1] == "w9"
+    assert "--cwd" in argv and argv[argv.index("--cwd") + 1] == "/wt/x"
+
+
+@pytest.mark.asyncio
+async def test_wait_status_reverse_maps_mc_enum(runtime, capture):
+    await runtime.wait("w2:p1", status=AgentStatus.ACTIVE, timeout_ms=500)
+    argv = capture()
+    assert argv[:4] == ["wait", "agent-status", "w2:p1", "--status"]
+    assert argv[4] == "working"
+    assert argv[-2:] == ["--timeout", "500"]
+
+
+@pytest.mark.asyncio
+async def test_wait_output_builds_command(runtime, capture):
+    await runtime.wait("w2:p1", output_match="BUILD OK", regex=True, timeout_ms=1000)
+    assert capture() == [
+        "wait",
+        "output",
+        "w2:p1",
+        "--match",
+        "BUILD OK",
+        "--regex",
+        "--timeout",
+        "1000",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_worktree_create_passes_json_flag(runtime, capture):
+    await runtime.worktree_create(branch="feat/x", cwd="/repo")
+    argv = capture()
+    assert argv[:3] == ["worktree", "create", "--json"]
+    assert "--branch" in argv and argv[argv.index("--branch") + 1] == "feat/x"
+    assert "--cwd" in argv and argv[argv.index("--cwd") + 1] == "/repo"
+
+
+@pytest.mark.asyncio
+async def test_worktree_remove_builds_command(runtime, capture):
+    await runtime.worktree_remove("w9", force=True)
+    assert capture() == ["worktree", "remove", "--workspace", "w9", "--json", "--force"]

--- a/tests/test_herdr_runtime.py
+++ b/tests/test_herdr_runtime.py
@@ -88,6 +88,9 @@ case "$1 $2" in
   "worktree remove")
     echo '{"id":"cli:worktree:remove","result":{"type":"worktree_removed","forced":false,"path":"/tmp/wt/x","workspace_id":"w9"}}'
     ;;
+  "pane close")
+    echo '{"id":"cli:pane:close","result":{"type":"pane_closed","pane_id":"w2:p1"}}'
+    ;;
   *)
     echo "{\"id\":\"cli:unknown\",\"error\":{\"code\":\"unknown_command\",\"message\":\"fake herdr got: $*\"}}"
     ;;
@@ -325,6 +328,26 @@ async def test_spawn_returns_paneref(runtime):
     assert isinstance(ref, PaneRef)
     assert ref.pane_id == "w4:p1"
     assert ref.workspace_id == "w4"
+
+
+@pytest.mark.asyncio
+async def test_close_invokes_pane_close(runtime, monkeypatch, tmp_path):
+    cap = tmp_path / "close_args.txt"
+    monkeypatch.setenv("HERDR_CAPTURE_FILE", str(cap))
+    assert await runtime.close(PaneRef(pane_id="w4:p1")) is None
+    assert cap.read_text().split() == ["pane", "close", "w4:p1"]
+
+
+@pytest.mark.asyncio
+async def test_close_accepts_raw_pane_id(runtime):
+    assert await runtime.close("w2:p1") is None
+
+
+@pytest.mark.asyncio
+async def test_close_raises_when_unavailable(fake_herdr_on_path):
+    rt = _make_runtime(herdr_runtime_enabled=False)
+    with pytest.raises(HerdrUnavailable):
+        await rt.close("w2:p1")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What ships
A thin adapter — `pocketpaw.agents.herdr_runtime.HerdrRuntime` — that lets PocketPaw spawn and drive coding-agent terminals through herdr (an external terminal multiplexer for coding agents) over its CLI: spawn/status/wait/read/send/attach_info/list plus worktree create/remove. No consumers are wired yet; this is the single seam the belt, LIVE-tier, and cockpit work will build on.

## Why
First code slice of the herdr agent-runtime arc (design/PRD/tasks live on the `docs/herdr-agent-runtime` branch). One adapter, four future consumers, so herdr integration sits in exactly one place we can swap or disable.

## Design notes for review
- **Off by default.** Gated by the new `herdr_runtime_enabled` setting (default False). When the flag is off, the binary is missing, or a call fails, every method raises `HerdrUnavailable` — callers catch it and behave exactly as today. Same fail-open discipline as the Fable advisor. `available` (cheap, no subprocess) and `probe()` (live check) let callers guard without the exception path.
- **Process boundary only.** herdr is AGPL-3.0. The adapter shells out via async `create_subprocess_exec` (arg-list, no shell — injection-safe) and never imports or links herdr code.
- **Error detection.** herdr exits 0 even on its JSON error envelope, so failure is read from the `error` key, not the exit code. Confirmed against a live herdr 0.7.4.
- **Status mapping** onto Mission Control's `AgentStatus` (working→ACTIVE, idle/done→IDLE, blocked→BLOCKED, unknown→OFFLINE), imported lazily to avoid an agents↔mission_control cycle. Both import-linter configs were checked — the edge is boundary-clean.
- **Opaque ids** (pane/workspace/terminal) are only read from herdr JSON, never constructed.

## Tests
45 fake-shim tests — a canned-JSON `herdr` stub on a temp PATH, so CI needs no real herdr server. Covers parsing, status mapping, and the fail-open paths. Green locally (45 passed); adjacent agent tests still pass (43).

## Scope
New module + its test, plus three mechanically-required edits: the feature flag in config.py, the `HerdrUnavailable` error class, and a test-file-scoped E501 ignore for the stub's JSON lines. No consumers, no behavior change with the flag off.