### PR TITLE
Actually rewire imported forms so their leads reach the workspace

### DIFF
--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -1020,6 +1020,69 @@ class _SubprocessRunner:
         return await self.build_static(project_dir, gate=True)
 
 
+async def run_import(
+    files: dict[str, str],
+    *,
+    site_id: str,
+    capture_api_base: str,
+    capture_signed_key: str,
+    _exec: Any = None,
+) -> dict[str, Any]:
+    """Run imported files through the paw-sites ``import`` generator subcommand and
+    return ``{source, assets, report}`` — the rewired html source map, the base64
+    binary sideband, and the authoritative import report.
+
+    This is what makes an imported ``<form>`` actually post to the capture API: the
+    generator runs buildImportPlan + rewireForms over ``files`` (path -> base64
+    bytes) using ``siteConfig`` (the site id + capture base + the site's signed
+    key), rewrites each form's action to ``{captureApiBase}/capture/form`` with the
+    hidden paw_* fields, and returns the rewired source plus a report whose keys are
+    the exact snake_case shape the Site doc + /sites report panel read.
+
+    Shells out to the SAME tokenised generator command as apply_leaf_edits
+    (``_gen_cmd_argv()`` + ``import --input <tempfile>``) and emits exactly ONE JSON
+    line on stdout. A PURE transform — no bun install / build / workerd — so it is
+    fast and safe to call inline on the import path before publish. Failure surfaces
+    as a ``RuntimeError`` (non-zero exit carries the CLI stderr; a wedged run is a
+    failed run, mirroring generate()/apply_leaf_edits). ``_exec`` is the injectable
+    subprocess-exec seam tests stub so the bridge is unit-testable without Bun."""
+    input_path = ""
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            input_path = fh.name
+            json.dump(
+                {
+                    "files": files,
+                    "siteConfig": {
+                        "siteId": site_id,
+                        "captureApiBase": capture_api_base,
+                        "captureSignedKey": capture_signed_key,
+                    },
+                },
+                fh,
+            )
+        timeout_s = _build_timeout_sec()
+        proc = await (_exec or asyncio.create_subprocess_exec)(
+            *_gen_cmd_argv(),
+            "import",
+            "--input",
+            input_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            stdout, stderr = await _communicate_bounded(proc, timeout_s, "import")
+        except _BuildTimeout as exc:
+            raise RuntimeError(f"import timed out after {exc.timeout_s}s") from exc
+        if proc.returncode != 0:
+            raise RuntimeError(f"import failed: {stderr.decode()}")
+        return json.loads(stdout.decode().strip().splitlines()[-1])
+    finally:
+        if input_path and os.path.exists(input_path):
+            os.unlink(input_path)
+
+
 async def apply_leaf_edits(
     source: dict[str, str],
     edits: list[dict[str, Any]],

--- a/ee/pocketpaw_ee/sites/import_service.py
+++ b/ee/pocketpaw_ee/sites/import_service.py
@@ -1,5 +1,14 @@
 # ee/pocketpaw_ee/sites/import_service.py — Paw Sites IMPORT control plane (SI-4).
 #
+# Edited 2026-07-23 (SI-FIX — wire the rewire pipeline): both the zip and crawl
+# paths now run the unpacked/harvested files through the generator's ``import``
+# subcommand (``_plan_import`` -> ``generator_client.run_import``) BEFORE publish, so
+# imported ``<form>``s are actually rewired to the capture API and the report carries
+# real per-form ``rewired`` verdicts. This replaces the interim Python
+# ``derive_import_report`` (which shipped raw source + ``rewired: False``) — the
+# rewired source is what we persist on the pocket and deploy. The draft Site doc is
+# minted first so its ``signed_key`` can be baked into the forms.
+#
 # Created 2026-07-22 (feat/sites-import-endpoint): the service half of the two
 # import endpoints — POST /sites/import (zip upload) and POST /sites/import/from-url
 # (crawler-backed, next slice). Owns:
@@ -53,7 +62,6 @@ import io
 import logging
 import zipfile
 from datetime import UTC, datetime
-from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -248,84 +256,66 @@ def unpack_zip(data: bytes) -> tuple[dict[str, str], dict[str, str]]:
     return source, assets
 
 
-class _PageScan(HTMLParser):
-    """One-pass scan of an imported HTML page: <title>, <form action=...>, and
-    <script src=...> refs — the raw material for the minimal import report."""
+async def _plan_import(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    source: dict[str, str],
+    assets: dict[str, str],
+    _run_import: Any | None = None,
+) -> tuple[dict[str, str], dict[str, str], dict[str, Any]]:
+    """Run the imported files through the generator's import pipeline and return the
+    REWIRED ``(source, assets, report)``.
 
-    def __init__(self) -> None:
-        super().__init__()
-        self.title = ""
-        self._in_title = False
-        self.form_actions: list[str] = []
-        self.script_srcs: list[str] = []
+    This is the seam that makes an imported ``<form>`` actually post to the capture
+    API. The generator's ``buildImportPlan`` + ``rewireForms`` need the site's
+    ``signed_key`` to bake into each form, so the draft Site doc (minted by
+    ``_mint_import_pocket``) must already exist — we read its key here and hand it to
+    the generator. ``publish`` reuses that same stored key, so the key in the
+    deployed forms matches the one the capture endpoint verifies.
 
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        attr_map = {k: (v or "") for k, v in attrs}
-        if tag == "title":
-            self._in_title = True
-        elif tag == "form":
-            self.form_actions.append(attr_map.get("action", ""))
-        elif tag == "script" and attr_map.get("src"):
-            self.script_srcs.append(attr_map["src"])
+    Returns the authoritative report (per-form ``rewired`` verdicts + original
+    actions, page titles, asset tallies, warnings) verbatim from the generator; the
+    caller merges any path-specific extras (crawl stats, status)."""
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 
-    def handle_endtag(self, tag: str) -> None:
-        if tag == "title":
-            self._in_title = False
-
-    def handle_data(self, data: str) -> None:
-        if self._in_title:
-            self.title += data
-
-
-def derive_import_report(source: dict[str, str], assets: dict[str, str]) -> dict[str, Any]:
-    """Derive the MINIMAL import report from the unpacked zip contents.
-
-    Shape: {pages: [{path, title}], asset_count, asset_bytes,
-            forms: [{page, original_action, rewired}], scripts: [...], warnings: [...]}.
-
-    ENRICHMENT SEAM (cross-repo): the paw-sites generator's import plan will
-    provide the authoritative report — including per-form REWIRING verdicts (the
-    generator rewrites <form> actions to the native capture POST) — in a parallel
-    slice. Until it lands, this derivation reports what the zip CONTAINS and marks
-    every form ``rewired: False`` (nothing is confirmed rewired yet)."""
-    pages: list[dict[str, str]] = []
-    forms: list[dict[str, Any]] = []
-    scripts: list[str] = []
-    for path in sorted(source):
-        if not path.endswith((".html", ".htm")):
-            continue
-        scan = _PageScan()
-        try:
-            scan.feed(source[path])
-        except Exception:  # noqa: BLE001 — a malformed page still lists, just untitled
-            logger.debug("import report: page %s did not parse cleanly", path)
-        pages.append({"path": path, "title": scan.title.strip()})
-        forms.extend(
-            {"page": path, "original_action": action, "rewired": False}
-            for action in scan.form_actions
+    oid = sites_service._live_object_id(workspace_id, pocket_id)
+    doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None or not doc.signed_key:
+        raise Internal(
+            "sites.import_no_draft_key",
+            "the import draft site is missing its capture signing key",
         )
-        scripts.extend(src for src in scan.script_srcs if src not in scripts)
 
-    asset_bytes = sum(len(base64.b64decode(b64)) for b64 in assets.values())
-    warnings: list[str] = []
-    if forms:
-        warnings.append(
-            "form rewiring is confirmed by the generator-side import plan (pending "
-            "paw-sites slice) — forms are listed but not yet verified as rewired"
-        )
-    if assets:
-        warnings.append(
-            "binary assets deploy at import time; re-publishing from the builder will "
-            "not carry them until the pocket asset sideband lands"
-        )
-    return {
-        "pages": pages,
-        "asset_count": len(assets),
-        "asset_bytes": asset_bytes,
-        "forms": forms,
-        "scripts": scripts,
-        "warnings": warnings,
+    # Merge text (utf-8 -> base64) + binary (already base64) into the single
+    # {path: base64} map the generator's ``import`` command ingests.
+    files: dict[str, str] = {
+        path: base64.b64encode(text.encode("utf-8")).decode("ascii")
+        for path, text in source.items()
     }
+    files.update(assets)
+
+    from pocketpaw_ee.sites import generator_client
+
+    run = _run_import if _run_import is not None else generator_client.run_import
+    try:
+        result = await run(
+            files,
+            site_id=str(oid),
+            # The SAME capture base publish passes the generator, so the action baked
+            # into the forms matches the site the capture endpoint verifies.
+            capture_api_base=sites_service._capture_base(),
+            capture_signed_key=doc.signed_key,
+        )
+    except Exception as exc:  # noqa: BLE001 — fail CLOSED, never fall back to raw source
+        # A rewire failure must not silently deploy the un-rewired upload — that
+        # would leak the site's leads to its original form backend. Raise a clean
+        # error the zip endpoint maps to a 5xx and the crawl path turns into a
+        # failed report.
+        raise Internal(
+            "sites.import_rewire_failed", "the imported site could not be processed"
+        ) from exc
+    return result["source"], result.get("assets", {}), result["report"]
 
 
 def _emit_import_journal(
@@ -402,6 +392,7 @@ async def import_zip_site(
     _generator: Any | None = None,
     _cloudflare: Any | None = None,
     _local_deploy: Any | None = None,
+    _run_import: Any | None = None,
 ) -> Any:
     """Import an uploaded site zip end to end: unpack safely → mint pocket + draft
     Site doc → publish through the EXISTING html/static deploy path (with the
@@ -418,7 +409,17 @@ async def import_zip_site(
     pocket_id = await _mint_import_pocket(
         workspace_id=workspace_id, user_id=user_id, name=site_name, source=source
     )
-    report = derive_import_report(source, assets)
+    # Run the files through the generator's import pipeline: forms get rewired to the
+    # capture API, links/titles resolved, and an authoritative report produced. The
+    # REWIRED source (not the raw upload) is what we store + deploy.
+    source, assets, report = await _plan_import(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        source=source,
+        assets=assets,
+        _run_import=_run_import,
+    )
+    report["status"] = "imported"
 
     doc = await sites_service.publish(
         workspace_id=workspace_id,
@@ -429,10 +430,8 @@ async def import_zip_site(
         name=site_name,
         engine="html",
         source=source,
-        # CROSS-REPO SEAM: ``assets`` is the base64 binary sideband the paw-sites
-        # generator is gaining in a parallel slice ({path: base64} written verbatim
-        # into the static tree). Until that lands, a generator that ignores the key
-        # deploys the text tree only — the report's warning covers it.
+        # ``assets`` is the base64 binary sideband ({path: base64}) the html
+        # generator writes verbatim into the static tree.
         assets=assets or None,
         pattern=IMPORT_PATTERN,
         _generator=_generator,
@@ -523,6 +522,7 @@ async def crawl_site_from_url(
     _generator: Any | None = None,
     _cloudflare: Any | None = None,
     _local_deploy: Any | None = None,
+    _run_import: Any | None = None,
 ) -> Any:
     """SI-5: crawl ``url`` (same-site, SSRF-pinned — see url_crawler) and run the
     harvest through the SAME import pipeline as the zip path: text/binary split →
@@ -577,7 +577,21 @@ async def crawl_site_from_url(
         )
         return doc
 
-    report = derive_import_report(source, assets)
+    try:
+        # Same rewire pipeline as the zip path: forms get pointed at the capture
+        # API and an authoritative report comes back. The REWIRED source is what we
+        # persist + deploy.
+        source, assets, report = await _plan_import(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            source=source,
+            assets=assets,
+            _run_import=_run_import,
+        )
+    except Exception as exc:  # noqa: BLE001 — a planning failure is a safe failed report
+        logger.warning("sites import: planning crawl of %s failed", url, exc_info=True)
+        await _mark_import_failed(doc, url=url, message=_safe_crawl_failure(exc))
+        return doc
     report["warnings"].extend(crawl.warnings)
     report["crawl"] = crawl.stats.as_dict()
     report["status"] = "imported"

--- a/tests/ee/sites/conftest.py
+++ b/tests/ee/sites/conftest.py
@@ -46,10 +46,13 @@
 
 from __future__ import annotations
 
+import base64
+import re
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+import pytest_asyncio
 
 pytest.importorskip("pocketpaw_ee")
 
@@ -159,3 +162,67 @@ def _default_sites_plan(request: pytest.FixtureRequest):
         new=AsyncMock(return_value="go"),
     ):
         yield
+
+
+# Updated 2026-07-23 (SI-FIX — wire the import rewire pipeline): a shared stub for
+# the paw-sites ``import`` generator subcommand. The real generator_client.run_import
+# shells out to paw-sites-gen (Bun); this deterministic stand-in lets the import +
+# crawler tests exercise the backend WIRING (publish receives the REWIRED source, the
+# authoritative report persists) without Bun on PATH. Real rewire fidelity is proven
+# by paw-sites' own tests + the cross-repo integration check.
+def stub_import_result(
+    files: dict, *, site_id: str, capture_api_base: str, capture_signed_key: str
+) -> dict:
+    source: dict[str, str] = {}
+    assets: dict[str, str] = {}
+    pages: list[dict[str, str]] = []
+    forms: list[dict[str, Any]] = []
+    scripts: list[str] = []
+    asset_bytes = 0
+    for path in sorted(files):
+        raw = base64.b64decode(files[path])
+        if path.endswith((".html", ".htm")):
+            text = raw.decode("utf-8")
+            m = re.search(r"action=['\"]([^'\"]+)['\"]", text)
+            if m:
+                text = re.sub(
+                    r"action=['\"][^'\"]+['\"]",
+                    f"action='{capture_api_base}/capture/form'",
+                    text,
+                    count=1,
+                )
+                text = text.replace("<form ", f"<form data-paw-original-action='{m.group(1)}' ", 1)
+                forms.append({"page": path, "original_action": m.group(1), "rewired": True})
+            source[path] = text
+            tm = re.search(r"<title>([^<]*)</title>", text)
+            pages.append({"path": path, "title": (tm.group(1) if tm else "").strip()})
+        elif path.endswith((".css", ".js", ".txt", ".json", ".xml", ".svg")):
+            source[path] = raw.decode("utf-8")
+            if path.endswith(".js"):
+                scripts.append(path)
+        else:
+            assets[path] = files[path]
+            asset_bytes += len(raw)
+    return {
+        "source": source,
+        "assets": assets,
+        "report": {
+            "pages": pages,
+            "asset_count": len(assets),
+            "asset_bytes": asset_bytes,
+            "forms": forms,
+            "scripts": scripts,
+            "warnings": [],
+        },
+    }
+
+
+@pytest_asyncio.fixture
+async def _fake_run_import(monkeypatch):
+    """Stub generator_client.run_import with the deterministic rewire above."""
+    from pocketpaw_ee.sites import generator_client
+
+    async def _run(files, **kw):
+        return stub_import_result(files, **kw)
+
+    monkeypatch.setattr(generator_client, "run_import", _run)

--- a/tests/ee/sites/test_import.py
+++ b/tests/ee/sites/test_import.py
@@ -161,19 +161,23 @@ async def _post_zip(app: FastAPI, data: bytes, name: str = "") -> Any:
 
 
 @pytest.mark.asyncio
-async def test_import_zip_happy_path(_fake_publish, monkeypatch):
+async def test_import_zip_happy_path(_fake_publish, _fake_run_import, monkeypatch):
     """A good zip imports end to end: Site doc minted + flipped live, the generator
-    input carries engine=html / text source / base64 assets, and the import_report
-    (pages, asset counts, forms) is persisted and returned."""
+    input carries engine=html / text source / base64 assets, forms are REWIRED to the
+    capture API, and the authoritative import_report is persisted and returned."""
     app = _build_app("ws_owner", monkeypatch)
     resp = await _post_zip(app, _good_zip(), name="My imported site")
     assert resp.status_code == 200, resp.text
     body = resp.json()
 
-    # The publish rode the html engine with the text source map + assets sideband.
+    # The publish rode the html engine with the REWIRED source map + assets sideband.
     assert _fake_publish["engine"] == "html"
     assert set(_fake_publish["source"]) == {"index.html", "about.html", "app.js"}
-    assert _fake_publish["source"]["index.html"] == _INDEX_HTML
+    # The deployed html is the rewired source, not the raw upload: the form now posts
+    # to the capture endpoint and the original action is preserved on the element.
+    deployed_index = _fake_publish["source"]["index.html"]
+    assert f"action='{sites_service._capture_base()}/capture/form'" in deployed_index
+    assert "data-paw-original-action='https://old-backend.example/submit'" in deployed_index
     assert _fake_publish["assets"] == {"img/logo.png": base64.b64encode(_PNG_BYTES).decode("ascii")}
     assert _fake_publish["pattern"] == "imported"
 
@@ -189,7 +193,7 @@ async def test_import_zip_happy_path(_fake_publish, monkeypatch):
         {
             "page": "index.html",
             "original_action": "https://old-backend.example/submit",
-            "rewired": False,
+            "rewired": True,
         }
     ]
     assert "app.js" in report["scripts"]
@@ -204,7 +208,24 @@ async def test_import_zip_happy_path(_fake_publish, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_import_zip_single_root_dir_flattens(_fake_publish, monkeypatch):
+async def test_import_rewire_failure_does_not_deploy(_fake_publish, monkeypatch):
+    """If the rewire pipeline fails, the import FAILS closed — it never falls back to
+    deploying the raw, un-rewired upload (which would leak leads to the origin site)."""
+    from pocketpaw_ee.sites import generator_client
+
+    async def _boom(files, **kw):
+        raise RuntimeError("generator import command unavailable")
+
+    monkeypatch.setattr(generator_client, "run_import", _boom)
+    app = _build_app("ws_owner", monkeypatch)
+    resp = await _post_zip(app, _good_zip(), name="My imported site")
+    assert resp.status_code >= 400, resp.text
+    # publish was never reached — nothing was deployed with un-rewired forms.
+    assert _fake_publish == {}
+
+
+@pytest.mark.asyncio
+async def test_import_zip_single_root_dir_flattens(_fake_publish, _fake_run_import, monkeypatch):
     """The `zip -r site site/` shape (one top dir holding index.html) imports as if
     that dir were the root."""
     app = _build_app("ws_owner", monkeypatch)
@@ -300,7 +321,7 @@ async def test_import_zip_not_a_zip_rejected(beanie_test_db, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_import_cross_tenant_site_is_invisible(_fake_publish, monkeypatch):
+async def test_import_cross_tenant_site_is_invisible(_fake_publish, _fake_run_import, monkeypatch):
     """An imported site never leaks cross-tenant: the intruder's gallery list is
     empty and the site-scoped detail read (domains) is a 404."""
     owner_app = _build_app("ws_owner", monkeypatch)

--- a/tests/ee/sites/test_import_crawler.py
+++ b/tests/ee/sites/test_import_crawler.py
@@ -365,7 +365,7 @@ async def _queue_import(monkeypatch, url: str = "https://example.com/") -> dict[
 
 
 @pytest.mark.asyncio
-async def test_from_url_import_happy_path(_fake_publish, monkeypatch):
+async def test_from_url_import_happy_path(_fake_publish, _fake_run_import, monkeypatch):
     """2-page fixture site with css + img: the crawl runs the SAME pipeline as
     the zip path — text/binary split, publish with the assets sideband, report
     persisted with crawl stats — and the harvested source lands on the pocket."""


### PR DESCRIPTION
Imported sites were shipping their forms un-rewired. import_service used an interim Python derivation that hardcoded rewired=False and deployed the raw upload, so an imported form still posted to its original backend (formspree, etc.) and the site's leads never reached the workspace. The rewire pipeline existed in the paw-sites generator, but nothing on the backend called it — the served-artifact e2e passed because it exercised the pipeline directly, not the seam the backend runs.

Both the zip and crawl paths now run the unpacked/harvested files through the generator's import command (generator_client.run_import) before publish:

- The draft Site doc is minted first, so its signed_key bakes into each form and matches the key the capture endpoint verifies.
- The rewired source is what we persist on the pocket and deploy — not the raw upload.
- The authoritative report (real per-form rewired verdicts, original actions, page titles, asset tallies) is what we store and surface.
- A rewire failure fails closed: it raises rather than falling back to deploying the un-rewired site.

Verified against the real built generator command end to end (not just the mocked seam): a formspree form comes back posting to /capture/form with the original action preserved and rewired=true. 58 import + crawler tests green including a fail-closed test; full sites suite 476 green.

Depends on the paw-sites import-command PR (qbtrix/paw-sites#37) landing + a generator re-vendor for prod. Codes to that command's JSON contract.