### PR TITLE
Persist the rewired source on an imported pocket, not the raw upload

### DIFF
--- a/ee/pocketpaw_ee/sites/import_service.py
+++ b/ee/pocketpaw_ee/sites/import_service.py
@@ -1,5 +1,9 @@
 # ee/pocketpaw_ee/sites/import_service.py — Paw Sites IMPORT control plane (SI-4).
 #
+# Edited 2026-07-23 (SI-FIX review): the zip path now persists the REWIRED source on
+# the pocket too (set_imported_source), not just the deployed artifact — a re-publish
+# from the builder was reading the raw upload and redeploying un-rewired forms.
+#
 # Edited 2026-07-23 (SI-FIX — wire the rewire pipeline): both the zip and crawl
 # paths now run the unpacked/harvested files through the generator's ``import``
 # subcommand (``_plan_import`` -> ``generator_client.run_import``) BEFORE publish, so
@@ -420,6 +424,15 @@ async def import_zip_site(
         _run_import=_run_import,
     )
     report["status"] = "imported"
+
+    # Persist the REWIRED source on the pocket (the durable re-publish source),
+    # mirroring the crawl path. The pocket was minted above with the RAW upload to
+    # get its signed_key; without this overwrite a later re-publish from the builder
+    # would read the raw source and redeploy forms that still post to the origin
+    # backend — leaking the site's leads.
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    await pockets_service.set_imported_source(pocket_id, workspace_id=workspace_id, source=source)
 
     doc = await sites_service.publish(
         workspace_id=workspace_id,

--- a/tests/ee/sites/test_import.py
+++ b/tests/ee/sites/test_import.py
@@ -206,6 +206,17 @@ async def test_import_zip_happy_path(_fake_publish, _fake_run_import, monkeypatc
     assert len(rows) == 1
     assert rows[0]["import_report"]["asset_count"] == 1
 
+    # The pocket stores the REWIRED source, not the raw upload — so a later
+    # re-publish from the builder redeploys forms that still post to capture.
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    pocket = await _PocketDoc.find_one({"workspace": "ws_owner"})
+    assert pocket is not None
+    stored_index = (pocket.source or {})["index.html"]
+    # The stored form posts to capture, with the original preserved on the element.
+    assert f"action='{sites_service._capture_base()}/capture/form'" in stored_index
+    assert "data-paw-original-action='https://old-backend.example/submit'" in stored_index
+
 
 @pytest.mark.asyncio
 async def test_import_rewire_failure_does_not_deploy(_fake_publish, monkeypatch):


### PR DESCRIPTION
A pre-deploy review of the import wiring caught this. The zip import path mints the pocket with the raw upload (it needs the pocket first to read the draft site's signing key), then deploys the rewired source — but it never wrote the rewired source back to the pocket. Since the pocket is the durable source a re-publish or builder edit reads, a later re-publish would redeploy forms that still post to the site's original backend, leaking its leads.

The crawl path already persisted the rewired source; the zip path now matches it with a single set_imported_source call. A test asserts the pocket stores the capture-rewired form with the original action preserved. 58 import + crawler tests green, full sites suite 477 green.

Follow-up to #1772; wants a generator re-vendor + backend rebuild for prod (same as #1772).