### PR TITLE
Title chat sessions from the user's message, not the context preamble

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -639,7 +639,20 @@ _TITLE_PLACEHOLDER_LIMIT = 60
 
 
 def _truncate_for_title(message: str) -> str:
-    raw = (message or "").strip().replace("\n", " ").replace("\r", " ")
+    """One-line excerpt of the user's message, used as the placeholder title.
+
+    Strips any client context preamble first (2026-07-22). This placeholder is
+    written to Mongo and pushed over SSE *before* Haiku runs, so it is what the
+    user actually sees in the sidebar — titling the raw wire content named every
+    home-started chat "[Home page snapshot] Time of day: afternoon…". Shares the
+    strip helper with the Haiku path so both agree where the user's words start.
+    """
+    from pocketpaw.memory.titler import (  # type: ignore[import-untyped]
+        strip_context_preamble,
+    )
+
+    cleaned = strip_context_preamble(message or "")
+    raw = cleaned.strip().replace("\n", " ").replace("\r", " ")
     one_line = " ".join(raw.split())
     if len(one_line) > _TITLE_PLACEHOLDER_LIMIT:
         return one_line[:_TITLE_PLACEHOLDER_LIMIT].rstrip() + "…"

--- a/src/pocketpaw/memory/titler.py
+++ b/src/pocketpaw/memory/titler.py
@@ -3,6 +3,14 @@
 Uses a Haiku-class Anthropic model to produce a short (≤6 word) title. The
 caller is responsible for persisting the title and emitting the
 ``session_titled`` SystemEvent — this module only generates.
+
+Surface context is stripped before titling (2026-07-22). Clients may prepend a
+machine-readable context block to the wire content — the home chat sends a
+snapshot of the user's pinned widgets and recent activity so the agent can
+answer "what's on my home page?" without being told. That block is for the
+AGENT, never for the human: titling the raw payload produced session names like
+"[Home Page Snapshot] Time Of Day: Afternoon" instead of what the user actually
+typed. ``strip_context_preamble`` recovers the real message.
 """
 
 from __future__ import annotations
@@ -10,6 +18,33 @@ from __future__ import annotations
 import logging
 
 logger = logging.getLogger(__name__)
+
+# Marker a client places between its context block and the user's own words.
+# Contract shared with the paw-enterprise client (see home-context.ts, which
+# emits ``f"{ctx}\n\n[User message]\n{text}"``). Kept as a lone constant so the
+# convention is greppable from both sides.
+_USER_MESSAGE_MARKER = "\n[User message]\n"
+
+
+def strip_context_preamble(message: str) -> str:
+    """Return the user's own words from a possibly context-wrapped message.
+
+    Clients wrap outgoing content as ``<context>\\n\\n[User message]\\n<text>``.
+    Everything up to and including the marker is scaffolding for the agent, so
+    the title should come from what follows it. Messages without the marker —
+    every ordinary chat — are returned unchanged.
+
+    The LAST marker wins: a user who quotes the marker inside their own message
+    still gets their trailing text, and a title can never expose more of the
+    preamble than the client intended.
+    """
+    if not message:
+        return message
+    index = message.rfind(_USER_MESSAGE_MARKER)
+    if index == -1:
+        return message
+    return message[index + len(_USER_MESSAGE_MARKER) :]
+
 
 _PROMPT = (
     "Write a concise chat title (max 6 words, Title Case, no quotes, no"
@@ -26,8 +61,13 @@ def fallback_title(first_message: str) -> str | None:
 
     Collapses whitespace and truncates to ~60 chars. Returns None when the
     message is empty so callers can skip the event altogether.
+
+    Strips any client context preamble first — this is the path that produced
+    the visible bug (a 60-char excerpt of the home-page snapshot as the session
+    name). Stripping is idempotent, so it is safe that ``generate_title`` has
+    usually stripped already.
     """
-    text = (first_message or "").strip()
+    text = strip_context_preamble(first_message or "").strip()
     if not text:
         return None
     one_line = " ".join(text.split())
@@ -44,8 +84,14 @@ async def generate_title(
     Prefers a Haiku-generated title; falls back to a trimmed first-message
     excerpt when the SDK / API key / network fails, so chats always get a
     non-default title. Returns None only for an empty first message.
+
+    Any client context preamble is stripped up front, so BOTH paths title from
+    what the user actually typed — the model never sees the snapshot block
+    either, which kept it from titling chats after the surface instead of the
+    subject.
     """
-    text = (first_message or "").strip()
+    first_message = strip_context_preamble(first_message or "")
+    text = first_message.strip()
     if not text:
         return None
     if len(text) > _MAX_INPUT_CHARS:

--- a/tests/cloud/test_session_title_context.py
+++ b/tests/cloud/test_session_title_context.py
@@ -1,0 +1,43 @@
+"""The cloud placeholder title must not leak the client's context preamble.
+
+``_generate_session_title`` writes a placeholder to Mongo and pushes it over
+SSE *before* Haiku runs, so the placeholder is what the user actually sees in
+the sidebar first. Titling the raw wire content named every home-started chat
+"[Home page snapshot] Time of day: afternoon…" — fixing only the Haiku path
+would have left that visible until the model replied (and permanently whenever
+Haiku is unavailable, which is the default in local/dev deployments).
+"""
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.chat.runs.run_core import _truncate_for_title
+
+# The exact shape paw-enterprise sends (see home-context.ts).
+WRAPPED = (
+    "[Home page snapshot]\n"
+    "Time of day: afternoon\n"
+    "Status: 6 pinned widgets\n"
+    "\n"
+    "[User message]\n"
+    "how do I add a chart to my home?"
+)
+
+
+def test_placeholder_titles_the_user_text_not_the_snapshot():
+    assert _truncate_for_title(WRAPPED) == "how do I add a chart to my home?"
+
+
+def test_placeholder_leaves_ordinary_messages_alone():
+    assert _truncate_for_title("ship the release") == "ship the release"
+
+
+def test_placeholder_still_truncates_long_user_text():
+    title = _truncate_for_title("ctx\n[User message]\n" + ("word " * 40))
+    assert title.endswith("…")
+    assert "ctx" not in title
+
+
+def test_placeholder_is_empty_when_only_a_preamble_was_sent():
+    # Empty placeholder → the caller skips writing a title rather than naming
+    # the session after scaffolding.
+    assert _truncate_for_title("ctx\n[User message]\n   ") == ""

--- a/tests/test_titler_context_preamble.py
+++ b/tests/test_titler_context_preamble.py
@@ -1,0 +1,125 @@
+"""Session titles must come from what the USER typed, not the client's
+context preamble.
+
+Regression cover for the visible bug: the home chat prepends a machine-readable
+snapshot of the user's pinned widgets/activity to the wire content, so every
+home-started session was named "[Home Page Snapshot] Time Of Day: Afternoon…"
+instead of the actual first message. The strip lives in the titler because both
+title paths (Haiku and the offline fallback) flow through it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.memory.titler import (
+    fallback_title,
+    generate_title,
+    strip_context_preamble,
+)
+
+# The exact shape paw-enterprise sends (see home-context.ts).
+WRAPPED = (
+    "[Home page snapshot]\n"
+    "Time of day: afternoon\n"
+    "Status: 6 pinned widgets\n"
+    "Recent activity: 3 runs\n"
+    "\n"
+    "[User message]\n"
+    "how do I add a chart to my home?"
+)
+
+
+class TestStripContextPreamble:
+    def test_returns_only_the_user_text(self):
+        assert strip_context_preamble(WRAPPED) == "how do I add a chart to my home?"
+
+    def test_leaves_an_ordinary_message_untouched(self):
+        assert strip_context_preamble("just a normal question") == "just a normal question"
+
+    def test_handles_empty_and_missing_input(self):
+        assert strip_context_preamble("") == ""
+        assert strip_context_preamble("   ") == "   "
+
+    def test_last_marker_wins_so_the_preamble_can_never_leak(self):
+        # A user quoting the marker inside their own text must not cause the
+        # snapshot above it to survive into the title.
+        quoted = (
+            "[Home page snapshot]\ncontext\n\n[User message]\nwhy does\n[User message]\nrepeat?"
+        )
+        assert strip_context_preamble(quoted) == "repeat?"
+
+    def test_marker_at_the_very_end_yields_empty(self):
+        assert strip_context_preamble("context\n[User message]\n") == ""
+
+
+class TestFallbackTitle:
+    def test_titles_the_user_text_not_the_snapshot(self):
+        assert fallback_title(WRAPPED) == "how do I add a chart to my home?"
+
+    def test_ordinary_message_is_unaffected(self):
+        assert fallback_title("ship the release") == "ship the release"
+
+    def test_empty_after_stripping_returns_none(self):
+        # Nothing but a preamble — the caller skips the event entirely rather
+        # than naming the session after the scaffolding.
+        assert fallback_title("context\n[User message]\n   ") is None
+
+    def test_long_user_text_still_truncates(self):
+        long_msg = "context\n[User message]\n" + ("word " * 40)
+        title = fallback_title(long_msg)
+        assert title is not None
+        assert title.endswith("…")
+        assert len(title) <= 61
+        assert "context" not in title
+
+
+class TestGenerateTitle:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_the_clean_user_text_without_an_api_key(self):
+        # No api_key → fallback path, which is exactly the path that shipped
+        # the bug in local/dev deployments.
+        title = await generate_title(WRAPPED, model="claude-haiku-4-5", api_key=None)
+        assert title == "how do I add a chart to my home?"
+
+    @pytest.mark.asyncio
+    async def test_preamble_only_message_produces_no_title(self):
+        title = await generate_title(
+            "[Home page snapshot]\nstuff\n\n[User message]\n   ",
+            model="claude-haiku-4-5",
+            api_key=None,
+        )
+        assert title is None
+
+    @pytest.mark.asyncio
+    async def test_the_model_never_sees_the_preamble(self, monkeypatch):
+        """The Haiku prompt is built from the stripped text — otherwise the
+        model titles the chat after the surface rather than the subject."""
+        seen: dict[str, str] = {}
+
+        class _FakeMessages:
+            async def create(self, *, model, max_tokens, messages):  # noqa: ARG002
+                seen["prompt"] = messages[0]["content"]
+
+                class _Block:
+                    text = "Adding A Home Chart"
+
+                class _Resp:
+                    content = [_Block()]
+
+                return _Resp()
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs):
+                self.messages = _FakeMessages()
+
+        import anthropic
+
+        monkeypatch.setattr(anthropic, "AsyncAnthropic", _FakeClient)
+
+        title = await generate_title(WRAPPED, model="claude-haiku-4-5", api_key="sk-test")
+
+        assert title == "Adding A Home Chart"
+        assert "how do I add a chart to my home?" in seen["prompt"]
+        assert "Home page snapshot" not in seen["prompt"]
+        assert "pinned widgets" not in seen["prompt"]


### PR DESCRIPTION
## The bug

Every chat started from the home surface was named after the client's context block:

> **[Home page snapshot] Time of day: afternoon Status: 6 pinn…**

The home chat prepends a machine-readable snapshot of pinned widgets and recent activity so the agent can answer "what's on my home page?" without being told. That block is for the **agent** — but the titler was reading the raw wire content, so it became the session name in the sidebar.

## The fix

`strip_context_preamble()` in `memory/titler.py` recovers the user's own words from the `<context>\n\n[User message]\n<text>` shape the client sends (contract shared with paw-enterprise's `home-context.ts`). The **last** marker wins, so a user who quotes the marker in their own message can never cause the preamble above it to survive into a title.

**Applied on both title paths — that turned out to matter.** The cloud executor writes a placeholder title via its own `_truncate_for_title` and pushes it over SSE *before* Haiku runs, so the placeholder is what the user actually sees first. I nearly shipped the titler fix alone; it would have left the bad title visible until the model replied, and permanently wherever Haiku is unavailable — which is the default in local/dev deployments. The Haiku prompt is built from the stripped text too, so the model titles the subject rather than the surface.

## Tests

16 new (12 OSS titler + 4 cloud placeholder), covering the wrapped shape, ordinary messages, preamble-only input, truncation, the quoted-marker case, and an assertion that the model never receives the snapshot.

Mutation-checked: disabling the strip fails 9 of 12, so the suite isn't vacuous.

Pre-existing unrelated failures in `tests/cloud` (run_core surface-meta, tasks router, connectors execute) and the two `tests/cloud/extraction` collection errors are unchanged — verified they fail identically on clean dev.

## Related

Frontend counterpart landed in paw-enterprise (qbtrix/paw-enterprise#657), which strips the same preamble when rendering restored transcripts. This closes the server-side half.