### PR TITLE
Two prompts on one starter are two projects

### DIFF
--- a/ee/pocketpaw_ee/cloud/codeproject/domain.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/domain.py
@@ -4,6 +4,11 @@
 # view without tenancy is a TypeError, so a leak can't be minted by omission.
 # Mirrors websandbox/domain.py; a CodeProjectView is only ever built from a
 # persisted, tenant-checked row.
+#
+# Modified 2026-07-22 (fix/starter-project-collision): added ``STARTER_PROVIDER``
+# and ``is_scaffold_provider`` — the named test for "this project's ``repo`` field
+# holds a TEMPLATE id, not a repo IDENTITY". ``create_project``'s idempotency
+# reads it to decide whether a second create is the same project or a new one.
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -11,6 +16,34 @@ from datetime import datetime
 from typing import NewType
 
 CodeProjectId = NewType("CodeProjectId", str)
+
+#: The ``provider`` value marking a SCAFFOLD project — one composed from a pinned
+#: starter template rather than cloned from a code host. Must stay spelled the
+#: same as ``STARTER_PROVIDER`` in paw-enterprise ``core/codeproject/source.ts``;
+#: the two are the same discriminator read from opposite ends of the wire.
+STARTER_PROVIDER = "starter"
+
+#: Providers whose ``repo`` field names a TEMPLATE rather than an IDENTITY.
+#:
+#: A frozenset rather than an ``== STARTER_PROVIDER`` check because "starter" is
+#: the first scaffold source, not the only conceivable one (a template gallery,
+#: an uploaded zip) — a second one should be a line here, not a second branch
+#: at every call site.
+_SCAFFOLD_PROVIDERS = frozenset({STARTER_PROVIDER})
+
+
+def is_scaffold_provider(provider: str) -> bool:
+    """Does this provider's ``repo`` value name a template instead of a project?
+
+    The distinction drives ``create_project``'s idempotency. For an identity
+    provider (``github``) the repo string IS the project — ``acme/widgets``
+    means one project no matter how many times it is submitted, so a repeat
+    create returns the existing row. For a scaffold provider the repo string is
+    the *template* the project starts from, and the catalog holds four of them,
+    so two unrelated projects sharing ``react`` is the normal case rather than a
+    duplicate.
+    """
+    return provider in _SCAFFOLD_PROVIDERS
 
 
 @dataclass(frozen=True)
@@ -39,6 +72,8 @@ class CodeProjectView:
 
 
 __all__ = [
+    "STARTER_PROVIDER",
     "CodeProjectId",
     "CodeProjectView",
+    "is_scaffold_provider",
 ]

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -11,9 +11,21 @@
 # ``current_sandbox_id`` and resolved lazily by ``codeproject/lifecycle.open_project``
 # (reuse the bound row if it's live, else provision a fresh one and rebind). The
 # orchestration lives in lifecycle.py so this module stays the sole doc writer.
+#
+# Modified 2026-07-22 (fix/starter-project-collision): ``create_project``'s
+# idempotency is now provider-dependent. It was keyed on
+# (workspace, user, provider, repo) for every provider, which is only correct
+# while ``repo`` names an IDENTITY. A starter project puts a TEMPLATE id there
+# and the catalog has four, so "build me a todo app" and "build me a blog" both
+# planned to ``react``, hit the idempotency check, and the second create returned
+# the FIRST project — the user's name was discarded, they were navigated to the
+# older project, and the projects tab still showed one row. Scaffold providers
+# now always insert; identity providers keep the existing behaviour exactly, so a
+# returning user still lands back on the same ``/code/<id>`` for a repo.
 from __future__ import annotations
 
 import logging
+import secrets
 from datetime import UTC, datetime
 
 from pocketpaw_ee.cloud._core.errors import NotFound
@@ -24,7 +36,11 @@ from pocketpaw_ee.cloud._core.realtime.events import (
     CodeProjectOpened,
     CodeProjectRenamed,
 )
-from pocketpaw_ee.cloud.codeproject.domain import CodeProjectId, CodeProjectView
+from pocketpaw_ee.cloud.codeproject.domain import (
+    CodeProjectId,
+    CodeProjectView,
+    is_scaffold_provider,
+)
 from pocketpaw_ee.cloud.codeproject.dto import (
     CodeProjectResponse,
     CreateProjectRequest,
@@ -46,6 +62,21 @@ def _short_name(repo: str) -> str:
         trimmed = trimmed[: -len(".git")]
     tail = trimmed.rsplit("/", 1)[-1]
     return tail or trimmed
+
+
+def _registry_key(provider: str) -> str:
+    """The immutable tail of the registry key for a new row.
+
+    Empty for an identity provider, so every project for a given repo shares one
+    key and the collection's unique index enforces one-project-per-repo. A fresh
+    random token for a scaffold provider, so two projects built from the same
+    starter are two rows rather than a duplicate-key collision.
+
+    The token is minted here, at insert, and never rewritten — the whole point of
+    keying on it instead of on ``name`` is that nothing a user does later can
+    move it.
+    """
+    return secrets.token_hex(8) if is_scaffold_provider(provider) else ""
 
 
 def _doc_to_view(doc: _CodeProjectDoc) -> CodeProjectView:
@@ -87,26 +118,41 @@ async def create_project(
     user_id: str,
     body: CreateProjectRequest | dict,
 ) -> CodeProjectView:
-    """Register (or return) the durable project for a (workspace, user, provider, repo).
+    """Register (or return) the durable project for a create request.
 
-    Idempotent on the registry key: a second create for the same repo returns the
-    EXISTING project unchanged rather than minting a duplicate — a returning user
-    lands back on the same ``/code/<id>``. Only an actual insert emits
-    ``CodeProjectCreated`` (an idempotent hit is not a mutation).
+    Idempotency is PROVIDER-DEPENDENT, because ``repo`` means two different
+    things depending on who filled it in.
+
+    For an identity provider (``github``) the repo string names the project:
+    cloning ``acme/widgets`` twice is the same project, so a second create
+    returns the EXISTING row unchanged and a returning user lands back on the
+    same ``/code/<id>``. That behaviour is deliberate and unchanged.
+
+    For a scaffold provider (``starter``) the repo string names the TEMPLATE the
+    project starts from. The catalog holds four, so two unrelated prompts sharing
+    one starter is the ordinary case, not a duplicate — deduplicating there
+    silently swallowed the user's second project. Scaffold creates therefore
+    always insert. Guarding a double-submit is the caller's job (the ``/code``
+    landing page latches its confirm button and navigates away on success); it is
+    not something the registry can infer from a template id.
+
+    Only an actual insert emits ``CodeProjectCreated`` (an idempotent hit is not
+    a mutation).
     """
     body = CreateProjectRequest.model_validate(body)
 
-    existing = await _CodeProjectDoc.find_one(
-        {  # Rule 7 tenant + owner filter
-            "workspace_id": workspace_id,
-            "user_id": user_id,
-            "provider": body.provider,
-            "repo": body.repo,
-        }
-    )
-    if existing is not None:
-        # no-event: idempotent hit — nothing was written, so nothing to announce.
-        return _doc_to_view(existing)
+    if not is_scaffold_provider(body.provider):
+        existing = await _CodeProjectDoc.find_one(
+            {  # Rule 7 tenant + owner filter
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "provider": body.provider,
+                "repo": body.repo,
+            }
+        )
+        if existing is not None:
+            # no-event: idempotent hit — nothing was written, so nothing to announce.
+            return _doc_to_view(existing)
 
     doc = _CodeProjectDoc(
         workspace_id=workspace_id,
@@ -114,6 +160,7 @@ async def create_project(
         name=body.name or _short_name(body.repo),
         provider=body.provider,
         repo=body.repo,
+        registry_key=_registry_key(body.provider),
     )
     await doc.insert()
 

--- a/ee/pocketpaw_ee/cloud/models/code_project.py
+++ b/ee/pocketpaw_ee/cloud/models/code_project.py
@@ -8,9 +8,24 @@ sandbox. Opening a project reuses its live sandbox or provisions a fresh one and
 restores the snapshot into it, so a user who returns after a long gap gets their
 work back instead of an empty machine.
 
-One row per (workspace_id, user_id, provider, repo). Only
+One row per (workspace_id, user_id, provider, repo, registry_key). Only
 ``ee.cloud.codeproject.service`` imports this doc class directly (import-linter
 "CodeProject" contract, same discipline as WebSandbox / AuditEvent).
+
+Modified 2026-07-22 (fix/starter-project-collision): added ``registry_key`` and
+widened the unique index to include it. The old key was
+(workspace_id, user_id, provider, repo), which is right only while ``repo``
+names an IDENTITY. A SCAFFOLD project (``provider="starter"``) puts a TEMPLATE
+id there, and the catalog has four, so two unrelated prompts that both plan to
+``react`` collided and the second create silently returned the first project.
+``registry_key`` is the immutable tail that separates them: empty for identity
+providers (so one row per repo still holds, enforced by the index and not just
+by the service's read-then-insert), a per-row token for scaffold providers (so
+they never dedupe). NOTE: the index has a NEW NAME, and Beanie only ever
+*creates* indexes — the superseded ``ws_user_provider_repo_unique`` survives in
+every existing deployment and would still reject the second starter row, so
+``shared/db.py`` drops it at boot (same reconcile the invite-token rollout
+needed).
 
 Relation to WebSandbox: WebSandbox stays the EPHEMERAL runtime row (Daytona VM +
 lifecycle); CodeProject is the durable owner and points at the current one via
@@ -36,8 +51,23 @@ class CodeProject(Document):
     # plain str (not an enum) so a new provider needs no migration.
     provider: str = "github"
     # The provider-native repo identifier (a public URL today; "owner/repo" once
-    # the GitHub App connect flow lands).
+    # the GitHub App connect flow lands). For a SCAFFOLD provider ("starter")
+    # this is a starter id from the codescaffold catalog, not a repo.
     repo: str
+    # The immutable tail of the registry key — what makes two rows that share
+    # (workspace, user, provider, repo) legitimately distinct.
+    #
+    # Empty for identity providers (github): every row for a given repo carries
+    # "", so the unique index below enforces one-project-per-repo. A per-row
+    # token for scaffold providers, where `repo` names a template and two
+    # projects sharing it is normal.
+    #
+    # Deliberately NOT the display name, even though name is what distinguishes
+    # two starter projects to the user: `rename_project` mutates the name, and a
+    # registry key a rename can move is not a key. Keying on it would let a
+    # rename collide two rows into a DuplicateKeyError, and would make a
+    # re-create under a since-renamed name mint a surprise duplicate.
+    registry_key: str = ""
     # Durable blob-storage snapshot pointer (an EEUploadService FileRecord id).
     # The project's files live HERE between sandboxes — this is why the project
     # survives VM reaping. Null until the first backup.
@@ -53,11 +83,20 @@ class CodeProject(Document):
     class Settings:
         name = "code_projects"
         indexes = [
-            # One project per (workspace, user, provider, repo) — the registry key.
+            # The registry key. `registry_key` is "" for identity providers, so
+            # this still reads as one-project-per-(workspace, user, provider,
+            # repo) for git; scaffold rows each carry their own token and so
+            # never collide with a sibling built from the same starter.
             IndexModel(
-                [("workspace_id", 1), ("user_id", 1), ("provider", 1), ("repo", 1)],
+                [
+                    ("workspace_id", 1),
+                    ("user_id", 1),
+                    ("provider", 1),
+                    ("repo", 1),
+                    ("registry_key", 1),
+                ],
                 unique=True,
-                name="ws_user_provider_repo_unique",
+                name="ws_user_provider_repo_key_unique",
             ),
             # The per-user list read path (list_projects).
             IndexModel([("workspace_id", 1), ("user_id", 1)]),

--- a/ee/pocketpaw_ee/cloud/shared/db.py
+++ b/ee/pocketpaw_ee/cloud/shared/db.py
@@ -1,5 +1,14 @@
 """MongoDB connection and Beanie ODM initialization.
 
+2026-07-22 (fix/starter-project-collision): added
+``_drop_legacy_code_project_index`` and called it after ``init_beanie``, beside
+the invite-token reconcile and for the identical reason. ``CodeProject``'s
+registry key grew a ``registry_key`` column so two projects can be built from
+one starter template; the superseded four-column unique index
+``ws_user_provider_repo_unique`` would still reject that second row, and Beanie
+never drops an index the model stopped declaring. Without this the fix passes on
+mongomock and 500s in production.
+
 2026-07-15 (fix/workspace-vm-map-to-db): added ``migrate_workspace_vm_map_to_db``
 — a best-effort, one-time boot task that imports the captain's existing
 workspace→VM entries from the legacy local JSON file
@@ -89,6 +98,61 @@ async def _drop_legacy_invite_token_index(db) -> None:  # type: ignore[no-untype
         )
     except Exception:  # pragma: no cover - startup must not fail on drop
         logger.exception("Failed to drop legacy 'token_1' index on invites")
+
+
+async def _drop_legacy_code_project_index(db) -> None:  # type: ignore[no-untyped-def]
+    """Drop the superseded ``ws_user_provider_repo_unique`` index on ``code_projects``.
+
+    ``CodeProject`` now keys the registry on
+    (workspace_id, user_id, provider, repo, registry_key) — the extra column is
+    what lets two starter projects share one template id. The superseded
+    four-column index would still reject that second row, and Beanie only ever
+    *creates* the indexes a model declares, so it survives in every existing
+    deployment. Without this, the starter fix passes on mongomock and fails in
+    production with a ``DuplicateKeyError`` on the second create.
+
+    Idempotent and best-effort, exactly like the invite-token reconcile above:
+    only drops the precise legacy shape, and never raises into startup.
+    """
+    try:
+        coll = db["code_projects"]
+        info = await coll.index_information()
+    except Exception:  # pragma: no cover - startup must not fail on probe
+        logger.exception(
+            "Could not read code_projects index information; skipping legacy-index cleanup"
+        )
+        return
+
+    legacy = info.get("ws_user_provider_repo_unique")
+    if not legacy:
+        return
+
+    # Only touch the exact legacy shape: the four-column unique registry key,
+    # not some later index that happens to reuse the name.
+    is_legacy_shape = (
+        list(legacy.get("key", []))
+        == [
+            ("workspace_id", 1),
+            ("user_id", 1),
+            ("provider", 1),
+            ("repo", 1),
+        ]
+        and legacy.get("unique") is True
+    )
+    if not is_legacy_shape:
+        return
+
+    try:
+        await coll.drop_index("ws_user_provider_repo_unique")
+        logger.warning(
+            "Dropped superseded unique index 'ws_user_provider_repo_unique' on "
+            "code_projects — the registry key now includes registry_key; the old "
+            "index made a second project from the same starter collide."
+        )
+    except Exception:  # pragma: no cover - startup must not fail on drop
+        logger.exception(
+            "Failed to drop legacy 'ws_user_provider_repo_unique' index on code_projects"
+        )
 
 
 async def migrate_workspace_vm_map_to_db() -> None:
@@ -184,6 +248,7 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
     # declares. The invite-token hashing rollout left a unique index on the
     # now-nullable `token` column that 500s every second invite.
     await _drop_legacy_invite_token_index(db)
+    await _drop_legacy_code_project_index(db)
 
     # One-time import of the legacy workspace→VM JSON map into Mongo. Runs after
     # init_beanie so the ``workspace_vms`` collection is live. Best-effort — the

--- a/tests/cloud/test_codeproject.py
+++ b/tests/cloud/test_codeproject.py
@@ -284,3 +284,61 @@ async def test_open_project_swallows_restore_failure(monkeypatch) -> None:
     second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
     assert second.status == "ready"
     assert second.id == first.id
+
+
+# ---------------------------------------------------------------------------
+# starter projects — two prompts, two projects.
+# ---------------------------------------------------------------------------
+#
+# Added 2026-07-22 reproducing a captain-reported bug: "when I try to create a
+# project by prompt then I don't see that project in the project tab."
+#
+# The cause is that idempotency is keyed on ``(workspace, user, provider, repo)``
+# and a STARTER project puts the starter id in ``repo``. For a git project that
+# key is right — cloning github.com/acme/widgets twice is the same project. For a
+# starter it conflates "which TEMPLATE" with "which PROJECT", and the catalog has
+# only four entries (react / vue / svelte / next), so two unrelated prompts
+# collide almost immediately.
+#
+# The user then gets navigated to the FIRST project, their new name is silently
+# discarded, and the projects tab still shows one row.
+
+_STARTER = "react"
+
+
+async def test_two_prompts_on_the_same_starter_make_two_projects() -> None:
+    """The bug, stated as the behaviour we want.
+
+    "A todo app" and "a blog" both plan to the react starter. They are two
+    different projects that happen to share a template.
+    """
+    todo = await service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "todo app"}
+    )
+    blog = await service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "blog"}
+    )
+
+    assert blog.id != todo.id, (
+        "the second prompt returned the FIRST project — the registry key treats "
+        "'which template' as 'which project', so every later prompt on this "
+        "starter is swallowed"
+    )
+    assert blog.name == "blog", "the name the user chose was discarded"
+
+    listing = await service.list_projects(_WS, _USER)
+    assert len(listing) == 2, (
+        f"the projects tab shows {len(listing)} project(s), not 2 — this is "
+        "exactly what the user reports as 'I don't see that project'"
+    )
+
+
+async def test_a_git_repo_stays_idempotent() -> None:
+    """The guard on the fix. Whatever makes starters distinct must NOT make a
+    returning user's git clone mint a duplicate — that idempotency is deliberate
+    and separately tested above."""
+    first = await service.create_project(_WS, _USER, {"repo": _REPO, "name": "Widgets"})
+    second = await service.create_project(_WS, _USER, {"repo": _REPO})
+
+    assert second.id == first.id
+    assert len(await service.list_projects(_WS, _USER)) == 1

--- a/tests/cloud/test_codeproject_registry_index.py
+++ b/tests/cloud/test_codeproject_registry_index.py
@@ -1,0 +1,89 @@
+# test_codeproject_registry_index.py — the startup reconciler that retires the
+# superseded CodeProject registry index.
+#
+# Created 2026-07-22 (fix/starter-project-collision). The starter-collision fix
+# widened the registry key from (workspace, user, provider, repo) to that plus
+# ``registry_key``, so two projects built from one starter template are two rows.
+# Beanie only ever CREATES the indexes a model declares — it never drops one that
+# disappeared — so the superseded four-column unique index survives in every
+# existing deployment and would still reject that second row. The service-level
+# fix therefore passes on mongomock and 500s in production unless the old index
+# is actually dropped at boot.
+#
+# These tests cover the reconciler that does it, mirroring the invite-token
+# reconciler's tests in workspace/test_invite_send_500_regression.py: it drops the
+# legacy shape, no-ops when it is absent, and leaves the current index alone.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.shared.db import _drop_legacy_code_project_index
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_LEGACY = "ws_user_provider_repo_unique"
+_CURRENT = "ws_user_provider_repo_key_unique"
+_LEGACY_KEYS = [("workspace_id", 1), ("user_id", 1), ("provider", 1), ("repo", 1)]
+_CURRENT_KEYS = [*_LEGACY_KEYS, ("registry_key", 1)]
+
+
+async def test_drops_the_superseded_registry_index(mongo_db) -> None:
+    """A deployment created before the fix carries the four-column unique index.
+
+    Left in place it re-imposes exactly the constraint the fix removed, so the
+    reconciler has to drop it.
+    """
+    coll = mongo_db["code_projects"]
+    await coll.create_index(_LEGACY_KEYS, unique=True, name=_LEGACY)
+    assert _LEGACY in await coll.index_information()
+
+    await _drop_legacy_code_project_index(mongo_db)
+
+    assert _LEGACY not in await coll.index_information()
+
+
+async def test_is_a_noop_on_a_fresh_deployment(mongo_db) -> None:
+    """No legacy index → nothing to reconcile, and nothing else is touched.
+
+    The ``mongo_db`` fixture runs ``init_beanie``, so the collection already
+    carries the model's own indexes and nothing else — which is precisely the
+    state of a deployment created after this fix.
+    """
+    coll = mongo_db["code_projects"]
+    before = set(await coll.index_information())
+    assert _LEGACY not in before
+    assert _CURRENT in before, "Beanie should have created the model's registry index"
+
+    await _drop_legacy_code_project_index(mongo_db)
+
+    assert set(await coll.index_information()) == before
+
+
+async def test_preserves_the_current_registry_index(mongo_db) -> None:
+    """Mid-upgrade both indexes exist. Only the superseded one may go — dropping
+    the current one would leave the registry with no uniqueness at all.
+
+    The current index here is the real one Beanie built from the model, not a
+    replica, so this also pins that the two are distinguishable by name.
+    """
+    coll = mongo_db["code_projects"]
+    await coll.create_index(_LEGACY_KEYS, unique=True, name=_LEGACY)
+
+    await _drop_legacy_code_project_index(mongo_db)
+
+    info = await coll.index_information()
+    assert _LEGACY not in info
+    assert _CURRENT in info
+
+
+async def test_leaves_a_non_unique_index_of_the_same_name_alone(mongo_db) -> None:
+    """The reconciler matches on shape, not just on name.
+
+    An index that reuses the name without being the legacy unique constraint is
+    somebody else's, and dropping it is not this function's business.
+    """
+    coll = mongo_db["code_projects"]
+    await coll.create_index(_LEGACY_KEYS, name=_LEGACY)  # not unique
+
+    await _drop_legacy_code_project_index(mongo_db)
+
+    assert _LEGACY in await coll.index_information()


### PR DESCRIPTION
Reported: creating a project by prompt doesn't show it in the projects tab.

## What was happening

`create_project` was idempotent on `(workspace, user, provider, repo)` for every provider. That key is right only while `repo` names an **identity**.

A starter project puts a **template** id there, and the catalog has four — react, vue, svelte, next. So "build me a todo app" and "build me a blog" both plan to `react`, hit the idempotency check, and the second create returns the *first* project. The name you typed is discarded, you land on the older project, and the tab still shows one row.

Reproduced first, in its own commit, before anything was changed:

```
AssertionError: the second prompt returned the FIRST project — the registry
key treats 'which template' as 'which project'
assert '6a60a5ed524fd4e249b6b45f' != '6a60a5ed524fd4e249b6b45f'
```

## The fix

Idempotency is now provider-dependent. Identity providers are untouched: cloning `acme/widgets` twice is still one project, and a returning user still lands back on the same `/code/<id>`. Scaffold providers always insert.

The separator is a new `registry_key` column, not the project name. Empty for identity providers, so one-row-per-repo still holds and is still enforced by the **unique index** rather than only by the service's read-then-insert. A per-row token for scaffold providers, minted at insert and never rewritten.

Keying on the name was the obvious alternative and is worse two ways: a later rename could collide two projects that were distinct when created, and unnamed starter creates would go straight back to colliding on `_short_name`.

## The part tests would not have caught

**Beanie only ever creates the indexes a model declares — it never drops one.**

Widening the registry key gives the index a new name, but the superseded `ws_user_provider_repo_unique` survives in every existing deployment, and it would still reject the second starter row. A service-and-model-only fix passes on mongomock and 500s in production with a `DuplicateKeyError` on the second create.

So `shared/db.py` drops it at boot, beside the invite-token reconcile and for the identical reason. Idempotent, best-effort, and it only ever removes the precise legacy shape — a non-unique index that happens to share the name is left alone.

## Testing

24 tests in `test_codeproject.py`, including the reproduction above and its guard that git idempotency survives — the point of that guard is that the fix must not be "remove idempotency".

Four more in `test_codeproject_registry_index.py` cover the reconcile specifically: drops the legacy index, no-ops on a fresh deployment, preserves the current index, and leaves a same-named non-unique index alone.

Adjacent suites (`test_codescaffold`, `test_websandbox_scaffold`, `test_websandbox_provision`) green at 88 passed, 4 skipped.

## Note for reviewers

The first `/code` project a user ever creates was never affected — only the second and later prompt-created ones. If anyone has seen a *first* project fail to appear, that's a different cause and worth reporting separately.