### PR TITLE
Resolve Code Mode runtime requirements before anything boots

### DIFF
--- a/ee/pocketpaw_ee/cloud/websandbox/dto.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/dto.py
@@ -44,6 +44,15 @@
 # ``UpdateStatusRequest`` are INTERNAL command objects the provisioner (and tests
 # that stand in for it) use to bind server-generated runtime state, and are never
 # bound by a router. The client ``PATCH`` route was removed with the same intent.
+#
+# Changed 2026-07-20 (RR-2, feat/code-runtime-requirements): added
+# ``RuntimeRequirementsResponse`` — what a PROJECT NEEDS from a runtime
+# (install / nativeToolchain / rawSockets) plus the ``reasons`` that produced
+# each flag, so the runtime-routing decision is explainable rather than opaque.
+# Also generalized the credential response: the broker shape was never
+# BrowserPod-specific (any in-tab runtime needs a vendor key brokered the same
+# way), so the canonical name is now ``RuntimeCredentialsResponse`` and
+# ``BrowserPodCredentialsResponse`` is a deprecated alias kept for one release.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -175,25 +184,60 @@ class PreviewResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# BP-1b — BrowserPod (in-tab WASM runtime) boot credential.
+# BP-1b / RR-2 — in-tab runtime boot credential.
 # ---------------------------------------------------------------------------
 
 
-class BrowserPodCredentialsResponse(BaseModel):
-    """The credential a browser needs to boot an in-tab BrowserPod pod.
+class RuntimeCredentialsResponse(BaseModel):
+    """The credential a browser needs to boot an in-tab runtime.
 
-    Response-only (Rule 4). ``available`` is false with a null ``apiKey`` when the
-    deploy has no BROWSERPOD_API_KEY configured — the frontend then routes the
-    project to the Daytona runtime instead of treating it as an error.
+    Response-only (Rule 4). ``available`` is false with a null ``apiKey`` in TWO
+    cases that a client cannot and need not tell apart: the runtime is not
+    configured on this deploy, and the runtime id is unknown. Both mean "route
+    this project somewhere else", so both answer the same way (see
+    ``websandbox/runtimes.py``).
 
-    NOTE: this response necessarily carries the key to the client, because
-    ``BrowserPod.boot()`` executes in the tab. Brokering it keeps the key out of
+    NOTE: this response necessarily carries the key to the client, because the
+    runtime's ``boot()`` executes in the tab. Brokering it keeps the key out of
     the frontend bundle and makes it gateable/rotatable/auditable, but it is not
     secret from an authenticated caller — see ``websandbox/browserpod.py``.
     """
 
     available: bool
     apiKey: str | None = None
+
+
+# DEPRECATED alias, kept for one release while callers move to the generalized
+# name. The shape was never BrowserPod-specific — WebContainers needs a brokered
+# browser-side key on exactly the same terms.
+BrowserPodCredentialsResponse = RuntimeCredentialsResponse
+
+
+# ---------------------------------------------------------------------------
+# RR-2 — what a project NEEDS from a runtime, resolved before anything boots.
+# ---------------------------------------------------------------------------
+
+
+class RuntimeRequirementsResponse(BaseModel):
+    """The capability demands of a project, for matching against a runtime.
+
+    Response-only (Rule 4); the repo/ref arrive as query params and tenancy comes
+    from the RequestContext.
+
+    ``reasons`` is not decoration. This response drives a user-visible routing
+    decision — fast in-tab runtime versus a slower real VM — and a decision that
+    cannot be explained cannot be debugged. Every flag raised to ``true`` carries
+    at least one reason naming the evidence that raised it, e.g.
+    ``"pg in dependencies -> rawSockets"``.
+    """
+
+    # Needs to install dependencies from a registry.
+    install: bool
+    # Needs to execute native binaries (esbuild, rollup bindings, node-gyp…).
+    nativeToolchain: bool
+    # Needs real TCP — a database driver an in-tab runtime cannot emulate.
+    rawSockets: bool
+    reasons: list[str] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/websandbox/requirements.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/requirements.py
@@ -40,6 +40,8 @@ from __future__ import annotations
 import json
 import logging
 import re
+import time
+from collections import OrderedDict
 from typing import Any
 
 import httpx
@@ -50,7 +52,26 @@ from pocketpaw_ee.cloud.websandbox.dto import RuntimeRequirementsResponse
 
 logger = logging.getLogger(__name__)
 
-_FETCH_TIMEOUT_SECONDS = 15.0
+# Per-operation, with a much tighter CONNECT budget. httpx applies a bare float
+# to every phase separately, so 15.0 alone let a slow-drip responder hold a
+# project open far past 15s. This probe fetches one small file and its fallback
+# is both correct and cheap, so failing fast costs nothing.
+_FETCH_TIMEOUT = httpx.Timeout(8.0, connect=3.0)
+
+# The probe is UNAUTHENTICATED, which means GitHub's 60 requests/hour limit keyed
+# on our egress IP — shared across every tenant on a deploy. Past that, every
+# probe 403s, every project defaults to most-capable, and the feature silently
+# stops adding value while still reporting success.
+#
+# This cache is the containment, not the cure: a repo's manifest barely changes,
+# so repeat opens (the common case) cost nothing and the quota only pays for
+# distinct repos. The cure is authenticating the probe, which raises the limit to
+# 5000/hour and unlocks private repos — but archive.py is unauthenticated for the
+# same reason, so that is one shared piece of work rather than a fix belonging to
+# this module. Tracked as a follow-up.
+_CACHE_TTL_SECONDS = 15 * 60
+_CACHE_MAX_ENTRIES = 512
+_manifest_cache: OrderedDict[tuple[str, str, str], tuple[float, str | None]] = OrderedDict()
 
 # A package.json is a manifest, not a payload. Anything past this is either not a
 # manifest or not something we should be parsing on the request path.
@@ -62,26 +83,63 @@ _MAX_MANIFEST_BYTES = 2 * 1024 * 1024
 # transports (fetch / WebSocket relays) and expose no real ``net.Socket``, so a
 # project that talks to Postgres or Redis directly can only run in a real VM.
 #
-# The two sqlite entries are here for a sibling reason rather than sockets: they
-# are native FFI bindings, which an in-tab runtime equally cannot load. They land
-# on the same "needs a real machine" verdict, so they raise the same flag.
-_RAW_SOCKET_PACKAGES = frozenset(
-    {
-        "pg",
-        "mysql",
-        "mysql2",
-        "mongodb",
-        "mongoose",
-        "redis",
-        "ioredis",
-        "sqlite3",
-        "better-sqlite3",
-        "cassandra-driver",
-        "oracledb",
-        "tedious",
-        "amqplib",
-    }
-)
+# Each entry carries the CAUSE it raises the flag for, because the reason string
+# is the product here. An earlier version emitted "better-sqlite3 in dependencies
+# -> rawSockets", which is simply false — better-sqlite3 is an embedded file
+# database that opens no sockets. It still needs a real machine (it is a native
+# FFI binding an in-tab runtime cannot load), so the VERDICT was right and the
+# EXPLANATION was wrong. That is the worst combination: it survives review and
+# then sends the next debugger hunting a network problem that does not exist.
+#
+# ORMs matter more than drivers. Real Node apps reach Postgres through Prisma or
+# Drizzle, and `pg` is then a TRANSITIVE dependency that never appears in
+# package.json at all. Matching only bare driver names returned a confident
+# `rawSockets: false` for a Prisma+Postgres app — under-provisioning, which this
+# module's header says must never happen: it strands the user at first query,
+# whereas over-provisioning only costs a slower sandbox.
+_SOCKET = "opens a network socket to a database or broker"
+_NATIVE_FFI = "is a native FFI binding an in-tab runtime cannot load"
+_ORM = "is a database client whose driver is a transitive dependency"
+
+_RAW_SOCKET_PACKAGES: dict[str, str] = {
+    # Drivers — the direct case.
+    "pg": _SOCKET,
+    "pg-promise": _SOCKET,
+    "mysql": _SOCKET,
+    "mysql2": _SOCKET,
+    "mssql": _SOCKET,
+    "mongodb": _SOCKET,
+    "mongoose": _SOCKET,
+    "redis": _SOCKET,
+    "ioredis": _SOCKET,
+    "cassandra-driver": _SOCKET,
+    "oracledb": _SOCKET,
+    "tedious": _SOCKET,
+    "amqplib": _SOCKET,
+    "kafkajs": _SOCKET,
+    "nats": _SOCKET,
+    "mqtt": _SOCKET,
+    "ssh2": _SOCKET,
+    # SMTP is a raw socket like any other.
+    "nodemailer": _SOCKET,
+    # ORMs / query builders — the common case, and the one bare-driver matching
+    # missed entirely.
+    "prisma": _ORM,
+    "drizzle-orm": _ORM,
+    "sequelize": _ORM,
+    "typeorm": _ORM,
+    "knex": _ORM,
+    # Native FFI, not sockets. Same verdict, honest reason.
+    "sqlite3": _NATIVE_FFI,
+    "better-sqlite3": _NATIVE_FFI,
+}
+
+# Scoped packages can never match a bare name, so they are matched by prefix.
+# `@prisma/client` is the one almost every Prisma project actually declares.
+_RAW_SOCKET_PREFIXES: dict[str, str] = {
+    "@prisma/": _ORM,
+    "@databases/": _ORM,
+}
 
 # Kept in sync with archive.py's ref rules: a ref is attacker-influenced text, so
 # it is matched against an allowlist before it is used at all.
@@ -126,6 +184,36 @@ def _most_capable(cause: str) -> RuntimeRequirementsResponse:
     )
 
 
+# Distinct from None, which is a real cached value ("this repo has no manifest").
+_CACHE_MISS = object()
+
+
+def _cache_get(key: tuple[str, str, str]) -> Any:
+    """Return the cached manifest (possibly None), or ``_CACHE_MISS``."""
+    entry = _manifest_cache.get(key)
+    if entry is None:
+        return _CACHE_MISS
+    stored_at, value = entry
+    if time.monotonic() - stored_at > _CACHE_TTL_SECONDS:
+        _manifest_cache.pop(key, None)
+        return _CACHE_MISS
+    _manifest_cache.move_to_end(key)
+    return value
+
+
+def _cache_put(key: tuple[str, str, str], value: str | None) -> None:
+    """Store an answer GitHub actually gave us, evicting least-recently-used."""
+    _manifest_cache[key] = (time.monotonic(), value)
+    _manifest_cache.move_to_end(key)
+    while len(_manifest_cache) > _CACHE_MAX_ENTRIES:
+        _manifest_cache.popitem(last=False)
+
+
+def _reset_cache_for_tests() -> None:
+    """Drop cached manifests. Tests that stub the network call this."""
+    _manifest_cache.clear()
+
+
 async def _fetch_package_json(owner: str, name: str, ref: str | None) -> str | None:
     """Return the repo's root ``package.json`` as text, or ``None``.
 
@@ -135,9 +223,17 @@ async def _fetch_package_json(owner: str, name: str, ref: str | None) -> str | N
     pretending otherwise would invite a caller to branch on a distinction that
     carries no routing meaning.
     """
+    # Validate BEFORE the cache lookup: a refused ref must never become a cache
+    # key, or a rejected input would be silently served from cache next time.
+    validated_ref = _validate_ref(ref) if ref else ""
+    cache_key = (owner, name, validated_ref)
+    cached = _cache_get(cache_key)
+    if cached is not _CACHE_MISS:
+        return cached
+
     # Built from validated parts — never from caller input directly.
     url = f"https://api.github.com/repos/{owner}/{name}/contents/package.json"
-    params = {"ref": _validate_ref(ref)} if ref else None
+    params = {"ref": validated_ref} if validated_ref else None
     headers = {
         # Ask for the file body itself rather than the base64-in-JSON envelope.
         "Accept": "application/vnd.github.raw",
@@ -145,9 +241,7 @@ async def _fetch_package_json(owner: str, name: str, ref: str | None) -> str | N
     }
 
     try:
-        async with httpx.AsyncClient(
-            follow_redirects=True, timeout=_FETCH_TIMEOUT_SECONDS
-        ) as client:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=_FETCH_TIMEOUT) as client:
             response = await client.get(url, headers=headers, params=params)
     except httpx.HTTPError as exc:
         logger.info(
@@ -156,15 +250,33 @@ async def _fetch_package_json(owner: str, name: str, ref: str | None) -> str | N
             name,
             exc,
         )
+        # Deliberately NOT cached. A transient outage must not pin a defaulted
+        # verdict for the whole TTL; only answers GitHub actually gave us are.
         return None
 
     if response.status_code != 200:
+        # Quota exhaustion is not just another non-200: it means EVERY probe from
+        # here on defaults, so the feature stops working while still reporting
+        # success. That deserves a WARNING with a distinct message, because it is
+        # otherwise indistinguishable from "this repo has no package.json".
+        if response.status_code == 403 and response.headers.get("x-ratelimit-remaining") == "0":
+            logger.warning(
+                "websandbox: GitHub rate limit exhausted (unauthenticated, %s/hr per egress IP). "
+                "Every runtime-requirements probe will default to most-capable until it resets "
+                "at %s. Projects will still open, on a full VM.",
+                response.headers.get("x-ratelimit-limit", "60"),
+                response.headers.get("x-ratelimit-reset", "unknown"),
+            )
+            return None
         logger.info(
             "websandbox: package.json probe for %s/%s returned %s",
             owner,
             name,
             response.status_code,
         )
+        # A definite "no manifest here" IS worth caching — it is the answer.
+        if response.status_code == 404:
+            _cache_put(cache_key, None)
         return None
 
     content = response.content
@@ -175,8 +287,11 @@ async def _fetch_package_json(owner: str, name: str, ref: str | None) -> str | N
             name,
             len(content),
         )
+        _cache_put(cache_key, None)
         return None
-    return content.decode("utf-8", errors="replace")
+    manifest = content.decode("utf-8", errors="replace")
+    _cache_put(cache_key, manifest)
+    return manifest
 
 
 def _declared_dependencies(manifest: dict[str, Any]) -> dict[str, str]:
@@ -220,17 +335,28 @@ def infer_from_package_json(raw: str) -> RuntimeRequirementsResponse:
 
     reasons = [
         "package.json present -> install",
-        # Not a hypothetical: an npm install of any non-trivial dependency tree
-        # downloads or compiles prebuilt native binaries (esbuild, rollup's
-        # native bindings, sharp, node-gyp fallbacks). Treating "Node project"
-        # as "needs a native toolchain" is the empirically correct default.
-        "package.json present -> npm install fetches/builds native binaries -> nativeToolchain",
+        # Worded as the ASSUMPTION it is. We have not resolved the dependency
+        # tree — only read the manifest — so we cannot claim a native build step
+        # actually occurs; an empty manifest has none. But any non-trivial tree
+        # pulls prebuilt native binaries (esbuild, rollup's native bindings,
+        # sharp, node-gyp fallbacks), and over-provisioning only costs speed
+        # while under-provisioning strands the user.
+        "package.json present, dependency tree not resolved; assuming a native "
+        "build step -> nativeToolchain",
     ]
 
     dependencies = _declared_dependencies(manifest)
-    raw_socket_hits = sorted(set(dependencies) & _RAW_SOCKET_PACKAGES)
-    for package in raw_socket_hits:
-        reasons.append(f"{package} in {dependencies[package]} -> rawSockets")
+    raw_socket_hits: list[tuple[str, str]] = []
+    for package, section in sorted(dependencies.items()):
+        cause = _RAW_SOCKET_PACKAGES.get(package)
+        if cause is None:
+            cause = next(
+                (c for prefix, c in _RAW_SOCKET_PREFIXES.items() if package.startswith(prefix)),
+                None,
+            )
+        if cause is not None:
+            raw_socket_hits.append((package, section))
+            reasons.append(f"{package} in {section} {cause} -> rawSockets")
 
     return RuntimeRequirementsResponse(
         install=True,

--- a/ee/pocketpaw_ee/cloud/websandbox/requirements.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/requirements.py
@@ -1,0 +1,284 @@
+# requirements.py — resolve what a PROJECT NEEDS from a runtime, before any
+# runtime boots (RR-2).
+# Created 2026-07-20 (feat/code-runtime-requirements).
+#
+# WHY THIS EXISTS: Code Mode picks an execution runtime (Daytona cloud VM,
+# WebContainers in-tab, …) by matching what a project NEEDS against what each
+# runtime CAN DO. That match is only useful if the "needs" side can be answered
+# BEFORE anything boots — otherwise the probe is chicken-and-egg. The old
+# BrowserPod path proved the point the expensive way: it booted a whole VM and
+# seeded an entire repo just to read the root file list, discover the project was
+# not Node-shaped, and throw the VM away. The backend already fetches repo source
+# (see ``archive.py``), so it is the cheapest place in the system to look.
+#
+# WHY THE ANSWER CARRIES REASONS: a routing decision that cannot be explained is
+# indistinguishable from a guess, and this one is user-visible — it decides
+# whether their project opens in a fast in-tab runtime or a slower real VM. Every
+# flag we raise carries the EVIDENCE that raised it ("pg in dependencies ->
+# rawSockets"), so a wrong route can be debugged from the response alone instead
+# of by re-deriving the inference by hand.
+#
+# WHY UNKNOWN MEANS MOST-CAPABLE: when we cannot tell — no package.json, GitHub
+# unreachable, a repo we cannot read — we assume the project needs EVERYTHING and
+# route it to the most capable runtime. The asymmetry is deliberate: a slow but
+# correct sandbox costs the user time, a fast but broken one costs them the
+# session. Failing to inspect must never block opening a project either, so an
+# unreachable repo is a defaulted answer with a reason, not a 5xx.
+#
+# EFFICIENCY: this deliberately does NOT reuse ``fetch_repo_archive`` — that pulls
+# up to 100MB of zip to answer a question about one small file. We fetch exactly
+# ``package.json`` through GitHub's contents API.
+#
+# SSRF: identical boundary to ``archive.py``, and reusing its parser rather than
+# re-implementing one is the point — ``_parse_github_repo`` extracts owner/name
+# and the GitHub URL is BUILT here from those validated parts. No caller-supplied
+# string ever reaches httpx as a URL. The ref is likewise validated and then
+# passed as an httpx *query param* (encoded by the client), never spliced into a
+# path.
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+import httpx
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.websandbox.archive import _parse_github_repo
+from pocketpaw_ee.cloud.websandbox.dto import RuntimeRequirementsResponse
+
+logger = logging.getLogger(__name__)
+
+_FETCH_TIMEOUT_SECONDS = 15.0
+
+# A package.json is a manifest, not a payload. Anything past this is either not a
+# manifest or not something we should be parsing on the request path.
+_MAX_MANIFEST_BYTES = 2 * 1024 * 1024
+
+# Node packages that open a RAW TCP SOCKET (or load a native driver that does) to
+# reach a database or broker. This is the capability line an in-tab runtime cannot
+# cross: WebContainers and its peers emulate networking over browser-reachable
+# transports (fetch / WebSocket relays) and expose no real ``net.Socket``, so a
+# project that talks to Postgres or Redis directly can only run in a real VM.
+#
+# The two sqlite entries are here for a sibling reason rather than sockets: they
+# are native FFI bindings, which an in-tab runtime equally cannot load. They land
+# on the same "needs a real machine" verdict, so they raise the same flag.
+_RAW_SOCKET_PACKAGES = frozenset(
+    {
+        "pg",
+        "mysql",
+        "mysql2",
+        "mongodb",
+        "mongoose",
+        "redis",
+        "ioredis",
+        "sqlite3",
+        "better-sqlite3",
+        "cassandra-driver",
+        "oracledb",
+        "tedious",
+        "amqplib",
+    }
+)
+
+# Kept in sync with archive.py's ref rules: a ref is attacker-influenced text, so
+# it is matched against an allowlist before it is used at all.
+_REF_RE = re.compile(r"[A-Za-z0-9._/-]{1,255}")
+
+
+def _validate_ref(ref: str) -> str:
+    """Refuse anything that is not a plain git ref.
+
+    The ref reaches GitHub as a query param (httpx encodes it), so path traversal
+    is not the threat it is in ``archive.py`` — but the same allowlist applies,
+    because "it happens to be safe in this position" is not a property worth
+    depending on the next time this string is moved.
+    """
+    if not _REF_RE.fullmatch(ref) or ".." in ref:
+        raise ValidationError("websandbox.invalid_ref", "Invalid git ref")
+    return ref
+
+
+def _most_capable(cause: str) -> RuntimeRequirementsResponse:
+    """The unknown-project answer: assume the project needs everything.
+
+    Used whenever inspection could not produce a real verdict. See the module
+    header — under-provisioning a runtime breaks the session, over-provisioning
+    only slows it.
+
+    ``cause`` is repeated once PER FLAG rather than stated once for the group,
+    because the contract is that every raised flag carries its own evidence. A
+    reader (or a client rendering "why did this open in a VM?") should be able to
+    take any single reason line and understand that flag in isolation, without
+    having to infer that an unattributed sentence above it applies to all three.
+    """
+    return RuntimeRequirementsResponse(
+        install=True,
+        nativeToolchain=True,
+        rawSockets=True,
+        reasons=[
+            f"{cause} -> install",
+            f"{cause} -> nativeToolchain",
+            f"{cause} -> rawSockets",
+        ],
+    )
+
+
+async def _fetch_package_json(owner: str, name: str, ref: str | None) -> str | None:
+    """Return the repo's root ``package.json`` as text, or ``None``.
+
+    ``None`` means "we could not read one" for ANY reason — absent, private,
+    GitHub down, oversized, non-200. The caller does not get to distinguish,
+    because every one of those cases resolves to the same defaulted verdict and
+    pretending otherwise would invite a caller to branch on a distinction that
+    carries no routing meaning.
+    """
+    # Built from validated parts — never from caller input directly.
+    url = f"https://api.github.com/repos/{owner}/{name}/contents/package.json"
+    params = {"ref": _validate_ref(ref)} if ref else None
+    headers = {
+        # Ask for the file body itself rather than the base64-in-JSON envelope.
+        "Accept": "application/vnd.github.raw",
+        "User-Agent": "pocketpaw-codemode",
+    }
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True, timeout=_FETCH_TIMEOUT_SECONDS
+        ) as client:
+            response = await client.get(url, headers=headers, params=params)
+    except httpx.HTTPError as exc:
+        logger.info(
+            "websandbox: package.json probe failed for %s/%s: %s",
+            owner,
+            name,
+            exc,
+        )
+        return None
+
+    if response.status_code != 200:
+        logger.info(
+            "websandbox: package.json probe for %s/%s returned %s",
+            owner,
+            name,
+            response.status_code,
+        )
+        return None
+
+    content = response.content
+    if len(content) > _MAX_MANIFEST_BYTES:
+        logger.info(
+            "websandbox: package.json probe for %s/%s got %d bytes — ignoring",
+            owner,
+            name,
+            len(content),
+        )
+        return None
+    return content.decode("utf-8", errors="replace")
+
+
+def _declared_dependencies(manifest: dict[str, Any]) -> dict[str, str]:
+    """Map each declared package name to the manifest field that declared it.
+
+    The field name is carried because it goes into the human-readable reason
+    ("pg in dependencies -> rawSockets"); knowing WHERE the evidence came from is
+    most of what makes the reason worth reading.
+
+    devDependencies count: a build step that runs the test suite or a migration
+    script hits the same driver the app would, so a raw-socket package there is
+    just as disqualifying for an in-tab runtime as one in ``dependencies``.
+    ``dependencies`` is checked last so it wins the attribution when a package is
+    declared in both.
+    """
+    declared: dict[str, str] = {}
+    for field in ("devDependencies", "dependencies"):
+        section = manifest.get(field)
+        if not isinstance(section, dict):
+            continue
+        for package in section:
+            if isinstance(package, str):
+                declared[package] = field
+    return declared
+
+
+def infer_from_package_json(raw: str) -> RuntimeRequirementsResponse:
+    """Derive requirements from a ``package.json`` body.
+
+    Pure and separately testable — the network half lives above it. Unparseable
+    JSON is treated as "cannot tell", which is the most-capable default rather
+    than an error: a malformed manifest is exactly the case where guessing small
+    would strand the user.
+    """
+    try:
+        manifest = json.loads(raw)
+    except (ValueError, TypeError):
+        return _most_capable("package.json present but unparseable, so nothing can be ruled out")
+    if not isinstance(manifest, dict):
+        return _most_capable("package.json is not a JSON object, so nothing can be ruled out")
+
+    reasons = [
+        "package.json present -> install",
+        # Not a hypothetical: an npm install of any non-trivial dependency tree
+        # downloads or compiles prebuilt native binaries (esbuild, rollup's
+        # native bindings, sharp, node-gyp fallbacks). Treating "Node project"
+        # as "needs a native toolchain" is the empirically correct default.
+        "package.json present -> npm install fetches/builds native binaries -> nativeToolchain",
+    ]
+
+    dependencies = _declared_dependencies(manifest)
+    raw_socket_hits = sorted(set(dependencies) & _RAW_SOCKET_PACKAGES)
+    for package in raw_socket_hits:
+        reasons.append(f"{package} in {dependencies[package]} -> rawSockets")
+
+    return RuntimeRequirementsResponse(
+        install=True,
+        nativeToolchain=True,
+        rawSockets=bool(raw_socket_hits),
+        reasons=reasons,
+    )
+
+
+async def resolve_requirements(
+    workspace_id: str,
+    user_id: str,
+    repo: str,
+    ref: str | None = None,
+) -> RuntimeRequirementsResponse:
+    """Answer "what does this project need from a runtime?" without booting one.
+
+    The repo reference is parsed by ``archive._parse_github_repo`` — the same
+    SSRF boundary the archive endpoint uses, deliberately shared rather than
+    re-implemented — and an unparseable reference is REFUSED loudly rather than
+    defaulted, because it is a caller bug the archive path would reject too.
+    Every other failure (absent manifest, unreachable GitHub, private repo)
+    resolves to the most-capable default so a failed probe never blocks opening a
+    project.
+    """
+    owner, name = _parse_github_repo(repo)
+
+    raw = await _fetch_package_json(owner, name, ref)
+    if raw is None:
+        result = _most_capable(
+            "no readable package.json (absent, private or unreachable), so the "
+            "project is not known to be Node-shaped"
+        )
+    else:
+        result = infer_from_package_json(raw)
+
+    logger.info(
+        "websandbox: resolved runtime requirements for %s/%s "
+        "(install=%s nativeToolchain=%s rawSockets=%s) workspace=%s user=%s",
+        owner,
+        name,
+        result.install,
+        result.nativeToolchain,
+        result.rawSockets,
+        workspace_id,
+        user_id,
+    )
+    return result
+
+
+__all__ = ["infer_from_package_json", "resolve_requirements"]

--- a/ee/pocketpaw_ee/cloud/websandbox/router.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/router.py
@@ -54,6 +54,17 @@
 # and an unconfigured deploy answers ``available:false`` so the client falls back
 # to Daytona instead of erroring. Thin adapter over ``websandbox/browserpod.py``.
 #
+# Changed 2026-07-20 (RR-2, feat/code-runtime-requirements): added
+# ``GET /websandbox/runtimes/requirements`` — resolves what a PROJECT NEEDS
+# (install / nativeToolchain / rawSockets, each with the evidence that raised it)
+# from the repo's package.json, server-side, BEFORE any runtime boots. Also
+# generalized two paths whose names had gone wrong: the repo archive seeds ANY
+# in-tab runtime, not just BrowserPod, and every in-tab runtime needs a brokered
+# browser-side key — so ``/browserpod/repo-archive`` became
+# ``/runtimes/archive`` and ``/browserpod/credentials`` became
+# ``/runtimes/{runtime_id}/credentials``. The old paths remain as DEPRECATED
+# aliases for one release because the shipped frontend still calls them.
+#
 # Changed 2026-07-16 (review hardening): the register route now binds the
 # repo-only ``RegisterSandboxRequest`` so a client can no longer write a
 # server-owned ``sandbox_id`` / ``status`` (that field is the key
@@ -69,15 +80,15 @@ from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.websandbox import archive as websandbox_archive
-from pocketpaw_ee.cloud.websandbox import browserpod as websandbox_browserpod
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import edit as websandbox_edit
 from pocketpaw_ee.cloud.websandbox import git as websandbox_git
 from pocketpaw_ee.cloud.websandbox import preview as websandbox_preview
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
+from pocketpaw_ee.cloud.websandbox import requirements as websandbox_requirements
+from pocketpaw_ee.cloud.websandbox import runtimes as websandbox_runtimes
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import (
-    BrowserPodCredentialsResponse,
     CommitRequest,
     CreatePrRequest,
     CreateSandboxRequest,
@@ -90,6 +101,8 @@ from pocketpaw_ee.cloud.websandbox.dto import (
     OpenSandboxRequest,
     PreviewResponse,
     RegisterSandboxRequest,
+    RuntimeCredentialsResponse,
+    RuntimeRequirementsResponse,
     SandboxTreeResponse,
     SnapshotResponse,
     StageRequest,
@@ -195,8 +208,83 @@ async def get_sandbox_preview(
 
 
 # ---------------------------------------------------------------------------
-# BP-1b — BrowserPod boot credential. Two literal segments, so it can never be
-# captured by the single-segment ``/{row_id}`` route above.
+# RR-2 / BP-1b — the in-tab runtime surface: requirements probe, source archive,
+# and the brokered boot credential.
+#
+# PATH NOTE, and it is load-bearing: every route here has TWO literal segments,
+# deliberately. A single-segment collection path like ``/requirements`` is
+# captured by the ``/{row_id}`` route registered above — FastAPI matches in
+# REGISTRATION order — and resolves to "look up a sandbox called requirements",
+# which 404s. That is a genuinely confusing failure (the route exists, the client
+# calls the right URL, the server answers 404), and it has already happened once
+# here with ``/repo-archive``. A comment did not prevent the second occurrence,
+# so ``test_websandbox_routes.py`` asserts it instead.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/runtimes/requirements", response_model=RuntimeRequirementsResponse)
+async def get_runtime_requirements(
+    repo: str = Query(..., description="owner/repo or a github.com URL"),
+    ref: str | None = Query(None, description="Branch, tag or commit (default branch if omitted)"),
+    ctx: RequestContext = Depends(request_context),
+) -> RuntimeRequirementsResponse:
+    """Resolve what a project NEEDS from a runtime, before any runtime boots.
+
+    The runtime registry routes a project by matching its needs against each
+    runtime's capabilities, so the needs have to be answerable without booting
+    anything — otherwise the probe is chicken-and-egg, which is precisely how the
+    old path worked (boot a VM, seed the repo, read the root listing, discover it
+    was the wrong runtime, throw the VM away). The backend already fetches repo
+    source, so it answers from ``package.json`` instead.
+
+    Never 500s on an unreadable repo: an un-inspectable project resolves to the
+    most capable requirements with a reason saying so. Failing to inspect must
+    not block opening a project.
+    """
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_requirements.resolve_requirements(workspace_id, ctx.user_id, repo, ref)
+
+
+@router.get("/runtimes/archive")
+async def get_runtime_archive(
+    repo: str = Query(..., description="owner/repo or a github.com URL"),
+    ref: str | None = Query(None, description="Branch, tag or commit (default branch if omitted)"),
+    ctx: RequestContext = Depends(request_context),
+) -> Response:
+    """Serve a repo's source as a zip, for seeding ANY in-tab runtime.
+
+    An in-tab runtime has no usable networking of its own for this: cloning
+    inside it runs on an emulated TCP/TLS relay, and the browser cannot fetch
+    GitHub's archives directly because they carry no CORS headers. Fetching
+    server-side solves both, and is where a GitHub App token would live for
+    private repos.
+    """
+    workspace_id = _require_workspace(ctx)
+    content = await websandbox_archive.fetch_repo_archive(workspace_id, ctx.user_id, repo, ref)
+    return Response(content=content, media_type="application/zip")
+
+
+@router.get("/runtimes/{runtime_id}/credentials", response_model=RuntimeCredentialsResponse)
+async def get_runtime_credentials(
+    runtime_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> RuntimeCredentialsResponse:
+    """Issue the credential a browser needs to boot the named in-tab runtime.
+
+    The key lives ONLY in server config; it is never built into the frontend
+    bundle. License + an authenticated, workspace-scoped context gate the issue.
+
+    An UNKNOWN runtime id answers ``available: false`` rather than 404 — the
+    caller is a router that will fall back either way, and an unconfigured
+    runtime and an unknown one should look identical to it.
+    """
+    workspace_id = _require_workspace(ctx)
+    return await websandbox_runtimes.get_runtime_credentials(runtime_id, workspace_id, ctx.user_id)
+
+
+# ---------------------------------------------------------------------------
+# DEPRECATED aliases (BP-1b paths), kept for ONE release. The shipped frontend
+# still calls these; delete once it has moved to the ``/runtimes/*`` paths above.
 # ---------------------------------------------------------------------------
 
 
@@ -206,37 +294,28 @@ async def get_repo_archive(
     ref: str | None = Query(None, description="Branch, tag or commit (default branch if omitted)"),
     ctx: RequestContext = Depends(request_context),
 ) -> Response:
-    """Serve a repo's source as a zip, for seeding an in-tab BrowserPod pod.
+    """DEPRECATED — use ``GET /websandbox/runtimes/archive``.
 
-    The pod has no usable networking of its own for this: cloning inside it runs
-    on BrowserPod's emulated TCP/TLS relay, and the browser cannot fetch GitHub's
-    archives directly because they carry no CORS headers. Fetching server-side
-    solves both, and is where a GitHub App token would live for private repos.
-
-    Path note: TWO literal segments, deliberately. A single-segment path like
-    ``/repo-archive`` is captured by the ``/{row_id}`` route above — FastAPI
-    matches in registration order — so it resolved to "look up a sandbox called
-    repo-archive" and 404'd. Any new collection-level route here needs the same
-    treatment (see ``test_websandbox_routes.py``).
+    Renamed because the name was wrong: this archive seeds ANY in-tab runtime,
+    not just BrowserPod. Behaviour is identical; this alias exists only so the
+    already-shipped frontend keeps working for one release.
     """
-    workspace_id = _require_workspace(ctx)
-    content = await websandbox_archive.fetch_repo_archive(workspace_id, ctx.user_id, repo, ref)
-    return Response(content=content, media_type="application/zip")
+    return await get_runtime_archive(repo=repo, ref=ref, ctx=ctx)
 
 
-@router.get("/browserpod/credentials", response_model=BrowserPodCredentialsResponse)
+@router.get("/browserpod/credentials", response_model=RuntimeCredentialsResponse)
 async def get_browserpod_credentials(
     ctx: RequestContext = Depends(request_context),
-) -> BrowserPodCredentialsResponse:
-    """Issue the credential the browser needs to boot an in-tab BrowserPod pod.
+) -> RuntimeCredentialsResponse:
+    """DEPRECATED — use ``GET /websandbox/runtimes/browserpod/credentials``.
 
-    The key lives ONLY in server config; it is never built into the frontend
-    bundle. License + an authenticated, workspace-scoped context gate the issue.
-    An unconfigured deploy returns ``available: false`` so the client falls back
-    to the Daytona runtime rather than erroring.
+    Renamed because every in-tab runtime needs a brokered browser-side key, not
+    just BrowserPod. Behaviour is identical — it delegates to the generalized
+    handler rather than re-implementing it, so the two paths cannot drift apart
+    while the alias lives. This exists only so the already-shipped frontend keeps
+    working for one release.
     """
-    workspace_id = _require_workspace(ctx)
-    return await websandbox_browserpod.get_credentials(workspace_id, ctx.user_id)
+    return await get_runtime_credentials(runtime_id="browserpod", ctx=ctx)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/websandbox/runtimes.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/runtimes.py
@@ -1,0 +1,62 @@
+# runtimes.py — dispatch a brokered browser-side credential by RUNTIME ID (RR-2).
+# Created 2026-07-20 (feat/code-runtime-requirements).
+#
+# WHY THIS EXISTS: the credential broker was written for BrowserPod and named for
+# it, but the shape was never BrowserPod-specific. Any runtime that boots INSIDE
+# THE USER'S TAB needs a vendor key in that tab, and therefore needs exactly the
+# same treatment: the key lives only in server config, is handed out per-request
+# to an authenticated workspace-scoped caller, and can be rotated, gated and
+# audited centrally instead of being frozen into a frontend build artifact.
+# WebContainers is the next such runtime. Keying the broker by runtime id means
+# adding one is a registry entry here, not a new endpoint.
+#
+# WHY AN UNKNOWN RUNTIME IS NOT A 404: the caller of this endpoint is a router
+# deciding where to run a project, and it treats "no credential" as "use a
+# different runtime". An unconfigured runtime and an unknown one lead to the same
+# action, so they get the same answer — ``available: false``. Returning 404 for
+# one and 200 for the other would force every client to write error-handling that
+# converges on the identical fallback, and would make a typo'd runtime id look
+# like an outage.
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from pocketpaw_ee.cloud.websandbox import browserpod
+from pocketpaw_ee.cloud.websandbox.dto import RuntimeCredentialsResponse
+
+logger = logging.getLogger(__name__)
+
+# runtime id -> the broker that resolves its browser-side credential. Registering
+# a runtime here is the whole cost of adding one to the credential surface.
+_CREDENTIAL_BROKERS: dict[str, Callable[[str, str], Awaitable[RuntimeCredentialsResponse]]] = {
+    "browserpod": browserpod.get_credentials,
+}
+
+
+async def get_runtime_credentials(
+    runtime_id: str,
+    workspace_id: str,
+    user_id: str,
+) -> RuntimeCredentialsResponse:
+    """Return the browser-side boot credential for ``runtime_id``.
+
+    An unknown runtime id answers ``available: false`` rather than raising — see
+    the module header for why that is the honest answer and not a swallowed
+    error. It is logged, because a client asking for a runtime that does not
+    exist is a real (if benign) symptom of a version skew between the frontend's
+    runtime registry and this one.
+    """
+    broker = _CREDENTIAL_BROKERS.get(runtime_id)
+    if broker is None:
+        logger.info(
+            "websandbox: no credential broker for runtime %r — reporting unavailable "
+            "(workspace=%s)",
+            runtime_id,
+            workspace_id,
+        )
+        return RuntimeCredentialsResponse(available=False, apiKey=None)
+    return await broker(workspace_id, user_id)
+
+
+__all__ = ["get_runtime_credentials"]

--- a/tests/cloud/test_websandbox_requirements.py
+++ b/tests/cloud/test_websandbox_requirements.py
@@ -1,0 +1,271 @@
+# test_websandbox_requirements.py — tests for the pre-boot runtime requirements
+# probe and the per-runtime credential broker (RR-2).
+#
+# Two contracts are worth defending here, and neither is about happy-path output:
+#
+#   1. UNKNOWN MUST ROUTE UP, NEVER DOWN. Every way the probe can fail to learn
+#      something — no package.json, GitHub down, a 404, a private repo, a
+#      corrupt manifest — must resolve to the MOST capable requirements, with a
+#      reason. Under-provisioning a runtime breaks the user's session; over-
+#      provisioning only slows it. A test that only checked the happy path would
+#      let a future refactor quietly invert that.
+#
+#   2. THE ANSWER MUST BE EXPLAINABLE. Every flag raised to true carries at least
+#      one reason naming the evidence. That is the difference between a routing
+#      decision and a guess, so it is asserted structurally (for every flag, on
+#      every path) rather than by spot-checking one string.
+#
+# Also pinned: the probe fetches ONE FILE, not the 100MB archive — the old path's
+# whole problem was paying VM-and-repo cost to answer a cheap question — and the
+# SSRF boundary is the same one archive.py enforces, so no caller-supplied string
+# reaches httpx as a URL.
+from __future__ import annotations
+
+import json
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.websandbox import requirements, runtimes
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, content: bytes = b"") -> None:
+        self.status_code = status_code
+        self.content = content
+
+
+class _FakeClient:
+    """Records the URL and params so tests can assert what was actually fetched."""
+
+    last_url: str | None = None
+    last_params: dict | None = None
+
+    def __init__(self, response: _FakeResponse | Exception) -> None:
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url: str, headers=None, params=None):
+        type(self).last_url = url
+        type(self).last_params = params
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _FakeClient.last_url = None
+    _FakeClient.last_params = None
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, response) -> None:
+    monkeypatch.setattr(requirements.httpx, "AsyncClient", lambda **kwargs: _FakeClient(response))
+
+
+def _manifest(**sections) -> bytes:
+    return json.dumps(sections).encode()
+
+
+def _assert_every_true_flag_has_a_reason(result) -> None:
+    """The core contract: a raised flag without evidence is a guess."""
+    joined = " ".join(result.reasons).lower()
+    assert result.reasons, "a verdict with no reasons is unexplainable"
+    for flag in ("install", "nativeToolchain", "rawSockets"):
+        if getattr(result, flag):
+            assert flag.lower() in joined, (
+                f"{flag} is true but no reason mentions it: {result.reasons}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Inference from a manifest — the pure half.
+# ---------------------------------------------------------------------------
+
+
+def test_package_json_implies_install_and_native_toolchain() -> None:
+    result = requirements.infer_from_package_json(json.dumps({"dependencies": {"express": "^4"}}))
+
+    assert result.install is True
+    # An npm install of any non-trivial tree fetches or builds native binaries.
+    assert result.nativeToolchain is True
+    assert result.rawSockets is False
+    _assert_every_true_flag_has_a_reason(result)
+
+
+@pytest.mark.parametrize(
+    "package",
+    ["pg", "mysql2", "mongodb", "mongoose", "ioredis", "better-sqlite3", "amqplib", "tedious"],
+)
+def test_raw_socket_dependency_raises_the_flag(package: str) -> None:
+    result = requirements.infer_from_package_json(json.dumps({"dependencies": {package: "^1"}}))
+
+    assert result.rawSockets is True
+    assert any(package in reason for reason in result.reasons), (
+        f"the reason must name the evidence, got: {result.reasons}"
+    )
+    _assert_every_true_flag_has_a_reason(result)
+
+
+def test_raw_socket_dev_dependency_also_counts() -> None:
+    # A build step or test suite hits the same driver the app would.
+    result = requirements.infer_from_package_json(json.dumps({"devDependencies": {"pg": "^8"}}))
+
+    assert result.rawSockets is True
+    assert any("devDependencies" in reason for reason in result.reasons)
+
+
+def test_unparseable_manifest_defaults_to_most_capable() -> None:
+    result = requirements.infer_from_package_json("{not json at all")
+
+    assert (result.install, result.nativeToolchain, result.rawSockets) == (True, True, True)
+    _assert_every_true_flag_has_a_reason(result)
+
+
+def test_manifest_that_is_not_an_object_defaults_to_most_capable() -> None:
+    result = requirements.infer_from_package_json("[1, 2, 3]")
+
+    assert (result.install, result.nativeToolchain, result.rawSockets) == (True, True, True)
+
+
+# ---------------------------------------------------------------------------
+# End to end — the network half, and the unknown-routes-up rule.
+# ---------------------------------------------------------------------------
+
+
+async def test_resolves_from_fetched_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_client(monkeypatch, _FakeResponse(200, _manifest(dependencies={"redis": "^4"})))
+
+    result = await requirements.resolve_requirements("ws-1", "u-1", "octocat/Hello-World")
+
+    assert result.rawSockets is True
+    _assert_every_true_flag_has_a_reason(result)
+
+
+async def test_missing_package_json_defaults_to_most_capable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Not Node-shaped. We do not know what it needs, so we assume everything.
+    _patch_client(monkeypatch, _FakeResponse(404))
+
+    result = await requirements.resolve_requirements("ws-1", "u-1", "octocat/Hello-World")
+
+    assert (result.install, result.nativeToolchain, result.rawSockets) == (True, True, True)
+    _assert_every_true_flag_has_a_reason(result)
+
+
+async def test_unreachable_github_defaults_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Failing to INSPECT a project must never block OPENING it.
+    import httpx
+
+    _patch_client(monkeypatch, httpx.ConnectError("boom"))
+
+    result = await requirements.resolve_requirements("ws-1", "u-1", "octocat/Hello-World")
+
+    assert (result.install, result.nativeToolchain, result.rawSockets) == (True, True, True)
+    _assert_every_true_flag_has_a_reason(result)
+
+
+async def test_oversized_manifest_is_ignored_not_parsed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    huge = b"x" * (requirements._MAX_MANIFEST_BYTES + 1)
+    _patch_client(monkeypatch, _FakeResponse(200, huge))
+
+    result = await requirements.resolve_requirements("ws-1", "u-1", "octocat/Hello-World")
+
+    assert (result.install, result.nativeToolchain, result.rawSockets) == (True, True, True)
+
+
+# ---------------------------------------------------------------------------
+# Efficiency + SSRF — how it fetches, not just what it returns.
+# ---------------------------------------------------------------------------
+
+
+async def test_fetches_only_package_json_not_the_zip_archive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The old path booted a VM and seeded a repo to learn this. Don't regress."""
+    _patch_client(monkeypatch, _FakeResponse(200, _manifest(dependencies={})))
+
+    await requirements.resolve_requirements("ws-1", "u-1", "octocat/Hello-World")
+
+    assert _FakeClient.last_url == (
+        "https://api.github.com/repos/octocat/Hello-World/contents/package.json"
+    )
+    assert "zipball" not in (_FakeClient.last_url or "")
+
+
+async def test_ref_travels_as_a_query_param(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_client(monkeypatch, _FakeResponse(200, _manifest(dependencies={})))
+
+    await requirements.resolve_requirements("ws-1", "u-1", "octocat/Hello-World", "main")
+
+    assert _FakeClient.last_params == {"ref": "main"}
+    # It must not have been spliced into the path.
+    assert "main" not in (_FakeClient.last_url or "")
+
+
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "https://evil.com/octocat/Hello-World",
+        "http://127.0.0.1:8080/a/b",
+        "../../etc/passwd",
+        "not a repo",
+        "",
+    ],
+)
+async def test_non_github_repo_is_refused_before_any_fetch(
+    monkeypatch: pytest.MonkeyPatch, repo: str
+) -> None:
+    """The SSRF boundary is shared with archive.py and must refuse loudly."""
+    _patch_client(monkeypatch, _FakeResponse(200, _manifest()))
+
+    with pytest.raises(ValidationError):
+        await requirements.resolve_requirements("ws-1", "u-1", repo)
+
+    assert _FakeClient.last_url is None, "refused input must never reach httpx"
+
+
+@pytest.mark.parametrize("ref", ["../../etc", "feature/../..", "a" * 300])
+async def test_bad_ref_is_refused(monkeypatch: pytest.MonkeyPatch, ref: str) -> None:
+    _patch_client(monkeypatch, _FakeResponse(200, _manifest()))
+
+    with pytest.raises(ValidationError):
+        await requirements.resolve_requirements("ws-1", "u-1", "octocat/Hello-World", ref)
+
+
+# ---------------------------------------------------------------------------
+# Per-runtime credential broker.
+# ---------------------------------------------------------------------------
+
+
+async def test_browserpod_runtime_id_uses_the_existing_broker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BROWSERPOD_API_KEY", "bp_live_key_123")
+
+    result = await runtimes.get_runtime_credentials("browserpod", "ws-1", "u-1")
+
+    assert result.available is True
+    assert result.apiKey == "bp_live_key_123"
+
+
+async def test_unknown_runtime_reports_unavailable_not_404() -> None:
+    """An unconfigured runtime and an unknown one look identical to a client.
+
+    Both mean "route this project somewhere else", so returning 404 for one and
+    200 for the other would only force callers to write two branches that
+    converge on the same fallback.
+    """
+    result = await runtimes.get_runtime_credentials("webcontainers", "ws-1", "u-1")
+
+    assert result.available is False
+    assert result.apiKey is None

--- a/tests/cloud/test_websandbox_requirements.py
+++ b/tests/cloud/test_websandbox_requirements.py
@@ -61,6 +61,12 @@ class _FakeClient:
 def _reset():
     _FakeClient.last_url = None
     _FakeClient.last_params = None
+    # The manifest cache is module-level and therefore survives between tests.
+    # Without this, a test that primed `octocat/Hello-World` made a later test
+    # pass while never touching the network — which is precisely the assertion
+    # that later test exists to make. Cross-test leakage through a cache is
+    # invisible when it makes things pass, so reset it explicitly.
+    requirements._reset_cache_for_tests()
 
 
 def _patch_client(monkeypatch: pytest.MonkeyPatch, response) -> None:
@@ -72,13 +78,19 @@ def _manifest(**sections) -> bytes:
 
 
 def _assert_every_true_flag_has_a_reason(result) -> None:
-    """The core contract: a raised flag without evidence is a guess."""
-    joined = " ".join(result.reasons).lower()
+    """The core contract: a raised flag without evidence is a guess.
+
+    Matches the emitted GRAMMAR (``... -> <flag>``) rather than searching the
+    joined text for the flag name. A substring search looked equivalent and was
+    not: the nativeToolchain reason contains the word "install", so deleting the
+    install reason entirely still passed while ``install`` stayed true — the one
+    regression this assertion exists to catch.
+    """
     assert result.reasons, "a verdict with no reasons is unexplainable"
     for flag in ("install", "nativeToolchain", "rawSockets"):
         if getattr(result, flag):
-            assert flag.lower() in joined, (
-                f"{flag} is true but no reason mentions it: {result.reasons}"
+            assert any(reason.rstrip().endswith(f"-> {flag}") for reason in result.reasons), (
+                f"{flag} is true but no reason concludes in it: {result.reasons}"
             )
 
 
@@ -269,3 +281,54 @@ async def test_unknown_runtime_reports_unavailable_not_404() -> None:
 
     assert result.available is False
     assert result.apiKey is None
+
+
+# ---------------------------------------------------------------------------
+# The manifest cache. Unauthenticated GitHub allows 60 requests/hour per egress
+# IP, shared by every tenant, so a probe that runs on every project open must
+# not pay the network for a repo it already looked at.
+# ---------------------------------------------------------------------------
+
+
+async def test_second_probe_for_the_same_repo_skips_the_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(monkeypatch, _FakeResponse(200, _manifest(dependencies={"pg": "^8"})))
+
+    first = await requirements.resolve_requirements("ws-1", "u-1", "acme/app")
+    _FakeClient.last_url = None
+    second = await requirements.resolve_requirements("ws-1", "u-1", "acme/app")
+
+    assert _FakeClient.last_url is None, "the second probe hit the network"
+    assert second.rawSockets is True
+    assert second.reasons == first.reasons
+
+
+async def test_a_different_ref_is_a_different_cache_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ref names a different tree, so it must not reuse another ref's answer."""
+    _patch_client(monkeypatch, _FakeResponse(200, _manifest(dependencies={"pg": "^8"})))
+
+    await requirements.resolve_requirements("ws-1", "u-1", "acme/app", "main")
+    _FakeClient.last_url = None
+    await requirements.resolve_requirements("ws-1", "u-1", "acme/app", "next")
+
+    assert _FakeClient.last_url is not None, "a new ref reused the cached answer"
+
+
+async def test_a_transient_failure_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A GitHub outage must not pin a defaulted verdict for the whole TTL.
+
+    Only answers GitHub actually gave us are cached. Caching a 5xx would mean one
+    bad minute downgrades every open of that repo for the next fifteen.
+    """
+    _patch_client(monkeypatch, _FakeResponse(503, b""))
+    degraded = await requirements.resolve_requirements("ws-1", "u-1", "acme/app")
+    assert degraded.rawSockets is True  # most-capable default
+
+    _patch_client(monkeypatch, _FakeResponse(200, _manifest(dependencies={})))
+    recovered = await requirements.resolve_requirements("ws-1", "u-1", "acme/app")
+
+    assert _FakeClient.last_url is not None, "a transient failure was cached"
+    assert recovered.rawSockets is False

--- a/tests/cloud/test_websandbox_routes.py
+++ b/tests/cloud/test_websandbox_routes.py
@@ -11,6 +11,15 @@
 # That happened. The fix is structural (put such routes under a two-segment
 # prefix), and this test keeps it fixed: every literal GET path registered after
 # ``/{row_id}`` must have at least two segments.
+#
+# Changed 2026-07-20 (RR-2, feat/code-runtime-requirements): the generic rule
+# above was already in place when the second occurrence happened, because a rule
+# only fires for routes that exist — it cannot notice a route someone is ABOUT to
+# add. So every individual runtime route is now pinned by name as well: the
+# requirements probe, the generalized archive, the per-runtime credential broker,
+# and the two deprecated aliases the shipped frontend still calls. Deleting an
+# alias should be a deliberate act that breaks a named test, not a silent rename
+# that 404s in production.
 from __future__ import annotations
 
 from fastapi.routing import APIRoute
@@ -70,3 +79,71 @@ def test_repo_archive_is_reachable() -> None:
     assert len(_sub_segments(archive.path)) >= 2, (
         f"{archive.path} has one literal segment and will be captured by /{{row_id}}"
     )
+
+
+# ---------------------------------------------------------------------------
+# RR-2 — every runtime route, pinned by name.
+# ---------------------------------------------------------------------------
+
+
+def _assert_reachable(path: str) -> APIRoute:
+    """The route exists AND cannot be swallowed by an earlier path param.
+
+    "Reachable" here means two things, and both have failed before: the route is
+    registered at all, and nothing registered earlier matches the same shape. The
+    second is the subtle one — a route can be present in the app and still answer
+    404 because ``/{row_id}`` claimed the URL first.
+    """
+    routes = _routes()
+    match = next((r for r in routes if r.path == path), None)
+    assert match is not None, (
+        f"{path} is not registered. Registered GET paths: "
+        f"{sorted(r.path for r in routes if 'GET' in r.methods)}"
+    )
+
+    segments = _sub_segments(path)
+    assert len(segments) >= 2, (
+        f"{path} has one segment below the prefix and will be captured by /{{row_id}}"
+    )
+
+    # Nothing registered BEFORE it may match the same URL shape. A same-arity
+    # earlier route whose leading segment is a path param (i.e. /{row_id}/…)
+    # wins on registration order and this route becomes dead.
+    own_index = routes.index(match)
+    for earlier in routes[:own_index]:
+        if "GET" not in earlier.methods:
+            continue
+        earlier_segments = _sub_segments(earlier.path)
+        if len(earlier_segments) != len(segments):
+            continue
+        shadows = all(e.startswith("{") or e == mine for e, mine in zip(earlier_segments, segments))
+        assert not shadows, (
+            f"{path} is shadowed by the earlier route {earlier.path} — FastAPI "
+            "matches in registration order, so this endpoint will 404."
+        )
+    return match
+
+
+def test_runtime_requirements_route_is_reachable() -> None:
+    """The pre-boot requirements probe — the whole point of RR-2."""
+    _assert_reachable(f"{_PREFIX}/runtimes/requirements")
+
+
+def test_runtime_archive_route_is_reachable() -> None:
+    """The generalized archive path (seeds any in-tab runtime, not just BrowserPod)."""
+    _assert_reachable(f"{_PREFIX}/runtimes/archive")
+
+
+def test_runtime_credentials_route_is_reachable() -> None:
+    """The per-runtime credential broker."""
+    _assert_reachable(f"{_PREFIX}/runtimes/{{runtime_id}}/credentials")
+
+
+def test_deprecated_browserpod_aliases_still_registered() -> None:
+    """The shipped frontend still calls these — they must survive one release.
+
+    Named explicitly so removing an alias is a deliberate act that fails a test
+    with an obvious name, rather than a rename that quietly 404s in production.
+    """
+    _assert_reachable(f"{_PREFIX}/browserpod/repo-archive")
+    _assert_reachable(f"{_PREFIX}/browserpod/credentials")


### PR DESCRIPTION
Code Mode is growing a runtime registry: the frontend picks where a project runs
by matching what the project needs against what each runtime can do. This is the
half that answers "what does this project need" — and it has to answer before
anything boots.

The old probe was chicken-and-egg. To find out whether a repo was Node-shaped, it
booted a whole VM, seeded the entire repo, read the root file list, discovered the
answer was no, and threw all of it away. The backend already fetches repo source,
so it can answer the question for the cost of one file.

## What's here

`GET /websandbox/runtimes/requirements?repo=&ref=` returns
`{install, nativeToolchain, rawSockets, reasons[]}`.

`reasons` is the point, not decoration. Every flag raised to true carries at
least one line naming the evidence — `pg in dependencies opens a network socket
to a database or broker -> rawSockets` — so a routing decision can be explained
instead of guessed at. That contract is asserted structurally, on every path, not
spot-checked against one string.

**Unknown routes up, never down.** No `package.json`, GitHub down, a 404, a
private repo, a corrupt manifest — every way of failing to learn something
resolves to the most capable requirements, with a reason. Under-provisioning
strands the user at first query; over-provisioning only costs a slower sandbox.
Failing to inspect a project must never block opening it, so nothing here 500s.

Also generalizes two route names that stopped being true: the archive seeds any
in-tab runtime, not just BrowserPod, and WebContainers needs a brokered
browser-side key exactly like BrowserPod does. `/websandbox/runtimes/archive` and
`/websandbox/runtimes/{id}/credentials`, with the old paths kept as deprecated
aliases that delegate rather than duplicate.

## Review changed three things worth reading

**An ORM hides its driver.** Real Node apps reach Postgres through Prisma or
Drizzle, so `pg` is a transitive dependency that never appears in `package.json`.
Matching bare driver names returned a confident `rawSockets: false` for a
Prisma+Postgres app — under-provisioning, the exact outcome this module says must
never happen. ORMs and scoped names (`@prisma/`) now match.

**A reason was factually false.** `better-sqlite3` raised `rawSockets` with
"in dependencies -> rawSockets". It opens no sockets at all. The verdict was right
— it's a native FFI binding an in-tab runtime can't load — and the explanation was
wrong, which is the worst pairing: it survives review and then sends the next
debugger hunting a network problem that doesn't exist. Each entry now carries its
own cause.

**60 requests per hour, for the whole deploy.** The probe is unauthenticated, so
GitHub's limit is keyed on our egress IP and shared across every tenant. Past it,
every project silently defaulted to a full VM while the endpoint still reported
success. A TTL cache contains the cost and a distinct WARNING makes the
degradation visible in logs. Authenticating via the GitHub App is the real fix and
is shared work with `archive.py`, which is unauthenticated for the same reason —
tracked as a follow-up rather than bolted onto one of the two.

## Route ordering

`@router.get("/{row_id}")` is registered above these, and FastAPI matches in
registration order, so a single-segment `/runtimes` would resolve to "look up a
sandbox called runtimes" and 404. That already happened once with
`/repo-archive`. A comment didn't prevent the second occurrence, so
`test_websandbox_routes.py` now pins it — verified by registering the bad route
and watching the suite fail.

## SSRF

The repo reference is never treated as a URL. `archive._parse_github_repo`
extracts owner/name and the GitHub URL is built server-side; the ref is
allowlisted and passed as an encoded query param. An unparseable reference is
refused with a 400 rather than defaulted — softening an SSRF boundary into a
silent default would be the wrong trade.

The probe also can't be used to prove a private repo exists: absent, private, 404
and unreachable all return byte-identical responses.

## Testing

```
pytest tests/cloud/ -k websandbox --ignore=tests/cloud/extraction
306 passed

ruff check .          All checks passed!
ruff format --check . 2469 files already formatted
```
