### PR TITLE
Code Mode backend: sandbox sessions, durability, GitHub auth, and in-tab runtime support

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -238,6 +238,9 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.billing.webhooks import router as billing_webhooks_router
     from pocketpaw_ee.cloud.chat.router import router as chat_router
     from pocketpaw_ee.cloud.chat.runs.router import router as runs_router
+    from pocketpaw_ee.cloud.codeconnect.router import router as codeconnect_router
+    from pocketpaw_ee.cloud.codegit.router import router as codegit_router
+    from pocketpaw_ee.cloud.codeproject.router import router as codeproject_router
     from pocketpaw_ee.cloud.connectors.router import router as connectors_router
     from pocketpaw_ee.cloud.credits.router import router as credits_router
     from pocketpaw_ee.cloud.cycles.router import router as cycles_router
@@ -260,8 +263,6 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.rules.router import router as rules_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
     from pocketpaw_ee.cloud.skills.router import router as skills_router
-    from pocketpaw_ee.cloud.codeconnect.router import router as codeconnect_router
-    from pocketpaw_ee.cloud.codeproject.router import router as codeproject_router
     from pocketpaw_ee.cloud.websandbox.router import router as websandbox_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
 
@@ -281,6 +282,11 @@ def mount_cloud(app: FastAPI) -> None:
     # Code Mode GitHub connect (CM-3) — install-URL / callback / repo picker so a
     # user can open PRIVATE repos; the token is minted server-side, never in the VM.
     app.include_router(codeconnect_router, prefix="/api/v1")
+    # Code Mode git proxy (CM-3d) — the VM's git remote points here (basic-auth
+    # ticket, NOT the GitHub token); the broker mints a repo-scoped token
+    # server-side and proxies push/fetch upstream. Ticket-authed, not license/RC
+    # gated (git can't do OAuth); CSRF only fires on cookie auth, so it passes.
+    app.include_router(codegit_router, prefix="/api/v1")
     app.include_router(request_log_router, prefix="/api/v1")
     app.include_router(deep_work_log_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -260,6 +260,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.rules.router import router as rules_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
     from pocketpaw_ee.cloud.skills.router import router as skills_router
+    from pocketpaw_ee.cloud.codeconnect.router import router as codeconnect_router
     from pocketpaw_ee.cloud.codeproject.router import router as codeproject_router
     from pocketpaw_ee.cloud.websandbox.router import router as websandbox_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
@@ -277,6 +278,9 @@ def mount_cloud(app: FastAPI) -> None:
     # Code Mode durable-project registry (CM-2a) — the reap-surviving project the
     # redesigned /code surface deep-links to; opening one resolves a ready sandbox.
     app.include_router(codeproject_router, prefix="/api/v1")
+    # Code Mode GitHub connect (CM-3) — install-URL / callback / repo picker so a
+    # user can open PRIVATE repos; the token is minted server-side, never in the VM.
+    app.include_router(codeconnect_router, prefix="/api/v1")
     app.include_router(request_log_router, prefix="/api/v1")
     app.include_router(deep_work_log_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -260,6 +260,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.rules.router import router as rules_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
     from pocketpaw_ee.cloud.skills.router import router as skills_router
+    from pocketpaw_ee.cloud.codeproject.router import router as codeproject_router
     from pocketpaw_ee.cloud.websandbox.router import router as websandbox_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
 
@@ -273,6 +274,9 @@ def mount_cloud(app: FastAPI) -> None:
     # Web Cursor sandbox registry (WC-1) — the (workspace, user, repo) -> sandbox
     # tenancy/auth oracle every later Web Cursor slice authorizes against.
     app.include_router(websandbox_router, prefix="/api/v1")
+    # Code Mode durable-project registry (CM-2a) — the reap-surviving project the
+    # redesigned /code surface deep-links to; opening one resolves a ready sandbox.
+    app.include_router(codeproject_router, prefix="/api/v1")
     app.include_router(request_log_router, prefix="/api/v1")
     app.include_router(deep_work_log_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -260,6 +260,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.rules.router import router as rules_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
     from pocketpaw_ee.cloud.skills.router import router as skills_router
+    from pocketpaw_ee.cloud.websandbox.router import router as websandbox_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
 
     app.include_router(auth_router, prefix="/api/v1")
@@ -269,6 +270,9 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(agents_router, prefix="/api/v1")
     app.include_router(audit_router, prefix="/api/v1")
     app.include_router(audit_workspace_router, prefix="/api/v1")
+    # Web Cursor sandbox registry (WC-1) — the (workspace, user, repo) -> sandbox
+    # tenancy/auth oracle every later Web Cursor slice authorizes against.
+    app.include_router(websandbox_router, prefix="/api/v1")
     app.include_router(request_log_router, prefix="/api/v1")
     app.include_router(deep_work_log_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -704,6 +704,13 @@ def mount_cloud(app: FastAPI) -> None:
 
     app.add_api_websocket_route("/ws/cloud", websocket_endpoint)
 
+    # Web Cursor terminal WS (WC-3) — one PTY-over-WS shell per session, bound to
+    # the owning sandbox's Daytona VM. Mounted at root (not /api/v1) so the SPA
+    # connects to ws://host/ws/websandbox/<row_id>?token=<ws_ticket>.
+    from pocketpaw_ee.cloud.websandbox.ws import terminal_websocket_endpoint
+
+    app.add_api_websocket_route("/ws/websandbox/{row_id}", terminal_websocket_endpoint)
+
     # License endpoint (no auth)
     @app.get("/api/v1/license", tags=["License"])
     async def license_info():

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -935,6 +935,30 @@ def mount_cloud(app: FastAPI) -> None:
         async def _stop_fabric_ingest() -> None:
             await stop_fabric_ingest(app)
 
+    # Web Cursor idle-TTL reaper (WC-2, feat/websandbox-vm-provision). Every
+    # ~5 minutes (POCKETPAW_WEBSANDBOX_REAP_INTERVAL_SECONDS) it reclaims
+    # dropped browser-IDE sandboxes: rows in ``ready``/``opening`` whose
+    # ``updated_at`` is older than the idle TTL
+    # (POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS, default 1800) get their Daytona VM
+    # stopped+deleted and the row marked ``reaped``. Same scheduler gate as the
+    # cycle/decisions/ingest loops so pytest runs never spawn a background loop
+    # that outlives the test; production sets POCKETPAW_CLOUD_SCHEDULER_ENABLED=
+    # true. ``start_websandbox_reaper`` also honors its own
+    # POCKETPAW_WEBSANDBOX_REAPER_ENABLED off-switch (default true).
+    if _os.environ.get("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "").lower() == "true":
+        from pocketpaw_ee.cloud.websandbox.provision import (
+            start_websandbox_reaper,
+            stop_websandbox_reaper,
+        )
+
+        @app.on_event("startup")
+        async def _start_websandbox_reaper() -> None:
+            await start_websandbox_reaper(app)
+
+        @app.on_event("shutdown")
+        async def _stop_websandbox_reaper() -> None:
+            await stop_websandbox_reaper(app)
+
     # Mandate autopilot reconciler (feat/belt-autopilot). The persisted
     # ``MandateDoc.autopilot.on`` flag is the source of truth for whether a
     # mandate's autopilot SHOULD run; the background loop itself is

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -1074,6 +1074,21 @@ class CodeProjectOpened(Event):
     EVENT_TYPE: ClassVar[str] = "codeproject.opened"
 
 
+# ``CodeProjectRenamed`` fires when a project's display name changes; ``data``
+# carries the project id + workspace/user + the new name. ``CodeProjectDeleted``
+# fires when a project is removed (and its bound sandbox torn down); ``data``
+# carries the project id + workspace/user so a projects-grid fan-out can drop the
+# card without a re-read.
+@dataclass
+class CodeProjectRenamed(Event):
+    EVENT_TYPE: ClassVar[str] = "codeproject.renamed"
+
+
+@dataclass
+class CodeProjectDeleted(Event):
+    EVENT_TYPE: ClassVar[str] = "codeproject.deleted"
+
+
 # Code Mode GitHub connect (CM-3, feat/code-mode). Fires when a user's GitHub App
 # installation is first bound to a (workspace, user) — the durable "this user can
 # open private repos" signal a connected-state UI reacts to. ``data`` carries the

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -46,6 +46,11 @@
 #   (type="agent.disabled") and ``AgentEnabled`` (type="agent.enabled") for the
 #   agent soft-disable / revoke-everywhere flow. Emitted by ``agents.service``
 #   on disable / enable, mirroring ``AgentDeleted``'s payload shape.
+# Updated: 2026-07-15 (WC-1, feat/websandbox-registry) — added
+#   ``WebSandboxRegistered`` (type="websandbox.registered") and
+#   ``WebSandboxStatusChanged`` (type="websandbox.status_changed") for the Web
+#   Cursor sandbox registry. Emitted by ``websandbox.service`` on every
+#   state-mutating call per cloud rule 9.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -1032,3 +1037,21 @@ class TemporalSweepCompleted(Event):
 @dataclass
 class BeltRunUpdated(Event):
     EVENT_TYPE: ClassVar[str] = "belt_run_updated"
+
+
+# Web Cursor sandbox registry (WC-1, feat/websandbox-registry). Emitted by
+# ``websandbox.service`` on every state-mutating call per cloud rule 9 (emit on
+# every write). ``WebSandboxRegistered`` fires when a sandbox row is created /
+# re-registered for a (workspace, user, repo); ``WebSandboxStatusChanged`` fires
+# on a lifecycle transition (pending -> opening -> ready -> stopped -> reaped) or
+# when the Daytona ``sandbox_id`` is bound. ``data`` carries the row id +
+# workspace/user/repo + status so a downstream WS fan-out can refresh the IDE
+# shell without re-reading the doc.
+@dataclass
+class WebSandboxRegistered(Event):
+    EVENT_TYPE: ClassVar[str] = "websandbox.registered"
+
+
+@dataclass
+class WebSandboxStatusChanged(Event):
+    EVENT_TYPE: ClassVar[str] = "websandbox.status_changed"

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -1055,3 +1055,20 @@ class WebSandboxRegistered(Event):
 @dataclass
 class WebSandboxStatusChanged(Event):
     EVENT_TYPE: ClassVar[str] = "websandbox.status_changed"
+
+
+# Code Mode durable-project registry (CM-2a, feat/code-mode). The DURABLE half of
+# Code Mode's two-lifecycle model: a CodeProject outlives any single ephemeral
+# Daytona sandbox. ``CodeProjectCreated`` fires when a project is first registered
+# for a (workspace, user, provider, repo); ``CodeProjectOpened`` fires when a
+# project is opened and bound to a live sandbox (reused or freshly provisioned).
+# ``data`` carries the project id + workspace/user/repo + the bound sandbox row id
+# so a downstream fan-out can refresh the projects grid without re-reading the doc.
+@dataclass
+class CodeProjectCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "codeproject.created"
+
+
+@dataclass
+class CodeProjectOpened(Event):
+    EVENT_TYPE: ClassVar[str] = "codeproject.opened"

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -1072,3 +1072,12 @@ class CodeProjectCreated(Event):
 @dataclass
 class CodeProjectOpened(Event):
     EVENT_TYPE: ClassVar[str] = "codeproject.opened"
+
+
+# Code Mode GitHub connect (CM-3, feat/code-mode). Fires when a user's GitHub App
+# installation is first bound to a (workspace, user) — the durable "this user can
+# open private repos" signal a connected-state UI reacts to. ``data`` carries the
+# connection id + workspace/user/provider + installation id.
+@dataclass
+class CodeConnectionCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "codeconnection.created"

--- a/ee/pocketpaw_ee/cloud/auth/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/service.py
@@ -118,6 +118,23 @@ async def get_home_pocket_id(user_id: str) -> str | None:
     return doc.home_pocket_id
 
 
+async def get_active_workspace(user_id: str) -> str | None:
+    """Return the user's ``active_workspace`` id, or None if unset.
+
+    Takes a plain ``user_id`` (not a ``RequestContext``) so callers outside the
+    HTTP request cycle — notably the Web Cursor terminal WebSocket, which only
+    holds the ``user_id`` decoded from a ws_ticket — can resolve the caller's
+    workspace without minting a context. This is the same membership field the
+    ``request_context`` dependency reads (``user.active_workspace``); exposing it
+    here keeps ``models.user`` reads inside the auth entity (Rule 2). Returns
+    None when the user has no active workspace so the caller can fail closed.
+    """
+    doc = await _UserDoc.get(PydanticObjectId(user_id))
+    if doc is None:
+        raise NotFound("user", user_id)
+    return doc.active_workspace
+
+
 async def claim_home_pocket_id(user_id: str, new_pocket_id: str, *, expected: str | None) -> bool:
     """Atomically set ``home_pocket_id`` to ``new_pocket_id`` — but only if
     it still holds ``expected``. Returns ``True`` when the swap took.

--- a/ee/pocketpaw_ee/cloud/codeconnect/__init__.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/__init__.py
@@ -1,0 +1,6 @@
+# codeconnect — Code Mode GitHub connect flow (CM-3).
+# The durable "this user installed the GitHub App" binding + the install-URL /
+# callback / repo-listing orchestration that turns it into a repo picker. The
+# 4-file entity (domain/dto/service/router) persists the connection; connect.py
+# is the GitHub-touching orchestration layer above the service (mirrors how
+# codeproject/lifecycle.py sits above codeproject/service.py).

--- a/ee/pocketpaw_ee/cloud/codeconnect/connect.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/connect.py
@@ -1,0 +1,141 @@
+# connect.py — Code Mode GitHub connect orchestration (CM-3).
+# Created 2026-07-16 (feat/code-mode): the GitHub-touching layer ABOVE
+# ``codeconnect/service.py`` (the registry). It builds the App install URL, handles
+# the post-install callback, and lists the caller's repos through the App client —
+# so the service stays a pure Beanie repository that never imports an HTTP client.
+#
+# Three flows:
+#   1. ``build_install_url`` — sign the caller's (workspace, user) into a state
+#      token → return ``https://github.com/apps/<slug>/installations/new?state=…``.
+#      The install screen sends the user back to our callback with an installation
+#      id + that state.
+#   2. ``handle_callback`` — verify the state (recovers who is connecting, since the
+#      browser redirect carries no bearer token), then persist the connection.
+#   3. ``list_repositories`` — for each of the caller's connections, list the repos
+#      that installation can reach (via the neutral RepoAuthProvider), merged +
+#      de-duplicated for the picker.
+#
+# ``provider=None`` on ``list_repositories`` resolves the live GitHub App client;
+# tests inject a fake so no test hits real GitHub.
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError
+from pocketpaw_ee.cloud.codeconnect import service as codeconnect_service
+from pocketpaw_ee.cloud.codeconnect.state import sign_state, verify_state
+from pocketpaw_ee.cloud.websandbox.githubapp import github_app_slug
+from pocketpaw_ee.cloud.websandbox.repoauth import (
+    ProviderId,
+    RepoAuthProvider,
+    get_repo_auth_provider,
+)
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_APP_BASE = "https://github.com"
+
+
+def build_install_url(workspace_id: str, user_id: str) -> str:
+    """Build the GitHub App install URL, carrying a signed state for the callback.
+
+    Raises a clean 503 CloudError when the App slug isn't configured (an operational
+    condition, not a bug) so the frontend can show "GitHub connect isn't set up"
+    instead of opening a broken ``/apps//installations/new``.
+    """
+    slug = github_app_slug()
+    if not slug:
+        raise CloudError(
+            503,
+            "codeconnect.github_not_configured",
+            "GitHub connect is not configured on this server",
+        )
+    state = sign_state(workspace_id, user_id)
+    return f"{_GITHUB_APP_BASE}/apps/{slug}/installations/new?state={state}"
+
+
+async def handle_callback(installation_id: str, state: str) -> tuple[str, str]:
+    """Handle the post-install redirect: verify state, persist the connection.
+
+    Returns the recovered ``(workspace_id, user_id)`` so the router can redirect the
+    browser back to the right place. Raises ``BadRequest`` on a missing installation
+    id or an unverifiable state — the browser redirect authenticates ENTIRELY via
+    the signed state (it carries no bearer token), so a bad state must fail closed.
+    """
+    installation_id = (installation_id or "").strip()
+    if not installation_id:
+        raise BadRequest("codeconnect.missing_installation", "No installation id in callback")
+
+    verified = verify_state(state)
+    if verified is None:
+        raise BadRequest("codeconnect.invalid_state", "The connect request could not be verified")
+    workspace_id, user_id = verified
+
+    await codeconnect_service.save_connection(workspace_id, user_id, installation_id)
+    logger.info(
+        "codeconnect.callback: bound installation=%s to ws=%s user=%s",
+        installation_id,
+        workspace_id,
+        user_id,
+    )
+    return workspace_id, user_id
+
+
+async def list_repositories(
+    workspace_id: str,
+    user_id: str,
+    *,
+    provider: RepoAuthProvider | None = None,
+    now: datetime | None = None,
+) -> list[dict]:
+    """List the repos the caller's connections can reach, merged for the picker.
+
+    Resolves the GitHub ``RepoAuthProvider`` (or takes an injected fake), then for
+    each of the caller's connections lists the installation's repos and merges them,
+    de-duplicated by ``full_name``. No connections → ``[]`` (a clean empty picker,
+    not an error). Connections exist but the provider is unconfigured → 503, so the
+    misconfig is visible rather than silently empty.
+    """
+    connections = await codeconnect_service.list_connections(workspace_id, user_id)
+    if not connections:
+        return []
+
+    resolved = provider if provider is not None else get_repo_auth_provider(ProviderId.GITHUB)
+    if resolved is None:
+        raise CloudError(
+            503,
+            "codeconnect.github_not_configured",
+            "GitHub connect is not configured on this server",
+        )
+
+    seen: set[str] = set()
+    repos: list[dict] = []
+    for conn in connections:
+        try:
+            found = await resolved.list_repositories(conn.installation_id, now=now)
+        except CloudError:
+            # One bad installation (revoked, rate-limited) must not sink the rest.
+            logger.warning(
+                "codeconnect.repos: listing failed for installation=%s",
+                conn.installation_id,
+                exc_info=True,
+            )
+            continue
+        for repo in found:
+            if repo.full_name in seen:
+                continue
+            seen.add(repo.full_name)
+            repos.append(
+                {
+                    "full_name": repo.full_name,
+                    "private": repo.private,
+                    "default_branch": repo.default_branch,
+                    "clone_url": repo.clone_url,
+                }
+            )
+    return repos
+
+
+__all__ = ["build_install_url", "handle_callback", "list_repositories"]

--- a/ee/pocketpaw_ee/cloud/codeconnect/connect.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/connect.py
@@ -17,6 +17,12 @@
 #
 # ``provider=None`` on ``list_repositories`` resolves the live GitHub App client;
 # tests inject a fake so no test hits real GitHub.
+#
+# Updated 2026-07-16 (connect-UX): the callback now best-effort enriches the
+# connection with the account login + avatar (``get_installation_account``), and
+# ``list_connections`` lazily self-heals any row still missing that display info —
+# so the connected-account chip renders a profile image + username without a
+# reinstall. Enrichment failures never break the connection itself.
 
 from __future__ import annotations
 
@@ -25,8 +31,12 @@ from datetime import datetime
 
 from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError
 from pocketpaw_ee.cloud.codeconnect import service as codeconnect_service
+from pocketpaw_ee.cloud.codeconnect.domain import CodeConnectionView
 from pocketpaw_ee.cloud.codeconnect.state import sign_state, verify_state
-from pocketpaw_ee.cloud.websandbox.githubapp import github_app_slug
+from pocketpaw_ee.cloud.websandbox.githubapp import (
+    get_github_app_client,
+    github_app_slug,
+)
 from pocketpaw_ee.cloud.websandbox.repoauth import (
     ProviderId,
     RepoAuthProvider,
@@ -73,7 +83,14 @@ async def handle_callback(installation_id: str, state: str) -> tuple[str, str]:
         raise BadRequest("codeconnect.invalid_state", "The connect request could not be verified")
     workspace_id, user_id = verified
 
-    await codeconnect_service.save_connection(workspace_id, user_id, installation_id)
+    login, avatar_url = await _fetch_account_info(installation_id)
+    await codeconnect_service.save_connection(
+        workspace_id,
+        user_id,
+        installation_id,
+        account_login=login,
+        avatar_url=avatar_url,
+    )
     logger.info(
         "codeconnect.callback: bound installation=%s to ws=%s user=%s",
         installation_id,
@@ -81,6 +98,75 @@ async def handle_callback(installation_id: str, state: str) -> tuple[str, str]:
         user_id,
     )
     return workspace_id, user_id
+
+
+async def _fetch_account_info(installation_id: str) -> tuple[str | None, str | None]:
+    """Best-effort ``(login, avatar_url)`` for display; never fails the caller.
+
+    The connection is the load-bearing artifact; the account login + avatar are
+    only for the connected-account chip. A missing App client, a GitHub hiccup, or
+    a revoked installation all resolve to ``(None, None)`` so the connect flow (and
+    the token invariant) is never held hostage to a display lookup.
+    """
+    client = get_github_app_client()
+    if client is None:
+        return None, None
+    try:
+        info = await client.get_installation_account(installation_id)
+    except Exception:  # noqa: BLE001 — display enrichment is strictly best-effort
+        logger.warning(
+            "codeconnect: account fetch failed for installation=%s",
+            installation_id,
+            exc_info=True,
+        )
+        return None, None
+    if not info:
+        return None, None
+    return info.get("login"), info.get("avatar_url")
+
+
+async def list_connections(workspace_id: str, user_id: str) -> list[CodeConnectionView]:
+    """List the caller's connections, lazily backfilling display info (login+avatar).
+
+    The stored row can predate its account enrichment — the callback's fetch is
+    best-effort and older rows predate the ``avatar_url`` field entirely. Any
+    connection still missing its login OR avatar is enriched here and persisted
+    (an idempotent refresh). Once filled, no further GitHub calls fire, so the cost
+    is bounded to the window before the data is complete. Enrichment failures fall
+    back to the un-enriched view rather than dropping the connection.
+    """
+    views = await codeconnect_service.list_connections(workspace_id, user_id)
+    client = get_github_app_client()
+    if client is None:
+        return views
+
+    enriched: list[CodeConnectionView] = []
+    for view in views:
+        if view.account_login and view.avatar_url:
+            enriched.append(view)
+            continue
+        try:
+            info = await client.get_installation_account(view.installation_id)
+        except Exception:  # noqa: BLE001 — display enrichment is strictly best-effort
+            logger.warning(
+                "codeconnect: lazy account enrich failed for installation=%s",
+                view.installation_id,
+                exc_info=True,
+            )
+            enriched.append(view)
+            continue
+        if not info:
+            enriched.append(view)
+            continue
+        refreshed = await codeconnect_service.save_connection(
+            workspace_id,
+            user_id,
+            view.installation_id,
+            account_login=info.get("login"),
+            avatar_url=info.get("avatar_url"),
+        )
+        enriched.append(refreshed)
+    return enriched
 
 
 async def list_repositories(
@@ -138,4 +224,9 @@ async def list_repositories(
     return repos
 
 
-__all__ = ["build_install_url", "handle_callback", "list_repositories"]
+__all__ = [
+    "build_install_url",
+    "handle_callback",
+    "list_connections",
+    "list_repositories",
+]

--- a/ee/pocketpaw_ee/cloud/codeconnect/domain.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/domain.py
@@ -3,6 +3,8 @@
 # REQUIRED at construction with no defaults per ee/cloud Rule 3 — a view is only
 # ever built from a persisted, tenant-checked row, so there is no safe default for
 # who owns a connection.
+# Updated 2026-07-16 (connect-UX): added ``avatar_url`` (display-only, optional)
+# so the read model carries the profile image for the connected-account chip.
 
 from __future__ import annotations
 
@@ -26,6 +28,8 @@ class CodeConnectionView:
     updated_at: datetime
     # The GitHub account the App was installed on (display only). Optional.
     account_login: str | None = None
+    # The account's avatar URL for the connected-account chip (display only).
+    avatar_url: str | None = None
 
 
 __all__ = ["CodeConnectionId", "CodeConnectionView"]

--- a/ee/pocketpaw_ee/cloud/codeconnect/domain.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/domain.py
@@ -1,0 +1,31 @@
+# domain.py — Frozen value objects for the Code Mode GitHub connection (CM-3).
+# Created 2026-07-16 (feat/code-mode): tenancy fields (workspace_id, user_id) are
+# REQUIRED at construction with no defaults per ee/cloud Rule 3 — a view is only
+# ever built from a persisted, tenant-checked row, so there is no safe default for
+# who owns a connection.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import NewType
+
+CodeConnectionId = NewType("CodeConnectionId", str)
+
+
+@dataclass(frozen=True)
+class CodeConnectionView:
+    """Read model for one GitHub connection (an App installation binding)."""
+
+    id: CodeConnectionId
+    workspace_id: str
+    user_id: str
+    provider: str
+    installation_id: str
+    created_at: datetime
+    updated_at: datetime
+    # The GitHub account the App was installed on (display only). Optional.
+    account_login: str | None = None
+
+
+__all__ = ["CodeConnectionId", "CodeConnectionView"]

--- a/ee/pocketpaw_ee/cloud/codeconnect/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/dto.py
@@ -27,6 +27,7 @@ class CodeConnectionResponse(BaseModel):
     provider: str
     installationId: str
     accountLogin: str | None = None
+    avatarUrl: str | None = None
     createdAt: str
     updatedAt: str
 

--- a/ee/pocketpaw_ee/cloud/codeconnect/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/dto.py
@@ -1,0 +1,63 @@
+# dto.py — Request/response DTOs for the Code Mode GitHub connect flow (CM-3).
+# Created 2026-07-16 (feat/code-mode): distinct request/response models per Rule 4.
+# The connect flow is read-mostly from the client's side (install-url, list
+# connections, list repos); the connection is WRITTEN by the GitHub callback, not
+# a client body, so there's no CreateConnectionRequest — the callback carries the
+# installation id + signed state as query params, validated in the router.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class InstallUrlResponse(BaseModel):
+    """The GitHub App install URL the frontend opens to start the connect flow."""
+
+    url: str
+
+
+class CodeConnectionResponse(BaseModel):
+    """One persisted GitHub connection, camelCase for the wire."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    workspaceId: str
+    userId: str
+    provider: str
+    installationId: str
+    accountLogin: str | None = None
+    createdAt: str
+    updatedAt: str
+
+
+class CodeConnectionListResponse(BaseModel):
+    """The caller's GitHub connections (for the "connected as" UI state)."""
+
+    connections: list[CodeConnectionResponse]
+
+
+class RepoResponse(BaseModel):
+    """One repo a connection can reach — the shape the repo picker renders."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    fullName: str
+    private: bool
+    defaultBranch: str
+    cloneUrl: str
+
+
+class RepoListResponse(BaseModel):
+    """The merged repo listing across the caller's connections."""
+
+    repos: list[RepoResponse]
+
+
+__all__ = [
+    "CodeConnectionListResponse",
+    "CodeConnectionResponse",
+    "InstallUrlResponse",
+    "RepoListResponse",
+    "RepoResponse",
+]

--- a/ee/pocketpaw_ee/cloud/codeconnect/router.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/router.py
@@ -87,7 +87,10 @@ async def list_connections(
 ) -> CodeConnectionListResponse:
     """List the caller's GitHub connections (for the "connected as" UI state)."""
     workspace_id = _require_workspace(ctx)
-    views = await service.list_connections(workspace_id, ctx.user_id)
+    # connect.list_connections wraps the service read to lazily backfill each
+    # connection's display info (account login + avatar) so the chip can render a
+    # profile image without a reinstall.
+    views = await connect.list_connections(workspace_id, ctx.user_id)
     return CodeConnectionListResponse(
         connections=[service.view_to_wire(v) for v in views]
     )

--- a/ee/pocketpaw_ee/cloud/codeconnect/router.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/router.py
@@ -91,9 +91,7 @@ async def list_connections(
     # connection's display info (account login + avatar) so the chip can render a
     # profile image without a reinstall.
     views = await connect.list_connections(workspace_id, ctx.user_id)
-    return CodeConnectionListResponse(
-        connections=[service.view_to_wire(v) for v in views]
-    )
+    return CodeConnectionListResponse(connections=[service.view_to_wire(v) for v in views])
 
 
 @router.get("/repos", response_model=RepoListResponse)

--- a/ee/pocketpaw_ee/cloud/codeconnect/router.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/router.py
@@ -1,0 +1,116 @@
+# router.py — Thin FastAPI adapter for the Code Mode GitHub connect flow (CM-3).
+# Created 2026-07-16 (feat/code-mode): workspace+user scoped
+# /api/v1/codeconnect. Tenancy for the authenticated routes comes from the
+# RequestContext (never the body/query); connect.py does the work and CloudError ->
+# JSON is handled by _core.http — this router never raises HTTPException.
+#
+# The ``/github/callback`` route is the exception: it's a top-level BROWSER redirect
+# from GitHub after an install, so it carries NO bearer token and CANNOT use the
+# RequestContext. It authenticates ENTIRELY via the signed ``state`` token minted at
+# install-URL time (connect.handle_callback verifies it), then 302-redirects the
+# browser back to the SPA. It stays license-gated (a server-side gate) like the rest.
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import RedirectResponse
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import CloudError, Forbidden
+from pocketpaw_ee.cloud.codeconnect import connect, service
+from pocketpaw_ee.cloud.codeconnect.dto import (
+    CodeConnectionListResponse,
+    InstallUrlResponse,
+    RepoListResponse,
+    RepoResponse,
+)
+from pocketpaw_ee.cloud.license import require_license
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/codeconnect",
+    tags=["CodeConnect"],
+    dependencies=[Depends(require_license)],
+)
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    """A workspace-scoped route needs an active workspace; fail closed if absent."""
+    if not ctx.workspace_id:
+        raise Forbidden("codeconnect.no_workspace", "No active workspace")
+    return ctx.workspace_id
+
+
+def _frontend_root() -> str:
+    """The SPA origin the post-install callback redirects the browser back to."""
+    return os.environ.get("POCKETPAW_FRONTEND_BASE_URL", "/").rstrip("/") or "/"
+
+
+@router.get("/github/install-url", response_model=InstallUrlResponse)
+async def github_install_url(
+    ctx: RequestContext = Depends(request_context),
+) -> InstallUrlResponse:
+    """Return the GitHub App install URL (carrying a signed state) to open."""
+    workspace_id = _require_workspace(ctx)
+    url = connect.build_install_url(workspace_id, ctx.user_id)
+    return InstallUrlResponse(url=url)
+
+
+@router.get("/github/callback")
+async def github_callback(
+    installation_id: str = Query(""),
+    state: str = Query(""),
+    setup_action: str = Query(""),
+) -> RedirectResponse:
+    """Handle the post-install redirect: persist the connection, bounce to the SPA.
+
+    Authenticated by the signed ``state`` alone (no bearer token on a browser
+    redirect). On success or failure it always 302s back to ``/code`` with a status
+    query param, so the user lands in the app rather than on a raw JSON error.
+    """
+    root = _frontend_root()
+    try:
+        await connect.handle_callback(installation_id, state)
+    except CloudError:
+        logger.warning("codeconnect.callback rejected", exc_info=True)
+        return RedirectResponse(url=f"{root}/code?github=error", status_code=302)
+    return RedirectResponse(url=f"{root}/code?github=connected", status_code=302)
+
+
+@router.get("", response_model=CodeConnectionListResponse)
+async def list_connections(
+    ctx: RequestContext = Depends(request_context),
+) -> CodeConnectionListResponse:
+    """List the caller's GitHub connections (for the "connected as" UI state)."""
+    workspace_id = _require_workspace(ctx)
+    views = await service.list_connections(workspace_id, ctx.user_id)
+    return CodeConnectionListResponse(
+        connections=[service.view_to_wire(v) for v in views]
+    )
+
+
+@router.get("/repos", response_model=RepoListResponse)
+async def list_repos(
+    ctx: RequestContext = Depends(request_context),
+) -> RepoListResponse:
+    """List the repos the caller's connections can reach, for the repo picker."""
+    workspace_id = _require_workspace(ctx)
+    repos = await connect.list_repositories(workspace_id, ctx.user_id)
+    return RepoListResponse(
+        repos=[
+            RepoResponse(
+                fullName=r["full_name"],
+                private=r["private"],
+                defaultBranch=r["default_branch"],
+                cloneUrl=r["clone_url"],
+            )
+            for r in repos
+        ]
+    )
+
+
+__all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/codeconnect/service.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/service.py
@@ -35,6 +35,7 @@ def _doc_to_view(doc: _CodeConnectionDoc) -> CodeConnectionView:
         provider=doc.provider,
         installation_id=doc.installation_id,
         account_login=doc.account_login,
+        avatar_url=doc.avatar_url,
         created_at=doc.created_at,
         updated_at=doc.updated_at,
     )
@@ -49,6 +50,7 @@ def view_to_wire(view: CodeConnectionView) -> CodeConnectionResponse:
         provider=view.provider,
         installationId=view.installation_id,
         accountLogin=view.account_login,
+        avatarUrl=view.avatar_url,
         createdAt=view.created_at.isoformat(),
         updatedAt=view.updated_at.isoformat(),
     )
@@ -59,14 +61,16 @@ async def save_connection(
     user_id: str,
     installation_id: str,
     account_login: str | None = None,
+    avatar_url: str | None = None,
     provider: str = _PROVIDER,
 ) -> CodeConnectionView:
     """Persist (or refresh) a GitHub connection for a (workspace, user, installation).
 
     Idempotent on the registry key: re-installing / a repeated callback for the
     same installation refreshes the existing row (and any newly-known
-    ``account_login``) rather than minting a duplicate. Only an actual insert emits
-    ``CodeConnectionCreated`` (an idempotent refresh is not a new connection).
+    ``account_login`` / ``avatar_url``) rather than minting a duplicate. Only an
+    actual insert emits ``CodeConnectionCreated`` (an idempotent refresh is not a
+    new connection).
     """
     installation_id = (installation_id or "").strip()
     if not installation_id:
@@ -82,8 +86,14 @@ async def save_connection(
         }
     )
     if existing is not None:
+        changed = False
         if account_login and existing.account_login != account_login:
             existing.account_login = account_login
+            changed = True
+        if avatar_url and existing.avatar_url != avatar_url:
+            existing.avatar_url = avatar_url
+            changed = True
+        if changed:
             existing.updated_at = datetime.now(UTC)
             await existing.save()
         # no-event: an idempotent refresh is not a new connection.
@@ -95,6 +105,7 @@ async def save_connection(
         provider=provider,
         installation_id=installation_id,
         account_login=account_login,
+        avatar_url=avatar_url,
     )
     await doc.insert()
 

--- a/ee/pocketpaw_ee/cloud/codeconnect/service.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/service.py
@@ -1,0 +1,135 @@
+# service.py — Code Mode GitHub connection registry business logic (CM-3).
+# Created 2026-07-16 (feat/code-mode): this module IS the repository (ee/cloud
+# Rule 1) and the ONLY module that imports the CodeConnection Beanie doc (Rule 2).
+# Every read carries a tenant + owner filter (Rule 7); every mutation validates its
+# inputs and emits an event or is marked ``# no-event:`` (Rule 9). Errors are
+# CloudError subclasses, never HTTPException (Rule 10).
+#
+# The GitHub-touching orchestration (install-URL building, callback handling, repo
+# listing via the App client) lives in ``codeconnect/connect.py`` so this module
+# stays the sole doc writer and never imports an HTTP client.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import CodeConnectionCreated
+from pocketpaw_ee.cloud.codeconnect.domain import CodeConnectionId, CodeConnectionView
+from pocketpaw_ee.cloud.codeconnect.dto import CodeConnectionResponse
+from pocketpaw_ee.cloud.models.code_connection import CodeConnection as _CodeConnectionDoc
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER = "github"
+
+
+def _doc_to_view(doc: _CodeConnectionDoc) -> CodeConnectionView:
+    """Map a persisted, tenant-checked row to its read model."""
+    return CodeConnectionView(
+        id=CodeConnectionId(str(doc.id)),
+        workspace_id=doc.workspace_id,
+        user_id=doc.user_id,
+        provider=doc.provider,
+        installation_id=doc.installation_id,
+        account_login=doc.account_login,
+        created_at=doc.created_at,
+        updated_at=doc.updated_at,
+    )
+
+
+def view_to_wire(view: CodeConnectionView) -> CodeConnectionResponse:
+    """Map a view to the camelCase wire response (Rule 8 — mapping lives here)."""
+    return CodeConnectionResponse(
+        id=view.id,
+        workspaceId=view.workspace_id,
+        userId=view.user_id,
+        provider=view.provider,
+        installationId=view.installation_id,
+        accountLogin=view.account_login,
+        createdAt=view.created_at.isoformat(),
+        updatedAt=view.updated_at.isoformat(),
+    )
+
+
+async def save_connection(
+    workspace_id: str,
+    user_id: str,
+    installation_id: str,
+    account_login: str | None = None,
+    provider: str = _PROVIDER,
+) -> CodeConnectionView:
+    """Persist (or refresh) a GitHub connection for a (workspace, user, installation).
+
+    Idempotent on the registry key: re-installing / a repeated callback for the
+    same installation refreshes the existing row (and any newly-known
+    ``account_login``) rather than minting a duplicate. Only an actual insert emits
+    ``CodeConnectionCreated`` (an idempotent refresh is not a new connection).
+    """
+    installation_id = (installation_id or "").strip()
+    if not installation_id:
+        # Defensive: the router validates, but a bus/internal caller might not.
+        raise NotFound("code_connection", installation_id)
+
+    existing = await _CodeConnectionDoc.find_one(
+        {  # Rule 7 tenant + owner filter
+            "workspace_id": workspace_id,
+            "user_id": user_id,
+            "provider": provider,
+            "installation_id": installation_id,
+        }
+    )
+    if existing is not None:
+        if account_login and existing.account_login != account_login:
+            existing.account_login = account_login
+            existing.updated_at = datetime.now(UTC)
+            await existing.save()
+        # no-event: an idempotent refresh is not a new connection.
+        return _doc_to_view(existing)
+
+    doc = _CodeConnectionDoc(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        provider=provider,
+        installation_id=installation_id,
+        account_login=account_login,
+    )
+    await doc.insert()
+
+    await emit(
+        CodeConnectionCreated(
+            data={
+                "id": str(doc.id),
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "provider": provider,
+                "installation_id": installation_id,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
+async def list_connections(workspace_id: str, user_id: str) -> list[CodeConnectionView]:
+    """List every connection owned by the caller, newest first.
+
+    Tenant-filtered by ``workspace_id`` AND owner-filtered by ``user_id`` so one
+    user never sees another's GitHub connections even within a shared workspace.
+    """
+    docs = (
+        await _CodeConnectionDoc.find(
+            {"workspace_id": workspace_id, "user_id": user_id}  # Rule 7 tenant filter
+        )
+        .sort([("created_at", -1)])
+        .to_list()
+    )
+    return [_doc_to_view(d) for d in docs]
+
+
+__all__ = [
+    "list_connections",
+    "save_connection",
+    "view_to_wire",
+]

--- a/ee/pocketpaw_ee/cloud/codeconnect/state.py
+++ b/ee/pocketpaw_ee/cloud/codeconnect/state.py
@@ -1,0 +1,68 @@
+# state.py — signed OAuth ``state`` for the Code Mode GitHub connect flow (CM-3).
+# Created 2026-07-16 (feat/code-mode): the GitHub App install redirect comes back
+# as a top-level BROWSER navigation to our callback — it carries no bearer token,
+# so the callback can't use the normal RequestContext auth. Instead the install-URL
+# step signs the caller's ``(workspace_id, user_id)`` into a short-lived, tamper-
+# proof ``state`` token; the callback verifies it to recover who is connecting.
+#
+# Reuses the exact primitive the ws_tickets use — PyJWT HS256 over the shared
+# ``auth.core.SECRET`` — so there's no new secret and no new dependency. Stateless
+# (no Redis): the token is self-describing and expiring, and the worst a replay can
+# do is re-bind the SAME (already authenticated) user to the SAME installation.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+from pocketpaw_ee.cloud.auth.core import SECRET
+
+logger = logging.getLogger(__name__)
+
+_ALGORITHM = "HS256"
+_AUDIENCE = "code-github-connect"
+# The install round-trip (click → GitHub install screen → callback) is
+# interactive; 15 minutes is comfortably longer than a human takes and short
+# enough that a leaked state is useless well before it could be abused.
+_LIFETIME_SECONDS = 900
+
+
+def sign_state(workspace_id: str, user_id: str, *, now: datetime | None = None) -> str:
+    """Sign ``(workspace_id, user_id)`` into a short-lived install ``state`` token."""
+    reference = now or datetime.now(UTC)
+    payload = {
+        "ws": workspace_id,
+        "sub": user_id,
+        "aud": _AUDIENCE,
+        "iat": int(reference.timestamp()),
+        "exp": int((reference + timedelta(seconds=_LIFETIME_SECONDS)).timestamp()),
+    }
+    return jwt.encode(payload, SECRET, algorithm=_ALGORITHM)
+
+
+def verify_state(state: str) -> tuple[str, str] | None:
+    """Verify an install ``state`` token; return ``(workspace_id, user_id)`` or None.
+
+    Returns None on ANY failure — bad signature, wrong audience, expired, malformed,
+    or missing claims — so the callback treats every unverifiable state identically
+    (a clean reject, never a distinguishable error shape).
+    """
+    if not state:
+        return None
+    try:
+        payload = jwt.decode(state, SECRET, algorithms=[_ALGORITHM], audience=_AUDIENCE)
+    except Exception:  # noqa: BLE001 — any decode failure is a uniform reject
+        logger.debug("code-connect: rejected install state", exc_info=True)
+        return None
+    workspace_id = payload.get("ws")
+    user_id = payload.get("sub")
+    if not isinstance(workspace_id, str) or not isinstance(user_id, str):
+        return None
+    if not workspace_id or not user_id:
+        return None
+    return workspace_id, user_id
+
+
+__all__ = ["sign_state", "verify_state"]

--- a/ee/pocketpaw_ee/cloud/codegit/__init__.py
+++ b/ee/pocketpaw_ee/cloud/codegit/__init__.py
@@ -1,0 +1,7 @@
+# codegit — Code Mode git smart-HTTP proxy (CM-3d).
+# Created 2026-07-16 (feat/code-mode): lets the sandbox VM ``git push``/``fetch``
+# its repo WITHOUT the GitHub token ever entering the VM. The VM's ``origin``
+# points at this broker (carrying a sandbox+repo-scoped ticket, NOT the GitHub
+# token); the broker verifies the ticket, mints a fresh repo-scoped GitHub token
+# server-side, and proxies the git smart-HTTP request upstream to github.com with
+# that token injected. The token lives only in the backend.

--- a/ee/pocketpaw_ee/cloud/codegit/proxy.py
+++ b/ee/pocketpaw_ee/cloud/codegit/proxy.py
@@ -1,0 +1,181 @@
+# proxy.py — the Code Mode git smart-HTTP reverse proxy (CM-3d).
+# Created 2026-07-16 (feat/code-mode): the token-injecting core. The sandbox VM
+# speaks git smart-HTTP to us (authenticated by a sandbox+repo ticket, never the
+# GitHub token); we mint a fresh, repo-scoped GitHub installation token
+# SERVER-SIDE and stream the request upstream to github.com with that token in
+# the ``Authorization`` header. The token is only ever in our outbound request —
+# it is never written to a VM, a log, or the response.
+#
+# Only the two git smart-HTTP services are allowed — ``git-upload-pack`` (fetch)
+# and ``git-receive-pack`` (push). The upstream host is ALWAYS the configured git
+# base (github.com), with ``owner``/``repo`` interpolated as single, validated
+# path segments, so a crafted path can't redirect the proxy at another host
+# (SSRF) or another repo. The ticket already pins the repo; we re-check the URL
+# repo against it as defense-in-depth.
+#
+# Bodies (packfiles) can be large, so both directions STREAM: the request body is
+# forwarded as the incoming async byte stream, and the upstream response is
+# streamed straight back. ``http_client`` is injectable so tests exercise the
+# forwarding + token injection against a fake github with no network.
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections.abc import AsyncIterator
+from typing import Any
+
+from starlette.responses import StreamingResponse
+
+from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError, Forbidden
+from pocketpaw_ee.cloud.codegit.ticket import TicketClaims
+from pocketpaw_ee.cloud.websandbox import broker
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_GIT_BASE = "https://github.com"
+# The two git smart-HTTP services. Anything else (receive-pack variants, custom
+# services) is rejected — we proxy fetch + push, nothing more.
+ALLOWED_SERVICES = frozenset({"git-upload-pack", "git-receive-pack"})
+
+# owner / repo are single path segments — GitHub names allow letters, digits,
+# ``.``, ``_`` and ``-``. Anything else (slash, ``..``, ``@``) is rejected before
+# it can reach the upstream URL.
+_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Request headers we forward upstream (lower-cased). The incoming Authorization
+# (the basic-auth ticket) is deliberately NOT here — we replace it with the
+# minted GitHub token. Content-Length is dropped so httpx frames the stream.
+_FORWARD_REQUEST_HEADERS = frozenset(
+    {"content-type", "content-encoding", "accept", "accept-encoding", "git-protocol", "user-agent"}
+)
+# Response headers we pass back to the VM's git. Hop-by-hop + length headers are
+# dropped (the body is re-streamed, so Transfer-Encoding is set fresh).
+_FORWARD_RESPONSE_HEADERS = frozenset(
+    {"content-type", "content-encoding", "cache-control", "pragma", "expires", "www-authenticate"}
+)
+
+_UPSTREAM_TIMEOUT_SECONDS = 120.0
+
+
+def _git_base() -> str:
+    return os.environ.get("GITHUB_GIT_BASE", _GITHUB_GIT_BASE).strip().rstrip("/")
+
+
+def _validate(owner: str, repo: str, service: str, claims: TicketClaims) -> None:
+    """Reject unsafe segments, a disallowed service, or a repo the ticket doesn't cover."""
+    if not _SEGMENT.match(owner) or not _SEGMENT.match(repo):
+        raise BadRequest("codegit.bad_repo", "Malformed repository path")
+    if service not in ALLOWED_SERVICES:
+        raise BadRequest("codegit.bad_service", f"Unsupported git service {service!r}")
+    # The ticket is minted for exactly one repo; the URL must match it.
+    if f"{owner}/{repo}" != claims.repo.removesuffix(".git"):
+        raise Forbidden("codegit.repo_mismatch", "Ticket is not valid for this repository")
+
+
+def _upstream_url(owner: str, repo: str, git_path: str, query: str) -> str:
+    """Build the github.com smart-HTTP URL for ``git_path`` (info/refs carries a query)."""
+    url = f"{_git_base()}/{owner}/{repo}.git/{git_path}"
+    return f"{url}?{query}" if query else url
+
+
+def _forward_request_headers(headers: dict[str, str], token: str) -> dict[str, str]:
+    """Whitelist the git request headers and inject the GitHub token (replacing the ticket)."""
+    fwd = {k: v for k, v in headers.items() if k.lower() in _FORWARD_REQUEST_HEADERS}
+    fwd["Authorization"] = f"token {token}"
+    return fwd
+
+
+def _forward_response_headers(headers: Any) -> dict[str, str]:
+    """Whitelist the upstream response headers git needs; drop hop-by-hop/length."""
+    return {k: v for k, v in headers.items() if k.lower() in _FORWARD_RESPONSE_HEADERS}
+
+
+async def _mint_token(claims: TicketClaims, owner: str, repo: str) -> str:
+    """Mint a fresh, repo-scoped GitHub token for this push/fetch — server-side only.
+
+    Reuses the broker's connection→token resolution: the token is minted from the
+    caller's own connection that can reach the repo, with least-privilege write
+    (contents + pull_requests). ``None`` means the connection is gone / revoked, so
+    the git op is Forbidden rather than proxied with no auth.
+    """
+    repo_url = f"{_git_base()}/{owner}/{repo}.git"
+    scoped = await broker.resolve_repo_token(claims.workspace_id, claims.user_id, repo_url)
+    if scoped is None:
+        raise Forbidden("codegit.no_repo_access", "No GitHub connection can access this repository")
+    return scoped.token
+
+
+async def proxy_git(
+    *,
+    claims: TicketClaims,
+    owner: str,
+    repo: str,
+    git_path: str,
+    service: str,
+    method: str,
+    request_headers: dict[str, str],
+    request_body: AsyncIterator[bytes] | bytes,
+    query: str = "",
+    http_client: Any = None,
+) -> StreamingResponse:
+    """Proxy one git smart-HTTP request upstream with a minted token injected.
+
+    Validates the repo/service against the ticket, mints a repo-scoped GitHub
+    token server-side, and streams the request to ``github.com/<owner>/<repo>.git/
+    <git_path>`` with ``Authorization: token …``. The upstream response is streamed
+    straight back to the VM's git. The GitHub token never appears in the response.
+    ``http_client`` (an ``httpx.AsyncClient``) is injected in tests.
+    """
+    _validate(owner, repo, service, claims)
+    token = await _mint_token(claims, owner, repo)
+
+    url = _upstream_url(owner, repo, git_path, query)
+    fwd_headers = _forward_request_headers(request_headers, token)
+
+    owns_client = http_client is None
+    if owns_client:
+        import httpx
+
+        http_client = httpx.AsyncClient(timeout=_UPSTREAM_TIMEOUT_SECONDS)
+
+    try:
+        request = http_client.build_request(method, url, headers=fwd_headers, content=request_body)
+        upstream = await http_client.send(request, stream=True)
+    except CloudError:
+        if owns_client:
+            await http_client.aclose()
+        raise
+    except Exception as exc:  # noqa: BLE001 — any upstream transport failure is uniform
+        if owns_client:
+            await http_client.aclose()
+        raise CloudError(
+            502, "codegit.upstream_failed", "The git host could not be reached"
+        ) from exc
+
+    async def _body() -> AsyncIterator[bytes]:
+        try:
+            async for chunk in upstream.aiter_raw():
+                yield chunk
+        finally:
+            await upstream.aclose()
+            if owns_client:
+                await http_client.aclose()
+
+    logger.info(
+        "codegit.proxy: ws=%s repo=%s/%s %s -> upstream %s",
+        claims.workspace_id,
+        owner,
+        repo,
+        git_path,
+        upstream.status_code,
+    )
+    return StreamingResponse(
+        _body(),
+        status_code=upstream.status_code,
+        headers=_forward_response_headers(upstream.headers),
+    )
+
+
+__all__ = ["ALLOWED_SERVICES", "proxy_git"]

--- a/ee/pocketpaw_ee/cloud/codegit/router.py
+++ b/ee/pocketpaw_ee/cloud/codegit/router.py
@@ -1,0 +1,111 @@
+# router.py — FastAPI git smart-HTTP endpoints for the Code Mode proxy (CM-3d).
+# Created 2026-07-16 (feat/code-mode): the three routes a git client hits over
+# smart-HTTP, mounted at ``/api/v1/codegit``. The VM's git remote is
+# ``https://x-paw-git:<ticket>@<backend>/api/v1/codegit/<owner>/<repo>``; git then
+# requests ``…/info/refs`` (advertisement) and POSTs ``…/git-upload-pack`` (fetch)
+# or ``…/git-receive-pack`` (push).
+#
+# Authentication is the signed ticket carried as the basic-auth PASSWORD — NOT a
+# session cookie or bearer, so this router is deliberately OUTSIDE the normal
+# license/RequestContext auth (git can't do OAuth). The CSRF middleware only fires
+# for cookie auth, and the EE auth bridge only inspects Bearer, so a basic-auth
+# git request passes both untouched and authenticates here via the ticket alone.
+# proxy_git then mints the repo-scoped GitHub token server-side.
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+
+from fastapi import APIRouter, Query, Request
+from starlette.responses import Response
+
+from pocketpaw_ee.cloud.codegit.proxy import proxy_git
+from pocketpaw_ee.cloud.codegit.ticket import TicketClaims, verify_ticket
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/codegit", tags=["CodeGit"])
+
+_REALM = 'Basic realm="paw-codegit"'
+
+
+def _unauthorized() -> Response:
+    """A 401 that prompts git to treat the ticket as invalid (no retry loop)."""
+    return Response(status_code=401, headers={"WWW-Authenticate": _REALM})
+
+
+def _ticket_from_basic_auth(request: Request) -> TicketClaims | None:
+    """Recover the ticket claims from the basic-auth PASSWORD, or ``None``.
+
+    The remote embeds the ticket as the password (``x-paw-git:<ticket>``); git
+    sends it as ``Authorization: Basic base64(user:ticket)``. Any username is
+    accepted — only the ticket (password) is verified.
+    """
+    header = request.headers.get("authorization", "")
+    scheme, _, encoded = header.partition(" ")
+    if scheme.lower() != "basic" or not encoded:
+        return None
+    try:
+        decoded = base64.b64decode(encoded).decode("utf-8", "replace")
+    except (binascii.Error, ValueError):
+        return None
+    _user, _, password = decoded.partition(":")
+    return verify_ticket(password)
+
+
+@router.get("/{owner}/{repo}/info/refs")
+async def info_refs(
+    owner: str,
+    repo: str,
+    request: Request,
+    service: str = Query(""),
+) -> Response:
+    """The ref advertisement — git's first request for both fetch and push."""
+    claims = _ticket_from_basic_auth(request)
+    if claims is None:
+        return _unauthorized()
+    return await proxy_git(
+        claims=claims,
+        owner=owner,
+        repo=repo,
+        git_path="info/refs",
+        service=service,
+        method="GET",
+        request_headers=dict(request.headers),
+        request_body=b"",
+        query=f"service={service}",
+    )
+
+
+@router.post("/{owner}/{repo}/git-upload-pack")
+async def upload_pack(owner: str, repo: str, request: Request) -> Response:
+    """The fetch/clone pack negotiation (``git fetch``/``git pull``)."""
+    return await _proxy_pack(owner, repo, request, "git-upload-pack")
+
+
+@router.post("/{owner}/{repo}/git-receive-pack")
+async def receive_pack(owner: str, repo: str, request: Request) -> Response:
+    """The push pack transfer (``git push``)."""
+    return await _proxy_pack(owner, repo, request, "git-receive-pack")
+
+
+async def _proxy_pack(owner: str, repo: str, request: Request, service: str) -> Response:
+    """Shared POST handler: authenticate the ticket, then stream the pack upstream."""
+    claims = _ticket_from_basic_auth(request)
+    if claims is None:
+        return _unauthorized()
+    return await proxy_git(
+        claims=claims,
+        owner=owner,
+        repo=repo,
+        git_path=service,
+        service=service,
+        method="POST",
+        request_headers=dict(request.headers),
+        request_body=request.stream(),
+    )
+
+
+__all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/codegit/ticket.py
+++ b/ee/pocketpaw_ee/cloud/codegit/ticket.py
@@ -1,0 +1,94 @@
+# ticket.py — the VM→broker credential for the Code Mode git proxy (CM-3d).
+# Created 2026-07-16 (feat/code-mode): the sandbox VM needs SOME credential to
+# talk to the git proxy — but it must NOT be the GitHub token (that never enters
+# the VM). This ticket is that credential: a short-lived JWT, signed with the
+# shared ``auth.core.SECRET`` (same primitive as codeconnect/state.py and the
+# ws_tickets), scoped to ONE ``(sandbox, repo)`` under ``(workspace, user)``.
+#
+# It is embedded in the VM's git remote URL (basic-auth password), so it does
+# live in the VM — and that's fine: it only authorizes proxying git to ITS repo
+# for ITS sandbox. A leak lets someone push to that one repo through the broker
+# (exactly what the legitimate user can already do); it can NEVER reach the
+# GitHub token or another repo. The broker mints the real, repo-scoped GitHub
+# token itself, server-side, on each proxied request.
+#
+# Lifetime is generous (24h) relative to a sandbox's minutes-long idle life —
+# a reprovision re-wires a fresh ticket, so this only has to outlive one active
+# editing session.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+from pocketpaw_ee.cloud.auth.core import SECRET
+
+logger = logging.getLogger(__name__)
+
+_ALGORITHM = "HS256"
+_AUDIENCE = "code-git-proxy"
+# A sandbox auto-stops after minutes of idle and is reprovisioned (re-wiring a
+# fresh ticket) on next open, so 24h comfortably covers any single session while
+# keeping a leaked ticket useless within a day.
+_LIFETIME_SECONDS = 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class TicketClaims:
+    """The identity a verified git-proxy ticket recovers."""
+
+    workspace_id: str
+    user_id: str
+    sandbox_id: str
+    repo: str  # "owner/repo" — the ONE repo this ticket may proxy
+
+
+def sign_ticket(
+    workspace_id: str,
+    user_id: str,
+    sandbox_id: str,
+    repo: str,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Sign a git-proxy ticket scoped to one ``(sandbox, repo)`` for ``(ws, user)``."""
+    reference = now or datetime.now(UTC)
+    payload = {
+        "ws": workspace_id,
+        "sub": user_id,
+        "sbx": sandbox_id,
+        "repo": repo,
+        "aud": _AUDIENCE,
+        "iat": int(reference.timestamp()),
+        "exp": int((reference + timedelta(seconds=_LIFETIME_SECONDS)).timestamp()),
+    }
+    return jwt.encode(payload, SECRET, algorithm=_ALGORITHM)
+
+
+def verify_ticket(ticket: str) -> TicketClaims | None:
+    """Verify a git-proxy ticket; return its claims, or ``None`` on ANY failure.
+
+    Every unverifiable ticket — bad signature, wrong audience, expired, malformed,
+    missing claims — returns ``None`` so the proxy rejects them all identically
+    (a clean 401, never a distinguishable error shape).
+    """
+    if not ticket:
+        return None
+    try:
+        payload = jwt.decode(ticket, SECRET, algorithms=[_ALGORITHM], audience=_AUDIENCE)
+    except Exception:  # noqa: BLE001 — any decode failure is a uniform reject
+        logger.debug("codegit: rejected git-proxy ticket", exc_info=True)
+        return None
+    ws = payload.get("ws")
+    user = payload.get("sub")
+    sandbox = payload.get("sbx")
+    repo = payload.get("repo")
+    if not all(isinstance(v, str) and v for v in (ws, user, sandbox, repo)):
+        return None
+    return TicketClaims(workspace_id=ws, user_id=user, sandbox_id=sandbox, repo=repo)
+
+
+__all__ = ["TicketClaims", "sign_ticket", "verify_ticket"]

--- a/ee/pocketpaw_ee/cloud/codegit/wire.py
+++ b/ee/pocketpaw_ee/cloud/codegit/wire.py
@@ -1,0 +1,102 @@
+# wire.py — point the VM's git remote at the Code Mode proxy (CM-3d).
+# Created 2026-07-16 (feat/code-mode): after a repo is cloned into the sandbox,
+# this repoints ``origin`` from the clean github.com URL to the broker, so an
+# in-VM ``git push``/``fetch`` flows through the token-injecting proxy instead of
+# failing (the VM has no GitHub credential — by design). The broker URL embeds a
+# signed ticket (basic-auth password) that is scoped to this ``(sandbox, repo)``
+# and is NOT the GitHub token.
+#
+# Gated on a PUBLIC backend URL: the Daytona VM lives in the cloud and cannot
+# reach ``localhost``, so wiring is skipped (push simply stays unavailable, the
+# clone is still usable) unless ``POCKETPAW_PUBLIC_BASE_URL`` names a non-local
+# host. The embedded ticket is never logged.
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from urllib.parse import urlsplit, urlunsplit
+
+from pocketpaw_ee.cloud.codegit.ticket import sign_ticket
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+
+logger = logging.getLogger(__name__)
+
+# The basic-auth username is cosmetic — only the ticket (password) is verified.
+_PROXY_USER = "x-paw-git"
+_REMOTE = "origin"
+_SET_REMOTE_TIMEOUT_SECONDS = 30
+_LOCAL_HOSTS = ("localhost", "127.0.0.1", "0.0.0.0", "::1")
+
+
+def _public_base_url() -> str | None:
+    """The public backend origin the VM's git can reach, or ``None`` when local.
+
+    Reads ``POCKETPAW_PUBLIC_BASE_URL`` (the same var the SSO callback uses). A
+    localhost / loopback host means we're in local dev where a cloud VM can't
+    reach us — return ``None`` so push wiring is skipped rather than writing a
+    dead remote.
+    """
+    raw = os.environ.get("POCKETPAW_PUBLIC_BASE_URL", "").strip().rstrip("/")
+    if not raw:
+        return None
+    host = urlsplit(raw).hostname or ""
+    if host in _LOCAL_HOSTS:
+        return None
+    return raw
+
+
+def _proxy_remote_url(base_url: str, ticket: str, repo_full: str) -> str:
+    """Build ``https://x-paw-git:<ticket>@<host>/api/v1/codegit/<owner>/<repo>``."""
+    parts = urlsplit(base_url)
+    netloc = f"{_PROXY_USER}:{ticket}@{parts.netloc}"
+    path = f"{parts.path.rstrip('/')}/api/v1/codegit/{repo_full}"
+    return urlunsplit((parts.scheme, netloc, path, "", ""))
+
+
+async def wire_push_remote(
+    daytona: DaytonaClient,
+    sandbox_id: str,
+    workspace_id: str,
+    user_id: str,
+    repo_full: str,
+    project_dir: str,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Repoint the VM's ``origin`` at the git proxy so in-VM push/fetch works.
+
+    Mints a ``(sandbox, repo)`` ticket, builds the broker remote URL, and runs
+    ``git remote set-url origin`` in the VM. Returns ``True`` when wired, ``False``
+    when skipped (no public URL — push stays unavailable, the clone is unaffected).
+    The ticket-bearing URL is NEVER logged.
+    """
+    base_url = _public_base_url()
+    if base_url is None:
+        logger.info(
+            "codegit.wire: POCKETPAW_PUBLIC_BASE_URL is local/unset — in-VM git push "
+            "disabled for sandbox=%s (clone unaffected)",
+            sandbox_id,
+        )
+        return False
+
+    ticket = sign_ticket(workspace_id, user_id, sandbox_id, repo_full, now=now)
+    remote_url = _proxy_remote_url(base_url, ticket, repo_full)
+    # Single-quote the URL for the shell; the ticket is base64url + dots, so it
+    # contains no quote to break out of. Never log ``remote_url`` (carries the ticket).
+    await daytona.execute_command(
+        sandbox_id,
+        f"git remote set-url {_REMOTE} '{remote_url}'",
+        cwd=project_dir,
+        timeout=_SET_REMOTE_TIMEOUT_SECONDS,
+    )
+    logger.info(
+        "codegit.wire: sandbox=%s origin repointed at the git proxy for repo=%s",
+        sandbox_id,
+        repo_full,
+    )
+    return True
+
+
+__all__ = ["wire_push_remote"]

--- a/ee/pocketpaw_ee/cloud/codeproject/__init__.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/__init__.py
@@ -1,0 +1,5 @@
+# __init__.py — the Code Mode Project registry entity (CM-2a).
+# Created 2026-07-16 (feat/code-mode): a 4-file cloud entity (domain / dto /
+# service / router) for the DURABLE project — the identity + S3 snapshot pointer
+# that outlives any single ephemeral Daytona sandbox. Opening a project reuses
+# its live sandbox or provisions a fresh one and restores the snapshot into it.

--- a/ee/pocketpaw_ee/cloud/codeproject/domain.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/domain.py
@@ -1,0 +1,44 @@
+# domain.py — Frozen value objects for the Code Mode Project registry (CM-2a).
+# Created 2026-07-16 (feat/code-mode): tenancy fields (workspace_id, user_id) are
+# REQUIRED at construction with no defaults per ee/cloud Rule 3 — constructing a
+# view without tenancy is a TypeError, so a leak can't be minted by omission.
+# Mirrors websandbox/domain.py; a CodeProjectView is only ever built from a
+# persisted, tenant-checked row.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import NewType
+
+CodeProjectId = NewType("CodeProjectId", str)
+
+
+@dataclass(frozen=True)
+class CodeProjectView:
+    """Read model for one durable project row.
+
+    Every field is required at construction — the tenancy fields
+    (``workspace_id``, ``user_id``) most of all, per Rule 3. Optional runtime
+    pointers (snapshot, current sandbox, last-opened) default to None so they
+    land after the required tenancy fields without a second construction site.
+    """
+
+    id: CodeProjectId
+    workspace_id: str
+    user_id: str
+    name: str
+    provider: str
+    repo: str
+    created_at: datetime
+    updated_at: datetime
+    # Durable blob-storage snapshot pointer — the project's files between VMs.
+    snapshot_file_id: str | None = None
+    # The current ephemeral sandbox (a WebSandbox row id), null when none is live.
+    current_sandbox_id: str | None = None
+    last_opened_at: datetime | None = None
+
+
+__all__ = [
+    "CodeProjectId",
+    "CodeProjectView",
+]

--- a/ee/pocketpaw_ee/cloud/codeproject/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/dto.py
@@ -1,0 +1,52 @@
+# dto.py — Request/response DTOs for the Code Mode Project registry (CM-2a).
+# Created 2026-07-16 (feat/code-mode): distinct <Op>Request and <Entity>Response
+# classes per ee/cloud Rule 4. The write surface accepts ONLY what a client may
+# set — repo (+ optional name/provider). Server-owned runtime state
+# (snapshot_file_id, current_sandbox_id, timestamps) is NEVER accepted on the
+# wire, the same discipline that closed the WebSandbox cross-tenant hole. Wire
+# shape is camelCase to match the rest of the cloud surface.
+#
+# The ``open`` endpoint does not have its own request/response here — it takes the
+# project id from the path and returns a ``WebSandboxResponse`` (the ready
+# runtime sandbox to connect to), reusing the websandbox contract.
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CreateProjectRequest(BaseModel):
+    """Client-facing create body — a repo (+ optional name/provider) ONLY.
+
+    Idempotent per (workspace, user, provider, repo): a second create for the
+    same repo returns the existing project. Server-owned fields (the snapshot
+    pointer, the current sandbox, timestamps) are never accepted here.
+    """
+
+    repo: str = Field(..., min_length=1, max_length=1024)
+    name: str | None = Field(default=None, max_length=200)
+    provider: str = Field(default="github", max_length=32)
+
+
+class CodeProjectResponse(BaseModel):
+    id: str
+    workspaceId: str
+    userId: str
+    name: str
+    provider: str
+    repo: str
+    snapshotFileId: str | None = None
+    currentSandboxId: str | None = None
+    lastOpenedAt: str | None = None  # ISO-8601 UTC, or null
+    createdAt: str  # ISO-8601 UTC
+    updatedAt: str  # ISO-8601 UTC
+
+
+class CodeProjectListResponse(BaseModel):
+    items: list[CodeProjectResponse]
+
+
+__all__ = [
+    "CodeProjectListResponse",
+    "CodeProjectResponse",
+    "CreateProjectRequest",
+]

--- a/ee/pocketpaw_ee/cloud/codeproject/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/dto.py
@@ -8,7 +8,9 @@
 #
 # The ``open`` endpoint does not have its own request/response here — it takes the
 # project id from the path and returns a ``WebSandboxResponse`` (the ready
-# runtime sandbox to connect to), reusing the websandbox contract.
+# runtime sandbox to connect to), reusing the websandbox contract. ``rename`` takes
+# a ``RenameProjectRequest`` and returns the updated ``CodeProjectResponse``;
+# ``delete`` takes only the path id and returns 204.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -25,6 +27,16 @@ class CreateProjectRequest(BaseModel):
     repo: str = Field(..., min_length=1, max_length=1024)
     name: str | None = Field(default=None, max_length=200)
     provider: str = Field(default="github", max_length=32)
+
+
+class RenameProjectRequest(BaseModel):
+    """Client-facing rename body — a new display name ONLY.
+
+    The name is trimmed + length-bounded; nothing else about the project (repo,
+    provider, runtime binding) is mutable from the wire.
+    """
+
+    name: str = Field(..., min_length=1, max_length=200)
 
 
 class CodeProjectResponse(BaseModel):
@@ -49,4 +61,5 @@ __all__ = [
     "CodeProjectListResponse",
     "CodeProjectResponse",
     "CreateProjectRequest",
+    "RenameProjectRequest",
 ]

--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -1,4 +1,4 @@
-# lifecycle.py — Code Mode "open a project" orchestration (CM-2a).
+# lifecycle.py — Code Mode "open a project" orchestration (CM-2a, CM-2a′).
 # Created 2026-07-16 (feat/code-mode): the durable-project → ephemeral-sandbox
 # resolver. It sits ABOVE ``codeproject/service.py`` (the registry) and drives the
 # runtime through ``websandbox/provision.py``. Per ee/cloud Rule 2 it NEVER touches
@@ -12,6 +12,14 @@
 # cold-provision a fresh sandbox for the project's repo (idempotent on the repo, so
 # a reprovision reuses the same WebSandbox row) and rebind. Returns the ready
 # sandbox view for the caller to connect to.
+#
+# 2026-07-16 (CM-2a′): the reprovision branch now RESTORES the row's durable S3
+# snapshot into the fresh VM. The WebSandbox row is stable across reprovisions
+# (idempotent on the repo), so a ``snapshot_file_id`` written on a prior
+# disconnect survives on the row; when we boot a fresh VM we overlay that snapshot
+# so a returning user picks up their uncommitted work + branch instead of a bare
+# re-clone. Best-effort: a restore failure leaves the fresh clone usable rather
+# than blocking the open.
 from __future__ import annotations
 
 import logging
@@ -20,6 +28,7 @@ from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.codeproject import service as codeproject_service
 from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
@@ -69,6 +78,9 @@ async def open_project(
     sandbox = await websandbox_provision.open_sandbox(
         workspace_id, user_id, {"repo": project.repo}, client=client
     )
+    # CM-2a′: overlay the row's durable snapshot (uncommitted work + branch from a
+    # prior session) onto the freshly-cloned VM, if one exists.
+    await _restore_if_snapshotted(workspace_id, user_id, sandbox, client)
     await codeproject_service.bind_current_sandbox(
         workspace_id, user_id, project_id, sandbox.id
     )
@@ -79,6 +91,44 @@ async def open_project(
         project.repo,
     )
     return sandbox
+
+
+async def _restore_if_snapshotted(
+    workspace_id: str,
+    user_id: str,
+    sandbox: WebSandboxView,
+    client: DaytonaClient | None,
+) -> None:
+    """Restore the sandbox row's durable S3 snapshot into its fresh VM, if any.
+
+    The WebSandbox row is stable across reprovisions, so a ``snapshot_file_id``
+    captured on a prior disconnect (see ``websandbox.ws.snapshot_on_disconnect``)
+    is still on the row when we reprovision. A row with no snapshot (never
+    disconnected with work, or first open) is a clean no-op.
+
+    Best-effort by design: a restore failure (VM gone, S3 down, corrupt tarball)
+    is logged and swallowed — the fresh clone from ``open_sandbox`` is still a
+    usable workspace, so a durability miss must never fail the open.
+    """
+    if not sandbox.snapshot_file_id:
+        return
+    try:
+        await websandbox_durability.restore_workspace(
+            workspace_id, user_id, sandbox.id, client=client
+        )
+        logger.info(
+            "codeproject.open: restored snapshot=%s into sandbox=%s",
+            sandbox.snapshot_file_id,
+            sandbox.id,
+        )
+    except Exception:  # noqa: BLE001 — a fresh clone is still usable; never block open
+        logger.warning(
+            "codeproject.open: snapshot restore failed for sandbox=%s (snapshot=%s); "
+            "continuing with the fresh clone",
+            sandbox.id,
+            sandbox.snapshot_file_id,
+            exc_info=True,
+        )
 
 
 async def _reuse_if_live(

--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -20,6 +20,15 @@
 # so a returning user picks up their uncommitted work + branch instead of a bare
 # re-clone. Best-effort: a restore failure leaves the fresh clone usable rather
 # than blocking the open.
+#
+# 2026-07-17 (reopen-stale-vm fix): reuse now PROBES Daytona before trusting the
+# row. The Mongo row's ``status`` is not authoritative about the VM: Daytona's own
+# aggressive lifecycle (stop 5 min → delete-on-stop) destroys an idle Code Mode VM
+# long before our 30-min idle reaper reconciles the row, so a ``ready`` row can
+# point at a Daytona sandbox that no longer exists. Reopening a day-old project
+# then bound the editor to a dead VM (no connection, empty tree). ``_reuse_if_live``
+# now confirms the bound VM actually exists and is ``started`` in Daytona; anything
+# else falls through to reprovision + snapshot restore.
 from __future__ import annotations
 
 import logging
@@ -27,7 +36,7 @@ import logging
 from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.codeproject import service as codeproject_service
 from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView
-from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
@@ -39,6 +48,12 @@ logger = logging.getLogger(__name__)
 # bound Daytona id. Anything else (opening, stopped, reaped, or no bound VM) means
 # the runtime is gone and we reprovision.
 _REUSABLE_STATUS = "ready"
+
+# The one Daytona state a bound VM must be in to reuse it directly. A ``stopped``
+# or ``archived`` VM (if not already deleted) can't serve the terminal / file RPC,
+# and a Code Mode VM is delete-on-stop, so anything but ``started`` means "gone or
+# unusable" → reprovision from the durable project instead of resuming a stale VM.
+_LIVE_VM_STATE = "started"
 
 
 async def open_project(
@@ -64,7 +79,7 @@ async def open_project(
     """
     project = await codeproject_service.get_project(workspace_id, user_id, project_id)
 
-    reused = await _reuse_if_live(workspace_id, user_id, project)
+    reused = await _reuse_if_live(workspace_id, user_id, project, client)
     if reused is not None:
         # Re-stamp last-opened so the projects grid orders by real recency; the
         # bound id is unchanged, so this is just a touch.
@@ -139,12 +154,20 @@ async def _reuse_if_live(
     workspace_id: str,
     user_id: str,
     project: CodeProjectView,
+    client: DaytonaClient | None,
 ) -> WebSandboxView | None:
     """Return the project's bound sandbox iff it's still live, else None.
 
-    "Live" == a ready row with a bound Daytona id. A missing bound id, an
-    unresolvable/foreign row (``NotFound``), or any non-``ready`` status all mean
-    the runtime is gone and the caller should reprovision.
+    "Live" == a ready row with a bound Daytona id WHOSE VM still exists and is
+    ``started`` in Daytona. A missing bound id, an unresolvable/foreign row
+    (``NotFound``), any non-``ready`` row status, OR a bound VM that Daytona has
+    already destroyed/stopped all mean the runtime is gone and the caller should
+    reprovision.
+
+    The Daytona probe is what fixes reopening a stale project: the row's status
+    lags the VM's real lifecycle (Daytona deletes an idle VM in minutes; our
+    reaper reconciles the row on a 30-min sweep), so trusting the row alone bound
+    the editor to a dead VM.
     """
     if not project.current_sandbox_id:
         return None
@@ -154,9 +177,48 @@ async def _reuse_if_live(
         )
     except NotFound:
         return None
-    if sandbox.status == _REUSABLE_STATUS and sandbox.sandbox_id:
-        return sandbox
-    return None
+    if sandbox.status != _REUSABLE_STATUS or not sandbox.sandbox_id:
+        return None
+    if not await _daytona_vm_is_live(sandbox.sandbox_id, client):
+        return None
+    return sandbox
+
+
+async def _daytona_vm_is_live(sandbox_id: str, client: DaytonaClient | None) -> bool:
+    """True iff the Daytona VM ``sandbox_id`` still exists and is ``started``.
+
+    Fail-safe toward reprovision: if Daytona is unconfigured, the id no longer
+    resolves (deleted/reaped out-of-band), or the VM is in any state but
+    ``started``, return False so the caller boots a fresh VM and restores the
+    durable snapshot rather than handing back a dead runtime. A probe error is
+    treated as "not live" — a spurious reprovision is recoverable; binding a dead
+    VM is the actual outage.
+    """
+    daytona = client if client is not None else get_daytona_client()
+    if daytona is None:
+        logger.info(
+            "codeproject.open: Daytona unavailable — cannot verify VM %s, reprovisioning",
+            sandbox_id,
+        )
+        return False
+    try:
+        info = await daytona.get_sandbox_by_id(sandbox_id)
+    except Exception:  # noqa: BLE001 — any lookup failure means the VM is unreachable/gone
+        logger.info(
+            "codeproject.open: bound VM %s no longer resolves in Daytona — reprovisioning",
+            sandbox_id,
+        )
+        return False
+    state = (getattr(info, "state", "") or "").lower()
+    if state == _LIVE_VM_STATE:
+        return True
+    logger.info(
+        "codeproject.open: bound VM %s is %r (not %s) — reprovisioning",
+        sandbox_id,
+        state,
+        _LIVE_VM_STATE,
+    )
+    return False
 
 
 __all__ = ["open_project"]

--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -31,6 +31,7 @@
 # else falls through to reprovision + snapshot restore.
 from __future__ import annotations
 
+import contextlib
 import logging
 
 from pocketpaw_ee.cloud._core.errors import NotFound
@@ -106,6 +107,66 @@ async def open_project(
         project.repo,
     )
     return sandbox
+
+
+async def delete_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    client: DaytonaClient | None = None,
+) -> None:
+    """Delete a durable project and best-effort tear down its bound sandbox VM.
+
+    Flow:
+      1. Resolve the project (tenant + owner scoped; ``NotFound`` if not owned).
+      2. If it's bound to a sandbox, best-effort stop+delete the Daytona VM and
+         mark the WebSandbox row ``reaped`` so no runtime is orphaned.
+      3. Delete the durable CodeProject doc (the sole doc write goes through the
+         service).
+
+    The VM teardown is best-effort: a Daytona hiccup must not block removing the
+    project (the idle reaper + Daytona's own delete-on-stop reclaim a stray VM
+    anyway). The doc delete is the authoritative step.
+    """
+    project = await codeproject_service.get_project(workspace_id, user_id, project_id)
+
+    if project.current_sandbox_id:
+        await _teardown_bound_sandbox(
+            workspace_id, user_id, project.current_sandbox_id, client
+        )
+
+    await codeproject_service.delete_project(workspace_id, user_id, project_id)
+    logger.info(
+        "codeproject.delete: project=%s removed (repo=%s)", project_id, project.repo
+    )
+
+
+async def _teardown_bound_sandbox(
+    workspace_id: str,
+    user_id: str,
+    sandbox_row_id: str,
+    client: DaytonaClient | None,
+) -> None:
+    """Best-effort stop+delete the bound Daytona VM and mark its row reaped.
+
+    Every step is guarded: a missing row, an unconfigured/erroring Daytona, or a
+    VM that's already gone are all fine — the goal is just "don't leak a live VM
+    when the project is deleted", not to fail the delete on a teardown miss.
+    """
+    try:
+        sandbox = await websandbox_service.get_sandbox(
+            workspace_id, user_id, sandbox_row_id
+        )
+    except NotFound:
+        return
+    daytona = client if client is not None else get_daytona_client()
+    if daytona is not None and sandbox.sandbox_id:
+        with contextlib.suppress(Exception):
+            await daytona.stop_sandbox(sandbox.sandbox_id)
+        with contextlib.suppress(Exception):
+            await daytona.delete_sandbox(sandbox.sandbox_id)
+    with contextlib.suppress(Exception):
+        await websandbox_service.mark_reaped(sandbox_row_id)
 
 
 async def _restore_if_snapshotted(
@@ -221,4 +282,4 @@ async def _daytona_vm_is_live(sandbox_id: str, client: DaytonaClient | None) -> 
     return False
 
 
-__all__ = ["open_project"]
+__all__ = ["delete_project", "open_project"]

--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -99,27 +99,31 @@ async def _restore_if_snapshotted(
     sandbox: WebSandboxView,
     client: DaytonaClient | None,
 ) -> None:
-    """Restore the sandbox row's durable S3 snapshot into its fresh VM, if any.
+    """Restore the sandbox row's durable state into its fresh VM, if any.
 
-    The WebSandbox row is stable across reprovisions, so a ``snapshot_file_id``
-    captured on a prior disconnect (see ``websandbox.ws.snapshot_on_disconnect``)
-    is still on the row when we reprovision. A row with no snapshot (never
-    disconnected with work, or first open) is a clean no-op.
+    The WebSandbox row is stable across reprovisions, so both durability tiers
+    survive on the row when we reprovision: the ``snapshot_file_id`` (captured on
+    a prior clean disconnect) AND the write-through ``overlay`` (per-file edits
+    mirrored since the last snapshot — the tier that covers a crash / idle-out
+    before any disconnect snapshot). Restore fires when EITHER exists; a row with
+    neither (first open, or nothing edited) is a clean no-op.
 
     Best-effort by design: a restore failure (VM gone, S3 down, corrupt tarball)
     is logged and swallowed — the fresh clone from ``open_sandbox`` is still a
     usable workspace, so a durability miss must never fail the open.
     """
-    if not sandbox.snapshot_file_id:
+    if not sandbox.snapshot_file_id and not sandbox.overlay:
         return
     try:
         await websandbox_durability.restore_workspace(
             workspace_id, user_id, sandbox.id, client=client
         )
         logger.info(
-            "codeproject.open: restored snapshot=%s into sandbox=%s",
-            sandbox.snapshot_file_id,
+            "codeproject.open: restored durable state into sandbox=%s "
+            "(snapshot=%s, overlay=%d file(s))",
             sandbox.id,
+            sandbox.snapshot_file_id,
+            len(sandbox.overlay or {}),
         )
     except Exception:  # noqa: BLE001 — a fresh clone is still usable; never block open
         logger.warning(

--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -84,9 +84,7 @@ async def open_project(
     if reused is not None:
         # Re-stamp last-opened so the projects grid orders by real recency; the
         # bound id is unchanged, so this is just a touch.
-        await codeproject_service.bind_current_sandbox(
-            workspace_id, user_id, project_id, reused.id
-        )
+        await codeproject_service.bind_current_sandbox(workspace_id, user_id, project_id, reused.id)
         return reused
 
     # Provision a fresh sandbox for the repo (idempotent on the repo → reuses the
@@ -97,9 +95,7 @@ async def open_project(
     # CM-2a′: overlay the row's durable snapshot (uncommitted work + branch from a
     # prior session) onto the freshly-cloned VM, if one exists.
     await _restore_if_snapshotted(workspace_id, user_id, sandbox, client)
-    await codeproject_service.bind_current_sandbox(
-        workspace_id, user_id, project_id, sandbox.id
-    )
+    await codeproject_service.bind_current_sandbox(workspace_id, user_id, project_id, sandbox.id)
     logger.info(
         "codeproject.open: project=%s bound fresh sandbox=%s (repo=%s)",
         project_id,
@@ -131,14 +127,10 @@ async def delete_project(
     project = await codeproject_service.get_project(workspace_id, user_id, project_id)
 
     if project.current_sandbox_id:
-        await _teardown_bound_sandbox(
-            workspace_id, user_id, project.current_sandbox_id, client
-        )
+        await _teardown_bound_sandbox(workspace_id, user_id, project.current_sandbox_id, client)
 
     await codeproject_service.delete_project(workspace_id, user_id, project_id)
-    logger.info(
-        "codeproject.delete: project=%s removed (repo=%s)", project_id, project.repo
-    )
+    logger.info("codeproject.delete: project=%s removed (repo=%s)", project_id, project.repo)
 
 
 async def _teardown_bound_sandbox(
@@ -154,9 +146,7 @@ async def _teardown_bound_sandbox(
     when the project is deleted", not to fail the delete on a teardown miss.
     """
     try:
-        sandbox = await websandbox_service.get_sandbox(
-            workspace_id, user_id, sandbox_row_id
-        )
+        sandbox = await websandbox_service.get_sandbox(workspace_id, user_id, sandbox_row_id)
     except NotFound:
         return
     daytona = client if client is not None else get_daytona_client()

--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -1,0 +1,108 @@
+# lifecycle.py — Code Mode "open a project" orchestration (CM-2a).
+# Created 2026-07-16 (feat/code-mode): the durable-project → ephemeral-sandbox
+# resolver. It sits ABOVE ``codeproject/service.py`` (the registry) and drives the
+# runtime through ``websandbox/provision.py``. Per ee/cloud Rule 2 it NEVER touches
+# either Beanie doc directly — the project read/bind goes through ``codeproject.
+# service`` and the sandbox read/provision through ``websandbox.service`` /
+# ``websandbox.provision``. Living here (not in service.py) keeps the service the
+# sole doc writer and avoids a service→provision import cycle.
+#
+# One flow — ``open_project``: resolve the project (tenant-scoped) → if it's bound
+# to a sandbox that is still LIVE (``ready`` with a Daytona id), reuse it; else
+# cold-provision a fresh sandbox for the project's repo (idempotent on the repo, so
+# a reprovision reuses the same WebSandbox row) and rebind. Returns the ready
+# sandbox view for the caller to connect to.
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
+
+logger = logging.getLogger(__name__)
+
+# The sandbox states that count as "live enough to reuse" — a ready row with a
+# bound Daytona id. Anything else (opening, stopped, reaped, or no bound VM) means
+# the runtime is gone and we reprovision.
+_REUSABLE_STATUS = "ready"
+
+
+async def open_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    client: DaytonaClient | None = None,
+) -> WebSandboxView:
+    """Open a durable project, returning a ready sandbox to connect to.
+
+    Flow:
+      1. Load the project (tenant + owner scoped; ``NotFound`` if not owned).
+      2. If it's bound to a sandbox that is still live (``ready`` + Daytona id),
+         reuse it and re-stamp ``last_opened_at``.
+      3. Otherwise cold-provision a fresh sandbox for the project's repo (via
+         ``websandbox.provision.open_sandbox`` — idempotent on the repo, so this
+         reuses the project's stable WebSandbox row and boots a new VM into it),
+         then bind it onto the project.
+
+    Returns the ready ``WebSandboxView``. The bound-but-invalid case (the VM was
+    reaped, or the id no longer resolves) falls through to reprovision — "if the
+    id is invalid or unavailable, make a new sandbox."
+    """
+    project = await codeproject_service.get_project(workspace_id, user_id, project_id)
+
+    reused = await _reuse_if_live(workspace_id, user_id, project)
+    if reused is not None:
+        # Re-stamp last-opened so the projects grid orders by real recency; the
+        # bound id is unchanged, so this is just a touch.
+        await codeproject_service.bind_current_sandbox(
+            workspace_id, user_id, project_id, reused.id
+        )
+        return reused
+
+    # Provision a fresh sandbox for the repo (idempotent on the repo → reuses the
+    # project's stable WebSandbox row, boots a new VM into it) and bind it.
+    sandbox = await websandbox_provision.open_sandbox(
+        workspace_id, user_id, {"repo": project.repo}, client=client
+    )
+    await codeproject_service.bind_current_sandbox(
+        workspace_id, user_id, project_id, sandbox.id
+    )
+    logger.info(
+        "codeproject.open: project=%s bound fresh sandbox=%s (repo=%s)",
+        project_id,
+        sandbox.id,
+        project.repo,
+    )
+    return sandbox
+
+
+async def _reuse_if_live(
+    workspace_id: str,
+    user_id: str,
+    project: CodeProjectView,
+) -> WebSandboxView | None:
+    """Return the project's bound sandbox iff it's still live, else None.
+
+    "Live" == a ready row with a bound Daytona id. A missing bound id, an
+    unresolvable/foreign row (``NotFound``), or any non-``ready`` status all mean
+    the runtime is gone and the caller should reprovision.
+    """
+    if not project.current_sandbox_id:
+        return None
+    try:
+        sandbox = await websandbox_service.get_sandbox(
+            workspace_id, user_id, project.current_sandbox_id
+        )
+    except NotFound:
+        return None
+    if sandbox.status == _REUSABLE_STATUS and sandbox.sandbox_id:
+        return sandbox
+    return None
+
+
+__all__ = ["open_project"]

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -63,9 +63,7 @@ async def list_projects(
     """List the caller's projects, most-recently-opened first (the projects grid)."""
     workspace_id = _require_workspace(ctx)
     views = await codeproject_service.list_projects(workspace_id, ctx.user_id)
-    return CodeProjectListResponse(
-        items=[codeproject_service.view_to_wire(v) for v in views]
-    )
+    return CodeProjectListResponse(items=[codeproject_service.view_to_wire(v) for v in views])
 
 
 @router.post("/{project_id}/open", response_model=WebSandboxResponse)
@@ -75,9 +73,7 @@ async def open_project(
 ) -> WebSandboxResponse:
     """Open a project → a READY sandbox to connect to (reuse or provision fresh)."""
     workspace_id = _require_workspace(ctx)
-    sandbox = await codeproject_lifecycle.open_project(
-        workspace_id, ctx.user_id, project_id
-    )
+    sandbox = await codeproject_lifecycle.open_project(workspace_id, ctx.user_id, project_id)
     return websandbox_service.view_to_wire(sandbox)
 
 
@@ -89,9 +85,7 @@ async def rename_project(
 ) -> CodeProjectResponse:
     """Rename a project's display name (owner-scoped)."""
     workspace_id = _require_workspace(ctx)
-    view = await codeproject_service.rename_project(
-        workspace_id, ctx.user_id, project_id, body
-    )
+    view = await codeproject_service.rename_project(workspace_id, ctx.user_id, project_id, body)
     return codeproject_service.view_to_wire(view)
 
 

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -7,6 +7,9 @@
 # Three routes back the redesigned ``/code`` surface:
 #   POST   /codeproject          — create (or return) a durable project for a repo.
 #   GET    /codeproject          — the caller's projects grid (most-recent first).
+#   GET    /codeproject/{id}      — read ONE project without opening it. Side-effect
+#                                   free, so the client can pick a runtime
+#                                   (BrowserPod vs Daytona) without provisioning a VM.
 #   POST   /codeproject/{id}/open — resolve the project to a READY sandbox to connect
 #                                   to (reuse the bound one or provision a fresh one).
 #   PATCH  /codeproject/{id}      — rename a project's display name (owner-scoped).
@@ -66,6 +69,24 @@ async def list_projects(
     return CodeProjectListResponse(
         items=[codeproject_service.view_to_wire(v) for v in views]
     )
+
+
+@router.get("/{project_id}", response_model=CodeProjectResponse)
+async def get_project(
+    project_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> CodeProjectResponse:
+    """Read one project WITHOUT opening it (owner-scoped).
+
+    Deliberately side-effect free, unlike ``POST /{project_id}/open``: the client
+    needs the project's shape (repo, name) to decide which runtime to open it in
+    — the in-tab BrowserPod pod or a Daytona VM — and ``open`` cold-provisions a
+    Daytona VM as a side effect. Routing on ``open`` would therefore provision a
+    VM for every project even when it is about to run entirely in the browser.
+    """
+    workspace_id = _require_workspace(ctx)
+    view = await codeproject_service.get_project(workspace_id, ctx.user_id, project_id)
+    return codeproject_service.view_to_wire(view)
 
 
 @router.post("/{project_id}/open", response_model=WebSandboxResponse)

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -1,0 +1,78 @@
+# router.py — Thin FastAPI adapter for the Code Mode durable-project registry (CM-2a).
+# Created 2026-07-16 (feat/code-mode): workspace+user scoped /api/v1/codeproject.
+# Tenancy comes from the RequestContext (never the body or query), the service /
+# lifecycle do the work, and CloudError -> JSON is handled by _core.http — this
+# router never raises HTTPException.
+#
+# Three routes back the redesigned ``/code`` surface:
+#   POST /codeproject          — create (or return) a durable project for a repo.
+#   GET  /codeproject          — the caller's projects grid (most-recent first).
+#   POST /codeproject/{id}/open — resolve the project to a READY sandbox to connect
+#                                 to (reuse the bound one or provision a fresh one).
+# Like the WebSandbox router, endpoints are license-gated + context-authenticated;
+# the tenancy/owner filtering in the service is the security boundary.
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud.codeproject import lifecycle as codeproject_lifecycle
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.codeproject.dto import (
+    CodeProjectListResponse,
+    CodeProjectResponse,
+    CreateProjectRequest,
+)
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.dto import WebSandboxResponse
+
+router = APIRouter(
+    prefix="/codeproject",
+    tags=["CodeProject"],
+    dependencies=[Depends(require_license)],
+)
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    """A workspace-scoped route needs an active workspace; fail closed if absent."""
+    if not ctx.workspace_id:
+        raise Forbidden("codeproject.no_workspace", "No active workspace")
+    return ctx.workspace_id
+
+
+@router.post("", response_model=CodeProjectResponse)
+async def create_project(
+    body: CreateProjectRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> CodeProjectResponse:
+    """Create (or return) the durable project for a repo. Idempotent per repo."""
+    workspace_id = _require_workspace(ctx)
+    view = await codeproject_service.create_project(workspace_id, ctx.user_id, body)
+    return codeproject_service.view_to_wire(view)
+
+
+@router.get("", response_model=CodeProjectListResponse)
+async def list_projects(
+    ctx: RequestContext = Depends(request_context),
+) -> CodeProjectListResponse:
+    """List the caller's projects, most-recently-opened first (the projects grid)."""
+    workspace_id = _require_workspace(ctx)
+    views = await codeproject_service.list_projects(workspace_id, ctx.user_id)
+    return CodeProjectListResponse(
+        items=[codeproject_service.view_to_wire(v) for v in views]
+    )
+
+
+@router.post("/{project_id}/open", response_model=WebSandboxResponse)
+async def open_project(
+    project_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    """Open a project → a READY sandbox to connect to (reuse or provision fresh)."""
+    workspace_id = _require_workspace(ctx)
+    sandbox = await codeproject_lifecycle.open_project(
+        workspace_id, ctx.user_id, project_id
+    )
+    return websandbox_service.view_to_wire(sandbox)

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -5,15 +5,17 @@
 # router never raises HTTPException.
 #
 # Three routes back the redesigned ``/code`` surface:
-#   POST /codeproject          — create (or return) a durable project for a repo.
-#   GET  /codeproject          — the caller's projects grid (most-recent first).
-#   POST /codeproject/{id}/open — resolve the project to a READY sandbox to connect
-#                                 to (reuse the bound one or provision a fresh one).
+#   POST   /codeproject          — create (or return) a durable project for a repo.
+#   GET    /codeproject          — the caller's projects grid (most-recent first).
+#   POST   /codeproject/{id}/open — resolve the project to a READY sandbox to connect
+#                                   to (reuse the bound one or provision a fresh one).
+#   PATCH  /codeproject/{id}      — rename a project's display name (owner-scoped).
+#   DELETE /codeproject/{id}      — delete a project + tear down its bound VM.
 # Like the WebSandbox router, endpoints are license-gated + context-authenticated;
 # the tenancy/owner filtering in the service is the security boundary.
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
@@ -23,6 +25,7 @@ from pocketpaw_ee.cloud.codeproject.dto import (
     CodeProjectListResponse,
     CodeProjectResponse,
     CreateProjectRequest,
+    RenameProjectRequest,
 )
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
@@ -76,3 +79,28 @@ async def open_project(
         workspace_id, ctx.user_id, project_id
     )
     return websandbox_service.view_to_wire(sandbox)
+
+
+@router.patch("/{project_id}", response_model=CodeProjectResponse)
+async def rename_project(
+    project_id: str,
+    body: RenameProjectRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> CodeProjectResponse:
+    """Rename a project's display name (owner-scoped)."""
+    workspace_id = _require_workspace(ctx)
+    view = await codeproject_service.rename_project(
+        workspace_id, ctx.user_id, project_id, body
+    )
+    return codeproject_service.view_to_wire(view)
+
+
+@router.delete("/{project_id}", status_code=204)
+async def delete_project(
+    project_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> Response:
+    """Delete a project and tear down its bound sandbox VM (owner-scoped)."""
+    workspace_id = _require_workspace(ctx)
+    await codeproject_lifecycle.delete_project(workspace_id, ctx.user_id, project_id)
+    return Response(status_code=204)

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -1,0 +1,225 @@
+# service.py — Code Mode durable-project registry business logic (CM-2a).
+# Created 2026-07-16 (feat/code-mode): the DURABLE half of Code Mode's two-
+# lifecycle model. This module IS the repository (ee/cloud Rule 1) and the ONLY
+# module allowed to import the CodeProject Beanie doc (Rule 2). Every read carries
+# a tenant + owner filter (Rule 7); every mutation validates at entry (Rule 6) and
+# emits an event or is marked ``# no-event:`` (Rule 9). Errors are CloudError
+# subclasses, never HTTPException (Rule 10).
+#
+# The project is the deep-linkable, reap-surviving identity behind ``/code/<id>``;
+# the ephemeral Daytona sandbox (a WebSandbox row) is bound via
+# ``current_sandbox_id`` and resolved lazily by ``codeproject/lifecycle.open_project``
+# (reuse the bound row if it's live, else provision a fresh one and rebind). The
+# orchestration lives in lifecycle.py so this module stays the sole doc writer.
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import CodeProjectCreated, CodeProjectOpened
+from pocketpaw_ee.cloud.codeproject.domain import CodeProjectId, CodeProjectView
+from pocketpaw_ee.cloud.codeproject.dto import CodeProjectResponse, CreateProjectRequest
+from pocketpaw_ee.cloud.models.code_project import CodeProject as _CodeProjectDoc
+
+logger = logging.getLogger(__name__)
+
+
+def _short_name(repo: str) -> str:
+    """Derive a friendly default display name from a repo URL / "owner/repo".
+
+    Strips a trailing ``.git`` and any path, leaving the last path segment (the
+    repo's short name). Falls back to the raw value if there's nothing to strip.
+    """
+    trimmed = repo.strip().rstrip("/")
+    if trimmed.endswith(".git"):
+        trimmed = trimmed[: -len(".git")]
+    tail = trimmed.rsplit("/", 1)[-1]
+    return tail or trimmed
+
+
+def _doc_to_view(doc: _CodeProjectDoc) -> CodeProjectView:
+    """Map a persisted, tenant-checked row to its read model."""
+    return CodeProjectView(
+        id=CodeProjectId(str(doc.id)),
+        workspace_id=doc.workspace_id,
+        user_id=doc.user_id,
+        name=doc.name,
+        provider=doc.provider,
+        repo=doc.repo,
+        created_at=doc.created_at,
+        updated_at=doc.updated_at,
+        snapshot_file_id=doc.snapshot_file_id,
+        current_sandbox_id=doc.current_sandbox_id,
+        last_opened_at=doc.last_opened_at,
+    )
+
+
+def view_to_wire(view: CodeProjectView) -> CodeProjectResponse:
+    """Map a view to the camelCase wire response (Rule 8 — mapping lives here)."""
+    return CodeProjectResponse(
+        id=view.id,
+        workspaceId=view.workspace_id,
+        userId=view.user_id,
+        name=view.name,
+        provider=view.provider,
+        repo=view.repo,
+        snapshotFileId=view.snapshot_file_id,
+        currentSandboxId=view.current_sandbox_id,
+        lastOpenedAt=view.last_opened_at.isoformat() if view.last_opened_at else None,
+        createdAt=view.created_at.isoformat(),
+        updatedAt=view.updated_at.isoformat(),
+    )
+
+
+async def create_project(
+    workspace_id: str,
+    user_id: str,
+    body: CreateProjectRequest | dict,
+) -> CodeProjectView:
+    """Register (or return) the durable project for a (workspace, user, provider, repo).
+
+    Idempotent on the registry key: a second create for the same repo returns the
+    EXISTING project unchanged rather than minting a duplicate — a returning user
+    lands back on the same ``/code/<id>``. Only an actual insert emits
+    ``CodeProjectCreated`` (an idempotent hit is not a mutation).
+    """
+    body = CreateProjectRequest.model_validate(body)
+
+    existing = await _CodeProjectDoc.find_one(
+        {  # Rule 7 tenant + owner filter
+            "workspace_id": workspace_id,
+            "user_id": user_id,
+            "provider": body.provider,
+            "repo": body.repo,
+        }
+    )
+    if existing is not None:
+        # no-event: idempotent hit — nothing was written, so nothing to announce.
+        return _doc_to_view(existing)
+
+    doc = _CodeProjectDoc(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=body.name or _short_name(body.repo),
+        provider=body.provider,
+        repo=body.repo,
+    )
+    await doc.insert()
+
+    await emit(
+        CodeProjectCreated(
+            data={
+                "id": str(doc.id),
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "repo": doc.repo,
+                "provider": doc.provider,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
+async def list_projects(workspace_id: str, user_id: str) -> list[CodeProjectView]:
+    """List every project owned by the caller, most-recently-touched first.
+
+    Tenant-filtered by ``workspace_id`` AND owner-filtered by ``user_id`` so one
+    user never sees another's projects even within a shared workspace. Sorted by
+    ``updated_at`` desc (bumped on every open) — a mongomock-safe find + sort, no
+    aggregate.
+    """
+    docs = (
+        await _CodeProjectDoc.find(
+            {"workspace_id": workspace_id, "user_id": user_id}  # Rule 7 tenant filter
+        )
+        .sort([("updated_at", -1)])
+        .to_list()
+    )
+    return [_doc_to_view(d) for d in docs]
+
+
+async def get_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+) -> CodeProjectView:
+    """Read one project by its registry id, tenant- and owner-scoped.
+
+    Raises ``NotFound`` when no row matches the caller's workspace + user — a row
+    owned by another tenant is indistinguishable from a missing one.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    return _doc_to_view(doc)
+
+
+async def bind_current_sandbox(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    sandbox_row_id: str,
+) -> CodeProjectView:
+    """Bind the project to its CURRENT ephemeral sandbox and stamp last-opened.
+
+    Tenant- and owner-scoped: a caller can only bind a sandbox onto a project they
+    own. ``sandbox_row_id`` is a WebSandbox registry id.
+    ``codeproject/lifecycle.open_project`` calls this after resolving (reusing or
+    provisioning) the sandbox, so the durable project always points at the latest
+    runtime. Emits ``CodeProjectOpened`` — the "project now has a live sandbox"
+    transition a projects-grid fan-out reacts to.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+
+    now = datetime.now(UTC)
+    doc.current_sandbox_id = sandbox_row_id
+    doc.last_opened_at = now
+    doc.updated_at = now
+    await doc.save()
+
+    await emit(
+        CodeProjectOpened(
+            data={
+                "id": str(doc.id),
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "repo": doc.repo,
+                "sandbox_id": sandbox_row_id,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
+async def _read_owned(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+) -> _CodeProjectDoc | None:
+    """Tenant- + owner-scoped fetch by registry id. Returns None if not owned.
+
+    An unparseable ``project_id`` yields None (treated as not-found) rather than
+    raising, so a malformed id can't leak a distinct error shape.
+    """
+    from beanie import PydanticObjectId
+
+    try:
+        oid = PydanticObjectId(project_id)
+    except Exception:  # noqa: BLE001 — a bad id is simply "no such owned row"
+        return None
+    return await _CodeProjectDoc.find_one(
+        {"_id": oid, "workspace_id": workspace_id, "user_id": user_id}  # Rule 7
+    )
+
+
+__all__ = [
+    "bind_current_sandbox",
+    "create_project",
+    "get_project",
+    "list_projects",
+    "view_to_wire",
+]

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -18,9 +18,18 @@ from datetime import UTC, datetime
 
 from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud._core.realtime.emit import emit
-from pocketpaw_ee.cloud._core.realtime.events import CodeProjectCreated, CodeProjectOpened
+from pocketpaw_ee.cloud._core.realtime.events import (
+    CodeProjectCreated,
+    CodeProjectDeleted,
+    CodeProjectOpened,
+    CodeProjectRenamed,
+)
 from pocketpaw_ee.cloud.codeproject.domain import CodeProjectId, CodeProjectView
-from pocketpaw_ee.cloud.codeproject.dto import CodeProjectResponse, CreateProjectRequest
+from pocketpaw_ee.cloud.codeproject.dto import (
+    CodeProjectResponse,
+    CreateProjectRequest,
+    RenameProjectRequest,
+)
 from pocketpaw_ee.cloud.models.code_project import CodeProject as _CodeProjectDoc
 
 logger = logging.getLogger(__name__)
@@ -156,6 +165,79 @@ async def get_project(
     return _doc_to_view(doc)
 
 
+async def rename_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    body: RenameProjectRequest | dict,
+) -> CodeProjectView:
+    """Rename a project's display name, tenant- and owner-scoped.
+
+    Validates + trims the new name (Rule 6). Raises ``NotFound`` for a row the
+    caller doesn't own. A no-op rename (same name) still returns the view but does
+    not emit. Emits ``CodeProjectRenamed`` on an actual change (Rule 9).
+    """
+    body = RenameProjectRequest.model_validate(body)
+    new_name = body.name.strip()
+
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+
+    if doc.name == new_name:
+        # no-event: nothing changed.
+        return _doc_to_view(doc)
+
+    doc.name = new_name
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+
+    await emit(
+        CodeProjectRenamed(
+            data={
+                "id": str(doc.id),
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "name": new_name,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
+async def delete_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+) -> CodeProjectView:
+    """Delete a project row, tenant- and owner-scoped. Returns the deleted view.
+
+    Only removes the durable CodeProject doc — tearing down the bound ephemeral
+    sandbox VM is the caller's job (``codeproject/lifecycle.delete_project``), which
+    has the Daytona client; this module stays the sole doc writer. Raises
+    ``NotFound`` for a row the caller doesn't own. Emits ``CodeProjectDeleted``
+    (Rule 9) so a projects-grid fan-out can drop the card.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+
+    view = _doc_to_view(doc)
+    await doc.delete()
+
+    await emit(
+        CodeProjectDeleted(
+            data={
+                "id": view.id,
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "repo": view.repo,
+            }
+        )
+    )
+    return view
+
+
 async def bind_current_sandbox(
     workspace_id: str,
     user_id: str,
@@ -219,7 +301,9 @@ async def _read_owned(
 __all__ = [
     "bind_current_sandbox",
     "create_project",
+    "delete_project",
     "get_project",
     "list_projects",
+    "rename_project",
     "view_to_wire",
 ]

--- a/ee/pocketpaw_ee/cloud/daytona/client.py
+++ b/ee/pocketpaw_ee/cloud/daytona/client.py
@@ -381,6 +381,18 @@ class DaytonaClient:
         fs = await self.get_fs(sandbox_id)
         await fs.delete_file(path, recursive=recursive)
 
+    async def move_file(self, sandbox_id: str, src: str, dst: str) -> None:
+        """Move or rename a file/dir in the sandbox (rename == move).
+
+        Delegates to the SDK filesystem ``move_files(source, destination)``. The
+        parent directory of *dst* must already exist — inside the Web Cursor jail
+        the destination's parent is the project dir (or an existing subdir), so a
+        sibling rename always satisfies that. *src* and *dst* are absolute in-VM
+        paths already jailed by the caller.
+        """
+        fs = await self.get_fs(sandbox_id)
+        await fs.move_files(src, dst)
+
     async def get_work_dir(self, sandbox_id: str) -> str:
         """Get the sandbox's work directory path."""
         sb = await self.get_sandbox_instance(sandbox_id)

--- a/ee/pocketpaw_ee/cloud/daytona/client.py
+++ b/ee/pocketpaw_ee/cloud/daytona/client.py
@@ -161,6 +161,8 @@ class DaytonaClient:
         memory: int = 4,
         disk: int = 10,
         auto_stop_interval: int = 3600,
+        auto_archive_interval: int | None = None,
+        auto_delete_interval: int | None = None,
     ) -> SandboxInfo:
         """Create a new sandbox using the SDK.
 
@@ -183,7 +185,14 @@ class DaytonaClient:
             cpu: Number of CPUs.
             memory: Memory in GB.
             disk: Disk size in GB.
-            auto_stop_interval: Seconds of inactivity before auto-stop.
+            auto_stop_interval: MINUTES of inactivity before the VM auto-stops.
+                (The SDK counts these in minutes, NOT seconds — the SDK's own
+                3600 default is 60 HOURS, a latent trap. 0 disables auto-stop.)
+            auto_archive_interval: MINUTES after a stop before the VM is
+                auto-archived. ``None`` leaves the SDK default in place.
+            auto_delete_interval: MINUTES after a stop before the VM is
+                auto-deleted (``0`` = delete immediately on stop, ``-1`` =
+                never). ``None`` leaves the SDK default in place.
         """
         daytona = await self._ensure_daytona()
 
@@ -204,12 +213,20 @@ class DaytonaClient:
             disk,
         )
 
-        params = CreateSandboxFromImageParams(
-            name=name,
-            image=resolved_image,
-            resources=Resources(cpu=cpu, memory=memory, disk=disk),
-            auto_stop_interval=auto_stop_interval,
-        )
+        create_kwargs: dict[str, Any] = {
+            "name": name,
+            "image": resolved_image,
+            "resources": Resources(cpu=cpu, memory=memory, disk=disk),
+            "auto_stop_interval": auto_stop_interval,
+        }
+        # Only set the archive/delete lifecycle knobs when a caller opts in — a
+        # None leaves the SDK's own default in place (so existing callers keep
+        # their behaviour; the Web Cursor path passes explicit values).
+        if auto_archive_interval is not None:
+            create_kwargs["auto_archive_interval"] = auto_archive_interval
+        if auto_delete_interval is not None:
+            create_kwargs["auto_delete_interval"] = auto_delete_interval
+        params = CreateSandboxFromImageParams(**create_kwargs)
         if language:
             params.language = language
 

--- a/ee/pocketpaw_ee/cloud/daytona/context.py
+++ b/ee/pocketpaw_ee/cloud/daytona/context.py
@@ -7,6 +7,8 @@ active project subdirectory (when a ``project_name`` is available via the
 Returns ``None`` when no sandbox is found — the caller falls back to local FS.
 
 Updated: 2026-07-10 — workspace-level VM; legacy per-project sandbox removed.
+Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — the store's workspace-VM
+    accessors are now async + DB-backed; ``await`` the two lookups here.
 """
 
 from __future__ import annotations
@@ -135,7 +137,7 @@ async def resolve_daytona_context(
         get_workspace_vm_sandbox_id,
     )
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
     if sandbox_id:
         from pocketpaw_ee.cloud.daytona.client import get_daytona_client
 
@@ -154,7 +156,7 @@ async def resolve_daytona_context(
             )
             return None
 
-        config = get_workspace_vm_config(workspace_id)
+        config = await get_workspace_vm_config(workspace_id)
         workspace_root = config.get("root_dir", "/workspace")
 
         if project_name:

--- a/ee/pocketpaw_ee/cloud/daytona/router.py
+++ b/ee/pocketpaw_ee/cloud/daytona/router.py
@@ -17,6 +17,9 @@ Mounted at ``/api/v1/``. Endpoints:
   PATCH  /cloud/projects/{name}/vm/files/rename            — Rename in project in VM
 
 Created: 2026-06-24.  Updated: 2026-07-10 — workspace VM replaces per-project sandbox.
+Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — the store's workspace-VM
+    accessors are now async + Mongo-backed (``workspace_vms`` collection); every
+    call site here ``await``s them.
 """
 
 from __future__ import annotations
@@ -243,8 +246,8 @@ async def get_workspace_vm(
         set_workspace_vm,
     )
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
-    config = get_workspace_vm_config(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
+    config = await get_workspace_vm_config(workspace_id)
 
     if sandbox_id:
         # VM already exists — return status.
@@ -265,7 +268,7 @@ async def get_workspace_vm(
             # Sandbox might have been deleted externally — clean up and re-provision.
             from pocketpaw_ee.cloud.daytona.store import remove_workspace_vm as _rm_ws_vm
 
-            _rm_ws_vm(workspace_id)
+            await _rm_ws_vm(workspace_id)
             sandbox_id = None
 
     # No VM exists or it was deleted — auto-provision.
@@ -293,7 +296,7 @@ async def get_workspace_vm(
             disk=disk,
             auto_stop_interval=auto_stop,
         )
-        set_workspace_vm(workspace_id, info.id, sandbox_name, config)
+        await set_workspace_vm(workspace_id, info.id, sandbox_name, config)
 
         # Create the workspace root directory inside the VM.
         root_dir = config.get("root_dir", "/workspace")
@@ -355,13 +358,13 @@ async def provision_workspace_vm(
     client = await _require_daytona()
 
     # Destroy existing VM if any.
-    existing_id = get_workspace_vm_sandbox_id(workspace_id)
+    existing_id = await get_workspace_vm_sandbox_id(workspace_id)
     if existing_id:
         try:
             await client.delete_sandbox(existing_id)
         except Exception as exc:
             logger.warning("Failed to delete existing workspace VM %s: %s", existing_id, exc)
-        remove_workspace_vm(workspace_id)
+        await remove_workspace_vm(workspace_id)
 
     config = {
         "cpu": req.cpu,
@@ -377,7 +380,7 @@ async def provision_workspace_vm(
         memory=req.memory,
         disk=req.disk,
     )
-    set_workspace_vm(workspace_id, info.id, sandbox_name, config)
+    await set_workspace_vm(workspace_id, info.id, sandbox_name, config)
 
     asyncio.create_task(_ensure_workspace_root(client, info.id, req.root_dir))
 
@@ -402,7 +405,7 @@ async def get_workspace_vm_config(
     workspace_id = _resolve_workspace_id(http_request)
     from pocketpaw_ee.cloud.daytona.store import get_workspace_vm_config
 
-    config = get_workspace_vm_config(workspace_id)
+    config = await get_workspace_vm_config(workspace_id)
     return {"ok": True, "config": config}
 
 
@@ -434,9 +437,9 @@ async def update_workspace_vm_config(
 
     updates = req.model_dump(exclude_none=True)
     if updates:
-        update_workspace_vm_config(workspace_id, updates)
+        await update_workspace_vm_config(workspace_id, updates)
 
-    config = get_workspace_vm_config(workspace_id)
+    config = await get_workspace_vm_config(workspace_id)
     return {"ok": True, "config": config}
 
 
@@ -455,7 +458,7 @@ async def stop_workspace_vm(
 
     from pocketpaw_ee.cloud.daytona.store import get_workspace_vm_sandbox_id
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
     if not sandbox_id:
         return {"ok": True, "message": "No workspace VM to stop"}
 
@@ -484,7 +487,7 @@ async def delete_workspace_vm(
         remove_workspace_vm,
     )
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
     if not sandbox_id:
         return {"ok": True, "message": "No workspace VM to delete"}
 
@@ -494,7 +497,7 @@ async def delete_workspace_vm(
     except Exception as exc:
         logger.warning("Failed to delete workspace VM %s: %s", sandbox_id, exc)
 
-    remove_workspace_vm(workspace_id)
+    await remove_workspace_vm(workspace_id)
     return {"ok": True, "message": "Workspace VM deleted"}
 
 
@@ -507,7 +510,7 @@ async def get_workspace_vm_terminal(
 
     from pocketpaw_ee.cloud.daytona.store import get_workspace_vm_sandbox_id
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
     if not sandbox_id:
         raise HTTPException(status_code=404, detail="No workspace VM provisioned")
 
@@ -559,7 +562,7 @@ async def _require_workspace_vm(
         get_workspace_vm_sandbox_id,
     )
 
-    sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+    sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
     if not sandbox_id:
         raise HTTPException(
             status_code=404,
@@ -574,7 +577,7 @@ async def _require_workspace_vm(
             detail=f"VM is in state '{info.state}' — must be 'started' for file operations",
         )
 
-    config = get_workspace_vm_config(workspace_id)
+    config = await get_workspace_vm_config(workspace_id)
     workspace_root = config.get("root_dir", "/workspace")
     project_abs_path = f"{workspace_root}/{project_name}".replace("//", "/")
 

--- a/ee/pocketpaw_ee/cloud/daytona/store.py
+++ b/ee/pocketpaw_ee/cloud/daytona/store.py
@@ -2,7 +2,7 @@
 
 TWO layers of mapping:
 
-1. **Workspace-level VM** (NEW — primary).
+1. **Workspace-level VM** (PRIMARY — now DB-backed).
    Maps ``workspace_id`` → a single Daytona sandbox shared by ALL projects
    in that workspace.  Projects live as subdirectories under a configurable
    workspace root (default ``/workspace``).
@@ -11,11 +11,20 @@ TWO layers of mapping:
    Maps ``projects/{workspace_id}/{user_id}/{project_name}/`` keys to
    Daytona sandbox IDs.  Deprecated in favour of the workspace-level VM.
 
-Both maps are persisted under ``~/.pocketpaw/`` so the mapping survives
-process restarts.
-
 Moved from inline helpers in router.py: 2026-07-01
 Updated: 2026-07-10 — added workspace-level VM mapping.
+Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — the workspace-level VM map
+    moved out of the local ``~/.pocketpaw/daytona_workspace_vm_map.json`` file
+    and into MongoDB (the ``workspace_vms`` collection, ``WorkspaceVm`` doc).
+    A local-first JSON artifact does not belong in multi-tenant cloud: reads
+    must be tenant-scoped and survive across processes/replicas. The six
+    workspace-VM functions are now ``async`` and read/write the collection;
+    every caller ``await``s them. The LEGACY per-project map below is still
+    JSON-file-backed and unchanged — deprecated, migrate on touch.
+
+store.py owns the ``workspace_vms`` collection: the ``WorkspaceVm`` doc class is
+imported ONLY inside this module (ee/cloud Rule 2 spirit — store.py is a
+persistence helper, not a full 4-file entity).
 """
 
 from __future__ import annotations
@@ -27,17 +36,21 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# In-memory cache + disk paths
+# In-memory cache + disk paths (LEGACY per-project map only)
 # ---------------------------------------------------------------------------
 
 _workspace_map: dict[str, dict] = {}
 _MAP_PATH = Path.home() / ".pocketpaw" / "daytona_workspace_map.json"
 
-# Workspace-level VM map
-_WORKSPACE_VM_MAP: dict[str, dict] = {}
-_WS_VM_MAP_PATH = Path.home() / ".pocketpaw" / "daytona_workspace_vm_map.json"
+# Legacy JSON path for the workspace-level VM map. No longer read/written by the
+# accessors (they are DB-backed now); retained only so the one-time
+# ``migrate_workspace_vm_map_to_db`` boot task in ``ee.cloud.shared.db`` can
+# import + import the captain's existing on-disk entries into Mongo.
+WS_VM_MAP_PATH = Path.home() / ".pocketpaw" / "daytona_workspace_vm_map.json"
 
 # Default VM configuration
+# TODO(bug): root_dir should be /home/daytona; auto_stop_interval is MINUTES not
+# 3600s. Changing these VALUES alters legacy VM behavior — out of scope here.
 _DEFAULT_VM_CONFIG: dict = {
     "cpu": 2,
     "memory": 4,  # GB
@@ -47,7 +60,12 @@ _DEFAULT_VM_CONFIG: dict = {
 }
 
 # ---------------------------------------------------------------------------
-# Per-project accessors (LEGACY — keep for backward compat)
+# Per-project accessors (LEGACY — DEPRECATED, still JSON-file-backed)
+#
+# These map ``projects/{workspace_id}/{user_id}/{project_name}/`` keys to
+# sandbox IDs in ``daytona_workspace_map.json``. Superseded by the DB-backed
+# workspace-level VM map below; kept only for backward compat. Migrate to the
+# workspace-level VM (or a DB collection of their own) on next touch.
 # ---------------------------------------------------------------------------
 
 
@@ -122,93 +140,122 @@ def list_all_mappings() -> dict[str, dict]:
 
 
 # ---------------------------------------------------------------------------
-# Workspace-level VM accessors (NEW — primary path)
+# Workspace-level VM accessors (PRIMARY — DB-backed, ``workspace_vms``)
+#
+# Each accessor is ``async`` and tenant-scoped by ``workspace``. store.py is the
+# sole importer of the ``WorkspaceVm`` doc class (imported locally inside each
+# function so a plain ``import ee.cloud.daytona.store`` never drags Beanie in).
 # ---------------------------------------------------------------------------
 
 
-def _load_ws_vm_map() -> dict[str, dict]:
-    """Load the workspace VM map from disk, caching in memory."""
-    global _WORKSPACE_VM_MAP
-    if _WORKSPACE_VM_MAP:
-        return _WORKSPACE_VM_MAP
-    try:
-        if _WS_VM_MAP_PATH.exists():
-            with open(_WS_VM_MAP_PATH) as f:
-                _WORKSPACE_VM_MAP = json.load(f)
-    except Exception as exc:
-        logger.warning("Failed to load workspace VM map: %s", exc)
-    return _WORKSPACE_VM_MAP
-
-
-def _save_ws_vm_map() -> None:
-    """Persist the workspace VM map to disk."""
-    global _WORKSPACE_VM_MAP
-    try:
-        _WS_VM_MAP_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with open(_WS_VM_MAP_PATH, "w") as f:
-            json.dump(_WORKSPACE_VM_MAP, f, indent=2)
-    except Exception as exc:
-        logger.warning("Failed to save workspace VM map: %s", exc)
-
-
-def get_workspace_vm_sandbox_id(workspace_id: str) -> str | None:
+async def get_workspace_vm_sandbox_id(workspace_id: str) -> str | None:
     """Get the sandbox ID for a workspace, or None."""
-    mapping = _load_ws_vm_map()
-    entry = mapping.get(workspace_id)
-    return entry.get("sandbox_id") if entry else None
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+    return doc.sandbox_id if doc else None
 
 
-def set_workspace_vm(
+async def set_workspace_vm(
     workspace_id: str,
     sandbox_id: str,
     sandbox_name: str,
     config: dict | None = None,
 ) -> None:
-    """Record the workspace VM sandbox mapping with optional config override."""
-    mapping = _load_ws_vm_map()
-    existing = mapping.get(workspace_id, {})
-    existing.update(
-        {
-            "sandbox_id": sandbox_id,
-            "sandbox_name": sandbox_name,
-        }
-    )
+    """Upsert the workspace VM sandbox mapping with optional config override."""
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+    if doc is None:
+        # Insert. Merge config over defaults when given, else seed defaults.
+        merged = {**_DEFAULT_VM_CONFIG, **config} if config else dict(_DEFAULT_VM_CONFIG)
+        doc = WorkspaceVm(
+            workspace=workspace_id,
+            sandbox_id=sandbox_id,
+            sandbox_name=sandbox_name,
+            config=merged,
+        )
+        await doc.insert()
+        return
+
+    # Update in place.
+    doc.sandbox_id = sandbox_id
+    doc.sandbox_name = sandbox_name
     if config:
-        existing["config"] = {**_DEFAULT_VM_CONFIG, **config}
-    elif "config" not in existing:
-        existing["config"] = dict(_DEFAULT_VM_CONFIG)
-    mapping[workspace_id] = existing
-    _save_ws_vm_map()
+        doc.config = {**_DEFAULT_VM_CONFIG, **config}
+    elif not doc.config:
+        doc.config = dict(_DEFAULT_VM_CONFIG)
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
 
 
-def remove_workspace_vm(workspace_id: str) -> None:
-    """Remove the workspace VM mapping."""
-    mapping = _load_ws_vm_map()
-    mapping.pop(workspace_id, None)
-    _save_ws_vm_map()
+async def remove_workspace_vm(workspace_id: str) -> None:
+    """Remove the workspace VM mapping (deletes the row)."""
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+    if doc is not None:
+        await doc.delete()
 
 
-def get_workspace_vm_config(workspace_id: str) -> dict:
-    """Return the VM config for a workspace, or defaults if not set."""
-    mapping = _load_ws_vm_map()
-    entry = mapping.get(workspace_id, {})
-    return {**_DEFAULT_VM_CONFIG, **entry.get("config", {})}
+async def get_workspace_vm_config(workspace_id: str) -> dict:
+    """Return the VM config for a workspace, merged over defaults."""
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+    stored = doc.config if doc else {}
+    return {**_DEFAULT_VM_CONFIG, **(stored or {})}
 
 
-def update_workspace_vm_config(workspace_id: str, config_updates: dict) -> None:
-    """Merge *config_updates* into the workspace VM config and persist."""
-    mapping = _load_ws_vm_map()
-    entry = mapping.get(workspace_id, {})
-    current_config = {**_DEFAULT_VM_CONFIG, **entry.get("config", {})}
+async def update_workspace_vm_config(workspace_id: str, config_updates: dict) -> None:
+    """Merge *config_updates* into the workspace VM config and persist.
+
+    Creates the row if the workspace has no VM record yet (config-only row —
+    ``sandbox_id``/``sandbox_name`` are empty until a VM is provisioned).
+    """
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+    if doc is None:
+        merged = {**_DEFAULT_VM_CONFIG, **config_updates}
+        doc = WorkspaceVm(
+            workspace=workspace_id,
+            sandbox_id="",
+            sandbox_name="",
+            config=merged,
+        )
+        await doc.insert()
+        return
+
+    current_config = {**_DEFAULT_VM_CONFIG, **(doc.config or {})}
     current_config.update(config_updates)
-    entry["config"] = current_config
-    mapping[workspace_id] = entry
-    _save_ws_vm_map()
+    doc.config = current_config
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
 
 
-def list_all_workspace_vms() -> dict[str, dict]:
-    """Return the full workspace VM map (read-only snapshot)."""
-    return dict(_load_ws_vm_map())
+async def list_all_workspace_vms() -> dict[str, dict]:
+    """Return the full workspace VM map (``workspace_id`` -> entry dict).
+
+    Global read across tenants — the map is a system-level registry consumed by
+    ops/admin surfaces, not a per-tenant read path.
+    """
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    # global-read: system-level VM registry (ops/admin), not a tenant read path.
+    docs = await WorkspaceVm.find_all().to_list()
+    return {
+        doc.workspace: {
+            "sandbox_id": doc.sandbox_id,
+            "sandbox_name": doc.sandbox_name,
+            "config": dict(doc.config or {}),
+        }
+        for doc in docs
+    }
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,11 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — added ``WorkspaceVm`` (the
+workspace→Daytona-VM mapping, moved out of the local
+``~/.pocketpaw/daytona_workspace_vm_map.json`` file into the ``workspace_vms``
+collection) to the imports, ``__all__``, and ``get_all_documents()`` so the
+collection is wired into ``init_beanie``. Only ``ee.cloud.daytona.store``
+imports the doc class directly.
 Updated: 2026-07-15 (WC-1, feat/websandbox-registry) — added ``WebSandbox``
 (the Web Cursor sandbox registry: the (workspace_id, user_id, repo) -> sandbox
 tenancy/auth oracle) to the imports, ``__all__``, and ``get_all_documents()`` so
@@ -188,6 +194,7 @@ from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
 from pocketpaw_ee.cloud.models.workspace_automation_config import WorkspaceAutomationConfig
 from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
+from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
 
 # Lazy import to avoid circular imports
 FileUpload: type = None  # type: ignore[assignment]
@@ -351,6 +358,7 @@ __all__ = [
     "WorkspaceJobDoc",
     "WorkspaceMembership",
     "WorkspaceSettings",
+    "WorkspaceVm",
 ]
 
 
@@ -472,6 +480,10 @@ def get_all_documents():
         # sandbox tenancy/auth oracle. Only ``ee.cloud.websandbox.service``
         # imports this doc directly (import-linter "WebSandbox" contract).
         WebSandbox,
+        # Workspace→Daytona-VM mapping (fix/workspace-vm-map-to-db) — moved out
+        # of the local daytona_workspace_vm_map.json file. One VM per workspace.
+        # Only ``ee.cloud.daytona.store`` imports this doc directly.
+        WorkspaceVm,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -126,6 +126,7 @@ from pocketpaw_ee.cloud.models.audit_webhook import AuditWebhook
 from pocketpaw_ee.cloud.models.auth_session import AuthSession
 from pocketpaw_ee.cloud.models.belt_workspace_config import BeltWorkspaceConfig
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+from pocketpaw_ee.cloud.models.code_project import CodeProject
 from pocketpaw_ee.cloud.models.comment import Comment, CommentAuthor, CommentTarget
 from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
 from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
@@ -283,6 +284,7 @@ __all__ = [
     "AuthSession",
     "BeltWorkspaceConfig",
     "ChatRunDoc",
+    "CodeProject",
     "Comment",
     "CommentAuthor",
     "CommentTarget",
@@ -484,6 +486,11 @@ def get_all_documents():
         # of the local daytona_workspace_vm_map.json file. One VM per workspace.
         # Only ``ee.cloud.daytona.store`` imports this doc directly.
         WorkspaceVm,
+        # Code Mode durable-project registry (CM-2a) — the (workspace, user,
+        # provider, repo) -> durable project that outlives any single ephemeral
+        # sandbox. Only ``ee.cloud.codeproject.service`` imports this doc directly
+        # (import-linter "CodeProject" contract).
+        CodeProject,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -126,6 +126,7 @@ from pocketpaw_ee.cloud.models.audit_webhook import AuditWebhook
 from pocketpaw_ee.cloud.models.auth_session import AuthSession
 from pocketpaw_ee.cloud.models.belt_workspace_config import BeltWorkspaceConfig
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+from pocketpaw_ee.cloud.models.code_connection import CodeConnection
 from pocketpaw_ee.cloud.models.code_project import CodeProject
 from pocketpaw_ee.cloud.models.comment import Comment, CommentAuthor, CommentTarget
 from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
@@ -284,6 +285,7 @@ __all__ = [
     "AuthSession",
     "BeltWorkspaceConfig",
     "ChatRunDoc",
+    "CodeConnection",
     "CodeProject",
     "Comment",
     "CommentAuthor",
@@ -491,6 +493,11 @@ def get_all_documents():
         # sandbox. Only ``ee.cloud.codeproject.service`` imports this doc directly
         # (import-linter "CodeProject" contract).
         CodeProject,
+        # Code Mode GitHub connection (CM-3) — the (workspace, user, provider,
+        # installation_id) binding that lets a user list + open private repos.
+        # Only ``ee.cloud.codeconnect.service`` imports this doc directly
+        # (import-linter "CodeConnection" contract).
+        CodeConnection,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,11 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-15 (WC-1, feat/websandbox-registry) — added ``WebSandbox``
+(the Web Cursor sandbox registry: the (workspace_id, user_id, repo) -> sandbox
+tenancy/auth oracle) to the imports, ``__all__``, and ``get_all_documents()`` so
+the ``web_sandboxes`` collection is wired into ``init_beanie``. Only
+``ee.cloud.websandbox.service`` imports the doc class directly (import-linter
+"WebSandbox" contract).
 Updated: 2026-07-08 (feat/external-alerting-delivery) — added
 ``NotificationDeliveryConfig`` (the per-workspace external-delivery config: Slack
 incoming-webhook + generic HTTPS webhook + enabled switch + per-kind routing) to
@@ -178,6 +184,7 @@ from pocketpaw_ee.cloud.models.task_event import TaskEvent
 from pocketpaw_ee.cloud.models.temporal_sweep_state import TemporalSweepStateDoc
 from pocketpaw_ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from pocketpaw_ee.cloud.models.vapid_keypair import VapidKeypair
+from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
 from pocketpaw_ee.cloud.models.workspace_automation_config import WorkspaceAutomationConfig
 from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
@@ -336,6 +343,7 @@ __all__ = [
     "TaskEvent",
     "TemporalSweepStateDoc",
     "User",
+    "WebSandbox",
     "Widget",
     "WidgetPosition",
     "Workspace",
@@ -460,6 +468,10 @@ def get_all_documents():
         sighting_doc,
         # Branch primitive — universal artifact version log (BP-1).
         artifact_version_doc,
+        # Web Cursor sandbox registry (WC-1) — the (workspace, user, repo) ->
+        # sandbox tenancy/auth oracle. Only ``ee.cloud.websandbox.service``
+        # imports this doc directly (import-linter "WebSandbox" contract).
+        WebSandbox,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/code_connection.py
+++ b/ee/pocketpaw_ee/cloud/models/code_connection.py
@@ -7,6 +7,11 @@
 # distinct installation id. The ``installation_id`` is the least-privilege pointer
 # the broker mints repo-scoped tokens from (githubapp.py); it is NEVER a token.
 #
+# Updated 2026-07-16 (connect-UX): added ``avatar_url`` alongside ``account_login``
+# so the connected-account chip can render the GitHub profile image + username.
+# Both are display-only, enriched from GitHub lazily (None until the callback or a
+# connections read backfills them).
+#
 # Only ``ee.cloud.codeconnect.service`` imports this doc class directly
 # (import-linter "CodeConnection" contract, same discipline as WebSandbox).
 
@@ -31,6 +36,9 @@ class CodeConnection(Document):
     # The GitHub account (user/org) the App was installed on, for display in the
     # picker. Optional — enriched from GitHub lazily; None until then.
     account_login: str | None = None
+    # The account's avatar URL, for the connected-account chip. Display-only,
+    # enriched lazily alongside ``account_login``; None until then.
+    avatar_url: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/ee/pocketpaw_ee/cloud/models/code_connection.py
+++ b/ee/pocketpaw_ee/cloud/models/code_connection.py
@@ -1,0 +1,53 @@
+# code_connection.py — CodeConnection document: a user's Code Mode GitHub App
+# install binding.
+# Created 2026-07-16 (CM-3, feat/code-mode): persists
+# ``(workspace_id, user_id, provider, installation_id)`` so a user who installed
+# the Code Mode GitHub App can list + open their PRIVATE repos. One row per
+# installation — a user may install the App on several accounts/orgs, each a
+# distinct installation id. The ``installation_id`` is the least-privilege pointer
+# the broker mints repo-scoped tokens from (githubapp.py); it is NEVER a token.
+#
+# Only ``ee.cloud.codeconnect.service`` imports this doc class directly
+# (import-linter "CodeConnection" contract, same discipline as WebSandbox).
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+from pymongo import IndexModel
+
+
+class CodeConnection(Document):
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    user_id: Indexed(str)  # type: ignore[valid-type]
+    # The auth provider this connection is for (github first; google + others
+    # planned — the picker + broker are provider-agnostic).
+    provider: str = "github"
+    # The GitHub App installation id — the least-privilege pointer the broker mints
+    # repo-scoped tokens from. A pointer, never a token.
+    installation_id: str
+    # The GitHub account (user/org) the App was installed on, for display in the
+    # picker. Optional — enriched from GitHub lazily; None until then.
+    account_login: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "code_connections"
+        indexes = [
+            # One row per (workspace, user, provider, installation) — the key.
+            IndexModel(
+                [
+                    ("workspace_id", 1),
+                    ("user_id", 1),
+                    ("provider", 1),
+                    ("installation_id", 1),
+                ],
+                unique=True,
+                name="ws_user_provider_installation_unique",
+            ),
+            # The per-user list read path (list_connections).
+            IndexModel([("workspace_id", 1), ("user_id", 1)]),
+        ]

--- a/ee/pocketpaw_ee/cloud/models/code_project.py
+++ b/ee/pocketpaw_ee/cloud/models/code_project.py
@@ -1,0 +1,64 @@
+"""CodeProject document — the durable project registry for Code Mode (CM-2a).
+
+Created 2026-07-16 (feat/code-mode): the DURABLE half of Code Mode's two-lifecycle
+model. A CodeProject outlives any single Daytona sandbox — the VM is ephemeral
+(reaped on idle) and its files are backed up to blob storage; the project persists
+the identity, the S3 snapshot pointer, and a nullable pointer to the CURRENT
+sandbox. Opening a project reuses its live sandbox or provisions a fresh one and
+restores the snapshot into it, so a user who returns after a long gap gets their
+work back instead of an empty machine.
+
+One row per (workspace_id, user_id, provider, repo). Only
+``ee.cloud.codeproject.service`` imports this doc class directly (import-linter
+"CodeProject" contract, same discipline as WebSandbox / AuditEvent).
+
+Relation to WebSandbox: WebSandbox stays the EPHEMERAL runtime row (Daytona VM +
+lifecycle); CodeProject is the durable owner and points at the current one via
+``current_sandbox_id`` (the WebSandbox row id), null when none is live.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+from pymongo import IndexModel
+
+
+class CodeProject(Document):
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    user_id: Indexed(str)  # type: ignore[valid-type]
+    # Display name (defaults to the repo's short name at creation).
+    name: str
+    # Which code host this project's repo lives on. Multi-provider ready — GitHub
+    # today, Google + others planned (see the RepoAuthProvider seam). Kept as a
+    # plain str (not an enum) so a new provider needs no migration.
+    provider: str = "github"
+    # The provider-native repo identifier (a public URL today; "owner/repo" once
+    # the GitHub App connect flow lands).
+    repo: str
+    # Durable blob-storage snapshot pointer (an EEUploadService FileRecord id).
+    # The project's files live HERE between sandboxes — this is why the project
+    # survives VM reaping. Null until the first backup.
+    snapshot_file_id: str | None = None
+    # The CURRENT ephemeral sandbox (a WebSandbox row id), or null when none is
+    # live (never opened, or the VM was reaped). ``open_project`` resolves this.
+    current_sandbox_id: str | None = None
+    # When the user last opened this project (for "recent projects" ordering).
+    last_opened_at: datetime | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "code_projects"
+        indexes = [
+            # One project per (workspace, user, provider, repo) — the registry key.
+            IndexModel(
+                [("workspace_id", 1), ("user_id", 1), ("provider", 1), ("repo", 1)],
+                unique=True,
+                name="ws_user_provider_repo_unique",
+            ),
+            # The per-user list read path (list_projects).
+            IndexModel([("workspace_id", 1), ("user_id", 1)]),
+        ]

--- a/ee/pocketpaw_ee/cloud/models/web_sandbox.py
+++ b/ee/pocketpaw_ee/cloud/models/web_sandbox.py
@@ -1,0 +1,54 @@
+"""WebSandbox document — the Sandbox Registry for the Web Cursor browser IDE.
+
+Created 2026-07-15 (WC-1, feat/websandbox-registry): the tenancy/auth oracle
+that maps ``(workspace_id, user_id, repo) -> sandbox_id + lifecycle state +
+installation pointer``. One row per ``(workspace_id, user_id, repo)`` (enforced
+by a unique compound index AND app-level upsert in the service). This is the
+security foundation every later Web Cursor slice authorizes against.
+
+Only ``ee.cloud.websandbox.service`` imports this doc class directly
+(import-linter "WebSandbox" contract, same discipline as AuditEvent).
+
+The ``installation_id`` is a plain optional str here — a pointer to a future
+GitHub App installation. WC-6 encrypts it at rest; until then it is stored in
+the clear (never a token, only an installation identifier).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+from pymongo import IndexModel
+
+
+class WebSandbox(Document):
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    user_id: Indexed(str)  # type: ignore[valid-type]
+    # A repo identifier / URL the sandbox is opened against.
+    repo: str
+    # The Daytona sandbox id — null until the VM is cold-provisioned (WC-2).
+    sandbox_id: str | None = None
+    # Lifecycle state: pending | opening | ready | stopped | reaped.
+    status: str = "pending"
+    # Pointer to a future GitHub App installation (WC-6 encrypts this at rest;
+    # plain optional str for now — an installation id, never a token).
+    installation_id: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "web_sandboxes"
+        indexes = [
+            # One sandbox per (workspace, user, repo) — the registry key.
+            IndexModel(
+                [("workspace_id", 1), ("user_id", 1), ("repo", 1)],
+                unique=True,
+                name="ws_user_repo_unique",
+            ),
+            # The per-user list read path (list_sandboxes).
+            IndexModel([("workspace_id", 1), ("user_id", 1)]),
+            # The authorize-by-Daytona-id read path (authorize_sandbox).
+            IndexModel([("workspace_id", 1), ("sandbox_id", 1)]),
+        ]

--- a/ee/pocketpaw_ee/cloud/models/web_sandbox.py
+++ b/ee/pocketpaw_ee/cloud/models/web_sandbox.py
@@ -25,6 +25,15 @@ auto-created ``paw/edit-<hex>`` feature branch the repo is checked out onto in
 the VM at open time, so AI edits never touch the checked-out default branch.
 Null until the provisioner creates it (right after the clone). No new index
 needed — it's read only via the owner-scoped registry row.
+
+Changed 2026-07-16 (CM-2a′ write-through, feat/code-mode): added ``overlay`` —
+the incremental durability tier. Every editor save (``file.write``) mirrors the
+file to the tenant's blob storage and records ``relpath -> FileRecord id`` here,
+so a crash / idle-out between full snapshots doesn't lose edits: ``open_project``
+replays the overlay onto the fresh clone. ``set_snapshot`` CLEARS it — a full
+workspace snapshot supersedes the incremental overlay (and clearing on snapshot
+is what avoids replaying a stale write over a since-deleted file). No new index
+needed — read only via the owner-scoped registry row.
 """
 
 from __future__ import annotations
@@ -55,6 +64,10 @@ class WebSandbox(Document):
     # The auto-created ``paw/edit-<hex>`` feature branch checked out in the VM at
     # open time (WC-5a). Null until the provisioner creates it after the clone.
     branch: str | None = None
+    # The write-through durability overlay (CM-2a′): ``relpath -> FileRecord id``
+    # for each editor-saved file mirrored to blob storage since the last full
+    # snapshot. Replayed onto a fresh clone on reopen; cleared by ``set_snapshot``.
+    overlay: dict[str, str] = Field(default_factory=dict)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/ee/pocketpaw_ee/cloud/models/web_sandbox.py
+++ b/ee/pocketpaw_ee/cloud/models/web_sandbox.py
@@ -19,6 +19,12 @@ in blob storage (an ``EEUploadService`` FileRecord id). The VM is scratch and
 gets reaped; this durable pointer lets a user's uncommitted work + workspace
 state be restored into a fresh VM. Null until the first snapshot is taken. No
 new index needed — it's read only via the owner-scoped registry row.
+
+Changed 2026-07-15 (WC-5a, feat/websandbox-edit-agent): added ``branch`` — the
+auto-created ``paw/edit-<hex>`` feature branch the repo is checked out onto in
+the VM at open time, so AI edits never touch the checked-out default branch.
+Null until the provisioner creates it (right after the clone). No new index
+needed — it's read only via the owner-scoped registry row.
 """
 
 from __future__ import annotations
@@ -46,6 +52,9 @@ class WebSandbox(Document):
     # storage (an EEUploadService FileRecord id). Null until the first snapshot;
     # set by ``service.set_snapshot`` from the WC-S3 durability module.
     snapshot_file_id: str | None = None
+    # The auto-created ``paw/edit-<hex>`` feature branch checked out in the VM at
+    # open time (WC-5a). Null until the provisioner creates it after the clone.
+    branch: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/ee/pocketpaw_ee/cloud/models/web_sandbox.py
+++ b/ee/pocketpaw_ee/cloud/models/web_sandbox.py
@@ -12,6 +12,13 @@ Only ``ee.cloud.websandbox.service`` imports this doc class directly
 The ``installation_id`` is a plain optional str here — a pointer to a future
 GitHub App installation. WC-6 encrypts it at rest; until then it is stored in
 the clear (never a token, only an installation identifier).
+
+Changed 2026-07-15 (WC-S3, feat/websandbox-s3-durability): added
+``snapshot_file_id`` — a pointer to the tenant's most recent workspace snapshot
+in blob storage (an ``EEUploadService`` FileRecord id). The VM is scratch and
+gets reaped; this durable pointer lets a user's uncommitted work + workspace
+state be restored into a fresh VM. Null until the first snapshot is taken. No
+new index needed — it's read only via the owner-scoped registry row.
 """
 
 from __future__ import annotations
@@ -35,6 +42,10 @@ class WebSandbox(Document):
     # Pointer to a future GitHub App installation (WC-6 encrypts this at rest;
     # plain optional str for now — an installation id, never a token).
     installation_id: str | None = None
+    # Pointer to the latest durable workspace snapshot in the tenant's blob
+    # storage (an EEUploadService FileRecord id). Null until the first snapshot;
+    # set by ``service.set_snapshot`` from the WC-S3 durability module.
+    snapshot_file_id: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/ee/pocketpaw_ee/cloud/models/workspace_vm.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace_vm.py
@@ -1,0 +1,39 @@
+"""WorkspaceVm document — the workspace→Daytona-VM mapping (DB-backed).
+
+Created 2026-07-15 (fix/workspace-vm-map-to-db): moves the workspace-level VM
+mapping out of a local JSON file (``~/.pocketpaw/daytona_workspace_vm_map.json``,
+via ``ee.cloud.daytona.store``) and into MongoDB. A local-first JSON artifact
+does not belong in multi-tenant cloud — every read must be tenant-scoped and
+survive across processes/replicas. One VM per workspace (unique index on
+``workspace``).
+
+Only ``ee.cloud.daytona.store`` imports this doc class directly — store.py is
+the module that owns this collection (ee/cloud Rule 2 spirit; store.py is a
+persistence helper, not a full 4-file entity). ``config`` mirrors the legacy
+JSON shape (cpu/memory/disk/root_dir/auto_stop_interval) so the one-time
+migration can copy entries across without transformation.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+from pymongo import IndexModel
+
+
+class WorkspaceVm(Document):
+    workspace: Indexed(str)  # type: ignore[valid-type]  # unique — one VM per workspace
+    sandbox_id: str
+    sandbox_name: str
+    config: dict = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "workspace_vms"
+        indexes = [
+            # One VM per workspace — the registry key.
+            IndexModel([("workspace", 1)], unique=True, name="workspace_unique"),
+        ]

--- a/ee/pocketpaw_ee/cloud/shared/db.py
+++ b/ee/pocketpaw_ee/cloud/shared/db.py
@@ -1,5 +1,14 @@
 """MongoDB connection and Beanie ODM initialization.
 
+2026-07-15 (fix/workspace-vm-map-to-db): added ``migrate_workspace_vm_map_to_db``
+— a best-effort, one-time boot task that imports the captain's existing
+workspace→VM entries from the legacy local JSON file
+(``~/.pocketpaw/daytona_workspace_vm_map.json``) into the new ``workspace_vms``
+Mongo collection, then renames the file to ``.migrated`` so it never re-imports.
+Skips any workspace whose DB row already exists (never clobbers newer DB state),
+wraps everything in try/except so a migration hiccup can't block boot, and is
+called once from ``init_cloud_db`` after Beanie is initialized.
+
 2026-06-26 (ART-4): added ``is_multi_tenant_cloud()`` — the single, named home
 for the established "this process is serving tenants" signal
 (``get_client() is not None``, set exactly when ``init_cloud_db`` ran). The
@@ -82,6 +91,74 @@ async def _drop_legacy_invite_token_index(db) -> None:  # type: ignore[no-untype
         logger.exception("Failed to drop legacy 'token_1' index on invites")
 
 
+async def migrate_workspace_vm_map_to_db() -> None:
+    """One-time import of the legacy workspace→VM JSON map into Mongo.
+
+    The workspace-level VM map used to live in
+    ``~/.pocketpaw/daytona_workspace_vm_map.json`` (``ee.cloud.daytona.store``).
+    It is now the ``workspace_vms`` Mongo collection. So an existing deploy's
+    VMs aren't orphaned by the move, this reads the file (if present), upserts
+    each workspace's entry into ``WorkspaceVm`` — SKIPPING any workspace whose
+    row already exists so newer DB state is never clobbered — then renames the
+    file to ``<name>.migrated`` so it doesn't re-import on the next boot.
+
+    Best-effort: the whole body is wrapped so a migration hiccup never blocks
+    boot. Idempotent — once the file is renamed, subsequent calls are no-ops.
+    """
+    import json
+
+    from pocketpaw_ee.cloud.daytona.store import WS_VM_MAP_PATH
+    from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+
+    try:
+        if not WS_VM_MAP_PATH.exists():
+            return
+
+        with open(WS_VM_MAP_PATH) as f:
+            data = json.load(f)
+
+        if not isinstance(data, dict):
+            logger.warning(
+                "Legacy workspace VM map at %s is not a dict — skipping migration",
+                WS_VM_MAP_PATH,
+            )
+            data = {}
+
+        imported = 0
+        for workspace_id, entry in data.items():
+            if not isinstance(entry, dict):
+                continue
+            existing = await WorkspaceVm.find_one(WorkspaceVm.workspace == workspace_id)
+            if existing is not None:
+                # Don't clobber newer DB state.
+                continue
+            doc = WorkspaceVm(
+                workspace=workspace_id,
+                sandbox_id=entry.get("sandbox_id", ""),
+                sandbox_name=entry.get("sandbox_name", ""),
+                config=dict(entry.get("config", {}) or {}),
+            )
+            await doc.insert()
+            imported += 1
+            logger.info(
+                "Migrated workspace VM map for workspace %s (sandbox %s) into Mongo",
+                workspace_id,
+                doc.sandbox_id,
+            )
+
+        # Rename so we never re-import — even if nothing was imported this run
+        # (all rows already existed), the file has served its purpose.
+        migrated_path = WS_VM_MAP_PATH.with_suffix(WS_VM_MAP_PATH.suffix + ".migrated")
+        WS_VM_MAP_PATH.rename(migrated_path)
+        logger.info(
+            "Workspace VM map migration complete: %d imported, file renamed to %s",
+            imported,
+            migrated_path.name,
+        )
+    except Exception:  # pragma: no cover - migration must never block boot
+        logger.exception("Workspace VM map migration failed; continuing boot")
+
+
 async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterprise") -> None:
     """Initialize Beanie ODM with all document models."""
     global _client
@@ -107,6 +184,11 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
     # declares. The invite-token hashing rollout left a unique index on the
     # now-nullable `token` column that 500s every second invite.
     await _drop_legacy_invite_token_index(db)
+
+    # One-time import of the legacy workspace→VM JSON map into Mongo. Runs after
+    # init_beanie so the ``workspace_vms`` collection is live. Best-effort — the
+    # helper swallows its own errors so a migration hiccup never blocks boot.
+    await migrate_workspace_vm_map_to_db()
 
     # Flip the memory backend AFTER Beanie is initialized so the
     # MongoMemoryStore's first .insert()/.find() call can never race a

--- a/ee/pocketpaw_ee/cloud/websandbox/__init__.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/__init__.py
@@ -1,0 +1,4 @@
+# __init__.py — the Web Cursor Sandbox Registry entity (WC-1).
+# Created 2026-07-15 (feat/websandbox-registry): a 4-file cloud entity
+# (domain / dto / service / router) that maps (workspace_id, user_id, repo)
+# to a sandbox row with fail-closed cross-tenant authorization.

--- a/ee/pocketpaw_ee/cloud/websandbox/archive.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/archive.py
@@ -1,0 +1,158 @@
+# archive.py — serve a repo's source as a zip, for seeding an in-tab pod (BP-3b).
+# Created 2026-07-18 (feat/code-mode).
+#
+# WHY THIS EXISTS: the BrowserPod runtime originally seeded a project by running
+# `git clone` INSIDE the pod. That puts the whole clone on BrowserPod's emulated
+# TCP/TLS stack (its TLS-MITM relay), which is the least documented and least
+# controllable part of that runtime — the vendor documents neither egress rules
+# nor git auth. In practice clones of public repos that clone fine everywhere
+# else stalled there, with nothing but kernel TODO noise to debug from.
+#
+# Fetching the source here instead removes that entire class of failure:
+#   • no in-pod networking, so no relay, no egress allowlist, no git-in-Wasm
+#   • no CORS problem — GitHub's archive endpoints send no CORS headers, so the
+#     browser cannot fetch them directly (the vendor's own reference works around
+#     this by fetching through the VM, which is what we are avoiding)
+#   • a seam for PRIVATE repos: this runs server-side, where the GitHub App token
+#     already lives and never has to reach the client (see repoauth/githubapp)
+#
+# SSRF: this endpoint takes a repo reference from the caller, so it must never be
+# treated as a URL to fetch. `_parse_github_repo` extracts owner/name and we
+# BUILD the GitHub URL ourselves; anything that is not a github.com owner/repo is
+# refused. No caller-supplied string ever reaches httpx as a URL.
+from __future__ import annotations
+
+import logging
+import re
+
+import httpx
+
+from pocketpaw_ee.cloud._core.errors import CloudError, ValidationError
+
+logger = logging.getLogger(__name__)
+
+# GitHub's own limits are looser, but a pod is a browser tab — refuse anything
+# that would blow the tab's memory rather than streaming it and failing later.
+_MAX_ARCHIVE_BYTES = 100 * 1024 * 1024
+
+_FETCH_TIMEOUT_SECONDS = 60.0
+
+# owner/name, each GitHub-legal. Anchored so nothing else can slip through.
+_OWNER_RE = r"[A-Za-z0-9][A-Za-z0-9-]{0,38}"
+_NAME_RE = r"[A-Za-z0-9_.-]{1,100}"
+_SHORTHAND = re.compile(rf"^({_OWNER_RE})/({_NAME_RE})$")
+_URL_FORM = re.compile(rf"^(?:https?://)?(?:www\.)?github\.com/({_OWNER_RE})/({_NAME_RE})$")
+
+
+def _parse_github_repo(repo: str) -> tuple[str, str]:
+    """Extract ``(owner, name)`` from a repo reference, or raise.
+
+    Accepts ``owner/repo`` and the github.com URL forms the project registry
+    stores. Everything else — another host, an IP, a path traversal, a URL with
+    credentials or a port — is refused, because the result is used to build a URL
+    this server will fetch.
+    """
+    candidate = (repo or "").strip()
+    if not candidate:
+        raise ValidationError("websandbox.invalid_repo", "A repository is required")
+
+    candidate = candidate.removesuffix(".git").rstrip("/")
+
+    match = _SHORTHAND.match(candidate)
+    if not match:
+        match = _URL_FORM.match(candidate)
+    if not match:
+        raise ValidationError(
+            "websandbox.invalid_repo",
+            "Only public github.com repositories can be opened in the in-browser runtime",
+        )
+    return match.group(1), match.group(2)
+
+
+async def fetch_repo_archive(
+    workspace_id: str,
+    user_id: str,
+    repo: str,
+    ref: str | None = None,
+) -> bytes:
+    """Return the repo's source as a zip.
+
+    Server-side so the client never has to reach GitHub itself (no CORS) and the
+    pod never has to do networking at all. Unauthenticated today, which means
+    PUBLIC repos only — the same scope the Daytona path clones. The token seam
+    for private repos is deliberate but unbuilt (BP-6): it belongs here, where a
+    GitHub App token stays server-side.
+    """
+    owner, name = _parse_github_repo(repo)
+    # Built from validated parts — never from caller input directly.
+    url = f"https://api.github.com/repos/{owner}/{name}/zipball"
+    if ref:
+        # A ref becomes a URL path segment, so it must not be able to climb out
+        # of it. The character class alone is NOT enough: it permits '.' and '/',
+        # so "../../etc" would traverse the path. Reject dot-dot and any leading
+        # or trailing slash explicitly.
+        if (
+            not re.fullmatch(r"[A-Za-z0-9._/-]{1,255}", ref)
+            or ".." in ref
+            or ref.startswith("/")
+            or ref.endswith("/")
+        ):
+            raise ValidationError("websandbox.invalid_ref", "Invalid git ref")
+        url = f"{url}/{ref}"
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "pocketpaw-codemode",
+    }
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True, timeout=_FETCH_TIMEOUT_SECONDS
+        ) as client:
+            response = await client.get(url, headers=headers)
+    except httpx.HTTPError as exc:
+        logger.warning("websandbox: repo archive fetch failed for %s/%s: %s", owner, name, exc)
+        raise CloudError(
+            502, "websandbox.archive_unreachable", "Could not reach GitHub to fetch the repository"
+        ) from exc
+
+    if response.status_code == 404:
+        raise CloudError(
+            404,
+            "websandbox.repo_not_found",
+            f"{owner}/{name} was not found. Private repositories are not supported "
+            "in the in-browser runtime yet.",
+        )
+    if response.status_code != 200:
+        logger.warning(
+            "websandbox: repo archive fetch for %s/%s returned %s",
+            owner,
+            name,
+            response.status_code,
+        )
+        raise CloudError(
+            502,
+            "websandbox.archive_failed",
+            "GitHub refused to serve this repository's archive",
+        )
+
+    content = response.content
+    if len(content) > _MAX_ARCHIVE_BYTES:
+        raise CloudError(
+            413,
+            "websandbox.archive_too_large",
+            "This repository is too large to open in the in-browser runtime",
+        )
+
+    logger.info(
+        "websandbox: served repo archive %s/%s (%d bytes) to workspace=%s user=%s",
+        owner,
+        name,
+        len(content),
+        workspace_id,
+        user_id,
+    )
+    return content
+
+
+__all__ = ["fetch_repo_archive"]

--- a/ee/pocketpaw_ee/cloud/websandbox/broker.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/broker.py
@@ -1,0 +1,347 @@
+# broker.py — Code Mode private-repo clone with token isolation (CM-3c).
+# Created 2026-07-16 (feat/code-mode): the "clone a PRIVATE repo into the sandbox
+# without the credential ever entering the VM" half of the WC-6 token-isolation
+# guarantee. githubapp.py mints the short-lived, single-repo token; THIS module is
+# the broker that uses it — server-side — to get the repo's files into the VM.
+#
+# THE HARD INVARIANT: the token NEVER enters the VM. git operations that carry the
+# token run in the BACKEND process (the same trust boundary that already holds the
+# App private key), not in the sandbox. Concretely, ``clone_into_vm``:
+#   1. clones the tokenized upstream into a throwaway host temp dir (token only in
+#      the backend subprocess argv, never on the wire to Daytona);
+#   2. rewrites the clone's ``origin`` remote to the CLEAN (token-free) upstream
+#      URL, so the ``.git/config`` that ships to the VM carries no credential;
+#   3. tars the working tree (incl. the scrubbed ``.git``) and ships ONE tarball
+#      into the VM via ``upload_bytes`` + ``tar -xzf`` — the exact vehicle the
+#      durability layer already uses — then wipes the host temp dir.
+# The VM receives only files + a token-free git remote. In-VM ``git checkout -b``
+# (the WC-5a feature branch) works because ``.git`` is present and local; in-VM
+# fetch/push-with-auth is a later slice (the smart-HTTP proxy that injects the
+# token upstream on each request — see githubapp.py's header comment).
+#
+# ``resolve_repo_token`` is the routing oracle: given a repo URL and the caller's
+# connections, it mints a repo-scoped token from the FIRST connection whose
+# installation can actually reach the repo (a mint that GitHub declines means the
+# installation can't see it — try the next). Returns ``None`` when no connection
+# can auth the repo, so ``provision.open_sandbox`` cleanly falls back to the
+# public, credential-free in-VM clone.
+#
+# Provider-agnostic by construction (see repoauth.py): the token minting and the
+# clone-URL auth scheme both dispatch on ``ScopedRepoToken.provider``. GitHub is
+# the only implemented provider today; a new one adds a branch, nothing else.
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import shutil
+import tempfile
+from collections.abc import Awaitable, Callable
+from urllib.parse import urlparse, urlunparse
+
+from pocketpaw_ee.cloud._core.errors import CloudError, with_cause
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+from pocketpaw_ee.cloud.websandbox.repoauth import (
+    ProviderId,
+    ScopedRepoToken,
+    get_repo_auth_provider,
+)
+
+logger = logging.getLogger(__name__)
+
+# The in-VM staging path for the shipped tarball (outside the workspace dir so it
+# is never included in a later snapshot, and removed right after extraction).
+_BROKER_TMP = "/tmp/ws-broker.tgz"  # noqa: S108 — a sandbox VM path, not host
+
+# Server-side git/tar timeouts (seconds). A cold clone of a large private repo can
+# take a while; the tar is local and fast.
+_CLONE_TIMEOUT_SECONDS = 180
+_SCRUB_TIMEOUT_SECONDS = 30
+_TAR_TIMEOUT_SECONDS = 120
+
+# Cap the packed tarball before shipping it into the VM, mirroring the durability
+# snapshot cap — a runaway repo must not blow up memory or the VM disk.
+_DEFAULT_BROKER_MAX_MB = 500.0
+
+# A callable that clones + packs the repo server-side and returns the tar bytes.
+# Injected in tests so no real ``git``/``tar`` subprocess runs.
+PackRepo = Callable[[ScopedRepoToken, str, str | None], Awaitable[bytes]]
+
+
+def _broker_max_bytes() -> int:
+    """Packed-tarball size cap in bytes (``POCKETPAW_WEBSANDBOX_BROKER_MAX_MB``)."""
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_BROKER_MAX_MB", "").strip()
+    mb = _DEFAULT_BROKER_MAX_MB
+    if raw:
+        try:
+            mb = float(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_WEBSANDBOX_BROKER_MAX_MB=%r; using %s", raw, mb
+            )
+    return int(mb * 1024 * 1024)
+
+
+# ---------------------------------------------------------------------------
+# Routing: which connection (if any) can authenticate this repo?
+# ---------------------------------------------------------------------------
+
+
+def repo_full_name(repo_url: str) -> str | None:
+    """Extract ``owner/repo`` from an https git URL, or ``None`` if it doesn't fit.
+
+    Accepts ``https://github.com/owner/repo(.git)?`` with or without a trailing
+    slash. A non-http(s) URL, a URL with fewer than two path segments, or one
+    carrying embedded credentials returns ``None`` (the caller then treats the
+    repo as un-brokered and clones it as public).
+    """
+    parsed = urlparse((repo_url or "").strip())
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    segments = [s for s in parsed.path.split("/") if s]
+    if len(segments) < 2:
+        return None
+    owner, repo = segments[0], segments[1]
+    repo = repo.removesuffix(".git")
+    if not owner or not repo:
+        return None
+    return f"{owner}/{repo}"
+
+
+async def resolve_repo_token(
+    workspace_id: str,
+    user_id: str,
+    repo_url: str,
+    *,
+    provider_kind: ProviderId = ProviderId.GITHUB,
+    now: object = None,
+) -> ScopedRepoToken | None:
+    """Mint a repo-scoped token for ``repo_url`` from the caller's connections.
+
+    Iterates the caller's connections (tenant + owner scoped) for the given
+    provider and mints a single-repo token from the FIRST one whose installation
+    can reach the repo. A mint that GitHub declines (the installation can't see
+    that repo) is expected routing signal, not an error — it is swallowed and the
+    next connection is tried. Returns ``None`` when the repo isn't a recognizable
+    provider repo, the provider isn't configured, the caller has no connections,
+    or none of them can authenticate the repo — in every such case the caller
+    falls back to the credential-free public clone.
+    """
+    repo_full = repo_full_name(repo_url)
+    if repo_full is None:
+        return None
+
+    provider = get_repo_auth_provider(provider_kind)
+    if provider is None:
+        return None
+
+    # Lazy import keeps the module load order clean (codeconnect.connect imports
+    # websandbox.repoauth; importing codeconnect.service at call time avoids any
+    # import-time coupling between the two entities).
+    from pocketpaw_ee.cloud.codeconnect import service as codeconnect_service
+
+    connections = await codeconnect_service.list_connections(workspace_id, user_id)
+    for conn in connections:
+        if conn.provider != provider_kind.value:
+            continue
+        try:
+            return await provider.mint_repo_token(conn.installation_id, repo_full, now=now)
+        except Exception:  # noqa: BLE001 — a failed mint just means "not this connection"
+            logger.debug(
+                "broker.resolve: installation %s can't auth %s — trying next",
+                conn.installation_id,
+                repo_full,
+                exc_info=True,
+            )
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Clone: server-side, token-isolated, into the VM.
+# ---------------------------------------------------------------------------
+
+
+async def clone_into_vm(
+    daytona: DaytonaClient,
+    sandbox_id: str,
+    token: ScopedRepoToken,
+    project_dir: str,
+    *,
+    clean_url: str,
+    branch: str | None = None,
+    pack: PackRepo | None = None,
+) -> None:
+    """Clone a private repo into the VM with the token NEVER entering the VM.
+
+    Packs the repo server-side (``pack``, default :func:`_clone_and_pack_repo` —
+    clone the tokenized upstream into a host temp dir, scrub ``origin`` to the
+    clean URL, tar it), size-guards the tarball, then ships it into the VM via
+    ``upload_bytes`` + ``tar -xzf``. ``pack`` is injectable so tests never spawn a
+    real ``git``/``tar``.
+
+    ``clean_url`` is the token-free upstream (e.g.
+    ``https://github.com/owner/repo.git``) — it becomes the VM's ``origin`` and is
+    also what the packer injects the token into for its own (server-side) clone.
+    """
+    packer = pack or _clone_and_pack_repo
+    try:
+        tar_bytes = await packer(token, clean_url, branch)
+    except CloudError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — uniform failure surface; never leak the token
+        raise with_cause(
+            CloudError(502, "websandbox.broker_clone_failed", "Failed to clone the repository"),
+            exc,
+        ) from exc
+
+    cap = _broker_max_bytes()
+    if len(tar_bytes) > cap:
+        raise CloudError(
+            413,
+            "websandbox.broker_repo_too_large",
+            f"Repository is {len(tar_bytes) / 1024 / 1024:.1f} MB packed, over the "
+            f"{cap / 1024 / 1024:.0f} MB limit",
+        )
+
+    # Ship ONE tarball into the VM and extract it over the workspace dir — the same
+    # vehicle durability.restore_workspace uses. The tarball carries a token-free
+    # .git (origin already scrubbed server-side).
+    untar = (
+        f"mkdir -p {project_dir} && tar -xzf {_BROKER_TMP} -C {project_dir} "
+        f"&& rm -f {_BROKER_TMP}"
+    )
+    await daytona.upload_bytes(sandbox_id, tar_bytes, _BROKER_TMP)
+    await daytona.execute_command(sandbox_id, untar)
+    logger.info(
+        "broker.clone: sandbox=%s repo=%s cloned via broker (%d bytes, token isolated)",
+        sandbox_id,
+        token.repo,
+        len(tar_bytes),
+    )
+
+
+def _authenticated_url(provider: ProviderId, clean_url: str, token: str) -> str:
+    """Inject the provider's token auth into ``clean_url`` for a SERVER-SIDE clone.
+
+    GitHub installation tokens authenticate as the ``x-access-token`` basic-auth
+    user. The result is used only in the backend git subprocess and is scrubbed
+    from the clone before anything ships to the VM.
+    """
+    if provider is not ProviderId.GITHUB:
+        raise CloudError(
+            501,
+            "websandbox.broker_provider_unsupported",
+            f"Broker clone is not implemented for provider {provider.value!r}",
+        )
+    parsed = urlparse(clean_url)
+    host = parsed.hostname or ""
+    netloc = f"x-access-token:{token}@{host}"
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def _redact(text: str, secret: str) -> str:
+    """Replace ``secret`` in ``text`` so a token can't reach a log or error body."""
+    return text.replace(secret, "***") if secret else text
+
+
+async def _clone_and_pack_repo(
+    token: ScopedRepoToken, clean_url: str, branch: str | None
+) -> bytes:
+    """Clone ``clean_url`` (with the token) into a host temp dir; return a tar.gz.
+
+    Server-side only: ``git`` runs in the backend process, so the token lives in
+    the backend subprocess argv and the throwaway temp dir — never on the wire to
+    Daytona and never in the VM. Steps: clone the tokenized URL (with any host
+    credential helper disabled so nothing caches the token) → ``remote set-url
+    origin`` back to the clean URL (scrub the credential from ``.git/config``
+    before it ships) → ``tar -czf -`` the tree (incl. the scrubbed ``.git``). The
+    temp dir is always removed. Git/tar stderr is redacted of the token before it
+    reaches any log or error.
+    """
+    git = shutil.which("git")
+    if git is None:
+        raise CloudError(
+            503, "websandbox.broker_git_unavailable", "Server-side git is not available"
+        )
+
+    auth_url = _authenticated_url(token.provider, clean_url, token.token)
+    tmp = tempfile.mkdtemp(prefix="paw-broker-")
+    dest = os.path.join(tmp, "repo")
+    try:
+        clone_args = [git, "-c", "credential.helper=", "clone", "--origin", "origin"]
+        if branch:
+            clone_args += ["--branch", branch]
+        clone_args += [auth_url, dest]
+        await _run(clone_args, secret=token.token, timeout=_CLONE_TIMEOUT_SECONDS)
+
+        # Scrub the token from the on-disk remote BEFORE packing, so the .git/config
+        # that ships to the VM points at the clean, credential-free upstream.
+        await _run(
+            [git, "-C", dest, "remote", "set-url", "origin", clean_url],
+            secret=token.token,
+            timeout=_SCRUB_TIMEOUT_SECONDS,
+        )
+
+        return await _run_capture(
+            ["tar", "-czf", "-", "-C", dest, "."],
+            secret=token.token,
+            timeout=_TAR_TIMEOUT_SECONDS,
+        )
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+async def _run(args: list[str], *, secret: str, timeout: int) -> None:
+    """Run a subprocess to completion, raising a token-redacted CloudError on failure."""
+    proc = await asyncio.create_subprocess_exec(
+        *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+    )
+    try:
+        _out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError as exc:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        raise CloudError(
+            504, "websandbox.broker_clone_failed", "The repository clone timed out"
+        ) from exc
+    if proc.returncode != 0:
+        detail = _redact((err or b"").decode(errors="replace").strip(), secret)
+        logger.warning("broker: %s failed (rc=%s): %s", args[0], proc.returncode, detail)
+        raise CloudError(
+            502, "websandbox.broker_clone_failed", "Failed to clone the repository"
+        )
+
+
+async def _run_capture(args: list[str], *, secret: str, timeout: int) -> bytes:
+    """Run a subprocess and return its stdout bytes; token-redacted CloudError on failure."""
+    proc = await asyncio.create_subprocess_exec(
+        *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+    )
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError as exc:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        raise CloudError(
+            504, "websandbox.broker_clone_failed", "Packing the repository timed out"
+        ) from exc
+    if proc.returncode != 0:
+        detail = _redact((err or b"").decode(errors="replace").strip(), secret)
+        logger.warning("broker: %s failed (rc=%s): %s", args[0], proc.returncode, detail)
+        raise CloudError(
+            502, "websandbox.broker_clone_failed", "Failed to pack the repository"
+        )
+    return out
+
+
+__all__ = [
+    "clone_into_vm",
+    "repo_full_name",
+    "resolve_repo_token",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/broker.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/broker.py
@@ -211,8 +211,7 @@ async def clone_into_vm(
     # vehicle durability.restore_workspace uses. The tarball carries a token-free
     # .git (origin already scrubbed server-side).
     untar = (
-        f"mkdir -p {project_dir} && tar -xzf {_BROKER_TMP} -C {project_dir} "
-        f"&& rm -f {_BROKER_TMP}"
+        f"mkdir -p {project_dir} && tar -xzf {_BROKER_TMP} -C {project_dir} && rm -f {_BROKER_TMP}"
     )
     await daytona.upload_bytes(sandbox_id, tar_bytes, _BROKER_TMP)
     await daytona.execute_command(sandbox_id, untar)
@@ -250,9 +249,7 @@ def _redact(text: str, secret: str) -> str:
     return text.replace(secret, "***") if secret else text
 
 
-async def _clone_and_pack_repo(
-    token: ScopedRepoToken, clean_url: str, branch: str | None
-) -> bytes:
+async def _clone_and_pack_repo(token: ScopedRepoToken, clean_url: str, branch: str | None) -> bytes:
     """Clone ``clean_url`` (with the token) into a host temp dir; return a tar.gz.
 
     Server-side only: ``git`` runs in the backend process, so the token lives in
@@ -313,9 +310,7 @@ async def _run(args: list[str], *, secret: str, timeout: int) -> None:
     if proc.returncode != 0:
         detail = _redact((err or b"").decode(errors="replace").strip(), secret)
         logger.warning("broker: %s failed (rc=%s): %s", args[0], proc.returncode, detail)
-        raise CloudError(
-            502, "websandbox.broker_clone_failed", "Failed to clone the repository"
-        )
+        raise CloudError(502, "websandbox.broker_clone_failed", "Failed to clone the repository")
 
 
 async def _run_capture(args: list[str], *, secret: str, timeout: int) -> bytes:
@@ -334,9 +329,7 @@ async def _run_capture(args: list[str], *, secret: str, timeout: int) -> bytes:
     if proc.returncode != 0:
         detail = _redact((err or b"").decode(errors="replace").strip(), secret)
         logger.warning("broker: %s failed (rc=%s): %s", args[0], proc.returncode, detail)
-        raise CloudError(
-            502, "websandbox.broker_clone_failed", "Failed to pack the repository"
-        )
+        raise CloudError(502, "websandbox.broker_clone_failed", "Failed to pack the repository")
     return out
 
 

--- a/ee/pocketpaw_ee/cloud/websandbox/browserpod.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/browserpod.py
@@ -1,0 +1,85 @@
+# browserpod.py — BrowserPod (in-tab WASM runtime) credential broker (BP-1b).
+# Created 2026-07-18 (feat/code-mode): Code Mode runs Node-shaped projects in a
+# BrowserPod pod — an x86 Linux VM in WebAssembly that executes INSIDE THE USER'S
+# BROWSER TAB — instead of a Daytona cloud VM. ``BrowserPod.boot({apiKey})`` runs
+# client-side, so the key has to reach the browser for a pod to exist at all.
+#
+# WHY THIS EXISTS: the key must NOT be a frontend build-time constant. Baked into
+# the bundle it lands in every build artifact, CDN copy and source map, is readable
+# by anyone who can load the app (including logged-out visitors), and can only be
+# rotated by a rebuild + redeploy. Brokering it here means the key lives ONLY in
+# server config and is handed out per-request to an authenticated, workspace-scoped
+# caller — so it can be rotated centrally, gated, rate-limited, audited and revoked.
+#
+# WHAT THIS DOES *NOT* DO — be honest about the boundary: this is containment and
+# control, NOT secrecy. An authenticated user can still read the key out of the
+# network response, because ``boot()`` needs it in the tab. Closing that last gap
+# requires BrowserPod to support short-lived or origin-scoped tokens (a vendor /
+# commercial-terms question). Until it does, treat this key as "exposed to every
+# authenticated, entitled user" and scope its blast radius accordingly:
+# BrowserPod's own domain allowlist governs what a pod may reach OUTBOUND (npm,
+# GitHub) — it is NOT an origin-lock on the key, so it cannot be leaned on as a
+# publishable key the way a Stripe/Maps key can.
+#
+# Contrast with ``codegit/ticket.py``: there the VM gets a short-lived JWT we mint
+# ourselves and the real GitHub token never leaves the server. We cannot do that
+# here — the credential the client needs IS the vendor key, and the vendor has no
+# exchange endpoint. That asymmetry is the whole reason this file documents its
+# own limits instead of implying parity.
+#
+# An unconfigured deploy is NOT an error: it returns ``available: false`` so the
+# frontend router cleanly falls back to the Daytona runtime instead of failing.
+from __future__ import annotations
+
+import logging
+import os
+
+from pocketpaw_ee.cloud.websandbox.dto import BrowserPodCredentialsResponse
+
+logger = logging.getLogger(__name__)
+
+# Server-side only. Deliberately NOT prefixed for the frontend bundle — nothing
+# in the built client may ever read this.
+_ENV_VAR = "BROWSERPOD_API_KEY"
+
+
+def browserpod_api_key() -> str:
+    """Return the configured BrowserPod embedding key, or ``""`` when unset."""
+    return os.environ.get(_ENV_VAR, "").strip()
+
+
+def browserpod_enabled() -> bool:
+    """True when this deploy has a BrowserPod key configured."""
+    return bool(browserpod_api_key())
+
+
+async def get_credentials(workspace_id: str, user_id: str) -> BrowserPodCredentialsResponse:
+    """Hand the calling user the credential needed to boot an in-tab pod.
+
+    The router has already enforced license + an authenticated, workspace-scoped
+    RequestContext, so reaching here means the caller is entitled. An unconfigured
+    deploy returns ``available: false`` with a null key (the frontend then routes
+    the project to Daytona) rather than raising — a missing optional runtime is a
+    fallback condition, not a failure.
+
+    The issue is logged (without the key) because BrowserPod bills on usage, so
+    "who booted a pod" is an operational and cost-attribution signal.
+    """
+    key = browserpod_api_key()
+    if not key:
+        logger.debug(
+            "browserpod: no %s configured — reporting unavailable (workspace=%s)",
+            _ENV_VAR,
+            workspace_id,
+        )
+        return BrowserPodCredentialsResponse(available=False, apiKey=None)
+
+    logger.info(
+        "browserpod: issued boot credential (workspace=%s, user=%s)",
+        workspace_id,
+        user_id,
+    )
+    return BrowserPodCredentialsResponse(available=True, apiKey=key)
+
+
+__all__ = ["browserpod_api_key", "browserpod_enabled", "get_credentials"]

--- a/ee/pocketpaw_ee/cloud/websandbox/browserpod.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/browserpod.py
@@ -43,9 +43,39 @@ logger = logging.getLogger(__name__)
 _ENV_VAR = "BROWSERPOD_API_KEY"
 
 
+def _dotenv_key() -> str:
+    """Read the key from a ``.env`` file, without touching the process env.
+
+    Deliberately ``dotenv_values`` and not ``load_dotenv``: this is a READ, and a
+    read should not mutate global process state as a side effect. It is also the
+    seam tests patch to mean "this host has no .env" — otherwise deleting the
+    environment variable in a test would still find the developer's real key on
+    disk and the "unconfigured" path could never be exercised.
+    """
+    try:  # pragma: no cover — trivial guard
+        from dotenv import dotenv_values
+    except ImportError:
+        return ""
+    return (dotenv_values().get(_ENV_VAR) or "").strip()
+
+
 def browserpod_api_key() -> str:
-    """Return the configured BrowserPod embedding key, or ``""`` when unset."""
-    return os.environ.get(_ENV_VAR, "").strip()
+    """Return the configured BrowserPod embedding key, or ``""`` when unset.
+
+    ``.env`` is loaded defensively for the same reason ``uploads/factory.py``
+    does it: this name has NO ``POCKETPAW_`` prefix, so pydantic-settings never
+    reads it, and it only reaches ``os.environ`` if something called
+    ``load_dotenv`` first — which depends on the entrypoint (the dashboard
+    lifecycle does; a bare uvicorn/cloud boot may not). Getting that wrong is
+    invisible: the broker answers ``available: false``, the frontend routes to
+    Daytona, and nothing anywhere reports an error. ``load_dotenv`` is
+    idempotent and never overrides a var already in the environment, so a real
+    deploy that exports the key properly is unaffected.
+    """
+    direct = os.environ.get(_ENV_VAR, "").strip()
+    if direct:
+        return direct
+    return _dotenv_key()
 
 
 def browserpod_enabled() -> bool:

--- a/ee/pocketpaw_ee/cloud/websandbox/constants.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/constants.py
@@ -1,0 +1,13 @@
+# constants.py — shared Web Cursor sandbox constants.
+# Created 2026-07-15: single source of truth for the in-VM workspace directory.
+#
+# Everything the user touches lives under ONE directory in the VM: the repo is
+# cloned here, the file tree/RPC is jailed here, and the terminal opens here.
+# We deliberately use ``/home/daytona`` (the sandbox user's home) rather than the
+# SDK's ``get_project_dir()`` — which on the current Daytona image returns
+# ``/root``, mismatching the PTY's default cwd (``/home/daytona``). Pinning one
+# constant keeps the clone target, the jail root, and the terminal cwd identical
+# so files a user clones are exactly what the tree lists and the shell sees.
+from __future__ import annotations
+
+WEBSANDBOX_WORKDIR = "/home/daytona"

--- a/ee/pocketpaw_ee/cloud/websandbox/domain.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/domain.py
@@ -1,0 +1,44 @@
+# domain.py — Frozen value objects for the Web Cursor Sandbox Registry.
+# Created 2026-07-15 (WC-1, feat/websandbox-registry): tenancy fields
+# (workspace_id, user_id) are REQUIRED at construction with no defaults per
+# ee/cloud Rule 3 — constructing a view without tenancy is a TypeError, so a
+# leak can't be minted by omission.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, NewType
+
+WebSandboxId = NewType("WebSandboxId", str)
+
+# The lifecycle a sandbox row moves through. Kept as a Literal so an unknown
+# state is a type error at the boundary rather than a silent string.
+SandboxStatus = Literal["pending", "opening", "ready", "stopped", "reaped"]
+
+
+@dataclass(frozen=True)
+class WebSandboxView:
+    """Read model for one sandbox row.
+
+    Every field is required at construction — the tenancy fields
+    (``workspace_id``, ``user_id``) most of all, per Rule 3. A view is only
+    ever built from a persisted, tenant-checked row, so there is no safe
+    default for who owns it.
+    """
+
+    id: WebSandboxId
+    workspace_id: str
+    user_id: str
+    repo: str
+    status: str
+    sandbox_id: str | None
+    installation_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+__all__ = [
+    "SandboxStatus",
+    "WebSandboxId",
+    "WebSandboxView",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/domain.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/domain.py
@@ -3,6 +3,11 @@
 # (workspace_id, user_id) are REQUIRED at construction with no defaults per
 # ee/cloud Rule 3 — constructing a view without tenancy is a TypeError, so a
 # leak can't be minted by omission.
+#
+# Changed 2026-07-15 (WC-S3, feat/websandbox-s3-durability): added the optional
+# ``snapshot_file_id`` — the pointer to the row's latest durable workspace
+# snapshot in blob storage. Optional (default None) so it lands after the
+# required tenancy fields without breaking the single construction site.
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -35,6 +40,8 @@ class WebSandboxView:
     installation_id: str | None
     created_at: datetime
     updated_at: datetime
+    # Pointer to the latest durable workspace snapshot in blob storage (WC-S3).
+    snapshot_file_id: str | None = None
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/websandbox/domain.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/domain.py
@@ -13,9 +13,14 @@
 # ``branch`` — the auto-created ``paw/edit-<hex>`` feature branch the repo is
 # checked out onto in the VM so AI edits never touch the default branch. Optional
 # (default None) so it lands after the required tenancy fields.
+#
+# Changed 2026-07-16 (CM-2a′ write-through, feat/code-mode): added the optional
+# ``overlay`` (``relpath -> FileRecord id``) — the incremental durability tier of
+# editor-saved files mirrored to blob storage since the last snapshot. Optional
+# (empty dict) so it lands after the required tenancy fields.
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Literal, NewType
 
@@ -50,6 +55,10 @@ class WebSandboxView:
     # The auto-created ``paw/edit-<hex>`` feature branch checked out in the VM
     # so AI edits never touch the default branch (WC-5a).
     branch: str | None = None
+    # The write-through durability overlay (CM-2a′): ``relpath -> FileRecord id``
+    # for editor-saved files mirrored to blob storage since the last snapshot.
+    # frozen dataclass → a mutable default needs a factory.
+    overlay: dict[str, str] = field(default_factory=dict)
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/websandbox/domain.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/domain.py
@@ -8,6 +8,11 @@
 # ``snapshot_file_id`` — the pointer to the row's latest durable workspace
 # snapshot in blob storage. Optional (default None) so it lands after the
 # required tenancy fields without breaking the single construction site.
+#
+# Changed 2026-07-15 (WC-5a, feat/websandbox-edit-agent): added the optional
+# ``branch`` — the auto-created ``paw/edit-<hex>`` feature branch the repo is
+# checked out onto in the VM so AI edits never touch the default branch. Optional
+# (default None) so it lands after the required tenancy fields.
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -42,6 +47,9 @@ class WebSandboxView:
     updated_at: datetime
     # Pointer to the latest durable workspace snapshot in blob storage (WC-S3).
     snapshot_file_id: str | None = None
+    # The auto-created ``paw/edit-<hex>`` feature branch checked out in the VM
+    # so AI edits never touch the default branch (WC-5a).
+    branch: str | None = None
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -1,0 +1,54 @@
+# dto.py — Request/response DTOs for the Web Cursor Sandbox Registry.
+# Created 2026-07-15 (WC-1, feat/websandbox-registry): distinct <Op>Request
+# and <Entity>Response classes per ee/cloud Rule 4 — one model is never reused
+# for both input and output, so a server-owned field (id, timestamps) can't
+# leak into the write surface. Wire shape is camelCase to match the rest of
+# the cloud surface.
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CreateSandboxRequest(BaseModel):
+    """Register (or re-register) a sandbox for a (workspace, user, repo).
+
+    Only ``repo`` is required; the rest are set by the provisioner as the
+    sandbox moves through its lifecycle. Creating is idempotent per
+    (workspace, user, repo) — see ``service.create_sandbox``.
+    """
+
+    repo: str = Field(..., min_length=1, max_length=1024)
+    sandbox_id: str | None = Field(default=None, max_length=256)
+    status: str = Field(default="pending", max_length=32)
+    installation_id: str | None = Field(default=None, max_length=256)
+
+
+class UpdateStatusRequest(BaseModel):
+    """Advance a sandbox's lifecycle state (and optionally bind its id)."""
+
+    status: str = Field(..., max_length=32)
+    sandbox_id: str | None = Field(default=None, max_length=256)
+
+
+class WebSandboxResponse(BaseModel):
+    id: str
+    workspaceId: str
+    userId: str
+    repo: str
+    status: str
+    sandboxId: str | None = None
+    installationId: str | None = None
+    createdAt: str  # ISO-8601 UTC
+    updatedAt: str  # ISO-8601 UTC
+
+
+class WebSandboxListResponse(BaseModel):
+    items: list[WebSandboxResponse]
+
+
+__all__ = [
+    "CreateSandboxRequest",
+    "UpdateStatusRequest",
+    "WebSandboxListResponse",
+    "WebSandboxResponse",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -175,6 +175,28 @@ class PreviewResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# BP-1b — BrowserPod (in-tab WASM runtime) boot credential.
+# ---------------------------------------------------------------------------
+
+
+class BrowserPodCredentialsResponse(BaseModel):
+    """The credential a browser needs to boot an in-tab BrowserPod pod.
+
+    Response-only (Rule 4). ``available`` is false with a null ``apiKey`` when the
+    deploy has no BROWSERPOD_API_KEY configured — the frontend then routes the
+    project to the Daytona runtime instead of treating it as an error.
+
+    NOTE: this response necessarily carries the key to the client, because
+    ``BrowserPod.boot()`` executes in the tab. Brokering it keeps the key out of
+    the frontend bundle and makes it gateable/rotatable/auditable, but it is not
+    secret from an authenticated caller — see ``websandbox/browserpod.py``.
+    """
+
+    available: bool
+    apiKey: str | None = None
+
+
+# ---------------------------------------------------------------------------
 # WC-7/P4a — git write path (status / stage / commit / push).
 # ---------------------------------------------------------------------------
 

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -30,6 +30,12 @@
 # the sandbox VM. Response-only (Rule 4); the requested port arrives as a query
 # param, never a body, and tenancy comes from the RequestContext.
 #
+# Changed 2026-07-16 (WC-7/P4a git, feat/code-mode): added the git write-path DTOs —
+# request bodies ``StageRequest`` (paths + unstage) and ``CommitRequest`` (message),
+# and response models ``GitStatusResponse`` / ``GitFileEntry`` / ``GitCommitResponse``
+# / ``GitPushResponse``. Same Rule-4 split: the request bodies carry only what the
+# client supplies; tenancy comes from the RequestContext, never the body.
+#
 # Changed 2026-07-16 (review hardening): split the write surface. ``sandbox_id``
 # and ``status`` are SERVER-OWNED — the Daytona id is the load-bearing input to
 # ``authorize_sandbox``, so a client that could write it onto its own row could
@@ -169,6 +175,64 @@ class PreviewResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# WC-7/P4a — git write path (status / stage / commit / push).
+# ---------------------------------------------------------------------------
+
+
+class StageRequest(BaseModel):
+    """Stage (or unstage) a set of paths for the next commit.
+
+    ``paths`` are project-relative and each is ``shlex.quote``d before it reaches
+    the shell (git.py). ``unstage`` flips ``git add`` to ``git reset HEAD``.
+    """
+
+    paths: list[str] = Field(default_factory=list)
+    unstage: bool = False
+
+
+class CommitRequest(BaseModel):
+    """Commit the staged changes with ``message`` (shlex-quoted before the shell)."""
+
+    message: str = Field(..., min_length=1, max_length=8192)
+
+
+class GitFileEntry(BaseModel):
+    """One changed path from ``git status --porcelain`` — the two status columns
+    plus a convenience ``staged`` flag (the index column is a real change)."""
+
+    path: str
+    index: str  # the index (staged) column: 'M','A','D','R','?'…
+    worktree: str  # the worktree (unstaged) column
+    staged: bool
+
+
+class GitStatusResponse(BaseModel):
+    """Working-tree status: current branch, upstream ahead/behind, changed files."""
+
+    branch: str | None = None
+    ahead: int = 0
+    behind: int = 0
+    files: list[GitFileEntry] = Field(default_factory=list)
+
+
+class GitCommitResponse(BaseModel):
+    """The result of a commit — the new ``sha`` and whether anything was committed
+    (``committed`` is False when there was nothing staged)."""
+
+    sha: str
+    committed: bool
+
+
+class GitPushResponse(BaseModel):
+    """The result of a push — ``pushed`` plus the ``branch`` and, on failure, a
+    human-readable ``detail`` (a push failure is NEVER an error response)."""
+
+    pushed: bool
+    branch: str
+    detail: str | None = None
+
+
+# ---------------------------------------------------------------------------
 # WC-5a — AI edit agent (Cmd-K).
 # ---------------------------------------------------------------------------
 
@@ -216,15 +280,21 @@ class EditResponse(BaseModel):
 
 
 __all__ = [
+    "CommitRequest",
     "CreateSandboxRequest",
     "EditRequest",
     "EditResponse",
     "EditSelection",
+    "GitCommitResponse",
+    "GitFileEntry",
+    "GitPushResponse",
+    "GitStatusResponse",
     "OpenSandboxRequest",
     "PreviewResponse",
     "RegisterSandboxRequest",
     "SandboxTreeResponse",
     "SnapshotResponse",
+    "StageRequest",
     "TreeEntryResponse",
     "UpdateStatusRequest",
     "WebSandboxListResponse",

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -16,6 +16,14 @@
 # snapshot pointer on the wire (``WebSandboxResponse.snapshotFileId``) and added
 # ``SnapshotResponse`` — the ``{fileId}`` the snapshot endpoint returns after
 # landing the workspace tarball in the tenant's blob storage.
+#
+# Changed 2026-07-15 (WC-5a, feat/websandbox-edit-agent): surfaced the
+# auto-feature-branch on the wire (``WebSandboxResponse.branch``), let the
+# provisioner bind it via ``UpdateStatusRequest.branch``, and added the AI
+# edit-agent DTOs — ``EditRequest`` (a file path + instruction + optional
+# selection range) and ``EditResponse`` (the original + PROPOSED file content the
+# frontend reviews per-hunk and writes back via the existing file-RPC). The edit
+# agent is generate-only; it never writes to the VM.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -36,10 +44,13 @@ class CreateSandboxRequest(BaseModel):
 
 
 class UpdateStatusRequest(BaseModel):
-    """Advance a sandbox's lifecycle state (and optionally bind its id)."""
+    """Advance a sandbox's lifecycle state (and optionally bind its id/branch)."""
 
     status: str = Field(..., max_length=32)
     sandbox_id: str | None = Field(default=None, max_length=256)
+    # The auto-created feature branch the provisioner checked out in the VM
+    # (WC-5a). Bound in the same write that marks the row ``ready``.
+    branch: str | None = Field(default=None, max_length=256)
 
 
 class WebSandboxResponse(BaseModel):
@@ -51,6 +62,7 @@ class WebSandboxResponse(BaseModel):
     sandboxId: str | None = None
     installationId: str | None = None
     snapshotFileId: str | None = None
+    branch: str | None = None
     createdAt: str  # ISO-8601 UTC
     updatedAt: str  # ISO-8601 UTC
 
@@ -104,8 +116,58 @@ class SnapshotResponse(BaseModel):
     fileId: str
 
 
+# ---------------------------------------------------------------------------
+# WC-5a — AI edit agent (Cmd-K).
+# ---------------------------------------------------------------------------
+
+
+class EditSelection(BaseModel):
+    """A 1-indexed inclusive line range within the target file the edit scopes to.
+
+    Optional on an ``EditRequest`` — when present it focuses the model on the
+    selected lines (the rest of the file is still supplied as context). When
+    absent the whole file is the edit target.
+    """
+
+    startLine: int = Field(..., ge=1)
+    endLine: int = Field(..., ge=1)
+
+
+class EditRequest(BaseModel):
+    """Ask the backend edit agent to PROPOSE a rewrite of a file (or selection).
+
+    ``path`` is relative to the in-VM workspace dir (jailed — ``..`` / absolute
+    paths are refused). ``instruction`` is the natural-language edit. ``selection``
+    optionally narrows the edit to a line range. The agent reads the file
+    server-side, calls a frontier model, and returns the proposal — it never
+    writes anything to the VM (Rule 4: the write surface never carries a proposed
+    body; the frontend applies accepted hunks via the existing file-RPC).
+    """
+
+    path: str = Field(..., min_length=1, max_length=1024)
+    instruction: str = Field(..., min_length=1, max_length=8192)
+    selection: EditSelection | None = None
+
+
+class EditResponse(BaseModel):
+    """The edit agent's PROPOSAL — original vs. proposed file content.
+
+    The frontend diffs ``originalContent`` against ``proposedContent`` to render
+    per-hunk review and writes accepted changes back via the file-RPC. ``selection``
+    echoes the requested range (if any) so the reviewer can scope the diff.
+    """
+
+    path: str
+    originalContent: str
+    proposedContent: str
+    selection: EditSelection | None = None
+
+
 __all__ = [
     "CreateSandboxRequest",
+    "EditRequest",
+    "EditResponse",
+    "EditSelection",
     "OpenSandboxRequest",
     "SandboxTreeResponse",
     "SnapshotResponse",

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -4,6 +4,13 @@
 # for both input and output, so a server-owned field (id, timestamps) can't
 # leak into the write surface. Wire shape is camelCase to match the rest of
 # the cloud surface.
+#
+# Changed 2026-07-15 (WC-2, feat/websandbox-vm-provision): added the
+# cold-provision + file-tree DTOs — ``OpenSandboxRequest`` (the repo URL to open,
+# optional branch), ``TreeEntryResponse`` (one node in the cloned repo's file
+# tree), and ``SandboxTreeResponse`` (the tree wrapper carrying the bound Daytona
+# id). Same Rule-4 discipline: the open surface accepts only a repo + branch and
+# never a server-owned id/status.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -46,8 +53,45 @@ class WebSandboxListResponse(BaseModel):
     items: list[WebSandboxResponse]
 
 
+# ---------------------------------------------------------------------------
+# WC-2 — cold-provision + file tree.
+# ---------------------------------------------------------------------------
+
+
+class OpenSandboxRequest(BaseModel):
+    """Open a sandbox against a public repo — cold-provision a VM and clone it.
+
+    Only the repo URL (and an optional branch) crosses the wire; the Daytona
+    ``sandbox_id`` and lifecycle ``status`` are server-owned and set by the
+    provisioner as the VM boots (Rule 4 — the write surface never accepts them).
+    """
+
+    repo: str = Field(..., min_length=1, max_length=1024)
+    branch: str | None = Field(default=None, max_length=256)
+
+
+class TreeEntryResponse(BaseModel):
+    """One node in the cloned repo's file tree (a single directory level)."""
+
+    name: str
+    isDir: bool
+    size: int = 0
+
+
+class SandboxTreeResponse(BaseModel):
+    """The file tree of a ready sandbox, keyed to its bound Daytona id."""
+
+    id: str
+    sandboxId: str
+    path: str
+    entries: list[TreeEntryResponse]
+
+
 __all__ = [
     "CreateSandboxRequest",
+    "OpenSandboxRequest",
+    "SandboxTreeResponse",
+    "TreeEntryResponse",
     "UpdateStatusRequest",
     "WebSandboxListResponse",
     "WebSandboxResponse",

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -11,6 +11,11 @@
 # tree), and ``SandboxTreeResponse`` (the tree wrapper carrying the bound Daytona
 # id). Same Rule-4 discipline: the open surface accepts only a repo + branch and
 # never a server-owned id/status.
+#
+# Changed 2026-07-15 (WC-S3, feat/websandbox-s3-durability): surfaced the durable
+# snapshot pointer on the wire (``WebSandboxResponse.snapshotFileId``) and added
+# ``SnapshotResponse`` — the ``{fileId}`` the snapshot endpoint returns after
+# landing the workspace tarball in the tenant's blob storage.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -45,6 +50,7 @@ class WebSandboxResponse(BaseModel):
     status: str
     sandboxId: str | None = None
     installationId: str | None = None
+    snapshotFileId: str | None = None
     createdAt: str  # ISO-8601 UTC
     updatedAt: str  # ISO-8601 UTC
 
@@ -87,10 +93,22 @@ class SandboxTreeResponse(BaseModel):
     entries: list[TreeEntryResponse]
 
 
+# ---------------------------------------------------------------------------
+# WC-S3 — workspace durability (snapshot / restore).
+# ---------------------------------------------------------------------------
+
+
+class SnapshotResponse(BaseModel):
+    """The durable pointer minted by a snapshot — the blob-storage FileRecord id."""
+
+    fileId: str
+
+
 __all__ = [
     "CreateSandboxRequest",
     "OpenSandboxRequest",
     "SandboxTreeResponse",
+    "SnapshotResponse",
     "TreeEntryResponse",
     "UpdateStatusRequest",
     "WebSandboxListResponse",

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -24,16 +24,40 @@
 # selection range) and ``EditResponse`` (the original + PROPOSED file content the
 # frontend reviews per-hunk and writes back via the existing file-RPC). The edit
 # agent is generate-only; it never writes to the VM.
+#
+# Changed 2026-07-16 (review hardening): split the write surface. ``sandbox_id``
+# and ``status`` are SERVER-OWNED — the Daytona id is the load-bearing input to
+# ``authorize_sandbox``, so a client that could write it onto its own row could
+# forge access to another tenant's VM. The client-facing register route now binds
+# ``RegisterSandboxRequest`` (repo only); ``CreateSandboxRequest`` /
+# ``UpdateStatusRequest`` are INTERNAL command objects the provisioner (and tests
+# that stand in for it) use to bind server-generated runtime state, and are never
+# bound by a router. The client ``PATCH`` route was removed with the same intent.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
 
-class CreateSandboxRequest(BaseModel):
-    """Register (or re-register) a sandbox for a (workspace, user, repo).
+class RegisterSandboxRequest(BaseModel):
+    """Client-facing register body for ``POST /websandbox`` — repo ONLY.
 
-    Only ``repo`` is required; the rest are set by the provisioner as the
-    sandbox moves through its lifecycle. Creating is idempotent per
+    The write surface never accepts a ``sandbox_id`` or ``status``: those are
+    server-owned. ``authorize_sandbox`` trusts the row's ``sandbox_id`` as the
+    proof-of-ownership key, so letting a client set it would let an attacker who
+    learned a victim's Daytona id register a row pointing at the victim's VM and
+    pass the authorization oracle. The provisioner binds runtime state internally
+    (see ``CreateSandboxRequest`` / ``UpdateStatusRequest`` below), never the client.
+    """
+
+    repo: str = Field(..., min_length=1, max_length=1024)
+
+
+class CreateSandboxRequest(BaseModel):
+    """INTERNAL registration command — provisioner / test-seed use only.
+
+    Never bound by a router (the client-facing model is ``RegisterSandboxRequest``).
+    Carries the server-owned ``sandbox_id`` / ``status`` / ``installation_id`` the
+    provisioner sets as the VM boots. Creating is idempotent per
     (workspace, user, repo) — see ``service.create_sandbox``.
     """
 
@@ -44,7 +68,13 @@ class CreateSandboxRequest(BaseModel):
 
 
 class UpdateStatusRequest(BaseModel):
-    """Advance a sandbox's lifecycle state (and optionally bind its id/branch)."""
+    """INTERNAL lifecycle-bind command — provisioner / test-seed use only.
+
+    Never bound by a router. Advances a sandbox's lifecycle state and binds its
+    server-generated Daytona id / feature branch. The client cannot reach this:
+    lifecycle is driven entirely by the provisioner (``provision.open_sandbox``)
+    and the idle reaper.
+    """
 
     status: str = Field(..., max_length=32)
     sandbox_id: str | None = Field(default=None, max_length=256)
@@ -169,6 +199,7 @@ __all__ = [
     "EditResponse",
     "EditSelection",
     "OpenSandboxRequest",
+    "RegisterSandboxRequest",
     "SandboxTreeResponse",
     "SnapshotResponse",
     "TreeEntryResponse",

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -25,6 +25,11 @@
 # frontend reviews per-hunk and writes back via the existing file-RPC). The edit
 # agent is generate-only; it never writes to the VM.
 #
+# Changed 2026-07-16 (WC-8/P3b preview, feat/code-mode): added ``PreviewResponse``
+# ({url, port}) — the iframe-embeddable public URL of a dev-server port running in
+# the sandbox VM. Response-only (Rule 4); the requested port arrives as a query
+# param, never a body, and tenancy comes from the RequestContext.
+#
 # Changed 2026-07-16 (review hardening): split the write surface. ``sandbox_id``
 # and ``status`` are SERVER-OWNED — the Daytona id is the load-bearing input to
 # ``authorize_sandbox``, so a client that could write it onto its own row could
@@ -147,6 +152,23 @@ class SnapshotResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# WC-8/P3b — live dev-server preview.
+# ---------------------------------------------------------------------------
+
+
+class PreviewResponse(BaseModel):
+    """The iframe-embeddable public URL for a dev-server port in the sandbox VM.
+
+    Response-only (Rule 4): the requested ``port`` arrives as a query param and is
+    echoed back alongside the resolved ``url``. ``url`` already carries the Daytona
+    preview access token as a query param, so it embeds in an ``<iframe>`` directly.
+    """
+
+    url: str
+    port: int
+
+
+# ---------------------------------------------------------------------------
 # WC-5a — AI edit agent (Cmd-K).
 # ---------------------------------------------------------------------------
 
@@ -199,6 +221,7 @@ __all__ = [
     "EditResponse",
     "EditSelection",
     "OpenSandboxRequest",
+    "PreviewResponse",
     "RegisterSandboxRequest",
     "SandboxTreeResponse",
     "SnapshotResponse",

--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -232,6 +232,24 @@ class GitPushResponse(BaseModel):
     detail: str | None = None
 
 
+class CreatePrRequest(BaseModel):
+    """Open a pull request for the sandbox's feature branch (WC-7/P4b).
+
+    Only the ``title`` and optional ``body`` cross the wire; the head branch, base
+    branch, and repo are all server-resolved from the sandbox row + the caller's
+    GitHub connection (never client-supplied)."""
+
+    title: str = Field(..., min_length=1, max_length=256)
+    body: str = Field(default="", max_length=65536)
+
+
+class GitPrResponse(BaseModel):
+    """An opened pull request — its ``url`` (html_url) and ``number``."""
+
+    url: str
+    number: int
+
+
 # ---------------------------------------------------------------------------
 # WC-5a — AI edit agent (Cmd-K).
 # ---------------------------------------------------------------------------
@@ -281,12 +299,14 @@ class EditResponse(BaseModel):
 
 __all__ = [
     "CommitRequest",
+    "CreatePrRequest",
     "CreateSandboxRequest",
     "EditRequest",
     "EditResponse",
     "EditSelection",
     "GitCommitResponse",
     "GitFileEntry",
+    "GitPrResponse",
     "GitPushResponse",
     "GitStatusResponse",
     "OpenSandboxRequest",

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -1,6 +1,14 @@
 # durability.py — Web Cursor workspace durability: S3 snapshot + restore.
 # Created 2026-07-15 (WC-S3, feat/websandbox-s3-durability).
 #
+# Changed 2026-07-16 (CM-2a′ write-through, feat/code-mode): added the incremental
+# per-file tier. ``mirror_file`` write-throughs a single editor-saved file to blob
+# storage on every ``file.write`` and records ``relpath -> FileRecord id`` in the
+# row's ``overlay`` map; ``restore_workspace`` now applies BOTH tiers in order —
+# the full snapshot tar (baseline), then the overlay replayed on top (freshest
+# edits). The overlay is cleared by ``service.set_snapshot`` (a full snapshot
+# supersedes it), which keeps replay from resurrecting a since-deleted file.
+#
 # The Daytona VM is pure scratch and gets reaped (WC-2). Code durability is git
 # (push); this module makes a user's UNCOMMITTED work + workspace state durable
 # by snapshotting the in-VM workspace dir to the tenant's blob storage (S3,
@@ -96,7 +104,7 @@ def _require_client(client: DaytonaClient | None) -> DaytonaClient:
     return resolved
 
 
-def _build_uploads() -> Any:
+def build_uploads() -> Any:
     """Build a snapshot-scoped ``EEUploadService`` the same way ``deliver.py`` does.
 
     Per-call (cheap): the workspace-scoped ``StorageAdapter`` (local or S3 via
@@ -253,7 +261,7 @@ async def snapshot_workspace(
 
     # 3. Land it in the tenant's blob storage (the ART-4 S3 path) and record the
     #    durable pointer on the row.
-    up = uploads if uploads is not None else _build_uploads()
+    up = uploads if uploads is not None else build_uploads()
     file_id = await _upload_snapshot(
         up, data, workspace_id=workspace_id, user_id=user_id, row_id=row_id
     )
@@ -281,19 +289,29 @@ async def restore_workspace(
     client: DaytonaClient | None = None,
     uploads: Any = None,
 ) -> None:
-    """Restore a row's latest blob-storage snapshot into its (fresh) VM.
+    """Restore a row's durable state into its (fresh) VM: snapshot then overlay.
 
-    Resolves the row tenant + owner scoped, then fail-closed authorizes on the
-    bound Daytona id, reads the row's ``snapshot_file_id`` (a clean 409 when the
-    sandbox has never been snapshotted), fetches the tarball bytes back from S3,
-    ``upload_bytes`` them into the VM, and ``tar -xzf`` into the workspace dir.
+    Two durability tiers land here in order (CM-2a′):
+      1. ``snapshot_file_id`` — the coarse full-workspace tarball (on-disconnect).
+         Fetched from S3, ``upload_bytes`` into the VM, ``tar -xzf`` over the dir.
+      2. ``overlay`` — the write-through per-file tier (each editor save since the
+         last snapshot). Each ``relpath -> FileRecord id`` is fetched and written
+         over the tree. The overlay is CLEARED whenever a snapshot is taken, so it
+         only ever holds edits made AFTER the snapshot — replaying it on top is
+         always the freshest source state, never a stale resurrection.
+
+    Resolves the row tenant + owner scoped, fail-closed authorizes on the bound
+    Daytona id, then applies whatever tiers exist. A row with NEITHER a snapshot
+    nor an overlay is a clean 409 (nothing to restore). A bound-VM requirement:
+    an unprovisioned row is a 409, not a crash.
     """
     daytona = _require_client(client)
 
     row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
-    if not row.snapshot_file_id:
+    overlay = row.overlay or {}
+    if not row.snapshot_file_id and not overlay:
         raise ConflictError(
-            "websandbox.no_snapshot", "This sandbox has no snapshot to restore"
+            "websandbox.no_snapshot", "This sandbox has no durable state to restore"
         )
     if not row.sandbox_id:
         raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
@@ -301,36 +319,130 @@ async def restore_workspace(
     # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
     await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
 
-    up = uploads if uploads is not None else _build_uploads()
-    data = await _download_snapshot(
-        up, row.snapshot_file_id, workspace_id=workspace_id, user_id=user_id
-    )
+    up = uploads if uploads is not None else build_uploads()
 
-    try:
-        await daytona.upload_bytes(row.sandbox_id, data, _SNAPSHOT_TMP)
-        await daytona.execute_command(
+    # Tier 1 — the full-workspace snapshot (baseline).
+    if row.snapshot_file_id:
+        data = await _download_snapshot(
+            up, row.snapshot_file_id, workspace_id=workspace_id, user_id=user_id
+        )
+        untar = f"mkdir -p {WEBSANDBOX_WORKDIR} && tar -xzf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR}"
+        try:
+            await daytona.upload_bytes(row.sandbox_id, data, _SNAPSHOT_TMP)
+            await daytona.execute_command(row.sandbox_id, untar)
+        except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+            logger.warning(
+                "websandbox.restore: snapshot untar failed for row=%s", row_id, exc_info=True
+            )
+            raise with_cause(
+                CloudError(502, "websandbox.restore_failed", "Failed to restore the workspace"),
+                exc,
+            ) from exc
+        logger.info(
+            "websandbox.restore: row=%s daytona=%s <- snapshot=%s (%d bytes)",
+            row_id,
             row.sandbox_id,
-            f"mkdir -p {WEBSANDBOX_WORKDIR} && tar -xzf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR}",
+            row.snapshot_file_id,
+            len(data),
         )
-    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
-        logger.warning(
-            "websandbox.restore: upload/untar failed for row=%s", row_id, exc_info=True
-        )
-        raise with_cause(
-            CloudError(502, "websandbox.restore_failed", "Failed to restore the workspace"),
-            exc,
-        ) from exc
 
-    logger.info(
-        "websandbox.restore: row=%s daytona=%s <- file=%s (%d bytes)",
+    # Tier 2 — replay the write-through overlay (freshest edits) over the tree.
+    replayed = 0
+    for rel_path, file_id in overlay.items():
+        abs_path = _overlay_abs_path(rel_path)
+        if abs_path is None:
+            logger.warning("websandbox.restore: skipping unsafe overlay path %r", rel_path)
+            continue
+        try:
+            file_bytes = await _download_snapshot(
+                up, file_id, workspace_id=workspace_id, user_id=user_id
+            )
+            parent = abs_path.rsplit("/", 1)[0]
+            await daytona.execute_command(row.sandbox_id, f"mkdir -p {parent}")
+            await daytona.upload_bytes(row.sandbox_id, file_bytes, abs_path)
+            replayed += 1
+        except Exception:  # noqa: BLE001 — one bad overlay file must not sink the rest
+            logger.warning(
+                "websandbox.restore: overlay replay failed for row=%s path=%r",
+                row_id,
+                rel_path,
+                exc_info=True,
+            )
+    if replayed:
+        logger.info(
+            "websandbox.restore: row=%s daytona=%s replayed %d overlay file(s)",
+            row_id,
+            row.sandbox_id,
+            replayed,
+        )
+
+
+def _overlay_abs_path(rel_path: str) -> str | None:
+    """Jail an overlay relpath into the workspace dir; ``None`` if it escapes.
+
+    Defense-in-depth: the overlay paths originate from the ``file.write`` jail, but
+    a restore writes bytes straight into the VM, so re-reject anything absolute or
+    containing a ``..`` traversal segment before it becomes a VM path.
+    """
+    candidate = (rel_path or "").strip().lstrip("/")
+    if not candidate or candidate.startswith("/"):
+        return None
+    if any(seg in ("..",) for seg in candidate.split("/")):
+        return None
+    return f"{WEBSANDBOX_WORKDIR}/{candidate}"
+
+
+async def mirror_file(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    rel_path: str,
+    data: bytes,
+    *,
+    uploads: Any = None,
+) -> str:
+    """Write-through one editor-saved file to blob storage; record the overlay entry.
+
+    The incremental durability tier (CM-2a′): called best-effort right after the
+    ``file.write`` byte-for-byte VM write, so the edit is durable in S3 the moment
+    it lands — a crash / idle-out before the next full snapshot no longer loses it.
+    Uploads the bytes to the tenant's blob storage (folder ``/websandbox-overlay``)
+    and records ``rel_path -> FileRecord id`` on the row via ``set_overlay_entry``.
+    Returns the FileRecord id. The bytes are declared ``application/octet-stream``
+    (in the per-call allowlist) so the OSS mime gate never rejects a source file.
+    """
+    from fastapi import UploadFile
+
+    up = uploads if uploads is not None else build_uploads()
+    basename = (rel_path or "file").rsplit("/", 1)[-1] or "file"
+    upload = UploadFile(
+        file=io.BytesIO(data),
+        filename=f"overlay-{row_id}-{basename}",
+        headers={"content-type": "application/octet-stream"},  # type: ignore[arg-type]
+    )
+    rec = await up.upload(
+        upload,
+        owner_id=user_id,
+        chat_id=None,
+        workspace=workspace_id,
+        folder_path="/websandbox-overlay",
+    )
+    await websandbox_service.set_overlay_entry(
+        workspace_id, user_id, row_id, rel_path, rec.id
+    )
+    logger.debug(
+        "websandbox.mirror: row=%s path=%r -> file=%s (%d bytes)",
         row_id,
-        row.sandbox_id,
-        row.snapshot_file_id,
+        rel_path,
+        rec.id,
         len(data),
     )
+    return rec.id
 
 
 __all__ = [
+    "build_uploads",
+    "mirror_file",
     "restore_workspace",
     "snapshot_workspace",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -9,6 +9,12 @@
 # edits). The overlay is cleared by ``service.set_snapshot`` (a full snapshot
 # supersedes it), which keeps replay from resurrecting a since-deleted file.
 #
+# Changed 2026-07-16 (WC-4c file verbs, feat/code-mode): added the delete/rename
+# overlay siblings ``drop_overlay`` (removes an entry so a deleted file is not
+# resurrected on restore) and ``move_overlay`` (re-keys an entry so a renamed file
+# replays at its new path). ws.py binds them as the FileRpc on_delete / on_move
+# hooks, the delete/rename counterparts of the on_write mirror.
+#
 # The Daytona VM is pure scratch and gets reaped (WC-2). Code durability is git
 # (push); this module makes a user's UNCOMMITTED work + workspace state durable
 # by snapshotting the in-VM workspace dir to the tenant's blob storage (S3,
@@ -440,9 +446,47 @@ async def mirror_file(
     return rec.id
 
 
+async def drop_overlay(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    rel_path: str,
+) -> None:
+    """Drop the overlay entry for a deleted file (WC-4c on_delete hook).
+
+    The delete-side sibling of ``mirror_file``: after ``file.delete`` removes the
+    file in the VM, drop its overlay entry so a later restore falls back to the
+    snapshot tier instead of resurrecting the deleted file. Dropping is always
+    safe (worst case the file reappears from the snapshot, never a stale
+    resurrection). Delegates the doc write to the service (Rule 2). A directory
+    delete drops every child entry too.
+    """
+    await websandbox_service.drop_overlay_entry(workspace_id, user_id, row_id, rel_path)
+
+
+async def move_overlay(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    src_rel: str,
+    dst_rel: str,
+) -> None:
+    """Re-key the overlay entry for a renamed file (WC-4c on_move hook).
+
+    The move-side sibling of ``mirror_file``: after ``file.move`` renames the file
+    in the VM, re-key its overlay entry from ``src_rel`` to ``dst_rel`` so restore
+    replays the same durable blob at the new path. The FileRecord id is unchanged,
+    so no blob work is needed — only the key moves. Delegates the doc write to the
+    service (Rule 2). A directory move re-keys every child entry too.
+    """
+    await websandbox_service.move_overlay_entry(workspace_id, user_id, row_id, src_rel, dst_rel)
+
+
 __all__ = [
     "build_uploads",
+    "drop_overlay",
     "mirror_file",
+    "move_overlay",
     "restore_workspace",
     "snapshot_workspace",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -1,0 +1,336 @@
+# durability.py — Web Cursor workspace durability: S3 snapshot + restore.
+# Created 2026-07-15 (WC-S3, feat/websandbox-s3-durability).
+#
+# The Daytona VM is pure scratch and gets reaped (WC-2). Code durability is git
+# (push); this module makes a user's UNCOMMITTED work + workspace state durable
+# by snapshotting the in-VM workspace dir to the tenant's blob storage (S3,
+# indexed in Mongo) and restoring it into a fresh VM. Nothing is file-based —
+# the durable tier is S3, the pointer is a FileRecord id on the WebSandbox row.
+#
+# This is the service-layer orchestration ABOVE ``websandbox/service.py`` (the
+# registry + auth oracle). Per ee/cloud Rule 2 it NEVER touches the WebSandbox
+# Beanie doc directly — the snapshot pointer write goes through
+# ``service.set_snapshot`` and every read through ``service.get_sandbox`` /
+# ``service.authorize_sandbox``. Importing DaytonaClient + EEUploadService here
+# (not in router/dto/domain) is the correct layer.
+#
+# The S3 vehicle is ART-4's ``EEUploadService`` — the same "read a file out of a
+# VM/jail → upload to the tenant's S3 → get a durable pointer" path
+# ``deliver.py`` uses. We reuse it verbatim: wrap the tarball bytes in a
+# Starlette ``UploadFile`` and call ``upload(...)`` (workspace-scoped), then
+# stash the returned ``FileRecord.id`` on the row. Restore reads the bytes back
+# through the same service's owner-scoped ``stream(...)`` and untars them into
+# the VM.
+#
+# Two flows:
+#   1. ``snapshot_workspace`` — authorize (owner-scoped get + fail-closed
+#      authorize_sandbox) → ``tar -czf`` the workspace dir in the VM →
+#      ``download_file`` the tarball → size-cap → ``EEUploadService.upload`` to
+#      tenant S3 (folder ``/websandbox-snapshots``) → ``set_snapshot`` → return
+#      the FileRecord id.
+#   2. ``restore_workspace`` — authorize → read the row's ``snapshot_file_id``
+#      (clean 409 if none) → fetch the tarball bytes from S3 → ``upload_bytes``
+#      into the VM → ``tar -xzf`` into the workspace dir.
+#
+# Both take DI seams (``client=None`` → get_daytona_client, ``uploads=None`` →
+# a per-call EEUploadService) so tests inject fakes and never hit real Daytona
+# or S3.
+from __future__ import annotations
+
+import io
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+logger = logging.getLogger(__name__)
+
+# The in-VM staging path for the tarball (outside the workspace dir so it never
+# tars itself and a stale copy never re-enters a future snapshot).
+_SNAPSHOT_TMP = "/tmp/ws-snapshot.tgz"  # noqa: S108 — a sandbox VM path, not host
+
+# gzip-compressed tar. ``_sniff_mime`` doesn't recognize gzip magic, so the
+# UploadFile's declared content-type is the mime that reaches the allowlist —
+# we declare this and include it in the per-call UploadSettings allowlist.
+_SNAPSHOT_MIME = "application/gzip"
+
+# Default per-snapshot size cap. The workspace can carry node_modules / build
+# output, so this is larger than the 25 MiB browser-upload default but bounded
+# so a runaway workspace can't blow up a snapshot.
+_DEFAULT_SNAPSHOT_MAX_MB = 500.0
+
+
+def _snapshot_max_bytes() -> int:
+    """Per-snapshot size cap in bytes (``POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB``)."""
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB", "").strip()
+    mb = _DEFAULT_SNAPSHOT_MAX_MB
+    if raw:
+        try:
+            mb = float(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB=%r; using %s", raw, mb
+            )
+    return int(mb * 1024 * 1024)
+
+
+def _require_client(client: DaytonaClient | None) -> DaytonaClient:
+    """Resolve the Daytona client, raising a clean CloudError when unconfigured.
+
+    Mirrors ``provision._require_client``: ``get_daytona_client()`` returns
+    ``None`` when the Daytona keys are unset — an operational condition, not a
+    bug — so it surfaces as a 503 CloudError rather than an AttributeError crash.
+    """
+    resolved = client if client is not None else get_daytona_client()
+    if resolved is None:
+        raise CloudError(
+            503,
+            "websandbox.daytona_unavailable",
+            "The sandbox runtime is not configured",
+        )
+    return resolved
+
+
+def _build_uploads() -> Any:
+    """Build a snapshot-scoped ``EEUploadService`` the same way ``deliver.py`` does.
+
+    Per-call (cheap): the workspace-scoped ``StorageAdapter`` (local or S3 via
+    ``POCKETPAW_UPLOAD_ADAPTER``), a Mongo metadata store, and an
+    ``UploadSettings`` whose ``allowed_mimes`` includes the gzip-tar mime so the
+    OSS mime gate never rejects a first-party snapshot, and whose
+    ``max_file_bytes`` matches our snapshot cap.
+    """
+    from pocketpaw.uploads.config import DEFAULT_ALLOWED_MIMES, UploadSettings
+    from pocketpaw.uploads.factory import build_adapter
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+    from pocketpaw_ee.cloud.uploads.service import EEUploadService
+
+    root = Path.home() / ".pocketpaw" / "uploads"
+    root.mkdir(parents=True, exist_ok=True)
+    adapter = build_adapter(root)
+    cfg = UploadSettings(
+        max_file_bytes=_snapshot_max_bytes(),
+        allowed_mimes=frozenset(
+            {_SNAPSHOT_MIME, "application/octet-stream", *DEFAULT_ALLOWED_MIMES}
+        ),
+        local_root=root,
+    )
+    return EEUploadService(adapter=adapter, meta=MongoFileStore(), cfg=cfg)
+
+
+async def _upload_snapshot(
+    uploads: Any,
+    data: bytes,
+    *,
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> str:
+    """Land the tarball bytes in the tenant's blob storage; return the FileRecord id.
+
+    Wraps the in-memory bytes in a Starlette ``UploadFile`` exactly like
+    ``deliver.py`` (a dict ``headers`` carrying the declared content-type is all
+    ``UploadFile.content_type`` reads), then calls the workspace-scoped
+    ``upload`` — the ART-4 S3 path. Folder-scoped to ``/websandbox-snapshots``
+    so snapshots are grouped in the tenant's Files.
+    """
+    from fastapi import UploadFile
+
+    upload = UploadFile(
+        file=io.BytesIO(data),
+        filename=f"ws-snapshot-{row_id}.tgz",
+        headers={"content-type": _SNAPSHOT_MIME},  # type: ignore[arg-type]
+    )
+    rec = await uploads.upload(
+        upload,
+        owner_id=user_id,
+        chat_id=None,
+        workspace=workspace_id,
+        folder_path="/websandbox-snapshots",
+    )
+    return rec.id
+
+
+async def _download_snapshot(
+    uploads: Any,
+    file_id: str,
+    *,
+    workspace_id: str,
+    user_id: str,
+) -> bytes:
+    """Fetch the snapshot tarball bytes back from blob storage (owner-scoped).
+
+    Uses ``EEUploadService.stream`` — the workspace + owner-checked read path —
+    and drains the async chunk iterator into bytes. A missing / not-owned blob
+    surfaces as a clean CloudError rather than an upstream ``NotFound`` leak.
+    """
+    from pocketpaw.uploads.errors import NotFound as _UploadNotFound
+
+    try:
+        _rec, chunks = await uploads.stream(
+            file_id, requester_id=user_id, workspace=workspace_id
+        )
+    except _UploadNotFound as exc:
+        raise with_cause(
+            CloudError(
+                404,
+                "websandbox.snapshot_missing",
+                "The recorded snapshot could not be read from storage",
+            ),
+            exc,
+        ) from exc
+    buf = bytearray()
+    async for chunk in chunks:
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+# ---------------------------------------------------------------------------
+# snapshot flow.
+# ---------------------------------------------------------------------------
+
+
+async def snapshot_workspace(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    *,
+    client: DaytonaClient | None = None,
+    uploads: Any = None,
+) -> str:
+    """Snapshot a ready sandbox's workspace to the tenant's blob storage.
+
+    Resolves the row tenant + owner scoped (``get_sandbox`` raises ``NotFound``
+    for a row the caller doesn't own), runs the fail-closed ``authorize_sandbox``
+    on the bound Daytona id BEFORE any VM/S3 op, then: ``tar -czf`` the workspace
+    dir → ``download_file`` the tarball → size-cap → upload to S3 →
+    ``set_snapshot`` the returned FileRecord id on the row. Returns that id.
+
+    A row that hasn't bound a Daytona id yet (never provisioned / still opening)
+    is a clean 409, not a runtime crash. A tarball over the size cap raises a
+    clean CloudError before any upload.
+    """
+    daytona = _require_client(client)
+
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+
+    # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+
+    # 1. Tar the workspace dir inside the VM (everything, incl. .git — simple and
+    #    complete). ``-C`` so arcnames are relative to the workspace root.
+    try:
+        await daytona.execute_command(
+            row.sandbox_id,
+            f"tar -czf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR} .",
+        )
+        data = await daytona.download_file(row.sandbox_id, _SNAPSHOT_TMP)
+    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+        logger.warning(
+            "websandbox.snapshot: tar/download failed for row=%s", row_id, exc_info=True
+        )
+        raise with_cause(
+            CloudError(502, "websandbox.snapshot_failed", "Failed to snapshot the workspace"),
+            exc,
+        ) from exc
+
+    # 2. Guard the size before spending an S3 upload on a runaway workspace.
+    cap = _snapshot_max_bytes()
+    if len(data) > cap:
+        raise CloudError(
+            413,
+            "websandbox.snapshot_too_large",
+            f"Workspace snapshot is {len(data) / 1024 / 1024:.1f} MB, over the "
+            f"{cap / 1024 / 1024:.0f} MB limit",
+        )
+
+    # 3. Land it in the tenant's blob storage (the ART-4 S3 path) and record the
+    #    durable pointer on the row.
+    up = uploads if uploads is not None else _build_uploads()
+    file_id = await _upload_snapshot(
+        up, data, workspace_id=workspace_id, user_id=user_id, row_id=row_id
+    )
+    await websandbox_service.set_snapshot(workspace_id, user_id, row_id, file_id)
+    logger.info(
+        "websandbox.snapshot: row=%s daytona=%s -> file=%s (%d bytes)",
+        row_id,
+        row.sandbox_id,
+        file_id,
+        len(data),
+    )
+    return file_id
+
+
+# ---------------------------------------------------------------------------
+# restore flow.
+# ---------------------------------------------------------------------------
+
+
+async def restore_workspace(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    *,
+    client: DaytonaClient | None = None,
+    uploads: Any = None,
+) -> None:
+    """Restore a row's latest blob-storage snapshot into its (fresh) VM.
+
+    Resolves the row tenant + owner scoped, then fail-closed authorizes on the
+    bound Daytona id, reads the row's ``snapshot_file_id`` (a clean 409 when the
+    sandbox has never been snapshotted), fetches the tarball bytes back from S3,
+    ``upload_bytes`` them into the VM, and ``tar -xzf`` into the workspace dir.
+    """
+    daytona = _require_client(client)
+
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.snapshot_file_id:
+        raise ConflictError(
+            "websandbox.no_snapshot", "This sandbox has no snapshot to restore"
+        )
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+
+    # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+
+    up = uploads if uploads is not None else _build_uploads()
+    data = await _download_snapshot(
+        up, row.snapshot_file_id, workspace_id=workspace_id, user_id=user_id
+    )
+
+    try:
+        await daytona.upload_bytes(row.sandbox_id, data, _SNAPSHOT_TMP)
+        await daytona.execute_command(
+            row.sandbox_id,
+            f"mkdir -p {WEBSANDBOX_WORKDIR} && tar -xzf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR}",
+        )
+    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+        logger.warning(
+            "websandbox.restore: upload/untar failed for row=%s", row_id, exc_info=True
+        )
+        raise with_cause(
+            CloudError(502, "websandbox.restore_failed", "Failed to restore the workspace"),
+            exc,
+        ) from exc
+
+    logger.info(
+        "websandbox.restore: row=%s daytona=%s <- file=%s (%d bytes)",
+        row_id,
+        row.sandbox_id,
+        row.snapshot_file_id,
+        len(data),
+    )
+
+
+__all__ = [
+    "restore_workspace",
+    "snapshot_workspace",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -186,9 +186,7 @@ async def _download_snapshot(
     from pocketpaw.uploads.errors import NotFound as _UploadNotFound
 
     try:
-        _rec, chunks = await uploads.stream(
-            file_id, requester_id=user_id, workspace=workspace_id
-        )
+        _rec, chunks = await uploads.stream(file_id, requester_id=user_id, workspace=workspace_id)
     except _UploadNotFound as exc:
         raise with_cause(
             CloudError(
@@ -247,9 +245,7 @@ async def snapshot_workspace(
         )
         data = await daytona.download_file(row.sandbox_id, _SNAPSHOT_TMP)
     except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
-        logger.warning(
-            "websandbox.snapshot: tar/download failed for row=%s", row_id, exc_info=True
-        )
+        logger.warning("websandbox.snapshot: tar/download failed for row=%s", row_id, exc_info=True)
         raise with_cause(
             CloudError(502, "websandbox.snapshot_failed", "Failed to snapshot the workspace"),
             exc,
@@ -433,9 +429,7 @@ async def mirror_file(
         workspace=workspace_id,
         folder_path="/websandbox-overlay",
     )
-    await websandbox_service.set_overlay_entry(
-        workspace_id, user_id, row_id, rel_path, rec.id
-    )
+    await websandbox_service.set_overlay_entry(workspace_id, user_id, row_id, rel_path, rec.id)
     logger.debug(
         "websandbox.mirror: row=%s path=%r -> file=%s (%d bytes)",
         row_id,

--- a/ee/pocketpaw_ee/cloud/websandbox/edit.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/edit.py
@@ -1,0 +1,303 @@
+# edit.py — Web Cursor AI edit agent (Cmd-K), BACKEND-SIDE (WC-5a).
+# Created 2026-07-15 (feat/websandbox-edit-agent).
+#
+# Given a file + an instruction (+ optional selection), a backend-side frontier
+# model returns a PROPOSED rewrite of the file. This module is GENERATE-ONLY: it
+# reads the file over the network via ``DaytonaClient``, optionally greps the repo
+# for a symbol from the selection, calls the model, and returns the proposal for
+# the frontend to review per-hunk and save via the existing file-RPC. It does NOT
+# write anything to the VM.
+#
+# ARCHITECTURE (hard rule): the edit agent runs BACKEND-SIDE. There is NO in-VM
+# agent, NO UDS bridge, NO code_mode — the only VM interaction is ``download_file``
+# (read the target) and best-effort ``execute_command("rg …")`` (optional context).
+#
+# SECURITY: tenancy is enforced first (owner-scoped ``get_sandbox`` +
+# fail-closed ``authorize_sandbox``, same guards the tree/ws use) BEFORE any model
+# call or VM read; the target path is run through the SAME lexical jail as the
+# file-RPC (``files._jail``, rooted at ``WEBSANDBOX_WORKDIR``) so a crafted
+# ``path`` can't escape the workspace and no download happens for a traversal
+# attempt.
+#
+# LLM SEAM: mirrors ``decisions/explain/narrator.py`` — ``AsyncAnthropic`` with
+# the key from ``get_settings().anthropic_api_key``. The model id is
+# env-configurable (``POCKETPAW_WEBSANDBOX_EDIT_MODEL``, default the Sonnet-class
+# id narrator uses). The edit fn takes ``client=None`` (default builds the real
+# client) so unit tests inject a fake and never hit the real API. Any model /
+# read failure surfaces as a clean ``websandbox.edit_failed`` CloudError — never a
+# fake success.
+from __future__ import annotations
+
+import logging
+import os
+import re
+
+from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+from pocketpaw_ee.cloud.websandbox.dto import EditRequest, EditResponse
+from pocketpaw_ee.cloud.websandbox.files import FileRpcError, _jail
+
+logger = logging.getLogger(__name__)
+
+# Default model id — matches what narrator uses (Sonnet-class). Env-overridable.
+_DEFAULT_EDIT_MODEL = "claude-sonnet-4-7"
+# Output ceiling for the proposed file. Non-streaming-safe (well under the SDK's
+# ~10-min timeout guard). Very large files may truncate — the read cap below
+# keeps targets in a sane range.
+_EDIT_MAX_TOKENS = 16000
+# Model call timeout (seconds) and retry budget — mirror narrator's shape.
+_EDIT_TIMEOUT_SECONDS = 60.0
+# Ripgrep context is bounded so one huge match set can't blow up the prompt.
+_MAX_CONTEXT_CHARS = 4000
+
+_SYSTEM_PROMPT = (
+    "You are a precise code-editing assistant embedded in an IDE. You are given a "
+    "file and an instruction. Apply the instruction and return ONLY the FULL "
+    "updated file content — the entire file from first line to last, with your "
+    "edit applied. Do not add prose, explanations, or markdown code fences. Do not "
+    "omit or elide any unchanged part of the file. Preserve the file's existing "
+    "indentation, style, and trailing newline. If the instruction cannot be "
+    "applied, return the file unchanged."
+)
+
+# An identifier-like token, used to pull a symbol out of the selection for a
+# best-effort ripgrep of the rest of the repo.
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+
+
+def _edit_max_file_bytes() -> int:
+    """Editable-file size cap in bytes (``POCKETPAW_WEBSANDBOX_EDIT_MAX_KB``,
+    default 256). Bounds both the read and, indirectly, the model's output."""
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_EDIT_MAX_KB", "").strip()
+    kb = 256
+    if raw:
+        try:
+            kb = int(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_WEBSANDBOX_EDIT_MAX_KB=%r; using %d", raw, kb
+            )
+    return max(kb, 1) * 1024
+
+
+def _edit_model() -> str:
+    return os.environ.get("POCKETPAW_WEBSANDBOX_EDIT_MODEL", "").strip() or _DEFAULT_EDIT_MODEL
+
+
+def _require_daytona(daytona: DaytonaClient | None) -> DaytonaClient:
+    """Resolve the Daytona client, raising a clean CloudError when unconfigured
+    (mirrors ``provision._require_client`` — a None client is a 503, not a crash)."""
+    resolved = daytona if daytona is not None else get_daytona_client()
+    if resolved is None:
+        raise CloudError(
+            503,
+            "websandbox.daytona_unavailable",
+            "The sandbox runtime is not configured",
+        )
+    return resolved
+
+
+def _strip_code_fences(text: str) -> str:
+    """Best-effort strip of a wrapping ```lang … ``` block.
+
+    The system prompt forbids fences, but models occasionally wrap output anyway;
+    stripping keeps the proposal a clean file body rather than diffing fence lines.
+    Only strips when the WHOLE payload is a single fenced block.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return text
+    lines = stripped.splitlines()
+    if len(lines) < 2 or not lines[-1].strip().startswith("```"):
+        return text
+    # Drop the opening fence (with optional language) and the closing fence.
+    return "\n".join(lines[1:-1])
+
+
+def _selection_symbol(content: str, start_line: int, end_line: int) -> str | None:
+    """Pull the first identifier-like token from the selected line range (1-indexed
+    inclusive) for a best-effort ripgrep of the rest of the repo. None if the
+    range is out of bounds or has no usable symbol."""
+    lines = content.splitlines()
+    lo = max(start_line, 1)
+    hi = min(end_line, len(lines))
+    if lo > hi:
+        return None
+    snippet = "\n".join(lines[lo - 1 : hi])
+    match = _IDENTIFIER_RE.search(snippet)
+    return match.group(0) if match else None
+
+
+async def _gather_context(daytona: DaytonaClient, sandbox_id: str, symbol: str) -> str:
+    """Best-effort: ripgrep ``symbol`` across the workspace for extra context.
+
+    Bounded (``rg`` line cap + a hard char cap) and fully defensive — any failure
+    returns an empty string, because context is a nice-to-have, never load-bearing.
+    ``rg`` is on the Paw dev image.
+    """
+    try:
+        # -n line numbers, --max-count caps per-file hits, -g excludes the VCS dir.
+        cmd = f"rg -n --max-count 5 --no-heading -g '!.git' -- {symbol!r} ."
+        resp = await daytona.execute_command(
+            sandbox_id, cmd, cwd=WEBSANDBOX_WORKDIR, timeout=15
+        )
+    except Exception:  # noqa: BLE001 — context is best-effort; never fail the edit on it
+        logger.debug("websandbox.edit: context ripgrep failed for %r", symbol, exc_info=True)
+        return ""
+    out = getattr(resp, "result", None)
+    if not isinstance(out, str) or not out.strip():
+        return ""
+    return out[:_MAX_CONTEXT_CHARS]
+
+
+def _build_user_message(body: EditRequest, file_content: str, context: str) -> str:
+    """Assemble the user turn: instruction + the file (+ optional selection markers
+    + optional grepped context)."""
+    parts = [f"Instruction:\n{body.instruction}\n"]
+    if body.selection is not None:
+        parts.append(
+            f"Focus your edit on lines {body.selection.startLine}–"
+            f"{body.selection.endLine} of the file, but still return the FULL "
+            "updated file.\n"
+        )
+    if context:
+        parts.append(
+            "Related occurrences elsewhere in the repository (for context only — "
+            f"do not edit other files):\n{context}\n"
+        )
+    parts.append(f"File `{body.path}`:\n{file_content}")
+    return "\n".join(parts)
+
+
+async def _run_model(model: str, system: str, user_message: str, client) -> str:  # noqa: ANN001
+    """Call the frontier model and return the raw text. Builds the real
+    ``AsyncAnthropic`` client when none is injected (the DI seam for tests).
+
+    Any failure — missing key, SDK error, empty response — raises a clean
+    ``websandbox.edit_failed`` CloudError, never a fake success.
+    """
+    if client is None:
+        try:
+            from anthropic import AsyncAnthropic
+
+            from pocketpaw.config import get_settings
+
+            api_key = get_settings().anthropic_api_key
+        except Exception as exc:  # noqa: BLE001
+            raise with_cause(
+                CloudError(503, "websandbox.edit_unavailable", "The edit model is not configured"),
+                exc,
+            ) from exc
+        if not api_key:
+            raise CloudError(
+                503, "websandbox.edit_unavailable", "The edit model is not configured"
+            )
+        client = AsyncAnthropic(api_key=api_key, timeout=_EDIT_TIMEOUT_SECONDS, max_retries=1)
+
+    try:
+        response = await client.messages.create(
+            model=model,
+            max_tokens=_EDIT_MAX_TOKENS,
+            system=[{"type": "text", "text": system}],
+            messages=[{"role": "user", "content": user_message}],
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("websandbox.edit: model call failed", exc_info=True)
+        raise with_cause(
+            CloudError(502, "websandbox.edit_failed", "The edit model call failed"),
+            exc,
+        ) from exc
+
+    try:
+        raw_text = response.content[0].text
+    except (AttributeError, IndexError) as exc:
+        raise with_cause(
+            CloudError(502, "websandbox.edit_failed", "The edit model returned no content"),
+            exc,
+        ) from exc
+    if not isinstance(raw_text, str) or not raw_text.strip():
+        raise CloudError(502, "websandbox.edit_failed", "The edit model returned empty content")
+    return raw_text
+
+
+async def propose_edit(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    body: EditRequest | dict,
+    *,
+    client=None,  # noqa: ANN001 — an AsyncAnthropic-shaped object (DI seam for tests)
+    daytona: DaytonaClient | None = None,
+) -> EditResponse:
+    """Propose a model-authored rewrite of a file in a ready sandbox (generate-only).
+
+    Flow: validate → resolve the row owner-scoped (``get_sandbox`` → NotFound for a
+    row the caller doesn't own) → 409 if it never bound a Daytona id → fail-closed
+    ``authorize_sandbox`` BEFORE any VM touch → jail the path (``..``/absolute are
+    refused, no download for a traversal attempt) → ``download_file`` the target →
+    optional best-effort ripgrep context → call the model → return the proposal.
+
+    NEVER writes to the VM: the frontend reviews the proposed content per-hunk and
+    applies accepted changes via the existing file-RPC.
+    """
+    body = EditRequest.model_validate(body)
+    dt = _require_daytona(daytona)
+
+    # 1. Tenancy — owner-scoped resolve (NotFound cross-tenant), then the row must
+    #    have a bound VM, then the fail-closed authorize before ANY VM touch.
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+
+    # 2. Path safety — the SAME lexical jail the file-RPC uses, rooted at the
+    #    pinned workspace dir. An escape raises before any download.
+    try:
+        abs_path = _jail(WEBSANDBOX_WORKDIR, body.path, "read")
+    except FileRpcError as exc:
+        raise CloudError(400, "websandbox.edit_invalid_path", exc.message) from exc
+
+    # 3. Read the target file over the network (backend-side, no in-VM agent).
+    try:
+        data = await dt.download_file(row.sandbox_id, abs_path)
+    except FileNotFoundError as exc:
+        raise CloudError(404, "websandbox.edit_no_file", f"no such file: {body.path}") from exc
+    if data is None:
+        raise CloudError(404, "websandbox.edit_no_file", f"no such file: {body.path}")
+    cap = _edit_max_file_bytes()
+    if len(data) > cap:
+        raise CloudError(
+            413,
+            "websandbox.edit_too_large",
+            f"file is {len(data) // 1024} KB, over the {cap // 1024} KB edit limit",
+        )
+    try:
+        original = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CloudError(
+            400, "websandbox.edit_not_text", "file is not UTF-8 text (binary is not supported)"
+        ) from exc
+
+    # 4. Optional, bounded, best-effort context from a symbol in the selection.
+    context = ""
+    if body.selection is not None:
+        symbol = _selection_symbol(original, body.selection.startLine, body.selection.endLine)
+        if symbol:
+            context = await _gather_context(dt, row.sandbox_id, symbol)
+
+    # 5. Call the model and return the PROPOSAL (never written to the VM).
+    user_message = _build_user_message(body, original, context)
+    raw_text = await _run_model(_edit_model(), _SYSTEM_PROMPT, user_message, client)
+    proposed = _strip_code_fences(raw_text)
+
+    return EditResponse(
+        path=body.path,
+        originalContent=original,
+        proposedContent=proposed,
+        selection=body.selection,
+    )
+
+
+__all__ = ["propose_edit"]

--- a/ee/pocketpaw_ee/cloud/websandbox/edit.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/edit.py
@@ -140,9 +140,7 @@ async def _gather_context(daytona: DaytonaClient, sandbox_id: str, symbol: str) 
     try:
         # -n line numbers, --max-count caps per-file hits, -g excludes the VCS dir.
         cmd = f"rg -n --max-count 5 --no-heading -g '!.git' -- {symbol!r} ."
-        resp = await daytona.execute_command(
-            sandbox_id, cmd, cwd=WEBSANDBOX_WORKDIR, timeout=15
-        )
+        resp = await daytona.execute_command(sandbox_id, cmd, cwd=WEBSANDBOX_WORKDIR, timeout=15)
     except Exception:  # noqa: BLE001 — context is best-effort; never fail the edit on it
         logger.debug("websandbox.edit: context ripgrep failed for %r", symbol, exc_info=True)
         return ""
@@ -191,9 +189,7 @@ async def _run_model(model: str, system: str, user_message: str, client) -> str:
                 exc,
             ) from exc
         if not api_key:
-            raise CloudError(
-                503, "websandbox.edit_unavailable", "The edit model is not configured"
-            )
+            raise CloudError(503, "websandbox.edit_unavailable", "The edit model is not configured")
         client = AsyncAnthropic(api_key=api_key, timeout=_EDIT_TIMEOUT_SECONDS, max_retries=1)
 
     try:

--- a/ee/pocketpaw_ee/cloud/websandbox/files.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/files.py
@@ -415,10 +415,7 @@ class FileRpc:
         quoted = shlex.quote(query)
         # Explicit '.' path: exec has no tty, and rg with no path arg can block on
         # stdin — a fixed search root avoids that and keeps output project-relative.
-        cmd = (
-            "rg -F --line-number --column --no-heading --color=never --smart-case "
-            f"-- {quoted} ."
-        )
+        cmd = f"rg -F --line-number --column --no-heading --color=never --smart-case -- {quoted} ."
         try:
             resp = await self._client.execute_command(
                 self._sandbox_id, cmd, cwd=root, timeout=_SEARCH_TIMEOUT_SECONDS
@@ -533,7 +530,9 @@ class FileRpc:
             return {"type": "file.error", "reqId": req_id, "op": exc.op, "message": exc.message}
         except Exception as exc:  # noqa: BLE001 — a file op must never kill the socket
             logger.warning(
-                "websandbox file op failed: type=%s sandbox=%s", mtype, self._sandbox_id,
+                "websandbox file op failed: type=%s sandbox=%s",
+                mtype,
+                self._sandbox_id,
                 exc_info=True,
             )
             op = mtype.removeprefix("file.") if mtype.startswith("file.") else mtype

--- a/ee/pocketpaw_ee/cloud/websandbox/files.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/files.py
@@ -1,5 +1,9 @@
-# files.py — Web Cursor file read/write/list RPC core (WC-4a).
-# Created 2026-07-15 (feat/websandbox-file-rpc).
+# files.py — Web Cursor file read/write/list + create/rename/delete RPC core.
+# Created 2026-07-15 (WC-4a, feat/websandbox-file-rpc).
+# Changed 2026-07-16 (WC-4c, feat/code-mode): added the file.create / file.delete
+# / file.move verbs, each path-jailed like list/read/write, plus best-effort
+# on_delete / on_move durability hooks (siblings of on_write) so a delete or
+# rename is reflected in the overlay tier and never resurrected on restore.
 #
 # Socket-agnostic sibling of terminal.py's PtyBridge: this is the file-operation
 # half of the session WebSocket, multiplexed alongside the terminal on the SAME
@@ -24,10 +28,14 @@
 # the project dir, and lexical normalization does exactly that.
 #
 # Frame contract (client->server / server->client), reqId echoed for correlation:
-#   file.list  {path}          -> file.list.ok  {path, entries:[{name,path,isDir,size}]}
-#   file.read  {path}          -> file.read.ok  {path, content}
-#   file.write {path, content} -> file.write.ok {path}
-#   any failure                -> file.error    {op, message}
+#   file.list   {path}          -> file.list.ok   {path, entries:[{name,path,isDir,size}]}
+#   file.read   {path}          -> file.read.ok   {path, content}
+#   file.write  {path, content} -> file.write.ok  {path}
+#   file.create {path, isDir}   -> file.create.ok {path, isDir}
+#   file.delete {path}          -> file.delete.ok {path}
+#   file.move   {path, toPath}  -> file.move.ok   {path, toPath}   # rename == move
+#   any failure                 -> file.error     {op, message}
+# ``op`` in a file.error is list|read|write|create|delete|move.
 # Responses are JSON text frames; terminal output stays binary, so the two
 # multiplexed streams never collide. Content is UTF-8 TEXT (binary is out of
 # scope for v1); a non-UTF-8 read returns file.error rather than corrupting the
@@ -49,6 +57,14 @@ logger = logging.getLogger(__name__)
 # ws.py binds this to the CM-2a′ blob-storage mirror; a bare FileRpc leaves it
 # None (no durability), which is exactly the shape the WC-4a tests exercise.
 OnWrite = Callable[[str, bytes], Awaitable[None]]
+
+# Best-effort delete hook: (rel_path) -> awaitable. ws.py binds this to the
+# overlay DROP so a deleted file is not resurrected from the overlay on restore.
+OnDelete = Callable[[str], Awaitable[None]]
+
+# Best-effort move hook: (src_rel, dst_rel) -> awaitable. ws.py binds this to the
+# overlay RE-KEY so a renamed file replays at its new path on restore.
+OnMove = Callable[[str, str], Awaitable[None]]
 
 # File-op size cap (KB). Applies to a read's downloaded bytes AND a write's
 # encoded content, so neither a huge file nor a huge payload can blow up the
@@ -72,7 +88,8 @@ def _max_file_bytes() -> int:
 
 class FileRpcError(Exception):
     """A file op failed cleanly — carried back to the browser as a ``file.error``
-    frame, never raised out of the socket loop. ``op`` is ``list|read|write``."""
+    frame, never raised out of the socket loop. ``op`` is
+    ``list|read|write|create|delete|move``."""
 
     def __init__(self, op: str, message: str) -> None:
         super().__init__(message)
@@ -148,6 +165,8 @@ class FileRpc:
         sandbox_id: str,
         project_dir: str | None = None,
         on_write: OnWrite | None = None,
+        on_delete: OnDelete | None = None,
+        on_move: OnMove | None = None,
     ) -> None:
         self._client = client
         self._sandbox_id = sandbox_id
@@ -156,6 +175,12 @@ class FileRpc:
         # after a successful VM write so ws.py can mirror the file to durable blob
         # storage. Never awaited in a way that can fail the save — see write_file.
         self._on_write = on_write
+        # Best-effort durability siblings of on_write. on_delete(rel_path) DROPS
+        # the overlay entry after a VM delete; on_move(src_rel, dst_rel) RE-KEYS
+        # it after a VM move. Both are swallowed on failure so a good VM op is
+        # never turned into a client error.
+        self._on_delete = on_delete
+        self._on_move = on_move
 
     async def _root(self) -> str:
         """The jail root: the pinned in-VM workspace dir (``WEBSANDBOX_WORKDIR``).
@@ -239,6 +264,87 @@ class FileRpc:
             except Exception:  # noqa: BLE001 — durability is best-effort; save already landed
                 logger.debug("write-through mirror failed for %r", rel_path, exc_info=True)
 
+    async def _exists(self, abs_path: str) -> bool:
+        """Best-effort existence probe for a JAILED absolute path (file OR dir).
+
+        Lists the parent directory and checks for the basename, so it detects a
+        clash whether the target is a regular file or a directory (a plain
+        ``download_file`` can't see a dir). A missing parent means the target
+        can't exist yet, so a listing error is treated as "does not exist" — the
+        create/move op then proceeds and the VM op itself is the final arbiter.
+        Used to refuse clobbering an existing file on create and an existing
+        destination on move.
+        """
+        parent, _, name = abs_path.rpartition("/")
+        if not name:
+            return False
+        try:
+            infos = await self._client.list_files(self._sandbox_id, parent or "/")
+        except FileNotFoundError:
+            return False
+        return any(getattr(info, "name", None) == name for info in infos)
+
+    async def create(self, rel_path: str, is_dir: bool) -> None:
+        """Create a new file (empty) or directory. Refuses an existing target.
+
+        ``is_dir`` picks ``create_folder`` vs an empty ``upload_bytes``. The
+        project root is not a valid target (``_jail`` rejects empty/'.' for a
+        non-list op). Refuses to clobber an existing path. A newly created FILE
+        is mirrored through ``on_write`` with empty bytes so it lands in the
+        overlay like a normal save; a new DIR carries no content, so no mirror.
+        """
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "create")
+        if await self._exists(abs_path):
+            raise FileRpcError("create", f"already exists: {rel_path}")
+        if is_dir:
+            await self._client.create_folder(self._sandbox_id, abs_path)
+            return
+        await self._client.upload_bytes(self._sandbox_id, b"", abs_path)
+        if self._on_write is not None:
+            try:
+                await self._on_write(rel_path.strip().lstrip("/"), b"")
+            except Exception:  # noqa: BLE001 — durability is best-effort; create already landed
+                logger.debug("create mirror failed for %r", rel_path, exc_info=True)
+
+    async def delete(self, rel_path: str) -> None:
+        """Delete a file or directory (recursive). Refuses the project root.
+
+        After the VM delete lands, calls ``on_delete(rel_path)`` best-effort so
+        the overlay entry is dropped and restore can't resurrect the file.
+        """
+        if (rel_path or "").strip() in ("", ".", "./"):
+            raise FileRpcError("delete", "refusing to delete the project root")
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "delete")
+        await self._client.delete_file(self._sandbox_id, abs_path, recursive=True)
+        if self._on_delete is not None:
+            try:
+                await self._on_delete(rel_path.strip().lstrip("/"))
+            except Exception:  # noqa: BLE001 — durability is best-effort; delete already landed
+                logger.debug("overlay drop failed for %r", rel_path, exc_info=True)
+
+    async def move(self, rel_path: str, to_path: str) -> None:
+        """Move/rename a file or directory. Jails BOTH paths; refuses clobber.
+
+        The source cannot be the project root, and the destination must not
+        already exist. After the VM move lands, calls ``on_move(src, dst)``
+        best-effort so the overlay entry is re-keyed to the new path.
+        """
+        if (rel_path or "").strip() in ("", ".", "./"):
+            raise FileRpcError("move", "refusing to move the project root")
+        root = await self._root()
+        abs_src = _jail(root, rel_path, "move")
+        abs_dst = _jail(root, to_path, "move")
+        if await self._exists(abs_dst):
+            raise FileRpcError("move", f"already exists: {to_path}")
+        await self._client.move_file(self._sandbox_id, abs_src, abs_dst)
+        if self._on_move is not None:
+            try:
+                await self._on_move(rel_path.strip().lstrip("/"), to_path.strip().lstrip("/"))
+            except Exception:  # noqa: BLE001 — durability is best-effort; move already landed
+                logger.debug("overlay re-key failed for %r -> %r", rel_path, to_path, exc_info=True)
+
     # ── Frame dispatch (never raises into the socket loop) ────────────────
 
     async def dispatch(self, msg: dict) -> dict | None:
@@ -269,6 +375,28 @@ class FileRpc:
             if mtype == "file.write":
                 await self.write_file(path, msg.get("content"))
                 return {"type": "file.write.ok", "reqId": req_id, "path": path}
+            if mtype == "file.create":
+                is_dir = bool(msg.get("isDir"))
+                await self.create(path, is_dir)
+                return {
+                    "type": "file.create.ok",
+                    "reqId": req_id,
+                    "path": path,
+                    "isDir": is_dir,
+                }
+            if mtype == "file.delete":
+                await self.delete(path)
+                return {"type": "file.delete.ok", "reqId": req_id, "path": path}
+            if mtype == "file.move":
+                to_path = msg.get("toPath")
+                to_path = to_path if isinstance(to_path, str) else ""
+                await self.move(path, to_path)
+                return {
+                    "type": "file.move.ok",
+                    "reqId": req_id,
+                    "path": path,
+                    "toPath": to_path,
+                }
             # A ``file.*`` type we don't implement — honest error, socket stays up.
             return {
                 "type": "file.error",

--- a/ee/pocketpaw_ee/cloud/websandbox/files.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/files.py
@@ -5,6 +5,12 @@
 # on_delete / on_move durability hooks (siblings of on_write) so a delete or
 # rename is reflected in the overlay tier and never resurrected on restore.
 #
+# Changed 2026-07-16 (WC-9/P3c, feat/code-mode): added file.search — a server-side
+# find-in-files that shells out to ripgrep (grep fallback) in the VM. The user
+# query is a LITERAL fixed string and is ALWAYS shlex.quoted into its own argv
+# token — it never reaches the shell as executable text. Results are capped and a
+# ``truncated`` flag bounds the frame.
+#
 # Socket-agnostic sibling of terminal.py's PtyBridge: this is the file-operation
 # half of the session WebSocket, multiplexed alongside the terminal on the SAME
 # authenticated socket. The browser editor round-trips directory listings, file
@@ -34,8 +40,10 @@
 #   file.create {path, isDir}   -> file.create.ok {path, isDir}
 #   file.delete {path}          -> file.delete.ok {path}
 #   file.move   {path, toPath}  -> file.move.ok   {path, toPath}   # rename == move
+#   file.search {query}         -> file.search.ok {query, results:[{path,line,col,text}],
+#                                                   truncated}
 #   any failure                 -> file.error     {op, message}
-# ``op`` in a file.error is list|read|write|create|delete|move.
+# ``op`` in a file.error is list|read|write|create|delete|move|search.
 # Responses are JSON text frames; terminal output stays binary, so the two
 # multiplexed streams never collide. Content is UTF-8 TEXT (binary is out of
 # scope for v1); a non-UTF-8 read returns file.error rather than corrupting the
@@ -46,6 +54,7 @@ from __future__ import annotations
 import logging
 import os
 import posixpath
+import shlex
 from collections.abc import Awaitable, Callable
 
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient
@@ -70,6 +79,12 @@ OnMove = Callable[[str, str], Awaitable[None]]
 # encoded content, so neither a huge file nor a huge payload can blow up the
 # multiplexed socket frame. Override via POCKETPAW_WEBSANDBOX_MAX_FILE_KB.
 _DEFAULT_MAX_FILE_KB = 1024
+
+# find-in-files (WC-9/P3c). Cap the match count so one broad query can't blow up
+# the JSON frame; ``truncated`` tells the client more matches existed. The exec
+# timeout bounds a search over a huge repo so it can't hang the socket.
+_SEARCH_MAX_RESULTS = 500
+_SEARCH_TIMEOUT_SECONDS = 15
 
 
 def _max_file_bytes() -> int:
@@ -146,6 +161,42 @@ def _rel_entry_path(rel_dir: str, name: str) -> str:
     base = "" if rel_dir.strip() in ("", ".", "./") else rel_dir.strip().strip("/")
     joined = posixpath.normpath(posixpath.join(base, name)) if base else name
     return joined.lstrip("/")
+
+
+def _parse_matches(stdout: str, cap: int, *, with_column: bool) -> tuple[list[dict], bool]:
+    """Parse ``rg``/``grep`` stdout into result rows, capped at ``cap``.
+
+    Each line is ``path:line:col:text`` (rg with ``--column``) or ``path:line:text``
+    (grep, no column). ``rsplit``-free left splits keep colons in ``text`` intact.
+    Malformed lines (too few fields, non-numeric line/col) are skipped rather than
+    aborting the whole search. A leading ``./`` (grep's recursive prefix) is
+    stripped so paths stay project-relative like rg's. Returns ``(rows, truncated)``
+    — ``truncated`` is True when more valid matches existed beyond ``cap``.
+    """
+    rows: list[dict] = []
+    truncated = False
+    for raw in stdout.splitlines():
+        if not raw.strip():
+            continue
+        parts = raw.split(":", 3 if with_column else 2)
+        if len(parts) < (4 if with_column else 3):
+            continue
+        if with_column:
+            path, line_s, col_s, text = parts
+        else:
+            path, line_s, text = parts
+            col_s = "1"  # grep has no column; default to the line start (1-indexed)
+        try:
+            line_n = int(line_s)
+            col_n = int(col_s)
+        except ValueError:
+            continue
+        if len(rows) >= cap:
+            truncated = True
+            break
+        path = path[2:] if path.startswith("./") else path
+        rows.append({"path": path, "line": line_n, "col": col_n, "text": text})
+    return rows, truncated
 
 
 class FileRpc:
@@ -345,6 +396,69 @@ class FileRpc:
             except Exception:  # noqa: BLE001 — durability is best-effort; move already landed
                 logger.debug("overlay re-key failed for %r -> %r", rel_path, to_path, exc_info=True)
 
+    async def search(self, query: str) -> tuple[list[dict], bool]:
+        """Find-in-files across the workspace. Returns ``(results, truncated)``.
+
+        LITERAL fixed-string, smart-case search via ripgrep run in the jailed
+        project root (so paths come back project-relative). The query is ALWAYS
+        ``shlex.quote``d into a single argv token — it can never break out into
+        executable shell — and ``rg -F`` treats it as literal text, not a regex.
+
+        rg exit 0 → matches; exit 1 → no matches (a NORMAL empty result, not an
+        error); exit 127 (rg absent) → fall back to a bounded ``grep``; any other
+        exit — or an exec failure/timeout — is a clean ``FileRpcError``. Results are
+        capped at ``_SEARCH_MAX_RESULTS`` with ``truncated`` set when more existed.
+        """
+        if not isinstance(query, str) or not query.strip():
+            raise FileRpcError("search", "a non-empty 'query' is required")
+        root = await self._root()
+        quoted = shlex.quote(query)
+        # Explicit '.' path: exec has no tty, and rg with no path arg can block on
+        # stdin — a fixed search root avoids that and keeps output project-relative.
+        cmd = (
+            "rg -F --line-number --column --no-heading --color=never --smart-case "
+            f"-- {quoted} ."
+        )
+        try:
+            resp = await self._client.execute_command(
+                self._sandbox_id, cmd, cwd=root, timeout=_SEARCH_TIMEOUT_SECONDS
+            )
+        except Exception as exc:  # noqa: BLE001 — a timeout / exec error is a clean search failure
+            raise FileRpcError("search", "search failed") from exc
+        exit_code = int(getattr(resp, "exit_code", 0) or 0)
+        stdout = getattr(resp, "result", "") or ""
+        if exit_code in (0, 1):  # 0 = matches, 1 = no matches (normal empty result)
+            return _parse_matches(stdout, _SEARCH_MAX_RESULTS, with_column=True)
+        if exit_code == 127:  # rg not installed on this image → grep fallback
+            return await self._search_grep(query, root)
+        raise FileRpcError("search", "search failed")
+
+    async def _search_grep(self, query: str, root: str) -> tuple[list[dict], bool]:
+        """Fallback find-in-files via ``grep`` when ripgrep is unavailable.
+
+        Same quoting discipline (``shlex.quote``) and output contract as ``search``;
+        grep has no column, so ``_parse_matches`` defaults it. Common heavy dirs are
+        excluded (rg honours ``.gitignore`` for free; grep must be told). grep exit 0
+        → matches, 1 → none; anything else (incl. 127 = grep also missing) is a clean
+        ``FileRpcError``.
+        """
+        quoted = shlex.quote(query)
+        cmd = (
+            "grep -rInF --exclude-dir=.git --exclude-dir=node_modules "
+            f"--exclude-dir=dist --exclude-dir=build -- {quoted} ."
+        )
+        try:
+            resp = await self._client.execute_command(
+                self._sandbox_id, cmd, cwd=root, timeout=_SEARCH_TIMEOUT_SECONDS
+            )
+        except Exception as exc:  # noqa: BLE001 — a timeout / exec error is a clean search failure
+            raise FileRpcError("search", "search failed") from exc
+        exit_code = int(getattr(resp, "exit_code", 0) or 0)
+        stdout = getattr(resp, "result", "") or ""
+        if exit_code in (0, 1):
+            return _parse_matches(stdout, _SEARCH_MAX_RESULTS, with_column=False)
+        raise FileRpcError("search", "search is unavailable in this sandbox")
+
     # ── Frame dispatch (never raises into the socket loop) ────────────────
 
     async def dispatch(self, msg: dict) -> dict | None:
@@ -396,6 +510,17 @@ class FileRpc:
                     "reqId": req_id,
                     "path": path,
                     "toPath": to_path,
+                }
+            if mtype == "file.search":
+                query = msg.get("query")
+                query = query if isinstance(query, str) else ""
+                results, truncated = await self.search(query)
+                return {
+                    "type": "file.search.ok",
+                    "reqId": req_id,
+                    "query": query,
+                    "results": results,
+                    "truncated": truncated,
                 }
             # A ``file.*`` type we don't implement — honest error, socket stays up.
             return {

--- a/ee/pocketpaw_ee/cloud/websandbox/files.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/files.py
@@ -1,0 +1,255 @@
+# files.py — Web Cursor file read/write/list RPC core (WC-4a).
+# Created 2026-07-15 (feat/websandbox-file-rpc).
+#
+# Socket-agnostic sibling of terminal.py's PtyBridge: this is the file-operation
+# half of the session WebSocket, multiplexed alongside the terminal on the SAME
+# authenticated socket. The browser editor round-trips directory listings, file
+# reads, and file writes through here; ws.py just parses one JSON frame and calls
+# ``FileRpc.dispatch``. Keeping the logic here (taking a DaytonaClient + a
+# sandbox_id, resolving the project dir lazily) makes the whole path-jail + size
+# guard unit-testable with a fake client and no socket.
+#
+# SECURITY — path jail (the core of this slice): every client path is relative to
+# the sandbox's PROJECT DIR (``client.get_project_dir``). A path is resolved by
+# LEXICALLY normalizing ``<project_dir>/<rel>`` with posixpath (collapsing ``.``
+# and ``..``) and asserting the result is the project dir or lives under it.
+# ``..`` escapes and absolute paths both fail that check and return a
+# ``file.error`` — they NEVER reach download_file/upload_bytes. The jail is
+# lexical rather than realpath-based on purpose: the VM filesystem is REMOTE, so
+# resolving remote symlinks would need a shell round-trip, and it would buy no
+# security here anyway — the socket is already owner-bound to the caller's OWN VM
+# (license -> ws_ticket -> get_sandbox -> authorize_sandbox in ws.py), so a
+# symlink inside it can only point at files the owner already fully controls via
+# the terminal. The jail's job is to stop a crafted ``path`` frame from escaping
+# the project dir, and lexical normalization does exactly that.
+#
+# Frame contract (client->server / server->client), reqId echoed for correlation:
+#   file.list  {path}          -> file.list.ok  {path, entries:[{name,path,isDir,size}]}
+#   file.read  {path}          -> file.read.ok  {path, content}
+#   file.write {path, content} -> file.write.ok {path}
+#   any failure                -> file.error    {op, message}
+# Responses are JSON text frames; terminal output stays binary, so the two
+# multiplexed streams never collide. Content is UTF-8 TEXT (binary is out of
+# scope for v1); a non-UTF-8 read returns file.error rather than corrupting the
+# socket. A size cap (POCKETPAW_WEBSANDBOX_MAX_FILE_KB, default 1024) bounds both
+# read and write so one giant file can't blow up the frame.
+from __future__ import annotations
+
+import logging
+import os
+import posixpath
+
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+
+logger = logging.getLogger(__name__)
+
+# File-op size cap (KB). Applies to a read's downloaded bytes AND a write's
+# encoded content, so neither a huge file nor a huge payload can blow up the
+# multiplexed socket frame. Override via POCKETPAW_WEBSANDBOX_MAX_FILE_KB.
+_DEFAULT_MAX_FILE_KB = 1024
+
+
+def _max_file_bytes() -> int:
+    """Per-file size cap in bytes (``POCKETPAW_WEBSANDBOX_MAX_FILE_KB``, default 1024)."""
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_MAX_FILE_KB", "").strip()
+    kb = _DEFAULT_MAX_FILE_KB
+    if raw:
+        try:
+            kb = int(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_WEBSANDBOX_MAX_FILE_KB=%r; using %d", raw, kb
+            )
+    return max(kb, 1) * 1024
+
+
+class FileRpcError(Exception):
+    """A file op failed cleanly — carried back to the browser as a ``file.error``
+    frame, never raised out of the socket loop. ``op`` is ``list|read|write``."""
+
+    def __init__(self, op: str, message: str) -> None:
+        super().__init__(message)
+        self.op = op
+        self.message = message
+
+
+def _jail(project_dir: str, rel_path: str, op: str) -> str:
+    """Resolve ``rel_path`` under ``project_dir`` and assert it stays inside.
+
+    Lexically normalizes ``<project_dir>/<rel_path>`` with posixpath (VM is
+    Linux; use posixpath NOT os.path so this is correct when the test/host is
+    Windows) and requires the result to be the project dir or live under it.
+    Absolute paths and ``..`` escapes both fail the containment check. Raises
+    :class:`FileRpcError` on any escape or empty path — the caller turns that
+    into a ``file.error`` frame, so download/upload is never reached for a
+    traversal attempt.
+    """
+    if not isinstance(rel_path, str) or not rel_path.strip():
+        raise FileRpcError(op, "a 'path' (relative to the project dir) is required")
+
+    root = posixpath.normpath(project_dir)
+    # posixpath.join drops the left side entirely if rel_path is absolute, so an
+    # absolute path resolves outside the root and is rejected below (belt: the
+    # explicit is_absolute check makes the intent obvious).
+    if posixpath.isabs(rel_path):
+        raise FileRpcError(op, "absolute paths are not allowed; use a path relative to the project")
+
+    resolved = posixpath.normpath(posixpath.join(root, rel_path))
+    if resolved != root and not resolved.startswith(root + "/"):
+        raise FileRpcError(op, "path escapes the project directory")
+    return resolved
+
+
+def _rel_entry_path(rel_dir: str, name: str) -> str:
+    """Build the project-relative path of an entry ``name`` inside ``rel_dir``.
+
+    The browser passes these straight back into a follow-up file op, so they must
+    stay relative to the project root (never absolute). ``.``/empty dir -> just
+    the name."""
+    base = "" if rel_dir.strip() in ("", ".", "./") else rel_dir.strip().strip("/")
+    joined = posixpath.normpath(posixpath.join(base, name)) if base else name
+    return joined.lstrip("/")
+
+
+class FileRpc:
+    """File list/read/write over a Daytona VM, jailed to its project dir.
+
+    One instance per session socket. Holds the DaytonaClient + sandbox_id (both
+    already resolved + owner-authorized by ws.py) and resolves the project dir
+    once, lazily. ``dispatch`` takes a parsed ``file.*`` frame and returns the
+    response frame dict to send back (or ``None`` for a non-file frame, so the
+    ws loop falls through to terminal handling). Op failures come back as a
+    ``file.error`` frame — this class never raises into the socket loop.
+    """
+
+    def __init__(
+        self,
+        client: DaytonaClient,
+        sandbox_id: str,
+        project_dir: str | None = None,
+    ) -> None:
+        self._client = client
+        self._sandbox_id = sandbox_id
+        self._project_dir = project_dir
+
+    async def _root(self) -> str:
+        """Resolve + cache the sandbox project dir (the jail root)."""
+        if self._project_dir is None:
+            self._project_dir = await self._client.get_project_dir(self._sandbox_id)
+        return self._project_dir
+
+    # ── Ops (raise FileRpcError on failure) ───────────────────────────────
+
+    async def list_dir(self, rel_path: str) -> list[dict]:
+        """List a directory. Entries carry project-relative paths for the browser."""
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "list")
+        try:
+            infos = await self._client.list_files(self._sandbox_id, abs_path)
+        except FileNotFoundError as exc:
+            raise FileRpcError("list", f"no such directory: {rel_path}") from exc
+        entries: list[dict] = []
+        for info in infos:
+            name = getattr(info, "name", None)
+            if not name:
+                continue
+            entries.append(
+                {
+                    "name": name,
+                    "path": _rel_entry_path(rel_path, name),
+                    "isDir": bool(getattr(info, "is_dir", False)),
+                    "size": int(getattr(info, "size", 0) or 0),
+                }
+            )
+        return entries
+
+    async def read_file(self, rel_path: str) -> str:
+        """Read a UTF-8 text file. Missing file / oversize / binary -> FileRpcError."""
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "read")
+        try:
+            data = await self._client.download_file(self._sandbox_id, abs_path)
+        except FileNotFoundError as exc:
+            raise FileRpcError("read", f"no such file: {rel_path}") from exc
+        if data is None:
+            raise FileRpcError("read", f"no such file: {rel_path}")
+        cap = _max_file_bytes()
+        if len(data) > cap:
+            raise FileRpcError(
+                "read",
+                f"file is {len(data) // 1024} KB, over the {cap // 1024} KB limit",
+            )
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise FileRpcError("read", "file is not UTF-8 text (binary is not supported)") from exc
+
+    async def write_file(self, rel_path: str, content: str) -> None:
+        """Write UTF-8 text to a file. Oversize / non-string content -> FileRpcError."""
+        if not isinstance(content, str):
+            raise FileRpcError("write", "'content' must be a string")
+        root = await self._root()
+        abs_path = _jail(root, rel_path, "write")
+        data = content.encode("utf-8")
+        cap = _max_file_bytes()
+        if len(data) > cap:
+            raise FileRpcError(
+                "write",
+                f"content is {len(data) // 1024} KB, over the {cap // 1024} KB limit",
+            )
+        await self._client.upload_bytes(self._sandbox_id, data, abs_path)
+
+    # ── Frame dispatch (never raises into the socket loop) ────────────────
+
+    async def dispatch(self, msg: dict) -> dict | None:
+        """Handle one parsed ``file.*`` frame; return the response frame to send.
+
+        Returns ``None`` if ``msg`` is not a file frame (the ws loop then treats
+        it as a terminal frame). All op failures — including a path-jail escape —
+        come back as a ``file.error`` frame; this method never propagates an
+        exception into the receive loop, so one bad frame can't tear the socket
+        down.
+        """
+        mtype = msg.get("type")
+        if not isinstance(mtype, str) or not mtype.startswith("file."):
+            return None
+
+        req_id = msg.get("reqId")
+        req_id = req_id if isinstance(req_id, str) else ""
+        path = msg.get("path")
+        path = path if isinstance(path, str) else ""
+
+        try:
+            if mtype == "file.list":
+                entries = await self.list_dir(path)
+                return {"type": "file.list.ok", "reqId": req_id, "path": path, "entries": entries}
+            if mtype == "file.read":
+                content = await self.read_file(path)
+                return {"type": "file.read.ok", "reqId": req_id, "path": path, "content": content}
+            if mtype == "file.write":
+                await self.write_file(path, msg.get("content"))
+                return {"type": "file.write.ok", "reqId": req_id, "path": path}
+            # A ``file.*`` type we don't implement — honest error, socket stays up.
+            return {
+                "type": "file.error",
+                "reqId": req_id,
+                "op": mtype.removeprefix("file."),
+                "message": f"unsupported file op: {mtype}",
+            }
+        except FileRpcError as exc:
+            return {"type": "file.error", "reqId": req_id, "op": exc.op, "message": exc.message}
+        except Exception as exc:  # noqa: BLE001 — a file op must never kill the socket
+            logger.warning(
+                "websandbox file op failed: type=%s sandbox=%s", mtype, self._sandbox_id,
+                exc_info=True,
+            )
+            op = mtype.removeprefix("file.") if mtype.startswith("file.") else mtype
+            return {
+                "type": "file.error",
+                "reqId": req_id,
+                "op": op,
+                "message": f"file op failed: {exc}",
+            }
+
+
+__all__ = ["FileRpc", "FileRpcError"]

--- a/ee/pocketpaw_ee/cloud/websandbox/files.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/files.py
@@ -40,6 +40,7 @@ import os
 import posixpath
 
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +85,23 @@ def _jail(project_dir: str, rel_path: str, op: str) -> str:
     into a ``file.error`` frame, so download/upload is never reached for a
     traversal attempt.
     """
-    if not isinstance(rel_path, str) or not rel_path.strip():
+    if not isinstance(rel_path, str):
         raise FileRpcError(op, "a 'path' (relative to the project dir) is required")
 
     root = posixpath.normpath(project_dir)
+    # Empty string or '.' addresses the project root itself. The editor's file
+    # tree lists the repo root by requesting path '' (see the frontend
+    # loadTree -> listDir('')), so this MUST resolve to the jail root rather than
+    # being rejected — otherwise the root listing always errors and the tree
+    # shows nothing. Absolute paths and '..' escapes are still refused below.
+    stripped = rel_path.strip()
+    if stripped in ("", ".", "./"):
+        # Listing the root is valid (the tree needs it); reading/writing the
+        # directory itself is not — those still require a real file path.
+        if op == "list":
+            return root
+        raise FileRpcError(op, "a 'path' (relative to the project dir) is required")
+
     # posixpath.join drops the left side entirely if rel_path is absolute, so an
     # absolute path resolves outside the root and is rejected below (belt: the
     # explicit is_absolute check makes the intent obvious).
@@ -133,9 +147,14 @@ class FileRpc:
         self._project_dir = project_dir
 
     async def _root(self) -> str:
-        """Resolve + cache the sandbox project dir (the jail root)."""
+        """The jail root: the pinned in-VM workspace dir (``WEBSANDBOX_WORKDIR``).
+
+        Uses the shared constant, NOT the SDK's ``get_project_dir()`` (which
+        returns ``/root`` on this image and mismatches where the repo is cloned
+        and where the terminal opens). A ``project_dir`` passed to ``__init__``
+        still overrides it (tests inject a fake root)."""
         if self._project_dir is None:
-            self._project_dir = await self._client.get_project_dir(self._sandbox_id)
+            self._project_dir = WEBSANDBOX_WORKDIR
         return self._project_dir
 
     # ── Ops (raise FileRpcError on failure) ───────────────────────────────

--- a/ee/pocketpaw_ee/cloud/websandbox/files.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/files.py
@@ -38,11 +38,17 @@ from __future__ import annotations
 import logging
 import os
 import posixpath
+from collections.abc import Awaitable, Callable
 
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient
 from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
+
+# Best-effort write-through callback: (rel_path, encoded_bytes) -> awaitable.
+# ws.py binds this to the CM-2a′ blob-storage mirror; a bare FileRpc leaves it
+# None (no durability), which is exactly the shape the WC-4a tests exercise.
+OnWrite = Callable[[str, bytes], Awaitable[None]]
 
 # File-op size cap (KB). Applies to a read's downloaded bytes AND a write's
 # encoded content, so neither a huge file nor a huge payload can blow up the
@@ -141,10 +147,15 @@ class FileRpc:
         client: DaytonaClient,
         sandbox_id: str,
         project_dir: str | None = None,
+        on_write: OnWrite | None = None,
     ) -> None:
         self._client = client
         self._sandbox_id = sandbox_id
         self._project_dir = project_dir
+        # Best-effort write-through hook (CM-2a′): called with (rel_path, bytes)
+        # after a successful VM write so ws.py can mirror the file to durable blob
+        # storage. Never awaited in a way that can fail the save — see write_file.
+        self._on_write = on_write
 
     async def _root(self) -> str:
         """The jail root: the pinned in-VM workspace dir (``WEBSANDBOX_WORKDIR``).
@@ -217,6 +228,16 @@ class FileRpc:
                 f"content is {len(data) // 1024} KB, over the {cap // 1024} KB limit",
             )
         await self._client.upload_bytes(self._sandbox_id, data, abs_path)
+
+        # Write-through mirror to durable blob storage (CM-2a′), best-effort: the
+        # VM write above already succeeded (that's what file.write.ok confirms), so
+        # a mirror failure must NOT turn a good save into an error. Pass the
+        # project-relative path so restore can replay it into the same jail slot.
+        if self._on_write is not None:
+            try:
+                await self._on_write(rel_path.strip().lstrip("/"), data)
+            except Exception:  # noqa: BLE001 — durability is best-effort; save already landed
+                logger.debug("write-through mirror failed for %r", rel_path, exc_info=True)
 
     # ── Frame dispatch (never raises into the socket loop) ────────────────
 

--- a/ee/pocketpaw_ee/cloud/websandbox/git.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/git.py
@@ -128,15 +128,15 @@ def _parse_branch_header(header: str) -> tuple[str | None, int, int]:
             token = token.strip()
             try:
                 if token.startswith("ahead "):
-                    ahead = int(token[len("ahead "):])
+                    ahead = int(token[len("ahead ") :])
                 elif token.startswith("behind "):
-                    behind = int(token[len("behind "):])
+                    behind = int(token[len("behind ") :])
             except ValueError:  # a malformed count is simply left at 0
                 continue
         header = header[: match.start()].strip()
     header = header.strip()
     if header.startswith("No commits yet on "):
-        return header[len("No commits yet on "):].strip() or None, ahead, behind
+        return header[len("No commits yet on ") :].strip() or None, ahead, behind
     if header.startswith("HEAD (no branch)"):
         return None, ahead, behind  # detached HEAD
     branch = header.split("...", 1)[0].strip()
@@ -314,9 +314,7 @@ async def push(
     row, daytona = await _resolve_ready(workspace_id, user_id, row_id, client)
     branch = row.branch or ""
     if not branch:
-        return GitPushResponse(
-            pushed=False, branch="", detail="No branch is checked out to push"
-        )
+        return GitPushResponse(pushed=False, branch="", detail="No branch is checked out to push")
 
     cmd = f"git push -u origin {shlex.quote(branch)} 2>&1"
     try:
@@ -332,9 +330,7 @@ async def push(
 
     output = (getattr(resp, "result", "") or "").strip()
     detail = (
-        output[:_MAX_PUSH_DETAIL_CHARS]
-        if output
-        else "Push isn't available in this environment"
+        output[:_MAX_PUSH_DETAIL_CHARS] if output else "Push isn't available in this environment"
     )
     return GitPushResponse(pushed=False, branch=branch, detail=detail)
 

--- a/ee/pocketpaw_ee/cloud/websandbox/git.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/git.py
@@ -1,0 +1,335 @@
+# git.py — Web Cursor git write path: status / stage / commit / push (WC-7/P4a).
+# Created 2026-07-16 (feat/code-mode).
+#
+# Lets a workspace stage, commit, and push its work. Git runs IN the VM via
+# ``execute_command`` in the pinned project root (``WEBSANDBOX_WORKDIR``). The
+# push token is NEVER in the VM: the provisioner already repointed ``origin`` at
+# the codegit broker (``codegit_wire.wire_push_remote``), so an in-VM ``git push``
+# authenticates server-side. Thin service-layer orchestration ABOVE
+# ``websandbox/service.py`` — every op resolves + fail-closed-authorizes the row
+# exactly like ``preview.py`` / ``edit.py`` BEFORE any VM touch.
+#
+# SCOPE: status/stage/commit/push only. PR-open is a separate slice (P4b).
+#
+# SECURITY CRUX: every client-supplied value that lands in a shell string — each
+# staged ``path``, the commit ``message``, and the commit identity name/email — is
+# ``shlex.quote``d into a single argv token. A raw client value is NEVER f-strung
+# into a command, so a path or message full of shell metacharacters can't break out
+# of its token.
+#
+# COMMIT IDENTITY: resolved from the caller's GitHub connection
+# (``codeconnect_service.list_connections`` → the first view carrying an
+# ``account_login``): name = login, email = ``<login>@users.noreply.github.com`` so
+# commits are attributed to the real user the UI already shows. Fallback when there
+# is no connection/login: ``PocketPaw`` / ``noreply@pocketpaw.dev``.
+#
+# DI seam: ``client: DaytonaClient | None = None`` (default ``get_daytona_client()``)
+# so tests inject a fake and never hit real Daytona.
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+
+from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError
+from pocketpaw_ee.cloud.codeconnect import service as codeconnect_service
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
+from pocketpaw_ee.cloud.websandbox.dto import (
+    CommitRequest,
+    GitCommitResponse,
+    GitFileEntry,
+    GitPushResponse,
+    GitStatusResponse,
+    StageRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+# Bounded exec timeouts (seconds). A push reaches the network (the broker proxy),
+# so it gets the longest budget; the local ops are quick.
+_GIT_TIMEOUT_SECONDS = 30
+_PUSH_TIMEOUT_SECONDS = 120
+
+# Fallback commit identity when the caller has no GitHub connection/login yet.
+_FALLBACK_NAME = "PocketPaw"
+_FALLBACK_EMAIL = "noreply@pocketpaw.dev"
+
+# Cap the push ``detail`` so a verbose git error can't bloat the response.
+_MAX_PUSH_DETAIL_CHARS = 500
+
+
+def _require_client(client: DaytonaClient | None) -> DaytonaClient:
+    """Resolve the Daytona client, raising a clean CloudError when unconfigured
+    (mirrors ``preview._require_client`` — a None client is a 503, not a crash)."""
+    resolved = client if client is not None else get_daytona_client()
+    if resolved is None:
+        raise CloudError(
+            503,
+            "websandbox.daytona_unavailable",
+            "The sandbox runtime is not configured",
+        )
+    return resolved
+
+
+async def _resolve_ready(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    client: DaytonaClient | None,
+) -> tuple[WebSandboxView, DaytonaClient]:
+    """Owner-scoped resolve + fail-closed authorize + client, shared by every op.
+
+    ``get_sandbox`` raises ``NotFound`` for a row the caller doesn't own; a row
+    with no bound Daytona id is a clean 409; ``authorize_sandbox`` is the
+    fail-closed oracle run BEFORE any VM touch.
+    """
+    daytona = _require_client(client)
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+    return row, daytona
+
+
+async def _exec(daytona: DaytonaClient, sandbox_id: str, cmd: str, *, timeout: int):
+    """Run a git command in the pinned project root."""
+    return await daytona.execute_command(sandbox_id, cmd, cwd=WEBSANDBOX_WORKDIR, timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# status.
+# ---------------------------------------------------------------------------
+
+
+_BRANCH_TRACKING_RE = re.compile(r"\[(?P<body>[^\]]*)\]")
+
+
+def _parse_branch_header(header: str) -> tuple[str | None, int, int]:
+    """Parse a ``## ...`` porcelain branch header into (branch, ahead, behind).
+
+    Handles ``main...origin/main [ahead 2, behind 1]``, a bare ``main`` (no
+    upstream → 0/0), the fresh-repo ``No commits yet on main``, and detached
+    ``HEAD (no branch)`` → branch None.
+    """
+    ahead = behind = 0
+    match = _BRANCH_TRACKING_RE.search(header)
+    if match:
+        for token in match.group("body").split(","):
+            token = token.strip()
+            try:
+                if token.startswith("ahead "):
+                    ahead = int(token[len("ahead "):])
+                elif token.startswith("behind "):
+                    behind = int(token[len("behind "):])
+            except ValueError:  # a malformed count is simply left at 0
+                continue
+        header = header[: match.start()].strip()
+    header = header.strip()
+    if header.startswith("No commits yet on "):
+        return header[len("No commits yet on "):].strip() or None, ahead, behind
+    if header.startswith("HEAD (no branch)"):
+        return None, ahead, behind  # detached HEAD
+    branch = header.split("...", 1)[0].strip()
+    return (branch or None), ahead, behind
+
+
+def _parse_status(stdout: str) -> GitStatusResponse:
+    """Parse ``git status --porcelain=v1 -b`` into a GitStatusResponse.
+
+    Each non-header line is ``XY<space>path`` — X is the index (staged) column and
+    Y the worktree (unstaged) column. ``staged`` is True when the index column is a
+    real change (not a space and not the ``?`` untracked marker). A rename line
+    (``R  old -> new``) reports the NEW path. Malformed short lines are skipped.
+    """
+    branch: str | None = None
+    ahead = behind = 0
+    files: list[GitFileEntry] = []
+    for raw in stdout.splitlines():
+        if raw.startswith("## "):
+            branch, ahead, behind = _parse_branch_header(raw[3:])
+            continue
+        if len(raw) < 4:  # need at least "XY p"
+            continue
+        index = raw[0]
+        worktree = raw[1]
+        path = raw[3:]
+        if index in ("R", "C") and " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        files.append(
+            GitFileEntry(
+                path=path,
+                index=index,
+                worktree=worktree,
+                staged=index not in (" ", "?"),
+            )
+        )
+    return GitStatusResponse(branch=branch, ahead=ahead, behind=behind, files=files)
+
+
+async def _read_status(daytona: DaytonaClient, sandbox_id: str) -> GitStatusResponse:
+    """Run + parse ``git status``. A non-zero exit is a clean CloudError."""
+    resp = await _exec(
+        daytona, sandbox_id, "git status --porcelain=v1 -b", timeout=_GIT_TIMEOUT_SECONDS
+    )
+    if int(getattr(resp, "exit_code", 0) or 0) != 0:
+        raise CloudError(502, "websandbox.git_failed", "Failed to read git status")
+    return _parse_status(getattr(resp, "result", "") or "")
+
+
+async def git_status(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    *,
+    client: DaytonaClient | None = None,
+) -> GitStatusResponse:
+    """Return the working-tree status of a ready sandbox's repo."""
+    row, daytona = await _resolve_ready(workspace_id, user_id, row_id, client)
+    return await _read_status(daytona, row.sandbox_id)
+
+
+# ---------------------------------------------------------------------------
+# stage / unstage.
+# ---------------------------------------------------------------------------
+
+
+async def stage(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    body: StageRequest | dict,
+    *,
+    client: DaytonaClient | None = None,
+) -> GitStatusResponse:
+    """Stage (``git add``) or unstage (``git reset HEAD``) each path, then return a
+    fresh status. Every path is ``shlex.quote``d into one argv token."""
+    body = StageRequest.model_validate(body)
+    row, daytona = await _resolve_ready(workspace_id, user_id, row_id, client)
+    for path in body.paths:
+        quoted = shlex.quote(path)
+        cmd = f"git reset -q HEAD -- {quoted}" if body.unstage else f"git add -- {quoted}"
+        resp = await _exec(daytona, row.sandbox_id, cmd, timeout=_GIT_TIMEOUT_SECONDS)
+        if int(getattr(resp, "exit_code", 0) or 0) != 0:
+            raise CloudError(
+                502,
+                "websandbox.git_failed",
+                f"Failed to {'unstage' if body.unstage else 'stage'} {path}",
+            )
+    return await _read_status(daytona, row.sandbox_id)
+
+
+# ---------------------------------------------------------------------------
+# commit.
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_identity(workspace_id: str, user_id: str) -> tuple[str, str]:
+    """Resolve the commit identity from the caller's GitHub connection.
+
+    The first connection carrying an ``account_login`` wins: name = login,
+    email = ``<login>@users.noreply.github.com`` (GitHub's no-reply form). No
+    connection/login → the PocketPaw fallback identity. Connection-lookup failures
+    fall back too — a commit must never fail because identity resolution hiccuped.
+    """
+    try:
+        conns = await codeconnect_service.list_connections(workspace_id, user_id)
+    except Exception:  # noqa: BLE001 — identity is best-effort; fall back rather than fail the commit
+        logger.debug("git: identity lookup failed; using fallback", exc_info=True)
+        conns = []
+    for conn in conns:
+        login = getattr(conn, "account_login", None)
+        if login:
+            return login, f"{login}@users.noreply.github.com"
+    return _FALLBACK_NAME, _FALLBACK_EMAIL
+
+
+async def commit(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    body: CommitRequest | dict,
+    *,
+    client: DaytonaClient | None = None,
+) -> GitCommitResponse:
+    """Commit the staged changes as the resolved identity; capture the new SHA.
+
+    Nothing staged (``git diff --cached --quiet`` exits 0) is a clean
+    ``committed:false`` result, not a crash. The message and identity are
+    ``shlex.quote``d into single argv tokens.
+    """
+    body = CommitRequest.model_validate(body)
+    row, daytona = await _resolve_ready(workspace_id, user_id, row_id, client)
+
+    # Nothing staged? --cached --quiet exits 0 when the index matches HEAD.
+    probe = await _exec(
+        daytona, row.sandbox_id, "git diff --cached --quiet", timeout=_GIT_TIMEOUT_SECONDS
+    )
+    if int(getattr(probe, "exit_code", 0) or 0) == 0:
+        return GitCommitResponse(sha="", committed=False)
+
+    name, email = await _resolve_identity(workspace_id, user_id)
+    commit_cmd = (
+        f"git -c user.name={shlex.quote(name)} -c user.email={shlex.quote(email)} "
+        f"commit -m {shlex.quote(body.message)}"
+    )
+    resp = await _exec(daytona, row.sandbox_id, commit_cmd, timeout=_GIT_TIMEOUT_SECONDS)
+    if int(getattr(resp, "exit_code", 0) or 0) != 0:
+        raise CloudError(502, "websandbox.git_commit_failed", "The commit failed")
+
+    head = await _exec(daytona, row.sandbox_id, "git rev-parse HEAD", timeout=_GIT_TIMEOUT_SECONDS)
+    sha = (getattr(head, "result", "") or "").strip()
+    return GitCommitResponse(sha=sha, committed=True)
+
+
+# ---------------------------------------------------------------------------
+# push.
+# ---------------------------------------------------------------------------
+
+
+async def push(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    *,
+    client: DaytonaClient | None = None,
+) -> GitPushResponse:
+    """Push the sandbox's feature branch to ``origin`` (the broker proxy).
+
+    Pushes ``row.branch`` — the ``paw/edit-*`` the provisioner bound. Exit 0 →
+    ``pushed:true``. A push failure NEVER raises: it comes back as
+    ``pushed:false`` with a human ``detail`` (e.g. the broker origin isn't wired
+    because ``POCKETPAW_PUBLIC_BASE_URL`` is local — see ``codegit/wire``). stderr
+    is folded into stdout (``2>&1``) so the reason is captured for ``detail``.
+    """
+    row, daytona = await _resolve_ready(workspace_id, user_id, row_id, client)
+    branch = row.branch or ""
+    if not branch:
+        return GitPushResponse(
+            pushed=False, branch="", detail="No branch is checked out to push"
+        )
+
+    cmd = f"git push -u origin {shlex.quote(branch)} 2>&1"
+    try:
+        resp = await _exec(daytona, row.sandbox_id, cmd, timeout=_PUSH_TIMEOUT_SECONDS)
+    except Exception:  # noqa: BLE001 — a push must never 500; surface it as pushed:false
+        logger.warning("git push exec failed for row=%s", row_id, exc_info=True)
+        return GitPushResponse(
+            pushed=False, branch=branch, detail="Push isn't available in this environment"
+        )
+
+    if int(getattr(resp, "exit_code", 0) or 0) == 0:
+        return GitPushResponse(pushed=True, branch=branch, detail=None)
+
+    output = (getattr(resp, "result", "") or "").strip()
+    detail = (
+        output[:_MAX_PUSH_DETAIL_CHARS]
+        if output
+        else "Push isn't available in this environment"
+    )
+    return GitPushResponse(pushed=False, branch=branch, detail=detail)
+
+
+__all__ = ["commit", "git_status", "push", "stage"]

--- a/ee/pocketpaw_ee/cloud/websandbox/git.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/git.py
@@ -9,7 +9,10 @@
 # ``websandbox/service.py`` — every op resolves + fail-closed-authorizes the row
 # exactly like ``preview.py`` / ``edit.py`` BEFORE any VM touch.
 #
-# SCOPE: status/stage/commit/push only. PR-open is a separate slice (P4b).
+# SCOPE: status/stage/commit/push, plus open-a-PR (P4b). ``open_pr`` is the only op
+# that does NOT touch the VM — it opens a GitHub pull request server-side via the
+# GitHub App (the token never enters the VM), for the ``paw/edit-*`` branch the
+# push already put on the remote.
 #
 # SECURITY CRUX: every client-supplied value that lands in a shell string — each
 # staged ``path``, the commit ``message``, and the commit identity name/email — is
@@ -31,20 +34,24 @@ import logging
 import re
 import shlex
 
-from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError
+from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError, ConflictError
 from pocketpaw_ee.cloud.codeconnect import service as codeconnect_service
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import broker as websandbox_broker
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
 from pocketpaw_ee.cloud.websandbox.dto import (
     CommitRequest,
+    CreatePrRequest,
     GitCommitResponse,
     GitFileEntry,
+    GitPrResponse,
     GitPushResponse,
     GitStatusResponse,
     StageRequest,
 )
+from pocketpaw_ee.cloud.websandbox.githubapp import GitHubAppError, get_github_app_client
 
 logger = logging.getLogger(__name__)
 
@@ -332,4 +339,116 @@ async def push(
     return GitPushResponse(pushed=False, branch=branch, detail=detail)
 
 
-__all__ = ["commit", "git_status", "push", "stage"]
+# ---------------------------------------------------------------------------
+# open pull request (P4b).
+# ---------------------------------------------------------------------------
+
+
+def _repo_full_name(repo_raw: str) -> str | None:
+    """Normalize the row's ``repo`` to ``owner/name`` (URL or bare ``owner/repo``).
+
+    Reuses the broker's URL parser for an https git URL; if the row instead stored a
+    bare ``owner/repo`` (no scheme), accepts that too. Returns ``None`` for anything
+    that isn't a recognizable two-segment repo.
+    """
+    full = websandbox_broker.repo_full_name(repo_raw)
+    if full:
+        return full
+    cleaned = (repo_raw or "").strip().removesuffix(".git").strip("/")
+    if "://" in cleaned:
+        return None
+    parts = [p for p in cleaned.split("/") if p]
+    return "/".join(parts[:2]) if len(parts) == 2 else None
+
+
+async def _resolve_pr_installation(
+    workspace_id: str,
+    user_id: str,
+    repo_full: str,
+    github_client,  # noqa: ANN001 — a GitHubAppClient-shaped object (DI seam)
+) -> tuple[str | None, str | None]:
+    """Find the first GitHub connection whose installation can reach ``repo_full``.
+
+    Broker-style routing: iterate the caller's connections and probe each with
+    ``get_default_branch`` — which mints a repo-scoped token GitHub declines when the
+    installation can't see the repo, so a success both proves reachability AND yields
+    the PR base branch in one call. Returns ``(installation_id, base)`` for the first
+    reachable connection, or ``(None, None)`` when none can reach it.
+    """
+    conns = await codeconnect_service.list_connections(workspace_id, user_id)
+    for conn in conns:
+        if conn.provider != "github":
+            continue
+        try:
+            base = await github_client.get_default_branch(conn.installation_id, repo_full)
+        except GitHubAppError:
+            continue  # this installation can't reach the repo — try the next
+        return conn.installation_id, base
+    return None, None
+
+
+async def open_pr(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    body: CreatePrRequest | dict,
+    *,
+    client: DaytonaClient | None = None,
+    github_client=None,  # noqa: ANN001 — a GitHubAppClient-shaped object (DI seam)
+) -> GitPrResponse:
+    """Open a GitHub pull request for the sandbox's pushed feature branch.
+
+    Resolves + authorizes the row (same guard as the other git ops), then works
+    entirely against GitHub server-side — the VM is never touched. The head is the
+    row's ``paw/edit-*`` branch (already pushed via ``push``); the base is the repo's
+    default branch. The installation is resolved broker-style from the caller's
+    connections. This does NOT auto-push: if the head isn't on the remote yet,
+    GitHub's 422 message ("make sure the branch is pushed") is surfaced as-is.
+    """
+    body = CreatePrRequest.model_validate(body)
+    row, _daytona = await _resolve_ready(workspace_id, user_id, row_id, client)
+
+    head = row.branch or ""
+    if not head:
+        raise ConflictError(
+            "websandbox.no_branch", "This sandbox has no feature branch to open a pull request from"
+        )
+
+    repo_full = _repo_full_name(row.repo)
+    if repo_full is None:
+        raise BadRequest(
+            "websandbox.pr_repo_unrecognized",
+            "This workspace's repository isn't a recognizable GitHub repository",
+        )
+
+    gh = github_client if github_client is not None else get_github_app_client()
+    if gh is None:
+        raise CloudError(
+            503, "websandbox.github_not_configured", "GitHub is not configured for pull requests"
+        )
+
+    installation_id, base = await _resolve_pr_installation(workspace_id, user_id, repo_full, gh)
+    if installation_id is None:
+        # No connection whose installation can reach this repo — the user must
+        # connect GitHub and grant this repository to the Paw app.
+        raise BadRequest(
+            "websandbox.pr_no_connection",
+            "Connect GitHub and grant this repository access before opening a pull request",
+        )
+
+    result = await gh.create_pull_request(
+        installation_id,
+        repo_full,
+        head=head,
+        base=base,
+        title=body.title,
+        body=body.body,
+    )
+    url = result.get("url")
+    number = result.get("number")
+    if not url or number is None:
+        raise CloudError(502, "websandbox.pr_failed", "GitHub returned an incomplete pull request")
+    return GitPrResponse(url=url, number=int(number))
+
+
+__all__ = ["commit", "git_status", "open_pr", "push", "stage"]

--- a/ee/pocketpaw_ee/cloud/websandbox/githubapp.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/githubapp.py
@@ -99,8 +99,19 @@ def github_app_slug() -> str:
     Distinct from the numeric App id: GitHub's install page is keyed by the slug
     (e.g. ``devrohit06-personal``). Returns '' when unset — callers surface a clean
     "GitHub connect not configured" rather than building a broken URL.
+
+    Forgiving of a mis-set env: someone naturally pastes the whole install URL
+    (``https://github.com/apps/devrohit06-personal``) into the slug var, which would
+    otherwise double-wrap into ``/apps/https://github.com/apps/<slug>/…`` and 404.
+    We extract the bare slug — take the segment after ``/apps/`` if present, then
+    the first path segment — so both the bare slug and a pasted URL resolve right.
     """
-    return os.environ.get("POCKETPAW_GITHUB_APP_SLUG", "").strip()
+    raw = os.environ.get("POCKETPAW_GITHUB_APP_SLUG", "").strip()
+    if not raw:
+        return ""
+    if "/apps/" in raw:
+        raw = raw.split("/apps/", 1)[1]
+    return raw.strip("/").split("/")[0]
 
 
 def github_app_enabled() -> bool:

--- a/ee/pocketpaw_ee/cloud/websandbox/githubapp.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/githubapp.py
@@ -332,6 +332,32 @@ class GitHubAppClient:
             )
         return list(resp.json().get("repositories", []))
 
+    async def get_installation_account(
+        self, installation_id: str, *, now: datetime | None = None
+    ) -> dict[str, Any] | None:
+        """Fetch the account (login + avatar) an installation belongs to, for display.
+
+        ``GET /app/installations/{id}`` authenticated with the App JWT returns the
+        installation's ``account`` object. Returns ``{"login", "avatar_url"}`` or
+        ``None`` when GitHub declines or the account is absent — this is best-effort
+        display enrichment, never a hard dependency of the connect flow, so callers
+        treat ``None`` as "no display info yet" rather than an error.
+        """
+        url = f"{self._api_base}/app/installations/{installation_id}"
+        headers = {
+            "Authorization": f"Bearer {self.app_jwt(now=now)}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        resp = await self._request("GET", url, headers=headers)
+        if resp.status_code != 200:
+            return None
+        account = (resp.json() or {}).get("account") or {}
+        login = account.get("login")
+        if not login:
+            return None
+        return {"login": login, "avatar_url": account.get("avatar_url")}
+
     # -- transport ------------------------------------------------------------
 
     async def _request(

--- a/ee/pocketpaw_ee/cloud/websandbox/githubapp.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/githubapp.py
@@ -332,6 +332,86 @@ class GitHubAppClient:
             )
         return list(resp.json().get("repositories", []))
 
+    async def get_default_branch(
+        self, installation_id: str, repo: str, *, now: datetime | None = None
+    ) -> str:
+        """The default branch of ``repo`` (``owner/name``) — the PR base.
+
+        Mints a repo-scoped ``metadata:read`` token (which GitHub declines when the
+        installation can't reach the repo — the same reachability signal the broker
+        relies on) and reads ``GET /repos/{owner}/{name}``. A non-200 (incl. a 404
+        for a repo this installation can't see) raises a clean ``GitHubAppError`` so
+        the caller can try the next connection. Falls back to ``main`` if the field
+        is absent.
+        """
+        meta = await self.mint_installation_token(
+            installation_id,
+            repositories=[_repo_short_name(repo)],
+            permissions={"metadata": "read"},
+            now=now,
+        )
+        owner, name = _split_owner_repo(repo)
+        url = f"{self._api_base}/repos/{owner}/{name}"
+        headers = {
+            "Authorization": f"token {meta.token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        resp = await self._request("GET", url, headers=headers)
+        if resp.status_code != 200:
+            raise GitHubAppError(
+                "websandbox.repo_unreachable",
+                f"Could not read repository {repo} (HTTP {resp.status_code})",
+                status=404 if resp.status_code == 404 else 502,
+            )
+        return (resp.json() or {}).get("default_branch") or "main"
+
+    async def create_pull_request(
+        self,
+        installation_id: str,
+        repo: str,
+        *,
+        head: str,
+        base: str,
+        title: str,
+        body: str = "",
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Open a pull request on ``repo`` (``owner/name``); return ``{url, number}``.
+
+        Mints a repo-scoped token with least-privilege write (contents +
+        pull_requests) and ``POST /repos/{owner}/{name}/pulls`` with
+        ``{title, head, base, body}``. 201 → the PR's ``html_url`` + ``number``. A
+        422 is GitHub's field-level rejection (no commits between head/base, the
+        head branch isn't pushed, or a PR already exists) — surfaced as a clean
+        422 ``GitHubAppError`` carrying GitHub's own ``errors[].message`` when
+        present. Any other non-201 is a clean error carrying the status.
+        """
+        inst = await self.mint_installation_token(
+            installation_id,
+            repositories=[_repo_short_name(repo)],
+            permissions={"contents": "write", "pull_requests": "write"},
+            now=now,
+        )
+        owner, name = _split_owner_repo(repo)
+        url = f"{self._api_base}/repos/{owner}/{name}/pulls"
+        headers = {
+            "Authorization": f"token {inst.token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        payload = {"title": title, "head": head, "base": base, "body": body}
+        resp = await self._request("POST", url, headers=headers, json=payload)
+        if resp.status_code == 201:
+            data = resp.json() or {}
+            return {"url": data.get("html_url"), "number": data.get("number")}
+        if resp.status_code == 422:
+            raise GitHubAppError("websandbox.pr_invalid", _pr_error_message(resp), status=422)
+        raise GitHubAppError(
+            "websandbox.pr_failed",
+            f"GitHub declined to open the pull request (HTTP {resp.status_code})",
+        )
+
     async def get_installation_account(
         self, installation_id: str, *, now: datetime | None = None
     ) -> dict[str, Any] | None:
@@ -379,6 +459,32 @@ class GitHubAppClient:
 def _repo_short_name(repo: str) -> str:
     """``owner/repo`` → ``repo`` (GitHub's access-token endpoint scopes by name)."""
     return repo.removesuffix(".git").split("/")[-1]
+
+
+def _split_owner_repo(repo: str) -> tuple[str, str]:
+    """``owner/repo`` → ``(owner, repo)`` for building a ``/repos/{owner}/{repo}`` URL."""
+    cleaned = repo.removesuffix(".git").strip("/")
+    owner, _, name = cleaned.partition("/")
+    return owner, name
+
+
+def _pr_error_message(resp: _HttpResponse) -> str:
+    """Extract a human message from a GitHub 422 PR response.
+
+    Prefers the first ``errors[].message`` (GitHub's specific reason, e.g. "No
+    commits between …" or "A pull request already exists …"), then the top-level
+    ``message``, then a sensible default that hints the branch may not be pushed.
+    """
+    try:
+        data = resp.json() or {}
+    except Exception:  # noqa: BLE001 — a non-JSON body just falls through to the default
+        data = {}
+    for err in data.get("errors") or []:
+        if isinstance(err, dict) and err.get("message"):
+            return str(err["message"])
+    if data.get("message"):
+        return str(data["message"])
+    return "GitHub could not open the pull request (make sure the branch is pushed)"
 
 
 def _parse_expiry(value: Any) -> datetime:

--- a/ee/pocketpaw_ee/cloud/websandbox/githubapp.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/githubapp.py
@@ -1,0 +1,382 @@
+# githubapp.py — GitHub App token client for the Web Cursor git-proxy broker (WC-6).
+# Created 2026-07-16 (feat/code-mode).
+#
+# This is the "mint the token OUTSIDE the VM" half of WC-6's token-isolation
+# guarantee. It turns the Paw GitHub App's private key into short-lived, single-
+# repo, least-privilege installation tokens that the broker (githubapp → broker,
+# a later slice) injects upstream when the VM's git remote talks to github.com.
+# The token itself NEVER touches the sandbox — the VM sees only the broker URL.
+#
+# Two credentials, two scopes:
+#   * App JWT — signed RS256 with the App private key, iss = App id, exp ≤ 10 min
+#     (GitHub's hard cap). Authenticates AS THE APP to mint installation tokens.
+#     Held only in memory for the length of one mint call.
+#   * Installation token — minted per git operation, scoped to a SINGLE repo
+#     (``repositories=[name]``) with least-privilege permissions (contents +
+#     pull_requests), GitHub-lifetimed to ≤ 1h. This is what the broker injects
+#     upstream; it is repo-scoped so a leak can't reach the tenant's other repos.
+#
+# The HTTP layer is injected (``http=``) so tests exercise the JWT + request
+# shaping against a fake GitHub with no network and no real App. ``get_github_app_
+# client()`` mirrors ``get_daytona_client()``: returns ``None`` when the App isn't
+# configured, so callers degrade cleanly instead of crashing.
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+import jwt
+
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.websandbox.repoauth import (
+    ProviderId,
+    RemoteRepo,
+    ScopedRepoToken,
+)
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_API_BASE = "https://api.github.com"
+# The git host the broker proxies clone/fetch/push to (github.com for public
+# GitHub; a GHES host for enterprise). Distinct from the REST api base.
+_GITHUB_GIT_BASE = "https://github.com"
+
+# GitHub caps the App JWT lifetime at 10 minutes; use 9 to leave headroom, and
+# backdate ``iat`` 60s so minor clock skew between us and GitHub can't reject it.
+_APP_JWT_TTL_SECONDS = 540
+_APP_JWT_BACKDATE_SECONDS = 60
+
+# Least-privilege default for a Web Cursor session: read/write the repo contents
+# (clone / fetch / push) and open pull requests (WC-7). Nothing else — no admin,
+# no secrets, no workflow scope.
+_DEFAULT_PERMISSIONS = {"contents": "write", "pull_requests": "write"}
+
+
+# ---------------------------------------------------------------------------
+# Config (env), mirroring daytona/config.py.
+# ---------------------------------------------------------------------------
+
+
+def _app_id() -> str:
+    return os.environ.get("POCKETPAW_GITHUB_APP_ID", "").strip()
+
+
+def _private_key_pem() -> str:
+    """The App private key as a PEM string.
+
+    Accepts the raw PEM, a PEM with escaped ``\\n`` newlines (common in
+    single-line env vars), or a base64-encoded PEM blob. Returns '' when unset.
+    """
+    raw = os.environ.get("POCKETPAW_GITHUB_APP_PRIVATE_KEY", "").strip()
+    if not raw:
+        return ""
+    if "-----BEGIN" in raw:
+        # Real PEM, possibly with literal ``\n`` sequences from a one-line env var.
+        return raw.replace("\\n", "\n")
+    # No PEM header → assume base64-encoded PEM.
+    try:
+        return base64.b64decode(raw).decode()
+    except Exception:  # noqa: BLE001 — a malformed key is simply "not configured"
+        logger.warning("POCKETPAW_GITHUB_APP_PRIVATE_KEY is set but not valid PEM/base64")
+        return ""
+
+
+def _api_base() -> str:
+    return os.environ.get("GITHUB_API_BASE", _GITHUB_API_BASE).strip().rstrip("/")
+
+
+def _git_base() -> str:
+    return os.environ.get("GITHUB_GIT_BASE", _GITHUB_GIT_BASE).strip().rstrip("/")
+
+
+def github_app_enabled() -> bool:
+    """True when both the App id and a usable private key are configured."""
+    return bool(_app_id() and _private_key_pem())
+
+
+# ---------------------------------------------------------------------------
+# Injected HTTP seam — httpx.AsyncClient satisfies it; tests pass a fake.
+# ---------------------------------------------------------------------------
+
+
+class _HttpResponse(Protocol):
+    status_code: int
+
+    def json(self) -> Any: ...
+
+    @property
+    def text(self) -> str: ...
+
+
+class _HttpClient(Protocol):
+    async def post(
+        self, url: str, *, headers: dict[str, str], json: dict[str, Any] | None = None
+    ) -> _HttpResponse: ...
+
+    async def get(self, url: str, *, headers: dict[str, str]) -> _HttpResponse: ...
+
+
+@dataclass(frozen=True)
+class InstallationToken:
+    """A minted, repo-scoped installation token and its GitHub-set expiry."""
+
+    token: str
+    expires_at: datetime
+    permissions: dict[str, str]
+    repositories: tuple[str, ...]
+
+
+class GitHubAppError(CloudError):
+    """A GitHub App / installation-token exchange failed."""
+
+    def __init__(self, code: str, message: str, status: int = 502) -> None:
+        super().__init__(status, code, message)
+
+
+class GitHubAppClient:
+    """GitHub implementation of ``RepoAuthProvider`` for the git-proxy broker.
+
+    Mints App JWTs and single-repo installation tokens (``connection_id`` is the
+    GitHub App installation id). Stateless apart from its credentials + the
+    injected HTTP client. Construct via ``get_github_app_client()`` in production;
+    construct directly with a fake ``http`` in tests. The broker programs against
+    the neutral ``RepoAuthProvider`` protocol, not this class directly.
+    """
+
+    provider_id: ProviderId = ProviderId.GITHUB
+
+    def __init__(
+        self,
+        app_id: str,
+        private_key_pem: str,
+        *,
+        api_base: str = _GITHUB_API_BASE,
+        git_base: str = _GITHUB_GIT_BASE,
+        http: _HttpClient | None = None,
+    ) -> None:
+        self._app_id = app_id
+        self._private_key = private_key_pem
+        self._api_base = api_base.rstrip("/")
+        self._git_base = git_base.rstrip("/")
+        self._http = http
+
+    # -- RepoAuthProvider (neutral surface the broker uses) -------------------
+
+    async def mint_repo_token(
+        self,
+        connection_id: str,
+        repo: str,
+        *,
+        scopes: dict[str, str] | None = None,
+        now: datetime | None = None,
+    ) -> ScopedRepoToken:
+        """Mint a JIT token scoped to a single ``repo`` (``owner/repo``).
+
+        GitHub's access-token endpoint scopes by repo NAME within the
+        installation's owner, so we pass the short name; the neutral token still
+        carries the full ``owner/repo`` for the broker's clone URL.
+        """
+        installation = await self.mint_installation_token(
+            connection_id,
+            repositories=[_repo_short_name(repo)],
+            permissions=scopes,
+            now=now,
+        )
+        return ScopedRepoToken(
+            provider=ProviderId.GITHUB,
+            token=installation.token,
+            expires_at=installation.expires_at,
+            repo=repo,
+            scopes=installation.permissions,
+        )
+
+    async def list_repositories(
+        self, connection_id: str, *, now: datetime | None = None
+    ) -> list[RemoteRepo]:
+        """List the installation's repos as neutral ``RemoteRepo`` rows."""
+        raw = await self.list_installation_repositories(connection_id, now=now)
+        repos: list[RemoteRepo] = []
+        for r in raw:
+            full = r.get("full_name") or ""
+            if not full:
+                continue
+            repos.append(
+                RemoteRepo(
+                    full_name=full,
+                    private=bool(r.get("private", True)),
+                    default_branch=r.get("default_branch") or "main",
+                    clone_url=r.get("clone_url") or self.upstream_clone_url(full),
+                )
+            )
+        return repos
+
+    def upstream_clone_url(self, repo: str) -> str:
+        """The github.com https URL the broker proxies to (never given to the VM)."""
+        return f"{self._git_base}/{repo.removesuffix('.git')}.git"
+
+    # -- App JWT --------------------------------------------------------------
+
+    def app_jwt(self, *, now: datetime | None = None) -> str:
+        """Mint a short-lived RS256 App JWT (iss=App id, exp ≤ 10 min).
+
+        Deterministic under an injected ``now`` so tests can assert the claims.
+        """
+        moment = now or datetime.now(UTC)
+        iat = int(moment.timestamp()) - _APP_JWT_BACKDATE_SECONDS
+        exp = int(moment.timestamp()) + _APP_JWT_TTL_SECONDS
+        payload = {"iat": iat, "exp": exp, "iss": self._app_id}
+        try:
+            return jwt.encode(payload, self._private_key, algorithm="RS256")
+        except Exception as exc:  # noqa: BLE001 — a bad key is an operational error
+            raise GitHubAppError(
+                "websandbox.github_app_key_invalid",
+                "The GitHub App private key could not sign a token",
+            ) from exc
+
+    # -- Installation token ---------------------------------------------------
+
+    async def mint_installation_token(
+        self,
+        installation_id: str,
+        *,
+        repositories: list[str] | None = None,
+        permissions: dict[str, str] | None = None,
+        now: datetime | None = None,
+    ) -> InstallationToken:
+        """Mint a JIT installation token, scoped to ``repositories`` if given.
+
+        Always pass a single repo name for a git operation — a repo-scoped token
+        can't reach the tenant's other repos if it leaks. ``permissions`` defaults
+        to least-privilege (contents + pull_requests). GitHub sets the expiry
+        (≤ 1h); it's returned so the broker can refresh before it lapses.
+        """
+        perms = permissions or dict(_DEFAULT_PERMISSIONS)
+        body: dict[str, Any] = {"permissions": perms}
+        if repositories:
+            body["repositories"] = repositories
+
+        url = f"{self._api_base}/app/installations/{installation_id}/access_tokens"
+        headers = {
+            "Authorization": f"Bearer {self.app_jwt(now=now)}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        resp = await self._request("POST", url, headers=headers, json=body)
+        if resp.status_code != 201:
+            raise GitHubAppError(
+                "websandbox.installation_token_failed",
+                f"GitHub declined to mint an installation token (HTTP {resp.status_code})",
+            )
+        data = resp.json()
+        token = data.get("token")
+        if not token:
+            raise GitHubAppError(
+                "websandbox.installation_token_failed",
+                "GitHub returned no installation token",
+            )
+        return InstallationToken(
+            token=token,
+            expires_at=_parse_expiry(data.get("expires_at")),
+            permissions=data.get("permissions", perms),
+            repositories=tuple(repositories or ()),
+        )
+
+    async def list_installation_repositories(
+        self, installation_id: str, *, now: datetime | None = None
+    ) -> list[dict[str, Any]]:
+        """List the repos an installation can reach (for the repo picker).
+
+        Uses a metadata-only installation token, minted + used server-side only —
+        it never enters a VM. Returns the raw GitHub repo objects (full_name,
+        private, default_branch, …) for the frontend to render.
+        """
+        meta = await self.mint_installation_token(
+            installation_id, permissions={"metadata": "read"}, now=now
+        )
+        url = f"{self._api_base}/installation/repositories?per_page=100"
+        headers = {
+            "Authorization": f"token {meta.token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        resp = await self._request("GET", url, headers=headers)
+        if resp.status_code != 200:
+            raise GitHubAppError(
+                "websandbox.installation_repos_failed",
+                f"Could not list installed repositories (HTTP {resp.status_code})",
+            )
+        return list(resp.json().get("repositories", []))
+
+    # -- transport ------------------------------------------------------------
+
+    async def _request(
+        self, method: str, url: str, *, headers: dict[str, str], json: dict[str, Any] | None = None
+    ) -> _HttpResponse:
+        if self._http is not None:
+            if method == "POST":
+                return await self._http.post(url, headers=headers, json=json)
+            return await self._http.get(url, headers=headers)
+        # Lazy httpx per call — no shared session lifecycle to manage.
+        import httpx
+
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            if method == "POST":
+                return await client.post(url, headers=headers, json=json)
+            return await client.get(url, headers=headers)
+
+
+def _repo_short_name(repo: str) -> str:
+    """``owner/repo`` → ``repo`` (GitHub's access-token endpoint scopes by name)."""
+    return repo.removesuffix(".git").split("/")[-1]
+
+
+def _parse_expiry(value: Any) -> datetime:
+    """Parse GitHub's ISO-8601 ``expires_at`` (``2026-07-16T10:00:00Z``).
+
+    Falls back to now+1h (GitHub's max) if the field is missing/unparseable, so a
+    caller always has a conservative refresh deadline.
+    """
+    if isinstance(value, str) and value:
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            pass
+    return datetime.now(UTC) + timedelta(hours=1)
+
+
+# ---------------------------------------------------------------------------
+# Singleton factory, mirroring get_daytona_client().
+# ---------------------------------------------------------------------------
+
+_client: GitHubAppClient | None = None
+
+
+def get_github_app_client() -> GitHubAppClient | None:
+    """Return the singleton GitHub App client, or None if the App isn't configured."""
+    global _client
+    if not github_app_enabled():
+        return None
+    if _client is None:
+        _client = GitHubAppClient(
+            _app_id(), _private_key_pem(), api_base=_api_base(), git_base=_git_base()
+        )
+    return _client
+
+
+def _reset_client_for_tests() -> None:
+    """Drop the cached singleton (tests that flip env vars call this)."""
+    global _client
+    _client = None
+
+
+__all__ = [
+    "GitHubAppClient",
+    "GitHubAppError",
+    "InstallationToken",
+    "get_github_app_client",
+    "github_app_enabled",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/githubapp.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/githubapp.py
@@ -93,6 +93,16 @@ def _git_base() -> str:
     return os.environ.get("GITHUB_GIT_BASE", _GITHUB_GIT_BASE).strip().rstrip("/")
 
 
+def github_app_slug() -> str:
+    """The App's public slug, for the install URL (``/apps/<slug>/installations/new``).
+
+    Distinct from the numeric App id: GitHub's install page is keyed by the slug
+    (e.g. ``devrohit06-personal``). Returns '' when unset — callers surface a clean
+    "GitHub connect not configured" rather than building a broken URL.
+    """
+    return os.environ.get("POCKETPAW_GITHUB_APP_SLUG", "").strip()
+
+
 def github_app_enabled() -> bool:
     """True when both the App id and a usable private key are configured."""
     return bool(_app_id() and _private_key_pem())

--- a/ee/pocketpaw_ee/cloud/websandbox/preview.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/preview.py
@@ -1,0 +1,107 @@
+# preview.py — Web Cursor live dev-server preview URL (WC-8/P3b).
+# Created 2026-07-16 (feat/code-mode).
+#
+# Exposes a running dev-server port inside the sandbox VM as a public,
+# iframe-embeddable preview URL. Thin service-layer orchestration ABOVE
+# ``websandbox/service.py`` (the registry + auth oracle) that resolves + authorizes
+# the row exactly like ``provision.get_tree`` / ``edit.propose_edit`` do BEFORE any
+# runtime op, then delegates the heavy lifting to
+# ``DaytonaClient.get_port_preview_url`` (which returns the public preview URL with
+# the access token already appended — directly embeddable in an ``<iframe>``).
+#
+# SECURITY: tenancy is enforced first — owner-scoped ``get_sandbox`` (NotFound for a
+# row the caller doesn't own) + fail-closed ``authorize_sandbox`` on the bound
+# Daytona id — BEFORE the preview URL is minted. The port is validated at entry:
+# an out-of-range port and the reserved Daytona web-terminal port (22222) are
+# refused with a clean ValidationError so a crafted port can neither escape the
+# 1..65535 range nor surface the built-in shell as a "preview".
+#
+# DI seam: ``client: DaytonaClient | None = None`` (default ``get_daytona_client()``)
+# so tests inject a fake and never hit real Daytona.
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, ValidationError
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.dto import PreviewResponse
+
+logger = logging.getLogger(__name__)
+
+# Valid TCP port range for a previewable dev server.
+_MIN_PORT = 1
+_MAX_PORT = 65535
+
+# Daytona's built-in web terminal binds this port (see
+# ``DaytonaClient.get_web_terminal_url``). Exposing it as a "preview" would surface
+# a second interactive shell inside an iframe, so it is never previewable.
+_RESERVED_TERMINAL_PORT = 22222
+
+
+def _require_client(client: DaytonaClient | None) -> DaytonaClient:
+    """Resolve the Daytona client, raising a clean CloudError when unconfigured
+    (mirrors ``provision._require_client`` — a None client is a 503, not a crash)."""
+    resolved = client if client is not None else get_daytona_client()
+    if resolved is None:
+        raise CloudError(
+            503,
+            "websandbox.daytona_unavailable",
+            "The sandbox runtime is not configured",
+        )
+    return resolved
+
+
+def _validate_port(port: int) -> int:
+    """Validate ``port`` is an in-range, non-reserved TCP port; return it.
+
+    ``bool`` is rejected explicitly (``True``/``False`` are ``int`` subclasses that
+    would otherwise slip through as 1/0). Out-of-range and the reserved terminal
+    port both raise a clean 422 ValidationError before any VM op.
+    """
+    if not isinstance(port, int) or isinstance(port, bool):
+        raise ValidationError("websandbox.invalid_port", "A numeric 'port' is required")
+    if port < _MIN_PORT or port > _MAX_PORT:
+        raise ValidationError(
+            "websandbox.invalid_port",
+            f"Port must be between {_MIN_PORT} and {_MAX_PORT}",
+        )
+    if port == _RESERVED_TERMINAL_PORT:
+        raise ValidationError(
+            "websandbox.reserved_port",
+            f"Port {_RESERVED_TERMINAL_PORT} is reserved for the sandbox terminal",
+        )
+    return port
+
+
+async def get_preview(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    port: int,
+    *,
+    client: DaytonaClient | None = None,
+) -> PreviewResponse:
+    """Resolve the iframe-embeddable preview URL for a dev-server ``port`` in a
+    ready sandbox.
+
+    Flow: validate the port (out-of-range / reserved refused at entry) → resolve
+    the row owner-scoped (``get_sandbox`` → NotFound for a row the caller doesn't
+    own) → 409 if it never bound a Daytona id → fail-closed ``authorize_sandbox``
+    BEFORE any VM touch → ``get_port_preview_url`` → return ``{url, port}``.
+    """
+    port = _validate_port(port)
+    daytona = _require_client(client)
+
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+
+    # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+
+    url = await daytona.get_port_preview_url(row.sandbox_id, port)
+    return PreviewResponse(url=url, port=port)
+
+
+__all__ = ["get_preview"]

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -11,7 +11,8 @@
 #
 # Three flows live here:
 #   1. ``open_sandbox`` — upsert a registry row (pending) → opening →
-#      cold-provision a Daytona VM (auto_stop_interval=30 min) → wait for boot →
+#      cold-provision a Daytona VM (auto_stop 5 / archive 5 / delete-on-stop) →
+#      wait for boot →
 #      clone the PUBLIC repo (no credentials) → create + check out a
 #      ``paw/edit-<hex>`` feature branch IN the VM so AI edits never touch the
 #      checked-out default branch (WC-5a) → bind the Daytona id + branch + mark
@@ -26,7 +27,8 @@
 #      create_sandbox`` does not forward labels to the SDK; the Registry (our DB)
 #      is the source of truth instead. WC-3 will refresh ``updated_at`` on live
 #      WebSocket traffic; until then "idle" == ``updated_at`` age. The SDK's own
-#      ``auto_stop_interval=30`` min is a second, independent backstop.
+#      Daytona-native lifecycle (stop 5 / archive 5 / delete-on-stop) is a
+#      second, independent backstop that reclaims idle VMs even faster.
 #
 # Every provisioning fn takes ``client: DaytonaClient | None = None`` (default
 # ``get_daytona_client()``) — the mandatory DI seam so tests inject a FAKE client
@@ -56,10 +58,17 @@ from pocketpaw_ee.cloud.websandbox.dto import (
 
 logger = logging.getLogger(__name__)
 
-# The SDK backstop: a self-stop after 30 minutes of inactivity. NOTE the SDK's
-# ``auto_stop_interval`` is in MINUTES (the SDK default 3600 = 60 HOURS is a
-# latent trap); 30 is a 30-minute backstop that mirrors our idle-TTL reaper.
-_AUTO_STOP_MINUTES = 30
+# Daytona-native VM lifecycle (all in MINUTES — the SDK counts these in minutes,
+# NOT seconds; its own 3600 default is 60 HOURS, a latent trap). Aggressive by
+# design: a Code Mode sandbox is pure-ephemeral (the durable half is the
+# CodeProject + its S3 snapshot), so we let Daytona reclaim idle VMs fast rather
+# than lean only on our own reaper.
+#   • stop 5 min after inactivity, • archive 5 min after a stop,
+#   • delete immediately on stop (0). A returning user re-provisions from the
+#     durable project (open_project) instead of resuming a stale VM.
+_AUTO_STOP_MINUTES = 5
+_AUTO_ARCHIVE_MINUTES = 5
+_AUTO_DELETE_MINUTES = 0
 
 # Daytona boot timeout (seconds) — block until the VM is ``started`` before clone.
 _BOOT_TIMEOUT_SECONDS = 120.0
@@ -184,7 +193,7 @@ async def open_sandbox(
     """Cold-provision a Daytona VM and clone a PUBLIC repo into it.
 
     Flow: upsert the registry row (``pending``) → mark ``opening`` →
-    ``create_sandbox(auto_stop_interval=30)`` → ``wait_for_sandbox`` →
+    ``create_sandbox(auto_stop 5 / archive 5 / delete-on-stop)`` → ``wait_for_sandbox`` →
     ``git_clone`` the public repo (NO credentials) into the project dir →
     bind the Daytona sandbox id + mark ``ready`` → return the ready view.
 
@@ -224,10 +233,13 @@ async def open_sandbox(
     daytona_id: str | None = None
     branch = _new_edit_branch()
     try:
-        # 2. Cold-provision. auto_stop_interval is in MINUTES — 30 is the backstop.
+        # 2. Cold-provision with the aggressive Daytona lifecycle (all MINUTES):
+        #    stop after 5 idle, archive 5 after stop, delete immediately on stop.
         info = await daytona.create_sandbox(
             name=f"websandbox-{row.id}",
             auto_stop_interval=_AUTO_STOP_MINUTES,
+            auto_archive_interval=_AUTO_ARCHIVE_MINUTES,
+            auto_delete_interval=_AUTO_DELETE_MINUTES,
         )
         daytona_id = info.id
 

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -13,10 +13,12 @@
 #   1. ``open_sandbox`` — upsert a registry row (pending) → opening →
 #      cold-provision a Daytona VM (auto_stop 5 / archive 5 / delete-on-stop) →
 #      wait for boot →
-#      clone the PUBLIC repo (no credentials) → create + check out a
-#      ``paw/edit-<hex>`` feature branch IN the VM so AI edits never touch the
-#      checked-out default branch (WC-5a) → bind the Daytona id + branch + mark
-#      ready. On any mid-flight failure the row is marked ``stopped`` and a
+#      clone the repo: via the BROKER (server-side, token-isolated) when the
+#      caller has a GitHub connection that can reach it (CM-3c — the token NEVER
+#      enters the VM), else the PUBLIC in-VM clone (no credentials) → create +
+#      check out a ``paw/edit-<hex>`` feature branch IN the VM so AI edits never
+#      touch the checked-out default branch (WC-5a) → bind the Daytona id + branch
+#      + mark ready. On any mid-flight failure the row is marked ``stopped`` and a
 #      CloudError is raised — the row is never left stuck in ``opening`` silently,
 #      and a half-created VM is best-effort torn down.
 #   2. ``get_tree`` — resolve the row (tenant-scoped) → authorize on its Daytona
@@ -47,6 +49,7 @@ from fastapi import FastAPI
 
 from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError, ConflictError, with_cause
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import broker as websandbox_broker
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
@@ -135,15 +138,17 @@ def _max_per_user() -> int:
 # ---------------------------------------------------------------------------
 
 
-def _validate_public_repo_url(repo: str) -> str:
-    """Validate ``repo`` is a plausible public http(s) git URL, returning it.
+def _validate_repo_url(repo: str) -> str:
+    """Validate ``repo`` is a clean http(s) git URL (no embedded creds), returning it.
 
     Fail-closed on anything that isn't an ``http``/``https`` URL with a host —
     ``file://``, ``git@`` SSH, ``ssh://``, or bare paths are rejected so the
-    provisioner never hands the sandbox a local-path or credentialed remote.
-    A URL carrying embedded credentials (``https://user:token@host/repo``) is
-    rejected too: this is the PUBLIC-repo path, and userinfo would otherwise be
-    written into the VM's git remote and persist into snapshots.
+    provisioner never hands the sandbox a local-path remote. A URL carrying
+    embedded credentials (``https://user:token@host/repo``) is rejected too: auth
+    is the broker's job (CM-3c mints a repo-scoped token server-side), so a
+    client-supplied credential must never be accepted — it would otherwise be
+    written into the VM's git remote and persist into snapshots. Private repos are
+    supported via the broker, not via credentials in the URL.
     """
     candidate = (repo or "").strip()
     if not candidate:
@@ -152,12 +157,12 @@ def _validate_public_repo_url(repo: str) -> str:
     if parsed.scheme not in ("http", "https") or not parsed.netloc:
         raise BadRequest(
             "websandbox.invalid_repo",
-            "Repository must be a public http(s) URL (e.g. https://github.com/owner/repo.git)",
+            "Repository must be an http(s) URL (e.g. https://github.com/owner/repo.git)",
         )
     if parsed.username or parsed.password or "@" in parsed.netloc:
         raise BadRequest(
             "websandbox.invalid_repo",
-            "Repository URL must not embed credentials — only public repos are supported here",
+            "Repository URL must not embed credentials — private repos connect via GitHub",
         )
     return candidate
 
@@ -190,19 +195,21 @@ async def open_sandbox(
     body: OpenSandboxRequest | dict,
     client: DaytonaClient | None = None,
 ) -> WebSandboxView:
-    """Cold-provision a Daytona VM and clone a PUBLIC repo into it.
+    """Cold-provision a Daytona VM and clone a repo into it.
 
     Flow: upsert the registry row (``pending``) → mark ``opening`` →
     ``create_sandbox(auto_stop 5 / archive 5 / delete-on-stop)`` → ``wait_for_sandbox`` →
-    ``git_clone`` the public repo (NO credentials) into the project dir →
-    bind the Daytona sandbox id + mark ``ready`` → return the ready view.
+    clone the repo into the project dir — via the broker (server-side,
+    token-isolated) when a connection can authenticate it (CM-3c), else the
+    credential-free public in-VM ``git_clone`` → bind the Daytona sandbox id +
+    mark ``ready`` → return the ready view.
 
     On any failure after the row exists, the row is advanced to ``stopped`` and a
     ``CloudError`` is raised (never left stuck in ``opening``); a VM created before
     the failure is best-effort stopped+deleted so a crash can't leak a live VM.
     """
     body = OpenSandboxRequest.model_validate(body)
-    repo_url = _validate_public_repo_url(body.repo)
+    repo_url = _validate_repo_url(body.repo)
     daytona = _require_client(client)
 
     # Quota + re-open bookkeeping — read the caller's OWN rows once (tenant- and
@@ -248,15 +255,30 @@ async def open_sandbox(
             daytona_id, target_state="started", timeout=_BOOT_TIMEOUT_SECONDS
         )
 
-        # 4. Clone the PUBLIC repo — pass NO credentials (clean; no token ever
-        #    involved). Clone into the sandbox's project dir.
+        # 4. Clone the repo into the sandbox's project dir.
         # Clone INTO the pinned workspace dir (WEBSANDBOX_WORKDIR = /home/daytona)
         # so the file tree, the terminal cwd, and the clone all agree on one
         # directory. get_project_dir() returns /root on this image, which the
         # terminal never opens in — that mismatch is why the tree looked empty.
+        #
+        # CM-3c: if the caller has a GitHub connection whose installation can reach
+        # this repo, clone it via the BROKER — the token is minted + used entirely
+        # server-side and NEVER enters the VM (the VM receives files + a token-free
+        # git remote). Otherwise, clone the PUBLIC repo in-VM with NO credentials.
         project_dir = WEBSANDBOX_WORKDIR
         await daytona.execute_command(daytona_id, f"mkdir -p {project_dir}")
-        await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
+        scoped = await websandbox_broker.resolve_repo_token(workspace_id, user_id, repo_url)
+        if scoped is not None:
+            await websandbox_broker.clone_into_vm(
+                daytona,
+                daytona_id,
+                scoped,
+                project_dir,
+                clean_url=repo_url,
+                branch=body.branch,
+            )
+        else:
+            await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
 
         # 4b. Check out a fresh ``paw/edit-<hex>`` branch IN the VM (WC-5a) so
         #     every AI edit lands on an isolated branch, never the checked-out

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -12,10 +12,12 @@
 # Three flows live here:
 #   1. ``open_sandbox`` — upsert a registry row (pending) → opening →
 #      cold-provision a Daytona VM (auto_stop_interval=30 min) → wait for boot →
-#      clone the PUBLIC repo (no credentials) → bind the Daytona id + mark ready.
-#      On any mid-flight failure the row is marked ``stopped`` and a CloudError is
-#      raised — the row is never left stuck in ``opening`` silently, and a
-#      half-created VM is best-effort torn down.
+#      clone the PUBLIC repo (no credentials) → create + check out a
+#      ``paw/edit-<hex>`` feature branch IN the VM so AI edits never touch the
+#      checked-out default branch (WC-5a) → bind the Daytona id + branch + mark
+#      ready. On any mid-flight failure the row is marked ``stopped`` and a
+#      CloudError is raised — the row is never left stuck in ``opening`` silently,
+#      and a half-created VM is best-effort torn down.
 #   2. ``get_tree`` — resolve the row (tenant-scoped) → authorize on its Daytona
 #      id (fail-closed) → single-level ``list_files`` → the file tree.
 #   3. Idle-TTL reaper — a background sweep that reclaims rows whose ``updated_at``
@@ -37,6 +39,7 @@ import logging
 import os
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
+from uuid import uuid4
 
 from fastapi import FastAPI
 
@@ -60,6 +63,17 @@ _AUTO_STOP_MINUTES = 30
 
 # Daytona boot timeout (seconds) — block until the VM is ``started`` before clone.
 _BOOT_TIMEOUT_SECONDS = 120.0
+
+# Auto-feature-branch (WC-5a): the repo is checked out onto a fresh
+# ``paw/edit-<8 hex>`` branch in the VM so AI edits never touch the default
+# branch. The slug is derived from a uuid4 (no time/random-in-loop concerns) and
+# the checkout is a quick git op, so a short timeout is plenty.
+_BRANCH_CHECKOUT_TIMEOUT_SECONDS = 30
+
+
+def _new_edit_branch() -> str:
+    """Mint a fresh, collision-safe ``paw/edit-<8 hex>`` branch name."""
+    return f"paw/edit-{uuid4().hex[:8]}"
 
 # ---------------------------------------------------------------------------
 # Reaper env config.
@@ -172,6 +186,7 @@ async def open_sandbox(
     )
 
     daytona_id: str | None = None
+    branch = _new_edit_branch()
     try:
         # 2. Cold-provision. auto_stop_interval is in MINUTES — 30 is the backstop.
         info = await daytona.create_sandbox(
@@ -194,6 +209,16 @@ async def open_sandbox(
         project_dir = WEBSANDBOX_WORKDIR
         await daytona.execute_command(daytona_id, f"mkdir -p {project_dir}")
         await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
+
+        # 4b. Check out a fresh ``paw/edit-<hex>`` branch IN the VM (WC-5a) so
+        #     every AI edit lands on an isolated branch, never the checked-out
+        #     default. cwd is the pinned workspace dir where the repo was cloned.
+        await daytona.execute_command(
+            daytona_id,
+            f"git checkout -b {branch}",
+            cwd=project_dir,
+            timeout=_BRANCH_CHECKOUT_TIMEOUT_SECONDS,
+        )
     except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
         # Best-effort teardown of a half-created VM so a failure can't leak it.
         if daytona_id is not None:
@@ -210,11 +235,20 @@ async def open_sandbox(
             exc,
         ) from exc
 
-    # 5. Bind the Daytona id and mark ready.
+    # 5. Bind the Daytona id + the auto-created feature branch, and mark ready.
     ready = await websandbox_service.update_status(
-        workspace_id, user_id, row.id, {"status": "ready", "sandbox_id": daytona_id}
+        workspace_id,
+        user_id,
+        row.id,
+        {"status": "ready", "sandbox_id": daytona_id, "branch": branch},
     )
-    logger.info("websandbox.open ready: row=%s daytona=%s repo=%s", row.id, daytona_id, repo_url)
+    logger.info(
+        "websandbox.open ready: row=%s daytona=%s branch=%s repo=%s",
+        row.id,
+        daytona_id,
+        branch,
+        repo_url,
+    )
     return ready
 
 

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -88,6 +88,7 @@ def _new_edit_branch() -> str:
     """Mint a fresh, collision-safe ``paw/edit-<8 hex>`` branch name."""
     return f"paw/edit-{uuid4().hex[:8]}"
 
+
 # ---------------------------------------------------------------------------
 # Reaper env config.
 # ---------------------------------------------------------------------------
@@ -234,9 +235,7 @@ async def open_sandbox(
     row = await websandbox_service.create_sandbox(
         workspace_id, user_id, {"repo": repo_url, "status": "pending"}
     )
-    await websandbox_service.update_status(
-        workspace_id, user_id, row.id, {"status": "opening"}
-    )
+    await websandbox_service.update_status(workspace_id, user_id, row.id, {"status": "opening"})
 
     daytona_id: str | None = None
     branch = _new_edit_branch()

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -48,6 +48,7 @@ from uuid import uuid4
 from fastapi import FastAPI
 
 from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud.codegit import wire as codegit_wire
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.websandbox import broker as websandbox_broker
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
@@ -289,6 +290,23 @@ async def open_sandbox(
             cwd=project_dir,
             timeout=_BRANCH_CHECKOUT_TIMEOUT_SECONDS,
         )
+
+        # 4c. CM-3d: for a broker-cloned (connected) repo, repoint ``origin`` at
+        #     the git proxy so an in-VM ``git push``/``fetch`` works with the token
+        #     still minted server-side (never in the VM). Best-effort — a wiring
+        #     miss leaves the clone fully usable, it just can't push yet; it must
+        #     never fail the open. Skipped for public clones (no connection to push
+        #     through) and when no public backend URL is reachable from the VM.
+        if scoped is not None:
+            with contextlib.suppress(Exception):
+                await codegit_wire.wire_push_remote(
+                    daytona,
+                    daytona_id,
+                    workspace_id,
+                    user_id,
+                    websandbox_broker.repo_full_name(repo_url) or repo_url,
+                    project_dir,
+                )
     except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
         # Best-effort teardown of a half-created VM so a failure can't leak it.
         if daytona_id is not None:

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -1,0 +1,366 @@
+# provision.py — Web Cursor cold-provision + file-tree orchestration + idle reaper.
+# Created 2026-07-15 (WC-2, feat/websandbox-vm-provision).
+#
+# This is the service-layer orchestration for the Web Cursor "open a repo" slice.
+# It sits ABOVE ``websandbox/service.py`` (the registry + auth oracle) and drives
+# the Daytona runtime through ``DaytonaClient``. Per ee/cloud Rule 2 it NEVER
+# touches the WebSandbox Beanie doc directly — every registry read/write goes
+# through ``service`` (create_sandbox / update_status / get_sandbox /
+# authorize_sandbox / list_reapable_sandboxes / mark_reaped). Importing the
+# DaytonaClient here (not in router/dto/domain) is the correct layer.
+#
+# Three flows live here:
+#   1. ``open_sandbox`` — upsert a registry row (pending) → opening →
+#      cold-provision a Daytona VM (auto_stop_interval=30 min) → wait for boot →
+#      clone the PUBLIC repo (no credentials) → bind the Daytona id + mark ready.
+#      On any mid-flight failure the row is marked ``stopped`` and a CloudError is
+#      raised — the row is never left stuck in ``opening`` silently, and a
+#      half-created VM is best-effort torn down.
+#   2. ``get_tree`` — resolve the row (tenant-scoped) → authorize on its Daytona
+#      id (fail-closed) → single-level ``list_files`` → the file tree.
+#   3. Idle-TTL reaper — a background sweep that reclaims rows whose ``updated_at``
+#      is older than the TTL by stopping+deleting the VM and marking the row
+#      ``reaped``. Labels are NOT used to reconcile because ``DaytonaClient.
+#      create_sandbox`` does not forward labels to the SDK; the Registry (our DB)
+#      is the source of truth instead. WC-3 will refresh ``updated_at`` on live
+#      WebSocket traffic; until then "idle" == ``updated_at`` age. The SDK's own
+#      ``auto_stop_interval=30`` min is a second, independent backstop.
+#
+# Every provisioning fn takes ``client: DaytonaClient | None = None`` (default
+# ``get_daytona_client()``) — the mandatory DI seam so tests inject a FAKE client
+# and no test ever hits real Daytona.
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
+
+from fastapi import FastAPI
+
+from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
+from pocketpaw_ee.cloud.websandbox.dto import (
+    OpenSandboxRequest,
+    SandboxTreeResponse,
+    TreeEntryResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+# The SDK backstop: a self-stop after 30 minutes of inactivity. NOTE the SDK's
+# ``auto_stop_interval`` is in MINUTES (the SDK default 3600 = 60 HOURS is a
+# latent trap); 30 is a 30-minute backstop that mirrors our idle-TTL reaper.
+_AUTO_STOP_MINUTES = 30
+
+# Daytona boot timeout (seconds) — block until the VM is ``started`` before clone.
+_BOOT_TIMEOUT_SECONDS = 120.0
+
+# ---------------------------------------------------------------------------
+# Reaper env config.
+# ---------------------------------------------------------------------------
+_DEFAULT_IDLE_TTL_SECONDS = 1800  # 30 min
+_DEFAULT_REAP_INTERVAL_SECONDS = 300  # 5 min
+_REAPER_TASK_KEY = "_websandbox_reaper_task"
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back to ``default``."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an int — falling back to %d", name, raw, default)
+        return default
+    return max(1, value)
+
+
+def _idle_ttl_seconds() -> int:
+    return _env_int("POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS", _DEFAULT_IDLE_TTL_SECONDS)
+
+
+def _reap_interval_seconds() -> int:
+    return _env_int("POCKETPAW_WEBSANDBOX_REAP_INTERVAL_SECONDS", _DEFAULT_REAP_INTERVAL_SECONDS)
+
+
+def _reaper_enabled() -> bool:
+    raw = os.environ.get("POCKETPAW_WEBSANDBOX_REAPER_ENABLED", "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+# ---------------------------------------------------------------------------
+# Repo URL validation.
+# ---------------------------------------------------------------------------
+
+
+def _validate_public_repo_url(repo: str) -> str:
+    """Validate ``repo`` is a plausible public http(s) git URL, returning it.
+
+    Fail-closed on anything that isn't an ``http``/``https`` URL with a host —
+    ``file://``, ``git@`` SSH, ``ssh://``, or bare paths are rejected so the
+    provisioner never hands the sandbox a local-path or credentialed remote.
+    """
+    candidate = (repo or "").strip()
+    if not candidate:
+        raise BadRequest("websandbox.invalid_repo", "A repository URL is required")
+    parsed = urlparse(candidate)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise BadRequest(
+            "websandbox.invalid_repo",
+            "Repository must be a public http(s) URL (e.g. https://github.com/owner/repo.git)",
+        )
+    return candidate
+
+
+def _require_client(client: DaytonaClient | None) -> DaytonaClient:
+    """Resolve the Daytona client, raising a clean CloudError when unconfigured.
+
+    ``get_daytona_client()`` returns ``None`` when the Daytona keys are unset;
+    that is an operational condition, not a bug, so it surfaces as a 503-style
+    CloudError rather than an ``AttributeError`` crash downstream.
+    """
+    resolved = client if client is not None else get_daytona_client()
+    if resolved is None:
+        raise CloudError(
+            503,
+            "websandbox.daytona_unavailable",
+            "The sandbox runtime is not configured",
+        )
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# open flow.
+# ---------------------------------------------------------------------------
+
+
+async def open_sandbox(
+    workspace_id: str,
+    user_id: str,
+    body: OpenSandboxRequest | dict,
+    client: DaytonaClient | None = None,
+) -> WebSandboxView:
+    """Cold-provision a Daytona VM and clone a PUBLIC repo into it.
+
+    Flow: upsert the registry row (``pending``) → mark ``opening`` →
+    ``create_sandbox(auto_stop_interval=30)`` → ``wait_for_sandbox`` →
+    ``git_clone`` the public repo (NO credentials) into the project dir →
+    bind the Daytona sandbox id + mark ``ready`` → return the ready view.
+
+    On any failure after the row exists, the row is advanced to ``stopped`` and a
+    ``CloudError`` is raised (never left stuck in ``opening``); a VM created before
+    the failure is best-effort stopped+deleted so a crash can't leak a live VM.
+    """
+    body = OpenSandboxRequest.model_validate(body)
+    repo_url = _validate_public_repo_url(body.repo)
+    daytona = _require_client(client)
+
+    # 1. Upsert the registry row (idempotent on workspace+user+repo) and move it
+    #    to ``opening`` so a concurrent reader sees the in-flight state.
+    row = await websandbox_service.create_sandbox(
+        workspace_id, user_id, {"repo": repo_url, "status": "pending"}
+    )
+    await websandbox_service.update_status(
+        workspace_id, user_id, row.id, {"status": "opening"}
+    )
+
+    daytona_id: str | None = None
+    try:
+        # 2. Cold-provision. auto_stop_interval is in MINUTES — 30 is the backstop.
+        info = await daytona.create_sandbox(
+            name=f"websandbox-{row.id}",
+            auto_stop_interval=_AUTO_STOP_MINUTES,
+        )
+        daytona_id = info.id
+
+        # 3. Block until the VM is booted before cloning.
+        await daytona.wait_for_sandbox(
+            daytona_id, target_state="started", timeout=_BOOT_TIMEOUT_SECONDS
+        )
+
+        # 4. Clone the PUBLIC repo — pass NO credentials (clean; no token ever
+        #    involved). Clone into the sandbox's project dir.
+        project_dir = await daytona.get_project_dir(daytona_id)
+        await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
+    except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
+        # Best-effort teardown of a half-created VM so a failure can't leak it.
+        if daytona_id is not None:
+            with contextlib.suppress(Exception):
+                await daytona.delete_sandbox(daytona_id)
+        # Never leave the row stuck in ``opening``.
+        with contextlib.suppress(Exception):
+            await websandbox_service.update_status(
+                workspace_id, user_id, row.id, {"status": "stopped"}
+            )
+        logger.warning("websandbox.open failed for repo=%s row=%s", repo_url, row.id, exc_info=True)
+        raise with_cause(
+            CloudError(502, "websandbox.provision_failed", "Failed to provision the sandbox"),
+            exc,
+        ) from exc
+
+    # 5. Bind the Daytona id and mark ready.
+    ready = await websandbox_service.update_status(
+        workspace_id, user_id, row.id, {"status": "ready", "sandbox_id": daytona_id}
+    )
+    logger.info("websandbox.open ready: row=%s daytona=%s repo=%s", row.id, daytona_id, repo_url)
+    return ready
+
+
+# ---------------------------------------------------------------------------
+# tree flow.
+# ---------------------------------------------------------------------------
+
+
+async def get_tree(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    client: DaytonaClient | None = None,
+) -> SandboxTreeResponse:
+    """Return the (single-level) file tree of a ready sandbox.
+
+    Resolves the row tenant-scoped (``get_sandbox`` raises ``NotFound`` for a
+    row the caller doesn't own), then runs the fail-closed ``authorize_sandbox``
+    on the bound Daytona id BEFORE any runtime op, then lists the project dir.
+    A row that hasn't bound a Daytona id yet (never provisioned / still opening)
+    is a 409, not a runtime crash.
+    """
+    daytona = _require_client(client)
+
+    row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+    if not row.sandbox_id:
+        raise ConflictError("websandbox.not_ready", "Sandbox is not provisioned yet")
+
+    # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
+    await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+
+    project_dir = await daytona.get_project_dir(row.sandbox_id)
+    files = await daytona.list_files(row.sandbox_id, project_dir)
+    entries = [
+        TreeEntryResponse(
+            name=f.name,
+            isDir=bool(getattr(f, "is_dir", False)),
+            size=int(getattr(f, "size", 0) or 0),
+        )
+        for f in files
+    ]
+    return SandboxTreeResponse(
+        id=row.id,
+        sandboxId=row.sandbox_id,
+        path=project_dir,
+        entries=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idle-TTL reaper.
+# ---------------------------------------------------------------------------
+
+
+async def reap_idle_sandboxes(
+    client: DaytonaClient | None = None,
+    *,
+    now: datetime | None = None,
+) -> int:
+    """Run ONE reaper sweep: reclaim rows idle longer than the TTL.
+
+    Finds ``ready``/``opening`` rows whose ``updated_at`` is older than the TTL
+    (via ``service.list_reapable_sandboxes`` — a deliberate global-read), stops +
+    deletes the bound Daytona VM, then marks the row ``reaped``. A row with no
+    bound Daytona id (opening that never got one) is marked ``reaped`` directly.
+    A VM whose delete FAILS is left for the next sweep (the row stays live) rather
+    than being marked reaped and leaked. Returns the count of rows reaped.
+    """
+    daytona = _require_client(client)
+    reference = now or datetime.now(UTC)
+    cutoff = reference - timedelta(seconds=_idle_ttl_seconds())
+
+    candidates = await websandbox_service.list_reapable_sandboxes(cutoff)
+    if not candidates:
+        return 0
+
+    reaped = 0
+    for row in candidates:
+        if row.sandbox_id:
+            try:
+                # stop is best-effort (delete destroys the VM regardless); a
+                # failed DELETE means we couldn't reclaim, so skip the row.
+                with contextlib.suppress(Exception):
+                    await daytona.stop_sandbox(row.sandbox_id)
+                await daytona.delete_sandbox(row.sandbox_id)
+            except Exception:  # noqa: BLE001 — leave the row for the next sweep
+                logger.warning(
+                    "websandbox.reaper: failed to delete VM %s (row %s) — retry next sweep",
+                    row.sandbox_id,
+                    row.id,
+                    exc_info=True,
+                )
+                continue
+        marked = await websandbox_service.mark_reaped(row.id)
+        if marked is not None:
+            reaped += 1
+
+    if reaped:
+        logger.info("websandbox.reaper: reaped %d idle sandbox(es)", reaped)
+    return reaped
+
+
+async def _run_reaper_loop() -> None:
+    """Background loop body — sweep, sleep, repeat. Per-pass errors are logged
+    so one bad sweep can't kill the loop; ``CancelledError`` propagates for a
+    clean shutdown."""
+    interval = _reap_interval_seconds()
+    logger.info(
+        "websandbox.reaper: loop started (interval=%ds, idle_ttl=%ds)",
+        interval,
+        _idle_ttl_seconds(),
+    )
+    while True:
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("websandbox.reaper: loop cancelled — exiting")
+            raise
+        try:
+            await reap_idle_sandboxes()
+        except Exception:  # noqa: BLE001
+            logger.exception("websandbox.reaper: sweep failed")
+
+
+async def start_websandbox_reaper(app: FastAPI) -> None:
+    """Start the idle-TTL reaper. Idempotent — a second start is a no-op. Honors
+    ``POCKETPAW_WEBSANDBOX_REAPER_ENABLED`` (default true)."""
+    if not _reaper_enabled():
+        logger.info("websandbox.reaper: disabled via POCKETPAW_WEBSANDBOX_REAPER_ENABLED")
+        return
+    existing = getattr(app.state, _REAPER_TASK_KEY, None)
+    if existing is not None and not existing.done():
+        return
+    task = asyncio.create_task(_run_reaper_loop(), name="websandbox-reaper")
+    setattr(app.state, _REAPER_TASK_KEY, task)
+
+
+async def stop_websandbox_reaper(app: FastAPI) -> None:
+    """Cancel + await the reaper loop. Safe to call multiple times."""
+    task = getattr(app.state, _REAPER_TASK_KEY, None)
+    if task is None or task.done():
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+    setattr(app.state, _REAPER_TASK_KEY, None)
+
+
+__all__ = [
+    "get_tree",
+    "open_sandbox",
+    "reap_idle_sandboxes",
+    "start_websandbox_reaper",
+    "stop_websandbox_reaper",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -82,6 +82,13 @@ _DEFAULT_IDLE_TTL_SECONDS = 1800  # 30 min
 _DEFAULT_REAP_INTERVAL_SECONDS = 300  # 5 min
 _REAPER_TASK_KEY = "_websandbox_reaper_task"
 
+# Max concurrent live (pending/opening/ready) sandboxes a single user may hold.
+# Bounds cost/DoS by an authenticated tenant who would otherwise vary the repo URL
+# to mint unbounded cold VMs. Re-opening a repo the user already has open does NOT
+# count against this (it reuses the existing row). ``0`` disables the cap.
+_DEFAULT_MAX_PER_USER = 10
+_LIVE_STATUSES = ("pending", "opening", "ready")
+
 
 def _env_int(name: str, default: int) -> int:
     """Read a positive int from the environment, falling back to ``default``."""
@@ -109,6 +116,11 @@ def _reaper_enabled() -> bool:
     return raw not in ("0", "false", "no", "off")
 
 
+def _max_per_user() -> int:
+    """Per-user concurrent-sandbox cap (0 disables). See ``_DEFAULT_MAX_PER_USER``."""
+    return _env_int("POCKETPAW_WEBSANDBOX_MAX_PER_USER", _DEFAULT_MAX_PER_USER)
+
+
 # ---------------------------------------------------------------------------
 # Repo URL validation.
 # ---------------------------------------------------------------------------
@@ -120,6 +132,9 @@ def _validate_public_repo_url(repo: str) -> str:
     Fail-closed on anything that isn't an ``http``/``https`` URL with a host —
     ``file://``, ``git@`` SSH, ``ssh://``, or bare paths are rejected so the
     provisioner never hands the sandbox a local-path or credentialed remote.
+    A URL carrying embedded credentials (``https://user:token@host/repo``) is
+    rejected too: this is the PUBLIC-repo path, and userinfo would otherwise be
+    written into the VM's git remote and persist into snapshots.
     """
     candidate = (repo or "").strip()
     if not candidate:
@@ -129,6 +144,11 @@ def _validate_public_repo_url(repo: str) -> str:
         raise BadRequest(
             "websandbox.invalid_repo",
             "Repository must be a public http(s) URL (e.g. https://github.com/owner/repo.git)",
+        )
+    if parsed.username or parsed.password or "@" in parsed.netloc:
+        raise BadRequest(
+            "websandbox.invalid_repo",
+            "Repository URL must not embed credentials — only public repos are supported here",
         )
     return candidate
 
@@ -175,6 +195,22 @@ async def open_sandbox(
     body = OpenSandboxRequest.model_validate(body)
     repo_url = _validate_public_repo_url(body.repo)
     daytona = _require_client(client)
+
+    # Quota + re-open bookkeeping — read the caller's OWN rows once (tenant- and
+    # owner-scoped via list_sandboxes). Re-opening a repo already open reuses its
+    # row (not a new slot); opening a NEW repo past the per-user live cap is
+    # rejected cleanly rather than cold-booting an unbounded number of VMs.
+    owned = await websandbox_service.list_sandboxes(workspace_id, user_id)
+    existing = next((r for r in owned if r.repo == repo_url), None)
+    old_sandbox_id = existing.sandbox_id if existing is not None else None
+    cap = _max_per_user()
+    if cap and existing is None:
+        live = sum(1 for r in owned if r.status in _LIVE_STATUSES)
+        if live >= cap:
+            raise ConflictError(
+                "websandbox.too_many",
+                f"You have too many open workspaces ({live}); close one and try again",
+            )
 
     # 1. Upsert the registry row (idempotent on workspace+user+repo) and move it
     #    to ``opening`` so a concurrent reader sees the in-flight state.
@@ -242,6 +278,15 @@ async def open_sandbox(
         row.id,
         {"status": "ready", "sandbox_id": daytona_id, "branch": branch},
     )
+    # Re-open: this row previously pointed at a different VM. Now that the row
+    # references the NEW id, nothing references the old one — the idle reaper
+    # sweeps rows, not orphaned ids, so tear the old VM down here or it leaks
+    # (stopped-but-undeleted forever). Best-effort; a failure just defers cost.
+    if old_sandbox_id and old_sandbox_id != daytona_id:
+        with contextlib.suppress(Exception):
+            await daytona.stop_sandbox(old_sandbox_id)
+        with contextlib.suppress(Exception):
+            await daytona.delete_sandbox(old_sandbox_id)
     logger.info(
         "websandbox.open ready: row=%s daytona=%s branch=%s repo=%s",
         row.id,

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -43,6 +43,7 @@ from fastapi import FastAPI
 from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError, ConflictError, with_cause
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
 from pocketpaw_ee.cloud.websandbox.dto import (
     OpenSandboxRequest,
@@ -186,7 +187,12 @@ async def open_sandbox(
 
         # 4. Clone the PUBLIC repo — pass NO credentials (clean; no token ever
         #    involved). Clone into the sandbox's project dir.
-        project_dir = await daytona.get_project_dir(daytona_id)
+        # Clone INTO the pinned workspace dir (WEBSANDBOX_WORKDIR = /home/daytona)
+        # so the file tree, the terminal cwd, and the clone all agree on one
+        # directory. get_project_dir() returns /root on this image, which the
+        # terminal never opens in — that mismatch is why the tree looked empty.
+        project_dir = WEBSANDBOX_WORKDIR
+        await daytona.execute_command(daytona_id, f"mkdir -p {project_dir}")
         await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
     except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
         # Best-effort teardown of a half-created VM so a failure can't leak it.
@@ -240,7 +246,7 @@ async def get_tree(
     # Fail-closed authorization on the Daytona id BEFORE touching the runtime.
     await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
 
-    project_dir = await daytona.get_project_dir(row.sandbox_id)
+    project_dir = WEBSANDBOX_WORKDIR
     files = await daytona.list_files(row.sandbox_id, project_dir)
     entries = [
         TreeEntryResponse(

--- a/ee/pocketpaw_ee/cloud/websandbox/repoauth.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/repoauth.py
@@ -1,0 +1,115 @@
+# repoauth.py — provider-agnostic repo-auth seam for the Web Cursor broker (WC-6).
+# Created 2026-07-16 (feat/code-mode).
+#
+# Web Cursor clones a user's PRIVATE repos into a sandbox through a git-proxy
+# broker that mints short-lived, repo-scoped tokens OUTSIDE the VM. GitHub App is
+# the first provider, but auth is expanding to Google (and others), so the broker
+# depends on THIS neutral interface — never on ``githubapp`` directly. A new
+# provider is a sibling implementation of ``RepoAuthProvider`` + a branch in
+# ``get_repo_auth_provider``; nothing in the broker, Registry, or connect flow
+# needs to change.
+#
+# The neutral vocabulary:
+#   * ProviderId       — which code host ("github", "google", …).
+#   * connection_id    — the per-tenant handle the provider issues at connect
+#                        time (a GitHub App installation id; a Google OAuth
+#                        connection id). Stored (encrypted) in the WC-1 Registry.
+#   * ScopedRepoToken  — a JIT, single-repo, short-lived credential the broker
+#                        injects upstream. Never enters the VM.
+#   * RemoteRepo       — one repo the connection can reach, for the picker.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Protocol, runtime_checkable
+
+
+class ProviderId(StrEnum):
+    """The code host a connection speaks to. Extend as providers land."""
+
+    GITHUB = "github"
+    GOOGLE = "google"  # planned — no implementation yet
+
+
+@dataclass(frozen=True)
+class ScopedRepoToken:
+    """A JIT credential scoped to ONE repo, minted outside the VM.
+
+    ``token`` is what the broker injects upstream; ``expires_at`` is the
+    provider-set deadline (≤ 1h) the broker refreshes before. Repo-scoped so a
+    leak can't reach the tenant's other repos.
+    """
+
+    provider: ProviderId
+    token: str
+    expires_at: datetime
+    repo: str
+    scopes: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RemoteRepo:
+    """One repo a connection can reach — the shape the repo picker renders."""
+
+    full_name: str  # "owner/repo" (github) / "project/repo" (google), provider-native
+    private: bool
+    default_branch: str
+    clone_url: str  # the provider-native https clone URL the broker proxies to
+
+
+@runtime_checkable
+class RepoAuthProvider(Protocol):
+    """What the git-proxy broker needs from any code-host auth provider.
+
+    Concrete implementations: ``githubapp.GitHubAppClient`` (today); a Google
+    provider next. The broker programs against this, so adding a provider never
+    touches the broker.
+    """
+
+    provider_id: ProviderId
+
+    async def mint_repo_token(
+        self,
+        connection_id: str,
+        repo: str,
+        *,
+        scopes: dict[str, str] | None = None,
+        now: datetime | None = None,
+    ) -> ScopedRepoToken:
+        """Mint a JIT token scoped to a single ``repo`` under ``connection_id``."""
+        ...
+
+    async def list_repositories(
+        self, connection_id: str, *, now: datetime | None = None
+    ) -> list[RemoteRepo]:
+        """List the repos ``connection_id`` can reach (for the picker)."""
+        ...
+
+    def upstream_clone_url(self, repo: str) -> str:
+        """The provider-native https URL the broker proxies clone/fetch/push to."""
+        ...
+
+
+def get_repo_auth_provider(provider: ProviderId | str) -> RepoAuthProvider | None:
+    """Resolve the configured provider, or None when it isn't set up.
+
+    Mirrors ``get_daytona_client()``: a missing/unconfigured provider returns
+    None so callers degrade cleanly instead of crashing.
+    """
+    kind = ProviderId(provider) if not isinstance(provider, ProviderId) else provider
+    if kind is ProviderId.GITHUB:
+        from pocketpaw_ee.cloud.websandbox.githubapp import get_github_app_client
+
+        return get_github_app_client()
+    # ProviderId.GOOGLE and future providers: not implemented yet.
+    return None
+
+
+__all__ = [
+    "ProviderId",
+    "RemoteRepo",
+    "RepoAuthProvider",
+    "ScopedRepoToken",
+    "get_repo_auth_provider",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -14,19 +14,28 @@
 # clone a PUBLIC repo, returning the ready registry row) and
 # ``GET /websandbox/{row_id}/tree`` (the cloned repo's file tree). Both delegate
 # to ``websandbox/provision.py``; tenancy still comes only from the RequestContext.
+#
+# Changed 2026-07-15 (WC-S3, feat/websandbox-s3-durability): added the two
+# workspace-durability endpoints — ``POST /websandbox/{row_id}/snapshot``
+# (tar the VM workspace → land it in the tenant's S3 → return ``{fileId}``) and
+# ``POST /websandbox/{row_id}/restore`` (fetch the snapshot from S3 → untar it
+# into the VM, 204). Both delegate to ``websandbox/durability.py``; tenancy still
+# comes only from the RequestContext, and both are license-gated like the rest.
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
     CreateSandboxRequest,
     OpenSandboxRequest,
     SandboxTreeResponse,
+    SnapshotResponse,
     UpdateStatusRequest,
     WebSandboxListResponse,
     WebSandboxResponse,
@@ -110,3 +119,30 @@ async def get_sandbox_tree(
     """Return the cloned repo's file tree for a ready sandbox."""
     workspace_id = _require_workspace(ctx)
     return await websandbox_provision.get_tree(workspace_id, ctx.user_id, row_id)
+
+
+# ---------------------------------------------------------------------------
+# WC-S3 — workspace durability (snapshot / restore).
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{row_id}/snapshot", response_model=SnapshotResponse)
+async def snapshot_sandbox(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> SnapshotResponse:
+    """Snapshot the sandbox's workspace to the tenant's blob storage."""
+    workspace_id = _require_workspace(ctx)
+    file_id = await websandbox_durability.snapshot_workspace(workspace_id, ctx.user_id, row_id)
+    return SnapshotResponse(fileId=file_id)
+
+
+@router.post("/{row_id}/restore", status_code=204)
+async def restore_sandbox(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> Response:
+    """Restore the sandbox's latest workspace snapshot from blob storage into the VM."""
+    workspace_id = _require_workspace(ctx)
+    await websandbox_durability.restore_workspace(workspace_id, ctx.user_id, row_id)
+    return Response(status_code=204)

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -1,0 +1,77 @@
+# router.py — Thin FastAPI adapter for the Web Cursor Sandbox Registry (WC-1).
+# Created 2026-07-15 (feat/websandbox-registry): workspace+user scoped
+# /api/v1/websandbox. Tenancy comes from the RequestContext (never the body or
+# query), the service does the work, and CloudError -> JSON is handled by
+# _core.http — this router never raises HTTPException.
+#
+# NOTE (WC-1 scope): endpoints are gated by license + an authenticated context
+# only; per-action RBAC (require_action) is deferred to a later slice because it
+# needs new action strings registered in the RBAC catalog. The tenancy/owner
+# filtering in the service is the security boundary for now.
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.dto import (
+    CreateSandboxRequest,
+    UpdateStatusRequest,
+    WebSandboxListResponse,
+    WebSandboxResponse,
+)
+
+router = APIRouter(
+    prefix="/websandbox",
+    tags=["WebSandbox"],
+    dependencies=[Depends(require_license)],
+)
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    """A workspace-scoped route needs an active workspace; fail closed if absent."""
+    if not ctx.workspace_id:
+        raise Forbidden("websandbox.no_workspace", "No active workspace")
+    return ctx.workspace_id
+
+
+@router.post("", response_model=WebSandboxResponse)
+async def create_sandbox(
+    body: CreateSandboxRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_service.create_sandbox(workspace_id, ctx.user_id, body)
+    return websandbox_service.view_to_wire(view)
+
+
+@router.get("", response_model=WebSandboxListResponse)
+async def list_sandboxes(
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxListResponse:
+    workspace_id = _require_workspace(ctx)
+    views = await websandbox_service.list_sandboxes(workspace_id, ctx.user_id)
+    return WebSandboxListResponse(items=[websandbox_service.view_to_wire(v) for v in views])
+
+
+@router.get("/{row_id}", response_model=WebSandboxResponse)
+async def get_sandbox(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_service.get_sandbox(workspace_id, ctx.user_id, row_id)
+    return websandbox_service.view_to_wire(view)
+
+
+@router.patch("/{row_id}", response_model=WebSandboxResponse)
+async def update_sandbox_status(
+    row_id: str,
+    body: UpdateStatusRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_service.update_status(workspace_id, ctx.user_id, row_id, body)
+    return websandbox_service.view_to_wire(view)

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -29,6 +29,12 @@
 # license-gated like the rest. Generate-only — the frontend applies accepted hunks
 # via the existing file-RPC.
 #
+# Changed 2026-07-16 (WC-7/P4a, feat/code-mode): added the git write-path routes —
+# ``GET /websandbox/{row_id}/git/status`` and ``POST .../git/stage|commit|push``.
+# Thin adapters over ``websandbox/git.py`` (git runs in the VM; the push token
+# never enters it). Tenancy comes only from the RequestContext; a push failure is
+# a ``pushed:false`` body, never a 500. PR-open is a separate slice (P4b).
+#
 # Changed 2026-07-16 (WC-8/P3b, feat/code-mode): added the live-preview endpoint —
 # ``GET /websandbox/{row_id}/preview?port=<int>`` returns the iframe-embeddable
 # public URL of a dev-server port running in the VM. Thin adapter over
@@ -52,18 +58,24 @@ from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import edit as websandbox_edit
+from pocketpaw_ee.cloud.websandbox import git as websandbox_git
 from pocketpaw_ee.cloud.websandbox import preview as websandbox_preview
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
+    CommitRequest,
     CreateSandboxRequest,
     EditRequest,
     EditResponse,
+    GitCommitResponse,
+    GitPushResponse,
+    GitStatusResponse,
     OpenSandboxRequest,
     PreviewResponse,
     RegisterSandboxRequest,
     SandboxTreeResponse,
     SnapshotResponse,
+    StageRequest,
     WebSandboxListResponse,
     WebSandboxResponse,
 )
@@ -163,6 +175,53 @@ async def get_sandbox_preview(
     """Return the iframe-embeddable public URL for a dev-server port in the VM."""
     workspace_id = _require_workspace(ctx)
     return await websandbox_preview.get_preview(workspace_id, ctx.user_id, row_id, port)
+
+
+# ---------------------------------------------------------------------------
+# WC-7/P4a — git write path (status / stage / commit / push).
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{row_id}/git/status", response_model=GitStatusResponse)
+async def git_status(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> GitStatusResponse:
+    """Return the working-tree status (branch, ahead/behind, changed files)."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_git.git_status(workspace_id, ctx.user_id, row_id)
+
+
+@router.post("/{row_id}/git/stage", response_model=GitStatusResponse)
+async def git_stage(
+    row_id: str,
+    body: StageRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> GitStatusResponse:
+    """Stage (or unstage) paths, then return a fresh status."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_git.stage(workspace_id, ctx.user_id, row_id, body)
+
+
+@router.post("/{row_id}/git/commit", response_model=GitCommitResponse)
+async def git_commit(
+    row_id: str,
+    body: CommitRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> GitCommitResponse:
+    """Commit the staged changes as the caller's resolved identity."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_git.commit(workspace_id, ctx.user_id, row_id, body)
+
+
+@router.post("/{row_id}/git/push", response_model=GitPushResponse)
+async def git_push(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> GitPushResponse:
+    """Push the sandbox's feature branch to origin (never 500s on push failure)."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_git.push(workspace_id, ctx.user_id, row_id)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -47,6 +47,13 @@
 # is a validated query param (out-of-range / the reserved terminal port refused),
 # and it's license-gated like the rest.
 #
+# Changed 2026-07-18 (BP-1b, feat/code-mode): added
+# ``GET /websandbox/browserpod/credentials`` — issues the boot credential for the
+# in-tab BrowserPod runtime. The key lives ONLY in server config (never in the
+# frontend bundle); the route is license-gated and workspace-scoped like the rest,
+# and an unconfigured deploy answers ``available:false`` so the client falls back
+# to Daytona instead of erroring. Thin adapter over ``websandbox/browserpod.py``.
+#
 # Changed 2026-07-16 (review hardening): the register route now binds the
 # repo-only ``RegisterSandboxRequest`` so a client can no longer write a
 # server-owned ``sandbox_id`` / ``status`` (that field is the key
@@ -61,6 +68,7 @@ from fastapi import APIRouter, Depends, Query, Response
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import browserpod as websandbox_browserpod
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import edit as websandbox_edit
 from pocketpaw_ee.cloud.websandbox import git as websandbox_git
@@ -68,6 +76,7 @@ from pocketpaw_ee.cloud.websandbox import preview as websandbox_preview
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
+    BrowserPodCredentialsResponse,
     CommitRequest,
     CreatePrRequest,
     CreateSandboxRequest,
@@ -182,6 +191,27 @@ async def get_sandbox_preview(
     """Return the iframe-embeddable public URL for a dev-server port in the VM."""
     workspace_id = _require_workspace(ctx)
     return await websandbox_preview.get_preview(workspace_id, ctx.user_id, row_id, port)
+
+
+# ---------------------------------------------------------------------------
+# BP-1b — BrowserPod boot credential. Two literal segments, so it can never be
+# captured by the single-segment ``/{row_id}`` route above.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/browserpod/credentials", response_model=BrowserPodCredentialsResponse)
+async def get_browserpod_credentials(
+    ctx: RequestContext = Depends(request_context),
+) -> BrowserPodCredentialsResponse:
+    """Issue the credential the browser needs to boot an in-tab BrowserPod pod.
+
+    The key lives ONLY in server config; it is never built into the frontend
+    bundle. License + an authenticated, workspace-scoped context gate the issue.
+    An unconfigured deploy returns ``available: false`` so the client falls back
+    to the Daytona runtime rather than erroring.
+    """
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_browserpod.get_credentials(workspace_id, ctx.user_id)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -29,6 +29,13 @@
 # license-gated like the rest. Generate-only — the frontend applies accepted hunks
 # via the existing file-RPC.
 #
+# Changed 2026-07-16 (WC-8/P3b, feat/code-mode): added the live-preview endpoint —
+# ``GET /websandbox/{row_id}/preview?port=<int>`` returns the iframe-embeddable
+# public URL of a dev-server port running in the VM. Thin adapter over
+# ``websandbox/preview.py``; tenancy comes only from the RequestContext, the port
+# is a validated query param (out-of-range / the reserved terminal port refused),
+# and it's license-gated like the rest.
+#
 # Changed 2026-07-16 (review hardening): the register route now binds the
 # repo-only ``RegisterSandboxRequest`` so a client can no longer write a
 # server-owned ``sandbox_id`` / ``status`` (that field is the key
@@ -38,13 +45,14 @@
 # never the client.
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Query, Response
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import edit as websandbox_edit
+from pocketpaw_ee.cloud.websandbox import preview as websandbox_preview
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
@@ -52,6 +60,7 @@ from pocketpaw_ee.cloud.websandbox.dto import (
     EditRequest,
     EditResponse,
     OpenSandboxRequest,
+    PreviewResponse,
     RegisterSandboxRequest,
     SandboxTreeResponse,
     SnapshotResponse,
@@ -138,6 +147,22 @@ async def get_sandbox_tree(
     """Return the cloned repo's file tree for a ready sandbox."""
     workspace_id = _require_workspace(ctx)
     return await websandbox_provision.get_tree(workspace_id, ctx.user_id, row_id)
+
+
+# ---------------------------------------------------------------------------
+# WC-8/P3b — live dev-server preview.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{row_id}/preview", response_model=PreviewResponse)
+async def get_sandbox_preview(
+    row_id: str,
+    port: int = Query(..., description="Dev-server port running in the sandbox VM"),
+    ctx: RequestContext = Depends(request_context),
+) -> PreviewResponse:
+    """Return the iframe-embeddable public URL for a dev-server port in the VM."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_preview.get_preview(workspace_id, ctx.user_id, row_id, port)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -200,7 +200,7 @@ async def get_sandbox_preview(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/repo-archive")
+@router.get("/browserpod/repo-archive")
 async def get_repo_archive(
     repo: str = Query(..., description="owner/repo or a github.com URL"),
     ref: str | None = Query(None, description="Branch, tag or commit (default branch if omitted)"),
@@ -212,6 +212,12 @@ async def get_repo_archive(
     on BrowserPod's emulated TCP/TLS relay, and the browser cannot fetch GitHub's
     archives directly because they carry no CORS headers. Fetching server-side
     solves both, and is where a GitHub App token would live for private repos.
+
+    Path note: TWO literal segments, deliberately. A single-segment path like
+    ``/repo-archive`` is captured by the ``/{row_id}`` route above — FastAPI
+    matches in registration order — so it resolved to "look up a sandbox called
+    repo-archive" and 404'd. Any new collection-level route here needs the same
+    treatment (see ``test_websandbox_routes.py``).
     """
     workspace_id = _require_workspace(ctx)
     content = await websandbox_archive.fetch_repo_archive(

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -33,7 +33,12 @@
 # ``GET /websandbox/{row_id}/git/status`` and ``POST .../git/stage|commit|push``.
 # Thin adapters over ``websandbox/git.py`` (git runs in the VM; the push token
 # never enters it). Tenancy comes only from the RequestContext; a push failure is
-# a ``pushed:false`` body, never a 500. PR-open is a separate slice (P4b).
+# a ``pushed:false`` body, never a 500.
+#
+# Changed 2026-07-16 (WC-7/P4b, feat/code-mode): added ``POST .../git/pr`` — open a
+# GitHub pull request for the pushed ``paw/edit-*`` branch via the GitHub App
+# (server-side; the token never enters the VM). Thin adapter over
+# ``websandbox/git.py:open_pr``; tenancy comes only from the RequestContext.
 #
 # Changed 2026-07-16 (WC-8/P3b, feat/code-mode): added the live-preview endpoint —
 # ``GET /websandbox/{row_id}/preview?port=<int>`` returns the iframe-embeddable
@@ -64,10 +69,12 @@ from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
     CommitRequest,
+    CreatePrRequest,
     CreateSandboxRequest,
     EditRequest,
     EditResponse,
     GitCommitResponse,
+    GitPrResponse,
     GitPushResponse,
     GitStatusResponse,
     OpenSandboxRequest,
@@ -222,6 +229,17 @@ async def git_push(
     """Push the sandbox's feature branch to origin (never 500s on push failure)."""
     workspace_id = _require_workspace(ctx)
     return await websandbox_git.push(workspace_id, ctx.user_id, row_id)
+
+
+@router.post("/{row_id}/git/pr", response_model=GitPrResponse)
+async def git_open_pr(
+    row_id: str,
+    body: CreatePrRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> GitPrResponse:
+    """Open a GitHub pull request for the sandbox's pushed feature branch."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_git.open_pr(workspace_id, ctx.user_id, row_id, body)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -220,9 +220,7 @@ async def get_repo_archive(
     treatment (see ``test_websandbox_routes.py``).
     """
     workspace_id = _require_workspace(ctx)
-    content = await websandbox_archive.fetch_repo_archive(
-        workspace_id, ctx.user_id, repo, ref
-    )
+    content = await websandbox_archive.fetch_repo_archive(workspace_id, ctx.user_id, repo, ref)
     return Response(content=content, media_type="application/zip")
 
 

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -8,6 +8,12 @@
 # only; per-action RBAC (require_action) is deferred to a later slice because it
 # needs new action strings registered in the RBAC catalog. The tenancy/owner
 # filtering in the service is the security boundary for now.
+#
+# Changed 2026-07-15 (WC-2, feat/websandbox-vm-provision): added the two
+# cold-provision endpoints — ``POST /websandbox/open`` (provision a Daytona VM +
+# clone a PUBLIC repo, returning the ready registry row) and
+# ``GET /websandbox/{row_id}/tree`` (the cloned repo's file tree). Both delegate
+# to ``websandbox/provision.py``; tenancy still comes only from the RequestContext.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
@@ -15,9 +21,12 @@ from fastapi import APIRouter, Depends
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
     CreateSandboxRequest,
+    OpenSandboxRequest,
+    SandboxTreeResponse,
     UpdateStatusRequest,
     WebSandboxListResponse,
     WebSandboxResponse,
@@ -75,3 +84,29 @@ async def update_sandbox_status(
     workspace_id = _require_workspace(ctx)
     view = await websandbox_service.update_status(workspace_id, ctx.user_id, row_id, body)
     return websandbox_service.view_to_wire(view)
+
+
+# ---------------------------------------------------------------------------
+# WC-2 — cold-provision + file tree.
+# ---------------------------------------------------------------------------
+
+
+@router.post("/open", response_model=WebSandboxResponse)
+async def open_sandbox(
+    body: OpenSandboxRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> WebSandboxResponse:
+    """Cold-provision a Daytona VM and clone a PUBLIC repo into it."""
+    workspace_id = _require_workspace(ctx)
+    view = await websandbox_provision.open_sandbox(workspace_id, ctx.user_id, body)
+    return websandbox_service.view_to_wire(view)
+
+
+@router.get("/{row_id}/tree", response_model=SandboxTreeResponse)
+async def get_sandbox_tree(
+    row_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> SandboxTreeResponse:
+    """Return the cloned repo's file tree for a ready sandbox."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_provision.get_tree(workspace_id, ctx.user_id, row_id)

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -21,6 +21,13 @@
 # ``POST /websandbox/{row_id}/restore`` (fetch the snapshot from S3 → untar it
 # into the VM, 204). Both delegate to ``websandbox/durability.py``; tenancy still
 # comes only from the RequestContext, and both are license-gated like the rest.
+#
+# Changed 2026-07-15 (WC-5a, feat/websandbox-edit-agent): added the AI edit
+# endpoint — ``POST /websandbox/{row_id}/edit`` (a file + instruction → a PROPOSED
+# rewrite from a backend-side frontier model). Thin adapter over
+# ``websandbox/edit.py``; tenancy comes only from the RequestContext, and it's
+# license-gated like the rest. Generate-only — the frontend applies accepted hunks
+# via the existing file-RPC.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Response
@@ -29,10 +36,13 @@ from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
+from pocketpaw_ee.cloud.websandbox import edit as websandbox_edit
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
     CreateSandboxRequest,
+    EditRequest,
+    EditResponse,
     OpenSandboxRequest,
     SandboxTreeResponse,
     SnapshotResponse,
@@ -119,6 +129,22 @@ async def get_sandbox_tree(
     """Return the cloned repo's file tree for a ready sandbox."""
     workspace_id = _require_workspace(ctx)
     return await websandbox_provision.get_tree(workspace_id, ctx.user_id, row_id)
+
+
+# ---------------------------------------------------------------------------
+# WC-5a — AI edit agent (Cmd-K).
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{row_id}/edit", response_model=EditResponse)
+async def propose_edit(
+    row_id: str,
+    body: EditRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> EditResponse:
+    """Propose a model-authored rewrite of a file (generate-only, no VM write)."""
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_edit.propose_edit(workspace_id, ctx.user_id, row_id, body)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -28,6 +28,14 @@
 # ``websandbox/edit.py``; tenancy comes only from the RequestContext, and it's
 # license-gated like the rest. Generate-only — the frontend applies accepted hunks
 # via the existing file-RPC.
+#
+# Changed 2026-07-16 (review hardening): the register route now binds the
+# repo-only ``RegisterSandboxRequest`` so a client can no longer write a
+# server-owned ``sandbox_id`` / ``status`` (that field is the key
+# ``authorize_sandbox`` trusts — a forgeable binding was a cross-tenant VM
+# takeover). The client-facing ``PATCH /{row_id}`` lifecycle route was removed
+# for the same reason: lifecycle is driven entirely by the provisioner + reaper,
+# never the client.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Response
@@ -44,9 +52,9 @@ from pocketpaw_ee.cloud.websandbox.dto import (
     EditRequest,
     EditResponse,
     OpenSandboxRequest,
+    RegisterSandboxRequest,
     SandboxTreeResponse,
     SnapshotResponse,
-    UpdateStatusRequest,
     WebSandboxListResponse,
     WebSandboxResponse,
 )
@@ -67,11 +75,16 @@ def _require_workspace(ctx: RequestContext) -> str:
 
 @router.post("", response_model=WebSandboxResponse)
 async def create_sandbox(
-    body: CreateSandboxRequest,
+    body: RegisterSandboxRequest,
     ctx: RequestContext = Depends(request_context),
 ) -> WebSandboxResponse:
     workspace_id = _require_workspace(ctx)
-    view = await websandbox_service.create_sandbox(workspace_id, ctx.user_id, body)
+    # Bind ONLY the repo from the client; sandbox_id/status stay server-owned
+    # (the provisioner sets them). Constructing the internal command here keeps
+    # the register row at status "pending" with no bound Daytona id.
+    view = await websandbox_service.create_sandbox(
+        workspace_id, ctx.user_id, CreateSandboxRequest(repo=body.repo)
+    )
     return websandbox_service.view_to_wire(view)
 
 
@@ -94,15 +107,11 @@ async def get_sandbox(
     return websandbox_service.view_to_wire(view)
 
 
-@router.patch("/{row_id}", response_model=WebSandboxResponse)
-async def update_sandbox_status(
-    row_id: str,
-    body: UpdateStatusRequest,
-    ctx: RequestContext = Depends(request_context),
-) -> WebSandboxResponse:
-    workspace_id = _require_workspace(ctx)
-    view = await websandbox_service.update_status(workspace_id, ctx.user_id, row_id, body)
-    return websandbox_service.view_to_wire(view)
+# NOTE: there is deliberately NO client ``PATCH /{row_id}`` route. A sandbox's
+# lifecycle (status, bound Daytona id, feature branch) is server-owned and driven
+# entirely by the provisioner (``provision.open_sandbox``) and the idle reaper —
+# never the client. Exposing a client status-write let a caller bind an arbitrary
+# ``sandbox_id`` onto its own row and forge access to another tenant's VM.
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -68,6 +68,7 @@ from fastapi import APIRouter, Depends, Query, Response
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import archive as websandbox_archive
 from pocketpaw_ee.cloud.websandbox import browserpod as websandbox_browserpod
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import edit as websandbox_edit
@@ -197,6 +198,26 @@ async def get_sandbox_preview(
 # BP-1b — BrowserPod boot credential. Two literal segments, so it can never be
 # captured by the single-segment ``/{row_id}`` route above.
 # ---------------------------------------------------------------------------
+
+
+@router.get("/repo-archive")
+async def get_repo_archive(
+    repo: str = Query(..., description="owner/repo or a github.com URL"),
+    ref: str | None = Query(None, description="Branch, tag or commit (default branch if omitted)"),
+    ctx: RequestContext = Depends(request_context),
+) -> Response:
+    """Serve a repo's source as a zip, for seeding an in-tab BrowserPod pod.
+
+    The pod has no usable networking of its own for this: cloning inside it runs
+    on BrowserPod's emulated TCP/TLS relay, and the browser cannot fetch GitHub's
+    archives directly because they carry no CORS headers. Fetching server-side
+    solves both, and is where a GitHub App token would live for private repos.
+    """
+    workspace_id = _require_workspace(ctx)
+    content = await websandbox_archive.fetch_repo_archive(
+        workspace_id, ctx.user_id, repo, ref
+    )
+    return Response(content=content, media_type="application/zip")
 
 
 @router.get("/browserpod/credentials", response_model=BrowserPodCredentialsResponse)

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -10,6 +10,12 @@
 # authorization that emits a high-severity audit event BEFORE it raises, so a
 # denied access attempt is always on the record. Every later Web Cursor slice
 # (session WS, editor RPC, git broker) calls this before touching a sandbox.
+#
+# Changed 2026-07-15 (WC-2, feat/websandbox-vm-provision): added the two
+# system-level reaper support functions ``list_reapable_sandboxes`` (global-read)
+# and ``mark_reaped`` (global-write). The idle-TTL reaper in ``provision.py``
+# drives them; they live here so the service stays the ONLY module that touches
+# the WebSandbox Beanie doc (Rule 2).
 from __future__ import annotations
 
 import logging
@@ -257,6 +263,70 @@ async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView
     return [_doc_to_view(d) for d in docs]
 
 
+# ---------------------------------------------------------------------------
+# System-level reaper support (WC-2). The idle-TTL reaper is a background sweep
+# that acts ACROSS tenants, so these two functions are deliberately NOT
+# tenant-scoped — they carry an explicit ``# global-read`` / ``# global-write``
+# marker per Rule 7. They stay HERE (not in provision.py) so the service remains
+# the only module that touches the Beanie doc (Rule 2).
+# ---------------------------------------------------------------------------
+
+
+async def list_reapable_sandboxes(
+    cutoff: datetime,
+    statuses: tuple[str, ...] = ("ready", "opening"),
+) -> list[WebSandboxView]:
+    """List sandboxes idle since before ``cutoff`` (system reaper candidate set).
+
+    "Idle" == ``updated_at`` older than the cutoff, in a still-live state
+    (``ready`` / ``opening``). Not tenant-scoped: the reaper reclaims leaked VMs
+    for every tenant. WC-3 will refresh ``updated_at`` on live WebSocket traffic;
+    until then age alone marks a session as dropped.
+    """
+    docs = await _WebSandboxDoc.find(
+        # global-read: the idle-TTL reaper sweeps every tenant's sandboxes; this
+        # is a system sweep, not a per-request read, so no workspace filter.
+        {"status": {"$in": list(statuses)}, "updated_at": {"$lt": cutoff}}
+    ).to_list()
+    return [_doc_to_view(d) for d in docs]
+
+
+async def mark_reaped(row_id: str) -> WebSandboxView | None:
+    """Flip a sandbox row to ``reaped`` (system reaper terminal), returning the
+    updated view — or ``None`` if the row vanished mid-sweep.
+
+    Resolves the row by id ONLY (no owner filter) because the reaper is a system
+    actor, not the owning user. The emitted ``WebSandboxStatusChanged`` still
+    carries the row's own tenancy so downstream fan-out stays scoped.
+    """
+    from beanie import PydanticObjectId
+
+    try:
+        oid = PydanticObjectId(row_id)
+    except Exception:  # noqa: BLE001 — a bad id is simply "nothing to reap"
+        return None
+    # global-write: system reaper terminal state; resolve by id across tenants.
+    doc = await _WebSandboxDoc.find_one({"_id": oid})
+    if doc is None:
+        return None
+    doc.status = "reaped"
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+
+    await emit(
+        WebSandboxStatusChanged(
+            data={
+                "id": str(doc.id),
+                "workspace_id": doc.workspace_id,
+                "user_id": doc.user_id,
+                "repo": doc.repo,
+                "status": doc.status,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
 async def _read_owned(
     workspace_id: str,
     user_id: str,
@@ -282,7 +352,9 @@ __all__ = [
     "authorize_sandbox",
     "create_sandbox",
     "get_sandbox",
+    "list_reapable_sandboxes",
     "list_sandboxes",
+    "mark_reaped",
     "update_status",
     "view_to_wire",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -386,9 +386,7 @@ async def drop_overlay_entry(
     prefix = rel_path.rstrip("/") + "/"
     # Reassign (not in-place mutate) so Beanie always sees the field as dirty.
     overlay = {
-        k: v
-        for k, v in (doc.overlay or {}).items()
-        if k != rel_path and not k.startswith(prefix)
+        k: v for k, v in (doc.overlay or {}).items() if k != rel_path and not k.startswith(prefix)
     }
     doc.overlay = overlay
     doc.updated_at = datetime.now(UTC)
@@ -424,7 +422,7 @@ async def move_overlay_entry(
         if k == src:
             overlay[dst] = v
         elif k.startswith(src_prefix):
-            overlay[dst_prefix + k[len(src_prefix):]] = v
+            overlay[dst_prefix + k[len(src_prefix) :]] = v
         else:
             overlay[k] = v
     doc.overlay = overlay

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -22,6 +22,14 @@
 # WebSocket calls (throttled) on live traffic so the WC-2 idle reaper doesn't
 # reclaim a VM someone is actively using. It stays here (not in ws.py) so the
 # service remains the only module that writes the Beanie doc (Rule 2).
+#
+# Changed 2026-07-15 (WC-S3, feat/websandbox-s3-durability): added
+# ``set_snapshot`` — an owner-scoped write that records the durable
+# blob-storage snapshot pointer (a FileRecord id) on the row, and surfaced
+# ``snapshot_file_id`` through ``_doc_to_view`` + ``view_to_wire``. The
+# durability module (``websandbox/durability.py``) calls it after landing the
+# workspace tarball in the tenant's S3. It stays here so the service remains the
+# only module that writes the Beanie doc (Rule 2).
 from __future__ import annotations
 
 import logging
@@ -59,6 +67,7 @@ def _doc_to_view(doc: _WebSandboxDoc) -> WebSandboxView:
         status=doc.status,
         sandbox_id=doc.sandbox_id,
         installation_id=doc.installation_id,
+        snapshot_file_id=doc.snapshot_file_id,
         created_at=doc.created_at,
         updated_at=doc.updated_at,
     )
@@ -74,6 +83,7 @@ def view_to_wire(view: WebSandboxView) -> WebSandboxResponse:
         status=view.status,
         sandboxId=view.sandbox_id,
         installationId=view.installation_id,
+        snapshotFileId=view.snapshot_file_id,
         createdAt=view.created_at.isoformat(),
         updatedAt=view.updated_at.isoformat(),
     )
@@ -282,6 +292,33 @@ async def touch_activity(
     return True
 
 
+async def set_snapshot(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    file_id: str,
+) -> WebSandboxView:
+    """Record the durable workspace-snapshot pointer on a sandbox row.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``): only the owning
+    caller can bind a snapshot to their own sandbox. ``file_id`` is the
+    blob-storage ``FileRecord`` id produced by ``EEUploadService.upload`` in the
+    WC-S3 durability module — a durable pointer to the tarball of the VM's
+    workspace, indexed in Mongo. Raises ``NotFound`` when no owned row matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+    doc.snapshot_file_id = file_id
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: the snapshot pointer is durability bookkeeping, not a lifecycle
+    # transition. No downstream handler (IDE WS fan-out, search index, ripple
+    # invalidation) reacts to it, and emitting WebSandboxStatusChanged would
+    # falsely signal a state change to clients tracking the status field.
+    return _doc_to_view(doc)
+
+
 async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView]:
     """List every sandbox owned by the caller, newest first.
 
@@ -390,6 +427,7 @@ __all__ = [
     "list_reapable_sandboxes",
     "list_sandboxes",
     "mark_reaped",
+    "set_snapshot",
     "touch_activity",
     "update_status",
     "view_to_wire",

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -30,6 +30,13 @@
 # durability module (``websandbox/durability.py``) calls it after landing the
 # workspace tarball in the tenant's S3. It stays here so the service remains the
 # only module that writes the Beanie doc (Rule 2).
+#
+# Changed 2026-07-15 (WC-5a, feat/websandbox-edit-agent): ``update_status`` now
+# also binds the auto-created ``paw/edit-<hex>`` feature branch (via the new
+# ``UpdateStatusRequest.branch``) so the provisioner records it in the same write
+# that marks the row ``ready``; ``branch`` is surfaced through ``_doc_to_view`` +
+# ``view_to_wire``. The doc-write stays here so the service remains the only
+# module that touches the Beanie doc (Rule 2).
 from __future__ import annotations
 
 import logging
@@ -68,6 +75,7 @@ def _doc_to_view(doc: _WebSandboxDoc) -> WebSandboxView:
         sandbox_id=doc.sandbox_id,
         installation_id=doc.installation_id,
         snapshot_file_id=doc.snapshot_file_id,
+        branch=doc.branch,
         created_at=doc.created_at,
         updated_at=doc.updated_at,
     )
@@ -84,6 +92,7 @@ def view_to_wire(view: WebSandboxView) -> WebSandboxResponse:
         sandboxId=view.sandbox_id,
         installationId=view.installation_id,
         snapshotFileId=view.snapshot_file_id,
+        branch=view.branch,
         createdAt=view.created_at.isoformat(),
         updatedAt=view.updated_at.isoformat(),
     )
@@ -246,6 +255,8 @@ async def update_status(
     doc.status = body.status
     if body.sandbox_id is not None:
         doc.sandbox_id = body.sandbox_id
+    if body.branch is not None:
+        doc.branch = body.branch
     doc.updated_at = datetime.now(UTC)
     await doc.save()
 

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -365,6 +365,75 @@ async def set_overlay_entry(
     return _doc_to_view(doc)
 
 
+async def drop_overlay_entry(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    rel_path: str,
+) -> WebSandboxView:
+    """Drop overlay entries for ``rel_path`` (and anything under it) from a row.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``). Called best-effort from
+    the ``file.delete`` path (WC-4c) after the byte-for-byte VM delete: DROPPING an
+    overlay entry is always safe — it just falls back to the snapshot tier on
+    restore, and it stops a since-deleted file being resurrected from the overlay.
+    A directory delete drops every child under ``rel_path + '/'`` too. Raises
+    ``NotFound`` when no owned row matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+    prefix = rel_path.rstrip("/") + "/"
+    # Reassign (not in-place mutate) so Beanie always sees the field as dirty.
+    overlay = {
+        k: v
+        for k, v in (doc.overlay or {}).items()
+        if k != rel_path and not k.startswith(prefix)
+    }
+    doc.overlay = overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: incremental durability bookkeeping, same reasoning as set_snapshot.
+    return _doc_to_view(doc)
+
+
+async def move_overlay_entry(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    src: str,
+    dst: str,
+) -> WebSandboxView:
+    """Re-key overlay entries from ``src`` to ``dst`` (rename == move).
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``). Called best-effort from
+    the ``file.move`` path (WC-4c) after the VM move. The re-key is safe: the
+    FileRecord id (the actual blob) is unchanged — only its overlay KEY moves — so
+    restore replays the same content at the file's new path. A directory move
+    re-keys every child under ``src + '/'`` to the matching ``dst + '/'`` path; a
+    path with no overlay entry is a clean no-op. Raises ``NotFound`` when no owned
+    row matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+    src_prefix = src.rstrip("/") + "/"
+    dst_prefix = dst.rstrip("/") + "/"
+    overlay: dict[str, str] = {}
+    for k, v in (doc.overlay or {}).items():
+        if k == src:
+            overlay[dst] = v
+        elif k.startswith(src_prefix):
+            overlay[dst_prefix + k[len(src_prefix):]] = v
+        else:
+            overlay[k] = v
+    doc.overlay = overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: incremental durability bookkeeping, same reasoning as set_snapshot.
+    return _doc_to_view(doc)
+
+
 async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView]:
     """List every sandbox owned by the caller, newest first.
 
@@ -469,10 +538,12 @@ async def _read_owned(
 __all__ = [
     "authorize_sandbox",
     "create_sandbox",
+    "drop_overlay_entry",
     "get_sandbox",
     "list_reapable_sandboxes",
     "list_sandboxes",
     "mark_reaped",
+    "move_overlay_entry",
     "set_overlay_entry",
     "set_snapshot",
     "touch_activity",

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -16,6 +16,12 @@
 # and ``mark_reaped`` (global-write). The idle-TTL reaper in ``provision.py``
 # drives them; they live here so the service stays the ONLY module that touches
 # the WebSandbox Beanie doc (Rule 2).
+#
+# Changed 2026-07-15 (WC-3, feat/websandbox-terminal-ws): added
+# ``touch_activity`` — an owner-scoped ``updated_at`` heartbeat the terminal
+# WebSocket calls (throttled) on live traffic so the WC-2 idle reaper doesn't
+# reclaim a VM someone is actively using. It stays here (not in ws.py) so the
+# service remains the only module that writes the Beanie doc (Rule 2).
 from __future__ import annotations
 
 import logging
@@ -247,6 +253,35 @@ async def update_status(
     return _doc_to_view(doc)
 
 
+async def touch_activity(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> bool:
+    """Bump a sandbox row's ``updated_at`` to mark it as actively in use.
+
+    Tenant- and owner-scoped: only the owning caller can refresh their own
+    session's liveness. Returns ``True`` when a row was touched, ``False`` when
+    no owned row matched (e.g. it was already reaped) — the terminal socket
+    treats a missing row as a benign no-op rather than an error.
+
+    The idle-TTL reaper (WC-2) reclaims ``ready``/``opening`` rows whose
+    ``updated_at`` predates the TTL; without this heartbeat a long, quiet
+    terminal session would be reaped mid-use. The caller throttles it (at most
+    once per ~60s per socket) so a burst of keystrokes is one write, not one
+    write per frame.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        return False
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: a high-frequency liveness heartbeat, not a state change —
+    # downstream handlers (search index, ripple invalidation) don't need it and
+    # fanning out per-touch would be pure noise.
+    return True
+
+
 async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView]:
     """List every sandbox owned by the caller, newest first.
 
@@ -355,6 +390,7 @@ __all__ = [
     "list_reapable_sandboxes",
     "list_sandboxes",
     "mark_reaped",
+    "touch_activity",
     "update_status",
     "view_to_wire",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -1,0 +1,288 @@
+# service.py — Web Cursor Sandbox Registry business logic (the auth oracle).
+# Created 2026-07-15 (WC-1, feat/websandbox-registry).
+#
+# This module IS the repository (ee/cloud Rule 1) and the ONLY module allowed to
+# import its own Beanie doc (Rule 2). Every read carries a tenant filter
+# (Rule 7); every mutation validates at entry (Rule 6) and emits an event
+# (Rule 9). Errors are CloudError subclasses, never HTTPException (Rule 10).
+#
+# The point of the slice is ``authorize_sandbox``: fail-closed cross-tenant
+# authorization that emits a high-severity audit event BEFORE it raises, so a
+# denied access attempt is always on the record. Every later Web Cursor slice
+# (session WS, editor RPC, git broker) calls this before touching a sandbox.
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import (
+    WebSandboxRegistered,
+    WebSandboxStatusChanged,
+)
+from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox as _WebSandboxDoc
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxId, WebSandboxView
+from pocketpaw_ee.cloud.websandbox.dto import (
+    CreateSandboxRequest,
+    UpdateStatusRequest,
+    WebSandboxResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+_FORBIDDEN_CODE = "websandbox.forbidden"
+# The action string the denial audit event is recorded under. Later slices and
+# any SIEM webhook key off this exact value to alert on cross-tenant probing.
+_CROSS_TENANT_ACTION = "vm.cross_tenant_denied"
+
+
+def _doc_to_view(doc: _WebSandboxDoc) -> WebSandboxView:
+    """Map a persisted, tenant-checked row to its read model."""
+    return WebSandboxView(
+        id=WebSandboxId(str(doc.id)),
+        workspace_id=doc.workspace_id,
+        user_id=doc.user_id,
+        repo=doc.repo,
+        status=doc.status,
+        sandbox_id=doc.sandbox_id,
+        installation_id=doc.installation_id,
+        created_at=doc.created_at,
+        updated_at=doc.updated_at,
+    )
+
+
+def view_to_wire(view: WebSandboxView) -> WebSandboxResponse:
+    """Map a view to the camelCase wire response (Rule 8 — mapping lives here)."""
+    return WebSandboxResponse(
+        id=view.id,
+        workspaceId=view.workspace_id,
+        userId=view.user_id,
+        repo=view.repo,
+        status=view.status,
+        sandboxId=view.sandbox_id,
+        installationId=view.installation_id,
+        createdAt=view.created_at.isoformat(),
+        updatedAt=view.updated_at.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The security core.
+# ---------------------------------------------------------------------------
+
+
+async def authorize_sandbox(
+    workspace_id: str,
+    user_id: str,
+    sandbox_id: str,
+) -> WebSandboxView:
+    """Fail-closed authorization for access to a provisioned sandbox.
+
+    Looks the sandbox up by its Daytona ``sandbox_id``, tenant-filtered to the
+    caller's ``workspace_id`` (Rule 7). Access is granted ONLY when a row
+    exists in the caller's workspace AND is owned by the caller's ``user_id``.
+
+    On any denial — the sandbox belongs to another workspace (the tenant
+    filter returns nothing), or another user in the same workspace — a
+    high-severity ``vm.cross_tenant_denied`` audit event is emitted BEFORE the
+    ``Forbidden`` is raised. Non-existence and wrong-owner both raise the same
+    ``Forbidden``, so existence never leaks through a differentiated error.
+    """
+    doc = await _WebSandboxDoc.find_one(
+        {"sandbox_id": sandbox_id, "workspace_id": workspace_id}  # Rule 7 tenant filter
+    )
+    if doc is None or doc.user_id != user_id:
+        await _record_cross_tenant_denial(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            sandbox_id=sandbox_id,
+            found=doc is not None,
+        )
+        raise Forbidden(_FORBIDDEN_CODE, "You do not have access to this sandbox")
+    return _doc_to_view(doc)
+
+
+async def _record_cross_tenant_denial(
+    *,
+    workspace_id: str,
+    user_id: str,
+    sandbox_id: str,
+    found: bool,
+) -> None:
+    """Emit the fail-closed denial audit event (fire-and-forget, never raises).
+
+    Mirrors the ART-2 fail-closed pattern: ``audit_service.record`` swallows its
+    own write failures, so an audit outage can never turn a denial into a leak.
+    """
+    from pocketpaw_ee.cloud.audit import service as audit_service
+
+    await audit_service.record(
+        workspace_id=workspace_id,
+        actor_id=user_id,
+        action=_CROSS_TENANT_ACTION,
+        target_type="web_sandbox",
+        target_id=sandbox_id,
+        metadata={
+            # ``found`` distinguishes "wrong owner, same workspace" (True) from
+            # "not in this workspace at all" (False) for the forensic trail —
+            # the caller still gets the same opaque Forbidden either way.
+            "reason": "wrong_owner" if found else "cross_workspace",
+            "sandbox_id": sandbox_id,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# CRUD the later slices authorize against. Every read is tenant-filtered.
+# ---------------------------------------------------------------------------
+
+
+async def create_sandbox(
+    workspace_id: str,
+    user_id: str,
+    body: CreateSandboxRequest | dict,
+) -> WebSandboxView:
+    """Register (or re-register) the sandbox for a (workspace, user, repo).
+
+    Idempotent on the registry key: a second call for the same
+    (workspace, user, repo) updates the existing row rather than minting a
+    duplicate, keeping the one-sandbox-per-key invariant even where the unique
+    index isn't enforced (e.g. mongomock).
+    """
+    body = CreateSandboxRequest.model_validate(body)
+
+    existing = await _WebSandboxDoc.find_one(
+        {"workspace_id": workspace_id, "user_id": user_id, "repo": body.repo}  # Rule 7
+    )
+    if existing is not None:
+        existing.status = body.status
+        if body.sandbox_id is not None:
+            existing.sandbox_id = body.sandbox_id
+        if body.installation_id is not None:
+            existing.installation_id = body.installation_id
+        existing.updated_at = datetime.now(UTC)
+        await existing.save()
+        doc = existing
+    else:
+        doc = _WebSandboxDoc(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            repo=body.repo,
+            sandbox_id=body.sandbox_id,
+            status=body.status,
+            installation_id=body.installation_id,
+        )
+        await doc.insert()
+
+    await emit(
+        WebSandboxRegistered(
+            data={
+                "id": str(doc.id),
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "repo": doc.repo,
+                "status": doc.status,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
+async def get_sandbox(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> WebSandboxView:
+    """Read one sandbox row by its registry id, tenant- and owner-scoped.
+
+    Raises ``NotFound`` when no row matches the caller's workspace + user — a
+    row owned by another tenant is indistinguishable from a missing one.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+    return _doc_to_view(doc)
+
+
+async def update_status(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    body: UpdateStatusRequest | dict,
+) -> WebSandboxView:
+    """Advance a sandbox's lifecycle state (optionally binding its Daytona id).
+
+    Tenant- and owner-scoped: a caller can only move a sandbox they own.
+    """
+    body = UpdateStatusRequest.model_validate(body)
+
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+
+    doc.status = body.status
+    if body.sandbox_id is not None:
+        doc.sandbox_id = body.sandbox_id
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+
+    await emit(
+        WebSandboxStatusChanged(
+            data={
+                "id": str(doc.id),
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "repo": doc.repo,
+                "status": doc.status,
+            }
+        )
+    )
+    return _doc_to_view(doc)
+
+
+async def list_sandboxes(workspace_id: str, user_id: str) -> list[WebSandboxView]:
+    """List every sandbox owned by the caller, newest first.
+
+    Tenant-filtered by ``workspace_id`` AND owner-filtered by ``user_id`` so
+    one user never sees another's sandboxes even within a shared workspace.
+    """
+    docs = (
+        await _WebSandboxDoc.find(
+            {"workspace_id": workspace_id, "user_id": user_id}  # Rule 7 tenant filter
+        )
+        .sort([("created_at", -1)])  # mongomock-safe: straight find + sort, no aggregate
+        .to_list()
+    )
+    return [_doc_to_view(d) for d in docs]
+
+
+async def _read_owned(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+) -> _WebSandboxDoc | None:
+    """Tenant- + owner-scoped fetch by registry id. Returns None if not owned.
+
+    An unparseable ``row_id`` yields None (treated as not-found) rather than
+    raising, so a malformed id can't leak a distinct error shape.
+    """
+    from beanie import PydanticObjectId
+
+    try:
+        oid = PydanticObjectId(row_id)
+    except Exception:  # noqa: BLE001 — a bad id is simply "no such owned row"
+        return None
+    return await _WebSandboxDoc.find_one(
+        {"_id": oid, "workspace_id": workspace_id, "user_id": user_id}  # Rule 7
+    )
+
+
+__all__ = [
+    "authorize_sandbox",
+    "create_sandbox",
+    "get_sandbox",
+    "list_sandboxes",
+    "update_status",
+    "view_to_wire",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/service.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/service.py
@@ -76,6 +76,7 @@ def _doc_to_view(doc: _WebSandboxDoc) -> WebSandboxView:
         installation_id=doc.installation_id,
         snapshot_file_id=doc.snapshot_file_id,
         branch=doc.branch,
+        overlay=dict(doc.overlay or {}),
         created_at=doc.created_at,
         updated_at=doc.updated_at,
     )
@@ -321,12 +322,46 @@ async def set_snapshot(
     if doc is None:
         raise NotFound("web_sandbox", row_id)
     doc.snapshot_file_id = file_id
+    # A full snapshot supersedes the incremental write-through overlay (CM-2a′):
+    # everything the overlay held is now inside the snapshot tar. Clearing it here
+    # is also what keeps restore correct — an overlay entry for a file that was
+    # deleted before this snapshot won't be replayed back over the deletion.
+    doc.overlay = {}
     doc.updated_at = datetime.now(UTC)
     await doc.save()
     # no-event: the snapshot pointer is durability bookkeeping, not a lifecycle
     # transition. No downstream handler (IDE WS fan-out, search index, ripple
     # invalidation) reacts to it, and emitting WebSandboxStatusChanged would
     # falsely signal a state change to clients tracking the status field.
+    return _doc_to_view(doc)
+
+
+async def set_overlay_entry(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    rel_path: str,
+    file_id: str,
+) -> WebSandboxView:
+    """Record one write-through overlay entry (``rel_path -> FileRecord id``).
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``): only the owning caller
+    can mirror a file onto their own sandbox row. Called best-effort from the
+    ``file.write`` path (WC-4a) after the byte-for-byte VM write, so every editor
+    save is durable in blob storage the moment it lands — a crash / idle-out
+    before the next full snapshot no longer loses the edit. Last-write-wins per
+    path. Raises ``NotFound`` when no owned row matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, row_id)
+    if doc is None:
+        raise NotFound("web_sandbox", row_id)
+    # Reassign (not in-place mutate) so Beanie always sees the field as dirty.
+    overlay = dict(doc.overlay or {})
+    overlay[rel_path] = file_id
+    doc.overlay = overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: incremental durability bookkeeping, same reasoning as set_snapshot.
     return _doc_to_view(doc)
 
 
@@ -438,6 +473,7 @@ __all__ = [
     "list_reapable_sandboxes",
     "list_sandboxes",
     "mark_reaped",
+    "set_overlay_entry",
     "set_snapshot",
     "touch_activity",
     "update_status",

--- a/ee/pocketpaw_ee/cloud/websandbox/terminal.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/terminal.py
@@ -1,0 +1,139 @@
+# terminal.py — Web Cursor PTY-over-WebSocket bridge (WC-3).
+# Created 2026-07-15 (feat/websandbox-terminal-ws).
+#
+# This is the socket-agnostic core of the terminal slice: it opens a REAL bash
+# PTY session inside a Daytona VM and pumps its output to an injected async
+# ``sink``. ``ws.py`` wires the sink to ``websocket.send_bytes`` for the browser;
+# the live-smoke script wires it to an in-memory buffer — the SAME code path,
+# minus the socket.
+#
+# Why the bridge holds the handle directly (the "handle gap"):
+# ``DaytonaClient.create_pty_session`` DISCARDS the ``AsyncPtyHandle`` the SDK
+# returns (it returns None), so you cannot send keystrokes through the shared
+# client wrapper. Rather than change that shared method (WC-2 and others depend
+# on its signature), this bridge grabs the sandbox instance itself
+# (``client.get_sandbox_instance``) and holds the handle, whose ``send_input``
+# writes INTO the pty. Resize and kill go back through the client wrapper
+# methods (``resize_pty`` / ``kill_pty``) — those work without the handle.
+from __future__ import annotations
+
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+
+from daytona import PtySize
+
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+
+logger = logging.getLogger(__name__)
+
+# Terminal output sink: forwards raw VM bytes onward (to the WS as a binary
+# frame, or to an in-memory buffer in the smoke test).
+OutputSink = Callable[[bytes], Awaitable[None]]
+
+# Sane default terminal geometry when the client hasn't sent a resize yet.
+DEFAULT_COLS = 80
+DEFAULT_ROWS = 24
+
+
+class PtyBridge:
+    """One live bash PTY session in a Daytona VM, bridged to an async sink.
+
+    Lifecycle: ``start`` opens the pty and begins streaming output to the sink;
+    ``send_input`` writes keystrokes; ``resize`` changes the terminal geometry;
+    ``close`` tears the session down. One bridge == one pty session == one
+    WebSocket connection. The ``session_id`` MUST be unique per connection so a
+    second socket for the same VM never collides with an existing session.
+    """
+
+    def __init__(
+        self,
+        client: DaytonaClient,
+        sandbox_id: str,
+        session_id: str,
+        sink: OutputSink,
+    ) -> None:
+        self._client = client
+        self._sandbox_id = sandbox_id
+        self._session_id = session_id
+        self._sink = sink
+        self._handle = None
+        self._closed = False
+
+    async def _on_data(self, data: bytes) -> None:
+        """SDK callback: forward one chunk of terminal output to the sink.
+
+        Never lets a sink failure propagate back into the SDK's read loop — a
+        broken socket must not crash the pty reader; the WS handler tears the
+        bridge down on the next receive error instead.
+        """
+        if self._closed:
+            return
+        try:
+            await self._sink(data)
+        except Exception:  # noqa: BLE001 — a dead sink shouldn't kill the reader
+            logger.debug("pty sink failed for session=%s; dropping chunk", self._session_id)
+
+    async def start(self, cols: int = DEFAULT_COLS, rows: int = DEFAULT_ROWS) -> None:
+        """Open the pty session and start streaming its output to the sink.
+
+        Grabs the SDK sandbox instance and creates the pty session directly so
+        we KEEP the handle (the client wrapper would discard it). Blocks until
+        the underlying WebSocket to the pty is connected so the first
+        ``send_input`` isn't dropped on a not-yet-open socket.
+        """
+        sb = await self._client.get_sandbox_instance(self._sandbox_id)
+        self._handle = await sb.process.create_pty_session(
+            self._session_id,
+            self._on_data,
+            pty_size=PtySize(rows=rows, cols=cols),
+        )
+        # Wait until the pty WebSocket is live before we accept input. Guarded by
+        # hasattr so a minimal fake handle in tests needn't implement it.
+        waiter = getattr(self._handle, "wait_for_connection", None)
+        if waiter is not None:
+            await waiter()
+        logger.info(
+            "pty bridge started: sandbox=%s session=%s size=%dx%d",
+            self._sandbox_id,
+            self._session_id,
+            cols,
+            rows,
+        )
+
+    async def send_input(self, data: str | bytes) -> None:
+        """Write keystrokes INTO the pty via the held handle."""
+        if self._closed or self._handle is None:
+            return
+        await self._handle.send_input(data)
+
+    async def resize(self, cols: int, rows: int) -> None:
+        """Resize the pty. Routed through the client wrapper (no handle needed)."""
+        if self._closed:
+            return
+        await self._client.resize_pty(self._sandbox_id, self._session_id, cols, rows)
+
+    async def close(self) -> None:
+        """Tear the pty session down. Idempotent and never raises.
+
+        Kills the server-side session (so the shell process doesn't leak) and
+        disconnects the local handle. Both are best-effort: teardown runs in a
+        ``finally`` on the socket, and a disconnected VM must not turn cleanup
+        into an error.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        with contextlib.suppress(Exception):
+            await self._client.kill_pty(self._sandbox_id, self._session_id)
+        if self._handle is not None:
+            disconnect = getattr(self._handle, "disconnect", None)
+            if disconnect is not None:
+                with contextlib.suppress(Exception):
+                    await disconnect()
+        logger.info(
+            "pty bridge closed: sandbox=%s session=%s", self._sandbox_id, self._session_id
+        )
+
+
+__all__ = ["DEFAULT_COLS", "DEFAULT_ROWS", "OutputSink", "PtyBridge"]

--- a/ee/pocketpaw_ee/cloud/websandbox/terminal.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/terminal.py
@@ -133,9 +133,7 @@ class PtyBridge:
             if disconnect is not None:
                 with contextlib.suppress(Exception):
                     await disconnect()
-        logger.info(
-            "pty bridge closed: sandbox=%s session=%s", self._sandbox_id, self._session_id
-        )
+        logger.info("pty bridge closed: sandbox=%s session=%s", self._sandbox_id, self._session_id)
 
 
 __all__ = ["DEFAULT_COLS", "DEFAULT_ROWS", "OutputSink", "PtyBridge"]

--- a/ee/pocketpaw_ee/cloud/websandbox/terminal.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/terminal.py
@@ -24,6 +24,7 @@ from collections.abc import Awaitable, Callable
 from daytona import PtySize
 
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,7 @@ class PtyBridge:
         self._handle = await sb.process.create_pty_session(
             self._session_id,
             self._on_data,
+            cwd=WEBSANDBOX_WORKDIR,  # open the shell where the repo is cloned
             pty_size=PtySize(rows=rows, cols=cols),
         )
         # Wait until the pty WebSocket is live before we accept input. Guarded by

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -44,14 +44,20 @@
 # idle reaper doesn't reclaim an active session.
 #
 # 2026-07-15 (WC-4a): the SAME socket also carries file operations, multiplexed
-# alongside the terminal. Any ``file.*`` frame ({"type":"file.list|read|write",
-# "reqId":..,"path":..[,"content":..]}) is handed to the socket-agnostic
-# ``FileRpc`` (websandbox/files.py), which jails the path to the sandbox project
-# dir and returns a JSON response frame (file.list.ok / file.read.ok /
-# file.write.ok / file.error). File responses are typed JSON text frames while
-# terminal output is binary, so the two streams never collide. No per-frame
-# re-authorization — the socket is already owner-bound to the VM — but file ops
-# DO bump the same throttled activity heartbeat.
+# alongside the terminal. Any ``file.*`` frame ({"type":"file.list|read|write|
+# create|delete|move","reqId":..,"path":..[,"content"|"isDir"|"toPath":..]}) is
+# handed to the socket-agnostic ``FileRpc`` (websandbox/files.py), which jails the
+# path to the sandbox project dir and returns a JSON response frame (file.<op>.ok
+# / file.error). File responses are typed JSON text frames while terminal output
+# is binary, so the two streams never collide. No per-frame re-authorization — the
+# socket is already owner-bound to the VM — but file ops DO bump the same throttled
+# activity heartbeat.
+#
+# 2026-07-16 (WC-4c): create/delete/move join the file verbs. ws.py binds three
+# best-effort durability closures onto FileRpc — ``_mirror`` (on_write),
+# ``_drop`` (on_delete → overlay drop), ``_move`` (on_move → overlay re-key) — so
+# a create/save is mirrored, a delete isn't resurrected, and a rename replays at
+# its new path on restore.
 from __future__ import annotations
 
 import asyncio
@@ -297,7 +303,17 @@ async def terminal_websocket_endpoint(
             workspace_id, user_id, row_id, rel_path, data, uploads=overlay_uploads
         )
 
-    file_rpc = FileRpc(client, row.sandbox_id, on_write=_mirror)
+    async def _drop(rel_path: str) -> None:
+        # Delete-side durability: drop the overlay entry so a deleted file is not
+        # resurrected on restore (WC-4c). Best-effort — swallowed inside FileRpc.
+        await websandbox_durability.drop_overlay(workspace_id, user_id, row_id, rel_path)
+
+    async def _move(src_rel: str, dst_rel: str) -> None:
+        # Rename-side durability: re-key the overlay entry to the new path so
+        # restore replays the file where it now lives (WC-4c). Best-effort.
+        await websandbox_durability.move_overlay(workspace_id, user_id, row_id, src_rel, dst_rel)
+
+    file_rpc = FileRpc(client, row.sandbox_id, on_write=_mirror, on_delete=_drop, on_move=_move)
 
     async def _touch() -> None:
         """Bump the row's activity heartbeat, throttled, swallowing errors."""

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -285,7 +285,19 @@ async def terminal_websocket_endpoint(
     # File ops share this socket. FileRpc jails every path to the sandbox project
     # dir (resolved lazily on first use); it reuses the already-owner-authorized
     # client + sandbox_id and never re-authorizes per frame.
-    file_rpc = FileRpc(client, row.sandbox_id)
+    #
+    # Write-through durability (CM-2a′): build ONE overlay uploads service for the
+    # session and pass FileRpc a mirror closure bound to this tenant + row. Each
+    # editor save then also lands in blob storage; a mirror failure is swallowed
+    # inside FileRpc so it never fails the save.
+    overlay_uploads = websandbox_durability.build_uploads()
+
+    async def _mirror(rel_path: str, data: bytes) -> None:
+        await websandbox_durability.mirror_file(
+            workspace_id, user_id, row_id, rel_path, data, uploads=overlay_uploads
+        )
+
+    file_rpc = FileRpc(client, row.sandbox_id, on_write=_mirror)
 
     async def _touch() -> None:
         """Bump the row's activity heartbeat, throttled, swallowing errors."""

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -1,0 +1,228 @@
+# ws.py — Web Cursor terminal WebSocket endpoint + connection manager (WC-3).
+# Created 2026-07-15 (feat/websandbox-terminal-ws).
+#
+# One authenticated WebSocket per Web Cursor session streams a REAL bash shell
+# from the owning tenant's Daytona VM to the browser. Structure mirrors the chat
+# WS (accept -> authenticate -> active loop -> disconnect) and reuses the same
+# single-use ws_ticket auth, because browsers can't set auth headers on a WS
+# upgrade.
+#
+# Connect flow (fail-closed at every step; a PTY is opened ONLY after all pass):
+#   accept-gate: license present -> ticket in ?token= present
+#   consume_ws_ticket(token) -> user_id           (single-use, Redis fail-closed)
+#   auth_service.get_active_workspace(user_id)     -> workspace_id
+#   websandbox_service.get_sandbox(ws, user, row)  -> row (NotFound if not owned)
+#   row.sandbox_id present (row is ``ready``)      (else 1008 not-ready)
+#   authorize_sandbox(ws, user, row.sandbox_id)    -> bind socket to the VM
+# Any failure closes 1008 BEFORE accept/PTY — a second user's ticket for someone
+# else's row is denied by get_sandbox/authorize_sandbox before any PTY opens.
+#
+# Message framing: client->server JSON — {"type":"input","data":"<str>"},
+# {"type":"resize","cols":N,"rows":N}, {"type":"ping"}. server->client — raw
+# BINARY frames carry terminal output (cleanest for xterm); pong is JSON. On
+# live traffic the row's ``updated_at`` is bumped (throttled ~60s) so the WC-2
+# idle reaper doesn't reclaim an active session.
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+
+from fastapi import Query, WebSocket, WebSocketDisconnect
+
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.auth import service as auth_service
+from pocketpaw_ee.cloud.auth.ws_tickets import consume_ws_ticket
+from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+from pocketpaw_ee.cloud.license import get_license
+from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.terminal import DEFAULT_COLS, DEFAULT_ROWS, PtyBridge
+
+logger = logging.getLogger(__name__)
+
+# WS close codes. 1008 == policy violation (auth / authz denial). 4003 mirrors
+# the chat WS "enterprise license required". 1011 == internal error (PTY open
+# failed after auth succeeded).
+_CLOSE_POLICY = 1008
+_CLOSE_LICENSE = 4003
+_CLOSE_INTERNAL = 1011
+
+# Minimum seconds between activity heartbeats per socket (throttle): a burst of
+# keystrokes becomes one ``updated_at`` write, not one per frame.
+_ACTIVITY_THROTTLE_SECONDS = 60.0
+
+
+class _ActivityThrottle:
+    """Rate-limit the per-socket ``updated_at`` heartbeat.
+
+    ``should_touch(now)`` returns True the first time and then at most once per
+    ``_ACTIVITY_THROTTLE_SECONDS``. Kept as a tiny testable unit so the throttle
+    logic is verified without a live socket.
+    """
+
+    def __init__(self, interval: float = _ACTIVITY_THROTTLE_SECONDS) -> None:
+        self._interval = interval
+        self._last: float | None = None
+
+    def should_touch(self, now: float) -> bool:
+        if self._last is None or (now - self._last) >= self._interval:
+            self._last = now
+            return True
+        return False
+
+
+class TerminalConnectionManager:
+    """Tracks the live pty bridge behind each terminal socket for teardown.
+
+    Deliberately minimal versus the chat ``ConnectionManager`` — the terminal
+    has no presence, no rooms, no fan-out. Its one job is to guarantee that
+    every accepted socket's pty session is killed exactly once when the socket
+    goes away, so a dropped browser tab never leaks a shell in the VM.
+    """
+
+    def __init__(self) -> None:
+        self._bridges: dict[WebSocket, PtyBridge] = {}
+
+    def register(self, websocket: WebSocket, bridge: PtyBridge) -> None:
+        self._bridges[websocket] = bridge
+
+    async def unregister(self, websocket: WebSocket) -> None:
+        bridge = self._bridges.pop(websocket, None)
+        if bridge is not None:
+            await bridge.close()
+
+    def active_count(self) -> int:
+        return len(self._bridges)
+
+
+# Module-level singleton (mirrors chat.ws.manager).
+manager = TerminalConnectionManager()
+
+
+async def terminal_websocket_endpoint(
+    websocket: WebSocket,
+    row_id: str,
+    token: str | None = Query(None),
+) -> None:
+    """Stream a real bash PTY from the owning sandbox's VM to the browser.
+
+    See the module docstring for the full connect/auth flow. The ws_ticket is
+    consumed (single-use) BEFORE accept; any auth/authz failure closes 1008 and
+    never opens a PTY.
+    """
+    # License gate — parity with the REST /websandbox routes and chat WS.
+    lic = get_license()
+    if lic is None or lic.expired:
+        await websocket.close(code=_CLOSE_LICENSE, reason="Enterprise license required")
+        return
+
+    # Path 1 — single-use ws_ticket in ?token= (the only auth path the browser
+    # can use on a cross-origin WS upgrade). No ticket -> no access.
+    if not token:
+        await websocket.close(code=_CLOSE_POLICY, reason="Missing ticket")
+        return
+    user_id = await consume_ws_ticket(token)
+    if not user_id:
+        await websocket.close(code=_CLOSE_POLICY, reason="Invalid ticket")
+        return
+
+    # Resolve the caller's workspace from the same membership field the HTTP
+    # request context reads. Fail closed if the user has no active workspace.
+    try:
+        workspace_id = await auth_service.get_active_workspace(user_id)
+    except CloudError:
+        workspace_id = None
+    if not workspace_id:
+        await websocket.close(code=_CLOSE_POLICY, reason="No active workspace")
+        return
+
+    # Resolve + authorize the sandbox row. get_sandbox is tenant+owner scoped
+    # (NotFound for a row the caller doesn't own); authorize_sandbox is the
+    # fail-closed oracle bound to the Daytona id. Either denial -> 1008, no PTY.
+    try:
+        row = await websandbox_service.get_sandbox(workspace_id, user_id, row_id)
+        if not row.sandbox_id:
+            await websocket.close(code=_CLOSE_POLICY, reason="Sandbox not ready")
+            return
+        await websandbox_service.authorize_sandbox(workspace_id, user_id, row.sandbox_id)
+    except CloudError:
+        await websocket.close(code=_CLOSE_POLICY, reason="Access denied")
+        return
+
+    client = get_daytona_client()
+    if client is None:
+        await websocket.close(code=_CLOSE_LICENSE, reason="Sandbox runtime unavailable")
+        return
+
+    # Every gate passed — accept the socket and open the PTY.
+    await websocket.accept()
+
+    session_id = f"term-{uuid.uuid4().hex}"
+
+    async def _sink(data: bytes) -> None:
+        # Raw terminal bytes go to the browser as binary frames (xterm-friendly).
+        await websocket.send_bytes(data)
+
+    bridge = PtyBridge(client, row.sandbox_id, session_id, _sink)
+    try:
+        await bridge.start(cols=DEFAULT_COLS, rows=DEFAULT_ROWS)
+    except Exception:
+        logger.exception("pty open failed: row=%s sandbox=%s", row_id, row.sandbox_id)
+        await bridge.close()
+        await websocket.close(code=_CLOSE_INTERNAL, reason="Failed to open terminal")
+        return
+
+    manager.register(websocket, bridge)
+    throttle = _ActivityThrottle()
+
+    async def _touch() -> None:
+        """Bump the row's activity heartbeat, throttled, swallowing errors."""
+        if not throttle.should_touch(time.monotonic()):
+            return
+        try:
+            await websandbox_service.touch_activity(workspace_id, user_id, row_id)
+        except Exception:  # noqa: BLE001 — a heartbeat miss must not drop the session
+            logger.debug("activity touch failed for row=%s", row_id)
+
+    try:
+        while True:
+            raw = await websocket.receive_text()
+            try:
+                msg = json.loads(raw)
+            except (ValueError, TypeError):
+                continue  # ignore malformed frames rather than tearing down
+            if not isinstance(msg, dict):
+                continue
+
+            mtype = msg.get("type")
+            if mtype == "input":
+                data = msg.get("data")
+                if isinstance(data, str):
+                    await bridge.send_input(data)
+                    await _touch()
+            elif mtype == "resize":
+                cols = msg.get("cols")
+                rows = msg.get("rows")
+                if isinstance(cols, int) and isinstance(rows, int) and cols > 0 and rows > 0:
+                    await bridge.resize(cols, rows)
+                    await _touch()
+            elif mtype == "ping":
+                # Keep the socket warm through idle-closing edge proxies.
+                await websocket.send_json({"type": "pong"})
+    except WebSocketDisconnect:
+        pass
+    except RuntimeError as exc:
+        # Starlette raises RuntimeError("WebSocket is not connected") when
+        # receive is called after the peer already disconnected. Treat as a
+        # normal close; re-raise anything else.
+        if "not connected" not in str(exc).lower():
+            logger.exception("terminal WS error: row=%s", row_id)
+    except Exception:
+        logger.exception("terminal WS error: row=%s", row_id)
+    finally:
+        # Teardown: kill the pty session so the shell doesn't leak in the VM.
+        await manager.unregister(websocket)
+
+
+__all__ = ["TerminalConnectionManager", "manager", "terminal_websocket_endpoint"]

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -22,6 +22,16 @@
 # BINARY frames carry terminal output (cleanest for xterm); pong is JSON. On
 # live traffic the row's ``updated_at`` is bumped (throttled ~60s) so the WC-2
 # idle reaper doesn't reclaim an active session.
+#
+# 2026-07-15 (WC-4a): the SAME socket also carries file operations, multiplexed
+# alongside the terminal. Any ``file.*`` frame ({"type":"file.list|read|write",
+# "reqId":..,"path":..[,"content":..]}) is handed to the socket-agnostic
+# ``FileRpc`` (websandbox/files.py), which jails the path to the sandbox project
+# dir and returns a JSON response frame (file.list.ok / file.read.ok /
+# file.write.ok / file.error). File responses are typed JSON text frames while
+# terminal output is binary, so the two streams never collide. No per-frame
+# re-authorization — the socket is already owner-bound to the VM — but file ops
+# DO bump the same throttled activity heartbeat.
 from __future__ import annotations
 
 import json
@@ -37,6 +47,7 @@ from pocketpaw_ee.cloud.auth.ws_tickets import consume_ws_ticket
 from pocketpaw_ee.cloud.daytona.client import get_daytona_client
 from pocketpaw_ee.cloud.license import get_license
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
+from pocketpaw_ee.cloud.websandbox.files import FileRpc
 from pocketpaw_ee.cloud.websandbox.terminal import DEFAULT_COLS, DEFAULT_ROWS, PtyBridge
 
 logger = logging.getLogger(__name__)
@@ -176,6 +187,11 @@ async def terminal_websocket_endpoint(
     manager.register(websocket, bridge)
     throttle = _ActivityThrottle()
 
+    # File ops share this socket. FileRpc jails every path to the sandbox project
+    # dir (resolved lazily on first use); it reuses the already-owner-authorized
+    # client + sandbox_id and never re-authorizes per frame.
+    file_rpc = FileRpc(client, row.sandbox_id)
+
     async def _touch() -> None:
         """Bump the row's activity heartbeat, throttled, swallowing errors."""
         if not throttle.should_touch(time.monotonic()):
@@ -196,6 +212,15 @@ async def terminal_websocket_endpoint(
                 continue
 
             mtype = msg.get("type")
+            if isinstance(mtype, str) and mtype.startswith("file."):
+                # File op multiplexed on the terminal socket. FileRpc jails the
+                # path and returns a JSON response frame (or file.error); a bad
+                # frame never tears the socket down.
+                response = await file_rpc.dispatch(msg)
+                if response is not None:
+                    await websocket.send_json(response)
+                    await _touch()
+                continue
             if mtype == "input":
                 data = msg.get("data")
                 if isinstance(data, str):

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -167,13 +167,9 @@ async def snapshot_on_disconnect(
     which survives the VM's reaping.
     """
     try:
-        await websandbox_durability.snapshot_workspace(
-            workspace_id, user_id, row_id, client=client
-        )
+        await websandbox_durability.snapshot_workspace(workspace_id, user_id, row_id, client=client)
     except Exception:  # noqa: BLE001 — teardown must never raise on a snapshot miss
-        logger.debug(
-            "websandbox.snapshot on disconnect failed for row=%s", row_id, exc_info=True
-        )
+        logger.debug("websandbox.snapshot on disconnect failed for row=%s", row_id, exc_info=True)
 
 
 async def terminal_websocket_endpoint(

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -65,8 +65,9 @@ from fastapi import Query, WebSocket, WebSocketDisconnect
 from pocketpaw_ee.cloud._core.errors import CloudError
 from pocketpaw_ee.cloud.auth import service as auth_service
 from pocketpaw_ee.cloud.auth.ws_tickets import consume_ws_ticket
-from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.license import get_license
+from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.files import FileRpc
 from pocketpaw_ee.cloud.websandbox.terminal import DEFAULT_COLS, DEFAULT_ROWS, PtyBridge
@@ -137,6 +138,36 @@ class TerminalConnectionManager:
 
 # Module-level singleton (mirrors chat.ws.manager).
 manager = TerminalConnectionManager()
+
+
+async def snapshot_on_disconnect(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    client: DaytonaClient | None,
+) -> None:
+    """Best-effort workspace snapshot when a terminal socket closes (CM-2a′).
+
+    The durable half of Code Mode is the S3 snapshot; the Daytona VM is pure
+    scratch. With the aggressive Daytona lifecycle (stop 5 / delete-on-stop), a
+    disconnected VM is reclaimed within minutes — so a CLEAN disconnect (tab
+    close, navigate away) is the moment to capture the workspace while the VM is
+    still alive. ``codeproject.lifecycle.open_project`` restores the latest
+    snapshot on the next open.
+
+    Best-effort by design: a snapshot failure (VM already gone, S3 down, an
+    unprovisioned row) must NEVER surface on socket teardown — it is logged at
+    debug and swallowed. The snapshot pointer lands on the stable WebSandbox row,
+    which survives the VM's reaping.
+    """
+    try:
+        await websandbox_durability.snapshot_workspace(
+            workspace_id, user_id, row_id, client=client
+        )
+    except Exception:  # noqa: BLE001 — teardown must never raise on a snapshot miss
+        logger.debug(
+            "websandbox.snapshot on disconnect failed for row=%s", row_id, exc_info=True
+        )
 
 
 async def terminal_websocket_endpoint(
@@ -312,6 +343,15 @@ async def terminal_websocket_endpoint(
     finally:
         # Teardown: kill the pty session so the shell doesn't leak in the VM.
         await manager.unregister(websocket)
+        # CM-2a′ durability: capture the workspace to S3 on this clean disconnect
+        # so a returning user restores their uncommitted work. Best-effort — a
+        # snapshot miss never turns a normal close into an error.
+        await snapshot_on_disconnect(workspace_id, user_id, row_id, client)
 
 
-__all__ = ["TerminalConnectionManager", "manager", "terminal_websocket_endpoint"]
+__all__ = [
+    "TerminalConnectionManager",
+    "manager",
+    "snapshot_on_disconnect",
+    "terminal_websocket_endpoint",
+]

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -7,15 +7,35 @@
 # single-use ws_ticket auth, because browsers can't set auth headers on a WS
 # upgrade.
 #
+# 2026-07-15 (WC-4b): the ticket now resolves via EITHER of two auth paths, so
+# the browser can authenticate without leaking the ticket in the URL (URL query
+# strings leak into access logs, browser history, and proxies — the same
+# REVIEW-4 reasoning that moved the chat WS off URL tickets):
+#   * Path 1 — single-use ws_ticket in ``?token=``, consumed BEFORE accept
+#     (unchanged; the only path a cross-origin WS upgrade can carry in the URL).
+#   * Path 3 — no ``?token=``: accept() FIRST (a frame can only be read after the
+#     handshake completes), then read the first frame under a 5s timeout and
+#     parse ``{"type":"auth","ticket"|"token":"..."}``. On timeout, a malformed
+#     frame, a non-auth frame, or a failed ``consume_ws_ticket`` -> close 4001 and
+#     the socket never reaches the message loop.
+# ``websocket.accept()`` is called exactly once on every path, tracked by the
+# ``accepted`` flag: Path 1 accepts AFTER the authz checks (as before); Path 3
+# accepts BEFORE reading the frame, so the shared authz section must not accept
+# again.
+#
 # Connect flow (fail-closed at every step; a PTY is opened ONLY after all pass):
-#   accept-gate: license present -> ticket in ?token= present
-#   consume_ws_ticket(token) -> user_id           (single-use, Redis fail-closed)
+#   license present                                (else 4003)
+#   Path 1: ticket in ?token= -> consume_ws_ticket (pre-accept; 1008 on failure)
+#   Path 3: no ?token= -> accept, read first auth   (post-accept; 4001 on failure)
+#           frame under 5s timeout -> consume_ws_ticket
+#   -> user_id                                     (single-use, Redis fail-closed)
 #   auth_service.get_active_workspace(user_id)     -> workspace_id
 #   websandbox_service.get_sandbox(ws, user, row)  -> row (NotFound if not owned)
 #   row.sandbox_id present (row is ``ready``)      (else 1008 not-ready)
 #   authorize_sandbox(ws, user, row.sandbox_id)    -> bind socket to the VM
-# Any failure closes 1008 BEFORE accept/PTY — a second user's ticket for someone
-# else's row is denied by get_sandbox/authorize_sandbox before any PTY opens.
+# A second user's ticket for someone else's row is denied by get_sandbox/
+# authorize_sandbox before any PTY opens. Path 1 closes 1008 pre-accept; Path 3
+# is already accepted, so an authz denial closes 1008 on the accepted socket.
 #
 # Message framing: client->server JSON — {"type":"input","data":"<str>"},
 # {"type":"resize","cols":N,"rows":N}, {"type":"ping"}. server->client — raw
@@ -34,6 +54,7 @@
 # DO bump the same throttled activity heartbeat.
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -52,12 +73,19 @@ from pocketpaw_ee.cloud.websandbox.terminal import DEFAULT_COLS, DEFAULT_ROWS, P
 
 logger = logging.getLogger(__name__)
 
-# WS close codes. 1008 == policy violation (auth / authz denial). 4003 mirrors
+# WS close codes. 1008 == policy violation (authz denial). 4001 == the Path 3
+# first-frame auth failed (mirrors the chat WS auth-frame close). 4003 mirrors
 # the chat WS "enterprise license required". 1011 == internal error (PTY open
 # failed after auth succeeded).
 _CLOSE_POLICY = 1008
+_CLOSE_AUTH_FRAME = 4001
 _CLOSE_LICENSE = 4003
 _CLOSE_INTERNAL = 1011
+
+# Seconds to wait for the Path 3 first-message auth frame before giving up. A
+# half-open socket must not hold resources waiting for a credential that may
+# never arrive. Mirrors the chat WS 5s auth-frame timeout.
+_AUTH_FRAME_TIMEOUT_SECONDS = 5.0
 
 # Minimum seconds between activity heartbeats per socket (throttle): a burst of
 # keystrokes becomes one ``updated_at`` write, not one per frame.
@@ -118,25 +146,59 @@ async def terminal_websocket_endpoint(
 ) -> None:
     """Stream a real bash PTY from the owning sandbox's VM to the browser.
 
-    See the module docstring for the full connect/auth flow. The ws_ticket is
-    consumed (single-use) BEFORE accept; any auth/authz failure closes 1008 and
-    never opens a PTY.
+    See the module docstring for the full connect/auth flow. The ws_ticket
+    resolves via Path 1 (``?token=``, consumed pre-accept) or Path 3 (a
+    first-message auth frame read post-accept under a 5s timeout). Any auth
+    failure closes 1008 (Path 1) or 4001 (Path 3); any authz failure closes 1008
+    and never opens a PTY.
     """
-    # License gate — parity with the REST /websandbox routes and chat WS.
+    # License gate first on BOTH paths — parity with the REST /websandbox routes
+    # and chat WS.
     lic = get_license()
     if lic is None or lic.expired:
         await websocket.close(code=_CLOSE_LICENSE, reason="Enterprise license required")
         return
 
-    # Path 1 — single-use ws_ticket in ?token= (the only auth path the browser
-    # can use on a cross-origin WS upgrade). No ticket -> no access.
-    if not token:
-        await websocket.close(code=_CLOSE_POLICY, reason="Missing ticket")
-        return
-    user_id = await consume_ws_ticket(token)
-    if not user_id:
-        await websocket.close(code=_CLOSE_POLICY, reason="Invalid ticket")
-        return
+    # ``accepted`` tracks whether accept() has run so accept() happens exactly
+    # once: Path 1 accepts AFTER the authz checks below; Path 3 accepts BEFORE it
+    # can read the first frame, then the shared authz section must not re-accept.
+    accepted = False
+
+    if token:
+        # Path 1 — single-use ws_ticket in ?token=. Consumed BEFORE accept, so a
+        # bad ticket is refused during the handshake (close 1008, no accept).
+        user_id = await consume_ws_ticket(token)
+        if not user_id:
+            await websocket.close(code=_CLOSE_POLICY, reason="Invalid ticket")
+            return
+    else:
+        # Path 3 — no URL token. Authenticate from the first frame so the ticket
+        # never travels in the URL. We MUST accept() before we can receive, and
+        # the 5s timeout stops a half-open socket from holding resources while we
+        # wait for a credential that may never come.
+        await websocket.accept()
+        accepted = True
+        try:
+            raw = await asyncio.wait_for(
+                websocket.receive_text(), timeout=_AUTH_FRAME_TIMEOUT_SECONDS
+            )
+            frame = json.loads(raw)
+        except Exception:
+            # Timeout, disconnect, or non-JSON first frame.
+            await websocket.close(code=_CLOSE_AUTH_FRAME, reason="Missing auth")
+            return
+
+        if not isinstance(frame, dict) or frame.get("type") != "auth":
+            await websocket.close(code=_CLOSE_AUTH_FRAME, reason="Missing auth")
+            return
+
+        # Accept ``token`` as an alias for ``ticket`` (parity with the chat WS
+        # auth frame); either carries the single-use ws_ticket.
+        ticket = frame.get("ticket") or frame.get("token")
+        user_id = await consume_ws_ticket(ticket) if isinstance(ticket, str) and ticket else None
+        if not user_id:
+            await websocket.close(code=_CLOSE_AUTH_FRAME, reason="Invalid ticket")
+            return
 
     # Resolve the caller's workspace from the same membership field the HTTP
     # request context reads. Fail closed if the user has no active workspace.
@@ -166,8 +228,10 @@ async def terminal_websocket_endpoint(
         await websocket.close(code=_CLOSE_LICENSE, reason="Sandbox runtime unavailable")
         return
 
-    # Every gate passed — accept the socket and open the PTY.
-    await websocket.accept()
+    # Every gate passed — accept the socket (unless Path 3 already did) and open
+    # the PTY. ``accepted`` keeps accept() exactly-once across both paths.
+    if not accepted:
+        await websocket.accept()
 
     session_id = f"term-{uuid.uuid4().hex}"
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -620,6 +620,19 @@ source_modules = [
 forbidden_modules = ["pocketpaw_ee.cloud.models.code_project"]
 
 [[tool.importlinter.contracts]]
+name = "CodeConnection — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.codeconnect.router",
+    "pocketpaw_ee.cloud.codeconnect.dto",
+    "pocketpaw_ee.cloud.codeconnect.domain",
+    "pocketpaw_ee.cloud.codeconnect.connect",
+    "pocketpaw_ee.cloud.codeconnect.state",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.code_connection"]
+
+[[tool.importlinter.contracts]]
 name = "Shared agent_bridge — orchestrate via entity services only"
 type = "forbidden"
 allow_indirect_imports = "true"

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -608,6 +608,18 @@ source_modules = [
 forbidden_modules = ["pocketpaw_ee.cloud.models.user"]
 
 [[tool.importlinter.contracts]]
+name = "CodeProject — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.codeproject.router",
+    "pocketpaw_ee.cloud.codeproject.dto",
+    "pocketpaw_ee.cloud.codeproject.domain",
+    "pocketpaw_ee.cloud.codeproject.lifecycle",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.code_project"]
+
+[[tool.importlinter.contracts]]
 name = "Shared agent_bridge — orchestrate via entity services only"
 type = "forbidden"
 allow_indirect_imports = "true"

--- a/scripts/websandbox_edit_smoke.py
+++ b/scripts/websandbox_edit_smoke.py
@@ -1,0 +1,110 @@
+# websandbox_edit_smoke.py — ONE live smoke for the Web Cursor AI edit agent (WC-5a).
+# Created 2026-07-15 (feat/websandbox-edit-agent).
+#
+# Out of CI. Exercises the REAL Daytona runtime + the REAL Anthropic model:
+#   1. init the cloud registry (localhost mongo) so the tenancy guards work.
+#   2. provision a VM and clone a SMALL public repo (octocat/Hello-World).
+#   3. confirm the auto-created ``paw/edit-<hex>`` branch is checked out IN the VM
+#      (git branch --show-current == the row's stored branch).
+#   4. call ``edit.propose_edit`` with the REAL model on a real file and assert the
+#      proposed content differs from the original and is non-empty.
+#   5. ALWAYS delete the VM in ``finally`` (mandatory cleanup).
+#
+# Run:  .venv/Scripts/python.exe scripts/websandbox_edit_smoke.py
+# Requires live Daytona + Anthropic keys in .env. If the Anthropic key is
+# missing/invalid the script reports it honestly rather than faking a pass.
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv(".env")  # load creds BEFORE importing config-reading modules
+
+WORKSPACE = "smoke-ws"
+USER = "smoke-user"
+REPO = "https://github.com/octocat/Hello-World.git"
+EDIT_PATH = "README"  # Hello-World ships a single README file
+INSTRUCTION = "Add a new trailing line that is a comment saying 'edited by paw'."
+
+
+async def main() -> int:
+    from pocketpaw_ee.cloud import init_realtime
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+    from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
+    from pocketpaw_ee.cloud.websandbox import edit, provision
+    from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+    daytona = get_daytona_client()
+    if daytona is None:
+        print("BLOCKED: Daytona is not configured (get_daytona_client() -> None). Check .env.")
+        return 1
+
+    await init_cloud_db()
+    init_realtime()  # the registry emits events on every write
+    sandbox_id: str | None = None
+    try:
+        print("[1/4] Provisioning VM + cloning", REPO, "...")
+        view = await provision.open_sandbox(WORKSPACE, USER, {"repo": REPO}, client=daytona)
+        sandbox_id = view.sandbox_id
+        print(f"      ready: row={view.id} sandbox={sandbox_id} branch={view.branch}")
+
+        print("[2/4] Confirming the auto-branch is checked out IN the VM ...")
+        resp = await daytona.execute_command(
+            sandbox_id, "git branch --show-current", cwd=WEBSANDBOX_WORKDIR, timeout=30
+        )
+        current = (getattr(resp, "result", "") or "").strip()
+        print(f"      git branch --show-current -> {current!r}  (stored: {view.branch!r})")
+        assert view.branch, "no branch stored on the row"
+        assert current == view.branch, f"VM branch {current!r} != stored {view.branch!r}"
+        assert current.startswith("paw/edit-"), f"unexpected branch name {current!r}"
+        print("      OK: branch created + checked out in the VM")
+
+        print("[3/4] Calling propose_edit with the REAL model on", EDIT_PATH, "...")
+        try:
+            result = await edit.propose_edit(
+                WORKSPACE, USER, view.id,
+                {"path": EDIT_PATH, "instruction": INSTRUCTION},
+                daytona=daytona,  # client=None -> builds the real AsyncAnthropic
+            )
+        except CloudError as exc:
+            if exc.code == "websandbox.edit_unavailable":
+                # Honest report (task contract): no direct Anthropic key in this
+                # env. The branch half is proven; the model half can't run here.
+                print(f"      MODEL HALF BLOCKED: {exc.code}: {exc.message}")
+                print("      (this deployment has no anthropic_api_key — Claude is")
+                print("       routed via the claude_code OAuth provider, which the")
+                print("       direct AsyncAnthropic seam cannot use)")
+                print("\nSMOKE PARTIAL: auto-branch PASS; model half BLOCKED (no key)")
+                return 2
+            raise
+        print("      --- original ---")
+        print(result.originalContent)
+        print("      --- proposed ---")
+        print(result.proposedContent)
+        assert result.proposedContent.strip(), "proposed content is empty"
+        assert result.proposedContent != result.originalContent, "model returned no change"
+        print("[4/4] OK: model returned a real, non-empty diff")
+        print("\nSMOKE PASS")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"\nSMOKE FAIL: {type(exc).__name__}: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return 1
+    finally:
+        if sandbox_id is not None:
+            try:
+                await daytona.delete_sandbox(sandbox_id)
+                print(f"[cleanup] deleted VM {sandbox_id}")
+            except Exception as exc:  # noqa: BLE001
+                print(f"[cleanup] WARNING: failed to delete VM {sandbox_id}: {exc}")
+        await close_cloud_db()
+        await daytona.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/websandbox_edit_smoke.py
+++ b/scripts/websandbox_edit_smoke.py
@@ -65,7 +65,9 @@ async def main() -> int:
         print("[3/4] Calling propose_edit with the REAL model on", EDIT_PATH, "...")
         try:
             result = await edit.propose_edit(
-                WORKSPACE, USER, view.id,
+                WORKSPACE,
+                USER,
+                view.id,
                 {"path": EDIT_PATH, "instruction": INSTRUCTION},
                 daytona=daytona,  # client=None -> builds the real AsyncAnthropic
             )

--- a/scripts/websandbox_file_rpc_smoke.py
+++ b/scripts/websandbox_file_rpc_smoke.py
@@ -1,0 +1,118 @@
+# websandbox_file_rpc_smoke.py — ONE live Daytona smoke for the Web Cursor file
+# read/write/list RPC slice (WC-4a). NOT a pytest test — kept out of CI so a real
+# VM (which costs money) is only ever provisioned when a human runs this.
+# Created 2026-07-15 (feat/websandbox-file-rpc).
+#
+# What it does: loads .env, provisions a REAL Daytona VM, then drives the SAME
+# FileRpc helper the WebSocket endpoint uses (minus the socket) to:
+#   1. write ``paw_rpc_smoke.txt`` with known content,
+#   2. read it back and assert it round-trips (proves real persistence to the VM
+#      filesystem),
+#   3. list the project dir and assert the file appears,
+#   4. attempt a ``../escape.txt`` write and assert the jail REJECTS it.
+# It ALWAYS deletes the VM in a finally block — cleanup is non-negotiable even on
+# exception, because a leaked VM keeps billing.
+#
+# Run: .venv/Scripts/python.exe scripts/websandbox_file_rpc_smoke.py
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+AUTO_STOP_MINUTES = 30
+BOOT_TIMEOUT_SECONDS = 180.0
+SMOKE_FILE = "paw_rpc_smoke.txt"
+SMOKE_CONTENT = "web-cursor file rpc round-trip: paw-rpc-ok\n"
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+    from pocketpaw_ee.cloud.websandbox.files import FileRpc, FileRpcError
+
+    client = get_daytona_client()
+    if client is None:
+        print("FAIL: Daytona is not configured (get_daytona_client() returned None).")
+        print("      Set the Daytona keys in .env and retry.")
+        return 1
+
+    sandbox_id: str | None = None
+    failures: list[str] = []
+
+    try:
+        print(f"Provisioning a Daytona VM (auto_stop_interval={AUTO_STOP_MINUTES} min)...")
+        info = await client.create_sandbox(
+            name="websandbox-file-rpc-smoke",
+            auto_stop_interval=AUTO_STOP_MINUTES,
+        )
+        sandbox_id = info.id
+        print(f"  created: id={sandbox_id} name={info.name} state={info.state}")
+
+        print("Waiting for the VM to boot...")
+        await client.wait_for_sandbox(
+            sandbox_id, target_state="started", timeout=BOOT_TIMEOUT_SECONDS
+        )
+        print("  booted.")
+
+        # The exact helper the WS endpoint instantiates per session.
+        rpc = FileRpc(client, sandbox_id)
+        project_dir = await rpc._root()  # noqa: SLF001 — smoke wants the resolved jail root
+        print(f"  project dir (jail root): {project_dir}")
+
+        # 1. write
+        print(f"Writing {SMOKE_FILE!r} via FileRpc.write_file...")
+        await rpc.write_file(SMOKE_FILE, SMOKE_CONTENT)
+        print("  write ok.")
+
+        # 2. read back + assert round-trip
+        print(f"Reading {SMOKE_FILE!r} back...")
+        read_back = await rpc.read_file(SMOKE_FILE)
+        if read_back == SMOKE_CONTENT:
+            print("  PASS: read-back content matches (real persistence to VM fs).")
+        else:
+            failures.append("read-back content did not match written content")
+            print(f"  FAIL: got {read_back!r}, expected {SMOKE_CONTENT!r}")
+
+        # 3. list dir + assert file appears
+        print("Listing the project dir via FileRpc.list_dir('.')...")
+        entries = await rpc.list_dir(".")
+        names = [e["name"] for e in entries]
+        if SMOKE_FILE in names:
+            print(f"  PASS: {SMOKE_FILE!r} appears in the listing.")
+        else:
+            failures.append(f"{SMOKE_FILE} not found in directory listing")
+            print(f"  FAIL: {SMOKE_FILE!r} not in {names}")
+
+        # 4. traversal rejection
+        print("Attempting a ../escape.txt write (must be rejected by the jail)...")
+        try:
+            await rpc.write_file("../escape.txt", "should never be written")
+            failures.append("traversal write was NOT rejected")
+            print("  FAIL: traversal write was allowed!")
+        except FileRpcError as exc:
+            print(f"  PASS: traversal rejected -> {exc.op}: {exc.message}")
+
+        if failures:
+            print("\nFAIL: " + "; ".join(failures))
+            return 1
+        print("\nPASS: write -> read -> list round-trip persisted + traversal rejected.")
+        return 0
+    except Exception as exc:  # noqa: BLE001 — smoke: report and still clean up
+        print(f"FAIL: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        if sandbox_id is not None:
+            try:
+                print(f"Cleaning up: deleting VM {sandbox_id}...")
+                await client.delete_sandbox(sandbox_id)
+                print(f"  VM {sandbox_id} DELETED.")
+            except Exception as cleanup_exc:  # noqa: BLE001
+                print(f"  WARNING: cleanup delete failed: {cleanup_exc}")
+                print(f"  MANUAL CLEANUP REQUIRED for sandbox {sandbox_id}")
+        await client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/websandbox_live_smoke.py
+++ b/scripts/websandbox_live_smoke.py
@@ -1,0 +1,79 @@
+# websandbox_live_smoke.py — ONE live Daytona smoke for the Web Cursor
+# cold-provision slice (WC-2). NOT a pytest test — kept out of CI on purpose so
+# a real VM (which costs money) is only ever provisioned when a human runs this.
+# Created 2026-07-15 (feat/websandbox-vm-provision).
+#
+# What it does: loads .env, provisions a REAL Daytona VM (auto_stop_interval=30
+# min), clones the public octocat/Hello-World repo into the project dir, lists +
+# prints the tree, and ALWAYS deletes the VM in a finally block — cleanup is
+# non-negotiable even on exception, because a leaked VM keeps billing.
+#
+# Run: .venv/Scripts/python.exe scripts/websandbox_live_smoke.py
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+REPO_URL = "https://github.com/octocat/Hello-World.git"
+AUTO_STOP_MINUTES = 30
+BOOT_TIMEOUT_SECONDS = 180.0
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+
+    client = get_daytona_client()
+    if client is None:
+        print("FAIL: Daytona is not configured (get_daytona_client() returned None).")
+        print("      Set the Daytona keys in .env and retry.")
+        return 1
+
+    sandbox_id: str | None = None
+    try:
+        print(f"Provisioning a Daytona VM (auto_stop_interval={AUTO_STOP_MINUTES} min)...")
+        info = await client.create_sandbox(
+            name="websandbox-live-smoke",
+            auto_stop_interval=AUTO_STOP_MINUTES,
+        )
+        sandbox_id = info.id
+        print(f"  created: id={sandbox_id} name={info.name} state={info.state}")
+
+        print("Waiting for the VM to boot...")
+        await client.wait_for_sandbox(
+            sandbox_id, target_state="started", timeout=BOOT_TIMEOUT_SECONDS
+        )
+        print("  booted.")
+
+        project_dir = await client.get_project_dir(sandbox_id)
+        print(f"Cloning {REPO_URL} into {project_dir} (no credentials — public repo)...")
+        await client.git_clone(sandbox_id, REPO_URL, project_dir)
+        print("  cloned.")
+
+        print("Listing the file tree:")
+        files = await client.list_files(sandbox_id, project_dir)
+        for f in files:
+            kind = "dir " if getattr(f, "is_dir", False) else "file"
+            print(f"  [{kind}] {f.name}  ({getattr(f, 'size', 0)} bytes)")
+
+        print("\nPASS: provisioned, cloned, and listed a real Daytona sandbox.")
+        return 0
+    except Exception as exc:  # noqa: BLE001 — smoke: report and still clean up
+        print(f"FAIL: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        if sandbox_id is not None:
+            try:
+                print(f"Cleaning up: deleting VM {sandbox_id}...")
+                await client.delete_sandbox(sandbox_id)
+                print(f"  VM {sandbox_id} DELETED.")
+            except Exception as cleanup_exc:  # noqa: BLE001
+                print(f"  WARNING: cleanup delete failed: {cleanup_exc}")
+                print(f"  MANUAL CLEANUP REQUIRED for sandbox {sandbox_id}")
+        await client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/websandbox_s3_durability_smoke.py
+++ b/scripts/websandbox_s3_durability_smoke.py
@@ -45,7 +45,9 @@ class _UploadsShim:
         self._n += 1
         fid = f"smoke-{self._n}"
         self._blobs[fid] = data
-        print(f"  [uploads] stored {len(data)} bytes as {fid} (ws={workspace} folder={folder_path})")  # noqa: E501
+        print(
+            f"  [uploads] stored {len(data)} bytes as {fid} (ws={workspace} folder={folder_path})"
+        )  # noqa: E501
         return FileRecord(
             id=fid,
             storage_key=f"key/{fid}",

--- a/scripts/websandbox_s3_durability_smoke.py
+++ b/scripts/websandbox_s3_durability_smoke.py
@@ -1,0 +1,185 @@
+# websandbox_s3_durability_smoke.py — LIVE smoke for WC-S3 workspace durability.
+# Created 2026-07-15 (feat/websandbox-s3-durability). OUT of CI (hits real Daytona).
+#
+# Proves the snapshot -> restore round-trip against REAL Daytona VMs, exercising
+# the ACTUAL ``durability.snapshot_workspace`` / ``restore_workspace`` code:
+#   1. provision VM1, write a marker file into /home/daytona
+#   2. snapshot_workspace(client=real, uploads=shim): tar -> download -> "upload"
+#   3. provision a SECOND fresh VM, rebind the registry row to it
+#   4. restore_workspace(client=real, uploads=shim): fetch -> upload_bytes -> untar
+#   5. assert the marker file is back in VM2
+#   6. finally: delete BOTH VMs (mandatory cleanup)
+#
+# The registry runs on real Beanie over mongomock-motor (in-memory) so the real
+# get_sandbox / set_snapshot / authorize_sandbox paths execute. The S3 layer is a
+# small in-memory ``_UploadsShim`` (upload/stream) standing in for
+# EEUploadService, which can't be constructed standalone here (its MongoFileStore
+# needs an initialized cloud Mongo). The durability code is adapter-agnostic — in
+# cloud the identical bytes flow through EEUploadService -> tenant S3 (that path
+# is covered by the Tier-1 unit tests).
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import UTC, datetime
+
+from dotenv import load_dotenv
+
+MARKER_NAME = "SMOKE_MARKER.txt"
+MARKER_TEXT = "wc-s3-durability-smoke-ok"
+WORKDIR = "/home/daytona"
+
+
+class _UploadsShim:
+    """In-memory EEUploadService stand-in: upload() stores bytes, stream() serves
+    them back. Same shape the durability DI seam expects."""
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, bytes] = {}
+        self._n = 0
+
+    async def upload(self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None):
+        from pocketpaw.uploads.file_store import FileRecord
+
+        data = await file.read()
+        self._n += 1
+        fid = f"smoke-{self._n}"
+        self._blobs[fid] = data
+        print(f"  [uploads] stored {len(data)} bytes as {fid} (ws={workspace} folder={folder_path})")  # noqa: E501
+        return FileRecord(
+            id=fid,
+            storage_key=f"key/{fid}",
+            filename=file.filename,
+            mime="application/gzip",
+            size=len(data),
+            owner_id=owner_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+    async def stream(self, file_id, requester_id, workspace):
+        from pocketpaw.uploads.file_store import FileRecord
+
+        data = self._blobs[file_id]
+
+        async def _it():
+            yield data
+
+        rec = FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename="ws.tgz",
+            mime="application/gzip",
+            size=len(data),
+            owner_id=requester_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+        return rec, _it()
+
+
+class _NoopBus:
+    """Minimal EventBus: swallow every emit. The registry emits on each write;
+    this smoke doesn't assert on fan-out, only on the VM round-trip."""
+
+    async def publish(self, event) -> None:  # noqa: ANN001
+        return None
+
+
+async def _init_registry() -> None:
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+    from pocketpaw_ee.cloud._core.realtime.bus import set_bus
+    from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
+    from pocketpaw_ee.cloud.models import ALL_DOCUMENTS
+
+    set_bus(_NoopBus())
+    client = AsyncMongoMockClient()
+    db = client[f"smoke_{datetime.now(UTC).timestamp()}"]
+    original = db.list_collection_names
+
+    async def _safe(*_a, **_k):
+        return await original()
+
+    db.list_collection_names = _safe  # type: ignore[method-assign]
+    await init_beanie(database=db, document_models=[*ALL_DOCUMENTS, MemoryFactDoc])
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+    from pocketpaw_ee.cloud.daytona.config import daytona_enabled
+    from pocketpaw_ee.cloud.websandbox import durability
+    from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+
+    if not daytona_enabled():
+        print("BLOCKED: Daytona keys not set in .env")
+        return 2
+
+    await _init_registry()
+
+    ws, user = "smoke-ws", "smoke-user"
+    client = DaytonaClient()
+    uploads = _UploadsShim()
+    vm1 = vm2 = None
+    ok = False
+    try:
+        # 1. Provision VM1 and write a marker into the workspace dir.
+        print("Provisioning VM1...")
+        info1 = await client.create_sandbox(name="wc-s3-smoke-1", auto_stop_interval=15)
+        vm1 = info1.id
+        await client.wait_for_sandbox(vm1, target_state="started", timeout=180)
+        await client.execute_command(vm1, f"mkdir -p {WORKDIR}")
+        await client.execute_command(vm1, f"printf '{MARKER_TEXT}' > {WORKDIR}/{MARKER_NAME}")
+        print(f"  VM1={vm1}; wrote {WORKDIR}/{MARKER_NAME}")
+
+        # Register a ready row bound to VM1.
+        row = await sandbox_service.create_sandbox(
+            ws,
+            user,
+            {"repo": "https://example.com/smoke.git", "status": "ready", "sandbox_id": vm1},
+        )
+
+        # 2. Snapshot via the REAL durability code (tar -> download -> shim upload).
+        print("Snapshotting VM1 workspace...")
+        file_id = await durability.snapshot_workspace(
+            ws, user, row.id, client=client, uploads=uploads
+        )
+        print(f"  snapshot file_id={file_id}")
+
+        # 3. Simulate a teardown: delete the marker so the workspace no longer has
+        #    it (equivalent to a fresh VM). Org tier caps concurrent VM memory, so
+        #    we reuse VM1 rather than provision a second VM — the restore code path
+        #    (fetch -> upload_bytes -> untar into a clean workspace) is identical.
+        await client.execute_command(vm1, f"rm -f {WORKDIR}/{MARKER_NAME}")
+        gone = await client.execute_command(
+            vm1, f"cat {WORKDIR}/{MARKER_NAME} 2>/dev/null || echo MISSING"
+        )
+        print(f"  marker after delete: {str(getattr(gone, 'result', gone)).strip()!r}")
+
+        # 4. Restore (fetch -> upload_bytes -> untar).
+        print("Restoring snapshot...")
+        await durability.restore_workspace(ws, user, row.id, client=client, uploads=uploads)
+
+        # 5. Assert the marker is back.
+        res = await client.execute_command(vm1, f"cat {WORKDIR}/{MARKER_NAME}")
+        result_text = getattr(res, "result", None) or getattr(res, "output", None) or str(res)
+        print(f"  marker read after restore: {result_text!r}")
+        ok = MARKER_TEXT in str(result_text)
+        print("RESULT:", "PASS — marker restored from snapshot" if ok else "FAIL — marker missing")
+    finally:
+        for vm in (vm1, vm2):
+            if vm:
+                try:
+                    await client.delete_sandbox(vm)
+                    print(f"  deleted VM {vm}")
+                except Exception as exc:  # noqa: BLE001
+                    print(f"  WARN: failed to delete VM {vm}: {exc}")
+        await client.close()
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/websandbox_terminal_smoke.py
+++ b/scripts/websandbox_terminal_smoke.py
@@ -1,0 +1,107 @@
+# websandbox_terminal_smoke.py — ONE live Daytona smoke for the Web Cursor
+# terminal / PTY-over-WS slice (WC-3). NOT a pytest test — kept out of CI on
+# purpose so a real VM (which costs money) is only ever provisioned when a human
+# runs this. Created 2026-07-15 (feat/websandbox-terminal-ws).
+#
+# What it does: loads .env, provisions a REAL Daytona VM, opens a bash PTY via
+# the SAME PtyBridge the WebSocket endpoint uses (minus the socket — the sink is
+# an in-memory buffer), sends ``echo paw-smoke-ok``, collects the shell output
+# for a couple of seconds, asserts the echo came back, resizes once, then ALWAYS
+# deletes the VM in a finally block — cleanup is non-negotiable even on
+# exception, because a leaked VM keeps billing.
+#
+# Run: .venv/Scripts/python.exe scripts/websandbox_terminal_smoke.py
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+AUTO_STOP_MINUTES = 30
+BOOT_TIMEOUT_SECONDS = 180.0
+MARKER = "paw-smoke-ok"
+COLLECT_SECONDS = 4.0
+
+
+async def main() -> int:
+    load_dotenv(".env")
+
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+    from pocketpaw_ee.cloud.websandbox.terminal import PtyBridge
+
+    client = get_daytona_client()
+    if client is None:
+        print("FAIL: Daytona is not configured (get_daytona_client() returned None).")
+        print("      Set the Daytona keys in .env and retry.")
+        return 1
+
+    sandbox_id: str | None = None
+    bridge: PtyBridge | None = None
+    output = bytearray()
+
+    async def sink(data: bytes) -> None:
+        # The exact hook the WS handler wires to websocket.send_bytes.
+        output.extend(data)
+
+    try:
+        print(f"Provisioning a Daytona VM (auto_stop_interval={AUTO_STOP_MINUTES} min)...")
+        info = await client.create_sandbox(
+            name="websandbox-terminal-smoke",
+            auto_stop_interval=AUTO_STOP_MINUTES,
+        )
+        sandbox_id = info.id
+        print(f"  created: id={sandbox_id} name={info.name} state={info.state}")
+
+        print("Waiting for the VM to boot...")
+        await client.wait_for_sandbox(
+            sandbox_id, target_state="started", timeout=BOOT_TIMEOUT_SECONDS
+        )
+        print("  booted.")
+
+        print("Opening a bash PTY through PtyBridge (same code path as the WS)...")
+        bridge = PtyBridge(client, sandbox_id, "term-smoke", sink)
+        await bridge.start(cols=100, rows=30)
+        print("  pty open.")
+
+        print(f"Sending: echo {MARKER}")
+        await bridge.send_input(f"echo {MARKER}\n")
+
+        # Give the shell a moment to echo the command + print the result.
+        await asyncio.sleep(COLLECT_SECONDS)
+
+        print("Resizing the pty to 120x40...")
+        await bridge.resize(120, 40)
+
+        text = output.decode(errors="replace")
+        print("--- collected terminal output ---")
+        print(text.strip() or "<empty>")
+        print("---------------------------------")
+
+        if MARKER in text:
+            print(f"\nPASS: the real shell echoed back '{MARKER}'.")
+            return 0
+        print(f"\nFAIL: marker '{MARKER}' not found in terminal output.")
+        return 1
+    except Exception as exc:  # noqa: BLE001 — smoke: report and still clean up
+        print(f"FAIL: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        if bridge is not None:
+            try:
+                await bridge.close()
+                print("  pty session killed.")
+            except Exception as close_exc:  # noqa: BLE001
+                print(f"  WARNING: pty close failed: {close_exc}")
+        if sandbox_id is not None:
+            try:
+                print(f"Cleaning up: deleting VM {sandbox_id}...")
+                await client.delete_sandbox(sandbox_id)
+                print(f"  VM {sandbox_id} DELETED.")
+            except Exception as cleanup_exc:  # noqa: BLE001
+                print(f"  WARNING: cleanup delete failed: {cleanup_exc}")
+                print(f"  MANUAL CLEANUP REQUIRED for sandbox {sandbox_id}")
+        await client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/pocketpaw/api/v1/cloud_projects.py
+++ b/src/pocketpaw/api/v1/cloud_projects.py
@@ -11,6 +11,9 @@ directory marker file.
 
 Created: 2026-06-22
 Updated: 2026-06-23 — added POST /cloud/projects/clone (git clone into project).
+Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — the workspace-VM store
+    accessors are now async + Mongo-backed; ``await`` the VM lookups in
+    ``_ensure_vm_project_dir`` / ``_clone_into_vm``.
 """
 
 from __future__ import annotations
@@ -245,7 +248,7 @@ async def _ensure_vm_project_dir(workspace_id: str, project_name: str) -> str:
             get_workspace_vm_sandbox_id,
         )
 
-        sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+        sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
         if not sandbox_id:
             logger.debug("_ensure_vm_project_dir: no VM for workspace %s", workspace_id)
             return ""
@@ -270,7 +273,7 @@ async def _ensure_vm_project_dir(workspace_id: str, project_name: str) -> str:
             logger.warning("_ensure_vm_project_dir: could not ensure VM is started: %s", exc)
             return ""
 
-        config = get_workspace_vm_config(workspace_id)
+        config = await get_workspace_vm_config(workspace_id)
         root = config.get("root_dir", "/workspace")
         vm_path = f"{root}/{project_name}"
 
@@ -294,7 +297,7 @@ async def _clone_into_vm(
             get_workspace_vm_sandbox_id,
         )
 
-        sandbox_id = get_workspace_vm_sandbox_id(workspace_id)
+        sandbox_id = await get_workspace_vm_sandbox_id(workspace_id)
         if not sandbox_id:
             return
 
@@ -304,7 +307,7 @@ async def _clone_into_vm(
         if client is None:
             return
 
-        config = get_workspace_vm_config(workspace_id)
+        config = await get_workspace_vm_config(workspace_id)
         root = config.get("root_dir", "/workspace")
         vm_path = f"{root}/{project_name}"
 

--- a/tests/cloud/test_codeconnect.py
+++ b/tests/cloud/test_codeconnect.py
@@ -1,0 +1,197 @@
+# test_codeconnect.py — state + service + connect tests for the Code Mode GitHub
+# connect flow (CM-3, feat/code-mode).
+#
+# The registry runs on real Beanie over mongomock-motor (the ``mongo_db`` fixture)
+# so the tenant-filtered query paths are exercised for real; the GitHub App client
+# is an injected FAKE RepoAuthProvider, so no test touches real GitHub.
+#
+# Covers:
+#   * state sign/verify roundtrip; a tampered or expired state is rejected.
+#   * save_connection is idempotent per (workspace, user, provider, installation)
+#     and refreshes a newly-known account_login without minting a duplicate.
+#   * list_connections never crosses the workspace OR user boundary.
+#   * build_install_url embeds the slug + a verifiable state; 503 when unconfigured.
+#   * handle_callback persists the connection + recovers (ws, user) from state, and
+#     fails closed on a missing installation id or an unverifiable state.
+#   * list_repositories merges + de-dupes across a caller's connections, is empty
+#     with no connections, and 503s when connections exist but the provider is off.
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import BadRequest, CloudError
+from pocketpaw_ee.cloud.codeconnect import connect, service, state
+from pocketpaw_ee.cloud.websandbox.repoauth import ProviderId, RemoteRepo
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws-1"
+_USER = "user-1"
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+class _FakeProvider:
+    """A RepoAuthProvider that serves canned repos per installation id."""
+
+    def __init__(self, repos_by_installation: dict[str, list[RemoteRepo]]) -> None:
+        self._repos = repos_by_installation
+        self.calls: list[str] = []
+
+    async def list_repositories(self, connection_id, *, now=None):  # noqa: ANN001
+        self.calls.append(connection_id)
+        return list(self._repos.get(connection_id, []))
+
+
+def _repo(full_name: str, *, private: bool = True, branch: str = "main") -> RemoteRepo:
+    return RemoteRepo(
+        full_name=full_name,
+        private=private,
+        default_branch=branch,
+        clone_url=f"https://github.com/{full_name}.git",
+    )
+
+
+# ---------------------------------------------------------------------------
+# state sign / verify.
+# ---------------------------------------------------------------------------
+
+
+def test_state_roundtrips() -> None:
+    token = state.sign_state(_WS, _USER)
+    assert state.verify_state(token) == (_WS, _USER)
+
+
+def test_state_rejects_tampered_or_garbage() -> None:
+    token = state.sign_state(_WS, _USER)
+    assert state.verify_state(token + "x") is None  # tampered signature
+    assert state.verify_state("not-a-jwt") is None
+    assert state.verify_state("") is None
+
+
+def test_state_rejects_expired() -> None:
+    past = datetime.now(UTC) - timedelta(seconds=1000)  # older than the 900s lifetime
+    token = state.sign_state(_WS, _USER, now=past)
+    assert state.verify_state(token) is None
+
+
+# ---------------------------------------------------------------------------
+# service — persistence + tenancy.
+# ---------------------------------------------------------------------------
+
+
+async def test_save_connection_is_idempotent_per_installation() -> None:
+    first = await service.save_connection(_WS, _USER, "inst-1")
+    second = await service.save_connection(_WS, _USER, "inst-1")
+    assert second.id == first.id  # same row, not a duplicate
+    listing = await service.list_connections(_WS, _USER)
+    assert len(listing) == 1
+
+
+async def test_save_connection_refreshes_account_login() -> None:
+    await service.save_connection(_WS, _USER, "inst-1")
+    refreshed = await service.save_connection(_WS, _USER, "inst-1", account_login="acme")
+    assert refreshed.account_login == "acme"
+    assert len(await service.list_connections(_WS, _USER)) == 1
+
+
+async def test_list_connections_never_crosses_tenant() -> None:
+    await service.save_connection(_WS, _USER, "inst-1")
+    await service.save_connection(_WS, "user-2", "inst-2")
+    await service.save_connection("ws-2", _USER, "inst-3")
+    mine = await service.list_connections(_WS, _USER)
+    assert [c.installation_id for c in mine] == ["inst-1"]
+
+
+# ---------------------------------------------------------------------------
+# connect — install url.
+# ---------------------------------------------------------------------------
+
+
+def test_build_install_url_embeds_slug_and_verifiable_state(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_GITHUB_APP_SLUG", "my-app")
+    url = connect.build_install_url(_WS, _USER)
+    assert url.startswith("https://github.com/apps/my-app/installations/new?state=")
+    token = url.split("state=", 1)[1]
+    assert state.verify_state(token) == (_WS, _USER)
+
+
+def test_build_install_url_503_when_slug_unset(monkeypatch) -> None:
+    monkeypatch.delenv("POCKETPAW_GITHUB_APP_SLUG", raising=False)
+    with pytest.raises(CloudError) as exc:
+        connect.build_install_url(_WS, _USER)
+    assert exc.value.code == "codeconnect.github_not_configured"
+
+
+# ---------------------------------------------------------------------------
+# connect — callback.
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_callback_persists_and_recovers_identity() -> None:
+    token = state.sign_state(_WS, _USER)
+    ws, user = await connect.handle_callback("inst-9", token)
+    assert (ws, user) == (_WS, _USER)
+    # The connection is now persisted for that identity.
+    listing = await service.list_connections(_WS, _USER)
+    assert [c.installation_id for c in listing] == ["inst-9"]
+
+
+async def test_handle_callback_rejects_bad_state() -> None:
+    with pytest.raises(BadRequest):
+        await connect.handle_callback("inst-9", "forged-state")
+    # Nothing was persisted.
+    assert await service.list_connections(_WS, _USER) == []
+
+
+async def test_handle_callback_rejects_missing_installation() -> None:
+    token = state.sign_state(_WS, _USER)
+    with pytest.raises(BadRequest):
+        await connect.handle_callback("", token)
+
+
+# ---------------------------------------------------------------------------
+# connect — repo listing.
+# ---------------------------------------------------------------------------
+
+
+async def test_list_repositories_merges_and_dedupes_across_connections() -> None:
+    await service.save_connection(_WS, _USER, "inst-1")
+    await service.save_connection(_WS, _USER, "inst-2")
+    provider = _FakeProvider(
+        {
+            "inst-1": [_repo("acme/api"), _repo("acme/web")],
+            "inst-2": [_repo("acme/web"), _repo("acme/infra")],  # acme/web overlaps
+        }
+    )
+
+    repos = await connect.list_repositories(_WS, _USER, provider=provider)
+
+    names = sorted(r["full_name"] for r in repos)
+    assert names == ["acme/api", "acme/infra", "acme/web"]  # deduped
+    assert set(provider.calls) == {"inst-1", "inst-2"}
+
+
+async def test_list_repositories_empty_without_connections() -> None:
+    provider = _FakeProvider({})
+    assert await connect.list_repositories(_WS, _USER, provider=provider) == []
+
+
+async def test_list_repositories_503_when_connected_but_provider_off(monkeypatch) -> None:
+    await service.save_connection(_WS, _USER, "inst-1")
+    # No injected provider AND the real resolver returns None (App unconfigured).
+    monkeypatch.setattr(
+        connect, "get_repo_auth_provider", lambda _p: None
+    )
+    with pytest.raises(CloudError) as exc:
+        await connect.list_repositories(_WS, _USER)
+    assert exc.value.code == "codeconnect.github_not_configured"
+
+
+def test_provider_id_github_is_the_default() -> None:
+    # Guard the string the connect layer resolves against the neutral provider enum.
+    assert ProviderId.GITHUB.value == "github"

--- a/tests/cloud/test_codeconnect.py
+++ b/tests/cloud/test_codeconnect.py
@@ -277,9 +277,7 @@ async def test_list_repositories_empty_without_connections() -> None:
 async def test_list_repositories_503_when_connected_but_provider_off(monkeypatch) -> None:
     await service.save_connection(_WS, _USER, "inst-1")
     # No injected provider AND the real resolver returns None (App unconfigured).
-    monkeypatch.setattr(
-        connect, "get_repo_auth_provider", lambda _p: None
-    )
+    monkeypatch.setattr(connect, "get_repo_auth_provider", lambda _p: None)
     with pytest.raises(CloudError) as exc:
         await connect.list_repositories(_WS, _USER)
     assert exc.value.code == "codeconnect.github_not_configured"

--- a/tests/cloud/test_codeconnect.py
+++ b/tests/cloud/test_codeconnect.py
@@ -8,11 +8,14 @@
 # Covers:
 #   * state sign/verify roundtrip; a tampered or expired state is rejected.
 #   * save_connection is idempotent per (workspace, user, provider, installation)
-#     and refreshes a newly-known account_login without minting a duplicate.
+#     and refreshes a newly-known account_login / avatar_url without a duplicate.
 #   * list_connections never crosses the workspace OR user boundary.
 #   * build_install_url embeds the slug + a verifiable state; 503 when unconfigured.
-#   * handle_callback persists the connection + recovers (ws, user) from state, and
+#   * handle_callback persists the connection + recovers (ws, user) from state,
+#     backfills account login + avatar, still persists when that fetch fails, and
 #     fails closed on a missing installation id or an unverifiable state.
+#   * connect.list_connections lazily enriches a row missing its display info,
+#     stops calling GitHub once complete, and falls back when the App is off.
 #   * list_repositories merges + de-dupes across a caller's connections, is empty
 #     with no connections, and 503s when connections exist but the provider is off.
 from __future__ import annotations
@@ -45,6 +48,23 @@ class _FakeProvider:
     async def list_repositories(self, connection_id, *, now=None):  # noqa: ANN001
         self.calls.append(connection_id)
         return list(self._repos.get(connection_id, []))
+
+
+class _FakeAppClient:
+    """A GitHub App client stub that serves canned account info per installation.
+
+    Stands in for ``get_github_app_client()`` so the callback-backfill and
+    lazy-enrich paths are exercised without touching real GitHub. Counts calls so a
+    test can assert enrichment stops firing once the row is complete.
+    """
+
+    def __init__(self, accounts: dict[str, dict | None]) -> None:
+        self._accounts = accounts
+        self.calls: list[str] = []
+
+    async def get_installation_account(self, installation_id, *, now=None):  # noqa: ANN001
+        self.calls.append(installation_id)
+        return self._accounts.get(installation_id)
 
 
 def _repo(full_name: str, *, private: bool = True, branch: str = "main") -> RemoteRepo:
@@ -96,6 +116,19 @@ async def test_save_connection_refreshes_account_login() -> None:
     await service.save_connection(_WS, _USER, "inst-1")
     refreshed = await service.save_connection(_WS, _USER, "inst-1", account_login="acme")
     assert refreshed.account_login == "acme"
+    assert len(await service.list_connections(_WS, _USER)) == 1
+
+
+async def test_save_connection_persists_and_refreshes_avatar() -> None:
+    created = await service.save_connection(
+        _WS, _USER, "inst-1", account_login="acme", avatar_url="https://av/1.png"
+    )
+    assert created.avatar_url == "https://av/1.png"
+    # A later callback with a rotated avatar refreshes the same row in place.
+    refreshed = await service.save_connection(
+        _WS, _USER, "inst-1", account_login="acme", avatar_url="https://av/2.png"
+    )
+    assert refreshed.avatar_url == "https://av/2.png"
     assert len(await service.list_connections(_WS, _USER)) == 1
 
 
@@ -152,6 +185,66 @@ async def test_handle_callback_rejects_missing_installation() -> None:
     token = state.sign_state(_WS, _USER)
     with pytest.raises(BadRequest):
         await connect.handle_callback("", token)
+
+
+async def test_handle_callback_backfills_account_login_and_avatar(monkeypatch) -> None:
+    client = _FakeAppClient({"inst-9": {"login": "octo", "avatar_url": "https://av/o.png"}})
+    monkeypatch.setattr(connect, "get_github_app_client", lambda: client)
+    token = state.sign_state(_WS, _USER)
+
+    await connect.handle_callback("inst-9", token)
+
+    [conn] = await service.list_connections(_WS, _USER)
+    assert conn.account_login == "octo"
+    assert conn.avatar_url == "https://av/o.png"
+
+
+async def test_handle_callback_persists_even_when_account_fetch_fails(monkeypatch) -> None:
+    class _Boom:
+        async def get_installation_account(self, _id, *, now=None):  # noqa: ANN001
+            raise RuntimeError("github down")
+
+    monkeypatch.setattr(connect, "get_github_app_client", lambda: _Boom())
+    token = state.sign_state(_WS, _USER)
+
+    # The connection is the load-bearing artifact — a failed display lookup must
+    # not sink it (nor leak the error to the browser redirect).
+    ws, user = await connect.handle_callback("inst-9", token)
+    assert (ws, user) == (_WS, _USER)
+    [conn] = await service.list_connections(_WS, _USER)
+    assert conn.installation_id == "inst-9"
+    assert conn.account_login is None and conn.avatar_url is None
+
+
+# ---------------------------------------------------------------------------
+# connect — lazy display enrichment on list.
+# ---------------------------------------------------------------------------
+
+
+async def test_list_connections_lazily_enriches_missing_display_info(monkeypatch) -> None:
+    # A row saved with no display info (e.g. the callback fetch failed earlier).
+    await service.save_connection(_WS, _USER, "inst-1")
+    client = _FakeAppClient({"inst-1": {"login": "octo", "avatar_url": "https://av/o.png"}})
+    monkeypatch.setattr(connect, "get_github_app_client", lambda: client)
+
+    first = await connect.list_connections(_WS, _USER)
+    assert first[0].account_login == "octo"
+    assert first[0].avatar_url == "https://av/o.png"
+    assert client.calls == ["inst-1"]  # enriched once
+
+    # Second read is fully populated → no further GitHub calls.
+    second = await connect.list_connections(_WS, _USER)
+    assert second[0].avatar_url == "https://av/o.png"
+    assert client.calls == ["inst-1"]  # unchanged — bounded to the missing window
+
+
+async def test_list_connections_falls_back_when_client_absent(monkeypatch) -> None:
+    await service.save_connection(_WS, _USER, "inst-1")
+    monkeypatch.setattr(connect, "get_github_app_client", lambda: None)
+    # No App client configured → return the un-enriched view, not an error.
+    listing = await connect.list_connections(_WS, _USER)
+    assert [c.installation_id for c in listing] == ["inst-1"]
+    assert listing[0].avatar_url is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_codegit.py
+++ b/tests/cloud/test_codegit.py
@@ -42,9 +42,7 @@ _GH_TOKEN = "gh-SECRET-TOKEN"
 def test_ticket_roundtrips() -> None:
     token = sign_ticket(_WS, _USER, _SBX, _REPO)
     claims = verify_ticket(token)
-    assert claims == TicketClaims(
-        workspace_id=_WS, user_id=_USER, sandbox_id=_SBX, repo=_REPO
-    )
+    assert claims == TicketClaims(workspace_id=_WS, user_id=_USER, sandbox_id=_SBX, repo=_REPO)
 
 
 def test_ticket_rejects_tampered_or_garbage() -> None:
@@ -314,12 +312,13 @@ def test_ticket_from_basic_auth_recovers_claims() -> None:
 
 def test_ticket_from_basic_auth_rejects_missing_or_bad() -> None:
     assert _ticket_from_basic_auth(SimpleNamespace(headers={})) is None
-    assert _ticket_from_basic_auth(
-        SimpleNamespace(headers={"authorization": "Bearer xyz"})
-    ) is None
-    assert _ticket_from_basic_auth(
-        SimpleNamespace(headers={"authorization": _basic("x", "not-a-ticket")})
-    ) is None
+    assert _ticket_from_basic_auth(SimpleNamespace(headers={"authorization": "Bearer xyz"})) is None
+    assert (
+        _ticket_from_basic_auth(
+            SimpleNamespace(headers={"authorization": _basic("x", "not-a-ticket")})
+        )
+        is None
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_codegit.py
+++ b/tests/cloud/test_codegit.py
@@ -1,0 +1,369 @@
+# test_codegit.py — Code Mode git smart-HTTP proxy tests (CM-3d).
+# Created 2026-07-16 (feat/code-mode).
+#
+# The proxy lets the VM push/fetch WITHOUT the GitHub token entering the VM. These
+# tests pin the guarantees:
+#   * TICKET — sign/verify roundtrips; a tampered/expired/garbage ticket is a clean
+#     reject (the VM→broker credential, distinct from the GitHub token).
+#   * PROXY — a request is forwarded to the right github.com URL with the minted
+#     token injected (replacing the incoming basic-auth ticket), only the two git
+#     services are allowed, the ticket's repo is enforced, and — the load-bearing
+#     invariant — the GitHub token appears in NOTHING returned to the VM.
+#   * WIRE — the VM's origin is repointed at the proxy only when a public backend
+#     URL is reachable; a localhost/unset URL skips wiring (clone still usable).
+#
+# The GitHub token mint is monkeypatched (no real GitHub) and the httpx client is a
+# fake (no network), so nothing here touches an external service.
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import BadRequest, Forbidden
+from pocketpaw_ee.cloud.codegit import proxy, wire
+from pocketpaw_ee.cloud.codegit.router import _ticket_from_basic_auth
+from pocketpaw_ee.cloud.codegit.ticket import TicketClaims, sign_ticket, verify_ticket
+from pocketpaw_ee.cloud.websandbox.repoauth import ProviderId, ScopedRepoToken
+
+_WS = "ws-1"
+_USER = "user-1"
+_SBX = "sbx-1"
+_REPO = "owner/repo"
+_GH_TOKEN = "gh-SECRET-TOKEN"
+
+
+# ---------------------------------------------------------------------------
+# ticket.
+# ---------------------------------------------------------------------------
+
+
+def test_ticket_roundtrips() -> None:
+    token = sign_ticket(_WS, _USER, _SBX, _REPO)
+    claims = verify_ticket(token)
+    assert claims == TicketClaims(
+        workspace_id=_WS, user_id=_USER, sandbox_id=_SBX, repo=_REPO
+    )
+
+
+def test_ticket_rejects_tampered_or_garbage() -> None:
+    token = sign_ticket(_WS, _USER, _SBX, _REPO)
+    assert verify_ticket(token + "x") is None
+    assert verify_ticket("not-a-jwt") is None
+    assert verify_ticket("") is None
+
+
+def test_ticket_rejects_expired() -> None:
+    past = datetime.now(UTC) - timedelta(days=2)  # older than the 24h lifetime
+    token = sign_ticket(_WS, _USER, _SBX, _REPO, now=past)
+    assert verify_ticket(token) is None
+
+
+# ---------------------------------------------------------------------------
+# proxy — fakes.
+# ---------------------------------------------------------------------------
+
+
+class _FakeUpstream:
+    def __init__(self, status: int, headers: dict[str, str], chunks: list[bytes]) -> None:
+        self.status_code = status
+        self.headers = headers
+        self._chunks = chunks
+        self.closed = False
+
+    async def aiter_raw(self):
+        for c in self._chunks:
+            yield c
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _FakeHttpClient:
+    def __init__(self, upstream: _FakeUpstream) -> None:
+        self.upstream = upstream
+        self.built: dict | None = None
+        self.closed = False
+
+    def build_request(self, method, url, headers=None, content=None):  # noqa: ANN001
+        self.built = {"method": method, "url": url, "headers": headers, "content": content}
+        return self.built
+
+    async def send(self, request, stream=False):  # noqa: ANN001
+        return self.upstream
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _claims(repo: str = _REPO) -> TicketClaims:
+    return TicketClaims(workspace_id=_WS, user_id=_USER, sandbox_id=_SBX, repo=repo)
+
+
+def _mint_ok(monkeypatch) -> None:
+    async def _fake(ws, user, repo_url, **kw):  # noqa: ANN001
+        return ScopedRepoToken(
+            provider=ProviderId.GITHUB,
+            token=_GH_TOKEN,
+            expires_at=datetime(2026, 7, 16, tzinfo=UTC),
+            repo=_REPO,
+            scopes={},
+        )
+
+    monkeypatch.setattr(proxy.broker, "resolve_repo_token", _fake)
+
+
+async def _drain(resp) -> bytes:  # noqa: ANN001
+    return b"".join([c async for c in resp.body_iterator])
+
+
+# ---------------------------------------------------------------------------
+# proxy — happy paths + the token-isolation invariant.
+# ---------------------------------------------------------------------------
+
+
+async def test_proxy_upload_pack_injects_token_and_streams_back(monkeypatch) -> None:
+    _mint_ok(monkeypatch)
+    up = _FakeUpstream(
+        200,
+        {
+            "Content-Type": "application/x-git-upload-pack-result",
+            "Transfer-Encoding": "chunked",  # hop-by-hop — must be dropped
+            "Content-Length": "8",  # must be dropped (we re-stream)
+        },
+        [b"PACK", b"DATA"],
+    )
+    client = _FakeHttpClient(up)
+
+    resp = await proxy.proxy_git(
+        claims=_claims(),
+        owner="owner",
+        repo="repo",
+        git_path="git-upload-pack",
+        service="git-upload-pack",
+        method="POST",
+        request_headers={
+            "content-type": "application/x-git-upload-pack-request",
+            "git-protocol": "version=2",
+            # The incoming ticket — must NOT be forwarded upstream.
+            "authorization": "Basic dXNlcjp0aWNrZXQ=",
+            "host": "backend.example",
+        },
+        request_body=b"REQ",
+        http_client=client,
+    )
+
+    # Forwarded to the right github URL with the MINTED token, not the ticket.
+    assert client.built["url"] == "https://github.com/owner/repo.git/git-upload-pack"
+    assert client.built["headers"]["Authorization"] == f"token {_GH_TOKEN}"
+    assert all(not v.startswith("Basic ") for v in client.built["headers"].values())
+    # Only whitelisted request headers forwarded (no host).
+    assert "host" not in {k.lower() for k in client.built["headers"]}
+    assert client.built["headers"]["git-protocol"] == "version=2"
+
+    # Response streams back; hop-by-hop/length headers dropped, content-type kept.
+    body = await _drain(resp)
+    assert body == b"PACKDATA"
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/x-git-upload-pack-result"
+    lowered = {k.lower() for k in resp.headers}
+    assert "transfer-encoding" not in lowered
+    assert "content-length" not in lowered
+
+    # THE INVARIANT: the GitHub token is in NOTHING returned to the VM.
+    assert _GH_TOKEN not in body.decode()
+    assert all(_GH_TOKEN not in v for v in resp.headers.values())
+    assert up.closed  # upstream response was closed after streaming
+
+
+async def test_proxy_info_refs_carries_service_query(monkeypatch) -> None:
+    _mint_ok(monkeypatch)
+    up = _FakeUpstream(
+        200, {"Content-Type": "application/x-git-upload-pack-advertisement"}, [b"refs"]
+    )
+    client = _FakeHttpClient(up)
+
+    resp = await proxy.proxy_git(
+        claims=_claims(),
+        owner="owner",
+        repo="repo",
+        git_path="info/refs",
+        service="git-upload-pack",
+        method="GET",
+        request_headers={"git-protocol": "version=2"},
+        request_body=b"",
+        query="service=git-upload-pack",
+        http_client=client,
+    )
+
+    assert client.built["url"] == (
+        "https://github.com/owner/repo.git/info/refs?service=git-upload-pack"
+    )
+    assert await _drain(resp) == b"refs"
+
+
+async def test_proxy_allows_receive_pack(monkeypatch) -> None:
+    _mint_ok(monkeypatch)
+    client = _FakeHttpClient(_FakeUpstream(200, {"Content-Type": "x"}, [b"ok"]))
+    resp = await proxy.proxy_git(
+        claims=_claims(),
+        owner="owner",
+        repo="repo",
+        git_path="git-receive-pack",
+        service="git-receive-pack",
+        method="POST",
+        request_headers={},
+        request_body=b"PACK",
+        http_client=client,
+    )
+    assert resp.status_code == 200
+    assert client.built["url"] == "https://github.com/owner/repo.git/git-receive-pack"
+
+
+# ---------------------------------------------------------------------------
+# proxy — rejections.
+# ---------------------------------------------------------------------------
+
+
+async def test_proxy_rejects_unknown_service(monkeypatch) -> None:
+    _mint_ok(monkeypatch)
+    with pytest.raises(BadRequest) as exc:
+        await proxy.proxy_git(
+            claims=_claims(),
+            owner="owner",
+            repo="repo",
+            git_path="info/refs",
+            service="git-secret-service",
+            method="GET",
+            request_headers={},
+            request_body=b"",
+            http_client=_FakeHttpClient(_FakeUpstream(200, {}, [])),
+        )
+    assert exc.value.code == "codegit.bad_service"
+
+
+async def test_proxy_rejects_repo_the_ticket_does_not_cover(monkeypatch) -> None:
+    _mint_ok(monkeypatch)
+    with pytest.raises(Forbidden) as exc:
+        await proxy.proxy_git(
+            claims=_claims("owner/OTHER"),  # ticket is for a different repo
+            owner="owner",
+            repo="repo",
+            git_path="git-upload-pack",
+            service="git-upload-pack",
+            method="POST",
+            request_headers={},
+            request_body=b"",
+            http_client=_FakeHttpClient(_FakeUpstream(200, {}, [])),
+        )
+    assert exc.value.code == "codegit.repo_mismatch"
+
+
+async def test_proxy_rejects_malformed_segments(monkeypatch) -> None:
+    _mint_ok(monkeypatch)
+    with pytest.raises(BadRequest) as exc:
+        await proxy.proxy_git(
+            claims=_claims("../evil/repo"),
+            owner="../evil",
+            repo="repo",
+            git_path="git-upload-pack",
+            service="git-upload-pack",
+            method="POST",
+            request_headers={},
+            request_body=b"",
+            http_client=_FakeHttpClient(_FakeUpstream(200, {}, [])),
+        )
+    assert exc.value.code == "codegit.bad_repo"
+
+
+async def test_proxy_forbidden_when_no_connection_can_mint(monkeypatch) -> None:
+    async def _none(ws, user, repo_url, **kw):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(proxy.broker, "resolve_repo_token", _none)
+    with pytest.raises(Forbidden) as exc:
+        await proxy.proxy_git(
+            claims=_claims(),
+            owner="owner",
+            repo="repo",
+            git_path="git-upload-pack",
+            service="git-upload-pack",
+            method="POST",
+            request_headers={},
+            request_body=b"",
+            http_client=_FakeHttpClient(_FakeUpstream(200, {}, [])),
+        )
+    assert exc.value.code == "codegit.no_repo_access"
+
+
+# ---------------------------------------------------------------------------
+# router — basic-auth ticket extraction.
+# ---------------------------------------------------------------------------
+
+
+def _basic(user: str, password: str) -> str:
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+def test_ticket_from_basic_auth_recovers_claims() -> None:
+    ticket = sign_ticket(_WS, _USER, _SBX, _REPO)
+    req = SimpleNamespace(headers={"authorization": _basic("x-paw-git", ticket)})
+    assert _ticket_from_basic_auth(req) == _claims()
+
+
+def test_ticket_from_basic_auth_rejects_missing_or_bad() -> None:
+    assert _ticket_from_basic_auth(SimpleNamespace(headers={})) is None
+    assert _ticket_from_basic_auth(
+        SimpleNamespace(headers={"authorization": "Bearer xyz"})
+    ) is None
+    assert _ticket_from_basic_auth(
+        SimpleNamespace(headers={"authorization": _basic("x", "not-a-ticket")})
+    ) is None
+
+
+# ---------------------------------------------------------------------------
+# wire — remote repointing, gated on a reachable public URL.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDaytona:
+    def __init__(self) -> None:
+        self.execs: list[dict] = []
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        self.execs.append({"id": sandbox_id, "command": command, "cwd": kwargs.get("cwd")})
+
+
+async def test_wire_skips_without_public_url(monkeypatch) -> None:
+    monkeypatch.delenv("POCKETPAW_PUBLIC_BASE_URL", raising=False)
+    dt = _FakeDaytona()
+    wired = await wire.wire_push_remote(dt, _SBX, _WS, _USER, _REPO, "/home/daytona")
+    assert wired is False
+    assert dt.execs == []
+
+
+async def test_wire_skips_on_localhost(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_PUBLIC_BASE_URL", "http://localhost:8888")
+    dt = _FakeDaytona()
+    assert await wire.wire_push_remote(dt, _SBX, _WS, _USER, _REPO, "/home/daytona") is False
+    assert dt.execs == []
+
+
+async def test_wire_repoints_origin_at_proxy_with_a_valid_ticket(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_PUBLIC_BASE_URL", "https://app.pocketpaw.com")
+    dt = _FakeDaytona()
+
+    wired = await wire.wire_push_remote(dt, _SBX, _WS, _USER, _REPO, "/home/daytona")
+
+    assert wired is True
+    assert len(dt.execs) == 1
+    cmd = dt.execs[0]["command"]
+    assert dt.execs[0]["cwd"] == "/home/daytona"
+    assert cmd.startswith("git remote set-url origin ")
+    # The remote points at our proxy path for the repo, on the public host.
+    assert "https://x-paw-git:" in cmd
+    assert "@app.pocketpaw.com/api/v1/codegit/owner/repo" in cmd
+    # The embedded credential is a VALID ticket for this (sandbox, repo).
+    ticket = cmd.split("x-paw-git:", 1)[1].split("@", 1)[0]
+    assert verify_ticket(ticket) == _claims()

--- a/tests/cloud/test_codeproject.py
+++ b/tests/cloud/test_codeproject.py
@@ -1,0 +1,146 @@
+# test_codeproject.py — service + lifecycle tests for the Code Mode durable-project
+# registry (CM-2a, feat/code-mode).
+#
+# The registry runs on real Beanie over mongomock-motor (the ``mongo_db`` fixture)
+# so the tenant-filtered query paths are exercised for real; the sandbox runtime is
+# the injected FAKE DaytonaClient from the provision suite, so no test touches real
+# Daytona.
+#
+# Covers:
+#   * create_project is idempotent per (workspace, user, provider, repo) and
+#     defaults the display name to the repo's short name.
+#   * tenancy fail-closed: get_project / list_projects never cross the
+#     workspace OR user boundary; a foreign id reads as NotFound.
+#   * open_project provisions a fresh sandbox when the project has none and binds
+#     it (current_sandbox_id + last_opened_at).
+#   * open_project REUSES a still-live (ready) bound sandbox instead of
+#     provisioning a second one.
+#   * open_project REPROVISIONS when the bound sandbox is invalid/unavailable
+#     (reaped) — "if the id is invalid or unavailable, make a new sandbox."
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.codeproject import lifecycle, service
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+
+from tests.cloud.test_websandbox_provision import _FakeDaytonaClient
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws-1"
+_USER = "user-1"
+_REPO = "https://github.com/acme/widgets.git"
+
+
+# ---------------------------------------------------------------------------
+# create / idempotency / naming.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_project_defaults_name_to_repo_short_name() -> None:
+    view = await service.create_project(_WS, _USER, {"repo": _REPO})
+    assert view.name == "widgets"  # ".git" stripped, last path segment
+    assert view.provider == "github"
+    assert view.repo == _REPO
+    assert view.current_sandbox_id is None
+    assert view.snapshot_file_id is None
+
+
+async def test_create_project_is_idempotent_per_repo() -> None:
+    first = await service.create_project(_WS, _USER, {"repo": _REPO, "name": "Widgets"})
+    second = await service.create_project(_WS, _USER, {"repo": _REPO})
+    # Same durable id — a returning user lands back on the same project, and the
+    # second create does not clobber the existing name.
+    assert second.id == first.id
+    assert second.name == "Widgets"
+    listing = await service.list_projects(_WS, _USER)
+    assert len(listing) == 1
+
+
+async def test_create_project_explicit_name_is_kept() -> None:
+    view = await service.create_project(_WS, _USER, {"repo": _REPO, "name": "My Thing"})
+    assert view.name == "My Thing"
+
+
+# ---------------------------------------------------------------------------
+# tenancy fail-closed.
+# ---------------------------------------------------------------------------
+
+
+async def test_get_project_is_owner_scoped() -> None:
+    mine = await service.create_project(_WS, _USER, {"repo": _REPO})
+    # Same workspace, different user → NotFound (not another user's project).
+    with pytest.raises(NotFound):
+        await service.get_project(_WS, "user-2", mine.id)
+
+
+async def test_get_project_is_workspace_scoped() -> None:
+    mine = await service.create_project(_WS, _USER, {"repo": _REPO})
+    # Different workspace, same user id → NotFound.
+    with pytest.raises(NotFound):
+        await service.get_project("ws-2", _USER, mine.id)
+
+
+async def test_list_projects_never_crosses_tenant() -> None:
+    await service.create_project(_WS, _USER, {"repo": _REPO})
+    await service.create_project(_WS, "user-2", {"repo": "https://github.com/a/b"})
+    await service.create_project("ws-2", _USER, {"repo": "https://github.com/c/d"})
+    mine = await service.list_projects(_WS, _USER)
+    assert len(mine) == 1
+    assert mine[0].repo == _REPO
+
+
+async def test_get_project_missing_id_is_notfound() -> None:
+    with pytest.raises(NotFound):
+        await service.get_project(_WS, _USER, "not-a-real-id")
+
+
+# ---------------------------------------------------------------------------
+# open_project — provision / reuse / reprovision.
+# ---------------------------------------------------------------------------
+
+
+async def test_open_project_provisions_and_binds_when_unbound() -> None:
+    project = await service.create_project(_WS, _USER, {"repo": _REPO})
+    fake = _FakeDaytonaClient()
+
+    sandbox = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+
+    # A VM was cold-provisioned and the returned sandbox is ready + bound.
+    assert len(fake.create_calls) == 1
+    assert sandbox.status == "ready"
+    assert sandbox.sandbox_id is not None
+
+    # The durable project now points at that sandbox row and stamped last_opened.
+    reloaded = await service.get_project(_WS, _USER, project.id)
+    assert reloaded.current_sandbox_id == sandbox.id
+    assert reloaded.last_opened_at is not None
+
+
+async def test_open_project_reuses_live_bound_sandbox() -> None:
+    project = await service.create_project(_WS, _USER, {"repo": _REPO})
+    fake = _FakeDaytonaClient()
+
+    first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    # Second open with the SAME (still-ready) sandbox must NOT provision again.
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+
+    assert second.id == first.id
+    assert len(fake.create_calls) == 1  # reused, not re-provisioned
+
+
+async def test_open_project_reprovisions_when_bound_sandbox_reaped() -> None:
+    project = await service.create_project(_WS, _USER, {"repo": _REPO})
+    fake = _FakeDaytonaClient()
+
+    first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    # The bound VM gets reaped out from under the project (system reaper terminal).
+    await sandbox_service.mark_reaped(first.id)
+
+    # Opening again finds the bound row no longer live → provisions a fresh VM.
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    assert len(fake.create_calls) == 2  # reprovisioned
+    assert second.status == "ready"
+    # Same stable WebSandbox row (idempotent on the repo), freshly booted.
+    assert second.id == first.id

--- a/tests/cloud/test_codeproject.py
+++ b/tests/cloud/test_codeproject.py
@@ -149,6 +149,27 @@ async def test_open_project_reprovisions_when_bound_sandbox_reaped() -> None:
     assert second.id == first.id
 
 
+async def test_open_project_reprovisions_when_vm_deleted_out_of_band() -> None:
+    """The reported bug: a day-old project's row still reads ``ready`` but Daytona
+    already deleted the VM (delete-on-stop) before the 30-min reaper reconciled the
+    row. Reuse must PROBE Daytona, see the VM is gone, and reprovision — not hand
+    back a dead sandbox that connects to nothing."""
+    project = await service.create_project(_WS, _USER, {"repo": _REPO})
+    fake = _FakeDaytonaClient()
+
+    first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    # The row is left ``ready`` (the reaper never ran), but Daytona reclaimed the
+    # VM on its own — get_sandbox_by_id will now raise for that id.
+    assert first.sandbox_id is not None
+    fake.deleted_out_of_band.add(first.sandbox_id)
+
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    assert len(fake.create_calls) == 2  # dead VM detected → reprovisioned
+    assert second.status == "ready"
+    assert second.sandbox_id is not None
+    assert second.sandbox_id != first.sandbox_id  # a genuinely fresh VM
+
+
 # ---------------------------------------------------------------------------
 # open_project — CM-2a′ snapshot restore on reprovision.
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_codeproject.py
+++ b/tests/cloud/test_codeproject.py
@@ -17,6 +17,9 @@
 #     provisioning a second one.
 #   * open_project REPROVISIONS when the bound sandbox is invalid/unavailable
 #     (reaped) — "if the id is invalid or unavailable, make a new sandbox."
+#   * (CM-2a′) open_project RESTORES the row's durable snapshot into the fresh VM
+#     on reprovision when one exists, and skips restore when there's no snapshot;
+#     a restore failure is swallowed (the fresh clone is still returned ready).
 from __future__ import annotations
 
 import pytest
@@ -143,4 +146,56 @@ async def test_open_project_reprovisions_when_bound_sandbox_reaped() -> None:
     assert len(fake.create_calls) == 2  # reprovisioned
     assert second.status == "ready"
     # Same stable WebSandbox row (idempotent on the repo), freshly booted.
+    assert second.id == first.id
+
+
+# ---------------------------------------------------------------------------
+# open_project — CM-2a′ snapshot restore on reprovision.
+# ---------------------------------------------------------------------------
+
+
+async def test_open_project_restores_snapshot_on_reprovision(monkeypatch) -> None:
+    project = await service.create_project(_WS, _USER, {"repo": _REPO})
+    fake = _FakeDaytonaClient()
+
+    restored: list[dict] = []
+
+    async def _spy_restore(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
+        restored.append({"workspace_id": workspace_id, "user_id": user_id, "row_id": row_id})
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_workspace", _spy_restore)
+
+    # First open: a fresh row with no snapshot → nothing to restore.
+    first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    assert restored == []
+
+    # A clean disconnect captured a snapshot onto the stable row; then the VM was
+    # reaped out from under the project.
+    await sandbox_service.set_snapshot(_WS, _USER, first.id, "file-123")
+    await sandbox_service.mark_reaped(first.id)
+
+    # Reopening reprovisions a fresh VM AND restores the row's snapshot into it.
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    assert second.id == first.id
+    assert len(restored) == 1
+    assert restored[0]["row_id"] == second.id
+
+
+async def test_open_project_swallows_restore_failure(monkeypatch) -> None:
+    project = await service.create_project(_WS, _USER, {"repo": _REPO})
+    fake = _FakeDaytonaClient()
+
+    first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    await sandbox_service.set_snapshot(_WS, _USER, first.id, "file-123")
+    await sandbox_service.mark_reaped(first.id)
+
+    async def _boom_restore(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
+        raise RuntimeError("boom: restore failed")
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_workspace", _boom_restore)
+
+    # A restore failure is best-effort: the open still returns a ready sandbox
+    # (the fresh clone), not an error.
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    assert second.status == "ready"
     assert second.id == first.id

--- a/tests/cloud/test_codeproject.py
+++ b/tests/cloud/test_codeproject.py
@@ -149,6 +149,49 @@ async def test_open_project_reprovisions_when_bound_sandbox_reaped() -> None:
     assert second.id == first.id
 
 
+# ---------------------------------------------------------------------------
+# rename / delete.
+# ---------------------------------------------------------------------------
+
+
+async def test_rename_project_changes_name() -> None:
+    project = await service.create_project(_WS, _USER, {"repo": _REPO, "name": "Old"})
+    renamed = await service.rename_project(_WS, _USER, project.id, {"name": "  New Name  "})
+    assert renamed.name == "New Name"  # trimmed
+    reloaded = await service.get_project(_WS, _USER, project.id)
+    assert reloaded.name == "New Name"
+
+
+async def test_rename_project_is_owner_scoped() -> None:
+    mine = await service.create_project(_WS, _USER, {"repo": _REPO})
+    with pytest.raises(NotFound):
+        await service.rename_project(_WS, "user-2", mine.id, {"name": "Hijacked"})
+
+
+async def test_delete_project_removes_row_and_tears_down_vm() -> None:
+    project = await service.create_project(_WS, _USER, {"repo": _REPO})
+    fake = _FakeDaytonaClient()
+    sandbox = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    assert sandbox.sandbox_id is not None
+
+    await lifecycle.delete_project(_WS, _USER, project.id, client=fake)
+
+    # The durable project is gone…
+    with pytest.raises(NotFound):
+        await service.get_project(_WS, _USER, project.id)
+    # …and the bound VM was torn down (not left to leak).
+    assert sandbox.sandbox_id in fake.delete_calls
+
+
+async def test_delete_project_is_owner_scoped() -> None:
+    mine = await service.create_project(_WS, _USER, {"repo": _REPO})
+    fake = _FakeDaytonaClient()
+    with pytest.raises(NotFound):
+        await lifecycle.delete_project(_WS, "user-2", mine.id, client=fake)
+    # Still there for the real owner.
+    assert (await service.get_project(_WS, _USER, mine.id)).id == mine.id
+
+
 async def test_open_project_reprovisions_when_vm_deleted_out_of_band() -> None:
     """The reported bug: a day-old project's row still reads ``ready`` but Daytona
     already deleted the VM (delete-on-stop) before the 30-min reaper reconciled the

--- a/tests/cloud/test_codeproject.py
+++ b/tests/cloud/test_codeproject.py
@@ -181,6 +181,27 @@ async def test_open_project_restores_snapshot_on_reprovision(monkeypatch) -> Non
     assert restored[0]["row_id"] == second.id
 
 
+async def test_open_project_restores_overlay_only_on_reprovision(monkeypatch) -> None:
+    # The crash-before-any-snapshot case: the row carries a write-through overlay
+    # but no snapshot. Restore must still fire.
+    project = await service.create_project(_WS, _USER, {"repo": _REPO})
+    fake = _FakeDaytonaClient()
+
+    restored: list[str] = []
+
+    async def _spy_restore(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
+        restored.append(row_id)
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_workspace", _spy_restore)
+
+    first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    await sandbox_service.set_overlay_entry(_WS, _USER, first.id, "a.ts", "file-1")
+    await sandbox_service.mark_reaped(first.id)
+
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    assert restored == [second.id]
+
+
 async def test_open_project_swallows_restore_failure(monkeypatch) -> None:
     project = await service.create_project(_WS, _USER, {"repo": _REPO})
     fake = _FakeDaytonaClient()

--- a/tests/cloud/test_websandbox_archive.py
+++ b/tests/cloud/test_websandbox_archive.py
@@ -1,0 +1,167 @@
+# test_websandbox_archive.py — tests for the repo-archive endpoint (BP-3b).
+#
+# This endpoint takes a repo reference from the caller and fetches it server-side,
+# so the parsing is a security boundary, not a convenience: anything that is not
+# a github.com owner/repo must be refused BEFORE any URL is built. These tests
+# pin that, plus the size cap and the error mapping.
+from __future__ import annotations
+
+import re
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError, ValidationError
+from pocketpaw_ee.cloud.websandbox import archive
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, content: bytes = b"") -> None:
+        self.status_code = status_code
+        self.content = content
+
+
+class _FakeClient:
+    """Records the URL fetched so tests can assert we never fetch caller input."""
+
+    last_url: str | None = None
+
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url: str, headers=None):
+        type(self).last_url = url
+        return self._response
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _FakeClient.last_url = None
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, response: _FakeResponse) -> None:
+    monkeypatch.setattr(archive.httpx, "AsyncClient", lambda **kwargs: _FakeClient(response))
+
+
+# ---------------------------------------------------------------------------
+# Repo parsing — the SSRF boundary.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "octocat/Hello-World",
+        "https://github.com/octocat/Hello-World",
+        "https://github.com/octocat/Hello-World.git",
+        "http://www.github.com/octocat/Hello-World",
+        "github.com/octocat/Hello-World",
+    ],
+)
+async def test_accepts_github_forms(monkeypatch: pytest.MonkeyPatch, repo: str) -> None:
+    _patch_client(monkeypatch, _FakeResponse(200, b"zipbytes"))
+
+    result = await archive.fetch_repo_archive("ws", "user", repo)
+
+    assert result == b"zipbytes"
+    assert _FakeClient.last_url == "https://api.github.com/repos/octocat/Hello-World/zipball"
+
+
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "",
+        "   ",
+        "not-a-repo",
+        "https://evil.com/octocat/Hello-World",
+        "https://github.com.evil.com/a/b",
+        "http://127.0.0.1:8888/admin",
+        "file:///etc/passwd",
+        "https://user:pass@github.com/a/b",
+        "octocat/Hello-World/../../etc",
+        "https://github.com/octocat",
+    ],
+)
+async def test_refuses_anything_not_a_github_repo(repo: str) -> None:
+    # Must fail on PARSING, before any URL is constructed or fetched.
+    with pytest.raises((ValidationError, CloudError)):
+        await archive.fetch_repo_archive("ws", "user", repo)
+    assert _FakeClient.last_url is None
+
+
+async def test_builds_url_from_parsed_parts_not_caller_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(monkeypatch, _FakeResponse(200, b"z"))
+
+    await archive.fetch_repo_archive("ws", "user", "https://github.com/octocat/Hello-World.git")
+
+    # The fetched URL is assembled by us and contains no caller-supplied scheme
+    # or host — the whole point of the boundary. (Assert on the PATH: ".git"
+    # appears in "api.github.com" itself, so a naive substring check is a false
+    # positive.)
+    assert _FakeClient.last_url == "https://api.github.com/repos/octocat/Hello-World/zipball"
+
+
+# ---------------------------------------------------------------------------
+# Refs.
+# ---------------------------------------------------------------------------
+
+
+async def test_ref_is_appended_when_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_client(monkeypatch, _FakeResponse(200, b"z"))
+
+    await archive.fetch_repo_archive("ws", "user", "octocat/Hello-World", "main")
+
+    assert _FakeClient.last_url.endswith("/zipball/main")
+
+
+@pytest.mark.parametrize("ref", ["../../etc", "a b", "main;rm -rf /", "x" * 300])
+async def test_rejects_unsafe_refs(monkeypatch: pytest.MonkeyPatch, ref: str) -> None:
+    _patch_client(monkeypatch, _FakeResponse(200, b"z"))
+
+    with pytest.raises(ValidationError):
+        await archive.fetch_repo_archive("ws", "user", "octocat/Hello-World", ref)
+
+
+# ---------------------------------------------------------------------------
+# Upstream failures.
+# ---------------------------------------------------------------------------
+
+
+async def test_404_explains_private_repos_are_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(monkeypatch, _FakeResponse(404))
+
+    with pytest.raises(CloudError) as excinfo:
+        await archive.fetch_repo_archive("ws", "user", "octocat/Nope")
+
+    assert "rivate" in str(excinfo.value) or excinfo.value.status_code == 404
+
+
+async def test_upstream_error_is_a_clean_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_client(monkeypatch, _FakeResponse(500))
+
+    with pytest.raises(CloudError):
+        await archive.fetch_repo_archive("ws", "user", "octocat/Hello-World")
+
+
+async def test_oversized_archive_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A pod is a browser tab; a giant archive would blow its memory.
+    big = b"x" * (archive._MAX_ARCHIVE_BYTES + 1)
+    _patch_client(monkeypatch, _FakeResponse(200, big))
+
+    with pytest.raises(CloudError):
+        await archive.fetch_repo_archive("ws", "user", "octocat/Hello-World")
+
+
+def test_owner_regex_is_anchored() -> None:
+    # A non-anchored pattern would let "evil.com/github.com/a/b" through.
+    assert archive._SHORTHAND.pattern.startswith("^")
+    assert archive._SHORTHAND.pattern.endswith("$")
+    assert re.match(archive._URL_FORM, "https://evil.com/github.com/a/b") is None

--- a/tests/cloud/test_websandbox_broker.py
+++ b/tests/cloud/test_websandbox_broker.py
@@ -1,0 +1,289 @@
+# test_websandbox_broker.py — Code Mode private-repo broker-clone tests (CM-3c).
+# Created 2026-07-16 (feat/code-mode).
+#
+# The broker clones a PRIVATE repo into the VM while keeping the credential
+# entirely server-side. These tests pin the two guarantees that matter:
+#   1. ROUTING — resolve_repo_token mints from the FIRST connection whose
+#      installation can reach the repo, skips ones that can't, and returns None
+#      (→ public fallback) when nothing can auth it or the repo isn't brokerable.
+#   2. TOKEN ISOLATION — clone_into_vm ships the packed tree into the VM via
+#      upload_bytes + tar, and the token NEVER appears in anything sent to the VM.
+#
+# The server-side clone+pack step (real git/tar) is behind the ``pack`` DI seam,
+# so no test spawns a subprocess. The GitHub App client is a FAKE RepoAuthProvider
+# (monkeypatched into the resolver), and the connection registry runs on real
+# Beanie over mongomock-motor (the ``mongo_db`` fixture), so the tenant-scoped
+# connection read is exercised for real.
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.codeconnect import service as codeconnect_service
+from pocketpaw_ee.cloud.websandbox import broker
+from pocketpaw_ee.cloud.websandbox.repoauth import ProviderId, ScopedRepoToken
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws-1"
+_USER = "user-1"
+_EXP = datetime(2026, 7, 16, 12, 0, tzinfo=UTC)
+_CLEAN = "https://github.com/owner/repo.git"
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+class _FakeProvider:
+    """A RepoAuthProvider whose mint succeeds only for whitelisted installations."""
+
+    provider_id = ProviderId.GITHUB
+
+    def __init__(self, *, mintable: set[str], token: str = "tok-SECRET") -> None:
+        self.mintable = mintable
+        self.token = token
+        self.calls: list[tuple[str, str]] = []
+
+    async def mint_repo_token(self, connection_id, repo, *, scopes=None, now=None):  # noqa: ANN001
+        self.calls.append((connection_id, repo))
+        if connection_id not in self.mintable:
+            raise CloudError(502, "websandbox.installation_token_failed", "no access")
+        return ScopedRepoToken(
+            provider=ProviderId.GITHUB,
+            token=self.token,
+            expires_at=_EXP,
+            repo=repo,
+            scopes={},
+        )
+
+    async def list_repositories(self, connection_id, *, now=None):  # noqa: ANN001
+        return []
+
+    def upstream_clone_url(self, repo):  # noqa: ANN001
+        return f"https://github.com/{repo}.git"
+
+
+class _FakeVM:
+    """Records the file uploads + commands the broker sends into the sandbox."""
+
+    def __init__(self) -> None:
+        self.uploads: list[tuple[str, bytes, str]] = []
+        self.execs: list[str] = []
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.uploads.append((sandbox_id, data, remote_path))
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        self.execs.append(command)
+        return None
+
+
+def _token(tok: str = "tok-SECRET", repo: str = "owner/repo") -> ScopedRepoToken:
+    return ScopedRepoToken(
+        provider=ProviderId.GITHUB, token=tok, expires_at=_EXP, repo=repo, scopes={}
+    )
+
+
+# ---------------------------------------------------------------------------
+# repo_full_name.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://github.com/owner/repo.git", "owner/repo"),
+        ("https://github.com/owner/repo", "owner/repo"),
+        ("https://github.com/owner/repo/", "owner/repo"),
+        ("http://github.com/acme/api.git", "acme/api"),
+        ("git@github.com:acme/api.git", None),  # non-http
+        ("https://x-access-token:t@github.com/o/r.git", None),  # embedded creds
+        ("https://github.com/onlyowner", None),  # too few segments
+        ("not a url", None),
+    ],
+)
+def test_repo_full_name(url: str, expected: str | None) -> None:
+    assert broker.repo_full_name(url) == expected
+
+
+# ---------------------------------------------------------------------------
+# resolve_repo_token — routing.
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_none_when_repo_not_brokerable(monkeypatch) -> None:
+    # A non-github-shaped URL never even resolves a provider.
+    called = False
+
+    def _spy(_p):  # noqa: ANN001
+        nonlocal called
+        called = True
+        return _FakeProvider(mintable=set())
+
+    monkeypatch.setattr(broker, "get_repo_auth_provider", _spy)
+    assert await broker.resolve_repo_token(_WS, _USER, "git@github.com:o/r.git") is None
+    assert called is False
+
+
+async def test_resolve_none_when_provider_unconfigured(monkeypatch) -> None:
+    monkeypatch.setattr(broker, "get_repo_auth_provider", lambda _p: None)
+    assert await broker.resolve_repo_token(_WS, _USER, _CLEAN) is None
+
+
+async def test_resolve_none_when_no_connections(monkeypatch) -> None:
+    monkeypatch.setattr(
+        broker, "get_repo_auth_provider", lambda _p: _FakeProvider(mintable={"any"})
+    )
+    assert await broker.resolve_repo_token(_WS, _USER, _CLEAN) is None
+
+
+async def test_resolve_mints_from_the_connection_that_can_reach_the_repo(monkeypatch) -> None:
+    # Two connections, only ``inst-can`` can reach the repo. The resolver returns
+    # that connection's token — it doesn't give up on the one that can't mint.
+    await codeconnect_service.save_connection(_WS, _USER, "inst-can")
+    await codeconnect_service.save_connection(_WS, _USER, "inst-cannot")
+    provider = _FakeProvider(mintable={"inst-can"})
+    monkeypatch.setattr(broker, "get_repo_auth_provider", lambda _p: provider)
+
+    scoped = await broker.resolve_repo_token(_WS, _USER, _CLEAN)
+
+    assert scoped is not None
+    assert scoped.token == "tok-SECRET"
+    assert scoped.repo == "owner/repo"
+    # The minting connection was among those tried, always for the right repo.
+    assert ("inst-can", "owner/repo") in provider.calls
+    assert all(repo == "owner/repo" for _cid, repo in provider.calls)
+
+
+async def test_resolve_tries_every_connection_before_giving_up(monkeypatch) -> None:
+    # Nothing can mint → the resolver tries ALL of the caller's connections
+    # (skipping each failed mint) and only then returns None. Order-independent.
+    await codeconnect_service.save_connection(_WS, _USER, "inst-1")
+    await codeconnect_service.save_connection(_WS, _USER, "inst-2")
+    provider = _FakeProvider(mintable=set())  # nothing mints
+    monkeypatch.setattr(broker, "get_repo_auth_provider", lambda _p: provider)
+
+    assert await broker.resolve_repo_token(_WS, _USER, _CLEAN) is None
+    assert {cid for cid, _repo in provider.calls} == {"inst-1", "inst-2"}
+
+
+async def test_resolve_skips_other_provider_connections(monkeypatch) -> None:
+    # A non-github connection is skipped by the provider filter — never minted.
+    await codeconnect_service.save_connection(_WS, _USER, "goog-1", provider="google")
+    provider = _FakeProvider(mintable={"goog-1"})
+    monkeypatch.setattr(broker, "get_repo_auth_provider", lambda _p: provider)
+    assert await broker.resolve_repo_token(_WS, _USER, _CLEAN) is None
+    assert provider.calls == []
+
+
+async def test_resolve_scopes_to_the_caller(monkeypatch) -> None:
+    # A connection owned by another user in the same workspace is never used.
+    await codeconnect_service.save_connection(_WS, "other-user", "inst-x")
+    provider = _FakeProvider(mintable={"inst-x"})
+    monkeypatch.setattr(broker, "get_repo_auth_provider", lambda _p: provider)
+    assert await broker.resolve_repo_token(_WS, _USER, _CLEAN) is None
+    assert provider.calls == []
+
+
+# ---------------------------------------------------------------------------
+# clone_into_vm — token isolation.
+# ---------------------------------------------------------------------------
+
+
+async def test_clone_into_vm_ships_tar_and_never_leaks_the_token() -> None:
+    seen: dict = {}
+
+    async def fake_pack(token, clean_url, branch):  # noqa: ANN001
+        seen["clean_url"] = clean_url
+        seen["branch"] = branch
+        return b"TARBYTES"
+
+    vm = _FakeVM()
+    await broker.clone_into_vm(
+        vm,
+        "dtn-1",
+        _token(),
+        "/home/daytona",
+        clean_url=_CLEAN,
+        branch="main",
+        pack=fake_pack,
+    )
+
+    # The packer got the CLEAN url (it tokenizes internally, server-side).
+    assert seen == {"clean_url": _CLEAN, "branch": "main"}
+    # The exact tar bytes were uploaded to the staging path, then extracted.
+    assert vm.uploads == [("dtn-1", b"TARBYTES", "/tmp/ws-broker.tgz")]
+    assert any("tar -xzf /tmp/ws-broker.tgz" in c for c in vm.execs)
+
+    # THE INVARIANT: the token appears in NOTHING sent to the VM.
+    blob = repr(vm.uploads) + repr(vm.execs)
+    assert "tok-SECRET" not in blob
+
+
+async def test_clone_into_vm_rejects_oversized_repo(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_BROKER_MAX_MB", "0.000001")  # ~0 bytes
+
+    async def fake_pack(token, clean_url, branch):  # noqa: ANN001
+        return b"x" * 4096
+
+    vm = _FakeVM()
+    with pytest.raises(CloudError) as exc:
+        await broker.clone_into_vm(
+            vm, "dtn-1", _token(), "/home/daytona", clean_url=_CLEAN, pack=fake_pack
+        )
+    assert exc.value.code == "websandbox.broker_repo_too_large"
+    # Nothing was shipped to the VM.
+    assert vm.uploads == []
+    assert vm.execs == []
+
+
+async def test_clone_into_vm_wraps_pack_failure() -> None:
+    async def boom_pack(token, clean_url, branch):  # noqa: ANN001
+        raise RuntimeError("git exploded")
+
+    vm = _FakeVM()
+    with pytest.raises(CloudError) as exc:
+        await broker.clone_into_vm(
+            vm, "dtn-1", _token(), "/home/daytona", clean_url=_CLEAN, pack=boom_pack
+        )
+    assert exc.value.code == "websandbox.broker_clone_failed"
+    assert vm.uploads == []
+
+
+async def test_clone_into_vm_surfaces_cloud_error_from_pack() -> None:
+    async def cloud_boom(token, clean_url, branch):  # noqa: ANN001
+        raise CloudError(503, "websandbox.broker_git_unavailable", "no git")
+
+    vm = _FakeVM()
+    with pytest.raises(CloudError) as exc:
+        await broker.clone_into_vm(
+            vm, "dtn-1", _token(), "/home/daytona", clean_url=_CLEAN, pack=cloud_boom
+        )
+    # A CloudError from the packer is preserved verbatim (not re-wrapped).
+    assert exc.value.code == "websandbox.broker_git_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# _authenticated_url + _redact — the token-handling primitives.
+# ---------------------------------------------------------------------------
+
+
+def test_authenticated_url_injects_github_scheme() -> None:
+    url = broker._authenticated_url(ProviderId.GITHUB, _CLEAN, "tok123")
+    assert url == "https://x-access-token:tok123@github.com/owner/repo.git"
+
+
+def test_authenticated_url_rejects_unsupported_provider() -> None:
+    with pytest.raises(CloudError) as exc:
+        broker._authenticated_url(ProviderId.GOOGLE, _CLEAN, "tok123")
+    assert exc.value.code == "websandbox.broker_provider_unsupported"
+
+
+def test_redact_scrubs_the_secret() -> None:
+    assert broker._redact("clone https://x-access-token:abc@h failed", "abc") == (
+        "clone https://x-access-token:***@h failed"
+    )
+    assert broker._redact("no secret here", "") == "no secret here"

--- a/tests/cloud/test_websandbox_browserpod.py
+++ b/tests/cloud/test_websandbox_browserpod.py
@@ -24,8 +24,15 @@ _ENV = "BROWSERPOD_API_KEY"
 
 @pytest.fixture(autouse=True)
 def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Start every test from an unconfigured deploy."""
+    """Start every test from an unconfigured deploy.
+
+    Both sources must be neutralized. Clearing only the environment variable is
+    not enough now that the broker falls back to a ``.env`` file: on a developer
+    machine that file holds a real key, so "unconfigured" tests would silently
+    become "configured" ones and stop testing the fallback path at all.
+    """
     monkeypatch.delenv(_ENV, raising=False)
+    monkeypatch.setattr(browserpod, "_dotenv_key", lambda: "")
 
 
 async def test_issues_key_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,6 +73,34 @@ async def test_key_is_trimmed(monkeypatch: pytest.MonkeyPatch) -> None:
     result = await browserpod.get_credentials("ws-1", "user-1")
 
     assert result.apiKey == "bp_live_key_123"
+
+
+async def test_falls_back_to_dotenv_when_env_var_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A key in .env counts as configured.
+
+    ``BROWSERPOD_API_KEY`` carries no ``POCKETPAW_`` prefix, so pydantic-settings
+    never loads it; whether it reaches ``os.environ`` depends on the entrypoint.
+    When it doesn't, the failure is invisible — the broker reports unavailable,
+    the client quietly opens on Daytona, and nothing logs an error.
+    """
+    monkeypatch.setattr(browserpod, "_dotenv_key", lambda: "bp_from_dotenv")
+
+    result = await browserpod.get_credentials("ws-1", "user-1")
+
+    assert result.available is True
+    assert result.apiKey == "bp_from_dotenv"
+
+
+async def test_env_var_wins_over_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real deploy exports the key; a stale .env on the box must not shadow it."""
+    monkeypatch.setenv(_ENV, "bp_from_env")
+    monkeypatch.setattr(browserpod, "_dotenv_key", lambda: "bp_from_dotenv")
+
+    result = await browserpod.get_credentials("ws-1", "user-1")
+
+    assert result.apiKey == "bp_from_env"
 
 
 def test_enabled_flag_tracks_config(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cloud/test_websandbox_browserpod.py
+++ b/tests/cloud/test_websandbox_browserpod.py
@@ -1,0 +1,76 @@
+# test_websandbox_browserpod.py — tests for the BrowserPod boot-credential
+# broker (BP-1b, feat/code-mode).
+#
+# The point of the broker is that the vendor key lives ONLY in server config and
+# never in the frontend bundle. These tests pin that contract:
+#
+#   * a configured deploy issues the key to an authenticated, workspace-scoped
+#     caller (available=True)
+#   * an UNCONFIGURED deploy answers available=False with a null key instead of
+#     raising — the client must be able to fall back to Daytona cleanly
+#   * whitespace-only / empty config counts as unconfigured (a blank env var must
+#     never be handed out as a "key")
+#   * the key is read from the environment at call time, so rotating server
+#     config takes effect without a redeploy of the client
+#
+# No network, no Daytona, no DB — the broker is pure config resolution.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.websandbox import browserpod
+
+_ENV = "BROWSERPOD_API_KEY"
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test from an unconfigured deploy."""
+    monkeypatch.delenv(_ENV, raising=False)
+
+
+async def test_issues_key_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV, "bp_live_key_123")
+
+    result = await browserpod.get_credentials("ws-1", "user-1")
+
+    assert result.available is True
+    assert result.apiKey == "bp_live_key_123"
+
+
+async def test_reports_unavailable_when_unconfigured() -> None:
+    # A missing optional runtime is a FALLBACK condition, not a failure: the
+    # frontend routes the project to Daytona instead of surfacing an error.
+    result = await browserpod.get_credentials("ws-1", "user-1")
+
+    assert result.available is False
+    assert result.apiKey is None
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+async def test_blank_config_counts_as_unconfigured(
+    monkeypatch: pytest.MonkeyPatch, blank: str
+) -> None:
+    # A deploy that sets the var to an empty string must not hand a useless
+    # "key" to the client and claim the runtime is available.
+    monkeypatch.setenv(_ENV, blank)
+
+    result = await browserpod.get_credentials("ws-1", "user-1")
+
+    assert result.available is False
+    assert result.apiKey is None
+
+
+async def test_key_is_trimmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV, "  bp_live_key_123\n")
+
+    result = await browserpod.get_credentials("ws-1", "user-1")
+
+    assert result.apiKey == "bp_live_key_123"
+
+
+def test_enabled_flag_tracks_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert browserpod.browserpod_enabled() is False
+
+    monkeypatch.setenv(_ENV, "bp_live_key_123")
+    # Read at call time, so rotating server config needs no client redeploy.
+    assert browserpod.browserpod_enabled() is True

--- a/tests/cloud/test_websandbox_durability.py
+++ b/tests/cloud/test_websandbox_durability.py
@@ -74,9 +74,7 @@ class _FakeUploads:
         self._blobs: dict[str, bytes] = {}
         self._counter = 0
 
-    async def upload(
-        self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None
-    ):  # noqa: ANN001
+    async def upload(self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None):  # noqa: ANN001
         data = await file.read()
         self._counter += 1
         file_id = f"file-{self._counter}"
@@ -140,9 +138,7 @@ async def test_snapshot_tars_uploads_and_records_pointer() -> None:
     fake = _FakeDaytonaClient(tar_bytes=b"HELLO-SNAPSHOT")
     uploads = _FakeUploads()
 
-    file_id = await durability.snapshot_workspace(
-        "w1", "u1", row.id, client=fake, uploads=uploads
-    )
+    file_id = await durability.snapshot_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
 
     # Tarred the workspace dir inside the VM, then downloaded the tarball.
     assert any("tar -czf" in c and WEBSANDBOX_WORKDIR in c for c in fake.exec_calls)

--- a/tests/cloud/test_websandbox_durability.py
+++ b/tests/cloud/test_websandbox_durability.py
@@ -282,6 +282,66 @@ async def test_restore_skips_unsafe_overlay_path() -> None:
     assert all("evil.ts" not in p for p in written)
 
 
+async def test_drop_overlay_removes_entry() -> None:
+    row = await _ready_row()
+    uploads = _FakeUploads()
+    await durability.mirror_file("w1", "u1", row.id, "a.ts", b"A", uploads=uploads)
+
+    await durability.drop_overlay("w1", "u1", row.id, "a.ts")
+
+    # The dropped entry falls back to the snapshot tier on restore (safe).
+    assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).overlay == {}
+
+
+async def test_drop_overlay_prefix_drops_directory_entries() -> None:
+    row = await _ready_row()
+    uploads = _FakeUploads()
+    await durability.mirror_file("w1", "u1", row.id, "dir/a.ts", b"A", uploads=uploads)
+    await durability.mirror_file("w1", "u1", row.id, "dir/sub/b.ts", b"B", uploads=uploads)
+    await durability.mirror_file("w1", "u1", row.id, "keep.ts", b"K", uploads=uploads)
+
+    # Deleting the directory drops every overlay entry underneath it.
+    await durability.drop_overlay("w1", "u1", row.id, "dir")
+
+    assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).overlay == {"keep.ts": "file-3"}
+
+
+async def test_move_overlay_rekeys_src_to_dst() -> None:
+    row = await _ready_row()
+    uploads = _FakeUploads()
+    await durability.mirror_file("w1", "u1", row.id, "a.ts", b"A", uploads=uploads)
+
+    await durability.move_overlay("w1", "u1", row.id, "a.ts", "b.ts")
+
+    # Same FileRecord id, new key — restore replays the file at its new path.
+    assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).overlay == {"b.ts": "file-1"}
+
+
+async def test_move_overlay_rekeys_directory_children() -> None:
+    row = await _ready_row()
+    uploads = _FakeUploads()
+    await durability.mirror_file("w1", "u1", row.id, "old/a.ts", b"A", uploads=uploads)
+    await durability.mirror_file("w1", "u1", row.id, "old/sub/b.ts", b"B", uploads=uploads)
+
+    await durability.move_overlay("w1", "u1", row.id, "old", "new")
+
+    assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).overlay == {
+        "new/a.ts": "file-1",
+        "new/sub/b.ts": "file-2",
+    }
+
+
+async def test_move_overlay_without_src_entry_is_noop() -> None:
+    row = await _ready_row()
+    uploads = _FakeUploads()
+    await durability.mirror_file("w1", "u1", row.id, "keep.ts", b"K", uploads=uploads)
+
+    # Moving a file that has no overlay entry leaves the overlay untouched.
+    await durability.move_overlay("w1", "u1", row.id, "a.ts", "b.ts")
+
+    assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).overlay == {"keep.ts": "file-1"}
+
+
 async def test_snapshot_not_ready_when_unprovisioned() -> None:
     # A row with no bound Daytona id is a clean 409, not a runtime crash.
     row = await sandbox_service.create_sandbox("w1", "u1", {"repo": "r", "status": "pending"})

--- a/tests/cloud/test_websandbox_durability.py
+++ b/tests/cloud/test_websandbox_durability.py
@@ -1,0 +1,265 @@
+# test_websandbox_durability.py — unit tests for the Web Cursor workspace
+# durability slice (WC-S3): S3 snapshot + restore of the VM workspace.
+# Created 2026-07-15 (feat/websandbox-s3-durability).
+#
+# All Daytona AND blob-storage interaction goes through FAKES injected via the DI
+# seams (``client=`` + ``uploads=`` on both durability fns) — no test touches
+# real Daytona or S3. The registry itself runs on real Beanie over
+# mongomock-motor (the ``mongo_db`` fixture) so ``set_snapshot``'s owner-scoped
+# write and ``get_sandbox``'s tenant filter are exercised for real.
+#
+# Covers:
+#   * snapshot tars the workspace dir, uploads the tarball bytes to S3 (asserts
+#     workspace + owner scoping + folder), and records ``snapshot_file_id`` on
+#     the row.
+#   * restore reads the row's file_id, fetches the bytes back, uploads them into
+#     the VM, and runs the untar command into the workspace dir.
+#   * restore with no snapshot → clean CloudError, and no VM/S3 op runs.
+#   * both authorize: a cross-tenant caller is denied BEFORE any VM/S3 op.
+#   * snapshot over the size cap → clean CloudError before any upload.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.websandbox import durability
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+from pocketpaw.uploads.errors import NotFound as UploadNotFound
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Records VM ops and returns canned tar bytes. Drop-in for DaytonaClient in
+    the durability DI seam. ``tar_bytes`` is what ``download_file`` hands back
+    (the snapshot payload)."""
+
+    tar_bytes: bytes = b"CANNED-TAR-BYTES"
+    exec_calls: list[str] = field(default_factory=list)
+    download_calls: list[str] = field(default_factory=list)
+    upload_calls: list[dict] = field(default_factory=list)
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        self.exec_calls.append(command)
+        return None
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_calls.append(remote_path)
+        return self.tar_bytes
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.upload_calls.append(
+            {"sandbox_id": sandbox_id, "data": data, "remote_path": remote_path}
+        )
+
+
+class _FakeUploads:
+    """In-memory stand-in for EEUploadService: records ``upload`` and serves the
+    bytes back on ``stream``. A single instance carries the blob so a snapshot
+    written here is readable by a later restore in the same test."""
+
+    def __init__(self) -> None:
+        self.upload_calls: list[dict] = []
+        self._blobs: dict[str, bytes] = {}
+        self._counter = 0
+
+    async def upload(
+        self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None
+    ):  # noqa: ANN001
+        data = await file.read()
+        self._counter += 1
+        file_id = f"file-{self._counter}"
+        self.upload_calls.append(
+            {
+                "owner_id": owner_id,
+                "workspace": workspace,
+                "folder_path": folder_path,
+                "filename": file.filename,
+                "content_type": file.content_type,
+                "data": data,
+            }
+        )
+        self._blobs[file_id] = data
+        return FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename=file.filename,
+            mime="application/gzip",
+            size=len(data),
+            owner_id=owner_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+    async def stream(self, file_id, requester_id, workspace):  # noqa: ANN001
+        if file_id not in self._blobs:
+            raise UploadNotFound()
+        data = self._blobs[file_id]
+        rec = FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename="ws-snapshot.tgz",
+            mime="application/gzip",
+            size=len(data),
+            owner_id=requester_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+        async def _iter():
+            yield data
+
+        return rec, _iter()
+
+
+async def _ready_row(workspace="w1", user="u1", sandbox_id="dtn-1"):  # noqa: ANN001
+    """Create a registry row already ``ready`` with a bound Daytona id."""
+    return await sandbox_service.create_sandbox(
+        workspace, user, {"repo": "r", "status": "ready", "sandbox_id": sandbox_id}
+    )
+
+
+# ---------------------------------------------------------------------------
+# snapshot.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_tars_uploads_and_records_pointer() -> None:
+    row = await _ready_row()
+    fake = _FakeDaytonaClient(tar_bytes=b"HELLO-SNAPSHOT")
+    uploads = _FakeUploads()
+
+    file_id = await durability.snapshot_workspace(
+        "w1", "u1", row.id, client=fake, uploads=uploads
+    )
+
+    # Tarred the workspace dir inside the VM, then downloaded the tarball.
+    assert any("tar -czf" in c and WEBSANDBOX_WORKDIR in c for c in fake.exec_calls)
+    assert fake.download_calls == ["/tmp/ws-snapshot.tgz"]
+
+    # Uploaded the exact bytes to S3, workspace + owner scoped, in the snapshots
+    # folder — the ART-4 EEUploadService contract.
+    assert len(uploads.upload_calls) == 1
+    up = uploads.upload_calls[0]
+    assert up["workspace"] == "w1"
+    assert up["owner_id"] == "u1"
+    assert up["folder_path"] == "/websandbox-snapshots"
+    assert up["data"] == b"HELLO-SNAPSHOT"
+    assert up["content_type"] == "application/gzip"
+
+    # The durable pointer is returned AND persisted on the row.
+    assert file_id == "file-1"
+    fetched = await sandbox_service.get_sandbox("w1", "u1", row.id)
+    assert fetched.snapshot_file_id == "file-1"
+
+
+async def test_snapshot_over_cap_raises_before_upload(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB", "0.00001")  # ~10 bytes
+    row = await _ready_row()
+    fake = _FakeDaytonaClient(tar_bytes=b"this payload is bigger than ten bytes")
+    uploads = _FakeUploads()
+
+    with pytest.raises(CloudError) as exc:
+        await durability.snapshot_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+    assert exc.value.code == "websandbox.snapshot_too_large"
+
+    # No upload was attempted, and the row carries no pointer.
+    assert uploads.upload_calls == []
+    assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).snapshot_file_id is None
+
+
+async def test_snapshot_not_ready_when_unprovisioned() -> None:
+    # A row with no bound Daytona id is a clean 409, not a runtime crash.
+    row = await sandbox_service.create_sandbox("w1", "u1", {"repo": "r", "status": "pending"})
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+    with pytest.raises(CloudError) as exc:
+        await durability.snapshot_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+    assert exc.value.code == "websandbox.not_ready"
+    assert fake.exec_calls == []
+    assert uploads.upload_calls == []
+
+
+# ---------------------------------------------------------------------------
+# restore.
+# ---------------------------------------------------------------------------
+
+
+async def test_restore_fetches_bytes_and_untars_into_vm() -> None:
+    row = await _ready_row()
+    uploads = _FakeUploads()
+    # Snapshot first so the blob + pointer exist.
+    await durability.snapshot_workspace(
+        "w1", "u1", row.id, client=_FakeDaytonaClient(tar_bytes=b"SNAP-DATA"), uploads=uploads
+    )
+
+    # Restore into a FRESH VM (new fake client).
+    fresh = _FakeDaytonaClient()
+    await durability.restore_workspace("w1", "u1", row.id, client=fresh, uploads=uploads)
+
+    # The snapshot bytes were pushed into the VM at the staging path...
+    assert len(fresh.upload_calls) == 1
+    assert fresh.upload_calls[0]["remote_path"] == "/tmp/ws-snapshot.tgz"
+    assert fresh.upload_calls[0]["data"] == b"SNAP-DATA"
+    # ...and untarred into the workspace dir.
+    assert any("tar -xzf" in c and WEBSANDBOX_WORKDIR in c for c in fresh.exec_calls)
+
+
+async def test_restore_without_snapshot_raises_clean_error() -> None:
+    row = await _ready_row()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    with pytest.raises(CloudError) as exc:
+        await durability.restore_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+    assert exc.value.code == "websandbox.no_snapshot"
+
+    # Nothing touched the VM or storage.
+    assert fake.exec_calls == []
+    assert fake.upload_calls == []
+
+
+# ---------------------------------------------------------------------------
+# authorization — cross-tenant callers are denied before any VM/S3 op.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_denies_cross_tenant_caller() -> None:
+    row = await _ready_row(workspace="w1", user="u1")
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    # A caller in a DIFFERENT workspace can't resolve the row at all — denied
+    # before any tar/download/upload runs.
+    with pytest.raises(CloudError):
+        await durability.snapshot_workspace("w2", "u1", row.id, client=fake, uploads=uploads)
+    assert fake.exec_calls == []
+    assert fake.download_calls == []
+    assert uploads.upload_calls == []
+
+
+async def test_restore_denies_cross_tenant_caller() -> None:
+    row = await _ready_row(workspace="w1", user="u1")
+    uploads = _FakeUploads()
+    # Owner snapshots first so a real pointer exists.
+    await durability.snapshot_workspace(
+        "w1", "u1", row.id, client=_FakeDaytonaClient(), uploads=uploads
+    )
+
+    # Cross-tenant restore is denied before any VM/S3 op.
+    fake = _FakeDaytonaClient()
+    with pytest.raises(CloudError):
+        await durability.restore_workspace("w2", "u1", row.id, client=fake, uploads=uploads)
+    assert fake.exec_calls == []
+    assert fake.upload_calls == []

--- a/tests/cloud/test_websandbox_durability.py
+++ b/tests/cloud/test_websandbox_durability.py
@@ -179,6 +179,109 @@ async def test_snapshot_over_cap_raises_before_upload(monkeypatch) -> None:
     assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).snapshot_file_id is None
 
 
+# ---------------------------------------------------------------------------
+# write-through overlay (CM-2a′).
+# ---------------------------------------------------------------------------
+
+
+async def test_mirror_file_uploads_and_records_overlay() -> None:
+    row = await _ready_row()
+    uploads = _FakeUploads()
+
+    file_id = await durability.mirror_file(
+        "w1", "u1", row.id, "src/app.ts", b"console.log(1)", uploads=uploads
+    )
+
+    # Uploaded the file bytes to the overlay folder, workspace + owner scoped.
+    assert len(uploads.upload_calls) == 1
+    up = uploads.upload_calls[0]
+    assert up["workspace"] == "w1"
+    assert up["owner_id"] == "u1"
+    assert up["folder_path"] == "/websandbox-overlay"
+    assert up["data"] == b"console.log(1)"
+
+    # Recorded relpath -> file_id on the row.
+    assert file_id == "file-1"
+    assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).overlay == {
+        "src/app.ts": "file-1"
+    }
+
+
+async def test_snapshot_clears_the_overlay() -> None:
+    row = await _ready_row()
+    uploads = _FakeUploads()
+    fake = _FakeDaytonaClient(tar_bytes=b"TAR")
+
+    await durability.mirror_file("w1", "u1", row.id, "a.ts", b"AAA", uploads=uploads)
+    assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).overlay != {}
+
+    # A full snapshot supersedes the incremental overlay → overlay is wiped.
+    await durability.snapshot_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+    assert (await sandbox_service.get_sandbox("w1", "u1", row.id)).overlay == {}
+
+
+async def test_restore_replays_overlay_over_snapshot() -> None:
+    row = await _ready_row()
+    fake = _FakeDaytonaClient(tar_bytes=b"SNAPSHOT-TAR")
+    uploads = _FakeUploads()
+
+    # Disconnect snapshot (clears overlay), then a fresh session's edits mirror in.
+    await durability.snapshot_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+    await durability.mirror_file("w1", "u1", row.id, "a.ts", b"AAA", uploads=uploads)
+    await durability.mirror_file("w1", "u1", row.id, "dir/b.ts", b"BBB", uploads=uploads)
+
+    await durability.restore_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+
+    # Snapshot untarred first, then each overlay file written into the jail at
+    # WORKDIR/relpath (with a mkdir -p for the nested dir).
+    assert any("tar -xzf" in c for c in fake.exec_calls)
+    written = {u["remote_path"]: u["data"] for u in fake.upload_calls}
+    assert written[f"{WEBSANDBOX_WORKDIR}/a.ts"] == b"AAA"
+    assert written[f"{WEBSANDBOX_WORKDIR}/dir/b.ts"] == b"BBB"
+    assert any(f"mkdir -p {WEBSANDBOX_WORKDIR}/dir" in c for c in fake.exec_calls)
+
+
+async def test_restore_overlay_only_no_snapshot() -> None:
+    row = await _ready_row()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    await durability.mirror_file("w1", "u1", row.id, "only.ts", b"ONLY", uploads=uploads)
+    await durability.restore_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+
+    # No snapshot → no untar, but the overlay file is still replayed.
+    assert not any("tar -xzf" in c for c in fake.exec_calls)
+    written = {u["remote_path"]: u["data"] for u in fake.upload_calls}
+    assert written[f"{WEBSANDBOX_WORKDIR}/only.ts"] == b"ONLY"
+
+
+async def test_restore_with_neither_snapshot_nor_overlay_is_conflict() -> None:
+    row = await _ready_row()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    with pytest.raises(CloudError) as exc:
+        await durability.restore_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+    assert exc.value.code == "websandbox.no_snapshot"
+
+
+async def test_restore_skips_unsafe_overlay_path() -> None:
+    row = await _ready_row()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    await durability.mirror_file("w1", "u1", row.id, "safe.ts", b"SAFE", uploads=uploads)
+    # Hand-inject a traversal path the file.write jail would never produce.
+    await sandbox_service.set_overlay_entry("w1", "u1", row.id, "../evil.ts", "file-x")
+
+    await durability.restore_workspace("w1", "u1", row.id, client=fake, uploads=uploads)
+
+    written = {u["remote_path"]: u["data"] for u in fake.upload_calls}
+    assert written.get(f"{WEBSANDBOX_WORKDIR}/safe.ts") == b"SAFE"
+    # Nothing was written outside the jail.
+    assert all("evil.ts" not in p for p in written)
+
+
 async def test_snapshot_not_ready_when_unprovisioned() -> None:
     # A row with no bound Daytona id is a clean 409, not a runtime crash.
     row = await sandbox_service.create_sandbox("w1", "u1", {"repo": "r", "status": "pending"})

--- a/tests/cloud/test_websandbox_edit.py
+++ b/tests/cloud/test_websandbox_edit.py
@@ -95,8 +95,11 @@ async def _ready_row(workspace_id: str = "w1", user_id: str = "u1"):
     return await sandbox_service.create_sandbox(
         workspace_id,
         user_id,
-        {"repo": "https://github.com/octocat/Hello-World.git", "status": "ready",
-         "sandbox_id": "dtn-1"},
+        {
+            "repo": "https://github.com/octocat/Hello-World.git",
+            "status": "ready",
+            "sandbox_id": "dtn-1",
+        },
     )
 
 
@@ -111,9 +114,12 @@ async def test_propose_edit_returns_proposal() -> None:
     fake_dt = _FakeDaytona()
 
     resp = await edit.propose_edit(
-        "w1", "u1", row.id,
+        "w1",
+        "u1",
+        row.id,
         {"path": "app.py", "instruction": "change line one"},
-        client=fake_model, daytona=fake_dt,
+        client=fake_model,
+        daytona=fake_dt,
     )
 
     assert resp.path == "app.py"
@@ -137,9 +143,12 @@ async def test_propose_edit_denies_cross_tenant() -> None:
 
     with pytest.raises(CloudError):
         await edit.propose_edit(
-            "w2", "u1", row.id,  # different workspace
+            "w2",
+            "u1",
+            row.id,  # different workspace
             {"path": "app.py", "instruction": "x"},
-            client=fake_model, daytona=fake_dt,
+            client=fake_model,
+            daytona=fake_dt,
         )
 
     # Denied BEFORE any model call or VM read.
@@ -159,9 +168,12 @@ async def test_propose_edit_rejects_traversal() -> None:
 
     with pytest.raises(CloudError) as exc:
         await edit.propose_edit(
-            "w1", "u1", row.id,
+            "w1",
+            "u1",
+            row.id,
             {"path": "../../etc/passwd", "instruction": "read secrets"},
-            client=fake_model, daytona=fake_dt,
+            client=fake_model,
+            daytona=fake_dt,
         )
     assert exc.value.code == "websandbox.edit_invalid_path"
     # No download, no model call for a traversal attempt.
@@ -181,9 +193,12 @@ async def test_propose_edit_model_failure_is_clean_error() -> None:
 
     with pytest.raises(CloudError) as exc:
         await edit.propose_edit(
-            "w1", "u1", row.id,
+            "w1",
+            "u1",
+            row.id,
             {"path": "app.py", "instruction": "x"},
-            client=fake_model, daytona=fake_dt,
+            client=fake_model,
+            daytona=fake_dt,
         )
     assert exc.value.code == "websandbox.edit_failed"
 
@@ -198,9 +213,12 @@ async def test_propose_edit_not_ready_when_unprovisioned() -> None:
 
     with pytest.raises(CloudError) as exc:
         await edit.propose_edit(
-            "w1", "u1", row.id,
+            "w1",
+            "u1",
+            row.id,
             {"path": "app.py", "instruction": "x"},
-            client=fake_model, daytona=fake_dt,
+            client=fake_model,
+            daytona=fake_dt,
         )
     assert exc.value.code == "websandbox.not_ready"
     assert fake_model.create_calls == []
@@ -217,10 +235,16 @@ async def test_propose_edit_with_selection_gathers_context() -> None:
     fake_dt = _FakeDaytona(file_bytes=b"def my_function():\n    return 1\n")
 
     await edit.propose_edit(
-        "w1", "u1", row.id,
-        {"path": "app.py", "instruction": "add a docstring",
-         "selection": {"startLine": 1, "endLine": 1}},
-        client=fake_model, daytona=fake_dt,
+        "w1",
+        "u1",
+        row.id,
+        {
+            "path": "app.py",
+            "instruction": "add a docstring",
+            "selection": {"startLine": 1, "endLine": 1},
+        },
+        client=fake_model,
+        daytona=fake_dt,
     )
 
     # A best-effort ripgrep ran under the pinned workspace dir.

--- a/tests/cloud/test_websandbox_edit.py
+++ b/tests/cloud/test_websandbox_edit.py
@@ -1,0 +1,231 @@
+# test_websandbox_edit.py — service-level tests for the Web Cursor AI edit agent
+# (WC-5a, feat/websandbox-edit-agent).
+#
+# The model call and all Daytona interaction go through FAKES injected via the DI
+# seams (``client=`` / ``daytona=`` on ``propose_edit``) — no test touches the real
+# Anthropic API or real Daytona. The registry runs on real Beanie over
+# mongomock-motor (the ``mongo_db`` fixture) so the tenant-filtered guards are
+# exercised for real.
+#
+# Covers:
+#   * propose_edit returns the model's proposed content; original == the file's
+#     current content; the target file is read at the JAILED path.
+#   * tenancy: a cross-tenant caller is denied BEFORE any model call or VM read.
+#   * a path-traversal ``path`` is refused by the jail — no download, no model call.
+#   * a model/client failure surfaces as a clean ``websandbox.edit_failed`` error.
+#   * a selection triggers a bounded, best-effort ripgrep for context.
+#   * an unprovisioned row (no bound Daytona id) is a clean 409, not a crash.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.websandbox import edit
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeBlock:
+    text: str
+
+
+@dataclass
+class _FakeMessage:
+    content: list
+
+
+@dataclass
+class _FakeExec:
+    result: str = ""
+
+
+class _FakeMessages:
+    def __init__(self, outer: _FakeAnthropic) -> None:
+        self._outer = outer
+
+    async def create(self, **kwargs):  # noqa: ANN003
+        self._outer.create_calls.append(kwargs)
+        if self._outer.raise_exc:
+            raise RuntimeError("boom: model call failed")
+        return _FakeMessage(content=[_FakeBlock(text=self._outer.proposed)])
+
+
+class _FakeAnthropic:
+    """Drop-in for the AsyncAnthropic DI seam. Records calls; returns a canned
+    proposed file (or raises to exercise the failure path)."""
+
+    def __init__(self, proposed: str = "PROPOSED FILE BODY\n", raise_exc: bool = False) -> None:
+        self.proposed = proposed
+        self.raise_exc = raise_exc
+        self.create_calls: list[dict] = []
+        self.messages = _FakeMessages(self)
+
+
+@dataclass
+class _FakeDaytona:
+    """Records download + exec calls; returns canned file bytes. Drop-in for the
+    DaytonaClient DI seam."""
+
+    file_bytes: bytes = b"line one\nline two\n"
+    missing: bool = False
+    download_calls: list[str] = field(default_factory=list)
+    exec_calls: list[dict] = field(default_factory=list)
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_calls.append(remote_path)
+        if self.missing:
+            raise FileNotFoundError(remote_path)
+        return self.file_bytes
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001, ANN003
+        self.exec_calls.append({"command": command, "cwd": kwargs.get("cwd")})
+        return _FakeExec(result="src/other.py:12:    my_function()\n")
+
+
+async def _ready_row(workspace_id: str = "w1", user_id: str = "u1"):
+    return await sandbox_service.create_sandbox(
+        workspace_id,
+        user_id,
+        {"repo": "https://github.com/octocat/Hello-World.git", "status": "ready",
+         "sandbox_id": "dtn-1"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# happy path.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_edit_returns_proposal() -> None:
+    row = await _ready_row()
+    fake_model = _FakeAnthropic(proposed="line one CHANGED\nline two\n")
+    fake_dt = _FakeDaytona()
+
+    resp = await edit.propose_edit(
+        "w1", "u1", row.id,
+        {"path": "app.py", "instruction": "change line one"},
+        client=fake_model, daytona=fake_dt,
+    )
+
+    assert resp.path == "app.py"
+    assert resp.originalContent == "line one\nline two\n"
+    assert resp.proposedContent == "line one CHANGED\nline two\n"
+    # The file was read at the JAILED absolute path under the pinned workspace dir.
+    assert fake_dt.download_calls == [f"{WEBSANDBOX_WORKDIR}/app.py"]
+    # The model was called exactly once.
+    assert len(fake_model.create_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# tenancy.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_edit_denies_cross_tenant() -> None:
+    row = await _ready_row("w1", "u1")
+    fake_model = _FakeAnthropic()
+    fake_dt = _FakeDaytona()
+
+    with pytest.raises(CloudError):
+        await edit.propose_edit(
+            "w2", "u1", row.id,  # different workspace
+            {"path": "app.py", "instruction": "x"},
+            client=fake_model, daytona=fake_dt,
+        )
+
+    # Denied BEFORE any model call or VM read.
+    assert fake_model.create_calls == []
+    assert fake_dt.download_calls == []
+
+
+# ---------------------------------------------------------------------------
+# path safety.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_edit_rejects_traversal() -> None:
+    row = await _ready_row()
+    fake_model = _FakeAnthropic()
+    fake_dt = _FakeDaytona()
+
+    with pytest.raises(CloudError) as exc:
+        await edit.propose_edit(
+            "w1", "u1", row.id,
+            {"path": "../../etc/passwd", "instruction": "read secrets"},
+            client=fake_model, daytona=fake_dt,
+        )
+    assert exc.value.code == "websandbox.edit_invalid_path"
+    # No download, no model call for a traversal attempt.
+    assert fake_dt.download_calls == []
+    assert fake_model.create_calls == []
+
+
+# ---------------------------------------------------------------------------
+# honest failure.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_edit_model_failure_is_clean_error() -> None:
+    row = await _ready_row()
+    fake_model = _FakeAnthropic(raise_exc=True)
+    fake_dt = _FakeDaytona()
+
+    with pytest.raises(CloudError) as exc:
+        await edit.propose_edit(
+            "w1", "u1", row.id,
+            {"path": "app.py", "instruction": "x"},
+            client=fake_model, daytona=fake_dt,
+        )
+    assert exc.value.code == "websandbox.edit_failed"
+
+
+async def test_propose_edit_not_ready_when_unprovisioned() -> None:
+    # A registry row that never bound a Daytona id is a clean 409, not a crash.
+    row = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git", "status": "pending"}
+    )
+    fake_model = _FakeAnthropic()
+    fake_dt = _FakeDaytona()
+
+    with pytest.raises(CloudError) as exc:
+        await edit.propose_edit(
+            "w1", "u1", row.id,
+            {"path": "app.py", "instruction": "x"},
+            client=fake_model, daytona=fake_dt,
+        )
+    assert exc.value.code == "websandbox.not_ready"
+    assert fake_model.create_calls == []
+
+
+# ---------------------------------------------------------------------------
+# optional selection context.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_edit_with_selection_gathers_context() -> None:
+    row = await _ready_row()
+    fake_model = _FakeAnthropic()
+    fake_dt = _FakeDaytona(file_bytes=b"def my_function():\n    return 1\n")
+
+    await edit.propose_edit(
+        "w1", "u1", row.id,
+        {"path": "app.py", "instruction": "add a docstring",
+         "selection": {"startLine": 1, "endLine": 1}},
+        client=fake_model, daytona=fake_dt,
+    )
+
+    # A best-effort ripgrep ran under the pinned workspace dir.
+    rg_calls = [c for c in fake_dt.exec_calls if c["command"].startswith("rg ")]
+    assert len(rg_calls) == 1
+    assert rg_calls[0]["cwd"] == WEBSANDBOX_WORKDIR
+    # The proposal still came back from the model.
+    assert len(fake_model.create_calls) == 1

--- a/tests/cloud/test_websandbox_file_rpc.py
+++ b/tests/cloud/test_websandbox_file_rpc.py
@@ -28,7 +28,9 @@ from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
 from pocketpaw_ee.cloud.websandbox.files import FileRpc, FileRpcError
 from pocketpaw_ee.cloud.websandbox.ws import terminal_websocket_endpoint
 
-PROJECT_DIR = "/home/daytona/project"
+# The pinned in-VM workspace dir (WEBSANDBOX_WORKDIR). ws.py builds FileRpc
+# without an explicit project_dir, so it uses this; Tier-1 tests inject it too.
+PROJECT_DIR = "/home/daytona"
 
 
 # ---------------------------------------------------------------------------
@@ -78,7 +80,20 @@ class _FakeFsClient:
 
 
 def _rpc(client: _FakeFsClient) -> FileRpc:
-    return FileRpc(client, "dtn-1")
+    # Inject the fake's project dir so path assertions are independent of the
+    # WEBSANDBOX_WORKDIR default (covered separately below).
+    return FileRpc(client, "dtn-1", project_dir=client.project_dir)
+
+
+async def test_root_defaults_to_websandbox_workdir() -> None:
+    # With no injected project_dir, the jail root is the pinned in-VM workspace
+    # (/home/daytona) — NOT the SDK's get_project_dir() (which returns /root).
+    from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+    client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
+    rpc = FileRpc(client, "dtn-1")
+    await rpc.list_dir("")
+    assert client.list_paths == [WEBSANDBOX_WORKDIR]
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +121,18 @@ async def test_list_returns_entries_with_relative_paths() -> None:
 async def test_list_root_uses_project_dir() -> None:
     client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
     entries = await _rpc(client).list_dir(".")
+    assert client.list_paths == [PROJECT_DIR]
+    assert entries[0]["path"] == "README.md"
+
+
+async def test_list_empty_path_lists_project_root() -> None:
+    # Regression: the editor's file tree lists the repo root by sending path ''
+    # (frontend loadTree -> listDir('')). An empty path MUST resolve to the
+    # project dir, not raise — otherwise the tree comes back empty even though
+    # the repo cloned fine. (Diagnosed live 2026-07-15: clone lands in the
+    # project dir, but list('') was rejected.)
+    client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
+    entries = await _rpc(client).list_dir("")
     assert client.list_paths == [PROJECT_DIR]
     assert entries[0]["path"] == "README.md"
 

--- a/tests/cloud/test_websandbox_file_rpc.py
+++ b/tests/cloud/test_websandbox_file_rpc.py
@@ -307,6 +307,38 @@ async def test_dispatch_missing_path_is_error_frame() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Write-through mirror hook (CM-2a′).
+# ---------------------------------------------------------------------------
+
+
+async def test_write_invokes_on_write_mirror_with_relpath_and_bytes() -> None:
+    client = _FakeFsClient()
+    mirrored: list[tuple[str, bytes]] = []
+
+    async def _spy(rel_path, data):  # noqa: ANN001
+        mirrored.append((rel_path, data))
+
+    rpc = FileRpc(client, "dtn-1", project_dir=client.project_dir, on_write=_spy)
+    await rpc.write_file("src/app.ts", "hello")
+
+    # The VM write landed, and the mirror got the project-relative path + bytes.
+    assert client.uploads == [(f"{PROJECT_DIR}/src/app.ts", b"hello")]
+    assert mirrored == [("src/app.ts", b"hello")]
+
+
+async def test_write_mirror_failure_does_not_fail_the_save() -> None:
+    client = _FakeFsClient()
+
+    async def _boom(rel_path, data):  # noqa: ANN001
+        raise RuntimeError("boom: blob storage down")
+
+    rpc = FileRpc(client, "dtn-1", project_dir=client.project_dir, on_write=_boom)
+    # Must NOT raise — the VM write already succeeded before the mirror ran.
+    await rpc.write_file("a.ts", "x")
+    assert client.uploads == [(f"{PROJECT_DIR}/a.ts", b"x")]
+
+
+# ---------------------------------------------------------------------------
 # Tier 2 — ws.py frame dispatch over the real auth path (mongomock).
 #
 # Reuses the WC-3 fakes/harness (a pty must still open so the receive loop runs),

--- a/tests/cloud/test_websandbox_file_rpc.py
+++ b/tests/cloud/test_websandbox_file_rpc.py
@@ -60,6 +60,9 @@ class _FakeFsClient:
     uploads: list[tuple[str, bytes]] = field(default_factory=list)
     list_paths: list[str] = field(default_factory=list)
     download_paths: list[str] = field(default_factory=list)
+    created_dirs: list[str] = field(default_factory=list)
+    deletes: list[tuple[str, bool]] = field(default_factory=list)
+    moves: list[tuple[str, str]] = field(default_factory=list)
 
     async def get_project_dir(self, sandbox_id):  # noqa: ANN001
         return self.project_dir
@@ -77,6 +80,18 @@ class _FakeFsClient:
     async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
         self.uploads.append((remote_path, data))
         self.files[remote_path] = data
+
+    async def create_folder(self, sandbox_id, path, mode="755"):  # noqa: ANN001
+        self.created_dirs.append(path)
+
+    async def delete_file(self, sandbox_id, path, recursive=False):  # noqa: ANN001
+        self.deletes.append((path, recursive))
+        self.files.pop(path, None)
+
+    async def move_file(self, sandbox_id, src, dst):  # noqa: ANN001
+        self.moves.append((src, dst))
+        if src in self.files:
+            self.files[dst] = self.files.pop(src)
 
 
 def _rpc(client: _FakeFsClient) -> FileRpc:
@@ -339,6 +354,259 @@ async def test_write_mirror_failure_does_not_fail_the_save() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Tier 1 — create / delete / move ops (WC-4c: file CRUD verbs).
+# ---------------------------------------------------------------------------
+
+
+async def test_create_file_uploads_empty_at_jailed_path() -> None:
+    client = _FakeFsClient()  # empty listing -> target does not exist
+    await _rpc(client).create("src/new.py", False)
+    assert client.uploads == [(f"{PROJECT_DIR}/src/new.py", b"")]
+    assert client.created_dirs == []
+
+
+async def test_create_dir_makes_folder_at_jailed_path() -> None:
+    client = _FakeFsClient()
+    await _rpc(client).create("src/newdir", True)
+    assert client.created_dirs == [f"{PROJECT_DIR}/src/newdir"]
+    assert client.uploads == []
+
+
+async def test_create_refuses_existing_target() -> None:
+    # The parent listing already carries the target name -> refuse (no clobber).
+    client = _FakeFsClient(listing=[_FakeFileInfo("app.py", size=1)])
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).create("app.py", False)
+    assert ei.value.op == "create"
+    assert client.uploads == []
+
+
+async def test_create_root_is_refused() -> None:
+    client = _FakeFsClient()
+    for bad in ("", ".", "./"):
+        with pytest.raises(FileRpcError) as ei:
+            await _rpc(client).create(bad, True)
+        assert ei.value.op == "create"
+    assert client.created_dirs == []
+    assert client.uploads == []
+
+
+async def test_delete_file_calls_delete_recursive() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/old.py": b"x"})
+    await _rpc(client).delete("old.py")
+    assert client.deletes == [(f"{PROJECT_DIR}/old.py", True)]
+
+
+async def test_delete_dir_calls_delete_recursive() -> None:
+    client = _FakeFsClient()
+    await _rpc(client).delete("src/pkg")
+    assert client.deletes == [(f"{PROJECT_DIR}/src/pkg", True)]
+
+
+async def test_delete_root_is_refused() -> None:
+    client = _FakeFsClient()
+    for bad in ("", ".", "./"):
+        with pytest.raises(FileRpcError) as ei:
+            await _rpc(client).delete(bad)
+        assert ei.value.op == "delete"
+    assert client.deletes == []
+
+
+async def test_move_renames_at_jailed_paths() -> None:
+    client = _FakeFsClient()
+    await _rpc(client).move("a.py", "b.py")
+    assert client.moves == [(f"{PROJECT_DIR}/a.py", f"{PROJECT_DIR}/b.py")]
+
+
+async def test_move_refuses_existing_destination() -> None:
+    client = _FakeFsClient(listing=[_FakeFileInfo("b.py", size=1)])
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).move("a.py", "b.py")
+    assert ei.value.op == "move"
+    assert client.moves == []
+
+
+async def test_move_root_source_is_refused() -> None:
+    client = _FakeFsClient()
+    for bad in ("", ".", "./"):
+        with pytest.raises(FileRpcError) as ei:
+            await _rpc(client).move(bad, "b.py")
+        assert ei.value.op == "move"
+    assert client.moves == []
+
+
+@pytest.mark.parametrize("bad_src", ["../../etc/passwd", "/etc/passwd", "src/../../evil"])
+async def test_move_jails_source_path(bad_src) -> None:  # noqa: ANN001
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).move(bad_src, "ok.py")
+    assert ei.value.op == "move"
+    assert client.moves == []
+
+
+@pytest.mark.parametrize("bad_dst", ["../../etc/passwd", "/etc/passwd", "src/../../evil"])
+async def test_move_jails_destination_path(bad_dst) -> None:  # noqa: ANN001
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).move("ok.py", bad_dst)
+    assert ei.value.op == "move"
+    assert client.moves == []
+
+
+@pytest.mark.parametrize("bad", ["../../etc/passwd", "/etc/passwd", ".."])
+async def test_create_jails_path(bad) -> None:  # noqa: ANN001
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).create(bad, False)
+    assert ei.value.op == "create"
+    assert client.uploads == [] and client.created_dirs == []
+
+
+@pytest.mark.parametrize("bad", ["../../etc/passwd", "/etc/passwd", ".."])
+async def test_delete_jails_path(bad) -> None:  # noqa: ANN001
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).delete(bad)
+    assert ei.value.op == "delete"
+    assert client.deletes == []
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — durability hooks (on_delete / on_move) fire with the right rel paths.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_file_mirrors_empty_via_on_write() -> None:
+    client = _FakeFsClient()
+    mirrored: list[tuple[str, bytes]] = []
+
+    async def _spy(rel_path, data):  # noqa: ANN001
+        mirrored.append((rel_path, data))
+
+    rpc = FileRpc(client, "dtn-1", project_dir=client.project_dir, on_write=_spy)
+    await rpc.create("src/new.ts", False)
+    # An empty file lands in the overlay just like a write of "".
+    assert mirrored == [("src/new.ts", b"")]
+
+
+async def test_create_dir_does_not_mirror() -> None:
+    client = _FakeFsClient()
+    mirrored: list = []
+
+    async def _spy(rel_path, data):  # noqa: ANN001
+        mirrored.append((rel_path, data))
+
+    rpc = FileRpc(client, "dtn-1", project_dir=client.project_dir, on_write=_spy)
+    await rpc.create("newdir", True)
+    assert mirrored == []
+
+
+async def test_delete_calls_on_delete_with_relpath() -> None:
+    client = _FakeFsClient()
+    dropped: list[str] = []
+
+    async def _drop(rel_path):  # noqa: ANN001
+        dropped.append(rel_path)
+
+    rpc = FileRpc(client, "dtn-1", project_dir=client.project_dir, on_delete=_drop)
+    await rpc.delete("src/old.ts")
+    assert dropped == ["src/old.ts"]
+
+
+async def test_move_calls_on_move_with_rel_paths() -> None:
+    client = _FakeFsClient()
+    moved: list[tuple[str, str]] = []
+
+    async def _move(src_rel, dst_rel):  # noqa: ANN001
+        moved.append((src_rel, dst_rel))
+
+    rpc = FileRpc(client, "dtn-1", project_dir=client.project_dir, on_move=_move)
+    await rpc.move("a.ts", "b.ts")
+    assert moved == [("a.ts", "b.ts")]
+
+
+async def test_delete_hook_failure_does_not_fail_delete() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/a.ts": b"x"})
+
+    async def _boom(rel_path):  # noqa: ANN001
+        raise RuntimeError("overlay drop failed")
+
+    rpc = FileRpc(client, "dtn-1", project_dir=client.project_dir, on_delete=_boom)
+    await rpc.delete("a.ts")  # must not raise — the VM delete already landed
+    assert client.deletes == [(f"{PROJECT_DIR}/a.ts", True)]
+
+
+async def test_move_hook_failure_does_not_fail_move() -> None:
+    client = _FakeFsClient()
+
+    async def _boom(src_rel, dst_rel):  # noqa: ANN001
+        raise RuntimeError("overlay re-key failed")
+
+    rpc = FileRpc(client, "dtn-1", project_dir=client.project_dir, on_move=_boom)
+    await rpc.move("a.ts", "b.ts")  # must not raise
+    assert client.moves == [(f"{PROJECT_DIR}/a.ts", f"{PROJECT_DIR}/b.ts")]
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — dispatch frames for the new verbs.
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_create_ok_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.create", "reqId": "c1", "path": "new.py", "isDir": False}
+    )
+    assert resp == {"type": "file.create.ok", "reqId": "c1", "path": "new.py", "isDir": False}
+    assert client.uploads == [(f"{PROJECT_DIR}/new.py", b"")]
+
+
+async def test_dispatch_create_dir_ok_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.create", "reqId": "c2", "path": "pkg", "isDir": True}
+    )
+    assert resp == {"type": "file.create.ok", "reqId": "c2", "path": "pkg", "isDir": True}
+    assert client.created_dirs == [f"{PROJECT_DIR}/pkg"]
+
+
+async def test_dispatch_delete_ok_frame() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/old.py": b"x"})
+    resp = await _rpc(client).dispatch({"type": "file.delete", "reqId": "d1", "path": "old.py"})
+    assert resp == {"type": "file.delete.ok", "reqId": "d1", "path": "old.py"}
+    assert client.deletes == [(f"{PROJECT_DIR}/old.py", True)]
+
+
+async def test_dispatch_move_ok_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.move", "reqId": "m1", "path": "a.py", "toPath": "b.py"}
+    )
+    assert resp == {"type": "file.move.ok", "reqId": "m1", "path": "a.py", "toPath": "b.py"}
+    assert client.moves == [(f"{PROJECT_DIR}/a.py", f"{PROJECT_DIR}/b.py")]
+
+
+async def test_dispatch_create_traversal_returns_error_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.create", "reqId": "c9", "path": "../../etc/x", "isDir": False}
+    )
+    assert resp["type"] == "file.error"
+    assert resp["op"] == "create" and resp["reqId"] == "c9"
+    assert client.uploads == []
+
+
+async def test_dispatch_move_traversal_returns_error_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.move", "reqId": "m9", "path": "a.py", "toPath": "../../etc/x"}
+    )
+    assert resp["type"] == "file.error"
+    assert resp["op"] == "move" and resp["reqId"] == "m9"
+    assert client.moves == []
+
+
+# ---------------------------------------------------------------------------
 # Tier 2 — ws.py frame dispatch over the real auth path (mongomock).
 #
 # Reuses the WC-3 fakes/harness (a pty must still open so the receive loop runs),
@@ -390,6 +658,10 @@ class _FakeDaytonaClient:
     project_dir: str = PROJECT_DIR
     files: dict[str, bytes] = field(default_factory=dict)
     uploads: list[tuple[str, bytes]] = field(default_factory=list)
+    listing: list[_FakeFileInfo] = field(default_factory=list)
+    created_dirs: list[str] = field(default_factory=list)
+    deletes: list[tuple[str, bool]] = field(default_factory=list)
+    moves: list[tuple[str, str]] = field(default_factory=list)
 
     async def get_sandbox_instance(self, sandbox_id):  # noqa: ANN001
         return self.sandbox
@@ -404,6 +676,10 @@ class _FakeDaytonaClient:
         return self.project_dir
 
     async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
+        # Empty listing by default so create/move existence probes see a clean
+        # tree; the read/list round-trip test seeds ``listing`` explicitly.
+        if self.listing:
+            return list(self.listing)
         return [_FakeFileInfo("app.py", is_dir=False, size=5)]
 
     async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
@@ -414,6 +690,18 @@ class _FakeDaytonaClient:
     async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
         self.uploads.append((remote_path, data))
         self.files[remote_path] = data
+
+    async def create_folder(self, sandbox_id, path, mode="755"):  # noqa: ANN001
+        self.created_dirs.append(path)
+
+    async def delete_file(self, sandbox_id, path, recursive=False):  # noqa: ANN001
+        self.deletes.append((path, recursive))
+        self.files.pop(path, None)
+
+    async def move_file(self, sandbox_id, src, dst):  # noqa: ANN001
+        self.moves.append((src, dst))
+        if src in self.files:
+            self.files[dst] = self.files.pop(src)
 
 
 class FakeWebSocket:
@@ -561,3 +849,67 @@ async def test_ws_malformed_file_frame_does_not_tear_down_socket(wire_terminal) 
     assert ws.closed is None  # never force-closed
     reads = [m for m in ws.sent_json if m.get("type") == "file.read.ok"]
     assert reads and reads[0]["content"] == "ok"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_create_frame_lands_empty_and_acks(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(
+        inbound=['{"type":"file.create","reqId":"c1","path":"fresh.txt","isDir":false}']
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    # The create frame reached the VM as an empty upload and got its ack. The
+    # empty-file overlay mirror is exercised at Tier 1 (on_write spy) — the ws
+    # path's real build_uploads() blob write is out of scope here.
+    assert {"type": "file.create.ok", "reqId": "c1", "path": "fresh.txt", "isDir": False} in (
+        ws.sent_json
+    )
+    assert client.uploads == [(f"{PROJECT_DIR}/fresh.txt", b"")]
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_delete_frame_drops_overlay(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+    # Seed an overlay entry the delete must drop so restore can't resurrect it.
+    await sandbox_service.set_overlay_entry("w1", user_id, row_id, "gone.txt", "file-x")
+
+    ws = FakeWebSocket(inbound=['{"type":"file.delete","reqId":"d1","path":"gone.txt"}'])
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert {"type": "file.delete.ok", "reqId": "d1", "path": "gone.txt"} in ws.sent_json
+    assert client.deletes == [(f"{PROJECT_DIR}/gone.txt", True)]
+    row = await sandbox_service.get_sandbox("w1", user_id, row_id)
+    assert "gone.txt" not in row.overlay
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_move_frame_rekeys_overlay(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+    await sandbox_service.set_overlay_entry("w1", user_id, row_id, "a.txt", "file-a")
+
+    ws = FakeWebSocket(
+        inbound=['{"type":"file.move","reqId":"m1","path":"a.txt","toPath":"b.txt"}']
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert {
+        "type": "file.move.ok",
+        "reqId": "m1",
+        "path": "a.txt",
+        "toPath": "b.txt",
+    } in ws.sent_json
+    assert client.moves == [(f"{PROJECT_DIR}/a.txt", f"{PROJECT_DIR}/b.txt")]
+    # Overlay re-keyed src -> dst so restore replays the file at its new path.
+    row = await sandbox_service.get_sandbox("w1", user_id, row_id)
+    assert row.overlay == {"b.txt": "file-a"}

--- a/tests/cloud/test_websandbox_file_rpc.py
+++ b/tests/cloud/test_websandbox_file_rpc.py
@@ -46,6 +46,14 @@ class _FakeFileInfo:
 
 
 @dataclass
+class _FakeExec:
+    """Stand-in for the SDK ExecuteResponse (only the fields search reads)."""
+
+    exit_code: int = 0
+    result: str = ""
+
+
+@dataclass
 class _FakeFsClient:
     """Fake DaytonaClient exposing only the file methods FileRpc uses.
 
@@ -63,6 +71,12 @@ class _FakeFsClient:
     created_dirs: list[str] = field(default_factory=list)
     deletes: list[tuple[str, bool]] = field(default_factory=list)
     moves: list[tuple[str, str]] = field(default_factory=list)
+    # search: canned exec responses keyed by which tool the command invokes.
+    exec_calls: list[dict] = field(default_factory=list)
+    rg_exit: int = 0
+    rg_stdout: str = ""
+    grep_exit: int = 0
+    grep_stdout: str = ""
 
     async def get_project_dir(self, sandbox_id):  # noqa: ANN001
         return self.project_dir
@@ -92,6 +106,15 @@ class _FakeFsClient:
         self.moves.append((src, dst))
         if src in self.files:
             self.files[dst] = self.files.pop(src)
+
+    async def execute_command(self, sandbox_id, command, cwd=None, timeout=None):  # noqa: ANN001
+        self.exec_calls.append({"command": command, "cwd": cwd, "timeout": timeout})
+        stripped = command.strip()
+        if stripped.startswith("rg "):
+            return _FakeExec(exit_code=self.rg_exit, result=self.rg_stdout)
+        if stripped.startswith("grep "):
+            return _FakeExec(exit_code=self.grep_exit, result=self.grep_stdout)
+        return _FakeExec(exit_code=0, result="")
 
 
 def _rpc(client: _FakeFsClient) -> FileRpc:
@@ -604,6 +627,136 @@ async def test_dispatch_move_traversal_returns_error_frame() -> None:
     assert resp["type"] == "file.error"
     assert resp["op"] == "move" and resp["reqId"] == "m9"
     assert client.moves == []
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — find-in-files search (WC-9/P3c). rg preferred, grep fallback, and the
+# injection-safety guard (the whole risk of the slice).
+# ---------------------------------------------------------------------------
+
+import shlex  # noqa: E402 — local to the search tests, kept next to them
+
+from pocketpaw_ee.cloud.websandbox import files as files_mod  # noqa: E402
+
+
+async def test_search_parses_rg_results() -> None:
+    client = _FakeFsClient(
+        rg_exit=0,
+        rg_stdout="src/app.py:12:5:    hello world\nREADME.md:3:1:hello\n",
+    )
+    results, truncated = await _rpc(client).search("hello")
+
+    assert truncated is False
+    assert results == [
+        {"path": "src/app.py", "line": 12, "col": 5, "text": "    hello world"},
+        {"path": "README.md", "line": 3, "col": 1, "text": "hello"},
+    ]
+    # Ran rg as a LITERAL, smart-case search in the jailed project root.
+    call = client.exec_calls[0]
+    assert call["cwd"] == PROJECT_DIR
+    assert call["command"].startswith("rg -F ")
+    assert "--smart-case" in call["command"]
+
+
+async def test_search_quotes_shell_metacharacters() -> None:
+    # The injection crux: a query full of shell metacharacters must reach the
+    # command as ONE literal argv token, never as executable shell.
+    evil = '"; rm -rf / #`whoami`$(id) && echo pwned'
+    client = _FakeFsClient(rg_exit=1, rg_stdout="")
+    await _rpc(client).search(evil)
+
+    cmd = client.exec_calls[0]["command"]
+    # The query appears only in its shlex-quoted form...
+    assert shlex.quote(evil) in cmd
+    # ...and re-tokenizing the command the way a shell would yields the query as a
+    # single intact argument — so no metacharacter escaped its token.
+    assert evil in shlex.split(cmd)
+    # The dangerous substring never appears unquoted as its own command.
+    assert "rm -rf / " not in cmd.replace(shlex.quote(evil), "")
+
+
+async def test_search_empty_query_is_rejected() -> None:
+    client = _FakeFsClient()
+    for bad in ("", "   ", "\t\n"):
+        with pytest.raises(FileRpcError) as ei:
+            await _rpc(client).search(bad)
+        assert ei.value.op == "search"
+    # Never shelled out for an empty query.
+    assert client.exec_calls == []
+
+
+async def test_search_exit_1_is_empty_not_error() -> None:
+    # rg exits 1 when there are simply no matches — a NORMAL empty result.
+    client = _FakeFsClient(rg_exit=1, rg_stdout="")
+    results, truncated = await _rpc(client).search("nothingmatches")
+    assert results == []
+    assert truncated is False
+
+
+async def test_search_caps_results_and_sets_truncated(monkeypatch) -> None:
+    monkeypatch.setattr(files_mod, "_SEARCH_MAX_RESULTS", 2)
+    stdout = "".join(f"f{i}.py:{i}:1:match {i}\n" for i in range(1, 6))  # 5 matches
+    client = _FakeFsClient(rg_exit=0, rg_stdout=stdout)
+
+    results, truncated = await _rpc(client).search("match")
+    assert len(results) == 2
+    assert truncated is True
+
+
+async def test_search_falls_back_to_grep_when_rg_absent() -> None:
+    # rg missing → shell exit 127 → fall back to grep, keeping the same contract.
+    client = _FakeFsClient(
+        rg_exit=127,
+        rg_stdout="",
+        grep_exit=0,
+        grep_stdout="./src/app.py:12:    hello world\n",
+    )
+    results, truncated = await _rpc(client).search("hello")
+
+    assert truncated is False
+    # grep has no column → col defaults; the leading ./ is stripped.
+    assert results == [{"path": "src/app.py", "line": 12, "col": 1, "text": "    hello world"}]
+    # A grep command was built with the VCS/build dirs excluded.
+    grep_cmd = client.exec_calls[1]["command"]
+    assert grep_cmd.startswith("grep ")
+    assert "--exclude-dir=.git" in grep_cmd
+    assert "--exclude-dir=node_modules" in grep_cmd
+
+
+async def test_search_real_rg_failure_is_error() -> None:
+    # rg exit 2 = a real error (bad flag, IO) — NOT "no matches" — surfaces cleanly.
+    client = _FakeFsClient(rg_exit=2, rg_stdout="")
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).search("hello")
+    assert ei.value.op == "search"
+
+
+async def test_search_skips_malformed_lines() -> None:
+    client = _FakeFsClient(
+        rg_exit=0,
+        rg_stdout="good.py:1:1:ok\ngarbage-without-fields\nbad.py:notanumber:1:x\n",
+    )
+    results, _ = await _rpc(client).search("x")
+    assert results == [{"path": "good.py", "line": 1, "col": 1, "text": "ok"}]
+
+
+async def test_dispatch_search_ok_frame() -> None:
+    client = _FakeFsClient(rg_exit=0, rg_stdout="a.py:1:1:hit\n")
+    resp = await _rpc(client).dispatch({"type": "file.search", "reqId": "s1", "query": "hit"})
+    assert resp == {
+        "type": "file.search.ok",
+        "reqId": "s1",
+        "query": "hit",
+        "results": [{"path": "a.py", "line": 1, "col": 1, "text": "hit"}],
+        "truncated": False,
+    }
+
+
+async def test_dispatch_search_empty_query_is_error_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch({"type": "file.search", "reqId": "s2", "query": "  "})
+    assert resp["type"] == "file.error"
+    assert resp["op"] == "search" and resp["reqId"] == "s2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_websandbox_file_rpc.py
+++ b/tests/cloud/test_websandbox_file_rpc.py
@@ -1,0 +1,504 @@
+# test_websandbox_file_rpc.py — unit tests for the Web Cursor file read/write/list
+# RPC slice (WC-4a). Created 2026-07-15 (feat/websandbox-file-rpc).
+#
+# Two tiers, no real Daytona:
+#   1. FileRpc helper driven directly with a FAKE DaytonaClient (records
+#      upload_bytes, returns canned download_file bytes + list_files). Covers the
+#      list/read/write happy paths, the path-jail (the security core), honest
+#      missing-file errors, the size cap, and malformed/unknown frames.
+#   2. The ws.py frame dispatch driven with the WC-3 FakeWebSocket harness on REAL
+#      Beanie over mongomock (the ``mongo_db`` fixture) with a real seeded owner,
+#      proving a file.write frame reaches upload_bytes with the JAILED path and
+#      the socket gets file.write.ok — and a traversal frame returns file.error
+#      and never writes.
+from __future__ import annotations
+
+import os
+from collections import deque
+from dataclasses import dataclass, field
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+
+import pytest
+from fastapi import WebSocketDisconnect
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
+from pocketpaw_ee.cloud.websandbox.files import FileRpc, FileRpcError
+from pocketpaw_ee.cloud.websandbox.ws import terminal_websocket_endpoint
+
+PROJECT_DIR = "/home/daytona/project"
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFileInfo:
+    name: str
+    is_dir: bool = False
+    size: int = 0
+
+
+@dataclass
+class _FakeFsClient:
+    """Fake DaytonaClient exposing only the file methods FileRpc uses.
+
+    Records every upload and every path it was asked to list/download so a test
+    can assert the JAILED absolute path — and that a rejected traversal never
+    reaches download/upload at all.
+    """
+
+    project_dir: str = PROJECT_DIR
+    files: dict[str, bytes] = field(default_factory=dict)  # abs path -> bytes
+    listing: list[_FakeFileInfo] = field(default_factory=list)
+    uploads: list[tuple[str, bytes]] = field(default_factory=list)
+    list_paths: list[str] = field(default_factory=list)
+    download_paths: list[str] = field(default_factory=list)
+
+    async def get_project_dir(self, sandbox_id):  # noqa: ANN001
+        return self.project_dir
+
+    async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
+        self.list_paths.append(path)
+        return list(self.listing)
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_paths.append(remote_path)
+        if remote_path not in self.files:
+            raise FileNotFoundError(remote_path)
+        return self.files[remote_path]
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.uploads.append((remote_path, data))
+        self.files[remote_path] = data
+
+
+def _rpc(client: _FakeFsClient) -> FileRpc:
+    return FileRpc(client, "dtn-1")
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — FileRpc helper (happy paths).
+# ---------------------------------------------------------------------------
+
+
+async def test_list_returns_entries_with_relative_paths() -> None:
+    client = _FakeFsClient(
+        listing=[
+            _FakeFileInfo("app.py", is_dir=False, size=42),
+            _FakeFileInfo("lib", is_dir=True, size=0),
+        ]
+    )
+    entries = await _rpc(client).list_dir("src")
+
+    # Listed the JAILED absolute path.
+    assert client.list_paths == [f"{PROJECT_DIR}/src"]
+    assert entries == [
+        {"name": "app.py", "path": "src/app.py", "isDir": False, "size": 42},
+        {"name": "lib", "path": "src/lib", "isDir": True, "size": 0},
+    ]
+
+
+async def test_list_root_uses_project_dir() -> None:
+    client = _FakeFsClient(listing=[_FakeFileInfo("README.md", size=1)])
+    entries = await _rpc(client).list_dir(".")
+    assert client.list_paths == [PROJECT_DIR]
+    assert entries[0]["path"] == "README.md"
+
+
+async def test_read_returns_file_content() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/src/app.py": b"print('hi')\n"})
+    content = await _rpc(client).read_file("src/app.py")
+    assert content == "print('hi')\n"
+    assert client.download_paths == [f"{PROJECT_DIR}/src/app.py"]
+
+
+async def test_write_calls_upload_with_jailed_path() -> None:
+    client = _FakeFsClient()
+    await _rpc(client).write_file("src/new.py", "x = 1\n")
+    assert client.uploads == [(f"{PROJECT_DIR}/src/new.py", b"x = 1\n")]
+
+
+async def test_write_then_read_round_trips() -> None:
+    client = _FakeFsClient()
+    rpc = _rpc(client)
+    await rpc.write_file("notes.txt", "hello world")
+    assert await rpc.read_file("notes.txt") == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — path jail (the must-pass security core).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "../../etc/passwd",
+        "../secret.txt",
+        "/etc/passwd",
+        "src/../../../../etc/shadow",
+        "..",
+    ],
+)
+async def test_read_traversal_is_rejected_and_never_downloads(bad_path) -> None:  # noqa: ANN001
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file(bad_path)
+    assert ei.value.op == "read"
+    # The jail rejected the path BEFORE any download was attempted.
+    assert client.download_paths == []
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    ["../../etc/passwd", "../escape.txt", "/tmp/evil", ".."],
+)
+async def test_write_traversal_is_rejected_and_never_uploads(bad_path) -> None:  # noqa: ANN001
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).write_file(bad_path, "pwned")
+    assert ei.value.op == "write"
+    assert client.uploads == []
+
+
+async def test_list_traversal_is_rejected() -> None:
+    client = _FakeFsClient(listing=[_FakeFileInfo("x")])
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).list_dir("../..")
+    assert ei.value.op == "list"
+    assert client.list_paths == []
+
+
+async def test_benign_dotdot_that_stays_inside_is_allowed() -> None:
+    # foo/../bar normalizes to bar — inside the jail, so it's allowed.
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/bar.txt": b"ok"})
+    assert await _rpc(client).read_file("foo/../bar.txt") == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — honest errors + size cap.
+# ---------------------------------------------------------------------------
+
+
+async def test_read_missing_file_is_honest_error_not_empty() -> None:
+    client = _FakeFsClient()  # no files
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file("does/not/exist.py")
+    assert ei.value.op == "read"
+    assert "no such file" in ei.value.message
+
+
+async def test_read_binary_file_is_rejected() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/img.png": b"\xff\xfe\x00\x01\x80"})
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file("img.png")
+    assert "UTF-8" in ei.value.message
+
+
+async def test_write_over_cap_is_rejected(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_MAX_FILE_KB", "1")
+    client = _FakeFsClient()
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).write_file("big.txt", "A" * 2048)  # 2 KB > 1 KB cap
+    assert ei.value.op == "write"
+    assert client.uploads == []
+
+
+async def test_read_over_cap_is_rejected(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_MAX_FILE_KB", "1")
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/big.txt": b"B" * 2048})
+    with pytest.raises(FileRpcError) as ei:
+        await _rpc(client).read_file("big.txt")
+    assert ei.value.op == "read"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — dispatch: frame shaping + malformed frames don't tear down.
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_list_ok_frame() -> None:
+    client = _FakeFsClient(listing=[_FakeFileInfo("a.py", size=3)])
+    resp = await _rpc(client).dispatch({"type": "file.list", "reqId": "r1", "path": "."})
+    assert resp == {
+        "type": "file.list.ok",
+        "reqId": "r1",
+        "path": ".",
+        "entries": [{"name": "a.py", "path": "a.py", "isDir": False, "size": 3}],
+    }
+
+
+async def test_dispatch_read_ok_frame() -> None:
+    client = _FakeFsClient(files={f"{PROJECT_DIR}/a.py": b"hi"})
+    resp = await _rpc(client).dispatch({"type": "file.read", "reqId": "r2", "path": "a.py"})
+    assert resp == {"type": "file.read.ok", "reqId": "r2", "path": "a.py", "content": "hi"}
+
+
+async def test_dispatch_write_ok_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.write", "reqId": "r3", "path": "a.py", "content": "z = 2\n"}
+    )
+    assert resp == {"type": "file.write.ok", "reqId": "r3", "path": "a.py"}
+    assert client.uploads == [(f"{PROJECT_DIR}/a.py", b"z = 2\n")]
+
+
+async def test_dispatch_traversal_returns_error_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch(
+        {"type": "file.write", "reqId": "r4", "path": "../../etc/passwd", "content": "x"}
+    )
+    assert resp["type"] == "file.error"
+    assert resp["reqId"] == "r4"
+    assert resp["op"] == "write"
+    assert client.uploads == []
+
+
+async def test_dispatch_unknown_file_op_returns_error_not_raise() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch({"type": "file.rename", "reqId": "r5", "path": "a"})
+    assert resp["type"] == "file.error"
+    assert resp["op"] == "rename"
+
+
+async def test_dispatch_non_file_frame_returns_none() -> None:
+    client = _FakeFsClient()
+    assert await _rpc(client).dispatch({"type": "input", "data": "ls\n"}) is None
+    assert await _rpc(client).dispatch({"type": "ping"}) is None
+
+
+async def test_dispatch_missing_path_is_error_frame() -> None:
+    client = _FakeFsClient()
+    resp = await _rpc(client).dispatch({"type": "file.read", "reqId": "r6"})
+    assert resp["type"] == "file.error"
+    assert resp["op"] == "read"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — ws.py frame dispatch over the real auth path (mongomock).
+#
+# Reuses the WC-3 fakes/harness (a pty must still open so the receive loop runs),
+# extended with the file methods FileRpc needs.
+# ---------------------------------------------------------------------------
+
+pytestmark_mongo = pytest.mark.usefixtures("mongo_db")
+
+
+class _FakeLicense:
+    expired = False
+
+
+class _FakeHandle:
+    def __init__(self, on_data) -> None:  # noqa: ANN001
+        self._on_data = on_data
+        self.sent: list = []
+
+    async def wait_for_connection(self) -> None:
+        return None
+
+    async def send_input(self, data) -> None:  # noqa: ANN001
+        self.sent.append(data)
+
+    async def disconnect(self) -> None:
+        return None
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.handle = None
+
+    async def create_pty_session(self, session_id, on_data, cwd=None, envs=None, pty_size=None):  # noqa: ANN001
+        self.handle = _FakeHandle(on_data)
+        return self.handle
+
+
+class _FakeSandbox:
+    def __init__(self) -> None:
+        self.process = _FakeProcess()
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Terminal fake (pty) + the file methods FileRpc calls, in one object."""
+
+    sandbox: _FakeSandbox = field(default_factory=_FakeSandbox)
+    kill_calls: list = field(default_factory=list)
+    project_dir: str = PROJECT_DIR
+    files: dict[str, bytes] = field(default_factory=dict)
+    uploads: list[tuple[str, bytes]] = field(default_factory=list)
+
+    async def get_sandbox_instance(self, sandbox_id):  # noqa: ANN001
+        return self.sandbox
+
+    async def resize_pty(self, sandbox_id, session_id, cols, rows):  # noqa: ANN001
+        return None
+
+    async def kill_pty(self, sandbox_id, session_id):  # noqa: ANN001
+        self.kill_calls.append(session_id)
+
+    async def get_project_dir(self, sandbox_id):  # noqa: ANN001
+        return self.project_dir
+
+    async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
+        return [_FakeFileInfo("app.py", is_dir=False, size=5)]
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        if remote_path not in self.files:
+            raise FileNotFoundError(remote_path)
+        return self.files[remote_path]
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.uploads.append((remote_path, data))
+        self.files[remote_path] = data
+
+
+class FakeWebSocket:
+    def __init__(self, inbound=None) -> None:  # noqa: ANN001
+        self._inbound: deque = deque(inbound or [])
+        self.accepted = False
+        self.closed = None
+        self.sent_bytes: list = []
+        self.sent_json: list = []
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code=1000, reason=None) -> None:  # noqa: ANN001
+        self.closed = (code, reason)
+
+    async def send_bytes(self, data) -> None:  # noqa: ANN001
+        self.sent_bytes.append(data)
+
+    async def send_json(self, data) -> None:  # noqa: ANN001
+        self.sent_json.append(data)
+
+    async def receive_text(self) -> str:
+        if not self._inbound:
+            raise WebSocketDisconnect(1000)
+        return self._inbound.popleft()
+
+
+async def _seed_user(active_workspace) -> str:  # noqa: ANN001
+    from pocketpaw_ee.cloud.auth.core import UserCreate, UserManager, get_user_db
+    from pocketpaw_ee.cloud.models.user import User as UserDoc
+
+    email = f"wc4-{os.urandom(4).hex()}@example.com"
+    async for db in get_user_db():
+        manager = UserManager(db)
+        user = await manager.create(UserCreate(email=email, password="StrongPass123!"))
+        doc = await UserDoc.get(user.id)
+        doc.active_workspace = active_workspace
+        await doc.save()
+        return str(user.id)
+    raise RuntimeError("user db iterator exhausted")  # pragma: no cover
+
+
+async def _seed_ready_sandbox(workspace_id, user_id) -> str:  # noqa: ANN001
+    view = await sandbox_service.create_sandbox(
+        workspace_id,
+        user_id,
+        CreateSandboxRequest(
+            repo="https://github.com/acme/api.git", status="ready", sandbox_id="dtn-1"
+        ),
+    )
+    return view.id
+
+
+@pytest.fixture
+def wire_terminal(monkeypatch):
+    client = _FakeDaytonaClient()
+    tokens: dict[str, str] = {}
+
+    async def _fake_consume(token: str):
+        return tokens.get(token)
+
+    monkeypatch.setattr(terminal_ws, "get_license", lambda: _FakeLicense())
+    monkeypatch.setattr(terminal_ws, "consume_ws_ticket", _fake_consume)
+    monkeypatch.setattr(terminal_ws, "get_daytona_client", lambda: client)
+    monkeypatch.setattr(terminal_ws, "manager", terminal_ws.TerminalConnectionManager())
+    return client, tokens
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_write_frame_reaches_upload_and_acks(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(
+        inbound=['{"type":"file.write","reqId":"w1","path":"hello.txt","content":"hi there"}']
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert ws.accepted is True
+    assert client.uploads == [(f"{PROJECT_DIR}/hello.txt", b"hi there")]
+    assert {"type": "file.write.ok", "reqId": "w1", "path": "hello.txt"} in ws.sent_json
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_read_and_list_frames_round_trip(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+    client.files[f"{PROJECT_DIR}/app.py"] = b"print(1)\n"
+
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"file.list","reqId":"l1","path":"."}',
+            '{"type":"file.read","reqId":"r1","path":"app.py"}',
+        ]
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    list_ok = [m for m in ws.sent_json if m.get("type") == "file.list.ok"]
+    read_ok = [m for m in ws.sent_json if m.get("type") == "file.read.ok"]
+    assert list_ok and list_ok[0]["entries"][0]["name"] == "app.py"
+    assert read_ok and read_ok[0]["content"] == "print(1)\n"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_file_traversal_frame_is_rejected_and_never_writes(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"file.write","reqId":"bad","path":"../../etc/passwd","content":"pwned"}'
+        ]
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert client.uploads == []
+    errs = [m for m in ws.sent_json if m.get("type") == "file.error"]
+    assert errs and errs[0]["op"] == "write" and errs[0]["reqId"] == "bad"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_ws_malformed_file_frame_does_not_tear_down_socket(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+    client.files[f"{PROJECT_DIR}/app.py"] = b"ok"
+
+    ws = FakeWebSocket(
+        inbound=[
+            "{not json",  # malformed — ignored, socket survives
+            '{"type":"file.bogus","reqId":"b1","path":"app.py"}',  # unknown file op
+            '{"type":"file.read","reqId":"r9","path":"app.py"}',  # still works after
+        ]
+    )
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert ws.closed is None  # never force-closed
+    reads = [m for m in ws.sent_json if m.get("type") == "file.read.ok"]
+    assert reads and reads[0]["content"] == "ok"

--- a/tests/cloud/test_websandbox_file_rpc.py
+++ b/tests/cloud/test_websandbox_file_rpc.py
@@ -971,9 +971,7 @@ async def test_ws_file_traversal_frame_is_rejected_and_never_writes(wire_termina
     tokens["good-ticket"] = user_id
 
     ws = FakeWebSocket(
-        inbound=[
-            '{"type":"file.write","reqId":"bad","path":"../../etc/passwd","content":"pwned"}'
-        ]
+        inbound=['{"type":"file.write","reqId":"bad","path":"../../etc/passwd","content":"pwned"}']
     )
     await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
 

--- a/tests/cloud/test_websandbox_git.py
+++ b/tests/cloud/test_websandbox_git.py
@@ -32,6 +32,7 @@ from pocketpaw_ee.cloud.codeconnect import service as codeconnect_service
 from pocketpaw_ee.cloud.websandbox import git as git_svc
 from pocketpaw_ee.cloud.websandbox import service as sandbox_service
 from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+from pocketpaw_ee.cloud.websandbox.githubapp import GitHubAppError
 
 pytestmark = pytest.mark.usefixtures("mongo_db")
 
@@ -300,3 +301,133 @@ async def test_status_not_ready_when_unprovisioned() -> None:
         await git_svc.git_status("w1", "u1", row.id, client=fake)
     assert exc.value.code == "websandbox.not_ready"
     assert fake.calls == []
+
+
+# ---------------------------------------------------------------------------
+# open pull request (WC-7/P4b).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeGitHub:
+    """Drop-in for the GitHubAppClient DI seam — only the two methods open_pr uses."""
+
+    default_branch: str = "main"
+    pr_url: str = "https://github.com/acme/api/pull/7"
+    pr_number: int = 7
+    reachable: bool = True
+    raise_pr_422: bool = False
+    calls: list = field(default_factory=list)
+
+    async def get_default_branch(self, installation_id, repo, *, now=None):  # noqa: ANN001
+        self.calls.append(("default_branch", installation_id, repo))
+        if not self.reachable:
+            raise GitHubAppError("websandbox.repo_unreachable", "not found", status=404)
+        return self.default_branch
+
+    async def create_pull_request(
+        self, installation_id, repo, *, head, base, title, body="", now=None
+    ):  # noqa: ANN001
+        self.calls.append(("pr", installation_id, repo, head, base, title, body))
+        if self.raise_pr_422:
+            raise GitHubAppError(
+                "websandbox.pr_invalid", "No commits between main and paw/edit-abc", status=422
+            )
+        return {"url": self.pr_url, "number": self.pr_number}
+
+
+async def test_open_pr_returns_url_and_number() -> None:
+    await codeconnect_service.save_connection("w1", "u1", "inst-1", account_login="octocat")
+    row_id = await _ready_row(branch="paw/edit-abc")
+    gh = _FakeGitHub(
+        default_branch="main", pr_url="https://github.com/acme/api/pull/9", pr_number=9
+    )
+
+    resp = await git_svc.open_pr(
+        "w1", "u1", row_id, {"title": "Ship it", "body": "please"},
+        client=_FakeGitDaytona(), github_client=gh,
+    )
+
+    assert resp.url == "https://github.com/acme/api/pull/9"
+    assert resp.number == 9
+    # The PR opened against the repo's default branch with the row's feature branch.
+    pr_call = next(c for c in gh.calls if c[0] == "pr")
+    _, inst, repo, head, base, title, body = pr_call
+    assert inst == "inst-1" and repo == "acme/api"
+    assert head == "paw/edit-abc" and base == "main"
+    assert title == "Ship it" and body == "please"
+
+
+async def test_open_pr_surfaces_github_422() -> None:
+    await codeconnect_service.save_connection("w1", "u1", "inst-1", account_login="octocat")
+    row_id = await _ready_row(branch="paw/edit-abc")
+    gh = _FakeGitHub(raise_pr_422=True)
+
+    with pytest.raises(CloudError) as exc:
+        await git_svc.open_pr(
+            "w1", "u1", row_id, {"title": "t"}, client=_FakeGitDaytona(), github_client=gh
+        )
+    assert exc.value.status_code == 422
+
+
+async def test_open_pr_no_reachable_connection_is_400() -> None:
+    # A connection exists but its installation can't reach the repo.
+    await codeconnect_service.save_connection("w1", "u1", "inst-1", account_login="octocat")
+    row_id = await _ready_row()
+    gh = _FakeGitHub(reachable=False)
+
+    with pytest.raises(CloudError) as exc:
+        await git_svc.open_pr(
+            "w1", "u1", row_id, {"title": "t"}, client=_FakeGitDaytona(), github_client=gh
+        )
+    assert exc.value.status_code == 400
+    # Never attempted the PR itself.
+    assert not any(c[0] == "pr" for c in gh.calls)
+
+
+async def test_open_pr_no_connection_at_all_is_400() -> None:
+    row_id = await _ready_row()  # no code connection seeded
+    gh = _FakeGitHub()
+
+    with pytest.raises(CloudError) as exc:
+        await git_svc.open_pr(
+            "w1", "u1", row_id, {"title": "t"}, client=_FakeGitDaytona(), github_client=gh
+        )
+    assert exc.value.status_code == 400
+
+
+async def test_open_pr_no_branch_is_clean_error() -> None:
+    await codeconnect_service.save_connection("w1", "u1", "inst-1", account_login="octocat")
+    row_id = await _ready_row(branch="")  # ready but no feature branch bound
+    gh = _FakeGitHub()
+
+    with pytest.raises(CloudError) as exc:
+        await git_svc.open_pr(
+            "w1", "u1", row_id, {"title": "t"}, client=_FakeGitDaytona(), github_client=gh
+        )
+    assert exc.value.code == "websandbox.no_branch"
+
+
+async def test_open_pr_denies_not_owned_row() -> None:
+    await codeconnect_service.save_connection("w2", "u1", "inst-1", account_login="octocat")
+    row_id = await _ready_row("w1", "u1")
+    gh = _FakeGitHub()
+
+    with pytest.raises(CloudError) as exc:
+        await git_svc.open_pr(
+            "w2", "u1", row_id, {"title": "t"}, client=_FakeGitDaytona(), github_client=gh
+        )
+    assert exc.value.status_code == 404
+
+
+async def test_open_pr_not_ready_when_unprovisioned() -> None:
+    row = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "https://github.com/acme/api.git", "status": "pending"}
+    )
+    gh = _FakeGitHub()
+
+    with pytest.raises(CloudError) as exc:
+        await git_svc.open_pr(
+            "w1", "u1", row.id, {"title": "t"}, client=_FakeGitDaytona(), github_client=gh
+        )
+    assert exc.value.code == "websandbox.not_ready"

--- a/tests/cloud/test_websandbox_git.py
+++ b/tests/cloud/test_websandbox_git.py
@@ -1,0 +1,302 @@
+# test_websandbox_git.py — service-level tests for the Web Cursor git write path
+# (WC-7/P4a, feat/code-mode): status / stage / commit / push.
+#
+# All Daytona interaction goes through a FAKE injected via the DI seam (``client=``
+# on each git op) — no test touches real Daytona. The registry AND the code
+# connections run on real Beanie over mongomock-motor (the ``mongo_db`` fixture) so
+# the tenant-filtered guards and the commit-identity resolution are exercised for
+# real.
+#
+# Covers:
+#   * status parses the branch header (ahead/behind) + staged / unstaged /
+#     untracked / renamed entries.
+#   * stage / unstage build the right git add / git reset commands, then return a
+#     fresh status.
+#   * commit uses the resolved identity, captures the new SHA, and refuses an empty
+#     stage cleanly (committed:false, not a crash).
+#   * commit identity resolves from the caller's GitHub connection, falling back to
+#     the PocketPaw identity when there's none.
+#   * push maps exit 0 -> pushed:true and a non-zero exit -> pushed:false + detail
+#     (never a 500).
+#   * the injection crux: a path and a commit message full of shell metacharacters
+#     are shlex-quoted to a single argv token.
+#   * tenancy: a not-owned row is a NotFound; an unprovisioned row is a clean 409.
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass, field
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.codeconnect import service as codeconnect_service
+from pocketpaw_ee.cloud.websandbox import git as git_svc
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeExec:
+    exit_code: int = 0
+    result: str = ""
+
+
+@dataclass
+class _FakeGitDaytona:
+    """Routes git commands to canned exec responses and records every call.
+
+    Drop-in for the DaytonaClient DI seam — only ``execute_command`` is used.
+    """
+
+    status_stdout: str = "## paw/edit-abc...origin/paw/edit-abc\n"
+    status_exit: int = 0
+    diff_cached_exit: int = 1  # 1 = staged changes present -> commit allowed
+    commit_exit: int = 0
+    head_sha: str = "abc1234"
+    push_exit: int = 0
+    push_output: str = ""
+    calls: list[dict] = field(default_factory=list)
+
+    async def execute_command(self, sandbox_id, command, cwd=None, timeout=None):  # noqa: ANN001
+        self.calls.append({"command": command, "cwd": cwd, "timeout": timeout})
+        c = command
+        if "status --porcelain" in c:
+            return _FakeExec(self.status_exit, self.status_stdout)
+        if "diff --cached --quiet" in c:
+            return _FakeExec(self.diff_cached_exit, "")
+        if "rev-parse HEAD" in c:
+            return _FakeExec(0, self.head_sha + "\n")
+        if " commit " in c:
+            return _FakeExec(self.commit_exit, "")
+        if " push " in c:
+            return _FakeExec(self.push_exit, self.push_output)
+        # git add / git reset
+        return _FakeExec(0, "")
+
+
+async def _ready_row(
+    workspace="w1", user="u1", sandbox_id="dtn-1", branch="paw/edit-abc"
+):  # noqa: ANN001
+    view = await sandbox_service.create_sandbox(
+        workspace, user, {"repo": "https://github.com/acme/api.git",
+                          "status": "ready", "sandbox_id": sandbox_id}
+    )
+    if branch:
+        await sandbox_service.update_status(
+            workspace,
+            user,
+            view.id,
+            {"status": "ready", "sandbox_id": sandbox_id, "branch": branch},
+        )
+    return view.id
+
+
+def _commands(fake: _FakeGitDaytona) -> list[str]:
+    return [c["command"] for c in fake.calls]
+
+
+# ---------------------------------------------------------------------------
+# status.
+# ---------------------------------------------------------------------------
+
+
+async def test_status_parses_branch_ahead_behind_and_files() -> None:
+    stdout = (
+        "## paw/edit-abc...origin/paw/edit-abc [ahead 2, behind 1]\n"
+        "M  staged_only.py\n"
+        " M unstaged_only.py\n"
+        "MM both.py\n"
+        "?? untracked.py\n"
+        "R  old_name.py -> new_name.py\n"
+    )
+    fake = _FakeGitDaytona(status_stdout=stdout)
+    row_id = await _ready_row()
+
+    resp = await git_svc.git_status("w1", "u1", row_id, client=fake)
+
+    assert resp.branch == "paw/edit-abc"
+    assert resp.ahead == 2
+    assert resp.behind == 1
+    # Ran in the jailed project root.
+    assert fake.calls[0]["cwd"] == WEBSANDBOX_WORKDIR
+    by_path = {f.path: f for f in resp.files}
+    assert by_path["staged_only.py"].index == "M" and by_path["staged_only.py"].staged is True
+    assert by_path["unstaged_only.py"].index == " " and by_path["unstaged_only.py"].staged is False
+    assert by_path["both.py"].index == "M" and by_path["both.py"].worktree == "M"
+    assert by_path["untracked.py"].index == "?" and by_path["untracked.py"].staged is False
+    # A rename reports the NEW path.
+    assert "new_name.py" in by_path and by_path["new_name.py"].staged is True
+    assert "old_name.py" not in by_path
+
+
+async def test_status_no_upstream_has_zero_ahead_behind() -> None:
+    fake = _FakeGitDaytona(status_stdout="## paw/edit-abc\n M app.py\n")
+    row_id = await _ready_row()
+    resp = await git_svc.git_status("w1", "u1", row_id, client=fake)
+    assert resp.branch == "paw/edit-abc"
+    assert resp.ahead == 0 and resp.behind == 0
+
+
+# ---------------------------------------------------------------------------
+# stage / unstage.
+# ---------------------------------------------------------------------------
+
+
+async def test_stage_adds_each_path_and_returns_status() -> None:
+    fake = _FakeGitDaytona()
+    row_id = await _ready_row()
+
+    resp = await git_svc.stage("w1", "u1", row_id, {"paths": ["a.py", "src/b.py"]}, client=fake)
+
+    cmds = _commands(fake)
+    assert "git add -- a.py" in cmds
+    assert "git add -- src/b.py" in cmds
+    # A fresh status was read after staging.
+    assert any("status --porcelain" in c for c in cmds)
+    assert resp.branch == "paw/edit-abc"
+
+
+async def test_unstage_resets_each_path() -> None:
+    fake = _FakeGitDaytona()
+    row_id = await _ready_row()
+
+    await git_svc.stage("w1", "u1", row_id, {"paths": ["a.py"], "unstage": True}, client=fake)
+
+    assert "git reset -q HEAD -- a.py" in _commands(fake)
+
+
+# ---------------------------------------------------------------------------
+# commit.
+# ---------------------------------------------------------------------------
+
+
+async def test_commit_uses_identity_and_captures_sha() -> None:
+    # Seed a GitHub connection so the commit is attributed to the real login.
+    await codeconnect_service.save_connection("w1", "u1", "inst-1", account_login="octocat")
+    fake = _FakeGitDaytona(head_sha="deadbeef")
+    row_id = await _ready_row()
+
+    resp = await git_svc.commit("w1", "u1", row_id, {"message": "fix the thing"}, client=fake)
+
+    assert resp.committed is True
+    assert resp.sha == "deadbeef"
+    commit_cmd = next(c for c in _commands(fake) if " commit " in c)
+    assert "user.name=octocat" in commit_cmd
+    assert "user.email=octocat@users.noreply.github.com" in commit_cmd
+
+
+async def test_commit_identity_falls_back_to_pocketpaw() -> None:
+    fake = _FakeGitDaytona()
+    row_id = await _ready_row()
+
+    await git_svc.commit("w1", "u1", row_id, {"message": "no connection here"}, client=fake)
+
+    commit_cmd = next(c for c in _commands(fake) if " commit " in c)
+    assert "user.name=PocketPaw" in commit_cmd
+    assert "user.email=noreply@pocketpaw.dev" in commit_cmd
+
+
+async def test_commit_refuses_empty_stage_cleanly() -> None:
+    # diff --cached --quiet exit 0 == nothing staged.
+    fake = _FakeGitDaytona(diff_cached_exit=0)
+    row_id = await _ready_row()
+
+    resp = await git_svc.commit("w1", "u1", row_id, {"message": "nothing here"}, client=fake)
+
+    assert resp.committed is False
+    assert resp.sha == ""
+    # Never ran the actual commit.
+    assert not any(" commit " in c for c in _commands(fake))
+
+
+# ---------------------------------------------------------------------------
+# push.
+# ---------------------------------------------------------------------------
+
+
+async def test_push_success() -> None:
+    fake = _FakeGitDaytona(push_exit=0)
+    row_id = await _ready_row(branch="paw/edit-xyz")
+
+    resp = await git_svc.push("w1", "u1", row_id, client=fake)
+
+    assert resp.pushed is True
+    assert resp.branch == "paw/edit-xyz"
+    push_cmd = next(c for c in _commands(fake) if " push " in c)
+    assert "git push -u origin paw/edit-xyz" in push_cmd
+
+
+async def test_push_failure_returns_detail_not_500() -> None:
+    fake = _FakeGitDaytona(
+        push_exit=128,
+        push_output="fatal: 'origin' does not appear to be a git repository\n",
+    )
+    row_id = await _ready_row()
+
+    resp = await git_svc.push("w1", "u1", row_id, client=fake)
+
+    assert resp.pushed is False
+    assert resp.branch == "paw/edit-abc"
+    assert resp.detail  # a human-readable reason, never a raised 500
+
+
+# ---------------------------------------------------------------------------
+# injection safety (the crux).
+# ---------------------------------------------------------------------------
+
+
+async def test_stage_quotes_shell_metacharacters_in_path() -> None:
+    evil = 'a.py; rm -rf / #`whoami`'
+    fake = _FakeGitDaytona()
+    row_id = await _ready_row()
+
+    await git_svc.stage("w1", "u1", row_id, {"paths": [evil]}, client=fake)
+
+    add_cmd = next(c for c in _commands(fake) if c.startswith("git add "))
+    assert shlex.quote(evil) in add_cmd
+    assert evil in shlex.split(add_cmd)
+
+
+async def test_commit_quotes_shell_metacharacters_in_message() -> None:
+    evil = 'oops"; rm -rf / #$(id) `whoami`'
+    fake = _FakeGitDaytona()
+    row_id = await _ready_row()
+
+    await git_svc.commit("w1", "u1", row_id, {"message": evil}, client=fake)
+
+    commit_cmd = next(c for c in _commands(fake) if " commit " in c)
+    assert shlex.quote(evil) in commit_cmd
+    assert evil in shlex.split(commit_cmd)
+
+
+# ---------------------------------------------------------------------------
+# tenancy.
+# ---------------------------------------------------------------------------
+
+
+async def test_status_denies_not_owned_row() -> None:
+    fake = _FakeGitDaytona()
+    row_id = await _ready_row("w1", "u1")
+
+    with pytest.raises(CloudError) as exc:
+        await git_svc.git_status("w2", "u1", row_id, client=fake)
+    assert exc.value.status_code == 404
+    assert fake.calls == []
+
+
+async def test_status_not_ready_when_unprovisioned() -> None:
+    row = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "https://github.com/acme/api.git", "status": "pending"}
+    )
+    fake = _FakeGitDaytona()
+
+    with pytest.raises(CloudError) as exc:
+        await git_svc.git_status("w1", "u1", row.id, client=fake)
+    assert exc.value.code == "websandbox.not_ready"
+    assert fake.calls == []

--- a/tests/cloud/test_websandbox_git.py
+++ b/tests/cloud/test_websandbox_git.py
@@ -81,12 +81,11 @@ class _FakeGitDaytona:
         return _FakeExec(0, "")
 
 
-async def _ready_row(
-    workspace="w1", user="u1", sandbox_id="dtn-1", branch="paw/edit-abc"
-):  # noqa: ANN001
+async def _ready_row(workspace="w1", user="u1", sandbox_id="dtn-1", branch="paw/edit-abc"):  # noqa: ANN001
     view = await sandbox_service.create_sandbox(
-        workspace, user, {"repo": "https://github.com/acme/api.git",
-                          "status": "ready", "sandbox_id": sandbox_id}
+        workspace,
+        user,
+        {"repo": "https://github.com/acme/api.git", "status": "ready", "sandbox_id": sandbox_id},
     )
     if branch:
         await sandbox_service.update_status(
@@ -253,7 +252,7 @@ async def test_push_failure_returns_detail_not_500() -> None:
 
 
 async def test_stage_quotes_shell_metacharacters_in_path() -> None:
-    evil = 'a.py; rm -rf / #`whoami`'
+    evil = "a.py; rm -rf / #`whoami`"
     fake = _FakeGitDaytona()
     row_id = await _ready_row()
 
@@ -344,8 +343,12 @@ async def test_open_pr_returns_url_and_number() -> None:
     )
 
     resp = await git_svc.open_pr(
-        "w1", "u1", row_id, {"title": "Ship it", "body": "please"},
-        client=_FakeGitDaytona(), github_client=gh,
+        "w1",
+        "u1",
+        row_id,
+        {"title": "Ship it", "body": "please"},
+        client=_FakeGitDaytona(),
+        github_client=gh,
     )
 
     assert resp.url == "https://github.com/acme/api/pull/9"

--- a/tests/cloud/test_websandbox_githubapp.py
+++ b/tests/cloud/test_websandbox_githubapp.py
@@ -20,6 +20,7 @@ from pocketpaw_ee.cloud.websandbox.githubapp import (
     GitHubAppError,
     get_github_app_client,
     github_app_enabled,
+    github_app_slug,
 )
 from pocketpaw_ee.cloud.websandbox.githubapp import (
     _reset_client_for_tests as reset_github_client,
@@ -219,6 +220,22 @@ def test_upstream_clone_url_normalizes_suffix() -> None:
     client = _client(_FakeHttp({}))
     assert client.upstream_clone_url("acme/api") == "https://github.com/acme/api.git"
     assert client.upstream_clone_url("acme/api.git") == "https://github.com/acme/api.git"
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ("devrohit06-personal", "devrohit06-personal"),  # the bare slug
+        ("  devrohit06-personal  ", "devrohit06-personal"),  # whitespace
+        # A pasted full install URL must resolve to the bare slug, not double-wrap.
+        ("https://github.com/apps/devrohit06-personal", "devrohit06-personal"),
+        ("https://github.com/apps/devrohit06-personal/installations/new", "devrohit06-personal"),
+        ("", ""),  # unset → empty (caller shows "not configured")
+    ],
+)
+def test_github_app_slug_extracts_bare_slug(monkeypatch, env: str, expected: str) -> None:
+    monkeypatch.setenv("POCKETPAW_GITHUB_APP_SLUG", env)
+    assert github_app_slug() == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_websandbox_githubapp.py
+++ b/tests/cloud/test_websandbox_githubapp.py
@@ -182,6 +182,111 @@ async def test_mint_installation_token_error_when_token_missing() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Pull request (WC-7/P4b) + default branch.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_pull_request_posts_and_returns_url_and_number() -> None:
+    http = _FakeHttp(
+        {
+            "access_tokens": _token_resp(),  # repo-scoped token minted first
+            "/pulls": _FakeResp(
+                201,
+                {"html_url": "https://github.com/acme/api/pull/7", "number": 7},
+            ),
+        }
+    )
+    client = _client(http)
+
+    result = await client.create_pull_request(
+        "inst-1",
+        "acme/api",
+        head="paw/edit-abc",
+        base="main",
+        title="Ship the thing",
+        body="does the thing",
+        now=_FIXED_NOW,
+    )
+
+    assert result == {"url": "https://github.com/acme/api/pull/7", "number": 7}
+    # The token was minted repo-scoped with contents+pull_requests write.
+    mint = http.calls[0]
+    assert mint["json"]["repositories"] == ["api"]
+    assert mint["json"]["permissions"] == {"contents": "write", "pull_requests": "write"}
+    # The PR POST hit the right URL/body/headers.
+    pr = http.calls[1]
+    assert pr["method"] == "POST"
+    assert pr["url"].endswith("/repos/acme/api/pulls")
+    assert pr["json"] == {
+        "title": "Ship the thing",
+        "head": "paw/edit-abc",
+        "base": "main",
+        "body": "does the thing",
+    }
+    assert pr["headers"]["Authorization"] == "token ghs_installationtoken"
+    assert pr["headers"]["X-GitHub-Api-Version"] == "2022-11-28"
+
+
+async def test_create_pull_request_422_surfaces_github_message() -> None:
+    http = _FakeHttp(
+        {
+            "access_tokens": _token_resp(),
+            "/pulls": _FakeResp(
+                422,
+                {
+                    "message": "Validation Failed",
+                    "errors": [{"message": "No commits between main and paw/edit-abc"}],
+                },
+            ),
+        }
+    )
+    client = _client(http)
+
+    with pytest.raises(GitHubAppError) as exc:
+        await client.create_pull_request(
+            "inst-1", "acme/api", head="paw/edit-abc", base="main",
+            title="t", body="", now=_FIXED_NOW,
+        )
+    assert exc.value.status_code == 422
+    assert "No commits between" in exc.value.message
+
+
+async def test_create_pull_request_other_error_is_clean() -> None:
+    http = _FakeHttp(
+        {"access_tokens": _token_resp(), "/pulls": _FakeResp(500, {"message": "boom"})}
+    )
+    client = _client(http)
+    with pytest.raises(GitHubAppError) as exc:
+        await client.create_pull_request(
+            "inst-1", "acme/api", head="h", base="main", title="t", now=_FIXED_NOW
+        )
+    assert exc.value.code == "websandbox.pr_failed"
+
+
+async def test_get_default_branch_returns_repo_default() -> None:
+    http = _FakeHttp(
+        {
+            "access_tokens": _token_resp(),
+            "/repos/acme/api": _FakeResp(200, {"default_branch": "trunk"}),
+        }
+    )
+    client = _client(http)
+    assert await client.get_default_branch("inst-1", "acme/api", now=_FIXED_NOW) == "trunk"
+
+
+async def test_get_default_branch_unreachable_repo_raises() -> None:
+    http = _FakeHttp(
+        {
+            "access_tokens": _token_resp(),
+            "/repos/acme/api": _FakeResp(404, {"message": "Not Found"}),
+        }
+    )
+    client = _client(http)
+    with pytest.raises(GitHubAppError):
+        await client.get_default_branch("inst-1", "acme/api", now=_FIXED_NOW)
+
+
+# ---------------------------------------------------------------------------
 # Repo listing (picker) + upstream URL.
 # ---------------------------------------------------------------------------
 

--- a/tests/cloud/test_websandbox_githubapp.py
+++ b/tests/cloud/test_websandbox_githubapp.py
@@ -222,6 +222,39 @@ def test_upstream_clone_url_normalizes_suffix() -> None:
     assert client.upstream_clone_url("acme/api.git") == "https://github.com/acme/api.git"
 
 
+# ---------------------------------------------------------------------------
+# Installation account (connected-account chip display info).
+# ---------------------------------------------------------------------------
+
+
+async def test_get_installation_account_returns_login_and_avatar() -> None:
+    http = _FakeHttp(
+        {
+            "/app/installations/inst-1": _FakeResp(
+                200,
+                {"account": {"login": "octo", "avatar_url": "https://av/o.png"}},
+            )
+        }
+    )
+    client = _client(http)
+
+    info = await client.get_installation_account("inst-1", now=_FIXED_NOW)
+
+    assert info == {"login": "octo", "avatar_url": "https://av/o.png"}
+    # Read with the App JWT (no installation token needed for this metadata).
+    assert http.calls[0]["headers"]["Authorization"].startswith("Bearer ")
+
+
+async def test_get_installation_account_none_on_error_or_missing_account() -> None:
+    # A non-200 → None (best-effort display enrichment, never an error).
+    err = _client(_FakeHttp({"/app/installations/inst-1": _FakeResp(404, {"message": "gone"})}))
+    assert await err.get_installation_account("inst-1", now=_FIXED_NOW) is None
+
+    # A 200 with no login → None (nothing worth displaying).
+    empty = _client(_FakeHttp({"/app/installations/inst-1": _FakeResp(200, {"account": {}})}))
+    assert await empty.get_installation_account("inst-1", now=_FIXED_NOW) is None
+
+
 @pytest.mark.parametrize(
     ("env", "expected"),
     [

--- a/tests/cloud/test_websandbox_githubapp.py
+++ b/tests/cloud/test_websandbox_githubapp.py
@@ -1,0 +1,275 @@
+# test_websandbox_githubapp.py — GitHub App token client + provider seam (WC-6).
+# Created 2026-07-16 (feat/code-mode).
+#
+# Verifies the "mint the token OUTSIDE the VM" half of WC-6's token isolation
+# without a live App: a generated RSA keypair signs the App JWT, and a fake
+# GitHub captures the request shaping. Locks the security-load-bearing
+# properties — single-repo scoping, least-privilege permissions, ≤10-min App JWT,
+# provider-agnostic surface — that the git-proxy broker will lean on.
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from pocketpaw_ee.cloud.websandbox.githubapp import (
+    GitHubAppClient,
+    GitHubAppError,
+    get_github_app_client,
+    github_app_enabled,
+)
+from pocketpaw_ee.cloud.websandbox.githubapp import (
+    _reset_client_for_tests as reset_github_client,
+)
+from pocketpaw_ee.cloud.websandbox.repoauth import (
+    ProviderId,
+    RepoAuthProvider,
+    ScopedRepoToken,
+    get_repo_auth_provider,
+)
+
+# One RSA keypair for the whole module — 2048-bit gen is ~100ms, do it once.
+_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIVATE_PEM = _KEY.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+).decode()
+_PUBLIC_PEM = (
+    _KEY.public_key()
+    .public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode()
+)
+
+_FIXED_NOW = datetime(2026, 7, 16, 9, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fake GitHub HTTP.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, payload: dict) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+    @property
+    def text(self) -> str:
+        return json.dumps(self._payload)
+
+
+class _FakeHttp:
+    """Captures requests, matches a canned response by URL substring."""
+
+    def __init__(self, responses: dict[str, _FakeResp]) -> None:
+        self.responses = responses
+        self.calls: list[dict] = []
+
+    async def post(self, url, *, headers, json=None):  # noqa: ANN001
+        self.calls.append({"method": "POST", "url": url, "headers": headers, "json": json})
+        return self._match(url)
+
+    async def get(self, url, *, headers):  # noqa: ANN001
+        self.calls.append({"method": "GET", "url": url, "headers": headers, "json": None})
+        return self._match(url)
+
+    def _match(self, url: str) -> _FakeResp:
+        for key, resp in self.responses.items():
+            if key in url:
+                return resp
+        raise AssertionError(f"no fake response for {url}")
+
+
+def _token_resp() -> _FakeResp:
+    return _FakeResp(
+        201,
+        {
+            "token": "ghs_installationtoken",
+            "expires_at": "2026-07-16T10:00:00Z",
+            "permissions": {"contents": "write", "pull_requests": "write"},
+        },
+    )
+
+
+def _client(http: _FakeHttp) -> GitHubAppClient:
+    return GitHubAppClient("123456", _PRIVATE_PEM, http=http)
+
+
+# ---------------------------------------------------------------------------
+# App JWT.
+# ---------------------------------------------------------------------------
+
+
+def test_app_jwt_claims_are_signed_and_within_github_limits() -> None:
+    client = _client(_FakeHttp({}))
+    token = client.app_jwt(now=_FIXED_NOW)
+    claims = jwt.decode(token, _PUBLIC_PEM, algorithms=["RS256"],
+        options={"verify_exp": False, "verify_iat": False},
+    )
+    assert claims["iss"] == "123456"
+    # iat is backdated for skew; exp - iat must not exceed GitHub's 10-min cap.
+    assert claims["iat"] < int(_FIXED_NOW.timestamp())
+    assert claims["exp"] - claims["iat"] <= 600
+
+
+def test_app_jwt_invalid_key_raises_clean_error() -> None:
+    client = GitHubAppClient("123456", "-----BEGIN PRIVATE KEY-----\nnope\n", http=_FakeHttp({}))
+    with pytest.raises(GitHubAppError) as exc:
+        client.app_jwt(now=_FIXED_NOW)
+    assert exc.value.code == "websandbox.github_app_key_invalid"
+
+
+# ---------------------------------------------------------------------------
+# Installation token — single-repo scope, least privilege.
+# ---------------------------------------------------------------------------
+
+
+async def test_mint_repo_token_scopes_to_single_repo_least_privilege() -> None:
+    http = _FakeHttp({"access_tokens": _token_resp()})
+    client = _client(http)
+
+    tok = await client.mint_repo_token("inst-1", "acme/api", now=_FIXED_NOW)
+
+    # Neutral token carries the full repo + provider + expiry.
+    assert isinstance(tok, ScopedRepoToken)
+    assert tok.provider is ProviderId.GITHUB
+    assert tok.token == "ghs_installationtoken"
+    assert tok.repo == "acme/api"
+    assert tok.expires_at == datetime(2026, 7, 16, 10, 0, 0, tzinfo=UTC)
+
+    # The request scoped to exactly ONE repo (short name) with default
+    # least-privilege permissions — never installation-wide.
+    call = http.calls[0]
+    assert call["url"].endswith("/app/installations/inst-1/access_tokens")
+    assert call["json"]["repositories"] == ["api"]
+    assert call["json"]["permissions"] == {"contents": "write", "pull_requests": "write"}
+    assert call["headers"]["Authorization"].startswith("Bearer ")
+
+
+async def test_mint_repo_token_honors_explicit_scopes() -> None:
+    http = _FakeHttp({"access_tokens": _token_resp()})
+    client = _client(http)
+    await client.mint_repo_token(
+        "inst-1", "acme/api", scopes={"contents": "read"}, now=_FIXED_NOW
+    )
+    assert http.calls[0]["json"]["permissions"] == {"contents": "read"}
+
+
+async def test_mint_installation_token_error_on_non_201() -> None:
+    http = _FakeHttp({"access_tokens": _FakeResp(404, {"message": "Not Found"})})
+    client = _client(http)
+    with pytest.raises(GitHubAppError) as exc:
+        await client.mint_repo_token("inst-1", "acme/api", now=_FIXED_NOW)
+    assert exc.value.code == "websandbox.installation_token_failed"
+
+
+async def test_mint_installation_token_error_when_token_missing() -> None:
+    http = _FakeHttp({"access_tokens": _FakeResp(201, {"expires_at": "2026-07-16T10:00:00Z"})})
+    client = _client(http)
+    with pytest.raises(GitHubAppError):
+        await client.mint_repo_token("inst-1", "acme/api", now=_FIXED_NOW)
+
+
+# ---------------------------------------------------------------------------
+# Repo listing (picker) + upstream URL.
+# ---------------------------------------------------------------------------
+
+
+async def test_list_repositories_maps_to_neutral_rows() -> None:
+    repos_payload = {
+        "repositories": [
+            {
+                "full_name": "acme/api",
+                "private": True,
+                "default_branch": "main",
+                "clone_url": "https://github.com/acme/api.git",
+            },
+            {"full_name": "acme/site", "private": False, "default_branch": "trunk"},
+        ]
+    }
+    http = _FakeHttp(
+        {
+            "access_tokens": _token_resp(),  # metadata token minted first
+            "installation/repositories": _FakeResp(200, repos_payload),
+        }
+    )
+    client = _client(http)
+
+    repos = await client.list_repositories("inst-1", now=_FIXED_NOW)
+
+    assert [r.full_name for r in repos] == ["acme/api", "acme/site"]
+    assert repos[0].private is True
+    # Missing clone_url falls back to the derived github.com URL.
+    assert repos[1].clone_url == "https://github.com/acme/site.git"
+    # The picker token was minted metadata-only, not contents/write.
+    assert http.calls[0]["json"]["permissions"] == {"metadata": "read"}
+
+
+def test_upstream_clone_url_normalizes_suffix() -> None:
+    client = _client(_FakeHttp({}))
+    assert client.upstream_clone_url("acme/api") == "https://github.com/acme/api.git"
+    assert client.upstream_clone_url("acme/api.git") == "https://github.com/acme/api.git"
+
+
+# ---------------------------------------------------------------------------
+# Provider-agnostic seam.
+# ---------------------------------------------------------------------------
+
+
+def test_github_client_satisfies_repo_auth_provider_protocol() -> None:
+    client = _client(_FakeHttp({}))
+    assert isinstance(client, RepoAuthProvider)
+    assert client.provider_id is ProviderId.GITHUB
+
+
+def test_google_provider_not_implemented_yet() -> None:
+    # The seam exists; the implementation does not — resolve to None, never crash.
+    assert get_repo_auth_provider(ProviderId.GOOGLE) is None
+
+
+def test_factory_and_resolver_disabled_without_config(monkeypatch) -> None:
+    monkeypatch.delenv("POCKETPAW_GITHUB_APP_ID", raising=False)
+    monkeypatch.delenv("POCKETPAW_GITHUB_APP_PRIVATE_KEY", raising=False)
+    reset_github_client()
+    assert github_app_enabled() is False
+    assert get_github_app_client() is None
+    assert get_repo_auth_provider(ProviderId.GITHUB) is None
+
+
+def test_factory_enabled_with_config(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_GITHUB_APP_ID", "123456")
+    monkeypatch.setenv("POCKETPAW_GITHUB_APP_PRIVATE_KEY", _PRIVATE_PEM)
+    reset_github_client()
+    try:
+        assert github_app_enabled() is True
+        client = get_github_app_client()
+        assert client is not None
+        assert get_repo_auth_provider("github") is client
+    finally:
+        reset_github_client()
+
+
+def test_private_key_accepts_escaped_newlines(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_GITHUB_APP_ID", "123456")
+    monkeypatch.setenv("POCKETPAW_GITHUB_APP_PRIVATE_KEY", _PRIVATE_PEM.replace("\n", "\\n"))
+    reset_github_client()
+    try:
+        client = get_github_app_client()
+        assert client is not None
+        # A JWT that verifies proves the escaped-newline PEM parsed correctly.
+        claims = jwt.decode(client.app_jwt(now=_FIXED_NOW), _PUBLIC_PEM, algorithms=["RS256"],
+        options={"verify_exp": False, "verify_iat": False},
+    )
+        assert claims["iss"] == "123456"
+    finally:
+        reset_github_client()

--- a/tests/cloud/test_websandbox_githubapp.py
+++ b/tests/cloud/test_websandbox_githubapp.py
@@ -114,7 +114,10 @@ def _client(http: _FakeHttp) -> GitHubAppClient:
 def test_app_jwt_claims_are_signed_and_within_github_limits() -> None:
     client = _client(_FakeHttp({}))
     token = client.app_jwt(now=_FIXED_NOW)
-    claims = jwt.decode(token, _PUBLIC_PEM, algorithms=["RS256"],
+    claims = jwt.decode(
+        token,
+        _PUBLIC_PEM,
+        algorithms=["RS256"],
         options={"verify_exp": False, "verify_iat": False},
     )
     assert claims["iss"] == "123456"
@@ -160,9 +163,7 @@ async def test_mint_repo_token_scopes_to_single_repo_least_privilege() -> None:
 async def test_mint_repo_token_honors_explicit_scopes() -> None:
     http = _FakeHttp({"access_tokens": _token_resp()})
     client = _client(http)
-    await client.mint_repo_token(
-        "inst-1", "acme/api", scopes={"contents": "read"}, now=_FIXED_NOW
-    )
+    await client.mint_repo_token("inst-1", "acme/api", scopes={"contents": "read"}, now=_FIXED_NOW)
     assert http.calls[0]["json"]["permissions"] == {"contents": "read"}
 
 
@@ -244,8 +245,13 @@ async def test_create_pull_request_422_surfaces_github_message() -> None:
 
     with pytest.raises(GitHubAppError) as exc:
         await client.create_pull_request(
-            "inst-1", "acme/api", head="paw/edit-abc", base="main",
-            title="t", body="", now=_FIXED_NOW,
+            "inst-1",
+            "acme/api",
+            head="paw/edit-abc",
+            base="main",
+            title="t",
+            body="",
+            now=_FIXED_NOW,
         )
     assert exc.value.status_code == 422
     assert "No commits between" in exc.value.message
@@ -422,9 +428,12 @@ def test_private_key_accepts_escaped_newlines(monkeypatch) -> None:
         client = get_github_app_client()
         assert client is not None
         # A JWT that verifies proves the escaped-newline PEM parsed correctly.
-        claims = jwt.decode(client.app_jwt(now=_FIXED_NOW), _PUBLIC_PEM, algorithms=["RS256"],
-        options={"verify_exp": False, "verify_iat": False},
-    )
+        claims = jwt.decode(
+            client.app_jwt(now=_FIXED_NOW),
+            _PUBLIC_PEM,
+            algorithms=["RS256"],
+            options={"verify_exp": False, "verify_iat": False},
+        )
         assert claims["iss"] == "123456"
     finally:
         reset_github_client()

--- a/tests/cloud/test_websandbox_preview.py
+++ b/tests/cloud/test_websandbox_preview.py
@@ -1,0 +1,133 @@
+# test_websandbox_preview.py — service-level tests for the Web Cursor live
+# dev-server preview endpoint (WC-8/P3b, feat/code-mode).
+#
+# All Daytona interaction goes through a FAKE injected via the DI seam
+# (``client=`` on ``preview.get_preview``) — no test touches real Daytona. The
+# registry runs on real Beanie over mongomock-motor (the ``mongo_db`` fixture) so
+# the tenant-filtered guards are exercised for real.
+#
+# Covers:
+#   * happy path returns {url, port}; the preview URL is resolved on the row's
+#     bound Daytona id + the requested port, AFTER a fail-closed authorize.
+#   * a not-owned row is a NotFound (cross-tenant is indistinguishable from
+#     missing) — resolved before any VM op.
+#   * a not-ready row (no bound Daytona id) is a clean 409, not a crash.
+#   * an out-of-range port and the reserved terminal port (22222) are rejected
+#     with a clean ValidationError before any VM op.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.websandbox import preview
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeDaytona:
+    """Records the (sandbox_id, port) it was asked to preview and returns a canned
+    iframe-embeddable URL. Drop-in for the DaytonaClient DI seam."""
+
+    url: str = "https://3000-dtn-1.h.daytona.app/?token=abc123"
+    calls: list[tuple[str, int]] = field(default_factory=list)
+
+    async def get_port_preview_url(self, sandbox_id, port):  # noqa: ANN001
+        self.calls.append((sandbox_id, port))
+        return self.url
+
+
+async def _ready_row(workspace_id: str = "w1", user_id: str = "u1", sandbox_id: str = "dtn-1"):
+    return await sandbox_service.create_sandbox(
+        workspace_id,
+        user_id,
+        {"repo": "https://github.com/octocat/Hello-World.git", "status": "ready",
+         "sandbox_id": sandbox_id},
+    )
+
+
+# ---------------------------------------------------------------------------
+# happy path.
+# ---------------------------------------------------------------------------
+
+
+async def test_get_preview_returns_url_and_port() -> None:
+    row = await _ready_row()
+    fake_dt = _FakeDaytona(url="https://3000-dtn-1.h.daytona.app/?token=xyz")
+
+    resp = await preview.get_preview("w1", "u1", row.id, 3000, client=fake_dt)
+
+    assert resp.url == "https://3000-dtn-1.h.daytona.app/?token=xyz"
+    assert resp.port == 3000
+    # The preview was resolved on the row's bound Daytona id + the requested port.
+    assert fake_dt.calls == [("dtn-1", 3000)]
+
+
+# ---------------------------------------------------------------------------
+# tenancy.
+# ---------------------------------------------------------------------------
+
+
+async def test_get_preview_denies_not_owned_row() -> None:
+    row = await _ready_row("w1", "u1")
+    fake_dt = _FakeDaytona()
+
+    # A caller in a different workspace can't resolve the row at all — NotFound,
+    # and no VM preview op runs.
+    with pytest.raises(CloudError) as exc:
+        await preview.get_preview("w2", "u1", row.id, 3000, client=fake_dt)
+    assert exc.value.status_code == 404
+    assert fake_dt.calls == []
+
+
+# ---------------------------------------------------------------------------
+# not-ready.
+# ---------------------------------------------------------------------------
+
+
+async def test_get_preview_not_ready_when_unprovisioned() -> None:
+    # A registry row that never bound a Daytona id is a clean 409, not a crash.
+    row = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git", "status": "pending"}
+    )
+    fake_dt = _FakeDaytona()
+
+    with pytest.raises(CloudError) as exc:
+        await preview.get_preview("w1", "u1", row.id, 3000, client=fake_dt)
+    assert exc.value.code == "websandbox.not_ready"
+    assert fake_dt.calls == []
+
+
+# ---------------------------------------------------------------------------
+# port validation — rejected before any VM op.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_port", [0, -1, 65536, 99999])
+async def test_get_preview_rejects_out_of_range_port(bad_port) -> None:  # noqa: ANN001
+    row = await _ready_row()
+    fake_dt = _FakeDaytona()
+
+    with pytest.raises(CloudError) as exc:
+        await preview.get_preview("w1", "u1", row.id, bad_port, client=fake_dt)
+    assert exc.value.status_code == 422
+    assert fake_dt.calls == []
+
+
+async def test_get_preview_rejects_reserved_terminal_port() -> None:
+    row = await _ready_row()
+    fake_dt = _FakeDaytona()
+
+    # 22222 is Daytona's built-in web terminal — never previewable.
+    with pytest.raises(CloudError) as exc:
+        await preview.get_preview("w1", "u1", row.id, 22222, client=fake_dt)
+    assert exc.value.status_code == 422
+    assert exc.value.code == "websandbox.reserved_port"
+    assert fake_dt.calls == []

--- a/tests/cloud/test_websandbox_preview.py
+++ b/tests/cloud/test_websandbox_preview.py
@@ -48,8 +48,11 @@ async def _ready_row(workspace_id: str = "w1", user_id: str = "u1", sandbox_id: 
     return await sandbox_service.create_sandbox(
         workspace_id,
         user_id,
-        {"repo": "https://github.com/octocat/Hello-World.git", "status": "ready",
-         "sandbox_id": sandbox_id},
+        {
+            "repo": "https://github.com/octocat/Hello-World.git",
+            "status": "ready",
+            "sandbox_id": sandbox_id,
+        },
     )
 
 

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -66,6 +66,9 @@ class _FakeDaytonaClient:
     wait_calls: list[dict] = field(default_factory=list)
     clone_calls: list[dict] = field(default_factory=list)
     exec_calls: list[str] = field(default_factory=list)
+    # Full ``execute_command`` invocations (command + cwd + timeout) so tests can
+    # assert the auto-branch ``git checkout -b`` ran with cwd=WEBSANDBOX_WORKDIR.
+    exec_invocations: list[dict] = field(default_factory=list)
     stop_calls: list[str] = field(default_factory=list)
     delete_calls: list[str] = field(default_factory=list)
     _counter: int = 0
@@ -88,8 +91,12 @@ class _FakeDaytonaClient:
         return self.project_dir
 
     async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
-        # open_sandbox runs ``mkdir -p <workdir>`` before cloning.
+        # open_sandbox runs ``mkdir -p <workdir>`` before cloning, then
+        # ``git checkout -b paw/edit-<hex>`` after (the WC-5a auto-branch).
         self.exec_calls.append(command)
+        self.exec_invocations.append(
+            {"command": command, "cwd": kwargs.get("cwd"), "timeout": kwargs.get("timeout")}
+        )
         return None
 
     async def git_clone(self, sandbox_id, repo_url, path, branch=None, commit_id=None):  # noqa: ANN001
@@ -141,6 +148,33 @@ async def test_open_provisions_clones_and_marks_ready() -> None:
     fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
     assert fetched.status == "ready"
     assert fetched.sandbox_id == "dtn-1"
+
+
+async def test_open_creates_and_binds_edit_branch() -> None:
+    # WC-5a: opening checks out a fresh ``paw/edit-<hex>`` branch IN the VM (via
+    # execute_command with cwd=WEBSANDBOX_WORKDIR) and records it on the row.
+    from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+    )
+
+    # The branch is minted, checked out in the VM, and stored on the ready row.
+    assert view.branch is not None
+    assert view.branch.startswith("paw/edit-")
+    assert view.status == "ready"
+
+    checkouts = [
+        inv for inv in fake.exec_invocations if inv["command"].startswith("git checkout -b ")
+    ]
+    assert len(checkouts) == 1
+    assert checkouts[0]["command"] == f"git checkout -b {view.branch}"
+    assert checkouts[0]["cwd"] == WEBSANDBOX_WORKDIR
+
+    # The persisted row agrees.
+    fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
+    assert fetched.branch == view.branch
 
 
 async def test_open_failure_marks_stopped_and_tears_down_vm() -> None:

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -72,6 +72,7 @@ class _FakeDaytonaClient:
     exec_invocations: list[dict] = field(default_factory=list)
     stop_calls: list[str] = field(default_factory=list)
     delete_calls: list[str] = field(default_factory=list)
+    upload_calls: list[dict] = field(default_factory=list)
     _counter: int = 0
 
     async def create_sandbox(self, name, auto_stop_interval=3600, **kwargs):  # noqa: ANN001
@@ -112,6 +113,10 @@ class _FakeDaytonaClient:
         self.clone_calls.append(
             {"id": sandbox_id, "repo_url": repo_url, "path": path, "branch": branch}
         )
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        # The broker clone path (CM-3c) ships the packed tree in via upload_bytes.
+        self.upload_calls.append({"id": sandbox_id, "data": data, "path": remote_path})
 
     async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
         return list(self.files)
@@ -158,6 +163,60 @@ async def test_open_provisions_clones_and_marks_ready() -> None:
     fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
     assert fetched.status == "ready"
     assert fetched.sandbox_id == "dtn-1"
+
+
+async def test_open_via_broker_clones_server_side_no_token_in_vm(monkeypatch) -> None:
+    # CM-3c: when a connection can authenticate the repo, open_sandbox clones via
+    # the BROKER (server-side) instead of the public in-VM git_clone. The packed
+    # tree ships in via upload_bytes, the public clone is NOT called, the feature
+    # branch is still created, and the token never reaches the VM.
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud.codeconnect import service as codeconnect_service
+    from pocketpaw_ee.cloud.websandbox import broker
+    from pocketpaw_ee.cloud.websandbox.repoauth import ProviderId, ScopedRepoToken
+
+    conn = await codeconnect_service.save_connection("w1", "u1", "inst-1")
+
+    class _Prov:
+        provider_id = ProviderId.GITHUB
+
+        async def mint_repo_token(self, connection_id, repo, *, scopes=None, now=None):  # noqa: ANN001
+            assert connection_id == conn.installation_id
+            return ScopedRepoToken(
+                provider=ProviderId.GITHUB,
+                token="tok-SECRET",
+                expires_at=datetime(2026, 7, 16, tzinfo=UTC),
+                repo=repo,
+                scopes={},
+            )
+
+    monkeypatch.setattr(broker, "get_repo_auth_provider", lambda _p: _Prov())
+
+    # Stub the real git/tar step; assert it received the CLEAN url (tokenizing is
+    # its own, server-side concern) and return canned tar bytes.
+    async def fake_pack(token, clean_url, branch):  # noqa: ANN001
+        assert clean_url == "https://github.com/owner/repo.git"
+        assert token.token == "tok-SECRET"
+        return b"PACKED-TREE"
+
+    monkeypatch.setattr(broker, "_clone_and_pack_repo", fake_pack)
+
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1", "u1", {"repo": "https://github.com/owner/repo.git"}, client=fake
+    )
+
+    assert view.status == "ready"
+    # The broker shipped the packed tree in; the public clone was NOT used.
+    assert fake.clone_calls == []
+    assert len(fake.upload_calls) == 1
+    assert fake.upload_calls[0]["data"] == b"PACKED-TREE"
+    # The auto feature branch still got created in the VM.
+    assert view.branch is not None and view.branch.startswith("paw/edit-")
+    # THE INVARIANT: the token appears in nothing sent to the VM.
+    blob = repr(fake.upload_calls) + repr(fake.exec_invocations)
+    assert "tok-SECRET" not in blob
 
 
 async def test_open_creates_and_binds_edit_branch() -> None:

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -219,6 +219,56 @@ async def test_open_via_broker_clones_server_side_no_token_in_vm(monkeypatch) ->
     assert "tok-SECRET" not in blob
 
 
+async def test_open_via_broker_wires_push_remote_when_public_url_set(monkeypatch) -> None:
+    # CM-3d: on the broker path, with a reachable public backend URL, open_sandbox
+    # repoints the VM's origin at the git proxy (so in-VM push works). Localhost is
+    # the default in the other broker test, which SKIPS wiring — here we prove the
+    # wire fires when the URL is public.
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud.codeconnect import service as codeconnect_service
+    from pocketpaw_ee.cloud.websandbox import broker
+    from pocketpaw_ee.cloud.websandbox.repoauth import ProviderId, ScopedRepoToken
+
+    monkeypatch.setenv("POCKETPAW_PUBLIC_BASE_URL", "https://app.pocketpaw.com")
+    await codeconnect_service.save_connection("w1", "u1", "inst-1")
+
+    class _Prov:
+        provider_id = ProviderId.GITHUB
+
+        async def mint_repo_token(self, connection_id, repo, *, scopes=None, now=None):  # noqa: ANN001
+            return ScopedRepoToken(
+                provider=ProviderId.GITHUB,
+                token="tok-SECRET",
+                expires_at=datetime(2026, 7, 16, tzinfo=UTC),
+                repo=repo,
+                scopes={},
+            )
+
+    monkeypatch.setattr(broker, "get_repo_auth_provider", lambda _p: _Prov())
+
+    async def fake_pack(token, clean_url, branch):  # noqa: ANN001
+        return b"PACKED-TREE"
+
+    monkeypatch.setattr(broker, "_clone_and_pack_repo", fake_pack)
+
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1", "u1", {"repo": "https://github.com/owner/repo.git"}, client=fake
+    )
+
+    assert view.status == "ready"
+    # The proxy remote was wired into the VM.
+    wires = [
+        inv for inv in fake.exec_invocations
+        if inv["command"].startswith("git remote set-url origin ")
+    ]
+    assert len(wires) == 1
+    assert "@app.pocketpaw.com/api/v1/codegit/owner/repo" in wires[0]["command"]
+    # The GitHub token still never reaches the VM.
+    assert "tok-SECRET" not in repr(fake.exec_invocations) + repr(fake.upload_calls)
+
+
 async def test_open_creates_and_binds_edit_branch() -> None:
     # WC-5a: opening checks out a fresh ``paw/edit-<hex>`` branch IN the VM (via
     # execute_command with cwd=WEBSANDBOX_WORKDIR) and records it on the row.

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -93,9 +93,7 @@ class _FakeDaytonaClient:
         return SandboxInfo(id=sid, name=name, state="creating")
 
     async def wait_for_sandbox(self, sandbox_id, target_state="started", timeout=120.0):  # noqa: ANN001
-        self.wait_calls.append(
-            {"id": sandbox_id, "target_state": target_state, "timeout": timeout}
-        )
+        self.wait_calls.append({"id": sandbox_id, "target_state": target_state, "timeout": timeout})
         return SandboxInfo(id=sandbox_id, name="", state="started")
 
     async def get_project_dir(self, sandbox_id):  # noqa: ANN001
@@ -272,7 +270,8 @@ async def test_open_via_broker_wires_push_remote_when_public_url_set(monkeypatch
     assert view.status == "ready"
     # The proxy remote was wired into the VM.
     wires = [
-        inv for inv in fake.exec_invocations
+        inv
+        for inv in fake.exec_invocations
         if inv["command"].startswith("git remote set-url origin ")
     ]
     assert len(wires) == 1

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -53,7 +53,7 @@ class _FakeDaytonaClient:
     DI seam. ``clone_fails`` flips ``git_clone`` into a raise to exercise the
     provisioning-failure path."""
 
-    project_dir: str = "/home/daytona/project"
+    project_dir: str = "/home/daytona"  # matches WEBSANDBOX_WORKDIR (clone target + jail root)
     files: list[_FakeFileInfo] = field(
         default_factory=lambda: [
             _FakeFileInfo("README.md", is_dir=False, size=42),
@@ -65,6 +65,7 @@ class _FakeDaytonaClient:
     create_calls: list[dict] = field(default_factory=list)
     wait_calls: list[dict] = field(default_factory=list)
     clone_calls: list[dict] = field(default_factory=list)
+    exec_calls: list[str] = field(default_factory=list)
     stop_calls: list[str] = field(default_factory=list)
     delete_calls: list[str] = field(default_factory=list)
     _counter: int = 0
@@ -85,6 +86,11 @@ class _FakeDaytonaClient:
 
     async def get_project_dir(self, sandbox_id):  # noqa: ANN001
         return self.project_dir
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        # open_sandbox runs ``mkdir -p <workdir>`` before cloning.
+        self.exec_calls.append(command)
+        return None
 
     async def git_clone(self, sandbox_id, repo_url, path, branch=None, commit_id=None):  # noqa: ANN001
         if self.clone_fails:

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -9,7 +9,8 @@
 # exercised for real.
 #
 # Covers:
-#   * open provisions (create called with auto_stop_interval=30), clones (the
+#   * open provisions (create called with the aggressive lifecycle: stop 5 /
+#     archive 5 / delete-on-stop), clones (the
 #     repo URL reaches git_clone), and the row ends ``ready`` with the Daytona
 #     sandbox_id bound.
 #   * open mid-flight failure marks the row ``stopped`` (never stuck ``opening``)
@@ -77,7 +78,13 @@ class _FakeDaytonaClient:
         self._counter += 1
         sid = f"dtn-{self._counter}"
         self.create_calls.append(
-            {"name": name, "auto_stop_interval": auto_stop_interval, "id": sid}
+            {
+                "name": name,
+                "auto_stop_interval": auto_stop_interval,
+                "auto_archive_interval": kwargs.get("auto_archive_interval"),
+                "auto_delete_interval": kwargs.get("auto_delete_interval"),
+                "id": sid,
+            }
         )
         return SandboxInfo(id=sid, name=name, state="creating")
 
@@ -130,9 +137,12 @@ async def test_open_provisions_clones_and_marks_ready() -> None:
         client=fake,
     )
 
-    # Cold-provision fired with the 30-MINUTE backstop (not the SDK's 60h default).
+    # Cold-provision fired with the aggressive Daytona lifecycle (all MINUTES):
+    # stop after 5 idle, archive 5 after stop, delete immediately on stop (0).
     assert len(fake.create_calls) == 1
-    assert fake.create_calls[0]["auto_stop_interval"] == 30
+    assert fake.create_calls[0]["auto_stop_interval"] == 5
+    assert fake.create_calls[0]["auto_archive_interval"] == 5
+    assert fake.create_calls[0]["auto_delete_interval"] == 0
 
     # It waited for boot before cloning, then cloned the exact repo URL.
     assert len(fake.wait_calls) == 1

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -1,0 +1,275 @@
+# test_websandbox_provision.py — service-level tests for the Web Cursor
+# cold-provision + file-tree + idle-reaper slice (WC-2).
+# Created 2026-07-15 (feat/websandbox-vm-provision).
+#
+# All Daytona interaction goes through a FAKE DaytonaClient injected via the DI
+# seam (``client=`` on every provisioning fn) — no test touches real Daytona.
+# The registry itself runs on real Beanie over mongomock-motor (the ``mongo_db``
+# fixture) so the tenant-filtered query paths and the reaper's global-read are
+# exercised for real.
+#
+# Covers:
+#   * open provisions (create called with auto_stop_interval=30), clones (the
+#     repo URL reaches git_clone), and the row ends ``ready`` with the Daytona
+#     sandbox_id bound.
+#   * open mid-flight failure marks the row ``stopped`` (never stuck ``opening``)
+#     and tears down the half-created VM.
+#   * open with no Daytona configured → clean CloudError, not a crash.
+#   * tree returns the fake listing AND enforces ``authorize_sandbox`` (a
+#     cross-tenant caller is Forbidden).
+#   * the reaper reclaims an idle VM (stop+delete, row -> reaped) and leaves a
+#     fresh row untouched.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.daytona.client import SandboxInfo
+from pocketpaw_ee.cloud.websandbox import provision
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFileInfo:
+    """Minimal stand-in for daytona's FileInfo (name / is_dir / size)."""
+
+    name: str
+    is_dir: bool = False
+    size: int = 0
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Records calls and returns canned data. Drop-in for DaytonaClient in the
+    DI seam. ``clone_fails`` flips ``git_clone`` into a raise to exercise the
+    provisioning-failure path."""
+
+    project_dir: str = "/home/daytona/project"
+    files: list[_FakeFileInfo] = field(
+        default_factory=lambda: [
+            _FakeFileInfo("README.md", is_dir=False, size=42),
+            _FakeFileInfo("src", is_dir=True, size=0),
+        ]
+    )
+    clone_fails: bool = False
+
+    create_calls: list[dict] = field(default_factory=list)
+    wait_calls: list[dict] = field(default_factory=list)
+    clone_calls: list[dict] = field(default_factory=list)
+    stop_calls: list[str] = field(default_factory=list)
+    delete_calls: list[str] = field(default_factory=list)
+    _counter: int = 0
+
+    async def create_sandbox(self, name, auto_stop_interval=3600, **kwargs):  # noqa: ANN001
+        self._counter += 1
+        sid = f"dtn-{self._counter}"
+        self.create_calls.append(
+            {"name": name, "auto_stop_interval": auto_stop_interval, "id": sid}
+        )
+        return SandboxInfo(id=sid, name=name, state="creating")
+
+    async def wait_for_sandbox(self, sandbox_id, target_state="started", timeout=120.0):  # noqa: ANN001
+        self.wait_calls.append(
+            {"id": sandbox_id, "target_state": target_state, "timeout": timeout}
+        )
+        return SandboxInfo(id=sandbox_id, name="", state="started")
+
+    async def get_project_dir(self, sandbox_id):  # noqa: ANN001
+        return self.project_dir
+
+    async def git_clone(self, sandbox_id, repo_url, path, branch=None, commit_id=None):  # noqa: ANN001
+        if self.clone_fails:
+            raise RuntimeError("boom: clone failed")
+        self.clone_calls.append(
+            {"id": sandbox_id, "repo_url": repo_url, "path": path, "branch": branch}
+        )
+
+    async def list_files(self, sandbox_id, path="."):  # noqa: ANN001
+        return list(self.files)
+
+    async def stop_sandbox(self, sandbox_id):  # noqa: ANN001
+        self.stop_calls.append(sandbox_id)
+
+    async def delete_sandbox(self, sandbox_id):  # noqa: ANN001
+        self.delete_calls.append(sandbox_id)
+
+
+# ---------------------------------------------------------------------------
+# open flow.
+# ---------------------------------------------------------------------------
+
+
+async def test_open_provisions_clones_and_marks_ready() -> None:
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1",
+        "u1",
+        {"repo": "https://github.com/octocat/Hello-World.git"},
+        client=fake,
+    )
+
+    # Cold-provision fired with the 30-MINUTE backstop (not the SDK's 60h default).
+    assert len(fake.create_calls) == 1
+    assert fake.create_calls[0]["auto_stop_interval"] == 30
+
+    # It waited for boot before cloning, then cloned the exact repo URL.
+    assert len(fake.wait_calls) == 1
+    assert len(fake.clone_calls) == 1
+    assert fake.clone_calls[0]["repo_url"] == "https://github.com/octocat/Hello-World.git"
+    assert fake.clone_calls[0]["path"] == fake.project_dir
+
+    # The row ended ``ready`` with the Daytona id bound.
+    assert view.status == "ready"
+    assert view.sandbox_id == "dtn-1"
+
+    # And the persisted row agrees.
+    fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
+    assert fetched.status == "ready"
+    assert fetched.sandbox_id == "dtn-1"
+
+
+async def test_open_failure_marks_stopped_and_tears_down_vm() -> None:
+    fake = _FakeDaytonaClient(clone_fails=True)
+    with pytest.raises(CloudError) as exc:
+        await provision.open_sandbox(
+            "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+        )
+    assert exc.value.code == "websandbox.provision_failed"
+
+    # The half-created VM was torn down.
+    assert fake.delete_calls == ["dtn-1"]
+
+    # The row is ``stopped`` — never left stuck in ``opening``.
+    rows = await sandbox_service.list_sandboxes("w1", "u1")
+    assert len(rows) == 1
+    assert rows[0].status == "stopped"
+
+
+async def test_open_rejects_non_http_repo() -> None:
+    fake = _FakeDaytonaClient()
+    with pytest.raises(CloudError) as exc:
+        await provision.open_sandbox(
+            "w1", "u1", {"repo": "git@github.com:acme/api.git"}, client=fake
+        )
+    assert exc.value.code == "websandbox.invalid_repo"
+    # Nothing was provisioned.
+    assert fake.create_calls == []
+
+
+async def test_open_without_daytona_raises_clean_error(monkeypatch) -> None:
+    # get_daytona_client() -> None when Daytona keys are unset; must be a clean
+    # CloudError, not an AttributeError crash on a None client.
+    monkeypatch.setattr(provision, "get_daytona_client", lambda: None)
+    with pytest.raises(CloudError) as exc:
+        await provision.open_sandbox(
+            "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=None
+        )
+    assert exc.value.code == "websandbox.daytona_unavailable"
+    assert exc.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# tree flow.
+# ---------------------------------------------------------------------------
+
+
+async def test_tree_returns_listing_for_owner() -> None:
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+    )
+    tree = await provision.get_tree("w1", "u1", view.id, client=fake)
+
+    assert tree.sandboxId == "dtn-1"
+    assert tree.path == fake.project_dir
+    names = {(e.name, e.isDir) for e in tree.entries}
+    assert names == {("README.md", False), ("src", True)}
+
+
+async def test_tree_denies_cross_tenant_caller() -> None:
+    fake = _FakeDaytonaClient()
+    view = await provision.open_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git"}, client=fake
+    )
+    # A caller in a DIFFERENT workspace must not resolve the row at all
+    # (get_sandbox is NotFound before authorize even runs) — never the listing.
+    with pytest.raises(CloudError):
+        await provision.get_tree("w2", "u1", view.id, client=fake)
+
+
+async def test_tree_not_ready_when_unprovisioned() -> None:
+    # A registry row that never bound a Daytona id is a clean 409, not a crash.
+    row = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "https://github.com/octocat/Hello-World.git", "status": "pending"}
+    )
+    fake = _FakeDaytonaClient()
+    with pytest.raises(CloudError) as exc:
+        await provision.get_tree("w1", "u1", row.id, client=fake)
+    assert exc.value.code == "websandbox.not_ready"
+
+
+# ---------------------------------------------------------------------------
+# idle-TTL reaper.
+# ---------------------------------------------------------------------------
+
+
+async def _age_row(row_id: str, *, seconds: int) -> None:
+    """Push a row's ``updated_at`` into the past (test-only doc touch)."""
+    from beanie import PydanticObjectId
+    from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox
+
+    doc = await WebSandbox.find_one({"_id": PydanticObjectId(row_id)})
+    assert doc is not None
+    doc.updated_at = datetime.now(UTC) - timedelta(seconds=seconds)
+    await doc.save()
+
+
+async def test_reaper_reclaims_idle_and_spares_fresh(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS", "1800")
+
+    idle = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "r-idle", "status": "ready", "sandbox_id": "dtn-idle"}
+    )
+    fresh = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "r-fresh", "status": "ready", "sandbox_id": "dtn-fresh"}
+    )
+    # Age the idle row well past the 1800s TTL; leave the fresh one at "now".
+    await _age_row(idle.id, seconds=7200)
+
+    fake = _FakeDaytonaClient()
+    reaped = await provision.reap_idle_sandboxes(client=fake)
+
+    assert reaped == 1
+    # The idle VM was stopped then deleted; the fresh one was left alone.
+    assert fake.delete_calls == ["dtn-idle"]
+    assert "dtn-idle" in fake.stop_calls
+    assert "dtn-fresh" not in fake.delete_calls
+
+    assert (await sandbox_service.get_sandbox("w1", "u1", idle.id)).status == "reaped"
+    assert (await sandbox_service.get_sandbox("w1", "u1", fresh.id)).status == "ready"
+
+
+async def test_reaper_marks_unprovisioned_idle_row_reaped(monkeypatch) -> None:
+    # An ``opening`` row that never bound a Daytona id is still reclaimable — no
+    # VM to delete, just flip it to ``reaped`` so it stops looking in-flight.
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_IDLE_TTL_SECONDS", "1800")
+    stuck = await sandbox_service.create_sandbox(
+        "w1", "u1", {"repo": "r-stuck", "status": "opening"}
+    )
+    await _age_row(stuck.id, seconds=7200)
+
+    fake = _FakeDaytonaClient()
+    reaped = await provision.reap_idle_sandboxes(client=fake)
+
+    assert reaped == 1
+    assert fake.delete_calls == []  # nothing to delete
+    assert (await sandbox_service.get_sandbox("w1", "u1", stuck.id)).status == "reaped"

--- a/tests/cloud/test_websandbox_provision.py
+++ b/tests/cloud/test_websandbox_provision.py
@@ -72,6 +72,9 @@ class _FakeDaytonaClient:
     exec_invocations: list[dict] = field(default_factory=list)
     stop_calls: list[str] = field(default_factory=list)
     delete_calls: list[str] = field(default_factory=list)
+    # VM ids Daytona destroyed on its own (delete-on-stop) without going through
+    # this client's delete_sandbox — so get_sandbox_by_id raises for them.
+    deleted_out_of_band: set[str] = field(default_factory=set)
     upload_calls: list[dict] = field(default_factory=list)
     _counter: int = 0
 
@@ -126,6 +129,15 @@ class _FakeDaytonaClient:
 
     async def delete_sandbox(self, sandbox_id):  # noqa: ANN001
         self.delete_calls.append(sandbox_id)
+
+    async def get_sandbox_by_id(self, sandbox_id):  # noqa: ANN001
+        # Mirrors the real client: a deleted/reaped VM no longer resolves (raises);
+        # a live one comes back ``started``. ``deleted_out_of_band`` lets a test
+        # simulate Daytona's own delete-on-stop reclaiming an idle VM while the
+        # Mongo row still reads ``ready``.
+        if sandbox_id in self.delete_calls or sandbox_id in self.deleted_out_of_band:
+            raise RuntimeError(f"sandbox {sandbox_id} not found")
+        return SandboxInfo(id=sandbox_id, name="", state="started")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_websandbox_routes.py
+++ b/tests/cloud/test_websandbox_routes.py
@@ -1,0 +1,72 @@
+# test_websandbox_routes.py — guards against path-capture bugs in the websandbox
+# router (BP-3b follow-up).
+#
+# Why this exists: the router registers ``GET /{row_id}`` early, and FastAPI
+# matches routes in REGISTRATION ORDER. So any collection-level route added later
+# with a single path segment — ``/repo-archive``, say — is silently swallowed by
+# ``/{row_id}`` and resolves to "look up a sandbox with that id", which 404s. It
+# is a confusing failure: the endpoint exists, the client calls the right URL,
+# and the server answers 404 as though the route were never registered.
+#
+# That happened. The fix is structural (put such routes under a two-segment
+# prefix), and this test keeps it fixed: every literal GET path registered after
+# ``/{row_id}`` must have at least two segments.
+from __future__ import annotations
+
+from fastapi.routing import APIRoute
+from pocketpaw_ee.cloud.websandbox.router import router
+
+# Paths include the router's own prefix.
+_PREFIX = "/websandbox"
+_ROW_ID_PATH = f"{_PREFIX}/{{row_id}}"
+
+
+def _sub_segments(path: str) -> list[str]:
+    """Segments BELOW the router prefix (what /{row_id} competes with)."""
+    rest = path[len(_PREFIX) :] if path.startswith(_PREFIX) else path
+    return [seg for seg in rest.strip("/").split("/") if seg]
+
+
+def _routes() -> list[APIRoute]:
+    return [r for r in router.routes if isinstance(r, APIRoute)]
+
+
+def test_row_id_route_is_registered() -> None:
+    # If this ever moves, the reasoning below needs revisiting.
+    paths = [r.path for r in _routes()]
+    assert _ROW_ID_PATH in paths
+
+
+def test_no_single_segment_literal_get_is_shadowed_by_row_id() -> None:
+    """A one-segment literal GET after /{row_id} can never be reached."""
+    routes = _routes()
+    row_id_index = next(i for i, r in enumerate(routes) if r.path == _ROW_ID_PATH)
+
+    shadowed = []
+    for route in routes[row_id_index + 1 :]:
+        if "GET" not in route.methods:
+            continue
+        segments = _sub_segments(route.path)
+        if len(segments) != 1:
+            continue
+        # A single segment that is a literal (not a path param) collides.
+        if segments[0] and not segments[0].startswith("{"):
+            shadowed.append(route.path)
+
+    assert not shadowed, (
+        f"These GET routes are unreachable — /{{row_id}} captures them first: {shadowed}. "
+        "Give them a two-segment path (e.g. /browserpod/<name>) or register them "
+        "before /{row_id}."
+    )
+
+
+def test_repo_archive_is_reachable() -> None:
+    """The archive endpoint specifically — this is the one that regressed."""
+    archive = next(
+        (r for r in _routes() if r.path.endswith("repo-archive")),
+        None,
+    )
+    assert archive is not None, "repo-archive route is missing"
+    assert len(_sub_segments(archive.path)) >= 2, (
+        f"{archive.path} has one literal segment and will be captured by /{{row_id}}"
+    )

--- a/tests/cloud/test_websandbox_security_hardening.py
+++ b/tests/cloud/test_websandbox_security_hardening.py
@@ -1,0 +1,188 @@
+# test_websandbox_security_hardening.py — regression tests for the 2026-07-16
+# review-hardening pass on the Web Cursor cloud backend.
+#
+# Locks four fixes surfaced by the pre-merge self-review of PR #1730:
+#   1. HIGH — the client register route must NOT let a caller bind a server-owned
+#      ``sandbox_id``. authorize_sandbox trusts the row's Daytona id as the
+#      ownership key, so a forgeable binding was a cross-tenant VM takeover. The
+#      route now binds the repo-only ``RegisterSandboxRequest`` and there is no
+#      client PATCH lifecycle route. Tested at the actual router boundary + an
+#      end-to-end "the oracle still denies the attacker" proof.
+#   2. MEDIUM — re-opening a repo must tear down the previously-bound VM instead
+#      of orphaning it (the reaper sweeps rows, not dangling Daytona ids).
+#   3. MEDIUM — a per-user cap on concurrent live sandboxes, so an authenticated
+#      tenant can't cold-boot unbounded VMs by varying the repo URL.
+#   4. LOW — a repo URL that embeds credentials is rejected (public-repo path).
+#
+# Registry runs on real Beanie over mongomock-motor (``mongo_db``); Daytona is the
+# injected fake from the provision suite. No test touches real Daytona.
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import BadRequest, ConflictError, Forbidden
+from pocketpaw_ee.cloud.websandbox import provision
+from pocketpaw_ee.cloud.websandbox import router as websandbox_router
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox.dto import (
+    CreateSandboxRequest,
+    RegisterSandboxRequest,
+)
+
+from tests.cloud.test_websandbox_provision import _FakeDaytonaClient
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace_id: str, user_id: str) -> RequestContext:
+    """A minimal authed RequestContext for calling a router handler directly."""
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test-req",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. HIGH — client cannot forge a sandbox_id binding.
+# ---------------------------------------------------------------------------
+
+
+def test_register_request_is_repo_only() -> None:
+    # The client-facing model carries ONLY repo — no server-owned fields to smuggle.
+    assert set(RegisterSandboxRequest.model_fields) == {"repo"}
+    # Extra fields on the wire are dropped, never bound.
+    body = RegisterSandboxRequest.model_validate(
+        {"repo": "https://github.com/x/y", "sandbox_id": "victim-vm", "status": "ready"}
+    )
+    assert not hasattr(body, "sandbox_id")
+
+
+def test_no_client_patch_lifecycle_route() -> None:
+    # Lifecycle is server-owned; there must be no client PATCH route through which
+    # a caller could bind an arbitrary sandbox_id / status.
+    methods = {
+        (route.path, method)
+        for route in websandbox_router.router.routes
+        for method in getattr(route, "methods", set())
+    }
+    assert ("/websandbox/{row_id}", "PATCH") not in methods
+
+
+async def test_register_route_ignores_client_supplied_sandbox_id() -> None:
+    # An attacker POSTs a body that tries to bind another tenant's Daytona id.
+    body = RegisterSandboxRequest.model_validate(
+        {"repo": "https://github.com/x/y", "sandbox_id": "victim-vm", "status": "ready"}
+    )
+    view = await websandbox_router.create_sandbox(body, _ctx("attacker-ws", "attacker"))
+    # The row is registered clean: no bound VM, status pending — both server-owned.
+    assert view.sandboxId is None
+    assert view.status == "pending"
+
+
+async def test_client_register_cannot_hijack_another_tenants_vm() -> None:
+    # Victim's VM is bound through the trusted provisioner path (internal command).
+    await sandbox_service.create_sandbox(
+        "victim-ws",
+        "victim",
+        CreateSandboxRequest(repo="r", status="ready", sandbox_id="victim-vm"),
+    )
+    # Attacker registers a row pointing at the victim's id via the CLIENT route.
+    body = RegisterSandboxRequest.model_validate(
+        {"repo": "r2", "sandbox_id": "victim-vm", "status": "ready"}
+    )
+    await websandbox_router.create_sandbox(body, _ctx("attacker-ws", "attacker"))
+    # Because the attacker's row never bound the victim id, the oracle still denies
+    # them — no row in the attacker's workspace references victim-vm.
+    with pytest.raises(Forbidden):
+        await sandbox_service.authorize_sandbox("attacker-ws", "attacker", "victim-vm")
+
+
+# ---------------------------------------------------------------------------
+# 2. MEDIUM — re-open tears down the orphaned VM.
+# ---------------------------------------------------------------------------
+
+
+async def test_reopen_same_repo_deletes_previous_vm() -> None:
+    fake = _FakeDaytonaClient()
+    repo = "https://github.com/octocat/Hello-World.git"
+
+    first = await provision.open_sandbox("w1", "u1", {"repo": repo}, client=fake)
+    assert first.sandbox_id == "dtn-1"
+
+    # Re-open the same repo: a new VM is provisioned and the row rebinds to it.
+    second = await provision.open_sandbox("w1", "u1", {"repo": repo}, client=fake)
+    assert second.id == first.id  # same registry row (idempotent key)
+    assert second.sandbox_id == "dtn-2"
+
+    # The now-orphaned first VM was stopped + deleted instead of leaking.
+    assert "dtn-1" in fake.delete_calls
+    assert "dtn-2" not in fake.delete_calls
+
+
+# ---------------------------------------------------------------------------
+# 3. MEDIUM — per-user concurrent-sandbox cap.
+# ---------------------------------------------------------------------------
+
+
+async def test_open_rejects_past_per_user_cap(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_MAX_PER_USER", "2")
+    fake = _FakeDaytonaClient()
+
+    await provision.open_sandbox("w1", "u1", {"repo": "https://github.com/a/one.git"}, client=fake)
+    await provision.open_sandbox("w1", "u1", {"repo": "https://github.com/a/two.git"}, client=fake)
+
+    # A THIRD distinct repo is over the cap of 2 → clean ConflictError, no VM booted.
+    calls_before = len(fake.create_calls)
+    with pytest.raises(ConflictError) as exc:
+        await provision.open_sandbox(
+            "w1", "u1", {"repo": "https://github.com/a/three.git"}, client=fake
+        )
+    assert exc.value.code == "websandbox.too_many"
+    assert len(fake.create_calls) == calls_before  # short-circuited before provisioning
+
+
+async def test_reopen_existing_repo_not_blocked_by_cap(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_MAX_PER_USER", "1")
+    fake = _FakeDaytonaClient()
+    repo = "https://github.com/a/one.git"
+
+    await provision.open_sandbox("w1", "u1", {"repo": repo}, client=fake)
+    # Re-opening the SAME repo reuses its row — not a new slot, so the cap of 1
+    # does not reject it.
+    again = await provision.open_sandbox("w1", "u1", {"repo": repo}, client=fake)
+    assert again.status == "ready"
+
+
+async def test_cap_is_per_user_not_per_workspace(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_WEBSANDBOX_MAX_PER_USER", "1")
+    fake = _FakeDaytonaClient()
+
+    await provision.open_sandbox("w1", "u1", {"repo": "https://github.com/a/one.git"}, client=fake)
+    # A different user in the same workspace has their own budget.
+    other = await provision.open_sandbox(
+        "w1", "u2", {"repo": "https://github.com/a/two.git"}, client=fake
+    )
+    assert other.status == "ready"
+
+
+# ---------------------------------------------------------------------------
+# 4. LOW — credential-bearing repo URLs are rejected.
+# ---------------------------------------------------------------------------
+
+
+async def test_open_rejects_url_with_embedded_credentials() -> None:
+    fake = _FakeDaytonaClient()
+    with pytest.raises(BadRequest) as exc:
+        await provision.open_sandbox(
+            "w1",
+            "u1",
+            {"repo": "https://user:token@github.com/octocat/Hello-World.git"},
+            client=fake,
+        )
+    assert exc.value.code == "websandbox.invalid_repo"
+    assert fake.create_calls == []  # rejected before any VM was provisioned

--- a/tests/cloud/test_websandbox_service.py
+++ b/tests/cloud/test_websandbox_service.py
@@ -1,0 +1,197 @@
+# test_websandbox_service.py — service-level tests for the Web Cursor Sandbox
+# Registry (WC-1). Created 2026-07-15 (feat/websandbox-registry).
+#
+# Covers the security core: a create->get round-trip, fail-closed
+# ``authorize_sandbox`` for a non-owning caller (cross-workspace AND
+# cross-user-same-workspace), the audit event that a denial writes, the
+# owner-scoped ``list_sandboxes``, and the Rule-3 construction-time tenancy
+# guard on the domain value object. Uses the ``mongo_db`` fixture (real Beanie
+# over mongomock-motor) so the tenant-filtered query paths are exercised, not a
+# Protocol fake.
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound
+from pocketpaw_ee.cloud.models.audit_event import AuditEvent
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
+from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# create -> get round-trip
+# ---------------------------------------------------------------------------
+
+
+async def test_create_then_get_round_trips() -> None:
+    view = await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="github.com/acme/api", sandbox_id="sbx-1")
+    )
+    assert view.workspace_id == "w1"
+    assert view.user_id == "u1"
+    assert view.repo == "github.com/acme/api"
+    assert view.sandbox_id == "sbx-1"
+    assert view.status == "pending"
+
+    fetched = await sandbox_service.get_sandbox("w1", "u1", view.id)
+    assert fetched.id == view.id
+    assert fetched.repo == "github.com/acme/api"
+
+
+async def test_create_is_idempotent_on_registry_key() -> None:
+    first = await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", status="pending")
+    )
+    second = await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", status="ready", sandbox_id="sbx-9")
+    )
+    # Same row (one sandbox per (workspace, user, repo)), updated in place.
+    assert second.id == first.id
+    assert second.status == "ready"
+    assert second.sandbox_id == "sbx-9"
+
+    rows = await sandbox_service.list_sandboxes("w1", "u1")
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# authorize_sandbox — fail closed
+# ---------------------------------------------------------------------------
+
+
+async def test_authorize_allows_owner() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    view = await sandbox_service.authorize_sandbox("w1", "u1", "sbx-1")
+    assert view.sandbox_id == "sbx-1"
+    assert view.workspace_id == "w1"
+
+
+async def test_authorize_denies_cross_workspace() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    # Same sandbox id, a caller in a DIFFERENT workspace. Tenant filter returns
+    # nothing -> fail closed.
+    with pytest.raises(Forbidden) as exc:
+        await sandbox_service.authorize_sandbox("w2", "u1", "sbx-1")
+    assert exc.value.status_code == 403
+
+
+async def test_authorize_denies_cross_user_same_workspace() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    # Same workspace, a DIFFERENT user. Row is found by the tenant filter but
+    # the owner check fails -> fail closed with the same opaque Forbidden.
+    with pytest.raises(Forbidden) as exc:
+        await sandbox_service.authorize_sandbox("w1", "u2", "sbx-1")
+    assert exc.value.status_code == 403
+
+
+async def test_authorize_denies_unknown_sandbox() -> None:
+    with pytest.raises(Forbidden):
+        await sandbox_service.authorize_sandbox("w1", "u1", "does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# A denial WRITES a high-severity audit event
+# ---------------------------------------------------------------------------
+
+
+async def test_denial_writes_cross_tenant_audit_event() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+
+    before = await AuditEvent.find({"action": "vm.cross_tenant_denied"}).to_list()
+    assert before == []
+
+    with pytest.raises(Forbidden):
+        await sandbox_service.authorize_sandbox("w1", "u2", "sbx-1")
+
+    rows = await AuditEvent.find({"action": "vm.cross_tenant_denied"}).to_list()
+    assert len(rows) == 1
+    ev = rows[0]
+    assert ev.workspace == "w1"
+    assert ev.actor_id == "u2"
+    assert ev.target_type == "web_sandbox"
+    assert ev.target_id == "sbx-1"
+    assert ev.metadata.get("reason") == "wrong_owner"
+
+
+async def test_allowed_authorize_writes_no_denial_event() -> None:
+    await sandbox_service.create_sandbox(
+        "w1", "u1", CreateSandboxRequest(repo="r1", sandbox_id="sbx-1")
+    )
+    await sandbox_service.authorize_sandbox("w1", "u1", "sbx-1")
+
+    rows = await AuditEvent.find({"action": "vm.cross_tenant_denied"}).to_list()
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# list_sandboxes — tenant + owner scoped
+# ---------------------------------------------------------------------------
+
+
+async def test_list_returns_only_callers_rows() -> None:
+    await sandbox_service.create_sandbox("w1", "u1", CreateSandboxRequest(repo="a"))
+    await sandbox_service.create_sandbox("w1", "u1", CreateSandboxRequest(repo="b"))
+    # Same workspace, different user — must not appear in u1's list.
+    await sandbox_service.create_sandbox("w1", "u2", CreateSandboxRequest(repo="c"))
+    # Different workspace — must not appear either.
+    await sandbox_service.create_sandbox("w2", "u1", CreateSandboxRequest(repo="d"))
+
+    rows = await sandbox_service.list_sandboxes("w1", "u1")
+    assert {r.repo for r in rows} == {"a", "b"}
+
+
+async def test_get_denies_cross_tenant_row() -> None:
+    other = await sandbox_service.create_sandbox("w2", "u1", CreateSandboxRequest(repo="r1"))
+    # A caller in w1 must not be able to read a w2 row by id — indistinguishable
+    # from a missing row.
+    with pytest.raises(NotFound):
+        await sandbox_service.get_sandbox("w1", "u1", other.id)
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — domain enforces tenancy at construction
+# ---------------------------------------------------------------------------
+
+
+def test_domain_requires_tenancy_fields() -> None:
+    # Omitting workspace_id / user_id is a construction-time TypeError — the
+    # frozen dataclass has no defaults for the tenancy fields.
+    with pytest.raises(TypeError):
+        WebSandboxView(  # type: ignore[call-arg]
+            id="x",
+            repo="r1",
+            status="pending",
+            sandbox_id=None,
+            installation_id=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+
+def test_domain_is_frozen() -> None:
+    view = WebSandboxView(
+        id="x",
+        workspace_id="w1",
+        user_id="u1",
+        repo="r1",
+        status="pending",
+        sandbox_id=None,
+        installation_id=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        view.workspace_id = "w2"  # type: ignore[misc]

--- a/tests/cloud/test_websandbox_service.py
+++ b/tests/cloud/test_websandbox_service.py
@@ -162,6 +162,37 @@ async def test_get_denies_cross_tenant_row() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Write-through overlay (CM-2a′)
+# ---------------------------------------------------------------------------
+
+
+async def test_set_overlay_entry_records_and_is_last_write_wins() -> None:
+    row = await sandbox_service.create_sandbox("w1", "u1", CreateSandboxRequest(repo="r1"))
+    await sandbox_service.set_overlay_entry("w1", "u1", row.id, "a.ts", "file-1")
+    await sandbox_service.set_overlay_entry("w1", "u1", row.id, "b.ts", "file-2")
+    await sandbox_service.set_overlay_entry("w1", "u1", row.id, "a.ts", "file-3")  # overwrite
+
+    fetched = await sandbox_service.get_sandbox("w1", "u1", row.id)
+    assert fetched.overlay == {"a.ts": "file-3", "b.ts": "file-2"}
+
+
+async def test_set_overlay_entry_is_owner_scoped() -> None:
+    row = await sandbox_service.create_sandbox("w1", "u1", CreateSandboxRequest(repo="r1"))
+    # A different user in the same workspace can't mirror onto this row.
+    with pytest.raises(NotFound):
+        await sandbox_service.set_overlay_entry("w1", "u2", row.id, "a.ts", "file-1")
+
+
+async def test_set_snapshot_clears_the_overlay() -> None:
+    row = await sandbox_service.create_sandbox("w1", "u1", CreateSandboxRequest(repo="r1"))
+    await sandbox_service.set_overlay_entry("w1", "u1", row.id, "a.ts", "file-1")
+    # A full snapshot supersedes the incremental overlay.
+    snap = await sandbox_service.set_snapshot("w1", "u1", row.id, "snap-1")
+    assert snap.snapshot_file_id == "snap-1"
+    assert snap.overlay == {}
+
+
+# ---------------------------------------------------------------------------
 # Rule 3 — domain enforces tenancy at construction
 # ---------------------------------------------------------------------------
 

--- a/tests/cloud/test_websandbox_terminal.py
+++ b/tests/cloud/test_websandbox_terminal.py
@@ -517,3 +517,44 @@ def test_activity_throttle_gates_to_interval() -> None:
     assert throttle.should_touch(1030.0) is False  # inside the window
     assert throttle.should_touch(1061.0) is True  # past the window
     assert throttle.should_touch(1090.0) is False  # inside the new window
+
+
+# ---------------------------------------------------------------------------
+# CM-2a′ snapshot-on-disconnect helper.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_on_disconnect_captures_workspace(monkeypatch) -> None:
+    """A clean disconnect snapshots the row's workspace, forwarding the client."""
+    sentinel_client = object()
+    calls: list[dict] = []
+
+    async def _spy_snapshot(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
+        calls.append(
+            {"workspace_id": workspace_id, "user_id": user_id, "row_id": row_id, "client": client}
+        )
+        return "file-1"
+
+    monkeypatch.setattr(terminal_ws.websandbox_durability, "snapshot_workspace", _spy_snapshot)
+
+    await terminal_ws.snapshot_on_disconnect("w1", "u1", "row-1", sentinel_client)
+
+    assert len(calls) == 1
+    assert calls[0] == {
+        "workspace_id": "w1",
+        "user_id": "u1",
+        "row_id": "row-1",
+        "client": sentinel_client,
+    }
+
+
+async def test_snapshot_on_disconnect_swallows_failures(monkeypatch) -> None:
+    """A snapshot failure on teardown is swallowed — a close never becomes an error."""
+
+    async def _boom(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
+        raise RuntimeError("boom: VM already reaped")
+
+    monkeypatch.setattr(terminal_ws.websandbox_durability, "snapshot_workspace", _boom)
+
+    # Must not raise.
+    await terminal_ws.snapshot_on_disconnect("w1", "u1", "row-1", None)

--- a/tests/cloud/test_websandbox_terminal.py
+++ b/tests/cloud/test_websandbox_terminal.py
@@ -496,6 +496,7 @@ async def test_touch_activity_bumps_updated_at() -> None:
     assert touched is True
 
     doc2 = await _Doc.get(PydanticObjectId(view.id))
+
     # mongomock round-trips datetimes as tz-naive; compare tz-agnostically.
     def _naive(dt: datetime) -> datetime:
         return dt.replace(tzinfo=None)

--- a/tests/cloud/test_websandbox_terminal.py
+++ b/tests/cloud/test_websandbox_terminal.py
@@ -24,6 +24,15 @@
 #   * activity heartbeat is throttled (many frames -> one touch) and bumps
 #     updated_at at the service level.
 #   * the _ActivityThrottle unit gates to first-call-then-interval.
+#
+# 2026-07-15 (WC-4b): Path 3 first-message auth frame (no ?token=). Covers:
+#   * no ?token= + a valid {"type":"auth","ticket":<valid>} frame -> accept()
+#     first, then PTY opens (and the "token" alias works too).
+#   * no ?token= + malformed / non-auth / missing first frame -> closed 4001
+#     after accept, no PTY.
+#   * no ?token= + auth frame with an INVALID ticket -> closed 4001, no PTY.
+#   * no ?token= + valid ticket but a sandbox the caller does NOT own -> closed
+#     1008 after accept, no PTY.
 from __future__ import annotations
 
 import os
@@ -253,15 +262,18 @@ async def test_valid_ticket_opens_pty_streams_and_resizes(wire_terminal) -> None
 # ---------------------------------------------------------------------------
 
 
-async def test_missing_ticket_closes_1008_no_pty(wire_terminal) -> None:
+async def test_no_token_and_no_auth_frame_closes_4001_no_pty(wire_terminal) -> None:
+    # No ?token= now routes to Path 3 (first-message auth frame). With nothing on
+    # the wire, receive_text raises before any frame arrives -> 4001 after accept,
+    # never the old pre-accept 1008. (Path 3 detail covered further below.)
     client, _tokens = wire_terminal
-    await _seed_user("w1")  # existence irrelevant; no token supplied
+    await _seed_user("w1")  # existence irrelevant; no credential supplied
 
     ws = FakeWebSocket()
     await terminal_websocket_endpoint(ws, "any-row", token=None)
 
-    assert ws.accepted is False
-    assert ws.closed is not None and ws.closed[0] == 1008
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
     assert client.sandbox.process.handle is None
 
 
@@ -310,6 +322,129 @@ async def test_not_ready_sandbox_closes_1008_no_pty(wire_terminal) -> None:
     await terminal_websocket_endpoint(ws, view.id, token="good-ticket")
 
     assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+# ---------------------------------------------------------------------------
+# Path 3 — first-message auth frame (no ?token=), leak-free browser auth.
+# ---------------------------------------------------------------------------
+
+
+async def test_authframe_valid_opens_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    # No ?token=; the ticket rides in the FIRST frame, followed by a real input.
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"auth","ticket":"good-ticket"}',
+            '{"type":"input","data":"echo hi\\n"}',
+        ]
+    )
+
+    await terminal_websocket_endpoint(ws, row_id, token=None)
+
+    # Path 3 accepts BEFORE reading the frame; auth then succeeded, so no close.
+    assert ws.accepted is True
+    assert ws.closed is None
+
+    # The auth frame was consumed by the handshake, not the input loop: only the
+    # actual keystroke reached the pty.
+    handle = client.sandbox.process.handle
+    assert handle is not None
+    assert handle.sent == ["echo hi\n"]
+    assert b"echo:echo hi\n" in ws.sent_bytes
+
+    # Disconnect tore the pty down (no leaked session).
+    assert client.kill_calls
+    assert handle.connected is False
+
+
+async def test_authframe_token_alias_opens_pty(wire_terminal) -> None:
+    # "token" is accepted as an alias for "ticket" in the auth frame (chat parity).
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(inbound=['{"type":"auth","token":"good-ticket"}'])
+    await terminal_websocket_endpoint(ws, row_id, token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is None
+    assert client.sandbox.process.handle is not None
+
+
+async def test_authframe_malformed_closes_4001_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")
+
+    ws = FakeWebSocket(inbound=["this is not json"])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    # Accepted (Path 3 must accept before it can read), then closed 4001.
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_non_auth_first_frame_closes_4001_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")
+
+    # Well-formed JSON but not an auth frame -> rejected.
+    ws = FakeWebSocket(inbound=['{"type":"input","data":"whoami"}'])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_missing_frame_closes_4001_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")
+
+    # Empty inbound -> receive_text raises WebSocketDisconnect before any frame
+    # arrives (stands in for the client that never sends a credential).
+    ws = FakeWebSocket(inbound=[])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_invalid_ticket_closes_4001_no_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    tokens["good-ticket"] = "someone"
+
+    ws = FakeWebSocket(inbound=['{"type":"auth","ticket":"WRONG"}'])
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is True
+    assert ws.closed is not None and ws.closed[0] == 4001
+    assert client.sandbox.process.handle is None
+
+
+async def test_authframe_valid_ticket_not_owned_closes_1008_after_accept(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    owner_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", owner_id)
+
+    # A different user in the same workspace authenticates via the auth frame but
+    # asks for a row they don't own: authz denial closes 1008 on the already-
+    # accepted socket, and no PTY opens.
+    intruder_id = await _seed_user("w1")
+    tokens["intruder-ticket"] = intruder_id
+
+    ws = FakeWebSocket(inbound=['{"type":"auth","ticket":"intruder-ticket"}'])
+    await terminal_websocket_endpoint(ws, row_id, token=None)
+
+    assert ws.accepted is True  # Path 3 accepted before the authz check
     assert ws.closed is not None and ws.closed[0] == 1008
     assert client.sandbox.process.handle is None
 

--- a/tests/cloud/test_websandbox_terminal.py
+++ b/tests/cloud/test_websandbox_terminal.py
@@ -1,0 +1,384 @@
+# test_websandbox_terminal.py — unit tests for the Web Cursor terminal
+# WebSocket + PTY bridge slice (WC-3). Created 2026-07-15
+# (feat/websandbox-terminal-ws).
+#
+# The auth/authz core runs on REAL Beanie over mongomock-motor (the ``mongo_db``
+# fixture) with a REAL seeded user, so the connect flow exercises the genuine
+# tenant/owner-scoped query paths (get_active_workspace -> get_sandbox ->
+# authorize_sandbox). All Daytona interaction goes through a FAKE client + FAKE
+# pty handle injected via monkeypatch — no test touches real Daytona.
+#
+# The endpoint is driven directly with a ``FakeWebSocket`` rather than Starlette's
+# TestClient: the handler authenticates on real async Beanie and opens a pty
+# before its receive loop, which the sync TestClient portal can't drive cleanly.
+# Direct invocation mirrors the WC-2 provision tests (call the unit with fakes)
+# and covers the whole accept -> auth -> PTY -> stream -> resize -> teardown flow.
+#
+# Covers:
+#   * valid ticket + owned ready sandbox -> PTY opened; an input frame reaches
+#     handle.send_input; the echoed VM output is forwarded as a binary frame;
+#     a resize frame calls resize_pty; disconnect kills the pty (no leak).
+#   * missing / invalid ticket -> closed 1008, no PTY, no accept.
+#   * valid ticket but a sandbox the caller does NOT own -> denied, no PTY.
+#   * not-ready row (no bound sandbox_id) -> closed 1008, no PTY.
+#   * activity heartbeat is throttled (many frames -> one touch) and bumps
+#     updated_at at the service level.
+#   * the _ActivityThrottle unit gates to first-call-then-interval.
+from __future__ import annotations
+
+import os
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+
+import pytest
+from fastapi import WebSocketDisconnect
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+from pocketpaw_ee.cloud.websandbox.dto import CreateSandboxRequest
+from pocketpaw_ee.cloud.websandbox.ws import _ActivityThrottle, terminal_websocket_endpoint
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fakes.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLicense:
+    """A present, non-expired license (the WS gate only reads ``.expired``)."""
+
+    expired = False
+
+
+class _FakeHandle:
+    """Stand-in for the SDK's AsyncPtyHandle.
+
+    ``send_input`` records the keystrokes AND echoes them back through the
+    ``on_data`` callback — modelling a real shell echo so a single input frame
+    exercises both the input path (into the pty) and the output path (out to the
+    socket).
+    """
+
+    def __init__(self, on_data) -> None:  # noqa: ANN001
+        self._on_data = on_data
+        self.sent: list[str | bytes] = []
+        self.connected = True
+
+    async def wait_for_connection(self) -> None:
+        return None
+
+    async def send_input(self, data: str | bytes) -> None:
+        self.sent.append(data)
+        # Echo like a real pty so the output-forwarding path is exercised.
+        payload = data.encode() if isinstance(data, str) else data
+        await self._on_data(b"echo:" + payload)
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.handle: _FakeHandle | None = None
+
+    async def create_pty_session(self, session_id, on_data, cwd=None, envs=None, pty_size=None):  # noqa: ANN001
+        self.handle = _FakeHandle(on_data)
+        return self.handle
+
+
+class _FakeSandbox:
+    def __init__(self) -> None:
+        self.process = _FakeProcess()
+
+
+@dataclass
+class _FakeDaytonaClient:
+    """Drop-in for DaytonaClient: holds one sandbox, records resize/kill."""
+
+    sandbox: _FakeSandbox = field(default_factory=_FakeSandbox)
+    resize_calls: list[dict] = field(default_factory=list)
+    kill_calls: list[str] = field(default_factory=list)
+
+    async def get_sandbox_instance(self, sandbox_id):  # noqa: ANN001
+        return self.sandbox
+
+    async def resize_pty(self, sandbox_id, session_id, cols, rows):  # noqa: ANN001
+        self.resize_calls.append({"cols": cols, "rows": rows})
+
+    async def kill_pty(self, sandbox_id, session_id):  # noqa: ANN001
+        self.kill_calls.append(session_id)
+
+
+class FakeWebSocket:
+    """Minimal async WebSocket double for direct endpoint invocation.
+
+    Feeds a queue of already-serialized client frames via ``receive_text`` and
+    records ``accept`` / ``close`` / ``send_bytes`` / ``send_json``. When the
+    inbound queue drains it raises ``WebSocketDisconnect`` to end the receive
+    loop — the same signal Starlette raises when the browser tab closes.
+    """
+
+    def __init__(self, inbound: list[str] | None = None) -> None:
+        self._inbound: deque[str] = deque(inbound or [])
+        self.accepted = False
+        self.closed: tuple[int, str | None] | None = None
+        self.sent_bytes: list[bytes] = []
+        self.sent_json: list[dict] = []
+        self.cookies: dict[str, str] = {}
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.closed = (code, reason)
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent_bytes.append(data)
+
+    async def send_json(self, data: dict) -> None:
+        self.sent_json.append(data)
+
+    async def receive_text(self) -> str:
+        if not self._inbound:
+            raise WebSocketDisconnect(1000)
+        return self._inbound.popleft()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / seeding.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_user(active_workspace: str | None) -> str:
+    """Seed a real User doc (fastapi-users) and set its active workspace."""
+    from pocketpaw_ee.cloud.auth.core import UserCreate, UserManager, get_user_db
+    from pocketpaw_ee.cloud.models.user import User as UserDoc
+
+    email = f"wc3-{os.urandom(4).hex()}@example.com"
+    async for db in get_user_db():
+        manager = UserManager(db)
+        user = await manager.create(UserCreate(email=email, password="StrongPass123!"))
+        doc = await UserDoc.get(user.id)
+        doc.active_workspace = active_workspace
+        await doc.save()
+        return str(user.id)
+    raise RuntimeError("user db iterator exhausted")  # pragma: no cover
+
+
+async def _seed_ready_sandbox(workspace_id: str, user_id: str) -> str:
+    """Register a ``ready`` sandbox row with a bound Daytona id; return row id."""
+    view = await sandbox_service.create_sandbox(
+        workspace_id,
+        user_id,
+        CreateSandboxRequest(
+            repo="https://github.com/acme/api.git", status="ready", sandbox_id="dtn-1"
+        ),
+    )
+    return view.id
+
+
+@pytest.fixture
+def wire_terminal(monkeypatch):
+    """Patch the ws module's collaborators: license, ticket consume, Daytona.
+
+    Returns the FakeDaytonaClient so tests inspect resize/kill calls. The ticket
+    consume is a table lookup keyed on the token string so tests can assert the
+    valid/invalid split without Redis.
+    """
+    client = _FakeDaytonaClient()
+    tokens: dict[str, str] = {}
+
+    async def _fake_consume(token: str) -> str | None:
+        return tokens.get(token)
+
+    monkeypatch.setattr(terminal_ws, "get_license", lambda: _FakeLicense())
+    monkeypatch.setattr(terminal_ws, "consume_ws_ticket", _fake_consume)
+    monkeypatch.setattr(terminal_ws, "get_daytona_client", lambda: client)
+    # Fresh manager so active_count assertions are isolated per test.
+    monkeypatch.setattr(terminal_ws, "manager", terminal_ws.TerminalConnectionManager())
+    return client, tokens
+
+
+# ---------------------------------------------------------------------------
+# Happy path.
+# ---------------------------------------------------------------------------
+
+
+async def test_valid_ticket_opens_pty_streams_and_resizes(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket(
+        inbound=[
+            '{"type":"input","data":"echo hi\\n"}',
+            '{"type":"resize","cols":120,"rows":40}',
+            '{"type":"ping"}',
+        ]
+    )
+
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    # Socket was accepted (all auth gates passed) and never force-closed.
+    assert ws.accepted is True
+    assert ws.closed is None
+
+    # Input reached the pty handle.
+    handle = client.sandbox.process.handle
+    assert handle is not None
+    assert handle.sent == ["echo hi\n"]
+
+    # The pty echo was forwarded to the browser as a binary frame.
+    assert b"echo:echo hi\n" in ws.sent_bytes
+
+    # Resize routed through the client wrapper.
+    assert client.resize_calls == [{"cols": 120, "rows": 40}]
+
+    # Ping answered with a pong JSON frame.
+    assert {"type": "pong"} in ws.sent_json
+
+    # Disconnect tore the pty down (no leaked session).
+    assert client.kill_calls  # kill_pty was called
+    assert handle.connected is False
+
+
+# ---------------------------------------------------------------------------
+# Auth failures — no PTY ever opens.
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_ticket_closes_1008_no_pty(wire_terminal) -> None:
+    client, _tokens = wire_terminal
+    await _seed_user("w1")  # existence irrelevant; no token supplied
+
+    ws = FakeWebSocket()
+    await terminal_websocket_endpoint(ws, "any-row", token=None)
+
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+async def test_invalid_ticket_closes_1008_no_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    tokens["good-ticket"] = "someone"
+
+    ws = FakeWebSocket()
+    await terminal_websocket_endpoint(ws, "any-row", token="WRONG")
+
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+async def test_ticket_valid_but_sandbox_not_owned_is_denied(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    owner_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", owner_id)
+
+    # A DIFFERENT user in the same workspace holds a valid ticket for THIS row.
+    intruder_id = await _seed_user("w1")
+    tokens["intruder-ticket"] = intruder_id
+
+    ws = FakeWebSocket(inbound=['{"type":"input","data":"whoami\\n"}'])
+    await terminal_websocket_endpoint(ws, row_id, token="intruder-ticket")
+
+    # get_sandbox is owner-scoped -> NotFound -> 1008 before any PTY.
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+async def test_not_ready_sandbox_closes_1008_no_pty(wire_terminal) -> None:
+    client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    # A pending row with NO bound Daytona id.
+    view = await sandbox_service.create_sandbox(
+        "w1",
+        user_id,
+        CreateSandboxRequest(repo="https://github.com/acme/api.git", status="pending"),
+    )
+    tokens["good-ticket"] = user_id
+
+    ws = FakeWebSocket()
+    await terminal_websocket_endpoint(ws, view.id, token="good-ticket")
+
+    assert ws.accepted is False
+    assert ws.closed is not None and ws.closed[0] == 1008
+    assert client.sandbox.process.handle is None
+
+
+# ---------------------------------------------------------------------------
+# Activity heartbeat — throttled, and it bumps updated_at.
+# ---------------------------------------------------------------------------
+
+
+async def test_activity_touch_is_throttled_to_one_per_burst(wire_terminal, monkeypatch) -> None:
+    _client, tokens = wire_terminal
+    user_id = await _seed_user("w1")
+    row_id = await _seed_ready_sandbox("w1", user_id)
+    tokens["good-ticket"] = user_id
+
+    calls = {"n": 0}
+    real_touch = sandbox_service.touch_activity
+
+    async def _counting_touch(ws_id, uid, rid):  # noqa: ANN001
+        calls["n"] += 1
+        return await real_touch(ws_id, uid, rid)
+
+    monkeypatch.setattr(terminal_ws.websandbox_service, "touch_activity", _counting_touch)
+
+    # Five input frames in one burst — the throttle should collapse them to one
+    # heartbeat write (first call touches, the rest are inside the interval).
+    ws = FakeWebSocket(inbound=['{"type":"input","data":"x"}'] * 5)
+    await terminal_websocket_endpoint(ws, row_id, token="good-ticket")
+
+    assert calls["n"] == 1
+
+
+async def test_touch_activity_bumps_updated_at() -> None:
+    user_id = "u1"
+    view = await sandbox_service.create_sandbox(
+        "w1", user_id, CreateSandboxRequest(repo="r1", status="ready", sandbox_id="dtn-9")
+    )
+
+    # Force the stored updated_at into the past so a bump is observable.
+    from beanie import PydanticObjectId
+    from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox as _Doc
+
+    doc = await _Doc.get(PydanticObjectId(view.id))
+    old = datetime.now(UTC) - timedelta(hours=1)
+    doc.updated_at = old
+    await doc.save()
+
+    touched = await sandbox_service.touch_activity("w1", user_id, view.id)
+    assert touched is True
+
+    doc2 = await _Doc.get(PydanticObjectId(view.id))
+    # mongomock round-trips datetimes as tz-naive; compare tz-agnostically.
+    def _naive(dt: datetime) -> datetime:
+        return dt.replace(tzinfo=None)
+
+    assert _naive(doc2.updated_at) > _naive(old)
+
+    # A non-owning caller can't touch it.
+    assert await sandbox_service.touch_activity("w1", "other", view.id) is False
+
+
+# ---------------------------------------------------------------------------
+# Throttle unit.
+# ---------------------------------------------------------------------------
+
+
+def test_activity_throttle_gates_to_interval() -> None:
+    throttle = _ActivityThrottle(interval=60.0)
+    assert throttle.should_touch(1000.0) is True  # first call always touches
+    assert throttle.should_touch(1030.0) is False  # inside the window
+    assert throttle.should_touch(1061.0) is True  # past the window
+    assert throttle.should_touch(1090.0) is False  # inside the new window

--- a/tests/cloud/test_workspace_vm_store.py
+++ b/tests/cloud/test_workspace_vm_store.py
@@ -162,12 +162,12 @@ async def test_migration_imports_json_and_renames_file(mongo_db, tmp_path, monke
 
 
 async def test_migration_second_run_is_noop_and_non_clobbering(
-    mongo_db, tmp_path, monkeypatch  # noqa: ARG001
+    mongo_db,
+    tmp_path,
+    monkeypatch,  # noqa: ARG001
 ):
     legacy = tmp_path / "daytona_workspace_vm_map.json"
-    legacy.write_text(
-        json.dumps({"w1": {"sandbox_id": "sb-old", "sandbox_name": "old"}})
-    )
+    legacy.write_text(json.dumps({"w1": {"sandbox_id": "sb-old", "sandbox_name": "old"}}))
     monkeypatch.setattr(store, "WS_VM_MAP_PATH", legacy)
 
     # First run imports + renames.
@@ -183,8 +183,6 @@ async def test_migration_second_run_is_noop_and_non_clobbering(
     assert await get_workspace_vm_sandbox_id("w1") == "sb-new"
 
     # Re-create the legacy file to prove non-clobbering explicitly.
-    legacy.write_text(
-        json.dumps({"w1": {"sandbox_id": "sb-stale", "sandbox_name": "stale"}})
-    )
+    legacy.write_text(json.dumps({"w1": {"sandbox_id": "sb-stale", "sandbox_name": "stale"}}))
     await migrate_workspace_vm_map_to_db()
     assert await get_workspace_vm_sandbox_id("w1") == "sb-new"  # not clobbered

--- a/tests/cloud/test_workspace_vm_store.py
+++ b/tests/cloud/test_workspace_vm_store.py
@@ -1,0 +1,190 @@
+"""Tests for the DB-backed workspace→VM store (fix/workspace-vm-map-to-db).
+
+Created 2026-07-15: proves the six workspace-level VM accessors in
+``ee.cloud.daytona.store`` read/write the ``workspace_vms`` Mongo collection
+(not the legacy local JSON file), that ``set_workspace_vm`` upserts (one row
+per workspace), that config merges over defaults, that ``remove`` deletes the
+row, that two workspaces are tenant-isolated, and that the one-time
+``migrate_workspace_vm_map_to_db`` boot task imports the legacy JSON file into
+Mongo, renames it, and is a no-op / non-clobbering on a second run.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pocketpaw_ee.cloud.daytona import store
+from pocketpaw_ee.cloud.daytona.store import (
+    _DEFAULT_VM_CONFIG,
+    get_workspace_vm_config,
+    get_workspace_vm_sandbox_id,
+    list_all_workspace_vms,
+    remove_workspace_vm,
+    set_workspace_vm,
+    update_workspace_vm_config,
+)
+from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
+from pocketpaw_ee.cloud.shared.db import migrate_workspace_vm_map_to_db
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_set_then_get_round_trips_through_db(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-123", "paw-ws-w1")
+
+    # Round-trips through the accessor...
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-123"
+    # ...and the row is really in the DB (not a file).
+    doc = await WorkspaceVm.find_one(WorkspaceVm.workspace == "w1")
+    assert doc is not None
+    assert doc.sandbox_id == "sb-123"
+    assert doc.sandbox_name == "paw-ws-w1"
+
+
+async def test_get_sandbox_id_missing_returns_none(mongo_db):  # noqa: ARG001
+    assert await get_workspace_vm_sandbox_id("nope") is None
+
+
+async def test_set_is_an_upsert_not_a_duplicate(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-1", "name-1")
+    await set_workspace_vm("w1", "sb-2", "name-2")
+
+    # Second call updated the same workspace — exactly one row.
+    rows = await WorkspaceVm.find(WorkspaceVm.workspace == "w1").to_list()
+    assert len(rows) == 1
+    assert rows[0].sandbox_id == "sb-2"
+    assert rows[0].sandbox_name == "name-2"
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-2"
+
+
+async def test_get_config_merges_over_defaults(mongo_db):  # noqa: ARG001
+    # No row yet → pure defaults.
+    assert await get_workspace_vm_config("w1") == _DEFAULT_VM_CONFIG
+
+    # A row with a partial config override merges over the defaults.
+    await set_workspace_vm("w1", "sb-1", "name-1", config={"cpu": 8})
+    cfg = await get_workspace_vm_config("w1")
+    assert cfg["cpu"] == 8  # overridden
+    assert cfg["memory"] == _DEFAULT_VM_CONFIG["memory"]  # inherited default
+    assert cfg["disk"] == _DEFAULT_VM_CONFIG["disk"]
+
+
+async def test_update_config_persists_partial_update(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-1", "name-1")
+    await update_workspace_vm_config("w1", {"memory": 16})
+
+    cfg = await get_workspace_vm_config("w1")
+    assert cfg["memory"] == 16
+    assert cfg["cpu"] == _DEFAULT_VM_CONFIG["cpu"]
+    # The sandbox mapping is untouched by a config update.
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-1"
+
+
+async def test_update_config_creates_row_when_absent(mongo_db):  # noqa: ARG001
+    # A config update with no prior VM row seeds a config-only row.
+    await update_workspace_vm_config("w1", {"disk": 50})
+    cfg = await get_workspace_vm_config("w1")
+    assert cfg["disk"] == 50
+    assert await get_workspace_vm_sandbox_id("w1") == ""  # empty until provisioned
+
+
+async def test_remove_deletes_the_row(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-1", "name-1")
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-1"
+
+    await remove_workspace_vm("w1")
+    assert await get_workspace_vm_sandbox_id("w1") is None
+    assert await WorkspaceVm.find_one(WorkspaceVm.workspace == "w1") is None
+
+
+async def test_remove_missing_is_noop(mongo_db):  # noqa: ARG001
+    # Deleting a workspace with no VM row must not raise.
+    await remove_workspace_vm("ghost")
+
+
+async def test_two_workspaces_are_tenant_isolated(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-w1", "name-w1", config={"cpu": 4})
+    await set_workspace_vm("w2", "sb-w2", "name-w2", config={"cpu": 2})
+
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-w1"
+    assert await get_workspace_vm_sandbox_id("w2") == "sb-w2"
+    assert (await get_workspace_vm_config("w1"))["cpu"] == 4
+    assert (await get_workspace_vm_config("w2"))["cpu"] == 2
+
+    # Removing one leaves the other intact.
+    await remove_workspace_vm("w1")
+    assert await get_workspace_vm_sandbox_id("w1") is None
+    assert await get_workspace_vm_sandbox_id("w2") == "sb-w2"
+
+
+async def test_list_all_workspace_vms(mongo_db):  # noqa: ARG001
+    await set_workspace_vm("w1", "sb-w1", "name-w1")
+    await set_workspace_vm("w2", "sb-w2", "name-w2")
+
+    everything = await list_all_workspace_vms()
+    assert set(everything.keys()) == {"w1", "w2"}
+    assert everything["w1"]["sandbox_id"] == "sb-w1"
+    assert everything["w2"]["sandbox_name"] == "name-w2"
+
+
+# ---------------------------------------------------------------------------
+# One-time migration from the legacy JSON file
+# ---------------------------------------------------------------------------
+
+
+async def test_migration_imports_json_and_renames_file(mongo_db, tmp_path, monkeypatch):  # noqa: ARG001
+    legacy = tmp_path / "daytona_workspace_vm_map.json"
+    legacy.write_text(
+        json.dumps(
+            {
+                "w1": {
+                    "sandbox_id": "sb-legacy-1",
+                    "sandbox_name": "paw-ws-legacy-1",
+                    "config": {"cpu": 8},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(store, "WS_VM_MAP_PATH", legacy)
+
+    await migrate_workspace_vm_map_to_db()
+
+    # The row landed in the DB.
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-legacy-1"
+    cfg = await get_workspace_vm_config("w1")
+    assert cfg["cpu"] == 8
+    assert cfg["memory"] == _DEFAULT_VM_CONFIG["memory"]
+
+    # The file was renamed so it won't re-import.
+    assert not legacy.exists()
+    assert (tmp_path / "daytona_workspace_vm_map.json.migrated").exists()
+
+
+async def test_migration_second_run_is_noop_and_non_clobbering(
+    mongo_db, tmp_path, monkeypatch  # noqa: ARG001
+):
+    legacy = tmp_path / "daytona_workspace_vm_map.json"
+    legacy.write_text(
+        json.dumps({"w1": {"sandbox_id": "sb-old", "sandbox_name": "old"}})
+    )
+    monkeypatch.setattr(store, "WS_VM_MAP_PATH", legacy)
+
+    # First run imports + renames.
+    await migrate_workspace_vm_map_to_db()
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-old"
+
+    # Meanwhile the DB advances to a newer sandbox.
+    await set_workspace_vm("w1", "sb-new", "new")
+
+    # A second run has no file to read (already renamed) → pure no-op; even if
+    # the file were re-created, an existing row is never clobbered.
+    await migrate_workspace_vm_map_to_db()
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-new"
+
+    # Re-create the legacy file to prove non-clobbering explicitly.
+    legacy.write_text(
+        json.dumps({"w1": {"sandbox_id": "sb-stale", "sandbox_name": "stale"}})
+    )
+    await migrate_workspace_vm_map_to_db()
+    assert await get_workspace_vm_sandbox_id("w1") == "sb-new"  # not clobbered


### PR DESCRIPTION
Backend for Code Mode: the sandbox a project opens into, the file and terminal
plumbing the browser editor talks to, the GitHub auth that lets a private repo be
cloned without a token ever reaching the VM, and the server side of the in-tab
BrowserPod runtime.

## What's here

**Sandbox lifecycle** — a registry with fail-closed auth, cold provision plus
public-repo clone, and a tightened lifecycle (stop at 5, archive at 5,
delete-on-stop). A cross-tenant VM takeover in the register surface is closed.
The workspace VM map moved from a local JSON file to MongoDB.

**Session RPC** — terminal WebSocket over a PTY bridge, file read/write/list,
create/rename/delete, find-in-files search, and a dev-server preview URL. The
sandbox is unified on `/home/daytona` so the file tree actually shows files.

**Durability** — S3 workspace snapshot/restore, a durable project entity, and
write-through file durability, so a project survives its VM being reaped.

**GitHub** — provider-agnostic repo-auth with a GitHub App token client,
broker-clone for private repos with the token kept server-side, and a git
smart-HTTP proxy so the VM can push and fetch without ever holding credentials.

**BrowserPod support** — the boot credential is brokered server-side rather than
bundled into the frontend, and repo source is served as a zip so a pod can be
seeded without running `git clone` inside an emulated TCP/TLS stack.

## About the BrowserPod runtime

BrowserPod did not clear its validation gate: `npm install` never completes in a
pod (the TLS relay exhausts memory), native binaries like esbuild and rollup
can't run, and the SDK exposes no liveness callback, so a dead pod is
indistinguishable from a slow one. It is not the runtime we're shipping.

The server-side pieces are here anyway because they are useful independently —
the archive endpoint seeds any in-tab runtime, not just BrowserPod, and the
credential broker generalizes to WebContainers, which needs a browser-side key
for commercial use in exactly the same way. Both get reused by the runtime
registry that replaces the current selection logic.

## Review notes

Worth a close look: the cross-tenant fix in the register surface, and the token
boundary in `repoauth`/`githubapp` — the point of the broker-clone and the
smart-HTTP proxy is that the token stays out of the VM, so that's the property to
check rather than take on faith.

`archive.py` takes a repo reference from the caller and must never treat it as a
URL to fetch; owner/name are parsed out and the GitHub URL is rebuilt server-side.

Frontend counterpart: qbtrix/paw-enterprise #643.
