### PR TITLE
Park a backend turn until the browser answers

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -174,6 +174,13 @@ cloud Mongo client is connected — so it hard-failed EVERY workspace-less run
 ``run_core.execute_run`` now wraps the run lifecycle in ``mark_cloud_chat_run``
 and the jail fails closed only when this marker is set; otherwise it falls back
 to ``settings.file_jail_path`` (pre-ART-2 behavior).
+
+Changes: 2026-07-22 (CD-1, feat/code-delegate-channel) — added
+``has_sse_event_sink()`` beside ``push_sse_event``. Read-only introspection of
+the same ContextVar, added for Code Mode's browser-delegate channel: that caller
+pushes a frame and then PARKS waiting for the browser's reply, so a push into no
+stream has to be a fast, distinct failure rather than a silent no-op followed by
+a full-length timeout. No behaviour change to any existing push path.
 """
 
 from __future__ import annotations
@@ -380,6 +387,21 @@ def push_sse_event(name: str, data: dict[str, Any]) -> None:
         sink.put_nowait((name, data))
     except Exception:
         logger.debug("sse sink rejected %s payload", name, exc_info=True)
+
+
+def has_sse_event_sink() -> bool:
+    """True when there IS a live stream to push to.
+
+    ``push_sse_event`` is deliberately a no-op without a sink, which is right for
+    an observability frame nobody is obliged to see. It is wrong for a frame the
+    caller then WAITS on: Code Mode's ``code_delegate`` (see
+    ``cloud/codeagent/delegates.py``) parks a turn until the browser answers, so
+    pushing into nothing would park for the full timeout before reporting a
+    failure that was knowable at the push. This lets such a caller fail fast and
+    say which problem it hit — "no browser attached" rather than "the browser
+    was slow".
+    """
+    return _sse_event_sink.get() is not None
 
 
 def push_pocket_mutation(payload: dict[str, Any]) -> None:

--- a/ee/pocketpaw_ee/cloud/codeagent/__init__.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/__init__.py
@@ -5,3 +5,11 @@
 # the context it read through its own CodeFileSession, which is what lets one
 # endpoint serve both the Daytona and WebContainer runtimes. Supersedes
 # websandbox/edit.py (deleted in CA-4).
+#
+# Modified: 2026-07-22 (CD-1). Adds a fifth file, ``delegates.py`` — the
+# browser-delegate channel. It breaks the 4-file shape on purpose: it is not
+# another entity but the transport under one route, and the same "the work
+# happens in the browser" constraint that made the turn stateless is what makes
+# a backend tool have to park on a future and wait for the tab to answer.
+# Keeping that rendezvous out of ``service.py`` keeps that file about calling a
+# model.

--- a/ee/pocketpaw_ee/cloud/codeagent/delegates.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/delegates.py
@@ -1,0 +1,430 @@
+# delegates.py — The browser-delegate channel for Code Mode (CD-1).
+#
+# Created 2026-07-22 (feat/code-delegate-channel). The main chat agent is about
+# to gain ONE tool, ``code_mode``, that hands a coding task to the Code Mode
+# sub-agent. That tool runs in the BACKEND, but the work has to happen in the
+# USER'S BROWSER — a WebContainer project runs in the tab and has no server-side
+# row for a backend to reach, which is the same constraint that shaped the rest
+# of this module (see ``service.py``: the server never opens a file).
+#
+# So the call is inverted. The backend does not execute the task; it PARKS on a
+# future, pushes a ``code_delegate`` frame down the live SSE stream, and waits
+# for the browser to post the answer back to ``POST /codeagent/resolve``. This
+# module is both ends of that rendezvous and nothing else — it knows what a
+# correlation id is and how to wake a parked caller, and it knows nothing about
+# what the task said or what the browser did with it.
+#
+# Modelled on ``pocketpaw.agents.plan_mode.PlanApprovalManager``, the shipped
+# precedent for parking a backend caller with a timeout. Two deliberate
+# differences: this is keyed by CORRELATION ID rather than by session (one turn
+# can delegate more than once, and a session key cannot tell two of them apart),
+# and the future carries a RESULT PAYLOAD rather than a bare approve/reject.
+#
+# The one property everything here is built around: A PARKED CALLER MUST NEVER
+# HANG. A browser that closed the tab, a user that navigated away, a frame that
+# was pushed into a stream nobody is reading — each of those has to end as an
+# error the tool can report, not as a chat turn that sits there forever. Every
+# exit from ``wait`` therefore produces a ``DelegateOutcome``, and every exit
+# removes the registry entry.
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import uuid4
+
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+
+logger = logging.getLogger(__name__)
+
+# ── The park budget ─────────────────────────────────────────────────────────
+# How long the backend will hold a turn open waiting for the browser.
+#
+# This is a MACHINE round trip, not a human decision, so ``plan_mode``'s 300s
+# (a person reading a plan and clicking approve) is the wrong reference. The
+# right lower bound is the browser's own work: the delegate frame kicks off at
+# least one ``POST /codeagent/turn``, and that call alone is capped at
+# ``MODEL_TIMEOUT_SECONDS`` = 120. Anything under two minutes would therefore
+# expire the delegate BEFORE the sub-agent's own model call could even fail, and
+# the user would be told "the browser did not answer" about a browser that was
+# still working.
+#
+# 180 is that floor plus headroom for the SSE hop and the client's own fs reads.
+# It deliberately does NOT cover the worst case — Code Mode's retrieval loop can
+# run up to ``MAX_TOOL_ITERATIONS`` rounds, which no bounded park would survive.
+# That is the correct trade: this number is a LIVENESS guarantee for the chat
+# turn, not a spend budget for the sub-agent. A long task that overruns it
+# reports a clean timeout instead of holding a stream open indefinitely.
+#
+# A spike will tune this against real delegate latencies; it is a module
+# constant so that tuning is a one-line change with no call sites to chase.
+CODE_DELEGATE_TIMEOUT_SECONDS = 180.0
+
+# Ceiling on the payload the browser may post back. The client caps what it
+# sends, but a server that trusts a client-supplied length has no ceiling at
+# all — the same reasoning as ``MAX_TOOL_RESULT_CHARS`` in ``domain.py``, and
+# the same order of magnitude as one turn's whole context budget.
+MAX_DELEGATE_RESULT_CHARS = 200_000
+
+# The SSE event name the browser listens for.
+DELEGATE_EVENT = "code_delegate"
+
+# Machine-readable failure codes on the outcome. They are codes rather than
+# exceptions because the caller is an agent TOOL: a tool that raises kills the
+# turn, a tool that returns "the browser did not answer" lets the model say so.
+ERROR_TIMEOUT = "code_delegate.timeout"
+ERROR_NO_CLIENT = "code_delegate.no_client"
+ERROR_ABORTED = "code_delegate.aborted"
+
+
+@dataclass(frozen=True)
+class DelegateOutcome:
+    """How one delegation ended.
+
+    ``ok`` is the branch the caller reads. On success ``result`` is whatever the
+    browser posted back, verbatim — this module does not interpret it, because
+    the shape belongs to the Code Mode client and pinning it here would mean two
+    places to change every time the sub-agent learns a new answer shape.
+
+    On failure ``error`` carries one of the module's codes and ``message`` is the
+    sentence a model can repeat to the user. Both are always present on a
+    failure, and both are empty on a success.
+    """
+
+    ok: bool
+    result: dict = field(default_factory=dict)
+    error: str = ""
+    message: str = ""
+
+    def to_dict(self) -> dict:
+        """Flatten for a tool result. Keeps the failure codes machine-readable
+        so a caller can branch on ``error`` rather than parsing prose."""
+        if self.ok:
+            return {"ok": True, "result": self.result}
+        return {"ok": False, "error": self.error, "message": self.message}
+
+
+@dataclass
+class _Pending:
+    """One parked caller. ``workspace_id`` is captured at park time so the
+    resolve route can check that the poster belongs to the same tenant as the
+    parked turn — the correlation id is unguessable, but tenancy that rests on
+    unguessability is not tenancy."""
+
+    workspace_id: str
+    future: asyncio.Future[DelegateOutcome]
+
+
+def _set_if_pending(fut: asyncio.Future[DelegateOutcome], outcome: DelegateOutcome) -> None:
+    """Settle a future, tolerating a race that already settled it."""
+    if not fut.done():
+        fut.set_result(outcome)
+
+
+class PendingDelegates:
+    """Correlation id → parked caller.
+
+    In-process and single-loop by construction, which is the honest description
+    of the transport it sits on: ``push_sse_event`` writes to a queue held by the
+    live HTTP stream in THIS worker. A resolve that lands on a different worker
+    finds no entry and is rejected as unknown — a clean 404 rather than a silent
+    drop, but still a real limitation worth knowing about before this ships
+    behind more than one uvicorn process (see the report's concerns).
+    """
+
+    def __init__(self) -> None:
+        self._pending: dict[str, _Pending] = {}
+
+    def __len__(self) -> int:
+        return len(self._pending)
+
+    def __bool__(self) -> bool:
+        """A registry is a registry whether or not anything is parked in it.
+
+        Without this, ``__len__`` makes an EMPTY registry falsy, and the obvious
+        way to write an optional-dependency default — ``registry or
+        get_pending_delegates()`` — silently swaps a caller's injected registry
+        for the process singleton at exactly the moment it is empty, which is
+        every first use. The call sites use ``is None`` anyway; this closes the
+        trap for the next one that does not.
+        """
+        return True
+
+    def __contains__(self, corr_id: object) -> bool:
+        return corr_id in self._pending
+
+    def open(self, workspace_id: str) -> str:
+        """Register a new parked slot and return its correlation id.
+
+        Split from ``wait`` on purpose: the caller has to get the id BEFORE it
+        pushes the frame, or the browser could answer a correlation id the
+        registry has not heard of yet.
+        """
+        corr_id = uuid4().hex
+        fut: asyncio.Future[DelegateOutcome] = asyncio.get_running_loop().create_future()
+        self._pending[corr_id] = _Pending(workspace_id=workspace_id, future=fut)
+        return corr_id
+
+    def discard(self, corr_id: str) -> None:
+        """Drop a slot without settling it. For the caller that failed to push —
+        nobody is waiting on that future, so there is nothing to wake."""
+        self._pending.pop(corr_id, None)
+
+    async def wait(
+        self,
+        corr_id: str,
+        *,
+        timeout: float = CODE_DELEGATE_TIMEOUT_SECONDS,
+    ) -> DelegateOutcome:
+        """Park until the browser resolves ``corr_id``, or the budget runs out.
+
+        Returns an outcome on EVERY path, including timeout — a tool that raises
+        on a slow browser turns a recoverable delay into a dead turn.
+
+        The ``finally`` is the anti-leak guarantee: whether this returns, times
+        out, or the awaiting task is cancelled (a disconnected client tears down
+        the whole run task), the entry leaves the registry. A stranded entry is
+        not just memory — it is a correlation id that a late browser could
+        resolve into a future nobody is reading.
+        """
+        entry = self._pending.get(corr_id)
+        if entry is None:
+            # Only reachable if something discarded the slot between open and
+            # wait. Report it rather than parking on a future nothing can reach.
+            return DelegateOutcome(
+                ok=False,
+                error=ERROR_ABORTED,
+                message="The delegated task was cancelled before it started.",
+            )
+        try:
+            return await asyncio.wait_for(entry.future, timeout=timeout)
+        except TimeoutError:
+            logger.warning(
+                "codeagent.delegate timed out after %.0fs corr=%s ws=%s",
+                timeout,
+                corr_id,
+                entry.workspace_id,
+            )
+            return DelegateOutcome(
+                ok=False,
+                error=ERROR_TIMEOUT,
+                message=(
+                    "The browser did not finish the delegated task in "
+                    f"{int(timeout)}s. It may still be running in the tab."
+                ),
+            )
+        finally:
+            self._pending.pop(corr_id, None)
+
+    def resolve(self, corr_id: str, result: dict, *, workspace_id: str) -> bool:
+        """Wake the caller parked on ``corr_id``. False if there is nobody there.
+
+        The entry is popped BEFORE the future is settled, which makes a duplicate
+        resolve indistinguishable from an unknown id — one lookup miss, one
+        rejection path, no second mechanism to keep in step with the first.
+
+        A workspace mismatch is also a miss rather than a distinct error: telling
+        a caller "that id exists but is not yours" confirms the id exists.
+        """
+        entry = self._pending.get(corr_id)
+        if entry is None:
+            return False
+        if entry.workspace_id != workspace_id:
+            logger.warning(
+                "codeagent.delegate resolve rejected: workspace mismatch corr=%s", corr_id
+            )
+            return False
+        self._pending.pop(corr_id, None)
+        return self._settle(entry.future, DelegateOutcome(ok=True, result=result))
+
+    def abort(self, corr_id: str, *, message: str = "") -> bool:
+        """Fail a parked caller deliberately (shutdown, stream teardown).
+
+        Distinct from ``discard``: this one WAKES the waiter with an error rather
+        than leaving it to time out, so a known-dead delegation costs the user
+        nothing instead of three minutes.
+        """
+        entry = self._pending.pop(corr_id, None)
+        if entry is None:
+            return False
+        return self._settle(
+            entry.future,
+            DelegateOutcome(
+                ok=False,
+                error=ERROR_ABORTED,
+                message=message or "The delegated task was cancelled.",
+            ),
+        )
+
+    def abort_all(self, *, message: str = "") -> int:
+        """Abort every parked caller. Returns how many were woken."""
+        return sum(1 for corr_id in list(self._pending) if self.abort(corr_id, message=message))
+
+    @staticmethod
+    def _settle(fut: asyncio.Future[DelegateOutcome], outcome: DelegateOutcome) -> bool:
+        """Set a result on the future's OWN loop.
+
+        Normally that is the loop we are already on and this is a plain
+        ``set_result``. The cross-loop branch exists because the resolve arrives
+        on an HTTP request while the parked caller lives in a run task, and
+        nothing in the type system guarantees those share a loop forever;
+        ``set_result`` from the wrong loop corrupts the waiter's scheduling in a
+        way that is very hard to read back from a bug report.
+        """
+        if fut.done():
+            return False
+        loop = fut.get_loop()
+        try:
+            running: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
+        except RuntimeError:  # pragma: no cover — resolve is always called from a loop
+            running = None
+        if running is loop:
+            fut.set_result(outcome)
+        else:  # pragma: no cover — single-loop in every shipped deployment
+            loop.call_soon_threadsafe(_set_if_pending, fut, outcome)
+        return True
+
+
+# Singleton, mirroring ``plan_mode.get_plan_manager``. Both ends of the
+# rendezvous — an MCP tool deep in a run task and a FastAPI route — need the
+# SAME registry and neither can be handed one, so the process owns it.
+_registry: PendingDelegates | None = None
+
+
+def get_pending_delegates() -> PendingDelegates:
+    """Get the process-wide pending-delegate registry."""
+    global _registry
+    if _registry is None:
+        _registry = PendingDelegates()
+    return _registry
+
+
+async def delegate_to_browser(
+    workspace_id: str,
+    task: str,
+    mode: str = "ask",
+    *,
+    timeout: float = CODE_DELEGATE_TIMEOUT_SECONDS,
+    registry: PendingDelegates | None = None,
+    push: Callable[[str, dict[str, Any]], None] | None = None,
+) -> DelegateOutcome:
+    """Hand ``task`` to the browser's Code Mode sub-agent and wait for its answer.
+
+    This is the whole outbound half of the channel and the only entry point
+    CD-2's ``code_mode`` tool needs: register a slot, push one ``code_delegate``
+    frame, park.
+
+    It FAILS FAST when there is no SSE stream in scope. ``push_sse_event`` is a
+    documented no-op outside a stream, so without that check a tool invoked from
+    a CLI handler, a background job, or a unit test would push into nothing and
+    then park for the full budget before reporting a timeout that was knowable
+    at once. The distinct ``no_client`` code also gives the model something true
+    to say — "there is no browser attached" is a different problem from "the
+    browser was slow".
+
+    ``registry`` and ``push`` are DI seams, matching the ``client=`` seam
+    ``service.run_turn`` uses so the suite runs with no stream and no network.
+    """
+    reg = get_pending_delegates() if registry is None else registry
+
+    if push is None:
+        # Deferred import: every other cloud module reaches ``agent_service``
+        # this way, because importing it at module scope pulls the chat stack
+        # into anything that touches codeagent and reintroduces a cycle.
+        from pocketpaw_ee.cloud.chat.agent_service import has_sse_event_sink, push_sse_event
+
+        if not has_sse_event_sink():
+            logger.debug("codeagent.delegate refused: no SSE stream in scope")
+            return DelegateOutcome(
+                ok=False,
+                error=ERROR_NO_CLIENT,
+                message=(
+                    "No browser session is attached to this conversation, so the "
+                    "coding task cannot be run."
+                ),
+            )
+        push = push_sse_event
+
+    corr_id = reg.open(workspace_id)
+    try:
+        push(DELEGATE_EVENT, {"corrId": corr_id, "task": task, "mode": mode})
+    except Exception:  # noqa: BLE001 — a failed push must not kill the turn
+        logger.warning("codeagent.delegate push failed corr=%s", corr_id, exc_info=True)
+        # Nobody is parked on this future yet, so drop the slot rather than
+        # settling it — an abort here would wake a waiter that does not exist.
+        reg.discard(corr_id)
+        return DelegateOutcome(
+            ok=False,
+            error=ERROR_NO_CLIENT,
+            message="The coding task could not be sent to the browser.",
+        )
+
+    logger.debug(
+        "codeagent.delegate parked corr=%s ws=%s mode=%s timeout=%.0f",
+        corr_id,
+        workspace_id,
+        mode,
+        timeout,
+    )
+    return await reg.wait(corr_id, timeout=timeout)
+
+
+def resolve_pending(
+    workspace_id: str,
+    corr_id: str,
+    result: dict,
+    *,
+    registry: PendingDelegates | None = None,
+) -> None:
+    """Inbound half: deliver the browser's answer to the parked caller.
+
+    Raises ``NotFound`` when there is nothing parked under ``corr_id`` — which
+    covers an unknown id, a SECOND resolve of an id already answered, a resolve
+    that arrives after the park timed out, and a resolve from the wrong
+    workspace. They are one case on purpose: in all four, the honest answer is
+    "there is no turn here waiting for you", and splitting them would leak
+    whether a given id ever existed.
+    """
+    _guard_result_size(result)
+    reg = get_pending_delegates() if registry is None else registry
+    if not reg.resolve(corr_id, result, workspace_id=workspace_id):
+        raise NotFound("code_delegate", corr_id)
+
+
+def _guard_result_size(result: dict) -> None:
+    """Reject a payload past ``MAX_DELEGATE_RESULT_CHARS``.
+
+    Measured on the serialized form, since that is what the parked caller will
+    end up putting in front of a model. A payload that cannot be serialized at
+    all is rejected here too rather than exploding later inside a tool result.
+    """
+    try:
+        size = len(json.dumps(result, default=str))
+    except (TypeError, ValueError) as exc:
+        raise ValidationError(
+            "code_delegate.invalid_result",
+            "The delegate result could not be read",
+        ) from exc
+    if size > MAX_DELEGATE_RESULT_CHARS:
+        raise ValidationError(
+            "code_delegate.result_too_large",
+            f"The delegate result exceeds {MAX_DELEGATE_RESULT_CHARS} characters",
+        )
+
+
+__all__ = [
+    "CODE_DELEGATE_TIMEOUT_SECONDS",
+    "DELEGATE_EVENT",
+    "ERROR_ABORTED",
+    "ERROR_NO_CLIENT",
+    "ERROR_TIMEOUT",
+    "MAX_DELEGATE_RESULT_CHARS",
+    "DelegateOutcome",
+    "PendingDelegates",
+    "delegate_to_browser",
+    "get_pending_delegates",
+    "resolve_pending",
+]

--- a/ee/pocketpaw_ee/cloud/codeagent/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/dto.py
@@ -15,6 +15,14 @@
 # permission set. It defaults to ``ask``, so a caller that omits it gets the
 # read-only tools — the failure mode of a forgotten field is "cannot edit", not
 # "can edit unexpectedly".
+#
+# Modified: 2026-07-22 (CD-1, delegate channel). Adds
+# ``DelegateResolveRequest`` / ``DelegateResolveResponse`` for
+# ``POST /codeagent/resolve`` — the INBOUND half of the browser-delegate
+# rendezvous (``delegates.py``). Note what is not here: no schema for ``result``.
+# The payload is whatever the Code Mode client answered with, and pinning its
+# shape at the wire would mean changing this file every time the sub-agent
+# learns a new answer shape, for a value the backend only forwards.
 from __future__ import annotations
 
 from typing import Literal
@@ -139,11 +147,37 @@ class AgentTurnResponse(BaseModel):
     truncated: bool = False
 
 
+class DelegateResolveRequest(BaseModel):
+    """The browser handing back the answer to one ``code_delegate`` frame.
+
+    ``corrId`` is the id the backend minted when it parked, echoed verbatim. It
+    is the ONLY thing tying this POST to a waiting turn, which is why it is
+    length-bounded here rather than trusted — an unbounded id would be a free
+    dictionary key on a process-global registry.
+    """
+
+    corrId: str = Field(..., min_length=1, max_length=128)
+    result: dict = Field(default_factory=dict)
+
+
+class DelegateResolveResponse(BaseModel):
+    """Acknowledgement only. There is nothing to return — the value went to the
+    parked caller, not back down this request. ``accepted`` is always true on a
+    2xx; an unresolvable ``corrId`` is a 404 (``code_delegate.not_found``), not a
+    200 with ``accepted: false``, so a client cannot mistake "nobody was waiting"
+    for success.
+    """
+
+    accepted: bool = True
+
+
 __all__ = [
     "AgentMessage",
     "AgentTurnRequest",
     "AgentTurnResponse",
     "ContextItem",
+    "DelegateResolveRequest",
+    "DelegateResolveResponse",
     "ToolCall",
     "ToolResult",
 ]

--- a/ee/pocketpaw_ee/cloud/codeagent/router.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/router.py
@@ -18,6 +18,18 @@
 # the workspace check is about METERING and abuse (this route spends money),
 # not about authorizing access to a row. That is why it fails closed on a
 # missing workspace but does no per-object lookup.
+#
+# Modified: 2026-07-22 (CD-1, delegate channel). Second route:
+#
+#   POST /codeagent/resolve — hand a delegated task's result back to the backend.
+#
+# It is the return leg of a call the BACKEND started: the main agent's
+# ``code_mode`` tool pushes a ``code_delegate`` SSE frame and parks, the browser
+# does the work (it is the only side that can — a WebContainer project lives in
+# the tab), and this route wakes the parked turn. Unlike ``/turn`` it spends no
+# money and calls no model; the workspace check here is genuine tenancy, since
+# the correlation id it carries names another user's parked turn if it names
+# anything at all.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
@@ -25,7 +37,12 @@ from fastapi import APIRouter, Depends
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.codeagent import service as codeagent_service
-from pocketpaw_ee.cloud.codeagent.dto import AgentTurnRequest, AgentTurnResponse
+from pocketpaw_ee.cloud.codeagent.dto import (
+    AgentTurnRequest,
+    AgentTurnResponse,
+    DelegateResolveRequest,
+    DelegateResolveResponse,
+)
 from pocketpaw_ee.cloud.license import require_license
 
 router = APIRouter(
@@ -51,3 +68,18 @@ async def run_turn(
     mode it PROPOSES one, and the client holds it for the user's review."""
     workspace_id = _require_workspace(ctx)
     return await codeagent_service.run_turn(workspace_id, ctx.user_id, body)
+
+
+@router.post("/resolve", response_model=DelegateResolveResponse)
+async def resolve_delegate(
+    body: DelegateResolveRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> DelegateResolveResponse:
+    """Deliver a delegated task's result to the backend turn waiting on it.
+
+    404 (``code_delegate.not_found``) when nothing is parked under the given
+    ``corrId`` — including a second POST for an id already answered, and one
+    that arrives after the park timed out.
+    """
+    workspace_id = _require_workspace(ctx)
+    return await codeagent_service.resolve_delegate(workspace_id, ctx.user_id, body)

--- a/ee/pocketpaw_ee/cloud/codeagent/service.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/service.py
@@ -37,12 +37,19 @@
 # That matters more than it looks: the client executes whatever it is handed, so
 # this filter is the only thing standing between a hallucinated ``deleteEntry``
 # and a browser that would run it.
+#
+# Modified: 2026-07-22 (CD-1, delegate channel). Adds ``resolve_delegate`` — the
+# service half of ``POST /codeagent/resolve``. It is a thin pass-through to
+# ``delegates.resolve_pending`` and exists only so the router keeps ONE shape
+# (router → service) for both of its routes; the rendezvous logic itself has no
+# business in this file, which is about calling a model.
 from __future__ import annotations
 
 import logging
 import os
 
 from pocketpaw_ee.cloud._core.errors import CloudError, with_cause
+from pocketpaw_ee.cloud.codeagent import delegates
 from pocketpaw_ee.cloud.codeagent.domain import (
     MAX_OUTPUT_TOKENS,
     MAX_TOOL_ITERATIONS,
@@ -55,6 +62,8 @@ from pocketpaw_ee.cloud.codeagent.domain import (
 from pocketpaw_ee.cloud.codeagent.dto import (
     AgentTurnRequest,
     AgentTurnResponse,
+    DelegateResolveRequest,
+    DelegateResolveResponse,
     ToolCall,
     ToolResult,
 )
@@ -345,4 +354,32 @@ async def run_turn(
     )
 
 
-__all__ = ["run_turn"]
+async def resolve_delegate(
+    workspace_id: str,
+    user_id: str,
+    body: DelegateResolveRequest | dict,
+) -> DelegateResolveResponse:
+    """Deliver the browser's answer to the turn parked on ``body.corrId``.
+
+    Raises ``NotFound`` when nothing is parked under that id — unknown, already
+    resolved, already timed out, or belonging to another workspace all land
+    there, deliberately (see ``delegates.resolve_pending``).
+
+    ``user_id`` is carried for logging symmetry with ``run_turn`` and is NOT an
+    authorization input: the delegate belongs to a workspace's live stream, and
+    two tabs of the same workspace legitimately share it.
+    """
+    # no-event: nothing is persisted. The whole write is waking an in-process
+    # future, and the caller it wakes is the thing that goes on to emit.
+    body = DelegateResolveRequest.model_validate(body)
+    logger.debug(
+        "codeagent.resolve ws=%s user=%s corr=%s",
+        workspace_id,
+        user_id,
+        body.corrId,
+    )
+    delegates.resolve_pending(workspace_id, body.corrId, body.result)
+    return DelegateResolveResponse(accepted=True)
+
+
+__all__ = ["resolve_delegate", "run_turn"]

--- a/tests/cloud/test_codeagent_delegates.py
+++ b/tests/cloud/test_codeagent_delegates.py
@@ -1,0 +1,400 @@
+# test_codeagent_delegates.py — The browser-delegate channel (CD-1).
+#
+# Created 2026-07-22 (feat/code-delegate-channel). Covers the rendezvous that
+# lets a BACKEND tool have work done in the USER'S BROWSER: park on a future,
+# push a `code_delegate` SSE frame, wait for `POST /codeagent/resolve`.
+#
+# The property most of these tests exist to defend is "a parked caller never
+# hangs". Timeout, an abort, a push that failed, no stream at all — each has to
+# end as a `DelegateOutcome` the tool can report, and each has to leave the
+# registry empty. Every test therefore asserts on the outcome AND on `len(reg)`;
+# a leaked entry is a correlation id a late browser could resolve into a future
+# nobody is reading.
+#
+# Kept apart from test_codeagent*.py (the model turn) — those drive a fake
+# Anthropic client, these drive no model at all.
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.codeagent import delegates
+from pocketpaw_ee.cloud.codeagent import service as codeagent_service
+from pocketpaw_ee.cloud.codeagent.delegates import (
+    DELEGATE_EVENT,
+    ERROR_ABORTED,
+    ERROR_NO_CLIENT,
+    ERROR_TIMEOUT,
+    MAX_DELEGATE_RESULT_CHARS,
+    DelegateOutcome,
+    PendingDelegates,
+    delegate_to_browser,
+    get_pending_delegates,
+    resolve_pending,
+)
+from pocketpaw_ee.cloud.codeagent.dto import DelegateResolveRequest
+
+WS = "ws-1"
+OTHER_WS = "ws-2"
+USER = "user-1"
+
+# Short enough that a "does it time out" test costs milliseconds, long enough
+# that a slow CI box does not trip it on the paths that should NOT time out.
+FAST = 0.05
+SLOW = 5.0
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+class _Recorder:
+    """Stands in for ``push_sse_event``. Records frames so a test can read the
+    corrId the backend minted — the browser's only handle on the parked turn."""
+
+    def __init__(self) -> None:
+        self.frames: list[tuple[str, dict]] = []
+
+    def __call__(self, name: str, data: dict) -> None:
+        self.frames.append((name, data))
+
+    @property
+    def corr_id(self) -> str:
+        return self.frames[0][1]["corrId"]
+
+
+async def _park(
+    reg: PendingDelegates,
+    push: object,
+    *,
+    workspace_id: str = WS,
+    task: str = "add a test",
+    mode: str = "ask",
+    timeout: float = SLOW,
+) -> asyncio.Task[DelegateOutcome]:
+    """Start a delegation and wait until it is actually parked.
+
+    The poll matters: without it a test can resolve a corrId before the caller
+    has reached ``wait``, which passes for the wrong reason. It watches for the
+    count to GROW rather than to be non-zero, so a test that parks twice does
+    not have its second call satisfied by the first one's entry.
+    """
+    before = len(reg)
+    task_handle = asyncio.create_task(
+        delegate_to_browser(
+            workspace_id,
+            task,
+            mode,
+            timeout=timeout,
+            registry=reg,
+            push=push,  # type: ignore[arg-type]
+        )
+    )
+    for _ in range(200):
+        if len(reg) > before:
+            return task_handle
+        await asyncio.sleep(0)
+    task_handle.cancel()
+    raise AssertionError("delegation never parked")
+
+
+@pytest.fixture
+def reg() -> PendingDelegates:
+    return PendingDelegates()
+
+
+@pytest.fixture
+def push() -> _Recorder:
+    return _Recorder()
+
+
+# ── The happy path ──────────────────────────────────────────────────────────
+
+
+async def test_park_then_resolve_returns_the_payload(reg, push):
+    handle = await _park(reg, push)
+
+    resolve_pending(WS, push.corr_id, {"answer": "done", "files": ["a.py"]}, registry=reg)
+    outcome = await asyncio.wait_for(handle, timeout=SLOW)
+
+    assert outcome.ok is True
+    assert outcome.result == {"answer": "done", "files": ["a.py"]}
+    assert outcome.error == ""
+    assert len(reg) == 0
+
+
+async def test_push_carries_corr_id_task_and_mode(reg, push):
+    handle = await _park(reg, push, task="rename the handler", mode="edit")
+
+    name, data = push.frames[0]
+    assert name == DELEGATE_EVENT
+    assert data["task"] == "rename the handler"
+    assert data["mode"] == "edit"
+    assert data["corrId"]
+
+    resolve_pending(WS, data["corrId"], {}, registry=reg)
+    await asyncio.wait_for(handle, timeout=SLOW)
+
+
+async def test_result_is_forwarded_verbatim(reg, push):
+    """The channel does not interpret the payload — the shape belongs to the
+    Code Mode client, and a backend that reshaped it would be a second place to
+    change every time the sub-agent learns a new answer shape."""
+    handle = await _park(reg, push)
+    payload = {"nested": {"diff": [1, 2, 3]}, "ok": False, "n": None}
+
+    resolve_pending(WS, push.corr_id, payload, registry=reg)
+    outcome = await asyncio.wait_for(handle, timeout=SLOW)
+
+    assert outcome.result == payload
+
+
+async def test_two_delegations_get_distinct_ids(reg, push):
+    first = await _park(reg, push)
+    second_push = _Recorder()
+    second = await _park(reg, second_push)
+
+    assert push.corr_id != second_push.corr_id
+    assert len(reg) == 2
+
+    # Resolving one must not disturb the other — the registry is keyed by
+    # correlation id precisely so one turn can delegate more than once.
+    resolve_pending(WS, second_push.corr_id, {"which": "second"}, registry=reg)
+    assert (await asyncio.wait_for(second, timeout=SLOW)).result == {"which": "second"}
+    assert len(reg) == 1
+
+    resolve_pending(WS, push.corr_id, {"which": "first"}, registry=reg)
+    assert (await asyncio.wait_for(first, timeout=SLOW)).result == {"which": "first"}
+    assert len(reg) == 0
+
+
+# ── Timeout: an error result, never a hang ──────────────────────────────────
+
+
+async def test_timeout_returns_an_error_outcome_and_does_not_hang(reg, push):
+    handle = await _park(reg, push, timeout=FAST)
+
+    # No resolve ever arrives. asyncio.wait_for here is the "does not hang"
+    # assertion: it is 100x the park budget, so a caller that failed to give up
+    # fails the test rather than stalling the suite.
+    outcome = await asyncio.wait_for(handle, timeout=SLOW)
+
+    assert outcome.ok is False
+    assert outcome.error == ERROR_TIMEOUT
+    assert outcome.message
+    assert len(reg) == 0
+
+
+async def test_resolve_after_timeout_is_rejected(reg, push):
+    handle = await _park(reg, push, timeout=FAST)
+    await asyncio.wait_for(handle, timeout=SLOW)
+
+    with pytest.raises(CloudError) as exc:
+        resolve_pending(WS, push.corr_id, {"late": True}, registry=reg)
+
+    assert exc.value.code == "code_delegate.not_found"
+    assert exc.value.status_code == 404
+
+
+# ── Unknown, duplicate, and cross-tenant resolves ───────────────────────────
+
+
+async def test_unknown_corr_id_is_rejected(reg):
+    with pytest.raises(CloudError) as exc:
+        resolve_pending(WS, "nope-not-a-real-id", {}, registry=reg)
+
+    assert exc.value.code == "code_delegate.not_found"
+    assert exc.value.status_code == 404
+
+
+async def test_duplicate_resolve_is_rejected(reg, push):
+    handle = await _park(reg, push)
+
+    resolve_pending(WS, push.corr_id, {"answer": "first"}, registry=reg)
+    outcome = await asyncio.wait_for(handle, timeout=SLOW)
+    assert outcome.result == {"answer": "first"}
+
+    with pytest.raises(CloudError) as exc:
+        resolve_pending(WS, push.corr_id, {"answer": "second"}, registry=reg)
+
+    assert exc.value.code == "code_delegate.not_found"
+
+
+async def test_resolve_from_another_workspace_is_rejected(reg, push):
+    """The corrId is unguessable, but tenancy that rests on unguessability is
+    not tenancy. The entry stays parked, so the real owner can still answer."""
+    handle = await _park(reg, push)
+
+    with pytest.raises(CloudError) as exc:
+        resolve_pending(OTHER_WS, push.corr_id, {"stolen": True}, registry=reg)
+    assert exc.value.code == "code_delegate.not_found"
+
+    assert len(reg) == 1
+    resolve_pending(WS, push.corr_id, {"mine": True}, registry=reg)
+    assert (await asyncio.wait_for(handle, timeout=SLOW)).result == {"mine": True}
+
+
+async def test_oversized_result_is_rejected(reg, push):
+    handle = await _park(reg, push, timeout=FAST)
+
+    with pytest.raises(CloudError) as exc:
+        resolve_pending(
+            WS,
+            push.corr_id,
+            {"answer": "x" * (MAX_DELEGATE_RESULT_CHARS + 1)},
+            registry=reg,
+        )
+
+    assert exc.value.code == "code_delegate.result_too_large"
+    assert exc.value.status_code == 422
+    # The caller is untouched by a rejected payload and still times out cleanly.
+    assert (await asyncio.wait_for(handle, timeout=SLOW)).error == ERROR_TIMEOUT
+
+
+# ── Abort and cancellation: a disconnected client strands nothing ───────────
+
+
+async def test_abort_wakes_the_caller_with_an_error(reg, push):
+    handle = await _park(reg, push)
+
+    assert reg.abort(push.corr_id, message="stream closed") is True
+    outcome = await asyncio.wait_for(handle, timeout=SLOW)
+
+    assert outcome.ok is False
+    assert outcome.error == ERROR_ABORTED
+    assert outcome.message == "stream closed"
+    assert len(reg) == 0
+
+
+async def test_abort_all_wakes_every_parked_caller(reg, push):
+    first = await _park(reg, push)
+    second_push = _Recorder()
+    second = await _park(reg, second_push)
+
+    assert reg.abort_all() == 2
+    for handle in (first, second):
+        assert (await asyncio.wait_for(handle, timeout=SLOW)).error == ERROR_ABORTED
+    assert len(reg) == 0
+
+
+async def test_abort_of_an_unknown_id_is_a_no_op(reg):
+    assert reg.abort("nope") is False
+    assert reg.abort_all() == 0
+
+
+async def test_cancelling_the_caller_removes_the_registry_entry(reg, push):
+    """A disconnected client tears down the run task. If the entry survived
+    that, the correlation id would outlive its future forever."""
+    handle = await _park(reg, push)
+
+    handle.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await handle
+
+    assert len(reg) == 0
+    with pytest.raises(CloudError):
+        resolve_pending(WS, push.corr_id, {}, registry=reg)
+
+
+async def test_a_failed_push_gives_up_immediately(reg):
+    def _explode(_name: str, _data: dict) -> None:
+        raise RuntimeError("sink is gone")
+
+    outcome = await asyncio.wait_for(
+        delegate_to_browser(WS, "task", registry=reg, push=_explode, timeout=SLOW),
+        timeout=SLOW,
+    )
+
+    assert outcome.ok is False
+    assert outcome.error == ERROR_NO_CLIENT
+    assert len(reg) == 0
+
+
+# ── The real SSE seam ───────────────────────────────────────────────────────
+
+
+async def test_no_sse_stream_fails_fast_rather_than_parking(reg):
+    """No ``push=`` here on purpose: this drives the REAL
+    ``push_sse_event`` / ``has_sse_event_sink`` pair. Outside a stream the push
+    is a documented no-op, so parking would burn the full budget on a failure
+    that was knowable at the push."""
+    outcome = await asyncio.wait_for(
+        delegate_to_browser(WS, "task", registry=reg, timeout=SLOW),
+        timeout=SLOW,
+    )
+
+    assert outcome.ok is False
+    assert outcome.error == ERROR_NO_CLIENT
+    assert len(reg) == 0
+
+
+async def test_frame_reaches_a_real_attached_sse_sink(reg):
+    """End to end over the actual transport: bind a queue the way the chat
+    stream does, delegate, and read the frame off the queue."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+
+    queue: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(queue)
+    try:
+        handle = asyncio.create_task(
+            delegate_to_browser(WS, "refactor it", "edit", timeout=SLOW, registry=reg)
+        )
+        name, data = await asyncio.wait_for(queue.get(), timeout=SLOW)
+        assert name == DELEGATE_EVENT
+        assert data["task"] == "refactor it"
+        assert data["mode"] == "edit"
+
+        resolve_pending(WS, data["corrId"], {"answer": "ok"}, registry=reg)
+        assert (await asyncio.wait_for(handle, timeout=SLOW)).result == {"answer": "ok"}
+    finally:
+        detach_sse_event_sink(token)
+
+
+# ── Wiring: the DTO, the service, and the singleton ─────────────────────────
+
+
+async def test_service_resolve_delegate_wakes_the_parked_caller(reg, push, monkeypatch):
+    """The route's path, one layer down: the singleton registry is what both
+    ends actually share in production, so pin that it is the one used."""
+    monkeypatch.setattr(delegates, "_registry", reg)
+    handle = await _park(reg, push)
+
+    response = await codeagent_service.resolve_delegate(
+        WS, USER, {"corrId": push.corr_id, "result": {"answer": "via service"}}
+    )
+
+    assert response.accepted is True
+    assert (await asyncio.wait_for(handle, timeout=SLOW)).result == {"answer": "via service"}
+
+
+async def test_service_resolve_delegate_rejects_an_unknown_id(reg, monkeypatch):
+    monkeypatch.setattr(delegates, "_registry", reg)
+
+    with pytest.raises(CloudError) as exc:
+        await codeagent_service.resolve_delegate(WS, USER, {"corrId": "ghost", "result": {}})
+
+    assert exc.value.code == "code_delegate.not_found"
+
+
+def test_resolve_request_requires_a_corr_id():
+    with pytest.raises(ValueError):
+        DelegateResolveRequest(corrId="", result={})
+
+
+def test_resolve_request_defaults_result_to_empty():
+    assert DelegateResolveRequest(corrId="abc").result == {}
+
+
+def test_get_pending_delegates_is_a_singleton():
+    assert get_pending_delegates() is get_pending_delegates()
+
+
+def test_outcome_to_dict_splits_success_from_failure():
+    ok = DelegateOutcome(ok=True, result={"a": 1}).to_dict()
+    assert ok == {"ok": True, "result": {"a": 1}}
+
+    failed = DelegateOutcome(ok=False, error=ERROR_TIMEOUT, message="slow").to_dict()
+    assert failed == {"ok": False, "error": ERROR_TIMEOUT, "message": "slow"}


### PR DESCRIPTION
Groundwork for handing a coding task from the main agent to Code Mode. The main agent is about to get one tool, `code_mode`; this PR builds the channel that tool will park on. The tool itself is a separate change.

## Why the call has to invert

The tool runs in the backend. The work can only happen in the browser, because a WebContainer project lives in the tab and has no server-side row anything could reach. That is the same constraint that made the Code Mode turn stateless in the first place: the server never opens a file.

So the backend mints a correlation id, pushes a `code_delegate` frame down the live SSE stream, and parks on a future until the browser POSTs the answer to `/codeagent/resolve`. `delegates.py` is both ends of that rendezvous and nothing else — it knows what a correlation id is and how to wake a parked caller, and knows nothing about what the task said or what the browser did with it.

Modelled on `plan_mode.PlanApprovalManager`, with two deliberate differences: keyed by correlation id rather than session, because one turn can delegate more than once and a session key cannot tell two of them apart; and the future carries a result payload rather than a bare approve/reject.

## A parked caller must never hang

That is the property everything here is built around. A closed tab, a user who navigated away, a frame pushed into a stream nobody reads — each has to end as an error the tool can report, not a chat turn that sits there forever.

Every exit from `wait` produces an outcome, including timeout. The `finally` removes the registry entry on return, timeout, and cancellation alike; a stranded entry is not just memory, it is a correlation id a late browser could resolve into a future nobody is reading. `open` is split from `wait` so the id exists before the frame is pushed, rather than the browser answering an id the registry has not heard of yet.

## The 180s budget is derived, not picked

`plan_mode` uses 300s for a person reading a plan and clicking approve. This is a machine round trip, so that is the wrong reference. The floor is the browser's own `/codeagent/turn` call, capped at `MODEL_TIMEOUT_SECONDS` = 120. Anything under two minutes would expire the delegate before the sub-agent's model call could even fail, and the user would be told the browser was silent about a browser that was still working.

It deliberately does not cover the worst case — the retrieval loop can run to `MAX_TOOL_ITERATIONS`, which no bounded park survives. That is the right trade: this is a liveness guarantee for the chat turn, not a spend budget for the sub-agent.

## Tenancy and replay

The workspace is captured at park time and checked on resolve. A mismatch is a miss rather than a distinct error, because telling a caller that an id exists but is not theirs confirms the id exists. Duplicate resolves take the same path: the entry is popped before the future is settled, so a second POST is indistinguishable from an unknown id and there is no second rejection mechanism to keep in step with the first. `corrId` is length-bounded at the wire, since an unbounded id is a free dictionary key on a process-global registry.

## Two changes outside the new file

`agent_service` gains `has_sse_event_sink`, read-only introspection of the same ContextVar. `push_sse_event` is rightly a no-op with no sink, which is correct for an observability frame nobody is obliged to see and wrong for a frame the caller then waits on. This lets the delegate fail fast and say "no browser attached" rather than park the full timeout and report a slow one.

`service.py` gains a `resolve_delegate` pass-through so the router keeps one shape for both routes, while the rendezvous logic stays out of a file that is about calling a model.

## Testing

23 tests cover park and resolve, timeout, abort, cancellation, duplicate and unknown ids, and cross-workspace rejection. The wider `codeagent` / `agent_service` / chat selection across `tests/cloud/` is green at 384 passed.