### PR TITLE
Derive the native-toolchain requirement from the manifest

### DIFF
--- a/ee/pocketpaw_ee/cloud/websandbox/requirements.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/requirements.py
@@ -88,12 +88,19 @@ _MAX_MANIFEST_BYTES = 2 * 1024 * 1024
 # project that talks to Postgres or Redis directly can only run in a real VM.
 #
 # Each entry carries the CAUSE it raises the flag for, because the reason string
-# is the product here. An earlier version emitted "better-sqlite3 in dependencies
-# -> rawSockets", which is simply false — better-sqlite3 is an embedded file
-# database that opens no sockets. It still needs a real machine (it is a native
-# FFI binding an in-tab runtime cannot load), so the VERDICT was right and the
-# EXPLANATION was wrong. That is the worst combination: it survives review and
-# then sends the next debugger hunting a network problem that does not exist.
+# is the product here. This table must contain ONLY packages that open a real
+# network socket — nothing else, however much it might also need a VM.
+#
+# sqlite3 and better-sqlite3 used to live here (as "native FFI, honest reason"),
+# because before ``nativeToolchain`` was derived, rawSockets was the ONLY lever
+# that could force an embedded-database project onto a real VM. That is no longer
+# true: the native-toolchain table below now catches them for the real reason
+# they need a machine (they compile), so keeping them here would emit a
+# ``-> rawSockets`` reason for a package that opens no socket — the exact
+# mislabel this comment used to describe as "the worst combination: it survives
+# review and then sends the next debugger hunting a network problem that does not
+# exist". The routing was always safe (a VM either way); the EVIDENCE was wrong,
+# and now that a correct lever exists the wrong one is simply removed.
 #
 # ORMs matter more than drivers. Real Node apps reach Postgres through Prisma or
 # Drizzle, and `pg` is then a TRANSITIVE dependency that never appears in
@@ -102,7 +109,6 @@ _MAX_MANIFEST_BYTES = 2 * 1024 * 1024
 # module's header says must never happen: it strands the user at first query,
 # whereas over-provisioning only costs a slower sandbox.
 _SOCKET = "opens a network socket to a database or broker"
-_NATIVE_FFI = "is a native FFI binding an in-tab runtime cannot load"
 _ORM = "is a database client whose driver is a transitive dependency"
 
 _RAW_SOCKET_PACKAGES: dict[str, str] = {
@@ -133,9 +139,9 @@ _RAW_SOCKET_PACKAGES: dict[str, str] = {
     "sequelize": _ORM,
     "typeorm": _ORM,
     "knex": _ORM,
-    # Native FFI, not sockets. Same verdict, honest reason.
-    "sqlite3": _NATIVE_FFI,
-    "better-sqlite3": _NATIVE_FFI,
+    # NOTE: sqlite3 / better-sqlite3 are deliberately NOT here — they open no
+    # socket. They are in _NATIVE_TOOLCHAIN_PACKAGES, which is the honest reason
+    # they need a VM. See the comment above.
 }
 
 # Scoped packages can never match a bare name, so they are matched by prefix.
@@ -208,36 +214,58 @@ _NATIVE_TOOLCHAIN_PACKAGES: dict[str, str] = {
     "prebuild-install": _COMPILES,
     "nan": _COMPILES,
     "node-addon-api": _COMPILES,
+    "ffi-napi": _COMPILES,
+    "re2": _COMPILES,
+    "keytar": _COMPILES,
     # Prebuilt machine code with no portable fallback. sharp wraps libvips;
-    # puppeteer and playwright each download a real browser binary.
+    # puppeteer and playwright each download a real browser binary; electron and
+    # sass-embedded each ship a platform binary with no WASM path (sass-embedded
+    # is the Dart binary — the plain `sass` package is the JS/WASM one and is NOT
+    # here).
     "sharp": _MACHINE_CODE,
     "puppeteer": _MACHINE_CODE,
     "playwright": _MACHINE_CODE,
+    "sass-embedded": _MACHINE_CODE,
+    "electron": _MACHINE_CODE,
+    "electron-builder": _MACHINE_CODE,
+    "@sentry/profiling-node": _MACHINE_CODE,
     "@tensorflow/tfjs-node": _MACHINE_CODE,
 }
 
 # Scoped native-binding families, matched by prefix for the same reason the raw
 # socket table has one. `@napi-rs/*` and `@node-rs/*` are Rust addons compiled to
-# `.node` files; `@swc/core` is a Rust binary — though note swc, like rollup,
-# also publishes a WASM build, so it sits here only when named directly.
+# `.node` files. `@playwright/*` is the canonical way Playwright enters a project
+# — `npm init playwright` installs `@playwright/test`, NOT the bare `playwright`
+# above — and every one of them drives a real downloaded browser binary, so the
+# prefix is what actually closes the common case; the bare name alone would strand
+# nearly every Playwright user on an in-tab runtime.
 _NATIVE_TOOLCHAIN_PREFIXES: dict[str, str] = {
     "@napi-rs/": _MACHINE_CODE,
     "@node-rs/": _MACHINE_CODE,
+    "@playwright/": _MACHINE_CODE,
 }
 
-# Tokens that, appearing in a `scripts` value, mean the manifest itself says it
-# shells out to a compiler. This is the strongest evidence available short of
-# resolving the tree — the project is describing its own build in its own words.
-_NATIVE_BUILD_MARKERS: tuple[str, ...] = (
-    "node-gyp",
-    "node-pre-gyp",
-    "cmake-js",
-    "prebuild",
-    "gcc ",
-    "g++ ",
-    "clang ",
-    "cargo build",
-    "make ",
+# Compiler invocations that, appearing in a `scripts` value, mean the manifest
+# itself says it shells out to a compiler — the strongest evidence available
+# short of resolving the tree, because the project is describing its own build in
+# its own words.
+#
+# Matched at a COMMAND BOUNDARY, not as a raw substring, and this is load-bearing
+# in both directions. Substring matching (the first cut) fired `make` inside
+# `cmake` and `prebuild` inside the npm `prebuild` lifecycle-script name — both
+# over-provision, which is safe for routing but re-hides the in-tab runtime for a
+# project that merely names a script `prebuild`, defeating the point of the whole
+# change. It is dropped entirely here: the `prebuild` / `prebuild-install`
+# PACKAGES are already in the toolchain table, so the marker only ever added
+# false positives. Each alternative below is bounded by a shell separator (start,
+# whitespace, `;`, `&`, `|`, or a paren) on both sides so `cmake` is its own
+# token and never the tail of another word. `cmake` is listed as its own marker
+# so it reports as cmake rather than mislabelling as make.
+_NATIVE_BUILD_RE = re.compile(
+    r"(?:^|[\s;&|()])"
+    r"(node-gyp|node-pre-gyp|cmake-js|cmake|gcc|clang|g\+\+|cargo\s+build|make)"
+    r"(?:$|[\s;&|()])",
+    re.IGNORECASE,
 )
 
 # Kept in sync with archive.py's ref rules: a ref is attacker-influenced text, so
@@ -444,7 +472,12 @@ def _match(
 
 
 def _compiling_scripts(manifest: dict[str, Any]) -> set[tuple[str, str]]:
-    """Return ``(script name, marker)`` for every script that shells out to a compiler.
+    """Return ``(script name, matched token)`` for every script that shells out to a compiler.
+
+    The matched token is carried through to the reason ("the build script runs
+    cmake …") so the evidence names what actually triggered it rather than a
+    canonical marker — the difference between "runs cmake" and the old
+    "runs make" for a ``cmake .`` command.
 
     Only the `scripts` block is read. A marker in a dependency's OWN scripts is
     invisible here — we have not resolved the tree — which is the same limit the
@@ -458,14 +491,12 @@ def _compiling_scripts(manifest: dict[str, Any]) -> set[tuple[str, str]]:
     for name, command in scripts.items():
         if not isinstance(name, str) or not isinstance(command, str):
             continue
-        # Padded so a bare "make " marker cannot match "makefile" or "cmake-js"
-        # mid-token; the command is lowercased because npm scripts are shell and
-        # casing is not meaningful for these binaries.
-        haystack = f" {command.lower()} "
-        for marker in _NATIVE_BUILD_MARKERS:
-            if marker in haystack:
-                hits.add((name, marker))
-                break
+        match = _NATIVE_BUILD_RE.search(command)
+        if match is not None:
+            # group(1) is the actual token, whitespace-normalised so
+            # "cargo   build" reads as "cargo build" in the reason.
+            token = " ".join(match.group(1).lower().split())
+            hits.add((name, token))
     return hits
 
 
@@ -509,11 +540,10 @@ def infer_from_package_json(raw: str) -> RuntimeRequirementsResponse:
             'the manifest sets "gypfile": true, so installing it runs node-gyp -> nativeToolchain'
         )
 
-    for script, marker in sorted(_compiling_scripts(manifest)):
+    for script, token in sorted(_compiling_scripts(manifest)):
         native_hits.append((script, "scripts"))
         reasons.append(
-            f'the "{script}" script runs {marker.strip()}, which needs a compiler '
-            f"-> nativeToolchain"
+            f'the "{script}" script runs {token}, which needs a compiler -> nativeToolchain'
         )
 
     return RuntimeRequirementsResponse(

--- a/ee/pocketpaw_ee/cloud/websandbox/requirements.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/requirements.py
@@ -1,6 +1,10 @@
 # requirements.py — resolve what a PROJECT NEEDS from a runtime, before any
 # runtime boots (RR-2).
 # Created 2026-07-20 (feat/code-runtime-requirements).
+# Modified 2026-07-21 — ``nativeToolchain`` is now DERIVED from the manifest
+# instead of hardcoded true. See the note above ``_NATIVE_TOOLCHAIN_PACKAGES``
+# for what the blanket assumption cost: it made every in-tab runtime
+# unselectable for every project, which is the whole point of the registry.
 #
 # WHY THIS EXISTS: Code Mode picks an execution runtime (Daytona cloud VM,
 # WebContainers in-tab, …) by matching what a project NEEDS against what each
@@ -140,6 +144,101 @@ _RAW_SOCKET_PREFIXES: dict[str, str] = {
     "@prisma/": _ORM,
     "@databases/": _ORM,
 }
+
+# Packages that genuinely need a NATIVE TOOLCHAIN — a compiler, or a prebuilt
+# machine-code binary with no portable fallback.
+#
+# WHAT THIS REPLACED, because the distinction is the entire fix: this probe used
+# to return ``nativeToolchain=True`` for EVERY manifest, on the reasoning that
+# "any non-trivial tree pulls prebuilt native binaries (esbuild, rollup's native
+# bindings, sharp, node-gyp fallbacks)". That sentence quietly merges two
+# different facts under one flag:
+#
+#   • esbuild and rollup ship prebuilt binaries AND a WASM/JS fallback. They run
+#     in an in-tab runtime. Our own 2026-07-18 WebContainers gate run is the
+#     evidence: `npm install` exit 0 across 320 packages, then a working Vite
+#     dev server on the rollup toolchain. The very packages the old reason cited
+#     as proof were the ones already demonstrated to work.
+#   • better-sqlite3 and sharp must compile, or load machine code with no
+#     portable path. They genuinely cannot.
+#
+# ``Capabilities.nativeToolchain`` on the client side is defined as the second
+# ("compile and run NATIVE code: gcc, node-gyp, native node modules, anything
+# that is not portable bytecode or WASM"). So the blanket true was not merely
+# cautious — it asserted, of every project, a need most of them do not have.
+# And because the WebContainers adapter honestly declares `nativeToolchain:
+# false`, the two combined made that runtime unselectable BY CONSTRUCTION: no
+# env var, no config, no operator could reach it. A registry that can only ever
+# pick one runtime is not a registry.
+#
+# THE DIRECTION OF ERROR IS STILL ASYMMETRIC, and this table is built for that.
+# Under-provisioning strands the user mid-build; over-provisioning only costs a
+# slower sandbox. So membership here is generous — anything that plausibly
+# compiles belongs — and the UNKNOWN paths (absent manifest, unparseable JSON,
+# unreachable GitHub) are untouched by this change and still route to
+# most-capable. What changed is only that a manifest we CAN read and that shows
+# no evidence of compiling now gets to say so.
+_COMPILES = "compiles native code at install time"
+_MACHINE_CODE = "loads a prebuilt machine-code binary with no WASM fallback"
+
+_NATIVE_TOOLCHAIN_PACKAGES: dict[str, str] = {
+    # node-gyp addons — the classic case.
+    "better-sqlite3": _COMPILES,
+    "sqlite3": _COMPILES,
+    "bcrypt": _COMPILES,
+    "argon2": _COMPILES,
+    "canvas": _COMPILES,
+    "node-sass": _COMPILES,
+    "zeromq": _COMPILES,
+    "serialport": _COMPILES,
+    "usb": _COMPILES,
+    "node-hid": _COMPILES,
+    "leveldown": _COMPILES,
+    "robotjs": _COMPILES,
+    "node-pty": _COMPILES,
+    "grpc": _COMPILES,
+    "libxmljs": _COMPILES,
+    # The build tooling itself. Its presence in a manifest is a direct statement
+    # that something here gets compiled.
+    "node-gyp": _COMPILES,
+    "node-pre-gyp": _COMPILES,
+    "@mapbox/node-pre-gyp": _COMPILES,
+    "cmake-js": _COMPILES,
+    "prebuild": _COMPILES,
+    "prebuild-install": _COMPILES,
+    "nan": _COMPILES,
+    "node-addon-api": _COMPILES,
+    # Prebuilt machine code with no portable fallback. sharp wraps libvips;
+    # puppeteer and playwright each download a real browser binary.
+    "sharp": _MACHINE_CODE,
+    "puppeteer": _MACHINE_CODE,
+    "playwright": _MACHINE_CODE,
+    "@tensorflow/tfjs-node": _MACHINE_CODE,
+}
+
+# Scoped native-binding families, matched by prefix for the same reason the raw
+# socket table has one. `@napi-rs/*` and `@node-rs/*` are Rust addons compiled to
+# `.node` files; `@swc/core` is a Rust binary — though note swc, like rollup,
+# also publishes a WASM build, so it sits here only when named directly.
+_NATIVE_TOOLCHAIN_PREFIXES: dict[str, str] = {
+    "@napi-rs/": _MACHINE_CODE,
+    "@node-rs/": _MACHINE_CODE,
+}
+
+# Tokens that, appearing in a `scripts` value, mean the manifest itself says it
+# shells out to a compiler. This is the strongest evidence available short of
+# resolving the tree — the project is describing its own build in its own words.
+_NATIVE_BUILD_MARKERS: tuple[str, ...] = (
+    "node-gyp",
+    "node-pre-gyp",
+    "cmake-js",
+    "prebuild",
+    "gcc ",
+    "g++ ",
+    "clang ",
+    "cargo build",
+    "make ",
+)
 
 # Kept in sync with archive.py's ref rules: a ref is attacker-influenced text, so
 # it is matched against an allowlist before it is used at all.
@@ -306,6 +405,16 @@ def _declared_dependencies(manifest: dict[str, Any]) -> dict[str, str]:
     just as disqualifying for an in-tab runtime as one in ``dependencies``.
     ``dependencies`` is checked last so it wins the attribution when a package is
     declared in both.
+
+    ``optionalDependencies`` is deliberately NOT read, and this is load-bearing
+    for ``nativeToolchain``. Rollup, esbuild and swc all publish their
+    per-platform prebuilt binaries there — ``@rollup/rollup-linux-x64-gnu``,
+    ``@esbuild/darwin-arm64`` — and npm installs only the one matching the host,
+    skipping the rest. Every one of them has a JS or WASM fallback, which is
+    precisely why the 2026-07-18 gate run's Vite app built in an in-tab runtime.
+    Scanning that section for native-looking names would mark every modern
+    frontend project as needing a compiler and quietly restore the blanket
+    behaviour this module was fixed to remove.
     """
     declared: dict[str, str] = {}
     for field in ("devDependencies", "dependencies"):
@@ -316,6 +425,48 @@ def _declared_dependencies(manifest: dict[str, Any]) -> dict[str, str]:
             if isinstance(package, str):
                 declared[package] = field
     return declared
+
+
+def _match(
+    package: str,
+    exact: dict[str, str],
+    prefixes: dict[str, str],
+) -> str | None:
+    """Look a package up by exact name, then by scoped prefix.
+
+    Shared by the raw-socket and native-toolchain tables because they had
+    identical lookup logic and one of them would inevitably drift.
+    """
+    cause = exact.get(package)
+    if cause is not None:
+        return cause
+    return next((c for prefix, c in prefixes.items() if package.startswith(prefix)), None)
+
+
+def _compiling_scripts(manifest: dict[str, Any]) -> set[tuple[str, str]]:
+    """Return ``(script name, marker)`` for every script that shells out to a compiler.
+
+    Only the `scripts` block is read. A marker in a dependency's OWN scripts is
+    invisible here — we have not resolved the tree — which is the same limit the
+    package tables work around by naming known offenders.
+    """
+    scripts = manifest.get("scripts")
+    if not isinstance(scripts, dict):
+        return set()
+
+    hits: set[tuple[str, str]] = set()
+    for name, command in scripts.items():
+        if not isinstance(name, str) or not isinstance(command, str):
+            continue
+        # Padded so a bare "make " marker cannot match "makefile" or "cmake-js"
+        # mid-token; the command is lowercased because npm scripts are shell and
+        # casing is not meaningful for these binaries.
+        haystack = f" {command.lower()} "
+        for marker in _NATIVE_BUILD_MARKERS:
+            if marker in haystack:
+                hits.add((name, marker))
+                break
+    return hits
 
 
 def infer_from_package_json(raw: str) -> RuntimeRequirementsResponse:
@@ -333,34 +484,41 @@ def infer_from_package_json(raw: str) -> RuntimeRequirementsResponse:
     if not isinstance(manifest, dict):
         return _most_capable("package.json is not a JSON object, so nothing can be ruled out")
 
-    reasons = [
-        "package.json present -> install",
-        # Worded as the ASSUMPTION it is. We have not resolved the dependency
-        # tree — only read the manifest — so we cannot claim a native build step
-        # actually occurs; an empty manifest has none. But any non-trivial tree
-        # pulls prebuilt native binaries (esbuild, rollup's native bindings,
-        # sharp, node-gyp fallbacks), and over-provisioning only costs speed
-        # while under-provisioning strands the user.
-        "package.json present, dependency tree not resolved; assuming a native "
-        "build step -> nativeToolchain",
-    ]
+    reasons = ["package.json present -> install"]
 
     dependencies = _declared_dependencies(manifest)
     raw_socket_hits: list[tuple[str, str]] = []
+    native_hits: list[tuple[str, str]] = []
     for package, section in sorted(dependencies.items()):
-        cause = _RAW_SOCKET_PACKAGES.get(package)
-        if cause is None:
-            cause = next(
-                (c for prefix, c in _RAW_SOCKET_PREFIXES.items() if package.startswith(prefix)),
-                None,
-            )
+        cause = _match(package, _RAW_SOCKET_PACKAGES, _RAW_SOCKET_PREFIXES)
         if cause is not None:
             raw_socket_hits.append((package, section))
             reasons.append(f"{package} in {section} {cause} -> rawSockets")
 
+        native_cause = _match(package, _NATIVE_TOOLCHAIN_PACKAGES, _NATIVE_TOOLCHAIN_PREFIXES)
+        if native_cause is not None:
+            native_hits.append((package, section))
+            reasons.append(f"{package} in {section} {native_cause} -> nativeToolchain")
+
+    # npm's own marker that the package carries a `binding.gyp`, i.e. that
+    # installing it runs node-gyp. Rare in an application manifest and decisive
+    # when present.
+    if manifest.get("gypfile") is True:
+        native_hits.append(("gypfile", "the manifest root"))
+        reasons.append(
+            'the manifest sets "gypfile": true, so installing it runs node-gyp -> nativeToolchain'
+        )
+
+    for script, marker in sorted(_compiling_scripts(manifest)):
+        native_hits.append((script, "scripts"))
+        reasons.append(
+            f'the "{script}" script runs {marker.strip()}, which needs a compiler '
+            f"-> nativeToolchain"
+        )
+
     return RuntimeRequirementsResponse(
         install=True,
-        nativeToolchain=True,
+        nativeToolchain=bool(native_hits),
         rawSockets=bool(raw_socket_hits),
         reasons=reasons,
     )

--- a/tests/cloud/test_websandbox_requirements.py
+++ b/tests/cloud/test_websandbox_requirements.py
@@ -99,14 +99,156 @@ def _assert_every_true_flag_has_a_reason(result) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_package_json_implies_install_and_native_toolchain() -> None:
+def test_package_json_implies_install() -> None:
     result = requirements.infer_from_package_json(json.dumps({"dependencies": {"express": "^4"}}))
 
     assert result.install is True
-    # An npm install of any non-trivial tree fetches or builds native binaries.
-    assert result.nativeToolchain is True
     assert result.rawSockets is False
     _assert_every_true_flag_has_a_reason(result)
+
+
+# ---------------------------------------------------------------------------
+# nativeToolchain — EVIDENCE, not assumption.
+#
+# The probe used to hardcode ``nativeToolchain=True`` for every manifest,
+# reasoning that "any non-trivial tree pulls prebuilt native binaries (esbuild,
+# rollup's native bindings, sharp, node-gyp fallbacks)". That conflated two
+# different things under one flag:
+#
+#   • a package that ships a prebuilt binary WITH a WASM fallback (esbuild,
+#     rollup) — runs fine in an in-tab runtime, which our own 2026-07-18
+#     WebContainers gate run demonstrated: npm install exit 0 over 320 packages,
+#     then a working Vite dev server on the rollup toolchain.
+#   • a package that must COMPILE native code or load a binary with no WASM
+#     path (better-sqlite3, node-gyp, sharp) — genuinely cannot.
+#
+# ``Capabilities.nativeToolchain`` in the client registry is defined as the
+# SECOND ("compile and run NATIVE code: gcc, node-gyp, native node modules"), so
+# the blanket true made every project claim a need it did not have, and no
+# in-tab runtime could ever be selected for anything. The flag is unselectable-
+# by-construction in one direction and useless in the other; these tests pin the
+# distinction.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dependencies",
+    [
+        {"express": "^4"},
+        # The exact packages the old blanket reason cited. Both ship prebuilt
+        # binaries with a WASM/JS fallback, and both are proven to work in an
+        # in-tab runtime by the gate run.
+        {"vite": "^5", "rollup": "^4"},
+        {"esbuild": "^0.20"},
+        {"svelte": "^5", "@sveltejs/kit": "^2"},
+    ],
+)
+def test_a_plain_node_project_does_not_need_a_native_toolchain(dependencies: dict) -> None:
+    result = requirements.infer_from_package_json(json.dumps({"dependencies": dependencies}))
+
+    assert result.nativeToolchain is False, (
+        f"{sorted(dependencies)} compiles nothing native; claiming otherwise makes every "
+        f"in-tab runtime unselectable. Reasons: {result.reasons}"
+    )
+    _assert_every_true_flag_has_a_reason(result)
+
+
+@pytest.mark.parametrize(
+    "package",
+    ["better-sqlite3", "sqlite3", "sharp", "canvas", "bcrypt", "node-gyp", "serialport"],
+)
+def test_a_package_that_compiles_native_code_raises_the_flag(package: str) -> None:
+    result = requirements.infer_from_package_json(json.dumps({"dependencies": {package: "^1"}}))
+
+    assert result.nativeToolchain is True
+    assert any(package in reason for reason in result.reasons), (
+        f"the reason must name the evidence, got: {result.reasons}"
+    )
+    _assert_every_true_flag_has_a_reason(result)
+
+
+def test_a_native_dev_dependency_also_counts() -> None:
+    # A build step that compiles an addon needs the toolchain just as much as a
+    # runtime dependency does.
+    result = requirements.infer_from_package_json(
+        json.dumps({"devDependencies": {"sharp": "^0.33"}})
+    )
+
+    assert result.nativeToolchain is True
+    assert any("devDependencies" in reason for reason in result.reasons)
+
+
+@pytest.mark.parametrize(
+    "scripts",
+    [
+        {"install": "node-gyp rebuild"},
+        {"postinstall": "node-pre-gyp install --fallback-to-build"},
+        {"rebuild": "cmake-js compile"},
+        {"build:native": "make -C src/native"},
+    ],
+)
+def test_a_build_script_that_compiles_raises_the_flag(scripts: dict) -> None:
+    # The strongest possible evidence: the manifest says, in its own words, that
+    # it shells out to a compiler.
+    result = requirements.infer_from_package_json(json.dumps({"scripts": scripts}))
+
+    assert result.nativeToolchain is True
+    _assert_every_true_flag_has_a_reason(result)
+
+
+def test_gypfile_raises_the_flag() -> None:
+    # npm's own marker that this package carries a binding.gyp.
+    result = requirements.infer_from_package_json(json.dumps({"gypfile": True}))
+
+    assert result.nativeToolchain is True
+
+
+def test_a_scoped_native_package_is_matched_by_prefix() -> None:
+    result = requirements.infer_from_package_json(
+        json.dumps({"dependencies": {"@napi-rs/canvas": "^0.1"}})
+    )
+
+    assert result.nativeToolchain is True
+
+
+def test_platform_binaries_in_optional_dependencies_do_not_raise_the_flag() -> None:
+    """The regression that would silently restore the old behaviour.
+
+    Rollup, esbuild and swc all declare their per-platform prebuilt binaries as
+    ``optionalDependencies`` — ``@rollup/rollup-linux-x64-gnu`` and friends. npm
+    installs whichever matches the host and SKIPS the rest, and every one of them
+    has a JS or WASM fallback, which is exactly why the gate run's Vite app
+    worked. Scanning that section for native-looking names would mark every
+    modern frontend project as needing a compiler again.
+    """
+    result = requirements.infer_from_package_json(
+        json.dumps(
+            {
+                "dependencies": {"vite": "^5"},
+                "optionalDependencies": {
+                    "@rollup/rollup-linux-x64-gnu": "4.9.0",
+                    "@esbuild/darwin-arm64": "0.20.0",
+                },
+            }
+        )
+    )
+
+    assert result.nativeToolchain is False, (
+        f"optionalDependencies are per-platform prebuilds with fallbacks: {result.reasons}"
+    )
+
+
+def test_an_unreadable_manifest_still_routes_up() -> None:
+    """The fail-up policy is unchanged by this fix, and must stay that way.
+
+    Narrowing ``nativeToolchain`` is only safe because "we could not tell" still
+    resolves to most-capable. If a future change ever made the unknown path
+    default small, an unreachable GitHub would start routing real projects to a
+    runtime that cannot build them.
+    """
+    result = requirements.infer_from_package_json("{not json at all")
+
+    assert result.nativeToolchain is True
 
 
 @pytest.mark.parametrize(

--- a/tests/cloud/test_websandbox_requirements.py
+++ b/tests/cloud/test_websandbox_requirements.py
@@ -155,7 +155,23 @@ def test_a_plain_node_project_does_not_need_a_native_toolchain(dependencies: dic
 
 @pytest.mark.parametrize(
     "package",
-    ["better-sqlite3", "sqlite3", "sharp", "canvas", "bcrypt", "node-gyp", "serialport"],
+    [
+        "better-sqlite3",
+        "sqlite3",
+        "sharp",
+        "canvas",
+        "bcrypt",
+        "node-gyp",
+        "serialport",
+        # The under-provisioning gap review caught: @playwright/test is the
+        # canonical Playwright install (npm init playwright), and the bare
+        # `playwright` name alone left it routing to an in-tab runtime it cannot
+        # run. sass-embedded / electron each ship a platform binary with no WASM
+        # path. All three would have STRANDED the user before this coverage.
+        "@playwright/test",
+        "sass-embedded",
+        "electron",
+    ],
 )
 def test_a_package_that_compiles_native_code_raises_the_flag(package: str) -> None:
     result = requirements.infer_from_package_json(json.dumps({"dependencies": {package: "^1"}}))
@@ -165,6 +181,25 @@ def test_a_package_that_compiles_native_code_raises_the_flag(package: str) -> No
         f"the reason must name the evidence, got: {result.reasons}"
     )
     _assert_every_true_flag_has_a_reason(result)
+
+
+@pytest.mark.parametrize("package", ["better-sqlite3", "sqlite3"])
+def test_an_embedded_database_needs_a_toolchain_but_opens_no_socket(package: str) -> None:
+    """The mislabel review caught: sqlite is a native FFI binding, not a socket.
+
+    It needs a VM (it compiles), and it must say so via nativeToolchain — but it
+    must NOT claim rawSockets, because it opens none. An earlier cut kept it in
+    the raw-socket table as the only lever that could force a VM; now that
+    nativeToolchain exists, the wrong lever is removed rather than left to send a
+    debugger hunting a network problem that does not exist.
+    """
+    result = requirements.infer_from_package_json(json.dumps({"dependencies": {package: "^1"}}))
+
+    assert result.nativeToolchain is True
+    assert result.rawSockets is False, (
+        f"{package} opens no socket; the reason must not claim one: {result.reasons}"
+    )
+    assert not any("-> rawSockets" in reason for reason in result.reasons)
 
 
 def test_a_native_dev_dependency_also_counts() -> None:
@@ -185,6 +220,10 @@ def test_a_native_dev_dependency_also_counts() -> None:
         {"postinstall": "node-pre-gyp install --fallback-to-build"},
         {"rebuild": "cmake-js compile"},
         {"build:native": "make -C src/native"},
+        # make with no trailing space (end of command) still counts.
+        {"build": "cd src/native && make"},
+        # cmake invoked directly compiles native code.
+        {"build": "cmake ."},
     ],
 )
 def test_a_build_script_that_compiles_raises_the_flag(scripts: dict) -> None:
@@ -196,6 +235,42 @@ def test_a_build_script_that_compiles_raises_the_flag(scripts: dict) -> None:
     _assert_every_true_flag_has_a_reason(result)
 
 
+def test_a_cmake_script_reports_cmake_not_make() -> None:
+    """The mislabel review caught: substring matching read `make` inside `cmake`.
+
+    Verdict was always right (cmake compiles), but the reason named the wrong
+    tool — and a reason that names a tool the command never ran is the same class
+    of defect as the sqlite rawSockets mislabel.
+    """
+    result = requirements.infer_from_package_json(json.dumps({"scripts": {"build": "cmake ."}}))
+
+    assert result.nativeToolchain is True
+    assert any("runs cmake" in reason for reason in result.reasons), result.reasons
+    assert not any("runs make" in reason for reason in result.reasons), result.reasons
+
+
+@pytest.mark.parametrize(
+    "scripts",
+    [
+        # `prebuild` as a substring is NOT evidence: it is the name of an npm
+        # lifecycle script (and any prebuild:* task), and firing on it re-hid the
+        # in-tab runtime for projects that merely ran another script. The
+        # `prebuild`/`prebuild-install` PACKAGES are covered by the table instead.
+        {"build": "npm run prebuild:clean && tsc"},
+        {"prebuild": "rimraf dist", "build": "tsc"},
+        # A plain JS/TS toolchain compiles nothing native.
+        {"build": "vite build", "test": "vitest run"},
+    ],
+)
+def test_a_plain_build_script_does_not_raise_the_flag(scripts: dict) -> None:
+    result = requirements.infer_from_package_json(json.dumps({"scripts": scripts}))
+
+    assert result.nativeToolchain is False, (
+        f"{scripts} shells out to no compiler; a false positive re-hides the in-tab "
+        f"runtime. Reasons: {result.reasons}"
+    )
+
+
 def test_gypfile_raises_the_flag() -> None:
     # npm's own marker that this package carries a binding.gyp.
     result = requirements.infer_from_package_json(json.dumps({"gypfile": True}))
@@ -203,10 +278,9 @@ def test_gypfile_raises_the_flag() -> None:
     assert result.nativeToolchain is True
 
 
-def test_a_scoped_native_package_is_matched_by_prefix() -> None:
-    result = requirements.infer_from_package_json(
-        json.dumps({"dependencies": {"@napi-rs/canvas": "^0.1"}})
-    )
+@pytest.mark.parametrize("package", ["@napi-rs/canvas", "@node-rs/argon2", "@playwright/test"])
+def test_a_scoped_native_package_is_matched_by_prefix(package: str) -> None:
+    result = requirements.infer_from_package_json(json.dumps({"dependencies": {package: "^0.1"}}))
 
     assert result.nativeToolchain is True
 
@@ -252,8 +326,10 @@ def test_an_unreadable_manifest_still_routes_up() -> None:
 
 
 @pytest.mark.parametrize(
+    # NOTE: no sqlite here — it opens no socket. See
+    # test_an_embedded_database_needs_a_toolchain_but_opens_no_socket.
     "package",
-    ["pg", "mysql2", "mongodb", "mongoose", "ioredis", "better-sqlite3", "amqplib", "tedious"],
+    ["pg", "mysql2", "mongodb", "mongoose", "ioredis", "amqplib", "tedious"],
 )
 def test_raw_socket_dependency_raises_the_flag(package: str) -> None:
     result = requirements.infer_from_package_json(json.dumps({"dependencies": {package: "^1"}}))


### PR DESCRIPTION
## The problem

The runtime-requirements probe marked every project that had a `package.json` as needing a native toolchain. The reasoning in the code was "any non-trivial tree pulls prebuilt native binaries" and it named esbuild and rollup as the examples.

Those two are exactly the wrong examples. Both ship a prebuilt binary *and* a WASM fallback, and our own WebContainers gate run on 2026-07-18 proved they work in the tab: `npm install` exit 0 over 320 packages, then a running Vite dev server on the rollup toolchain. The packages cited as proof that a project needs a real VM were the ones already shown running without one.

`Capabilities.nativeToolchain` on the client means the other thing — "compile and run native code: gcc, node-gyp, native modules." So the blanket `true` claimed, of every project, a need most of them don't have.

That wasn't just imprecise. The WebContainers adapter honestly declares `nativeToolchain: false`, so the two together made that runtime **unselectable for every repo** — no env var or operator config could reach it. The registry could only ever pick Daytona.

## The fix

`nativeToolchain` is now read from the manifest:

- a table of packages that actually compile (`node-gyp` addons, `better-sqlite3`, `sharp`) or ship machine code with no WASM path (`electron`, `playwright`, `sass-embedded`)
- npm's own `"gypfile": true` marker
- `scripts` that shell out to a compiler (`node-gyp`, `cmake`, `make`, `gcc`, matched at a command boundary, not as a substring)

`optionalDependencies` is deliberately not scanned. That's where rollup and esbuild put their per-platform prebuilds, and reading it would bring the old behaviour back under a new name.

The fail-up policy is untouched: an absent, unreadable, oversized, or unparseable manifest still routes to most-capable, and there's a test pinning that so a later change can't quietly invert it.

## Review

An adversarial review of the first commit found three real gaps, all fixed in the second commit:

- **`@playwright/test`** — the package `npm init playwright` installs — wasn't in the table, so Playwright projects routed to a runtime that can't launch a browser. This was the one defect in the stranding direction. Closed with an `@playwright/` prefix, plus `sass-embedded` and `electron`.
- **`better-sqlite3`** was emitting `rawSockets: true`. It opens no socket. It was in the socket table as a leftover from when that flag was the only way to force a VM. Now that `nativeToolchain` covers it honestly, the wrong reason is gone.
- The script scanner matched substrings, so `make` fired inside `cmake` and `prebuild` fired on the npm `prebuild` lifecycle-script name. Both over-provision, which re-hid the in-tab runtime. Replaced with a boundary regex; `cmake .` now reports "runs cmake".

## Tests

`tests/cloud/test_websandbox_requirements.py` — 63 passed. New coverage for each package class, the script false-positives, the sqlite mislabel, and the fail-up guarantee. mypy and ruff clean.
