### PR TITLE
Sites import: zip upload, from-url queue, and native form capture

### DIFF
--- a/ee/pocketpaw_ee/cloud/leads/router.py
+++ b/ee/pocketpaw_ee/cloud/leads/router.py
@@ -22,6 +22,20 @@
 # ``rate_key``. The caller-controlled ``body.submitter_ref`` is no longer the
 # limiter key (it was randomizable to dodge the cap); it rides through only as an
 # opaque, non-PII label on the stored Lead.
+#
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): added the NATIVE-FORM
+# capture sibling, POST /capture/form (final URL: {captureApiBase}/capture/form,
+# i.e. /api/v1/capture/form — captureApiBase already carries /api/v1, so the
+# spec's "/v1/capture/form" would have doubled the segment; this is the
+# router-consistent resolution and the cross-repo contract paw-sites' import
+# rewiring must target). IMPORTED sites rewire their <form>s to a plain
+# application/x-www-form-urlencoded POST here, with hidden fields ``paw_site_id``,
+# ``paw_key`` (the per-site signed key), ``paw_page``, ``paw_redirect`` and
+# optionally ``paw_form_type``. The endpoint runs the SAME hardening ladder as the
+# JSON capture (site exists → origin pin → constant-time signed key → payload size
+# cap → leads_service.capture), then 303-redirects to ``paw_redirect`` — which MUST
+# be a relative path (open-redirect guard: absolute / protocol-relative /
+# backslash / CR-LF all 400), resolved against the validated request Origin.
 
 from __future__ import annotations
 
@@ -29,7 +43,7 @@ import hashlib
 import json
 import secrets
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 
 from pocketpaw.sites_capture.ingest import origin_allowed
 from pocketpaw.sites_capture.models import MAX_PAYLOAD_BYTES
@@ -85,6 +99,88 @@ async def capture_lead(site_id: str, body: CaptureRequest, request: Request) -> 
     if lead is None:
         return CaptureResponse(ok=False, reason="dropped")
     return CaptureResponse(ok=True, lead_id=lead.id)
+
+
+def _safe_relative_redirect(path: str) -> bool:
+    """Open-redirect guard for the native-form 303: the redirect target must be a
+    RELATIVE path on the submitting site. Rejects absolute URLs (no leading "/"),
+    protocol-relative ("//host"), backslash tricks, embedded schemes, and CR/LF
+    (header injection). The accepted value is later prefixed with the VALIDATED
+    request Origin, so the browser can only ever land back on the pinned site."""
+    if not path.startswith("/") or path.startswith("//"):
+        return False
+    if "\\" in path or "\r" in path or "\n" in path or "://" in path:
+        return False
+    return len(path) <= 2048
+
+
+@router.post("/capture/form")
+async def capture_form(request: Request) -> Response:
+    """Native-form ingest for IMPORTED sites (SI-4). The imported page's <form>s
+    are rewired to POST application/x-www-form-urlencoded here with hidden fields:
+    ``paw_site_id`` (the site), ``paw_key`` (the per-site signed key), ``paw_page``
+    (provenance label), ``paw_redirect`` (relative post-submit path), and optional
+    ``paw_form_type`` (event-mapping key; defaults to "lead" — the mapping every
+    site doc seeds). CROSS-REPO CONTRACT: the final URL is
+    {captureApiBase}/capture/form (/api/v1/capture/form) — see the module comment.
+
+    Hardening mirrors the JSON capture exactly: site exists → origin pin →
+    constant-time key compare → payload size cap → the SAME
+    ``leads_service.capture`` pipeline (honeypot / rate limit / injection screen /
+    mapping). The open-redirect guard rejects any non-relative ``paw_redirect``
+    BEFORE anything is recorded. The response is a 303 See Other back to the
+    validated Origin + redirect path — a DROPPED submission still 303s (the
+    visitor is never shown an error that leaks the drop heuristics)."""
+    form = await request.form()
+    site_id = str(form.get("paw_site_id") or "")
+    key = str(form.get("paw_key") or "")
+    page = str(form.get("paw_page") or "")
+    redirect = str(form.get("paw_redirect") or "") or "/"
+    form_type = str(form.get("paw_form_type") or "lead")
+
+    # global-read: public ingest is keyed by site, not by a workspace session.
+    site = await _SiteDoc.find_one({"script_name": site_id}) if site_id else None
+    if site is None:
+        raise HTTPException(404, "Site not found")
+
+    if not origin_allowed(site.allowed_origins, request.headers.get("origin")):
+        raise HTTPException(403, "Origin not allowed for this site")
+
+    # H1 (same as the JSON path): constant-time compare — no timing side channel.
+    if not secrets.compare_digest(key, site.signed_key):
+        raise HTTPException(401, "Invalid signed key")
+
+    # Open-redirect guard BEFORE any write: a bad redirect fails the whole submit.
+    if not _safe_relative_redirect(redirect):
+        raise HTTPException(400, "paw_redirect must be a relative path on the site")
+
+    # The lead payload is every NON-``paw_*`` text field. UploadFile parts (a file
+    # input on an imported form) are skipped — the capture pipeline stores JSON
+    # properties, never file bodies.
+    payload = {
+        k: v for k, v in form.multi_items() if isinstance(v, str) and not k.startswith("paw_")
+    }
+
+    # C1 (same as the JSON path): cap the payload size before the service runs.
+    if len(json.dumps(payload, default=str).encode("utf-8")) > MAX_PAYLOAD_BYTES:
+        raise HTTPException(413, "Payload exceeds size cap")
+
+    await leads_service.capture(
+        site=site,
+        form_type=form_type,
+        payload=payload,
+        # Opaque provenance label (mirrors submitter_ref on the JSON path — never
+        # a limiter key). Truncated: paw_page is caller-controlled text.
+        submitter_ref=f"form:{page}"[:256] if page else "form",
+        rate_key=_rate_key(request),  # server-derived; the real per-IP limiter key
+    )
+
+    # 303 back to the site. The Location is the VALIDATED Origin (already pinned
+    # against site.allowed_origins above) + the RELATIVE redirect path, so the
+    # browser can only land back on the submitting site. origin_allowed fails
+    # closed on a missing Origin, so it is always present here.
+    origin = (request.headers.get("origin") or "").rstrip("/")
+    return Response(status_code=303, headers={"Location": f"{origin}{redirect}"})
 
 
 # Leads is a Sites surface, so its plan gate is the "sites" feature (go+) — the

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -103,6 +103,14 @@
 # can surface it on ``SiteResponse.provision_job_id``. None for a static publish and
 # for any DB-loaded doc (the PrivateAttr defaults to None). Private so it never
 # round-trips through the DB.
+#
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): added ``import_report`` —
+# the per-import summary an IMPORTED site carries ({pages, asset_count, asset_bytes,
+# forms, scripts, warnings}), persisted by the import service after the html deploy
+# and surfaced on ``SiteResponse.import_report``. Derived minimally from the zip
+# contents today; the generator-side import plan enriches it (form-rewiring
+# verdicts) once the parallel paw-sites slice lands. Defaults to an empty dict, so
+# every non-imported site and every pre-SI-4 row reads "no import" — no migration.
 
 from __future__ import annotations
 
@@ -193,6 +201,10 @@ class Site(TimestampedDocument):
     # carries the gated edit-bridge keyed on this origin. Persisted so a
     # component-edit republish can re-apply it and the site stays editable.
     builder_origin: str = ""
+    # SI-4: the import summary an IMPORTED site carries ({pages, asset_count,
+    # asset_bytes, forms, scripts, warnings}; from-url adds status/source_url).
+    # Empty for every non-imported site — no migration.
+    import_report: dict[str, Any] = Field(default_factory=dict)
     # Capture hardening config (mirrors sites_capture.SiteFormConfig fields).
     allowed_origins: list[str] = Field(default_factory=list)
     signed_key: str = ""

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -112,6 +112,12 @@
 # ``SiteStatusResponse`` gain ``engine`` ("svelte" | "ripple"; "" when unresolved) —
 # the sibling of DS-1a's ``pattern``, resolved from the source Pocket.engine so the
 # gallery can badge each card's engine (Custom vs Ripple) without a per-site fetch.
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): ``SiteResponse`` gains
+# ``import_report`` (the persisted import summary — None for non-imported sites),
+# and two new DTOs back the import surface: ImportFromUrlRequest ({url}, shape-
+# validated in the service) and ImportFromUrlResponse ({site_id, pocket_id,
+# status:"queued"} — the 202 body; the crawler is the next stacked slice). The zip
+# import endpoint reuses SiteResponse (it publishes live through the html path).
 
 from __future__ import annotations
 
@@ -180,6 +186,11 @@ class SiteResponse(BaseModel):
     # caller can poll the job. None for a static publish, and None on a single-flight
     # no-op (a second publish while already provisioning does not enqueue a job).
     provision_job_id: str | None = None
+    # SI-4: the persisted import summary for an IMPORTED site — {pages: [{path,
+    # title}], asset_count, asset_bytes, forms: [{page, original_action, rewired}],
+    # scripts, warnings} (from-url adds status/source_url). None for every
+    # non-imported site, so the field is backward-compatible and empty-safe.
+    import_report: dict[str, Any] | None = None
 
 
 class SitePreviewResponse(BaseModel):
@@ -419,6 +430,25 @@ class LeafEditsResponse(BaseModel):
 
     pocket_id: str
     results: list[LeafEditVerdict]
+
+
+class ImportFromUrlRequest(BaseModel):
+    """Body for POST /sites/import/from-url (SI-4): the site URL to crawl-import.
+    Shape validation (http(s), real host, length cap) runs in the import service so
+    direct service callers are covered too; the crawler itself is the next stacked
+    slice — this endpoint only queues."""
+
+    url: str
+
+
+class ImportFromUrlResponse(BaseModel):
+    """202 body of POST /sites/import/from-url (SI-4): the DRAFT site minted for the
+    queued crawl. ``status`` is "queued" — the crawler slice (SI-5) has not landed,
+    so the site's import_report carries a crawler-pending warning until it does."""
+
+    site_id: str
+    pocket_id: str
+    status: str  # queued
 
 
 class NativeArtifactResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -16,6 +16,15 @@
 # triggers a build, so the prod box stops running a 1-2 min SvelteKit build on every
 # site view. Builds now happen only at publish and (cached/pre-warmed) at edit-arm.
 #
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): build()/_build_one() gain an
+# OPTIONAL ``assets`` param — the base64 binary sideband ({path: base64}) an html
+# IMPORT carries alongside its text ``source`` map. It rides ``input.assets`` on the
+# html branch only, and ONLY when non-empty, so every existing ripple/svelte/html
+# payload stays byte-identical. CROSS-REPO SEAM: the paw-sites generator's ``assets``
+# key (decode + write each entry verbatim into the static tree) is being added in a
+# parallel paw-sites slice — this codes to that contract; a generator predating it
+# ignores the key and deploys the text tree only.
+#
 # Updated 2026-07-10 (HE-3 — html publish skips the Node build): build()/_build_one()
 # now branch the STAGE-2 payload AND the build chain on the engine's CAPABILITY, via
 # ``needs_node_build(engine)`` / ``is_source_engine(engine)`` from the canonical
@@ -1110,6 +1119,7 @@ class GeneratorClient:
         capture_signed_key: str,
         engine: str = "ripple",
         source: dict[str, Any] | None = None,
+        assets: dict[str, str] | None = None,
         builder_origin: str | None = None,
         d1_database_id: str = "",
         pocket_id: str | None = None,
@@ -1117,6 +1127,11 @@ class GeneratorClient:
         static_build: bool = True,
     ) -> BuildResult:
         """Generate + smoke-build a Paw Site, forking STAGE 2 on ``engine``.
+
+        ``assets`` (SI-4) is the html import's base64 BINARY sideband
+        ({path: base64}) — sent as ``input.assets`` on the html branch only, and only
+        when non-empty (see _build_one for the cross-repo seam note). ripple/svelte
+        payloads never carry it.
 
         ``engine="ripple"`` (default) compiles ``ripple_spec`` into the site;
         ``engine="svelte"`` materializes ``source`` (the pocket's hand-written
@@ -1188,6 +1203,7 @@ class GeneratorClient:
                 capture_signed_key=capture_signed_key,
                 engine=engine,
                 source=source,
+                assets=assets,
                 builder_origin=builder_origin,
                 d1_database_id=d1_database_id,
                 pocket_id=None,
@@ -1204,6 +1220,7 @@ class GeneratorClient:
                 capture_signed_key=capture_signed_key,
                 engine=engine,
                 source=source,
+                assets=assets,
                 builder_origin=builder_origin,
                 d1_database_id=d1_database_id,
                 pocket_id=pocket_id,
@@ -1227,6 +1244,7 @@ class GeneratorClient:
         pocket_id: str | None,
         smoke: bool,
         static_build: bool = True,
+        assets: dict[str, str] | None = None,
     ) -> BuildResult:
         # PERF-3: stable per-pocket working dir (overwrite the source each build)
         # so node_modules persists; fall back to a throwaway tempfile dir when no
@@ -1283,6 +1301,16 @@ class GeneratorClient:
             # source engine) is untouched by this branch and still sends rippleSpec
             # below, so its wire bytes — and svelte's — are unchanged.
             input_json["source"] = source or {}
+            # SI-4 CROSS-REPO SEAM: an html IMPORT also carries binary files, which
+            # cannot ride the text-only ``source`` map — they ride ``input.assets``
+            # ({path: base64}). The paw-sites generator's ``assets`` handling
+            # (decode + write each entry verbatim into the emitted static tree) is
+            # being added in a PARALLEL paw-sites slice; this codes to that
+            # contract. Sent ONLY when non-empty, so a plain html publish's payload
+            # stays byte-identical, and a generator predating the key ignores it
+            # (the import report warns that assets then don't deploy).
+            if assets:
+                input_json["assets"] = assets
         else:
             input_json["rippleSpec"] = ripple_spec
         gen = await self._runner.generate(input_json, out_dir)

--- a/ee/pocketpaw_ee/sites/import_service.py
+++ b/ee/pocketpaw_ee/sites/import_service.py
@@ -28,6 +28,9 @@
 # Tenancy: every entry point takes workspace_id/user_id and funnels through the
 # tenant-scoped pockets + sites services; the plan gate (require_sites_plan) runs
 # before any write.
+# Edited 2026-07-23 (security review): crafted/abnormal zip members (bad CRC,
+# encrypted, exotic compression) now map to 422 instead of escaping as 500s;
+# entry names carrying control characters are rejected as unsafe.
 
 from __future__ import annotations
 
@@ -83,6 +86,11 @@ def _safe_entry_path(raw_name: str) -> str:
         raise ValidationError(
             "sites.import_zip_entry_unsafe",
             f"Zip entry {raw_name!r} is an absolute path — archives must be relative.",
+        )
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in name):
+        raise ValidationError(
+            "sites.import_zip_entry_unsafe",
+            f"Zip entry {raw_name!r} contains control characters — not a safe archive path.",
         )
     parts = [p for p in name.split("/") if p not in ("", ".")]
     if not parts:
@@ -143,7 +151,9 @@ def unpack_zip(data: bytes) -> tuple[dict[str, str], dict[str, str]]:
         or the total UNCOMPRESSED size over MAX_IMPORT_UNCOMPRESSED_BYTES
         (decompression bomb; checked incrementally, never fully inflated first);
       * ``sites.import_zip_too_many_entries`` — over MAX_IMPORT_ENTRIES;
-      * ``sites.import_zip_entry_unsafe`` — zip-slip (absolute / ``..`` / backslash);
+      * ``sites.import_zip_entry_unsafe`` — zip-slip (absolute / ``..`` / backslash /
+        control characters — NUL or newline in a to-be-written path is generator input
+        the other side of the seam should never have to defend against);
       * ``sites.import_no_index`` — no index.html at the (flattened) root, which the
         html deploy path requires (its static smoke gates on it)."""
     if len(data) > MAX_IMPORT_ZIP_BYTES:
@@ -181,8 +191,20 @@ def unpack_zip(data: bytes) -> tuple[dict[str, str], dict[str, str]]:
                 "sites.import_zip_too_large",
                 "Import zip inflates past the uncompressed-size cap (decompression bomb?).",
             )
-        with zf.open(info) as fh:
-            blob = fh.read(MAX_IMPORT_UNCOMPRESSED_BYTES + 1)
+        try:
+            with zf.open(info) as fh:
+                blob = fh.read(MAX_IMPORT_UNCOMPRESSED_BYTES + 1)
+        except (zipfile.BadZipFile, RuntimeError, NotImplementedError) as exc:
+            # Per-entry reads raise outside the ZipFile() try above: bad CRC and
+            # lying size headers surface as BadZipFile, password-protected
+            # members as RuntimeError, exotic compression methods as
+            # NotImplementedError. All are a malformed/hostile-or-unsupported
+            # archive, not a server fault — map to the same 422 contract.
+            raise ValidationError(
+                "sites.import_zip_invalid",
+                f"Zip entry {info.filename!r} is unreadable "
+                "(corrupt, encrypted, or an unsupported compression method).",
+            ) from exc
         total_uncompressed += max(0, len(blob) - info.file_size)  # header lied → true bytes
         if total_uncompressed > MAX_IMPORT_UNCOMPRESSED_BYTES:
             raise ValidationError(

--- a/ee/pocketpaw_ee/sites/import_service.py
+++ b/ee/pocketpaw_ee/sites/import_service.py
@@ -1,0 +1,489 @@
+# ee/pocketpaw_ee/sites/import_service.py — Paw Sites IMPORT control plane (SI-4).
+#
+# Created 2026-07-22 (feat/sites-import-endpoint): the service half of the two
+# import endpoints — POST /sites/import (zip upload) and POST /sites/import/from-url
+# (crawler-backed, next slice). Owns:
+#   * SAFE zip unpacking, fully in memory: zip-slip guard (absolute paths, drive
+#     letters, backslashes, ``..`` traversal all rejected), an entry-count cap and a
+#     total-uncompressed-size cap (decompression-bomb guard), junk filtering
+#     (__MACOSX/, .DS_Store), and single-root flattening (a zip whose only top-level
+#     dir holds index.html imports as if that dir were the root).
+#   * Text/binary split by CONTENT sniff (NUL byte or non-UTF-8 → binary), building
+#     the generator input: text files ride ``source`` ({path: text}) — the existing
+#     html-engine source map — and binary files ride ``assets`` ({path: base64}).
+#     CROSS-REPO SEAM: the generator's ``assets`` base64 sideband is being added in a
+#     parallel paw-sites slice; this codes to that contract (see generator_client).
+#   * The import flow: mint the html POCKET (the durable source of truth, same as
+#     every other site) → mint the DRAFT Site doc (create_draft_site — the
+#     draft-first pattern) → publish through the EXISTING html/static deploy path →
+#     persist an ``import_report`` on the Site doc → best-effort Journal event.
+#   * A MINIMAL import report derived from the zip contents (pages + titles, asset
+#     count/bytes, forms with their original actions, script refs). ENRICHMENT SEAM:
+#     the generator-side import plan (form rewiring verdicts etc.) replaces this
+#     derivation once the parallel paw-sites slice lands — ``rewired`` is False until
+#     the generator confirms it.
+#   * from-url: URL-shape validation + draft Site mint + a queued report; the actual
+#     crawler is the NEXT stacked slice (``crawl_site_from_url`` raises
+#     NotImplementedError — a clean seam, nothing is fetched here).
+# Tenancy: every entry point takes workspace_id/user_id and funnels through the
+# tenant-scoped pockets + sites services; the plan gate (require_sites_plan) runs
+# before any write.
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import zipfile
+from datetime import UTC, datetime
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import urlparse
+from uuid import uuid4
+
+from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
+from pocketpaw_ee.sites import service as sites_service
+
+logger = logging.getLogger(__name__)
+
+# Upload cap for the zip itself (enforced at the router while reading the upload,
+# re-checked here for direct service callers).
+MAX_IMPORT_ZIP_BYTES = 25 * 1024 * 1024
+# Decompression-bomb guards: a hostile zip can be tiny on the wire yet explode on
+# extract. Cap both the entry count and the TOTAL uncompressed size (checked
+# incrementally while reading, so a bomb is rejected before it is fully inflated).
+MAX_IMPORT_ENTRIES = 2000
+MAX_IMPORT_UNCOMPRESSED_BYTES = 50 * 1024 * 1024
+# Per-URL shape cap for from-url imports.
+MAX_IMPORT_URL_LENGTH = 2048
+
+# The pocket authoring pattern stamped on imported sites so the gallery can badge
+# them and later slices (crawler, re-import) can find them.
+IMPORT_PATTERN = "imported"
+
+# macOS zip junk that should never become site files.
+_JUNK_PREFIXES = ("__MACOSX/",)
+_JUNK_BASENAMES = {".DS_Store", "Thumbs.db"}
+
+
+def _safe_entry_path(raw_name: str) -> str:
+    """Normalize one zip entry name to a safe, relative POSIX path.
+
+    Zip-slip guard: rejects backslashes (Windows-style traversal), absolute paths,
+    drive letters, ``..`` components, and empty/degenerate names. Raises
+    ``ValidationError('sites.import_zip_entry_unsafe')`` — the whole import fails
+    closed on ONE bad entry (a crafted archive is hostile; do not cherry-pick)."""
+    name = raw_name.strip()
+    if "\\" in name:
+        raise ValidationError(
+            "sites.import_zip_entry_unsafe",
+            f"Zip entry {raw_name!r} contains a backslash — not a safe archive path.",
+        )
+    if name.startswith("/") or (len(name) >= 2 and name[1] == ":"):
+        raise ValidationError(
+            "sites.import_zip_entry_unsafe",
+            f"Zip entry {raw_name!r} is an absolute path — archives must be relative.",
+        )
+    parts = [p for p in name.split("/") if p not in ("", ".")]
+    if not parts:
+        raise ValidationError(
+            "sites.import_zip_entry_unsafe",
+            f"Zip entry {raw_name!r} normalizes to an empty path.",
+        )
+    if ".." in parts:
+        raise ValidationError(
+            "sites.import_zip_entry_unsafe",
+            f"Zip entry {raw_name!r} traverses outside the archive root ('..').",
+        )
+    return "/".join(parts)
+
+
+def _is_junk(path: str) -> bool:
+    """macOS/Windows archive junk (resource forks, Finder metadata)."""
+    if any(path.startswith(p) for p in _JUNK_PREFIXES):
+        return True
+    return path.rsplit("/", 1)[-1] in _JUNK_BASENAMES
+
+
+def _is_text(data: bytes) -> bool:
+    """Content sniff: NUL byte or invalid UTF-8 → binary; else text. Extension is
+    deliberately NOT trusted (a .png named .html must still ride the binary
+    sideband, or the generator would corrupt it writing it as text)."""
+    if b"\x00" in data:
+        return False
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _flatten_single_root(entries: dict[str, bytes]) -> dict[str, bytes]:
+    """If the archive has NO root index.html but exactly ONE top-level directory
+    that contains one (the `zip -r site site/` shape every OS zipper produces),
+    strip that directory prefix so the site imports rooted correctly."""
+    if "index.html" in entries:
+        return entries
+    tops = {p.split("/", 1)[0] for p in entries}
+    if len(tops) != 1:
+        return entries
+    top = next(iter(tops))
+    prefix = f"{top}/"
+    if not all(p.startswith(prefix) for p in entries) or f"{prefix}index.html" not in entries:
+        return entries
+    return {p[len(prefix) :]: data for p, data in entries.items()}
+
+
+def unpack_zip(data: bytes) -> tuple[dict[str, str], dict[str, str]]:
+    """Unpack an uploaded site zip IN MEMORY into (text source map, base64 asset map).
+
+    Guards (all fail closed with a 4xx-mapped ValidationError):
+      * ``sites.import_zip_invalid`` — not a readable zip;
+      * ``sites.import_zip_too_large`` — the archive itself over MAX_IMPORT_ZIP_BYTES,
+        or the total UNCOMPRESSED size over MAX_IMPORT_UNCOMPRESSED_BYTES
+        (decompression bomb; checked incrementally, never fully inflated first);
+      * ``sites.import_zip_too_many_entries`` — over MAX_IMPORT_ENTRIES;
+      * ``sites.import_zip_entry_unsafe`` — zip-slip (absolute / ``..`` / backslash);
+      * ``sites.import_no_index`` — no index.html at the (flattened) root, which the
+        html deploy path requires (its static smoke gates on it)."""
+    if len(data) > MAX_IMPORT_ZIP_BYTES:
+        raise ValidationError(
+            "sites.import_zip_too_large",
+            f"Import zip exceeds the {MAX_IMPORT_ZIP_BYTES // (1024 * 1024)}MB upload cap.",
+        )
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        infos = zf.infolist()
+    except zipfile.BadZipFile as exc:
+        raise ValidationError(
+            "sites.import_zip_invalid", "The uploaded file is not a readable zip archive."
+        ) from exc
+
+    entries: dict[str, bytes] = {}
+    total_uncompressed = 0
+    for info in infos:
+        if info.is_dir():
+            continue
+        path = _safe_entry_path(info.filename)
+        if _is_junk(path):
+            continue
+        if len(entries) >= MAX_IMPORT_ENTRIES:
+            raise ValidationError(
+                "sites.import_zip_too_many_entries",
+                f"Import zip has more than {MAX_IMPORT_ENTRIES} files.",
+            )
+        # Incremental bomb guard: trust neither the header's file_size (it can lie)
+        # nor a single up-front sum — count REAL inflated bytes as we read, and stop
+        # the moment the running total crosses the cap.
+        total_uncompressed += info.file_size
+        if total_uncompressed > MAX_IMPORT_UNCOMPRESSED_BYTES:
+            raise ValidationError(
+                "sites.import_zip_too_large",
+                "Import zip inflates past the uncompressed-size cap (decompression bomb?).",
+            )
+        with zf.open(info) as fh:
+            blob = fh.read(MAX_IMPORT_UNCOMPRESSED_BYTES + 1)
+        total_uncompressed += max(0, len(blob) - info.file_size)  # header lied → true bytes
+        if total_uncompressed > MAX_IMPORT_UNCOMPRESSED_BYTES:
+            raise ValidationError(
+                "sites.import_zip_too_large",
+                "Import zip inflates past the uncompressed-size cap (decompression bomb?).",
+            )
+        entries[path] = blob
+
+    entries = _flatten_single_root(entries)
+    if "index.html" not in entries:
+        raise ValidationError(
+            "sites.import_no_index",
+            "The zip has no index.html at its root — an importable site needs one.",
+        )
+
+    source: dict[str, str] = {}
+    assets: dict[str, str] = {}
+    for path, blob in entries.items():
+        if _is_text(blob):
+            source[path] = blob.decode("utf-8")
+        else:
+            assets[path] = base64.b64encode(blob).decode("ascii")
+    return source, assets
+
+
+class _PageScan(HTMLParser):
+    """One-pass scan of an imported HTML page: <title>, <form action=...>, and
+    <script src=...> refs — the raw material for the minimal import report."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title = ""
+        self._in_title = False
+        self.form_actions: list[str] = []
+        self.script_srcs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {k: (v or "") for k, v in attrs}
+        if tag == "title":
+            self._in_title = True
+        elif tag == "form":
+            self.form_actions.append(attr_map.get("action", ""))
+        elif tag == "script" and attr_map.get("src"):
+            self.script_srcs.append(attr_map["src"])
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self.title += data
+
+
+def derive_import_report(source: dict[str, str], assets: dict[str, str]) -> dict[str, Any]:
+    """Derive the MINIMAL import report from the unpacked zip contents.
+
+    Shape: {pages: [{path, title}], asset_count, asset_bytes,
+            forms: [{page, original_action, rewired}], scripts: [...], warnings: [...]}.
+
+    ENRICHMENT SEAM (cross-repo): the paw-sites generator's import plan will
+    provide the authoritative report — including per-form REWIRING verdicts (the
+    generator rewrites <form> actions to the native capture POST) — in a parallel
+    slice. Until it lands, this derivation reports what the zip CONTAINS and marks
+    every form ``rewired: False`` (nothing is confirmed rewired yet)."""
+    pages: list[dict[str, str]] = []
+    forms: list[dict[str, Any]] = []
+    scripts: list[str] = []
+    for path in sorted(source):
+        if not path.endswith((".html", ".htm")):
+            continue
+        scan = _PageScan()
+        try:
+            scan.feed(source[path])
+        except Exception:  # noqa: BLE001 — a malformed page still lists, just untitled
+            logger.debug("import report: page %s did not parse cleanly", path)
+        pages.append({"path": path, "title": scan.title.strip()})
+        forms.extend(
+            {"page": path, "original_action": action, "rewired": False}
+            for action in scan.form_actions
+        )
+        scripts.extend(src for src in scan.script_srcs if src not in scripts)
+
+    asset_bytes = sum(len(base64.b64decode(b64)) for b64 in assets.values())
+    warnings: list[str] = []
+    if forms:
+        warnings.append(
+            "form rewiring is confirmed by the generator-side import plan (pending "
+            "paw-sites slice) — forms are listed but not yet verified as rewired"
+        )
+    if assets:
+        warnings.append(
+            "binary assets deploy at import time; re-publishing from the builder will "
+            "not carry them until the pocket asset sideband lands"
+        )
+    return {
+        "pages": pages,
+        "asset_count": len(assets),
+        "asset_bytes": asset_bytes,
+        "forms": forms,
+        "scripts": scripts,
+        "warnings": warnings,
+    }
+
+
+def _emit_import_journal(
+    *,
+    action: str,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    site_id: str,
+    payload: dict[str, Any],
+) -> None:
+    """Append the import Journal event (best-effort, mirrors versions/service.py's
+    ``_emit_version_event``). The Site doc + import_report are the durable record;
+    the event is the audit echo, so a journal-less context degrades silently."""
+    try:
+        from soul_protocol.spec.journal import Actor, EventEntry
+
+        from pocketpaw.journal_dep import get_journal
+    except Exception:  # noqa: BLE001 — journal dep unavailable on a fork
+        logger.debug("journal dep unavailable — skipping %s event", action)
+        return
+
+    scope = [f"pocket:{pocket_id}", f"site:{site_id}", f"workspace:{workspace_id}"]
+    event = EventEntry(
+        id=uuid4(),
+        ts=datetime.now(UTC),
+        actor=Actor(kind="user", id=user_id, scope_context=scope),
+        action=action,
+        scope=scope,
+        payload=payload,
+    )
+    try:
+        get_journal().append(event)
+    except Exception:  # noqa: BLE001 — audit echo must not break the import
+        logger.warning("sites import: failed to append %s journal event", action, exc_info=True)
+
+
+async def _mint_import_pocket(
+    *, workspace_id: str, user_id: str, name: str, source: dict[str, str]
+) -> str:
+    """Create the html POCKET an import is rooted on (the durable source of truth
+    every other site flow — publish/preview/status/versions — already reads), then
+    mint the DRAFT Site doc for it (create_draft_site — the draft-first pattern, so
+    the site lists in the gallery and publish flips the SAME doc live)."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name=name,
+        type_="site",
+        pattern=IMPORT_PATTERN,
+        ripple_spec=None,
+        engine="html",
+        source=source,
+        # The source is the user's own uploaded files, not LLM-drafted ripple JSON —
+        # there is no catalog gate to run (same rationale as the svelte create path).
+        trusted=True,
+    )
+    if err is not None or pocket_id is None:
+        raise Internal("sites.import_pocket_failed", f"Could not create the site pocket: {err}")
+    await sites_service.create_draft_site(
+        workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id, name=name
+    )
+    return pocket_id
+
+
+async def import_zip_site(
+    *,
+    workspace_id: str,
+    user_id: str,
+    data: bytes,
+    name: str = "",
+    _generator: Any | None = None,
+    _cloudflare: Any | None = None,
+    _local_deploy: Any | None = None,
+) -> Any:
+    """Import an uploaded site zip end to end: unpack safely → mint pocket + draft
+    Site doc → publish through the EXISTING html/static deploy path (with the
+    binary ``assets`` sideband) → persist the import_report → Journal event.
+
+    Returns the live Site doc (import_report set). The generator / CF / local-deploy
+    seams forward to ``publish`` so tests never shell out to bun/workerd."""
+    # Plan gate FIRST — before any unpack work or pocket write — mirroring
+    # publish_pocket's gate-before-read ordering.
+    await sites_service.require_sites_plan(workspace_id)
+
+    source, assets = unpack_zip(data)
+    site_name = name.strip() or "Imported site"
+    pocket_id = await _mint_import_pocket(
+        workspace_id=workspace_id, user_id=user_id, name=site_name, source=source
+    )
+    report = derive_import_report(source, assets)
+
+    doc = await sites_service.publish(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        ripple_spec=None,
+        theme={},
+        name=site_name,
+        engine="html",
+        source=source,
+        # CROSS-REPO SEAM: ``assets`` is the base64 binary sideband the paw-sites
+        # generator is gaining in a parallel slice ({path: base64} written verbatim
+        # into the static tree). Until that lands, a generator that ignores the key
+        # deploys the text tree only — the report's warning covers it.
+        assets=assets or None,
+        pattern=IMPORT_PATTERN,
+        _generator=_generator,
+        _cloudflare=_cloudflare,
+        _local_deploy=_local_deploy,
+    )
+    doc.import_report = report
+    await doc.save()
+
+    _emit_import_journal(
+        action="site.imported",
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        site_id=str(doc.id),
+        payload={
+            "kind": "zip",
+            "pages": len(report["pages"]),
+            "asset_count": report["asset_count"],
+            "asset_bytes": report["asset_bytes"],
+            "forms": len(report["forms"]),
+        },
+    )
+    return doc
+
+
+def _validate_import_url(url: str) -> str:
+    """Shape-validate a from-url import target: http(s), a real host, sane length.
+    This is SHAPE validation only — the crawler slice (SI-5) must add SSRF guards
+    (private-range / loopback / metadata-IP denial) before it ever fetches."""
+    candidate = (url or "").strip()
+    if not candidate or len(candidate) > MAX_IMPORT_URL_LENGTH:
+        raise ValidationError("sites.import_url_invalid", "A non-empty http(s) URL is required.")
+    parsed = urlparse(candidate)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValidationError(
+            "sites.import_url_invalid",
+            "The import URL must be an absolute http(s) URL with a host.",
+        )
+    return candidate
+
+
+async def crawl_site_from_url(*, workspace_id: str, user_id: str, site_id: str, url: str) -> None:
+    """CRAWLER SEAM (next stacked slice, SI-5): fetch + mirror the target site into
+    the import pipeline. Deliberately NOT implemented here — the from-url endpoint
+    only queues. The implementation must add SSRF guards (deny loopback / private
+    ranges / cloud metadata IPs, cap redirects and fetch sizes) before fetching."""
+    raise NotImplementedError(
+        "sites import crawler is the next stacked slice (SI-5) — "
+        "POST /sites/import/from-url only queues the site today."
+    )
+
+
+async def import_from_url(*, workspace_id: str, user_id: str, url: str) -> dict[str, str]:
+    """Queue a from-url import: validate the URL shape, mint the pocket + DRAFT Site
+    doc (status stays draft / not deployed), stamp a queued import_report with the
+    crawler-pending warning, and return {site_id, pocket_id, status: "queued"}.
+    Nothing is fetched — the crawler is the next stacked slice (SI-5)."""
+    await sites_service.require_sites_plan(workspace_id)
+    candidate = _validate_import_url(url)
+    host = urlparse(candidate).netloc
+    site_name = f"Import of {host}"
+    pocket_id = await _mint_import_pocket(
+        workspace_id=workspace_id, user_id=user_id, name=site_name, source={}
+    )
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    oid = sites_service._live_object_id(workspace_id, pocket_id)
+    doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is not None:
+        doc.import_report = {
+            "pages": [],
+            "asset_count": 0,
+            "asset_bytes": 0,
+            "forms": [],
+            "scripts": [],
+            "warnings": [
+                f"crawler pending — the crawl of {candidate} is queued; the from-url "
+                "crawler is the next stacked slice and has not run yet"
+            ],
+            "status": "queued",
+            "source_url": candidate,
+        }
+        await doc.save()
+
+    _emit_import_journal(
+        action="site.import_queued",
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        site_id=str(oid),
+        payload={"kind": "from_url", "url": candidate},
+    )
+    return {"site_id": str(oid), "pocket_id": pocket_id, "status": "queued"}

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -365,8 +365,11 @@ async def import_site(
     the generator's ``assets`` base64 sideband), persist the ``import_report`` on
     the Site doc, and return the SiteResponse (carrying the report).
 
-    The 25MB upload cap is enforced HERE while reading the multipart part — the
-    body is never buffered past cap+1 bytes — and re-checked in the service for
+    The 25MB upload cap gates PROCESSING, not ingress: Starlette's multipart
+    parser spools the whole request body to a temp file before this handler
+    runs, so raw-ingress bounding belongs to the fronting proxy's body limit.
+    The handler reads at most cap+1 bytes of the part, and the cap is re-checked
+    in the service for
     direct callers. Oversized → 413; a malformed/hostile archive → 422 (the
     service's ValidationError codes map through the standard error envelope).
     Tenant-scoped on ctx (fabric.write, sites plan gate at the router level)."""

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -144,19 +144,37 @@
 # view). fabric.write is RETAINED because a COLD miss still builds (mutates on-disk
 # state), so the endpoint can still trigger work; it is not a pure read. The wire
 # contract (request/response, origin resolution, 422/404/403) is unchanged.
+#
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): added the two IMPORT
+# endpoints, both tenant-scoped writes (fabric.write) under the router's sites plan
+# gate like every sibling mutation:
+#   * POST /sites/import — multipart zip upload (25MB cap enforced while reading the
+#     upload). Delegates to import_service.import_zip_site: safe in-memory unpack
+#     (zip-slip + decompression-bomb guards), mint pocket + DRAFT Site doc, publish
+#     through the existing html/static deploy path (binary files ride the
+#     generator's ``assets`` base64 sideband — cross-repo seam), persist an
+#     ``import_report`` on the Site doc, Journal event. Returns the SiteResponse
+#     (now carrying import_report).
+#   * POST /sites/import/from-url — {url} → 202 {site_id, pocket_id,
+#     status:"queued"}. Validates the URL shape and mints the draft Site with a
+#     crawler-pending import_report; the crawler is the NEXT stacked slice (SI-5) —
+#     nothing is fetched here.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.deps import require_action_any_workspace, require_plan_feature
+from pocketpaw_ee.sites import import_service
 from pocketpaw_ee.sites import service as sites_service
 from pocketpaw_ee.sites.dto import (
     AuditResponse,
     DevPreviewResponse,
     DomainRequest,
     DomainStatusResponse,
+    ImportFromUrlRequest,
+    ImportFromUrlResponse,
     LeafEditsRequest,
     LeafEditsResponse,
     LeafEditVerdict,
@@ -332,6 +350,59 @@ async def native_artifact_by_pocket(
         builder_origin=builder_origin,
     )
     return NativeArtifactResponse(**result)
+
+
+@router.post("/sites/import", response_model=SiteResponse)
+async def import_site(
+    file: UploadFile = File(...),
+    name: str = Form(""),
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SiteResponse:
+    """Import an uploaded site zip (SI-4): unpack safely in memory (zip-slip +
+    decompression-bomb guards in the service), mint the html pocket + DRAFT Site
+    doc, publish through the existing html/static deploy path (binary files ride
+    the generator's ``assets`` base64 sideband), persist the ``import_report`` on
+    the Site doc, and return the SiteResponse (carrying the report).
+
+    The 25MB upload cap is enforced HERE while reading the multipart part — the
+    body is never buffered past cap+1 bytes — and re-checked in the service for
+    direct callers. Oversized → 413; a malformed/hostile archive → 422 (the
+    service's ValidationError codes map through the standard error envelope).
+    Tenant-scoped on ctx (fabric.write, sites plan gate at the router level)."""
+    cap = import_service.MAX_IMPORT_ZIP_BYTES
+    data = await file.read(cap + 1)
+    if len(data) > cap:
+        raise HTTPException(413, f"Import zip exceeds the {cap // (1024 * 1024)}MB upload cap")
+    doc = await import_service.import_zip_site(
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user_id,
+        data=data,
+        name=name,
+    )
+    return sites_service._to_response(doc, pattern=import_service.IMPORT_PATTERN, engine="html")
+
+
+@router.post(
+    "/sites/import/from-url",
+    response_model=ImportFromUrlResponse,
+    status_code=202,
+)
+async def import_site_from_url(
+    body: ImportFromUrlRequest,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> ImportFromUrlResponse:
+    """Queue a from-url import (SI-4): validate the URL shape, mint the pocket +
+    DRAFT Site doc with a crawler-pending ``import_report``, and return 202
+    {site_id, pocket_id, status:"queued"}. NOTHING is fetched — the crawler is the
+    next stacked slice (SI-5; ``import_service.crawl_site_from_url`` is its seam).
+    A malformed URL → 422 (ValidationError through the standard envelope).
+    Tenant-scoped on ctx (fabric.write), like every sibling sites mutation."""
+    queued = await import_service.import_from_url(
+        workspace_id=ctx.workspace_id, user_id=ctx.user_id, url=body.url
+    )
+    return ImportFromUrlResponse(**queued)
 
 
 @router.get("/sites", response_model=list[SiteResponse])

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,16 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): ``publish`` /
+# ``_deploy_site_doc`` gain an OPTIONAL ``assets`` pass-through — the base64 binary
+# sideband ({path: base64}) an html IMPORT sends alongside its text ``source`` map.
+# It is forwarded to ``GeneratorClient.build`` ONLY when non-empty, so every
+# existing publish path's build call stays byte-identical (cross-repo seam note in
+# generator_client.py). ``_to_response`` also surfaces the new
+# ``Site.import_report`` (None for non-imported sites). The import orchestration
+# itself lives in the sibling ``import_service.py`` — this file only carries the
+# sideband through the existing deploy chain.
+#
 # Updated 2026-07-17 (fix/sites-draft-visible — a DRAFT lists in the gallery):
 # added ``create_draft_site`` — the create-site MCP handlers now mint ONE Site doc
 # at CREATE time in a NOT-YET-DEPLOYED state so a draft-first pocket (pocketpaw#1744)
@@ -1423,6 +1433,9 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         # None for a static publish / any DB-loaded doc / a single-flight no-op).
         provision_status=getattr(doc, "provision_status", "none"),
         provision_job_id=getattr(doc, "_provision_job_id", None),
+        # SI-4: the persisted import summary for an imported site; None for every
+        # non-imported site (empty dict on the doc reads as None on the wire).
+        import_report=getattr(doc, "import_report", None) or None,
     )
 
 
@@ -1545,6 +1558,7 @@ async def publish(
     name: str = "",
     engine: str = "ripple",
     source: dict[str, str] | None = None,
+    assets: dict[str, str] | None = None,
     pattern: str | None = None,
     builder_origin: str | None = None,
     preview: bool = False,
@@ -1732,6 +1746,7 @@ async def publish(
         theme=theme,
         engine=engine,
         source=source,
+        assets=assets,
         pattern=pattern,
         builder_origin=builder_origin,
         generator=generator,
@@ -1754,6 +1769,7 @@ async def _deploy_site_doc(
     theme: dict[str, Any],
     engine: str = "ripple",
     source: dict[str, str] | None = None,
+    assets: dict[str, str] | None = None,
     pattern: str | None = None,
     builder_origin: str | None = None,
     generator: GeneratorClient | None = None,
@@ -1824,6 +1840,10 @@ async def _deploy_site_doc(
     # instead of letting a bare FileNotFoundError / RuntimeError / SmokeGateFailed
     # escape as an unhandled 500. A misconfigured image (no paw-sites-gen / bun on
     # PATH) is the bug this guards.
+    # SI-4: forward the html import's binary sideband ONLY when present, so every
+    # non-import publish's build call (and every injected fake's expected kwargs)
+    # stays byte-identical to before the assets seam existed.
+    _asset_kwargs: dict[str, Any] = {"assets": assets} if assets else {}
     build = await _build_or_cloud_error(
         gen,
         ripple_spec=ripple_spec,
@@ -1835,6 +1855,7 @@ async def _deploy_site_doc(
         engine=engine,
         source=source,
         builder_origin=builder_origin,
+        **_asset_kwargs,
         # PERF-3: build into the STABLE per-pocket working dir so node_modules
         # persists and `bun install` is cached across builds, cutting the dominant
         # per-edit cost.

--- a/tests/cloud/leads/test_router.py
+++ b/tests/cloud/leads/test_router.py
@@ -10,6 +10,13 @@
 # Updated 2026-05-30 (security hardening): added C1 oversized-payload→413 (no
 # lead written) and H1 constant-time signed-key compare (secrets.compare_digest
 # is the mechanism; valid key still 200, bad key still 401) coverage.
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): added coverage for the
+# NATIVE-FORM capture sibling POST /capture/form (final URL /api/v1/capture/form)
+# — the endpoint imported sites' rewired <form>s post to as urlencoded, with
+# hidden paw_site_id / paw_key / paw_page / paw_redirect fields. Valid key →
+# recorded through the SAME capture pipeline + 303 back to Origin+paw_redirect;
+# bad key → 401; absolute / protocol-relative paw_redirect → 400 (open-redirect
+# guard); wrong origin → 403; urlencoded content-type accepted natively.
 from __future__ import annotations
 
 import pytest
@@ -159,3 +166,131 @@ async def test_capture_uses_constant_time_key_compare(mongo_db, capture_app, mon
     assert resp.status_code == 200
     assert calls, "signed-key check must route through secrets.compare_digest"
     assert ("key_ok", "key_ok") in calls
+
+
+# --------------------------------------------------------------------------- #
+# SI-4 — native-form capture: POST /capture/form (final URL /api/v1/capture/form).
+# Imported sites rewire their <form>s to a plain urlencoded POST here, with hidden
+# paw_site_id / paw_key / paw_page / paw_redirect fields. Same hardening ladder as
+# the JSON path, then a 303 back to Origin + the RELATIVE paw_redirect.
+# --------------------------------------------------------------------------- #
+
+
+async def _form_site(ws="ws1", site_id="site_form") -> Site:
+    """A site seeded the way create/publish seeds it: a 'lead' event mapping (the
+    default form_type the rewired form posts under)."""
+    site = Site(
+        workspace=ws,
+        pocket_id="pk_form",
+        owner="u1",
+        script_name=site_id,
+        allowed_origins=["brightsmiledental.com"],
+        signed_key="key_ok",
+        event_mapping={
+            "lead": {
+                "creates": "Lead",
+                "fields": {"full_name": "{{ payload.full_name }}", "email": "{{ payload.email }}"},
+            }
+        },
+    )
+    await site.insert()
+    return site
+
+
+def _form_fields(**overrides) -> dict:
+    fields = {
+        "full_name": "Sam Smiles",
+        "email": "sam@example.com",
+        "paw_site_id": "site_form",
+        "paw_key": "key_ok",
+        "paw_page": "index.html",
+        "paw_redirect": "/thanks.html",
+    }
+    fields.update(overrides)
+    return fields
+
+
+@pytest.mark.asyncio
+async def test_capture_form_valid_key_records_and_303s(mongo_db, capture_app):
+    """A valid urlencoded native-form POST records the lead through the SAME
+    capture pipeline (mapping applied, paw_* control fields stripped) and 303s to
+    the validated Origin + the relative paw_redirect."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _form_site()
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        # httpx ``data=`` sends application/x-www-form-urlencoded — the exact
+        # content type a native <form method=post> submits.
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(),
+            headers={"origin": "https://brightsmiledental.com"},
+        )
+    assert resp.status_code == 303, resp.text
+    assert resp.headers["location"] == "https://brightsmiledental.com/thanks.html"
+
+    leads = await leads_service.list_for_site(site.workspace, "site_form")
+    assert len(leads) == 1
+    assert leads[0].properties["full_name"] == "Sam Smiles"
+    assert leads[0].properties["email"] == "sam@example.com"
+    # The paw_* control fields never become lead properties.
+    assert not any(k.startswith("paw_") for k in leads[0].properties)
+
+
+@pytest.mark.asyncio
+async def test_capture_form_invalid_key_is_401(mongo_db, capture_app):
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _form_site()
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(paw_key="WRONG"),
+            headers={"origin": "https://brightsmiledental.com"},
+        )
+    assert resp.status_code == 401
+    assert await leads_service.count_for_site(site.workspace, "site_form") == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_redirect",
+    ["https://evil.example.com/phish", "//evil.example.com", "/\\evil", "javascript://alert(1)"],
+)
+async def test_capture_form_non_relative_redirect_is_400(mongo_db, capture_app, bad_redirect):
+    """Open-redirect guard: an absolute / protocol-relative / backslash / scheme'd
+    paw_redirect is rejected BEFORE anything is recorded."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _form_site()
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(paw_redirect=bad_redirect),
+            headers={"origin": "https://brightsmiledental.com"},
+        )
+    assert resp.status_code == 400, resp.text
+    assert await leads_service.count_for_site(site.workspace, "site_form") == 0
+
+
+@pytest.mark.asyncio
+async def test_capture_form_wrong_origin_is_403(mongo_db, capture_app):
+    await _form_site()
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(),
+            headers={"origin": "https://evil.example.com"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_capture_form_unknown_site_is_404(mongo_db, capture_app):
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(paw_site_id="site_missing"),
+            headers={"origin": "https://brightsmiledental.com"},
+        )
+    assert resp.status_code == 404

--- a/tests/ee/sites/test_import.py
+++ b/tests/ee/sites/test_import.py
@@ -428,3 +428,45 @@ async def test_generator_html_payload_omits_assets_when_none(tmp_path):
     await client.build(**_gen_kwargs({"index.html": "<html><body><p>ok</p></body></html>"}))
     assert runner.input_json is not None
     assert "assets" not in runner.input_json
+
+
+# ---- Review fixes: crafted/abnormal members 422 (contract), never 500 ----
+
+
+async def test_import_zip_password_protected_member_is_422(beanie_test_db, monkeypatch):
+    """An encrypted member raises RuntimeError inside the per-entry read; the
+    contract maps it to sites.import_zip_invalid (422), not a 500."""
+    app = _build_app("ws_owner", monkeypatch)
+    data = bytearray(_zip_bytes({"index.html": _INDEX_HTML.encode()}))
+    data[6] |= 0x01  # encryption bit, local file header
+    cd = bytes(data).rfind(b"PK\x01\x02")
+    data[cd + 8] |= 0x01  # encryption bit, central directory (zipfile reads this one)
+    resp = await _post_zip(app, bytes(data))
+    assert resp.status_code == 422, resp.text
+    assert "import_zip_invalid" in resp.text
+    await _assert_nothing_minted()
+
+
+async def test_import_zip_unsupported_compression_is_422(beanie_test_db, monkeypatch):
+    """An exotic compression method (AES marker 99) raises NotImplementedError on
+    read; the contract maps it to 422, not a 500."""
+    app = _build_app("ws_owner", monkeypatch)
+    data = bytearray(_zip_bytes({"index.html": _INDEX_HTML.encode()}))
+    data[8:10] = (99).to_bytes(2, "little")  # local header method field
+    cd = bytes(data).rfind(b"PK\x01\x02")
+    data[cd + 10 : cd + 12] = (99).to_bytes(2, "little")  # central directory too
+    resp = await _post_zip(app, bytes(data))
+    assert resp.status_code == 422, resp.text
+    assert "import_zip_invalid" in resp.text
+    await _assert_nothing_minted()
+
+
+async def test_import_zip_control_char_entry_name_is_422(beanie_test_db, monkeypatch):
+    """Control characters in an entry name (NUL, newline) are generator-side path
+    input — rejected as unsafe, whole import fails closed."""
+    app = _build_app("ws_owner", monkeypatch)
+    data = _zip_bytes({"index.html": _INDEX_HTML.encode(), "a\nb.html": b"<p>x</p>"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    assert "import_zip_entry_unsafe" in resp.text
+    await _assert_nothing_minted()

--- a/tests/ee/sites/test_import.py
+++ b/tests/ee/sites/test_import.py
@@ -1,0 +1,430 @@
+# tests/ee/sites/test_import.py — SI-4 (feat/sites-import-endpoint): the Paw Sites
+# IMPORT control-plane path.
+#
+# Created 2026-07-22. Covers:
+#   * POST /sites/import happy path through the real router → import_service →
+#     pockets (real agent_create) → create_draft_site → publish (FAKED — a real
+#     publish spawns bun): the html pocket + Site doc are minted, the generator is
+#     handed engine="html" with the text ``source`` map and the base64 ``assets``
+#     sideband, and the derived ``import_report`` (pages/titles, asset counts,
+#     forms with original actions) is persisted on the Site doc AND surfaced on
+#     the response + the GET /sites read.
+#   * Safety guards, each failing closed as a 4xx: zip-slip (../ traversal and
+#     absolute entry paths), the entry-count cap, the uncompressed-size cap
+#     (decompression bomb), the 25MB upload cap at the router (413), and a zip
+#     with no root index.html.
+#   * Tenant scoping: the imported site is invisible cross-tenant (empty GET
+#     /sites; the site-scoped domains read 404s).
+#   * POST /sites/import/from-url: a valid URL → 202 {site_id, status:"queued"}
+#     with a crawler-pending import_report on a NOT-deployed draft Site doc (the
+#     crawler is the next stacked slice); a malformed URL / non-http scheme → 422.
+#   * GeneratorClient unit: the html STAGE-2 payload carries ``input.assets`` when
+#     (and ONLY when) an assets sideband is passed — the cross-repo seam contract.
+from __future__ import annotations
+
+import base64
+import io
+import zipfile
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.sites import import_service
+from pocketpaw_ee.sites import service as sites_service
+
+_INDEX_HTML = (
+    "<!doctype html><html><head><title>Bright Import</title></head>"
+    "<body><h1>Hi</h1>"
+    "<form action='https://old-backend.example/submit' method='post'>"
+    "<input name='email'></form>"
+    "<script src='app.js'></script>"
+    "</body></html>"
+)
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def _zip_bytes(entries: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _good_zip() -> bytes:
+    return _zip_bytes(
+        {
+            "index.html": _INDEX_HTML.encode(),
+            "about.html": (
+                b"<!doctype html><html><head><title>About</title></head><body></body></html>"
+            ),
+            "app.js": b"console.log('hi')",
+            "img/logo.png": _PNG_BYTES,
+        }
+    )
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "member") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, workspace_id: str) -> None:
+        self.id = "user-test-1"
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="member")]
+
+
+def _build_app(workspace_id: str, monkeypatch) -> FastAPI:
+    """Mirror tests/ee/sites/test_router.py's app wiring: override auth/context
+    deps, stub the workspace plan to one that unlocks Sites, mount the router."""
+    from datetime import UTC, datetime
+
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.sites.router import router as sites_router
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="go"))
+
+    fake_user = _FakeUser(workspace_id)
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(sites_router, prefix="/api/v1")
+
+    async def _ctx() -> RequestContext:
+        return RequestContext(
+            user_id=str(fake_user.id),
+            workspace_id=workspace_id,
+            request_id="test",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[current_active_user] = lambda: fake_user
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def _fake_publish(beanie_test_db, monkeypatch) -> dict[str, Any]:
+    """Fake sites_service.publish (a real one shells out to bun/the generator):
+    records the forwarded kwargs and flips the REAL draft Site doc (minted by the
+    real create_draft_site the import ran) to deployed, mirroring what the html
+    deploy path does. Returns the capture dict for assertions."""
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    captured: dict[str, Any] = {}
+
+    async def _publish(**kw):
+        captured.update(kw)
+        oid = sites_service._live_object_id(kw["workspace_id"], kw["pocket_id"])
+        doc = await _SiteDoc.find_one({"_id": oid, "workspace": kw["workspace_id"]})
+        assert doc is not None, "import must mint the draft Site doc before publishing"
+        doc.script_name = str(oid)
+        doc.deployed = True
+        doc.url = f"http://127.0.0.1:9999/{oid}/"
+        await doc.save()
+        return doc
+
+    monkeypatch.setattr(sites_service, "publish", _publish)
+    return captured
+
+
+async def _post_zip(app: FastAPI, data: bytes, name: str = "") -> Any:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        return await c.post(
+            "/api/v1/sites/import",
+            files={"file": ("site.zip", data, "application/zip")},
+            data={"name": name} if name else {},
+        )
+
+
+# --------------------------------------------------------------------------- #
+# zip import — happy path
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_import_zip_happy_path(_fake_publish, monkeypatch):
+    """A good zip imports end to end: Site doc minted + flipped live, the generator
+    input carries engine=html / text source / base64 assets, and the import_report
+    (pages, asset counts, forms) is persisted and returned."""
+    app = _build_app("ws_owner", monkeypatch)
+    resp = await _post_zip(app, _good_zip(), name="My imported site")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # The publish rode the html engine with the text source map + assets sideband.
+    assert _fake_publish["engine"] == "html"
+    assert set(_fake_publish["source"]) == {"index.html", "about.html", "app.js"}
+    assert _fake_publish["source"]["index.html"] == _INDEX_HTML
+    assert _fake_publish["assets"] == {"img/logo.png": base64.b64encode(_PNG_BYTES).decode("ascii")}
+    assert _fake_publish["pattern"] == "imported"
+
+    # The response is the live SiteResponse carrying the report.
+    assert body["deployed"] is True
+    report = body["import_report"]
+    assert {p["path"] for p in report["pages"]} == {"index.html", "about.html"}
+    titles = {p["path"]: p["title"] for p in report["pages"]}
+    assert titles["index.html"] == "Bright Import"
+    assert report["asset_count"] == 1
+    assert report["asset_bytes"] == len(_PNG_BYTES)
+    assert report["forms"] == [
+        {
+            "page": "index.html",
+            "original_action": "https://old-backend.example/submit",
+            "rewired": False,
+        }
+    ]
+    assert "app.js" in report["scripts"]
+
+    # The report persisted on the Site doc and surfaces on the gallery read too.
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        listed = await c.get("/api/v1/sites")
+    assert listed.status_code == 200
+    rows = listed.json()
+    assert len(rows) == 1
+    assert rows[0]["import_report"]["asset_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_import_zip_single_root_dir_flattens(_fake_publish, monkeypatch):
+    """The `zip -r site site/` shape (one top dir holding index.html) imports as if
+    that dir were the root."""
+    app = _build_app("ws_owner", monkeypatch)
+    data = _zip_bytes({"mysite/index.html": _INDEX_HTML.encode(), "mysite/style.css": b":root{}"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 200, resp.text
+    assert set(_fake_publish["source"]) == {"index.html", "style.css"}
+
+
+# --------------------------------------------------------------------------- #
+# zip import — guards (each fails closed as a 4xx, nothing minted)
+# --------------------------------------------------------------------------- #
+
+
+async def _assert_nothing_minted() -> None:
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    assert await _SiteDoc.find_one({"workspace": "ws_owner"}) is None
+
+
+@pytest.mark.asyncio
+async def test_import_zip_slip_traversal_rejected(beanie_test_db, monkeypatch):
+    """A ``..`` traversal entry fails the WHOLE import (422) — hostile archives are
+    not cherry-picked — and no pocket / Site doc is minted."""
+    app = _build_app("ws_owner", monkeypatch)
+    data = _zip_bytes({"index.html": _INDEX_HTML.encode(), "../evil.html": b"<p>evil</p>"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_absolute_path_rejected(beanie_test_db, monkeypatch):
+    app = _build_app("ws_owner", monkeypatch)
+    data = _zip_bytes({"index.html": _INDEX_HTML.encode(), "/etc/cron.d/evil": b"x"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_entry_cap_rejected(beanie_test_db, monkeypatch):
+    app = _build_app("ws_owner", monkeypatch)
+    monkeypatch.setattr(import_service, "MAX_IMPORT_ENTRIES", 3)
+    data = _zip_bytes({f"f{i}.txt": b"x" for i in range(5)} | {"index.html": b"<html></html>"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_uncompressed_cap_rejected(beanie_test_db, monkeypatch):
+    """A tiny-on-the-wire zip that INFLATES past the cap is rejected (bomb guard)."""
+    app = _build_app("ws_owner", monkeypatch)
+    monkeypatch.setattr(import_service, "MAX_IMPORT_UNCOMPRESSED_BYTES", 1024)
+    data = _zip_bytes({"index.html": b"<html>" + b"A" * 4096 + b"</html>"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_oversized_upload_is_413(beanie_test_db, monkeypatch):
+    """The router's streaming upload cap rejects an oversized body with 413 before
+    the service ever unpacks it."""
+    app = _build_app("ws_owner", monkeypatch)
+    monkeypatch.setattr(import_service, "MAX_IMPORT_ZIP_BYTES", 64)
+    resp = await _post_zip(app, _good_zip())
+    assert resp.status_code == 413, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_without_index_rejected(beanie_test_db, monkeypatch):
+    app = _build_app("ws_owner", monkeypatch)
+    data = _zip_bytes({"about.html": b"<html><body>no index</body></html>"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_not_a_zip_rejected(beanie_test_db, monkeypatch):
+    app = _build_app("ws_owner", monkeypatch)
+    resp = await _post_zip(app, b"this is not a zip archive")
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+# --------------------------------------------------------------------------- #
+# tenant scoping
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_import_cross_tenant_site_is_invisible(_fake_publish, monkeypatch):
+    """An imported site never leaks cross-tenant: the intruder's gallery list is
+    empty and the site-scoped detail read (domains) is a 404."""
+    owner_app = _build_app("ws_owner", monkeypatch)
+    resp = await _post_zip(owner_app, _good_zip())
+    assert resp.status_code == 200, resp.text
+    script_name = resp.json()["script_name"]
+
+    intruder_app = _build_app("ws_intruder", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=intruder_app), base_url="http://t") as c:
+        listed = await c.get("/api/v1/sites")
+        detail = await c.get(f"/api/v1/sites/{script_name}/domains")
+    assert listed.status_code == 200
+    assert listed.json() == []
+    assert detail.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# from-url — queue-only (the crawler is the next stacked slice)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_from_url_returns_202_queued(beanie_test_db, monkeypatch):
+    """A valid URL queues: 202 {site_id, pocket_id, status:"queued"}, the draft Site
+    doc exists NOT deployed, and its import_report carries the crawler-pending
+    warning + queued status."""
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/import/from-url", json={"url": "https://example.com/landing"}
+        )
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["status"] == "queued"
+    assert body["site_id"]
+    assert body["pocket_id"]
+
+    doc = await _SiteDoc.find_one({"workspace": "ws_owner", "pocket_id": body["pocket_id"]})
+    assert doc is not None
+    assert doc.deployed is False
+    assert doc.import_report["status"] == "queued"
+    assert doc.import_report["source_url"] == "https://example.com/landing"
+    assert any("crawler" in w for w in doc.import_report["warnings"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", ["notaurl", "ftp://example.com", "https://", "  "])
+async def test_from_url_invalid_shape_is_422(beanie_test_db, monkeypatch, bad):
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/import/from-url", json={"url": bad})
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_crawler_seam_is_explicitly_unimplemented():
+    """The crawl seam raises a clear NotImplementedError — the next stacked slice
+    (SI-5) owns it; nothing in SI-4 may silently fetch."""
+    with pytest.raises(NotImplementedError, match="next stacked slice"):
+        await import_service.crawl_site_from_url(
+            workspace_id="ws", user_id="u", site_id="s", url="https://example.com"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# generator payload — the cross-repo ``assets`` seam
+# --------------------------------------------------------------------------- #
+
+
+class _CapturingRunner:
+    """Fake runner capturing generate()'s input_json; projectDir points at a real
+    static tree so the html smoke passes (mirrors test_html_publish's spies)."""
+
+    def __init__(self, project_dir: str) -> None:
+        self._project_dir = project_dir
+        self.input_json: dict | None = None
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.input_json = input_json
+        return {"projectDir": self._project_dir, "engine": input_json.get("engine")}
+
+
+def _gen_kwargs(source: dict[str, str], **extra) -> dict:
+    return dict(
+        engine="html",
+        source=source,
+        ripple_spec=None,
+        theme={},
+        site_id="site_import",
+        title="Imported",
+        capture_api_base="https://api.paw.example/api/v1",
+        capture_signed_key="pp_tok_x",
+        **extra,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generator_html_payload_carries_assets_sideband(tmp_path):
+    """SI-4 seam: when an assets map is passed, the html STAGE-2 payload carries it
+    on ``input.assets`` verbatim ({path: base64}), alongside the text source."""
+    from pocketpaw_ee.sites.generator_client import GeneratorClient
+
+    (tmp_path / "index.html").write_text("<html><body><p>ok</p></body></html>")
+    runner = _CapturingRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    b64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    await client.build(
+        **_gen_kwargs({"index.html": "<html><body><p>ok</p></body></html>"}),
+        assets={"img/logo.png": b64},
+    )
+    sent = runner.input_json
+    assert sent is not None
+    assert sent["engine"] == "html"
+    assert sent["assets"] == {"img/logo.png": b64}
+
+
+@pytest.mark.asyncio
+async def test_generator_html_payload_omits_assets_when_none(tmp_path):
+    """No assets → the key is ABSENT (a plain html publish's payload stays
+    byte-identical to pre-SI-4)."""
+    from pocketpaw_ee.sites.generator_client import GeneratorClient
+
+    (tmp_path / "index.html").write_text("<html><body><p>ok</p></body></html>")
+    runner = _CapturingRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    await client.build(**_gen_kwargs({"index.html": "<html><body><p>ok</p></body></html>"}))
+    assert runner.input_json is not None
+    assert "assets" not in runner.input_json


### PR DESCRIPTION
Adds the control-plane path for bringing an existing website into Paw Sites: a zip import that deploys through the html engine, a from-url endpoint that queues a crawl, and a native form-capture route so imported sites' contact forms keep working after the move.

## Endpoints

**`POST /api/v1/sites/import`** — multipart zip upload (25MB cap). Unpacks fully in memory with a zip-slip guard (absolute paths, `..` traversal, backslashes all rejected), an entry-count cap (2000) and an incremental uncompressed-size cap (50MB, so a decompression bomb is rejected before it inflates). Text and binary files are split by content sniff: text rides the html engine's `source` map, binaries ride a base64 `assets` sideband. The flow mints the html pocket, mints the draft Site doc (same draft-first pattern as create), publishes through the existing html/static deploy path, and persists an `import_report` on the Site doc — `{pages, asset_count, asset_bytes, forms, scripts, warnings}` — which now also surfaces on `SiteResponse`.

**`POST /api/v1/sites/import/from-url`** — `{url}` → `202 {site_id, pocket_id, status: "queued"}`. Validates URL shape only, mints the draft site with a crawler-pending report, and stops. The crawler is the next stacked slice; `import_service.crawl_site_from_url` is its seam and raises `NotImplementedError` with a note that it must add SSRF guards before fetching anything.

**`POST /api/v1/capture/form`** — the native-form capture sibling. Imported sites' forms get rewired to a plain urlencoded POST here with hidden fields `paw_site_id`, `paw_key`, `paw_page`, `paw_redirect` (plus optional `paw_form_type`, default `lead`). Same hardening ladder as the JSON capture: site exists → origin pin → constant-time key compare → payload size cap → the shared capture pipeline (honeypot, rate limit, injection screen, mapping). Responds 303 to the validated Origin plus the redirect path.

Both import endpoints are tenant-scoped writes (`fabric.write`) under the router's sites plan gate, matching every sibling mutation. Cross-tenant reads stay 404/empty.

## Cross-repo seams (heads up for the paw-sites side)

1. **Generator `assets` key.** The html build payload now carries `input.assets` (`{path: base64}`) when an import has binaries — only then, so existing payloads are byte-identical. The paw-sites slice adding decode-and-write for that key is in flight; a generator that predates it deploys the text tree only, and the import report carries a warning saying so.
2. **Capture form path.** The spec said `{captureApiBase}/v1/capture/form`, but `captureApiBase` already ends in `/api/v1`, which would have doubled the segment. Final contract as built: **`{captureApiBase}/capture/form`**, i.e. `/api/v1/capture/form`. The paw-sites form rewiring must target that.

## Open-redirect guard

`paw_redirect` must be a relative path: no absolute URLs, no protocol-relative `//host`, no backslashes, no embedded scheme, no CR/LF (header injection), length-capped. The 303 Location is built as validated-Origin + relative path, so the browser can only land back on the pinned site.

## Security self-review notes

Ran the upload/capture surfaces against the security checklist. Findings worth stating:

- From-url does no fetching at all in this slice, so SSRF is structurally impossible here; the stub documents the guards the crawler slice must add (private ranges, loopback, metadata IPs, redirect and size caps).
- Binary assets are not persisted on the pocket (Mongo doc-size risk at 25MB+ base64), so a later re-publish from the builder loses them until the pocket asset sideband lands. The import report warns about this; it is not silent.
- A dropped form submission (honeypot/rate/injection) still 303s — visitors never see which heuristic dropped them.
- `paw_*` control fields are stripped before the payload reaches the lead pipeline; file parts are skipped entirely.

## How tested

`uv run pytest tests/ee/sites/ tests/cloud/leads/ tests/sites_capture/` — 468 passed, 2 skipped (both pre-existing env-gated integration skips). New coverage: zip happy path (generator handed engine=html + source + assets, report persisted and readable), single-root flattening, zip-slip and absolute-path rejection, entry/uncompressed/upload caps, missing index.html, not-a-zip, cross-tenant invisibility, from-url 202 + queued report + invalid shapes, crawler seam, assets-sideband payload contract (present when passed, absent otherwise), and the form capture matrix (valid key records + 303, bad key 401, wrong origin 403, unknown site 404, four flavors of bad redirect 400).
