### PR TITLE
Auto-provision a dedicated concierge agent per site

### DIFF
--- a/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
+++ b/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
@@ -1,0 +1,316 @@
+# ee/pocketpaw_ee/paw_bar/agent_provisioning.py — auto-provision a DEDICATED
+# concierge agent per Paw Site.
+#
+# Created 2026-07-23 (feat/site-dedicated-agent): every site's concierge is
+# answered by an agent that exists FOR that site — never a shared/universal
+# agent. ``ensure_site_agent(site, widget)`` is idempotent: a widget already
+# bound to a LIVE agent is returned unchanged (manual binds are never
+# overwritten); otherwise ONE dedicated agent is created (via the agents service
+# — never a direct Beanie write) and bound to the widget through the paw-bar
+# store's ``update_fields`` path. Two triggers funnel here: widget-create (no
+# agent_id + the pocket resolves to a Site) and concierge-enable (the site's
+# widget is still unbound). Both are FAILURE-SOFT — a provisioning failure logs
+# and leaves the widget unbound rather than 500-ing the caller (chat still 409s;
+# the dashboard offers a manual create).
+#
+# ASG-1 identity fields (welcome_message, conversation_starters) and agent
+# ``tags`` do NOT exist on the Agent/AgentConfig model on this branch, so the
+# seeding of those degrades gracefully to a no-op (see ``_seed_identity`` /
+# ``_seed_tags``). The derivation helpers still run + are unit-tested so the wire
+# is in place the moment the fields land; the derived values are logged, never
+# dropped silently.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The soul archetype every site concierge carries.
+_CONCIERGE_ARCHETYPE = "The Site Concierge"
+
+# Cap on conversation starters surfaced to a visitor (matches the frame config cap).
+_MAX_STARTERS = 4
+
+# Max length of the generated agent display name (Agent.name is capped at 100).
+_MAX_AGENT_NAME = 100
+
+
+def _store():
+    """The paw-bar widget store (the sole owner of widget writes)."""
+    from pocketpaw_ee.api import get_paw_bar_store
+
+    return get_paw_bar_store()
+
+
+def concierge_slug(site_id: str) -> str:
+    """Deterministic, workspace-unique slug for a site's concierge agent.
+
+    Deterministic on the site id so a retry after a partial provision (agent
+    created but the bind failed) RESOLVES the same agent by slug instead of
+    minting a duplicate — the idempotency backstop below relies on this.
+    """
+    return f"concierge-{site_id}"
+
+
+def concierge_name(site_name: str) -> str:
+    """The agent display name: ``<Site name> Concierge`` (``Site Concierge`` when
+    the site has no name). Truncated to the Agent.name cap."""
+    stripped = (site_name or "").strip()
+    name = f"{stripped} Concierge" if stripped else "Site Concierge"
+    return name[:_MAX_AGENT_NAME]
+
+
+def concierge_persona(site_name: str) -> str:
+    """The soul persona seeded on the concierge agent."""
+    subject = (site_name or "").strip() or "this site"
+    return (
+        f"You are the concierge for {subject}. You answer visitors' questions "
+        "about this site, grounded in its own knowledge."
+    )
+
+
+def derive_conversation_starters(widget: Any) -> list[str]:
+    """Derive up to four plain visitor questions from the widget spec.
+
+    Rules (order preserved, capped at ``_MAX_STARTERS``):
+      * a non-empty catalog adds ``"What do you sell?"``;
+      * each GATED action carrying a label adds ``"<label>?"`` (e.g. a
+        ``book_table`` action labelled "Book a table" → "Book a table?");
+      * if nothing derived, a single generic ``"What can you help me with?"``.
+    """
+    spec = getattr(widget, "spec", None)
+    starters: list[str] = []
+    if spec is not None and getattr(spec, "catalog", None):
+        starters.append("What do you sell?")
+    for action in (getattr(spec, "actions", None) or []):
+        if len(starters) >= _MAX_STARTERS:
+            break
+        label = (getattr(action, "label", "") or "").strip()
+        if getattr(action, "policy", "") == "gated" and label:
+            starters.append(f"{label}?")
+    if not starters:
+        starters.append("What can you help me with?")
+    return starters[:_MAX_STARTERS]
+
+
+def _seed_identity(body: Any, site: Any, widget: Any) -> None:
+    """Seed the ASG-1 identity fields on a create body IF the model supports them.
+
+    ``welcome_message`` ← ``Site.concierge_greeting`` (when non-empty),
+    ``conversation_starters`` ← ``derive_conversation_starters(widget)``. On this
+    branch the Agent create DTO carries NEITHER field, so this is a no-op beyond a
+    debug log — do NOT add the fields here (that is an Agent-model change, out of
+    scope). When the agent-studio identity fields land, this seeds them with no
+    other change.
+    """
+    greeting = (getattr(site, "concierge_greeting", "") or "").strip()
+    starters = derive_conversation_starters(widget)
+
+    seeded = False
+    if greeting and hasattr(body, "welcome_message"):
+        body.welcome_message = greeting
+        seeded = True
+    if hasattr(body, "conversation_starters"):
+        body.conversation_starters = starters
+        seeded = True
+
+    if not seeded:
+        logger.debug(
+            "paw-bar concierge: ASG-1 identity fields absent on Agent create DTO; "
+            "skipping welcome_message/conversation_starters seeding "
+            "(would have set greeting=%r, starters=%r)",
+            greeting,
+            starters,
+        )
+
+
+def _seed_tags(body: Any, site_id: str) -> None:
+    """Stamp the ``["concierge", "site:<id>"]`` tags IF the create DTO supports a
+    free-form ``tags`` field. The Agent model on this branch has no such field
+    (``scopes`` is a hierarchical SCOPE-tag list with its own validator, NOT a
+    label bag), so this is a graceful no-op here."""
+    if hasattr(body, "tags"):
+        body.tags = ["concierge", f"site:{site_id}"]
+    else:
+        logger.debug(
+            "paw-bar concierge: Agent create DTO has no free-form 'tags' field; "
+            "skipping tag seeding for site %s",
+            site_id,
+        )
+
+
+async def _seed_connectors(agent: Any, site: Any) -> None:
+    """Reserved seam for the connector-distribution wave (per-site connector
+    auto-binding). Intentionally a no-op today — the concierge is public and runs
+    fail-closed with NO connectors until the untrusted/public claude_sdk lockdown
+    mode ships (see ``concierge_chat``'s connector-lockdown guard). Present so the
+    provision path has one obvious place to wire connectors when that lands."""
+    return None
+
+
+async def ensure_site_agent(site: Any, widget: Any) -> str | None:
+    """Idempotently ensure ``widget`` is bound to a dedicated agent for ``site``.
+
+    Returns the bound agent id, or ``None`` when provisioning could not complete
+    (the caller keeps the widget unbound — chat still 409s). Never overwrites a
+    manual bind: if the widget already carries an ``agent_id`` that resolves to a
+    LIVE agent, that id is returned unchanged. Otherwise ONE dedicated agent is
+    created in the SITE's workspace, owned by the site owner, and bound to the
+    widget through the store — mirroring how the agents service derives ownership,
+    never cross-tenant.
+    """
+    from pocketpaw_ee.cloud._core.errors import ConflictError, NotFound
+    from pocketpaw_ee.cloud.agents import service as agents_service
+    from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+
+    workspace_id = site.workspace
+    owner_id = site.owner
+    site_id = str(site.id)
+
+    # (1) Respect an existing LIVE bind — a manual agent_id is never replaced.
+    existing_id = getattr(widget, "agent_id", "") or ""
+    if existing_id:
+        try:
+            await agents_service.get(existing_id)
+            return existing_id
+        except NotFound:
+            # Stale bind (agent deleted) — fall through and re-provision.
+            logger.info(
+                "paw-bar concierge: widget %s bound to missing agent %s; re-provisioning",
+                widget.id,
+                existing_id,
+            )
+
+    # (2) Resolve-or-create the dedicated agent. The slug is deterministic on the
+    # site id, so a create that races or retries after a failed bind RESOLVES the
+    # same agent instead of raising a duplicate-slug conflict.
+    slug = concierge_slug(site_id)
+    ctx = agents_service.legacy_ctx(owner_id, workspace_id)
+
+    agent = None
+    try:
+        agent = await agents_service.get_by_slug(workspace_id, slug)
+    except NotFound:
+        agent = None
+
+    if agent is None:
+        body = CreateAgentRequest(
+            name=concierge_name(site.name),
+            slug=slug,
+            visibility="workspace",
+            persona=concierge_persona(site.name),
+            soul_archetype=_CONCIERGE_ARCHETYPE,
+            # soul_enabled defaults True — the concierge carries a soul.
+        )
+        _seed_tags(body, site_id)
+        _seed_identity(body, site, widget)
+        try:
+            agent = await agents_service.create(ctx, workspace_id, body)
+        except ConflictError:
+            # Lost a create race on the deterministic slug — adopt the winner.
+            agent = await agents_service.get_by_slug(workspace_id, slug)
+
+    # Connector seam (no-op today).
+    await _seed_connectors(agent, site)
+
+    # (3) Bind the agent to the widget through the store's whitelisted update path.
+    updated = await _store().update_fields(
+        widget.id, {"agent_id": agent.id}, workspace_id=workspace_id
+    )
+    if updated is None:
+        logger.warning(
+            "paw-bar concierge: agent %s created but bind to widget %s returned no row",
+            agent.id,
+            widget.id,
+        )
+        return None
+    return agent.id
+
+
+async def _canonical_site_for_pocket(workspace_id: str, pocket_id: str) -> Any | None:
+    """The canonical Site doc for (workspace, pocket_id), or None (dedupe-aware).
+
+    Reuses the sites service's canonical resolver so a pocket that still carries
+    pre-dedupe duplicate Site docs resolves the SAME live doc the rest of the
+    stack uses. Best-effort import: if the sites service can't be reached, no
+    site is resolved (provisioning is skipped, the widget stays a plain widget).
+    """
+    if not pocket_id:
+        return None
+    try:
+        from pocketpaw_ee.sites import service as sites_service
+
+        return await sites_service.canonical_site_for_pocket(workspace_id, pocket_id)
+    except Exception:  # noqa: BLE001 — never fail the caller on a resolver hiccup
+        logger.warning(
+            "paw-bar concierge: site resolution failed for pocket %s", pocket_id, exc_info=True
+        )
+        return None
+
+
+async def provision_widget_on_create(widget: Any, workspace_id: str) -> Any:
+    """Widget-create trigger: provision a concierge agent when the widget's pocket
+    is a published Site and the widget is unbound.
+
+    Returns the widget with ``agent_id`` set on success, or the ORIGINAL widget
+    unchanged when there is no site for the pocket (plain widgets stay possible)
+    or when provisioning fails. FAILURE-SOFT: any error logs and returns the
+    original widget so widget-create never 500s on a provisioning problem.
+    """
+    if getattr(widget, "agent_id", ""):
+        return widget
+    try:
+        site = await _canonical_site_for_pocket(workspace_id, widget.pocket_id)
+        if site is None:
+            return widget  # no site for this pocket — a plain widget, not a concierge
+        await ensure_site_agent(site, widget)
+        refreshed = await _store().get_widget(widget.id, workspace_id=workspace_id)
+        return refreshed or widget
+    except Exception:  # noqa: BLE001 — provisioning must never 500 widget-create
+        logger.warning(
+            "paw-bar concierge: auto-provision on widget-create failed for widget %s "
+            "(returning unbound)",
+            getattr(widget, "id", "?"),
+            exc_info=True,
+        )
+        return widget
+
+
+async def provision_on_concierge_enable(site: Any, workspace_id: str) -> None:
+    """Concierge-enable trigger: provision the site's widget when it is unbound.
+
+    Resolves the site's paw-bar widget (workspace-scoped) and provisions a
+    dedicated agent when that widget exists and carries no agent yet. FAILURE-SOFT:
+    any error logs and returns so the settings PATCH never 500s. A no-op when the
+    site has no widget yet (the concierge is wired later) or the widget already has
+    an agent (manual or previously provisioned).
+    """
+    try:
+        if not site.pocket_id:
+            return
+        widgets = await _store().list_widgets(
+            pocket_id=site.pocket_id, workspace_id=workspace_id, limit=1
+        )
+        widget = widgets[0] if widgets else None
+        if widget is None or getattr(widget, "agent_id", ""):
+            return
+        await ensure_site_agent(site, widget)
+    except Exception:  # noqa: BLE001 — provisioning must never 500 the settings PATCH
+        logger.warning(
+            "paw-bar concierge: auto-provision on concierge-enable failed for site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
+
+
+__all__ = [
+    "concierge_name",
+    "concierge_persona",
+    "concierge_slug",
+    "derive_conversation_starters",
+    "ensure_site_agent",
+    "provision_on_concierge_enable",
+    "provision_widget_on_create",
+]

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -14,9 +14,14 @@
 #   failure-soft. (3) _pawbar_frame_config now carries ``starters`` (the bound
 #   agent's conversation starters, capped 4, empty default) — the owner preview
 #   frame threads the bound agent's starters (via _bound_agent_starters); the public
-#   frame passes []. The ASG-1 identity fields (welcome_message/conversation_starters)
-#   and agent free-form tags are ABSENT on this branch, so their seeding degrades to
-#   a graceful no-op (the unbound-chat 409 invariant is unchanged).
+#   frame passes []. (4) GET /paw-bar/admin/site/{id}/overview's widget block now
+#   carries ``agent_name`` (the bound agent's display name, resolved via the agents
+#   service) so the E2 dashboard card can show the concierge name + detect the
+#   "<x> Concierge" dedicated pattern; empty when unbound or the agent no longer
+#   resolves (a dangling agent_id degrades to absent, never 500s the overview). The
+#   ASG-1 identity fields (welcome_message/conversation_starters) and agent free-form
+#   tags are ABSENT on this branch, so their seeding degrades to a graceful no-op
+#   (the unbound-chat 409 invariant is unchanged).
 # Updated: 2026-07-17 (D5 owner preview frame) — added GET
 #   /paw-bar/admin/site/{site_id}/preview-frame → the concierge bar frame HTML for
 #   the OWNER to test inside the dashboard. SESSION-authed (paw_bar.read role gate)
@@ -498,6 +503,25 @@ async def _bound_agent_starters(agent_id: str) -> list[str]:
         return []
     starters = getattr(agent.config, "conversation_starters", None) or []
     return list(starters)[:4]
+
+
+async def _bound_agent_name(agent_id: str) -> str:
+    """Best-effort display name of a widget's BOUND agent (E2 dashboard card).
+
+    Resolved through the SAME agents-service read path the provisioner uses, so the
+    dashboard can show the concierge name and detect the "<x> Concierge" dedicated
+    pattern. Returns "" when the widget is unbound OR the agent no longer resolves —
+    a dangling agent_id degrades to absent rather than 500-ing the overview.
+    """
+    if not agent_id:
+        return ""
+    try:
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        agent = await agents_service.get(agent_id)
+    except Exception:  # noqa: BLE001 — a name read must never break the overview
+        return ""
+    return agent.name or ""
 
 
 def _dashboard_origin() -> str:
@@ -1107,6 +1131,12 @@ class AdminWidgetView(BaseModel):
     id: str
     spec: PawBarSpec
     agent_id: str = ""
+    # The bound agent's display name (feat/site-dedicated-agent, E2). Resolved from
+    # the agents service when ``agent_id`` is set so the dashboard card can show the
+    # concierge name and detect the "<x> Concierge" dedicated pattern. Empty when the
+    # widget is unbound OR the agent no longer resolves (a dangling agent_id degrades
+    # to "" rather than 500-ing the overview).
+    agent_name: str = ""
 
 
 class OverviewCounts(BaseModel):
@@ -1275,7 +1305,12 @@ async def get_site_overview(
     counts = OverviewCounts()
     widget_view: AdminWidgetView | None = None
     if widget is not None:
-        widget_view = AdminWidgetView(id=widget.id, spec=widget.spec, agent_id=widget.agent_id)
+        widget_view = AdminWidgetView(
+            id=widget.id,
+            spec=widget.spec,
+            agent_id=widget.agent_id,
+            agent_name=await _bound_agent_name(widget.agent_id),
+        )
         counts.pending_decisions = await _store().count_pending_decisions(widget.id)
         counts.handoffs = await _count_handoffs(widget.id, workspace_id)
     # Conversations are pocket-scoped (a Site is 1:1 with its pocket), so the

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -6,8 +6,11 @@
 #   and return the widget with agent_id set; a plain (non-site) widget stays unbound;
 #   FAILURE-SOFT (a provision error logs + returns the widget unbound, never 500s
 #   the create). A manual agent_id is honored and never replaced. (2)
-#   update_site_concierge_settings: flipping concierge_enabled ON provisions the
-#   site's widget when it is still unbound (provision_on_concierge_enable), also
+#   update_site_concierge_settings: ANY PATCH that sets concierge_enabled=true
+#   provisions the site's widget when it is still unbound (not only a false->true
+#   transition — the E2 one-click "create dedicated agent" re-PATCHes enabled=true
+#   on an already-enabled site as its provision hook), via
+#   provision_on_concierge_enable; idempotent + a no-op on a bound widget; also
 #   failure-soft. (3) _pawbar_frame_config now carries ``starters`` (the bound
 #   agent's conversation starters, capped 4, empty default) — the owner preview
 #   frame threads the bound agent's starters (via _bound_agent_starters); the public
@@ -996,14 +999,16 @@ async def update_site_concierge_settings(
     every time), so toggling ``concierge_enabled`` off silences the bar immediately.
     """
     site = await _load_site_scoped(site_id, workspace_id)
-    # Track whether this PATCH flips the concierge ON, so we can auto-provision the
+    # Track whether this PATCH SETS the concierge on, so we can auto-provision the
     # dedicated agent for a site whose widget is still unbound (the owner enabling
-    # the concierge is a natural provision point, alongside widget-create).
-    enabling = (
-        "concierge_enabled" in req.model_fields_set
-        and req.concierge_enabled is True
-        and not site.concierge_enabled
-    )
+    # the concierge is a natural provision point, alongside widget-create). We fire
+    # on ANY PATCH that sets concierge_enabled=true, NOT only a false->true
+    # transition: the E2 dashboard's one-click "create dedicated agent" re-PATCHes
+    # {concierge_enabled: true} on an already-enabled site as its provision hook, so
+    # a transition guard would leave that path no way in. It stays cheap + correct
+    # because provision_on_concierge_enable only acts on an UNBOUND widget and
+    # ensure_site_agent is idempotent, so a re-PATCH on a bound site is a no-op.
+    enabling = "concierge_enabled" in req.model_fields_set and req.concierge_enabled is True
     for name in req.model_fields_set:
         value = getattr(req, name)
         if value is not None:

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,19 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-23 (feat/site-dedicated-agent) — auto-provision a DEDICATED
+#   concierge agent per site. (1) create_widget: when the request carries NO
+#   agent_id and the pocket resolves to a published Site, provision + bind one
+#   dedicated agent after insert (via agent_provisioning.provision_widget_on_create)
+#   and return the widget with agent_id set; a plain (non-site) widget stays unbound;
+#   FAILURE-SOFT (a provision error logs + returns the widget unbound, never 500s
+#   the create). A manual agent_id is honored and never replaced. (2)
+#   update_site_concierge_settings: flipping concierge_enabled ON provisions the
+#   site's widget when it is still unbound (provision_on_concierge_enable), also
+#   failure-soft. (3) _pawbar_frame_config now carries ``starters`` (the bound
+#   agent's conversation starters, capped 4, empty default) — the owner preview
+#   frame threads the bound agent's starters (via _bound_agent_starters); the public
+#   frame passes []. The ASG-1 identity fields (welcome_message/conversation_starters)
+#   and agent free-form tags are ABSENT on this branch, so their seeding degrades to
+#   a graceful no-op (the unbound-chat 409 invariant is unchanged).
 # Updated: 2026-07-17 (D5 owner preview frame) — added GET
 #   /paw-bar/admin/site/{site_id}/preview-frame → the concierge bar frame HTML for
 #   the OWNER to test inside the dashboard. SESSION-authed (paw_bar.read role gate)
@@ -428,6 +443,7 @@ def _pawbar_frame_config(
     api_base: str,
     parent_origin: str,
     greeting: str,
+    starters: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build the ``window.__PAWBAR__`` bootstrap config shared by the public frame
     and the owner preview frame (D5).
@@ -437,6 +453,12 @@ def _pawbar_frame_config(
     only in WHERE the values come from — the public frame reads ``siteKey`` +
     ``parentOrigin`` from the world-visible key + allowlist, the owner preview from
     the resolved Site + the dashboard origin — and in the CSP ancestor they set.
+
+    ``starters`` are the bound agent's conversation starters (feat/site-dedicated-
+    agent, E3): additive, capped at 4, defaulting to an empty list so a frame with
+    no starters is unchanged. On this branch the Agent model carries no
+    ``conversation_starters`` field (the ASG-1 identity fields are absent), so
+    callers pass ``[]`` today — the wire is in place for when those fields land.
     """
     return {
         "siteKey": site_key,
@@ -447,8 +469,32 @@ def _pawbar_frame_config(
         # D1 / SS-6 — the owner's opening line; the glass app renders it (D4) and
         # falls back to its own default when "".
         "greeting": greeting or "",
+        # E3 — the bound agent's conversation starters (capped 4).
+        "starters": (starters or [])[:4],
         "tokens": {},
     }
+
+
+async def _bound_agent_starters(agent_id: str) -> list[str]:
+    """Best-effort conversation starters for a widget's BOUND agent (E3).
+
+    Returns the bound agent's ``conversation_starters`` (capped 4) for the frame
+    config, or ``[]`` when the widget is unbound, the agent is gone, or the Agent
+    model carries no ``conversation_starters`` field. NOTE: the ASG-1 identity
+    fields are ABSENT on this branch, so ``getattr`` misses and this returns ``[]``
+    today — the read is in place so starters flow the moment the field lands. Any
+    lookup failure degrades to ``[]`` (the frame must still render).
+    """
+    if not agent_id:
+        return []
+    try:
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        agent = await agents_service.get(agent_id)
+    except Exception:  # noqa: BLE001 — a starter read must never break the frame
+        return []
+    starters = getattr(agent.config, "conversation_starters", None) or []
+    return list(starters)[:4]
 
 
 def _dashboard_origin() -> str:
@@ -520,12 +566,19 @@ async def frame(
     # validated against the allowlist. ``siteKey`` in the page is fine — it is a
     # world-visible embed key by design.
     api_base = request.url.path.rsplit("/paw-bar/frame", 1)[0]
+    # E3 — the bound agent's conversation starters ride the config. The public
+    # frame is pre-auth (keyed on the world-visible embed key, no session) and does
+    # not load the widget here, so it defaults to []; the bound-agent starters are
+    # surfaced through the owner preview frame (below), where the widget is already
+    # resolved workspace-scoped. On this branch the value is [] regardless (the
+    # Agent ``conversation_starters`` field is absent — ASG-1 not merged here).
     config = _pawbar_frame_config(
         site_key=key,
         widget_id=w or "",
         api_base=api_base,
         parent_origin=_safe_parent_origin(po, site.allowed_origins),
         greeting=site.concierge_greeting or "",
+        starters=[],
     )
     html = _pawbar_bootstrap_html(config, PAWBAR_APP_MOUNT)
     return HTMLResponse(
@@ -652,7 +705,18 @@ async def create_widget(
         per_customer_limit_per_min=req.per_customer_limit_per_min,
         event_mapping=req.event_mapping,
     )
-    return await _store().create_widget(widget)
+    created = await _store().create_widget(widget)
+    # Auto-provision a DEDICATED concierge agent (feat/site-dedicated-agent). Only
+    # when the caller bound NO agent_id and the pocket resolves to a published Site
+    # — a plain (non-site) widget stays unbound. Failure-soft: a provisioning error
+    # logs and returns the widget UNBOUND rather than 500-ing the create (chat then
+    # 409s and the dashboard offers a manual create). A manual agent_id is honored
+    # and never replaced (the trigger returns early on a bound widget).
+    if not req.agent_id:
+        from pocketpaw_ee.paw_bar.agent_provisioning import provision_widget_on_create
+
+        created = await provision_widget_on_create(created, workspace_id)
+    return created
 
 
 @router.get(
@@ -932,11 +996,27 @@ async def update_site_concierge_settings(
     every time), so toggling ``concierge_enabled`` off silences the bar immediately.
     """
     site = await _load_site_scoped(site_id, workspace_id)
+    # Track whether this PATCH flips the concierge ON, so we can auto-provision the
+    # dedicated agent for a site whose widget is still unbound (the owner enabling
+    # the concierge is a natural provision point, alongside widget-create).
+    enabling = (
+        "concierge_enabled" in req.model_fields_set
+        and req.concierge_enabled is True
+        and not site.concierge_enabled
+    )
     for name in req.model_fields_set:
         value = getattr(req, name)
         if value is not None:
             setattr(site, name, value)
     await site.save()
+
+    # Concierge-enable provisioning trigger (feat/site-dedicated-agent). Failure-
+    # soft: a provisioning error logs and never fails this settings PATCH.
+    if enabling:
+        from pocketpaw_ee.paw_bar.agent_provisioning import provision_on_concierge_enable
+
+        await provision_on_concierge_enable(site, workspace_id)
+
     return ConciergeSettingsResponse(
         site_id=str(site.id),
         concierge_enabled=site.concierge_enabled,
@@ -1389,6 +1469,9 @@ async def get_site_preview_frame(
         raise HTTPException(status_code=500, detail="dashboard_origin_invalid")
 
     api_base = request.url.path.split("/paw-bar/", 1)[0]
+    # E3 — thread the BOUND agent's conversation starters (capped 4). The widget was
+    # resolved workspace-scoped above, so reading its agent's starters here is safe
+    # (no cross-tenant reach). [] on this branch until the ASG-1 identity fields land.
     config = _pawbar_frame_config(
         site_key=site.signed_key,
         widget_id=widget.id,
@@ -1397,6 +1480,7 @@ async def get_site_preview_frame(
         # glass app's postMessage targetOrigin is a clean scheme://host[:port].
         parent_origin=_safe_parent_origin(dash, [dash]),
         greeting=site.concierge_greeting or "",
+        starters=await _bound_agent_starters(widget.agent_id),
     )
     html = _pawbar_bootstrap_html(config, PAWBAR_APP_MOUNT)
     return HTMLResponse(

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -414,7 +414,13 @@ def _safe_parent_origin(po: str, allowed_origins: list[str]) -> str:
     return f"{scheme}://{hostport}"
 
 
-def _pawbar_bootstrap_html(config: dict[str, Any], asset_mount: str) -> str:
+# Dark page background for the OWNER preview frame only (not the public embed), so
+# the transparent glass bar sits on a dark surface matching the dashboard instead of
+# a white canvas. A near-black neutral tuned to the paw-enterprise dark theme.
+_PREVIEW_PAGE_BG = "#0d0e12"
+
+
+def _pawbar_bootstrap_html(config: dict[str, Any], asset_mount: str, page_bg: str = "") -> str:
     """Render the glass frame document: seed ``window.__PAWBAR__`` then load the app.
 
     The config dict is ``json.dumps``'d with ``<`` escaped to ``\\u003c`` so no
@@ -423,9 +429,19 @@ def _pawbar_bootstrap_html(config: dict[str, Any], asset_mount: str) -> str:
     ``</script>`` sequence or inject markup. Assets load from ``asset_mount`` (the
     root-absolute StaticFiles mount), so the document is valid wherever the API
     router is mounted.
+
+    ``page_bg`` is empty for the PUBLIC embed (the bar body stays transparent so it
+    sits over the customer's real page) and set ONLY by the owner preview frame to a
+    dark surface: a transparent-body iframe otherwise paints a white canvas backdrop,
+    which clashes with the dark dashboard the preview is embedded in. The value is a
+    hard-coded CSS color the server controls (never request-derived), so the inline
+    ``<style>`` cannot be injected.
     """
     config_json = json.dumps(config).replace("<", "\\u003c")
     v = _asset_version()
+    preview_style = (
+        f'<style>html,body{{background:{page_bg};color-scheme:dark}}</style>\n' if page_bg else ""
+    )
     return (
         "<!doctype html>\n"
         '<html lang="en">\n'
@@ -434,6 +450,7 @@ def _pawbar_bootstrap_html(config: dict[str, Any], asset_mount: str) -> str:
         '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
         "<title>Paw Bar</title>\n"
         f'<link rel="stylesheet" href="{asset_mount}/pawbar.css?v={v}">\n'
+        f"{preview_style}"
         "</head>\n"
         "<body>\n"
         '<div id="pawbar-root"></div>\n'
@@ -1522,7 +1539,10 @@ async def get_site_preview_frame(
         greeting=site.concierge_greeting or "",
         starters=await _bound_agent_starters(widget.agent_id),
     )
-    html = _pawbar_bootstrap_html(config, PAWBAR_APP_MOUNT)
+    # Preview-only dark page so the transparent bar reads as sitting on the dark
+    # dashboard, not a white canvas. The public /paw-bar/frame passes no page_bg
+    # (stays transparent over the customer's real site).
+    html = _pawbar_bootstrap_html(config, PAWBAR_APP_MOUNT, page_bg=_PREVIEW_PAGE_BG)
     return HTMLResponse(
         content=html,
         headers={"Content-Security-Policy": csp, "Cache-Control": "no-store"},

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,12 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-23 (feat/site-dedicated-agent): added the public
+# ``canonical_site_for_pocket(workspace_id, pocket_id)`` — a thin, tenant-scoped
+# wrapper over the private ``_canonical_site_doc`` so the paw-bar concierge
+# auto-provisioner resolves a pocket to its live Site through the SAME dedupe-aware
+# logic (never reaching into a private helper). Read-only; no write-path change.
+#
 # Updated 2026-07-22 (SI-4 — feat/sites-import-endpoint): ``publish`` /
 # ``_deploy_site_doc`` gain an OPTIONAL ``assets`` pass-through — the base64 binary
 # sideband ({path: base64}) an html IMPORT sends alongside its text ``source`` map.
@@ -2311,6 +2317,17 @@ async def _canonical_site_doc(workspace_id: str, pocket_id: str) -> _SiteDoc | N
     # Prefer the newest doc that carries a real url (the freshest live build);
     # fall back to the newest doc overall when none has one.
     return next((d for d in docs if d.url), docs[0])
+
+
+async def canonical_site_for_pocket(workspace_id: str, pocket_id: str) -> _SiteDoc | None:
+    """Public: the ONE canonical Site doc for (workspace, pocket_id), or None.
+
+    Thin, tenant-scoped wrapper over ``_canonical_site_doc`` so callers outside
+    this module (the paw-bar concierge auto-provisioner) resolve a pocket to its
+    live Site through the SAME dedupe-aware logic the rest of the sites stack uses,
+    without reaching into a private helper.
+    """
+    return await _canonical_site_doc(workspace_id, pocket_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_paw_bar_admin_aggregation.py
+++ b/tests/cloud/test_paw_bar_admin_aggregation.py
@@ -323,6 +323,52 @@ async def test_overview_reflects_kill_switch_and_greeting(client):
     assert body["greeting"] == "Back at 9am"
 
 
+@pytest.mark.asyncio
+async def test_overview_includes_agent_name_for_bound_widget(client):
+    """The overview widget block carries agent_name resolved from the agents
+    service so the E2 card can show the concierge name (feat/site-dedicated-agent)."""
+    from pocketpaw_ee.cloud.agents import service as agents_service
+    from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+
+    c, store, _fabric = client
+    site = await _site()
+    ctx = agents_service.legacy_ctx("user:maya", "ws-1")
+    agent = await agents_service.create(
+        ctx,
+        "ws-1",
+        CreateAgentRequest(name="Brew & Co Concierge", slug="concierge-brewco"),
+    )
+    await store.create_widget(_widget(agent_id=agent.id))
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/overview")).json()
+    assert body["widget"]["agent_id"] == agent.id
+    assert body["widget"]["agent_name"] == "Brew & Co Concierge"
+
+
+@pytest.mark.asyncio
+async def test_overview_agent_name_absent_when_unbound(client):
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget(agent_id=""))
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/overview")).json()
+    assert body["widget"]["agent_id"] == ""
+    assert body["widget"]["agent_name"] == ""
+
+
+@pytest.mark.asyncio
+async def test_overview_dangling_agent_id_degrades_to_empty_name(client):
+    """A bound agent_id that no longer resolves degrades to an empty agent_name
+    rather than 500-ing the overview."""
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget(agent_id="ffffffffffffffffffffffff"))
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/overview")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["widget"]["agent_id"] == "ffffffffffffffffffffffff"
+    assert body["widget"]["agent_name"] == ""
+
+
 # --------------------------------------------------------------------------- #
 # Layer 4 — decisions filtered to the widget
 # --------------------------------------------------------------------------- #

--- a/tests/cloud/test_paw_bar_agent_provisioning.py
+++ b/tests/cloud/test_paw_bar_agent_provisioning.py
@@ -318,6 +318,41 @@ class TestConciergeEnableTrigger:
         bound = await store.get_widget(widget.id, workspace_id=_WS)
         assert bound is not None and bound.agent_id == "agent-manual"
 
+    @pytest.mark.asyncio
+    async def test_re_patch_enabled_on_already_enabled_site_provisions_unbound(
+        self, client
+    ) -> None:
+        """The E2 one-click hook: a site that is ALREADY enabled with an UNBOUND
+        widget still provisions on a re-PATCH of concierge_enabled=true (no
+        false->true transition required)."""
+        c, store = client
+        site = await _site(concierge_enabled=True)  # already on
+        widget = await store.create_widget(_widget(agent_id=""))
+
+        res = await c.patch(
+            f"/paw-bar/admin/site/{site.id}/settings",
+            json={"concierge_enabled": True},
+        )
+        assert res.status_code == 200
+        bound = await store.get_widget(widget.id, workspace_id=_WS)
+        assert bound is not None and bound.agent_id, "re-enable should provision + bind"
+
+    @pytest.mark.asyncio
+    async def test_re_patch_enabled_on_bound_site_is_noop(self, client) -> None:
+        """A re-PATCH of concierge_enabled=true on an already-BOUND site leaves the
+        agent untouched (idempotent, unbound-only)."""
+        c, store = client
+        site = await _site(concierge_enabled=True)
+        widget = await store.create_widget(_widget(agent_id="agent-manual"))
+
+        res = await c.patch(
+            f"/paw-bar/admin/site/{site.id}/settings",
+            json={"concierge_enabled": True},
+        )
+        assert res.status_code == 200
+        bound = await store.get_widget(widget.id, workspace_id=_WS)
+        assert bound is not None and bound.agent_id == "agent-manual"
+
 
 # --------------------------------------------------------------------------- #
 # Regression — unbound chat still 409s (no fallback-to-universal)

--- a/tests/cloud/test_paw_bar_agent_provisioning.py
+++ b/tests/cloud/test_paw_bar_agent_provisioning.py
@@ -1,0 +1,394 @@
+# tests/cloud/test_paw_bar_agent_provisioning.py — auto-provision a DEDICATED
+# concierge agent per site (feat/site-dedicated-agent).
+#
+# Created 2026-07-23: covers ensure_site_agent + the two triggers.
+#   * Pure helpers: slug/name/persona derivation + conversation-starter rules
+#     (catalog, gated-action labels, generic fallback, cap 4).
+#   * Widget-create trigger: a widget with NO agent_id on a site-backed pocket
+#     auto-creates a dedicated agent named "<Site> Concierge", binds it, and emits
+#     AgentCreated (created THROUGH the agents service, not a direct write).
+#   * Idempotency: a re-run adopts the same agent; a manual agent_id is honored and
+#     never replaced; a plain (non-site) widget stays unbound.
+#   * Concierge-enable trigger: flipping the kill switch ON provisions an unbound
+#     site widget.
+#   * Regression: an unbound widget's chat still 409s (no fallback-to-universal).
+#   * Identity seeding: welcome_message/starters degrade gracefully because the
+#     ASG-1 identity fields are ABSENT on this branch (the created agent carries
+#     neither field); starters ride the frame config payload.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.paw_bar.models import (
+    PawBarActionSpec,
+    PawBarBlock,
+    PawBarCatalogItem,
+    PawBarSpec,
+    PawBarWidget,
+)
+from pocketpaw.paw_bar.store import PawBarStore
+
+_WS = "ws-1"
+_POCKET = "pocket-1"
+_OWNER = "user:maya"
+_VALID_KEY = "site_key_" + "a" * 24
+_ORIGIN = "https://brewco.com"
+_CUST = "cust-0001"
+
+
+# --------------------------------------------------------------------------- #
+# Spec / widget / site builders
+# --------------------------------------------------------------------------- #
+
+
+def _spec(
+    *,
+    with_catalog: bool = False,
+    with_actions: bool = False,
+    pocket_id: str = _POCKET,
+) -> PawBarSpec:
+    catalog = (
+        [PawBarCatalogItem(id="oat_latte", name="Oat Milk Latte", price_cents=500)]
+        if with_catalog
+        else []
+    )
+    actions = (
+        [
+            PawBarActionSpec(verb="book_table", policy="gated", label="Book a table"),
+            PawBarActionSpec(verb="request_quote", policy="gated", label="Request a quote"),
+        ]
+        if with_actions
+        else []
+    )
+    return PawBarSpec(
+        widget_id="pp_seed",
+        pocket_id=pocket_id,
+        blocks=[PawBarBlock(type="text", content="Hi from Brew & Co")],
+        catalog=catalog,
+        actions=actions,
+    )
+
+
+def _widget(**ov: Any) -> PawBarWidget:
+    d: dict[str, Any] = dict(
+        pocket_id=_POCKET,
+        owner=_OWNER,
+        name="Brew & Co",
+        spec=_spec(),
+        allowed_domains=["brewco.com"],
+        agent_id="",
+        workspace_id=_WS,
+        rate_limit_per_min=60,
+        per_customer_limit_per_min=10,
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+async def _site(**ov: Any):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace=_WS,
+        pocket_id=_POCKET,
+        owner=_OWNER,
+        name="Brew & Co",
+        signed_key=_VALID_KEY,
+        allowed_origins=["brewco.com"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+def _create_payload(**ov: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "pocket_id": _POCKET,
+        "owner": _OWNER,
+        "name": "Brew & Co",
+        "spec": _spec(with_catalog=True, with_actions=True).model_dump(),
+        "allowed_domains": ["brewco.com"],
+        "rate_limit_per_min": 60,
+        "per_customer_limit_per_min": 10,
+    }
+    payload.update(ov)
+    return payload
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path, mongo_db):
+    """A public+admin app client backed by a tmp paw-bar store (widget) + Beanie
+    (Site + Agent). ``current_workspace_id`` is pinned to ws-1. ``get_paw_bar_store``
+    is patched at the source so BOTH the router and the provisioning module resolve
+    the SAME tmp store. Yields ``(client, store)``."""
+    from unittest.mock import patch
+
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[current_workspace_id] = lambda: _WS
+
+    store = PawBarStore(tmp_path / "provisioning.db")
+    with patch("pocketpaw_ee.api.get_paw_bar_store", return_value=store):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as c:
+            yield c, store
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers — naming + conversation-starter derivation
+# --------------------------------------------------------------------------- #
+
+
+class TestHelpers:
+    def test_name_and_slug_and_persona(self) -> None:
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        assert ap.concierge_name("Brew & Co") == "Brew & Co Concierge"
+        assert ap.concierge_name("") == "Site Concierge"
+        assert ap.concierge_name("  ") == "Site Concierge"
+        assert ap.concierge_slug("abc123") == "concierge-abc123"
+        assert "Brew & Co" in ap.concierge_persona("Brew & Co")
+        assert "this site" in ap.concierge_persona("")
+
+    def test_starters_from_catalog_and_gated_actions(self) -> None:
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        widget = _widget(spec=_spec(with_catalog=True, with_actions=True))
+        starters = ap.derive_conversation_starters(widget)
+        assert starters[0] == "What do you sell?"
+        assert "Book a table?" in starters
+        assert "Request a quote?" in starters
+
+    def test_starters_generic_fallback_when_empty(self) -> None:
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        widget = _widget(spec=_spec())  # no catalog, no actions
+        assert ap.derive_conversation_starters(widget) == ["What can you help me with?"]
+
+    def test_starters_capped_at_four(self) -> None:
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        actions = [
+            PawBarActionSpec(verb=f"do_{i}", policy="gated", label=f"Action {i}") for i in range(6)
+        ]
+        spec = PawBarSpec(
+            widget_id="pp_seed",
+            pocket_id=_POCKET,
+            catalog=[PawBarCatalogItem(id="x", name="X")],
+            actions=actions,
+        )
+        starters = ap.derive_conversation_starters(_widget(spec=spec))
+        assert len(starters) == 4
+        assert starters[0] == "What do you sell?"
+
+    def test_starters_ignore_unlabeled_or_auto_actions(self) -> None:
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        spec = PawBarSpec(
+            widget_id="pp_seed",
+            pocket_id=_POCKET,
+            actions=[
+                PawBarActionSpec(verb="add_to_cart", policy="auto", label="Add to cart"),
+                PawBarActionSpec(verb="silent_verb", policy="gated", label=""),
+            ],
+        )
+        # auto action + label-less gated action → neither yields a starter → generic.
+        assert ap.derive_conversation_starters(_widget(spec=spec)) == ["What can you help me with?"]
+
+
+# --------------------------------------------------------------------------- #
+# Widget-create trigger
+# --------------------------------------------------------------------------- #
+
+
+class TestWidgetCreateTrigger:
+    @pytest.mark.asyncio
+    async def test_create_on_site_pocket_auto_provisions_and_binds(
+        self, client, recording_bus
+    ) -> None:
+        from pocketpaw_ee.cloud._core.realtime.events import AgentCreated
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        c, _store = client
+        site = await _site()
+
+        res = await c.post("/paw-bar/widgets", json=_create_payload())
+        assert res.status_code == 201
+        body = res.json()
+        agent_id = body["agent_id"]
+        assert agent_id, "widget should be bound to an auto-provisioned agent"
+
+        # The agent exists, is named for the site, and was created via the service.
+        agent = await agents_service.get(agent_id)
+        assert agent.name == "Brew & Co Concierge"
+        assert agent.slug == f"concierge-{site.id}"
+        assert agent.workspace_id == _WS
+        assert agent.owner == _OWNER
+        assert agent.config.soul_archetype == "The Site Concierge"
+        assert "Brew & Co" in agent.config.soul_persona
+
+        created = [e for e in recording_bus.events if isinstance(e, AgentCreated)]
+        assert any(e.data.get("agent_id") == agent_id for e in created)
+
+    @pytest.mark.asyncio
+    async def test_manual_agent_id_is_respected_not_replaced(self, client) -> None:
+        c, _store = client
+        await _site()
+        res = await c.post("/paw-bar/widgets", json=_create_payload(agent_id="agent-manual"))
+        assert res.status_code == 201
+        assert res.json()["agent_id"] == "agent-manual"
+
+    @pytest.mark.asyncio
+    async def test_create_without_site_stays_unbound(self, client) -> None:
+        # No Site inserted for this pocket → provisioning is skipped silently.
+        c, _store = client
+        res = await c.post("/paw-bar/widgets", json=_create_payload(pocket_id="pocket-orphan"))
+        assert res.status_code == 201
+        assert res.json()["agent_id"] == ""
+
+    @pytest.mark.asyncio
+    async def test_idempotent_second_create_adopts_same_agent(self, client) -> None:
+        c, _store = client
+        await _site()
+        first = (await c.post("/paw-bar/widgets", json=_create_payload())).json()
+        second = (await c.post("/paw-bar/widgets", json=_create_payload())).json()
+        # Deterministic slug → both widgets bind to the SAME dedicated agent.
+        assert first["agent_id"] == second["agent_id"]
+
+    @pytest.mark.asyncio
+    async def test_provisioning_failure_is_soft_returns_unbound(self, client) -> None:
+        from unittest.mock import patch
+
+        c, _store = client
+        await _site()
+        with patch(
+            "pocketpaw_ee.paw_bar.agent_provisioning.ensure_site_agent",
+            side_effect=RuntimeError("boom"),
+        ):
+            res = await c.post("/paw-bar/widgets", json=_create_payload())
+        # A provisioning error must NOT 500 the create — the widget returns unbound.
+        assert res.status_code == 201
+        assert res.json()["agent_id"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# Concierge-enable trigger
+# --------------------------------------------------------------------------- #
+
+
+class TestConciergeEnableTrigger:
+    @pytest.mark.asyncio
+    async def test_enabling_provisions_unbound_widget(self, client) -> None:
+        c, store = client
+        site = await _site(concierge_enabled=False)
+        widget = await store.create_widget(_widget(agent_id=""))
+
+        res = await c.patch(
+            f"/paw-bar/admin/site/{site.id}/settings",
+            json={"concierge_enabled": True},
+        )
+        assert res.status_code == 200
+
+        bound = await store.get_widget(widget.id, workspace_id=_WS)
+        assert bound is not None and bound.agent_id, "enabling should provision + bind an agent"
+
+    @pytest.mark.asyncio
+    async def test_enabling_leaves_manual_bind_untouched(self, client) -> None:
+        c, store = client
+        site = await _site(concierge_enabled=False)
+        widget = await store.create_widget(_widget(agent_id="agent-manual"))
+
+        res = await c.patch(
+            f"/paw-bar/admin/site/{site.id}/settings",
+            json={"concierge_enabled": True},
+        )
+        assert res.status_code == 200
+        bound = await store.get_widget(widget.id, workspace_id=_WS)
+        assert bound is not None and bound.agent_id == "agent-manual"
+
+
+# --------------------------------------------------------------------------- #
+# Regression — unbound chat still 409s (no fallback-to-universal)
+# --------------------------------------------------------------------------- #
+
+
+class TestUnboundChatStill409:
+    @pytest.mark.asyncio
+    async def test_unbound_widget_chat_is_409(self, client) -> None:
+        c, store = client
+        await _site()  # enabled, key resolves
+        widget = await store.create_widget(_widget(agent_id=""))
+        res = await c.post(
+            "/paw-bar/chat",
+            json={
+                "widget_id": widget.id,
+                "signed_key": _VALID_KEY,
+                "customer_ref": _CUST,
+                "message": "What time do you open?",
+            },
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 409
+        assert "no concierge agent" in res.text
+
+
+# --------------------------------------------------------------------------- #
+# ASG-1 identity fields absent on this branch + starters ride the frame config
+# --------------------------------------------------------------------------- #
+
+
+class TestIdentityAndFrameStarters:
+    @pytest.mark.asyncio
+    async def test_asg_identity_fields_absent_agent_has_neither(self, client) -> None:
+        """welcome_message + conversation_starters are ASG-1 fields NOT present on
+        this branch's Agent model — the provisioned agent carries neither, and the
+        seeding path degraded gracefully (no crash, agent still created + bound)."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        c, _store = client
+        await _site(concierge_greeting="Welcome to Brew & Co!")
+        agent_id = (await c.post("/paw-bar/widgets", json=_create_payload())).json()["agent_id"]
+        agent = await agents_service.get(agent_id)
+        assert not hasattr(agent.config, "welcome_message")
+        assert not hasattr(agent.config, "conversation_starters")
+
+    def test_frame_config_carries_starters_capped_four(self) -> None:
+        from pocketpaw_ee.paw_bar.router import _pawbar_frame_config
+
+        cfg = _pawbar_frame_config(
+            site_key="k",
+            widget_id="w",
+            api_base="",
+            parent_origin="",
+            greeting="",
+            starters=["a", "b", "c", "d", "e"],
+        )
+        assert cfg["starters"] == ["a", "b", "c", "d"]
+
+    def test_frame_config_starters_default_empty(self) -> None:
+        from pocketpaw_ee.paw_bar.router import _pawbar_frame_config
+
+        cfg = _pawbar_frame_config(
+            site_key="k", widget_id="w", api_base="", parent_origin="", greeting=""
+        )
+        assert cfg["starters"] == []
+
+    @pytest.mark.asyncio
+    async def test_public_frame_includes_starters_key(self, client) -> None:
+        c, _store = client
+        await _site()
+        res = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
+        assert res.status_code == 200
+        assert "starters" in res.text


### PR DESCRIPTION
## What

Every site's concierge is now answered by an agent that exists **for that site**, never a shared or universal one. This adds idempotent auto-provisioning on top of the existing manual-bind invariant (an unbound widget still 409s on chat).

New module `ee/pocketpaw_ee/paw_bar/agent_provisioning.py`:

- `ensure_site_agent(site, widget)` creates one dedicated agent through the agents service (never a direct Beanie write) and binds it to the widget via the store's `update_fields` path. A widget already bound to a live agent keeps that bind, so manual bindings are never overwritten. The slug is deterministic on the site id, so a retry after a partial provision adopts the same agent instead of minting a duplicate.
- The agent is created in the site's workspace, owned by the site owner, with a soul persona ("You are the concierge for <site>...") and the "The Site Concierge" archetype.
- A private `_seed_connectors` no-op marks where the connector-distribution wave will wire per-site connectors.

## Triggers (both failure-soft)

1. **Widget create** with no `agent_id`, when the pocket resolves to a published Site: provision and bind after insert, return the widget with `agent_id` set. A widget on a non-site pocket stays a plain unbound widget.
2. **Concierge enable**: flipping the kill switch on provisions the site's widget when it is still unbound.

A provisioning error logs and leaves the widget unbound rather than 500-ing the request. Chat then still returns 409 and the dashboard can offer a manual create.

## ASG-1 identity fields

`welcome_message`, `conversation_starters`, and a free-form agent `tags` field are **not present** on the Agent model on this branch, so their seeding degrades to a graceful no-op. The derivation logic (starters from catalog + gated-action labels, capped at 4) is unit-tested so it is ready the moment those fields land. The frame config gains a `starters` field (capped 4, empty default) threaded from the bound agent for the E3 bar slice.

## Sites service

Added a thin public `canonical_site_for_pocket(workspace_id, pocket_id)` wrapper over the private `_canonical_site_doc` so the provisioner resolves a pocket to its live Site through the same dedupe-aware logic without reaching into a private helper. Read-only, no write-path change.

## Tests

New `tests/cloud/test_paw_bar_agent_provisioning.py` (17 tests): naming/persona/starter derivation, the create trigger (auto-create + bind + AgentCreated emitted), idempotency, manual-bind respected, non-site skip, the enable trigger, the unbound-chat 409 regression, the ASG-fields-absent skip path, and starters riding the frame config.

Green: new suite (17) plus `test_paw_bar_backend`, `test_paw_bar_frame`, `test_paw_bar_concierge_settings` (64), and `test_paw_bar_ingest`, `test_paw_bar_concierge_chat`, `test_paw_bar_admin_aggregation` (83) as regression cover. Import-linter ee config: 31 kept, 0 broken.