### PR TITLE
Broker the WebContainers licence key the way BrowserPod's is

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,3 +129,22 @@
 #                                                # "python:3.12-slim"). Unset or "standard"
 #                                                # uses the pre-built Paw dev image with
 #                                                # Python, Node.js, GCC, Docker, and UV.
+
+# ── Code Mode in-tab runtimes (browser-side, no VM) ───────
+# Keys for runtimes that execute INSIDE the user's browser tab. Both are handed
+# to the browser per-request over /websandbox/runtimes/{id}/credentials — never
+# built into the frontend bundle — so they can be rotated and revoked here
+# without redeploying the client. An unset key is not an error: the runtime
+# reports itself unavailable and Code Mode uses the Daytona VM instead.
+#
+# The frontend must ALSO be told to use an in-tab runtime (PAW_CODE_RUNTIMES)
+# and be served cross-origin isolated (PAW_COI) — see paw-enterprise's
+# deploy/README-build.md § 2b.
+#
+# StackBlitz WebContainers. Licensed per deployment: keyless boots are permitted
+# on localhost, so local dev needs nothing here; any other origin requires this.
+# WEBCONTAINER_API_KEY=
+#
+# BrowserPod. Experimental and absent from every default runtime order — it
+# cannot complete an npm install (TLS relay OOM, observed 2026-07-18).
+# BROWSERPOD_API_KEY=

--- a/ee/pocketpaw_ee/cloud/websandbox/browserpod.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/browserpod.py
@@ -29,12 +29,18 @@
 #
 # An unconfigured deploy is NOT an error: it returns ``available: false`` so the
 # frontend router cleanly falls back to the Daytona runtime instead of failing.
+#
+# Modified 2026-07-21 (RR-4, feat/webcontainer-credentials): the key RESOLUTION
+# (env, then ``.env``, whitespace counts as unset) moved to ``vendor_keys.py``
+# when WebContainers needed exactly the same behaviour. Nothing about the
+# precedence, the test seam or this module's answers changed — the second caller
+# is the reason it is shared rather than copied.
 from __future__ import annotations
 
 import logging
-import os
 
 from pocketpaw_ee.cloud.websandbox.dto import BrowserPodCredentialsResponse
+from pocketpaw_ee.cloud.websandbox.vendor_keys import dotenv_value, read_vendor_key
 
 logger = logging.getLogger(__name__)
 
@@ -44,38 +50,33 @@ _ENV_VAR = "BROWSERPOD_API_KEY"
 
 
 def _dotenv_key() -> str:
-    """Read the key from a ``.env`` file, without touching the process env.
+    """``.env`` fallback for the key.
 
-    Deliberately ``dotenv_values`` and not ``load_dotenv``: this is a READ, and a
-    read should not mutate global process state as a side effect. It is also the
-    seam tests patch to mean "this host has no .env" — otherwise deleting the
+    Kept as a module-level function rather than inlined because it is the seam
+    tests patch to mean "this host has no .env" — otherwise deleting the
     environment variable in a test would still find the developer's real key on
     disk and the "unconfigured" path could never be exercised.
     """
-    try:  # pragma: no cover — trivial guard
-        from dotenv import dotenv_values
-    except ImportError:
-        return ""
-    return (dotenv_values().get(_ENV_VAR) or "").strip()
+    return dotenv_value(_ENV_VAR)
 
 
 def browserpod_api_key() -> str:
     """Return the configured BrowserPod embedding key, or ``""`` when unset.
 
-    ``.env`` is loaded defensively for the same reason ``uploads/factory.py``
+    ``.env`` is consulted defensively for the same reason ``uploads/factory.py``
     does it: this name has NO ``POCKETPAW_`` prefix, so pydantic-settings never
     reads it, and it only reaches ``os.environ`` if something called
     ``load_dotenv`` first — which depends on the entrypoint (the dashboard
     lifecycle does; a bare uvicorn/cloud boot may not). Getting that wrong is
     invisible: the broker answers ``available: false``, the frontend routes to
-    Daytona, and nothing anywhere reports an error. ``load_dotenv`` is
-    idempotent and never overrides a var already in the environment, so a real
-    deploy that exports the key properly is unaffected.
+    Daytona, and nothing anywhere reports an error.
+
+    Modified 2026-07-21 (RR-4): the resolution itself moved to
+    ``vendor_keys.read_vendor_key`` when WebContainers needed the identical
+    env-then-.env, whitespace-is-unset behaviour. Same precedence, same seam,
+    one implementation.
     """
-    direct = os.environ.get(_ENV_VAR, "").strip()
-    if direct:
-        return direct
-    return _dotenv_key()
+    return read_vendor_key(_ENV_VAR, _dotenv_key)
 
 
 def browserpod_enabled() -> bool:

--- a/ee/pocketpaw_ee/cloud/websandbox/runtimes.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/runtimes.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Awaitable, Callable
 
-from pocketpaw_ee.cloud.websandbox import browserpod
+from pocketpaw_ee.cloud.websandbox import browserpod, webcontainer
 from pocketpaw_ee.cloud.websandbox.dto import RuntimeCredentialsResponse
 
 logger = logging.getLogger(__name__)
@@ -31,6 +31,12 @@ logger = logging.getLogger(__name__)
 # a runtime here is the whole cost of adding one to the credential surface.
 _CREDENTIAL_BROKERS: dict[str, Callable[[str, str], Awaitable[RuntimeCredentialsResponse]]] = {
     "browserpod": browserpod.get_credentials,
+    # Added 2026-07-21 (RR-4). The prediction in the header above — "WebContainers
+    # is the next such runtime" — cashed out at exactly the cost it promised: one
+    # line here plus a broker module. Note that ``available: false`` means
+    # something different for this runtime than for BrowserPod, and the difference
+    # is the client's to act on; see webcontainer.py's header.
+    "webcontainer": webcontainer.get_credentials,
 }
 
 

--- a/ee/pocketpaw_ee/cloud/websandbox/vendor_keys.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/vendor_keys.py
@@ -1,0 +1,55 @@
+# vendor_keys.py — read an in-tab runtime's vendor key from server config (RR-4).
+# Created 2026-07-21 (feat/webcontainer-credentials).
+#
+# WHY THIS EXISTS: ``browserpod.py`` worked out how to resolve a vendor key on
+# this codebase, and every line of that reasoning is about the SHAPE of the
+# problem rather than about BrowserPod — these names carry no ``POCKETPAW_``
+# prefix, so pydantic-settings never sees them, and whether they reach
+# ``os.environ`` at all depends on which entrypoint booted the process. Getting
+# that wrong fails SILENTLY: the broker answers ``available: false``, the client
+# routes to Daytona, and nothing anywhere reports an error. WebContainers is the
+# second runtime with exactly that problem, so the resolution lives here once
+# instead of being copied and then drifting.
+#
+# What deliberately does NOT live here: the per-runtime env var name, the
+# logging, and the response shape. Those differ per runtime and belong with the
+# runtime. This module resolves a string.
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+
+def dotenv_value(name: str) -> str:
+    """Read ``name`` from a ``.env`` file without touching the process env.
+
+    Deliberately ``dotenv_values`` and not ``load_dotenv``: this is a READ, and a
+    read must not mutate global process state as a side effect. Callers wrap this
+    in their own module-level function so their tests have a seam to patch —
+    without one, deleting an environment variable in a test would still find the
+    developer's real key on disk and the "unconfigured" path could never be
+    exercised.
+    """
+    try:  # pragma: no cover — trivial guard
+        from dotenv import dotenv_values
+    except ImportError:
+        return ""
+    return (dotenv_values().get(name) or "").strip()
+
+
+def read_vendor_key(env_var: str, dotenv_reader: Callable[[], str]) -> str:
+    """Return the configured key for ``env_var``, or ``""`` when unset.
+
+    The environment wins over ``.env`` so a real deploy that exports the key
+    properly is never shadowed by a stray file. Whitespace-only counts as unset:
+    a blank env var handed out as a "key" produces a boot that fails inside the
+    vendor's SDK, which is strictly worse than reporting the runtime unavailable
+    and letting the caller fall back.
+    """
+    direct = os.environ.get(env_var, "").strip()
+    if direct:
+        return direct
+    return dotenv_reader()
+
+
+__all__ = ["dotenv_value", "read_vendor_key"]

--- a/ee/pocketpaw_ee/cloud/websandbox/webcontainer.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/webcontainer.py
@@ -1,0 +1,98 @@
+# webcontainer.py — WebContainers (in-tab WASM runtime) credential broker (RR-4).
+# Created 2026-07-21 (feat/webcontainer-credentials): Code Mode can run a project
+# inside StackBlitz's WebContainer — a Node.js runtime compiled to WebAssembly
+# that executes INSIDE THE USER'S BROWSER TAB — instead of a Daytona cloud VM.
+# ``configureAPIKey(key)`` runs client-side and must be called before
+# ``WebContainer.boot()``, so the key has to reach the browser for a container to
+# exist at all on a licensed origin.
+#
+# WHY THIS EXISTS: same reason as ``browserpod.py`` — the key must NOT be a
+# frontend build-time constant. Baked into the bundle it lands in every build
+# artifact, CDN copy and source map, is readable by anyone who can load the app,
+# and can only be rotated by a rebuild + redeploy. Brokered here, it lives ONLY
+# in server config and is handed out per-request to an authenticated,
+# workspace-scoped caller, so it can be rotated, gated, audited and revoked
+# centrally. Registered by runtime id in ``runtimes.py``; there is no
+# WebContainers-specific endpoint.
+#
+# WHAT THIS DOES *NOT* DO: this is containment and control, NOT secrecy. An
+# authenticated user can still read the key out of the network response, because
+# the SDK needs it in the tab. Do not document it as a secret.
+#
+# ONE REAL DIFFERENCE FROM BROWSERPOD, and it decides how the client uses this:
+# WebContainer boots WITHOUT a key on origins StackBlitz permits keyless
+# (localhost and their own domains), and requires a licensed key on any other
+# origin. So ``available: false`` here does NOT mean "this runtime cannot run" —
+# it means "this deploy has no licensed key", and the CLIENT decides whether its
+# own origin can proceed keyless. That is why this module reports configuration
+# and takes no view on the caller's origin, which it cannot see anyway.
+#
+# An unconfigured deploy is NOT an error: it returns ``available: false`` so the
+# frontend either boots keyless (localhost) or falls back to Daytona.
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.websandbox.dto import RuntimeCredentialsResponse
+from pocketpaw_ee.cloud.websandbox.vendor_keys import dotenv_value, read_vendor_key
+
+logger = logging.getLogger(__name__)
+
+# Server-side only. Deliberately NOT ``VITE_``-prefixed — nothing in the built
+# client may ever read this. The name matches StackBlitz's own docs for the
+# WebContainer API key so an operator can map it without a translation table.
+_ENV_VAR = "WEBCONTAINER_API_KEY"
+
+
+def _dotenv_key() -> str:
+    """``.env`` fallback for the key. Patched by tests to mean "no .env here"."""
+    return dotenv_value(_ENV_VAR)
+
+
+def webcontainer_api_key() -> str:
+    """Return the configured WebContainer API key, or ``""`` when unset."""
+    return read_vendor_key(_ENV_VAR, _dotenv_key)
+
+
+def webcontainer_enabled() -> bool:
+    """True when this deploy has a licensed WebContainer key configured.
+
+    Note the narrow claim: this is about the KEY, not about whether the runtime
+    is usable. A localhost deploy with no key still boots containers; a deploy
+    whose frontend has cross-origin isolation switched off cannot boot one even
+    with a key. Both of those live on the client, which is the only place that
+    knows its own origin and its own headers.
+    """
+    return bool(webcontainer_api_key())
+
+
+async def get_credentials(workspace_id: str, user_id: str) -> RuntimeCredentialsResponse:
+    """Hand the calling user the key needed to boot an in-tab WebContainer.
+
+    The router has already enforced license + an authenticated, workspace-scoped
+    RequestContext, so reaching here means the caller is entitled. An
+    unconfigured deploy returns ``available: false`` with a null key rather than
+    raising — see the module header for why that is a routing signal and not a
+    failure.
+
+    The issue is logged (without the key) because StackBlitz licenses this per
+    deployment, so "who booted a container" is an operational signal.
+    """
+    key = webcontainer_api_key()
+    if not key:
+        logger.debug(
+            "webcontainer: no %s configured — reporting unavailable (workspace=%s)",
+            _ENV_VAR,
+            workspace_id,
+        )
+        return RuntimeCredentialsResponse(available=False, apiKey=None)
+
+    logger.info(
+        "webcontainer: issued boot credential (workspace=%s, user=%s)",
+        workspace_id,
+        user_id,
+    )
+    return RuntimeCredentialsResponse(available=True, apiKey=key)
+
+
+__all__ = ["get_credentials", "webcontainer_api_key", "webcontainer_enabled"]

--- a/tests/cloud/test_websandbox_webcontainer.py
+++ b/tests/cloud/test_websandbox_webcontainer.py
@@ -1,0 +1,142 @@
+# test_websandbox_webcontainer.py — tests for the WebContainers boot-credential
+# broker (RR-4, feat/webcontainer-credentials).
+#
+# Created 2026-07-21. The point of the broker is that the vendor key lives ONLY
+# in server config and never in the frontend bundle. These tests pin that
+# contract, and one thing beyond it that BrowserPod's equivalent has no reason
+# to check: that this runtime is reachable THROUGH THE GENERIC DISPATCHER by its
+# id, because that dispatcher is the only path the client actually calls.
+#
+#   * a configured deploy issues the key to an authenticated, workspace-scoped
+#     caller (available=True)
+#   * an UNCONFIGURED deploy answers available=False with a null key instead of
+#     raising — for this runtime that means "no licensed key", NOT "cannot run",
+#     and the client decides whether its origin may boot keyless
+#   * whitespace-only / empty config counts as unconfigured
+#   * the key is read at CALL time, so rotating server config takes effect
+#     without redeploying the client
+#   * ``runtimes.get_runtime_credentials("webcontainer", …)`` reaches this broker
+#
+# No network, no Daytona, no DB — the broker is pure config resolution.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.websandbox import runtimes, webcontainer
+
+_ENV = "WEBCONTAINER_API_KEY"
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test from an unconfigured deploy.
+
+    Both sources must be neutralized. Clearing only the environment variable is
+    not enough: the broker falls back to a ``.env`` file, and on a developer
+    machine that file may hold a real key — so "unconfigured" tests would
+    silently become "configured" ones and stop testing the fallback at all.
+    """
+    monkeypatch.delenv(_ENV, raising=False)
+    monkeypatch.setattr(webcontainer, "_dotenv_key", lambda: "")
+
+
+async def test_issues_key_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV, "wc_api_key_123")
+
+    result = await webcontainer.get_credentials("ws-1", "user-1")
+
+    assert result.available is True
+    assert result.apiKey == "wc_api_key_123"
+
+
+async def test_reports_unavailable_when_unconfigured() -> None:
+    # For WebContainers this specifically means "this deploy holds no licensed
+    # key". The client still boots keyless on a permitted origin (localhost), so
+    # this answer is a routing input, not a verdict on the runtime.
+    result = await webcontainer.get_credentials("ws-1", "user-1")
+
+    assert result.available is False
+    assert result.apiKey is None
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+async def test_blank_config_counts_as_unconfigured(
+    monkeypatch: pytest.MonkeyPatch, blank: str
+) -> None:
+    # Handing a blank string to the client would fail inside StackBlitz's SDK
+    # after the boot had already started, which is strictly worse than reporting
+    # unavailable and letting the client choose keyless-or-Daytona up front.
+    monkeypatch.setenv(_ENV, blank)
+
+    result = await webcontainer.get_credentials("ws-1", "user-1")
+
+    assert result.available is False
+    assert result.apiKey is None
+
+
+async def test_key_is_trimmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV, "  wc_api_key_123\n")
+
+    result = await webcontainer.get_credentials("ws-1", "user-1")
+
+    assert result.apiKey == "wc_api_key_123"
+
+
+async def test_falls_back_to_dotenv_when_env_var_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The var carries no POCKETPAW_ prefix, so nothing loads it automatically;
+    # whether it reaches os.environ depends on the entrypoint. This fallback is
+    # what stops a correctly-configured .env from looking like an outage.
+    monkeypatch.setattr(webcontainer, "_dotenv_key", lambda: "wc_from_dotenv")
+
+    result = await webcontainer.get_credentials("ws-1", "user-1")
+
+    assert result.available is True
+    assert result.apiKey == "wc_from_dotenv"
+
+
+async def test_env_var_wins_over_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A real deploy exports the key; a stray .env on the same host must not
+    # shadow it.
+    monkeypatch.setenv(_ENV, "wc_from_env")
+    monkeypatch.setattr(webcontainer, "_dotenv_key", lambda: "wc_from_dotenv")
+
+    result = await webcontainer.get_credentials("ws-1", "user-1")
+
+    assert result.apiKey == "wc_from_env"
+
+
+async def test_rotation_takes_effect_without_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV, "wc_old")
+    first = await webcontainer.get_credentials("ws-1", "user-1")
+
+    monkeypatch.setenv(_ENV, "wc_new")
+    second = await webcontainer.get_credentials("ws-1", "user-1")
+
+    assert first.apiKey == "wc_old"
+    assert second.apiKey == "wc_new"
+
+
+def test_enabled_flag_tracks_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert webcontainer.webcontainer_enabled() is False
+    monkeypatch.setenv(_ENV, "wc_api_key_123")
+    assert webcontainer.webcontainer_enabled() is True
+
+
+async def test_reachable_through_the_generic_dispatcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The client calls ``/runtimes/{id}/credentials``, never this module directly.
+
+    Registering the broker is a one-line dict entry, and a missing entry does not
+    fail loudly — the dispatcher answers ``available: false`` for an unknown id
+    on purpose. So an unregistered runtime is INDISTINGUISHABLE from an
+    unconfigured one at the wire, and the only thing that can tell them apart is
+    a test that goes through the dispatcher with a key configured.
+    """
+    monkeypatch.setenv(_ENV, "wc_api_key_123")
+
+    result = await runtimes.get_runtime_credentials("webcontainer", "ws-1", "user-1")
+
+    assert result.available is True
+    assert result.apiKey == "wc_api_key_123"


### PR DESCRIPTION
Code Mode's in-tab runtime had an adapter but no key.

StackBlitz licenses WebContainer per deployment: a boot is permitted without a key on localhost, and needs a licensed key on any other origin. So the frontend adapter, which deliberately carried no key (a key in a bundle is a key that has leaked), could only ever work on a developer's machine.

The generic broker from #1750 was already the right shape. It just had one runtime registered, so this is a registration plus a module that resolves the key, and no new endpoint:

    GET /websandbox/runtimes/webcontainer/credentials

## What's here

- `webcontainer.py` resolves `WEBCONTAINER_API_KEY` and answers `available: false` when it isn't set, so the client falls through to Daytona instead of erroring.
- `vendor_keys.py` holds the resolution BrowserPod had already worked out (environment first, then `.env`, whitespace counts as unset). Every line of that reasoning is about the shape of the problem rather than about BrowserPod, and there are two callers now. Same precedence, same test seam, one implementation.
- `.env.example` documents both in-tab keys. Neither had an entry anywhere an operator would look, and "nothing visibly breaks, Code Mode just uses the VM" is not a behaviour anyone guesses from a blank line.

## One thing that reads differently for this runtime

`available: false` means "this deploy holds no licensed key", not "this runtime cannot run". Whether a keyless boot is allowed depends on the caller's origin, which the backend can't see, so the client decides. The frontend half is qbtrix/paw-enterprise#650.

## Verification

`tests/cloud/test_websandbox_webcontainer.py` covers the configured, unconfigured, blank, trimmed, `.env`-fallback and rotation paths, plus one that goes through the dispatcher by runtime id. That last one matters: an unregistered runtime and an unconfigured one both answer `available: false` on purpose, so a missing dict entry is invisible at the wire and only a test that dispatches by id can tell them apart.

317 websandbox tests pass. `ruff check` and `ruff format --check` clean.