### PR TITLE
ship: REST surface, app and deploy entities, deploy pipeline

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -72,6 +72,12 @@ workspace's source→Fabric mappings, now with a "connector" source_kind that
 dispatches through the OSS FABRIC_INGESTORS registry — gcalendar first) and
 POST /fabric/ingest/run (run one mapping immediately; misconfiguration reports
 status="error" in the body, never a 5xx).
+
+Updated: 2026-07-22 (SHIP-3, feat/ship-3-cloud-entity) — documented the
+Ship — Managed Deploys section: the workspace-scoped /ship surface for
+provisioning a box, registering and deploying an app, routing a domain,
+creating a linked database, and reading logs + box health. The two DELETE
+routes PARK a teardown for human approval and never destroy anything.
 -->
 
 # Cloud REST API Reference
@@ -1217,6 +1223,144 @@ Errors:
 | 404 | `pocket.not_found` | Unknown pocket id. |
 | 403 | `pocket.access_denied` | The caller lacks access to the pocket. |
 | 500 | `sites.generator_failed` | The arm build failed (missing toolchain, non-zero build, or smoke-gate failure). |
+
+## Ship — Managed Deploys
+
+SHIP-3. The `/api/v1/ship` surface behind the /ship console: a workspace
+provisions a **box** (a VPS running Dokku), registers **apps** on it, and
+deploys them. Every route is license-gated and scoped to the caller's active
+workspace — the workspace never travels in a body or query param, and an id
+belonging to another tenant reads as `404`, never `403` (existence does not
+leak).
+
+Long work never blocks the request. `POST /ship/boxes` and
+`POST /ship/apps/{id}/deploy` enqueue an ARQ job and return immediately with a
+pollable record; the engine-backed routes (domains, database, logs, metrics)
+run inline over SSH and answer `409` with `code: ship.*_failed` when the deploy
+engine refuses.
+
+**Secrets never cross this surface.** A box's SSH key is decrypted only inside
+the engine session and shredded with it. App env **names** are accepted and
+stored (`env_refs`); env **values** are not. A database's connection string
+stays on the box — `POST /ship/apps/{id}/db` returns the NAME of the variable
+holding it.
+
+### `POST /ship/boxes`
+
+Provision a box. Body: `{"provider": "hcloud"}`. `server_type` and `region` are
+optional; they default to `cx22` / `fsn1` (Hetzner: 2 vCPU / 4 GB / 40 GB in
+Falkenstein — the cheapest shape that comfortably runs Dokku plus a couple of
+app containers), overridable per deployment via `POCKETPAW_SHIP_SERVER_TYPE` /
+`POCKETPAW_SHIP_REGION`.
+
+Returns the box in `provisioning`; poll `GET /ship/boxes` until it is `ready`:
+
+```json
+{"id": "…", "provider": "hcloud", "ip": "", "status": "provisioning", "price_monthly": null}
+```
+
+`status` is one of `provisioning` | `ready` | `degraded` | `destroyed`.
+
+### `GET /ship/boxes`
+
+The workspace's boxes, newest first — a list of the object above.
+
+### `GET /ship/boxes/{box_id}/metrics`
+
+Live box health, read over SSH. Three percentages, `0.0`–`100.0`:
+
+```json
+{"cpu": 21.0, "mem": 37.5, "disk": 23.0}
+```
+
+`cpu` is derived from the 1-minute load average over the core count and capped
+at 100. A box that is not `ready` answers `409 ship.box_not_ready`.
+
+### `DELETE /ship/boxes/{box_id}`
+
+**Parks** a teardown for human approval. Nothing is destroyed, no engine command
+runs, and the box keeps its current `status`:
+
+```json
+{"status": "pending_approval", "proposal_id": "ship-destroy-…"}
+```
+
+Repeating the call returns the same `proposal_id`. Wiring the proposal into the
+Instinct approval queue (and executing on approve) is SHIP-4's job.
+
+### `POST /ship/apps`
+
+Register an app on a box. Body: `{"name": "demo", "box_id": "…"}`. Optional:
+`image` (the container image reference the deploy ships), `git_ref`,
+`build_path` (`dockerfile` | `nixpacks`), `prod`, and `env_refs` (variable
+NAMES only). Returns:
+
+```json
+{"id": "…", "name": "demo", "box_id": "…", "status": "created", "urls": []}
+```
+
+`status` walks `created` → `deploying` → `live` | `failed`. A duplicate name on
+the same box is `409 ship.app_exists`; a `box_id` from another workspace is
+`404`.
+
+### `GET /ship/apps?box_id=<id>`
+
+The workspace's apps, newest first, optionally narrowed to one box.
+
+### `POST /ship/apps/{app_id}/deploy`
+
+Enqueue a deploy. Takes **no body** — the app already carries its image, and the
+attempt pins that image so a later app edit cannot rewrite what is in flight. An
+app with no image is `422 ship.app_no_image`; a box that is not `ready` is
+`409 ship.box_not_ready`. Returns the attempt immediately:
+
+```json
+{"id": "…", "app_id": "…", "status": "queued", "started_at": "2026-07-22T…Z", "finished_at": null}
+```
+
+### `GET /ship/apps/{app_id}/deploys`
+
+The app's deploy attempts, newest first. `status` walks
+`queued` → `building` → `releasing` → `live`, or lands on `failed`;
+`finished_at` is set on a terminal state. Poll this to follow a deploy.
+
+### `POST /ship/apps/{app_id}/domains`
+
+Route a domain to the app and (by default) issue a certificate for it. Body:
+`{"domain": "demo.example.com", "enable_tls": true}`. Returns
+`{"domain": "…", "tls_enabled": true}` and adds the resulting URL to the app's
+`urls`.
+
+### `GET /ship/apps/{app_id}/domains`
+
+`{"domains": [{"domain": "…", "tls_enabled": true}]}` — the domains recorded at
+add time.
+
+### `POST /ship/apps/{app_id}/db`
+
+Create a database service and link it to the app. Body is optional; `service`
+defaults to `<app-name>-db`. Returns:
+
+```json
+{"service": "demo-db", "linked_app": "demo", "env_var": "MONGO_URL"}
+```
+
+`env_var` is the NAME of the variable the link injected. The connection string
+is a secret and never crosses the wire.
+
+### `GET /ship/apps/{app_id}/logs?num=<n>`
+
+Recent app log lines, newest last (`num` defaults to 100, max 1000). The engine
+redacts them before they leave the box:
+
+```json
+{"lines": ["2026-07-22T…Z app[web.1]: GET /health 200"]}
+```
+
+### `DELETE /ship/apps/{app_id}`
+
+**Parks** an app teardown for human approval, exactly like the box DELETE above.
+Nothing is destroyed.
 
 ## Fabric — Transform Mappings (source→Fabric ingest)
 

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -504,6 +504,14 @@ def mount_cloud(app: FastAPI) -> None:
 
     app.include_router(belt_mandates_router, prefix="/api/v1")
 
+    # /ship managed deploys (SHIP-3, feat/ship-3-cloud-entity). The
+    # workspace-scoped /api/v1/ship surface: provision a box, register + deploy
+    # an app, route a domain, create a database, read logs + box health. The two
+    # DELETEs PARK a teardown for approval and never execute one.
+    from pocketpaw_ee.cloud.ship.router import router as ship_router
+
+    app.include_router(ship_router, prefix="/api/v1")
+
     # Files Tab v2 — /api/v1/files/tree + /api/v1/files/browse. Mounted
     # inline (instead of via build_router's ctx_factory) so the routes can
     # use the canonical `Depends(current_active_user)` auth chain without

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -51,6 +51,11 @@
 #   ``WebSandboxStatusChanged`` (type="websandbox.status_changed") for the Web
 #   Cursor sandbox registry. Emitted by ``websandbox.service`` on every
 #   state-mutating call per cloud rule 9.
+# Updated: 2026-07-22 (SHIP-3, feat/ship-3-cloud-entity) — added the six
+#   ship.* events (box.created, app.created, app.updated, deploy.queued,
+#   deploy.status_changed, destroy.proposed) for the /ship managed-deploy
+#   surface. Emitted by ``ship.service`` + the arq deploy job on every
+#   state-mutating call per cloud rule 9.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -1096,3 +1101,45 @@ class CodeProjectDeleted(Event):
 @dataclass
 class CodeConnectionCreated(Event):
     EVENT_TYPE: ClassVar[str] = "codeconnection.created"
+
+
+# /ship managed deploys (SHIP-3, feat/ship-3-cloud-entity). Emitted by
+# ``ship.service`` and the arq deploy job on every state-mutating call per cloud
+# rule 9 (emit on every write). ``ShipBoxCreated`` fires when a provision is
+# accepted; ``ShipAppCreated`` when an app is registered on a box;
+# ``ShipAppUpdated`` when an app's domains / database link / status change;
+# ``ShipDeployQueued`` at enqueue and ``ShipDeployStatusChanged`` on each
+# ``queued -> building -> releasing -> live`` (or ``failed``) transition — the
+# worker-side emits ride the xproc bridge to the web bus, the same path
+# ``WorkspaceJobUpdated`` uses. ``ShipDestroyProposed`` fires when a DELETE parks
+# a teardown for human approval; NOTHING is destroyed by it.
+# ``data`` carries ids + workspace + status only — never SSH key material, env
+# values, or database connection strings.
+@dataclass
+class ShipBoxCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "ship.box.created"
+
+
+@dataclass
+class ShipAppCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "ship.app.created"
+
+
+@dataclass
+class ShipAppUpdated(Event):
+    EVENT_TYPE: ClassVar[str] = "ship.app.updated"
+
+
+@dataclass
+class ShipDeployQueued(Event):
+    EVENT_TYPE: ClassVar[str] = "ship.deploy.queued"
+
+
+@dataclass
+class ShipDeployStatusChanged(Event):
+    EVENT_TYPE: ClassVar[str] = "ship.deploy.status_changed"
+
+
+@dataclass
+class ShipDestroyProposed(Event):
+    EVENT_TYPE: ClassVar[str] = "ship.destroy.proposed"

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -1,5 +1,11 @@
 """arq worker entry point for Tier 2 run execution.
 
+Updated: 2026-07-22 (SHIP-3, feat/ship-3-cloud-entity) — registered the /ship
+deploy job ``deploy_app_job`` into ``WorkerSettings.functions``, wrapped the same
+way as ``provision_box_job``: its own long timeout (a deploy pulls an image and
+swaps containers) and ``max_tries=1`` (the job records the attempt ``failed``
+instead of raising, so an arq retry would only re-run a known-bad deploy).
+
 Updated: 2026-06-22 (feat/jobs-custom-job-entrypoints) — ``_startup`` now also
 calls ``load_entrypoint_jobs()`` right after ``register_builtins()`` so the
 worker registers WORKSPACE-CUSTOM jobs (declared under the ``pocketpaw.jobs``
@@ -71,6 +77,7 @@ from pocketpaw_ee.cloud.jobs.domain import job_timeout_seconds
 from pocketpaw_ee.cloud.jobs.worker import execute_workspace_job
 from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
 from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
+from pocketpaw_ee.cloud.ship.deploy_job import deploy_app_job
 from pocketpaw_ee.cloud.ship.job import provision_box_job
 
 logger = logging.getLogger(__name__)
@@ -251,10 +258,23 @@ _ship_provision_fn = func(
 )
 
 
+# The /ship deploy job (SHIP-3) rides the same worker, wrapped like the
+# provisioning job: its own long timeout (a deploy pulls an image and swaps
+# containers, well past the chat-run budget) and max_tries=1 — the job records
+# the attempt ``failed`` rather than raising, so an arq retry would only re-run
+# a known-bad deploy. The enqueue name is pinned to match ``ship/enqueue.py``.
+_ship_deploy_fn = func(
+    deploy_app_job,
+    name="deploy_app_job",
+    timeout=job_timeout_seconds(),
+    max_tries=1,
+)
+
+
 class WorkerSettings:
     """arq worker configuration. Loaded by ``arq <dotted-path>``."""
 
-    functions = [execute_run_job, _workspace_job_fn, _ship_provision_fn]
+    functions = [execute_run_job, _workspace_job_fn, _ship_provision_fn, _ship_deploy_fn]
     on_startup = _startup
     on_shutdown = _shutdown
     # Crash policy: no auto-retry. A failed run is left as ``failed``/``interrupted``

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,11 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-22 (SHIP-3, feat/ship-3-cloud-entity) — added ``ShipApp`` and
+``ShipDeploy`` (the /ship app + deploy-attempt docs) to the imports, ``__all__``
+and ``get_all_documents()`` so the ``ship_apps`` / ``ship_deploys`` collections
+are wired into ``init_beanie``. Only ``ee.cloud.ship.store`` imports the doc
+classes directly (import-linter "Ship" contract).
+
 Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — added ``WorkspaceVm`` (the
 workspace→Daytona-VM mapping, moved out of the local
 ``~/.pocketpaw/daytona_workspace_vm_map.json`` file into the ``workspace_vms``
@@ -162,7 +168,6 @@ from pocketpaw_ee.cloud.models.instinct_workspace_config import InstinctWorkspac
 from pocketpaw_ee.cloud.models.invite import Invite
 from pocketpaw_ee.cloud.models.lead import Lead, LeadSource
 from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
-from pocketpaw_ee.cloud.models.ship import ShipBox
 from pocketpaw_ee.cloud.models.meeting import (
     Meeting,
     MeetingProviderCredentials,
@@ -184,6 +189,7 @@ from pocketpaw_ee.cloud.models.request_log import RequestLog
 from pocketpaw_ee.cloud.models.sense_preference import WorkspaceSensePreference
 from pocketpaw_ee.cloud.models.session import Session
 from pocketpaw_ee.cloud.models.session_transcript import SessionTranscriptDoc
+from pocketpaw_ee.cloud.models.ship import ShipApp, ShipBox, ShipDeploy
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
 from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
@@ -322,7 +328,9 @@ __all__ = [
     "Lead",
     "LeadSource",
     "LiteLLMTenantKey",
+    "ShipApp",
     "ShipBox",
+    "ShipDeploy",
     "Meeting",
     "MeetingProviderCredentials",
     "MeetingsSettings",
@@ -424,9 +432,11 @@ def get_all_documents():
         # LiteLLM per-tenant virtual-key mapping (MCG-8). Only
         # ``ee.cloud.llm_provisioning.service`` writes this.
         LiteLLMTenantKey,
-        # Managed-deploy boxes (SHIP-2). Only ``ee.cloud.ship.service`` and the
-        # ``provision_box`` builtin write this.
+        # Managed-deploy boxes + their apps and deploy attempts (SHIP-2/SHIP-3).
+        # Only ``ee.cloud.ship.store`` reads/writes these.
         ShipBox,
+        ShipApp,
+        ShipDeploy,
         Invite,
         Group,
         InstinctApproval,

--- a/ee/pocketpaw_ee/cloud/models/ship.py
+++ b/ee/pocketpaw_ee/cloud/models/ship.py
@@ -1,6 +1,6 @@
-# ee/pocketpaw_ee/cloud/models/ship.py — the provisioned-box document for /ship.
+# ee/pocketpaw_ee/cloud/models/ship.py — the /ship managed-deploy documents.
 #
-# One Beanie document backs a workspace's managed deploy boxes:
+# Three Beanie documents back a workspace's managed deploys:
 #
 #   * ``ShipBox`` — one row per provisioned box. Records the provider, the
 #     provider-side server id, the reachable IP, the lifecycle status, the
@@ -9,6 +9,15 @@
 #     the box over SSH. The key is the box's blast radius, so it never lives in
 #     plaintext at rest and never leaves this layer in a DTO — the ship service
 #     decrypts it only to hand it to the SHIP-1 driver.
+#   * ``ShipApp`` — one row per app deployed onto a box (SHIP-3). Carries the
+#     build inputs (``build_path`` / ``git_ref`` / ``image``), the routed
+#     domains + URLs, the linked database service, and the app lifecycle
+#     status. ``env_refs`` holds env var NAMES only — values are the app's own
+#     secret material and are never persisted here (the SHIP-1 ``AppSpec``
+#     security invariant, carried through to storage).
+#   * ``ShipDeploy`` — one row per deploy attempt (SHIP-3). The pollable state
+#     the HTTP surface returns immediately while the arq deploy job advances it
+#     ``queued -> building -> releasing -> live`` (or ``failed``).
 #
 # WHY store the key on the box doc (encrypted) rather than the connector state
 # store: the connector state store is keyed on connector NAME + workspace and
@@ -26,15 +35,23 @@
 # Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new entity. Registered
 # in ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
 # ``init_beanie`` wires the ``ship_boxes`` collection. Only
-# ``ee.cloud.ship.service`` (SHIP-3) and the ``provision_box`` builtin job
-# (SHIP-2) read/write this document — the same one-service-owns-one-doc
-# isolation the credit / litellm-key / foresight docs use.
+# ``ee.cloud.ship.store`` reads/writes this document — the same
+# one-module-owns-one-doc isolation the credit / litellm-key / foresight docs
+# use.
+#
+# Changed 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): added ``ShipApp`` +
+# ``ShipDeploy`` (registered alongside ``ShipBox`` in ``cloud.models.__init__``)
+# so the workspace-scoped ``/api/v1/ship`` surface has app + deploy state to
+# read. Both are workspace-indexed and read exclusively through
+# ``ee.cloud.ship.store``.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal
 
 from beanie import Indexed
+from pydantic import Field
 from pymongo import IndexModel
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
@@ -95,9 +112,124 @@ class ShipBox(TimestampedDocument):
     # The provider-native server type + region the box was provisioned with.
     server_type: str = ""
     region: str = ""
+    # Set when a DELETE parked a teardown for human approval (SHIP-3). The box
+    # keeps its current ``status`` — the frozen ``BoxOut`` status vocabulary has
+    # no ``pending`` member, and a parked teardown has not changed the box's
+    # actual lifecycle state. SHIP-4 replaces the placeholder id with a real
+    # Instinct proposal id.
+    pending_destroy_proposal_id: str | None = None
 
     class Settings:
         name = "ship_boxes"
         indexes = [  # noqa: RUF012 — Beanie collection config, not shared mutable
             IndexModel([("workspace", 1), ("status", 1)], name="ix_workspace_status"),
+        ]
+
+
+# The app lifecycle. ``created`` is the birth state; a deploy job drives
+# ``deploying`` -> ``live`` / ``failed``.
+ShipAppStatus = Literal["created", "deploying", "live", "failed"]
+
+# How the app's image is produced. v1 deploys a pre-built image reference; the
+# build strategy is recorded now so the SHIP-5 build path has somewhere to read
+# it from without a migration.
+ShipBuildPath = Literal["dockerfile", "nixpacks"]
+
+
+class ShipApp(TimestampedDocument):
+    """One app deployed onto a workspace's managed box.
+
+    Tenancy: ``workspace`` is REQUIRED and every read filters on it (the ship
+    store asserts it). ``box_id`` is the owning ``ShipBox`` id — an app never
+    outlives its box.
+
+    SECURITY: ``env_refs`` carries env var NAMES only. Values are the app's
+    secret material; they live in the app's own environment on the box and are
+    never persisted, serialized, or logged here — the same invariant SHIP-1's
+    ``AppSpec``/``DbResult`` hold at the engine boundary.
+    """
+
+    # Tenancy filter — every ship read scopes on this.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The owning box's id (a ``ShipBox`` document id as a string).
+    box_id: str
+    # The engine-side app name (also the Dokku app name).
+    name: str
+    # How the image is built. v1 records it; the build itself is image-based.
+    build_path: ShipBuildPath = "dockerfile"
+    # The git ref the image was (or will be) built from — provenance only.
+    git_ref: str = ""
+    # The container image reference (tag included) the engine deploys.
+    image: str = ""
+    # Env var NAMES the app expects. NEVER values (see the class docstring).
+    env_refs: list[str] = Field(default_factory=list)
+    # Production flag — the console badges it; no behaviour hangs off it yet.
+    prod: bool = False
+    # Engine-reported URLs the app answers on (deploy URL + added domains).
+    urls: list[str] = Field(default_factory=list)
+    # Domains routed to the app via ``add_domain``.
+    domains: list[str] = Field(default_factory=list)
+    # The linked database service name + the env var name the link injected.
+    # The connection string itself is a secret and is NEVER stored.
+    db_service: str = ""
+    db_env_var: str = ""
+    # Lifecycle state (see ``ShipAppStatus``).
+    status: ShipAppStatus = "created"
+    # Set when a DELETE parked a teardown for human approval (SHIP-3); SHIP-4
+    # swaps the placeholder for a real Instinct proposal id.
+    pending_destroy_proposal_id: str | None = None
+
+    class Settings:
+        name = "ship_apps"
+        indexes = [  # noqa: RUF012 — Beanie collection config, not shared mutable
+            IndexModel([("workspace", 1), ("box_id", 1)], name="ix_workspace_box"),
+            IndexModel(
+                [("workspace", 1), ("box_id", 1), ("name", 1)],
+                name="ux_workspace_box_name",
+                unique=True,
+            ),
+        ]
+
+
+# The deploy lifecycle the arq deploy job walks. ``queued`` is written by the
+# web process at enqueue; the job advances it and ends on ``live`` or ``failed``.
+ShipDeployStatus = Literal["queued", "building", "releasing", "live", "failed"]
+
+
+class ShipDeploy(TimestampedDocument):
+    """One deploy attempt for a ``ShipApp``.
+
+    Tenancy: ``workspace`` is REQUIRED and every read filters on it. This is the
+    pollable record the HTTP surface hands back immediately — the long work runs
+    in the arq deploy job, which advances ``status`` and stamps ``finished_at``.
+
+    ``log_summary`` is a SHORT, already-redacted failure tail (SHIP-1's
+    ``CommandFailed`` redacts its command + stderr before construction), never a
+    raw engine transcript.
+    """
+
+    # Tenancy filter — every ship read scopes on this.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The deployed app's id (a ``ShipApp`` document id as a string).
+    app_id: str
+    # Lifecycle state (see ``ShipDeployStatus``).
+    status: ShipDeployStatus = "queued"
+    # When the attempt was accepted (stamped at enqueue, so it is always set).
+    started_at: datetime | None = None
+    # When the attempt reached a terminal state (``live`` / ``failed``).
+    finished_at: datetime | None = None
+    # The image reference this attempt deployed — pinned at enqueue so a later
+    # app edit never rewrites history.
+    image: str = ""
+    # A short, redacted outcome/failure summary. The log POINTER for the full
+    # transcript is the app's engine-side log stream (``GET .../logs``).
+    log_summary: str = ""
+
+    class Settings:
+        name = "ship_deploys"
+        indexes = [  # noqa: RUF012 — Beanie collection config, not shared mutable
+            IndexModel(
+                [("workspace", 1), ("app_id", 1), ("createdAt", -1)],
+                name="ix_workspace_app_created",
+            ),
         ]

--- a/ee/pocketpaw_ee/cloud/models/ship.py
+++ b/ee/pocketpaw_ee/cloud/models/ship.py
@@ -51,7 +51,7 @@ from datetime import datetime
 from typing import Literal
 
 from beanie import Indexed
-from pydantic import Field
+from pydantic import BaseModel, Field
 from pymongo import IndexModel
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
@@ -136,6 +136,18 @@ ShipAppStatus = Literal["created", "deploying", "live", "failed"]
 ShipBuildPath = Literal["dockerfile", "nixpacks"]
 
 
+class ShipAppDomain(BaseModel):
+    """One domain routed to an app, with the TLS outcome the engine reported.
+
+    Stored as a sub-document (not a bare string) because the /ship console shows
+    the certificate state per domain — persisting only the name would force the
+    read path to invent one.
+    """
+
+    domain: str
+    tls_enabled: bool = False
+
+
 class ShipApp(TimestampedDocument):
     """One app deployed onto a workspace's managed box.
 
@@ -167,8 +179,8 @@ class ShipApp(TimestampedDocument):
     prod: bool = False
     # Engine-reported URLs the app answers on (deploy URL + added domains).
     urls: list[str] = Field(default_factory=list)
-    # Domains routed to the app via ``add_domain``.
-    domains: list[str] = Field(default_factory=list)
+    # Domains routed to the app via ``add_domain`` (name + TLS outcome).
+    domains: list[ShipAppDomain] = Field(default_factory=list)
     # The linked database service name + the env var name the link injected.
     # The connection string itself is a secret and is NEVER stored.
     db_service: str = ""

--- a/ee/pocketpaw_ee/cloud/ship/__init__.py
+++ b/ee/pocketpaw_ee/cloud/ship/__init__.py
@@ -1,8 +1,16 @@
 # ee/pocketpaw_ee/cloud/ship/__init__.py — the /ship cloud entity package.
 #
-# SHIP-2 lands the provisioning half: ``store`` (the ShipBox persistence seam,
-# the only module that touches the ShipBox Beanie doc) and ``provisioning`` (the
-# pure box-lifecycle orchestrator the arq job drives). SHIP-3 adds the
-# domain/dto/service/router HTTP surface alongside these.
+# SHIP-2 landed the provisioning half: ``store`` (the persistence seam, the only
+# module that touches the Beanie docs) and ``provisioning`` + ``job`` (the
+# box-lifecycle orchestrator and its arq entry point).
+#
+# SHIP-3 adds the HTTP surface on top of it:
+#
+#   domain/dto/service/router  the 4-file entity shape behind /api/v1/ship
+#   engine                     box -> live DokkuDriver session (SSH key handling)
+#   deploy_job                 the arq deploy pipeline + its orchestrator
+#   enqueue                    the web-side dispatch for both jobs
 #
 # Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new package.
+# Changed 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): the entity + HTTP
+# surface landed alongside the provisioning half.

--- a/ee/pocketpaw_ee/cloud/ship/deploy_job.py
+++ b/ee/pocketpaw_ee/cloud/ship/deploy_job.py
@@ -64,10 +64,10 @@ async def run_deploy(
 ) -> ShipDeploy:
     """Take ``deploy`` to ``live`` (or ``failed``). Returns the updated doc.
 
-    Never raises for an engine failure — a ``ShipEngineError`` is recorded on the
-    attempt and the app is flipped ``failed``. A programming/infra error (a
-    missing encryption key, a broken bus) still propagates, matching the
-    provisioning orchestrator's posture.
+    Never raises for an engine or reachability failure (``engine.ENGINE_FAILURES``)
+    — it is recorded on the attempt and the app is flipped ``failed``. A
+    programming/infra error (a missing encryption key, a broken bus, a rejected
+    SSH key) still propagates, matching the provisioning orchestrator's posture.
     """
     factory = session_factory or ship_engine.box_session
 
@@ -77,7 +77,7 @@ async def run_deploy(
             result = await session.engine.deploy_app(
                 DeployRequest(app=AppSpec(name=app.name), image=deploy.image)
             )
-    except ShipEngineError as exc:
+    except ship_engine.ENGINE_FAILURES as exc:
         logger.warning("ship deploy failed for app=%s deploy=%s", app.id, deploy.id)
         await _mark_app(app, "failed")
         return await _advance(deploy, "failed", log_summary=_summary(exc))
@@ -160,6 +160,14 @@ def _app_payload(app: ShipApp) -> dict:
     }
 
 
-def _summary(exc: ShipEngineError) -> str:
-    """A short, already-redacted failure line for the attempt record."""
-    return str(exc)[:_SUMMARY_MAX_CHARS]
+def _summary(exc: BaseException) -> str:
+    """A short failure line for the attempt record.
+
+    SHIP-1 redacts ``CommandFailed``'s command + stderr tail before the exception
+    exists. A reachability error (``OSError``) is reported by class name only —
+    its message can carry the box's address, which does not belong in a record
+    the console renders.
+    """
+    if isinstance(exc, ShipEngineError):
+        return str(exc)[:_SUMMARY_MAX_CHARS]
+    return f"could not reach the box ({type(exc).__name__})"

--- a/ee/pocketpaw_ee/cloud/ship/deploy_job.py
+++ b/ee/pocketpaw_ee/cloud/ship/deploy_job.py
@@ -1,0 +1,165 @@
+# ee/pocketpaw_ee/cloud/ship/deploy_job.py — the arq entry point that deploys an
+# app, plus the pure orchestrator behind it (SHIP-3).
+#
+# Same two-layer shape as the SHIP-2 provisioning pair (``provisioning.py`` +
+# ``job.py``), kept in one module because the deploy wiring is thin:
+#
+#   * ``run_deploy`` — the orchestrator. Walks one ShipDeploy through
+#     ``queued -> building -> releasing -> live`` (or ``failed``), emitting a
+#     realtime event on every transition and persisting the app's new URL on
+#     success. The engine arrives through an injected ``BoxSessionFactory``, so
+#     the whole pipeline is testable against SHIP-1's zero-network fake
+#     transport.
+#   * ``deploy_app_job`` — the arq function. Loads the deploy, its app and its
+#     box WORKSPACE-SCOPED, then hands off. It never raises for an operational
+#     failure (the attempt is recorded ``failed`` and the job returns), so arq
+#     does not retry-storm a genuinely broken box.
+#
+# The status vocabulary maps to real pipeline stages: ``building`` is set as the
+# engine call goes out (Dokku creates the app, applies config, pulls the image),
+# ``releasing`` once the engine has answered and the new container is being
+# recorded, ``live`` when the app row carries the deployed image + URL.
+#
+# SECURITY: ``AppSpec`` is built with NO env — env VALUES are never stored by
+# this entity (``env_refs`` holds names only), so a deploy can never echo a
+# secret back through the engine. A failure summary comes from SHIP-1's
+# ``CommandFailed``, whose command + stderr tail are redacted before the
+# exception is constructed.
+#
+# Created 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): new module.
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import ShipAppUpdated, ShipDeployStatusChanged
+from pocketpaw_ee.cloud.ship import engine as ship_engine
+from pocketpaw_ee.cloud.ship import store
+from pocketpaw_ee.ship_engine.port import AppSpec, DeployRequest, ShipEngineError
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.cloud.models.ship import (
+        ShipApp,
+        ShipAppStatus,
+        ShipBox,
+        ShipDeploy,
+        ShipDeployStatus,
+    )
+
+logger = logging.getLogger(__name__)
+
+# A failure summary is a short operator hint, not a transcript — the full output
+# stays on the box and is read through ``GET /ship/apps/{id}/logs``.
+_SUMMARY_MAX_CHARS = 500
+
+
+async def run_deploy(
+    deploy: ShipDeploy,
+    *,
+    app: ShipApp,
+    box: ShipBox,
+    session_factory: ship_engine.BoxSessionFactory | None = None,
+) -> ShipDeploy:
+    """Take ``deploy`` to ``live`` (or ``failed``). Returns the updated doc.
+
+    Never raises for an engine failure — a ``ShipEngineError`` is recorded on the
+    attempt and the app is flipped ``failed``. A programming/infra error (a
+    missing encryption key, a broken bus) still propagates, matching the
+    provisioning orchestrator's posture.
+    """
+    factory = session_factory or ship_engine.box_session
+
+    deploy = await _advance(deploy, "building")
+    try:
+        async with factory(box) as session:
+            result = await session.engine.deploy_app(
+                DeployRequest(app=AppSpec(name=app.name), image=deploy.image)
+            )
+    except ShipEngineError as exc:
+        logger.warning("ship deploy failed for app=%s deploy=%s", app.id, deploy.id)
+        await _mark_app(app, "failed")
+        return await _advance(deploy, "failed", log_summary=_summary(exc))
+
+    deploy = await _advance(deploy, "releasing")
+    app = await store.record_app_deployed(app, image=result.image, app_url=result.app_url)
+    await emit(ShipAppUpdated(data=_app_payload(app)))
+    return await _advance(deploy, "live")
+
+
+async def deploy_app_job(ctx: dict, deploy_id: str, workspace_id: str) -> dict:
+    """arq function: run the deploy attempt ``deploy_id`` for ``workspace_id``.
+
+    ``ctx`` is arq's job context (unused here). Returns a small status dict for
+    observability; the durable outcome is the ShipDeploy ``status``.
+    """
+    deploy = await store.get_deploy(workspace_id, deploy_id)
+    if deploy is None:
+        logger.warning("ship deploy: attempt %s not found for workspace", deploy_id)
+        return {"ok": False, "reason": "deploy_not_found"}
+
+    app = await store.get_app(workspace_id, deploy.app_id)
+    if app is None:
+        updated = await _advance(deploy, "failed", log_summary="app no longer exists")
+        return {"ok": False, "reason": "app_not_found", "status": updated.status}
+
+    box = await store.get_box(workspace_id, app.box_id)
+    if box is None:
+        await _mark_app(app, "failed")
+        updated = await _advance(deploy, "failed", log_summary="box no longer exists")
+        return {"ok": False, "reason": "box_not_found", "status": updated.status}
+    if box.status != "ready":
+        await _mark_app(app, "failed")
+        updated = await _advance(
+            deploy, "failed", log_summary=f"box is {box.status}, not ready to accept a deploy"
+        )
+        return {"ok": False, "reason": "box_not_ready", "status": updated.status}
+
+    updated = await run_deploy(deploy, app=app, box=box)
+    return {"ok": updated.status == "live", "status": updated.status}
+
+
+# --------------------------------------------------------------------------- #
+# Internals
+# --------------------------------------------------------------------------- #
+
+
+async def _advance(
+    deploy: ShipDeploy, status: ShipDeployStatus, *, log_summary: str = ""
+) -> ShipDeploy:
+    """Persist a status transition and announce it."""
+    deploy = await store.set_deploy_status(deploy, status, log_summary=log_summary)
+    await emit(
+        ShipDeployStatusChanged(
+            data={
+                "id": str(deploy.id),
+                "workspace_id": deploy.workspace,
+                "app_id": deploy.app_id,
+                "status": deploy.status,
+            }
+        )
+    )
+    return deploy
+
+
+async def _mark_app(app: ShipApp, status: ShipAppStatus) -> None:
+    """Flip the app's own lifecycle status and announce it."""
+    app = await store.set_app_status(app, status)
+    await emit(ShipAppUpdated(data=_app_payload(app)))
+
+
+def _app_payload(app: ShipApp) -> dict:
+    """The event payload for an app write — ids + status + URLs, never secrets."""
+    return {
+        "id": str(app.id),
+        "workspace_id": app.workspace,
+        "box_id": app.box_id,
+        "status": app.status,
+        "urls": list(app.urls),
+    }
+
+
+def _summary(exc: ShipEngineError) -> str:
+    """A short, already-redacted failure line for the attempt record."""
+    return str(exc)[:_SUMMARY_MAX_CHARS]

--- a/ee/pocketpaw_ee/cloud/ship/domain.py
+++ b/ee/pocketpaw_ee/cloud/ship/domain.py
@@ -1,0 +1,152 @@
+# ee/pocketpaw_ee/cloud/ship/domain.py — frozen value objects for the /ship
+# managed-deploy entity (SHIP-3).
+#
+# These are the plain, framework-free shapes ``ship.service`` hands back across
+# the entity boundary — never the Beanie documents themselves (only
+# ``ship.store`` touches those). The router maps a view to its wire DTO through
+# the mappers in ``service.py``.
+#
+# Tenancy (ee/cloud Rule 3): ``workspace_id`` is REQUIRED on every view with no
+# default — a view can only be built from a persisted, tenant-checked row, so
+# constructing one without an owner is a TypeError, not a silent leak.
+#
+# SECURITY: no view carries secret material. A box's SSH private key never
+# leaves ``store.decrypt_ssh_key``; an app's env VALUES are never read out of the
+# engine — ``env_refs`` holds NAMES only, and ``DbView.env_var`` is the NAME of
+# the variable holding the connection string, never the string (SHIP-1's
+# ``DbResult`` invariant, carried up the stack).
+#
+# Created 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): new module.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import NewType
+
+BoxId = NewType("BoxId", str)
+AppId = NewType("AppId", str)
+DeployId = NewType("DeployId", str)
+
+
+@dataclass(frozen=True)
+class BoxView:
+    """Read model for one provisioned box."""
+
+    id: BoxId
+    workspace_id: str
+    provider: str
+    ip: str
+    status: str
+    price_monthly: float | None = None
+    # Set when a DELETE parked a teardown for human approval (SHIP-4 wires the
+    # real Instinct proposal); the box's ``status`` is unchanged.
+    pending_destroy_proposal_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AppView:
+    """Read model for one app deployed onto a box."""
+
+    id: AppId
+    workspace_id: str
+    box_id: str
+    name: str
+    status: str
+    build_path: str
+    git_ref: str
+    image: str
+    prod: bool
+    urls: tuple[str, ...] = ()
+    # Env var NAMES the app expects — never values.
+    env_refs: tuple[str, ...] = ()
+    pending_destroy_proposal_id: str | None = None
+
+
+@dataclass(frozen=True)
+class DeployView:
+    """Read model for one deploy attempt."""
+
+    id: DeployId
+    workspace_id: str
+    app_id: str
+    status: str
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    image: str = ""
+    log_summary: str = ""
+
+
+@dataclass(frozen=True)
+class DomainView:
+    """A domain routed to an app (mirrors SHIP-1's ``DomainResult``)."""
+
+    workspace_id: str
+    app_id: str
+    domain: str
+    tls_enabled: bool
+
+
+@dataclass(frozen=True)
+class DbView:
+    """A database service linked to an app (mirrors SHIP-1's ``DbResult``).
+
+    ``env_var`` is the NAME of the variable the link injected. The connection
+    string is a secret and never appears here.
+    """
+
+    workspace_id: str
+    app_id: str
+    # The engine-side app name the service was linked to.
+    linked_app: str
+    service: str
+    env_var: str
+
+
+@dataclass(frozen=True)
+class LogsView:
+    """A bounded chunk of an app's recent log lines, newest last."""
+
+    workspace_id: str
+    app_id: str
+    lines: tuple[str, ...] = field(default=())
+
+
+@dataclass(frozen=True)
+class BoxMetricsView:
+    """A point-in-time box health snapshot: three percentages, 0.0–100.0."""
+
+    workspace_id: str
+    box_id: str
+    cpu: float
+    mem: float
+    disk: float
+
+
+@dataclass(frozen=True)
+class DestroyProposalView:
+    """A PARKED teardown. Nothing was destroyed — a human still has to approve.
+
+    ``proposal_id`` is a placeholder id minted by ``ship.service`` in SHIP-3;
+    SHIP-4 replaces it with a real Instinct proposal id.
+    """
+
+    workspace_id: str
+    target_kind: str
+    target_id: str
+    proposal_id: str
+
+
+__all__ = [
+    "AppId",
+    "AppView",
+    "BoxId",
+    "BoxMetricsView",
+    "BoxView",
+    "DbView",
+    "DeployId",
+    "DeployView",
+    "DestroyProposalView",
+    "DomainView",
+    "LogsView",
+]

--- a/ee/pocketpaw_ee/cloud/ship/dto.py
+++ b/ee/pocketpaw_ee/cloud/ship/dto.py
@@ -24,10 +24,27 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# Names that reach the deploy engine are constrained HERE, at the boundary, the
+# same way SHIP-1's ``AppSpec`` constrains env keys: the driver shell-quotes
+# everything it interpolates, so this is not the injection defence — it is what
+# keeps unusable garbage (an app name Dokku will reject, a "domain" that is a
+# sentence) from becoming a failed SSH round trip.
+#
+# Dokku app / service names: lowercase alphanumeric, hyphens inside.
+_APP_NAME_RE = r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$"
+# A DNS hostname: two or more dot-separated labels, each starting and ending
+# alphanumeric with hyphens allowed inside. Written without look-around —
+# pydantic compiles patterns with the Rust regex engine, which has none.
+_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+_DOMAIN_RE = rf"^{_LABEL}(?:\.{_LABEL})+$"
+# POSIX environment variable NAME (values are never accepted).
+_ENV_NAME_RE = r"^[A-Za-z_][A-Za-z0-9_]*$"
 
 # ---------------------------------------------------------------------------
 # Requests
@@ -52,7 +69,7 @@ class CreateAppRequest(BaseModel):
     API never accepts env VALUES.
     """
 
-    name: str = Field(min_length=1, max_length=63)
+    name: str = Field(min_length=1, max_length=63, pattern=_APP_NAME_RE)
     box_id: str = Field(min_length=1)
     build_path: Literal["dockerfile", "nixpacks"] = "dockerfile"
     git_ref: str = ""
@@ -60,11 +77,24 @@ class CreateAppRequest(BaseModel):
     prod: bool = False
     env_refs: list[str] = Field(default_factory=list)
 
+    @field_validator("env_refs")
+    @classmethod
+    def _names_only(cls, value: list[str]) -> list[str]:
+        """Reject anything that is not a bare env var NAME.
+
+        A caller sending ``["API_KEY=hunter2"]`` is trying to store a secret in
+        a field that is never treated as one — refuse it rather than persist it.
+        """
+        for name in value:
+            if not re.match(_ENV_NAME_RE, name):
+                raise ValueError(f"env_refs takes variable names only, got {name!r}")
+        return value
+
 
 class AddDomainRequest(BaseModel):
     """Route a domain to an app and (by default) issue TLS for it."""
 
-    domain: str = Field(min_length=1, max_length=253)
+    domain: str = Field(min_length=1, max_length=253, pattern=_DOMAIN_RE)
     enable_tls: bool = True
 
 

--- a/ee/pocketpaw_ee/cloud/ship/dto.py
+++ b/ee/pocketpaw_ee/cloud/ship/dto.py
@@ -45,6 +45,15 @@ _LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
 _DOMAIN_RE = rf"^{_LABEL}(?:\.{_LABEL})+$"
 # POSIX environment variable NAME (values are never accepted).
 _ENV_NAME_RE = r"^[A-Za-z_][A-Za-z0-9_]*$"
+# An OCI image reference (``registry/repo:tag`` / ``@sha256:...``) and a git ref.
+# Both reach the engine as shell arguments, so they get the same boundary
+# treatment as the app name rather than being free strings: the driver quotes
+# them, and these keep shell metacharacters out of a value that would otherwise
+# only fail deep inside an SSH round trip.
+# Empty is allowed on both: it is the "not specified" value the create body
+# carries when a client registers an app before choosing what to ship.
+_IMAGE_RE = r"^$|^[A-Za-z0-9][A-Za-z0-9._/:@-]*$"
+_GIT_REF_RE = r"^$|^[A-Za-z0-9][A-Za-z0-9._/-]*$"
 
 # ---------------------------------------------------------------------------
 # Requests
@@ -72,8 +81,8 @@ class CreateAppRequest(BaseModel):
     name: str = Field(min_length=1, max_length=63, pattern=_APP_NAME_RE)
     box_id: str = Field(min_length=1)
     build_path: Literal["dockerfile", "nixpacks"] = "dockerfile"
-    git_ref: str = ""
-    image: str = ""
+    git_ref: str = Field(default="", max_length=255, pattern=_GIT_REF_RE)
+    image: str = Field(default="", max_length=255, pattern=_IMAGE_RE)
     prod: bool = False
     env_refs: list[str] = Field(default_factory=list)
 

--- a/ee/pocketpaw_ee/cloud/ship/dto.py
+++ b/ee/pocketpaw_ee/cloud/ship/dto.py
@@ -1,0 +1,163 @@
+# ee/pocketpaw_ee/cloud/ship/dto.py — request/response schemas for the /ship
+# HTTP surface (SHIP-3).
+#
+# Distinct Request / Response models per ee/cloud Rule 4 — one model never does
+# both jobs.
+#
+# FROZEN RESPONSE SHAPES. The /ship console (paw-enterprise#655) consumes these
+# verbatim; the five below are contract, not convenience. Do NOT rename a field
+# and do NOT add a REQUIRED one:
+#
+#   BoxOut     {id, provider, ip, status, price_monthly?}
+#   AppOut     {id, name, box_id, status, urls[]}
+#   DeployOut  {id, app_id, status, started_at, finished_at?}
+#   LogsOut    {lines[]}
+#   MetricsOut {cpu, mem, disk}
+#   delete     {status: "pending_approval", proposal_id}
+#
+# ``DomainOut`` / ``DbOut`` are not part of the frozen five; they mirror SHIP-1's
+# ``DomainResult`` / ``DbResult`` so the wire never invents a second vocabulary
+# for the same fact. ``DbOut.env_var`` is the NAME of the variable holding the
+# connection string — the string itself is a secret and never crosses the wire.
+#
+# Created 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): new module.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class CreateBoxRequest(BaseModel):
+    """Provision a box. ``server_type`` / ``region`` fall back to the deployment
+    defaults when omitted (see ``ship.service.DEFAULT_SERVER_TYPE``)."""
+
+    provider: str = "hcloud"
+    server_type: str | None = None
+    region: str | None = None
+
+
+class CreateAppRequest(BaseModel):
+    """Register an app on a box.
+
+    ``name`` + ``box_id`` are the documented body; the rest are optional build
+    inputs a client may supply up front so ``POST /apps/{id}/deploy`` (which
+    takes no body) has an image to ship. ``env_refs`` are variable NAMES — the
+    API never accepts env VALUES.
+    """
+
+    name: str = Field(min_length=1, max_length=63)
+    box_id: str = Field(min_length=1)
+    build_path: Literal["dockerfile", "nixpacks"] = "dockerfile"
+    git_ref: str = ""
+    image: str = ""
+    prod: bool = False
+    env_refs: list[str] = Field(default_factory=list)
+
+
+class AddDomainRequest(BaseModel):
+    """Route a domain to an app and (by default) issue TLS for it."""
+
+    domain: str = Field(min_length=1, max_length=253)
+    enable_tls: bool = True
+
+
+class CreateDbRequest(BaseModel):
+    """Create a database service and link it to the app.
+
+    ``service`` defaults to ``<app-name>-db`` when omitted.
+    """
+
+    service: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Responses (the frozen shapes)
+# ---------------------------------------------------------------------------
+
+
+class BoxOut(BaseModel):
+    """One provisioned box. FROZEN — see the module comment."""
+
+    id: str
+    provider: str
+    ip: str
+    status: Literal["provisioning", "ready", "degraded", "destroyed"]
+    price_monthly: float | None = None
+
+
+class AppOut(BaseModel):
+    """One app on a box. FROZEN — see the module comment."""
+
+    id: str
+    name: str
+    box_id: str
+    status: str
+    urls: list[str] = Field(default_factory=list)
+
+
+class DeployOut(BaseModel):
+    """One deploy attempt. FROZEN — see the module comment."""
+
+    id: str
+    app_id: str
+    status: Literal["queued", "building", "releasing", "live", "failed"]
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
+
+class LogsOut(BaseModel):
+    """A chunk of an app's recent log lines, newest last. FROZEN."""
+
+    lines: list[str] = Field(default_factory=list)
+
+
+class MetricsOut(BaseModel):
+    """Box health as three percentages, 0.0–100.0. FROZEN."""
+
+    cpu: float
+    mem: float
+    disk: float
+
+
+class PendingApprovalOut(BaseModel):
+    """The answer to a DELETE: the teardown is PARKED, not performed. FROZEN."""
+
+    status: Literal["pending_approval"] = "pending_approval"
+    proposal_id: str
+
+
+# ---------------------------------------------------------------------------
+# Responses (SHIP-1 result mirrors)
+# ---------------------------------------------------------------------------
+
+
+class DomainOut(BaseModel):
+    """A domain routed to an app; ``tls_enabled`` reports the cert outcome."""
+
+    domain: str
+    tls_enabled: bool
+
+
+class DomainListOut(BaseModel):
+    """The domains currently routed to an app."""
+
+    domains: list[DomainOut] = Field(default_factory=list)
+
+
+class DbOut(BaseModel):
+    """A database service linked to an app.
+
+    ``env_var`` is the NAME of the variable carrying the connection string; the
+    string itself never crosses the wire.
+    """
+
+    service: str
+    linked_app: str
+    env_var: str

--- a/ee/pocketpaw_ee/cloud/ship/engine.py
+++ b/ee/pocketpaw_ee/cloud/ship/engine.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING, Any
 
 from pocketpaw_ee.cloud.ship import store
 from pocketpaw_ee.ship_engine.dokku import AsyncSSHTransport, DokkuDriver, SSHTransport
-from pocketpaw_ee.ship_engine.port import ShipEngine
+from pocketpaw_ee.ship_engine.port import ShipEngine, ShipEngineError
 
 if TYPE_CHECKING:
     from pocketpaw_ee.cloud.models.ship import ShipBox
@@ -52,6 +52,19 @@ BOX_METRICS_COMMAND = (
     "free -m | awk '/^Mem:/{printf \"%.1f\\n\", $3/$2*100}'; "
     "df -Pk / | awk 'NR==2{print $5}'"
 )
+
+
+# What "the box could not be driven" looks like to a caller. ``ShipEngineError``
+# is the engine refusing a command; ``OSError`` is the box being unreachable —
+# connection refused, no route, DNS failure, timeout (``TimeoutError`` is an
+# OSError subclass). Callers map these to a 409.
+#
+# Deliberately NOT included: asyncssh's auth errors. A rejected key means the
+# credential we stored is wrong, which is a defect to alert on, not an
+# operational blip to fold into a 409 — it propagates as a 500. (Naming them
+# would also force the SSH stack to load at import time, which the transport
+# goes out of its way to avoid.)
+ENGINE_FAILURES: tuple[type[BaseException], ...] = (ShipEngineError, OSError)
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/ship/engine.py
+++ b/ee/pocketpaw_ee/cloud/ship/engine.py
@@ -1,0 +1,122 @@
+# ee/pocketpaw_ee/cloud/ship/engine.py — the box → live-engine seam.
+#
+# One place turns a persisted ``ShipBox`` into something that can talk to it:
+# ``box_session`` decrypts the box's SSH key, materializes it as a private temp
+# file (asyncssh reads a key PATH), opens SHIP-1's ``AsyncSSHTransport``, and
+# yields a ``BoxSession`` carrying both halves —
+#
+#   * ``engine`` — a SHIP-1 ``DokkuDriver`` for the nine typed app verbs.
+#   * ``transport`` — the raw exec channel, for BOX-level facts the port does
+#     not own (it is an app-level contract plus ``provision_box``). Box CPU /
+#     memory / disk is exactly such a fact, so it is read here rather than by
+#     bolting a tenth verb onto a frozen contract. SHIP-2's provisioning job
+#     already probes the box the same way (``dokku version`` over a raw
+#     transport), so this is the established seam, not a new one.
+#
+# It is ALSO the injection point: ``service`` and the deploy job take a
+# ``BoxSessionFactory`` and fall back to ``box_session``, so tests drive the
+# whole HTTP surface against SHIP-1's zero-network ``FakeSSHTransport`` +
+# recorded transcripts.
+#
+# SECURITY: the decrypted key exists only as a 0600 temp file for the life of
+# the session and is unlinked in ``finally`` — it never enters a DTO, an event,
+# or a log line.
+#
+# Created 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): new module.
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import tempfile
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from pocketpaw_ee.cloud.ship import store
+from pocketpaw_ee.ship_engine.dokku import AsyncSSHTransport, DokkuDriver, SSHTransport
+from pocketpaw_ee.ship_engine.port import ShipEngine
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.cloud.models.ship import ShipBox
+
+logger = logging.getLogger(__name__)
+
+# One round trip, four numeric lines: 1-minute load average, CPU count, memory
+# used as a percentage, root-filesystem used as a percentage. A fixed literal —
+# nothing is interpolated into it, so there is no injection surface.
+BOX_METRICS_COMMAND = (
+    "awk '{print $1}' /proc/loadavg; nproc; "
+    "free -m | awk '/^Mem:/{printf \"%.1f\\n\", $3/$2*100}'; "
+    "df -Pk / | awk 'NR==2{print $5}'"
+)
+
+
+@dataclass(frozen=True)
+class BoxSession:
+    """A live connection to one box: the typed engine plus the raw exec channel."""
+
+    engine: ShipEngine
+    transport: SSHTransport
+
+
+BoxSessionFactory = Callable[[Any], AbstractAsyncContextManager[BoxSession]]
+
+
+@asynccontextmanager
+async def box_session(box: ShipBox) -> AsyncIterator[BoxSession]:
+    """Open an engine session against ``box``, closing it (and shredding the
+    on-disk key) on the way out."""
+    key_path: str | None = None
+    transport: AsyncSSHTransport | None = None
+    try:
+        fd, key_path = tempfile.mkstemp(prefix="paw-ship-", suffix=".key")
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w") as fh:
+            fh.write(store.decrypt_ssh_key(box))
+        transport = AsyncSSHTransport(
+            box.ip,
+            port=box.ssh_port,
+            username=box.ssh_user,
+            client_key_path=key_path,
+        )
+        yield BoxSession(engine=DokkuDriver(transport), transport=transport)
+    finally:
+        if transport is not None:
+            with contextlib.suppress(Exception):  # best-effort teardown
+                await transport.aclose()
+        if key_path and os.path.exists(key_path):
+            os.unlink(key_path)
+
+
+async def read_box_metrics(session: BoxSession) -> tuple[float, float, float]:
+    """Read ``(cpu, mem, disk)`` percentages off the box. Never raises on a
+    weird box — an unparseable field reads as 0.0 rather than 500ing a poll."""
+    result = await session.transport.run(BOX_METRICS_COMMAND)
+    return parse_box_metrics(result.stdout)
+
+
+def parse_box_metrics(stdout: str) -> tuple[float, float, float]:
+    """Parse ``BOX_METRICS_COMMAND`` output into ``(cpu, mem, disk)`` percentages.
+
+    CPU has no cheap point-in-time percentage on a stock box, so it is derived
+    from the 1-minute load average over the core count and capped at 100 — the
+    same approximation every load-based CPU gauge uses.
+    """
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    load = _as_float(lines[0] if len(lines) > 0 else "")
+    cores = _as_float(lines[1] if len(lines) > 1 else "")
+    mem = _as_float(lines[2] if len(lines) > 2 else "")
+    disk = _as_float(lines[3].rstrip("%") if len(lines) > 3 else "")
+    cpu = min(100.0, round(load / cores * 100, 1)) if cores > 0 else 0.0
+    return cpu, min(100.0, mem), min(100.0, disk)
+
+
+def _as_float(raw: str) -> float:
+    try:
+        return float(raw)
+    except ValueError:
+        logger.debug("ship: unparseable box metric field %r", raw)
+        return 0.0

--- a/ee/pocketpaw_ee/cloud/ship/enqueue.py
+++ b/ee/pocketpaw_ee/cloud/ship/enqueue.py
@@ -10,12 +10,17 @@
 # pollable box id.
 #
 # Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new module.
+# Changed 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): added
+# ``enqueue_deploy`` — the same web-side contract for the deploy pipeline. It
+# inserts a ``queued`` ShipDeploy and dispatches ``deploy_app_job`` positionally,
+# so ``POST /ship/apps/{id}/deploy`` returns immediately with a pollable id.
 
 from __future__ import annotations
 
 import logging
 
 from pocketpaw_ee.cloud.ship import store
+from pocketpaw_ee.cloud.ship.deploy_job import deploy_app_job  # noqa: F401 — registration ref
 from pocketpaw_ee.cloud.ship.job import provision_box_job  # noqa: F401 — registration ref
 from pocketpaw_ee.ship_engine.keygen import generate_box_keypair
 
@@ -57,6 +62,31 @@ async def enqueue_provision(
         logger.exception("ship: enqueue failed for box %s", box.id)
         raise
     return box
+
+
+async def enqueue_deploy(
+    *,
+    workspace_id: str,
+    app_id: str,
+    image: str,
+    pool_factory=None,
+) -> object:
+    """Insert a ``queued`` deploy attempt and enqueue its deploy job.
+
+    ``image`` is pinned onto the attempt at enqueue so a later app edit never
+    rewrites what this attempt shipped. Returns the inserted ShipDeploy — the
+    router answers with it immediately; the arq job advances the status.
+    """
+    deploy = await store.create_deploy(workspace_id=workspace_id, app_id=app_id, image=image)
+
+    pool = await _resolve_pool(pool_factory)
+    try:
+        # Positional enqueue — see the note in ``enqueue_provision``.
+        await pool.enqueue_job("deploy_app_job", str(deploy.id), workspace_id)
+    except Exception:
+        logger.exception("ship: deploy enqueue failed for deploy %s", deploy.id)
+        raise
+    return deploy
 
 
 async def _resolve_pool(pool_factory):

--- a/ee/pocketpaw_ee/cloud/ship/router.py
+++ b/ee/pocketpaw_ee/cloud/ship/router.py
@@ -1,0 +1,208 @@
+# ee/pocketpaw_ee/cloud/ship/router.py — the thin FastAPI adapter for /ship
+# (SHIP-3). Mounted by ``mount_cloud()`` as ``/api/v1/ship``.
+#
+# Tenancy comes ONLY from the RequestContext — never a body field, never a query
+# param — so a caller cannot name another workspace. The service does the work;
+# ``_core.http`` maps ``CloudError`` to JSON, so this module never raises
+# ``HTTPException`` and never imports a Beanie document.
+#
+#   POST   /ship/boxes                  provision a box (202-style: pollable)
+#   GET    /ship/boxes                  list the workspace's boxes
+#   GET    /ship/boxes/{id}/metrics     live cpu / mem / disk for one box
+#   DELETE /ship/boxes/{id}             PARK a teardown — never executes it
+#   POST   /ship/apps                   register an app on a box
+#   GET    /ship/apps?box_id=           list apps (optionally one box's)
+#   POST   /ship/apps/{id}/deploy       enqueue a deploy (empty body)
+#   GET    /ship/apps/{id}/deploys      the app's deploy attempts, newest first
+#   POST   /ship/apps/{id}/domains      route a domain + issue TLS
+#   GET    /ship/apps/{id}/domains      the app's routed domains
+#   POST   /ship/apps/{id}/db           create + link a database service
+#   GET    /ship/apps/{id}/logs         recent app log lines
+#   DELETE /ship/apps/{id}              PARK a teardown — never executes it
+#
+# The two DELETEs answer ``{"status": "pending_approval", "proposal_id": ...}``.
+# Nothing is destroyed in this slice; SHIP-4 wires the real Instinct proposal.
+#
+# Created 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): new module.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.ship import service as ship_service
+from pocketpaw_ee.cloud.ship.dto import (
+    AddDomainRequest,
+    AppOut,
+    BoxOut,
+    CreateAppRequest,
+    CreateBoxRequest,
+    CreateDbRequest,
+    DbOut,
+    DeployOut,
+    DomainListOut,
+    DomainOut,
+    LogsOut,
+    MetricsOut,
+    PendingApprovalOut,
+)
+
+router = APIRouter(prefix="/ship", tags=["Ship"], dependencies=[Depends(require_license)])
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    """Every /ship route is workspace-scoped; fail closed without one."""
+    if not ctx.workspace_id:
+        raise Forbidden("ship.no_workspace", "No active workspace")
+    return ctx.workspace_id
+
+
+# ---------------------------------------------------------------------------
+# Boxes
+# ---------------------------------------------------------------------------
+
+
+@router.post("/boxes", response_model=BoxOut)
+async def create_box(
+    body: CreateBoxRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> BoxOut:
+    """Provision a box. Returns immediately in ``provisioning``; poll the list."""
+    workspace_id = _require_workspace(ctx)
+    view = await ship_service.create_box(workspace_id, ctx.user_id, body)
+    return ship_service.box_to_wire(view)
+
+
+@router.get("/boxes", response_model=list[BoxOut])
+async def list_boxes(ctx: RequestContext = Depends(request_context)) -> list[BoxOut]:
+    workspace_id = _require_workspace(ctx)
+    views = await ship_service.list_boxes(workspace_id)
+    return [ship_service.box_to_wire(v) for v in views]
+
+
+@router.get("/boxes/{box_id}/metrics", response_model=MetricsOut)
+async def get_box_metrics(
+    box_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> MetricsOut:
+    """Live box health: CPU, memory and root-filesystem use, each 0.0–100.0."""
+    workspace_id = _require_workspace(ctx)
+    view = await ship_service.get_box_metrics(workspace_id, box_id)
+    return ship_service.metrics_to_wire(view)
+
+
+@router.delete("/boxes/{box_id}", response_model=PendingApprovalOut)
+async def request_box_destroy(
+    box_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> PendingApprovalOut:
+    """PARK a box teardown for human approval. Destroys nothing."""
+    workspace_id = _require_workspace(ctx)
+    view = await ship_service.request_box_destroy(workspace_id, ctx.user_id, box_id)
+    return ship_service.proposal_to_wire(view)
+
+
+# ---------------------------------------------------------------------------
+# Apps
+# ---------------------------------------------------------------------------
+
+
+@router.post("/apps", response_model=AppOut)
+async def create_app(
+    body: CreateAppRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> AppOut:
+    workspace_id = _require_workspace(ctx)
+    view = await ship_service.create_app(workspace_id, ctx.user_id, body)
+    return ship_service.app_to_wire(view)
+
+
+@router.get("/apps", response_model=list[AppOut])
+async def list_apps(
+    box_id: str | None = Query(default=None),
+    ctx: RequestContext = Depends(request_context),
+) -> list[AppOut]:
+    workspace_id = _require_workspace(ctx)
+    views = await ship_service.list_apps(workspace_id, box_id=box_id)
+    return [ship_service.app_to_wire(v) for v in views]
+
+
+@router.post("/apps/{app_id}/deploy", response_model=DeployOut)
+async def deploy_app(
+    app_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> DeployOut:
+    """Enqueue a deploy. Takes no body — the app already carries its image."""
+    workspace_id = _require_workspace(ctx)
+    view = await ship_service.deploy_app(workspace_id, ctx.user_id, app_id)
+    return ship_service.deploy_to_wire(view)
+
+
+@router.get("/apps/{app_id}/deploys", response_model=list[DeployOut])
+async def list_deploys(
+    app_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> list[DeployOut]:
+    workspace_id = _require_workspace(ctx)
+    views = await ship_service.list_deploys(workspace_id, app_id)
+    return [ship_service.deploy_to_wire(v) for v in views]
+
+
+@router.post("/apps/{app_id}/domains", response_model=DomainOut)
+async def add_domain(
+    app_id: str,
+    body: AddDomainRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> DomainOut:
+    workspace_id = _require_workspace(ctx)
+    view = await ship_service.add_domain(workspace_id, ctx.user_id, app_id, body)
+    return ship_service.domain_to_wire(view)
+
+
+@router.get("/apps/{app_id}/domains", response_model=DomainListOut)
+async def list_domains(
+    app_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> DomainListOut:
+    workspace_id = _require_workspace(ctx)
+    views = await ship_service.list_domains(workspace_id, app_id)
+    return ship_service.domains_to_wire(views)
+
+
+@router.post("/apps/{app_id}/db", response_model=DbOut)
+async def create_db(
+    app_id: str,
+    ctx: RequestContext = Depends(request_context),
+    body: CreateDbRequest | None = None,
+) -> DbOut:
+    """Create a database service and link it. The body is optional — the service
+    name defaults to ``<app-name>-db``."""
+    workspace_id = _require_workspace(ctx)
+    view = await ship_service.create_db(
+        workspace_id, ctx.user_id, app_id, body or CreateDbRequest()
+    )
+    return ship_service.db_to_wire(view)
+
+
+@router.get("/apps/{app_id}/logs", response_model=LogsOut)
+async def get_logs(
+    app_id: str,
+    num: int = Query(default=ship_service.DEFAULT_LOG_LINES, ge=1, le=1000),
+    ctx: RequestContext = Depends(request_context),
+) -> LogsOut:
+    workspace_id = _require_workspace(ctx)
+    view = await ship_service.get_logs(workspace_id, app_id, num=num)
+    return ship_service.logs_to_wire(view)
+
+
+@router.delete("/apps/{app_id}", response_model=PendingApprovalOut)
+async def request_app_destroy(
+    app_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> PendingApprovalOut:
+    """PARK an app teardown for human approval. Destroys nothing."""
+    workspace_id = _require_workspace(ctx)
+    view = await ship_service.request_app_destroy(workspace_id, ctx.user_id, app_id)
+    return ship_service.proposal_to_wire(view)

--- a/ee/pocketpaw_ee/cloud/ship/service.py
+++ b/ee/pocketpaw_ee/cloud/ship/service.py
@@ -217,10 +217,14 @@ async def deploy_app(workspace_id: str, user_id: str, app_id: str) -> DeployView
     if box.status != "ready":
         raise ConflictError("ship.box_not_ready", f"Box is {box.status}, not ready")
 
+    # Flip the app BEFORE dispatching. The worker may pick the job up
+    # immediately and write a terminal status; writing "deploying" afterwards
+    # would clobber it. A dispatch failure leaves the app "deploying" with a
+    # "queued" attempt — a visibly stuck deploy, which is the honest state.
+    app = await store.set_app_status(app, "deploying")
     deploy = await enqueue.enqueue_deploy(
         workspace_id=workspace_id, app_id=str(app.id), image=app.image
     )
-    app = await store.set_app_status(app, "deploying")
     view = _deploy_view(deploy)
     await emit(
         ShipDeployQueued(

--- a/ee/pocketpaw_ee/cloud/ship/service.py
+++ b/ee/pocketpaw_ee/cloud/ship/service.py
@@ -74,7 +74,7 @@ from pocketpaw_ee.cloud.ship.dto import (
     MetricsOut,
     PendingApprovalOut,
 )
-from pocketpaw_ee.ship_engine.port import CommandFailed, ShipEngineError
+from pocketpaw_ee.ship_engine.port import CommandFailed
 
 if TYPE_CHECKING:
     from pocketpaw_ee.cloud.models.ship import ShipApp, ShipBox, ShipDeploy
@@ -150,7 +150,7 @@ async def get_box_metrics(
     try:
         async with factory(box) as session:
             cpu, mem, disk = await ship_engine.read_box_metrics(session)
-    except ShipEngineError as exc:
+    except ship_engine.ENGINE_FAILURES as exc:
         raise _engine_conflict("ship.metrics_failed", exc) from exc
     return BoxMetricsView(
         workspace_id=workspace_id, box_id=str(box.id), cpu=cpu, mem=mem, disk=disk
@@ -265,7 +265,7 @@ async def add_domain(
             result = await session.engine.add_domain(
                 app.name, body.domain, enable_tls=body.enable_tls
             )
-    except ShipEngineError as exc:
+    except ship_engine.ENGINE_FAILURES as exc:
         raise _engine_conflict("ship.domain_failed", exc) from exc
 
     scheme = "https" if result.tls_enabled else "http"
@@ -319,7 +319,7 @@ async def create_db(
     try:
         async with factory(box) as session:
             result = await session.engine.db_create(app.name, service)
-    except ShipEngineError as exc:
+    except ship_engine.ENGINE_FAILURES as exc:
         raise _engine_conflict("ship.db_failed", exc) from exc
 
     app = await store.record_app_db(app, service=result.service, env_var=result.exposed_env_var)
@@ -347,7 +347,7 @@ async def get_logs(
     try:
         async with factory(box) as session:
             chunk = await session.engine.logs(app.name, num=num)
-    except ShipEngineError as exc:
+    except ship_engine.ENGINE_FAILURES as exc:
         raise _engine_conflict("ship.logs_failed", exc) from exc
     return LogsView(workspace_id=workspace_id, app_id=str(app.id), lines=tuple(chunk.lines))
 
@@ -538,12 +538,13 @@ def _mint_proposal_id() -> str:
     return f"ship-destroy-{uuid.uuid4().hex}"
 
 
-def _engine_conflict(code: str, exc: ShipEngineError) -> ConflictError:
-    """Map an engine failure to a 409 carrying an already-redacted reason.
+def _engine_conflict(code: str, exc: BaseException) -> ConflictError:
+    """Map an engine/reachability failure to a 409 with a safe reason.
 
     SHIP-1 redacts ``CommandFailed``'s command + stderr tail before the exception
-    exists, so the tail is safe to surface; any other engine error is reported by
-    class name only.
+    exists, so the tail is safe to surface; anything else (an unreachable box, a
+    timeout) is reported by class name only — a raw ``OSError`` message can carry
+    the box's address, which is not this response's job to publish.
     """
     detail = exc.stderr_tail if isinstance(exc, CommandFailed) else type(exc).__name__
     logger.warning("ship engine call failed (%s)", code)

--- a/ee/pocketpaw_ee/cloud/ship/service.py
+++ b/ee/pocketpaw_ee/cloud/ship/service.py
@@ -1,0 +1,546 @@
+# ee/pocketpaw_ee/cloud/ship/service.py — the /ship business logic (SHIP-3).
+#
+# The workspace-scoped surface behind ``/api/v1/ship``: provision a box, register
+# an app, deploy it, route a domain, link a database, read logs and box health,
+# and PARK a teardown for approval. It is the entity's only caller-facing layer —
+# the router is a thin adapter, ``store`` owns the Beanie documents, ``engine``
+# owns the live SSH/driver seam, and the long deploy runs as an arq job.
+#
+# ee/cloud rules honored here:
+#   3  every domain view carries a REQUIRED ``workspace_id``.
+#   5  module-level ``async def op(workspace_id, user_id, body)``.
+#   6  validate at entry — ``body = <Request>.model_validate(body)`` first line.
+#   7  every read is tenant-filtered (``store`` takes ``workspace_id`` first and
+#      returns None for a foreign id; this module collapses that to ``NotFound``,
+#      so a cross-tenant probe reads as 404 and never leaks existence).
+#   9  emit on every write; read paths carry an explicit ``# no-event:``.
+#   10 CloudError subclasses only — never HTTPException.
+#
+# SECURITY: nothing here ever touches key material. The box's SSH key is
+# decrypted inside ``engine.box_session`` and shredded with the session; env
+# VALUES are never accepted or stored (``env_refs`` are NAMES); a database's
+# connection string never leaves the box (``DbView.env_var`` is the variable's
+# name, per SHIP-1's ``DbResult`` invariant).
+#
+# DESTROY IS NEVER EXECUTED HERE. ``request_box_destroy`` / ``request_app_destroy``
+# mint a placeholder proposal id and park it on the row — see the ``# SHIP-4:``
+# seam markers.
+#
+# Created 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): new module.
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import TYPE_CHECKING
+
+from pocketpaw_ee.cloud._core.errors import ConflictError, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import (
+    ShipAppCreated,
+    ShipAppUpdated,
+    ShipBoxCreated,
+    ShipDeployQueued,
+    ShipDestroyProposed,
+)
+from pocketpaw_ee.cloud.ship import engine as ship_engine
+from pocketpaw_ee.cloud.ship import enqueue, store
+from pocketpaw_ee.cloud.ship.domain import (
+    AppId,
+    AppView,
+    BoxId,
+    BoxMetricsView,
+    BoxView,
+    DbView,
+    DeployId,
+    DeployView,
+    DestroyProposalView,
+    DomainView,
+    LogsView,
+)
+from pocketpaw_ee.cloud.ship.dto import (
+    AddDomainRequest,
+    AppOut,
+    BoxOut,
+    CreateAppRequest,
+    CreateBoxRequest,
+    CreateDbRequest,
+    DbOut,
+    DeployOut,
+    DomainListOut,
+    DomainOut,
+    LogsOut,
+    MetricsOut,
+    PendingApprovalOut,
+)
+from pocketpaw_ee.ship_engine.port import CommandFailed, ShipEngineError
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.cloud.models.ship import ShipApp, ShipBox, ShipDeploy
+
+logger = logging.getLogger(__name__)
+
+# Deployment defaults for a freshly provisioned box. Hetzner's ``cx22`` (2 vCPU /
+# 4 GB / 40 GB) in ``fsn1`` is the cheapest shape that comfortably runs Dokku
+# plus a couple of app containers; both are env-overridable per deployment and
+# per request (``CreateBoxRequest.server_type`` / ``.region``).
+DEFAULT_SERVER_TYPE = os.environ.get("POCKETPAW_SHIP_SERVER_TYPE", "").strip() or "cx22"
+DEFAULT_REGION = os.environ.get("POCKETPAW_SHIP_REGION", "").strip() or "fsn1"
+
+# How many log lines ``GET /ship/apps/{id}/logs`` reads by default.
+DEFAULT_LOG_LINES = 100
+
+
+# --------------------------------------------------------------------------- #
+# Boxes
+# --------------------------------------------------------------------------- #
+
+
+async def create_box(workspace_id: str, user_id: str, body: CreateBoxRequest) -> BoxView:
+    """Accept a box provision. Returns immediately with a pollable box.
+
+    The actual provision runs as the SHIP-2 arq job; the returned box is in
+    ``provisioning`` until it answers over SSH.
+    """
+    body = CreateBoxRequest.model_validate(body)
+    box = await enqueue.enqueue_provision(
+        workspace_id=workspace_id,
+        provider=body.provider,
+        server_type=body.server_type or DEFAULT_SERVER_TYPE,
+        region=body.region or DEFAULT_REGION,
+    )
+    view = _box_view(box)
+    await emit(
+        ShipBoxCreated(
+            data={
+                "id": view.id,
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "provider": view.provider,
+                "status": view.status,
+            }
+        )
+    )
+    return view
+
+
+async def list_boxes(workspace_id: str) -> list[BoxView]:
+    """Every box the workspace owns, newest first."""
+    # no-event: read-only path; emit only on writes (cloud rule #9).
+    return [_box_view(box) for box in await store.list_boxes(workspace_id)]
+
+
+async def get_box_metrics(
+    workspace_id: str,
+    box_id: str,
+    *,
+    session_factory: ship_engine.BoxSessionFactory | None = None,
+) -> BoxMetricsView:
+    """Read live CPU / memory / disk off the box.
+
+    A box that is not ``ready`` has nothing to answer with — that is a 409, not
+    a fabricated row of zeroes.
+    """
+    # no-event: read-only path; emit only on writes (cloud rule #9).
+    box = await _require_box(workspace_id, box_id)
+    if box.status != "ready":
+        raise ConflictError("ship.box_not_ready", f"Box is {box.status}, not ready")
+    factory = session_factory or ship_engine.box_session
+    try:
+        async with factory(box) as session:
+            cpu, mem, disk = await ship_engine.read_box_metrics(session)
+    except ShipEngineError as exc:
+        raise _engine_conflict("ship.metrics_failed", exc) from exc
+    return BoxMetricsView(
+        workspace_id=workspace_id, box_id=str(box.id), cpu=cpu, mem=mem, disk=disk
+    )
+
+
+async def request_box_destroy(workspace_id: str, user_id: str, box_id: str) -> DestroyProposalView:
+    """PARK a box teardown for human approval. Destroys NOTHING."""
+    box = await _require_box(workspace_id, box_id)
+    proposal_id = box.pending_destroy_proposal_id or _mint_proposal_id()
+    # SHIP-4: replace the placeholder with a real Instinct proposal — raise it
+    # through the approvals service and store the returned proposal id here. The
+    # approve path (not this function) is what may ever call the engine's
+    # ``destroy`` verb.
+    box = await store.park_box_destroy(box, proposal_id=proposal_id)
+    return await _emit_destroy_proposal(
+        workspace_id, user_id, kind="box", target_id=str(box.id), proposal_id=proposal_id
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Apps
+# --------------------------------------------------------------------------- #
+
+
+async def create_app(workspace_id: str, user_id: str, body: CreateAppRequest) -> AppView:
+    """Register an app on one of the workspace's boxes."""
+    body = CreateAppRequest.model_validate(body)
+    box = await _require_box(workspace_id, body.box_id)
+    if await store.find_app_by_name(workspace_id, str(box.id), body.name):
+        raise ConflictError("ship.app_exists", f"An app named '{body.name}' already exists")
+
+    app = await store.create_app(
+        workspace_id=workspace_id,
+        box_id=str(box.id),
+        name=body.name,
+        build_path=body.build_path,
+        git_ref=body.git_ref,
+        image=body.image,
+        env_refs=body.env_refs,
+        prod=body.prod,
+    )
+    view = _app_view(app)
+    await emit(ShipAppCreated(data={**_app_event_payload(view), "user_id": user_id}))
+    return view
+
+
+async def list_apps(workspace_id: str, *, box_id: str | None = None) -> list[AppView]:
+    """Every app the workspace owns, optionally narrowed to one box."""
+    # no-event: read-only path; emit only on writes (cloud rule #9).
+    return [_app_view(app) for app in await store.list_apps(workspace_id, box_id=box_id)]
+
+
+async def deploy_app(workspace_id: str, user_id: str, app_id: str) -> DeployView:
+    """Enqueue a deploy for the app. Returns immediately with a pollable attempt."""
+    app = await _require_app(workspace_id, app_id)
+    if not app.image:
+        raise ValidationError(
+            "ship.app_no_image",
+            "The app has no image to deploy — set one when creating it",
+        )
+    # The box must exist and be reachable before we spend a worker slot on it.
+    box = await _require_box(workspace_id, app.box_id)
+    if box.status != "ready":
+        raise ConflictError("ship.box_not_ready", f"Box is {box.status}, not ready")
+
+    deploy = await enqueue.enqueue_deploy(
+        workspace_id=workspace_id, app_id=str(app.id), image=app.image
+    )
+    app = await store.set_app_status(app, "deploying")
+    view = _deploy_view(deploy)
+    await emit(
+        ShipDeployQueued(
+            data={
+                "id": view.id,
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "app_id": view.app_id,
+                "status": view.status,
+            }
+        )
+    )
+    await emit(ShipAppUpdated(data=_app_event_payload(_app_view(app))))
+    return view
+
+
+async def list_deploys(workspace_id: str, app_id: str) -> list[DeployView]:
+    """One app's deploy attempts, newest first."""
+    # no-event: read-only path; emit only on writes (cloud rule #9).
+    app = await _require_app(workspace_id, app_id)
+    return [_deploy_view(d) for d in await store.list_deploys(workspace_id, str(app.id))]
+
+
+async def add_domain(
+    workspace_id: str,
+    user_id: str,
+    app_id: str,
+    body: AddDomainRequest,
+    *,
+    session_factory: ship_engine.BoxSessionFactory | None = None,
+) -> DomainView:
+    """Route a domain to the app and (by default) issue TLS for it."""
+    body = AddDomainRequest.model_validate(body)
+    app, box = await _require_app_on_ready_box(workspace_id, app_id)
+    factory = session_factory or ship_engine.box_session
+    try:
+        async with factory(box) as session:
+            result = await session.engine.add_domain(
+                app.name, body.domain, enable_tls=body.enable_tls
+            )
+    except ShipEngineError as exc:
+        raise _engine_conflict("ship.domain_failed", exc) from exc
+
+    scheme = "https" if result.tls_enabled else "http"
+    app = await store.record_app_domain(
+        app,
+        domain=result.domain,
+        tls_enabled=result.tls_enabled,
+        url=f"{scheme}://{result.domain}",
+    )
+    await emit(ShipAppUpdated(data={**_app_event_payload(_app_view(app)), "user_id": user_id}))
+    return DomainView(
+        workspace_id=workspace_id,
+        app_id=str(app.id),
+        domain=result.domain,
+        tls_enabled=result.tls_enabled,
+    )
+
+
+async def list_domains(workspace_id: str, app_id: str) -> list[DomainView]:
+    """The domains currently routed to the app (as recorded at add time)."""
+    # no-event: read-only path; emit only on writes (cloud rule #9).
+    app = await _require_app(workspace_id, app_id)
+    return [
+        DomainView(
+            workspace_id=workspace_id,
+            app_id=str(app.id),
+            domain=d.domain,
+            tls_enabled=d.tls_enabled,
+        )
+        for d in app.domains
+    ]
+
+
+async def create_db(
+    workspace_id: str,
+    user_id: str,
+    app_id: str,
+    body: CreateDbRequest,
+    *,
+    session_factory: ship_engine.BoxSessionFactory | None = None,
+) -> DbView:
+    """Create a database service and link it to the app.
+
+    Only the NAME of the injected connection-string variable is recorded — the
+    connection string itself stays on the box.
+    """
+    body = CreateDbRequest.model_validate(body)
+    app, box = await _require_app_on_ready_box(workspace_id, app_id)
+    service = (body.service or f"{app.name}-db").strip()
+    factory = session_factory or ship_engine.box_session
+    try:
+        async with factory(box) as session:
+            result = await session.engine.db_create(app.name, service)
+    except ShipEngineError as exc:
+        raise _engine_conflict("ship.db_failed", exc) from exc
+
+    app = await store.record_app_db(app, service=result.service, env_var=result.exposed_env_var)
+    await emit(ShipAppUpdated(data={**_app_event_payload(_app_view(app)), "user_id": user_id}))
+    return DbView(
+        workspace_id=workspace_id,
+        app_id=str(app.id),
+        linked_app=result.linked_app,
+        service=result.service,
+        env_var=result.exposed_env_var,
+    )
+
+
+async def get_logs(
+    workspace_id: str,
+    app_id: str,
+    *,
+    num: int = DEFAULT_LOG_LINES,
+    session_factory: ship_engine.BoxSessionFactory | None = None,
+) -> LogsView:
+    """Read the app's most recent log lines (already redacted by the driver)."""
+    # no-event: read-only path; emit only on writes (cloud rule #9).
+    app, box = await _require_app_on_ready_box(workspace_id, app_id)
+    factory = session_factory or ship_engine.box_session
+    try:
+        async with factory(box) as session:
+            chunk = await session.engine.logs(app.name, num=num)
+    except ShipEngineError as exc:
+        raise _engine_conflict("ship.logs_failed", exc) from exc
+    return LogsView(workspace_id=workspace_id, app_id=str(app.id), lines=tuple(chunk.lines))
+
+
+async def request_app_destroy(workspace_id: str, user_id: str, app_id: str) -> DestroyProposalView:
+    """PARK an app teardown for human approval. Destroys NOTHING."""
+    app = await _require_app(workspace_id, app_id)
+    proposal_id = app.pending_destroy_proposal_id or _mint_proposal_id()
+    # SHIP-4: replace the placeholder with a real Instinct proposal — raise it
+    # through the approvals service and store the returned proposal id here. The
+    # approve path (not this function) is what may ever call the engine's
+    # ``destroy`` verb.
+    app = await store.park_app_destroy(app, proposal_id=proposal_id)
+    return await _emit_destroy_proposal(
+        workspace_id, user_id, kind="app", target_id=str(app.id), proposal_id=proposal_id
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Wire mapping (ee/cloud rule 8 — mapping lives in service.py)
+# --------------------------------------------------------------------------- #
+
+
+def box_to_wire(view: BoxView) -> BoxOut:
+    return BoxOut(
+        id=view.id,
+        provider=view.provider,
+        ip=view.ip,
+        status=view.status,  # type: ignore[arg-type] — the doc's Literal is the same set
+        price_monthly=view.price_monthly,
+    )
+
+
+def app_to_wire(view: AppView) -> AppOut:
+    return AppOut(
+        id=view.id,
+        name=view.name,
+        box_id=view.box_id,
+        status=view.status,
+        urls=list(view.urls),
+    )
+
+
+def deploy_to_wire(view: DeployView) -> DeployOut:
+    return DeployOut(
+        id=view.id,
+        app_id=view.app_id,
+        status=view.status,  # type: ignore[arg-type] — the doc's Literal is the same set
+        started_at=view.started_at,
+        finished_at=view.finished_at,
+    )
+
+
+def logs_to_wire(view: LogsView) -> LogsOut:
+    return LogsOut(lines=list(view.lines))
+
+
+def metrics_to_wire(view: BoxMetricsView) -> MetricsOut:
+    return MetricsOut(cpu=view.cpu, mem=view.mem, disk=view.disk)
+
+
+def domain_to_wire(view: DomainView) -> DomainOut:
+    return DomainOut(domain=view.domain, tls_enabled=view.tls_enabled)
+
+
+def domains_to_wire(views: list[DomainView]) -> DomainListOut:
+    return DomainListOut(domains=[domain_to_wire(v) for v in views])
+
+
+def db_to_wire(view: DbView) -> DbOut:
+    return DbOut(service=view.service, linked_app=view.linked_app, env_var=view.env_var)
+
+
+def proposal_to_wire(view: DestroyProposalView) -> PendingApprovalOut:
+    return PendingApprovalOut(proposal_id=view.proposal_id)
+
+
+# --------------------------------------------------------------------------- #
+# Internals
+# --------------------------------------------------------------------------- #
+
+
+def _box_view(box: ShipBox) -> BoxView:
+    return BoxView(
+        id=BoxId(str(box.id)),
+        workspace_id=box.workspace,
+        provider=box.provider,
+        ip=box.ip,
+        status=box.status,
+        price_monthly=box.price_monthly,
+        pending_destroy_proposal_id=box.pending_destroy_proposal_id,
+    )
+
+
+def _app_view(app: ShipApp) -> AppView:
+    return AppView(
+        id=AppId(str(app.id)),
+        workspace_id=app.workspace,
+        box_id=app.box_id,
+        name=app.name,
+        status=app.status,
+        build_path=app.build_path,
+        git_ref=app.git_ref,
+        image=app.image,
+        prod=app.prod,
+        urls=tuple(app.urls),
+        env_refs=tuple(app.env_refs),
+        pending_destroy_proposal_id=app.pending_destroy_proposal_id,
+    )
+
+
+def _deploy_view(deploy: ShipDeploy) -> DeployView:
+    return DeployView(
+        id=DeployId(str(deploy.id)),
+        workspace_id=deploy.workspace,
+        app_id=deploy.app_id,
+        status=deploy.status,
+        started_at=deploy.started_at,
+        finished_at=deploy.finished_at,
+        image=deploy.image,
+        log_summary=deploy.log_summary,
+    )
+
+
+def _app_event_payload(view: AppView) -> dict:
+    """Event payload for an app write — ids + status + URLs, never secrets."""
+    return {
+        "id": view.id,
+        "workspace_id": view.workspace_id,
+        "box_id": view.box_id,
+        "name": view.name,
+        "status": view.status,
+        "urls": list(view.urls),
+    }
+
+
+async def _require_box(workspace_id: str, box_id: str) -> ShipBox:
+    """Load a box or 404. A cross-tenant id is indistinguishable from a missing
+    one — the store's tenant filter returns None either way."""
+    box = await store.get_box(workspace_id, box_id)
+    if box is None:
+        raise NotFound("ship.box", box_id)
+    return box
+
+
+async def _require_app(workspace_id: str, app_id: str) -> ShipApp:
+    """Load an app or 404 (same tenant-filter collapse as ``_require_box``)."""
+    app = await store.get_app(workspace_id, app_id)
+    if app is None:
+        raise NotFound("ship.app", app_id)
+    return app
+
+
+async def _require_app_on_ready_box(workspace_id: str, app_id: str) -> tuple[ShipApp, ShipBox]:
+    """Load an app together with its box, refusing a box that cannot answer."""
+    app = await _require_app(workspace_id, app_id)
+    box = await _require_box(workspace_id, app.box_id)
+    if box.status != "ready":
+        raise ConflictError("ship.box_not_ready", f"Box is {box.status}, not ready")
+    return app, box
+
+
+async def _emit_destroy_proposal(
+    workspace_id: str, user_id: str, *, kind: str, target_id: str, proposal_id: str
+) -> DestroyProposalView:
+    view = DestroyProposalView(
+        workspace_id=workspace_id,
+        target_kind=kind,
+        target_id=target_id,
+        proposal_id=proposal_id,
+    )
+    await emit(
+        ShipDestroyProposed(
+            data={
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "target_kind": kind,
+                "target_id": target_id,
+                "proposal_id": proposal_id,
+            }
+        )
+    )
+    return view
+
+
+def _mint_proposal_id() -> str:
+    """A placeholder proposal id. SHIP-4 swaps this for a real Instinct id."""
+    return f"ship-destroy-{uuid.uuid4().hex}"
+
+
+def _engine_conflict(code: str, exc: ShipEngineError) -> ConflictError:
+    """Map an engine failure to a 409 carrying an already-redacted reason.
+
+    SHIP-1 redacts ``CommandFailed``'s command + stderr tail before the exception
+    exists, so the tail is safe to surface; any other engine error is reported by
+    class name only.
+    """
+    detail = exc.stderr_tail if isinstance(exc, CommandFailed) else type(exc).__name__
+    logger.warning("ship engine call failed (%s)", code)
+    return ConflictError(code, f"The deploy engine refused the request: {detail}"[:500])

--- a/ee/pocketpaw_ee/cloud/ship/store.py
+++ b/ee/pocketpaw_ee/cloud/ship/store.py
@@ -24,6 +24,7 @@ from bson.errors import InvalidId
 from pocketpaw_ee.cloud._core import crypto
 from pocketpaw_ee.cloud.models.ship import (
     ShipApp,
+    ShipAppDomain,
     ShipAppStatus,
     ShipBox,
     ShipBoxStatus,
@@ -222,10 +223,18 @@ async def record_app_deployed(app: ShipApp, *, image: str, app_url: str) -> Ship
     return app
 
 
-async def record_app_domain(app: ShipApp, *, domain: str, url: str) -> ShipApp:
-    """Record a routed domain (and the URL it serves on) against the app."""
-    if domain not in app.domains:
-        app.domains.append(domain)
+async def record_app_domain(app: ShipApp, *, domain: str, tls_enabled: bool, url: str) -> ShipApp:
+    """Record a routed domain (name + TLS outcome) and the URL it serves on.
+
+    Re-adding an existing domain refreshes its TLS flag rather than duplicating
+    the row — ``add_domain`` is idempotent at the engine, so it is here too.
+    """
+    for existing in app.domains:
+        if existing.domain == domain:
+            existing.tls_enabled = tls_enabled
+            break
+    else:
+        app.domains.append(ShipAppDomain(domain=domain, tls_enabled=tls_enabled))
     if url and url not in app.urls:
         app.urls.append(url)
     await app.save()

--- a/ee/pocketpaw_ee/cloud/ship/store.py
+++ b/ee/pocketpaw_ee/cloud/ship/store.py
@@ -1,18 +1,36 @@
-# ee/pocketpaw_ee/cloud/ship/store.py — the ShipBox persistence seam.
+# ee/pocketpaw_ee/cloud/ship/store.py — the /ship persistence seam.
 #
-# The ONLY module that reads/writes the ``ShipBox`` Beanie document (the same
-# one-service-owns-one-doc isolation the credit / litellm-key docs use; an
-# import-linter contract will keep the doc off every other layer). It hides the
-# Fernet envelope on the SSH private key: callers pass/receive PLAINTEXT keys,
-# the doc stores CIPHERTEXT. Every read is workspace-scoped — a box id alone is
-# never trusted without its owning workspace.
+# The ONLY module that reads/writes the ``ShipBox`` / ``ShipApp`` / ``ShipDeploy``
+# Beanie documents (the same one-module-owns-one-doc isolation the credit /
+# litellm-key docs use; the import-linter "Ship" contract keeps the docs off the
+# router / dto / domain layers). It hides the Fernet envelope on the SSH private
+# key: callers pass/receive PLAINTEXT keys, the doc stores CIPHERTEXT. Every read
+# is workspace-scoped — an id alone is never trusted without its owning
+# workspace.
 #
 # Created 2026-07-22 (feat/ship-2-provisioning, SHIP-2): new module.
+# Changed 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): added the app + deploy
+# halves — ``list_boxes``, the ``ShipApp`` CRUD used by the HTTP surface, the
+# ``ShipDeploy`` attempt log the arq deploy job advances, and the two
+# ``park_*_destroy`` writers that record a parked teardown without executing it.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
+from beanie import PydanticObjectId
+from bson.errors import InvalidId
+
 from pocketpaw_ee.cloud._core import crypto
-from pocketpaw_ee.cloud.models.ship import ShipBox, ShipBoxStatus
+from pocketpaw_ee.cloud.models.ship import (
+    ShipApp,
+    ShipAppStatus,
+    ShipBox,
+    ShipBoxStatus,
+    ShipBuildPath,
+    ShipDeploy,
+    ShipDeployStatus,
+)
 
 
 async def create_provisioning_box(
@@ -44,12 +62,32 @@ async def create_provisioning_box(
     return box
 
 
+def _as_object_id(value: str) -> PydanticObjectId | None:
+    """Coerce a path-segment id to an ObjectId, or None when it is malformed.
+
+    A caller-supplied id reaches ``get`` straight off the URL, so a garbage
+    segment must read as "not found", never as a 500 out of bson.
+    """
+    try:
+        return PydanticObjectId(value)
+    except (InvalidId, TypeError, ValueError):
+        return None
+
+
 async def get_box(workspace_id: str, box_id: str) -> ShipBox | None:
     """Load one box, workspace-scoped. A cross-tenant id yields None."""
-    box = await ShipBox.get(box_id)
+    oid = _as_object_id(box_id)
+    if oid is None:
+        return None
+    box = await ShipBox.get(oid)
     if box is None or box.workspace != workspace_id:
         return None
     return box
+
+
+async def list_boxes(workspace_id: str) -> list[ShipBox]:
+    """Every box the workspace owns, newest first. Tenant-filtered read."""
+    return await ShipBox.find(ShipBox.workspace == workspace_id).sort("-createdAt").to_list()
 
 
 async def mark_ready(
@@ -93,3 +131,179 @@ async def set_status(box: ShipBox, status: ShipBoxStatus) -> ShipBox:
 def decrypt_ssh_key(box: ShipBox) -> str:
     """Decrypt the box's SSH private key for driver use. Never logged/serialized."""
     return crypto.decrypt(box.ssh_private_key_enc)
+
+
+async def park_box_destroy(box: ShipBox, *, proposal_id: str) -> ShipBox:
+    """Record a PARKED teardown on the box. Destroys nothing.
+
+    The box keeps its lifecycle ``status`` — the frozen ``BoxOut`` status
+    vocabulary has no ``pending`` member, and a parked teardown has not changed
+    what the box actually is. ``pending_destroy_proposal_id`` is the pending
+    marker.
+    """
+    box.pending_destroy_proposal_id = proposal_id
+    await box.save()
+    return box
+
+
+# --------------------------------------------------------------------------- #
+# Apps
+# --------------------------------------------------------------------------- #
+
+
+async def create_app(
+    *,
+    workspace_id: str,
+    box_id: str,
+    name: str,
+    build_path: ShipBuildPath,
+    git_ref: str,
+    image: str,
+    env_refs: list[str],
+    prod: bool,
+) -> ShipApp:
+    """Insert a fresh app in ``created``. ``env_refs`` are NAMES only."""
+    app = ShipApp(
+        workspace=workspace_id,
+        box_id=box_id,
+        name=name,
+        build_path=build_path,
+        git_ref=git_ref,
+        image=image,
+        env_refs=list(env_refs),
+        prod=prod,
+    )
+    await app.insert()
+    return app
+
+
+async def get_app(workspace_id: str, app_id: str) -> ShipApp | None:
+    """Load one app, workspace-scoped. A cross-tenant id yields None."""
+    oid = _as_object_id(app_id)
+    if oid is None:
+        return None
+    app = await ShipApp.get(oid)
+    if app is None or app.workspace != workspace_id:
+        return None
+    return app
+
+
+async def find_app_by_name(workspace_id: str, box_id: str, name: str) -> ShipApp | None:
+    """Look an app up by its engine-side name within one box. Tenant-filtered."""
+    return await ShipApp.find_one(
+        ShipApp.workspace == workspace_id,
+        ShipApp.box_id == box_id,
+        ShipApp.name == name,
+    )
+
+
+async def list_apps(workspace_id: str, *, box_id: str | None = None) -> list[ShipApp]:
+    """Every app the workspace owns (optionally one box's), newest first."""
+    criteria = [ShipApp.workspace == workspace_id]
+    if box_id:
+        criteria.append(ShipApp.box_id == box_id)
+    return await ShipApp.find(*criteria).sort("-createdAt").to_list()
+
+
+async def set_app_status(app: ShipApp, status: ShipAppStatus) -> ShipApp:
+    """Set the app's lifecycle status."""
+    app.status = status
+    await app.save()
+    return app
+
+
+async def record_app_deployed(app: ShipApp, *, image: str, app_url: str) -> ShipApp:
+    """Flip the app ``live`` and merge the engine-reported URL into ``urls``."""
+    app.status = "live"
+    app.image = image
+    if app_url and app_url not in app.urls:
+        app.urls.append(app_url)
+    await app.save()
+    return app
+
+
+async def record_app_domain(app: ShipApp, *, domain: str, url: str) -> ShipApp:
+    """Record a routed domain (and the URL it serves on) against the app."""
+    if domain not in app.domains:
+        app.domains.append(domain)
+    if url and url not in app.urls:
+        app.urls.append(url)
+    await app.save()
+    return app
+
+
+async def record_app_db(app: ShipApp, *, service: str, env_var: str) -> ShipApp:
+    """Record the linked database service + the env var NAME the link injected.
+
+    The connection string is a secret and is never stored — SHIP-1's ``DbResult``
+    deliberately exposes only the variable's name.
+    """
+    app.db_service = service
+    app.db_env_var = env_var
+    await app.save()
+    return app
+
+
+async def park_app_destroy(app: ShipApp, *, proposal_id: str) -> ShipApp:
+    """Record a PARKED teardown on the app. Destroys nothing."""
+    app.pending_destroy_proposal_id = proposal_id
+    await app.save()
+    return app
+
+
+# --------------------------------------------------------------------------- #
+# Deploys
+# --------------------------------------------------------------------------- #
+
+
+async def create_deploy(*, workspace_id: str, app_id: str, image: str) -> ShipDeploy:
+    """Insert a ``queued`` deploy attempt, ``started_at`` stamped at acceptance."""
+    deploy = ShipDeploy(
+        workspace=workspace_id,
+        app_id=app_id,
+        status="queued",
+        started_at=datetime.now(UTC),
+        image=image,
+    )
+    await deploy.insert()
+    return deploy
+
+
+async def get_deploy(workspace_id: str, deploy_id: str) -> ShipDeploy | None:
+    """Load one deploy attempt, workspace-scoped. A cross-tenant id yields None."""
+    oid = _as_object_id(deploy_id)
+    if oid is None:
+        return None
+    deploy = await ShipDeploy.get(oid)
+    if deploy is None or deploy.workspace != workspace_id:
+        return None
+    return deploy
+
+
+async def list_deploys(workspace_id: str, app_id: str, *, limit: int = 50) -> list[ShipDeploy]:
+    """One app's deploy attempts, newest first. Tenant-filtered read."""
+    return (
+        await ShipDeploy.find(
+            ShipDeploy.workspace == workspace_id,
+            ShipDeploy.app_id == app_id,
+        )
+        .sort("-createdAt")
+        .limit(limit)
+        .to_list()
+    )
+
+
+async def set_deploy_status(
+    deploy: ShipDeploy,
+    status: ShipDeployStatus,
+    *,
+    log_summary: str = "",
+) -> ShipDeploy:
+    """Advance a deploy attempt. Terminal states stamp ``finished_at``."""
+    deploy.status = status
+    if log_summary:
+        deploy.log_summary = log_summary
+    if status in ("live", "failed"):
+        deploy.finished_at = datetime.now(UTC)
+    await deploy.save()
+    return deploy

--- a/ee/pocketpaw_ee/ship_engine/transcripts/box_metrics.txt
+++ b/ee/pocketpaw_ee/ship_engine/transcripts/box_metrics.txt
@@ -1,0 +1,10 @@
+# Recorded from a healthy 2-vCPU Hetzner cx22 box running one app.
+# Command: awk '{print $1}' /proc/loadavg; nproc; free -m | awk '/^Mem:/{...}'; df -Pk / | awk 'NR==2{print $5}'
+# Four lines: load1, cores, memory used %, root filesystem used %.
+EXIT: 0
+--- stdout ---
+0.42
+2
+37.5
+23%
+--- stderr ---

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -818,6 +818,26 @@ source_modules = [
 ]
 forbidden_modules = ["pocketpaw_ee.cloud.models.project"]
 
+# Ship — the /ship managed-deploy entity (SHIP-2/SHIP-3). This entity's
+# doc-owning module is ``ship/store.py`` rather than ``service.py``: the SSH
+# private key on a ShipBox is Fernet-encrypted at rest, and the store is what
+# hides that envelope so no caller ever handles ciphertext. The contract pins
+# the same boundary every other entity has — the router, DTOs and domain value
+# objects must never reach a Beanie document. ``service.py`` / ``engine.py`` /
+# the two arq job modules stay off the docs too, but by review rather than by
+# contract: they annotate with the doc types under ``TYPE_CHECKING``, which
+# import-linter counts as a real import.
+[[tool.importlinter.contracts]]
+name = "Ship — Beanie writes only from store.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.ship.router",
+    "pocketpaw_ee.cloud.ship.dto",
+    "pocketpaw_ee.cloud.ship.domain",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.ship"]
+
 [[tool.importlinter.contracts]]
 name = "Planner — Beanie writes only from service.py"
 type = "forbidden"

--- a/tests/cloud/ship/conftest.py
+++ b/tests/cloud/ship/conftest.py
@@ -102,3 +102,18 @@ def install_fake_engine(monkeypatch, replies: dict[str, str] | None = None) -> l
 
     monkeypatch.setattr(ship_engine, "box_session", _fake_session)
     return issued
+
+
+def install_refused_engine(monkeypatch) -> None:
+    """Point ``engine.box_session`` at a box that refuses the SSH connection.
+
+    The message deliberately carries the box's address so a test can prove the
+    recorded summary does not echo it back.
+    """
+
+    @asynccontextmanager
+    async def _refused(box):  # noqa: ARG001 — the fake ignores the box
+        raise ConnectionRefusedError("[Errno 61] connect to 203.0.113.9 port 22")
+        yield  # pragma: no cover — never reached; keeps this an async generator
+
+    monkeypatch.setattr(ship_engine, "box_session", _refused)

--- a/tests/cloud/ship/conftest.py
+++ b/tests/cloud/ship/conftest.py
@@ -1,0 +1,104 @@
+# tests/cloud/ship/conftest.py — shared wiring for the SHIP-3 HTTP + deploy
+# tests: a Fernet key, an arq pool that records instead of dispatching, and a
+# fake engine session built on SHIP-1's zero-network ``FakeSSHTransport``.
+#
+# The engine fake is the important one. It replays the SAME recorded Dokku
+# transcripts the SHIP-1 contract suite uses, through the SAME ``DokkuDriver``,
+# so an endpoint test exercises the real driver's command surface end to end
+# without a box, a network, or a mock of the thing under test. An unmapped
+# command fails loudly — if the driver's command surface changes, these tests
+# say so.
+#
+# Created 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): new module.
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+from cryptography.fernet import Fernet
+from pocketpaw_ee.cloud.ship import engine as ship_engine
+from pocketpaw_ee.ship_engine.dokku import DokkuDriver
+from pocketpaw_ee.ship_engine.transcripts import FakeSSHTransport
+
+# The transcripts are recorded against these names — reuse them so the exact
+# command strings the driver builds match a recorded reply.
+APP = "demo"
+IMAGE = "registry.paw.example/demo:9f3c2e1"
+DOMAIN = "demo.paw.example"
+SERVICE = "demo-db"
+
+# Secrets that live INSIDE the transcripts. No response body, no persisted doc
+# and no event payload may ever contain one.
+SECRET_MARKERS = ("s3cr3tpass8f2a",)
+
+# Every command the SHIP-3 surface can drive, mapped to its recorded output.
+SHIP3_REPLIES: dict[str, str] = {
+    f"dokku apps:exists {APP}": "apps_exists_missing.txt",
+    f"dokku apps:create {APP}": "apps_create.txt",
+    f"dokku git:from-image {APP} {IMAGE}": "git_from_image.txt",
+    f"dokku domains:add {APP} {DOMAIN}": "domains_add.txt",
+    f"dokku letsencrypt:enable {APP}": "letsencrypt_enable.txt",
+    f"dokku mongo:create {SERVICE}": "mongo_create.txt",
+    f"dokku mongo:link {SERVICE} {APP}": "mongo_link.txt",
+    f"dokku logs {APP} --num 100": "logs.txt",
+    ship_engine.BOX_METRICS_COMMAND: "box_metrics.txt",
+}
+
+# The same surface, but the image deploy fails.
+FAILING_REPLIES: dict[str, str] = {
+    **SHIP3_REPLIES,
+    f"dokku git:from-image {APP} {IMAGE}": "git_from_image_fail.txt",
+}
+
+_KEY_ENV = "CLOUD_ENCRYPTION_KEY"
+
+
+@pytest.fixture
+def enc_key(monkeypatch):
+    """A valid Fernet key so the store's at-rest SSH-key encryption works."""
+    monkeypatch.setenv(_KEY_ENV, Fernet.generate_key().decode())
+
+
+class FakePool:
+    """Records arq dispatches instead of touching Redis."""
+
+    def __init__(self) -> None:
+        self.enqueued: list[tuple] = []
+
+    async def enqueue_job(self, *args, **kwargs):
+        self.enqueued.append((args, kwargs))
+        return type("Job", (), {"job_id": f"arq-{len(self.enqueued)}"})()
+
+
+@pytest.fixture
+def arq_pool(monkeypatch) -> FakePool:
+    """Swap the shared arq pool getter the ship enqueues resolve through."""
+    pool = FakePool()
+
+    async def _get_pool():
+        return pool
+
+    from pocketpaw_ee.cloud.chat.runs import arq_executor
+
+    monkeypatch.setattr(arq_executor, "_get_pool", _get_pool)
+    return pool
+
+
+def install_fake_engine(monkeypatch, replies: dict[str, str] | None = None) -> list[str]:
+    """Point ``engine.box_session`` at a transcript-replaying DokkuDriver.
+
+    Returns the shared list of commands issued, so a test can assert on the
+    driver's exact command sequence (and prove no destroy ever ran).
+    """
+    issued: list[str] = []
+    mapped = replies if replies is not None else SHIP3_REPLIES
+
+    @asynccontextmanager
+    async def _fake_session(box):  # noqa: ARG001 — the fake ignores the box
+        transport = FakeSSHTransport(mapped)
+        transport.calls = issued  # share the recorder across sessions
+        yield ship_engine.BoxSession(engine=DokkuDriver(transport), transport=transport)
+
+    monkeypatch.setattr(ship_engine, "box_session", _fake_session)
+    return issued

--- a/tests/cloud/ship/test_deploy_job.py
+++ b/tests/cloud/ship/test_deploy_job.py
@@ -18,6 +18,7 @@ from tests.cloud.ship.conftest import (
     IMAGE,
     SECRET_MARKERS,
     install_fake_engine,
+    install_refused_engine,
 )
 
 _PRIV = "-----BEGIN OPENSSH PRIVATE KEY-----\nFAKEKEYBODY\n-----END OPENSSH PRIVATE KEY-----\n"
@@ -161,3 +162,21 @@ async def test_the_deploy_pins_the_image_from_the_attempt_not_the_app(
 
     assert f"dokku git:from-image {APP} {IMAGE}" in issued
     assert not any("NEWER" in cmd for cmd in issued)
+
+
+async def test_an_unreachable_box_fails_the_attempt_without_leaking_its_address(
+    mongo_db,
+    enc_key,
+    monkeypatch,  # noqa: ARG001
+):
+    """A box that stops answering is an operational failure, not a crash."""
+    install_refused_engine(monkeypatch)
+    _box, _app, deploy = await _app_and_deploy()
+
+    result = await deploy_job.deploy_app_job({}, str(deploy.id), "w1")
+
+    assert result == {"ok": False, "status": "failed"}
+    landed = await store.get_deploy("w1", str(deploy.id))
+    assert landed is not None
+    # The summary names the failure class, never the box's address.
+    assert landed.log_summary == "could not reach the box (ConnectionRefusedError)"

--- a/tests/cloud/ship/test_deploy_job.py
+++ b/tests/cloud/ship/test_deploy_job.py
@@ -1,0 +1,163 @@
+# tests/cloud/ship/test_deploy_job.py — the SHIP-3 deploy pipeline.
+#
+# Covers the arq job and the orchestrator behind it against SHIP-1's recorded
+# Dokku transcripts (zero network): the full ``queued -> building -> releasing
+# -> live`` walk with an event per transition, the failure path (the attempt is
+# recorded ``failed`` with a REDACTED summary, never raised), and the
+# workspace-scoped loads that make a cross-tenant job id a no-op.
+#
+# Created 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): new module.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.ship import deploy_job, store
+
+from tests.cloud.ship.conftest import (
+    APP,
+    FAILING_REPLIES,
+    IMAGE,
+    SECRET_MARKERS,
+    install_fake_engine,
+)
+
+_PRIV = "-----BEGIN OPENSSH PRIVATE KEY-----\nFAKEKEYBODY\n-----END OPENSSH PRIVATE KEY-----\n"
+_PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY paw-ship"
+
+
+async def _ready_box(workspace="w1"):
+    box = await store.create_provisioning_box(
+        workspace_id=workspace,
+        provider="hcloud",
+        server_type="cx22",
+        region="fsn1",
+        ssh_private_key=_PRIV,
+        ssh_public_key=_PUB,
+    )
+    return await store.mark_ready(box, server_id="srv-1", ip="203.0.113.9", price_monthly=8.25)
+
+
+async def _app_and_deploy(workspace="w1", *, box=None):
+    box = box or await _ready_box(workspace)
+    app = await store.create_app(
+        workspace_id=workspace,
+        box_id=str(box.id),
+        name=APP,
+        build_path="dockerfile",
+        git_ref="",
+        image=IMAGE,
+        env_refs=[],
+        prod=False,
+    )
+    deploy = await store.create_deploy(workspace_id=workspace, app_id=str(app.id), image=IMAGE)
+    return box, app, deploy
+
+
+async def test_job_walks_the_deploy_to_live(mongo_db, enc_key, monkeypatch, recording_bus):  # noqa: ARG001
+    install_fake_engine(monkeypatch)
+    _box, app, deploy = await _app_and_deploy()
+
+    result = await deploy_job.deploy_app_job({}, str(deploy.id), "w1")
+
+    assert result == {"ok": True, "status": "live"}
+    landed = await store.get_deploy("w1", str(deploy.id))
+    assert landed is not None
+    assert landed.status == "live"
+    assert landed.finished_at is not None
+
+    refreshed = await store.get_app("w1", str(app.id))
+    assert refreshed is not None
+    assert refreshed.status == "live"
+    assert refreshed.urls == ["http://demo.paw.example"]
+
+    # Every transition announced itself, in order.
+    transitions = [
+        e.data["status"] for e in recording_bus.events if e.type == "ship.deploy.status_changed"
+    ]
+    assert transitions == ["building", "releasing", "live"]
+
+
+async def test_engine_failure_is_recorded_not_raised(
+    mongo_db,
+    enc_key,
+    monkeypatch,
+    recording_bus,  # noqa: ARG001
+):
+    install_fake_engine(monkeypatch, FAILING_REPLIES)
+    _box, app, deploy = await _app_and_deploy()
+
+    result = await deploy_job.deploy_app_job({}, str(deploy.id), "w1")
+
+    assert result == {"ok": False, "status": "failed"}
+    landed = await store.get_deploy("w1", str(deploy.id))
+    assert landed is not None
+    assert landed.status == "failed"
+    assert landed.finished_at is not None
+    assert landed.log_summary  # an operator hint was recorded...
+    for marker in SECRET_MARKERS:  # ...and it carries no secret material.
+        assert marker not in landed.log_summary
+
+    refreshed = await store.get_app("w1", str(app.id))
+    assert refreshed is not None
+    assert refreshed.status == "failed"
+    assert refreshed.urls == []
+
+
+async def test_cross_tenant_deploy_id_is_a_no_op(mongo_db, enc_key, monkeypatch):  # noqa: ARG001
+    issued = install_fake_engine(monkeypatch)
+    _box, _app, deploy = await _app_and_deploy("w1")
+
+    result = await deploy_job.deploy_app_job({}, str(deploy.id), "w-attacker")
+
+    assert result == {"ok": False, "reason": "deploy_not_found"}
+    # The victim's attempt was never touched, and no command reached a box.
+    untouched = await store.get_deploy("w1", str(deploy.id))
+    assert untouched is not None
+    assert untouched.status == "queued"
+    assert issued == []
+
+
+async def test_a_box_that_is_not_ready_fails_the_attempt(mongo_db, enc_key, monkeypatch):  # noqa: ARG001
+    issued = install_fake_engine(monkeypatch)
+    box = await _ready_box()
+    await store.mark_degraded(box, reason="box did not become reachable")
+    _box, app, deploy = await _app_and_deploy(box=box)
+
+    result = await deploy_job.deploy_app_job({}, str(deploy.id), "w1")
+
+    assert result["reason"] == "box_not_ready"
+    landed = await store.get_deploy("w1", str(deploy.id))
+    assert landed is not None
+    assert landed.status == "failed"
+    assert "degraded" in landed.log_summary
+    assert (await store.get_app("w1", str(app.id))).status == "failed"
+    assert issued == []
+
+
+async def test_a_deleted_app_fails_the_attempt(mongo_db, enc_key, monkeypatch):  # noqa: ARG001
+    install_fake_engine(monkeypatch)
+    _box, app, deploy = await _app_and_deploy()
+    await app.delete()
+
+    result = await deploy_job.deploy_app_job({}, str(deploy.id), "w1")
+
+    assert result["reason"] == "app_not_found"
+    landed = await store.get_deploy("w1", str(deploy.id))
+    assert landed is not None
+    assert landed.status == "failed"
+
+
+async def test_the_deploy_pins_the_image_from_the_attempt_not_the_app(
+    mongo_db,
+    enc_key,
+    monkeypatch,  # noqa: ARG001
+):
+    """A later app edit must not rewrite what an in-flight attempt ships."""
+    issued = install_fake_engine(monkeypatch)
+    _box, app, deploy = await _app_and_deploy()
+    app.image = "registry.paw.example/demo:NEWER"
+    await app.save()
+
+    await deploy_job.deploy_app_job({}, str(deploy.id), "w1")
+
+    assert f"dokku git:from-image {APP} {IMAGE}" in issued
+    assert not any("NEWER" in cmd for cmd in issued)

--- a/tests/cloud/ship/test_engine_metrics.py
+++ b/tests/cloud/ship/test_engine_metrics.py
@@ -1,0 +1,31 @@
+# tests/cloud/ship/test_engine_metrics.py — the box-metrics parser (SHIP-3).
+#
+# ``parse_box_metrics`` turns four lines of shell output into the three
+# percentages ``GET /ship/boxes/{id}/metrics`` reports. It is pure, so it is
+# tested directly: the happy read comes from the recorded transcript in the
+# router suite; here we pin the arithmetic and the never-500 fallbacks.
+#
+# Created 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): new module.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.ship.engine import parse_box_metrics
+
+
+@pytest.mark.parametrize(
+    ("stdout", "expected"),
+    [
+        # load 0.42 over 2 cores -> 21% CPU; the rest passes through.
+        ("0.42\n2\n37.5\n23%\n", (21.0, 37.5, 23.0)),
+        # An overloaded box caps at 100 rather than reporting 400%.
+        ("8.0\n2\n99.9\n91%\n", (100.0, 99.9, 91.0)),
+        # Garbage on the wire reads as zero, never as a 500 on a health poll.
+        ("who knows\n\n\n\n", (0.0, 0.0, 0.0)),
+        ("", (0.0, 0.0, 0.0)),
+        # A zero core count must not divide by zero.
+        ("1.0\n0\n10\n10%\n", (0.0, 10.0, 10.0)),
+    ],
+)
+def test_parse_box_metrics(stdout, expected):
+    assert parse_box_metrics(stdout) == expected

--- a/tests/cloud/ship/test_ship_router.py
+++ b/tests/cloud/ship/test_ship_router.py
@@ -1,0 +1,421 @@
+# tests/cloud/ship/test_ship_router.py — the /api/v1/ship HTTP surface (SHIP-3).
+#
+# Drives all thirteen routes through a real FastAPI app against a real Beanie
+# store (mongomock) with the ShipEngine FAKED by SHIP-1's transcript-replaying
+# transport — zero network, zero box. Three things get pinned here:
+#
+#   1. TENANCY. Every read is workspace-filtered, and a cross-tenant request
+#      404s — not 200, not 500. The parametrized sweep covers every id-bearing
+#      route so a future route can't quietly skip the filter.
+#   2. THE FROZEN WIRE SHAPES. The /ship console consumes BoxOut / AppOut /
+#      DeployOut / LogsOut / MetricsOut and the delete envelope verbatim; the
+#      key sets are asserted exactly, so a rename breaks here first.
+#   3. DESTROY IS NEVER EXECUTED. A DELETE parks a proposal and issues no
+#      engine command at all.
+#
+# Created 2026-07-22 (feat/ship-3-cloud-entity, SHIP-3): new module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.ship import store
+from pocketpaw_ee.cloud.ship.router import router as ship_router
+
+from tests.cloud.ship.conftest import (
+    APP,
+    DOMAIN,
+    IMAGE,
+    SECRET_MARKERS,
+    SERVICE,
+    install_fake_engine,
+)
+
+
+def _build_app(workspace_id: str) -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(ship_router)
+
+    async def _ctx() -> RequestContext:
+        return RequestContext(
+            user_id="u1",
+            workspace_id=workspace_id,
+            request_id="test",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def w1(mongo_db, enc_key, arq_pool) -> AsyncClient:  # noqa: ARG001 — fixtures init state
+    transport = ASGITransport(app=_build_app("w1"))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2(mongo_db, enc_key, arq_pool) -> AsyncClient:  # noqa: ARG001 — fixtures init state
+    transport = ASGITransport(app=_build_app("w2"))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+async def _ready_box(client: AsyncClient) -> str:
+    """Provision a box through the API and flip it ``ready`` (the arq job's job)."""
+    resp = await client.post("/ship/boxes", json={"provider": "hcloud"})
+    assert resp.status_code == 200, resp.text
+    box_id = resp.json()["id"]
+    box = await store.get_box("w1", box_id)
+    assert box is not None
+    await store.mark_ready(box, server_id="srv-1", ip="203.0.113.9", price_monthly=8.25)
+    return box_id
+
+
+async def _app_on_box(client: AsyncClient, box_id: str) -> str:
+    resp = await client.post("/ship/apps", json={"name": APP, "box_id": box_id, "image": IMAGE})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Boxes
+# ---------------------------------------------------------------------------
+
+
+async def test_create_box_returns_frozen_shape_and_enqueues(w1, arq_pool):
+    resp = await w1.post("/ship/boxes", json={"provider": "hcloud"})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body) == {"id", "provider", "ip", "status", "price_monthly"}
+    assert body["provider"] == "hcloud"
+    assert body["status"] == "provisioning"
+
+    # The provision was handed to the worker, positionally, with the box id.
+    (args, kwargs) = arq_pool.enqueued[0]
+    assert args == ("provision_box_job", body["id"], "w1")
+    assert kwargs == {}
+
+
+async def test_create_box_uses_default_server_type_and_region(w1):
+    resp = await w1.post("/ship/boxes", json={})
+    box = await store.get_box("w1", resp.json()["id"])
+    assert box is not None
+    assert (box.server_type, box.region) == ("cx22", "fsn1")
+
+
+async def test_create_box_honors_explicit_shape(w1):
+    resp = await w1.post(
+        "/ship/boxes", json={"provider": "hcloud", "server_type": "cx32", "region": "nbg1"}
+    )
+    box = await store.get_box("w1", resp.json()["id"])
+    assert box is not None
+    assert (box.server_type, box.region) == ("cx32", "nbg1")
+
+
+async def test_list_boxes_is_workspace_scoped(w1, w2):
+    await w1.post("/ship/boxes", json={})
+
+    assert len((await w1.get("/ship/boxes")).json()) == 1
+    assert (await w2.get("/ship/boxes")).json() == []
+
+
+async def test_box_metrics_reads_live_percentages(w1, monkeypatch):
+    install_fake_engine(monkeypatch)
+    box_id = await _ready_box(w1)
+
+    resp = await w1.get(f"/ship/boxes/{box_id}/metrics")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body) == {"cpu", "mem", "disk"}
+    # box_metrics.txt: load 0.42 over 2 cores, 37.5% memory, 23% root fs.
+    assert body == {"cpu": 21.0, "mem": 37.5, "disk": 23.0}
+
+
+async def test_box_metrics_refuses_a_box_that_is_not_ready(w1, monkeypatch):
+    install_fake_engine(monkeypatch)
+    resp = await w1.post("/ship/boxes", json={})
+
+    metrics = await w1.get(f"/ship/boxes/{resp.json()['id']}/metrics")
+
+    assert metrics.status_code == 409
+    assert metrics.json()["error"]["code"] == "ship.box_not_ready"
+
+
+# ---------------------------------------------------------------------------
+# Apps
+# ---------------------------------------------------------------------------
+
+
+async def test_create_and_list_apps(w1):
+    box_id = await _ready_box(w1)
+
+    created = await w1.post("/ship/apps", json={"name": APP, "box_id": box_id})
+
+    assert created.status_code == 200, created.text
+    body = created.json()
+    assert set(body) == {"id", "name", "box_id", "status", "urls"}
+    assert (body["name"], body["box_id"], body["status"], body["urls"]) == (
+        APP,
+        box_id,
+        "created",
+        [],
+    )
+
+    listed = (await w1.get("/ship/apps")).json()
+    assert [a["id"] for a in listed] == [body["id"]]
+    assert (await w1.get(f"/ship/apps?box_id={box_id}")).json() == listed
+
+
+async def test_list_apps_filters_by_box(w1):
+    box_a = await _ready_box(w1)
+    box_b = await _ready_box(w1)
+    await w1.post("/ship/apps", json={"name": "app-a", "box_id": box_a})
+    await w1.post("/ship/apps", json={"name": "app-b", "box_id": box_b})
+
+    only_b = (await w1.get(f"/ship/apps?box_id={box_b}")).json()
+
+    assert [a["name"] for a in only_b] == ["app-b"]
+
+
+async def test_duplicate_app_name_on_the_same_box_conflicts(w1):
+    box_id = await _ready_box(w1)
+    await w1.post("/ship/apps", json={"name": APP, "box_id": box_id})
+
+    again = await w1.post("/ship/apps", json={"name": APP, "box_id": box_id})
+
+    assert again.status_code == 409
+    assert again.json()["error"]["code"] == "ship.app_exists"
+
+
+async def test_create_app_on_a_foreign_box_404s(w1, w2):
+    box_id = await _ready_box(w1)
+
+    resp = await w2.post("/ship/apps", json={"name": APP, "box_id": box_id})
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "ship.box.not_found"
+
+
+# ---------------------------------------------------------------------------
+# Deploys
+# ---------------------------------------------------------------------------
+
+
+async def test_deploy_enqueues_and_is_immediately_pollable(w1, arq_pool):
+    box_id = await _ready_box(w1)
+    app_id = await _app_on_box(w1, box_id)
+
+    resp = await w1.post(f"/ship/apps/{app_id}/deploy")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body) == {"id", "app_id", "status", "started_at", "finished_at"}
+    assert (body["app_id"], body["status"]) == (app_id, "queued")
+    assert body["started_at"] is not None
+    assert body["finished_at"] is None
+
+    assert arq_pool.enqueued[-1] == (("deploy_app_job", body["id"], "w1"), {})
+    # The app itself reports the in-flight deploy.
+    assert (await w1.get("/ship/apps")).json()[0]["status"] == "deploying"
+
+    listed = (await w1.get(f"/ship/apps/{app_id}/deploys")).json()
+    assert [d["id"] for d in listed] == [body["id"]]
+
+
+async def test_deploy_transitions_are_observable_through_the_deploys_route(w1, monkeypatch):
+    """The acceptance criterion: run the job, poll the route, see the walk end."""
+    from pocketpaw_ee.cloud.ship import deploy_job
+
+    install_fake_engine(monkeypatch)
+    box_id = await _ready_box(w1)
+    app_id = await _app_on_box(w1, box_id)
+    deploy_id = (await w1.post(f"/ship/apps/{app_id}/deploy")).json()["id"]
+
+    assert (await w1.get(f"/ship/apps/{app_id}/deploys")).json()[0]["status"] == "queued"
+
+    result = await deploy_job.deploy_app_job({}, deploy_id, "w1")
+
+    assert result == {"ok": True, "status": "live"}
+    landed = (await w1.get(f"/ship/apps/{app_id}/deploys")).json()[0]
+    assert landed["status"] == "live"
+    assert landed["finished_at"] is not None
+    # ...and the app picked up the engine-reported URL.
+    assert (await w1.get("/ship/apps")).json()[0] == {
+        "id": app_id,
+        "name": APP,
+        "box_id": box_id,
+        "status": "live",
+        "urls": ["http://demo.paw.example"],
+    }
+
+
+async def test_deploy_without_an_image_is_rejected(w1):
+    box_id = await _ready_box(w1)
+    resp = await w1.post("/ship/apps", json={"name": APP, "box_id": box_id})
+
+    deploy = await w1.post(f"/ship/apps/{resp.json()['id']}/deploy")
+
+    assert deploy.status_code == 422
+    assert deploy.json()["error"]["code"] == "ship.app_no_image"
+
+
+# ---------------------------------------------------------------------------
+# Domains, database, logs
+# ---------------------------------------------------------------------------
+
+
+async def test_add_and_list_domains(w1, monkeypatch):
+    install_fake_engine(monkeypatch)
+    app_id = await _app_on_box(w1, await _ready_box(w1))
+
+    added = await w1.post(f"/ship/apps/{app_id}/domains", json={"domain": DOMAIN})
+
+    assert added.status_code == 200, added.text
+    assert added.json() == {"domain": DOMAIN, "tls_enabled": True}
+
+    listed = await w1.get(f"/ship/apps/{app_id}/domains")
+    assert listed.json() == {"domains": [{"domain": DOMAIN, "tls_enabled": True}]}
+    # The HTTPS URL is now on the app.
+    assert f"https://{DOMAIN}" in (await w1.get("/ship/apps")).json()[0]["urls"]
+
+
+async def test_db_create_returns_the_env_var_name_never_the_dsn(w1, monkeypatch):
+    install_fake_engine(monkeypatch)
+    app_id = await _app_on_box(w1, await _ready_box(w1))
+
+    resp = await w1.post(f"/ship/apps/{app_id}/db")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"service": SERVICE, "linked_app": APP, "env_var": "MONGO_URL"}
+    # The transcripts print the full DSN; it must not reach the wire or the doc.
+    app_doc = await store.get_app("w1", app_id)
+    assert app_doc is not None
+    for marker in SECRET_MARKERS:
+        assert marker not in resp.text
+        assert marker not in app_doc.model_dump_json()
+
+
+async def test_logs_returns_the_frozen_lines_shape(w1, monkeypatch):
+    install_fake_engine(monkeypatch)
+    app_id = await _app_on_box(w1, await _ready_box(w1))
+
+    resp = await w1.get(f"/ship/apps/{app_id}/logs")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body) == {"lines"}
+    assert len(body["lines"]) == 3
+    assert body["lines"][-1].endswith("GET /health 200")
+
+
+# ---------------------------------------------------------------------------
+# Deletes — parked, never executed
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_box_parks_a_proposal_and_destroys_nothing(w1, monkeypatch):
+    issued = install_fake_engine(monkeypatch)
+    box_id = await _ready_box(w1)
+
+    resp = await w1.delete(f"/ship/boxes/{box_id}")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body) == {"status", "proposal_id"}
+    assert body["status"] == "pending_approval"
+    assert body["proposal_id"]
+
+    box = await store.get_box("w1", box_id)
+    assert box is not None
+    assert box.pending_destroy_proposal_id == body["proposal_id"]
+    # Still ready — parking a teardown does not change what the box IS...
+    assert box.status == "ready"
+    # ...and no engine command ran at all, least of all a destroy.
+    assert issued == []
+
+
+async def test_delete_app_parks_a_proposal_and_destroys_nothing(w1, monkeypatch):
+    issued = install_fake_engine(monkeypatch)
+    app_id = await _app_on_box(w1, await _ready_box(w1))
+
+    resp = await w1.delete(f"/ship/apps/{app_id}")
+
+    assert resp.json()["status"] == "pending_approval"
+    app_doc = await store.get_app("w1", app_id)
+    assert app_doc is not None
+    assert app_doc.pending_destroy_proposal_id == resp.json()["proposal_id"]
+    assert app_doc.status == "created"
+    assert issued == []
+
+
+async def test_repeated_delete_returns_the_same_proposal(w1):
+    app_id = await _app_on_box(w1, await _ready_box(w1))
+
+    first = (await w1.delete(f"/ship/apps/{app_id}")).json()["proposal_id"]
+    second = (await w1.delete(f"/ship/apps/{app_id}")).json()["proposal_id"]
+
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Tenancy — every id-bearing route
+# ---------------------------------------------------------------------------
+
+
+async def test_cross_tenant_box_routes_404(w1, w2, monkeypatch):
+    install_fake_engine(monkeypatch)
+    box_id = await _ready_box(w1)
+
+    assert (await w2.get(f"/ship/boxes/{box_id}/metrics")).status_code == 404
+    assert (await w2.delete(f"/ship/boxes/{box_id}")).status_code == 404
+    # ...and the foreign tenant's DELETE did not park anything on w1's box.
+    box = await store.get_box("w1", box_id)
+    assert box is not None
+    assert box.pending_destroy_proposal_id is None
+
+
+@pytest.mark.parametrize(
+    ("method", "suffix", "payload"),
+    [
+        ("post", "/deploy", None),
+        ("get", "/deploys", None),
+        ("post", "/domains", {"domain": DOMAIN}),
+        ("get", "/domains", None),
+        ("post", "/db", {}),
+        ("get", "/logs", None),
+        ("delete", "", None),
+    ],
+)
+async def test_cross_tenant_app_routes_404(w1, w2, monkeypatch, method, suffix, payload):
+    install_fake_engine(monkeypatch)
+    app_id = await _app_on_box(w1, await _ready_box(w1))
+
+    call = getattr(w2, method)
+    resp = (
+        await call(f"/ship/apps/{app_id}{suffix}", json=payload)
+        if payload
+        else await call(f"/ship/apps/{app_id}{suffix}")
+    )
+
+    assert resp.status_code == 404, f"{method.upper()} {suffix} leaked: {resp.status_code}"
+    assert resp.json()["error"]["code"] == "ship.app.not_found"
+
+
+async def test_a_malformed_id_reads_as_not_found_not_a_crash(w1):
+    resp = await w1.get("/ship/apps/not-an-object-id/deploys")
+
+    assert resp.status_code == 404

--- a/tests/cloud/ship/test_ship_router.py
+++ b/tests/cloud/ship/test_ship_router.py
@@ -419,3 +419,32 @@ async def test_a_malformed_id_reads_as_not_found_not_a_crash(w1):
     resp = await w1.get("/ship/apps/not-an-object-id/deploys")
 
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Input constraints at the DTO boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"name": "Demo App", "box_id": "x"},  # spaces / capitals aren't Dokku names
+        {"name": "-leading-hyphen", "box_id": "x"},
+        {"name": "demo", "box_id": "x", "env_refs": ["API_KEY=hunter2"]},  # a VALUE
+        {"name": "demo", "box_id": "x", "build_path": "bazel"},
+    ],
+)
+async def test_create_app_rejects_unusable_input(w1, payload):
+    resp = await w1.post("/ship/apps", json=payload)
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize("domain", ["not a domain", "-bad.example.com", "localhost"])
+async def test_add_domain_rejects_a_non_hostname(w1, domain):
+    app_id = await _app_on_box(w1, await _ready_box(w1))
+
+    resp = await w1.post(f"/ship/apps/{app_id}/domains", json={"domain": domain})
+
+    assert resp.status_code == 422

--- a/tests/cloud/ship/test_ship_router.py
+++ b/tests/cloud/ship/test_ship_router.py
@@ -448,3 +448,17 @@ async def test_add_domain_rejects_a_non_hostname(w1, domain):
     resp = await w1.post(f"/ship/apps/{app_id}/domains", json={"domain": domain})
 
     assert resp.status_code == 422
+
+
+async def test_metrics_on_an_unreachable_box_is_a_409_not_a_500(w1, monkeypatch):
+    from tests.cloud.ship.conftest import install_refused_engine
+
+    box_id = await _ready_box(w1)
+    install_refused_engine(monkeypatch)
+
+    resp = await w1.get(f"/ship/boxes/{box_id}/metrics")
+
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "ship.metrics_failed"
+    # The box's address is not published in the error body.
+    assert "203.0.113.9" not in resp.text

--- a/tests/cloud/ship/test_ship_router.py
+++ b/tests/cloud/ship/test_ship_router.py
@@ -433,12 +433,38 @@ async def test_a_malformed_id_reads_as_not_found_not_a_crash(w1):
         {"name": "-leading-hyphen", "box_id": "x"},
         {"name": "demo", "box_id": "x", "env_refs": ["API_KEY=hunter2"]},  # a VALUE
         {"name": "demo", "box_id": "x", "build_path": "bazel"},
+        # Shell metacharacters in the build inputs. The driver shell-quotes
+        # these, so this is defence in depth — but an image reference is a
+        # constrained grammar, so a value carrying `;`/`$()`/backticks is
+        # refused at the boundary rather than surviving to an SSH round trip.
+        {"name": "demo", "box_id": "x", "image": "alpine; rm -rf /"},
+        {"name": "demo", "box_id": "x", "image": "alpine$(id)"},
+        {"name": "demo", "box_id": "x", "git_ref": "main`id`"},
     ],
 )
 async def test_create_app_rejects_unusable_input(w1, payload):
     resp = await w1.post("/ship/apps", json=payload)
 
     assert resp.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "image,git_ref",
+    [
+        ("", ""),  # the "not specified yet" body
+        ("alpine:3.20", "main"),
+        ("ghcr.io/owner/repo@sha256:abc123", "v1.2.3"),
+    ],
+)
+async def test_create_app_accepts_real_build_inputs(w1, image, git_ref):
+    """The tightened image/git_ref patterns must not reject legitimate refs."""
+    box_id = await _ready_box(w1)
+    resp = await w1.post(
+        "/ship/apps",
+        json={"name": "demo", "box_id": box_id, "image": image, "git_ref": git_ref},
+    )
+
+    assert resp.status_code == 200, resp.text
 
 
 @pytest.mark.parametrize("domain", ["not a domain", "-bad.example.com", "localhost"])


### PR DESCRIPTION
> Stacked on #1759 (provisioning), which is stacked on #1757 (engine contract). Review those first; this PR's diff is only the HTTP surface.

Third slice of `/ship`. #1757 gave us a driver, #1759 gave us boxes — this one puts a workspace-scoped REST API in front of both, so the UI in paw-enterprise#655 has a backend to talk to.

## What's here

- **`cloud/ship/{domain,dto,service,router}.py`** on the ee/cloud 4-file shape, reusing the SHIP-2 modules rather than duplicating them. `store.py` stays the only module that touches the Beanie documents.
- **Two new documents** — `ShipApp` (name, box, build path, image/git ref, env var *names*, prod flag, URLs, routed domains) and `ShipDeploy` (the per-attempt log the deploy job advances).
- **The routes**: create and list boxes, box metrics, create and list apps, deploy, deploy history, add and list domains, create a database, read logs, plus the two DELETEs.
- **`engine.py`** — a session seam that decrypts the box key to a `0600` temp file, hands a `DokkuDriver` to the caller, and shreds the key in a `finally`. Every engine call in the slice goes through it.
- **Deploy pipeline** — an arq job on the shared worker with its own timeout (pulling an image and swapping containers outlasts a chat run), persisting `queued → building → releasing → live | failed` and emitting on transitions.

## Destroy does nothing yet, by design

Both DELETEs park a proposal and return `{status: "pending_approval", proposal_id}`. The engine's `destroy` verb is never called from the request path — there's a `# SHIP-4:` marker at each seam where the real Instinct proposal gets wired, and only the approve path will ever be allowed to execute. Repeat DELETEs reuse the existing proposal id instead of minting a second one.

## Testing

76 tests, no network — the engine is faked through the SHIP-1 transcript harness.

**Tenancy is the headline.** A parametrized sweep drives every id-bearing route as a second workspace and asserts `404` specifically — not 200, not 500. A cross-tenant deploy job id is a no-op, and a malformed id reads as "not found" rather than throwing out of bson.

Also covered: the frozen DTO shapes the UI consumes, deploy status transitions end to end, parked destroys leaving the entity intact, and an unreachable box answering `409` with a failed attempt rather than a `500`.

- `uv run pytest tests/cloud/ship/` → 76 passed
- `uv run pytest tests/cloud/chat/ tests/ship_engine/` → 143 passed
- `lint-imports` on both configs → 32 contracts kept
- ruff and ruff format clean

## Security notes

Every value that reaches a shell argument is constrained at the DTO boundary — app name, domain, and now image and git ref, which were free strings until review caught the asymmetry with their neighbours. The driver shell-quotes all of them regardless, so this is defence in depth rather than the only barrier; there are tests for both the hostile inputs and the legitimate ones (`ghcr.io/owner/repo@sha256:...` still works).

The API never accepts env *values* — only variable names. A body carrying `["API_KEY=hunter2"]` is refused rather than persisted, since that field is never treated as a secret.

## Notes for review

The import-linter contract for this entity names `store.py` as the doc owner rather than `service.py`, because the Fernet envelope on the SSH key lives there. The contract comment is explicit that `service.py`, `engine.py`, and the job modules stay off the documents by review rather than by contract — they annotate with the doc types under `TYPE_CHECKING`, which import-linter counts as a real import.

Box defaults are `cx22` in `fsn1` when a create body omits them.
