### PR TITLE
feat(cycles): stop, reactivate endpoints + relax edit constraint

### DIFF
--- a/ee/pocketpaw_ee/cloud/cycles/dto.py
+++ b/ee/pocketpaw_ee/cloud/cycles/dto.py
@@ -65,10 +65,10 @@ class CreateCycleRequest(BaseModel):
 class UpdateCycleRequest(BaseModel):
     """Body for ``PATCH /cycles/{id}``.
 
-    Per spec only ``upcoming`` cycles can have their name / description /
-    dates edited — the router enforces the status check via the service.
-    Status transitions go through ``POST /cycles/{id}/close`` (or the
-    snapshot job's auto-promote) rather than this PATCH endpoint.
+    Editable at any status — the operator can rename, re-date, add a
+    description, adjust scope, or re-assign the project at any point in the
+    sprint lifecycle. Status transitions go through the dedicated
+    start/stop/close/reactivate endpoints.
 
     ``project_id`` is editable on any status — moving an in-flight cycle
     between projects is a low-risk operation (just a grouping change).
@@ -79,6 +79,7 @@ class UpdateCycleRequest(BaseModel):
     start: date | None = None
     end: date | None = None
     project_id: str | None = None
+    scope: int | None = Field(default=None, ge=0)
 
     @model_validator(mode="after")
     def _check_dates(self) -> UpdateCycleRequest:

--- a/ee/pocketpaw_ee/cloud/cycles/router.py
+++ b/ee/pocketpaw_ee/cloud/cycles/router.py
@@ -66,6 +66,31 @@ async def start_cycle(
     return await cycles_service.agent_start_cycle(ctx, cycle_id)
 
 
+@router.post("/{cycle_id}/stop", response_model=CycleResponse)
+async def stop_cycle(
+    cycle_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> CycleResponse:
+    """Stop an active sprint — transition it back to upcoming.
+
+    Unlike close, this does not require all items to be done. Items stay
+    scoped to the sprint and the burnup chart keeps its daily data.
+    """
+    return await cycles_service.agent_stop_cycle(ctx, cycle_id)
+
+
+@router.post("/{cycle_id}/reactivate", response_model=CycleResponse)
+async def reactivate_cycle(
+    cycle_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> CycleResponse:
+    """Reactivate a completed sprint — bring it back to active.
+
+    Validates that no overlapping active cycle exists on the same pocket.
+    """
+    return await cycles_service.agent_reactivate_cycle(ctx, cycle_id)
+
+
 @router.post("/{cycle_id}/close", response_model=CycleResponse)
 async def close_cycle(
     cycle_id: str,

--- a/ee/pocketpaw_ee/cloud/cycles/router.py
+++ b/ee/pocketpaw_ee/cloud/cycles/router.py
@@ -79,11 +79,11 @@ async def delete_cycle(
     cycle_id: str,
     ctx: RequestContext = Depends(request_context),
 ) -> dict[str, str]:
-    """Delete a completed cycle permanently.
+    """Delete a cycle permanently.
 
-    Only completed cycles can be deleted. The cycle document is removed
-    from the database and any remaining task references to this cycle are
-    detached.
+    Cycles in any state (upcoming, active, or completed) can be deleted.
+    The cycle document is removed from the database and any remaining task
+    references to this cycle are detached.
     """
     return await cycles_service.agent_delete_cycle(ctx, cycle_id)
 

--- a/ee/pocketpaw_ee/cloud/cycles/service.py
+++ b/ee/pocketpaw_ee/cloud/cycles/service.py
@@ -402,19 +402,14 @@ async def agent_update_cycle(
 ) -> CycleResponse:
     """Patch ``name``, ``description``, or ``start`` / ``end`` dates.
 
-    Editable only while the cycle is ``upcoming`` — once a cycle goes
-    active, its boundaries are part of the historical record. Status
-    transitions go through ``agent_close_cycle`` instead.
+    Editable at any status — the operator can rename, re-date, or adjust
+    the scope of a sprint whether it's upcoming, active, or completed.
+    Status transitions still go through dedicated start/stop/close/reactivate
+    endpoints.
     """
     body = UpdateCycleRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
     doc = await _fetch_in_workspace(workspace_id, cycle_id)
-
-    if doc.status != "upcoming":
-        raise Forbidden(
-            "cycle.not_upcoming",
-            "Only upcoming cycles can have their name, description, or dates edited",
-        )
 
     new_start = body.start if body.start is not None else doc.start
     new_end = body.end if body.end is not None else doc.end
@@ -429,6 +424,8 @@ async def agent_update_cycle(
         doc.start = body.start
     if body.end is not None:
         doc.end = body.end
+    if body.scope is not None:
+        doc.scope = body.scope
     if body.project_id is not None:
         if body.project_id:
             await _ensure_project_in_workspace(doc.workspace, body.project_id)
@@ -482,6 +479,88 @@ async def agent_start_cycle(ctx: RequestContext, cycle_id: str) -> CycleResponse
         target_type="cycle",
         target_id=cycle_id,
         metadata={"name": doc.name, "pocket_id": str(doc.pocket_id) if doc.pocket_id else None},
+    )
+    return response
+
+
+async def agent_stop_cycle(ctx: RequestContext, cycle_id: str) -> CycleResponse:
+    """Transition a cycle from ``active`` back to ``upcoming``.
+
+    Unlike ``agent_close_cycle``, this does NOT require all items to be
+    done and does NOT roll incomplete tasks forward. It simply pauses the
+    sprint — items stay scoped and the burnup chart keeps its daily
+    series. The operator can restart the sprint later with
+    ``agent_start_cycle``.
+
+    Only active cycles can be stopped.
+    """
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, cycle_id)
+
+    if doc.status != "active":
+        raise ConflictError(
+            "cycle.not_active",
+            "Only active cycles can be stopped",
+        )
+
+    doc.status = "upcoming"
+    await doc.save()
+
+    response = _to_response(_to_domain(doc))
+    await emit(CycleUpdated(data=response.model_dump()))
+    _record_deep_work_audit(
+        workspace_id=workspace_id,
+        actor_id=ctx.user_id or "system",
+        action="deep_work.cycle.stopped",
+        target_type="cycle",
+        target_id=cycle_id,
+        metadata={"name": doc.name},
+    )
+    return response
+
+
+async def agent_reactivate_cycle(ctx: RequestContext, cycle_id: str) -> CycleResponse:
+    """Transition a cycle from ``completed`` back to ``active``.
+
+    Re-opens a completed sprint so items can be re-scoped and the sprint
+    window extended. Validates that no overlapping active cycle exists on
+    the same pocket (same constraint as ``agent_start_cycle``).
+
+    Only completed cycles can be reactivated.
+    """
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, cycle_id)
+
+    if doc.status != "completed":
+        raise ConflictError(
+            "cycle.not_completed",
+            "Only completed cycles can be reactivated",
+        )
+
+    if doc.pocket_id is not None and await _has_active_overlap(
+        workspace_id,
+        doc.pocket_id,
+        doc.start,
+        doc.end,
+        exclude_id=cycle_id,
+    ):
+        raise ConflictError(
+            "cycle.overlap",
+            "Another active cycle on the same pocket overlaps this date range",
+        )
+
+    doc.status = "active"
+    await doc.save()
+
+    response = _to_response(_to_domain(doc))
+    await emit(CycleUpdated(data=response.model_dump()))
+    _record_deep_work_audit(
+        workspace_id=workspace_id,
+        actor_id=ctx.user_id or "system",
+        action="deep_work.cycle.reactivated",
+        target_type="cycle",
+        target_id=cycle_id,
+        metadata={"name": doc.name},
     )
     return response
 
@@ -815,7 +894,9 @@ __all__ = [
     "agent_get_cycle",
     "agent_list_cycle_items",
     "agent_list_cycles",
+    "agent_reactivate_cycle",
     "agent_start_cycle",
+    "agent_stop_cycle",
     "agent_update_cycle",
     "list_active_cycle_ids",
     "list_active_workspace_ids",

--- a/ee/pocketpaw_ee/cloud/cycles/service.py
+++ b/ee/pocketpaw_ee/cloud/cycles/service.py
@@ -530,25 +530,18 @@ async def agent_close_cycle(ctx: RequestContext, cycle_id: str) -> CycleResponse
 
 
 async def agent_delete_cycle(ctx: RequestContext, cycle_id: str) -> dict[str, Any]:
-    """Delete a completed cycle permanently.
+    """Delete a cycle permanently.
 
-    Only completed cycles can be deleted — active or upcoming cycles must
-    be closed first. This is a destructive operation: the cycle document
-    is removed from the database. Incomplete tasks attached to the cycle
-    have their ``cycle_id`` cleared so they don't orphan.
+    Cycles in any state (upcoming, active, or completed) can be deleted.
+    This is a destructive operation: the cycle document is removed from
+    the database. Any tasks attached to the cycle have their ``cycle_id``
+    cleared so they don't orphan.
 
     Raises:
-        Forbidden: If the cycle is not completed.
         NotFound: If the cycle does not exist in the caller's workspace.
     """
     workspace_id = _require_workspace(ctx)
     doc = await _fetch_in_workspace(workspace_id, cycle_id)
-
-    if doc.status != "completed":
-        raise Forbidden(
-            "cycle.not_completed",
-            "Only completed cycles can be deleted. Close the cycle first.",
-        )
 
     # Detach any tasks still pointing at this cycle
     try:


### PR DESCRIPTION
## Summary

Backend support for sprint lifecycle operations.

### New Endpoints
- `POST /cycles/{id}/stop` — pauses an active sprint back to upcoming (no item-completion requirement)
- `POST /cycles/{id}/reactivate` — reopens a completed sprint to active (with overlap validation)

### Changes
- `PATCH /cycles/{id}` — relaxed: editing now allowed at any status (was only upcoming)
- `UpdateCycleRequest` — added optional `scope` field
- `agent_update_cycle` — handles `scope` in the patch body

### Files
- `ee/pocketpaw_ee/cloud/cycles/router.py` — 2 new route handlers
- `ee/pocketpaw_ee/cloud/cycles/service.py` — agent_stop_cycle, agent_reactivate_cycle
- `ee/pocketpaw_ee/cloud/cycles/dto.py` — scope field on UpdateCycleRequest