### PR TITLE
Asked for an app on /code, got a pocket

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -1353,13 +1353,42 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
     # ``surface_profile.ripple_mode="off"``) suppresses the ripple block.
     ripple_off = ctx.resolved_profile is not None and ctx.resolved_profile.ripple_mode == "off"
 
+    # A surface may replace the DELIVERABLE stack wholesale with its own system
+    # prompt. ``None`` (every surface but /code today, and the legacy
+    # ``resolved_profile is None`` path) keeps the assembly below untouched.
+    #
+    # What an override replaces: the ripple LAW, the pocket-delegation rule, the
+    # per-backend pocket prompts, and the artifact-delivery rule — everything
+    # that tells the agent what to BUILD. On a surface with a different
+    # deliverable each of those is an instruction to use a tool the profile has
+    # denied, and CD-3 already recorded what that costs ("the agent attempts
+    # them, takes hard errors, and burns turns"). ``ripple_mode="off"`` only ever
+    # covered the first two; /code showed the rest still landing.
+    #
+    # What it does NOT replace, and why the two survivors are not an oversight:
+    # ``_RUNTIME_IDENTITY_RULE`` is true on every surface (you are PocketPaw in a
+    # GUI chat; slash commands do not exist), and the Composio rules are gated on
+    # Composio actually being enabled, so prompt and tool list agree by
+    # construction. Both describe the ENVIRONMENT the agent is in. The override
+    # describes the WORK. Folding the environment rules into each surface's
+    # prompt would duplicate them per surface and let them drift.
+    override = ctx.resolved_profile.system_message_override if ctx.resolved_profile else None
     parts: list[str] = []
     parts.append(_RUNTIME_IDENTITY_RULE)
     # Artifact-delivery rule (ART-4): the agent builds files in a per-tenant jail
     # the user can't reach, so a downloadable result MUST go through
     # deliver_artifact (which lands it in tenant blob storage and returns a real
     # download URL) — not a printed container path and not a local preview server.
-    parts.append(_DELIVER_ARTIFACT_RULE)
+    #
+    # Dropped under an override, because it presumes the two things such a
+    # surface does not have. On /code the agent holds neither ``Write`` (to
+    # "write it to a file in your working directory") nor ``deliver_artifact``
+    # (``pocketpaw_deliver`` is not in the allow-list), so every step of this
+    # rule names a tool that is gone — and it describes a jail on the backend
+    # server, which is the exact wrong-machine confusion CD-3 removed from the
+    # preamble.
+    if override is None:
+        parts.append(_DELIVER_ARTIFACT_RULE)
     # Composio auth/search guidance is injected whenever Composio is
     # enabled. An enabled deployment ALWAYS surfaces at least the
     # discovery meta-tools — ``providers.py`` falls back to them when no
@@ -1380,7 +1409,15 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
     # dropped for a ``type="home"`` scope. The home agent then gets exactly
     # one consistent widget-creation instruction.
     is_home = ctx.pocket_type == "home"
-    if is_home:
+    if override is not None:
+        # The surface speaks for itself. Everything below this branch — the
+        # ripple LAW, the delegation rule, the per-backend pocket prompts, the
+        # home widget prompt — is the pocket-shaped deliverable stack the
+        # override exists to replace. Appending the override INSTEAD of them
+        # (not alongside) is the whole point: the /code bug was not a missing
+        # instruction, it was two instructions, and the trained-in one won.
+        parts.append(override)
+    elif is_home:
         # The home agent's only widget-creation instruction is
         # HOME_POCKET_PROMPT (appended below). It must not also receive the
         # specialist-delegation rule (MCP backends) or the heavy
@@ -1422,7 +1459,7 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
     # integration wired up" despite a configured backend. ``None`` renders as
     # "configured state unknown — call get_pocket to check". The literal
     # token never leaks because ``fill_current_pocket`` always replaces it.
-    if is_home:
+    if is_home and override is None:
         parts.append(
             fill_current_pocket(HOME_POCKET_PROMPT, ctx.pocket_id or "", ctx.backend_summary)
         )
@@ -1436,7 +1473,11 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
     # for intent="pocket_create" — that flow is about a NEW pocket, so the
     # anchor's summary would mislead (mirrors the <current-pocket> tag gate
     # in build_dynamic_context). ``None`` ⇒ no block, byte-identical prompt.
-    if ctx.pocket_summary and ctx.intent != "pocket_create":
+    # Also gated off under an override: a <pocket-summary> is pocket framing, and
+    # on a surface that cannot touch a pocket it reads as an invitation to talk
+    # about one ("your other dashboard does X") rather than as the anchor context
+    # it is elsewhere.
+    if ctx.pocket_summary and ctx.intent != "pocket_create" and override is None:
         parts.append(_render_pocket_summary_block(ctx.pocket_summary))
     # ADDITIVE member orientation (pp#1367): append the pre-rendered, capped
     # "about this member" block LAST so the agent greets the caller by name and

--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -231,11 +231,26 @@ class SurfaceProfile:
         svelte-create row.
       * ``skill_names`` — skills this surface surfaces to the agent. Tested DATA;
         skill-surfacing consumption lands in a later pass.
-      * ``system_message_override`` — optional full system-message swap for a
-        surface. Declared for a future PR; not consumed yet.
+      * ``system_message_override`` — the surface's own system prompt, replacing
+        the pocket-shaped DELIVERABLE stack. CONSUMED since 2026-07-22
+        (fix/code-surface-denies-pocket-authoring); set on the CODE row, ``None``
+        everywhere else. When set, ``build_behavior_instructions`` appends it
+        INSTEAD of the ripple LAW, the pocket-delegation rule, the per-backend
+        pocket prompts, the home widget prompt, and the artifact-delivery rule.
+        It does NOT displace the runtime-identity rule or the Composio rules —
+        those describe the ENVIRONMENT (and the Composio ones are gated on
+        Composio being enabled, so prompt and tool list agree); this field
+        describes the WORK. Prompt text lives in ``surface/system_prompts.py``.
 
-    ``ripple_mode`` and ``deny_mcp_tool_ids`` are CONSUMED today; the remaining
-    fields are intentionally populated-but-inert so the descriptor's shape is
+        Pairs with, and does not replace, the deny set: the prompt says what the
+        surface DOES build, the deny set makes the alternatives unreachable.
+        /code needed both — ``ripple_mode="off"`` plus a preamble forbidding
+        pockets still lost to a request whose vocabulary matched the
+        create-pocket skill, because a prohibition does not create a default.
+
+    ``ripple_mode``, ``deny_mcp_tool_ids``, ``allow_mcp_tool_ids`` and
+    ``system_message_override`` are CONSUMED today; ``allowed_sdk_tools`` and
+    ``skill_names`` remain populated-but-inert so the descriptor's shape is
     locked now and later passes add enforcement without re-designing the
     primitive.
     """

--- a/ee/pocketpaw_ee/cloud/surface/handlers/code.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/code.py
@@ -32,6 +32,19 @@
 # is two model calls deep (chat agent → code agent), so a redundant retrieval
 # round is paid twice, and the selection plus its file are already in context.
 #
+# Changed: 2026-07-22 (fix/code-surface-denies-pocket-authoring) — the procedure
+# block gained a paragraph on what "build an app" MEANS here. Reported from a
+# live session: with a React project open, "Let's build an employee management
+# app, with components, nice design etc" made the agent create a pocket and
+# author a ripple ui-spec. The orientation already said "do not create a pocket"
+# and lost anyway — the request's vocabulary ("app", "components", "design")
+# matches the create-pocket skill more strongly than a blanket prohibition
+# repels it. The new paragraph re-points those exact words at their ordinary
+# front-end meaning instead of restating the ban. The ENFORCEMENT is the profile's
+# widened deny set (``_CODE_POCKET_DENY``), which withholds the pocket / planner /
+# widget tools; this prose exists so the agent knows why they are absent rather
+# than discovering it as a tool error mid-turn.
+#
 # Mirrors the layout of handlers/sites.py and handlers/belt.py: an async
 # ``build_preamble`` returning an XML-ish ``<surface>`` + ``<orientation>`` +
 # ``<procedure>`` block.
@@ -116,6 +129,14 @@ def _procedure() -> str:
         "like it worked. They are withheld from you here for exactly that "
         "reason; if you find yourself reaching for one, the answer is "
         "`code_mode`.",
+        "Read a request to BUILD something as a request to build it in CODE. "
+        '"Build me an employee management app, with components and a nice '
+        "design\" means React/Vue/Svelte components and CSS in the user's "
+        "project — it does NOT mean a pocket, a dashboard, or a ripple ui-spec, "
+        'however closely the words match one. "Components", "design", '
+        '"dashboard" and "app" all keep their ordinary front-end meaning on '
+        "this surface. The pocket, planner, and widget tools are withheld from "
+        "you here for that reason; do not reach for a skill that calls them.",
         "Report only what actually happened. If `code_mode` returns an error or "
         "is unavailable, say so plainly — never describe a change as made when "
         "the tool did not confirm it. When it succeeds, briefly summarize what "

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -49,6 +49,19 @@
 # instruction to call what the agent no longer has. Still a static ``profile``:
 # both sets are module-level literals, nothing lazily loaded, not meta-aware. The
 # matching preamble rewrite is in ``handlers/code.py``.
+#
+# Changes: 2026-07-22 (fix/code-surface-denies-pocket-authoring) — CD-3's deny set
+# turned out to cover only HALF the surface's wrong turns. It removed the
+# file/shell built-ins (the wrong MACHINE) but left every pocket-authoring tool
+# reachable (the wrong DELIVERABLE), because ``allow_mcp_tool_ids`` cannot touch
+# them: ``claude_sdk`` unions ``POCKET_CREATION_GRANT``, ``WIDGET_TOOL_IDS`` and
+# every ``ALWAYS_ALLOWED_MCP_SERVERS`` tool back in AFTER a mode's allow-list is
+# applied, on purpose, so "create a pocket" works from every chat mode. On /code
+# that guarantee is the bug: a user with a React project open asked for "an
+# employee management app, with components, nice design" and got a pocket and a
+# ripple ui-spec. ``_CODE_POCKET_DENY`` closes it — deny runs BEFORE the grant is
+# unioned in and is the only lever that reaches those families. Read-only pocket
+# access survives deliberately. The CODE row stays STATIC.
 
 from __future__ import annotations
 
@@ -230,6 +243,54 @@ _CODE_MODE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_code__code_mode
 # legitimate work, and neither one reaches a filesystem.
 _CODE_BUILTIN_DENY: frozenset[str] = frozenset(
     {"Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent"}
+)
+
+# The pocket-AUTHORING tools the /code agent must not hold either.
+#
+# Reported from a live session: with a React project open on /code, "Let's build
+# an employee management app, with components, nice design etc" made the agent
+# create a pocket and author a ripple ui-spec instead of writing React. The user
+# asked for an app and got a dashboard.
+#
+# ``allow_mcp_tool_ids`` does NOT prevent this, which is the whole reason this
+# set exists. CD-3 scoped /code to ``code_mode``, but ``claude_sdk`` deliberately
+# lets three families survive ANY restrictive allow-list: ``POCKET_CREATION_GRANT``
+# (specialist create + planner), ``ALWAYS_ALLOWED_MCP_SERVERS`` (every tool on the
+# ``pocketpaw_pocket`` / ``_specialist`` / ``_planner`` servers), and
+# ``WIDGET_TOOL_IDS``. Those bypasses are RIGHT for a general chat surface — "create
+# a pocket" is the product's core capability and must work from anywhere — and
+# wrong for this one, where the deliverable is the user's code. Deny is applied
+# BEFORE the grant is unioned in, so it is the only lever that reaches them.
+#
+# Prose could not do this job. The preamble already says "do not build widgets,
+# charts, or a ui-spec, and do not create a pocket" and the agent did it anyway —
+# the same result /sites got before it denied these ids outright rather than
+# asking (see ``_SITES_SVELTE_CREATE_DENY``: "prose-only routing was proven to
+# fail"). Two surfaces have now independently confirmed it.
+#
+# READ-ONLY pocket access (``get_pocket`` / ``list_pockets``) is deliberately NOT
+# denied: reading a pocket cannot produce one, and a user on /code may reasonably
+# ask what a pocket contains. The line is drawn at AUTHORING.
+#
+# The widget ids are spelled out rather than imported so the CODE row stays a
+# STATIC profile (no lazy load, no resolver). ``test_code_deny_covers_every_widget
+# _tool`` pins this literal against the real ``WIDGET_TOOL_IDS``, so a widget tool
+# added later fails the suite instead of silently reopening the hole.
+_CODE_POCKET_DENY: frozenset[str] = frozenset(
+    {
+        # POCKET_CREATION_GRANT — survives the allow-list by design.
+        "mcp__pocketpaw_pocket_specialist__create",
+        "mcp__pocketpaw_pocket_planner__plan_pocket",
+        # ALWAYS_ALLOWED_MCP_SERVERS — the authoring verbs on the pocket servers.
+        "mcp__pocketpaw_pocket_specialist__edit",
+        "mcp__pocketpaw_pocket__add_widget",
+        "mcp__pocketpaw_pocket__update_widget",
+        # WIDGET_TOOL_IDS — the ripple catalog that turns "with components, nice
+        # design" into a ui-spec instead of React components.
+        "mcp__pocketpaw_widgets__get_widget_spec",
+        "mcp__pocketpaw_widgets__get_inline_widget_help",
+        "mcp__pocketpaw_widgets__start_flow",
+    }
 )
 
 
@@ -501,7 +562,7 @@ SURFACES: list[SurfaceSpec] = [
         profile=SurfaceProfile(
             ripple_mode="off",
             allow_mcp_tool_ids=_CODE_MODE_TOOL_IDS,
-            deny_mcp_tool_ids=_CODE_BUILTIN_DENY,
+            deny_mcp_tool_ids=_CODE_BUILTIN_DENY | _CODE_POCKET_DENY,
         ),
     ),
     SurfaceSpec(

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -60,8 +60,24 @@
 # that guarantee is the bug: a user with a React project open asked for "an
 # employee management app, with components, nice design" and got a pocket and a
 # ripple ui-spec. ``_CODE_POCKET_DENY`` closes it — deny runs BEFORE the grant is
-# unioned in and is the only lever that reaches those families. Read-only pocket
-# access survives deliberately. The CODE row stays STATIC.
+# unioned in and is the only lever that reaches those families.
+#
+# The row then went further, on the reading that /code should not reach a pocket
+# AT ALL. The pocket READ verbs join the deny set (a pocket the agent can inspect
+# is a pocket it can propose), and so does ``Skill`` (``_CODE_SKILL_DENY``) —
+# the bundled ``pocketpaw-create-pocket`` skill loads as a local PLUGIN, so
+# ``skill_names`` never withheld it and denying the invoking tool is the only
+# lever that does.
+#
+# And the row gained a ``system_message_override``: ``CODE_SYSTEM_PROMPT``. The
+# deny set alone would have left the agent with a pocket-shaped behavioral stack
+# it could no longer act on — the ripple LAW, the delegation rule and the
+# artifact rule all name tools that are now gone. Worse, a prohibition does not
+# create a DEFAULT: told only what not to build, the trained-in dashboard remains
+# the sole concrete plan in context. The override states the surface's own
+# deliverable instead. Both halves were needed; neither alone held.
+#
+# The CODE row stays STATIC — the prompt is a module constant like the tool ids.
 
 from __future__ import annotations
 
@@ -106,6 +122,7 @@ from pocketpaw_ee.cloud.surface.handlers import (
 from pocketpaw_ee.cloud.surface.handlers import (
     foresight as foresight_handler,
 )
+from pocketpaw_ee.cloud.surface.system_prompts import CODE_SYSTEM_PROMPT
 
 # The shape every handler module exports: an async preamble builder taking the
 # tenancy tuple + the validated client meta and returning the rendered block.
@@ -290,8 +307,40 @@ _CODE_POCKET_DENY: frozenset[str] = frozenset(
         "mcp__pocketpaw_widgets__get_widget_spec",
         "mcp__pocketpaw_widgets__get_inline_widget_help",
         "mcp__pocketpaw_widgets__start_flow",
+        # The READ verbs go too. An earlier pass kept them on the reasoning that
+        # reading a pocket cannot produce one — true in isolation, and beside the
+        # point: a pocket the agent can inspect is a pocket it can propose, and
+        # "let me look at how your other dashboard does this" is the first step
+        # back onto the path this profile exists to close. Nothing on /code needs
+        # them; the deliverable is the user's code.
+        "mcp__pocketpaw_pocket__get_pocket",
+        "mcp__pocketpaw_pocket__list_pockets",
     }
 )
+
+# ``Skill`` goes too, and it is the last door.
+#
+# The bundled skills ship as a Claude Code LOCAL PLUGIN, which is loaded from the
+# SDK ``plugins=`` option independently of ``skill_names`` — so a surface CANNOT
+# withhold ``pocketpaw-create-pocket`` by naming a narrower skill set, and CD-3's
+# empty ``skill_names`` never did. Its description ("create / build a pocket,
+# dashboard, tracker, tool, viewer ... with enterprise-quality design") matches a
+# request like "build an employee management app with components and nice design"
+# almost word for word, which is how the reported bug started.
+#
+# With every pocket tool denied above, invoking that skill can no longer BUILD
+# anything — but it would still cost the user a turn: the agent loads a long
+# instruction telling it to call ``get_widget_spec`` and ``pocket_specialist__
+# create``, attempts them, takes hard errors, and only then finds ``code_mode``.
+# CD-3 made exactly this argument when it dropped the `code` skill from the
+# profile ("absence is recoverable; contradiction is not"); the same reasoning
+# applies to a skill that teaches the wrong deliverable.
+#
+# /code needs no skill: ``CODE_SYSTEM_PROMPT`` is now the agent's whole guidance
+# here, and it is not a document the agent has to go and fetch. If a
+# code-targeted skill is ever written, removing ``Skill`` from this set is the
+# one-line change that admits it.
+_CODE_SKILL_DENY: frozenset[str] = frozenset({"Skill"})
 
 
 class _McpToolIds(NamedTuple):
@@ -562,7 +611,11 @@ SURFACES: list[SurfaceSpec] = [
         profile=SurfaceProfile(
             ripple_mode="off",
             allow_mcp_tool_ids=_CODE_MODE_TOOL_IDS,
-            deny_mcp_tool_ids=_CODE_BUILTIN_DENY | _CODE_POCKET_DENY,
+            deny_mcp_tool_ids=_CODE_BUILTIN_DENY | _CODE_POCKET_DENY | _CODE_SKILL_DENY,
+            # The surface's own system prompt, replacing the pocket-shaped
+            # behavioral stack the shared builder would otherwise assemble. See
+            # ``system_prompts.py`` for why a prohibition alone did not hold.
+            system_message_override=CODE_SYSTEM_PROMPT,
         ),
     ),
     SurfaceSpec(

--- a/ee/pocketpaw_ee/cloud/surface/system_prompts.py
+++ b/ee/pocketpaw_ee/cloud/surface/system_prompts.py
@@ -1,0 +1,113 @@
+# system_prompts.py — Per-surface system-prompt overrides.
+#
+# Created: 2026-07-22 (fix/code-surface-denies-pocket-authoring) — the text side
+# of ``SurfaceProfile.system_message_override``, which had been declared-but-inert
+# since 2026-06-05 (feat/surface-profile-bias-kill).
+#
+# Why a surface needs its own system prompt at all. The shared behavioral stack
+# assembled by ``build_behavior_instructions`` is written for a chat agent whose
+# deliverable is a POCKET: it carries the ~20k-char ripple LAW ("default to
+# ui-spec"), the pocket-delegation rule, and the artifact-delivery rule. A
+# surface whose deliverable is something else does not merely not-need those —
+# it is actively harmed by them, because each one is an instruction to use tools
+# the surface's profile has taken away.
+#
+# ``ripple_mode="off"`` was the first, coarse answer to that: it drops the ripple
+# LAW and the delegation rule. It is not enough. /code proved why — with ripple
+# off, the deny set closed, and a preamble saying "do not create a pocket", the
+# agent STILL answered "build me an employee management app, with components,
+# nice design" by creating a pocket and authoring a ui-spec. What remained was a
+# prompt that never said what the surface WAS, only what it must not do, plus an
+# artifact-delivery rule pointing at a filesystem the agent no longer has.
+#
+# The lesson the /code bug taught, and the reason this module exists: a
+# prohibition does not create a default. Telling an agent what NOT to build
+# leaves the trained-in default (a dashboard) as the only concrete plan in
+# context. The override has to give the surface a positive identity — this is
+# what you are, this is the one tool, this is what the deliverable looks like —
+# or the prohibition is competing against a habit with nothing to put in its
+# place.
+#
+# Scope of the swap (see ``build_behavior_instructions``): an override replaces
+# the DELIVERABLE stack — ripple LAW, pocket delegation, pocket prompts,
+# artifact delivery. It does NOT replace ``_RUNTIME_IDENTITY_RULE`` (true on
+# every surface: you are PocketPaw in a GUI chat, slash commands do not exist)
+# or the Composio rules (gated on Composio actually being enabled, so prompt and
+# tool list agree). Those describe the ENVIRONMENT; the override describes the
+# WORK.
+
+from __future__ import annotations
+
+# The /code system prompt.
+#
+# Paired with the CODE ``SurfaceProfile`` in ``surface_registry.py``: that row
+# denies the file/shell built-ins, ``Agent``, ``Skill``, and every pocket /
+# planner / widget tool, and scopes the MCP surface to ``code_mode``. Every
+# capability claimed below is one the profile actually grants, and every tool the
+# profile withholds is either unmentioned or explained as absent. If the profile
+# changes, change this text in the same commit — a system prompt that promises a
+# denied tool is the failure this whole file exists to remove.
+CODE_SYSTEM_PROMPT = """\
+<code-surface-role>
+You are PocketPaw's coding agent. The user is in a code editor looking at a real
+software project, and your deliverable is WORKING CODE in that project — files
+created and changed, tests passing. Nothing else counts as done.
+
+The project does NOT live on your machine. It lives in the user's own workspace,
+and the `code_mode` tool is the ONLY way to reach it. That tool resolves the
+project, reads it, and applies the change. You have no filesystem of your own
+here: no working directory, nothing to `cd` into, no path worth naming.
+</code-surface-role>
+
+<code-surface-deliverable>
+Read every request to BUILD something as a request to build it IN CODE, in
+whatever framework the project already uses.
+
+"Build me an employee management app, with components and a nice design" means
+components and styles in the user's project — React, Vue, Svelte, whatever is
+already there. It does NOT mean a pocket, a dashboard, or a ripple ui-spec,
+however closely the words match one. On this surface:
+
+  - "component" means a framework component in the user's codebase.
+  - "app" means their application, the one they have open.
+  - "design", "nice UI", "dashboard" mean CSS and markup you write into it.
+
+You cannot create a pocket here, and you should not offer to. The pocket,
+planner, and widget tools are withheld on this surface, as are the file and
+shell built-ins — not as a limitation to work around, but because none of them
+touch the user's project. `code_mode` is the path. If you catch yourself
+reaching for anything else, that is the signal you have drifted off this
+surface's job.
+</code-surface-deliverable>
+
+<code-surface-procedure>
+Treat the user's message as a coding task and do it by calling `code_mode`.
+Describe the change in the user's own terms; the tool locates the code itself,
+so do NOT go hunting for files first.
+
+Use `mode='ask'` to read, search, and answer questions about the code. Use
+`mode='edit'` only when the user actually wants the code changed.
+
+If the request is scoped to a selection the user has ALREADY made, call
+`code_mode` IMMEDIATELY with no exploratory retrieval. The selected code and its
+file are already in your context, and this path is two model calls deep — a
+redundant lookup is a round-trip the user waits through twice.
+
+For a task large enough to need several edits, sequence them: make the change,
+see what came back, then decide the next one. Do not narrate a plan you have not
+started.
+</code-surface-procedure>
+
+<code-surface-honesty>
+Report only what actually happened. `code_mode` tells you whether the change
+landed — say what it says.
+
+If it returns an error, or reports no browser session attached, say so plainly
+and stop. Never describe a file as written, a test as passing, or a feature as
+built when the tool did not confirm it. A wrong claim here is worse than a
+failure, because the user will act on it. When it succeeds, briefly summarize
+what changed and where.
+</code-surface-honesty>"""
+
+
+__all__ = ["CODE_SYSTEM_PROMPT"]

--- a/tests/cloud/chat/test_surface_system_prompt.py
+++ b/tests/cloud/chat/test_surface_system_prompt.py
@@ -1,0 +1,134 @@
+# tests/cloud/chat/test_surface_system_prompt.py — SurfaceProfile.system_message
+# _override, consumed by build_behavior_instructions.
+#
+# Created: 2026-07-22 (fix/code-surface-denies-pocket-authoring) — the field had
+# been declared-but-inert since 2026-06-05 and is now the /code surface's own
+# system prompt.
+#
+# What these guard, and why the deny set was not enough on its own. The reported
+# bug: with a React project open on /code, "Let's build an employee management
+# app, with components, nice design etc" made the agent create a pocket and
+# author a ripple ui-spec. Denying the pocket tools stops it BUILDING one. It
+# does not stop the shared behavioral stack from telling it to — that stack is
+# written for an agent whose deliverable is a pocket, and on /code every one of
+# its rules names a tool the profile has taken away (the artifact rule wants
+# ``Write`` + ``deliver_artifact``; the delegation rule wants the specialist).
+# An instruction to use a denied tool costs the user a turn and leaves the
+# trained-in default as the only concrete plan in context.
+#
+# So the two halves are tested as a pair: the deny set (in
+# tests/cloud/surface/test_studio_code_handlers.py) proves the alternatives are
+# unreachable; these prove the surface states its OWN deliverable instead of
+# only forbidding the other one.
+#
+# The regression half matters as much as the /code half. The override is read on
+# a path every cloud chat turn goes through, so a bug here would silently reshape
+# the prompt for every other surface — hence ``test_default_surface_prompt_is_
+# untouched``, which pins the ripple-on assembly byte-for-byte against a profile
+# that sets no override.
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, build_behavior_instructions
+from pocketpaw_ee.cloud.surface import SurfaceKind, SurfaceMeta, resolve_profile
+from pocketpaw_ee.cloud.surface.system_prompts import CODE_SYSTEM_PROMPT
+
+BACKEND = "claude_agent_sdk"
+
+
+def _ctx(**overrides: object) -> ScopeContext:
+    """A minimal workspace-scope context; ``overrides`` set the fields under test."""
+    base = ScopeContext(
+        kind="workspace",
+        scope_id="ws-sysprompt",
+        workspace_id="ws-sysprompt",
+        user_id="u-sysprompt",
+        members=[],
+        target_agent_id="agent-1",
+    )
+    return replace(base, **overrides)
+
+
+def _code_prompt() -> str:
+    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+    return build_behavior_instructions(_ctx(resolved_profile=profile), backend_name=BACKEND)
+
+
+def test_code_surface_prompt_is_the_override() -> None:
+    """The /code system prompt IS the surface's own text, not the shared stack."""
+    assert CODE_SYSTEM_PROMPT in _code_prompt()
+
+
+def test_code_surface_prompt_drops_the_pocket_deliverable_stack() -> None:
+    """Every pocket-shaped instruction is gone from the /code prompt.
+
+    Asserted by MARKER rather than by naming the constants, so the test keeps
+    holding if the ripple LAW or the delegation rule is reworded. Each marker
+    below is an instruction to build or delegate a pocket — the thing the user
+    did not ask for and got anyway."""
+    prompt = _code_prompt()
+
+    # The ripple LAW's own heading, and the delegation rule's instruction.
+    assert "INLINE RIPPLE" not in prompt.upper()
+    assert "pocket specialist" not in prompt
+    assert "add_widget" not in prompt
+    # The artifact rule: names Write + deliver_artifact, neither of which /code has.
+    assert "<artifact-delivery>" not in prompt
+    assert "deliver_artifact" not in prompt
+
+
+def test_code_surface_prompt_keeps_the_environment_rules() -> None:
+    """The override replaces the WORK, not the ENVIRONMENT.
+
+    ``runtime-identity`` is true on every surface — the agent is PocketPaw in a
+    GUI chat, slash commands do not exist here — and a /code agent that forgets
+    it starts telling the user to run ``/mcp``. Folding it into each surface's
+    prompt would duplicate it per surface and let the copies drift, so it stays
+    in the shared assembly and the override sits after it."""
+    prompt = _code_prompt()
+
+    assert "<runtime-identity>" in prompt
+    assert prompt.index("<runtime-identity>") < prompt.index(CODE_SYSTEM_PROMPT)
+
+
+def test_code_surface_prompt_is_far_smaller_than_the_default() -> None:
+    """Dropping the deliverable stack is a large, measurable saving.
+
+    Not a micro-optimization: the ripple LAW alone is ~20k chars of "default to
+    ui-spec" instruction, and it was in the /code agent's context on every turn
+    while the surface's actual job got a few hundred characters of preamble. The
+    ratio is why the prohibition kept losing."""
+    code_len = len(_code_prompt())
+    default = resolve_profile(SurfaceKind.CHAT, SurfaceMeta())
+    default_len = len(
+        build_behavior_instructions(_ctx(resolved_profile=default), backend_name=BACKEND)
+    )
+
+    assert code_len < default_len / 2, (
+        f"/code prompt is {code_len} chars vs {default_len} for the default "
+        f"surface — the deliverable stack does not look dropped"
+    )
+
+
+def test_default_surface_prompt_is_untouched() -> None:
+    """THE regression guard: a profile with no override is assembled exactly as
+    before.
+
+    ``build_behavior_instructions`` runs on every cloud chat turn, so the
+    override branch must be inert for every surface that does not set one. Both
+    a real ripple-on profile and the legacy ``resolved_profile is None`` path are
+    checked, since the latter is what a surface-less client still sends."""
+    default = resolve_profile(SurfaceKind.CHAT, SurfaceMeta())
+    with_profile = build_behavior_instructions(_ctx(resolved_profile=default), backend_name=BACKEND)
+    legacy = build_behavior_instructions(_ctx(), backend_name=BACKEND)
+
+    # The stack /code drops is still fully present on the default surface.
+    for marker in ("<artifact-delivery>", "deliver_artifact", "pocket specialist"):
+        assert marker in with_profile, f"{marker} vanished from the default surface prompt"
+        assert marker in legacy, f"{marker} vanished from the legacy (no-profile) prompt"
+
+    # And no surface leaks the /code prompt.
+    assert CODE_SYSTEM_PROMPT not in with_profile
+    assert CODE_SYSTEM_PROMPT not in legacy

--- a/tests/cloud/surface/test_studio_code_handlers.py
+++ b/tests/cloud/surface/test_studio_code_handlers.py
@@ -27,6 +27,20 @@
 # ``is_cloud_storage`` hints. The registry-import assertion is exercised too,
 # since the profile now leans on two module-level literals.
 #
+# Changes: 2026-07-22 (fix/code-surface-denies-pocket-authoring) — added the
+# pocket-authoring guards. CD-3's tests proved the /code agent could not reach the
+# wrong MACHINE; nothing proved it could not build the wrong DELIVERABLE, and it
+# did: "Let's build an employee management app, with components, nice design etc"
+# produced a pocket and a ripple ui-spec on a surface holding a React project.
+# ``test_code_profile_builds_no_pocket_in_the_effective_allowlist`` is the repro,
+# driven through the same real ``_build_options`` for the same reason — the
+# bypasses that caused the bug (``POCKET_CREATION_GRANT``, ``WIDGET_TOOL_IDS``,
+# ``ALWAYS_ALLOWED_MCP_SERVERS``) live in the COMPUTATION, so a profile-membership
+# assertion would have gone green while the agent still held the tools.
+# ``test_code_deny_covers_every_widget_tool_and_the_pocket_creation_grant`` pins
+# the deny literals against those real constants so a tool added to either family
+# later reopens the hole loudly instead of silently.
+#
 # The load-bearing one is
 # ``test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist``: it
 # drives the REAL ``ClaudeSDKBackend._build_options`` and reads the allowlist the
@@ -102,6 +116,20 @@ async def test_studio_handler_relays_provider_errors() -> None:
 # The file/shell built-ins the /code agent must not hold. They address the
 # backend server, which is not the machine the user's project is on.
 _FILESYSTEM_BUILTINS = frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"})
+
+# The pocket-AUTHORING tools the /code agent must not hold. Each one is a way to
+# answer "build me an app" with a dashboard instead of code. Read-only pocket
+# access (``get_pocket`` / ``list_pockets``) is deliberately absent from this set
+# — reading a pocket cannot produce one.
+_POCKET_AUTHORING_TOOLS = frozenset(
+    {
+        "mcp__pocketpaw_pocket_specialist__create",
+        "mcp__pocketpaw_pocket_specialist__edit",
+        "mcp__pocketpaw_pocket_planner__plan_pocket",
+        "mcp__pocketpaw_pocket__add_widget",
+        "mcp__pocketpaw_pocket__update_widget",
+    }
+)
 
 # The Daytona MCP tool names the old preamble advertised. They address an older
 # cloud-projects model that knows nothing of the current codeproject +
@@ -209,6 +237,22 @@ async def test_code_handler_leaks_no_filesystem_path_even_from_legacy_meta() -> 
         # Nothing to cd into, so no shell navigation instruction either.
         assert "cd to" not in lower
         assert "navigate to" not in lower
+
+
+async def test_code_handler_reads_build_an_app_as_code() -> None:
+    """The preamble re-points the vocabulary that caused the bug.
+
+    A blanket "do not create a pocket" was already present and still lost to a
+    request whose every noun ("app", "components", "design") matches the
+    create-pocket skill. So the prose has to claim those words for the front-end
+    reading, not just forbid the outcome."""
+    preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
+    lower = preamble.lower()
+
+    assert "component" in lower
+    # The words are named and reassigned, not merely banned.
+    assert "ui-spec" in lower or "ui spec" in lower
+    assert "withheld" in lower or "do not reach for a skill" in lower
 
 
 async def test_code_handler_forbids_phantom_success() -> None:
@@ -364,6 +408,108 @@ async def test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist
     assert any(t.startswith("mcp__") for t in effective), (
         "no mcp__ tool survived the allow-list filter — MCP resolution produced "
         "nothing, so the absence assertions above prove nothing"
+    )
+
+
+async def test_code_profile_builds_no_pocket_in_the_effective_allowlist() -> None:
+    """The /code agent must not be able to BUILD A POCKET.
+
+    Reported from a live session: with a React project open on /code, "Let's
+    build an employee management app, with components, nice design etc" made the
+    agent create a pocket and start authoring a ripple ui-spec instead of writing
+    React. The user asked for an app; the agent shipped a dashboard.
+
+    The preamble already forbids this in prose ("do not build widgets, charts, or
+    a ui-spec, and do not create a pocket"), and the prose lost — exactly as the
+    /sites svelte-create comment predicted when it denied the same two tools
+    rather than asking nicely.
+
+    The reason the deny was needed is that ``allow_mcp_tool_ids`` CANNOT express
+    it. CD-3 scoped /code to ``code_mode``, but ``claude_sdk`` deliberately lets
+    two families survive any restrictive allow-list: ``POCKET_CREATION_GRANT``
+    (create + plan) and ``ALWAYS_ALLOWED_MCP_SERVERS`` (the whole
+    ``pocketpaw_pocket*`` family), plus ``WIDGET_TOOL_IDS`` unioned into the
+    grant. Those bypasses are correct for a general chat surface — "create a
+    pocket" is the core capability — and wrong for this one, where the
+    deliverable is code. Deny runs BEFORE the grant is applied and is the only
+    lever that reaches them.
+
+    Asserted against the COMPUTED allowlist, not the declaration, for the same
+    reason the filesystem test above is: the bypasses live in the computation."""
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+    from pocketpaw.config import get_settings
+
+    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+    backend = ClaudeSDKBackend(get_settings())
+
+    built = await backend._build_options(
+        "Let's build an employee management app, with components, nice design etc",
+        system_prompt="you are on the code surface",
+        history=None,
+        session_key=None,
+        deny_mcp_tool_ids=profile.deny_mcp_tool_ids,
+        allow_sdk_tools=profile.allowed_sdk_tools or frozenset(),
+        allow_mcp_tool_ids=profile.allow_mcp_tool_ids,
+        skill_names=profile.skill_names,
+        stderr_sink=[],
+    )
+    effective = set(built.options_kwargs["allowed_tools"])
+
+    for tool in sorted(_POCKET_AUTHORING_TOOLS):
+        assert tool not in effective, (
+            f"{tool} reached the SDK's effective allowlist on /code — the agent "
+            f"can build a pocket instead of writing the user's code. Effective "
+            f"allowlist: {sorted(effective)}"
+        )
+
+    # The ripple widget catalog, by prefix so a widget tool added later is caught
+    # without anyone remembering to update this test. These are the tools that
+    # turn "with components, nice design" into a ui-spec.
+    leaked_widgets = sorted(t for t in effective if t.startswith("mcp__pocketpaw_widgets__"))
+    assert not leaked_widgets, (
+        f"ripple widget tools reached the effective allowlist on /code: "
+        f"{leaked_widgets}. 'Components' on this surface means React/Vue "
+        f"components in the user's project, not ripple widgets in a ui-spec."
+    )
+
+    # Positive controls, so the assertions above cannot pass vacuously.
+    assert "WebSearch" in effective
+    # READ-ONLY pocket access is deliberately NOT denied: listing or reading a
+    # pocket cannot produce a dashboard, and the user may legitimately ask about
+    # one from here. If this ever starts failing, the deny set has grown past
+    # what the bug called for.
+    assert "mcp__pocketpaw_pocket__list_pockets" in effective, (
+        "read-only pocket access was denied too — the fix over-reached; only the "
+        "AUTHORING tools should be withheld on /code"
+    )
+
+
+def test_code_deny_covers_every_widget_tool_and_the_pocket_creation_grant() -> None:
+    """The /code deny set is spelled as literals; pin it against the real sources.
+
+    ``_CODE_POCKET_DENY`` enumerates ids rather than importing them, so the CODE
+    row can stay a STATIC profile with no lazy load. The cost of a literal is
+    drift: a tool added to ``WIDGET_TOOL_IDS`` or ``POCKET_CREATION_GRANT`` later
+    would bypass the allow-list exactly as before and nobody would notice, because
+    both are grant families that survive any restrictive allow-list. This test is
+    what makes the literal safe — it fails the moment a new one appears."""
+    from pocketpaw.agents.claude_sdk import POCKET_CREATION_GRANT
+    from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
+
+    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+
+    missing_widgets = frozenset(WIDGET_TOOL_IDS) - profile.deny_mcp_tool_ids
+    assert not missing_widgets, (
+        f"ripple widget tools not denied on /code: {sorted(missing_widgets)}. "
+        f"WIDGET_TOOL_IDS is unioned into the MCP grant in claude_sdk, so it "
+        f"survives allow_mcp_tool_ids — add these to _CODE_POCKET_DENY."
+    )
+
+    missing_grant = POCKET_CREATION_GRANT - profile.deny_mcp_tool_ids
+    assert not missing_grant, (
+        f"pocket-creation grant tools not denied on /code: {sorted(missing_grant)}. "
+        f"POCKET_CREATION_GRANT bypasses every restrictive allow-list by design — "
+        f"add these to _CODE_POCKET_DENY."
     )
 
 

--- a/tests/cloud/surface/test_studio_code_handlers.py
+++ b/tests/cloud/surface/test_studio_code_handlers.py
@@ -294,6 +294,46 @@ def test_code_profile_ripple_off_and_scoped_to_code_mode() -> None:
     assert profile.allow_mcp_tool_ids == frozenset({"mcp__pocketpaw_code__code_mode"})
 
 
+def test_code_profile_denies_the_skill_tool() -> None:
+    """``Skill`` is denied, which is the only way to withhold create-pocket.
+
+    The bundled skills load as a Claude Code LOCAL PLUGIN, from the SDK
+    ``plugins=`` option — independent of ``skill_names``. So an empty
+    ``skill_names`` (what CD-3 set) does NOT keep ``pocketpaw-create-pocket``
+    away from this surface, and that skill's description matches "build an app
+    with components and nice design" almost word for word. Denying the tool that
+    invokes skills is the lever that actually exists."""
+    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+
+    assert "Skill" in profile.deny_mcp_tool_ids
+    # Research still works — neither reaches a filesystem or builds a pocket.
+    assert not {"WebSearch", "WebFetch"} & profile.deny_mcp_tool_ids
+
+
+def test_code_profile_carries_its_own_system_prompt() -> None:
+    """/code replaces the shared deliverable stack with its own system prompt.
+
+    The deny set makes a pocket unreachable; this makes CODE the default instead
+    of merely the permitted option. Both were needed — ``ripple_mode="off"`` plus
+    a preamble forbidding pockets still lost, because a prohibition does not
+    create a default."""
+    from pocketpaw_ee.cloud.surface.system_prompts import CODE_SYSTEM_PROMPT
+
+    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+
+    assert profile.system_message_override == CODE_SYSTEM_PROMPT
+    # It has to say what the surface DOES build, not only what it must not.
+    assert "code_mode" in CODE_SYSTEM_PROMPT
+    assert "WORKING CODE" in CODE_SYSTEM_PROMPT
+    # And it must not promise a tool the profile denies.
+    for denied in ("deliver_artifact", "get_widget_spec", "pocket_specialist"):
+        assert denied not in CODE_SYSTEM_PROMPT, (
+            f"the /code system prompt names {denied}, which this surface's "
+            f"profile withholds — a prompt that promises a denied tool is the "
+            f"contradiction this override exists to remove"
+        )
+
+
 def test_code_profile_surfaces_no_skill() -> None:
     """/code carries NO skill.
 
@@ -326,7 +366,13 @@ def test_code_profile_denies_the_filesystem_builtins_and_subagents() -> None:
     # Not smuggled back in through the additive allow-list either.
     assert not (profile.allowed_sdk_tools or frozenset()) & _FILESYSTEM_BUILTINS
     # Research tools survive — neither reaches a filesystem.
-    assert not {"WebSearch", "WebFetch", "Skill"} & profile.deny_mcp_tool_ids
+    #
+    # ``Skill`` was in this list until 2026-07-22 on the same reasoning. It is
+    # now denied (see ``test_code_profile_denies_the_skill_tool``): the bundled
+    # ``pocketpaw-create-pocket`` skill loads as a local plugin regardless of
+    # ``skill_names``, so this is the only lever that withholds it, and its
+    # description is a near-exact match for the request that triggered the bug.
+    assert not {"WebSearch", "WebFetch"} & profile.deny_mcp_tool_ids
 
 
 async def test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist() -> None:
@@ -472,15 +518,23 @@ async def test_code_profile_builds_no_pocket_in_the_effective_allowlist() -> Non
         f"components in the user's project, not ripple widgets in a ui-spec."
     )
 
+    # No pocket tool of ANY kind survives — read verbs included. An earlier pass
+    # kept ``get_pocket`` / ``list_pockets`` on the reasoning that reading a
+    # pocket cannot produce one; that is true and beside the point, since a
+    # pocket the agent can inspect is a pocket it can propose. Prefix scan, so a
+    # tool added to the server later is caught without updating this test.
+    leaked_pocket = sorted(t for t in effective if t.startswith("mcp__pocketpaw_pocket"))
+    assert not leaked_pocket, (
+        f"pocket tools reached the effective allowlist on /code: {leaked_pocket}. "
+        f"The deliverable on this surface is the user's code; nothing here needs "
+        f"a pocket, in read or write."
+    )
+
     # Positive controls, so the assertions above cannot pass vacuously.
     assert "WebSearch" in effective
-    # READ-ONLY pocket access is deliberately NOT denied: listing or reading a
-    # pocket cannot produce a dashboard, and the user may legitimately ask about
-    # one from here. If this ever starts failing, the deny set has grown past
-    # what the bug called for.
-    assert "mcp__pocketpaw_pocket__list_pockets" in effective, (
-        "read-only pocket access was denied too — the fix over-reached; only the "
-        "AUTHORING tools should be withheld on /code"
+    assert "mcp__pocketpaw_code__code_mode" in effective, (
+        "code_mode itself was filtered out — the surface has lost its only door "
+        "to the user's project, so the absence assertions above prove nothing"
     )
 
 


### PR DESCRIPTION
With a React project open on /code, "Let's build an employee management app, with components, nice design etc" made the agent create a pocket and start authoring a ripple ui-spec. It answered a request for an app with a dashboard.

## Why the existing guards missed it

CD-3 had already scoped this surface: ripple off, filesystem built-ins denied, MCP surface narrowed to `code_mode`. The preamble says "do not create a pocket" in plain words.

The scope could not hold. `claude_sdk` unions three families back in *after* a mode's allow-list is applied: `POCKET_CREATION_GRANT`, `WIDGET_TOOL_IDS`, and every tool on an `ALWAYS_ALLOWED_MCP_SERVERS` server. That is deliberate, and right for general chat, where creating a pocket is the core capability and has to work from anywhere. On /code it hands the agent the exact tools the surface exists to avoid. Dumping the allowlist the reported session ran with: `pocket_specialist__create`, `plan_pocket`, `add_widget`, `update_widget` and all three widget tools were sitting there.

The prose lost for a separate reason. Every noun in that request (app, components, design) matches the bundled create-pocket skill's description, and the skill loads as a local plugin, so `skill_names` never withheld it.

## What changed

Deny, because deny runs before the grant is unioned in and is the only lever that reaches those families. The pocket, planner and widget tools go, along with the read verbs and `Skill` itself.

/code also gets its own system prompt, which wires `SurfaceProfile.system_message_override` (declared back in June, never consumed). Denying the tools alone would have left the agent holding a pocket-shaped behavioral stack it could no longer act on: the artifact rule wants `Write` and `deliver_artifact`, the delegation rule wants the specialist. CD-3 already wrote down what that costs, the agent tries, takes hard errors, burns turns.

The bigger problem is that forbidding something does not replace it. Told only what *not* to build, the agent still has the dashboard as its one concrete plan. The new prompt says what the surface is instead: the project is not on this machine, `code_mode` is the only door, "components" means React components, and nothing counts as done until the tool confirms it.

An override swaps the deliverable stack and nothing else. The runtime identity rule and the Composio rules stay, since they describe the environment rather than the work, and the Composio ones are already gated on Composio being enabled. /code's system prompt drops from 42,781 chars to 7,186.

## Effective allowlist

Before:

```
code_mode, pocket_specialist__create, pocket_specialist__edit,
pocket_planner__plan_pocket, pocket__add_widget, pocket__update_widget,
pocket__get_pocket, pocket__list_pockets, widgets__get_widget_spec,
widgets__get_inline_widget_help, widgets__start_flow,
atlas__*, composio, Skill, WebSearch, WebFetch
```

After:

```
code_mode, atlas__*, composio, WebSearch, WebFetch
```

## Testing

The repro drives the real `_build_options` rather than asserting on the profile, because the bypasses that caused this live in the computation. A membership check on `deny_mcp_tool_ids` goes green while the agent still holds the tools, which is exactly how the original slipped through CD-3's suite.

A second test pins the deny literals against the real `WIDGET_TOOL_IDS` and `POCKET_CREATION_GRANT`, so a tool added to either family later reopens the hole loudly instead of silently.

`build_behavior_instructions` runs on every cloud chat turn, so there is a regression guard on the untouched path too, covering both a default ripple-on profile and the legacy no-profile case.

I enumerated every test file that touches the changed code paths (`build_behavior_instructions`, `resolve_profile`, `SurfaceProfile`, the deny/allow sets, `_build_options`, `surface_registry`) and ran that set against the clean base commit and against this branch:

| | Files | Result |
|---|---|---|
| Base `a08876ce` | 32 | 2 failed, 399 passed |
| This branch | 33 | 2 failed, 409 passed |

Same two failures either side (`test_run_core.py::test_execute_run_cancellation_preserves_original_exception` and `::test_execute_run_threads_surface_meta_into_ctx`), so both predate this work. The extra 10 passing are the new tests. `tests/cloud/workspace` and `test_auth_cookie_chain.py` were compared the same way and are also identical (2 failed, 189 passed on both), those failures being environmental: LiteLLM 503, mongomock, fastapi cookie fixtures.

## Note

One CD-3 assertion was inverted on purpose. It expected `Skill` to survive on this surface, on the same "it does not reach a filesystem" reasoning that keeps WebSearch. That reasoning holds for the filesystem question and misses this one.

Two lint errors remain in `ee/pocketpaw_ee/agent/mcp_servers/code.py` (E501). They predate this branch and I left them alone to keep the diff on topic.
