### PR TITLE
Same-site crawler for import-from-url (SI-5)

### DIFF
--- a/ee/pocketpaw_ee/cloud/leads/router.py
+++ b/ee/pocketpaw_ee/cloud/leads/router.py
@@ -22,6 +22,20 @@
 # ``rate_key``. The caller-controlled ``body.submitter_ref`` is no longer the
 # limiter key (it was randomizable to dodge the cap); it rides through only as an
 # opaque, non-PII label on the stored Lead.
+#
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): added the NATIVE-FORM
+# capture sibling, POST /capture/form (final URL: {captureApiBase}/capture/form,
+# i.e. /api/v1/capture/form — captureApiBase already carries /api/v1, so the
+# spec's "/v1/capture/form" would have doubled the segment; this is the
+# router-consistent resolution and the cross-repo contract paw-sites' import
+# rewiring must target). IMPORTED sites rewire their <form>s to a plain
+# application/x-www-form-urlencoded POST here, with hidden fields ``paw_site_id``,
+# ``paw_key`` (the per-site signed key), ``paw_page``, ``paw_redirect`` and
+# optionally ``paw_form_type``. The endpoint runs the SAME hardening ladder as the
+# JSON capture (site exists → origin pin → constant-time signed key → payload size
+# cap → leads_service.capture), then 303-redirects to ``paw_redirect`` — which MUST
+# be a relative path (open-redirect guard: absolute / protocol-relative /
+# backslash / CR-LF all 400), resolved against the validated request Origin.
 
 from __future__ import annotations
 
@@ -29,7 +43,7 @@ import hashlib
 import json
 import secrets
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 
 from pocketpaw.sites_capture.ingest import origin_allowed
 from pocketpaw.sites_capture.models import MAX_PAYLOAD_BYTES
@@ -85,6 +99,88 @@ async def capture_lead(site_id: str, body: CaptureRequest, request: Request) -> 
     if lead is None:
         return CaptureResponse(ok=False, reason="dropped")
     return CaptureResponse(ok=True, lead_id=lead.id)
+
+
+def _safe_relative_redirect(path: str) -> bool:
+    """Open-redirect guard for the native-form 303: the redirect target must be a
+    RELATIVE path on the submitting site. Rejects absolute URLs (no leading "/"),
+    protocol-relative ("//host"), backslash tricks, embedded schemes, and CR/LF
+    (header injection). The accepted value is later prefixed with the VALIDATED
+    request Origin, so the browser can only ever land back on the pinned site."""
+    if not path.startswith("/") or path.startswith("//"):
+        return False
+    if "\\" in path or "\r" in path or "\n" in path or "://" in path:
+        return False
+    return len(path) <= 2048
+
+
+@router.post("/capture/form")
+async def capture_form(request: Request) -> Response:
+    """Native-form ingest for IMPORTED sites (SI-4). The imported page's <form>s
+    are rewired to POST application/x-www-form-urlencoded here with hidden fields:
+    ``paw_site_id`` (the site), ``paw_key`` (the per-site signed key), ``paw_page``
+    (provenance label), ``paw_redirect`` (relative post-submit path), and optional
+    ``paw_form_type`` (event-mapping key; defaults to "lead" — the mapping every
+    site doc seeds). CROSS-REPO CONTRACT: the final URL is
+    {captureApiBase}/capture/form (/api/v1/capture/form) — see the module comment.
+
+    Hardening mirrors the JSON capture exactly: site exists → origin pin →
+    constant-time key compare → payload size cap → the SAME
+    ``leads_service.capture`` pipeline (honeypot / rate limit / injection screen /
+    mapping). The open-redirect guard rejects any non-relative ``paw_redirect``
+    BEFORE anything is recorded. The response is a 303 See Other back to the
+    validated Origin + redirect path — a DROPPED submission still 303s (the
+    visitor is never shown an error that leaks the drop heuristics)."""
+    form = await request.form()
+    site_id = str(form.get("paw_site_id") or "")
+    key = str(form.get("paw_key") or "")
+    page = str(form.get("paw_page") or "")
+    redirect = str(form.get("paw_redirect") or "") or "/"
+    form_type = str(form.get("paw_form_type") or "lead")
+
+    # global-read: public ingest is keyed by site, not by a workspace session.
+    site = await _SiteDoc.find_one({"script_name": site_id}) if site_id else None
+    if site is None:
+        raise HTTPException(404, "Site not found")
+
+    if not origin_allowed(site.allowed_origins, request.headers.get("origin")):
+        raise HTTPException(403, "Origin not allowed for this site")
+
+    # H1 (same as the JSON path): constant-time compare — no timing side channel.
+    if not secrets.compare_digest(key, site.signed_key):
+        raise HTTPException(401, "Invalid signed key")
+
+    # Open-redirect guard BEFORE any write: a bad redirect fails the whole submit.
+    if not _safe_relative_redirect(redirect):
+        raise HTTPException(400, "paw_redirect must be a relative path on the site")
+
+    # The lead payload is every NON-``paw_*`` text field. UploadFile parts (a file
+    # input on an imported form) are skipped — the capture pipeline stores JSON
+    # properties, never file bodies.
+    payload = {
+        k: v for k, v in form.multi_items() if isinstance(v, str) and not k.startswith("paw_")
+    }
+
+    # C1 (same as the JSON path): cap the payload size before the service runs.
+    if len(json.dumps(payload, default=str).encode("utf-8")) > MAX_PAYLOAD_BYTES:
+        raise HTTPException(413, "Payload exceeds size cap")
+
+    await leads_service.capture(
+        site=site,
+        form_type=form_type,
+        payload=payload,
+        # Opaque provenance label (mirrors submitter_ref on the JSON path — never
+        # a limiter key). Truncated: paw_page is caller-controlled text.
+        submitter_ref=f"form:{page}"[:256] if page else "form",
+        rate_key=_rate_key(request),  # server-derived; the real per-IP limiter key
+    )
+
+    # 303 back to the site. The Location is the VALIDATED Origin (already pinned
+    # against site.allowed_origins above) + the RELATIVE redirect path, so the
+    # browser can only land back on the submitting site. origin_allowed fails
+    # closed on a missing Origin, so it is always present here.
+    origin = (request.headers.get("origin") or "").rstrip("/")
+    return Response(status_code=303, headers={"Location": f"{origin}{redirect}"})
 
 
 # Leads is a Sites surface, so its plan gate is the "sites" feature (go+) — the

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -103,6 +103,14 @@
 # can surface it on ``SiteResponse.provision_job_id``. None for a static publish and
 # for any DB-loaded doc (the PrivateAttr defaults to None). Private so it never
 # round-trips through the DB.
+#
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): added ``import_report`` —
+# the per-import summary an IMPORTED site carries ({pages, asset_count, asset_bytes,
+# forms, scripts, warnings}), persisted by the import service after the html deploy
+# and surfaced on ``SiteResponse.import_report``. Derived minimally from the zip
+# contents today; the generator-side import plan enriches it (form-rewiring
+# verdicts) once the parallel paw-sites slice lands. Defaults to an empty dict, so
+# every non-imported site and every pre-SI-4 row reads "no import" — no migration.
 
 from __future__ import annotations
 
@@ -193,6 +201,10 @@ class Site(TimestampedDocument):
     # carries the gated edit-bridge keyed on this origin. Persisted so a
     # component-edit republish can re-apply it and the site stays editable.
     builder_origin: str = ""
+    # SI-4: the import summary an IMPORTED site carries ({pages, asset_count,
+    # asset_bytes, forms, scripts, warnings}; from-url adds status/source_url).
+    # Empty for every non-imported site — no migration.
+    import_report: dict[str, Any] = Field(default_factory=dict)
     # Capture hardening config (mirrors sites_capture.SiteFormConfig fields).
     allowed_origins: list[str] = Field(default_factory=list)
     signed_key: str = ""

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -4,6 +4,12 @@ Sole owner of writes to the ``Pocket`` Beanie document. Module-level
 ``async def`` API. The doc → domain mapping helpers (formerly in
 ``repositories.py``) live alongside the public API as private helpers.
 
+Updated: 2026-07-23 (SI-5, feat/sites-import-crawler) — added
+``set_imported_source``: the sites URL-import crawler persists its harvested
+html source map on the imported pocket through THIS service (entity isolation —
+the sites service never touches the Pocket model). Workspace-checked fail-closed,
+html-engine pockets only, background-safe (no request context required).
+
 Updated: 2026-06-28 (AW-7 template gate deny-on-no-match) — added
 ``resolve_workspace_template_default_deny`` — the effective TEMPLATE-level
 deny-by-default for a workspace (per-workspace ``instinct_template_default_deny``
@@ -2162,6 +2168,36 @@ async def set_svelte_source_file(
     # versioning is an additive history layer, never a gate on the edit.
     await _record_pocket_svelte_draft_version(doc, author=user_id)
     return await _resolved_wire_dict(doc, user_id), previous_source
+
+
+async def set_imported_source(
+    pocket_id: str,
+    *,
+    workspace_id: str,
+    source: dict[str, str],
+) -> None:
+    """Replace an IMPORTED html-engine pocket's whole ``source`` map (SI-5).
+
+    Called by the sites URL-import crawler after a successful crawl, so the
+    pocket — the durable source of truth every re-publish reads — carries the
+    harvested files. Background-safe: takes an explicit ``workspace_id`` and
+    fails CLOSED on a mismatch with the same NotFound a missing pocket raises
+    (no cross-tenant existence signal). html-engine pockets only — a spec/svelte
+    pocket must never have its content swapped by the import path.
+    """
+    doc = await _fetch_pocket(pocket_id)
+    if doc.workspace != workspace_id:
+        raise NotFound("pocket", pocket_id)
+    if getattr(doc, "engine", "ripple") != "html":
+        raise ValidationError(
+            "pocket.not_html_site",
+            "Only an imported html-engine pocket can receive crawled source.",
+        )
+    # Reassign a fresh dict so Beanie tracks the change (mirrors
+    # set_svelte_source_file's dirty-tracking note).
+    doc.source = dict(source)
+    await doc.save()
+    await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
 
 
 async def merge_spec(

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -112,6 +112,12 @@
 # ``SiteStatusResponse`` gain ``engine`` ("svelte" | "ripple"; "" when unresolved) —
 # the sibling of DS-1a's ``pattern``, resolved from the source Pocket.engine so the
 # gallery can badge each card's engine (Custom vs Ripple) without a per-site fetch.
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): ``SiteResponse`` gains
+# ``import_report`` (the persisted import summary — None for non-imported sites),
+# and two new DTOs back the import surface: ImportFromUrlRequest ({url}, shape-
+# validated in the service) and ImportFromUrlResponse ({site_id, pocket_id,
+# status:"queued"} — the 202 body; the crawler is the next stacked slice). The zip
+# import endpoint reuses SiteResponse (it publishes live through the html path).
 
 from __future__ import annotations
 
@@ -180,6 +186,11 @@ class SiteResponse(BaseModel):
     # caller can poll the job. None for a static publish, and None on a single-flight
     # no-op (a second publish while already provisioning does not enqueue a job).
     provision_job_id: str | None = None
+    # SI-4: the persisted import summary for an IMPORTED site — {pages: [{path,
+    # title}], asset_count, asset_bytes, forms: [{page, original_action, rewired}],
+    # scripts, warnings} (from-url adds status/source_url). None for every
+    # non-imported site, so the field is backward-compatible and empty-safe.
+    import_report: dict[str, Any] | None = None
 
 
 class SitePreviewResponse(BaseModel):
@@ -419,6 +430,25 @@ class LeafEditsResponse(BaseModel):
 
     pocket_id: str
     results: list[LeafEditVerdict]
+
+
+class ImportFromUrlRequest(BaseModel):
+    """Body for POST /sites/import/from-url (SI-4): the site URL to crawl-import.
+    Shape validation (http(s), real host, length cap) runs in the import service so
+    direct service callers are covered too; the crawler itself is the next stacked
+    slice — this endpoint only queues."""
+
+    url: str
+
+
+class ImportFromUrlResponse(BaseModel):
+    """202 body of POST /sites/import/from-url (SI-4): the DRAFT site minted for the
+    queued crawl. ``status`` is "queued" — the crawler slice (SI-5) has not landed,
+    so the site's import_report carries a crawler-pending warning until it does."""
+
+    site_id: str
+    pocket_id: str
+    status: str  # queued
 
 
 class NativeArtifactResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -16,6 +16,15 @@
 # triggers a build, so the prod box stops running a 1-2 min SvelteKit build on every
 # site view. Builds now happen only at publish and (cached/pre-warmed) at edit-arm.
 #
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): build()/_build_one() gain an
+# OPTIONAL ``assets`` param — the base64 binary sideband ({path: base64}) an html
+# IMPORT carries alongside its text ``source`` map. It rides ``input.assets`` on the
+# html branch only, and ONLY when non-empty, so every existing ripple/svelte/html
+# payload stays byte-identical. CROSS-REPO SEAM: the paw-sites generator's ``assets``
+# key (decode + write each entry verbatim into the static tree) is being added in a
+# parallel paw-sites slice — this codes to that contract; a generator predating it
+# ignores the key and deploys the text tree only.
+#
 # Updated 2026-07-10 (HE-3 — html publish skips the Node build): build()/_build_one()
 # now branch the STAGE-2 payload AND the build chain on the engine's CAPABILITY, via
 # ``needs_node_build(engine)`` / ``is_source_engine(engine)`` from the canonical
@@ -1110,6 +1119,7 @@ class GeneratorClient:
         capture_signed_key: str,
         engine: str = "ripple",
         source: dict[str, Any] | None = None,
+        assets: dict[str, str] | None = None,
         builder_origin: str | None = None,
         d1_database_id: str = "",
         pocket_id: str | None = None,
@@ -1117,6 +1127,11 @@ class GeneratorClient:
         static_build: bool = True,
     ) -> BuildResult:
         """Generate + smoke-build a Paw Site, forking STAGE 2 on ``engine``.
+
+        ``assets`` (SI-4) is the html import's base64 BINARY sideband
+        ({path: base64}) — sent as ``input.assets`` on the html branch only, and only
+        when non-empty (see _build_one for the cross-repo seam note). ripple/svelte
+        payloads never carry it.
 
         ``engine="ripple"`` (default) compiles ``ripple_spec`` into the site;
         ``engine="svelte"`` materializes ``source`` (the pocket's hand-written
@@ -1188,6 +1203,7 @@ class GeneratorClient:
                 capture_signed_key=capture_signed_key,
                 engine=engine,
                 source=source,
+                assets=assets,
                 builder_origin=builder_origin,
                 d1_database_id=d1_database_id,
                 pocket_id=None,
@@ -1204,6 +1220,7 @@ class GeneratorClient:
                 capture_signed_key=capture_signed_key,
                 engine=engine,
                 source=source,
+                assets=assets,
                 builder_origin=builder_origin,
                 d1_database_id=d1_database_id,
                 pocket_id=pocket_id,
@@ -1227,6 +1244,7 @@ class GeneratorClient:
         pocket_id: str | None,
         smoke: bool,
         static_build: bool = True,
+        assets: dict[str, str] | None = None,
     ) -> BuildResult:
         # PERF-3: stable per-pocket working dir (overwrite the source each build)
         # so node_modules persists; fall back to a throwaway tempfile dir when no
@@ -1283,6 +1301,16 @@ class GeneratorClient:
             # source engine) is untouched by this branch and still sends rippleSpec
             # below, so its wire bytes — and svelte's — are unchanged.
             input_json["source"] = source or {}
+            # SI-4 CROSS-REPO SEAM: an html IMPORT also carries binary files, which
+            # cannot ride the text-only ``source`` map — they ride ``input.assets``
+            # ({path: base64}). The paw-sites generator's ``assets`` handling
+            # (decode + write each entry verbatim into the emitted static tree) is
+            # being added in a PARALLEL paw-sites slice; this codes to that
+            # contract. Sent ONLY when non-empty, so a plain html publish's payload
+            # stays byte-identical, and a generator predating the key ignores it
+            # (the import report warns that assets then don't deploy).
+            if assets:
+                input_json["assets"] = assets
         else:
             input_json["rippleSpec"] = ripple_spec
         gen = await self._runner.generate(input_json, out_dir)

--- a/ee/pocketpaw_ee/sites/import_service.py
+++ b/ee/pocketpaw_ee/sites/import_service.py
@@ -28,6 +28,9 @@
 # Tenancy: every entry point takes workspace_id/user_id and funnels through the
 # tenant-scoped pockets + sites services; the plan gate (require_sites_plan) runs
 # before any write.
+# Edited 2026-07-23 (security review): crafted/abnormal zip members (bad CRC,
+# encrypted, exotic compression) now map to 422 instead of escaping as 500s;
+# entry names carrying control characters are rejected as unsafe.
 
 from __future__ import annotations
 
@@ -83,6 +86,11 @@ def _safe_entry_path(raw_name: str) -> str:
         raise ValidationError(
             "sites.import_zip_entry_unsafe",
             f"Zip entry {raw_name!r} is an absolute path — archives must be relative.",
+        )
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in name):
+        raise ValidationError(
+            "sites.import_zip_entry_unsafe",
+            f"Zip entry {raw_name!r} contains control characters — not a safe archive path.",
         )
     parts = [p for p in name.split("/") if p not in ("", ".")]
     if not parts:
@@ -143,7 +151,9 @@ def unpack_zip(data: bytes) -> tuple[dict[str, str], dict[str, str]]:
         or the total UNCOMPRESSED size over MAX_IMPORT_UNCOMPRESSED_BYTES
         (decompression bomb; checked incrementally, never fully inflated first);
       * ``sites.import_zip_too_many_entries`` — over MAX_IMPORT_ENTRIES;
-      * ``sites.import_zip_entry_unsafe`` — zip-slip (absolute / ``..`` / backslash);
+      * ``sites.import_zip_entry_unsafe`` — zip-slip (absolute / ``..`` / backslash /
+        control characters — NUL or newline in a to-be-written path is generator input
+        the other side of the seam should never have to defend against);
       * ``sites.import_no_index`` — no index.html at the (flattened) root, which the
         html deploy path requires (its static smoke gates on it)."""
     if len(data) > MAX_IMPORT_ZIP_BYTES:
@@ -181,8 +191,20 @@ def unpack_zip(data: bytes) -> tuple[dict[str, str], dict[str, str]]:
                 "sites.import_zip_too_large",
                 "Import zip inflates past the uncompressed-size cap (decompression bomb?).",
             )
-        with zf.open(info) as fh:
-            blob = fh.read(MAX_IMPORT_UNCOMPRESSED_BYTES + 1)
+        try:
+            with zf.open(info) as fh:
+                blob = fh.read(MAX_IMPORT_UNCOMPRESSED_BYTES + 1)
+        except (zipfile.BadZipFile, RuntimeError, NotImplementedError) as exc:
+            # Per-entry reads raise outside the ZipFile() try above: bad CRC and
+            # lying size headers surface as BadZipFile, password-protected
+            # members as RuntimeError, exotic compression methods as
+            # NotImplementedError. All are a malformed/hostile-or-unsupported
+            # archive, not a server fault — map to the same 422 contract.
+            raise ValidationError(
+                "sites.import_zip_invalid",
+                f"Zip entry {info.filename!r} is unreadable "
+                "(corrupt, encrypted, or an unsupported compression method).",
+            ) from exc
         total_uncompressed += max(0, len(blob) - info.file_size)  # header lied → true bytes
         if total_uncompressed > MAX_IMPORT_UNCOMPRESSED_BYTES:
             raise ValidationError(

--- a/ee/pocketpaw_ee/sites/import_service.py
+++ b/ee/pocketpaw_ee/sites/import_service.py
@@ -22,9 +22,22 @@
 #     the generator-side import plan (form rewiring verdicts etc.) replaces this
 #     derivation once the parallel paw-sites slice lands — ``rewired`` is False until
 #     the generator confirms it.
-#   * from-url: URL-shape validation + draft Site mint + a queued report; the actual
-#     crawler is the NEXT stacked slice (``crawl_site_from_url`` raises
-#     NotImplementedError — a clean seam, nothing is fetched here).
+#   * from-url (SI-5, updated 2026-07-23 feat/sites-import-crawler): full seed
+#     validation (SSRF shape floors from url_crawler — scheme/port/credentials/
+#     literal-IP checks → 422 BEFORE anything is minted) + draft Site mint + a
+#     queued report, then the crawl runs as a DETACHED BACKGROUND TASK (the
+#     pre-warm scheduler pattern from sites/service.py — patchable module attr,
+#     strong-ref task set) under a hard wall-clock cap. ``crawl_site_from_url``
+#     is now REAL: crawl (url_crawler — SSRF-pinned fetcher, same-host BFS,
+#     robots, caps) → the SAME pipeline as zip (text/binary split → publish with
+#     the assets sideband) → import_report with crawl stats; every failure mode
+#     lands as a safe ``status:"failed"`` report, never a stack trace.
+#     WHY background, not the workspace-jobs (ARQ) machinery: the jobs worker's
+#     writeback merges result state into the pocket's rippleSpec — an imported
+#     html pocket has no spec, so a successful crawl could be marked failed by
+#     the writeback gate. Tradeoff (documented): a web-process restart drops an
+#     in-flight crawl and the report stays "queued" — acceptable for v1, the
+#     durable-queue upgrade is a follow-up.
 # Tenancy: every entry point takes workspace_id/user_id and funnels through the
 # tenant-scoped pockets + sites services; the plan gate (require_sites_plan) runs
 # before any write.
@@ -34,6 +47,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import io
 import logging
@@ -44,7 +58,7 @@ from typing import Any
 from urllib.parse import urlparse
 from uuid import uuid4
 
-from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
+from pocketpaw_ee.cloud._core.errors import CloudError, Internal, ValidationError
 from pocketpaw_ee.sites import service as sites_service
 
 logger = logging.getLogger(__name__)
@@ -59,6 +73,10 @@ MAX_IMPORT_ENTRIES = 2000
 MAX_IMPORT_UNCOMPRESSED_BYTES = 50 * 1024 * 1024
 # Per-URL shape cap for from-url imports.
 MAX_IMPORT_URL_LENGTH = 2048
+# Hard wall-clock cap on one background crawl+import run (SI-5). The crawl's own
+# caps (pages/bytes/redirects/per-fetch timeout) bound it well below this in
+# practice; the timeout is the backstop against a slow-loris target.
+MAX_CRAWL_WALL_CLOCK_SEC = 120
 
 # The pocket authoring pattern stamped on imported sites so the gallery can badge
 # them and later slices (crawler, re-import) can find them.
@@ -442,9 +460,11 @@ async def import_zip_site(
 
 
 def _validate_import_url(url: str) -> str:
-    """Shape-validate a from-url import target: http(s), a real host, sane length.
-    This is SHAPE validation only — the crawler slice (SI-5) must add SSRF guards
-    (private-range / loopback / metadata-IP denial) before it ever fetches."""
+    """Validate a from-url import target: shape (http(s), a real host, sane length)
+    PLUS the crawler's SSRF shape floors — no credentials in the URL, no ports
+    beyond 80/443, and a literal-IP host must be publicly routable (loopback /
+    private / link-local / metadata / CGNAT all 422 here, before anything is
+    minted). Hostname RESOLUTION is checked later, inside the pinned fetcher."""
     candidate = (url or "").strip()
     if not candidate or len(candidate) > MAX_IMPORT_URL_LENGTH:
         raise ValidationError("sites.import_url_invalid", "A non-empty http(s) URL is required.")
@@ -454,25 +474,206 @@ def _validate_import_url(url: str) -> str:
             "sites.import_url_invalid",
             "The import URL must be an absolute http(s) URL with a host.",
         )
+    from pocketpaw_ee.sites import url_crawler
+
+    url_crawler.validate_seed_url(candidate)
     return candidate
 
 
-async def crawl_site_from_url(*, workspace_id: str, user_id: str, site_id: str, url: str) -> None:
-    """CRAWLER SEAM (next stacked slice, SI-5): fetch + mirror the target site into
-    the import pipeline. Deliberately NOT implemented here — the from-url endpoint
-    only queues. The implementation must add SSRF guards (deny loopback / private
-    ranges / cloud metadata IPs, cap redirects and fetch sizes) before fetching."""
-    raise NotImplementedError(
-        "sites import crawler is the next stacked slice (SI-5) — "
-        "POST /sites/import/from-url only queues the site today."
+def _safe_crawl_failure(exc: BaseException) -> str:
+    """Map a crawl/import failure to a SAFE message for the import report (which
+    every site viewer can read): our own errors carry fixed, safe text; anything
+    else degrades to a generic message. Full detail stays in the log only."""
+    from pocketpaw_ee.sites.url_crawler import CrawlError
+
+    if isinstance(exc, TimeoutError):
+        return f"crawl exceeded the {MAX_CRAWL_WALL_CLOCK_SEC}s wall-clock cap"
+    if isinstance(exc, (CrawlError, CloudError)):
+        return str(exc)
+    return "crawl failed"
+
+
+async def _mark_import_failed(doc: Any, *, url: str, message: str) -> None:
+    """Stamp a clear failed-state import report on the draft Site doc — the UI's
+    signal that the from-url import ended. Never a traceback, never raw upstream
+    text (``message`` comes from ``_safe_crawl_failure``)."""
+    doc.import_report = {
+        "pages": [],
+        "asset_count": 0,
+        "asset_bytes": 0,
+        "forms": [],
+        "scripts": [],
+        "warnings": [],
+        "status": "failed",
+        "error": message,
+        "source_url": url,
+    }
+    await doc.save()
+
+
+async def crawl_site_from_url(
+    *,
+    workspace_id: str,
+    user_id: str,
+    site_id: str,
+    url: str,
+    _transport: Any | None = None,
+    _resolver: Any | None = None,
+    _politeness_delay: float | None = None,
+    _generator: Any | None = None,
+    _cloudflare: Any | None = None,
+    _local_deploy: Any | None = None,
+) -> Any:
+    """SI-5: crawl ``url`` (same-site, SSRF-pinned — see url_crawler) and run the
+    harvest through the SAME import pipeline as the zip path: text/binary split →
+    persist the source on the pocket (durable re-publish source) → publish with the
+    assets sideband → import_report with crawl stats → Journal event.
+
+    Runs under a hard wall-clock cap. EVERY failure mode (unreachable seed, seed
+    blocked by robots, byte budget exceeded, deploy failure, timeout) marks the
+    draft Site's report ``status:"failed"`` with a safe error message and returns
+    the doc — it never raises into the background scheduler and never surfaces a
+    stack trace. The ``_transport``/``_resolver`` seams keep tests off the network;
+    the generator/CF/local-deploy seams forward to ``publish`` as in the zip path."""
+    from bson import ObjectId
+    from bson.errors import InvalidId
+
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+    from pocketpaw_ee.sites import url_crawler
+
+    try:
+        oid = ObjectId(site_id)
+    except (InvalidId, TypeError):
+        raise ValidationError("sites.import_site_missing", "Unknown import site id.")
+    doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise ValidationError("sites.import_site_missing", "Unknown import site id.")
+    pocket_id = doc.pocket_id
+
+    try:
+        async with asyncio.timeout(MAX_CRAWL_WALL_CLOCK_SEC):
+            crawl = await url_crawler.crawl_site(
+                url,
+                total_byte_cap=MAX_IMPORT_UNCOMPRESSED_BYTES,
+                transport=_transport,
+                resolver=_resolver,
+                politeness_delay=_politeness_delay,
+            )
+    except Exception as exc:  # noqa: BLE001 — every crawl failure becomes a safe report
+        logger.warning("sites import: crawl of %s failed", url, exc_info=True)
+        await _mark_import_failed(doc, url=url, message=_safe_crawl_failure(exc))
+        return doc
+
+    source: dict[str, str] = {}
+    assets: dict[str, str] = {}
+    for path, blob in crawl.files.items():
+        if _is_text(blob):
+            source[path] = blob.decode("utf-8")
+        else:
+            assets[path] = base64.b64encode(blob).decode("ascii")
+    if "index.html" not in source:
+        await _mark_import_failed(
+            doc, url=url, message="the crawl did not yield an importable index.html"
+        )
+        return doc
+
+    report = derive_import_report(source, assets)
+    report["warnings"].extend(crawl.warnings)
+    report["crawl"] = crawl.stats.as_dict()
+    report["status"] = "imported"
+    report["source_url"] = url
+    site_name = doc.name or f"Import of {urlparse(url).netloc}"
+
+    try:
+        # Persist the harvested source on the POCKET (the durable source of truth —
+        # re-publish from the builder reads it), then publish exactly like the zip
+        # path. Entity isolation: the Pocket Beanie write lives in pockets.service.
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        await pockets_service.set_imported_source(
+            pocket_id, workspace_id=workspace_id, source=source
+        )
+        doc = await sites_service.publish(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            ripple_spec=None,
+            theme={},
+            name=site_name,
+            engine="html",
+            source=source,
+            assets=assets or None,
+            pattern=IMPORT_PATTERN,
+            _generator=_generator,
+            _cloudflare=_cloudflare,
+            _local_deploy=_local_deploy,
+        )
+    except Exception as exc:  # noqa: BLE001 — deploy failures also become safe reports
+        logger.warning("sites import: deploy of crawled %s failed", url, exc_info=True)
+        fresh = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+        if fresh is not None:
+            await _mark_import_failed(fresh, url=url, message=_safe_crawl_failure(exc))
+            return fresh
+        return doc
+
+    doc.import_report = report
+    await doc.save()
+
+    _emit_import_journal(
+        action="site.imported",
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        site_id=str(doc.id),
+        payload={
+            "kind": "from_url",
+            "url": url,
+            "pages": len(report["pages"]),
+            "asset_count": report["asset_count"],
+            "crawl": report["crawl"],
+        },
     )
+    return doc
+
+
+# Background-task keepalive — mirrors sites/service.py's pre-warm scheduler:
+# asyncio holds only a weak ref to a bare create_task, so hold a strong ref until
+# done. Tests patch ``_default_crawl_scheduler`` to capture the coroutine.
+_CRAWL_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _default_crawl_scheduler(coro: Any) -> None:
+    """Detach the crawl coroutine as a background task on the running loop and
+    return immediately (the endpoint's 202 must not wait on the crawl). With no
+    running loop, close the coroutine and skip — the report stays ``queued``."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        coro.close()
+        return
+    task = loop.create_task(coro)
+    _CRAWL_TASKS.add(task)
+    task.add_done_callback(_CRAWL_TASKS.discard)
+
+
+async def _run_url_import(*, workspace_id: str, user_id: str, site_id: str, url: str) -> None:
+    """The background wrapper around ``crawl_site_from_url`` — it must NEVER let an
+    exception escape into the event loop (failures are already stamped on the
+    report inside; this catches only the truly unexpected)."""
+    try:
+        await crawl_site_from_url(
+            workspace_id=workspace_id, user_id=user_id, site_id=site_id, url=url
+        )
+    except Exception:  # noqa: BLE001 — background task: log, never crash the loop
+        logger.exception("sites import: background url import failed for site %s", site_id)
 
 
 async def import_from_url(*, workspace_id: str, user_id: str, url: str) -> dict[str, str]:
-    """Queue a from-url import: validate the URL shape, mint the pocket + DRAFT Site
-    doc (status stays draft / not deployed), stamp a queued import_report with the
-    crawler-pending warning, and return {site_id, pocket_id, status: "queued"}.
-    Nothing is fetched — the crawler is the next stacked slice (SI-5)."""
+    """Queue a from-url import: validate the URL (shape + SSRF floors → 422 before
+    any write), mint the pocket + DRAFT Site doc (status stays draft / not
+    deployed), stamp a queued import_report, schedule the background crawl
+    (SI-5 — ``crawl_site_from_url`` under the wall-clock cap), and return
+    {site_id, pocket_id, status: "queued"} immediately (the 202 contract)."""
     await sites_service.require_sites_plan(workspace_id)
     candidate = _validate_import_url(url)
     host = urlparse(candidate).netloc
@@ -492,8 +693,8 @@ async def import_from_url(*, workspace_id: str, user_id: str, url: str) -> dict[
             "forms": [],
             "scripts": [],
             "warnings": [
-                f"crawler pending — the crawl of {candidate} is queued; the from-url "
-                "crawler is the next stacked slice and has not run yet"
+                f"crawler queued — the crawl of {candidate} runs in the background; "
+                "refresh the site to see the import report"
             ],
             "status": "queued",
             "source_url": candidate,
@@ -507,5 +708,8 @@ async def import_from_url(*, workspace_id: str, user_id: str, url: str) -> dict[
         pocket_id=pocket_id,
         site_id=str(oid),
         payload={"kind": "from_url", "url": candidate},
+    )
+    _default_crawl_scheduler(
+        _run_url_import(workspace_id=workspace_id, user_id=user_id, site_id=str(oid), url=candidate)
     )
     return {"site_id": str(oid), "pocket_id": pocket_id, "status": "queued"}

--- a/ee/pocketpaw_ee/sites/import_service.py
+++ b/ee/pocketpaw_ee/sites/import_service.py
@@ -1,0 +1,489 @@
+# ee/pocketpaw_ee/sites/import_service.py — Paw Sites IMPORT control plane (SI-4).
+#
+# Created 2026-07-22 (feat/sites-import-endpoint): the service half of the two
+# import endpoints — POST /sites/import (zip upload) and POST /sites/import/from-url
+# (crawler-backed, next slice). Owns:
+#   * SAFE zip unpacking, fully in memory: zip-slip guard (absolute paths, drive
+#     letters, backslashes, ``..`` traversal all rejected), an entry-count cap and a
+#     total-uncompressed-size cap (decompression-bomb guard), junk filtering
+#     (__MACOSX/, .DS_Store), and single-root flattening (a zip whose only top-level
+#     dir holds index.html imports as if that dir were the root).
+#   * Text/binary split by CONTENT sniff (NUL byte or non-UTF-8 → binary), building
+#     the generator input: text files ride ``source`` ({path: text}) — the existing
+#     html-engine source map — and binary files ride ``assets`` ({path: base64}).
+#     CROSS-REPO SEAM: the generator's ``assets`` base64 sideband is being added in a
+#     parallel paw-sites slice; this codes to that contract (see generator_client).
+#   * The import flow: mint the html POCKET (the durable source of truth, same as
+#     every other site) → mint the DRAFT Site doc (create_draft_site — the
+#     draft-first pattern) → publish through the EXISTING html/static deploy path →
+#     persist an ``import_report`` on the Site doc → best-effort Journal event.
+#   * A MINIMAL import report derived from the zip contents (pages + titles, asset
+#     count/bytes, forms with their original actions, script refs). ENRICHMENT SEAM:
+#     the generator-side import plan (form rewiring verdicts etc.) replaces this
+#     derivation once the parallel paw-sites slice lands — ``rewired`` is False until
+#     the generator confirms it.
+#   * from-url: URL-shape validation + draft Site mint + a queued report; the actual
+#     crawler is the NEXT stacked slice (``crawl_site_from_url`` raises
+#     NotImplementedError — a clean seam, nothing is fetched here).
+# Tenancy: every entry point takes workspace_id/user_id and funnels through the
+# tenant-scoped pockets + sites services; the plan gate (require_sites_plan) runs
+# before any write.
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import zipfile
+from datetime import UTC, datetime
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import urlparse
+from uuid import uuid4
+
+from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
+from pocketpaw_ee.sites import service as sites_service
+
+logger = logging.getLogger(__name__)
+
+# Upload cap for the zip itself (enforced at the router while reading the upload,
+# re-checked here for direct service callers).
+MAX_IMPORT_ZIP_BYTES = 25 * 1024 * 1024
+# Decompression-bomb guards: a hostile zip can be tiny on the wire yet explode on
+# extract. Cap both the entry count and the TOTAL uncompressed size (checked
+# incrementally while reading, so a bomb is rejected before it is fully inflated).
+MAX_IMPORT_ENTRIES = 2000
+MAX_IMPORT_UNCOMPRESSED_BYTES = 50 * 1024 * 1024
+# Per-URL shape cap for from-url imports.
+MAX_IMPORT_URL_LENGTH = 2048
+
+# The pocket authoring pattern stamped on imported sites so the gallery can badge
+# them and later slices (crawler, re-import) can find them.
+IMPORT_PATTERN = "imported"
+
+# macOS zip junk that should never become site files.
+_JUNK_PREFIXES = ("__MACOSX/",)
+_JUNK_BASENAMES = {".DS_Store", "Thumbs.db"}
+
+
+def _safe_entry_path(raw_name: str) -> str:
+    """Normalize one zip entry name to a safe, relative POSIX path.
+
+    Zip-slip guard: rejects backslashes (Windows-style traversal), absolute paths,
+    drive letters, ``..`` components, and empty/degenerate names. Raises
+    ``ValidationError('sites.import_zip_entry_unsafe')`` — the whole import fails
+    closed on ONE bad entry (a crafted archive is hostile; do not cherry-pick)."""
+    name = raw_name.strip()
+    if "\\" in name:
+        raise ValidationError(
+            "sites.import_zip_entry_unsafe",
+            f"Zip entry {raw_name!r} contains a backslash — not a safe archive path.",
+        )
+    if name.startswith("/") or (len(name) >= 2 and name[1] == ":"):
+        raise ValidationError(
+            "sites.import_zip_entry_unsafe",
+            f"Zip entry {raw_name!r} is an absolute path — archives must be relative.",
+        )
+    parts = [p for p in name.split("/") if p not in ("", ".")]
+    if not parts:
+        raise ValidationError(
+            "sites.import_zip_entry_unsafe",
+            f"Zip entry {raw_name!r} normalizes to an empty path.",
+        )
+    if ".." in parts:
+        raise ValidationError(
+            "sites.import_zip_entry_unsafe",
+            f"Zip entry {raw_name!r} traverses outside the archive root ('..').",
+        )
+    return "/".join(parts)
+
+
+def _is_junk(path: str) -> bool:
+    """macOS/Windows archive junk (resource forks, Finder metadata)."""
+    if any(path.startswith(p) for p in _JUNK_PREFIXES):
+        return True
+    return path.rsplit("/", 1)[-1] in _JUNK_BASENAMES
+
+
+def _is_text(data: bytes) -> bool:
+    """Content sniff: NUL byte or invalid UTF-8 → binary; else text. Extension is
+    deliberately NOT trusted (a .png named .html must still ride the binary
+    sideband, or the generator would corrupt it writing it as text)."""
+    if b"\x00" in data:
+        return False
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _flatten_single_root(entries: dict[str, bytes]) -> dict[str, bytes]:
+    """If the archive has NO root index.html but exactly ONE top-level directory
+    that contains one (the `zip -r site site/` shape every OS zipper produces),
+    strip that directory prefix so the site imports rooted correctly."""
+    if "index.html" in entries:
+        return entries
+    tops = {p.split("/", 1)[0] for p in entries}
+    if len(tops) != 1:
+        return entries
+    top = next(iter(tops))
+    prefix = f"{top}/"
+    if not all(p.startswith(prefix) for p in entries) or f"{prefix}index.html" not in entries:
+        return entries
+    return {p[len(prefix) :]: data for p, data in entries.items()}
+
+
+def unpack_zip(data: bytes) -> tuple[dict[str, str], dict[str, str]]:
+    """Unpack an uploaded site zip IN MEMORY into (text source map, base64 asset map).
+
+    Guards (all fail closed with a 4xx-mapped ValidationError):
+      * ``sites.import_zip_invalid`` — not a readable zip;
+      * ``sites.import_zip_too_large`` — the archive itself over MAX_IMPORT_ZIP_BYTES,
+        or the total UNCOMPRESSED size over MAX_IMPORT_UNCOMPRESSED_BYTES
+        (decompression bomb; checked incrementally, never fully inflated first);
+      * ``sites.import_zip_too_many_entries`` — over MAX_IMPORT_ENTRIES;
+      * ``sites.import_zip_entry_unsafe`` — zip-slip (absolute / ``..`` / backslash);
+      * ``sites.import_no_index`` — no index.html at the (flattened) root, which the
+        html deploy path requires (its static smoke gates on it)."""
+    if len(data) > MAX_IMPORT_ZIP_BYTES:
+        raise ValidationError(
+            "sites.import_zip_too_large",
+            f"Import zip exceeds the {MAX_IMPORT_ZIP_BYTES // (1024 * 1024)}MB upload cap.",
+        )
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        infos = zf.infolist()
+    except zipfile.BadZipFile as exc:
+        raise ValidationError(
+            "sites.import_zip_invalid", "The uploaded file is not a readable zip archive."
+        ) from exc
+
+    entries: dict[str, bytes] = {}
+    total_uncompressed = 0
+    for info in infos:
+        if info.is_dir():
+            continue
+        path = _safe_entry_path(info.filename)
+        if _is_junk(path):
+            continue
+        if len(entries) >= MAX_IMPORT_ENTRIES:
+            raise ValidationError(
+                "sites.import_zip_too_many_entries",
+                f"Import zip has more than {MAX_IMPORT_ENTRIES} files.",
+            )
+        # Incremental bomb guard: trust neither the header's file_size (it can lie)
+        # nor a single up-front sum — count REAL inflated bytes as we read, and stop
+        # the moment the running total crosses the cap.
+        total_uncompressed += info.file_size
+        if total_uncompressed > MAX_IMPORT_UNCOMPRESSED_BYTES:
+            raise ValidationError(
+                "sites.import_zip_too_large",
+                "Import zip inflates past the uncompressed-size cap (decompression bomb?).",
+            )
+        with zf.open(info) as fh:
+            blob = fh.read(MAX_IMPORT_UNCOMPRESSED_BYTES + 1)
+        total_uncompressed += max(0, len(blob) - info.file_size)  # header lied → true bytes
+        if total_uncompressed > MAX_IMPORT_UNCOMPRESSED_BYTES:
+            raise ValidationError(
+                "sites.import_zip_too_large",
+                "Import zip inflates past the uncompressed-size cap (decompression bomb?).",
+            )
+        entries[path] = blob
+
+    entries = _flatten_single_root(entries)
+    if "index.html" not in entries:
+        raise ValidationError(
+            "sites.import_no_index",
+            "The zip has no index.html at its root — an importable site needs one.",
+        )
+
+    source: dict[str, str] = {}
+    assets: dict[str, str] = {}
+    for path, blob in entries.items():
+        if _is_text(blob):
+            source[path] = blob.decode("utf-8")
+        else:
+            assets[path] = base64.b64encode(blob).decode("ascii")
+    return source, assets
+
+
+class _PageScan(HTMLParser):
+    """One-pass scan of an imported HTML page: <title>, <form action=...>, and
+    <script src=...> refs — the raw material for the minimal import report."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title = ""
+        self._in_title = False
+        self.form_actions: list[str] = []
+        self.script_srcs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {k: (v or "") for k, v in attrs}
+        if tag == "title":
+            self._in_title = True
+        elif tag == "form":
+            self.form_actions.append(attr_map.get("action", ""))
+        elif tag == "script" and attr_map.get("src"):
+            self.script_srcs.append(attr_map["src"])
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self.title += data
+
+
+def derive_import_report(source: dict[str, str], assets: dict[str, str]) -> dict[str, Any]:
+    """Derive the MINIMAL import report from the unpacked zip contents.
+
+    Shape: {pages: [{path, title}], asset_count, asset_bytes,
+            forms: [{page, original_action, rewired}], scripts: [...], warnings: [...]}.
+
+    ENRICHMENT SEAM (cross-repo): the paw-sites generator's import plan will
+    provide the authoritative report — including per-form REWIRING verdicts (the
+    generator rewrites <form> actions to the native capture POST) — in a parallel
+    slice. Until it lands, this derivation reports what the zip CONTAINS and marks
+    every form ``rewired: False`` (nothing is confirmed rewired yet)."""
+    pages: list[dict[str, str]] = []
+    forms: list[dict[str, Any]] = []
+    scripts: list[str] = []
+    for path in sorted(source):
+        if not path.endswith((".html", ".htm")):
+            continue
+        scan = _PageScan()
+        try:
+            scan.feed(source[path])
+        except Exception:  # noqa: BLE001 — a malformed page still lists, just untitled
+            logger.debug("import report: page %s did not parse cleanly", path)
+        pages.append({"path": path, "title": scan.title.strip()})
+        forms.extend(
+            {"page": path, "original_action": action, "rewired": False}
+            for action in scan.form_actions
+        )
+        scripts.extend(src for src in scan.script_srcs if src not in scripts)
+
+    asset_bytes = sum(len(base64.b64decode(b64)) for b64 in assets.values())
+    warnings: list[str] = []
+    if forms:
+        warnings.append(
+            "form rewiring is confirmed by the generator-side import plan (pending "
+            "paw-sites slice) — forms are listed but not yet verified as rewired"
+        )
+    if assets:
+        warnings.append(
+            "binary assets deploy at import time; re-publishing from the builder will "
+            "not carry them until the pocket asset sideband lands"
+        )
+    return {
+        "pages": pages,
+        "asset_count": len(assets),
+        "asset_bytes": asset_bytes,
+        "forms": forms,
+        "scripts": scripts,
+        "warnings": warnings,
+    }
+
+
+def _emit_import_journal(
+    *,
+    action: str,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    site_id: str,
+    payload: dict[str, Any],
+) -> None:
+    """Append the import Journal event (best-effort, mirrors versions/service.py's
+    ``_emit_version_event``). The Site doc + import_report are the durable record;
+    the event is the audit echo, so a journal-less context degrades silently."""
+    try:
+        from soul_protocol.spec.journal import Actor, EventEntry
+
+        from pocketpaw.journal_dep import get_journal
+    except Exception:  # noqa: BLE001 — journal dep unavailable on a fork
+        logger.debug("journal dep unavailable — skipping %s event", action)
+        return
+
+    scope = [f"pocket:{pocket_id}", f"site:{site_id}", f"workspace:{workspace_id}"]
+    event = EventEntry(
+        id=uuid4(),
+        ts=datetime.now(UTC),
+        actor=Actor(kind="user", id=user_id, scope_context=scope),
+        action=action,
+        scope=scope,
+        payload=payload,
+    )
+    try:
+        get_journal().append(event)
+    except Exception:  # noqa: BLE001 — audit echo must not break the import
+        logger.warning("sites import: failed to append %s journal event", action, exc_info=True)
+
+
+async def _mint_import_pocket(
+    *, workspace_id: str, user_id: str, name: str, source: dict[str, str]
+) -> str:
+    """Create the html POCKET an import is rooted on (the durable source of truth
+    every other site flow — publish/preview/status/versions — already reads), then
+    mint the DRAFT Site doc for it (create_draft_site — the draft-first pattern, so
+    the site lists in the gallery and publish flips the SAME doc live)."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name=name,
+        type_="site",
+        pattern=IMPORT_PATTERN,
+        ripple_spec=None,
+        engine="html",
+        source=source,
+        # The source is the user's own uploaded files, not LLM-drafted ripple JSON —
+        # there is no catalog gate to run (same rationale as the svelte create path).
+        trusted=True,
+    )
+    if err is not None or pocket_id is None:
+        raise Internal("sites.import_pocket_failed", f"Could not create the site pocket: {err}")
+    await sites_service.create_draft_site(
+        workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id, name=name
+    )
+    return pocket_id
+
+
+async def import_zip_site(
+    *,
+    workspace_id: str,
+    user_id: str,
+    data: bytes,
+    name: str = "",
+    _generator: Any | None = None,
+    _cloudflare: Any | None = None,
+    _local_deploy: Any | None = None,
+) -> Any:
+    """Import an uploaded site zip end to end: unpack safely → mint pocket + draft
+    Site doc → publish through the EXISTING html/static deploy path (with the
+    binary ``assets`` sideband) → persist the import_report → Journal event.
+
+    Returns the live Site doc (import_report set). The generator / CF / local-deploy
+    seams forward to ``publish`` so tests never shell out to bun/workerd."""
+    # Plan gate FIRST — before any unpack work or pocket write — mirroring
+    # publish_pocket's gate-before-read ordering.
+    await sites_service.require_sites_plan(workspace_id)
+
+    source, assets = unpack_zip(data)
+    site_name = name.strip() or "Imported site"
+    pocket_id = await _mint_import_pocket(
+        workspace_id=workspace_id, user_id=user_id, name=site_name, source=source
+    )
+    report = derive_import_report(source, assets)
+
+    doc = await sites_service.publish(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        ripple_spec=None,
+        theme={},
+        name=site_name,
+        engine="html",
+        source=source,
+        # CROSS-REPO SEAM: ``assets`` is the base64 binary sideband the paw-sites
+        # generator is gaining in a parallel slice ({path: base64} written verbatim
+        # into the static tree). Until that lands, a generator that ignores the key
+        # deploys the text tree only — the report's warning covers it.
+        assets=assets or None,
+        pattern=IMPORT_PATTERN,
+        _generator=_generator,
+        _cloudflare=_cloudflare,
+        _local_deploy=_local_deploy,
+    )
+    doc.import_report = report
+    await doc.save()
+
+    _emit_import_journal(
+        action="site.imported",
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        site_id=str(doc.id),
+        payload={
+            "kind": "zip",
+            "pages": len(report["pages"]),
+            "asset_count": report["asset_count"],
+            "asset_bytes": report["asset_bytes"],
+            "forms": len(report["forms"]),
+        },
+    )
+    return doc
+
+
+def _validate_import_url(url: str) -> str:
+    """Shape-validate a from-url import target: http(s), a real host, sane length.
+    This is SHAPE validation only — the crawler slice (SI-5) must add SSRF guards
+    (private-range / loopback / metadata-IP denial) before it ever fetches."""
+    candidate = (url or "").strip()
+    if not candidate or len(candidate) > MAX_IMPORT_URL_LENGTH:
+        raise ValidationError("sites.import_url_invalid", "A non-empty http(s) URL is required.")
+    parsed = urlparse(candidate)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValidationError(
+            "sites.import_url_invalid",
+            "The import URL must be an absolute http(s) URL with a host.",
+        )
+    return candidate
+
+
+async def crawl_site_from_url(*, workspace_id: str, user_id: str, site_id: str, url: str) -> None:
+    """CRAWLER SEAM (next stacked slice, SI-5): fetch + mirror the target site into
+    the import pipeline. Deliberately NOT implemented here — the from-url endpoint
+    only queues. The implementation must add SSRF guards (deny loopback / private
+    ranges / cloud metadata IPs, cap redirects and fetch sizes) before fetching."""
+    raise NotImplementedError(
+        "sites import crawler is the next stacked slice (SI-5) — "
+        "POST /sites/import/from-url only queues the site today."
+    )
+
+
+async def import_from_url(*, workspace_id: str, user_id: str, url: str) -> dict[str, str]:
+    """Queue a from-url import: validate the URL shape, mint the pocket + DRAFT Site
+    doc (status stays draft / not deployed), stamp a queued import_report with the
+    crawler-pending warning, and return {site_id, pocket_id, status: "queued"}.
+    Nothing is fetched — the crawler is the next stacked slice (SI-5)."""
+    await sites_service.require_sites_plan(workspace_id)
+    candidate = _validate_import_url(url)
+    host = urlparse(candidate).netloc
+    site_name = f"Import of {host}"
+    pocket_id = await _mint_import_pocket(
+        workspace_id=workspace_id, user_id=user_id, name=site_name, source={}
+    )
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    oid = sites_service._live_object_id(workspace_id, pocket_id)
+    doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is not None:
+        doc.import_report = {
+            "pages": [],
+            "asset_count": 0,
+            "asset_bytes": 0,
+            "forms": [],
+            "scripts": [],
+            "warnings": [
+                f"crawler pending — the crawl of {candidate} is queued; the from-url "
+                "crawler is the next stacked slice and has not run yet"
+            ],
+            "status": "queued",
+            "source_url": candidate,
+        }
+        await doc.save()
+
+    _emit_import_journal(
+        action="site.import_queued",
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        site_id=str(oid),
+        payload={"kind": "from_url", "url": candidate},
+    )
+    return {"site_id": str(oid), "pocket_id": pocket_id, "status": "queued"}

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -365,8 +365,11 @@ async def import_site(
     the generator's ``assets`` base64 sideband), persist the ``import_report`` on
     the Site doc, and return the SiteResponse (carrying the report).
 
-    The 25MB upload cap is enforced HERE while reading the multipart part — the
-    body is never buffered past cap+1 bytes — and re-checked in the service for
+    The 25MB upload cap gates PROCESSING, not ingress: Starlette's multipart
+    parser spools the whole request body to a temp file before this handler
+    runs, so raw-ingress bounding belongs to the fronting proxy's body limit.
+    The handler reads at most cap+1 bytes of the part, and the cap is re-checked
+    in the service for
     direct callers. Oversized → 413; a malformed/hostile archive → 422 (the
     service's ValidationError codes map through the standard error envelope).
     Tenant-scoped on ctx (fabric.write, sites plan gate at the router level)."""

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -144,19 +144,37 @@
 # view). fabric.write is RETAINED because a COLD miss still builds (mutates on-disk
 # state), so the endpoint can still trigger work; it is not a pure read. The wire
 # contract (request/response, origin resolution, 422/404/403) is unchanged.
+#
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): added the two IMPORT
+# endpoints, both tenant-scoped writes (fabric.write) under the router's sites plan
+# gate like every sibling mutation:
+#   * POST /sites/import — multipart zip upload (25MB cap enforced while reading the
+#     upload). Delegates to import_service.import_zip_site: safe in-memory unpack
+#     (zip-slip + decompression-bomb guards), mint pocket + DRAFT Site doc, publish
+#     through the existing html/static deploy path (binary files ride the
+#     generator's ``assets`` base64 sideband — cross-repo seam), persist an
+#     ``import_report`` on the Site doc, Journal event. Returns the SiteResponse
+#     (now carrying import_report).
+#   * POST /sites/import/from-url — {url} → 202 {site_id, pocket_id,
+#     status:"queued"}. Validates the URL shape and mints the draft Site with a
+#     crawler-pending import_report; the crawler is the NEXT stacked slice (SI-5) —
+#     nothing is fetched here.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.deps import require_action_any_workspace, require_plan_feature
+from pocketpaw_ee.sites import import_service
 from pocketpaw_ee.sites import service as sites_service
 from pocketpaw_ee.sites.dto import (
     AuditResponse,
     DevPreviewResponse,
     DomainRequest,
     DomainStatusResponse,
+    ImportFromUrlRequest,
+    ImportFromUrlResponse,
     LeafEditsRequest,
     LeafEditsResponse,
     LeafEditVerdict,
@@ -332,6 +350,59 @@ async def native_artifact_by_pocket(
         builder_origin=builder_origin,
     )
     return NativeArtifactResponse(**result)
+
+
+@router.post("/sites/import", response_model=SiteResponse)
+async def import_site(
+    file: UploadFile = File(...),
+    name: str = Form(""),
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SiteResponse:
+    """Import an uploaded site zip (SI-4): unpack safely in memory (zip-slip +
+    decompression-bomb guards in the service), mint the html pocket + DRAFT Site
+    doc, publish through the existing html/static deploy path (binary files ride
+    the generator's ``assets`` base64 sideband), persist the ``import_report`` on
+    the Site doc, and return the SiteResponse (carrying the report).
+
+    The 25MB upload cap is enforced HERE while reading the multipart part — the
+    body is never buffered past cap+1 bytes — and re-checked in the service for
+    direct callers. Oversized → 413; a malformed/hostile archive → 422 (the
+    service's ValidationError codes map through the standard error envelope).
+    Tenant-scoped on ctx (fabric.write, sites plan gate at the router level)."""
+    cap = import_service.MAX_IMPORT_ZIP_BYTES
+    data = await file.read(cap + 1)
+    if len(data) > cap:
+        raise HTTPException(413, f"Import zip exceeds the {cap // (1024 * 1024)}MB upload cap")
+    doc = await import_service.import_zip_site(
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user_id,
+        data=data,
+        name=name,
+    )
+    return sites_service._to_response(doc, pattern=import_service.IMPORT_PATTERN, engine="html")
+
+
+@router.post(
+    "/sites/import/from-url",
+    response_model=ImportFromUrlResponse,
+    status_code=202,
+)
+async def import_site_from_url(
+    body: ImportFromUrlRequest,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> ImportFromUrlResponse:
+    """Queue a from-url import (SI-4): validate the URL shape, mint the pocket +
+    DRAFT Site doc with a crawler-pending ``import_report``, and return 202
+    {site_id, pocket_id, status:"queued"}. NOTHING is fetched — the crawler is the
+    next stacked slice (SI-5; ``import_service.crawl_site_from_url`` is its seam).
+    A malformed URL → 422 (ValidationError through the standard envelope).
+    Tenant-scoped on ctx (fabric.write), like every sibling sites mutation."""
+    queued = await import_service.import_from_url(
+        workspace_id=ctx.workspace_id, user_id=ctx.user_id, url=body.url
+    )
+    return ImportFromUrlResponse(**queued)
 
 
 @router.get("/sites", response_model=list[SiteResponse])

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -157,8 +157,15 @@
 #     (now carrying import_report).
 #   * POST /sites/import/from-url — {url} → 202 {site_id, pocket_id,
 #     status:"queued"}. Validates the URL shape and mints the draft Site with a
-#     crawler-pending import_report; the crawler is the NEXT stacked slice (SI-5) —
-#     nothing is fetched here.
+#     queued import_report.
+#
+# Updated 2026-07-23 (SI-5 — feat/sites-import-crawler): the from-url crawler is
+# REAL. The endpoint contract is unchanged (202 queued), but validation now also
+# runs the crawler's SSRF shape floors (non-http(s) scheme, embedded credentials,
+# non-80/443 port, literal private/loopback/metadata IP → 422 before any write),
+# and the service schedules the same-site crawl as a background task: crawl →
+# the zip import pipeline → import_report flips to "imported"/"failed" with
+# crawl stats. See import_service.crawl_site_from_url + url_crawler.
 
 from __future__ import annotations
 
@@ -396,11 +403,12 @@ async def import_site_from_url(
     ctx: RequestContext = Depends(request_context),
     _: object = Depends(require_action_any_workspace("fabric.write")),
 ) -> ImportFromUrlResponse:
-    """Queue a from-url import (SI-4): validate the URL shape, mint the pocket +
-    DRAFT Site doc with a crawler-pending ``import_report``, and return 202
-    {site_id, pocket_id, status:"queued"}. NOTHING is fetched — the crawler is the
-    next stacked slice (SI-5; ``import_service.crawl_site_from_url`` is its seam).
-    A malformed URL → 422 (ValidationError through the standard envelope).
+    """Queue a from-url import (SI-4 contract, SI-5 crawler): validate the URL
+    (shape + SSRF floors — bad scheme/port/credentials or a literal non-public IP
+    → 422 before anything is minted), mint the pocket + DRAFT Site doc with a
+    queued ``import_report``, schedule the background same-site crawl, and return
+    202 {site_id, pocket_id, status:"queued"} immediately. The crawl runs the zip
+    import pipeline and flips the report to "imported"/"failed" with crawl stats.
     Tenant-scoped on ctx (fabric.write), like every sibling sites mutation."""
     queued = await import_service.import_from_url(
         workspace_id=ctx.workspace_id, user_id=ctx.user_id, url=body.url

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,16 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): ``publish`` /
+# ``_deploy_site_doc`` gain an OPTIONAL ``assets`` pass-through — the base64 binary
+# sideband ({path: base64}) an html IMPORT sends alongside its text ``source`` map.
+# It is forwarded to ``GeneratorClient.build`` ONLY when non-empty, so every
+# existing publish path's build call stays byte-identical (cross-repo seam note in
+# generator_client.py). ``_to_response`` also surfaces the new
+# ``Site.import_report`` (None for non-imported sites). The import orchestration
+# itself lives in the sibling ``import_service.py`` — this file only carries the
+# sideband through the existing deploy chain.
+#
 # Updated 2026-07-17 (fix/sites-draft-visible — a DRAFT lists in the gallery):
 # added ``create_draft_site`` — the create-site MCP handlers now mint ONE Site doc
 # at CREATE time in a NOT-YET-DEPLOYED state so a draft-first pocket (pocketpaw#1744)
@@ -1423,6 +1433,9 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         # None for a static publish / any DB-loaded doc / a single-flight no-op).
         provision_status=getattr(doc, "provision_status", "none"),
         provision_job_id=getattr(doc, "_provision_job_id", None),
+        # SI-4: the persisted import summary for an imported site; None for every
+        # non-imported site (empty dict on the doc reads as None on the wire).
+        import_report=getattr(doc, "import_report", None) or None,
     )
 
 
@@ -1545,6 +1558,7 @@ async def publish(
     name: str = "",
     engine: str = "ripple",
     source: dict[str, str] | None = None,
+    assets: dict[str, str] | None = None,
     pattern: str | None = None,
     builder_origin: str | None = None,
     preview: bool = False,
@@ -1732,6 +1746,7 @@ async def publish(
         theme=theme,
         engine=engine,
         source=source,
+        assets=assets,
         pattern=pattern,
         builder_origin=builder_origin,
         generator=generator,
@@ -1754,6 +1769,7 @@ async def _deploy_site_doc(
     theme: dict[str, Any],
     engine: str = "ripple",
     source: dict[str, str] | None = None,
+    assets: dict[str, str] | None = None,
     pattern: str | None = None,
     builder_origin: str | None = None,
     generator: GeneratorClient | None = None,
@@ -1824,6 +1840,10 @@ async def _deploy_site_doc(
     # instead of letting a bare FileNotFoundError / RuntimeError / SmokeGateFailed
     # escape as an unhandled 500. A misconfigured image (no paw-sites-gen / bun on
     # PATH) is the bug this guards.
+    # SI-4: forward the html import's binary sideband ONLY when present, so every
+    # non-import publish's build call (and every injected fake's expected kwargs)
+    # stays byte-identical to before the assets seam existed.
+    _asset_kwargs: dict[str, Any] = {"assets": assets} if assets else {}
     build = await _build_or_cloud_error(
         gen,
         ripple_spec=ripple_spec,
@@ -1835,6 +1855,7 @@ async def _deploy_site_doc(
         engine=engine,
         source=source,
         builder_origin=builder_origin,
+        **_asset_kwargs,
         # PERF-3: build into the STABLE per-pocket working dir so node_modules
         # persists and `bun install` is cached across builds, cutting the dominant
         # per-edit cost.

--- a/ee/pocketpaw_ee/sites/url_crawler.py
+++ b/ee/pocketpaw_ee/sites/url_crawler.py
@@ -21,14 +21,19 @@
 #     the response is aborted the moment a cap is crossed, never buffered past it),
 #     no cookies (jar cleared after every response), no auth, no env proxies
 #     (trust_env=False), an honest User-Agent.
-# Crawl scope: BFS from the seed, EXACT host match only (www./apex are treated as
-# different hosts — documented v1 limitation), depth <= 3, pages <= 50, assets <= 200,
+# Crawl scope: BFS from the seed, EXACT host match only. The seed MAY redirect
+# off-host (apex->www is the common case) — the crawl then re-seeds to the final
+# host so the whole site imports; every OTHER fetch is scope-locked, so a
+# same-site page/asset cannot 30x us into fetching foreign content. Depth <= 3,
+# pages <= 50, assets <= 200,
 # robots.txt honored (simple RobotFileParser matching for our UA + '*'; a failed
 # robots fetch degrades to a polite warning), small politeness delay between fetches.
 # Harvest: pages/assets map to safe relative paths (sanitized through import_service's
 # ``_safe_entry_path`` — the SAME rule zip entries pass), absolute same-origin URLs in
 # HTML/CSS are rewritten root-relative, CSS url()/@import refs are chased same-origin.
 # Cross-origin refs are left as-is and counted for the import report.
+# Edited 2026-07-23 (SSRF review): redirect scope guard (off-host 30x rejected
+# for non-seed fetches) + seed apex->www re-seed; opposite-scheme origin rewrite.
 
 """Same-site crawler with SSRF-hardened fetching for Paw Sites URL imports."""
 
@@ -286,8 +291,15 @@ class SafeFetcher:
                 )
         return ips[0]
 
-    async def fetch(self, url: str) -> FetchResult:
-        """GET ``url`` with the full SSRF pipeline, following redirects manually."""
+    async def fetch(self, url: str, *, allowed_host: str | None = None) -> FetchResult:
+        """GET ``url`` with the full SSRF pipeline, following redirects manually.
+
+        Every hop is SSRF-revalidated regardless. ``allowed_host`` adds an
+        orthogonal SCOPE guard: when set, a redirect that leaves that host
+        raises ``sites.import_crawl_offsite_redirect`` so a same-site asset/page
+        can't 30x us into fetching (and deploying) foreign content. The seed
+        fetch passes ``None`` — the caller re-seeds the crawl host from the
+        final URL instead (so an apex->www redirect imports the whole site)."""
         current = url
         for _hop in range(MAX_REDIRECTS + 1):
             parsed = validate_seed_url(current)
@@ -297,6 +309,12 @@ class SafeFetcher:
                 if not location:
                     raise CrawlError("redirect response carried no Location header")
                 current = urljoin(current, location)
+                if allowed_host is not None and urlparse(current).netloc.lower() != allowed_host:
+                    raise CrawlError(
+                        f"redirect left the site ({allowed_host} -> "
+                        f"{urlparse(current).netloc.lower()})",
+                        code="sites.import_crawl_offsite_redirect",
+                    )
                 continue
             return FetchResult(url=current, status=status, content_type=content_type, body=body)
         raise CrawlError(f"too many redirects (max {MAX_REDIRECTS})")
@@ -508,22 +526,51 @@ async def crawl_site(
 
     delay = POLITENESS_DELAY_SEC if politeness_delay is None else politeness_delay
     seed = validate_seed_url(url)
-    seed_netloc = seed.netloc.lower()
-    origins = [f"{seed.scheme}://{seed.netloc}", f"//{seed.netloc}"]
+    # Crawl scope is MUTABLE: if the seed redirects to another host (apex->www,
+    # the overwhelmingly common case), we re-seed to the final host after the
+    # seed fetch so the whole site imports instead of a lone page + a wall of
+    # cross-origin warnings. `scope["netloc"]`/`scope["origins"]` are what
+    # `_same_site` and the URL rewrite read, so updating them re-homes the crawl.
+    scope: dict[str, Any] = {
+        "netloc": seed.netloc.lower(),
+        # Both schemes + protocol-relative, longest-first (see _origins_for).
+        "origins": [
+            f"https://{seed.netloc}",
+            f"http://{seed.netloc}",
+            f"//{seed.netloc}",
+        ],
+    }
 
     result = CrawlResult()
     fetcher = SafeFetcher(total_byte_cap=total_byte_cap, transport=transport, resolver=resolver)
     fetched_once = False
 
-    async def _polite_fetch(target: str) -> FetchResult:
+    async def _polite_fetch(target: str, *, allowed_host: str | None = None) -> FetchResult:
         nonlocal fetched_once
         if fetched_once and delay > 0:
             await asyncio.sleep(delay)
         fetched_once = True
-        return await fetcher.fetch(target)
+        return await fetcher.fetch(target, allowed_host=allowed_host)
+
+    def _origins_for(scheme: str, netloc: str) -> list[str]:
+        # Longest first so str.replace peels "scheme://host" before "//host".
+        # Both schemes are listed: a page served over https routinely hard-codes
+        # http://its-own-host refs, and rewriting only the matching scheme would
+        # mangle the other to "http:/path".
+        return [
+            f"https://{netloc}",
+            f"http://{netloc}",
+            f"//{netloc}",
+        ]
+
+    def _reseed(final_url: str) -> None:
+        """Re-home the crawl scope to the seed's post-redirect host."""
+        final = urlparse(final_url)
+        scope["netloc"] = final.netloc.lower()
+        scope["origins"] = _origins_for(final.scheme, final.netloc)
 
     def _same_site(candidate: Any) -> bool:
-        return candidate.scheme in ("http", "https") and candidate.netloc.lower() == seed_netloc
+        return candidate.scheme in ("http", "https") and candidate.netloc.lower() == scope["netloc"]
 
     def _claim_path(rel: str, source_url: str) -> str | None:
         """Sanitize + reserve a FileMap path; None (with a warning) when unsafe
@@ -573,7 +620,12 @@ async def crawl_site(
                     )
                 continue
             try:
-                fetched = await _polite_fetch(page_url)
+                # The seed may redirect off-host (apex->www): let it, then
+                # re-seed. Every OTHER fetch is scope-locked so a same-site
+                # resource can't redirect us into importing foreign content.
+                fetched = await _polite_fetch(
+                    page_url, allowed_host=None if is_seed else scope["netloc"]
+                )
             except CrawlBudgetExceeded:
                 raise
             except (CrawlError, ValidationError, httpx.HTTPError) as exc:
@@ -584,6 +636,8 @@ async def crawl_site(
                     ) from exc
                 result.warnings.append(f"skipped {page_url} — fetch failed")
                 continue
+            if is_seed and urlparse(fetched.url).netloc.lower() != scope["netloc"]:
+                _reseed(fetched.url)
             if fetched.status != 200:
                 if is_seed:
                     raise CrawlError(
@@ -645,7 +699,9 @@ async def crawl_site(
 
             rel = _claim_path(_rel_path_for_page(parsed_final.path), page_url)
             if rel:
-                result.files[rel] = _rewrite_same_origin(html_text, origins).encode("utf-8")
+                result.files[rel] = _rewrite_same_origin(html_text, scope["origins"]).encode(
+                    "utf-8"
+                )
 
         # ------------------------------------------------------------------- #
         # Assets (CSS refs chase same-origin, so the queue can grow here).
@@ -656,7 +712,7 @@ async def crawl_site(
                 result.stats.skipped_by_robots += 1
                 continue
             try:
-                fetched = await _polite_fetch(asset_url)
+                fetched = await _polite_fetch(asset_url, allowed_host=scope["netloc"])
             except CrawlBudgetExceeded:
                 raise
             except (CrawlError, ValidationError, httpx.HTTPError):
@@ -683,7 +739,7 @@ async def crawl_site(
                         _note_cross_origin(absolute)
                         continue
                     _note_asset(_normalize(absolute))
-                result.files[rel] = _rewrite_same_origin(css_text, origins).encode("utf-8")
+                result.files[rel] = _rewrite_same_origin(css_text, scope["origins"]).encode("utf-8")
             else:
                 result.files[rel] = fetched.body
             result.stats.assets_fetched += 1

--- a/ee/pocketpaw_ee/sites/url_crawler.py
+++ b/ee/pocketpaw_ee/sites/url_crawler.py
@@ -1,0 +1,713 @@
+# ee/pocketpaw_ee/sites/url_crawler.py — Paw Sites same-site URL crawler (SI-5).
+#
+# Created 2026-07-23 (feat/sites-import-crawler, stacked on SI-4): the fetch half of
+# POST /sites/import/from-url. Fills the ``crawl_site_from_url`` seam SI-4 left open.
+# SECURITY-CRITICAL — this module is the SSRF surface of the import path. Guards:
+#   * Seed/hop URL validation: http(s) only, no credentials in the URL, ports limited
+#     to 80/443/default, length-capped (``validate_seed_url`` — the endpoint calls it
+#     too, so a hostile seed 422s before anything is minted or fetched).
+#   * DNS is resolved HERE and the connection is PINNED to the validated IP (the
+#     request rides ``scheme://ip/...`` with the original Host header + SNI hostname
+#     for https), so a re-resolution between check and fetch (TOCTOU / DNS rebinding)
+#     cannot swap in a private address. ALL resolved addresses must pass — a mixed
+#     public+private answer is rejected outright.
+#   * Forbidden targets (both families): loopback, RFC1918/private, link-local (incl.
+#     169.254.169.254 metadata), CGNAT 100.64/10, unspecified/reserved/multicast,
+#     IPv6 ULA fc00::/7, fe80::/10, and v4 addresses EMBEDDED in v6 forms
+#     (IPv4-mapped, 6to4, Teredo, NAT64 64:ff9b::/96) are re-checked as v4.
+#   * Redirects are followed MANUALLY (max 5) and EVERY hop re-runs the full URL +
+#     DNS + IP validation; non-http(s) redirect targets are rejected.
+#   * Per-fetch timeout, per-response size cap, total crawl byte budget (streamed —
+#     the response is aborted the moment a cap is crossed, never buffered past it),
+#     no cookies (jar cleared after every response), no auth, no env proxies
+#     (trust_env=False), an honest User-Agent.
+# Crawl scope: BFS from the seed, EXACT host match only (www./apex are treated as
+# different hosts — documented v1 limitation), depth <= 3, pages <= 50, assets <= 200,
+# robots.txt honored (simple RobotFileParser matching for our UA + '*'; a failed
+# robots fetch degrades to a polite warning), small politeness delay between fetches.
+# Harvest: pages/assets map to safe relative paths (sanitized through import_service's
+# ``_safe_entry_path`` — the SAME rule zip entries pass), absolute same-origin URLs in
+# HTML/CSS are rewritten root-relative, CSS url()/@import refs are chased same-origin.
+# Cross-origin refs are left as-is and counted for the import report.
+
+"""Same-site crawler with SSRF-hardened fetching for Paw Sites URL imports."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import re
+import socket
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from typing import Any
+from urllib import robotparser
+from urllib.parse import unquote, urljoin, urlparse, urlunparse
+
+import httpx
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+
+logger = logging.getLogger(__name__)
+
+# Honest UA — robots groups for "pawsitesimporter" or "*" apply to us.
+USER_AGENT = "PawSitesImporter/1.0 (+https://pocketpaw.dev; site-import crawler)"
+
+MAX_URL_LENGTH = 2048
+MAX_REDIRECTS = 5
+MAX_CRAWL_DEPTH = 3
+MAX_CRAWL_PAGES = 50
+MAX_CRAWL_ASSETS = 200
+# Memory floor: a hostile 10MB page can carry millions of DISTINCT refs — the
+# discovery sets (assets to fetch, cross-origin URLs to count) stop growing at
+# this bound so link soup can't balloon the crawler's memory.
+MAX_TRACKED_URLS = 2000
+# Per-response cap — one file may not eat the whole budget.
+MAX_FETCH_BYTES = 10 * 1024 * 1024
+PER_FETCH_TIMEOUT_SEC = 10.0
+# Politeness delay between consecutive fetches (tests pass 0).
+POLITENESS_DELAY_SEC = 0.15
+
+_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+_CGNAT_V4 = ipaddress.ip_network("100.64.0.0/10")
+_NAT64_V6 = ipaddress.ip_network("64:ff9b::/96")
+
+_CSS_URL_RE = re.compile(r"url\(\s*['\"]?([^'\")\s]+)['\"]?\s*\)", re.IGNORECASE)
+_CSS_IMPORT_RE = re.compile(r"@import\s+['\"]([^'\"]+)['\"]", re.IGNORECASE)
+
+
+class CrawlError(RuntimeError):
+    """A crawl failure with a FIXED, safe message (it lands in the import report,
+    which viewers read — never raw upstream text, never a traceback)."""
+
+    def __init__(self, message: str, *, code: str = "sites.import_crawl_failed") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class CrawlBudgetExceeded(CrawlError):
+    """The total crawl byte budget was crossed — the whole import fails closed."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, code="sites.import_crawl_budget_exceeded")
+
+
+# --------------------------------------------------------------------------- #
+# URL + IP validation (the SSRF floors)
+# --------------------------------------------------------------------------- #
+
+
+def validate_seed_url(url: str) -> Any:
+    """Validate one crawl-target URL's SHAPE and return its ``urlparse`` result.
+
+    Enforced (each raises ``ValidationError`` → 422 at the endpoint, a failed
+    report in the background crawl): http/https only; a real hostname; NO
+    credentials in the URL; NO ports beyond 80/443/default; length cap. A
+    literal-IP host is additionally run through the forbidden-IP check here, so
+    ``http://169.254.169.254/`` dies at validation, before any socket."""
+    candidate = (url or "").strip()
+    if not candidate or len(candidate) > MAX_URL_LENGTH:
+        raise ValidationError("sites.import_url_invalid", "A non-empty http(s) URL is required.")
+    parsed = urlparse(candidate)
+    if parsed.scheme not in ("http", "https"):
+        raise ValidationError(
+            "sites.import_url_invalid", "Only http and https URLs can be imported."
+        )
+    if not parsed.hostname:
+        raise ValidationError("sites.import_url_invalid", "The import URL must carry a hostname.")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValidationError(
+            "sites.import_url_forbidden", "URLs with embedded credentials are not allowed."
+        )
+    try:
+        port = parsed.port  # raises ValueError on a malformed port
+    except ValueError as exc:
+        raise ValidationError(
+            "sites.import_url_invalid", "The import URL port is invalid."
+        ) from exc
+    if port not in (None, 80, 443):
+        raise ValidationError(
+            "sites.import_url_forbidden",
+            "Only the standard web ports (80/443) can be imported.",
+        )
+    try:
+        literal = ipaddress.ip_address(parsed.hostname)
+    except ValueError:
+        literal = None
+    if literal is not None:
+        reason = _forbidden_ip_reason(literal)
+        if reason:
+            raise ValidationError(
+                "sites.import_url_forbidden",
+                f"The import URL points at a non-public address ({reason}).",
+            )
+    return parsed
+
+
+def _forbidden_ip_reason(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str | None:
+    """Why this address may NOT be fetched, or None when it is publicly routable.
+
+    v6 forms that EMBED a v4 address (IPv4-mapped, 6to4, Teredo, NAT64) are
+    re-checked as the embedded v4 — ``::ffff:127.0.0.1`` is still loopback."""
+    if isinstance(ip, ipaddress.IPv6Address):
+        if ip.ipv4_mapped is not None:
+            return _forbidden_ip_reason(ip.ipv4_mapped)
+        if ip.sixtofour is not None and _forbidden_ip_reason(ip.sixtofour):
+            return "6to4-embedded private address"
+        if ip.teredo is not None and any(_forbidden_ip_reason(a) for a in ip.teredo):
+            return "teredo-embedded private address"
+        if ip in _NAT64_V6:
+            embedded = ipaddress.ip_address(int(ip) & 0xFFFFFFFF)
+            if _forbidden_ip_reason(embedded):
+                return "NAT64-embedded private address"
+    if ip.is_unspecified:
+        return "unspecified address"
+    if ip.is_loopback:
+        return "loopback address"
+    if ip.is_link_local:
+        return "link-local address"
+    if ip.is_multicast:
+        return "multicast address"
+    if ip.is_reserved:
+        return "reserved address"
+    if ip.is_private:
+        return "private address"
+    if isinstance(ip, ipaddress.IPv4Address) and ip in _CGNAT_V4:
+        return "carrier-grade NAT address"
+    return None
+
+
+async def _default_resolve(host: str) -> list[str]:
+    """Resolve ``host`` to its addresses via the event loop's resolver."""
+    loop = asyncio.get_running_loop()
+    infos = await loop.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    ips: list[str] = []
+    for info in infos:
+        addr = info[4][0]
+        if addr not in ips:
+            ips.append(addr)
+    return ips
+
+
+# --------------------------------------------------------------------------- #
+# The SSRF-pinned fetcher
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class FetchResult:
+    """One completed (post-redirect) fetch."""
+
+    url: str
+    status: int
+    content_type: str
+    body: bytes
+
+
+class SafeFetcher:
+    """httpx-based fetcher that resolves DNS itself and pins the connection.
+
+    Every ``fetch`` re-validates the URL shape, resolves the host, checks EVERY
+    resolved address against the forbidden ranges, then connects to the validated
+    IP with the original Host header (and SNI hostname for https) — the classic
+    check-then-fetch TOCTOU is closed because the socket never re-resolves.
+    Redirects are followed manually (max ``MAX_REDIRECTS``) with the full check
+    re-run per hop. Responses stream against a per-fetch cap and a shared total
+    byte budget. ``transport`` / ``resolver`` are test seams (MockTransport +
+    a fake resolver — tests never touch the network)."""
+
+    def __init__(
+        self,
+        *,
+        total_byte_cap: int,
+        per_fetch_cap: int = MAX_FETCH_BYTES,
+        timeout_sec: float = PER_FETCH_TIMEOUT_SEC,
+        transport: httpx.AsyncBaseTransport | None = None,
+        resolver: Callable[[str], Awaitable[list[str]]] | None = None,
+    ) -> None:
+        self._total_byte_cap = total_byte_cap
+        self._per_fetch_cap = per_fetch_cap
+        self._resolver = resolver or _default_resolve
+        self.bytes_fetched = 0
+        self._client = httpx.AsyncClient(
+            transport=transport,
+            timeout=httpx.Timeout(timeout_sec),
+            follow_redirects=False,  # hops are validated manually
+            trust_env=False,  # no env proxies — the pin must not be bypassed
+            headers={"User-Agent": USER_AGENT, "Accept": "*/*"},
+        )
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def _checked_ip(self, host: str) -> str:
+        """Resolve ``host`` and return a validated connect address. ALL resolved
+        addresses must be public — one private record fails the whole host."""
+        try:
+            literal = ipaddress.ip_address(host)
+        except ValueError:
+            literal = None
+        if literal is not None:
+            reason = _forbidden_ip_reason(literal)
+            if reason:
+                raise ValidationError(
+                    "sites.import_url_forbidden",
+                    f"Crawl target resolves to a non-public address ({reason}).",
+                )
+            return str(literal)
+        try:
+            ips = await self._resolver(host)
+        except (OSError, socket.gaierror) as exc:
+            raise CrawlError(
+                "DNS resolution failed for the crawl target",
+                code="sites.import_crawl_dns_failed",
+            ) from exc
+        if not ips:
+            raise CrawlError(
+                "DNS resolution returned no addresses for the crawl target",
+                code="sites.import_crawl_dns_failed",
+            )
+        for raw in ips:
+            try:
+                addr = ipaddress.ip_address(raw)
+            except ValueError as exc:
+                raise CrawlError(
+                    "DNS resolution returned an unparseable address",
+                    code="sites.import_crawl_dns_failed",
+                ) from exc
+            reason = _forbidden_ip_reason(addr)
+            if reason:
+                raise ValidationError(
+                    "sites.import_url_forbidden",
+                    f"Crawl target resolves to a non-public address ({reason}).",
+                )
+        return ips[0]
+
+    async def fetch(self, url: str) -> FetchResult:
+        """GET ``url`` with the full SSRF pipeline, following redirects manually."""
+        current = url
+        for _hop in range(MAX_REDIRECTS + 1):
+            parsed = validate_seed_url(current)
+            ip = await self._checked_ip(parsed.hostname)
+            status, content_type, location, body = await self._pinned_get(parsed, ip)
+            if status in _REDIRECT_STATUSES:
+                if not location:
+                    raise CrawlError("redirect response carried no Location header")
+                current = urljoin(current, location)
+                continue
+            return FetchResult(url=current, status=status, content_type=content_type, body=body)
+        raise CrawlError(f"too many redirects (max {MAX_REDIRECTS})")
+
+    async def _pinned_get(self, parsed: Any, ip: str) -> tuple[int, str, str, bytes]:
+        """One GET pinned to ``ip``: URL host swapped for the validated address,
+        original Host header (and SNI hostname for https) supplied explicitly."""
+        port = parsed.port
+        default_port = port is None or (parsed.scheme, port) in (("http", 80), ("https", 443))
+        host_header = parsed.hostname if default_port else f"{parsed.hostname}:{port}"
+        ip_host = f"[{ip}]" if ":" in ip else ip
+        netloc = ip_host if default_port else f"{ip_host}:{port}"
+        pinned = urlunparse((parsed.scheme, netloc, parsed.path or "/", "", parsed.query, ""))
+        request = self._client.build_request("GET", pinned, headers={"Host": host_header})
+        if parsed.scheme == "https":
+            # TLS must negotiate + verify against the REAL name, not the IP.
+            request.extensions["sni_hostname"] = parsed.hostname
+        response = await self._client.send(request, stream=True)
+        try:
+            declared = response.headers.get("content-length", "")
+            if declared.isdigit() and int(declared) > self._per_fetch_cap:
+                raise CrawlError(
+                    "response exceeds the per-fetch size cap",
+                    code="sites.import_crawl_response_too_large",
+                )
+            buf = bytearray()
+            async for chunk in response.aiter_bytes():
+                buf += chunk
+                if len(buf) > self._per_fetch_cap:
+                    raise CrawlError(
+                        "response exceeds the per-fetch size cap",
+                        code="sites.import_crawl_response_too_large",
+                    )
+                if self.bytes_fetched + len(buf) > self._total_byte_cap:
+                    raise CrawlBudgetExceeded("crawl exceeded the total byte budget")
+        finally:
+            await response.aclose()
+            # No cookie persistence — the crawler is stateless by design.
+            self._client.cookies.clear()
+        self.bytes_fetched += len(buf)
+        content_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
+        return response.status_code, content_type, response.headers.get("location", ""), bytes(buf)
+
+
+# --------------------------------------------------------------------------- #
+# HTML/CSS harvesting
+# --------------------------------------------------------------------------- #
+
+
+class _LinkScan(HTMLParser):
+    """One-pass scan of a fetched page: same-site page links (<a href>) and asset
+    refs (<link href>, <script src>, <img src/srcset>, <source src/srcset>,
+    <video/audio src>) — classification against the seed host happens later."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.page_links: list[str] = []
+        self.asset_refs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {k: (v or "") for k, v in attrs}
+        if tag == "a" and attr_map.get("href"):
+            self.page_links.append(attr_map["href"])
+        elif tag == "link" and attr_map.get("href"):
+            self.asset_refs.append(attr_map["href"])
+        elif tag == "script" and attr_map.get("src"):
+            self.asset_refs.append(attr_map["src"])
+        elif tag in ("img", "source", "video", "audio", "embed"):
+            if attr_map.get("src"):
+                self.asset_refs.append(attr_map["src"])
+            if attr_map.get("srcset"):
+                self.asset_refs.extend(_parse_srcset(attr_map["srcset"]))
+
+
+def _parse_srcset(srcset: str) -> list[str]:
+    """Extract the URL of each srcset candidate ("url 2x, url2 480w" → urls)."""
+    urls: list[str] = []
+    for part in srcset.split(","):
+        candidate = part.strip().split(" ")[0].strip()
+        if candidate:
+            urls.append(candidate)
+    return urls
+
+
+def _css_refs(css_text: str) -> list[str]:
+    """url()/@import references out of a stylesheet (data: URIs skipped)."""
+    refs = _CSS_URL_RE.findall(css_text) + _CSS_IMPORT_RE.findall(css_text)
+    return [r for r in refs if not r.lower().startswith("data:")]
+
+
+def _rewrite_same_origin(text: str, origins: list[str]) -> str:
+    """Rewrite absolute same-origin refs to root-relative so the generator's
+    import plan (which handles absolute→relative) works unchanged. Plain string
+    rewrite — v1 accepts the (documented) risk of touching prose that contains
+    the site's own URL; markup-aware rewriting is a later refinement."""
+    for origin in origins:
+        text = text.replace(origin + "/", "/")
+        text = text.replace(origin, "/")
+    return text
+
+
+def _rel_path_for_page(path: str) -> str:
+    """Map a page URL path to its FileMap path: "/" → index.html, a trailing
+    slash or an extension-less last segment → <path>/index.html."""
+    decoded = unquote(path or "/")
+    rel = decoded.lstrip("/")
+    if not rel:
+        return "index.html"
+    if rel.endswith("/"):
+        return rel + "index.html"
+    last = rel.rsplit("/", 1)[-1]
+    if "." not in last:
+        return rel + "/index.html"
+    return rel
+
+
+def _rel_path_for_asset(path: str) -> str:
+    """Map an asset URL path to its FileMap path (no index.html defaulting)."""
+    return unquote(path or "").lstrip("/")
+
+
+# --------------------------------------------------------------------------- #
+# The crawl
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class CrawlStats:
+    """Counters surfaced on the import report."""
+
+    pages_fetched: int = 0
+    assets_fetched: int = 0
+    bytes_fetched: int = 0
+    skipped_by_robots: int = 0
+    cross_origin_refs: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "pages_fetched": self.pages_fetched,
+            "assets_fetched": self.assets_fetched,
+            "bytes_fetched": self.bytes_fetched,
+            "skipped_by_robots": self.skipped_by_robots,
+            "cross_origin_refs": self.cross_origin_refs,
+        }
+
+
+@dataclass
+class CrawlResult:
+    """Everything the import pipeline needs: the harvested FileMap + stats."""
+
+    files: dict[str, bytes] = field(default_factory=dict)
+    stats: CrawlStats = field(default_factory=CrawlStats)
+    warnings: list[str] = field(default_factory=list)
+
+
+def _normalize(url: str) -> str:
+    """Dedupe key + fetch URL: drop fragment AND query (a static import keys
+    pages/assets by path; querystring variants collapse to one — documented v1
+    limitation)."""
+    parsed = urlparse(url)
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path or "/", "", "", ""))
+
+
+async def _load_robots(
+    fetcher: SafeFetcher, seed: Any
+) -> tuple[robotparser.RobotFileParser | None, str | None]:
+    """Fetch + parse robots.txt. Missing/failed → (None, warning-or-None): we
+    proceed politely, noting the failure on the report when the FETCH errored."""
+    robots_url = urlunparse((seed.scheme, seed.netloc, "/robots.txt", "", "", ""))
+    try:
+        result = await fetcher.fetch(robots_url)
+    except CrawlBudgetExceeded:
+        raise
+    except (CrawlError, ValidationError, httpx.HTTPError):
+        return None, "robots.txt could not be fetched — proceeding politely without it"
+    if result.status != 200:
+        return None, None  # no robots file — everything is allowed, not a warning
+    parser = robotparser.RobotFileParser()
+    parser.parse(result.body.decode("utf-8", errors="replace").splitlines())
+    return parser, None
+
+
+def _allowed_by_robots(robots: robotparser.RobotFileParser | None, url: str) -> bool:
+    if robots is None:
+        return True
+    try:
+        return robots.can_fetch(USER_AGENT, url)
+    except Exception:  # noqa: BLE001 — a pathological robots file never blocks the crawl
+        return True
+
+
+async def crawl_site(
+    url: str,
+    *,
+    total_byte_cap: int,
+    transport: httpx.AsyncBaseTransport | None = None,
+    resolver: Callable[[str], Awaitable[list[str]]] | None = None,
+    politeness_delay: float | None = None,
+) -> CrawlResult:
+    """BFS-crawl ``url``'s site (same exact host only) into a FileMap.
+
+    Raises on the FATAL failure modes — bad/forbidden seed, unreachable seed,
+    seed blocked by robots, byte budget exceeded. Per-page/per-asset problems
+    degrade to report warnings. ``transport``/``resolver`` are test seams;
+    ``politeness_delay`` overrides the module default (tests pass 0)."""
+    # Lazy import — import_service imports this module; the safe-path rule is
+    # shared with the zip path deliberately (ONE sanitizer for both imports).
+    from pocketpaw_ee.sites.import_service import _safe_entry_path
+
+    delay = POLITENESS_DELAY_SEC if politeness_delay is None else politeness_delay
+    seed = validate_seed_url(url)
+    seed_netloc = seed.netloc.lower()
+    origins = [f"{seed.scheme}://{seed.netloc}", f"//{seed.netloc}"]
+
+    result = CrawlResult()
+    fetcher = SafeFetcher(total_byte_cap=total_byte_cap, transport=transport, resolver=resolver)
+    fetched_once = False
+
+    async def _polite_fetch(target: str) -> FetchResult:
+        nonlocal fetched_once
+        if fetched_once and delay > 0:
+            await asyncio.sleep(delay)
+        fetched_once = True
+        return await fetcher.fetch(target)
+
+    def _same_site(candidate: Any) -> bool:
+        return candidate.scheme in ("http", "https") and candidate.netloc.lower() == seed_netloc
+
+    def _claim_path(rel: str, source_url: str) -> str | None:
+        """Sanitize + reserve a FileMap path; None (with a warning) when unsafe
+        or already taken (first fetch wins)."""
+        try:
+            safe = _safe_entry_path(rel)
+        except ValidationError:
+            result.warnings.append(f"skipped {source_url} — its path is not importable")
+            return None
+        if safe in result.files:
+            result.warnings.append(f"skipped {source_url} — path {safe!r} already imported")
+            return None
+        return safe
+
+    try:
+        robots, robots_warning = await _load_robots(fetcher, seed)
+        if robots_warning:
+            result.warnings.append(robots_warning)
+
+        seed_url = _normalize(url)
+        queue: deque[tuple[str, int]] = deque([(seed_url, 0)])
+        seen_pages = {seed_url}
+        asset_queue: deque[str] = deque()
+        seen_assets: set[str] = set()
+        cross_origin: set[str] = set()
+        pages_truncated = False
+
+        def _note_cross_origin(absolute: str) -> None:
+            # Bounded (MAX_TRACKED_URLS): link soup can't balloon memory.
+            if len(cross_origin) < MAX_TRACKED_URLS:
+                cross_origin.add(_normalize(absolute))
+
+        def _note_asset(normalized: str) -> None:
+            if normalized not in seen_assets and len(seen_assets) < MAX_TRACKED_URLS:
+                seen_assets.add(normalized)
+                asset_queue.append(normalized)
+
+        while queue and result.stats.pages_fetched < MAX_CRAWL_PAGES:
+            page_url, depth = queue.popleft()
+            is_seed = page_url == seed_url
+            if not _allowed_by_robots(robots, page_url):
+                result.stats.skipped_by_robots += 1
+                if is_seed:
+                    raise CrawlError(
+                        "the seed page is disallowed by the site's robots.txt",
+                        code="sites.import_crawl_blocked_by_robots",
+                    )
+                continue
+            try:
+                fetched = await _polite_fetch(page_url)
+            except CrawlBudgetExceeded:
+                raise
+            except (CrawlError, ValidationError, httpx.HTTPError) as exc:
+                if is_seed:
+                    raise CrawlError(
+                        "the seed URL could not be fetched",
+                        code="sites.import_crawl_seed_unreachable",
+                    ) from exc
+                result.warnings.append(f"skipped {page_url} — fetch failed")
+                continue
+            if fetched.status != 200:
+                if is_seed:
+                    raise CrawlError(
+                        f"the seed URL answered HTTP {fetched.status}",
+                        code="sites.import_crawl_seed_unreachable",
+                    )
+                result.warnings.append(f"skipped {page_url} — HTTP {fetched.status}")
+                continue
+
+            parsed_final = urlparse(fetched.url)
+            if fetched.content_type and fetched.content_type != "text/html":
+                # Content-type wins over the link's shape: a "page" link serving
+                # a non-HTML body imports as an asset.
+                if is_seed:
+                    raise CrawlError(
+                        "the seed URL did not return an HTML page",
+                        code="sites.import_crawl_seed_not_html",
+                    )
+                rel = _claim_path(_rel_path_for_asset(parsed_final.path), page_url)
+                if rel:
+                    result.files[rel] = fetched.body
+                    result.stats.assets_fetched += 1
+                continue
+
+            html_text = fetched.body.decode("utf-8", errors="replace")
+            scan = _LinkScan()
+            try:
+                scan.feed(html_text)
+            except Exception:  # noqa: BLE001 — a malformed page still imports, unscanned
+                result.warnings.append(f"{page_url} did not parse cleanly — links not followed")
+            result.stats.pages_fetched += 1
+
+            for href in scan.page_links:
+                absolute = urljoin(fetched.url, href)
+                candidate = urlparse(absolute)
+                if candidate.scheme not in ("http", "https"):
+                    continue  # mailto:, javascript:, tel: …
+                if not _same_site(candidate):
+                    _note_cross_origin(absolute)
+                    continue
+                normalized = _normalize(absolute)
+                if normalized in seen_pages or depth >= MAX_CRAWL_DEPTH:
+                    continue
+                if len(seen_pages) >= MAX_CRAWL_PAGES:
+                    pages_truncated = True
+                    continue
+                seen_pages.add(normalized)
+                queue.append((normalized, depth + 1))
+
+            for ref in scan.asset_refs:
+                absolute = urljoin(fetched.url, ref)
+                candidate = urlparse(absolute)
+                if candidate.scheme not in ("http", "https"):
+                    continue
+                if not _same_site(candidate):
+                    _note_cross_origin(absolute)
+                    continue
+                _note_asset(_normalize(absolute))
+
+            rel = _claim_path(_rel_path_for_page(parsed_final.path), page_url)
+            if rel:
+                result.files[rel] = _rewrite_same_origin(html_text, origins).encode("utf-8")
+
+        # ------------------------------------------------------------------- #
+        # Assets (CSS refs chase same-origin, so the queue can grow here).
+        # ------------------------------------------------------------------- #
+        while asset_queue and result.stats.assets_fetched < MAX_CRAWL_ASSETS:
+            asset_url = asset_queue.popleft()
+            if not _allowed_by_robots(robots, asset_url):
+                result.stats.skipped_by_robots += 1
+                continue
+            try:
+                fetched = await _polite_fetch(asset_url)
+            except CrawlBudgetExceeded:
+                raise
+            except (CrawlError, ValidationError, httpx.HTTPError):
+                result.warnings.append(f"skipped asset {asset_url} — fetch failed")
+                continue
+            if fetched.status != 200:
+                result.warnings.append(f"skipped asset {asset_url} — HTTP {fetched.status}")
+                continue
+            parsed_final = urlparse(fetched.url)
+            rel = _claim_path(_rel_path_for_asset(parsed_final.path), asset_url)
+            if rel is None:
+                continue
+            is_css = fetched.content_type == "text/css" or (
+                not fetched.content_type and rel.endswith(".css")
+            )
+            if is_css:
+                css_text = fetched.body.decode("utf-8", errors="replace")
+                for ref in _css_refs(css_text):
+                    absolute = urljoin(fetched.url, ref)
+                    candidate = urlparse(absolute)
+                    if candidate.scheme not in ("http", "https"):
+                        continue
+                    if not _same_site(candidate):
+                        _note_cross_origin(absolute)
+                        continue
+                    _note_asset(_normalize(absolute))
+                result.files[rel] = _rewrite_same_origin(css_text, origins).encode("utf-8")
+            else:
+                result.files[rel] = fetched.body
+            result.stats.assets_fetched += 1
+
+        if asset_queue:
+            result.warnings.append(
+                f"asset cap reached ({MAX_CRAWL_ASSETS}) — {len(asset_queue)} assets not fetched"
+            )
+        if queue or pages_truncated:
+            result.warnings.append(
+                f"page cap reached ({MAX_CRAWL_PAGES}) — some linked pages were not crawled"
+            )
+        result.stats.cross_origin_refs = len(cross_origin)
+        result.stats.bytes_fetched = fetcher.bytes_fetched
+        if cross_origin:
+            result.warnings.append(
+                f"{len(cross_origin)} cross-origin reference(s) left as-is — external "
+                "hosts are never crawled"
+            )
+        # v1 scope note surfaced honestly: exact-host matching only.
+        result.warnings.append(
+            "same-site matching is exact-host in v1 — www. and apex variants of the "
+            "seed host are treated as external"
+        )
+        return result
+    finally:
+        await fetcher.aclose()

--- a/tests/cloud/leads/test_router.py
+++ b/tests/cloud/leads/test_router.py
@@ -10,6 +10,13 @@
 # Updated 2026-05-30 (security hardening): added C1 oversized-payload→413 (no
 # lead written) and H1 constant-time signed-key compare (secrets.compare_digest
 # is the mechanism; valid key still 200, bad key still 401) coverage.
+# Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): added coverage for the
+# NATIVE-FORM capture sibling POST /capture/form (final URL /api/v1/capture/form)
+# — the endpoint imported sites' rewired <form>s post to as urlencoded, with
+# hidden paw_site_id / paw_key / paw_page / paw_redirect fields. Valid key →
+# recorded through the SAME capture pipeline + 303 back to Origin+paw_redirect;
+# bad key → 401; absolute / protocol-relative paw_redirect → 400 (open-redirect
+# guard); wrong origin → 403; urlencoded content-type accepted natively.
 from __future__ import annotations
 
 import pytest
@@ -159,3 +166,131 @@ async def test_capture_uses_constant_time_key_compare(mongo_db, capture_app, mon
     assert resp.status_code == 200
     assert calls, "signed-key check must route through secrets.compare_digest"
     assert ("key_ok", "key_ok") in calls
+
+
+# --------------------------------------------------------------------------- #
+# SI-4 — native-form capture: POST /capture/form (final URL /api/v1/capture/form).
+# Imported sites rewire their <form>s to a plain urlencoded POST here, with hidden
+# paw_site_id / paw_key / paw_page / paw_redirect fields. Same hardening ladder as
+# the JSON path, then a 303 back to Origin + the RELATIVE paw_redirect.
+# --------------------------------------------------------------------------- #
+
+
+async def _form_site(ws="ws1", site_id="site_form") -> Site:
+    """A site seeded the way create/publish seeds it: a 'lead' event mapping (the
+    default form_type the rewired form posts under)."""
+    site = Site(
+        workspace=ws,
+        pocket_id="pk_form",
+        owner="u1",
+        script_name=site_id,
+        allowed_origins=["brightsmiledental.com"],
+        signed_key="key_ok",
+        event_mapping={
+            "lead": {
+                "creates": "Lead",
+                "fields": {"full_name": "{{ payload.full_name }}", "email": "{{ payload.email }}"},
+            }
+        },
+    )
+    await site.insert()
+    return site
+
+
+def _form_fields(**overrides) -> dict:
+    fields = {
+        "full_name": "Sam Smiles",
+        "email": "sam@example.com",
+        "paw_site_id": "site_form",
+        "paw_key": "key_ok",
+        "paw_page": "index.html",
+        "paw_redirect": "/thanks.html",
+    }
+    fields.update(overrides)
+    return fields
+
+
+@pytest.mark.asyncio
+async def test_capture_form_valid_key_records_and_303s(mongo_db, capture_app):
+    """A valid urlencoded native-form POST records the lead through the SAME
+    capture pipeline (mapping applied, paw_* control fields stripped) and 303s to
+    the validated Origin + the relative paw_redirect."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _form_site()
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        # httpx ``data=`` sends application/x-www-form-urlencoded — the exact
+        # content type a native <form method=post> submits.
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(),
+            headers={"origin": "https://brightsmiledental.com"},
+        )
+    assert resp.status_code == 303, resp.text
+    assert resp.headers["location"] == "https://brightsmiledental.com/thanks.html"
+
+    leads = await leads_service.list_for_site(site.workspace, "site_form")
+    assert len(leads) == 1
+    assert leads[0].properties["full_name"] == "Sam Smiles"
+    assert leads[0].properties["email"] == "sam@example.com"
+    # The paw_* control fields never become lead properties.
+    assert not any(k.startswith("paw_") for k in leads[0].properties)
+
+
+@pytest.mark.asyncio
+async def test_capture_form_invalid_key_is_401(mongo_db, capture_app):
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _form_site()
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(paw_key="WRONG"),
+            headers={"origin": "https://brightsmiledental.com"},
+        )
+    assert resp.status_code == 401
+    assert await leads_service.count_for_site(site.workspace, "site_form") == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_redirect",
+    ["https://evil.example.com/phish", "//evil.example.com", "/\\evil", "javascript://alert(1)"],
+)
+async def test_capture_form_non_relative_redirect_is_400(mongo_db, capture_app, bad_redirect):
+    """Open-redirect guard: an absolute / protocol-relative / backslash / scheme'd
+    paw_redirect is rejected BEFORE anything is recorded."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _form_site()
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(paw_redirect=bad_redirect),
+            headers={"origin": "https://brightsmiledental.com"},
+        )
+    assert resp.status_code == 400, resp.text
+    assert await leads_service.count_for_site(site.workspace, "site_form") == 0
+
+
+@pytest.mark.asyncio
+async def test_capture_form_wrong_origin_is_403(mongo_db, capture_app):
+    await _form_site()
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(),
+            headers={"origin": "https://evil.example.com"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_capture_form_unknown_site_is_404(mongo_db, capture_app):
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(paw_site_id="site_missing"),
+            headers={"origin": "https://brightsmiledental.com"},
+        )
+    assert resp.status_code == 404

--- a/tests/ee/sites/test_import.py
+++ b/tests/ee/sites/test_import.py
@@ -428,3 +428,45 @@ async def test_generator_html_payload_omits_assets_when_none(tmp_path):
     await client.build(**_gen_kwargs({"index.html": "<html><body><p>ok</p></body></html>"}))
     assert runner.input_json is not None
     assert "assets" not in runner.input_json
+
+
+# ---- Review fixes: crafted/abnormal members 422 (contract), never 500 ----
+
+
+async def test_import_zip_password_protected_member_is_422(beanie_test_db, monkeypatch):
+    """An encrypted member raises RuntimeError inside the per-entry read; the
+    contract maps it to sites.import_zip_invalid (422), not a 500."""
+    app = _build_app("ws_owner", monkeypatch)
+    data = bytearray(_zip_bytes({"index.html": _INDEX_HTML.encode()}))
+    data[6] |= 0x01  # encryption bit, local file header
+    cd = bytes(data).rfind(b"PK\x01\x02")
+    data[cd + 8] |= 0x01  # encryption bit, central directory (zipfile reads this one)
+    resp = await _post_zip(app, bytes(data))
+    assert resp.status_code == 422, resp.text
+    assert "import_zip_invalid" in resp.text
+    await _assert_nothing_minted()
+
+
+async def test_import_zip_unsupported_compression_is_422(beanie_test_db, monkeypatch):
+    """An exotic compression method (AES marker 99) raises NotImplementedError on
+    read; the contract maps it to 422, not a 500."""
+    app = _build_app("ws_owner", monkeypatch)
+    data = bytearray(_zip_bytes({"index.html": _INDEX_HTML.encode()}))
+    data[8:10] = (99).to_bytes(2, "little")  # local header method field
+    cd = bytes(data).rfind(b"PK\x01\x02")
+    data[cd + 10 : cd + 12] = (99).to_bytes(2, "little")  # central directory too
+    resp = await _post_zip(app, bytes(data))
+    assert resp.status_code == 422, resp.text
+    assert "import_zip_invalid" in resp.text
+    await _assert_nothing_minted()
+
+
+async def test_import_zip_control_char_entry_name_is_422(beanie_test_db, monkeypatch):
+    """Control characters in an entry name (NUL, newline) are generator-side path
+    input — rejected as unsafe, whole import fails closed."""
+    app = _build_app("ws_owner", monkeypatch)
+    data = _zip_bytes({"index.html": _INDEX_HTML.encode(), "a\nb.html": b"<p>x</p>"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    assert "import_zip_entry_unsafe" in resp.text
+    await _assert_nothing_minted()

--- a/tests/ee/sites/test_import.py
+++ b/tests/ee/sites/test_import.py
@@ -1,0 +1,430 @@
+# tests/ee/sites/test_import.py — SI-4 (feat/sites-import-endpoint): the Paw Sites
+# IMPORT control-plane path.
+#
+# Created 2026-07-22. Covers:
+#   * POST /sites/import happy path through the real router → import_service →
+#     pockets (real agent_create) → create_draft_site → publish (FAKED — a real
+#     publish spawns bun): the html pocket + Site doc are minted, the generator is
+#     handed engine="html" with the text ``source`` map and the base64 ``assets``
+#     sideband, and the derived ``import_report`` (pages/titles, asset counts,
+#     forms with original actions) is persisted on the Site doc AND surfaced on
+#     the response + the GET /sites read.
+#   * Safety guards, each failing closed as a 4xx: zip-slip (../ traversal and
+#     absolute entry paths), the entry-count cap, the uncompressed-size cap
+#     (decompression bomb), the 25MB upload cap at the router (413), and a zip
+#     with no root index.html.
+#   * Tenant scoping: the imported site is invisible cross-tenant (empty GET
+#     /sites; the site-scoped domains read 404s).
+#   * POST /sites/import/from-url: a valid URL → 202 {site_id, status:"queued"}
+#     with a crawler-pending import_report on a NOT-deployed draft Site doc (the
+#     crawler is the next stacked slice); a malformed URL / non-http scheme → 422.
+#   * GeneratorClient unit: the html STAGE-2 payload carries ``input.assets`` when
+#     (and ONLY when) an assets sideband is passed — the cross-repo seam contract.
+from __future__ import annotations
+
+import base64
+import io
+import zipfile
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.sites import import_service
+from pocketpaw_ee.sites import service as sites_service
+
+_INDEX_HTML = (
+    "<!doctype html><html><head><title>Bright Import</title></head>"
+    "<body><h1>Hi</h1>"
+    "<form action='https://old-backend.example/submit' method='post'>"
+    "<input name='email'></form>"
+    "<script src='app.js'></script>"
+    "</body></html>"
+)
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def _zip_bytes(entries: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _good_zip() -> bytes:
+    return _zip_bytes(
+        {
+            "index.html": _INDEX_HTML.encode(),
+            "about.html": (
+                b"<!doctype html><html><head><title>About</title></head><body></body></html>"
+            ),
+            "app.js": b"console.log('hi')",
+            "img/logo.png": _PNG_BYTES,
+        }
+    )
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "member") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, workspace_id: str) -> None:
+        self.id = "user-test-1"
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="member")]
+
+
+def _build_app(workspace_id: str, monkeypatch) -> FastAPI:
+    """Mirror tests/ee/sites/test_router.py's app wiring: override auth/context
+    deps, stub the workspace plan to one that unlocks Sites, mount the router."""
+    from datetime import UTC, datetime
+
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.sites.router import router as sites_router
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="go"))
+
+    fake_user = _FakeUser(workspace_id)
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(sites_router, prefix="/api/v1")
+
+    async def _ctx() -> RequestContext:
+        return RequestContext(
+            user_id=str(fake_user.id),
+            workspace_id=workspace_id,
+            request_id="test",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[current_active_user] = lambda: fake_user
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def _fake_publish(beanie_test_db, monkeypatch) -> dict[str, Any]:
+    """Fake sites_service.publish (a real one shells out to bun/the generator):
+    records the forwarded kwargs and flips the REAL draft Site doc (minted by the
+    real create_draft_site the import ran) to deployed, mirroring what the html
+    deploy path does. Returns the capture dict for assertions."""
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    captured: dict[str, Any] = {}
+
+    async def _publish(**kw):
+        captured.update(kw)
+        oid = sites_service._live_object_id(kw["workspace_id"], kw["pocket_id"])
+        doc = await _SiteDoc.find_one({"_id": oid, "workspace": kw["workspace_id"]})
+        assert doc is not None, "import must mint the draft Site doc before publishing"
+        doc.script_name = str(oid)
+        doc.deployed = True
+        doc.url = f"http://127.0.0.1:9999/{oid}/"
+        await doc.save()
+        return doc
+
+    monkeypatch.setattr(sites_service, "publish", _publish)
+    return captured
+
+
+async def _post_zip(app: FastAPI, data: bytes, name: str = "") -> Any:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        return await c.post(
+            "/api/v1/sites/import",
+            files={"file": ("site.zip", data, "application/zip")},
+            data={"name": name} if name else {},
+        )
+
+
+# --------------------------------------------------------------------------- #
+# zip import — happy path
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_import_zip_happy_path(_fake_publish, monkeypatch):
+    """A good zip imports end to end: Site doc minted + flipped live, the generator
+    input carries engine=html / text source / base64 assets, and the import_report
+    (pages, asset counts, forms) is persisted and returned."""
+    app = _build_app("ws_owner", monkeypatch)
+    resp = await _post_zip(app, _good_zip(), name="My imported site")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # The publish rode the html engine with the text source map + assets sideband.
+    assert _fake_publish["engine"] == "html"
+    assert set(_fake_publish["source"]) == {"index.html", "about.html", "app.js"}
+    assert _fake_publish["source"]["index.html"] == _INDEX_HTML
+    assert _fake_publish["assets"] == {"img/logo.png": base64.b64encode(_PNG_BYTES).decode("ascii")}
+    assert _fake_publish["pattern"] == "imported"
+
+    # The response is the live SiteResponse carrying the report.
+    assert body["deployed"] is True
+    report = body["import_report"]
+    assert {p["path"] for p in report["pages"]} == {"index.html", "about.html"}
+    titles = {p["path"]: p["title"] for p in report["pages"]}
+    assert titles["index.html"] == "Bright Import"
+    assert report["asset_count"] == 1
+    assert report["asset_bytes"] == len(_PNG_BYTES)
+    assert report["forms"] == [
+        {
+            "page": "index.html",
+            "original_action": "https://old-backend.example/submit",
+            "rewired": False,
+        }
+    ]
+    assert "app.js" in report["scripts"]
+
+    # The report persisted on the Site doc and surfaces on the gallery read too.
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        listed = await c.get("/api/v1/sites")
+    assert listed.status_code == 200
+    rows = listed.json()
+    assert len(rows) == 1
+    assert rows[0]["import_report"]["asset_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_import_zip_single_root_dir_flattens(_fake_publish, monkeypatch):
+    """The `zip -r site site/` shape (one top dir holding index.html) imports as if
+    that dir were the root."""
+    app = _build_app("ws_owner", monkeypatch)
+    data = _zip_bytes({"mysite/index.html": _INDEX_HTML.encode(), "mysite/style.css": b":root{}"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 200, resp.text
+    assert set(_fake_publish["source"]) == {"index.html", "style.css"}
+
+
+# --------------------------------------------------------------------------- #
+# zip import — guards (each fails closed as a 4xx, nothing minted)
+# --------------------------------------------------------------------------- #
+
+
+async def _assert_nothing_minted() -> None:
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    assert await _SiteDoc.find_one({"workspace": "ws_owner"}) is None
+
+
+@pytest.mark.asyncio
+async def test_import_zip_slip_traversal_rejected(beanie_test_db, monkeypatch):
+    """A ``..`` traversal entry fails the WHOLE import (422) — hostile archives are
+    not cherry-picked — and no pocket / Site doc is minted."""
+    app = _build_app("ws_owner", monkeypatch)
+    data = _zip_bytes({"index.html": _INDEX_HTML.encode(), "../evil.html": b"<p>evil</p>"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_absolute_path_rejected(beanie_test_db, monkeypatch):
+    app = _build_app("ws_owner", monkeypatch)
+    data = _zip_bytes({"index.html": _INDEX_HTML.encode(), "/etc/cron.d/evil": b"x"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_entry_cap_rejected(beanie_test_db, monkeypatch):
+    app = _build_app("ws_owner", monkeypatch)
+    monkeypatch.setattr(import_service, "MAX_IMPORT_ENTRIES", 3)
+    data = _zip_bytes({f"f{i}.txt": b"x" for i in range(5)} | {"index.html": b"<html></html>"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_uncompressed_cap_rejected(beanie_test_db, monkeypatch):
+    """A tiny-on-the-wire zip that INFLATES past the cap is rejected (bomb guard)."""
+    app = _build_app("ws_owner", monkeypatch)
+    monkeypatch.setattr(import_service, "MAX_IMPORT_UNCOMPRESSED_BYTES", 1024)
+    data = _zip_bytes({"index.html": b"<html>" + b"A" * 4096 + b"</html>"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_oversized_upload_is_413(beanie_test_db, monkeypatch):
+    """The router's streaming upload cap rejects an oversized body with 413 before
+    the service ever unpacks it."""
+    app = _build_app("ws_owner", monkeypatch)
+    monkeypatch.setattr(import_service, "MAX_IMPORT_ZIP_BYTES", 64)
+    resp = await _post_zip(app, _good_zip())
+    assert resp.status_code == 413, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_without_index_rejected(beanie_test_db, monkeypatch):
+    app = _build_app("ws_owner", monkeypatch)
+    data = _zip_bytes({"about.html": b"<html><body>no index</body></html>"})
+    resp = await _post_zip(app, data)
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_import_zip_not_a_zip_rejected(beanie_test_db, monkeypatch):
+    app = _build_app("ws_owner", monkeypatch)
+    resp = await _post_zip(app, b"this is not a zip archive")
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+# --------------------------------------------------------------------------- #
+# tenant scoping
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_import_cross_tenant_site_is_invisible(_fake_publish, monkeypatch):
+    """An imported site never leaks cross-tenant: the intruder's gallery list is
+    empty and the site-scoped detail read (domains) is a 404."""
+    owner_app = _build_app("ws_owner", monkeypatch)
+    resp = await _post_zip(owner_app, _good_zip())
+    assert resp.status_code == 200, resp.text
+    script_name = resp.json()["script_name"]
+
+    intruder_app = _build_app("ws_intruder", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=intruder_app), base_url="http://t") as c:
+        listed = await c.get("/api/v1/sites")
+        detail = await c.get(f"/api/v1/sites/{script_name}/domains")
+    assert listed.status_code == 200
+    assert listed.json() == []
+    assert detail.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# from-url — queue-only (the crawler is the next stacked slice)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_from_url_returns_202_queued(beanie_test_db, monkeypatch):
+    """A valid URL queues: 202 {site_id, pocket_id, status:"queued"}, the draft Site
+    doc exists NOT deployed, and its import_report carries the crawler-pending
+    warning + queued status."""
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/import/from-url", json={"url": "https://example.com/landing"}
+        )
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["status"] == "queued"
+    assert body["site_id"]
+    assert body["pocket_id"]
+
+    doc = await _SiteDoc.find_one({"workspace": "ws_owner", "pocket_id": body["pocket_id"]})
+    assert doc is not None
+    assert doc.deployed is False
+    assert doc.import_report["status"] == "queued"
+    assert doc.import_report["source_url"] == "https://example.com/landing"
+    assert any("crawler" in w for w in doc.import_report["warnings"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", ["notaurl", "ftp://example.com", "https://", "  "])
+async def test_from_url_invalid_shape_is_422(beanie_test_db, monkeypatch, bad):
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/import/from-url", json={"url": bad})
+    assert resp.status_code == 422, resp.text
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_crawler_seam_is_explicitly_unimplemented():
+    """The crawl seam raises a clear NotImplementedError — the next stacked slice
+    (SI-5) owns it; nothing in SI-4 may silently fetch."""
+    with pytest.raises(NotImplementedError, match="next stacked slice"):
+        await import_service.crawl_site_from_url(
+            workspace_id="ws", user_id="u", site_id="s", url="https://example.com"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# generator payload — the cross-repo ``assets`` seam
+# --------------------------------------------------------------------------- #
+
+
+class _CapturingRunner:
+    """Fake runner capturing generate()'s input_json; projectDir points at a real
+    static tree so the html smoke passes (mirrors test_html_publish's spies)."""
+
+    def __init__(self, project_dir: str) -> None:
+        self._project_dir = project_dir
+        self.input_json: dict | None = None
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.input_json = input_json
+        return {"projectDir": self._project_dir, "engine": input_json.get("engine")}
+
+
+def _gen_kwargs(source: dict[str, str], **extra) -> dict:
+    return dict(
+        engine="html",
+        source=source,
+        ripple_spec=None,
+        theme={},
+        site_id="site_import",
+        title="Imported",
+        capture_api_base="https://api.paw.example/api/v1",
+        capture_signed_key="pp_tok_x",
+        **extra,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generator_html_payload_carries_assets_sideband(tmp_path):
+    """SI-4 seam: when an assets map is passed, the html STAGE-2 payload carries it
+    on ``input.assets`` verbatim ({path: base64}), alongside the text source."""
+    from pocketpaw_ee.sites.generator_client import GeneratorClient
+
+    (tmp_path / "index.html").write_text("<html><body><p>ok</p></body></html>")
+    runner = _CapturingRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    b64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    await client.build(
+        **_gen_kwargs({"index.html": "<html><body><p>ok</p></body></html>"}),
+        assets={"img/logo.png": b64},
+    )
+    sent = runner.input_json
+    assert sent is not None
+    assert sent["engine"] == "html"
+    assert sent["assets"] == {"img/logo.png": b64}
+
+
+@pytest.mark.asyncio
+async def test_generator_html_payload_omits_assets_when_none(tmp_path):
+    """No assets → the key is ABSENT (a plain html publish's payload stays
+    byte-identical to pre-SI-4)."""
+    from pocketpaw_ee.sites.generator_client import GeneratorClient
+
+    (tmp_path / "index.html").write_text("<html><body><p>ok</p></body></html>")
+    runner = _CapturingRunner(str(tmp_path))
+    client = GeneratorClient(_runner=runner)
+    await client.build(**_gen_kwargs({"index.html": "<html><body><p>ok</p></body></html>"}))
+    assert runner.input_json is not None
+    assert "assets" not in runner.input_json

--- a/tests/ee/sites/test_import.py
+++ b/tests/ee/sites/test_import.py
@@ -16,8 +16,12 @@
 #   * Tenant scoping: the imported site is invisible cross-tenant (empty GET
 #     /sites; the site-scoped domains read 404s).
 #   * POST /sites/import/from-url: a valid URL → 202 {site_id, status:"queued"}
-#     with a crawler-pending import_report on a NOT-deployed draft Site doc (the
-#     crawler is the next stacked slice); a malformed URL / non-http scheme → 422.
+#     with a queued import_report on a NOT-deployed draft Site doc, and the
+#     background crawl SCHEDULED (scheduler patched — nothing fetched in tests);
+#     a malformed URL / non-http scheme → 422.
+#     Updated 2026-07-23 (SI-5, feat/sites-import-crawler): the crawler seam is
+#     now real — the NotImplementedError test became a "crawl is scheduled" test;
+#     the crawler itself is covered in tests/ee/sites/test_import_crawler.py.
 #   * GeneratorClient unit: the html STAGE-2 payload carries ``input.assets`` when
 #     (and ONLY when) an assets sideband is passed — the cross-repo seam contract.
 from __future__ import annotations
@@ -314,16 +318,25 @@ async def test_import_cross_tenant_site_is_invisible(_fake_publish, monkeypatch)
 
 
 # --------------------------------------------------------------------------- #
-# from-url — queue-only (the crawler is the next stacked slice)
+# from-url — 202-queued contract + background crawl scheduling (SI-5)
 # --------------------------------------------------------------------------- #
 
 
 @pytest.mark.asyncio
 async def test_from_url_returns_202_queued(beanie_test_db, monkeypatch):
     """A valid URL queues: 202 {site_id, pocket_id, status:"queued"}, the draft Site
-    doc exists NOT deployed, and its import_report carries the crawler-pending
-    warning + queued status."""
+    doc exists NOT deployed, its import_report carries the queued status, and the
+    background crawl was SCHEDULED (scheduler patched to capture — tests never
+    touch the network)."""
     from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    scheduled: list[object] = []
+
+    def _capture(coro):
+        scheduled.append(coro)
+        coro.close()
+
+    monkeypatch.setattr(import_service, "_default_crawl_scheduler", _capture)
 
     app = _build_app("ws_owner", monkeypatch)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -335,6 +348,7 @@ async def test_from_url_returns_202_queued(beanie_test_db, monkeypatch):
     assert body["status"] == "queued"
     assert body["site_id"]
     assert body["pocket_id"]
+    assert len(scheduled) == 1  # SI-5: the crawl coroutine was handed to the scheduler
 
     doc = await _SiteDoc.find_one({"workspace": "ws_owner", "pocket_id": body["pocket_id"]})
     assert doc is not None
@@ -352,16 +366,6 @@ async def test_from_url_invalid_shape_is_422(beanie_test_db, monkeypatch, bad):
         resp = await c.post("/api/v1/sites/import/from-url", json={"url": bad})
     assert resp.status_code == 422, resp.text
     await _assert_nothing_minted()
-
-
-@pytest.mark.asyncio
-async def test_crawler_seam_is_explicitly_unimplemented():
-    """The crawl seam raises a clear NotImplementedError — the next stacked slice
-    (SI-5) owns it; nothing in SI-4 may silently fetch."""
-    with pytest.raises(NotImplementedError, match="next stacked slice"):
-        await import_service.crawl_site_from_url(
-            workspace_id="ws", user_id="u", site_id="s", url="https://example.com"
-        )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/ee/sites/test_import_crawler.py
+++ b/tests/ee/sites/test_import_crawler.py
@@ -1,0 +1,478 @@
+# tests/ee/sites/test_import_crawler.py — SI-5 (feat/sites-import-crawler): the
+# same-site URL crawler behind POST /sites/import/from-url.
+#
+# Created 2026-07-23. All network is mocked (httpx.MockTransport + a fake DNS
+# resolver) — nothing here ever opens a real socket. Covers:
+#   * SSRF floors: literal loopback / RFC1918 / link-local / metadata / CGNAT /
+#     v4-mapped-v6 seeds rejected at validation; a hostname RESOLVING private
+#     rejected with zero requests made; a redirect to a private host or to a
+#     non-http scheme rejected MID-CHAIN; ports beyond 80/443 rejected; file://
+#     and credentialed URLs rejected. The endpoint 422s forbidden seeds before
+#     anything is minted.
+#   * Connection pinning: the socket-level request goes to the RESOLVED IP while
+#     the Host header carries the original hostname (TOCTOU/rebinding closed).
+#   * Crawl semantics: BFS depth + page caps, robots.txt disallow honored (with
+#     the skipped counter), exact-host enforcement (cross-origin refs counted,
+#     never fetched), URL-path traversal sanitized through the shared
+#     safe-rel-path rule, total byte budget aborts the crawl.
+#   * The wired import: crawl_site_from_url end to end over a 2-page fixture
+#     site (css + img) → the SAME import pipeline as zip (publish faked) with
+#     the right FileMap split, absolute same-origin URLs rewritten
+#     root-relative, crawl stats + status on the persisted import_report, the
+#     harvested source persisted on the pocket, and failure modes (unreachable
+#     seed) landing as a safe ``status:"failed"`` report — never a traceback.
+from __future__ import annotations
+
+import base64
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.sites import import_service, url_crawler
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.url_crawler import CrawlBudgetExceeded, CrawlError
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+_PUBLIC_IPS = {
+    "example.com": ["93.184.216.34"],
+    "cdn.example": ["203.0.113.7"],
+    "other.example": ["203.0.113.8"],
+}
+
+
+def _resolver(table: dict[str, list[str]]):
+    async def resolve(host: str) -> list[str]:
+        if host not in table:
+            raise OSError(f"no DNS for {host}")
+        return table[host]
+
+    return resolve
+
+
+def _transport(pages: dict[tuple[str, str], httpx.Response], seen: list[httpx.Request]):
+    """MockTransport routing on (Host header, path) — the pinned request carries
+    the IP in the URL, so the ORIGINAL host is only in the Host header."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        key = (request.headers.get("host", ""), request.url.path)
+        return pages.get(key, httpx.Response(404, content=b"not found"))
+
+    return httpx.MockTransport(handler)
+
+
+def _html(body: str) -> httpx.Response:
+    return httpx.Response(200, headers={"content-type": "text/html"}, content=body.encode())
+
+
+async def _crawl(pages, *, table=None, seen=None, byte_cap=1024 * 1024, **kw):
+    seen = seen if seen is not None else []
+    return await url_crawler.crawl_site(
+        kw.pop("url", "https://example.com/"),
+        total_byte_cap=byte_cap,
+        transport=_transport(pages, seen),
+        resolver=_resolver(table or _PUBLIC_IPS),
+        politeness_delay=0,
+        **kw,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# SSRF floors — seed validation (no socket, no DNS)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "seed",
+    [
+        "http://127.0.0.1/",
+        "http://10.0.0.5/site",
+        "http://192.168.1.10/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://100.64.0.1/",
+        "http://0.0.0.0/",
+        "http://[::1]/",
+        "http://[::ffff:127.0.0.1]/",
+        "http://[fe80::1]/",
+        "http://[fc00::1]/",
+    ],
+)
+def test_non_public_literal_ip_seeds_rejected(seed):
+    with pytest.raises(ValidationError) as exc:
+        url_crawler.validate_seed_url(seed)
+    assert exc.value.code == "sites.import_url_forbidden"
+
+
+@pytest.mark.parametrize(
+    "seed, code",
+    [
+        ("http://example.com:8080/", "sites.import_url_forbidden"),
+        ("https://example.com:8443/", "sites.import_url_forbidden"),
+        ("file:///etc/passwd", "sites.import_url_invalid"),
+        ("gopher://example.com/", "sites.import_url_invalid"),
+        ("http://user:pass@example.com/", "sites.import_url_forbidden"),
+    ],
+)
+def test_bad_scheme_port_credentials_rejected(seed, code):
+    with pytest.raises(ValidationError) as exc:
+        url_crawler.validate_seed_url(seed)
+    assert exc.value.code == code
+
+
+@pytest.mark.asyncio
+async def test_hostname_resolving_private_makes_zero_requests():
+    """A clean-looking hostname whose DNS answer is private is rejected BEFORE
+    any request is sent — the resolve-check-pin order closes the rebinding hole."""
+    seen: list[httpx.Request] = []
+    with pytest.raises(CrawlError):
+        await _crawl({}, table={"example.com": ["10.0.0.5"]}, seen=seen)
+    assert seen == []  # nothing was ever fetched
+
+
+@pytest.mark.asyncio
+async def test_mixed_public_private_dns_answer_rejected():
+    seen: list[httpx.Request] = []
+    with pytest.raises(CrawlError):
+        await _crawl({}, table={"example.com": ["93.184.216.34", "10.0.0.5"]}, seen=seen)
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_redirect_to_private_host_rejected_mid_chain():
+    """Every redirect hop re-runs DNS + IP validation: a 302 bounce to an
+    internal host dies without the internal host ever being contacted."""
+    seen: list[httpx.Request] = []
+    pages = {
+        ("example.com", "/"): httpx.Response(
+            302, headers={"location": "http://internal.example/admin"}
+        ),
+    }
+    table = dict(_PUBLIC_IPS) | {"internal.example": ["192.168.1.1"]}
+    with pytest.raises(CrawlError) as exc:
+        await _crawl(pages, table=table, seen=seen)
+    assert exc.value.code == "sites.import_crawl_seed_unreachable"
+    assert all(r.headers.get("host") != "internal.example" for r in seen)
+
+
+@pytest.mark.asyncio
+async def test_redirect_to_non_http_scheme_rejected():
+    pages = {
+        ("example.com", "/"): httpx.Response(302, headers={"location": "file:///etc/passwd"}),
+    }
+    with pytest.raises(CrawlError) as exc:
+        await _crawl(pages)
+    assert exc.value.code == "sites.import_crawl_seed_unreachable"
+
+
+@pytest.mark.asyncio
+async def test_connection_is_pinned_to_resolved_ip():
+    """The wire request targets the RESOLVED IP; the hostname rides only in the
+    Host header — a second resolution can never swap the destination."""
+    seen: list[httpx.Request] = []
+    pages = {("example.com", "/"): _html("<html><body>hi</body></html>")}
+    await _crawl(pages, seen=seen)
+    page_requests = [r for r in seen if r.url.path == "/"]
+    assert page_requests, "the seed page was never fetched"
+    for request in page_requests:
+        assert request.url.host == "93.184.216.34"
+        assert request.headers["host"] == "example.com"
+
+
+# --------------------------------------------------------------------------- #
+# crawl semantics
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_bfs_respects_depth_cap():
+    """A 6-deep link chain stops at depth 3 (seed = depth 0)."""
+    pages = {
+        ("example.com", "/"): _html('<a href="/d1">1</a>'),
+        ("example.com", "/d1"): _html('<a href="/d2">2</a>'),
+        ("example.com", "/d2"): _html('<a href="/d3">3</a>'),
+        ("example.com", "/d3"): _html('<a href="/d4">4</a>'),
+        ("example.com", "/d4"): _html('<a href="/d5">5</a>'),
+    }
+    result = await _crawl(pages)
+    assert result.stats.pages_fetched == 4  # /, /d1, /d2, /d3
+    assert "d3/index.html" in result.files
+    assert "d4/index.html" not in result.files
+
+
+@pytest.mark.asyncio
+async def test_bfs_respects_page_cap(monkeypatch):
+    monkeypatch.setattr(url_crawler, "MAX_CRAWL_PAGES", 2)
+    pages = {
+        ("example.com", "/"): _html('<a href="/a">a</a><a href="/b">b</a><a href="/c">c</a>'),
+        ("example.com", "/a"): _html("<p>a</p>"),
+        ("example.com", "/b"): _html("<p>b</p>"),
+        ("example.com", "/c"): _html("<p>c</p>"),
+    }
+    result = await _crawl(pages)
+    assert result.stats.pages_fetched == 2
+    assert any("page cap" in w for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_robots_disallow_honored():
+    pages = {
+        ("example.com", "/robots.txt"): httpx.Response(
+            200,
+            headers={"content-type": "text/plain"},
+            content=b"User-agent: *\nDisallow: /private\n",
+        ),
+        ("example.com", "/"): _html('<a href="/private">p</a><a href="/public">ok</a>'),
+        ("example.com", "/private"): _html("<p>secret</p>"),
+        ("example.com", "/public"): _html("<p>open</p>"),
+    }
+    result = await _crawl(pages)
+    assert result.stats.skipped_by_robots == 1
+    assert "public/index.html" in result.files
+    assert "private/index.html" not in result.files
+
+
+@pytest.mark.asyncio
+async def test_cross_host_links_counted_never_fetched():
+    seen: list[httpx.Request] = []
+    pages = {
+        ("example.com", "/"): _html(
+            '<a href="https://other.example/page">x</a><img src="https://cdn.example/logo.png">'
+        ),
+    }
+    result = await _crawl(pages, seen=seen)
+    assert result.stats.cross_origin_refs == 2
+    assert all(r.headers.get("host") == "example.com" for r in seen)
+    assert any("cross-origin" in w for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_url_path_traversal_sanitized():
+    """A link whose decoded path traverses (..%2f..) is fetched-then-REFUSED a
+    FileMap slot by the shared safe-rel-path rule — no key ever escapes root."""
+    traversal = "/..%2f..%2fetc%2fpasswd"
+    pages = {
+        ("example.com", "/"): _html(f'<a href="{traversal}">evil</a>'),
+        # MockTransport sees the DECODED path on request.url.path.
+        ("example.com", "/../../etc/passwd"): _html("<p>gotcha</p>"),
+    }
+    result = await _crawl(pages)
+    assert all(".." not in path for path in result.files)
+    assert any("not importable" in w for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_total_byte_budget_aborts_crawl():
+    big = "<html><body>" + "A" * 4096 + "</body></html>"
+    pages = {("example.com", "/"): _html(big)}
+    with pytest.raises(CrawlBudgetExceeded):
+        await _crawl(pages, byte_cap=512)
+
+
+@pytest.mark.asyncio
+async def test_assets_and_css_refs_harvested_same_origin_only():
+    pages = {
+        ("example.com", "/"): _html(
+            "<html><head>"
+            '<link rel="stylesheet" href="/css/site.css">'
+            "</head><body>"
+            '<img src="/img/logo.png">'
+            '<script src="https://cdn.example/app.js"></script>'
+            "</body></html>"
+        ),
+        ("example.com", "/css/site.css"): httpx.Response(
+            200,
+            headers={"content-type": "text/css"},
+            content=b'body { background: url("/img/bg.png"); }',
+        ),
+        ("example.com", "/img/logo.png"): httpx.Response(
+            200, headers={"content-type": "image/png"}, content=_PNG_BYTES
+        ),
+        ("example.com", "/img/bg.png"): httpx.Response(
+            200, headers={"content-type": "image/png"}, content=_PNG_BYTES
+        ),
+    }
+    result = await _crawl(pages)
+    assert result.stats.assets_fetched == 3  # css + logo + the css-discovered bg
+    assert {"css/site.css", "img/logo.png", "img/bg.png"} <= set(result.files)
+    assert result.stats.cross_origin_refs == 1  # the cdn script, left as-is
+
+
+# --------------------------------------------------------------------------- #
+# the wired import — crawl_site_from_url end to end (publish faked)
+# --------------------------------------------------------------------------- #
+
+_WS = "ws_owner"
+_USER = "user-test-1"
+
+_INDEX = (
+    "<html><head><title>Crawled Home</title>"
+    '<link rel="stylesheet" href="/css/site.css"></head>'
+    '<body><a href="https://example.com/about">about</a>'
+    '<img src="/img/logo.png">'
+    '<form action="https://old.example/submit"><input name="e"></form>'
+    "</body></html>"
+)
+_ABOUT = "<html><head><title>Crawled About</title></head><body><p>hi</p></body></html>"
+
+_SITE_PAGES = {
+    ("example.com", "/"): _html(_INDEX),
+    ("example.com", "/about"): _html(_ABOUT),
+    ("example.com", "/css/site.css"): httpx.Response(
+        200, headers={"content-type": "text/css"}, content=b"body{color:#111}"
+    ),
+    ("example.com", "/img/logo.png"): httpx.Response(
+        200, headers={"content-type": "image/png"}, content=_PNG_BYTES
+    ),
+}
+
+
+@pytest_asyncio.fixture
+async def _fake_publish(beanie_test_db, monkeypatch) -> dict[str, Any]:
+    """Fake sites_service.publish (a real one shells out to bun/the generator) —
+    mirrors tests/ee/sites/test_import.py's fixture: record kwargs, flip the real
+    draft Site doc to deployed."""
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    captured: dict[str, Any] = {}
+
+    async def _publish(**kw):
+        captured.update(kw)
+        oid = sites_service._live_object_id(kw["workspace_id"], kw["pocket_id"])
+        doc = await _SiteDoc.find_one({"_id": oid, "workspace": kw["workspace_id"]})
+        assert doc is not None
+        doc.script_name = str(oid)
+        doc.deployed = True
+        doc.url = f"http://127.0.0.1:9999/{oid}/"
+        await doc.save()
+        return doc
+
+    monkeypatch.setattr(sites_service, "publish", _publish)
+    return captured
+
+
+async def _queue_import(monkeypatch, url: str = "https://example.com/") -> dict[str, str]:
+    """Run the real import_from_url (plan stubbed, scheduler captured-and-closed)
+    to mint the pocket + queued draft Site the crawl then fills."""
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="go"))
+    monkeypatch.setattr(import_service, "_default_crawl_scheduler", lambda coro: coro.close())
+    return await import_service.import_from_url(workspace_id=_WS, user_id=_USER, url=url)
+
+
+@pytest.mark.asyncio
+async def test_from_url_import_happy_path(_fake_publish, monkeypatch):
+    """2-page fixture site with css + img: the crawl runs the SAME pipeline as
+    the zip path — text/binary split, publish with the assets sideband, report
+    persisted with crawl stats — and the harvested source lands on the pocket."""
+    queued = await _queue_import(monkeypatch)
+    seen: list[httpx.Request] = []
+    doc = await import_service.crawl_site_from_url(
+        workspace_id=_WS,
+        user_id=_USER,
+        site_id=queued["site_id"],
+        url="https://example.com/",
+        _transport=_transport(_SITE_PAGES, seen),
+        _resolver=_resolver(_PUBLIC_IPS),
+        _politeness_delay=0,
+    )
+
+    # The publish rode the html engine with the harvested source + assets.
+    assert _fake_publish["engine"] == "html"
+    assert _fake_publish["pattern"] == "imported"
+    assert set(_fake_publish["source"]) == {"index.html", "about/index.html", "css/site.css"}
+    assert _fake_publish["assets"] == {"img/logo.png": base64.b64encode(_PNG_BYTES).decode("ascii")}
+    # Absolute same-origin links were rewritten root-relative.
+    assert 'href="/about"' in _fake_publish["source"]["index.html"]
+    assert "https://example.com" not in _fake_publish["source"]["index.html"]
+
+    # The report persisted with crawl stats + the derived page/form scan.
+    report = doc.import_report
+    assert report["status"] == "imported"
+    assert report["source_url"] == "https://example.com/"
+    assert report["crawl"]["pages_fetched"] == 2
+    assert report["crawl"]["assets_fetched"] == 2
+    assert report["crawl"]["skipped_by_robots"] == 0
+    assert report["crawl"]["bytes_fetched"] > 0
+    titles = {p["path"]: p["title"] for p in report["pages"]}
+    assert titles["index.html"] == "Crawled Home"
+    assert titles["about/index.html"] == "Crawled About"
+    assert report["forms"][0]["original_action"] == "https://old.example/submit"
+    assert doc.deployed is True
+
+    # The harvested source persisted on the POCKET (durable re-publish source).
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    pocket = await _PocketDoc.find_one({"workspace": _WS})
+    assert pocket is not None
+    assert set(pocket.source or {}) == {"index.html", "about/index.html", "css/site.css"}
+
+
+@pytest.mark.asyncio
+async def test_from_url_unreachable_seed_marks_failed_report(beanie_test_db, monkeypatch):
+    """An unreachable seed never crashes the background task — the draft Site's
+    report flips to a clear failed state with a SAFE message, no stack trace."""
+    queued = await _queue_import(monkeypatch, url="https://example.com/gone")
+    pages = {("example.com", "/gone"): httpx.Response(503, content=b"upstream exploded")}
+    doc = await import_service.crawl_site_from_url(
+        workspace_id=_WS,
+        user_id=_USER,
+        site_id=queued["site_id"],
+        url="https://example.com/gone",
+        _transport=_transport(pages, []),
+        _resolver=_resolver(_PUBLIC_IPS),
+        _politeness_delay=0,
+    )
+    assert doc.deployed is False
+    assert doc.import_report["status"] == "failed"
+    assert doc.import_report["error"]  # a clear, fixed message…
+    assert "Traceback" not in doc.import_report["error"]  # …never a stack trace
+    assert "upstream exploded" not in doc.import_report["error"]  # never raw upstream text
+
+
+@pytest.mark.asyncio
+async def test_from_url_byte_cap_marks_failed_report(beanie_test_db, monkeypatch):
+    queued = await _queue_import(monkeypatch)
+    big = _html("<html><body>" + "A" * 8192 + "</body></html>")
+    monkeypatch.setattr(import_service, "MAX_IMPORT_UNCOMPRESSED_BYTES", 512)
+    doc = await import_service.crawl_site_from_url(
+        workspace_id=_WS,
+        user_id=_USER,
+        site_id=queued["site_id"],
+        url="https://example.com/",
+        _transport=_transport({("example.com", "/"): big}, []),
+        _resolver=_resolver(_PUBLIC_IPS),
+        _politeness_delay=0,
+    )
+    assert doc.import_report["status"] == "failed"
+    assert "budget" in doc.import_report["error"]
+
+
+# --------------------------------------------------------------------------- #
+# endpoint-level SSRF: forbidden seeds 422 before anything is minted
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "seed",
+    [
+        "http://127.0.0.1/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.5/intranet",
+        "http://example.com:8080/",
+        "http://user:pass@example.com/",
+    ],
+)
+async def test_endpoint_rejects_forbidden_seed_with_422(beanie_test_db, monkeypatch, seed):
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="go"))
+    with pytest.raises(ValidationError):
+        await import_service.import_from_url(workspace_id=_WS, user_id=_USER, url=seed)
+    assert await _SiteDoc.find_one({"workspace": _WS}) is None

--- a/tests/ee/sites/test_import_crawler.py
+++ b/tests/ee/sites/test_import_crawler.py
@@ -476,3 +476,54 @@ async def test_endpoint_rejects_forbidden_seed_with_422(beanie_test_db, monkeypa
     with pytest.raises(ValidationError):
         await import_service.import_from_url(workspace_id=_WS, user_id=_USER, url=seed)
     assert await _SiteDoc.find_one({"workspace": _WS}) is None
+
+
+# --------------------------------------------------------------------------- #
+# Review fixes: redirect scope — off-site 30x rejected; apex->www re-seed
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_same_site_asset_redirect_offsite_is_not_imported():
+    """A same-site asset that 302s to another PUBLIC host must not be fetched or
+    imported — the redirect scope guard blocks it (SSRF was never the issue here;
+    importing foreign content into the tenant's site is)."""
+    seen: list[httpx.Request] = []
+    pages = {
+        ("example.com", "/"): _html(
+            '<html><body><link rel="stylesheet" href="/style.css"></body></html>'
+        ),
+        # same-site asset redirects off to a public third-party host
+        ("example.com", "/style.css"): httpx.Response(
+            302, headers={"location": "https://evil.example/payload.css"}
+        ),
+        ("evil.example", "/payload.css"): httpx.Response(
+            200, headers={"content-type": "text/css"}, content=b"body{color:red}"
+        ),
+    }
+    table = dict(_PUBLIC_IPS) | {"evil.example": ["203.0.113.99"]}
+    result = await _crawl(pages, table=table, seen=seen)
+    # The foreign host was never contacted and nothing foreign was imported.
+    assert all(r.headers.get("host") != "evil.example" for r in seen)
+    assert not any("payload.css" in p for p in result.files)
+    assert any("style.css" in w for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_seed_apex_to_www_redirect_reseeds_and_crawls_whole_site():
+    """The seed redirecting apex->www is the common real case: re-seed to the
+    final host so the whole site imports instead of one page + cross-origin soup."""
+    seen: list[httpx.Request] = []
+    pages = {
+        ("example.com", "/"): httpx.Response(301, headers={"location": "https://www.example.com/"}),
+        ("www.example.com", "/"): _html(
+            '<html><body><h1>Home</h1><a href="/about">About</a></body></html>'
+        ),
+        ("www.example.com", "/about"): _html("<html><body><h1>About</h1></body></html>"),
+    }
+    table = dict(_PUBLIC_IPS) | {"www.example.com": ["93.184.216.34"]}
+    result = await _crawl(pages, table=table, seen=seen)
+    # Both www pages imported — the internal /about link resolved same-site.
+    assert "index.html" in result.files
+    assert any("about" in p for p in result.files), result.files.keys()
+    assert result.stats.pages_fetched == 2


### PR DESCRIPTION
Stacked on #1770 (SI-4, `feat/sites-import-endpoint`) — review that one first. This slice fills the `crawl_site_from_url` seam SI-4 left open, so `POST /sites/import/from-url` actually imports a site now instead of parking it in "queued" forever.

## What it does

New module `ee/pocketpaw_ee/sites/url_crawler.py`: a same-site BFS crawler with an SSRF-hardened fetcher. `import_from_url` still returns 202 queued immediately, then runs the crawl as a detached background task (the same scheduler pattern the native-artifact pre-warm uses) with a 120s wall-clock backstop. The harvest goes through the exact pipeline the zip path built: text/binary split, publish with the base64 assets sideband, `import_report` persisted on the Site doc — now with crawl stats (pages, assets, bytes, robots skips, cross-origin ref count). The harvested source is also persisted on the pocket via a new `pockets.service.set_imported_source` (entity isolation: the Pocket write stays in the pockets service), so a later re-publish reads real content.

Every failure mode (unreachable seed, seed blocked by robots, byte budget blown, deploy error, timeout) lands as `status: "failed"` with a fixed safe message on the report. No stack traces, no raw upstream text.

## SSRF posture

This endpoint asks our server to fetch an attacker-chosen URL, so the fetcher treats everything as hostile:

- URL floors at validation time (the endpoint 422s these before minting anything): http/https only, no credentials in the URL, no ports beyond 80/443, and a literal-IP host is checked against the deny ranges immediately.
- DNS is resolved by the crawler itself and every resolved address must be public. The connection is then pinned to the validated IP: the request goes to `scheme://ip/...` with the original Host header, and SNI/cert verification runs against the real hostname. Re-resolution between check and connect (rebinding/TOCTOU) can't swap in a private address. A mixed public+private DNS answer is rejected outright.
- Deny ranges cover loopback, RFC1918, link-local (incl. 169.254.169.254), CGNAT 100.64/10, unspecified/reserved/multicast, IPv6 ULA and link-local, and v4 addresses embedded in v6 forms (v4-mapped, 6to4, Teredo, NAT64).
- Redirects are followed manually, max 5, with the full URL + DNS + IP check re-run per hop. A redirect to `file://` or an internal host dies mid-chain, and the internal host is never contacted (test asserts zero requests).
- Responses stream against a 10MB per-fetch cap and the 50MB total budget, aborted the moment a cap is crossed. Per-fetch timeout 10s. No cookies (jar cleared per response), no auth, `trust_env=False` so an env proxy can't bypass the pin. Honest User-Agent, robots.txt honored (failure to fetch robots degrades to a warning, not a block).
- Resource floors: pages <= 50, depth <= 3, assets <= 200, tracked-URL sets bounded so a link-soup page can't balloon memory, politeness delay between fetches.

## Known limitations (deliberate v1 calls, noted in code + report warnings)

- Same-site matching is exact-host: `www.` and apex are treated as different hosts. The report says so.
- Absolute same-origin URLs are rewritten root-relative with a plain string replace; prose that happens to contain the site's own URL gets rewritten too.
- Query strings are dropped when normalizing page/asset URLs.
- The background task is process-local. A web-process restart drops an in-flight crawl and the report stays "queued". The workspace-jobs (ARQ) machinery was considered and rejected for this slice: its writeback merges job state into the pocket's rippleSpec, and an imported html pocket has no spec, so a successful crawl could be marked failed by the writeback gate. Durable queueing is a follow-up.

## How it's tested

35 new tests in `tests/ee/sites/test_import_crawler.py`, all network mocked (httpx MockTransport + fake resolver, zero live sockets): forbidden literal-IP/port/scheme/credential seeds, private-resolving hostname making zero requests, mixed DNS answers, redirect-to-private and redirect-to-file mid-chain, IP pinning asserted at the wire level, BFS depth/page caps, robots disallow with the skip counter, cross-host refs counted but never fetched, encoded path traversal refused a FileMap slot, byte-budget abort, plus the wired happy path (2-page site with css + img through the faked publish, report + pocket source checked) and the failed-report modes. SI-4's `test_import.py` updated: the NotImplementedError seam test became a "crawl gets scheduled" test.

```
uv run pytest tests/ee/sites/test_import_crawler.py tests/ee/sites/test_import.py -q
52 passed in 2.57s

uv run pytest tests/ee/sites -q
471 passed, 2 skipped in 27.53s

uv run lint-imports && uv run lint-imports --config ee/pyproject.toml
Contracts: 1 kept, 0 broken / Contracts: 31 kept, 0 broken
```
