### PR TITLE
Stop the /code agent addressing the backend's own disk

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/code.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/code.py
@@ -1,22 +1,51 @@
 # code.py — /code surface preamble.
 #
 # Created: 2026-06-10 (feat/studio-code-migration) — Orients the chat agent when
-# the user is on the /code surface (the agent edits + runs code in the
-# workspace). Without it the surface falls back to GENERIC and the agent builds a
-# dashboard pocket instead of editing code — the same drift the /sites preamble
-# was created to fix. Static orientation — no live data to fake.
+# the user is on the /code surface. Without it the surface falls back to GENERIC
+# and the agent builds a dashboard pocket instead of writing code — the same
+# drift the /sites preamble was created to fix. Static orientation — no live data
+# to fake.
 #
-# Mirrors the layout of handlers/sites.py: an async ``build_preamble`` returning
-# an XML-ish ``<surface>`` + ``<orientation>`` + ``<procedure>`` block. The
-# procedure tells the agent to use the SDK built-in tools (Bash / Read / Write /
-# Edit / Glob / Grep), PREFER the bundled ``code`` skill (the edit→run→verify
-# loop), and VERIFY (run it / tests) before claiming done. The workspace is
-# jailed and destructive shell is blocked.
+# Rewritten: 2026-07-22 (feat/code-surface-profile, CD-3) — the original
+# preamble pointed the agent at the WRONG MACHINE, and did so silently.
 #
-# The /code SurfaceProfile sets ``ripple_mode="off"`` and an
-# ``allowed_sdk_tools`` allowlist (see service.py) so the agent does not inherit
-# the ~20k-char "default to ui-spec" ripple LAW and build a dashboard instead of
-# editing code.
+# It branched on four ``SurfaceMeta`` hints (``workspace_vm`` /
+# ``is_cloud_storage`` / ``current_dir`` / ``storage_root``) into three storage
+# flavours: a Daytona-VM branch naming MCP tools (read_file / write_file / shell
+# / run_python / sync_to_s3 / start_server / preview_url), an S3 branch pointing
+# at ``/cloud/projects/{name}/files/*``, and a local-disk branch. All three were
+# stale. The current /code page stamps NONE of those hints, so every real turn
+# fell through to the local-disk branch and told the agent "your working
+# directory is the workspace root" — which is the BACKEND SERVER's filesystem,
+# not the user's project. The agent would read and write the server's disk and
+# report success. Nothing routes to the main agent on /code yet, so the failure
+# was latent rather than observed; this rewrite removes it before that lands.
+# The Daytona MCP tools were equally stale — they address an older cloud-projects
+# model that knows nothing of the current ``codeproject`` + ``CodeFileSession``
+# runtime (nothing under ``cloud/daytona/`` so much as mentions either).
+#
+# The preamble now states the single truth of this surface: the user's code is
+# reachable ONLY through the ``code_mode`` tool, and the agent has no filesystem
+# of its own here. It also tells the agent to call ``code_mode`` IMMEDIATELY when
+# the user's edit is scoped to a selection they already made — no exploratory
+# retrieval first. That is a latency mitigation, not a style note: the /code path
+# is two model calls deep (chat agent → code agent), so a redundant retrieval
+# round is paid twice, and the selection plus its file are already in context.
+#
+# Mirrors the layout of handlers/sites.py and handlers/belt.py: an async
+# ``build_preamble`` returning an XML-ish ``<surface>`` + ``<orientation>`` +
+# ``<procedure>`` block.
+#
+# Enforcement lives in the profile, not in this prose — a preamble that merely
+# ASKS the agent not to touch the disk is not a control. The /code
+# ``SurfaceProfile`` (see ``surface_registry.py``) sets ``ripple_mode="off"`` so
+# the agent doesn't inherit the ~20k-char "default to ui-spec" ripple LAW, DENIES
+# the file/shell built-ins AND ``Agent`` outright, and scopes the MCP surface to
+# ``code_mode``. This text is the explanation the agent gets for a restriction
+# already applied; the two must agree, so if the profile changes, change this
+# too. The profile also carries NO skill: the `code` skill teaches only the
+# denied built-ins and is retargeted onto ``code_mode`` in CD-2, so until then
+# this preamble is the whole of the agent's guidance on this surface.
 
 from __future__ import annotations
 
@@ -24,166 +53,75 @@ from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
 
 
 async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
-    """Render the /code surface preamble — edit + run code in the workspace.
+    """Render the /code surface preamble — code reached only via ``code_mode``.
 
-    When the client stamps ``current_dir`` / ``project_name`` /
-    ``workspace_vm`` / ``storage_root`` / ``is_cloud_storage``
-    (set from the frontend's SurfaceMetaProvider on the /code page), the
-    preamble tells the agent EXACTLY where the project lives and how to
-    access its files.
-
-    Also sets the ``current_project_name`` ContextVar so Daytona tools
-    (MCP and SDK) automatically scope to the correct project subdirectory
-    inside the workspace VM.
-
-    Storage flavours:
-      * Workspace VM (NEW): ``workspace_vm = "true"`` means the project
-        lives inside a shared workspace VM. The agent uses Daytona MCP
-        tools (read_file, write_file, shell, run_python, etc.) which
-        route through the sandbox. The project is a subdirectory of the
-        VM's workspace root.
-      * Local-disk adapter: ``current_dir`` is a real filesystem path
-        (e.g. ``~/.pocketpaw/uploads/projects/{ws}/{uid}/{name}/``).
-        The agent can ``cd`` to ``current_dir`` and use Bash/Read/Write/Edit.
-      * Pure S3: ``is_cloud_storage = "true"``. Files aren't on disk.
+    Static: the preamble does not vary with storage flavour, working
+    directory, or sandbox state, because none of those are the agent's
+    concern on this surface. The ``code_mode`` tool owns the project — it
+    resolves the sandbox and the file session itself. The only thing read
+    from ``meta`` is ``project_name``, and purely so the agent can name the
+    project the user is looking at.
     """
     route = meta.route_path or "/code"
-
-    # ── Set project name context for Daytona tools ──────────────────────
-    if meta.project_name:
-        from pocketpaw_ee.cloud.daytona.context import set_current_project_name
-
-        set_current_project_name(meta.project_name)
-
-    # ── Storage type ────────────────────────────────────────────────────
-    is_vm = meta.workspace_vm == "true"
-    is_s3 = meta.is_cloud_storage == "true"
-    current_dir = meta.current_dir or "the workspace root"
-
-    # ── Orientation — one block per storage flavour ─────────────────────
-    orientation = _build_orientation(
-        current_dir,
-        meta.project_name,
-        is_vm,
-        is_s3,
-        meta.storage_root,
+    return (
+        f'<surface kind="code" route="{route}" />\n{_orientation(meta.project_name)}{_procedure()}'
     )
-    procedure = _build_procedure(is_vm, is_s3)
-
-    return f'<surface kind="code" route="{route}" />\n{orientation}{procedure}'
 
 
-def _build_orientation(
-    current_dir: str,
-    project_name: str | None,
-    is_vm: bool,
-    is_s3: bool,
-    storage_root: str | None,
-) -> str:
-    """Render the ``<code-orientation>`` block — tells the agent what
-    surface it's on, where the project lives, and how to refer to it."""
+def _orientation(project_name: str | None) -> str:
+    """Render the ``<code-orientation>`` block — what surface this is, and the
+    one door to the user's code."""
     lines = [
         "<code-orientation>",
-        "The user is on the CODE surface, a coding workspace. You EDIT and RUN "
-        "code here on the user's behalf. This is NOT a dashboard — do not build "
-        "widgets, charts, or a ui-spec, and do not create a pocket. The "
-        "deliverable is working CODE: files written or changed in the workspace "
-        "and verified by running them. Talk about the work as 'code', 'files', "
-        "'the workspace', 'tests' — never as a 'pocket' or 'dashboard'.",
+        "The user is on the CODE surface, a coding workspace. You write and "
+        "change code here on the user's behalf. This is NOT a dashboard — do not "
+        "build widgets, charts, or a ui-spec, and do not create a pocket. The "
+        "deliverable is working CODE: real changes to the user's project. Talk "
+        "about the work as 'code', 'files', 'the project', 'tests' — never as a "
+        "'pocket' or 'dashboard'.",
+        "The user's project does NOT live on your machine. It lives in the "
+        "user's own project workspace, and the `code_mode` tool is the ONLY way "
+        "to reach it — that tool resolves the project, reads it, and makes the "
+        "change. You have no filesystem of your own on this surface: there is no "
+        "working directory to sit in, nothing to `cd` into, and no path you can "
+        "usefully name.",
     ]
-
-    if is_vm:
-        # Workspace VM mode — files live in a shared VM.
-        lines.append(
-            f"This project runs inside a shared workspace VM (Daytona sandbox). "
-            f"The project directory is **{current_dir}** inside the VM. "
-            f"Use the Daytona MCP tools (read_file, write_file, edit_file, "
-            f"list_dir, shell, run_python, sync_to_s3, start_server, preview_url) "
-            f"for ALL file I/O and command execution — these operate directly "
-            f"inside the sandbox VM. Use start_server to start a web server "
-            f"and get a URL; use preview_url to get a URL for an existing "
-            f"server. The shell tool's working directory is already set to "
-            f"the project directory."
-        )
-    elif is_s3:
-        lines.append(
-            f"This project is backed by cloud storage (S3). "
-            f"The storage key prefix is **{current_dir}**. "
-            f"Files are NOT directly on the local filesystem. "
-        )
-        daytona_hint = (
-            f"If a Daytona sandbox is provisioned for project "
-            f"'{project_name}', use the Daytona MCP tools "
-            f"(read_file, write_file, edit_file, list_dir, shell, "
-            f"run_python, sync_to_s3, start_server, preview_url) to "
-            f"operate directly inside the sandbox VM."
-            if project_name
-            else "If a Daytona sandbox is provisioned, use the Daytona "
-            "MCP tools (read_file, write_file, edit_file, list_dir, "
-            "shell, run_python, sync_to_s3, start_server, preview_url) "
-            "to operate directly inside the sandbox VM."
-        )
-        lines.append(daytona_hint)
-    else:
-        lines.append(f"Your working directory is **{current_dir}**.")
 
     if project_name:
         lines.append(
-            f"The current project is **{project_name}** — all work "
-            f"should go into its directory tree."
+            f"The project the user is looking at is **{project_name}** — refer to it by name."
         )
 
     lines.append("</code-orientation>")
     return "\n".join(lines) + "\n"
 
 
-def _build_procedure(is_vm: bool, is_s3: bool) -> str:
+def _procedure() -> str:
     """Render the ``<code-procedure>`` block — how to do the work."""
     lines = [
         "<code-procedure>",
-        "Treat the user's message on this surface as a coding task. Use the "
-        "built-in tools to do the work. PREFER the `code` skill — invoke it "
-        "by intent (no slash command needed); it owns the edit→run→verify "
-        "loop. Always VERIFY before claiming the task is done: run the code "
-        "or its tests and confirm the output, rather than asserting success "
-        "from the edit alone. If a command fails, read the error, fix it, "
-        "and re-run.",
+        "Treat the user's message on this surface as a coding task, and do the "
+        "work by calling `code_mode`. Describe the change you want in the terms "
+        "the user gave you; the tool handles locating the code and applying the "
+        "edit.",
+        "If the user's request is scoped to a selection they have ALREADY made, "
+        "call `code_mode` IMMEDIATELY, with no exploratory retrieval first. The "
+        "selected code and the file it came from are already in your context — "
+        "going looking for them again is a wasted round-trip the user waits "
+        "through, on a path that is already two model calls deep.",
+        "Do NOT attempt `Bash`, `Read`, `Write`, `Edit`, `Glob`, or `Grep` on "
+        "this surface. They do not reach the user's project — they address the "
+        "machine you are running on, which is a different computer with none of "
+        "the user's code on it. Using them would edit the wrong files and look "
+        "like it worked. They are withheld from you here for exactly that "
+        "reason; if you find yourself reaching for one, the answer is "
+        "`code_mode`.",
+        "Report only what actually happened. If `code_mode` returns an error or "
+        "is unavailable, say so plainly — never describe a change as made when "
+        "the tool did not confirm it. When it succeeds, briefly summarize what "
+        "changed and where.",
+        "</code-procedure>",
     ]
-
-    if is_vm:
-        lines.extend(
-            [
-                "This project is in a shared workspace VM. Use the Daytona MCP "
-                "tools (read_file, write_file, edit_file, list_dir, shell, "
-                "run_python, sync_to_s3) for ALL work. Do NOT use local Bash, "
-                "Read, Write, Edit, Glob, or Grep — those operate on the local "
-                "filesystem, not the VM. The shell tool runs commands inside "
-                "the sandbox with the project directory as the working directory.",
-            ]
-        )
-    elif is_s3:
-        lines.extend(
-            [
-                "This is a cloud-storage project — files are in S3, not on the "
-                "local disk. If a Daytona sandbox is provisioned, use Daytona "
-                "MCP tools. Otherwise use the cloud project REST API endpoints "
-                "(/cloud/projects/{name}/files/*).",
-            ]
-        )
-    else:
-        lines.append(
-            "The workspace and project directory ARE on the local filesystem — "
-            "navigate to the working directory above and work there."
-        )
-
-    lines.extend(
-        [
-            "The workspace is JAILED — stay inside it. Destructive shell "
-            "operations are blocked. When done, briefly summarize what changed "
-            "and how you verified it.",
-            "</code-procedure>",
-        ]
-    )
     return "\n".join(lines) + "\n"
 
 

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -32,6 +32,23 @@
 # startup assertion (``_assert_registry_complete``, run at module import)
 # guarantees every ``SurfaceKind`` has exactly one row and no row names a bogus
 # kind — resolving the design's open question (keep the enum + assert).
+#
+# Changes: 2026-07-22 (feat/code-surface-profile, CD-3) — the CODE row stopped
+# addressing the wrong machine. It used to carry
+# ``allowed_sdk_tools={"Bash","Read","Write","Edit","Glob","Grep"}``, which read
+# like "scope the agent to the coding built-ins" but is ADDITIVE — those six are
+# in the SDK's default set already, so it granted nothing and restricted nothing.
+# Meanwhile the /code agent runs on the BACKEND SERVER: the user's project lives
+# in a sandbox behind the ``code_mode`` tool, so every one of those built-ins
+# would have read and written the server's own disk and reported success. The row
+# now DENIES them (``_CODE_BUILTIN_DENY`` — deny is the only lever that removes a
+# built-in) and scopes the MCP surface to the one tool that reaches the project
+# (``_CODE_MODE_TOOL_IDS``). ``Agent`` joins the deny set too: a spawned subagent
+# is a second, unsupervised path to tools. ``skill_names`` drops to empty — the
+# `code` skill teaches nothing BUT those built-ins, so keeping it would inject an
+# instruction to call what the agent no longer has. Still a static ``profile``:
+# both sets are module-level literals, nothing lazily loaded, not meta-aware. The
+# matching preamble rewrite is in ``handlers/code.py``.
 
 from __future__ import annotations
 
@@ -172,6 +189,48 @@ _SITES_BUILTIN_DENY: frozenset[str] = frozenset(
 # base. When both PRs land, swap this literal for the imported constant (same
 # None-degrade path as the loom/media imports below). Do NOT drift the id.
 _BELT_GATE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_belt__belt_propose_change"})
+
+# The single tool the /code agent reaches the user's project through. Everything
+# the surface can do to code happens behind it: the tool owns the sandbox, the
+# file session, and the edit. Spelled as a LITERAL for the same reason
+# ``_BELT_GATE_TOOL_IDS`` above is — its canonical constant lives in a SIBLING
+# branch's in-process MCP server (server ``pocketpaw_code``, tool ``code_mode``),
+# not importable on this base. When both PRs land, swap this literal for the
+# imported constant. The id format is the SDK's ``mcp__<server>__<tool>``
+# namespacing (see ``pocketpaw.agents.sdk_mcp_widgets``). Do NOT drift the id.
+_CODE_MODE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_code__code_mode"})
+
+# Built-in SDK tools the /code agent must NOT have. Same mechanism and same
+# reasoning as ``_SITES_BUILTIN_DENY`` above: these bare tool NAMES ride in
+# ``deny_mcp_tool_ids``, and the OSS backend's deny filter subtracts ANY matching
+# id from the launch allow-list — built-ins included — so naming them here
+# physically removes them before the SDK starts.
+#
+# This is load-bearing, not tidiness. The /code agent runs on the BACKEND SERVER,
+# not in the user's project: its cwd is the per-tenant scratch jail, and the
+# user's code is only ever reachable through ``code_mode``. Left in place, the
+# built-ins let the agent read and write the SERVER's filesystem and then report
+# success — a silent wrong-machine failure with no error to notice.
+#
+# ``allowed_sdk_tools`` cannot do this job: it is ADDITIVE (unioned INTO the
+# allow-list, ``effective = (agent_tools ∪ allow) − deny``), and the file/shell
+# built-ins are in the SDK's default set already, so listing them there was a
+# no-op that merely read like a restriction. ``allow_mcp_tool_ids`` cannot either
+# — it filters only ``mcp__*`` ids and never touches built-ins. Deny is the only
+# lever.
+#
+# ``Agent`` is denied for a reason beyond parity with SITES. Under this design
+# ``code_mode`` is the ONLY path to the user's files; a spawned subagent is a
+# SECOND path, with its own tool resolution and no supervision from this profile.
+# Denying the six file/shell tools while leaving the tool that spawns a fresh
+# tool-user would just move the hole one level down.
+#
+# WebSearch / WebFetch / Skill are deliberately NOT denied, the same reasoning
+# SITES gives: researching an API or an error message to write against is
+# legitimate work, and neither one reaches a filesystem.
+_CODE_BUILTIN_DENY: frozenset[str] = frozenset(
+    {"Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent"}
+)
 
 
 class _McpToolIds(NamedTuple):
@@ -420,15 +479,29 @@ SURFACES: list[SurfaceSpec] = [
         SurfaceKind.CODE,
         _route_for(SurfaceKind.CODE),
         code.build_preamble,
-        # Code: edit + run code. Ripple OFF so the agent edits code instead of
-        # building a dashboard; the SDK-tool allowlist scopes it to the coding
-        # built-ins; the `code` skill carries the edit→run→verify loop. No
-        # lazily-loaded MCP tool ids and not meta-aware, so this is a STATIC
-        # profile (no resolver needed).
+        # Code: edit + run code, but NOT on this machine. Ripple OFF so the
+        # agent edits code instead of building a dashboard. The user's project
+        # is reachable ONLY through ``code_mode`` (allow), and the file/shell
+        # built-ins are stripped (deny) because they address the backend
+        # server's own disk, not the project — see ``_CODE_BUILTIN_DENY``. Both
+        # sets are module-level literals, so this stays a STATIC profile (no
+        # lazily-loaded ids, not meta-aware, no resolver needed).
+        #
+        # ``skill_names`` is deliberately EMPTY, where it used to carry the
+        # `code` skill. That skill is not incidentally about the built-ins — it
+        # is entirely about them ("you use the built-in Bash / Read / Write /
+        # Edit / Glob / Grep tools", then a five-step loop built on them), so
+        # under the deny above it would be an injected instruction to call tools
+        # the agent no longer has: the agent attempts them, takes hard errors,
+        # and burns turns before finding the path the preamble already gave it.
+        # Absence is recoverable; contradiction is not. The skill's edit→run→
+        # verify DISCIPLINE is worth keeping and gets retargeted onto
+        # ``code_mode`` in CD-2 — rewriting SKILL.md here would teach a tool that
+        # does not exist yet, which is the same failure pointed the other way.
         profile=SurfaceProfile(
             ripple_mode="off",
-            skill_names=frozenset({"code"}),
-            allowed_sdk_tools=frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"}),
+            allow_mcp_tool_ids=_CODE_MODE_TOOL_IDS,
+            deny_mcp_tool_ids=_CODE_BUILTIN_DENY,
         ),
     ),
     SurfaceSpec(

--- a/tests/cloud/surface/test_studio_code_handlers.py
+++ b/tests/cloud/surface/test_studio_code_handlers.py
@@ -12,6 +12,28 @@
 # Also pins both profiles: ripple_mode="off" (so neither inherits the ripple
 # "default to ui-spec" LAW), the per-surface skill, and STUDIO's media-tool
 # allow-list / CODE's SDK-tool allow-list.
+#
+# Changes: 2026-07-22 (feat/code-surface-profile, CD-3) — the /code half was
+# guarding the WRONG MACHINE, so its assertions were rewritten rather than
+# extended. The old tests demanded the preamble NAME Bash/Read/Write/Edit/Glob/
+# Grep and that the profile carry them in ``allowed_sdk_tools``; both encoded the
+# stale belief that the /code agent works on a filesystem it can see. It does
+# not — it runs on the backend server, and the user's project is reachable only
+# through the ``code_mode`` tool. The replacements assert the inverse: the
+# resolved profile DENIES every file/shell built-in (plus ``Agent``), allows
+# exactly ``code_mode``, and surfaces NO skill; and the rendered preamble leaks
+# no path and names no Daytona MCP tool — including when a legacy client still
+# stamps the old ``current_dir`` / ``storage_root`` / ``workspace_vm`` /
+# ``is_cloud_storage`` hints. The registry-import assertion is exercised too,
+# since the profile now leans on two module-level literals.
+#
+# The load-bearing one is
+# ``test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist``: it
+# drives the REAL ``ClaudeSDKBackend._build_options`` and reads the allowlist the
+# SDK would launch with. A membership check on ``deny_mcp_tool_ids`` alone would
+# have gone green against the OLD profile too — that one named all six built-ins
+# in the additive ``allowed_sdk_tools`` and shipped them anyway — so the negative
+# has to be asserted against the COMPUTED result, not the declaration.
 
 from __future__ import annotations
 
@@ -77,6 +99,39 @@ async def test_studio_handler_relays_provider_errors() -> None:
 # --- /code handler ---
 
 
+# The file/shell built-ins the /code agent must not hold. They address the
+# backend server, which is not the machine the user's project is on.
+_FILESYSTEM_BUILTINS = frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"})
+
+# The Daytona MCP tool names the old preamble advertised. They address an older
+# cloud-projects model that knows nothing of the current codeproject +
+# CodeFileSession runtime, so naming ANY of them sends the agent at a machine
+# that will not have the user's code.
+_STALE_DAYTONA_TOOLS = (
+    "read_file",
+    "write_file",
+    "edit_file",
+    "list_dir",
+    "run_python",
+    "sync_to_s3",
+    "start_server",
+    "preview_url",
+    "daytona",
+)
+
+# The legacy storage hints the old handler branched on. A current /code page
+# stamps none of them, but an older client might — and if it does, none of the
+# values may reach the prompt as a place to work.
+_LEGACY_STORAGE_META = SurfaceMeta(
+    route_path="/code",
+    current_dir="/srv/pocketpaw/uploads/projects/ws1/u1/my-app/",
+    storage_root="projects/ws1/u1/my-app/",
+    project_name="my-app",
+    is_cloud_storage="true",
+    workspace_vm="true",
+)
+
+
 async def test_code_handler_carries_coding_orientation() -> None:
     """The preamble orients to editing + running code on the code surface — and
     must NOT frame the deliverable as a dashboard or a pocket."""
@@ -90,26 +145,80 @@ async def test_code_handler_carries_coding_orientation() -> None:
     assert "build a pocket" not in lower
 
 
-async def test_code_handler_names_builtin_tools_and_prefers_code_skill() -> None:
-    """The procedure names the built-in coding tools and prefers the `code`
-    skill (the edit→run→verify loop)."""
+async def test_code_handler_routes_all_work_through_code_mode() -> None:
+    """`code_mode` is named as the ONLY route to the user's project."""
     preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
 
-    assert "prefer" in preamble.lower()
-    assert "`code`" in preamble or "code skill" in preamble.lower()
-    # The built-in tools the SDK backend exposes for coding.
+    assert "code_mode" in preamble
+    lower = preamble.lower()
+    assert "only" in lower
+
+
+async def test_code_handler_forbids_the_filesystem_builtins() -> None:
+    """The procedure names the file/shell built-ins ONLY to forbid them — the
+    agent has no filesystem on this surface."""
+    preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
+
     for tool in ("Bash", "Read", "Write", "Edit", "Glob", "Grep"):
-        assert tool in preamble, f"preamble should name the {tool} tool"
+        assert tool in preamble, f"preamble should name the {tool} tool to forbid it"
+    lower = preamble.lower()
+    assert "do not attempt" in lower
+    assert "no filesystem" in lower
 
 
-async def test_code_handler_demands_verification_and_is_jailed() -> None:
-    """The procedure demands verifying (run it / tests) before claiming done, and
-    states the workspace is jailed + destructive shell is blocked."""
+async def test_code_handler_calls_code_mode_immediately_on_a_selection() -> None:
+    """An edit scoped to a selection the user already made goes straight to
+    `code_mode` — no exploratory retrieval first (the path is two model calls
+    deep, so a redundant round-trip is expensive)."""
     preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
     lower = preamble.lower()
-    assert "verify" in lower
-    assert "jailed" in lower
-    assert "destructive" in lower
+
+    assert "selection" in lower
+    assert "immediately" in lower
+    assert "retrieval" in lower
+
+
+async def test_code_handler_names_no_daytona_tool() -> None:
+    """The stale Daytona MCP tool names are gone — they point at a runtime that
+    knows nothing of codeproject / CodeFileSession."""
+    preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
+    lower = preamble.lower()
+
+    for tool in _STALE_DAYTONA_TOOLS:
+        assert tool not in lower, f"preamble must not name the stale {tool!r} tool"
+
+
+async def test_code_handler_leaks_no_filesystem_path_even_from_legacy_meta() -> None:
+    """No path reaches the prompt — not the backend's workspace root, not the
+    cloud-projects REST route, and not the legacy storage hints even when an
+    older client still stamps them.
+
+    This is the regression the rewrite exists for: the old handler fell through
+    to "your working directory is the workspace root", which is the BACKEND
+    SERVER's filesystem, and the agent would edit it and report success."""
+    for meta in (SurfaceMeta(route_path="/code"), _LEGACY_STORAGE_META):
+        preamble = await code_handler.build_preamble(WORKSPACE, USER, meta)
+        lower = preamble.lower()
+
+        assert "/srv/pocketpaw" not in lower
+        assert "projects/ws1/u1/my-app" not in lower
+        assert "/cloud/projects" not in lower
+        assert "~/.pocketpaw" not in lower
+        assert "working directory is" not in lower
+        assert "workspace root" not in lower
+        # Nothing to cd into, so no shell navigation instruction either.
+        assert "cd to" not in lower
+        assert "navigate to" not in lower
+
+
+async def test_code_handler_forbids_phantom_success() -> None:
+    """The agent reports only what `code_mode` confirmed — a tool error is
+    surfaced plainly, never dressed up as a completed change."""
+    preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
+    lower = preamble.lower()
+
+    assert "error" in lower
+    assert "never describe a change as made" in lower
 
 
 # --- Profiles (ripple-OFF on both) ---
@@ -132,16 +241,159 @@ def test_studio_profile_ripple_off_media_tools_and_skill() -> None:
     assert VIDEO_GENERATE_TOOL_ID in profile.allow_mcp_tool_ids
 
 
-def test_code_profile_ripple_off_sdk_allowlist_and_skill() -> None:
+def test_code_profile_ripple_off_and_scoped_to_code_mode() -> None:
     """The /code profile turns ripple OFF (so the agent edits code, not a
-    dashboard), restricts SDK tools to the coding built-ins, and surfaces the
-    code skill."""
+    dashboard) and scopes the MCP surface to exactly the ``code_mode`` tool."""
     profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+
     assert profile.ripple_mode == "off"
-    assert "code" in profile.skill_names
-    assert profile.allowed_sdk_tools == frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"})
-    # Code names no specialized MCP tools — it rides the built-in SDK tools.
-    assert profile.allow_mcp_tool_ids is None
+    assert profile.allow_mcp_tool_ids == frozenset({"mcp__pocketpaw_code__code_mode"})
+
+
+def test_code_profile_surfaces_no_skill() -> None:
+    """/code carries NO skill.
+
+    It used to carry `code`, whose body is entirely about the built-ins this
+    profile now denies. Under the deny that is an injected instruction to call
+    tools the agent does not have — it attempts them, takes hard errors, and
+    burns turns before falling back to the path the preamble gave it. The skill's
+    edit→run→verify discipline is retargeted onto ``code_mode`` in CD-2."""
+    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+
+    assert profile.skill_names == frozenset()
+
+
+def test_code_profile_denies_the_filesystem_builtins_and_subagents() -> None:
+    """The deny set names every file/shell built-in, plus ``Agent``.
+
+    ``allowed_sdk_tools`` cannot express this — it is ADDITIVE
+    (``effective = (agent_tools ∪ allow) − deny``) and the built-ins are in the
+    SDK's default set already, so listing them there restricted nothing.
+    ``allow_mcp_tool_ids`` cannot either: it filters only ``mcp__*`` ids. Deny is
+    the only lever. ``Agent`` is in the set because a spawned subagent is a
+    second path to tools that this profile does not supervise.
+
+    Membership only — ``test_code_profile_grants_no_filesystem_tool_in_the_
+    effective_allowlist`` below is the one that proves the effect."""
+    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+
+    assert _FILESYSTEM_BUILTINS <= profile.deny_mcp_tool_ids
+    assert "Agent" in profile.deny_mcp_tool_ids
+    # Not smuggled back in through the additive allow-list either.
+    assert not (profile.allowed_sdk_tools or frozenset()) & _FILESYSTEM_BUILTINS
+    # Research tools survive — neither reaches a filesystem.
+    assert not {"WebSearch", "WebFetch", "Skill"} & profile.deny_mcp_tool_ids
+
+
+async def test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist() -> None:
+    """THE test: drive the REAL allowlist computation and assert the built-ins
+    are absent from what the SDK would actually launch with.
+
+    A membership check on ``deny_mcp_tool_ids`` is not enough — the bug this task
+    fixes is precisely one a membership-only test passes. The old profile listed
+    all six built-ins in ``allowed_sdk_tools`` and any "are they named in the
+    profile?" assertion went green, while the effective allowlist still carried
+    them because that field is additive. So this test asks the question that
+    matters: feed the resolved CODE profile through
+    ``ClaudeSDKBackend._build_options`` (pure assembly — no client, no network,
+    the same call ``run`` and ``prewarm`` make) and read ``allowed_tools`` off
+    the options the SDK would receive.
+
+    It guards TWO wrong-machine paths, because the surface had two. The
+    file/shell built-ins are one. The ``mcp__pocketpaw_daytona__*`` family is the
+    other — ``shell`` / ``run_python`` / ``read_file`` / ``write_file`` /
+    ``edit_file`` / ``sync_to_s3`` all reach the SUPERSEDED cloud-projects
+    sandbox, which knows nothing of the ``codeproject`` + ``CodeFileSession``
+    runtime the user's project actually lives in. ``allow_mcp_tool_ids`` closes
+    that path (``pocketpaw_daytona`` is not in ``ALWAYS_ALLOWED_MCP_SERVERS``),
+    and the scan below is what pins it. Deliberately a PREFIX scan, not a list of
+    the eight tool names known today, so a daytona tool added later is caught
+    without anyone remembering to update this test.
+
+    Note we assert only ABSENCE. ``code_mode`` itself will not appear here until
+    CD-2 lands its MCP server: ``allow_mcp_tool_ids`` is a FILTER over the tools
+    that exist, not a grant that conjures one. Its presence is pinned at the
+    profile level in ``test_code_profile_ripple_off_and_scoped_to_code_mode``."""
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+    from pocketpaw.config import get_settings
+
+    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+    backend = ClaudeSDKBackend(get_settings())
+
+    built = await backend._build_options(
+        "refactor this",
+        system_prompt="you are on the code surface",
+        history=None,
+        session_key=None,
+        deny_mcp_tool_ids=profile.deny_mcp_tool_ids,
+        allow_sdk_tools=profile.allowed_sdk_tools or frozenset(),
+        allow_mcp_tool_ids=profile.allow_mcp_tool_ids,
+        skill_names=profile.skill_names,
+        stderr_sink=[],
+    )
+    effective = set(built.options_kwargs["allowed_tools"])
+
+    for tool in sorted(_FILESYSTEM_BUILTINS):
+        assert tool not in effective, (
+            f"{tool} reached the SDK's effective allowlist on /code — the agent "
+            f"would use it against the BACKEND SERVER's filesystem, not the "
+            f"user's project. Effective allowlist: {sorted(effective)}"
+        )
+    assert "Agent" not in effective, (
+        "Agent reached the effective allowlist — a spawned subagent is an "
+        "unsupervised second path to the tools denied above"
+    )
+
+    # The SECOND wrong-machine path: the Daytona sandbox tools. Prefix scan, so a
+    # daytona tool added after this test was written is caught automatically.
+    leaked_daytona = sorted(t for t in effective if t.startswith("mcp__pocketpaw_daytona__"))
+    assert not leaked_daytona, (
+        f"Daytona tools reached the effective allowlist on /code: {leaked_daytona}. "
+        f"These operate on the SUPERSEDED cloud-projects sandbox, not the user's "
+        f"project — the agent would edit a machine that does not hold their code "
+        f"and report success. The user's project is reachable only via code_mode."
+    )
+
+    # Positive controls, so none of the assertions above can pass vacuously.
+    # WebSearch proves the built-in path ran and was not emptied wholesale.
+    assert "WebSearch" in effective
+    # And at least one MCP id must survive, or a future change that nulls out MCP
+    # resolution entirely would make every `not in` above trivially true while the
+    # surface silently loses code_mode too. Not pinned to a specific server — any
+    # surviving mcp__ id proves the MCP filter ran on a populated list.
+    assert any(t.startswith("mcp__") for t in effective), (
+        "no mcp__ tool survived the allow-list filter — MCP resolution produced "
+        "nothing, so the absence assertions above prove nothing"
+    )
+
+
+def test_code_profile_is_static_and_meta_independent() -> None:
+    """The /code profile does not vary with the client's storage hints.
+
+    The old handler branched on ``workspace_vm`` / ``is_cloud_storage`` /
+    ``current_dir``; the surface no longer has storage flavours, so a legacy
+    client stamping them must not shift the tool policy."""
+    plain = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+    legacy = resolve_profile(SurfaceKind.CODE, _LEGACY_STORAGE_META)
+
+    assert plain == legacy
+
+
+def test_surface_registry_import_assertion_still_passes() -> None:
+    """The module-import completeness assertion survives the CODE row rewrite —
+    every ``SurfaceKind`` still has exactly one spec, and every spec a real
+    kind."""
+    from pocketpaw_ee.cloud.surface.surface_registry import (
+        SURFACES,
+        _assert_registry_complete,
+    )
+
+    _assert_registry_complete()  # raises if the registry drifted
+    code_specs = [spec for spec in SURFACES if spec.kind is SurfaceKind.CODE]
+    assert len(code_specs) == 1
+    # CODE stays STATIC — a literal profile, not a resolver.
+    assert code_specs[0].profile is not None
+    assert code_specs[0].profile_resolver is None
 
 
 def test_studio_and_code_kinds_map_from_wire_strings() -> None:


### PR DESCRIPTION
The `/code` surface is about to be driven by the main PocketPaw agent. Before that lands, its `SurfaceProfile` needs to stop handing that agent a shell and file read/write on the machine it runs on.

## The bug this removes

The CODE profile carried `allowed_sdk_tools={Bash, Read, Write, Edit, Glob, Grep}`, and the preamble branched on four `SurfaceMeta` hints into three storage flavours: a Daytona-VM branch naming MCP tools, an S3 branch pointing at `/cloud/projects/{name}/files/*`, and a local-disk branch.

All three were stale. The current `/code` page stamps none of those hints, so every turn fell through to the local-disk branch and told the agent "your working directory is the workspace root" — the backend server's filesystem, not the user's project. The agent would read and write the server's disk and report success. The Daytona tools were equally stale; they address an older cloud-projects model that knows nothing of the current `codeproject` + `CodeFileSession` runtime.

Nothing routes to the main agent on `/code` yet, so this was latent rather than observed. The task that switches it on is the rail cutover, which is why this merges first.

## What actually removes the tools

Not the field that looked like it would. `allowed_sdk_tools` is additive, not restrictive — `claude_sdk.py` resolves `effective = (agent_tools ∪ allow) − deny`, and the file/shell built-ins are in the SDK's default set already, so listing them there granted nothing and restricted nothing. `allow_mcp_tool_ids` cannot help either; it filters only `mcp__*` ids and never touches built-ins.

`deny_mcp_tool_ids` carrying the bare tool names is the only lever, which is exactly why `_SITES_BUILTIN_DENY` exists. `_CODE_BUILTIN_DENY` mirrors it.

`Agent` is denied alongside the six for a reason beyond parity with /sites: under this design `code_mode` is the only path to the user's files, and a spawned subagent is a second path with its own tool resolution and no supervision from this profile. `WebSearch` / `WebFetch` / `Skill` stay — researching an API to write against is legitimate and reaches no filesystem.

`skill_names` drops to empty. The bundled `code` skill teaches nothing but the denied built-ins, so keeping it would inject an instruction to call tools the agent no longer has. Its edit→run→verify discipline is worth keeping and gets retargeted onto `code_mode` in the tool task; rewriting the skill here would teach a tool that does not exist yet.

## Testing

The key test drives the real allowlist computation through `_build_options` and asserts absence in what the SDK would actually launch with, because a membership check on the profile is precisely the test this bug passes. Reverting the profile to its old shape makes it fail with `Bash` in the effective allowlist.

It guards both wrong-machine paths: the built-ins, and the `mcp__pocketpaw_daytona__*` family, as a prefix scan so a daytona tool added later is caught without anyone remembering to update the test. Two positive controls keep the absence assertions from passing vacuously.

`tests/cloud/surface/` is green apart from two failures that predate this branch and are unrelated (a `pinned-widgets` assertion in the home handler, and a /sites deny-set assertion in `test_run_core.py` that `3ea93fe8` widened without updating).

## Follow-up, not in this PR

`code.py` was the last reader of `current_dir` / `storage_root` / `is_cloud_storage` / `workspace_vm`. Those four are now dead on both `SurfaceMeta` and the wire DTO, with docstrings describing a storage model that no longer exists, and `surface/service.py:306` still threads `current_dir` into a field nothing consumes. Removing them touches the wire contract, so it belongs with the cutover cleanup rather than here.