### PR TITLE
ship: Hetzner provisioning and box lifecycle

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -71,6 +71,7 @@ from pocketpaw_ee.cloud.jobs.domain import job_timeout_seconds
 from pocketpaw_ee.cloud.jobs.worker import execute_workspace_job
 from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
 from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
+from pocketpaw_ee.cloud.ship.job import provision_box_job
 
 logger = logging.getLogger(__name__)
 
@@ -235,11 +236,25 @@ _workspace_job_fn = func(
     max_tries=1,
 )
 
+# The /ship box-provisioning job (SHIP-2) rides the same worker with its OWN
+# timeout: provisioning is a poll-and-probe loop that can run for minutes while
+# a fresh box boots and Dokku installs, so it must not be clipped by the
+# chat-run timeout. The enqueue name is pinned to match ``ship/enqueue.py``.
+# max_tries=1: the job never raises for an operational failure (it records the
+# box ``degraded`` and returns), and its create step is idempotent on the stored
+# server_id, so arq-level retries are neither needed nor wanted.
+_ship_provision_fn = func(
+    provision_box_job,
+    name="provision_box_job",
+    timeout=job_timeout_seconds(),
+    max_tries=1,
+)
+
 
 class WorkerSettings:
     """arq worker configuration. Loaded by ``arq <dotted-path>``."""
 
-    functions = [execute_run_job, _workspace_job_fn]
+    functions = [execute_run_job, _workspace_job_fn, _ship_provision_fn]
     on_startup = _startup
     on_shutdown = _shutdown
     # Crash policy: no auto-retry. A failed run is left as ``failed``/``interrupted``

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -162,6 +162,7 @@ from pocketpaw_ee.cloud.models.instinct_workspace_config import InstinctWorkspac
 from pocketpaw_ee.cloud.models.invite import Invite
 from pocketpaw_ee.cloud.models.lead import Lead, LeadSource
 from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+from pocketpaw_ee.cloud.models.ship import ShipBox
 from pocketpaw_ee.cloud.models.meeting import (
     Meeting,
     MeetingProviderCredentials,
@@ -321,6 +322,7 @@ __all__ = [
     "Lead",
     "LeadSource",
     "LiteLLMTenantKey",
+    "ShipBox",
     "Meeting",
     "MeetingProviderCredentials",
     "MeetingsSettings",
@@ -422,6 +424,9 @@ def get_all_documents():
         # LiteLLM per-tenant virtual-key mapping (MCG-8). Only
         # ``ee.cloud.llm_provisioning.service`` writes this.
         LiteLLMTenantKey,
+        # Managed-deploy boxes (SHIP-2). Only ``ee.cloud.ship.service`` and the
+        # ``provision_box`` builtin write this.
+        ShipBox,
         Invite,
         Group,
         InstinctApproval,

--- a/ee/pocketpaw_ee/cloud/models/ship.py
+++ b/ee/pocketpaw_ee/cloud/models/ship.py
@@ -85,6 +85,10 @@ class ShipBox(TimestampedDocument):
     # The box's SSH PRIVATE key, Fernet-encrypted at rest. Decrypted only inside
     # the ship service to build a driver; never serialized into a DTO or log.
     ssh_private_key_enc: str = ""
+    # The box's SSH PUBLIC key (not secret) — authorized on the box via
+    # cloud-init and re-supplied to the provisioner on a retry. Stored so the
+    # public half never has to be re-derived from the encrypted private key.
+    ssh_public_key: str = ""
     # The provider's quoted monthly price for the server type, captured at
     # provision (provenance; the cost recorder in SHIP-7 reads it).
     price_monthly: float | None = None

--- a/ee/pocketpaw_ee/cloud/models/ship.py
+++ b/ee/pocketpaw_ee/cloud/models/ship.py
@@ -1,0 +1,99 @@
+# ee/pocketpaw_ee/cloud/models/ship.py — the provisioned-box document for /ship.
+#
+# One Beanie document backs a workspace's managed deploy boxes:
+#
+#   * ``ShipBox`` — one row per provisioned box. Records the provider, the
+#     provider-side server id, the reachable IP, the lifecycle status, the
+#     monthly price captured at provision time, and an ENCRYPTED SSH private
+#     key (Fernet, via ``cloud._core.crypto``) the engine driver uses to reach
+#     the box over SSH. The key is the box's blast radius, so it never lives in
+#     plaintext at rest and never leaves this layer in a DTO — the ship service
+#     decrypts it only to hand it to the SHIP-1 driver.
+#
+# WHY store the key on the box doc (encrypted) rather than the connector state
+# store: the connector state store is keyed on connector NAME + workspace and
+# is owned by ``connectors/service.py`` for the external-integration lifecycle;
+# a provisioned box is not a connector. The box's SSH credential is 1:1 with the
+# box row and shares its lifecycle (minted at provision, destroyed with the
+# box), so it belongs on the box doc — encrypted at rest with the same
+# deployment Fernet key (``CLOUD_ENCRYPTION_KEY``) the connector/meetings
+# secrets already use.
+#
+# Status lifecycle: ``provisioning`` → ``ready`` (server up, SSH reachable,
+# ``dokku version`` answered) or ``degraded`` (a terminal provision failure,
+# ``status_reason`` set). ``destroyed`` is the post-teardown terminal state.
+#
+# Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new entity. Registered
+# in ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``ship_boxes`` collection. Only
+# ``ee.cloud.ship.service`` (SHIP-3) and the ``provision_box`` builtin job
+# (SHIP-2) read/write this document — the same one-service-owns-one-doc
+# isolation the credit / litellm-key / foresight docs use.
+
+from __future__ import annotations
+
+from typing import Literal
+
+from beanie import Indexed
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+# The box lifecycle states. ``provisioning`` is the birth state the enqueue
+# writes; the job advances it to exactly one terminal-ish state.
+ShipBoxStatus = Literal["provisioning", "ready", "degraded", "destroyed"]
+
+
+class ShipBox(TimestampedDocument):
+    """One managed-deploy box provisioned for a workspace.
+
+    Tenancy: ``workspace`` is REQUIRED and every read filters on it (the ship
+    service asserts it). ``server_id`` is the provider's server identifier
+    (empty until the provider create call returns) — it is also the
+    idempotency anchor: the provision job never creates a second server when a
+    row already carries one.
+
+    ``ssh_private_key_enc`` is a Fernet token (never plaintext); ``ssh_user`` /
+    ``ssh_port`` are the coordinates the SHIP-1 ``BoxHandle`` needs. The public
+    key is not stored — it is derived from config for the cloud-init authorize
+    step and is not secret.
+
+    ``price_monthly`` is the provider's quoted monthly price for the chosen
+    server type, captured at provision time (provenance, not a live bill).
+    ``status_reason`` carries the failure detail when ``status == 'degraded'``
+    (a fixed, PII-free string — never raw provider payloads).
+    """
+
+    # Tenancy filter — every ship read scopes on this. Indexed (non-unique: a
+    # workspace owns many boxes).
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # Provider discriminator; "hcloud" is the only v1 driver.
+    provider: str = "hcloud"
+    # The provider-side server id. Empty string until the create call returns;
+    # once set it is the idempotency guard against a double-create.
+    server_id: str = ""
+    # The box's reachable IPv4 (empty until the server has one).
+    ip: str = ""
+    # Lifecycle state (see module comment).
+    status: ShipBoxStatus = "provisioning"
+    # Failure detail when status == "degraded"; a fixed safe string, never a
+    # raw provider error payload.
+    status_reason: str | None = None
+    # SSH coordinates for the SHIP-1 BoxHandle.
+    ssh_user: str = "root"
+    ssh_port: int = 22
+    # The box's SSH PRIVATE key, Fernet-encrypted at rest. Decrypted only inside
+    # the ship service to build a driver; never serialized into a DTO or log.
+    ssh_private_key_enc: str = ""
+    # The provider's quoted monthly price for the server type, captured at
+    # provision (provenance; the cost recorder in SHIP-7 reads it).
+    price_monthly: float | None = None
+    # The provider-native server type + region the box was provisioned with.
+    server_type: str = ""
+    region: str = ""
+
+    class Settings:
+        name = "ship_boxes"
+        indexes = [  # noqa: RUF012 — Beanie collection config, not shared mutable
+            IndexModel([("workspace", 1), ("status", 1)], name="ix_workspace_status"),
+        ]

--- a/ee/pocketpaw_ee/cloud/ship/__init__.py
+++ b/ee/pocketpaw_ee/cloud/ship/__init__.py
@@ -1,0 +1,8 @@
+# ee/pocketpaw_ee/cloud/ship/__init__.py — the /ship cloud entity package.
+#
+# SHIP-2 lands the provisioning half: ``store`` (the ShipBox persistence seam,
+# the only module that touches the ShipBox Beanie doc) and ``provisioning`` (the
+# pure box-lifecycle orchestrator the arq job drives). SHIP-3 adds the
+# domain/dto/service/router HTTP surface alongside these.
+#
+# Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new package.

--- a/ee/pocketpaw_ee/cloud/ship/enqueue.py
+++ b/ee/pocketpaw_ee/cloud/ship/enqueue.py
@@ -1,0 +1,67 @@
+# ee/pocketpaw_ee/cloud/ship/enqueue.py — the web-process side of provisioning.
+#
+# ``enqueue_provision`` mints a fresh box keypair, inserts a ``provisioning``
+# ShipBox (the private key Fernet-encrypted by the store), and enqueues
+# ``provision_box_job`` on the shared arq pool. It mirrors the chat-run /
+# workspace-job enqueue contract: the arq queue selector kwarg pitfall is
+# avoided by enqueuing positionally, exactly like ``jobs/service.py``.
+#
+# Returns the created ShipBox so the caller (the SHIP-3 router) can 202 it with a
+# pollable box id.
+#
+# Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new module.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.ship import store
+from pocketpaw_ee.cloud.ship.job import provision_box_job  # noqa: F401 — registration ref
+from pocketpaw_ee.ship_engine.keygen import generate_box_keypair
+
+logger = logging.getLogger(__name__)
+
+
+async def enqueue_provision(
+    *,
+    workspace_id: str,
+    provider: str = "hcloud",
+    server_type: str,
+    region: str,
+    pool_factory=None,
+) -> object:
+    """Create a box row + keypair and enqueue its provisioning job.
+
+    ``pool_factory`` is an injection seam for tests (an async callable returning
+    an arq pool). In production it defaults to the chat-run executor's shared
+    pool getter, so ship jobs ride the same worker + Redis as everything else.
+    Returns the inserted ShipBox.
+    """
+    keypair = generate_box_keypair(comment=f"paw-ship-{workspace_id[:8]}")
+    box = await store.create_provisioning_box(
+        workspace_id=workspace_id,
+        provider=provider,
+        server_type=server_type,
+        region=region,
+        ssh_private_key=keypair.private_key_openssh,
+        ssh_public_key=keypair.public_key_openssh,
+    )
+
+    pool = await _resolve_pool(pool_factory)
+    try:
+        # Positional enqueue — no ``queue=`` kwarg (arq forwards non-control
+        # kwargs to the job function; see jobs/service.py's note). Ship jobs ride
+        # the shared default queue on the one worker process.
+        await pool.enqueue_job("provision_box_job", str(box.id), workspace_id)
+    except Exception:
+        logger.exception("ship: enqueue failed for box %s", box.id)
+        raise
+    return box
+
+
+async def _resolve_pool(pool_factory):
+    if pool_factory is not None:
+        return await pool_factory()
+    from pocketpaw_ee.cloud.chat.runs.arq_executor import _get_pool
+
+    return await _get_pool()

--- a/ee/pocketpaw_ee/cloud/ship/job.py
+++ b/ee/pocketpaw_ee/cloud/ship/job.py
@@ -1,0 +1,100 @@
+# ee/pocketpaw_ee/cloud/ship/job.py — the arq entry point that provisions a box.
+#
+# ``provision_box_job(ctx, box_id, workspace_id)`` is the durable job the web
+# process enqueues after inserting a ``provisioning`` ShipBox. It loads the box
+# (workspace-scoped), builds the real hcloud client + SSH readiness probe, and
+# hands off to the pure ``provisioning.run_provision`` orchestrator (which owns
+# the create/probe/idempotency logic and is unit-tested with fakes).
+#
+# The job itself is the THIN wiring layer: token resolution, real-seam
+# construction, and the inter-attempt sleep. It never raises for an operational
+# failure — ``run_provision`` records ``degraded`` on the box and returns — so
+# arq marks the job done (no retry storm on a genuinely dead provider).
+#
+# The readiness probe reuses SHIP-1's ``AsyncSSHTransport`` + ``DokkuDriver``:
+# it opens an SSH connection with the box's decrypted key and runs the driver's
+# ``metrics``/version path; a successful ``dokku version`` means ready.
+#
+# Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new module.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import tempfile
+from typing import Any
+
+from pocketpaw_ee.cloud.ship import provisioning, store
+from pocketpaw_ee.ship_engine.hcloud import HcloudProvisioner, build_hcloud_client
+from pocketpaw_ee.ship_engine.port import BoxHandle
+
+logger = logging.getLogger(__name__)
+
+_HCLOUD_TOKEN_ENV = "POCKETPAW_HCLOUD_TOKEN"
+
+
+async def _ssh_dokku_ready(handle: BoxHandle, ssh_private_key: str) -> bool:
+    """Real readiness probe: SSH in with the box key, confirm ``dokku version``.
+
+    Writes the key to a private temp file (asyncssh reads a key path), connects
+    via SHIP-1's ``AsyncSSHTransport``, and runs ``dokku version``. Any failure
+    (still booting, connection refused) returns False; the orchestrator retries.
+    """
+    from pocketpaw_ee.ship_engine.dokku import AsyncSSHTransport
+
+    key_path = None
+    try:
+        fd, key_path = tempfile.mkstemp(prefix="paw-ship-", suffix=".key")
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w") as fh:
+            fh.write(ssh_private_key)
+        transport = AsyncSSHTransport(
+            handle.host,
+            port=handle.ssh_port,
+            username=handle.ssh_user,
+            client_key_path=key_path,
+        )
+        result = await transport.run("dokku version")
+        await _safe_close(transport)
+        return result.exit_code == 0
+    finally:
+        if key_path and os.path.exists(key_path):
+            os.unlink(key_path)
+
+
+async def _safe_close(transport: Any) -> None:
+    close = getattr(transport, "aclose", None)
+    if close is not None:
+        try:
+            await close()
+        except Exception:  # noqa: BLE001 — best-effort teardown
+            logger.debug("ship probe transport aclose failed", exc_info=True)
+
+
+async def provision_box_job(ctx: dict, box_id: str, workspace_id: str) -> dict:
+    """arq function: provision the box ``box_id`` for ``workspace_id``.
+
+    ``ctx`` is arq's job context (unused here). Returns a small status dict for
+    observability; the durable outcome is the ShipBox ``status`` the orchestrator
+    writes.
+    """
+    box = await store.get_box(workspace_id, box_id)
+    if box is None:
+        # Nothing to do — the box was deleted or never existed for this tenant.
+        logger.warning("ship provision: box %s not found for workspace", box_id)
+        return {"ok": False, "reason": "box_not_found"}
+
+    token = os.environ.get(_HCLOUD_TOKEN_ENV, "").strip()
+    provisioner = HcloudProvisioner(build_hcloud_client(token))
+    ssh_private_key = store.decrypt_ssh_key(box)
+
+    updated = await provisioning.run_provision(
+        box,
+        provisioner=provisioner,
+        ssh_public_key=box.ssh_public_key,
+        ssh_private_key=ssh_private_key,
+        probe=_ssh_dokku_ready,
+        sleep=asyncio.sleep,
+    )
+    return {"ok": updated.status == "ready", "status": updated.status}

--- a/ee/pocketpaw_ee/cloud/ship/provisioning.py
+++ b/ee/pocketpaw_ee/cloud/ship/provisioning.py
@@ -1,0 +1,100 @@
+# ee/pocketpaw_ee/cloud/ship/provisioning.py — the box-lifecycle orchestrator.
+#
+# ``run_provision`` drives one ShipBox from ``provisioning`` to ``ready`` (or
+# ``degraded``) through injected seams, so the whole lifecycle is testable with
+# zero network / zero real box:
+#
+#   * ``provisioner`` — a SHIP-2 ``HcloudProvisioner`` (or fake) that creates the
+#     server and returns provider facts.
+#   * ``probe`` — an async readiness check ``(handle, ssh_private_key) -> bool``
+#     that returns True once the box answers ``dokku version`` over SSH. The real
+#     probe SSHes in; the fake returns a scripted sequence.
+#
+# IDEMPOTENCY: if the box already carries a ``server_id`` the create is SKIPPED
+# (a retry after the create landed but before ready never spins a second
+# server). READINESS is polled with a bounded attempt count; exhaustion →
+# ``degraded`` (never a hang). Every failure path writes a fixed, PII-free
+# ``status_reason`` — never a raw provider payload.
+#
+# Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new module.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from pocketpaw_ee.cloud.ship import store
+from pocketpaw_ee.ship_engine.hcloud import ProvisionError
+from pocketpaw_ee.ship_engine.port import BoxHandle, BoxSpec
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.cloud.models.ship import ShipBox
+    from pocketpaw_ee.ship_engine.hcloud import HcloudProvisioner
+
+logger = logging.getLogger(__name__)
+
+# The readiness probe polls this many times before declaring the box degraded.
+# The job wires a real inter-attempt sleep; the orchestrator itself takes an
+# injected ``sleep`` so tests advance instantly.
+DEFAULT_MAX_PROBE_ATTEMPTS = 30
+
+ReadinessProbe = Callable[[BoxHandle, str], Awaitable[bool]]
+Sleep = Callable[[float], Awaitable[None]]
+
+
+async def run_provision(
+    box: ShipBox,
+    *,
+    provisioner: HcloudProvisioner,
+    ssh_public_key: str,
+    ssh_private_key: str,
+    probe: ReadinessProbe,
+    sleep: Sleep,
+    max_probe_attempts: int = DEFAULT_MAX_PROBE_ATTEMPTS,
+    probe_interval_s: float = 10.0,
+) -> ShipBox:
+    """Take ``box`` to ``ready`` (or ``degraded``). Returns the updated doc.
+
+    Never raises for an operational failure — a provider or readiness failure is
+    recorded on the box as ``degraded`` and the box is returned. It DOES let a
+    programming error (e.g. a missing encryption key at store time) propagate,
+    matching the run-core gate's "infra failure propagates" posture.
+    """
+    spec = BoxSpec(
+        name=f"paw-ship-{str(box.id)[:12]}",
+        region=box.region,
+        size=box.server_type,
+    )
+    key_name = f"paw-ship-{str(box.id)[:12]}"
+
+    # (1) Create the server — SKIP if a prior attempt already did (idempotency).
+    if box.server_id:
+        handle = BoxHandle(box_id=box.server_id, host=box.ip, ssh_user=box.ssh_user)
+        price = box.price_monthly
+    else:
+        try:
+            result = provisioner.create_server(
+                spec, ssh_public_key=ssh_public_key, key_name=key_name
+            )
+        except ProvisionError as exc:
+            return await store.mark_degraded(box, reason=str(exc))
+        # Persist the server id + ip IMMEDIATELY so a retry reuses this server.
+        box = await store.mark_server_created(box, server_id=result.server_id, ip=result.ip)
+        handle = result.handle
+        price = result.price_monthly
+
+    # (2) Poll for readiness: the box answers ``dokku version`` over SSH.
+    for _ in range(max_probe_attempts):
+        try:
+            if await probe(handle, ssh_private_key):
+                return await store.mark_ready(
+                    box, server_id=box.server_id, ip=box.ip, price_monthly=price
+                )
+        except Exception:  # noqa: BLE001 — a probe blip is expected while booting
+            logger.debug("ship probe attempt failed for box=%s (still booting)", box.id)
+        await sleep(probe_interval_s)
+
+    return await store.mark_degraded(
+        box, reason="box did not become reachable within the provisioning window"
+    )

--- a/ee/pocketpaw_ee/cloud/ship/store.py
+++ b/ee/pocketpaw_ee/cloud/ship/store.py
@@ -1,0 +1,95 @@
+# ee/pocketpaw_ee/cloud/ship/store.py — the ShipBox persistence seam.
+#
+# The ONLY module that reads/writes the ``ShipBox`` Beanie document (the same
+# one-service-owns-one-doc isolation the credit / litellm-key docs use; an
+# import-linter contract will keep the doc off every other layer). It hides the
+# Fernet envelope on the SSH private key: callers pass/receive PLAINTEXT keys,
+# the doc stores CIPHERTEXT. Every read is workspace-scoped — a box id alone is
+# never trusted without its owning workspace.
+#
+# Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new module.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud._core import crypto
+from pocketpaw_ee.cloud.models.ship import ShipBox, ShipBoxStatus
+
+
+async def create_provisioning_box(
+    *,
+    workspace_id: str,
+    provider: str,
+    server_type: str,
+    region: str,
+    ssh_private_key: str,
+    ssh_public_key: str,
+) -> ShipBox:
+    """Insert a fresh box in ``provisioning`` and return it.
+
+    ``ssh_private_key`` is PLAINTEXT in; it is Fernet-encrypted before the doc is
+    written (encryption requires ``CLOUD_ENCRYPTION_KEY`` — a missing key raises
+    a clear setup error rather than persisting a secret in the clear). The public
+    key is stored as-is (not secret).
+    """
+    box = ShipBox(
+        workspace=workspace_id,
+        provider=provider,
+        server_type=server_type,
+        region=region,
+        status="provisioning",
+        ssh_private_key_enc=crypto.encrypt(ssh_private_key),
+        ssh_public_key=ssh_public_key,
+    )
+    await box.insert()
+    return box
+
+
+async def get_box(workspace_id: str, box_id: str) -> ShipBox | None:
+    """Load one box, workspace-scoped. A cross-tenant id yields None."""
+    box = await ShipBox.get(box_id)
+    if box is None or box.workspace != workspace_id:
+        return None
+    return box
+
+
+async def mark_ready(
+    box: ShipBox, *, server_id: str, ip: str, price_monthly: float | None
+) -> ShipBox:
+    """Record the provider facts and flip the box to ``ready``."""
+    box.server_id = server_id
+    box.ip = ip
+    box.price_monthly = price_monthly
+    box.status = "ready"
+    box.status_reason = None
+    await box.save()
+    return box
+
+
+async def mark_server_created(box: ShipBox, *, server_id: str, ip: str) -> ShipBox:
+    """Persist the provider server id + IP the moment the create returns, BEFORE
+    readiness. This is the idempotency anchor: a retry sees ``server_id`` set and
+    never creates a second server."""
+    box.server_id = server_id
+    box.ip = ip
+    await box.save()
+    return box
+
+
+async def mark_degraded(box: ShipBox, *, reason: str) -> ShipBox:
+    """Flip the box to ``degraded`` with a fixed, safe reason string."""
+    box.status = "degraded"
+    box.status_reason = reason
+    await box.save()
+    return box
+
+
+async def set_status(box: ShipBox, status: ShipBoxStatus) -> ShipBox:
+    """Set an arbitrary lifecycle status (used by teardown → ``destroyed``)."""
+    box.status = status
+    await box.save()
+    return box
+
+
+def decrypt_ssh_key(box: ShipBox) -> str:
+    """Decrypt the box's SSH private key for driver use. Never logged/serialized."""
+    return crypto.decrypt(box.ssh_private_key_enc)

--- a/ee/pocketpaw_ee/ship_engine/cloudinit.py
+++ b/ee/pocketpaw_ee/ship_engine/cloudinit.py
@@ -1,0 +1,74 @@
+# ee/pocketpaw_ee/ship_engine/cloudinit.py — the cloud-init user-data a fresh
+# box boots with so it comes up as a Dokku-ready deploy target.
+#
+# ``render_user_data`` returns the cloud-init YAML (a "#cloud-config" document)
+# that: installs Docker, installs a PINNED Dokku version, installs nixpacks (the
+# default builder for /code-built apps), and authorizes our provisioning public
+# key for the root and ``dokku`` users. Provisioning is poll-and-probe, not
+# phone-home (v1): the provisioner watches the provider status, then SSHes in
+# and runs ``dokku version`` to confirm readiness — so this template installs,
+# it does not call back.
+#
+# SECURITY: the template carries only the PUBLIC key. Private-key material never
+# appears in user-data (it is minted by the provisioner and stored Fernet-
+# encrypted on the ShipBox doc). The Dokku + nixpacks versions are pinned so a
+# box's control surface is reproducible and the SHIP-1 driver's transcript
+# assumptions hold.
+#
+# Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new module.
+
+from __future__ import annotations
+
+# Pinned so every box exposes the same Dokku control surface (the SHIP-1 driver
+# parses versioned output). Bump deliberately, in lockstep with the driver's
+# transcripts.
+DOKKU_VERSION = "0.35.20"
+NIXPACKS_VERSION = "1.29.1"
+
+
+def render_user_data(*, ssh_public_key: str) -> str:
+    """Render the cloud-init user-data for a Dokku-ready box.
+
+    ``ssh_public_key`` is the provisioning key's PUBLIC half — authorized for
+    root and the ``dokku`` user so the driver can reach the box. It must be a
+    single-line OpenSSH public key; anything else is rejected (a malformed key
+    would silently lock us out of the box).
+    """
+    key = ssh_public_key.strip()
+    if not key or "\n" in key or not key.startswith(("ssh-", "ecdsa-", "sk-")):
+        raise ValueError("ssh_public_key must be a single-line OpenSSH public key")
+
+    # A #cloud-config document. runcmd order matters: Docker first (Dokku's
+    # bootstrap needs it), then the pinned Dokku bootstrap, then nixpacks, then
+    # authorize the key for the dokku user (created by the Dokku install).
+    # The dokku-user authorize command is assembled here so no source line runs
+    # past the line-length limit (it is a single shell command by nature).
+    dokku_ssh_dir = "/home/dokku/.ssh"
+    authorize_dokku = (
+        f"mkdir -p {dokku_ssh_dir} && "
+        f"echo '{key}' >> {dokku_ssh_dir}/authorized_keys && "
+        f"chown -R dokku:dokku {dokku_ssh_dir} && "
+        f"chmod 600 {dokku_ssh_dir}/authorized_keys"
+    )
+    dokku_bootstrap = f"https://dokku.com/install/v{DOKKU_VERSION}/bootstrap.sh"
+
+    # A #cloud-config document. runcmd order matters: Docker first (Dokku's
+    # bootstrap needs it), then the pinned Dokku bootstrap, then nixpacks, then
+    # authorize the key for the dokku user (created by the Dokku install).
+    return f"""#cloud-config
+users:
+  - name: root
+    ssh_authorized_keys:
+      - {key}
+package_update: true
+packages:
+  - curl
+  - ca-certificates
+runcmd:
+  - [ sh, -c, "curl -fsSL https://get.docker.com | sh" ]
+  - [ sh, -c, "wget -qO /tmp/bootstrap.sh {dokku_bootstrap}" ]
+  - [ sh, -c, "DOKKU_TAG=v{DOKKU_VERSION} bash /tmp/bootstrap.sh" ]
+  - [ sh, -c, "curl -fsSL https://nixpacks.com/install.sh | VERSION={NIXPACKS_VERSION} bash" ]
+  - [ sh, -c, "{authorize_dokku}" ]
+  - [ sh, -c, "echo '{key}' | dokku ssh-keys:add admin" ]
+"""

--- a/ee/pocketpaw_ee/ship_engine/hcloud.py
+++ b/ee/pocketpaw_ee/ship_engine/hcloud.py
@@ -1,0 +1,221 @@
+# ee/pocketpaw_ee/ship_engine/hcloud.py — the Hetzner provisioner: turns a
+# workspace's Hetzner API token into a running, Dokku-ready box.
+#
+# ``HcloudProvisioner`` implements the ONE verb the SHIP-1 Dokku driver does
+# NOT (``DokkuDriver.provision_box`` raises ``VerbNotSupported``): it creates an
+# hcloud server with our provisioning SSH public key + a basic firewall
+# (22/80/443 in), captures the server type's monthly price at create time, and
+# returns a SHIP-1 ``BoxHandle`` plus the facts the ``provision_box`` job
+# persists onto the ``ShipBox`` doc.
+#
+# Provisioning is POLL-AND-PROBE (v1), not phone-home: ``create_server`` returns
+# a handle immediately; the caller (the arq job) waits for the provider to
+# report the server running, then SSH-probes ``dokku version`` for readiness.
+# This keeps the whole path box-free-testable — the hcloud client and the SSH
+# probe are both injectable seams.
+#
+# SECRETS: the keypair is minted by the CALLER (the job) and only the PUBLIC key
+# reaches this module (for the hcloud ssh-key upload + cloud-init authorize).
+# The private key is Fernet-encrypted onto the ShipBox doc by the job; it never
+# passes through here.
+#
+# Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new module.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+from pocketpaw_ee.ship_engine.cloudinit import render_user_data
+from pocketpaw_ee.ship_engine.port import BoxHandle, BoxSpec, ShipEngineError
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Inbound firewall the box boots behind: SSH for the driver, 80/443 for the
+# apps' HTTP(S) + Let's Encrypt challenges. Nothing else is exposed.
+_FIREWALL_PORTS = ("22", "80", "443")
+
+
+class ProvisionError(ShipEngineError):
+    """A clean, PII-free provisioning failure. The job surfaces ``str(exc)``
+    into the ShipBox ``status_reason``, so these messages are fixed safe
+    strings — never a raw provider payload."""
+
+
+@dataclass(frozen=True)
+class ProvisionResult:
+    """What a successful ``create_server`` yields.
+
+    ``handle`` is the SHIP-1 ``BoxHandle`` a driver targets; ``server_id`` is the
+    provider id (idempotency anchor + destroy key); ``price_monthly`` is the
+    server type's captured monthly gross price (None if the provider reported
+    none); ``server_type`` / ``region`` echo what was provisioned.
+    """
+
+    handle: BoxHandle
+    server_id: str
+    ip: str
+    price_monthly: float | None
+    server_type: str
+    region: str
+
+
+class HcloudClientLike(Protocol):
+    """The slice of the hcloud SDK the provisioner uses.
+
+    A Protocol so tests inject a fake without touching the network. The real
+    adapter (``build_hcloud_client``) wraps ``hcloud.Client``; the fake mirrors
+    these methods over in-memory state.
+    """
+
+    def ensure_ssh_key(self, *, name: str, public_key: str) -> Any: ...
+    def ensure_firewall(self, *, name: str, ports: tuple[str, ...]) -> Any: ...
+    def price_monthly(self, server_type: str) -> float | None: ...
+    def create_server(
+        self,
+        *,
+        name: str,
+        server_type: str,
+        image: str,
+        location: str,
+        ssh_key: Any,
+        firewall: Any,
+        user_data: str,
+    ) -> tuple[str, str]: ...
+
+
+class HcloudProvisioner:
+    """Provision Hetzner boxes for a workspace over an injected client seam."""
+
+    def __init__(self, client: HcloudClientLike, *, ssh_user: str = "root") -> None:
+        self._client = client
+        self._ssh_user = ssh_user
+
+    def create_server(
+        self, spec: BoxSpec, *, ssh_public_key: str, key_name: str
+    ) -> ProvisionResult:
+        """Create a server for ``spec`` and return a targetable box handle.
+
+        Uploads the provisioning public key + ensures the firewall, captures the
+        server type's monthly price, and creates the server with cloud-init that
+        installs Dokku. Raises ``ProvisionError`` (a safe string) on any provider
+        failure. This does NOT wait for readiness — the caller polls + probes.
+        """
+        try:
+            ssh_key = self._client.ensure_ssh_key(name=key_name, public_key=ssh_public_key)
+            firewall = self._client.ensure_firewall(name=f"{key_name}-fw", ports=_FIREWALL_PORTS)
+            price = self._client.price_monthly(spec.size)
+            user_data = render_user_data(ssh_public_key=ssh_public_key)
+            server_id, ip = self._client.create_server(
+                name=spec.name,
+                server_type=spec.size,
+                image=spec.image,
+                location=spec.region,
+                ssh_key=ssh_key,
+                firewall=firewall,
+                user_data=user_data,
+            )
+        except ProvisionError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — map ANY provider failure to a safe string
+            # Never leak the raw provider payload (may carry token fragments /
+            # account detail) into a persisted status_reason.
+            logger.warning("hcloud provision failed for box=%s: %s", spec.name, type(exc).__name__)
+            raise ProvisionError(f"provider create failed ({type(exc).__name__})") from exc
+
+        if not server_id:
+            raise ProvisionError("provider returned no server id")
+
+        handle = BoxHandle(box_id=server_id, host=ip, ssh_port=22, ssh_user=self._ssh_user)
+        return ProvisionResult(
+            handle=handle,
+            server_id=server_id,
+            ip=ip,
+            price_monthly=price,
+            server_type=spec.size,
+            region=spec.region,
+        )
+
+
+def build_hcloud_client(token: str) -> HcloudClientLike:  # pragma: no cover - thin SDK wiring
+    """Wrap ``hcloud.Client`` into the ``HcloudClientLike`` seam.
+
+    Lazy-imports the SDK so the module stays import-clean on the test path (the
+    fake client is used there). Real network calls live only inside the returned
+    adapter's methods.
+    """
+    from hcloud import Client
+    from hcloud.firewalls.domain import FirewallRule
+    from hcloud.images.domain import Image
+    from hcloud.locations.domain import Location
+    from hcloud.server_types.domain import ServerType
+
+    if not token:
+        raise ProvisionError("no Hetzner API token configured")
+
+    client = Client(token=token)
+
+    class _Adapter:
+        def ensure_ssh_key(self, *, name: str, public_key: str) -> Any:
+            existing = client.ssh_keys.get_by_name(name)
+            if existing is not None:
+                return existing
+            return client.ssh_keys.create(name=name, public_key=public_key)
+
+        def ensure_firewall(self, *, name: str, ports: tuple[str, ...]) -> Any:
+            existing = client.firewalls.get_by_name(name)
+            if existing is not None:
+                return existing
+            rules = [
+                FirewallRule(
+                    direction="in",
+                    protocol="tcp",
+                    port=p,
+                    source_ips=["0.0.0.0/0", "::/0"],
+                )
+                for p in ports
+            ]
+            return client.firewalls.create(name=name, rules=rules)
+
+        def price_monthly(self, server_type: str) -> float | None:
+            st = client.server_types.get_by_name(server_type)
+            if st is None or not getattr(st, "prices", None):
+                return None
+            for entry in st.prices:
+                monthly = (entry or {}).get("price_monthly") or {}
+                gross = monthly.get("gross")
+                if gross is not None:
+                    return float(gross)
+            return None
+
+        def create_server(
+            self,
+            *,
+            name: str,
+            server_type: str,
+            image: str,
+            location: str,
+            ssh_key: Any,
+            firewall: Any,
+            user_data: str,
+        ) -> tuple[str, str]:
+            resp = client.servers.create(
+                name=name,
+                server_type=ServerType(name=server_type),
+                image=Image(name=image),
+                ssh_keys=[ssh_key],
+                firewalls=[firewall],
+                location=Location(name=location) if location else None,
+                user_data=user_data,
+            )
+            server = resp.server
+            ip = ""
+            if server.public_net and server.public_net.ipv4:
+                ip = server.public_net.ipv4.ip
+            return str(server.id), ip
+
+    return _Adapter()

--- a/ee/pocketpaw_ee/ship_engine/keygen.py
+++ b/ee/pocketpaw_ee/ship_engine/keygen.py
@@ -1,0 +1,64 @@
+# ee/pocketpaw_ee/ship_engine/keygen.py — mint the per-box SSH keypair.
+#
+# Each provisioned box gets its OWN ed25519 keypair (blast radius = one box).
+# ``generate_box_keypair`` returns the OpenSSH private key (PEM, unencrypted —
+# it is Fernet-encrypted at rest by the caller before it touches Mongo) and the
+# matching single-line OpenSSH public key (authorized on the box via cloud-init;
+# not secret).
+#
+# ed25519 over RSA: smaller, modern, and asyncssh + Dokku both accept it. No
+# passphrase — the at-rest protection is the Fernet envelope on the ShipBox
+# doc, not a key passphrase we would then also have to store.
+#
+# Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new module.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+
+@dataclass(frozen=True)
+class BoxKeypair:
+    """A freshly minted box keypair.
+
+    ``private_key_openssh`` is an unencrypted OpenSSH private key (the caller
+    Fernet-encrypts it before persistence). ``public_key_openssh`` is the
+    single-line authorized-keys entry.
+    """
+
+    private_key_openssh: str
+    public_key_openssh: str
+
+
+def generate_box_keypair(*, comment: str = "paw-ship") -> BoxKeypair:
+    """Generate a new ed25519 keypair for a box.
+
+    ``comment`` is appended to the public key line (operator legibility in the
+    box's authorized_keys). Never logs or persists the private half — that is
+    the caller's Fernet-encrypt-then-store responsibility.
+    """
+    private_key = ed25519.Ed25519PrivateKey.generate()
+
+    private_openssh = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.OpenSSH,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+    public_openssh = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.OpenSSH,
+            format=serialization.PublicFormat.OpenSSH,
+        )
+        .decode()
+    )
+
+    safe_comment = comment.replace("\n", " ").strip()
+    return BoxKeypair(
+        private_key_openssh=private_openssh,
+        public_key_openssh=f"{public_openssh} {safe_comment}",
+    )

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -160,6 +160,7 @@ dependencies = [
     # uses it for the per-workspace keypair + subscribe/unsubscribe endpoints.
     "py-vapid>=1.9.0",
     "pywebpush>=2.3.0",
+    "hcloud>=2.23.0",
 ]
 
 [project.optional-dependencies]

--- a/ee/uv.lock
+++ b/ee/uv.lock
@@ -1589,6 +1589,19 @@ wheels = [
 ]
 
 [[package]]
+name = "hcloud"
+version = "2.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b0/f3a2e44ad8c295df58275585aecb979fb0829f0ac7d36d41db958dd85c65/hcloud-2.23.0.tar.gz", hash = "sha256:c12dce3f14404ea342d79236292a15fbc4ceeb7861724a09dd3fe60cef513e0b", size = 154918, upload-time = "2026-07-21T12:32:35.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/ae/bb107bd26049627c63da41868616533c004da69113cb2747e6a4e4eda949/hcloud-2.23.0-py3-none-any.whl", hash = "sha256:5a3fa1bbd1f87bfc5f0c726caebe041b9e1119b4361aafabc12fad284a2c445a", size = 111603, upload-time = "2026-07-21T12:32:34.025Z" },
+]
+
+[[package]]
 name = "hiredis"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3326,6 +3339,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "google-cloud-storage" },
+    { name = "hcloud" },
     { name = "igraph" },
     { name = "livekit-agents", extra = ["codecs"] },
     { name = "livekit-api" },
@@ -3374,6 +3388,7 @@ requires-dist = [
     { name = "google-auth-oauthlib", specifier = ">=1.2.0" },
     { name = "google-cloud-firestore", marker = "extra == 'firestore'", specifier = ">=2.27.0" },
     { name = "google-cloud-storage", specifier = ">=2.14.0" },
+    { name = "hcloud", specifier = ">=2.23.0" },
     { name = "igraph", specifier = ">=0.11" },
     { name = "livekit-agents", extras = ["codecs"], specifier = ">=1.5.9" },
     { name = "livekit-api", specifier = ">=0.6.0" },

--- a/tests/cloud/ship/__init__.py
+++ b/tests/cloud/ship/__init__.py
@@ -1,0 +1,1 @@
+# tests/cloud/ship/ — SHIP-2 provisioning coverage (cloud entity package).

--- a/tests/cloud/ship/test_cloudinit.py
+++ b/tests/cloud/ship/test_cloudinit.py
@@ -1,0 +1,52 @@
+# tests/cloud/ship/test_cloudinit.py — the cloud-init user-data template renders
+# a Dokku-ready box and never leaks private-key material.
+#
+# Covers SHIP-2 acceptance: pinned Dokku version, Docker install, nixpacks, and
+# the PUBLIC key all present; a malformed/multi-line public key is rejected; no
+# private-key material anywhere in the rendered output.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.ship_engine.cloudinit import (
+    DOKKU_VERSION,
+    NIXPACKS_VERSION,
+    render_user_data,
+)
+
+_PUBKEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY paw-ship"
+
+
+def test_renders_required_blocks():
+    out = render_user_data(ssh_public_key=_PUBKEY)
+    assert out.startswith("#cloud-config")
+    # Docker install
+    assert "get.docker.com" in out
+    # Pinned Dokku bootstrap — the version is the pin, not "latest".
+    assert f"install/v{DOKKU_VERSION}/bootstrap.sh" in out
+    assert f"DOKKU_TAG=v{DOKKU_VERSION}" in out
+    # nixpacks, pinned
+    assert "nixpacks.com/install.sh" in out
+    assert f"VERSION={NIXPACKS_VERSION}" in out
+    # The public key authorized for root AND the dokku user.
+    assert _PUBKEY in out
+    assert "dokku ssh-keys:add admin" in out
+
+
+def test_rejects_multiline_public_key():
+    with pytest.raises(ValueError, match="single-line OpenSSH public key"):
+        render_user_data(ssh_public_key="ssh-ed25519 AAAA...\nssh-ed25519 BBBB...")
+
+
+def test_rejects_non_openssh_public_key():
+    with pytest.raises(ValueError, match="single-line OpenSSH public key"):
+        render_user_data(ssh_public_key="-----BEGIN OPENSSH PRIVATE KEY-----")
+
+
+def test_no_private_key_material_in_output():
+    # A PRIVATE key body must never appear — the template only ever gets the
+    # public half, but assert the guard so a future edit that passes the wrong
+    # value is caught.
+    out = render_user_data(ssh_public_key=_PUBKEY)
+    assert "PRIVATE KEY" not in out
+    assert "BEGIN OPENSSH" not in out

--- a/tests/cloud/ship/test_enqueue.py
+++ b/tests/cloud/ship/test_enqueue.py
@@ -1,0 +1,73 @@
+# tests/cloud/ship/test_enqueue.py — the web-process enqueue seam.
+#
+# Covers: enqueue_provision mints a keypair, inserts a ``provisioning`` box with
+# the private key encrypted at rest, and enqueues ``provision_box_job``
+# POSITIONALLY (the arq contract — a ``queue=`` kwarg would be forwarded to the
+# job function and crash it, the pitfall jobs/service.py documents).
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+from pocketpaw_ee.cloud.ship import enqueue
+
+_KEY_ENV = "CLOUD_ENCRYPTION_KEY"
+
+
+@pytest.fixture
+def enc_key(monkeypatch):
+    monkeypatch.setenv(_KEY_ENV, Fernet.generate_key().decode())
+
+
+class FakePool:
+    def __init__(self):
+        self.enqueued = []
+
+    async def enqueue_job(self, *args, **kwargs):
+        self.enqueued.append((args, kwargs))
+        return type("Job", (), {"job_id": "arq-1"})()
+
+
+async def test_enqueue_creates_box_and_dispatches(mongo_db, enc_key):  # noqa: ARG001
+    pool = FakePool()
+
+    async def pool_factory():
+        return pool
+
+    box = await enqueue.enqueue_provision(
+        workspace_id="ws-1",
+        server_type="cx22",
+        region="fsn1",
+        pool_factory=pool_factory,
+    )
+
+    assert box.status == "provisioning"
+    assert box.workspace == "ws-1"
+    assert box.server_type == "cx22"
+    assert box.region == "fsn1"
+    # A real keypair was minted and the private half encrypted.
+    assert box.ssh_public_key.startswith("ssh-ed25519 ")
+    assert "PRIVATE KEY" not in box.ssh_private_key_enc
+
+    # The job was enqueued positionally with (job_name, box_id, workspace_id)
+    # and NO kwargs — arq forwards stray kwargs to the job function.
+    (args, kwargs) = pool.enqueued[0]
+    assert args == ("provision_box_job", str(box.id), "ws-1")
+    assert kwargs == {}
+
+
+async def test_enqueue_failure_propagates(mongo_db, enc_key):  # noqa: ARG001
+    class BadPool:
+        async def enqueue_job(self, *a, **k):
+            raise RuntimeError("redis down")
+
+    async def pool_factory():
+        return BadPool()
+
+    with pytest.raises(RuntimeError, match="redis down"):
+        await enqueue.enqueue_provision(
+            workspace_id="ws-1",
+            server_type="cx22",
+            region="fsn1",
+            pool_factory=pool_factory,
+        )

--- a/tests/cloud/ship/test_keygen.py
+++ b/tests/cloud/ship/test_keygen.py
@@ -1,0 +1,31 @@
+# tests/cloud/ship/test_keygen.py — the per-box ed25519 keypair mint.
+#
+# Covers: a valid OpenSSH keypair is produced, the public key is a single line
+# with the comment, distinct boxes get distinct keys, and the private half is an
+# unencrypted OpenSSH key (the Fernet envelope is the store's job, not the
+# keygen's).
+
+from __future__ import annotations
+
+from pocketpaw_ee.ship_engine.keygen import generate_box_keypair
+
+
+def test_generates_valid_openssh_keypair():
+    kp = generate_box_keypair(comment="paw-ship-abc")
+    assert kp.private_key_openssh.startswith("-----BEGIN OPENSSH PRIVATE KEY-----")
+    assert kp.public_key_openssh.startswith("ssh-ed25519 ")
+    assert kp.public_key_openssh.endswith(" paw-ship-abc")
+    # The public key is a single line (authorized_keys entry).
+    assert "\n" not in kp.public_key_openssh
+
+
+def test_distinct_boxes_get_distinct_keys():
+    a = generate_box_keypair()
+    b = generate_box_keypair()
+    assert a.private_key_openssh != b.private_key_openssh
+    assert a.public_key_openssh != b.public_key_openssh
+
+
+def test_comment_newlines_are_flattened():
+    kp = generate_box_keypair(comment="line1\nline2")
+    assert "\n" not in kp.public_key_openssh

--- a/tests/cloud/ship/test_provisioner.py
+++ b/tests/cloud/ship/test_provisioner.py
@@ -1,0 +1,92 @@
+# tests/cloud/ship/test_provisioner.py — HcloudProvisioner over a FAKE client.
+#
+# Covers SHIP-2 acceptance: create_server returns a targetable BoxHandle + the
+# captured monthly price, maps ANY provider failure to a safe ProvisionError
+# string (never a raw payload), and passes cloud-init that installs Dokku. Zero
+# network — the hcloud client is a Protocol fake.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.ship_engine.hcloud import HcloudProvisioner, ProvisionError
+from pocketpaw_ee.ship_engine.port import BoxSpec
+
+
+class FakeHcloudClient:
+    """In-memory stand-in for the hcloud SDK slice the provisioner uses."""
+
+    def __init__(self, *, price=7.5, fail_on=None, created=None):
+        self.price = price
+        self.fail_on = fail_on  # a method name to blow up on
+        self.created = created if created is not None else []
+        self.user_data_seen = None
+
+    def _maybe_fail(self, name):
+        if self.fail_on == name:
+            raise RuntimeError(f"boom-{name} secret-token-abc123")
+
+    def ensure_ssh_key(self, *, name, public_key):
+        self._maybe_fail("ensure_ssh_key")
+        return {"name": name}
+
+    def ensure_firewall(self, *, name, ports):
+        self._maybe_fail("ensure_firewall")
+        return {"name": name}
+
+    def price_monthly(self, server_type):
+        self._maybe_fail("price_monthly")
+        return self.price
+
+    def create_server(self, *, name, server_type, image, location, ssh_key, firewall, user_data):
+        self._maybe_fail("create_server")
+        self.user_data_seen = user_data
+        self.created.append(name)
+        return ("srv-123", "203.0.113.7")
+
+
+_SPEC = BoxSpec(name="paw-ship-box", region="fsn1", size="cx22")
+
+
+def test_create_server_returns_handle_and_price():
+    client = FakeHcloudClient(price=11.9)
+    prov = HcloudProvisioner(client)
+    result = prov.create_server(_SPEC, ssh_public_key="ssh-ed25519 AAAA x", key_name="k1")
+
+    assert result.server_id == "srv-123"
+    assert result.ip == "203.0.113.7"
+    assert result.price_monthly == 11.9
+    assert result.handle.box_id == "srv-123"
+    assert result.handle.host == "203.0.113.7"
+    assert result.handle.ssh_user == "root"
+    assert result.server_type == "cx22"
+    assert result.region == "fsn1"
+
+
+def test_create_server_passes_dokku_cloudinit():
+    client = FakeHcloudClient()
+    prov = HcloudProvisioner(client)
+    prov.create_server(_SPEC, ssh_public_key="ssh-ed25519 AAAA x", key_name="k1")
+    assert client.user_data_seen is not None
+    assert "DOKKU_TAG=v" in client.user_data_seen
+
+
+@pytest.mark.parametrize("fail_on", ["ensure_ssh_key", "ensure_firewall", "create_server"])
+def test_provider_failure_maps_to_safe_error(fail_on):
+    client = FakeHcloudClient(fail_on=fail_on)
+    prov = HcloudProvisioner(client)
+    with pytest.raises(ProvisionError) as exc:
+        prov.create_server(_SPEC, ssh_public_key="ssh-ed25519 AAAA x", key_name="k1")
+    # The safe string carries only the exception TYPE, never the raw payload
+    # (which here embedded a fake secret token).
+    assert "secret-token-abc123" not in str(exc.value)
+    assert "RuntimeError" in str(exc.value)
+
+
+def test_empty_server_id_is_rejected():
+    class NoIdClient(FakeHcloudClient):
+        def create_server(self, **kw):
+            return ("", "")
+
+    prov = HcloudProvisioner(NoIdClient())
+    with pytest.raises(ProvisionError, match="no server id"):
+        prov.create_server(_SPEC, ssh_public_key="ssh-ed25519 AAAA x", key_name="k1")

--- a/tests/cloud/ship/test_provisioning_lifecycle.py
+++ b/tests/cloud/ship/test_provisioning_lifecycle.py
@@ -1,0 +1,211 @@
+# tests/cloud/ship/test_provisioning_lifecycle.py — the ShipBox lifecycle.
+#
+# The core SHIP-2 coverage: ``run_provision`` walks a real ShipBox doc (Beanie on
+# mongomock) from ``provisioning`` to ``ready``, records ``degraded`` on a
+# provider failure AND on readiness exhaustion, and NEVER creates a second
+# server when a prior attempt already recorded one (idempotency). Also asserts
+# the at-rest secret contract: the private key is stored encrypted, decrypts
+# back through the store seam, and never appears in the doc's plaintext fields.
+#
+# Zero network, zero real box: the provisioner and the readiness probe are both
+# injected fakes, and ``sleep`` is a no-op so the poll loop runs instantly.
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+from pocketpaw_ee.cloud.ship import provisioning, store
+from pocketpaw_ee.ship_engine.hcloud import ProvisionError
+from pocketpaw_ee.ship_engine.port import BoxHandle
+
+_KEY_ENV = "CLOUD_ENCRYPTION_KEY"
+_PRIV = "-----BEGIN OPENSSH PRIVATE KEY-----\nFAKEKEYBODY\n-----END OPENSSH PRIVATE KEY-----\n"
+_PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY paw-ship"
+
+
+@pytest.fixture
+def enc_key(monkeypatch):
+    """A valid Fernet key so the store's at-rest encryption works."""
+    monkeypatch.setenv(_KEY_ENV, Fernet.generate_key().decode())
+
+
+class FakeProvisioner:
+    """Stands in for HcloudProvisioner: records calls, returns scripted facts."""
+
+    def __init__(self, *, fail: bool = False):
+        self.fail = fail
+        self.calls = 0
+
+    def create_server(self, spec, *, ssh_public_key, key_name):
+        self.calls += 1
+        if self.fail:
+            raise ProvisionError("provider create failed (RuntimeError)")
+        from pocketpaw_ee.ship_engine.hcloud import ProvisionResult
+
+        return ProvisionResult(
+            handle=BoxHandle(box_id="srv-9", host="203.0.113.9"),
+            server_id="srv-9",
+            ip="203.0.113.9",
+            price_monthly=8.25,
+            server_type=spec.size,
+            region=spec.region,
+        )
+
+
+def probe_script(*results):
+    """A readiness probe that returns each scripted result in turn."""
+    seq = list(results)
+
+    async def _probe(handle: BoxHandle, key: str) -> bool:
+        return seq.pop(0) if seq else False
+
+    return _probe
+
+
+async def _noop_sleep(_seconds: float) -> None:
+    return None
+
+
+async def _make_box(workspace="ws-1"):
+    return await store.create_provisioning_box(
+        workspace_id=workspace,
+        provider="hcloud",
+        server_type="cx22",
+        region="fsn1",
+        ssh_private_key=_PRIV,
+        ssh_public_key=_PUB,
+    )
+
+
+async def test_provisioning_to_ready(mongo_db, enc_key):  # noqa: ARG001 — fixtures init state
+    box = await _make_box()
+    assert box.status == "provisioning"
+
+    prov = FakeProvisioner()
+    updated = await provisioning.run_provision(
+        box,
+        provisioner=prov,
+        ssh_public_key=_PUB,
+        ssh_private_key=_PRIV,
+        probe=probe_script(False, True),  # still booting, then ready
+        sleep=_noop_sleep,
+    )
+
+    assert updated.status == "ready"
+    assert updated.server_id == "srv-9"
+    assert updated.ip == "203.0.113.9"
+    assert updated.price_monthly == 8.25
+    assert updated.status_reason is None
+    assert prov.calls == 1
+
+
+async def test_provider_failure_marks_degraded(mongo_db, enc_key):  # noqa: ARG001
+    box = await _make_box()
+    updated = await provisioning.run_provision(
+        box,
+        provisioner=FakeProvisioner(fail=True),
+        ssh_public_key=_PUB,
+        ssh_private_key=_PRIV,
+        probe=probe_script(True),
+        sleep=_noop_sleep,
+    )
+
+    assert updated.status == "degraded"
+    assert "provider create failed" in (updated.status_reason or "")
+    # No server was recorded, so a retry starts clean.
+    assert updated.server_id == ""
+
+
+async def test_readiness_exhaustion_marks_degraded(mongo_db, enc_key):  # noqa: ARG001
+    box = await _make_box()
+    updated = await provisioning.run_provision(
+        box,
+        provisioner=FakeProvisioner(),
+        ssh_public_key=_PUB,
+        ssh_private_key=_PRIV,
+        probe=probe_script(False, False, False),  # never ready
+        sleep=_noop_sleep,
+        max_probe_attempts=3,
+    )
+
+    assert updated.status == "degraded"
+    assert "did not become reachable" in (updated.status_reason or "")
+    # The server id IS recorded — a retry must reuse it, not orphan a second box.
+    assert updated.server_id == "srv-9"
+
+
+async def test_probe_exception_is_tolerated_then_ready(mongo_db, enc_key):  # noqa: ARG001
+    """A connection error while the box boots is expected, not fatal."""
+    box = await _make_box()
+    calls = {"n": 0}
+
+    async def flaky_probe(handle, key):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ConnectionRefusedError("still booting")
+        return True
+
+    updated = await provisioning.run_provision(
+        box,
+        provisioner=FakeProvisioner(),
+        ssh_public_key=_PUB,
+        ssh_private_key=_PRIV,
+        probe=flaky_probe,
+        sleep=_noop_sleep,
+    )
+    assert updated.status == "ready"
+
+
+async def test_retry_never_creates_a_second_server(mongo_db, enc_key):  # noqa: ARG001
+    """The idempotency guarantee: a box that already carries a server_id skips
+    the create entirely on a re-run (the exact double-spend defect)."""
+    box = await _make_box()
+
+    # First attempt: create lands, readiness never arrives → degraded w/ server_id.
+    first = await provisioning.run_provision(
+        box,
+        provisioner=FakeProvisioner(),
+        ssh_public_key=_PUB,
+        ssh_private_key=_PRIV,
+        probe=probe_script(False),
+        sleep=_noop_sleep,
+        max_probe_attempts=1,
+    )
+    assert first.server_id == "srv-9"
+
+    # Second attempt on the SAME box: the provisioner must not be called again.
+    prov2 = FakeProvisioner()
+    second = await provisioning.run_provision(
+        first,
+        provisioner=prov2,
+        ssh_public_key=_PUB,
+        ssh_private_key=_PRIV,
+        probe=probe_script(True),
+        sleep=_noop_sleep,
+    )
+
+    assert prov2.calls == 0, "a retry must reuse the existing server, never create a second"
+    assert second.status == "ready"
+    assert second.server_id == "srv-9"
+
+
+async def test_ssh_key_is_encrypted_at_rest(mongo_db, enc_key):  # noqa: ARG001
+    box = await _make_box()
+
+    # The stored field is ciphertext — the private key body never appears.
+    assert box.ssh_private_key_enc
+    assert "FAKEKEYBODY" not in box.ssh_private_key_enc
+    assert "BEGIN OPENSSH PRIVATE KEY" not in box.ssh_private_key_enc
+    # ...and the whole serialized doc carries no plaintext key material.
+    assert "FAKEKEYBODY" not in box.model_dump_json()
+    # The store seam round-trips it back for driver use.
+    assert store.decrypt_ssh_key(box) == _PRIV
+    # The PUBLIC key is stored as-is (not secret).
+    assert box.ssh_public_key == _PUB
+
+
+async def test_get_box_is_workspace_scoped(mongo_db, enc_key):  # noqa: ARG001
+    box = await _make_box(workspace="ws-owner")
+    assert await store.get_box("ws-owner", str(box.id)) is not None
+    # A different tenant may not read it, even with the right id.
+    assert await store.get_box("ws-attacker", str(box.id)) is None

--- a/uv.lock
+++ b/uv.lock
@@ -2254,6 +2254,19 @@ wheels = [
 ]
 
 [[package]]
+name = "hcloud"
+version = "2.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b0/f3a2e44ad8c295df58275585aecb979fb0829f0ac7d36d41db958dd85c65/hcloud-2.23.0.tar.gz", hash = "sha256:c12dce3f14404ea342d79236292a15fbc4ceeb7861724a09dd3fe60cef513e0b", size = 154918, upload-time = "2026-07-21T12:32:35.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/ae/bb107bd26049627c63da41868616533c004da69113cb2747e6a4e4eda949/hcloud-2.23.0-py3-none-any.whl", hash = "sha256:5a3fa1bbd1f87bfc5f0c726caebe041b9e1119b4361aafabc12fad284a2c445a", size = 111603, upload-time = "2026-07-21T12:32:34.025Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5328,6 +5341,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "google-cloud-storage" },
+    { name = "hcloud" },
     { name = "igraph" },
     { name = "livekit-agents", extra = ["codecs"] },
     { name = "livekit-api" },
@@ -5364,6 +5378,7 @@ requires-dist = [
     { name = "google-auth-oauthlib", specifier = ">=1.2.0" },
     { name = "google-cloud-firestore", marker = "extra == 'firestore'", specifier = ">=2.27.0" },
     { name = "google-cloud-storage", specifier = ">=2.14.0" },
+    { name = "hcloud", specifier = ">=2.23.0" },
     { name = "igraph", specifier = ">=0.11" },
     { name = "livekit-agents", extras = ["codecs"], specifier = ">=1.5.9" },
     { name = "livekit-api", specifier = ">=0.6.0" },


### PR DESCRIPTION
> Stacked on #1757 (the engine contract). Review that one first; this PR's diff is only the provisioning layer.

Second slice of `/ship`. #1757 gave us a driver that can talk to a Dokku box; this one **creates the box**. Hetzner via the official SDK, cloud-init installs a pinned Dokku plus nixpacks, and a `ShipBox` document tracks the lifecycle.

## What's here

- **`ShipBox` model** — one row per box: provider, server id, IP, status (`provisioning` → `ready` | `degraded` | `destroyed`), captured monthly price, and the box's SSH private key encrypted at rest. Registered with Beanie; only the ship service and the provisioning job touch the document, matching the one-service-owns-one-doc boundary the credit and litellm-key entities use.
- **`ship_engine/hcloud.py`** — creates the server behind an injectable client seam, uploads the provisioning key, ensures a firewall (22/80/443 in), and captures the server type's monthly price at create time.
- **`ship_engine/cloudinit.py`** — the user-data that installs Docker, a pinned Dokku, and nixpacks, and authorizes our key for both root and the `dokku` user. Versions are pinned so the control surface stays reproducible and #1757's transcript assumptions hold.
- **`ship_engine/keygen.py`** — a fresh ed25519 keypair per box, so one box's credential is one box's blast radius.
- **`cloud/ship/`** — the store seam (owns the document, hides the encryption envelope), the lifecycle orchestrator, the arq job, and the web-side enqueue.

## How provisioning behaves

Poll-and-probe, not phone-home: create the server, then poll until it answers `dokku version` over SSH. Bounded attempts, so a box that never comes up lands in `degraded` instead of hanging.

**The retry story matters more than the happy path.** The server id is persisted the moment the create returns, before readiness. A retry sees it and skips the create entirely — so a job that dies mid-provision never orphans a second paid server. There's a test that asserts the provisioner is called zero times on the second run.

Provider failures never escape as raw payloads; they're mapped to a fixed safe string before landing in `status_reason`, since provider errors can carry token fragments.

## Testing

22 tests, no network and no real box — the hcloud client and the readiness probe are both injected fakes and `sleep` is a no-op, so the poll loop runs instantly.

Covered: provisioning → ready, provider failure → degraded, readiness exhaustion → degraded (with the server id retained), a connection error mid-boot tolerated then ready, the retry-never-double-creates guarantee, private key encrypted at rest and absent from the serialized document, and cross-tenant reads returning nothing.

- `uv run pytest tests/cloud/ship/` → 22 passed
- `uv run pytest tests/cloud/chat/ tests/ship_engine/` → 143 passed (the worker and engine consumers of this change)
- `lint-imports` on both the core and `ee/pyproject.toml` configs → 32 contracts kept
- ruff and ruff format clean

## Notes for review

The SSH private key is stored Fernet-encrypted on the box document rather than in the connector state store — that store is keyed on connector name and owned by the connector lifecycle, while this credential is 1:1 with the box and dies with it. Same deployment key (`CLOUD_ENCRYPTION_KEY`) the meetings and connector secrets already use.

`hcloud` 2.23.0 is the one new dependency, aged well past the 7-day minimum-release-age policy. The provisioning job rides the existing worker with its own timeout, since a box boot plus Dokku install runs longer than a chat run.

Needs `POCKETPAW_HCLOUD_TOKEN` and `CLOUD_ENCRYPTION_KEY` set to provision for real; the live run happens in the dogfood slice later in this arc.
